### PR TITLE
Add developers menu and basic developer routes

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,12 +1,16 @@
 import React, { useState } from 'react';
 import SearchOverlay from './ui/SearchOverlay';
+import DevelopersMenu from './Header/DevelopersMenu';
 
 export default function Header() {
   const [searchOpen, setSearchOpen] = useState(false);
 
   return (
     <header className="flex items-center justify-between p-2 bg-gray-800 text-white">
-      <div className="font-bold">Kali Linux Portfolio</div>
+      <div className="flex items-center space-x-4">
+        <div className="font-bold">Kali Linux Portfolio</div>
+        <DevelopersMenu />
+      </div>
       <button
         type="button"
         aria-label="Search"

--- a/components/Header/DevelopersMenu.tsx
+++ b/components/Header/DevelopersMenu.tsx
@@ -1,0 +1,60 @@
+import React, { useState, useEffect, useRef } from 'react';
+import Link from 'next/link';
+
+const items = [
+  { href: '/git-repositories', label: 'Git Repositories' },
+  { href: '/packages', label: 'Packages' },
+  { href: '/auto-package-tests', label: 'Auto Package Tests' },
+  { href: '/bug-tracker', label: 'Bug Tracker' },
+  { href: '/nethunter-stats', label: 'NetHunter Stats' },
+];
+
+export default function DevelopersMenu() {
+  const [open, setOpen] = useState(false);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (!open) return;
+      const target = e.target as Node;
+      if (!menuRef.current?.contains(target) && !btnRef.current?.contains(target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  return (
+    <div className="relative">
+      <button
+        ref={btnRef}
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+      >
+        Developers
+      </button>
+      {open && (
+        <div
+          ref={menuRef}
+          className="absolute left-0 mt-1 z-50 bg-ub-grey text-white shadow-lg p-2"
+          tabIndex={-1}
+        >
+          {items.map(item => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="block px-2 py-1 hover:underline"
+              onClick={() => setOpen(false)}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/pages/auto-package-tests.tsx
+++ b/pages/auto-package-tests.tsx
@@ -1,0 +1,13 @@
+import DesktopLayout from '../components/desktop/DesktopLayout';
+
+export default function AutoPackageTests() {
+  return (
+    <DesktopLayout title="Auto Package Tests">
+      <div className="p-4">
+        <h1 className="text-xl font-bold">Auto Package Tests</h1>
+        <p>Automated test results and status will be displayed here.</p>
+      </div>
+    </DesktopLayout>
+  );
+}
+

--- a/pages/bug-tracker.tsx
+++ b/pages/bug-tracker.tsx
@@ -1,0 +1,13 @@
+import DesktopLayout from '../components/desktop/DesktopLayout';
+
+export default function BugTracker() {
+  return (
+    <DesktopLayout title="Bug Tracker">
+      <div className="p-4">
+        <h1 className="text-xl font-bold">Bug Tracker</h1>
+        <p>Track and manage project issues from this page.</p>
+      </div>
+    </DesktopLayout>
+  );
+}
+

--- a/pages/git-repositories.tsx
+++ b/pages/git-repositories.tsx
@@ -1,0 +1,13 @@
+import DesktopLayout from '../components/desktop/DesktopLayout';
+
+export default function GitRepositories() {
+  return (
+    <DesktopLayout title="Git Repositories">
+      <div className="p-4">
+        <h1 className="text-xl font-bold">Git Repositories</h1>
+        <p>Links to project repositories will appear here.</p>
+      </div>
+    </DesktopLayout>
+  );
+}
+

--- a/pages/nethunter-stats.tsx
+++ b/pages/nethunter-stats.tsx
@@ -1,0 +1,13 @@
+import DesktopLayout from '../components/desktop/DesktopLayout';
+
+export default function NetHunterStats() {
+  return (
+    <DesktopLayout title="NetHunter Stats">
+      <div className="p-4">
+        <h1 className="text-xl font-bold">NetHunter Stats</h1>
+        <p>Statistics and analytics for NetHunter will appear here.</p>
+      </div>
+    </DesktopLayout>
+  );
+}
+

--- a/pages/packages.tsx
+++ b/pages/packages.tsx
@@ -1,0 +1,13 @@
+import DesktopLayout from '../components/desktop/DesktopLayout';
+
+export default function Packages() {
+  return (
+    <DesktopLayout title="Packages">
+      <div className="p-4">
+        <h1 className="text-xl font-bold">Packages</h1>
+        <p>Browse available packages and related information.</p>
+      </div>
+    </DesktopLayout>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Add Developers menu with links to Git Repositories, Packages, Auto Package Tests, Bug Tracker, and NetHunter Stats
- Create placeholder pages for developer resources
- Integrate Developers menu into site header

## Testing
- `yarn test` *(fails: missing dependencies, failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68be6025a8e0832885ff3662a27c5ae7