### PR TITLE
feat: add inline callout component

### DIFF
--- a/components/mdx/InlineAdmonition.tsx
+++ b/components/mdx/InlineAdmonition.tsx
@@ -1,0 +1,77 @@
+import { ReactNode } from "react";
+
+type AdmonitionType = "info" | "note" | "warning";
+
+interface Props {
+  type?: AdmonitionType;
+  children: ReactNode;
+}
+
+const ICONS: Record<AdmonitionType, JSX.Element> = {
+  info: (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      className="h-4 w-4"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 16v-4m0-4h.01"
+      />
+    </svg>
+  ),
+  note: (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      className="h-4 w-4"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 20h9M12 4h9M4 9h16M4 15h16"
+      />
+    </svg>
+  ),
+  warning: (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      className="h-4 w-4"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 9v4m0 4h.01M10.29 3.86l-7.8 13.5A1 1 0 003.39 19h17.22a1 1 0 00.86-1.64l-7.8-13.5a1 1 0 00-1.72 0z"
+      />
+    </svg>
+  ),
+};
+
+const STYLES: Record<AdmonitionType, string> = {
+  info: "border-blue-500 bg-blue-500/10 text-blue-700",
+  note: "border-emerald-500 bg-emerald-500/10 text-emerald-700",
+  warning: "border-amber-500 bg-amber-500/10 text-amber-700",
+};
+
+export default function InlineAdmonition({ type = "info", children }: Props) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded border px-2 py-0.5 text-sm ${STYLES[type]}`}
+    >
+      {ICONS[type]}
+      <span>{children}</span>
+    </span>
+  );
+}

--- a/content/mdx.css
+++ b/content/mdx.css
@@ -62,3 +62,35 @@ pre code {
   border-color: #ef4444;
   background: color-mix(in srgb, #ef4444, transparent 85%);
 }
+
+/* Inline admonitions */
+.inline-admonition {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  border: 1px solid;
+  font-size: 0.875em;
+  line-height: 1.4;
+}
+
+.inline-admonition svg {
+  width: 1em;
+  height: 1em;
+}
+
+.inline-admonition-info {
+  border-color: var(--color-info);
+  background: color-mix(in srgb, var(--color-info), transparent 85%);
+}
+
+.inline-admonition-note {
+  border-color: var(--color-success);
+  background: color-mix(in srgb, var(--color-success), transparent 85%);
+}
+
+.inline-admonition-warning {
+  border-color: #f59e0b;
+  background: color-mix(in srgb, #f59e0b, transparent 85%);
+}

--- a/content/sample.mdx
+++ b/content/sample.mdx
@@ -1,7 +1,8 @@
-import './mdx.css';
+import "./mdx.css";
+import InlineAdmonition from "../components/mdx/InlineAdmonition";
 
-export const title = 'MDX Sample';
-export const summary = 'Demonstrates list, code, and admonition styling.';
+export const title = "MDX Sample";
+export const summary = "Demonstrates list, code, and admonition styling.";
 
 # MDX Sample
 
@@ -20,6 +21,8 @@ Inline `code` example.
 ```bash
 echo "Hello Kali"
 ```
+
+This sentence includes an inline callout <InlineAdmonition type="note">Remember this</InlineAdmonition> right in the flow of text.
 
 <div className="admonition admonition-note">
   <p>This is a note admonition.</p>

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -4,17 +4,17 @@
 
 Use the `space-*` scale to maintain an 8px rhythm across breakpoints. The tokens are available in Tailwind as margin, padding, gap and positional utilities (`p-space-2`, `mt-space-1`, etc.).
 
-| Token | Value |
-|-------|-------|
-| `space-0` | 0px |
-| `space-1` | 8px |
-| `space-2` | 16px |
-| `space-3` | 24px |
-| `space-4` | 32px |
-| `space-5` | 40px |
-| `space-6` | 48px |
-| `space-7` | 56px |
-| `space-8` | 64px |
+| Token     | Value |
+| --------- | ----- |
+| `space-0` | 0px   |
+| `space-1` | 8px   |
+| `space-2` | 16px  |
+| `space-3` | 24px  |
+| `space-4` | 32px  |
+| `space-5` | 40px  |
+| `space-6` | 48px  |
+| `space-7` | 56px  |
+| `space-8` | 64px  |
 
 Example:
 
@@ -25,3 +25,8 @@ Example:
 ```
 
 These tokens ensure that layouts snap to the 8px grid at all breakpoints.
+
+## Callouts
+
+Use **inline** callouts for quick reminders that fit within a sentence without breaking the reader's flow.
+Reach for **full-width** callouts when the message spans multiple sentences or needs extra emphasis on its own line.


### PR DESCRIPTION
## Summary
- create `InlineAdmonition` component for inline callouts
- style inline admonitions and document when to use them
- show usage in `content/sample.mdx`

## Testing
- `npx eslint components/mdx/InlineAdmonition.tsx`
- `yarn test components/mdx/InlineAdmonition.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be6c0943348328a65a8fd86802fb0a