### PR TITLE
feat: add color contrast widget

### DIFF
--- a/components/ContrastWidget.tsx
+++ b/components/ContrastWidget.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { contrastRatio } from './apps/Games/common/theme';
+
+export default function ContrastWidget() {
+  const [fg, setFg] = useState('#000000');
+  const [bg, setBg] = useState('#ffffff');
+  const ratio = contrastRatio(fg, bg);
+  const level = ratio >= 7 ? 'AAA' : ratio >= 4.5 ? 'AA' : 'Fail';
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex gap-4">
+        <label className="flex items-center gap-2">
+          <span>Foreground</span>
+          <input
+            type="color"
+            value={fg}
+            onChange={(e) => setFg(e.target.value)}
+            aria-label="Foreground color"
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          <span>Background</span>
+          <input
+            type="color"
+            value={bg}
+            onChange={(e) => setBg(e.target.value)}
+            aria-label="Background color"
+          />
+        </label>
+      </div>
+      <div
+        className="w-40 h-20 flex items-center justify-center rounded"
+        style={{ backgroundColor: bg, color: fg }}
+      >
+        Aa
+      </div>
+      <span className="text-sm">{`Contrast ${ratio.toFixed(2)}:1 ${level}`}</span>
+    </div>
+  );
+}

--- a/docs/design/colors.mdx
+++ b/docs/design/colors.mdx
@@ -1,0 +1,7 @@
+import ContrastWidget from '../../components/ContrastWidget';
+
+# Color Contrast
+
+Use the widget below to evaluate WCAG AA contrast compliance.
+
+<ContrastWidget />


### PR DESCRIPTION
## Summary
- add ContrastWidget component to test color combinations against WCAG AA
- document colors with interactive contrast widget

## Testing
- `npx eslint components/ContrastWidget.tsx docs/design/colors.mdx`
- `npx jest components/ContrastWidget.tsx --passWithNoTests`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Type 'undefined' cannot be used as an index type)*

------
https://chatgpt.com/codex/tasks/task_e_68be6025175483288cd29467fd6f848c