### PR TITLE
Add platform quick links to home page

### DIFF
--- a/components/home/PlatformLinks.tsx
+++ b/components/home/PlatformLinks.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+interface PlatformLink {
+  label: string;
+  slug: string;
+}
+
+const platforms: PlatformLink[] = [
+  { label: "ARM", slug: "arm" },
+  { label: "Bare Metal", slug: "installer" },
+  { label: "Cloud", slug: "cloud" },
+  { label: "Containers", slug: "containers" },
+  { label: "Mobile", slug: "mobile" },
+  { label: "USB", slug: "live" },
+  { label: "VMs", slug: "virtual-machines" },
+  { label: "WSL", slug: "wsl" },
+];
+
+export default function PlatformLinks() {
+  return (
+    <ul className="flex flex-wrap justify-center gap-4 text-sm sm:text-base md:text-lg">
+      {platforms.map((p) => (
+        <li key={p.slug}>
+          <a
+            href={`/get-kali#kali-${p.slug}`}
+            className="text-blue-500 hover:underline"
+          >
+            {p.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}
+

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -3,6 +3,7 @@ import { decode } from "blurhash";
 import { PNG } from "pngjs";
 import desktopsData from "../content/desktops.json";
 import { baseMetadata } from "../lib/metadata";
+import PlatformLinks from "../components/home/PlatformLinks";
 
 export const metadata = baseMetadata;
 
@@ -44,6 +45,9 @@ export default function Home({ desktops }) {
             <p className="mt-2 text-sm sm:text-base md:text-lg">{d.name}</p>
           </div>
         ))}
+      </div>
+      <div className="mt-6">
+        <PlatformLinks />
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- add PlatformLinks component with anchors to each platform section
- include platform link list on home page

## Testing
- `yarn lint` *(fails: Unable to resolve path to module '../components/ToolbarIcons'; 504 problems total)*
- `yarn test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell; other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68be6a9d55f88328ade540eb39c531c8