### PR TITLE
Refine developer navigation structure

### DIFF
--- a/__tests__/ia.test.tsx
+++ b/__tests__/ia.test.tsx
@@ -8,6 +8,11 @@ describe('IA navigation', () => {
     render(<Header />);
     (ia as any).header.forEach((item: any) => {
       expect(screen.getByText(item.label)).toBeInTheDocument();
+      if (item.children) {
+        item.children.forEach((child: any) => {
+          expect(screen.getByText(child.label)).toBeInTheDocument();
+        });
+      }
     });
   });
 

--- a/data/ia.json
+++ b/data/ia.json
@@ -15,11 +15,11 @@
       {"label": "Download Mirrors", "href": "https://http.kali.org/README?mirrorlist"}
     ]},
     {"label": "Developers", "children": [
-      {"label": "Git Repositories", "href": "https://gitlab.com/kalilinux"},
-      {"label": "Packages", "href": "https://pkg.kali.org/"},
-      {"label": "Auto Package Test", "href": "https://autopkgtest.kali.org/"},
       {"label": "Bug Tracker", "href": "https://bugs.kali.org/"},
-      {"label": "Kali NetHunter Stats", "href": "https://nethunter.kali.org/"}
+      {"label": "Continuous Integration", "href": "https://autopkgtest.kali.org/"},
+      {"label": "Network Mirror", "href": "https://http.kali.org/README?mirrorlist"},
+      {"label": "Package Tracker", "href": "https://pkg.kali.org/"},
+      {"label": "GitLab", "href": "https://gitlab.com/kalilinux"}
     ]},
     {"label": "About", "children": [
       {"label": "Kali Linux Overview", "href": "https://www.kali.org/features/"},


### PR DESCRIPTION
## Summary
- align Developers menu with Kali Linux developer resources (Bug Tracker, CI, Network Mirror, Package Tracker, GitLab)
- extend IA tests to verify header submenu links

## Testing
- `yarn test __tests__/ia.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be6a94f6b483289d8af30beff72476