### PR TITLE
feat: add release promo card to home

### DIFF
--- a/components/ReleasePromoCard.tsx
+++ b/components/ReleasePromoCard.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Link from 'next/link';
+
+interface ReleasePromoCardProps {
+  version: string;
+  tagline?: string;
+}
+
+export default function ReleasePromoCard({ version, tagline }: ReleasePromoCardProps) {
+  return (
+    <section className="mb-6 rounded border p-4 bg-ub-grey text-white">
+      <h2 className="text-xl font-bold mb-2">{version} Release</h2>
+      {tagline && <p className="mb-4">{tagline}</p>}
+      <Link
+        href="/get-kali"
+        className="inline-block bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+      >
+        Get Kali
+      </Link>
+    </section>
+  );
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,9 @@
 import Image from "next/image";
 import { decode } from "blurhash";
 import { PNG } from "pngjs";
+import { useEffect, useState } from "react";
+import posts from "../data/kali-blog.json";
+import ReleasePromoCard from "../components/ReleasePromoCard";
 import desktopsData from "../content/desktops.json";
 import { baseMetadata } from "../lib/metadata";
 
@@ -26,8 +29,25 @@ export async function getStaticProps() {
  * @returns {JSX.Element}
  */
 export default function Home({ desktops }) {
+  const [release, setRelease] = useState(null);
+
+  useEffect(() => {
+    const releasePost = posts.find((p) => /Release/i.test(p.title));
+    if (!releasePost) return;
+    const releaseDate = new Date(releasePost.date);
+    const now = new Date();
+    const diffDays = (now - releaseDate) / (1000 * 60 * 60 * 24);
+    if (diffDays <= 90) {
+      const match = releasePost.title.match(/(Kali Linux\s+[0-9.]+) Release\s*(?:\((.*)\))?/i);
+      const version = match ? match[1] : releasePost.title;
+      const tagline = match && match[2] ? match[2] : undefined;
+      setRelease({ version, tagline });
+    }
+  }, []);
+
   return (
     <main className="p-4">
+      {release && <ReleasePromoCard version={release.version} tagline={release.tagline} />}
       <h1 className="mb-4 text-2xl font-bold sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl 2xl:text-7xl">Choose the desktop you prefer</h1>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
         {desktops.map((d) => (


### PR DESCRIPTION
## Summary
- feature: add release promo card to home
- chore: wire up promo card to show recent releases

## Testing
- `npx eslint pages/index.jsx components/ReleasePromoCard.tsx`
- `npx jest components/ReleasePromoCard.tsx pages/index.jsx --passWithNoTests`
- `npx tsc --noEmit components/ReleasePromoCard.tsx` *(fails: Module can only be default-imported using esModuleInterop)*
- `pnpm -w typecheck` *(fails: --workspace-root may only be used inside a workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68be6a9be428832893b1c8f46df7dfbd