### PR TITLE
feat: organize notification center

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -194,6 +194,20 @@ html[data-theme='matrix'] {
 .notification-tabs button.active {
   font-weight: bold;
 }
+.notification-group header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.notification-actions {
+  display: flex;
+  gap: 0.25rem;
+}
+.timestamp-separator {
+  font-size: 0.75rem;
+  opacity: 0.7;
+  margin-top: 0.5rem;
+}
 .notification-group ul {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary
- split notifications into System and Apps categories
- add timestamp separators and collapsible, clearable groups
- keep notification center keyboard navigable

## Testing
- `yarn test` *(fails: Missing allowlist entries; TypeError in terminal worker)*
- `yarn typecheck` *(fails: numerous TypeScript errors in workers)*

------
https://chatgpt.com/codex/tasks/task_e_68be6c0f273c8328b18648c2b5153b09