### PR TITLE
feat(docs): add image and caption styles

### DIFF
--- a/components/mdx/index.tsx
+++ b/components/mdx/index.tsx
@@ -1,0 +1,24 @@
+import type { ComponentPropsWithoutRef } from 'react';
+import Admonition from './Admonition';
+
+function Img(
+  { className = '', border = false, ...props }: ComponentPropsWithoutRef<'img'> & { border?: boolean }
+) {
+  const classes = ['mdx-img', border ? 'mdx-img--border' : '', className]
+    .filter(Boolean)
+    .join(' ');
+  return <img {...props} className={classes} />;
+}
+
+function Figcaption({ className = '', ...props }: ComponentPropsWithoutRef<'figcaption'>) {
+  const classes = ['mdx-caption', className].filter(Boolean).join(' ');
+  return <figcaption {...props} className={classes} />;
+}
+
+export const mdxComponents = {
+  img: Img,
+  figcaption: Figcaption,
+  Admonition,
+};
+
+export default mdxComponents;

--- a/content/mdx.css
+++ b/content/mdx.css
@@ -62,3 +62,21 @@ pre code {
   border-color: #ef4444;
   background: color-mix(in srgb, #ef4444, transparent 85%);
 }
+
+/* Standardized image and caption styling */
+img.mdx-img {
+  display: block;
+  margin: 1.5rem auto;
+}
+
+img.mdx-img--border {
+  border: 1px solid var(--color-border);
+  border-radius: 0.25rem;
+}
+
+.mdx-caption {
+  margin-top: 0.5rem;
+  text-align: center;
+  font-size: 0.875em;
+  color: color-mix(in srgb, var(--color-text), transparent 40%);
+}

--- a/content/sample.mdx
+++ b/content/sample.mdx
@@ -32,3 +32,8 @@ echo "Hello Kali"
 <div className="admonition admonition-danger">
   <p>This is a danger admonition.</p>
 </div>
+
+<figure>
+  <img src="https://via.placeholder.com/300" alt="Placeholder" border />
+  <figcaption>Example image with optional border.</figcaption>
+</figure>


### PR DESCRIPTION
## Summary
- standardize image and caption styling for MDX docs
- support optional image borders via `mdx-img--border`
- expose MDX image and figcaption components

## Testing
- `yarn lint` *(fails: Unable to resolve path to module '../components/ToolbarIcons', etc)*
- `yarn test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68be6c05783083289cda24e8627f276a