### PR TITLE
feat: improve font fallbacks and heading typography

### DIFF
--- a/docs/font-loading-strategies.md
+++ b/docs/font-loading-strategies.md
@@ -1,0 +1,11 @@
+# Font Loading Strategies
+
+To reduce Flash of Unstyled Text (FOUT) and Flash of Invisible Text (FOIT), consider the following approaches:
+
+- **Self-host critical fonts** and serve them with long-lived cache headers to avoid network delays.
+- **Preload and preconnect** to font assets using `<link rel="preload">` and `<link rel="preconnect">` so browsers fetch resources sooner.
+- **Use `font-display`**, such as `swap` or `optional`, to ensure text remains visible while fonts load.
+- **Subset and compress fonts** to include only necessary glyphs, keeping payloads small.
+- **Provide comprehensive system font fallbacks** so content remains legible even if custom fonts fail to load.
+
+These techniques help maintain readable content and minimize visual shifts during font loading.

--- a/styles/index.css
+++ b/styles/index.css
@@ -93,21 +93,48 @@ body{
     }
 }
 
-/* Heading scale for vertical rhythm */
-h1, h2, h3, h4, h5, h6 {
-    line-height: 1.2;
+/* Heading scale and typography */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-family: var(--font-family-heading);
+    margin-top: 0;
 }
 
 h1 {
     font-size: clamp(1.875rem, 1.5rem + 1vw, 2.25rem);
+    line-height: 1.1;
+    letter-spacing: -0.015em;
 }
 
 h2 {
     font-size: clamp(1.5rem, 1.25rem + 0.5vw, 1.875rem);
+    line-height: 1.2;
+    letter-spacing: -0.01em;
 }
 
 h3 {
     font-size: clamp(1.25rem, 1rem + 0.5vw, 1.5rem);
+    line-height: 1.3;
+    letter-spacing: -0.005em;
+}
+
+h4 {
+    line-height: 1.4;
+    letter-spacing: 0;
+}
+
+h5 {
+    line-height: 1.5;
+    letter-spacing: 0.005em;
+}
+
+h6 {
+    line-height: 1.6;
+    letter-spacing: 0.01em;
 }
 
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -52,7 +52,8 @@
   --motion-slow: 500ms;
 
   /* Fonts */
-  --font-family-base: 'Ubuntu', sans-serif;
+  --font-family-base: 'Ubuntu', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+  --font-family-heading: 'Ubuntu', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;


### PR DESCRIPTION
## Summary
- add system font fallbacks for body and heading text
- tune heading letter-spacing and line-height for better readability without web fonts
- document strategies for minimizing FOUT/FOIT

## Testing
- `yarn test` *(fails: Cannot set properties of undefined (setting 'theme'))*

------
https://chatgpt.com/codex/tasks/task_e_68be6a9158748328b36dc85cdaa7885e