### PR TITLE
feat: add window shake effect with reduced motion option

### DIFF
--- a/__tests__/window-shake.test.tsx
+++ b/__tests__/window-shake.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import Window from '../components/desktop/Window';
+
+describe('window shake effect', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    (window as any).PointerEvent = window.PointerEvent || window.MouseEvent;
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        matches: false,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('dims other windows when shaken', () => {
+    render(
+      <>
+        <Window title="One">
+          <div>content</div>
+        </Window>
+        <Window title="Two">
+          <div>content</div>
+        </Window>
+      </>
+    );
+
+    const header = screen.getByText('One').parentElement!;
+    fireEvent.pointerDown(header, { clientX: 100, clientY: 0 });
+    act(() => {
+      window.dispatchEvent(new PointerEvent('pointermove', { clientX: 150 }));
+      window.dispatchEvent(new PointerEvent('pointermove', { clientX: 100 }));
+      window.dispatchEvent(new PointerEvent('pointermove', { clientX: 150 }));
+      window.dispatchEvent(new PointerEvent('pointermove', { clientX: 100 }));
+    });
+
+    const other = screen.getByText('Two').parentElement!.parentElement!;
+    expect(other.classList.contains('window-dimmed')).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+
+    expect(other.classList.contains('window-dimmed')).toBe(false);
+  });
+});

--- a/styles/index.css
+++ b/styles/index.css
@@ -193,6 +193,22 @@ select:focus-visible,
     border-block-end: 5px solid var(--color-muted);
 }
 
+@keyframes window-shake {
+    0% { transform: translateX(0); }
+    25% { transform: translateX(-5px); }
+    50% { transform: translateX(5px); }
+    75% { transform: translateX(-5px); }
+    100% { transform: translateX(0); }
+}
+
+.window-shake {
+    animation: window-shake 0.5s;
+}
+
+.window-dimmed {
+    filter: blur(2px) brightness(0.7);
+}
+
 
 .animateShow {
     animation: transformDownShow 200ms 1 forwards;


### PR DESCRIPTION
## Summary
- add rapid-movement detection to focused windows to trigger shake
- dim other windows during shake
- skip the effect when reduced motion is enabled and add tests

## Testing
- `yarn eslint components/desktop/Window.tsx __tests__/window-shake.test.tsx styles/index.css`
- `yarn test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `yarn test __tests__/window-shake.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be6c0cd22083289beda1897a697487