### PR TITLE
Expand a11y checks and semantic wallpaper picker

### DIFF
--- a/__tests__/a11y.window.test.ts
+++ b/__tests__/a11y.window.test.ts
@@ -1,0 +1,29 @@
+/** @jest-environment node */
+import { chromium } from 'playwright';
+import AxeBuilder from '@axe-core/playwright';
+import path from 'path';
+
+describe('window navigation', () => {
+  it('opens and closes dialog without focus traps', async () => {
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+    const file = 'file://' + path.join(__dirname, 'fixtures', 'a11y-window.html');
+    await page.goto(file);
+    await page.keyboard.press('Tab'); // focus open button
+    await page.keyboard.press('Enter'); // open dialog
+    const axe = await new AxeBuilder({ page })
+      .withRules(['label', 'color-contrast', 'focus-order-semantics'])
+      .analyze();
+    expect(axe.violations).toHaveLength(0);
+    const seen = new Set<string>();
+    for (let i = 0; i < 2; i++) {
+      seen.add(await page.evaluate(() => document.activeElement?.id || ''));
+      await page.keyboard.press('Tab');
+    }
+    expect(seen.size).toBeGreaterThan(1);
+    await page.keyboard.press('Enter'); // activate close button
+    const activeId = await page.evaluate(() => document.activeElement?.id);
+    expect(activeId).toBe('open');
+    await browser.close();
+  });
+});

--- a/__tests__/fixtures/a11y-window.html
+++ b/__tests__/fixtures/a11y-window.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Window Fixture</title>
+</head>
+<body>
+  <button id="open">Open Window</button>
+  <dialog id="win">
+    <p>Window Content</p>
+    <button id="close">Close</button>
+  </dialog>
+  <script>
+    const open = document.getElementById('open');
+    const dialog = document.getElementById('win');
+    const closeBtn = document.getElementById('close');
+    open.addEventListener('click', () => {
+      dialog.showModal();
+      closeBtn.focus();
+    });
+    closeBtn.addEventListener('click', () => dialog.close());
+  </script>
+</body>
+</html>

--- a/a11y/REPORT.md
+++ b/a11y/REPORT.md
@@ -9,6 +9,8 @@
 - Replaced generic elements with semantic buttons for app icons and window title bars.
   - `components/base/ubuntu_app.js`
   - `components/base/window.js`
+- Updated wallpaper picker to use semantic buttons.
+  - `components/apps/settings.js`
 - Added automated axe CLI and Playwright checks under `__tests__/`.
 
 ## Before / After Examples
@@ -19,4 +21,8 @@
 ```diff
 - <div role="button" ...>
 + <button type="button" ...>
+```
+```diff
+- <div role="button" aria-label={`Select ${name.replace('wall-', 'wallpaper ')}`} ...></div>
++ <button type="button" aria-label={`Select ${name.replace('wall-', 'wallpaper ')}`} ...></button>
 ```

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -238,24 +238,25 @@ export function Settings() {
             <div className="flex flex-wrap justify-center items-center border-t border-gray-900">
                 { 
                     wallpapers.map((name, index) => (
-                        <div
+                        <button
                             key={name}
-                            role="button"
+                            type="button"
                             aria-label={`Select ${name.replace('wall-', 'wallpaper ')}`}
                             aria-pressed={name === wallpaper}
-                            tabIndex="0"
                             onClick={changeBackgroundImage}
                             onFocus={changeBackgroundImage}
-                            onKeyDown={(e) => {
-                                if (e.key === 'Enter' || e.key === ' ') {
-                                    e.preventDefault();
-                                    changeBackgroundImage(e);
-                                }
-                            }}
                             data-path={name}
-                            className={((name === wallpaper) ? " border-yellow-700 " : " border-transparent ") + " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"}
-                            style={{ backgroundImage: `url(/wallpapers/${name}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}
-                        ></div>
+                            className={
+                                ((name === wallpaper) ? " border-yellow-700 " : " border-transparent ") +
+                                " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 border-4 border-opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
+                            }
+                            style={{
+                                backgroundImage: `url(/wallpapers/${name}.webp)`,
+                                backgroundSize: "cover",
+                                backgroundRepeat: "no-repeat",
+                                backgroundPosition: "center center",
+                            }}
+                        ></button>
                     ))
                 }
             </div>

--- a/pa11yci.json
+++ b/pa11yci.json
@@ -4,8 +4,9 @@
       "args": ["--no-sandbox"]
     },
     "runners": ["axe", "htmlcs"],
-    "standard": "WCAG2AA",
+    "standard": "WCAG2.2AA",
     "includeNotices": true,
+    "includeWarnings": true,
     "axe": {
       "rules": {
         "color-contrast": { "enabled": true },


### PR DESCRIPTION
## Summary
- upgrade pa11y config to WCAG 2.2 AA with warnings
- add Playwright dialog navigation test using axe-core
- replace wallpaper picker divs with semantic buttons and report update

## Testing
- `yarn test __tests__/a11y.cli.test.ts __tests__/a11y.playwright.test.ts __tests__/a11y.window.test.ts` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68be75d699448328938286f778d40a86