### PR TITLE
feat: add mirror information callout

### DIFF
--- a/components/ui/Callout.tsx
+++ b/components/ui/Callout.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 interface CalloutProps {
-  variant: 'defaultCredentials' | 'readDocs' | 'verifyDownload';
+  variant: 'defaultCredentials' | 'readDocs' | 'verifyDownload' | 'mirrorInfo';
   children: React.ReactNode;
 }
 
@@ -48,6 +48,18 @@ const ShieldCheckIcon = (props: React.SVGProps<SVGSVGElement>) => (
   </svg>
 );
 
+const InfoIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M12 9.75h.008v.008H12V9.75Zm0 2.25v3.75m9-3.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 const variants = {
   defaultCredentials: {
     icon: KeyIcon,
@@ -63,6 +75,11 @@ const variants = {
     icon: ShieldCheckIcon,
     border: 'border-green-400',
     label: 'Verify downloads',
+  },
+  mirrorInfo: {
+    icon: InfoIcon,
+    border: 'border-blue-400',
+    label: 'Mirror info',
   },
 };
 

--- a/pages/get-kali/index.tsx
+++ b/pages/get-kali/index.tsx
@@ -49,6 +49,21 @@ const GetKali: React.FC = () => (
       </div>
     </div>
     <div className="mt-6">
+      <Callout variant="mirrorInfo">
+        <p>
+          Downloads are automatically served from the nearest mirror for better
+          performance. View the{' '}
+          <a
+            href="https://http.kali.org/README.mirrorlist"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            full mirror list
+          </a>
+          .
+        </p>
+      </Callout>
       <Callout variant="verifyDownload">
         <p>
           Verify downloads using signatures or hashes.{' '}

--- a/pages/platforms/cloud.tsx
+++ b/pages/platforms/cloud.tsx
@@ -19,6 +19,21 @@ const CloudPage: React.FC = () => (
         {' '}to get started.
       </p>
     </Callout>
+    <Callout variant="mirrorInfo">
+      <p>
+        Downloads are served from the nearest mirror for best performance. See
+        the{' '}
+        <a
+          href="https://http.kali.org/README.mirrorlist"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          mirror locations
+        </a>
+        .
+      </p>
+    </Callout>
     <Callout variant="verifyDownload">
       <p>
         Verify the image after downloading using signatures or hashes.{' '}

--- a/pages/platforms/usb-live.tsx
+++ b/pages/platforms/usb-live.tsx
@@ -19,6 +19,21 @@ const USBLivePage: React.FC = () => (
         .
       </p>
     </Callout>
+    <Callout variant="mirrorInfo">
+      <p>
+        Downloads are served from the nearest mirror for best performance. See
+        the{' '}
+        <a
+          href="https://http.kali.org/README.mirrorlist"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          mirror locations
+        </a>
+        .
+      </p>
+    </Callout>
     <Callout variant="verifyDownload">
       <p>
         Verify the image after downloading using signatures or hashes.{' '}

--- a/pages/platforms/vmware.tsx
+++ b/pages/platforms/vmware.tsx
@@ -24,6 +24,21 @@ const VMwarePage: React.FC = () => (
         The default login for VMware images is <code>kali/kali</code>.
       </p>
     </Callout>
+    <Callout variant="mirrorInfo">
+      <p>
+        Downloads are served from the nearest mirror for best performance. See
+        the{' '}
+        <a
+          href="https://http.kali.org/README.mirrorlist"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          mirror locations
+        </a>
+        .
+      </p>
+    </Callout>
     <Callout variant="verifyDownload">
       <p>
         Verify the image after downloading using signatures or hashes.{' '}


### PR DESCRIPTION
## Summary
- add mirror info variant to Callout component
- show mirror tip with link on Get Kali and platform download pages

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot set properties of undefined (setting 'theme'))*
- `npm run typecheck` *(fails: type errors in various files)*

------
https://chatgpt.com/codex/tasks/task_e_68be6ac45bbc8328afb83828c84384fa