### PR TITLE
test: add window manager and game regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,22 @@ jobs:
           path: test-results/**/*.zip
           if-no-files-found: ignore
 
+  smoke:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: npx playwright install --with-deps
+      - run: |
+          yarn dev &
+          npx wait-on http://localhost:3000
+      - run: yarn smoke
+
   pa11y:
     runs-on: ubuntu-latest
     needs: install
@@ -143,6 +159,7 @@ validate-apps:
       - typecheck
       - test
       - e2e
+      - smoke
       - security
       - verify
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+## Running locally
+1. Install dependencies:
+   ```bash
+   yarn install
+   ```
+2. Start the development server:
+   ```bash
+   yarn dev
+   ```
+
+## Tests
+- **Unit tests**:
+  ```bash
+  yarn test
+  ```
+- **E2E tests**:
+  ```bash
+  yarn dev &
+  npx wait-on http://localhost:3000
+  npx playwright test tests/e2e
+  ```
+- **Smoke tests**:
+  ```bash
+  yarn dev &
+  npx wait-on http://localhost:3000
+  yarn smoke
+  ```
+
+## CI
+GitHub Actions runs linting, type checks, unit tests, Playwright E2E tests, and the smoke test (`yarn smoke`).

--- a/__tests__/game2048WinCondition.property.test.ts
+++ b/__tests__/game2048WinCondition.property.test.ts
@@ -1,0 +1,40 @@
+import { addRandomTile, Board } from '../apps/games/_2048/logic';
+import { random, reset } from '../apps/games/rng';
+
+const hasWon = (board: Board): boolean =>
+  board.some((row) => row.some((val) => val >= 2048));
+
+const randomBoard = (seed: string): Board => {
+  reset(seed);
+  const board: Board = Array.from({ length: 4 }, () => Array(4).fill(0));
+  for (let r = 0; r < 4; r++) {
+    for (let c = 0; c < 4; c++) {
+      const idx = Math.floor(random() * 12); // 0 -> empty, 1..11 -> powers of two
+      board[r][c] = idx === 0 ? 0 : 2 ** idx;
+    }
+  }
+  return board;
+};
+
+describe('2048 win condition', () => {
+  test('seeding RNG yields deterministic tile placement', () => {
+    for (let seed = 0; seed < 5; seed++) {
+      reset(seed.toString());
+      const a = addRandomTile(
+        Array.from({ length: 4 }, () => Array(4).fill(0)),
+      );
+      reset(seed.toString());
+      const b = addRandomTile(
+        Array.from({ length: 4 }, () => Array(4).fill(0)),
+      );
+      expect(a).toEqual(b);
+    }
+  });
+
+  test('hasWon matches presence of 2048 tile', () => {
+    for (let seed = 0; seed < 20; seed++) {
+      const board = randomBoard(seed.toString());
+      expect(hasWon(board)).toBe(board.flat().some((v) => v >= 2048));
+    }
+  });
+});

--- a/__tests__/sudokuWinCondition.property.test.ts
+++ b/__tests__/sudokuWinCondition.property.test.ts
@@ -1,0 +1,30 @@
+import { generateSudoku, isValid } from '../apps/games/sudoku';
+
+const isSolved = (board: number[][]): boolean =>
+  board.every((row, r) =>
+    row.every((val, c) => {
+      if (val === 0) return false;
+      board[r][c] = 0;
+      const ok = isValid(board, r, c, val);
+      board[r][c] = val;
+      return ok;
+    }),
+  );
+
+describe('sudoku win condition', () => {
+  test('solutions generated from seeds are valid', () => {
+    for (let seed = 0; seed < 5; seed++) {
+      const { solution } = generateSudoku('easy', seed);
+      expect(isSolved(solution)).toBe(true);
+    }
+  });
+
+  test('altered solution is detected as invalid', () => {
+    for (let seed = 0; seed < 5; seed++) {
+      const { solution } = generateSudoku('easy', seed);
+      const bad = solution.map((row) => row.slice());
+      bad[0][0] = (bad[0][0] % 9) + 1;
+      expect(isSolved(bad)).toBe(false);
+    }
+  });
+});

--- a/tests/e2e/window-manager.spec.ts
+++ b/tests/e2e/window-manager.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+test('multi-window management and dialogs', async ({ page }) => {
+  await page.goto('/');
+  const showApps = page.locator('nav [aria-label="Show Applications"]');
+  await showApps.click();
+  await page.locator('#app-terminal').click();
+  await showApps.click();
+  await page.locator('#app-gedit').click();
+
+  const terminal = page.locator('[data-app-id="terminal"]');
+  const gedit = page.locator('[data-app-id="gedit"]');
+
+  await gedit.click();
+  const zGedit = await gedit.evaluate((el) => Number(getComputedStyle(el).zIndex));
+  const zTerm = await terminal.evaluate((el) => Number(getComputedStyle(el).zIndex));
+  expect(zGedit).toBeGreaterThan(zTerm);
+
+  const gHeader = gedit.locator('.cursor-move');
+  const gBox = await gedit.boundingBox();
+  if (gBox) {
+    await gHeader.hover();
+    await page.mouse.down();
+    await page.mouse.move(gBox.x + 100, gBox.y + 100);
+    await page.mouse.up();
+    const moved = await gedit.boundingBox();
+    expect(moved && moved.x).toBeGreaterThan(gBox.x);
+  }
+
+  const tHeader = terminal.locator('.cursor-move');
+  const tBox = await terminal.boundingBox();
+  if (tBox) {
+    await tHeader.hover();
+    await page.mouse.down();
+    await page.mouse.move(5, tBox.y + 10);
+    await page.mouse.up();
+    const style = await terminal.getAttribute('style');
+    expect(style).toContain('left: 0');
+  }
+
+  await page.keyboard.down('Alt');
+  await page.keyboard.press('Tab');
+  await page.keyboard.up('Alt');
+  const zTermFront = await terminal.evaluate((el) => Number(getComputedStyle(el).zIndex));
+  const zGeditBack = await gedit.evaluate((el) => Number(getComputedStyle(el).zIndex));
+  expect(zTermFront).toBeGreaterThan(zGeditBack);
+
+  const zBefore = zTermFront;
+  page.once('dialog', (d) => d.dismiss());
+  await page.evaluate(() => alert('test'));
+  const zAfter = await terminal.evaluate((el) => Number(getComputedStyle(el).zIndex));
+  expect(zAfter).toBe(zBefore);
+});


### PR DESCRIPTION
## Summary
- add Playwright spec for multi-window behavior and dialogs
- add deterministic property tests for Sudoku and 2048 win conditions
- run smoke test in CI and document test commands in CONTRIBUTING

## Testing
- `node node_modules/jest/bin/jest.js __tests__/game2048WinCondition.property.test.ts __tests__/sudokuWinCondition.property.test.ts`
- `node node_modules/@playwright/test/cli.js test tests/e2e/window-manager.spec.ts` *(fails: browser executable doesn't exist; run `npx playwright install`)*
- `node --import tsx/esm scripts/smoke-all-apps.mjs` *(fails: SyntaxError on TypeScript import)*

------
https://chatgpt.com/codex/tasks/task_e_68be6c7c20888328bf3c37c648404216