### PR TITLE
Add window manager and game regression tests with smoke CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,22 @@ jobs:
           path: test-results/**/*.zip
           if-no-files-found: ignore
 
+  smoke:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: npx playwright install --with-deps
+      - run: |
+          yarn dev &
+          npx wait-on http://localhost:3000
+      - run: yarn smoke
+
   pa11y:
     runs-on: ubuntu-latest
     needs: install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+## Local Development
+
+1. Install dependencies with `yarn install`.
+2. Start the dev server: `yarn dev`.
+3. Run unit tests: `yarn test`.
+4. Run Playwright tests (requires the server):
+   ```sh
+   yarn dev &
+   npx wait-on http://localhost:3000
+   npx playwright test
+   ```
+5. Smoke-test all app routes headlessly: `yarn smoke`.
+
+## Continuous Integration
+
+CI runs the following checks:
+
+- `yarn lint`
+- `yarn typecheck`
+- `yarn test`
+- `npx playwright test` (including `yarn smoke`)
+
+Please ensure these commands pass before opening a pull request.

--- a/__tests__/2048.property.test.ts
+++ b/__tests__/2048.property.test.ts
@@ -1,0 +1,12 @@
+import fc from "fast-check";
+import { slide } from "../apps/games/_2048/logic";
+
+test("slide merges equal powers of two", () => {
+  fc.assert(
+    fc.property(fc.integer({ min: 1, max: 10 }), (exp) => {
+      const val = 2 ** exp;
+      const { row } = slide([val, val, 0, 0]);
+      expect(row[0]).toBe(val * 2);
+    }),
+  );
+});

--- a/__tests__/rng.deterministic.test.ts
+++ b/__tests__/rng.deterministic.test.ts
@@ -1,0 +1,14 @@
+import fc from "fast-check";
+import { reset, random } from "../apps/games/rng";
+
+test("seeded RNG produces deterministic sequences", () => {
+  fc.assert(
+    fc.property(fc.string(), (seed) => {
+      reset(seed);
+      const a = [random(), random(), random()];
+      reset(seed);
+      const b = [random(), random(), random()];
+      expect(a).toEqual(b);
+    }),
+  );
+});

--- a/__tests__/sudoku.property.test.ts
+++ b/__tests__/sudoku.property.test.ts
@@ -1,0 +1,14 @@
+import fc from "fast-check";
+import { generateSudoku } from "../apps/games/sudoku";
+import { solve } from "../workers/sudokuSolver";
+
+test("generated sudoku puzzles have valid unique solutions", () => {
+  fc.assert(
+    fc.property(fc.integer({ min: 1, max: 1_000_000 }), (seed) => {
+      const { puzzle, solution } = generateSudoku("easy", seed);
+      const solved = solve(puzzle.map((r) => r.slice())).solution;
+      expect(solved).toEqual(solution);
+    }),
+    { numRuns: 10 },
+  );
+});

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "eslint": "^9.13.0",
     "eslint-config-next": "15.5.2",
     "fake-indexeddb": "^6.1.0",
+    "fast-check": "^3.14.0",
     "fast-glob": "^3.3.3",
     "jest": "30.0.5",
     "jest-environment-jsdom": "30.0.5",

--- a/pages/window-manager-test.tsx
+++ b/pages/window-manager-test.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useMemo } from "react";
+import Window from "../components/desktop/Window";
+import WindowSwitcher, { WindowInfo } from "../src/wm/WindowSwitcher";
+
+export default function WindowManagerTest() {
+  const windows: WindowInfo[] = useMemo(
+    () => [
+      { id: "win1", title: "Window 1", icon: "/icon.png" },
+      { id: "win2", title: "Window 2", icon: "/icon.png" },
+    ],
+    [],
+  );
+
+  const select = (id: string) => {
+    document.getElementById(id)?.click();
+  };
+
+  return (
+    <main className="h-screen bg-ub-cool-grey">
+      <Window id="win1" title="Window 1" initialX={80} initialY={80}>
+        <button id="dialog-btn" onClick={() => alert("dialog")}>
+          Open Dialog
+        </button>
+      </Window>
+      <Window id="win2" title="Window 2" initialX={320} initialY={120}>
+        <p>Second window</p>
+      </Window>
+      <WindowSwitcher windows={windows} onSelect={select} />
+    </main>
+  );
+}

--- a/tests/e2e/window-manager.spec.ts
+++ b/tests/e2e/window-manager.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from "@playwright/test";
+
+// Regression tests for the standalone window component.
+// Verifies layering, dragging, snapping, keyboard navigation and dialog focus.
+test.describe("standalone window manager", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/window-manager-test");
+  });
+
+  test("z-index, drag, snap, keyboard nav and dialog focus", async ({
+    page,
+  }) => {
+    const win1 = page.locator("#win1");
+    const win2 = page.locator("#win2");
+
+    // Initial z-index order then bring second window to front
+    const z1 = await win1.evaluate((e) => Number(getComputedStyle(e).zIndex));
+    const z2 = await win2.evaluate((e) => Number(getComputedStyle(e).zIndex));
+    expect(z1).toBeGreaterThan(z2);
+    await win2.click();
+    const nz2 = await win2.evaluate((e) => Number(getComputedStyle(e).zIndex));
+    expect(nz2).toBeGreaterThan(z1);
+
+    // Drag window2
+    const header = win2.locator(".cursor-move");
+    const box = await header.boundingBox();
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + 100, box!.y + 100);
+    await page.mouse.up();
+    const pos = await win2.evaluate((e) => ({
+      left: parseInt(e.style.left),
+      top: parseInt(e.style.top),
+    }));
+    expect(pos.left).toBeGreaterThan(300);
+
+    // Snap to left edge via drag
+    await page.mouse.move(box!.x + 100, box!.y + 100);
+    await page.mouse.down();
+    await page.mouse.move(5, 10);
+    await expect(page.locator('[data-testid="snap-preview"]')).toBeVisible();
+    await page.mouse.up();
+    const snapped = await win2.evaluate((e) => ({
+      left: parseInt(e.style.left),
+      width: parseInt(e.style.width),
+    }));
+    const viewport = await page.viewportSize();
+    expect(snapped.left).toBe(0);
+    expect(snapped.width).toBeCloseTo((viewport!.width ?? 0) / 2, 0);
+
+    // Keyboard navigation via Alt+Tab
+    await page.keyboard.down("Alt");
+    await page.keyboard.press("Tab");
+    await expect(page.locator(".window-switcher-overlay")).toBeVisible();
+    await page.keyboard.up("Alt");
+    await expect(page.locator(".window-switcher-overlay")).toBeHidden();
+    const focusedId = await win2.evaluate(
+      (e) =>
+        Number(getComputedStyle(e).zIndex) >
+        Number(getComputedStyle(document.getElementById("win1")!).zIndex),
+    );
+    expect(focusedId).toBe(true);
+
+    // Dialog focus retention
+    await win1.click();
+    await page.locator("#dialog-btn").click();
+    const dialog = page.waitForEvent("dialog");
+    const dlg = await dialog;
+    await dlg.accept();
+    const stillFocused = await win1.evaluate(
+      (e) => !e.classList.contains("opacity-90"),
+    );
+    expect(stillFocused).toBe(true);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3957,7 +3957,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:19.1.12, @types/react@npm:>=16.9.11":
+"@types/react@npm:19.1.12":
   version: 19.1.12
   resolution: "@types/react@npm:19.1.12"
   dependencies:
@@ -7746,6 +7746,15 @@ __metadata:
   version: 6.2.2
   resolution: "fake-indexeddb@npm:6.2.2"
   checksum: 10c0/5ad98f05beb22d8591af1bcf8500d1a92d9a17b3e2c380dfa669770b4fecdbadc1ccd9c8ba5429a92a30fd2562f6ab24238992522a8574ffd365d7b809677f0a
+  languageName: node
+  linkType: hard
+
+"fast-check@npm:^3.14.0":
+  version: 3.23.2
+  resolution: "fast-check@npm:3.23.2"
+  dependencies:
+    pure-rand: "npm:^6.1.0"
+  checksum: 10c0/16fcff3c80321ee765e23c3aebd0f6427f175c9c6c1753104ec658970162365dc2d56bda046d815e8f2e90634c07ba7d6f0bcfd327fbd576d98c56a18a9765ed
   languageName: node
   linkType: hard
 
@@ -11914,6 +11923,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pure-rand@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "pure-rand@npm:6.1.0"
+  checksum: 10c0/1abe217897bf74dcb3a0c9aba3555fe975023147b48db540aa2faf507aee91c03bf54f6aef0eb2bf59cc259a16d06b28eca37f0dc426d94f4692aeff02fb0e65
+  languageName: node
+  linkType: hard
+
 "pure-rand@npm:^7.0.0":
   version: 7.0.1
   resolution: "pure-rand@npm:7.0.1"
@@ -14799,6 +14815,7 @@ __metadata:
     eslint: "npm:^9.13.0"
     eslint-config-next: "npm:15.5.2"
     fake-indexeddb: "npm:^6.1.0"
+    fast-check: "npm:^3.14.0"
     fast-glob: "npm:^3.3.3"
     fast-xml-parser: "npm:^4.3.5"
     figlet: "npm:^1.8.2"


### PR DESCRIPTION
## Summary
- add id support and playground for desktop window component
- add property-based RNG, 2048 merge, and seeded Sudoku tests
- run smoke tests for all app routes in CI
- document local/CI workflows in CONTRIBUTING

## Testing
- `yarn test __tests__/2048.property.test.ts __tests__/rng.deterministic.test.ts __tests__/sudoku.property.test.ts`
- `yarn test __tests__/csp.test.ts` *(fails: Missing allowlist entries)*
- `npx wait-on http://localhost:3000` *(fails: The "to" argument must be of type string)*

------
https://chatgpt.com/codex/tasks/task_e_68be6c8cda5883288bb26852a28fd6f6