### PR TITLE
feat(window): add snap overlay guides and tiling layouts

### DIFF
--- a/__tests__/window.new.test.tsx
+++ b/__tests__/window.new.test.tsx
@@ -9,7 +9,6 @@ jest.mock('react-draggable', () => ({
 
 describe('Window snap interactions', () => {
   it('shows snap preview near left edge and snaps on stop', () => {
-    jest.useFakeTimers();
     const ref = React.createRef<any>();
     render(
       <Window ref={ref}>
@@ -33,7 +32,6 @@ describe('Window snap interactions', () => {
 
     act(() => {
       ref.current.handleDrag();
-      jest.runAllTimers();
     });
     expect(screen.getByTestId('snap-preview')).toBeInTheDocument();
 
@@ -42,7 +40,40 @@ describe('Window snap interactions', () => {
     });
     expect(winEl.style.width).toBe('50%');
     expect(winEl.style.height).toBe('100%');
-    jest.useRealTimers();
+  });
+
+  it('snaps to center third when dragged to middle', () => {
+    const ref = React.createRef<any>();
+    render(
+      <Window ref={ref}>
+        <div>content</div>
+      </Window>
+    );
+
+    const winEl = screen.getByText('content').parentElement as HTMLElement;
+    const third = window.innerWidth / 3;
+    winEl.getBoundingClientRect = () => ({
+      left: third + 10,
+      top: 100,
+      right: third + 110,
+      bottom: 200,
+      width: 100,
+      height: 100,
+      x: third + 10,
+      y: 100,
+      toJSON: () => {},
+    } as any);
+
+    act(() => {
+      ref.current.handleDrag();
+    });
+
+    act(() => {
+      ref.current.handleStop();
+    });
+
+    expect(winEl.style.width).toBe('33.33%');
+    expect(winEl.style.height).toBe('100%');
   });
 
   it('snaps right with Alt+ArrowRight', () => {

--- a/components/window/Window.tsx
+++ b/components/window/Window.tsx
@@ -17,7 +17,20 @@ interface SnapPreview {
   height: string;
 }
 
-type SnapPosition = "left" | "right" | "max" | null;
+type SnapPosition =
+  | "left"
+  | "right"
+  | "top"
+  | "bottom"
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right"
+  | "left-third"
+  | "center-third"
+  | "right-third"
+  | "max"
+  | null;
 
 const EDGE_THRESHOLD = 30;
 
@@ -29,31 +42,57 @@ const Window = forwardRef<{ handleDrag: () => void; handleStop: () => void; hand
     const [snapped, setSnapped] = useState<SnapPosition>(null);
     const [width, setWidth] = useState(60);
     const [height, setHeight] = useState(85);
+    const [dragging, setDragging] = useState(false);
 
     const checkSnapPreview: DraggableEventHandler = () => {
       const node = nodeRef.current;
       if (!node) return;
       const rect = node.getBoundingClientRect();
+      const midX = rect.left + rect.width / 2;
+      const thirdW = window.innerWidth / 3;
 
-      if (rect.left <= EDGE_THRESHOLD) {
+      if (rect.left <= EDGE_THRESHOLD && rect.top <= EDGE_THRESHOLD) {
+        setSnapPreview({ left: "0", top: "0", width: "50%", height: "50%" });
+        setSnapPosition("top-left");
+      } else if (rect.right >= window.innerWidth - EDGE_THRESHOLD && rect.top <= EDGE_THRESHOLD) {
+        setSnapPreview({ left: "50%", top: "0", width: "50%", height: "50%" });
+        setSnapPosition("top-right");
+      } else if (rect.left <= EDGE_THRESHOLD && rect.bottom >= window.innerHeight - EDGE_THRESHOLD) {
+        setSnapPreview({ left: "0", top: "50%", width: "50%", height: "50%" });
+        setSnapPosition("bottom-left");
+      } else if (rect.right >= window.innerWidth - EDGE_THRESHOLD && rect.bottom >= window.innerHeight - EDGE_THRESHOLD) {
+        setSnapPreview({ left: "50%", top: "50%", width: "50%", height: "50%" });
+        setSnapPosition("bottom-right");
+      } else if (rect.top <= EDGE_THRESHOLD) {
+        setSnapPreview({ left: "0", top: "0", width: "100%", height: "50%" });
+        setSnapPosition("top");
+      } else if (rect.bottom >= window.innerHeight - EDGE_THRESHOLD) {
+        setSnapPreview({ left: "0", top: "50%", width: "100%", height: "50%" });
+        setSnapPosition("bottom");
+      } else if (rect.left <= EDGE_THRESHOLD) {
         setSnapPreview({ left: "0", top: "0", width: "50%", height: "100%" });
         setSnapPosition("left");
       } else if (rect.right >= window.innerWidth - EDGE_THRESHOLD) {
         setSnapPreview({ left: "50%", top: "0", width: "50%", height: "100%" });
         setSnapPosition("right");
-      } else if (rect.top <= EDGE_THRESHOLD) {
-        setSnapPreview({ left: "0", top: "0", width: "100%", height: "100%" });
-        setSnapPosition("max");
+      } else if (midX < thirdW) {
+        setSnapPreview({ left: "0", top: "0", width: "33.33%", height: "100%" });
+        setSnapPosition("left-third");
+      } else if (midX >= thirdW && midX < 2 * thirdW) {
+        setSnapPreview({ left: "33.33%", top: "0", width: "33.33%", height: "100%" });
+        setSnapPosition("center-third");
+      } else if (midX >= 2 * thirdW) {
+        setSnapPreview({ left: "66.66%", top: "0", width: "33.33%", height: "100%" });
+        setSnapPosition("right-third");
       } else if (snapPreview) {
         setSnapPreview(null);
         setSnapPosition(null);
       }
     };
 
-    const dragTimeout = useRef<number>();
     const handleDrag: DraggableEventHandler = (...args) => {
-      if (dragTimeout.current) window.clearTimeout(dragTimeout.current);
-      dragTimeout.current = window.setTimeout(() => checkSnapPreview(...args), 50);
+      setDragging(true);
+      checkSnapPreview(...args);
     };
 
     const snapWindow = (pos: SnapPosition) => {
@@ -67,6 +106,42 @@ const Window = forwardRef<{ handleDrag: () => void; handleStop: () => void; hand
         node.style.transform = `translate(${window.innerWidth / 2}px, 0px)`;
         setWidth(50);
         setHeight(100);
+      } else if (pos === "top") {
+        node.style.transform = `translate(0px, 0px)`;
+        setWidth(100);
+        setHeight(50);
+      } else if (pos === "bottom") {
+        node.style.transform = `translate(0px, ${window.innerHeight / 2}px)`;
+        setWidth(100);
+        setHeight(50);
+      } else if (pos === "top-left") {
+        node.style.transform = `translate(0px, 0px)`;
+        setWidth(50);
+        setHeight(50);
+      } else if (pos === "top-right") {
+        node.style.transform = `translate(${window.innerWidth / 2}px, 0px)`;
+        setWidth(50);
+        setHeight(50);
+      } else if (pos === "bottom-left") {
+        node.style.transform = `translate(0px, ${window.innerHeight / 2}px)`;
+        setWidth(50);
+        setHeight(50);
+      } else if (pos === "bottom-right") {
+        node.style.transform = `translate(${window.innerWidth / 2}px, ${window.innerHeight / 2}px)`;
+        setWidth(50);
+        setHeight(50);
+      } else if (pos === "left-third") {
+        node.style.transform = `translate(0px, 0px)`;
+        setWidth(33.33);
+        setHeight(100);
+      } else if (pos === "center-third") {
+        node.style.transform = `translate(${window.innerWidth / 3}px, 0px)`;
+        setWidth(33.33);
+        setHeight(100);
+      } else if (pos === "right-third") {
+        node.style.transform = `translate(${(2 * window.innerWidth) / 3}px, 0px)`;
+        setWidth(33.33);
+        setHeight(100);
       } else if (pos === "max") {
         node.style.transform = `translate(0px, 0px)`;
         setWidth(100);
@@ -79,6 +154,7 @@ const Window = forwardRef<{ handleDrag: () => void; handleStop: () => void; hand
       snapWindow(snapPosition);
       setSnapPreview(null);
       setSnapPosition(null);
+      setDragging(false);
     };
 
     const handleKeyDown = (e: any) => {
@@ -105,8 +181,30 @@ const Window = forwardRef<{ handleDrag: () => void; handleStop: () => void; hand
 
     useImperativeHandle(ref, () => ({ handleDrag, handleStop, handleKeyDown }));
 
+    const guides: SnapPreview[] = [
+      { left: "0", top: "0", width: "50%", height: "100%" },
+      { left: "50%", top: "0", width: "50%", height: "100%" },
+      { left: "0", top: "0", width: "100%", height: "50%" },
+      { left: "0", top: "50%", width: "100%", height: "50%" },
+      { left: "0", top: "0", width: "50%", height: "50%" },
+      { left: "50%", top: "0", width: "50%", height: "50%" },
+      { left: "0", top: "50%", width: "50%", height: "50%" },
+      { left: "50%", top: "50%", width: "50%", height: "50%" },
+      { left: "0", top: "0", width: "33.33%", height: "100%" },
+      { left: "33.33%", top: "0", width: "33.33%", height: "100%" },
+      { left: "66.66%", top: "0", width: "33.33%", height: "100%" },
+    ];
+
     return (
       <>
+        {dragging &&
+          guides.map((g, i) => (
+            <div
+              key={i}
+              className="fixed z-40 pointer-events-none border border-dashed border-white/20 bg-white/5"
+              style={g}
+            />
+          ))}
         {snapPreview && (
           <div
             data-testid="snap-preview"
@@ -114,7 +212,7 @@ const Window = forwardRef<{ handleDrag: () => void; handleStop: () => void; hand
             style={snapPreview}
           />
         )}
-        <Draggable onDrag={handleDrag} onStop={handleStop} nodeRef={nodeRef}>
+        <Draggable onStart={() => setDragging(true)} onDrag={handleDrag} onStop={handleStop} nodeRef={nodeRef}>
           <div
             ref={nodeRef}
             tabIndex={0}


### PR DESCRIPTION
## Summary
- show visual snap guides during window drag
- support half, quarter, and third tiling layouts with snap overlays
- smooth snap previews without drag jitter

## Testing
- `npx jest __tests__/window.new.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be6c0e1be08328919317564303fffa