### PR TITLE
feat(desktop): add hot corner hint and overview animation

### DIFF
--- a/src/components/desktop/Desktop.tsx
+++ b/src/components/desktop/Desktop.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import DesktopContextMenu from './DesktopContextMenu';
 import Dock from './Dock';
 import Panel from '../panel/Panel';
+import HotCorner from './HotCorner';
 
 export interface DesktopIcon {
   id: string;
@@ -77,6 +78,7 @@ export const Desktop: React.FC = () => {
         </div>
       ))}
       <Dock />
+      <HotCorner />
       <DesktopContextMenu
         position={menuPos}
         onClose={closeMenu}

--- a/src/components/desktop/HotCorner.tsx
+++ b/src/components/desktop/HotCorner.tsx
@@ -1,0 +1,52 @@
+import React, { useCallback, useState } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
+
+const HINT_KEY = 'hot-corner-hint';
+
+/**
+ * HotCorner component renders an interactive area in the top-left corner of the screen.
+ * Displays a subtle indicator on first use and triggers an overview overlay when activated.
+ * Respects reduced-motion preferences and allows users to disable hints.
+ */
+const HotCorner: React.FC = () => {
+  const [showHint, setShowHint] = usePersistentState<boolean>(HINT_KEY, true, (v): v is boolean => typeof v === 'boolean');
+  const [active, setActive] = useState(false);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  const activate = useCallback(() => {
+    setActive(true);
+    if (showHint) setShowHint(false);
+  }, [showHint, setShowHint]);
+
+  const deactivate = useCallback(() => setActive(false), []);
+
+  return (
+    <>
+      <div
+        className="absolute top-0 left-0 w-4 h-4 z-50"
+        onMouseEnter={activate}
+        onFocus={activate}
+        onMouseLeave={deactivate}
+        onBlur={deactivate}
+        tabIndex={0}
+      >
+        {showHint && (
+          <button
+            type="button"
+            className={`w-full h-full rounded-full bg-[var(--color-accent)] opacity-75 ${prefersReducedMotion ? '' : 'animate-pulse'}`}
+            onClick={() => setShowHint(false)}
+            aria-label="Dismiss hot corner hint"
+          />
+        )}
+      </div>
+      <div
+        className={`pointer-events-none absolute inset-0 bg-black/50 ${prefersReducedMotion ? '' : 'transition-opacity duration-300'} ${active ? 'opacity-100' : 'opacity-0'}`}
+        aria-hidden="true"
+      />
+    </>
+  );
+};
+
+export default HotCorner;
+


### PR DESCRIPTION
## Summary
- add hot corner overlay with dismissible hint respecting reduced motion
- wire hot corner into desktop

## Testing
- `yarn test` *(fails: missing allowlist entries, terminal errors, a11y browser missing, failing formula validation)*

------
https://chatgpt.com/codex/tasks/task_e_68be6c0c32548328baddf56fcaae7220