### PR TITLE
feat: add accessible pagination controls

### DIFF
--- a/components/ui/Pagination.tsx
+++ b/components/ui/Pagination.tsx
@@ -28,6 +28,12 @@ export default function Pagination({
       case "ArrowLeft":
         nextIndex = Math.max(currentIndex - 1, 0);
         break;
+      case "Home":
+        nextIndex = 0;
+        break;
+      case "End":
+        nextIndex = btnRefs.current.length - 1;
+        break;
       default:
         return;
     }

--- a/pages/tools/index.tsx
+++ b/pages/tools/index.tsx
@@ -1,19 +1,25 @@
-import { useState, useRef, KeyboardEvent } from 'react';
-import tools from '../../data/kali-tools.json';
-import Pagination from '../../components/ui/Pagination';
+import { useState, useRef, KeyboardEvent, ChangeEvent } from "react";
+import tools from "../../data/kali-tools.json";
+import Pagination from "../../components/ui/Pagination";
 
-const PAGE_SIZE = 30;
+const PAGE_SIZE_OPTIONS = [30, 60, 90];
 const COLUMNS = 3; // used for keyboard navigation
 
 const badgeClass =
-  'inline-block rounded bg-gray-200 px-2 py-1 text-xs font-semibold text-gray-800 dark:bg-gray-700 dark:text-gray-100';
+  "inline-block rounded bg-gray-200 px-2 py-1 text-xs font-semibold text-gray-800 dark:bg-gray-700 dark:text-gray-100";
 
 export default function ToolsPage() {
   const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(PAGE_SIZE_OPTIONS[0]);
   const itemRefs = useRef<Array<HTMLAnchorElement | null>>([]);
 
-  const pageCount = Math.ceil(tools.length / PAGE_SIZE);
-  const pageTools = tools.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+  const pageCount = Math.ceil(tools.length / pageSize);
+  const pageTools = tools.slice(page * pageSize, (page + 1) * pageSize);
+
+  const handlePageSizeChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    setPageSize(Number(e.target.value));
+    setPage(0);
+  };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLUListElement>) => {
     const currentIndex = itemRefs.current.findIndex(
@@ -24,16 +30,16 @@ export default function ToolsPage() {
 
     let nextIndex = currentIndex;
     switch (e.key) {
-      case 'ArrowRight':
+      case "ArrowRight":
         nextIndex = Math.min(currentIndex + 1, pageTools.length - 1);
         break;
-      case 'ArrowLeft':
+      case "ArrowLeft":
         nextIndex = Math.max(currentIndex - 1, 0);
         break;
-      case 'ArrowDown':
+      case "ArrowDown":
         nextIndex = Math.min(currentIndex + COLUMNS, pageTools.length - 1);
         break;
-      case 'ArrowUp':
+      case "ArrowUp":
         nextIndex = Math.max(currentIndex - COLUMNS, 0);
         break;
       default:
@@ -59,7 +65,9 @@ export default function ToolsPage() {
                 itemRefs.current[i] = el;
               }}
             >
-              <h3 className="font-semibold text-base sm:text-lg md:text-xl">{tool.name}</h3>
+              <h3 className="font-semibold text-base sm:text-lg md:text-xl">
+                {tool.name}
+              </h3>
               <div className="mt-2 flex flex-wrap gap-2">
                 <a
                   href={`https://gitlab.com/kalilinux/packages/${tool.id}`}
@@ -83,7 +91,24 @@ export default function ToolsPage() {
           </li>
         ))}
       </ul>
-      <div className="mt-4 flex justify-center">
+      <div className="mt-4 flex flex-col items-center gap-4 sm:flex-row sm:justify-between">
+        <div className="flex items-center gap-2">
+          <label htmlFor="page-size" className="text-sm">
+            Results per page:
+          </label>
+          <select
+            id="page-size"
+            value={pageSize}
+            onChange={handlePageSizeChange}
+            className="rounded border p-2"
+          >
+            {PAGE_SIZE_OPTIONS.map((size) => (
+              <option key={size} value={size}>
+                {size}
+              </option>
+            ))}
+          </select>
+        </div>
         <Pagination
           currentPage={page}
           totalPages={pageCount}
@@ -93,4 +118,3 @@ export default function ToolsPage() {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- allow Home/End key navigation in pagination
- add results-per-page selector on tools listing

## Testing
- `pnpm typecheck`
- `yarn test` *(fails: Missing allowlist entries in CSP tests)*

------
https://chatgpt.com/codex/tasks/task_e_68be6c0340608328a83b6dc81e284391