### PR TITLE
Add feature cards section below platform hero

### DIFF
--- a/data/features.ts
+++ b/data/features.ts
@@ -1,0 +1,23 @@
+export interface Feature {
+  title: string;
+  blurb: string;
+  href: string;
+}
+
+export const features: Feature[] = [
+  {
+    title: 'VMware',
+    blurb: 'Run Kali in a VMware virtual machine with snapshot support.',
+    href: '/platforms/vmware',
+  },
+  {
+    title: 'Cloud',
+    blurb: 'Deploy Kali on popular cloud providers for on-demand access.',
+    href: '/platforms/cloud',
+  },
+  {
+    title: 'USB Live',
+    blurb: 'Boot Kali from a portable USB drive and enable persistence.',
+    href: '/platforms/usb-live',
+  },
+];

--- a/pages/platform/[slug].tsx
+++ b/pages/platform/[slug].tsx
@@ -1,6 +1,7 @@
 import { GetStaticPaths, GetStaticProps } from 'next';
 import Hero from '../../components/ui/Hero';
 import { getPlatformSlugs, getPlatformBySlug, PlatformInfo } from '../../data/platforms';
+import { features } from '../../data/features';
 
 interface PlatformPageProps {
   platform: PlatformInfo;
@@ -8,8 +9,22 @@ interface PlatformPageProps {
 
 export default function PlatformPage({ platform }: PlatformPageProps) {
   return (
-    <main className="p-4">
+    <main className="p-4 space-y-8">
       <Hero title={platform.title} summary={platform.bullets} meta={platform.meta} />
+      <section className="grid gap-4 md:grid-cols-3">
+        {features.map((feature) => (
+          <div key={feature.title} className="border rounded p-4 flex flex-col">
+            <h3 className="text-lg font-semibold mb-2">{feature.title}</h3>
+            <p className="mb-4 flex-1">{feature.blurb}</p>
+            <a
+              href={feature.href}
+              className="text-blue-500 hover:underline mt-auto"
+            >
+              Read Docs
+            </a>
+          </div>
+        ))}
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable feature data with blurbs and doc links
- render feature cards grid beneath platform hero

## Testing
- `npx eslint data/features.ts pages/platform/[slug].tsx`
- `yarn test __tests__/Hero.test.tsx`
- `pnpm -w typecheck` *(fails: --workspace-root may only be used inside a workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68be6a9cc6f883288f7c06283b07e64e