### PR TITLE
feat(styleguide): add contrast ratio calculator

### DIFF
--- a/components/ui/ColorSwatch.tsx
+++ b/components/ui/ColorSwatch.tsx
@@ -10,15 +10,18 @@ interface ColorSwatchProps {
 export default function ColorSwatch({ fg, bg, label }: ColorSwatchProps) {
   const ratio = contrastRatio(fg, bg);
   const level = ratio >= 7 ? 'AAA' : ratio >= 4.5 ? 'AA' : 'Fail';
+  const fails = ratio < 4.5;
   return (
     <div className="flex flex-col items-center">
       <div
-        className="w-32 h-16 flex items-center justify-center rounded"
+        className={`w-32 h-16 flex items-center justify-center rounded ${
+          fails ? 'ring-2 ring-red-500' : ''
+        }`}
         style={{ backgroundColor: bg, color: fg }}
       >
         {label || `${fg} / ${bg}`}
       </div>
-      <span className="mt-2 text-sm">
+      <span className={`mt-2 text-sm ${fails ? 'text-red-600' : ''}`}>
         {`Contrast ${ratio.toFixed(2)}:1 ${level}`}
       </span>
     </div>

--- a/components/ui/ContrastChecker.tsx
+++ b/components/ui/ContrastChecker.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import { contrastRatio } from '../apps/Games/common/theme';
+
+export default function ContrastChecker() {
+  const [fg, setFg] = useState('#000000');
+  const [bg, setBg] = useState('#ffffff');
+  const ratio = contrastRatio(fg, bg);
+  const level = ratio >= 7 ? 'AAA' : ratio >= 4.5 ? 'AA' : 'Fail';
+  const fails = ratio < 4.5;
+
+  return (
+    <div className={`p-4 border rounded ${fails ? 'border-red-500' : 'border-gray-200'}`}>
+      <h2 className="text-xl font-bold mb-2">Contrast Ratio Calculator</h2>
+      <p className="mb-4 text-sm">
+        Select colors to verify they meet WCAG guidelines before use.
+      </p>
+      <div className="flex gap-4 mb-4">
+        <label className="flex items-center gap-2">
+          <span className="text-sm">Foreground</span>
+          <input
+            aria-label="Foreground color"
+            type="color"
+            value={fg}
+            onChange={(e) => setFg(e.target.value)}
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          <span className="text-sm">Background</span>
+          <input
+            aria-label="Background color"
+            type="color"
+            value={bg}
+            onChange={(e) => setBg(e.target.value)}
+          />
+        </label>
+      </div>
+      <div className="flex items-center gap-4">
+        <div
+          className={`w-20 h-10 flex items-center justify-center rounded ${
+            fails ? 'ring-2 ring-red-500' : ''
+          }`}
+          style={{ backgroundColor: bg, color: fg }}
+        >
+          Aa
+        </div>
+        <span className={`text-sm ${fails ? 'text-red-600' : 'text-green-700'}`}>
+          {`Contrast ${ratio.toFixed(2)}:1 ${level}`}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/docs/contrast-checker.md
+++ b/docs/contrast-checker.md
@@ -1,0 +1,10 @@
+# Contrast Checker
+
+The style guide includes an interactive **Contrast Ratio Calculator** to help designers verify foreground and background color combinations.
+
+1. Navigate to `/styleguide` in the application.
+2. Use the color pickers to choose foreground and background colors.
+3. The tool displays the WCAG contrast ratio and whether the pair meets AA (≥4.5:1) or AAA (≥7:1) requirements.
+4. Pairs that fail AA are highlighted in red so they can be adjusted before use.
+
+Use this widget to validate color choices before committing them to designs or code.

--- a/pages/styleguide/index.tsx
+++ b/pages/styleguide/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ColorSwatch from '../../components/ui/ColorSwatch';
+import ContrastChecker from '../../components/ui/ContrastChecker';
 
 const pairs = [
   { fg: '#000000', bg: '#ffffff', label: 'Black on White' },
@@ -13,11 +14,12 @@ export default function Styleguide() {
     <div className="p-8">
       <h1 className="text-2xl font-bold mb-4">Color Contrast Swatches</h1>
       <p className="mb-6">Examples of color pairs with their WCAG contrast levels.</p>
-      <div className="grid gap-4 sm:grid-cols-2">
+      <div className="grid gap-4 sm:grid-cols-2 mb-8">
         {pairs.map((p) => (
           <ColorSwatch key={p.label} {...p} />
         ))}
       </div>
+      <ContrastChecker />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add interactive contrast ratio calculator for designers
- flag color swatches failing WCAG AA
- document contrast checker usage

## Testing
- `yarn test __tests__/tokens-contrast.test.ts`
- `yarn eslint pages/styleguide/index.tsx components/ui/ColorSwatch.tsx components/ui/ContrastChecker.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68be6a9434008328ab30cfe1a0fe2b31