### PR TITLE
feat: add tool category landing pages

### DIFF
--- a/data/tool-categories.ts
+++ b/data/tool-categories.ts
@@ -1,0 +1,23 @@
+export interface ToolCategory {
+  id: string;
+  name: string;
+  intro: string;
+  tools: string[];
+}
+
+const categories: ToolCategory[] = [
+  {
+    id: 'information-gathering',
+    name: 'Information Gathering',
+    intro: 'Tools to discover and enumerate targets during reconnaissance.',
+    tools: ['nmap', 'dnsrecon', 'theharvester'],
+  },
+  {
+    id: 'password-attacks',
+    name: 'Password Attacks',
+    intro: 'Popular utilities for auditing and cracking passwords.',
+    tools: ['hashcat', 'john', 'hydra'],
+  },
+];
+
+export default categories;

--- a/pages/tools/categories/[category].tsx
+++ b/pages/tools/categories/[category].tsx
@@ -1,0 +1,56 @@
+import { GetStaticPaths, GetStaticProps } from 'next';
+import Link from 'next/link';
+import categories, { ToolCategory } from '../../../data/tool-categories';
+import toolData from '../../../data/tools.json';
+import Hero from '../../../components/ui/Hero';
+import CommandChip from '../../../components/ui/CommandChip';
+
+interface ToolInfo {
+  id: string;
+  name: string;
+  install: string;
+}
+
+interface CategoryPageProps {
+  category: ToolCategory;
+  tools: ToolInfo[];
+}
+
+export default function CategoryPage({ category, tools }: CategoryPageProps) {
+  return (
+    <div className="p-4 space-y-6">
+      <Hero title={category.name} summary={[category.intro]} />
+      <section>
+        <h2 className="text-xl font-semibold mb-4">Popular Tools</h2>
+        <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          {tools.map((tool) => (
+            <li key={tool.id} className="border rounded p-4 space-y-2">
+              <h3 className="font-semibold">
+                <Link href={`/tools/${tool.id}`}>{tool.name}</Link>
+              </h3>
+              {tool.install && <CommandChip command={tool.install} />}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: categories.map((c) => ({ params: { category: c.id } })),
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps<CategoryPageProps> = async ({ params }) => {
+  const id = params?.category as string;
+  const category = categories.find((c) => c.id === id)!;
+  const tools: ToolInfo[] = category.tools.map((tid) => {
+    const t = (toolData as any[]).find((tool) => tool.id === tid);
+    const install = t?.commands?.find((c: any) => c.label === 'Install')?.cmd || '';
+    return { id: tid, name: t?.name || tid, install };
+  });
+  return { props: { category, tools } };
+};

--- a/pages/tools/categories/index.tsx
+++ b/pages/tools/categories/index.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+import categories from '../../../data/tool-categories';
+
+export default function ToolCategoriesIndex() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Tool Categories</h1>
+      <ul className="list-disc list-inside space-y-2">
+        {categories.map((cat) => (
+          <li key={cat.id}>
+            <Link href={`/tools/categories/${cat.id}`} className="text-blue-600 underline">
+              {cat.name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold tool category data with popular tool references
- add category index linking to category landing pages
- create category landing page showing intro and tool grid

## Testing
- `yarn test tests/pages/tools-filters.spec.tsx` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68be6c01ce588328bfa1adb3a2825bb4