### PR TITLE
docs: add design tokens page

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,4 @@
+# Design Docs
+
+- [Design Guidelines](../design-guidelines.md)
+- [Design Tokens](./tokens.mdx)

--- a/docs/design/tokens.mdx
+++ b/docs/design/tokens.mdx
@@ -1,0 +1,59 @@
+import '../../styles/tokens.css';
+
+export const title = 'Design Tokens';
+export const summary = 'Live swatches and usage examples for color, typography, spacing and radii tokens.';
+
+# Design Tokens
+
+## Colors
+
+| Token | Swatch | Usage |
+|-------|--------|-------|
+| `bg` | <span style={{display:'inline-block',width:'2rem',height:'1rem',background:'var(--color-bg)',border:'1px solid var(--color-border)'}} /> | `bg-bg` |
+| `text` | <span style={{display:'inline-block',width:'2rem',height:'1rem',background:'var(--color-text)',border:'1px solid var(--color-border)'}} /> | `text-text` |
+| `accent` | <span style={{display:'inline-block',width:'2rem',height:'1rem',background:'var(--color-accent)',border:'1px solid var(--color-border)'}} /> | `text-accent` |
+| `ub-orange` | <span style={{display:'inline-block',width:'2rem',height:'1rem',background:'var(--color-ub-orange)',border:'1px solid var(--color-border)'}} /> | `bg-ub-orange` |
+| `ubt-blue` | <span style={{display:'inline-block',width:'2rem',height:'1rem',background:'var(--color-ubt-blue)',border:'1px solid var(--color-border)'}} /> | `text-ubt-blue` |
+
+## Typography
+
+<div className="space-y-2">
+  <p className="font-ubuntu text-base">Base text sample</p>
+  <p className="font-ubuntu text-h1">Heading 1</p>
+  <p className="font-ubuntu text-h2">Heading 2</p>
+  <p className="font-ubuntu text-h3">Heading 3</p>
+</div>
+
+```html
+<h1 class="font-ubuntu text-h1">Heading 1</h1>
+```
+
+## Spacing
+
+<div style={{display:'flex',alignItems:'flex-end',gap:'var(--space-2)'}}>
+  <div style={{width:'var(--space-1)',height:'var(--space-1)',background:'var(--color-ub-orange)'}} />
+  <div style={{width:'var(--space-2)',height:'var(--space-2)',background:'var(--color-ub-orange)'}} />
+  <div style={{width:'var(--space-3)',height:'var(--space-3)',background:'var(--color-ub-orange)'}} />
+  <div style={{width:'var(--space-4)',height:'var(--space-4)',background:'var(--color-ub-orange)'}} />
+  <div style={{width:'var(--space-5)',height:'var(--space-5)',background:'var(--color-ub-orange)'}} />
+  <div style={{width:'var(--space-6)',height:'var(--space-6)',background:'var(--color-ub-orange)'}} />
+</div>
+
+```html
+<div class="p-space-2 md:p-space-3">...</div>
+```
+
+## Radii
+
+<div style={{display:'flex',gap:'var(--space-2)'}}>
+  <div style={{width:'3rem',height:'3rem',background:'var(--color-ub-orange)',borderRadius:'var(--radius-sm)'}} />
+  <div style={{width:'3rem',height:'3rem',background:'var(--color-ub-orange)',borderRadius:'var(--radius-md)'}} />
+  <div style={{width:'3rem',height:'3rem',background:'var(--color-ub-orange)',borderRadius:'var(--radius-lg)'}} />
+  <div style={{width:'3rem',height:'3rem',background:'var(--color-ub-orange)',borderRadius:'var(--radius-round)'}} />
+</div>
+
+```css
+button {
+  border-radius: var(--radius-md);
+}
+```


### PR DESCRIPTION
## Summary
- add design tokens documentation with live color, typography, spacing, and radii swatches
- link tokens page from design docs navigation

## Testing
- `npx eslint docs/design/tokens.mdx docs/design/README.md` *(files ignored: no matching configuration)*
- `yarn test` *(fails: Missing allowlist entries and module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be6a604dac8328b35963f229208e98