### PR TITLE
feat(types): strengthen type safety

### DIFF
--- a/components/games/VirtualControls.tsx
+++ b/components/games/VirtualControls.tsx
@@ -3,12 +3,17 @@
 import React from 'react';
 import useGameInput from '../../hooks/useGameInput';
 
+interface VirtualControlsProps {
+  children?: React.ReactNode;
+  game?: string;
+}
+
 /**
  * Renders a container for virtual on-screen controls. By default it does not
  * render any controls but exposes a slot for custom controls. It registers the
  * game input hook so keyboard users can still interact without touch/gamepad.
  */
-export default function VirtualControls({ children, game }) {
+export default function VirtualControls({ children, game }: VirtualControlsProps) {
   useGameInput({ game });
   return <div className="virtual-controls">{children}</div>;
 }

--- a/docs/ts-strict-migration.md
+++ b/docs/ts-strict-migration.md
@@ -1,0 +1,13 @@
+# TypeScript strict mode migration
+
+The project now opts into stronger type safety via `strict`,
+`noUncheckedIndexedAccess`, and `noImplicitOverride` in `tsconfig.json`.
+Key components such as `VirtualControls` are migrated to TypeScript, and
+window manager state updates use a discriminated union of actions.
+
+These changes surface previously unchecked scenarios like accessing missing
+array entries or overriding methods unintentionally. Most issues were resolved
+by adding explicit types or guards.
+
+A new `persistentStorage` utility provides validated localStorage access to
+avoid corrupt data.

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -14,6 +14,27 @@ export interface DesktopSession {
   dock: string[];
 }
 
+export type WindowAction =
+  | { type: 'add'; window: SessionWindow }
+  | { type: 'remove'; id: string }
+  | { type: 'update'; id: string; updates: Partial<SessionWindow> };
+
+export function applyWindowAction(
+  windows: SessionWindow[],
+  action: WindowAction,
+): SessionWindow[] {
+  switch (action.type) {
+    case 'add':
+      return [...windows, action.window];
+    case 'remove':
+      return windows.filter((w) => w.id !== action.id);
+    case 'update':
+      return windows.map((w) =>
+        w.id === action.id ? { ...w, ...action.updates } : w,
+      );
+  }
+}
+
 const initialSession: DesktopSession = {
   windows: [],
   wallpaper: defaults.wallpaper,
@@ -53,5 +74,11 @@ export default function useSession() {
     clear();
   };
 
-  return { session, setSession, resetSession };
+  const dispatch = (action: WindowAction) =>
+    setSession((s) => ({
+      ...s,
+      windows: applyWindowAction(s.windows, action),
+    }));
+
+  return { session, setSession, resetSession, dispatch };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "strictNullChecks": true,
     "noImplicitAny": true,
     "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
     "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,

--- a/utils/gamepad.ts
+++ b/utils/gamepad.ts
@@ -72,7 +72,9 @@ export type GamepadEventMap = {
 type Listener<T> = (event: T) => void;
 
 class GamepadManager {
-  private listeners: Record<keyof GamepadEventMap, Set<Listener<any>>> = {
+  private listeners: {
+    [K in keyof GamepadEventMap]: Set<Listener<GamepadEventMap[K]>>;
+  } = {
     connected: new Set(),
     disconnected: new Set(),
     button: new Set(),

--- a/utils/persistentStorage.ts
+++ b/utils/persistentStorage.ts
@@ -1,0 +1,37 @@
+import { safeLocalStorage } from './safeStorage';
+
+export function getPersistent<T>(
+  key: string,
+  fallback: T,
+  validator: (value: unknown) => value is T,
+): T {
+  if (!safeLocalStorage) return fallback;
+  try {
+    const raw = safeLocalStorage.getItem(key);
+    if (raw !== null) {
+      const parsed = JSON.parse(raw);
+      if (validator(parsed)) return parsed;
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return fallback;
+}
+
+export function setPersistent<T>(key: string, value: T): void {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // ignore write errors
+  }
+}
+
+export function removePersistent(key: string): void {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.removeItem(key);
+  } catch {
+    // ignore remove errors
+  }
+}


### PR DESCRIPTION
## Summary
- enforce noImplicitOverride in TypeScript config
- migrate VirtualControls to TS with typed props
- add typed window manager actions and persistent storage helper

## Testing
- `yarn typecheck` *(fails: Type 'undefined' cannot be used as an index type)*
- `yarn test __tests__/gamepad.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68be6c6c342c83288c8d606ff3d883c4