### PR TITLE
feat: add development grid overlay

### DIFF
--- a/__tests__/GridOverlay.test.tsx
+++ b/__tests__/GridOverlay.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import GridOverlay from '../components/common/GridOverlay';
+
+describe('GridOverlay', () => {
+  it('toggles visibility with Alt+G', () => {
+    const { container } = render(<GridOverlay />);
+    expect(container.firstChild).toBeNull();
+    fireEvent.keyDown(window, { key: 'g', altKey: true });
+    expect(container.firstChild).not.toBeNull();
+    fireEvent.keyDown(window, { key: 'g', altKey: true });
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/components/common/GridOverlay.tsx
+++ b/components/common/GridOverlay.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const GridOverlay = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      const isInput =
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'SELECT' ||
+        target.isContentEditable;
+      if (isInput) return;
+      if (e.altKey && e.key.toLowerCase() === 'g') {
+        e.preventDefault();
+        setVisible((v) => !v);
+      }
+      if (e.key === 'Escape') {
+        setVisible(false);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  if (!visible || process.env.NODE_ENV === 'production') return null;
+
+  const widths = [640, 768, 1024, 1280, 1536];
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-0 z-[9999]"
+      style={{
+        backgroundImage:
+          'linear-gradient(rgba(0,0,0,0.2) 1px, transparent 1px), linear-gradient(90deg, rgba(0,0,0,0.2) 1px, transparent 1px)',
+        backgroundSize: '8px 8px',
+      }}
+    >
+      {widths.map((w) => (
+        <div
+          key={w}
+          className="absolute top-0 bottom-0 left-1/2 -translate-x-1/2"
+          style={{ width: w }}
+        >
+          <div className="absolute inset-0 border-l border-r border-blue-500/50">
+            <span className="absolute -top-4 left-0 text-blue-500 text-xs">{w}px</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default GridOverlay;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -34,6 +34,14 @@ if (process.env.NODE_ENV === 'production') {
   );
 }
 
+let GridOverlay = () => null;
+if (process.env.NODE_ENV !== 'production') {
+  GridOverlay = dynamic(
+    () => import('../components/common/GridOverlay'),
+    { ssr: false },
+  );
+}
+
 
 function MyApp(props) {
   const { Component, pageProps, nonce } = props;
@@ -253,6 +261,7 @@ function MyApp(props) {
                   <div aria-live="polite" id="live-region" />
                   <Component {...pageProps} />
                   <ShortcutOverlay />
+                  <GridOverlay />
                   {process.env.VERCEL_ANALYTICS_ID && (
                     <>
                       <Analytics


### PR DESCRIPTION
## Summary
- add grid overlay component with Alt+G shortcut for 8px grid and container widths
- wire overlay into app, only loading in non-production environments
- cover grid overlay behaviour with a unit test

## Testing
- `npx eslint pages/_app.jsx components/common/GridOverlay.tsx __tests__/GridOverlay.test.tsx --ext .js,.jsx,.ts,.tsx --max-warnings=0` *(fails: `@next/next/no-before-interactive-script-outside-document` warning)*
- `yarn test __tests__/GridOverlay.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be6a7753ec8328b668df64dbd5a1b5