### PR TITLE
docs: add base icon style guide and set

### DIFF
--- a/docs/icon-style-guide.md
+++ b/docs/icon-style-guide.md
@@ -1,0 +1,27 @@
+# Icon Style Guide
+
+This guide defines the geometry for application icons and the base icon set included in this repository.
+
+## 20 px Icons
+- **Artboard:** 20 × 20
+- **Padding:** 2 px on all sides (drawing area 16 × 16)
+- **Stroke width:** 1.5 px
+- **Corner radius:** 2 px for any shapes with corners
+- **Notes:** Align paths to the pixel grid using whole or 0.5 px coordinates so the icons render crisply at 1×, 2× and 3×.
+
+## 24 px Icons
+- **Artboard:** 24 × 24
+- **Padding:** 2 px on all sides (drawing area 20 × 20)
+- **Stroke width:** 2 px
+- **Corner radius:** 2 px for any shapes with corners
+- **Notes:** Use whole‑pixel coordinates to maintain sharp rendering at 1×, 2× and 3×.
+
+## Base Icon Set
+The base icons follow the above rules and live in `public/icons/20` and `public/icons/24`:
+
+- plus
+- minus
+- check
+- close
+
+All icons use `stroke-linecap="round"` and `stroke-linejoin="round"` so they scale cleanly across resolutions.

--- a/public/icons/20/check.svg
+++ b/public/icons/20/check.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 10l4 4 6-8"/>
+</svg>

--- a/public/icons/20/close.svg
+++ b/public/icons/20/close.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 6l8 8M14 6l-8 8"/>
+</svg>

--- a/public/icons/20/minus.svg
+++ b/public/icons/20/minus.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 10h12"/>
+</svg>

--- a/public/icons/20/plus.svg
+++ b/public/icons/20/plus.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M10 4v12M4 10h12"/>
+</svg>

--- a/public/icons/24/check.svg
+++ b/public/icons/24/check.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 12l5 5 7-9"/>
+</svg>

--- a/public/icons/24/close.svg
+++ b/public/icons/24/close.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 6l12 12M18 6l-12 12"/>
+</svg>

--- a/public/icons/24/minus.svg
+++ b/public/icons/24/minus.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 12h16"/>
+</svg>

--- a/public/icons/24/plus.svg
+++ b/public/icons/24/plus.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 4v16M4 12h16"/>
+</svg>


### PR DESCRIPTION
## Summary
- document stroke, corner radius, and padding rules for 20px and 24px icons
- add initial plus, minus, check, and close SVG icons in 20px and 24px sizes

## Testing
- `pnpm typecheck` (fails: Type errors in existing code)
- `tsc --noEmit -p packages/*` (fails: path does not exist)
- `yarn test __tests__/blackjack.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68be6a79139c8328bec6867713babcc9