### PR TITLE
feat: add global shortcut footer

### DIFF
--- a/components/common/GlobalShortcuts.tsx
+++ b/components/common/GlobalShortcuts.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import useKeymap from '../../apps/settings/keymapRegistry';
+import formatKeyboardEvent from '../../utils/formatKeyboardEvent';
+
+const GlobalShortcuts: React.FC = () => {
+  const { shortcuts } = useKeymap();
+  const router = useRouter();
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        (target as HTMLElement).isContentEditable
+      ) {
+        return;
+      }
+      const openSettings =
+        shortcuts.find((s) => s.description === 'Open settings')?.keys || 'Ctrl+,';
+      if (formatKeyboardEvent(e) === openSettings) {
+        e.preventDefault();
+        router.push('/settings');
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [shortcuts, router]);
+
+  return null;
+};
+
+export default GlobalShortcuts;

--- a/components/common/ShortcutFooter.tsx
+++ b/components/common/ShortcutFooter.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import React from 'react';
+import useKeymap from '../../apps/settings/keymapRegistry';
+import useScreenReader from '../../hooks/useScreenReader';
+
+const ShortcutFooter: React.FC = () => {
+  const { shortcuts } = useKeymap();
+  const isScreenReader = useScreenReader();
+
+  if (isScreenReader) return null;
+
+  return (
+    <div
+      className="fixed bottom-0 inset-x-0 z-40 text-xs text-white bg-black/60"
+      aria-hidden="true"
+    >
+      <ul className="flex flex-wrap justify-center gap-x-4 px-2 py-1">
+        {shortcuts.map((s) => (
+          <li key={s.description} className="flex items-center gap-1">
+            <kbd className="font-mono">{s.keys}</kbd>
+            <span>{s.description}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ShortcutFooter;

--- a/components/common/ShortcutOverlay.tsx
+++ b/components/common/ShortcutOverlay.tsx
@@ -2,17 +2,7 @@
 
 import React, { useEffect, useState, useCallback } from 'react';
 import useKeymap from '../../apps/settings/keymapRegistry';
-
-const formatEvent = (e: KeyboardEvent) => {
-  const parts = [
-    e.ctrlKey ? 'Ctrl' : '',
-    e.altKey ? 'Alt' : '',
-    e.shiftKey ? 'Shift' : '',
-    e.metaKey ? 'Meta' : '',
-    e.key.length === 1 ? e.key.toUpperCase() : e.key,
-  ];
-  return parts.filter(Boolean).join('+');
-};
+import formatKeyboardEvent from '../../utils/formatKeyboardEvent';
 
 const ShortcutOverlay: React.FC = () => {
   const [open, setOpen] = useState(false);
@@ -31,7 +21,7 @@ const ShortcutOverlay: React.FC = () => {
       const show =
         shortcuts.find((s) => s.description === 'Show keyboard shortcuts')?.keys ||
         '?';
-      if (formatEvent(e) === show) {
+      if (formatKeyboardEvent(e) === show) {
         e.preventDefault();
         toggle();
       } else if (e.key === 'Escape' && open) {

--- a/hooks/useScreenReader.ts
+++ b/hooks/useScreenReader.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+import usePrefersReducedMotion from './usePrefersReducedMotion';
+
+export default function useScreenReader() {
+  const reducedMotion = usePrefersReducedMotion();
+  const [forcedColors, setForcedColors] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(forced-colors: active)');
+    const update = () => setForcedColors(mq.matches);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+
+  return reducedMotion || forcedColors;
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,8 @@ import '../styles/resume-print.css';
 import '../styles/print.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
+import ShortcutFooter from '../components/common/ShortcutFooter';
+import GlobalShortcuts from '../components/common/GlobalShortcuts';
 import PipPortalProvider from '../components/common/PipPortal';
 import { TrayProvider } from '../hooks/useTray';
 import ErrorBoundary from '../components/core/ErrorBoundary';
@@ -253,6 +255,8 @@ function MyApp(props) {
                   <div aria-live="polite" id="live-region" />
                   <Component {...pageProps} />
                   <ShortcutOverlay />
+                  <GlobalShortcuts />
+                  <ShortcutFooter />
                   {process.env.VERCEL_ANALYTICS_ID && (
                     <>
                       <Analytics

--- a/utils/formatKeyboardEvent.ts
+++ b/utils/formatKeyboardEvent.ts
@@ -1,0 +1,10 @@
+export default function formatKeyboardEvent(e: KeyboardEvent): string {
+  const parts = [
+    e.ctrlKey ? 'Ctrl' : '',
+    e.altKey ? 'Alt' : '',
+    e.shiftKey ? 'Shift' : '',
+    e.metaKey ? 'Meta' : '',
+    e.key.length === 1 ? e.key.toUpperCase() : e.key,
+  ];
+  return parts.filter(Boolean).join('+');
+}


### PR DESCRIPTION
## Summary
- show keyboard shortcuts in a footer strip
- hide shortcut hints for screen reader users
- handle settings shortcut globally across pages

## Testing
- `yarn test __tests__/ShortcutOverlay.test.tsx`
- `npx eslint components/common/ShortcutFooter.tsx components/common/GlobalShortcuts.tsx hooks/useScreenReader.ts utils/formatKeyboardEvent.ts`


------
https://chatgpt.com/codex/tasks/task_e_68be6b308c388328b847debb7b020f18