### PR TITLE
feat: add mobile navigation sheet

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,18 +1,23 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import DocMegaMenu from './DocMegaMenu';
+import MobileNav from './MobileNav';
 
 export default function Header() {
   const [docsOpen, setDocsOpen] = useState(false);
   const closeDocs = () => setDocsOpen(false);
 
   return (
-    <header className="relative bg-gray-900 text-white rtl:text-right">
-      <nav className="flex gap-4 p-4 rtl:flex-row-reverse">
-        <a href="/" className="hover:underline">
+    <header className="relative bg-gray-900 text-white rtl:text-right flex items-center justify-between">
+      <Link href="/" className="p-4 hover:underline md:hidden">
+        Home
+      </Link>
+      <nav className="hidden md:flex gap-4 p-4 rtl:flex-row-reverse">
+        <Link href="/" className="hover:underline">
           Home
-        </a>
+        </Link>
         <div
           className="relative"
           onMouseEnter={() => setDocsOpen(true)}
@@ -27,6 +32,7 @@ export default function Header() {
           {docsOpen && <DocMegaMenu onClose={closeDocs} />}
         </div>
       </nav>
+      <MobileNav className="md:hidden" />
     </header>
   );
 }

--- a/components/layout/MobileNav.tsx
+++ b/components/layout/MobileNav.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Drawer from 'rc-drawer';
+import { Icon } from '../ui/Icon';
+import ia from '../../data/ia.json';
+
+interface Props {
+  className?: string;
+}
+
+interface NavItem {
+  label: string;
+  href?: string;
+  children?: NavItem[];
+}
+
+export default function MobileNav({ className }: Props) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const searchRef = useRef<HTMLInputElement>(null);
+  const touchStartX = useRef<number | null>(null);
+
+  const sections: NavItem[] = (ia as any).header;
+
+  useEffect(() => {
+    if (open) searchRef.current?.focus();
+  }, [open]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') setOpen(false);
+  };
+
+  const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+
+  const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
+    if (touchStartX.current !== null) {
+      const diff = e.touches[0].clientX - touchStartX.current;
+      if (diff < -50) {
+        setOpen(false);
+        touchStartX.current = null;
+      }
+    }
+  };
+
+  const filter = (label: string) => label.toLowerCase().includes(query.toLowerCase());
+
+  const filteredSections = sections
+    .map((sec) => {
+      const children = sec.children?.filter((c) => filter(c.label)) || [];
+      if (!query || filter(sec.label) || children.length > 0) {
+        return { ...sec, children };
+      }
+      return null;
+    })
+    .filter(Boolean) as NavItem[];
+
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        aria-label="Open navigation menu"
+        onClick={() => setOpen(true)}
+        className="p-4"
+      >
+        <Icon name="menu" className="w-6 h-6" />
+      </button>
+      <Drawer
+        open={open}
+        onClose={() => setOpen(false)}
+        handler={false}
+        placement="left"
+        width="100%"
+        level={null}
+      >
+        <div
+          className="h-full bg-gray-900 text-white flex flex-col"
+          onKeyDown={handleKeyDown}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+        >
+          <div className="p-4 border-b border-gray-800">
+            <input
+              ref={searchRef}
+              aria-label="Search navigation"
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search"
+              className="w-full p-2 rounded bg-gray-800"
+            />
+          </div>
+          <nav className="flex-1 overflow-y-auto" aria-label="Mobile navigation">
+            {filteredSections.map((section) => (
+              <div key={section.label} className="p-4 border-b border-gray-800">
+                {section.children && section.children.length > 0 ? (
+                  <>
+                    <h2 className="mb-2 text-sm font-bold">{section.label}</h2>
+                    <ul className="space-y-2">
+                      {section.children.map((child) => (
+                        <li key={child.label}>
+                          <a
+                            href={child.href}
+                            className="block px-2 py-1 rounded hover:bg-gray-800 focus:bg-gray-800"
+                          >
+                            {child.label}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </>
+                ) : (
+                  <a
+                    href={section.href}
+                    className="block font-bold hover:underline"
+                  >
+                    {section.label}
+                  </a>
+                )}
+              </div>
+            ))}
+          </nav>
+        </div>
+      </Drawer>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add full-height mobile navigation drawer with search and sections
- integrate drawer into header and convert home links to Next.js Link

## Testing
- `npx eslint components/layout/Header.tsx components/layout/MobileNav.tsx`
- `yarn test --findRelatedTests components/layout/Header.tsx components/layout/MobileNav.tsx --passWithNoTests`
- `yarn typecheck` *(fails: workers/sudokuSolver.ts(234,16): Type 'undefined' cannot be used as an index type.)*

------
https://chatgpt.com/codex/tasks/task_e_68be6a99911c83288344d00aaf61c870