### PR TITLE
feat: add tool version badges

### DIFF
--- a/data/kali-tools.json
+++ b/data/kali-tools.json
@@ -1,7 +1,12 @@
 [
-  { "id": "aircrack-ng", "name": "Aircrack-ng" },
-  { "id": "amap", "name": "Amap" },
-  { "id": "armitage", "name": "Armitage" },
+  { "id": "aircrack-ng", "name": "Aircrack-ng", "version": "1.7" },
+  { "id": "amap", "name": "Amap", "updated": true },
+  {
+    "id": "armitage",
+    "name": "Armitage",
+    "version": "2023.1",
+    "updated": true
+  },
   { "id": "autopsy", "name": "Autopsy" },
   { "id": "bettercap", "name": "Bettercap" },
   { "id": "burpsuite", "name": "Burpsuite" },

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -51,7 +51,12 @@ async function buildIndex() {
   // Tool names
   const toolsPath = path.join(process.cwd(), 'data', 'kali-tools.json');
   if (fs.existsSync(toolsPath)) {
-    const tools = JSON.parse(fs.readFileSync(toolsPath, 'utf8')) as { id: string; name: string }[];
+    const tools = JSON.parse(fs.readFileSync(toolsPath, 'utf8')) as {
+      id: string;
+      name: string;
+      version?: string;
+      updated?: boolean;
+    }[];
     for (const tool of tools) {
       idx.add({
         id: `tool-${tool.id}`,

--- a/pages/apps/kali-tools/index.jsx
+++ b/pages/apps/kali-tools/index.jsx
@@ -6,6 +6,9 @@ const letters = Array.from({ length: 26 }, (_, i) =>
   String.fromCharCode(65 + i),
 );
 
+const metaBadgeClass =
+  'ml-1 rounded bg-gray-200 px-1 text-[0.65rem] font-medium text-gray-700';
+
 const KaliToolsPage = () => {
   const [query, setQuery] = useState('');
   const filteredTools = useMemo(
@@ -73,7 +76,15 @@ const KaliToolsPage = () => {
                     rel="noopener noreferrer"
                     className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
                   >
-                    <span>{tool.name}</span>
+                    <span className="flex items-center justify-center">
+                      {tool.name}
+                      {tool.version && (
+                        <span className={metaBadgeClass}>{`v${tool.version}`}</span>
+                      )}
+                      {tool.updated && (
+                        <span className={metaBadgeClass}>Updated</span>
+                      )}
+                    </span>
                   </a>
                 ))}
               </div>

--- a/pages/tools/index.tsx
+++ b/pages/tools/index.tsx
@@ -1,5 +1,14 @@
 import { useState, useRef, KeyboardEvent } from 'react';
-import tools from '../../data/kali-tools.json';
+import toolsData from '../../data/kali-tools.json';
+
+interface Tool {
+  id: string;
+  name: string;
+  version?: string;
+  updated?: boolean;
+}
+
+const tools: Tool[] = toolsData;
 import Pagination from '../../components/ui/Pagination';
 
 const PAGE_SIZE = 30;
@@ -7,6 +16,8 @@ const COLUMNS = 3; // used for keyboard navigation
 
 const badgeClass =
   'inline-block rounded bg-gray-200 px-2 py-1 text-xs font-semibold text-gray-800 dark:bg-gray-700 dark:text-gray-100';
+const metaBadgeClass =
+  'ml-2 rounded bg-gray-200 px-1 text-[0.65rem] font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-100';
 
 export default function ToolsPage() {
   const [page, setPage] = useState(0);
@@ -59,7 +70,15 @@ export default function ToolsPage() {
                 itemRefs.current[i] = el;
               }}
             >
-              <h3 className="font-semibold text-base sm:text-lg md:text-xl">{tool.name}</h3>
+              <h3 className="font-semibold text-base sm:text-lg md:text-xl">
+                {tool.name}
+                {tool.version && (
+                  <span className={metaBadgeClass}>{`v${tool.version}`}</span>
+                )}
+                {tool.updated && (
+                  <span className={metaBadgeClass}>Updated</span>
+                )}
+              </h3>
               <div className="mt-2 flex flex-wrap gap-2">
                 <a
                   href={`https://gitlab.com/kalilinux/packages/${tool.id}`}


### PR DESCRIPTION
## Summary
- add optional version and update tags to tool metadata
- surface version or updated status as badges next to tool names
- allow search indexing to read new tool fields

## Testing
- `yarn lint pages/tools/index.tsx pages/apps/kali-tools/index.jsx lib/search.ts` (fails: Unable to resolve path modules / a11y warnings)
- `yarn test` (fails: multiple failing tests such as csp.test.ts, missing dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68be6b31d1e483288f39a01a417339fb