### PR TITLE
feat: add line number toggle to code block

### DIFF
--- a/components/ui/CodeBlock.tsx
+++ b/components/ui/CodeBlock.tsx
@@ -12,24 +12,72 @@ export default function CodeBlock({
 }: CodeBlockProps) {
   const ref = React.useRef<HTMLPreElement>(null);
 
+  const code = React.useMemo(
+    () => React.Children.toArray(children).join("") as string,
+    [children]
+  );
+
+  const [showLineNumbers, setShowLineNumbers] = React.useState(false);
+
+  React.useEffect(() => {
+    if (typeof window !== "undefined") {
+      const stored = window.localStorage.getItem("codeblock-line-numbers");
+      if (stored) setShowLineNumbers(stored === "true");
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(
+        "codeblock-line-numbers",
+        showLineNumbers.toString()
+      );
+    }
+  }, [showLineNumbers]);
+
+  const lines = React.useMemo(() => code.split("\n"), [code]);
+
   const copy = () => {
-    const text = ref.current?.innerText || "";
-    if (text) copyToClipboard(text);
+    if (code) copyToClipboard(code);
   };
 
   return (
     <div className="relative group">
       <pre ref={ref} className={className} {...props}>
-        <code>{children}</code>
+        <code>
+          {showLineNumbers
+            ? lines.map((line, i) => (
+                <span key={i} className="block">
+                  <span className="select-none opacity-50 mr-4 w-8 inline-block text-right">
+                    {i + 1}
+                  </span>
+                  {line}
+                </span>
+              ))
+            : code}
+        </code>
       </pre>
-      <button
-        type="button"
-        aria-label="Copy code"
-        onClick={copy}
-        className="absolute top-2 right-2 rounded bg-[var(--color-muted)] text-[var(--color-text)] px-1.5 py-1 text-xs opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-[var(--color-accent)] hover:text-[var(--color-inverse)] focus-visible:opacity-100 focus-visible:bg-[var(--color-accent)] focus-visible:text-[var(--color-inverse)]"
-      >
-        📋
-      </button>
+      <div className="absolute top-2 right-2 flex gap-2">
+        <button
+          type="button"
+          aria-label={
+            showLineNumbers ? "Hide line numbers" : "Show line numbers"
+          }
+          aria-pressed={showLineNumbers}
+          onClick={() => setShowLineNumbers((v) => !v)}
+          className="rounded bg-[var(--color-muted)] text-[var(--color-text)] px-1.5 py-1 text-xs opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-[var(--color-accent)] hover:text-[var(--color-inverse)] focus-visible:opacity-100 focus-visible:bg-[var(--color-accent)] focus-visible:text-[var(--color-inverse)]"
+        >
+          🔢
+        </button>
+        <button
+          type="button"
+          aria-label="Copy code"
+          onClick={copy}
+          className="rounded bg-[var(--color-muted)] text-[var(--color-text)] px-1.5 py-1 text-xs opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-[var(--color-accent)] hover:text-[var(--color-inverse)] focus-visible:opacity-100 focus-visible:bg-[var(--color-accent)] focus-visible:text-[var(--color-inverse)]"
+        >
+          📋
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow toggling of line numbers in code blocks with session persistence
- copy action now copies raw code without line numbers

## Testing
- `yarn exec eslint components/ui/CodeBlock.tsx`
- `yarn test components/ui/CodeBlock.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be6c09cb148328b1a6275b1af1b88e