### PR TITLE
Add ARM boards grid with compatibility badges

### DIFF
--- a/data/arm-boards.ts
+++ b/data/arm-boards.ts
@@ -1,0 +1,48 @@
+export interface ArmBoard {
+  slug: string;
+  name: string;
+  architectures: string[];
+}
+
+export const armBoards: ArmBoard[] = [
+  {
+    slug: 'raspberry-pi-2',
+    name: 'Raspberry Pi 2',
+    architectures: ['armhf'],
+  },
+  {
+    slug: 'raspberry-pi-3',
+    name: 'Raspberry Pi 3',
+    architectures: ['armhf', 'arm64'],
+  },
+  {
+    slug: 'raspberry-pi-4',
+    name: 'Raspberry Pi 4',
+    architectures: ['armhf', 'arm64'],
+  },
+  {
+    slug: 'raspberry-pi-zero-w',
+    name: 'Raspberry Pi Zero W',
+    architectures: ['armhf'],
+  },
+  {
+    slug: 'pinebook-pro',
+    name: 'Pinebook Pro',
+    architectures: ['arm64'],
+  },
+  {
+    slug: 'beaglebone-black',
+    name: 'BeagleBone Black',
+    architectures: ['armhf'],
+  },
+  {
+    slug: 'odroid-c2',
+    name: 'ODROID-C2',
+    architectures: ['arm64'],
+  },
+  {
+    slug: 'banana-pi',
+    name: 'Banana Pi',
+    architectures: ['armhf'],
+  },
+];

--- a/pages/platforms/arm.tsx
+++ b/pages/platforms/arm.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { armBoards } from '../../data/arm-boards';
+
+const ARMBoardsPage: React.FC = () => (
+  <main className="p-4 space-y-4">
+    <h1 className="text-2xl font-semibold">ARM Boards</h1>
+    <p>Images for ARM-based single-board computers.</p>
+    <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+      {armBoards.map((board) => (
+        <div key={board.slug} className="border rounded p-4 flex flex-col">
+          <h2 className="font-semibold mb-2">{board.name}</h2>
+          <ul className="flex flex-wrap gap-1 mt-auto">
+            {board.architectures.map((arch) => (
+              <li
+                key={arch}
+                className="bg-gray-200 text-gray-800 px-2 py-0.5 rounded text-xs"
+              >
+                {arch}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  </main>
+);
+
+export default ARMBoardsPage;


### PR DESCRIPTION
## Summary
- list supported ARM boards with architecture badges
- render responsive grid of ARM devices on ARM platform page

## Testing
- `npx eslint pages/platforms/arm.tsx data/arm-boards.ts`
- `yarn lint pages/platforms/arm.tsx data/arm-boards.ts` *(fails: Unable to resolve path to module '../components/ToolbarIcons', jsx-a11y/control-has-associated-label, etc.)*
- `yarn test` *(fails: Cannot set properties of undefined (setting 'theme'))*
- `yarn typecheck` *(fails: Type 'undefined' cannot be used as an index type)*

------
https://chatgpt.com/codex/tasks/task_e_68be6ac7ac988328bad9e9b159ddbf87