### PR TITLE
feat: add download verification callouts

### DIFF
--- a/pages/get-kali.tsx
+++ b/pages/get-kali.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Callout from '../components/ui/Callout';
 
 import * as Installer from '../content/get-kali/installer.mdx';
 import * as VMs from '../content/get-kali/vms.mdx';
@@ -61,6 +62,22 @@ const GetKali: React.FC = () => (
           </a>
         </div>
       ))}
+    </div>
+    <div className="mt-6">
+      <Callout variant="verifyDownload">
+        <p>
+          Verify downloads using signatures or hashes.{' '}
+          <a
+            href="https://www.kali.org/docs/introduction/download-validation/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            Verification instructions
+          </a>
+          .
+        </p>
+      </Callout>
     </div>
   </main>
 );

--- a/pages/install-options.tsx
+++ b/pages/install-options.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
+import Callout from '../components/ui/Callout';
 
 const InstallOptions: React.FC = () => (
   <main className="p-4">
@@ -25,6 +26,22 @@ const InstallOptions: React.FC = () => (
           Learn more
         </Link>
       </div>
+    </div>
+    <div className="mt-6">
+      <Callout variant="verifyDownload">
+        <p>
+          Verify downloads using signatures or hashes.{' '}
+          <a
+            href="https://www.kali.org/docs/introduction/download-validation/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            Verification instructions
+          </a>
+          .
+        </p>
+      </Callout>
     </div>
   </main>
 );


### PR DESCRIPTION
## Summary
- remind users to verify images on install options page
- show download verification callout on legacy get-kali page

## Testing
- `npx eslint pages/install-options.tsx pages/get-kali.tsx`
- `yarn test` *(fails: cannot find Chrome binary, Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68be6ab94b988328bdd451d27b2bab0e