### PR TITLE
Add Win-KeX platform tile

### DIFF
--- a/content/get-kali/win-kex.mdx
+++ b/content/get-kali/win-kex.mdx
@@ -1,0 +1,10 @@
+import MDXPageHeader from '../../components/ui/MDXPageHeader';
+
+<MDXPageHeader
+  breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Get Kali', href: '/get-kali' }, { label: 'Win-KeX' }]}
+  filePath="content/get-kali/win-kex.mdx"
+/>
+
+export const title = 'Win-KeX';
+export const summary = 'Graphical desktop experience for Kali on WSL.';
+export const badges = ['wsl'];

--- a/pages/get-kali.tsx
+++ b/pages/get-kali.tsx
@@ -8,6 +8,7 @@ import * as Cloud from '../content/get-kali/cloud.mdx';
 import * as Containers from '../content/get-kali/containers.mdx';
 import * as Live from '../content/get-kali/live.mdx';
 import * as WSL from '../content/get-kali/wsl.mdx';
+import * as WinKex from '../content/get-kali/win-kex.mdx';
 import * as Purple from '../content/get-kali/purple.mdx';
 import * as Docs from '../content/get-kali/docs.mdx';
 
@@ -28,6 +29,11 @@ const platforms: Platform[] = [
   { slug: 'containers', ...(Containers as any) },
   { slug: 'live', ...(Live as any) },
   { slug: 'wsl', ...(WSL as any) },
+  {
+    slug: 'win-kex',
+    url: 'https://www.kali.org/docs/wsl/win-kex/',
+    ...(WinKex as any),
+  },
   { slug: 'purple', ...(Purple as any) },
   { slug: 'docs', url: 'https://www.kali.org/docs/', ...(Docs as any) },
 ];


### PR DESCRIPTION
## Summary
- add Win-KeX platform card with documentation link
- register Win-KeX in Get Kali platform list

## Testing
- `npx eslint pages/get-kali.tsx content/get-kali/win-kex.mdx`
- `yarn test pages/get-kali.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be6ab89260832891ffefd261bc0ef4