### PR TITLE
feat: add release notes modal

### DIFF
--- a/components/ReleaseNotesModal.tsx
+++ b/components/ReleaseNotesModal.tsx
@@ -1,0 +1,67 @@
+import React, { useMemo } from 'react';
+import Image from 'next/image';
+import Modal from '@/components/base/Modal';
+import posts from '@/data/kali-blog.json';
+
+interface ReleaseNotesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function ReleaseNotesModal({ isOpen, onClose }: ReleaseNotesModalProps) {
+  const latest = useMemo(() => {
+    return posts
+      .filter(p => p.title.includes('Release'))
+      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())[0];
+  }, []);
+
+  if (!latest) return null;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+    >
+      <div className="window-shadow bg-ub-cool-grey rounded-md w-96 border border-black">
+        <div className="flex items-center bg-ub-window-title text-white h-11 rounded-t-md">
+          <div className="flex-1 text-center font-bold">Release Notes</div>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="m-1 bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 active:bg-opacity-80 rounded-full flex justify-center items-center h-6 w-6 focus-visible:outline focus-visible:outline-2 focus-visible:outline-white focus-visible:outline-offset-2 transition-colors"
+          >
+            <Image
+              src="/themes/Yaru/window/window-close-symbolic.svg"
+              alt="Close"
+              width={16}
+              height={16}
+              className="h-4 w-4"
+            />
+          </button>
+        </div>
+        <div className="p-4 text-sm">
+          <p className="mb-4">{latest.title}</p>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300"
+            >
+              Dismiss
+            </button>
+            <a
+              href={latest.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+            >
+              Read More
+            </a>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,8 +1,10 @@
 import Image from "next/image";
 import { decode } from "blurhash";
 import { PNG } from "pngjs";
+import { useEffect, useState } from "react";
 import desktopsData from "../content/desktops.json";
 import { baseMetadata } from "../lib/metadata";
+import ReleaseNotesModal from "../components/ReleaseNotesModal";
 
 export const metadata = baseMetadata;
 
@@ -26,6 +28,12 @@ export async function getStaticProps() {
  * @returns {JSX.Element}
  */
 export default function Home({ desktops }) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    setOpen(true);
+  }, []);
+
   return (
     <main className="p-4">
       <h1 className="mb-4 text-2xl font-bold sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl 2xl:text-7xl">Choose the desktop you prefer</h1>
@@ -45,6 +53,7 @@ export default function Home({ desktops }) {
           </div>
         ))}
       </div>
+      <ReleaseNotesModal isOpen={open} onClose={() => setOpen(false)} />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add window-styled release notes modal with dismiss and read more actions
- show release notes modal on homepage

## Testing
- `npx eslint -c eslint.config.mjs pages/index.jsx components/ReleaseNotesModal.tsx` (warnings: files ignored)
- `yarn lint pages/index.jsx components/ReleaseNotesModal.tsx` (fails: existing lint errors)
- `yarn test components/ReleaseNotesModal.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be6c0f94748328a798ee8578c8f858