### PR TITLE
docs: document and unify component state styles

### DIFF
--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import { stateStyles } from "./ui/stateStyles";
 
 type Tab<T extends string> = {
   id: T;
@@ -28,9 +29,11 @@ export default function Tabs<T extends string>({
           aria-selected={active === t.id}
           tabIndex={active === t.id ? 0 : -1}
           onClick={() => onChange(t.id)}
-          className={`px-4 py-2 focus:outline-none ${
-            active === t.id ? "bg-ub-orange text-white" : "text-ubt-grey"
-          }`}
+          className={`${stateStyles} px-4 py-2 ${
+            active === t.id
+              ? "bg-ub-orange text-white"
+              : "text-ubt-grey hover:bg-ub-orange/20"
+          } active:bg-ub-orange/40`}
         >
           {t.label}
         </button>

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,4 +1,5 @@
 import type { ButtonHTMLAttributes, CSSProperties } from "react";
+import { stateStyles } from "./stateStyles";
 
 export type ButtonVariant = "default" | "primary" | "secondary" | "danger";
 
@@ -34,7 +35,7 @@ export default function Button({
   const variantStyle = variantStyles[variant];
   return (
     <button
-      className={`btn ${className}`}
+      className={`btn ${stateStyles} ${className}`}
       style={{ ...variantStyle, ...style }}
       {...props}
     />

--- a/components/ui/CommandChip.tsx
+++ b/components/ui/CommandChip.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { stateStyles } from './stateStyles';
 
 interface CommandChipProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   command: string;
@@ -30,7 +31,7 @@ export default function CommandChip({ command, className = '', ...props }: Comma
     <button
       type="button"
       onClick={copy}
-      className={`inline-flex items-center gap-1 rounded-full border border-gray-600 bg-black px-2 py-1 font-mono text-green-400 text-sm ${className}`}
+      className={`${stateStyles} inline-flex items-center gap-1 rounded-full border border-gray-600 bg-black px-2 py-1 font-mono text-green-400 text-sm hover:bg-gray-900 active:bg-gray-800 ${className}`}
       aria-label={`Copy ${command}`}
       title="Copy command"
       {...props}

--- a/components/ui/stateStyles.ts
+++ b/components/ui/stateStyles.ts
@@ -1,0 +1,2 @@
+export const stateStyles =
+  "transition-colors motion-reduce:transition-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-95";

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -25,3 +25,55 @@ Example:
 ```
 
 These tokens ensure that layouts snap to the 8px grid at all breakpoints.
+
+## Component States
+
+Use consistent state styles across interactive elements to provide predictable feedback.
+The shared `stateStyles` utility adds transitions, focus outlines and respects reduced motion preferences.
+
+### Buttons
+
+`<Button>` already includes `stateStyles`. States:
+
+- **Hover:** lightens the background.
+- **Active:** further lightens and slightly scales down.
+- **Focus:** 2px outline using `--focus-outline-color`.
+- **Disabled:** native disabled behaviour.
+
+### Links
+
+Apply the utility to anchors for the same focus and transition behaviour:
+
+```html
+<a class="transition-colors motion-reduce:transition-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" href="#">Link</a>
+```
+
+### Inputs
+
+Inputs receive the shared focus outline. Add transition classes for hover effects:
+
+```html
+<input class="border px-2 py-1 transition-colors motion-reduce:transition-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" />
+```
+
+### Chips
+
+`<CommandChip>` uses `stateStyles` and darkens on hover and active states while showing the outline on focus.
+
+### Tabs
+
+Tab buttons import `stateStyles` so hover, active and focus treatments match buttons:
+
+```tsx
+<Tabs tabs={[{ id: 'a', label: 'A' }]} active="a" onChange={() => {}} />
+```
+
+### Reduced Motion
+
+Transitions include a fallback for users who prefer reduced motion via the `motion-reduce` variant:
+
+```html
+<button class="transition-colors motion-reduce:transition-none">Save</button>
+```
+
+When `prefers-reduced-motion` is enabled, the transition is removed.

--- a/styles/index.css
+++ b/styles/index.css
@@ -138,7 +138,7 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
 
 .btn:active {
     background-color: color-mix(in srgb, var(--btn-bg), var(--color-inverse) 20%);
-    transform: scale(0.98);
+    transform: scale(0.95);
 }
 
 .btn:focus-visible {


### PR DESCRIPTION
## Summary
- add shared `stateStyles` utility for consistent transitions
- document state guidelines for buttons, links, inputs, chips and tabs
- wire components to shared state styles and match reduced-motion behavior

## Testing
- `yarn test` (fails: Missing allowlist entries in csp.test.ts)
- `yarn lint` (fails: SessionNotCreatedError: cannot find Chrome binary)


------
https://chatgpt.com/codex/tasks/task_e_68be6a60d2d88328af4308a1ca4f79cd