### PR TITLE
Add color-blind friendly palette and switch

### DIFF
--- a/__tests__/colorblind-palette.test.ts
+++ b/__tests__/colorblind-palette.test.ts
@@ -1,0 +1,72 @@
+import { contrastRatio } from '../components/apps/Games/common/theme';
+
+const palette = {
+  info: '#56B4E9',
+  success: '#009E73',
+  warning: '#F0E442',
+  danger: '#D55E00',
+};
+
+const background = '#0f1317';
+
+const matrices = {
+  protanopia: [
+    [0.56667, 0.43333, 0],
+    [0.55833, 0.44167, 0],
+    [0, 0.24167, 0.75833],
+  ],
+  deuteranopia: [
+    [0.625, 0.375, 0],
+    [0.7, 0.3, 0],
+    [0, 0.3, 0.7],
+  ],
+  tritanopia: [
+    [0.95, 0.05, 0],
+    [0, 0.43333, 0.56667],
+    [0, 0.475, 0.525],
+  ],
+} as const;
+
+type RGB = { r: number; g: number; b: number };
+
+const hexToRgb = (hex: string): RGB => {
+  const n = parseInt(hex.replace('#', ''), 16);
+  return { r: (n >> 16) & 0xff, g: (n >> 8) & 0xff, b: n & 0xff };
+};
+
+const transform = ({ r, g, b }: RGB, matrix: number[][]): RGB => {
+  const R = r / 255;
+  const G = g / 255;
+  const B = b / 255;
+  const [m1, m2, m3] = matrix;
+  return {
+    r: Math.round((R * m1[0] + G * m1[1] + B * m1[2]) * 255),
+    g: Math.round((R * m2[0] + G * m2[1] + B * m2[2]) * 255),
+    b: Math.round((R * m3[0] + G * m3[1] + B * m3[2]) * 255),
+  };
+};
+
+const delta = (a: RGB, b: RGB): number =>
+  Math.sqrt((a.r - b.r) ** 2 + (a.g - b.g) ** 2 + (a.b - b.b) ** 2);
+
+describe('color-blind palette', () => {
+  test('maintains contrast against background', () => {
+    Object.values(palette).forEach((color) => {
+      expect(contrastRatio(color, background)).toBeGreaterThanOrEqual(4.5);
+    });
+  });
+
+  test.each(Object.entries(matrices))(
+    '%s simulation keeps state colors distinct',
+    (_, matrix) => {
+      const colors = Object.values(palette).map((hex) =>
+        transform(hexToRgb(hex), matrix)
+      );
+      for (let i = 0; i < colors.length; i++) {
+        for (let j = i + 1; j < colors.length; j++) {
+          expect(delta(colors[i], colors[j])).toBeGreaterThan(20);
+        }
+      }
+    }
+  );
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -32,6 +32,8 @@ export default function Settings() {
     setFontScale,
     highContrast,
     setHighContrast,
+    colorBlind,
+    setColorBlind,
     haptics,
     setHaptics,
     theme,
@@ -75,6 +77,8 @@ export default function Settings() {
       if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
+      if (parsed.colorBlind !== undefined)
+        setColorBlind(parsed.colorBlind);
       if (parsed.theme !== undefined) setTheme(parsed.theme);
     } catch (err) {
       console.error("Invalid settings", err);
@@ -113,6 +117,7 @@ export default function Settings() {
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
+    setColorBlind(defaults.colorBlind);
     setTheme("default");
   };
 
@@ -222,6 +227,14 @@ export default function Settings() {
               checked={highContrast}
               onChange={setHighContrast}
               ariaLabel="High Contrast"
+            />
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Color Blind Palette:</span>
+            <ToggleSwitch
+              checked={colorBlind}
+              onChange={setColorBlind}
+              ariaLabel="Color Blind Palette"
             />
           </div>
           <div className="flex justify-center my-4 items-center">

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -9,8 +9,16 @@ interface Props {
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const unlocked = getUnlockedThemes(highScore);
-  const { accent, setAccent, theme, setTheme, highContrast, setHighContrast } =
-    useSettings();
+  const {
+    accent,
+    setAccent,
+    theme,
+    setTheme,
+    highContrast,
+    setHighContrast,
+    colorBlind,
+    setColorBlind,
+  } = useSettings();
 
   return (
     <div>
@@ -33,15 +41,26 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
               ))}
             </select>
           </label>
-          <label className="mt-2 flex items-center gap-2">
+          <div className="mt-2 flex items-center gap-2">
             <input
               id="settings-high-contrast"
               type="checkbox"
+              aria-label="High Contrast"
               checked={highContrast}
               onChange={(e) => setHighContrast(e.target.checked)}
             />
-            <span>High Contrast</span>
-          </label>
+            <label htmlFor="settings-high-contrast">High Contrast</label>
+          </div>
+          <div className="mt-2 flex items-center gap-2">
+            <input
+              id="settings-color-blind"
+              type="checkbox"
+              aria-label="Color Blind Palette"
+              checked={colorBlind}
+              onChange={(e) => setColorBlind(e.target.checked)}
+            />
+            <label htmlFor="settings-color-blind">Color Blind Palette</label>
+          </div>
           <label>
             Accent
             <div

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -6,7 +6,7 @@ import { isBrowser } from '../../utils/env';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme, symbolicTrayIcons, setSymbolicTrayIcons } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, colorBlind, setColorBlind, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme, symbolicTrayIcons, setSymbolicTrayIcons } = useSettings();
     const [panelBehavior, setPanelBehavior] = usePersistentState('xfce.panel.autohideBehavior', 'never');
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
@@ -177,6 +177,17 @@ export function Settings() {
                 <label className="mr-2 text-ubt-grey flex items-center">
                     <input
                         type="checkbox"
+                        checked={colorBlind}
+                        onChange={(e) => setColorBlind(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Color Blind Palette
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
                         checked={allowNetwork}
                         onChange={(e) => setAllowNetwork(e.target.checked)}
                         className="mr-2"
@@ -318,6 +329,7 @@ export function Settings() {
                         setLargeHitAreas(defaults.largeHitAreas);
                         setFontScale(defaults.fontScale);
                         setHighContrast(defaults.highContrast);
+                        setColorBlind(defaults.colorBlind);
                         setTheme('default');
                     }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
@@ -342,6 +354,7 @@ export function Settings() {
                         if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
                         if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
                         if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
+                        if (parsed.colorBlind !== undefined) setColorBlind(parsed.colorBlind);
                         if (parsed.theme !== undefined) { setTheme(parsed.theme); }
                     } catch (err) {
                         console.error('Invalid settings', err);

--- a/components/settings/ChannelsInspector.tsx
+++ b/components/settings/ChannelsInspector.tsx
@@ -15,6 +15,7 @@ export default function ChannelsInspector() {
     reducedMotion,
     fontScale,
     highContrast,
+    colorBlind,
     largeHitAreas,
     pongSpin,
     allowNetwork,
@@ -26,7 +27,7 @@ export default function ChannelsInspector() {
   const channels = useMemo(
     () => ({
       appearance: { accent, wallpaper, density, fontScale, theme },
-      accessibility: { reducedMotion, highContrast, largeHitAreas, haptics },
+      accessibility: { reducedMotion, highContrast, colorBlind, largeHitAreas, haptics },
       gameplay: { pongSpin },
       privacy: { allowNetwork },
     }),
@@ -38,6 +39,7 @@ export default function ChannelsInspector() {
       theme,
       reducedMotion,
       highContrast,
+      colorBlind,
       largeHitAreas,
       haptics,
       pongSpin,

--- a/components/settings/Manager.tsx
+++ b/components/settings/Manager.tsx
@@ -47,6 +47,7 @@ export default function Manager() {
       reducedMotion: settingsCtx.setReducedMotion,
       fontScale: settingsCtx.setFontScale,
       highContrast: settingsCtx.setHighContrast,
+      colorBlind: settingsCtx.setColorBlind,
       largeHitAreas: settingsCtx.setLargeHitAreas,
       pongSpin: settingsCtx.setPongSpin,
       allowNetwork: settingsCtx.setAllowNetwork,
@@ -82,6 +83,7 @@ export default function Manager() {
           type="file"
           accept="application/zip"
           className="hidden"
+          aria-label="restore backup file"
           onChange={(e) => {
             const f = e.target.files?.[0];
             e.target.value = '';

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -10,6 +10,8 @@ import {
   setFontScale as saveFontScale,
   getHighContrast as loadHighContrast,
   setHighContrast as saveHighContrast,
+  getColorBlind as loadColorBlind,
+  setColorBlind as saveColorBlind,
   getLargeHitAreas as loadLargeHitAreas,
   setLargeHitAreas as saveLargeHitAreas,
   getPongSpin as loadPongSpin,
@@ -60,6 +62,7 @@ interface SettingsContextValue {
   reducedMotion: boolean;
   fontScale: number;
   highContrast: boolean;
+  colorBlind: boolean;
   largeHitAreas: boolean;
   pongSpin: boolean;
   allowNetwork: boolean;
@@ -73,6 +76,7 @@ interface SettingsContextValue {
   setReducedMotion: (value: boolean) => void;
   setFontScale: (value: number) => void;
   setHighContrast: (value: boolean) => void;
+  setColorBlind: (value: boolean) => void;
   setLargeHitAreas: (value: boolean) => void;
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
@@ -89,6 +93,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   reducedMotion: defaults.reducedMotion,
   fontScale: defaults.fontScale,
   highContrast: defaults.highContrast,
+  colorBlind: defaults.colorBlind,
   largeHitAreas: defaults.largeHitAreas,
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
@@ -102,6 +107,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setReducedMotion: () => {},
   setFontScale: () => {},
   setHighContrast: () => {},
+  setColorBlind: () => {},
   setLargeHitAreas: () => {},
   setPongSpin: () => {},
   setAllowNetwork: () => {},
@@ -131,6 +137,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
   const [highContrast, setHighContrast] = useState<boolean>(defaults.highContrast);
+  const [colorBlind, setColorBlind] = useState<boolean>(defaults.colorBlind);
   const [largeHitAreas, setLargeHitAreas] = useState<boolean>(defaults.largeHitAreas);
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
@@ -167,6 +174,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setReducedMotion(await loadReducedMotion());
       setFontScale(await loadFontScale());
       setHighContrast(await loadHighContrast());
+      setColorBlind(await loadColorBlind());
       setLargeHitAreas(await loadLargeHitAreas());
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
@@ -212,7 +220,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setWallpaper(base);
       setRotationIndex((index + 1) % rotationSet.length);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rotationMode, rotationSet]);
 
   useEffect(() => {
@@ -255,6 +262,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     document.documentElement.classList.toggle('high-contrast', highContrast);
     saveHighContrast(highContrast);
   }, [highContrast]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('colorblind', colorBlind);
+    saveColorBlind(colorBlind);
+  }, [colorBlind]);
 
   useEffect(() => {
     document.documentElement.classList.toggle('large-hit-area', largeHitAreas);
@@ -312,6 +324,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         reducedMotion,
         fontScale,
         highContrast,
+        colorBlind,
         largeHitAreas,
         pongSpin,
         allowNetwork,
@@ -325,6 +338,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setReducedMotion,
         setFontScale,
         setHighContrast,
+        setColorBlind,
         setLargeHitAreas,
         setPongSpin,
         setAllowNetwork,

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -47,6 +47,8 @@ export default function ThemeSettings({ wallpapers }: ThemeSettingsProps) {
     setTheme,
     highContrast,
     setHighContrast,
+    colorBlind,
+    setColorBlind,
     accent,
     setAccent,
     wallpaper,
@@ -112,42 +114,54 @@ export default function ThemeSettings({ wallpapers }: ThemeSettingsProps) {
           <label htmlFor="theme-high-contrast">High Contrast</label>
         </div>
 
+        <div className="mt-4 flex items-center gap-2">
+          <input
+            id="theme-color-blind"
+            type="checkbox"
+            aria-label="Color Blind Palette"
+            checked={colorBlind}
+            onChange={(e) => setColorBlind(e.target.checked)}
+          />
+          <label htmlFor="theme-color-blind">Color Blind Palette</label>
+        </div>
+
         <div className="mt-6">
           <h2 className="text-lg mb-2">Accent Color</h2>
           <div role="radiogroup" className="flex gap-2">
-            {ACCENT_OPTIONS.map((c) => (
-              <button
-                key={c}
-                role="radio"
-                aria-checked={accent === c}
-                onClick={() => setAccent(c)}
-                className={`w-6 h-6 rounded-full border-2 ${
-                  accent === c ? 'border-white' : 'border-transparent'
-                }`}
-                style={{ backgroundColor: c }}
-              />
-            ))}
+              {ACCENT_OPTIONS.map((c) => (
+                <button
+                  key={c}
+                  role="radio"
+                  aria-label={`select accent ${c}`}
+                  aria-checked={accent === c}
+                  onClick={() => setAccent(c)}
+                  className={`w-6 h-6 rounded-full border-2 ${
+                    accent === c ? 'border-white' : 'border-transparent'
+                  }`}
+                  style={{ backgroundColor: c }}
+                />
+              ))}
+            </div>
           </div>
-        </div>
 
         <div className="mt-6">
           <h2 className="text-lg mb-2">Wallpapers</h2>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
             {wallpapers.map((src) => {
               const base = src.replace(/^\/wallpapers\//, '').replace(/\.[^.]+$/, '');
-              return (
-                <button
-                  key={src}
-                  onClick={() => setWallpaper(base)}
-                  className={`relative border-2 ${
-                    wallpaper === base ? 'border-ubt-blue' : 'border-transparent'
-                  }`}
-                >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src={src} alt="" className="w-full h-24 object-cover" />
-                </button>
-              );
-            })}
+                return (
+                  <button
+                    key={src}
+                    aria-label={`select wallpaper ${base}`}
+                    onClick={() => setWallpaper(base)}
+                    className={`relative border-2 ${
+                      wallpaper === base ? 'border-ubt-blue' : 'border-transparent'
+                    }`}
+                  >
+                    <img src={src} alt="" className="w-full h-24 object-cover" />
+                  </button>
+                );
+              })}
           </div>
         </div>
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -91,6 +91,21 @@
   --game-color-danger: #ff0000;
 }
 
+/* Color-blind friendly palette using Okabe-Ito colors */
+.colorblind {
+  --color-primary: #0072b2;
+  --color-secondary: #e69f00;
+  --color-accent: #56b4e9;
+  --color-info: #56b4e9;
+  --color-success: #009e73;
+  --color-warning: #f0e442;
+  --color-danger: #d55e00;
+  --game-color-secondary: #0072b2;
+  --game-color-success: #009e73;
+  --game-color-warning: #f0e442;
+  --game-color-danger: #d55e00;
+}
+
 /* Dyslexia-friendly fonts */
 .dyslexia {
   --font-family-base: 'OpenDyslexic', 'Comic Sans MS', Arial, sans-serif;

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -11,6 +11,7 @@ const DEFAULT_SETTINGS = {
   reducedMotion: false,
   fontScale: 1,
   highContrast: false,
+  colorBlind: false,
   largeHitAreas: false,
   pongSpin: true,
   allowNetwork: false,
@@ -86,6 +87,16 @@ export async function setHighContrast(value) {
   window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
 }
 
+export async function getColorBlind() {
+  if (!isBrowser()) return DEFAULT_SETTINGS.colorBlind;
+  return window.localStorage.getItem('color-blind') === 'true';
+}
+
+export async function setColorBlind(value) {
+  if (!isBrowser()) return;
+  window.localStorage.setItem('color-blind', value ? 'true' : 'false');
+}
+
 export async function getLargeHitAreas() {
   if (!isBrowser()) return DEFAULT_SETTINGS.largeHitAreas;
   return window.localStorage.getItem('large-hit-areas') === 'true';
@@ -156,6 +167,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('reduced-motion');
   window.localStorage.removeItem('font-scale');
   window.localStorage.removeItem('high-contrast');
+  window.localStorage.removeItem('color-blind');
   window.localStorage.removeItem('large-hit-areas');
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
@@ -172,6 +184,7 @@ export async function exportSettings() {
     reducedMotion,
     fontScale,
     highContrast,
+    colorBlind,
     largeHitAreas,
     pongSpin,
     allowNetwork,
@@ -185,6 +198,7 @@ export async function exportSettings() {
     getReducedMotion(),
     getFontScale(),
     getHighContrast(),
+    getColorBlind(),
     getLargeHitAreas(),
     getPongSpin(),
     getAllowNetwork(),
@@ -200,6 +214,7 @@ export async function exportSettings() {
     reducedMotion,
     fontScale,
     highContrast,
+    colorBlind,
     largeHitAreas,
     pongSpin,
     allowNetwork,
@@ -226,6 +241,7 @@ export async function importSettings(json) {
     reducedMotion,
     fontScale,
     highContrast,
+    colorBlind,
     largeHitAreas,
     pongSpin,
     allowNetwork,
@@ -240,6 +256,7 @@ export async function importSettings(json) {
   if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
   if (fontScale !== undefined) await setFontScale(fontScale);
   if (highContrast !== undefined) await setHighContrast(highContrast);
+  if (colorBlind !== undefined) await setColorBlind(colorBlind);
   if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);


### PR DESCRIPTION
## Summary
- add color-blind friendly design tokens and expose toggle in settings
- persist color blind preference and apply palette at runtime
- add tests verifying palette contrast under simulated color vision deficiencies

## Testing
- `npx eslint apps/settings/index.tsx components/SettingsDrawer.tsx components/apps/settings.js components/settings/ChannelsInspector.tsx components/settings/Manager.tsx hooks/useSettings.tsx pages/ui/settings/theme.tsx styles/tokens.css utils/settingsStore.js __tests__/colorblind-palette.test.ts`
- `yarn test __tests__/colorblind-palette.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68be6a92b42c8328bc6c3bd0f32095bc