### PR TITLE
Add shadow and border token levels

### DIFF
--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -33,7 +33,7 @@ export default function ModuleCard({
   return (
     <button
       onClick={() => onSelect(module)}
-      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
+      className={`w-full text-left border border-100 shadow-100 rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
         selected ? 'bg-gray-100' : ''
       }`}
     >

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -801,7 +801,7 @@ export class Window extends Component {
                             (this.state.grabbed ? " opacity-70 " : "") +
                             (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") +
                             (this.props.isFocused ? "" : " notFocused") +
-                            " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                            " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute shadow-300 border border-200 border-t-0 flex flex-col"}
                         id={this.id}
                         data-context="window"
                         data-app-id={this.id}

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -62,7 +62,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
     const [subIndex, setSubIndex] = useState<number | null>(null);
 
     return (
-      <div className="cursor-default w-52 rounded-md border border-gray-700 context-menu-bg text-left text-white shadow-lg">
+      <div className="cursor-default w-52 rounded-md border border-100 context-menu-bg text-left text-white shadow-200">
         <ul className="py-2">
           {items.map((item, i) =>
             item.separator ? (

--- a/components/desktop/Window.tsx
+++ b/components/desktop/Window.tsx
@@ -195,7 +195,7 @@ const Window: React.FC<WindowProps> = ({
               ? "none"
               : "all 0.15s ease",
         }}
-        className={`absolute bg-white shadow-lg rounded-lg border border-gray-300 overflow-hidden ${
+        className={`absolute bg-white shadow-300 rounded-lg border border-200 overflow-hidden ${
           focused ? "" : "opacity-90"
         }`}
       >

--- a/components/menu/HelpMenu.tsx
+++ b/components/menu/HelpMenu.tsx
@@ -35,7 +35,7 @@ const HelpMenu: React.FC = () => {
       {open && (
         <div
           ref={menuRef}
-          className="absolute left-0 mt-1 z-50 bg-ub-grey text-white shadow-lg p-2"
+          className="absolute left-0 mt-1 z-50 bg-ub-grey text-white border border-100 shadow-200 p-2"
           tabIndex={-1}
         >
           <button

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -128,7 +128,7 @@ const WhiskerMenu: React.FC = () => {
       {open && (
         <div
           ref={menuRef}
-          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
+          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white border border-100 shadow-200"
           tabIndex={-1}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node)) {

--- a/components/platforms/PlatformCard.tsx
+++ b/components/platforms/PlatformCard.tsx
@@ -8,7 +8,7 @@ interface PlatformCardProps {
 
 export default function PlatformCard({ title, bullets, thumbnail }: PlatformCardProps) {
   return (
-    <div className="flex gap-4 rounded border p-4">
+    <div className="flex gap-4 rounded border border-100 shadow-100 p-4">
       <Image src={thumbnail} alt="" width={64} height={64} className="rounded" />
       <div className="space-y-2">
         <h3 className="font-bold">{title}</h3>

--- a/components/ui/ProgressDialog.tsx
+++ b/components/ui/ProgressDialog.tsx
@@ -51,7 +51,7 @@ export default function ProgressDialog({ isOpen, onCancel }: ProgressDialogProps
 
   return (
     <Modal isOpen={isOpen} onClose={handleCancel}>
-      <div className="p-4 bg-white rounded border border-window shadow-window w-64 text-center space-y-4">
+      <div className="p-4 bg-white rounded border border-200 shadow-300 w-64 text-center space-y-4">
         <div>Processing… {Math.round(progress)}%</div>
         <ProgressBar progress={progress} className="w-full" />
         <button

--- a/components/ui/PropertiesDialog.tsx
+++ b/components/ui/PropertiesDialog.tsx
@@ -46,7 +46,7 @@ const PropertiesDialog: React.FC<Props> = ({ item, onClose, onRenamed }) => {
       role="dialog"
       aria-modal="true"
     >
-      <div className="bg-ub-cool-grey p-4 rounded border border-window shadow-window text-white w-64">
+      <div className="bg-ub-cool-grey p-4 rounded border border-200 shadow-300 text-white w-64">
         <div className="flex items-center mb-4">
           <img
             src={iconSrc}

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -31,7 +31,7 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 border border-card shadow-card ${
+      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 border border-100 shadow-200 ${
         open ? '' : 'hidden'
       }`}
     >
@@ -71,7 +71,7 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
           aria-label="Reduced motion"
         />
       </div>
-      <div className="px-4 pt-2 border-t border-card mt-2 space-y-1">
+      <div className="px-4 pt-2 border-t border-100 mt-2 space-y-1">
         <button
           type="button"
           className="w-full text-left hover:underline"

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -164,7 +164,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
 
   return (
     <div
-      className={`flex flex-col w-full h-full border border-window shadow-window ${className}`.trim()}
+      className={`flex flex-col w-full h-full border border-200 shadow-300 ${className}`.trim()}
       tabIndex={0}
       onKeyDown={onKeyDown}
     >

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -38,7 +38,7 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform px-4 py-3 border border-card shadow-card flex items-center transition-transform duration-300 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform px-4 py-3 border border-100 shadow-100 flex items-center transition-transform duration-300 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
       style={{
         background: kaliTheme.bubble.background,
         color: kaliTheme.bubble.text,

--- a/components/ui/ToastProvider.tsx
+++ b/components/ui/ToastProvider.tsx
@@ -83,7 +83,7 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
             key={t.id}
             role="status"
             aria-live="polite"
-            className={`relative px-4 py-3 shadow-md transition-all duration-300 transform pointer-events-auto ${
+            className={`relative px-4 py-3 border border-100 shadow-100 transition-all duration-300 transform pointer-events-auto ${
               t.leaving
                 ? 'opacity-0 blur-md translate-x-2'
                 : 'opacity-100 blur-0 translate-x-0'
@@ -91,7 +91,6 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
             style={{
               background: kaliTheme.bubble.background,
               color: kaliTheme.bubble.text,
-              border: `1px solid ${kaliTheme.bubble.border}`,
               borderRadius: 'var(--radius-md)',
             }}
           >

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,5 @@
 @import './tokens.css';
+@import './shadows.css';
 
 /* Accessible theme color palette meeting WCAG AA contrast ratios */
 :root {

--- a/styles/shadows.css
+++ b/styles/shadows.css
@@ -1,0 +1,14 @@
+/* Shadow and border design tokens */
+:root {
+  /* Shadow levels */
+  --shadow-0: none;
+  --shadow-100: 0 2px 4px rgba(0, 0, 0, 0.1);
+  --shadow-200: 0 4px 8px rgba(0, 0, 0, 0.2);
+  --shadow-300: 0 8px 16px rgba(0, 0, 0, 0.3);
+
+  /* Border color levels */
+  --border-0: transparent;
+  --border-100: color-mix(in srgb, var(--color-border), transparent 50%);
+  --border-200: var(--color-border);
+  --border-300: color-mix(in srgb, var(--color-border), black 20%);
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -103,13 +103,17 @@ module.exports = {
       },
       boxShadow: {
         // eslint-disable-next-line no-top-level-window/no-top-level-window-or-document
-        window: '0 4px 8px rgba(0,0,0,0.3)',
-        card: '0 2px 4px rgba(0,0,0,0.2)',
+        0: 'var(--shadow-0)',
+        100: 'var(--shadow-100)',
+        200: 'var(--shadow-200)',
+        300: 'var(--shadow-300)',
       },
       borderColor: {
         // eslint-disable-next-line no-top-level-window/no-top-level-window-or-document
-        window: 'var(--color-border)',
-        card: 'var(--color-border)',
+        0: 'var(--border-0)',
+        100: 'var(--border-100)',
+        200: 'var(--border-200)',
+        300: 'var(--border-300)',
       },
       keyframes: {
         glow: {


### PR DESCRIPTION
## Summary
- add shadow and border design tokens for 0/100/200/300
- use tokenized shadows and borders in card, menu, toast, and window components

## Testing
- `npm test __tests__/csp.test.ts` *(fails: Missing allowlist entries)*

------
https://chatgpt.com/codex/tasks/task_e_68be602093dc83289d40bb479da2819c