### PR TITLE
feat: add radii scale tokens

### DIFF
--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -33,7 +33,7 @@ export default function ModuleCard({
   return (
     <button
       onClick={() => onSelect(module)}
-      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
+      className={`w-full text-left border rounded-lg p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
         selected ? 'bg-gray-100' : ''
       }`}
     >

--- a/components/PopularModules.tsx
+++ b/components/PopularModules.tsx
@@ -203,7 +203,7 @@ const PopularModules: React.FC = () => {
         placeholder="Search modules"
         value={search}
         onChange={(e) => setSearch(e.target.value)}
-        className="w-full p-2 text-black rounded"
+        className="w-full p-2 text-black rounded-md"
       />
       <div className="flex flex-wrap gap-2">
         <button
@@ -261,7 +261,7 @@ const PopularModules: React.FC = () => {
                   onChange={(e) =>
                     setOptions({ ...options, [o.name]: e.target.value })
                   }
-                  className="w-full p-1 mt-1 text-black rounded"
+                  className="w-full p-1 mt-1 text-black rounded-md"
                 />
               </label>
             ))}
@@ -284,13 +284,13 @@ const PopularModules: React.FC = () => {
           <div className="space-y-1">
             <label className="block text-sm">
               Filter logs
-              <input
-                placeholder="Filter logs"
-                type="text"
-                value={logFilter}
-                onChange={(e) => setLogFilter(e.target.value)}
-                className="w-full p-1 mt-1 text-black rounded"
-              />
+                <input
+                  placeholder="Filter logs"
+                  type="text"
+                  value={logFilter}
+                  onChange={(e) => setLogFilter(e.target.value)}
+                  className="w-full p-1 mt-1 text-black rounded-md"
+                />
             </label>
             <button
               type="button"

--- a/components/WorkflowCard.tsx
+++ b/components/WorkflowCard.tsx
@@ -25,7 +25,7 @@ const steps: Step[] = [
 ];
 
 const WorkflowCard: React.FC = () => (
-  <section className="p-4 rounded bg-ub-grey text-white">
+  <section className="p-4 rounded-lg bg-ub-grey text-white">
     <h2 className="text-xl font-bold mb-2">Workflow</h2>
     <ul>
       {steps.map((s) => (

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -31,7 +31,7 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 border border-card shadow-card ${
+      className={`absolute bg-ub-cool-grey rounded-lg py-4 top-9 right-3 border border-card shadow-card ${
         open ? '' : 'hidden'
       }`}
     >

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -164,7 +164,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
 
   return (
     <div
-      className={`flex flex-col w-full h-full border border-window shadow-window ${className}`.trim()}
+      className={`flex flex-col w-full h-full border border-window shadow-window rounded-lg ${className}`.trim()}
       tabIndex={0}
       onKeyDown={onKeyDown}
     >

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -25,3 +25,24 @@ Example:
 ```
 
 These tokens ensure that layouts snap to the 8px grid at all breakpoints.
+
+## Radii Tokens
+
+Use the `radius-*` scale to apply consistent rounding across components. These tokens are available in Tailwind via the standard `rounded` utilities (`rounded-md`, `rounded-lg`, etc.).
+
+| Token | Value |
+|-------|-------|
+| `radius-none` | 0 |
+| `radius-sm` | 2px |
+| `radius-md` | 4px |
+| `radius-lg` | 8px |
+| `radius-xl` | 16px |
+| `radius-round` | 9999px |
+
+Example:
+
+```html
+<button class="px-space-2 py-space-1 rounded-md">Save</button>
+```
+
+Buttons and inputs use `radius-md`, while larger surfaces like cards, panels and windows use `radius-lg`.

--- a/styles/index.css
+++ b/styles/index.css
@@ -132,6 +132,13 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
     transition: background-color var(--motion-fast), transform var(--motion-fast);
 }
 
+.input,
+input,
+textarea,
+select {
+    border-radius: var(--radius-md);
+}
+
 .btn:hover {
     background-color: color-mix(in srgb, var(--btn-bg), var(--color-inverse) 10%);
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -40,10 +40,12 @@
   --space-5: 1.5rem;
   --space-6: 2rem;
 
-  /* Radius */
+  /* Radius scale */
+  --radius-none: 0;
   --radius-sm: 2px;
   --radius-md: 4px;
   --radius-lg: 8px;
+  --radius-xl: 16px;
   --radius-round: 9999px;
 
   /* Motion durations */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -101,6 +101,15 @@ module.exports = {
         'tray-icon': '16px',
         'tray-icon-lg': '32px',
       },
+      borderRadius: {
+        none: 'var(--radius-none)',
+        sm: 'var(--radius-sm)',
+        DEFAULT: 'var(--radius-md)',
+        md: 'var(--radius-md)',
+        lg: 'var(--radius-lg)',
+        xl: 'var(--radius-xl)',
+        full: 'var(--radius-round)',
+      },
       boxShadow: {
         // eslint-disable-next-line no-top-level-window/no-top-level-window-or-document
         window: '0 4px 8px rgba(0,0,0,0.3)',


### PR DESCRIPTION
## Summary
- create CSS variable radii scale and expose through Tailwind
- standardize border radius on buttons, inputs, cards, panels, and windows
- document new `radius-*` tokens

## Testing
- `npm test` *(fails: Missing allowlist entries in csp.test.ts)*
- `npm run lint` *(command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68be6a920c4c8328aa094229c1447204