### PR TITLE
feat: centralize radius tokens and apply across UI

### DIFF
--- a/apps/calculator/styles.css
+++ b/apps/calculator/styles.css
@@ -11,7 +11,7 @@ body {
 .calculator {
   background: var(--color-surface);
   padding: 1rem;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   box-shadow: 0 2px 10px color-mix(in srgb, var(--color-inverse), transparent 90%);
   width: 100%;
   max-width: 240px;
@@ -25,7 +25,7 @@ body {
   padding: 0.5rem;
   text-align: right;
   font-size: 1.2rem;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   overflow-x: auto;
   width: 100%;
   box-sizing: border-box;
@@ -41,7 +41,7 @@ body {
   padding: 0.5rem;
   border: none;
   background: var(--color-muted);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   cursor: pointer;
 }
 
@@ -68,7 +68,7 @@ body {
   padding: 0.75rem;
   background: var(--color-muted);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   font-size: 1rem;
   cursor: pointer;
   min-height: 48px;

--- a/apps/color_picker/index.css
+++ b/apps/color_picker/index.css
@@ -10,7 +10,7 @@ h1 {
   width: 80px;
   height: 80px;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   transition: transform 0.2s ease;
@@ -28,7 +28,7 @@ h1 {
   width: 40px;
   height: 40px;
   border: 1px solid #ccc;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }

--- a/apps/sticky_notes/styles.css
+++ b/apps/sticky_notes/styles.css
@@ -30,7 +30,7 @@ body {
   overflow: auto;
   box-shadow: 0 4px 6px color-mix(in srgb, var(--color-inverse), transparent 90%),
     0 1px 3px color-mix(in srgb, var(--color-inverse), transparent 92%);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
 }
 
 .note textarea {

--- a/apps/timer_stopwatch/index.css
+++ b/apps/timer_stopwatch/index.css
@@ -34,7 +34,7 @@ li {
   background: #fff;
   margin: 2px 0;
   padding: 5px 10px;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   font-family: 'Courier New', monospace;
 }
 .hidden {

--- a/apps/timer_stopwatch/styles.css
+++ b/apps/timer_stopwatch/styles.css
@@ -51,7 +51,7 @@ li {
   background: var(--color-surface);
   margin: 2px 0;
   padding: 5px 10px;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   font-family: 'Courier New', monospace;
 }
 

--- a/apps/weather_widget/styles.css
+++ b/apps/weather_widget/styles.css
@@ -10,7 +10,7 @@ body {
 
 .widget-container {
   background: var(--color-surface);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   box-shadow: 0 4px 10px color-mix(in srgb, var(--color-inverse), transparent 90%);
   padding: 20px;
   display: flex;

--- a/content/mdx.css
+++ b/content/mdx.css
@@ -22,7 +22,7 @@ code {
   line-height: 1.5;
   background-color: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: 0.25rem;
+  border-radius: var(--radius-md);
   padding: 0.125rem 0.25rem;
 }
 
@@ -31,7 +31,7 @@ pre {
   background-color: var(--color-surface);
   padding: 1rem;
   overflow-x: auto;
-  border-radius: 0.25rem;
+  border-radius: var(--radius-md);
 }
 
 pre code {
@@ -44,7 +44,7 @@ pre code {
   margin: 1rem 0;
   padding: 0.75rem 1rem;
   border-left: 4px solid;
-  border-radius: 0.25rem;
+  border-radius: var(--radius-md);
   line-height: 1.6;
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,5 @@
 @import './tokens.css';
+@import './radii.css';
 
 /* Accessible theme color palette meeting WCAG AA contrast ratios */
 :root {

--- a/styles/index.css
+++ b/styles/index.css
@@ -78,10 +78,10 @@ body{
     background: transparent;
 }
 
-::-webkit-scrollbar-thumb {
-    background-color: var(--color-border);
-    border-radius: 4px;
-}
+  ::-webkit-scrollbar-thumb {
+      background-color: var(--color-border);
+      border-radius: var(--radius-md);
+  }
 
 @media (max-width: 600px) {
     html {
@@ -407,16 +407,16 @@ dialog {
     transition: transform 0.6s ease, opacity 0.3s ease;
 }
 
-.card-face {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    backface-visibility: hidden;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 0.25rem;
-}
+  .card-face {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      backface-visibility: hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--radius-md);
+  }
 
 .card-front {
     background: var(--color-surface);
@@ -722,9 +722,9 @@ textarea:focus-visible {
 }
 
 
-.tour-highlight {
-    position: relative;
-    z-index: 60 !important;
-    box-shadow: 0 0 0 4px rgba(251,191,36,0.9);
-    border-radius: 4px;
-}
+  .tour-highlight {
+      position: relative;
+      z-index: 60 !important;
+      box-shadow: 0 0 0 4px rgba(251,191,36,0.9);
+      border-radius: var(--radius-md);
+  }

--- a/styles/radii.css
+++ b/styles/radii.css
@@ -1,0 +1,8 @@
+/* Radius tokens */
+:root {
+  --radius-sm: 2px;
+  --radius-md: 4px;
+  --radius-lg: 8px;
+  --radius-xl: 16px;
+  --radius-round: 9999px;
+}

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -40,12 +40,6 @@
   --space-5: 1.5rem;
   --space-6: 2rem;
 
-  /* Radius */
-  --radius-sm: 2px;
-  --radius-md: 4px;
-  --radius-lg: 8px;
-  --radius-round: 9999px;
-
   /* Motion durations */
   --motion-fast: 150ms;
   --motion-medium: 300ms;

--- a/styles/whisker.css
+++ b/styles/whisker.css
@@ -5,7 +5,7 @@
   /* Width of the sidebar/dock */
   --sidebar-width: 4rem;
   /* Rounded corners for menus and sidebar */
-  --menu-border-radius: 0.5rem;
+  --menu-border-radius: var(--radius-lg);
   /* Overall menu opacity (0 - 1) */
   --menu-opacity: 0.9;
 }


### PR DESCRIPTION
## Summary
- introduce `styles/radii.css` with `sm/md/lg/xl` radius tokens
- refactor buttons, inputs, cards, panels, and windows to consume radius tokens
- update globals to import new token file

## Testing
- `npm test` *(fails: dynamic app imports missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68be602368988328ac5e7ca4841d67fe