### PR TITLE
feat: add typography font stacks

### DIFF
--- a/docs/design/typography.mdx
+++ b/docs/design/typography.mdx
@@ -1,0 +1,20 @@
+# Typography
+
+## Font stacks
+
+- **Sans-serif**: `'Ubuntu', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'`
+- **Serif**: `'Merriweather', Georgia, Cambria, 'Times New Roman', Times, serif`
+- **Monospace**: `'Ubuntu Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace`
+
+Each stack is defined in `styles/typography.css` and applied to relevant elements. Headings also receive custom tracking and leading values to maintain consistent rhythm across the scale.
+
+## Heading tracking and leading
+
+| Element | Letter spacing | Line height |
+|---------|----------------|-------------|
+| `h1`    | `-0.03em`      | `1.1`       |
+| `h2`    | `-0.02em`      | `1.15`      |
+| `h3`    | `-0.015em`     | `1.2`       |
+| `h4`    | `-0.01em`      | `1.25`      |
+| `h5`    | `-0.005em`     | `1.3`       |
+| `h6`    | `0`            | `1.35`      |

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,4 +1,5 @@
 @import './globals.css';
+@import './typography.css';
 @import './whisker.css';
 
 :root {

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -1,0 +1,59 @@
+/* Typography utilities */
+
+:root {
+  --font-sans: 'Ubuntu', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+    'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+    'Noto Color Emoji';
+  --font-serif: 'Merriweather', Georgia, Cambria, 'Times New Roman', Times, serif;
+  --font-mono: 'Ubuntu Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+}
+
+body {
+  font-family: var(--font-sans);
+}
+
+code,
+pre,
+kbd,
+samp {
+  font-family: var(--font-mono);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-sans);
+}
+
+h1 {
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+}
+
+h2 {
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+}
+
+h3 {
+  letter-spacing: -0.015em;
+  line-height: 1.2;
+}
+
+h4 {
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+}
+
+h5 {
+  letter-spacing: -0.005em;
+  line-height: 1.3;
+}
+
+h6 {
+  letter-spacing: 0;
+  line-height: 1.35;
+}


### PR DESCRIPTION
## Summary
- add global typography stylesheet defining font stacks and heading tracking/leading
- document font stacks and heading rhythm in design guide

## Testing
- `yarn test` *(fails: SessionNotCreatedError: cannot find Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_68be602280288328b99b0a34343e11d7