### PR TITLE
feat(ui): add compact and cozy density options

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -199,14 +199,12 @@ export default function Settings() {
           </div>
           <div className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Density:</label>
-            <select
-              value={density}
-              onChange={(e) => setDensity(e.target.value as any)}
+            <button
+              onClick={() => setDensity(density === 'cozy' ? 'compact' : 'cozy')}
               className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
             >
-              <option value="regular">Regular</option>
-              <option value="compact">Compact</option>
-            </select>
+              {density === 'cozy' ? 'Cozy' : 'Compact'}
+            </button>
           </div>
           <div className="flex justify-center my-4 items-center">
             <span className="mr-2 text-ubt-grey">Reduced Motion:</span>

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -107,14 +107,12 @@ export function Settings() {
             </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Density:</label>
-                <select
-                    value={density}
-                    onChange={(e) => setDensity(e.target.value)}
+                <button
+                    onClick={() => setDensity(density === 'cozy' ? 'compact' : 'cozy')}
                     className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
                 >
-                    <option value="regular">Regular</option>
-                    <option value="compact">Compact</option>
-                </select>
+                    {density === 'cozy' ? 'Cozy' : 'Compact'}
+                </button>
             </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Panel Autohide:</label>

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -25,7 +25,7 @@ import {
   defaults,
 } from '../utils/settingsStore';
 import { THEME_KEY, getTheme as getStoredTheme, setTheme as applyTheme } from '../utils/theme';
-type Density = 'regular' | 'compact';
+type Density = 'cozy' | 'compact';
 
 // Predefined accent palette exposed to settings UI
 export const ACCENT_OPTIONS = [
@@ -217,21 +217,21 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const spacing: Record<Density, Record<string, string>> = {
-      regular: {
-        '--space-1': '0.25rem',
-        '--space-2': '0.5rem',
-        '--space-3': '0.75rem',
-        '--space-4': '1rem',
-        '--space-5': '1.5rem',
-        '--space-6': '2rem',
+      cozy: {
+        '--space-1': 'var(--space-cozy-1)',
+        '--space-2': 'var(--space-cozy-2)',
+        '--space-3': 'var(--space-cozy-3)',
+        '--space-4': 'var(--space-cozy-4)',
+        '--space-5': 'var(--space-cozy-5)',
+        '--space-6': 'var(--space-cozy-6)',
       },
       compact: {
-        '--space-1': '0.125rem',
-        '--space-2': '0.25rem',
-        '--space-3': '0.5rem',
-        '--space-4': '0.75rem',
-        '--space-5': '1rem',
-        '--space-6': '1.5rem',
+        '--space-1': 'var(--space-compact-1)',
+        '--space-2': 'var(--space-compact-2)',
+        '--space-3': 'var(--space-compact-3)',
+        '--space-4': 'var(--space-compact-4)',
+        '--space-5': 'var(--space-compact-5)',
+        '--space-6': 'var(--space-compact-6)',
       },
     };
     const vars = spacing[density];

--- a/pages/apps/settings/dpi.tsx
+++ b/pages/apps/settings/dpi.tsx
@@ -7,14 +7,12 @@ export default function DpiSettings() {
       <h1 className="text-xl mb-4">Display</h1>
       <div className="flex items-center gap-2">
         <span>Interface density</span>
-        <select
-          value={density}
-          onChange={(e) => setDensity(e.target.value as any)}
+        <button
+          onClick={() => setDensity(density === 'cozy' ? 'compact' : 'cozy')}
           className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
         >
-          <option value="regular">Regular</option>
-          <option value="compact">Compact</option>
-        </select>
+          {density === 'cozy' ? 'Cozy' : 'Compact'}
+        </button>
       </div>
     </div>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -206,6 +206,18 @@ html[data-theme='matrix'] {
   to { opacity: 0; }
 }
 
+/* Global list and menu styling */
+ul,
+ol {
+  margin: var(--space-2) 0;
+  padding-left: var(--space-4);
+}
+
+menu {
+  margin: var(--space-2) 0;
+  padding: var(--space-2);
+}
+
 /* Global table styling */
 table {
   width: 100%;
@@ -214,7 +226,7 @@ table {
 
 th,
 td {
-  padding: 0.25rem 0.5rem;
+  padding: var(--space-1) var(--space-2);
 }
 
 tbody tr:nth-child(even) {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -33,12 +33,25 @@
   --game-color-danger: #b91c1c;
 
   /* Spacing scale */
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-  --space-5: 1.5rem;
-  --space-6: 2rem;
+  --space-cozy-1: 0.25rem;
+  --space-cozy-2: 0.5rem;
+  --space-cozy-3: 0.75rem;
+  --space-cozy-4: 1rem;
+  --space-cozy-5: 1.5rem;
+  --space-cozy-6: 2rem;
+  --space-compact-1: 0.125rem;
+  --space-compact-2: 0.25rem;
+  --space-compact-3: 0.5rem;
+  --space-compact-4: 0.75rem;
+  --space-compact-5: 1rem;
+  --space-compact-6: 1.5rem;
+  /* Default spacing (cozy) */
+  --space-1: var(--space-cozy-1);
+  --space-2: var(--space-cozy-2);
+  --space-3: var(--space-cozy-3);
+  --space-4: var(--space-cozy-4);
+  --space-5: var(--space-cozy-5);
+  --space-6: var(--space-cozy-6);
 
   /* Radius */
   --radius-sm: 2px;

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -7,7 +7,7 @@ import { safeLocalStorage } from './safeStorage';
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
   wallpaper: 'wall-2',
-  density: 'regular',
+  density: 'cozy',
   reducedMotion: false,
   fontScale: 1,
   highContrast: false,


### PR DESCRIPTION
## Summary
- add cozy and compact spacing tokens
- apply density-based spacing to lists, menus, and tables
- add one-click density toggle in settings

## Testing
- `yarn lint` *(fails: no output / terminated)*
- `yarn test` *(fails: missing Chrome binary and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be6a7886588328bf12715af76cec16