### PR TITLE
Reduce header size on md screens and add hero viewport test

### DIFF
--- a/components/desktop/TopPanel.tsx
+++ b/components/desktop/TopPanel.tsx
@@ -18,7 +18,7 @@ interface Props {
  */
 export default function TopPanel({ title }: Props) {
   return (
-    <header className="flex items-center justify-between w-full bg-ub-grey text-ubt-grey h-8 px-2 text-sm sticky top-0 z-40">
+    <header className="flex items-center justify-between w-full bg-ub-grey text-ubt-grey h-8 md:h-6 lg:h-8 px-2 md:px-1 lg:px-2 text-sm md:text-xs lg:text-sm sticky top-0 z-40">
       {/* App menu */}
       <div className="flex items-center">
         <WhiskerMenu />
@@ -34,7 +34,7 @@ export default function TopPanel({ title }: Props) {
       </div>
 
       {/* System indicators */}
-      <div className="flex items-center space-x-2" aria-label="System indicators">
+      <div className="flex items-center space-x-2 md:space-x-1 lg:space-x-2" aria-label="System indicators">
         <div className="hidden sm:block">
           <PanelClock />
         </div>

--- a/components/ui/Hero.tsx
+++ b/components/ui/Hero.tsx
@@ -13,7 +13,7 @@ interface HeroProps {
 
 export default function Hero({ title, summary, meta }: HeroProps) {
   return (
-    <section className="flex flex-col gap-6 md:flex-row">
+    <section className="flex flex-col gap-6 md:flex-row md:gap-4">
       <div className="flex-1 space-y-4">
         <h1 className="text-3xl font-bold">{title}</h1>
         <ul className="list-disc list-inside space-y-2">

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -81,11 +81,11 @@ export default function Status() {
   }, [register, unregister, theme]);
 
   return (
-    <div className="flex items-center gap-2" role="group" aria-label="System tray">
+    <div className="flex items-center gap-2 md:gap-1 lg:gap-2" role="group" aria-label="System tray">
       {icons.map((icon) => (
         <span
           key={icon.id}
-          className="relative flex items-center justify-center w-5 h-5"
+          className="relative flex items-center justify-center w-5 h-5 md:w-4 md:h-4 lg:w-5 lg:h-5"
           title={icon.tooltip}
         >
           <Image
@@ -97,7 +97,7 @@ export default function Status() {
                 : icon.legacy || icon.sni
             }
             alt={icon.tooltip || icon.id}
-            className="status-symbol w-5 h-5"
+            className="status-symbol w-5 h-5 md:w-4 md:h-4 lg:w-5 lg:h-5"
             sizes="20px"
           />
           {icon.id === 'network' && !allowNetwork && (
@@ -105,7 +105,7 @@ export default function Status() {
           )}
         </span>
       ))}
-      <span className="flex items-center justify-center w-5 h-5">
+      <span className="flex items-center justify-center w-5 h-5 md:w-4 md:h-4 lg:w-5 lg:h-5">
         <SmallArrow angle="down" className="status-symbol" />
       </span>
     </div>

--- a/tests/pages/hero-fold.spec.tsx
+++ b/tests/pages/hero-fold.spec.tsx
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+// Ensures hero content is visible without scrolling on a typical laptop viewport
+// by verifying the hero section fits within a 1366x768 viewport.
+test('hero content remains above the fold on laptop viewports', async ({ page }) => {
+  await page.setViewportSize({ width: 1366, height: 768 });
+  await page.goto('/platform/vmware');
+  const hero = page.locator('main section').first();
+  const box = await hero.boundingBox();
+  expect(box).not.toBeNull();
+  if (box) {
+    expect(box.y + box.height).toBeLessThanOrEqual(768);
+  }
+});


### PR DESCRIPTION
## Summary
- tweak top panel styling to shrink header and icon spacing on md viewports
- scale system tray icons responsively
- ensure hero layout stays above the fold and add viewport regression test

## Testing
- `yarn lint` *(fails: Unable to resolve module paths and label lint errors)*
- `yarn test` *(fails: missing Chrome binary and other failing suites)*
- `npx playwright test tests/pages/hero-fold.spec.tsx` *(fails: Playwright browser not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68be6a9b4b5c83288e5216cdc4a4ece3