### PR TITLE
feat: add footnote component with back links

### DIFF
--- a/__tests__/footnote.test.tsx
+++ b/__tests__/footnote.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { FootnoteProvider, Footnote } from '../components/mdx/Footnote';
+
+describe('Footnote', () => {
+  test('renders anchor and back link', () => {
+    render(
+      <FootnoteProvider>
+        <p>
+          Example<Footnote>Footnote text</Footnote>
+        </p>
+      </FootnoteProvider>
+    );
+
+    const refLink = screen.getByText('1');
+    expect(refLink.closest('a')).toHaveAttribute('href', '#fn1');
+
+    const backLink = screen.getByText(/Back to text/i);
+    expect(backLink).toHaveAttribute('href', '#fnref1');
+  });
+});

--- a/components/mdx/Footnote.tsx
+++ b/components/mdx/Footnote.tsx
@@ -1,0 +1,63 @@
+import { createContext, ReactNode, useContext, useRef, useState } from 'react';
+
+interface FootnoteItem {
+  id: number;
+  content: ReactNode;
+}
+
+interface FootnoteContextValue {
+  register: (content: ReactNode) => number;
+  footnotes: FootnoteItem[];
+}
+
+const FootnoteContext = createContext<FootnoteContextValue | null>(null);
+
+export function FootnoteProvider({ children }: { children: ReactNode }) {
+  const [footnotes, setFootnotes] = useState<FootnoteItem[]>([]);
+
+  const register = (content: ReactNode) => {
+    const id = footnotes.length + 1;
+    setFootnotes((prev) => [...prev, { id, content }]);
+    return id;
+  };
+
+  return (
+    <FootnoteContext.Provider value={{ register, footnotes }}>
+      {children}
+      {footnotes.length > 0 && (
+        <ol className="footnotes mt-8 list-decimal pl-4 text-sm">
+          {footnotes.map(({ id, content }) => (
+            <li key={id} id={`fn${id}`}>
+              {content}{' '}
+              <a href={`#fnref${id}`} className="ml-2 text-blue-600 hover:underline">
+                Back to text
+              </a>
+            </li>
+          ))}
+        </ol>
+      )}
+    </FootnoteContext.Provider>
+  );
+}
+
+export function Footnote({ children }: { children: ReactNode }) {
+  const context = useContext(FootnoteContext);
+  if (!context) {
+    throw new Error('Footnote must be used within FootnoteProvider');
+  }
+
+  const idRef = useRef<number>();
+  if (!idRef.current) {
+    idRef.current = context.register(children);
+  }
+  const id = idRef.current;
+
+  return (
+    <sup id={`fnref${id}`} className="ml-1">
+      <a href={`#fn${id}`} className="text-blue-600 hover:underline">
+        {id}
+      </a>
+    </sup>
+  );
+}
+

--- a/content/mdx.css
+++ b/content/mdx.css
@@ -62,3 +62,17 @@ pre code {
   border-color: #ef4444;
   background: color-mix(in srgb, #ef4444, transparent 85%);
 }
+
+.footnotes {
+  margin-top: 2rem;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  border-top: 1px solid var(--color-border);
+  padding-top: 1rem;
+}
+
+.footnotes li {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+

--- a/content/sample.mdx
+++ b/content/sample.mdx
@@ -1,8 +1,10 @@
 import './mdx.css';
+import { FootnoteProvider, Footnote } from '../components/mdx/Footnote';
 
 export const title = 'MDX Sample';
-export const summary = 'Demonstrates list, code, and admonition styling.';
+export const summary = 'Demonstrates list, code, admonition, and footnote styling.';
 
+<FootnoteProvider>
 # MDX Sample
 
 Here is a list:
@@ -32,3 +34,6 @@ echo "Hello Kali"
 <div className="admonition admonition-danger">
   <p>This is a danger admonition.</p>
 </div>
+
+Here is some text with a footnote<Footnote>Example footnote content.</Footnote>.
+</FootnoteProvider>

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -24,4 +24,13 @@ Example:
 </section>
 ```
 
-These tokens ensure that layouts snap to the 8px grid at all breakpoints.
+These tokens ensure that layouts snap to the 8px grid at all breakpoints.<sup id="fnref1"><a href="#fn1">1</a></sup>
+
+## Footnotes
+
+<ol>
+  <li id="fn1">
+    Using consistent spacing simplifies responsive design.
+    <a href="#fnref1">Back to text</a>
+  </li>
+</ol>


### PR DESCRIPTION
## Summary
- add `FootnoteProvider` and `Footnote` components with automatic numbering and back-to-text anchors
- style footnote lists and demonstrate usage in sample MDX and docs
- cover new component with unit test

## Testing
- `yarn eslint components/mdx/Footnote.tsx __tests__/footnote.test.tsx content/sample.mdx docs/design-guidelines.md`
- `yarn test __tests__/footnote.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be6c06f2e08328a0bedcd0e668481a