### PR TITLE
feat: add system status chip

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
-import SearchOverlay from './ui/SearchOverlay';
+import React, { useState } from "react";
+import SearchOverlay from "./ui/SearchOverlay";
+import SystemStatusChip from "./Header/SystemStatusChip";
 
 export default function Header() {
   const [searchOpen, setSearchOpen] = useState(false);
@@ -7,27 +8,30 @@ export default function Header() {
   return (
     <header className="flex items-center justify-between p-2 bg-gray-800 text-white">
       <div className="font-bold">Kali Linux Portfolio</div>
-      <button
-        type="button"
-        aria-label="Search"
-        onClick={() => setSearchOpen(true)}
-        className="p-2 hover:bg-gray-700 rounded transition-colors"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          className="w-5 h-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
+      <div className="flex items-center gap-2">
+        <SystemStatusChip />
+        <button
+          type="button"
+          aria-label="Search"
+          onClick={() => setSearchOpen(true)}
+          className="p-2 hover:bg-gray-700 rounded transition-colors"
         >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 1010.5 3a7.5 7.5 0 006.15 12.65z"
-          />
-        </svg>
-      </button>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="w-5 h-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 1010.5 3a7.5 7.5 0 006.15 12.65z"
+            />
+          </svg>
+        </button>
+      </div>
       <SearchOverlay open={searchOpen} onClose={() => setSearchOpen(false)} />
     </header>
   );

--- a/components/Header/SystemStatusChip.tsx
+++ b/components/Header/SystemStatusChip.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import ia from "../../data/ia.json";
+
+const STATUS_API = "https://status.kali.org/api/status-page/heartbeat/default";
+
+type State = "green" | "amber" | "red";
+
+export default function SystemStatusChip() {
+  const [state, setState] = useState<State>("green");
+
+  useEffect(() => {
+    const fetchStatus = async () => {
+      try {
+        const res = await fetch(STATUS_API);
+        const data = await res.json();
+        const heartbeatList = data?.heartbeatList || {};
+        const statuses = Object.values<any[]>(heartbeatList).map(
+          (arr) => arr?.[0]?.status ?? 1,
+        );
+        const worst = Math.max(...(statuses.length ? statuses : [1]));
+        setState(worst === 0 ? "red" : worst === 1 ? "green" : "amber");
+      } catch {
+        setState("amber");
+      }
+    };
+
+    fetchStatus();
+  }, []);
+
+  const statusLink =
+    (ia as any).footer.groups
+      .flatMap((g: any) => g.items)
+      .find((item: any) => item.label === "System Status")?.href || "#";
+
+  const color =
+    state === "green"
+      ? "bg-green-500"
+      : state === "amber"
+        ? "bg-amber-500"
+        : "bg-red-500";
+  const label =
+    state === "green"
+      ? "Operational"
+      : state === "amber"
+        ? "Degraded"
+        : "Outage";
+
+  return (
+    <a
+      href={statusLink}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 rounded-full bg-gray-700 px-2 py-1 text-xs"
+    >
+      <span className={`h-2 w-2 rounded-full ${color}`} aria-hidden="true" />
+      {label}
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary
- add SystemStatusChip component with green/amber/red states and link to status page
- display status chip in header next to search control

## Testing
- `yarn test` *(fails: browserType.launch executable doesn't exist; missing Chrome; other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68be6033c53c83289a5cb8cae8db36f3