### PR TITLE
feat: add elevation tokens and apply to surfaces

### DIFF
--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -33,7 +33,7 @@ export default function ModuleCard({
   return (
     <button
       onClick={() => onSelect(module)}
-      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
+      className={`w-full text-left border border-elevation-100 shadow-elevation-100 rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
         selected ? 'bg-gray-100' : ''
       }`}
     >

--- a/components/WorkflowCard.tsx
+++ b/components/WorkflowCard.tsx
@@ -25,7 +25,7 @@ const steps: Step[] = [
 ];
 
 const WorkflowCard: React.FC = () => (
-  <section className="p-4 rounded bg-ub-grey text-white">
+  <section className="p-4 rounded border border-elevation-100 shadow-elevation-100 bg-ub-grey text-white">
     <h2 className="text-xl font-bold mb-2">Workflow</h2>
     <ul>
       {steps.map((s) => (

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -62,11 +62,11 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
     const [subIndex, setSubIndex] = useState<number | null>(null);
 
     return (
-      <div className="cursor-default w-52 rounded-md border border-gray-700 context-menu-bg text-left text-white shadow-lg">
+      <div className="cursor-default w-52 rounded-md border border-elevation-200 context-menu-bg text-left text-white shadow-elevation-200">
         <ul className="py-2">
           {items.map((item, i) =>
             item.separator ? (
-              <li key={i} role="separator" className="mx-2 my-1 border-t border-gray-700" />
+              <li key={i} role="separator" className="mx-2 my-1 border-t border-elevation-200" />
             ) : (
               <li
                 key={i}

--- a/components/menu/HelpMenu.tsx
+++ b/components/menu/HelpMenu.tsx
@@ -35,7 +35,7 @@ const HelpMenu: React.FC = () => {
       {open && (
         <div
           ref={menuRef}
-          className="absolute left-0 mt-1 z-50 bg-ub-grey text-white shadow-lg p-2"
+          className="absolute left-0 mt-1 z-50 bg-ub-grey text-white border border-elevation-200 shadow-elevation-200 p-2"
           tabIndex={-1}
         >
           <button

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -128,7 +128,7 @@ const WhiskerMenu: React.FC = () => {
       {open && (
         <div
           ref={menuRef}
-          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
+          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white border border-elevation-200 shadow-elevation-200"
           tabIndex={-1}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node)) {

--- a/components/platforms/PlatformCard.tsx
+++ b/components/platforms/PlatformCard.tsx
@@ -8,7 +8,7 @@ interface PlatformCardProps {
 
 export default function PlatformCard({ title, bullets, thumbnail }: PlatformCardProps) {
   return (
-    <div className="flex gap-4 rounded border p-4">
+    <div className="flex gap-4 rounded border border-elevation-100 shadow-elevation-100 p-4">
       <Image src={thumbnail} alt="" width={64} height={64} className="rounded" />
       <div className="space-y-2">
         <h3 className="font-bold">{title}</h3>

--- a/components/ui/ProgressDialog.tsx
+++ b/components/ui/ProgressDialog.tsx
@@ -51,7 +51,7 @@ export default function ProgressDialog({ isOpen, onCancel }: ProgressDialogProps
 
   return (
     <Modal isOpen={isOpen} onClose={handleCancel}>
-      <div className="p-4 bg-white rounded border border-window shadow-window w-64 text-center space-y-4">
+      <div className="p-4 bg-white rounded border border-elevation-300 shadow-elevation-300 w-64 text-center space-y-4">
         <div>Processing… {Math.round(progress)}%</div>
         <ProgressBar progress={progress} className="w-full" />
         <button

--- a/components/ui/PropertiesDialog.tsx
+++ b/components/ui/PropertiesDialog.tsx
@@ -46,7 +46,7 @@ const PropertiesDialog: React.FC<Props> = ({ item, onClose, onRenamed }) => {
       role="dialog"
       aria-modal="true"
     >
-      <div className="bg-ub-cool-grey p-4 rounded border border-window shadow-window text-white w-64">
+      <div className="bg-ub-cool-grey p-4 rounded border border-elevation-300 shadow-elevation-300 text-white w-64">
         <div className="flex items-center mb-4">
           <img
             src={iconSrc}

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -31,7 +31,7 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 border border-card shadow-card ${
+      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 border border-elevation-200 shadow-elevation-200 ${
         open ? '' : 'hidden'
       }`}
     >
@@ -71,7 +71,7 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
           aria-label="Reduced motion"
         />
       </div>
-      <div className="px-4 pt-2 border-t border-card mt-2 space-y-1">
+      <div className="px-4 pt-2 border-t border-elevation-200 mt-2 space-y-1">
         <button
           type="button"
           className="w-full text-left hover:underline"

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -164,7 +164,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
 
   return (
     <div
-      className={`flex flex-col w-full h-full border border-window shadow-window ${className}`.trim()}
+      className={`flex flex-col w-full h-full border border-elevation-300 shadow-elevation-300 ${className}`.trim()}
       tabIndex={0}
       onKeyDown={onKeyDown}
     >

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -38,7 +38,7 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform px-4 py-3 border border-card shadow-card flex items-center transition-transform duration-300 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform px-4 py-3 border border-elevation-300 shadow-elevation-300 flex items-center transition-transform duration-300 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
       style={{
         background: kaliTheme.bubble.background,
         color: kaliTheme.bubble.text,

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -25,3 +25,22 @@ Example:
 ```
 
 These tokens ensure that layouts snap to the 8px grid at all breakpoints.
+
+## Elevation Tokens
+
+Use elevation tokens to convey surface hierarchy with shadows and borders. Apply the utilities `shadow-elevation-*` and `border-elevation-*`.
+
+| Token | Typical use |
+|-------|-------------|
+| `elevation-0` | Flat surfaces |
+| `elevation-100` | Cards |
+| `elevation-200` | Menus |
+| `elevation-300` | Toasts and windows |
+
+Example:
+
+```html
+<div class="border border-elevation-100 shadow-elevation-100">
+  <!-- card content -->
+</div>
+```

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -46,6 +46,16 @@
   --radius-lg: 8px;
   --radius-round: 9999px;
 
+  /* Elevation */
+  --elevation-0-shadow: none;
+  --elevation-0-border: var(--color-border);
+  --elevation-100-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  --elevation-100-border: var(--color-border);
+  --elevation-200-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  --elevation-200-border: var(--color-border);
+  --elevation-300-shadow: 0 8px 10px rgba(0, 0, 0, 0.35);
+  --elevation-300-border: var(--color-border);
+
   /* Motion durations */
   --motion-fast: 150ms;
   --motion-medium: 300ms;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -102,14 +102,16 @@ module.exports = {
         'tray-icon-lg': '32px',
       },
       boxShadow: {
-        // eslint-disable-next-line no-top-level-window/no-top-level-window-or-document
-        window: '0 4px 8px rgba(0,0,0,0.3)',
-        card: '0 2px 4px rgba(0,0,0,0.2)',
+        'elevation-0': 'var(--elevation-0-shadow)',
+        'elevation-100': 'var(--elevation-100-shadow)',
+        'elevation-200': 'var(--elevation-200-shadow)',
+        'elevation-300': 'var(--elevation-300-shadow)',
       },
       borderColor: {
-        // eslint-disable-next-line no-top-level-window/no-top-level-window-or-document
-        window: 'var(--color-border)',
-        card: 'var(--color-border)',
+        'elevation-0': 'var(--elevation-0-border)',
+        'elevation-100': 'var(--elevation-100-border)',
+        'elevation-200': 'var(--elevation-200-border)',
+        'elevation-300': 'var(--elevation-300-border)',
       },
       keyframes: {
         glow: {


### PR DESCRIPTION
## Summary
- add elevation shadow/border tokens
- apply elevation levels to cards, menus, toasts, and windows
- document elevation usage in design guidelines

## Testing
- `npm run lint -- styles/tokens.css tailwind.config.js components/ModuleCard.tsx components/WorkflowCard.tsx components/common/ContextMenu.tsx components/menu/HelpMenu.tsx components/menu/WhiskerMenu.tsx components/platforms/PlatformCard.tsx components/ui/ProgressDialog.tsx components/ui/PropertiesDialog.tsx components/ui/QuickSettings.tsx components/ui/TabbedWindow.tsx components/ui/Toast.tsx docs/design-guidelines.md` (fails: A control must be associated with a text label)
- `npm test` (fails: Missing allowlist entries for various domains)

------
https://chatgpt.com/codex/tasks/task_e_68be6a6ca05483288e5b373299bf34a4