### PR TITLE
feat: show latest release in header

### DIFF
--- a/components/Header/ReleasePill.tsx
+++ b/components/Header/ReleasePill.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { isBrowser } from '@/utils/env';
+
+interface ReleaseInfo {
+  tag_name: string;
+  html_url: string;
+  name?: string;
+}
+
+const API_URL = 'https://api.github.com/repos/unnippillil/kali-linux-portfolio/releases/latest';
+const STORAGE_KEY = 'release-pill-dismissed';
+
+export default function ReleasePill() {
+  const [release, setRelease] = useState<ReleaseInfo | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    async function fetchRelease() {
+      try {
+        const res = await fetch(API_URL);
+        if (!res.ok) return;
+        const data = await res.json();
+        setRelease(data);
+        if (isBrowser()) {
+          const dismissed = sessionStorage.getItem(STORAGE_KEY);
+          if (dismissed !== data.tag_name) {
+            setVisible(true);
+          }
+        }
+      } catch (e) {
+        console.error('Failed to fetch release', e);
+      }
+    }
+    fetchRelease();
+  }, []);
+
+  const dismiss = () => {
+    if (isBrowser() && release) {
+      sessionStorage.setItem(STORAGE_KEY, release.tag_name);
+    }
+    setVisible(false);
+  };
+
+  if (!visible || !release) return null;
+
+  return (
+    <div className="absolute top-2 right-2 flex items-center bg-blue-600 text-white text-xs rounded-full px-3 py-1 gap-2">
+      <a
+        href={release.html_url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline"
+      >
+        {release.name || release.tag_name}
+      </a>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss"
+        className="text-white hover:text-gray-200"
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import DocMegaMenu from './DocMegaMenu';
+import ReleasePill from '../Header/ReleasePill';
 
 export default function Header() {
   const [docsOpen, setDocsOpen] = useState(false);
@@ -27,6 +28,7 @@ export default function Header() {
           {docsOpen && <DocMegaMenu onClose={closeDocs} />}
         </div>
       </nav>
+      <ReleasePill />
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- add ReleasePill component to fetch latest GitHub release and allow dismissing
- surface ReleasePill in site header

## Testing
- `node --version` *(fails: command not found)*
- `apt-get install -y nodejs npm` *(fails: Unable to locate package nodejs)*

------
https://chatgpt.com/codex/tasks/task_e_68be602da82c83289dcfa837a02918ee