### PR TITLE
feat: add WSL setup info card

### DIFF
--- a/content/get-kali/wsl.mdx
+++ b/content/get-kali/wsl.mdx
@@ -1,9 +1,18 @@
 import MDXPageHeader from '../../components/ui/MDXPageHeader';
+import Admonition from '../../components/mdx/Admonition';
 
 <MDXPageHeader
   breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Get Kali', href: '/get-kali' }, { label: 'WSL' }]}
   filePath="content/get-kali/wsl.mdx"
 />
+
+<Admonition type="info">
+  WSL needs some extra setup for a smooth Kali experience. Install
+  <a href="/apps/help/win-kex" className="underline">Win-KeX</a>
+  and review the
+  <a href="/wsl-prep" className="underline">WSL preparation docs</a>
+  before installation.
+</Admonition>
 
 export const title = 'WSL';
 export const summary = 'Kali Linux for Windows Subsystem for Linux.';


### PR DESCRIPTION
## Summary
- add info note on WSL download page about extra setup
- link to Win-KeX help and WSL prep docs

## Testing
- `npx eslint content/get-kali/wsl.mdx` *(fails: File ignored because no matching configuration was supplied)*
- `npx playwright test tests/pages/wsl-prep.spec.tsx` *(fails: net::ERR_CONNECTION_REFUSED at http://localhost:3000/wsl-prep)*

------
https://chatgpt.com/codex/tasks/task_e_68be6ac5ee30832880050cda742d4776