### PR TITLE
feat: add card-table view toggle with persistent filters

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -2,6 +2,7 @@
   {
     "id": "dirbuster",
     "name": "DirBuster",
+    "category": "Information Gathering",
     "summary": "DirBuster is a multi threaded java application designed to brute force directories and files names on web/application servers.",
     "packages": [
       { "name": "dirbuster", "version": "1.0-RC1" }
@@ -16,6 +17,7 @@
   {
     "id": "gobuster",
     "name": "GoBuster",
+    "category": "Information Gathering",
     "summary": "Directory/file & DNS busting tool written in Go.",
     "packages": [
       { "name": "gobuster", "version": "3.5.0" }
@@ -30,6 +32,7 @@
   {
     "id": "feroxbuster",
     "name": "Feroxbuster",
+    "category": "Information Gathering",
     "summary": "A simple, fast, recursive content discovery tool written in Rust.",
     "packages": [
       { "name": "feroxbuster", "version": "2.10.4" }


### PR DESCRIPTION
## Summary
- add category metadata for tools dataset
- implement card/table view toggle with persistent category filters
- show tool name, category, packages, and commands in both layouts

## Testing
- `yarn test` *(fails: missing chrome binary; a11y tests cannot run)*

------
https://chatgpt.com/codex/tasks/task_e_68be6b2e453483288cc0c6253da19841