### PR TITLE
feat: add about menu and placeholder pages

### DIFF
--- a/components/Header/AboutMenu.tsx
+++ b/components/Header/AboutMenu.tsx
@@ -1,0 +1,63 @@
+import React, { useState, useEffect, useRef } from 'react';
+import Link from 'next/link';
+
+const AboutMenu: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (!open) return;
+      const target = e.target as Node;
+      if (!menuRef.current?.contains(target) && !btnRef.current?.contains(target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const items = [
+    { href: '/about', label: 'Overview' },
+    { href: '/about/wallpapers', label: 'Wallpapers' },
+    { href: '/about/swag-store', label: 'Swag Store' },
+    { href: '/about/team', label: 'Team' },
+    { href: '/about/partnerships', label: 'Partnerships' },
+    { href: '/about/contact', label: 'Contact' }
+  ];
+
+  return (
+    <div className="relative">
+      <button
+        ref={btnRef}
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+      >
+        About
+      </button>
+      {open && (
+        <div
+          ref={menuRef}
+          className="absolute left-0 mt-1 z-50 bg-ub-grey text-white shadow-lg p-2"
+          tabIndex={-1}
+        >
+          {items.map(item => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="block px-2 py-1 hover:underline"
+              onClick={() => setOpen(false)}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AboutMenu;
+

--- a/pages/about/contact.tsx
+++ b/pages/about/contact.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const ContactPage: React.FC = () => (
+  <div className="p-8">
+    <h1 className="text-2xl font-bold mb-4">Contact</h1>
+    <p>Placeholder page for contact information.</p>
+  </div>
+);
+
+export default ContactPage;
+

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const AboutOverview: React.FC = () => (
+  <div className="p-8">
+    <h1 className="text-2xl font-bold mb-4">About Kali Linux</h1>
+    <p>Placeholder content for the overview page.</p>
+  </div>
+);
+
+export default AboutOverview;
+

--- a/pages/about/partnerships.tsx
+++ b/pages/about/partnerships.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const PartnershipsPage: React.FC = () => (
+  <div className="p-8">
+    <h1 className="text-2xl font-bold mb-4">Partnerships</h1>
+    <p>Placeholder page for partnerships.</p>
+  </div>
+);
+
+export default PartnershipsPage;
+

--- a/pages/about/swag-store.tsx
+++ b/pages/about/swag-store.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const SwagStore: React.FC = () => (
+  <div className="p-8">
+    <h1 className="text-2xl font-bold mb-4">Swag Store</h1>
+    <p>Placeholder page for the swag store.</p>
+  </div>
+);
+
+export default SwagStore;
+

--- a/pages/about/team.tsx
+++ b/pages/about/team.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const TeamPage: React.FC = () => (
+  <div className="p-8">
+    <h1 className="text-2xl font-bold mb-4">Team</h1>
+    <p>Placeholder page for the team.</p>
+  </div>
+);
+
+export default TeamPage;
+

--- a/pages/about/wallpapers.tsx
+++ b/pages/about/wallpapers.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const AboutWallpapers: React.FC = () => (
+  <div className="p-8">
+    <h1 className="text-2xl font-bold mb-4">Wallpapers</h1>
+    <p>Placeholder page for wallpapers.</p>
+  </div>
+);
+
+export default AboutWallpapers;
+


### PR DESCRIPTION
## Summary
- add About menu with links to overview, wallpapers, swag store, team, partnerships and contact
- add placeholder pages for new about sections

## Testing
- `./node_modules/.bin/eslint components/Header/AboutMenu.tsx pages/about/*.tsx && echo 'eslint ok'`
- `npx jest components/Header/AboutMenu.tsx pages/about/index.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be60261cc08328b20a23f7e7a9f7bb