### PR TITLE
feat: add density context

### DIFF
--- a/components/DensityProvider.tsx
+++ b/components/DensityProvider.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+export type DensityPreset = 'regular' | 'compact';
+
+interface DensityContextValue {
+  density: DensityPreset;
+  setDensity: (preset: DensityPreset) => void;
+}
+
+const DensityContext = createContext<DensityContextValue | undefined>(undefined);
+
+export const DensityProvider = ({ children }: { children: ReactNode }) => {
+  const [density, setDensity] = useState<DensityPreset>('regular');
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove('density-regular', 'density-compact');
+    root.classList.add(`density-${density}`);
+  }, [density]);
+
+  return (
+    <DensityContext.Provider value={{ density, setDensity }}>
+      {children}
+    </DensityContext.Provider>
+  );
+};
+
+export const useDensity = () => {
+  const ctx = useContext(DensityContext);
+  if (!ctx) {
+    throw new Error('useDensity must be used within a DensityProvider');
+  }
+  return ctx;
+};
+
+export default DensityProvider;

--- a/styles/density.css
+++ b/styles/density.css
@@ -1,0 +1,19 @@
+/* Density spacing variables */
+:root,
+.density-regular {
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+}
+
+.density-compact {
+  --space-1: 0.125rem;
+  --space-2: 0.25rem;
+  --space-3: 0.5rem;
+  --space-4: 0.75rem;
+  --space-5: 1rem;
+  --space-6: 1.5rem;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,5 @@
 @import './tokens.css';
+@import './density.css';
 
 /* Accessible theme color palette meeting WCAG AA contrast ratios */
 :root {


### PR DESCRIPTION
## Summary
- add spacing variables for regular and compact density presets
- create DensityProvider to switch spacing presets via context

## Testing
- `yarn test` *(fails: TypeError cannot set properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68be6021c56883288021fc4f3a606548