### PR TITLE
feat: improve context menu submenu handling

### DIFF
--- a/docs/navigation-guidelines.md
+++ b/docs/navigation-guidelines.md
@@ -1,0 +1,13 @@
+# Navigation Guidelines
+
+## Context Menu Submenus
+
+- Submenus open to the right when there is sufficient horizontal space.
+- When the submenu would overflow the viewport, it flips to the left and the caret points left.
+- Submenus offset 4px from their trigger; the offset switches sides when flipped.
+
+## Viewport Collision
+
+- The root context menu repositions to remain fully visible within the viewport.
+- Open submenus adjust vertically to avoid clipping at the top or bottom edges.
+


### PR DESCRIPTION
## Summary
- orient submenu carets left or right based on viewport space
- prevent context menu and submenus from clipping outside the viewport
- document submenu positioning rules in navigation guidelines

## Testing
- `npx eslint components/common/ContextMenu.tsx docs/navigation-guidelines.md`
- `npx jest components/common/ContextMenu.tsx` *(fails: No tests found, exiting with code 1)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: many existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be6a98ceb083288ac45cab831a174e