### PR TITLE
feat: show latest release in header

### DIFF
--- a/__tests__/releasePill.test.tsx
+++ b/__tests__/releasePill.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Header from '../components/layout/Header';
+import posts from '../data/kali-blog.json';
+
+describe('release pill', () => {
+  const latest = (posts as any[]).find((p) => p.link.includes('release'))!;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  test('shows latest release link and allows dismissal', async () => {
+    render(<Header />);
+    const link = await screen.findByRole('link', { name: /new release/i });
+    expect(link).toHaveAttribute('href', latest.link);
+    expect(link.textContent).toContain(latest.title);
+    const button = screen.getByRole('button', {
+      name: /dismiss release notification/i,
+    });
+    fireEvent.click(button);
+    await waitFor(() =>
+      expect(screen.queryByRole('link', { name: /new release/i })).toBeNull(),
+    );
+    expect(sessionStorage.getItem('dismissed-release')).toBe(latest.date);
+  });
+
+  test('pill is hidden after dismissal for session', () => {
+    sessionStorage.setItem('dismissed-release', latest.date);
+    render(<Header />);
+    expect(screen.queryByRole('link', { name: new RegExp(latest.title, 'i') })).toBeNull();
+  });
+});

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,18 +1,74 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import DocMegaMenu from './DocMegaMenu';
+import posts from '../../data/kali-blog.json';
+import Link from 'next/link';
+
+interface Post {
+  title: string;
+  link: string;
+  date: string;
+}
 
 export default function Header() {
   const [docsOpen, setDocsOpen] = useState(false);
+  const [release, setRelease] = useState<Post | null>(null);
+  const [showRelease, setShowRelease] = useState(false);
   const closeDocs = () => setDocsOpen(false);
+
+  useEffect(() => {
+    const latest = (posts as Post[]).find((p) => p.link.includes('release'));
+    if (!latest) return;
+    try {
+      const dismissed = sessionStorage.getItem('dismissed-release');
+      if (dismissed === latest.date) return;
+    } catch {
+      // Ignore access errors
+    }
+    setRelease(latest);
+    setShowRelease(true);
+  }, []);
+
+  const dismissRelease = () => {
+    if (release) {
+      try {
+        sessionStorage.setItem('dismissed-release', release.date);
+      } catch {
+        // Ignore write errors
+      }
+    }
+    setShowRelease(false);
+  };
 
   return (
     <header className="relative bg-gray-900 text-white rtl:text-right">
+      {showRelease && release && (
+        <div className="absolute inset-x-0 top-0 flex justify-center mt-2">
+          <div className="flex items-center gap-2 px-4 py-1 rounded-full bg-blue-600 text-white text-sm">
+            <a
+              href={release.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:underline"
+            >
+              New release: {release.title}
+            </a>
+            <button
+              type="button"
+              aria-label="Dismiss release notification"
+              onClick={dismissRelease}
+              className="hover:text-gray-200"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      )}
       <nav className="flex gap-4 p-4 rtl:flex-row-reverse">
-        <a href="/" className="hover:underline">
+        <Link href="/" className="hover:underline">
           Home
-        </a>
+        </Link>
         <div
           className="relative"
           onMouseEnter={() => setDocsOpen(true)}


### PR DESCRIPTION
## Summary
- show announcement pill linking to latest Kali release and allow dismissal
- test release pill logic

## Testing
- `yarn test` *(fails: a11y.playwright test missing browser; csp allowlist; app import issues; etc.)*
- `npx eslint components/layout/Header.tsx __tests__/releasePill.test.tsx`
- `yarn typecheck` *(fails: numerous TypeScript errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68be6a96314883289f936611864f0ebb