### PR TITLE
feat: add system dialog error pages

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -2,23 +2,24 @@
 'use client';
 
 import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import SystemDialog from '../components/ui/SystemDialog';
 import { reportClientError } from '../lib/client-error-reporter';
 
 export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  const router = useRouter();
+
   useEffect(() => {
     reportClientError(error, error.stack);
   }, [error]);
 
   return (
-    <div className="flex flex-col items-center justify-center gap-4 p-4">
-      <h2 className="text-xl font-semibold">Something went wrong!</h2>
-      <button
-        type="button"
-        onClick={() => reset()}
-        className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
-      >
-        Try again
-      </button>
-    </div>
+    <SystemDialog
+      isOpen
+      title="Application error"
+      message="Something went wrong!"
+      primary={{ label: 'Try again', onClick: () => reset() }}
+      secondary={{ label: 'Go home', onClick: () => router.push('/') }}
+    />
   );
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import SystemDialog from '../components/ui/SystemDialog';
+
+export default function NotFound() {
+  const router = useRouter();
+
+  return (
+    <SystemDialog
+      isOpen
+      title="Page not found"
+      message="The page you are looking for does not exist."
+      primary={{ label: 'Go home', onClick: () => router.push('/') }}
+      secondary={{ label: 'Back', onClick: () => router.back() }}
+    />
+  );
+}
+

--- a/components/ui/SystemDialog.tsx
+++ b/components/ui/SystemDialog.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useId } from 'react';
+import Modal from '../base/Modal';
+
+interface Action {
+  label: string;
+  onClick: () => void;
+}
+
+interface SystemDialogProps {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  primary: Action;
+  secondary?: Action;
+}
+
+export default function SystemDialog({
+  isOpen,
+  title,
+  message,
+  primary,
+  secondary,
+}: SystemDialogProps) {
+  const headingId = useId();
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={primary.onClick}
+      ariaLabelledby={headingId}
+      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50"
+    >
+      <div className="bg-ub-cool-grey border border-window shadow-window p-4 text-white w-80 space-y-4">
+        <h2 id={headingId} className="text-lg font-semibold">
+          {title}
+        </h2>
+        <p>{message}</p>
+        <div className="flex justify-end gap-2 flex-row-reverse">
+          <button
+            type="button"
+            onClick={primary.onClick}
+            className="px-3 py-1 bg-black bg-opacity-50 rounded"
+          >
+            {primary.label}
+          </button>
+          {secondary && (
+            <button
+              type="button"
+              onClick={secondary.onClick}
+              className="px-3 py-1 bg-black bg-opacity-50 rounded"
+            >
+              {secondary.label}
+            </button>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add generic SystemDialog component with focus trapping
- render 404/500 error pages as centered system dialogs with primary and secondary actions

## Testing
- `npx eslint app/error.tsx app/not-found.tsx components/ui/SystemDialog.tsx`
- `yarn test __tests__/Modal.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68be67e456348328af78191bb551117c