### PR TITLE
Add window manager and game determinism tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+## Running locally
+1. Install dependencies with `yarn install`.
+2. Start the development server using `yarn dev`.
+3. Run unit tests with `yarn test`.
+4. Execute Playwright tests with `npx playwright test`.
+5. Smoke test all app routes via `yarn smoke`.
+
+## Continuous Integration
+The CI pipeline runs `yarn verify:all`, which now also executes `yarn smoke` to load every `/apps/*` route headlessly and fail on runtime errors.

--- a/__tests__/game2048.property.test.ts
+++ b/__tests__/game2048.property.test.ts
@@ -1,0 +1,38 @@
+import { addRandomTile, boardsEqual, hasWon, setSize, Board } from '../apps/games/_2048/logic';
+import { random, reset } from '../apps/games/rng';
+
+declare const global: any;
+
+const emptyBoard = (): Board => Array.from({ length: 4 }, () => Array(4).fill(0));
+
+describe('2048 deterministic RNG and win detection', () => {
+  test('random tile placement is deterministic for seeds', () => {
+    const seeds = ['alpha', 'beta', 'gamma', 'delta', 'epsilon'];
+    for (const seed of seeds) {
+      reset(seed);
+      setSize(4);
+      const a = emptyBoard();
+      addRandomTile(a); addRandomTile(a);
+      reset(seed);
+      setSize(4);
+      const b = emptyBoard();
+      addRandomTile(b); addRandomTile(b);
+      expect(boardsEqual(a, b)).toBe(true);
+    }
+  });
+
+  test('hasWon matches presence of >=2048 tile', () => {
+    for (let seed = 0; seed < 10; seed++) {
+      reset(String(seed));
+      const board = emptyBoard();
+      for (let r = 0; r < 4; r++) {
+        for (let c = 0; c < 4; c++) {
+          const vals = [0,2,4,8,16,32,64,128,256,512,1024,2048,4096];
+          board[r][c] = vals[Math.floor(random() * vals.length)];
+        }
+      }
+      const expected = board.flat().some(v => v >= 2048);
+      expect(hasWon(board)).toBe(expected);
+    }
+  });
+});

--- a/__tests__/sudoku.property.test.ts
+++ b/__tests__/sudoku.property.test.ts
@@ -1,0 +1,35 @@
+import { generateSudoku } from '../apps/games/sudoku';
+import { solve } from '../workers/sudokuSolver';
+
+const DIGITS = [1,2,3,4,5,6,7,8,9];
+
+const isValidBoard = (board: number[][]): boolean => {
+  const rows = board.every(row => {
+    const sorted = [...row].sort((a,b)=>a-b);
+    return DIGITS.every((n,i)=>sorted[i]===n);
+  });
+  const cols = DIGITS.every((_, c) => {
+    const col = board.map(row => row[c]).sort((a,b)=>a-b);
+    return DIGITS.every((n,i)=>col[i]===n);
+  });
+  const boxes = [0,3,6].every(r0 =>
+    [0,3,6].every(c0 => {
+      const cells: number[] = [];
+      for(let r=0;r<3;r++) for(let c=0;c<3;c++) cells.push(board[r0+r][c0+c]);
+      cells.sort((a,b)=>a-b);
+      return DIGITS.every((n,i)=>cells[i]===n);
+    })
+  );
+  return rows && cols && boxes;
+};
+
+describe('sudoku win conditions', () => {
+  test('generated puzzles are solvable for several seeds', () => {
+    for (let seed=0; seed<5; seed++) {
+      const { puzzle, solution } = generateSudoku('easy', seed);
+      const solved = solve(puzzle.map(r=>r.slice())).solution;
+      expect(solved).toEqual(solution);
+      expect(isValidBoard(solution)).toBe(true);
+    }
+  });
+});

--- a/apps/games/_2048/logic.ts
+++ b/apps/games/_2048/logic.ts
@@ -92,3 +92,6 @@ export const moveDown = (board: Board): MoveResult => {
 
 export const boardsEqual = (a: Board, b: Board) =>
   a.every((row, r) => row.every((cell, c) => cell === b[r][c]));
+
+export const hasWon = (board: Board) =>
+  board.some((row) => row.some((cell) => cell >= 2048));

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -55,6 +55,10 @@ const getPort = () =>
       logger.info(`✓ ${route}`);
     }
 
+    await run('yarn', ['smoke'], {
+      env: { ...process.env, BASE_URL: `http://localhost:${port}` },
+    });
+
     logger.info('verify: PASS');
     server.kill();
   } catch (err) {

--- a/tests/desktop/window-manager.spec.ts
+++ b/tests/desktop/window-manager.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+test('window manager interactions', async ({ page }) => {
+  await page.goto('/');
+
+  // open first app
+  await page.locator('nav [aria-label="Show Applications"]').click();
+  await page.locator('#app-terminal').click();
+  const termWin = page.locator('[data-app-id="terminal"]');
+  await expect(termWin).toBeVisible();
+
+  // open second app
+  await page.locator('nav [aria-label="Show Applications"]').click();
+  await page.locator('#app-chrome').click();
+  const chromeWin = page.locator('[data-app-id="chrome"]');
+  await expect(chromeWin).toBeVisible();
+
+  // z-index ordering
+  const zTerm = await termWin.evaluate(el => parseInt(getComputedStyle(el).zIndex || '0'));
+  const zChrome = await chromeWin.evaluate(el => parseInt(getComputedStyle(el).zIndex || '0'));
+  expect(zChrome).toBeGreaterThan(zTerm);
+
+  await termWin.click();
+  const zTermFront = await termWin.evaluate(el => parseInt(getComputedStyle(el).zIndex || '0'));
+  const zChromeBack = await chromeWin.evaluate(el => parseInt(getComputedStyle(el).zIndex || '0'));
+  expect(zTermFront).toBeGreaterThan(zChromeBack);
+
+  // drag behaviour
+  const bar = chromeWin.locator('button').first();
+  const box1 = await chromeWin.boundingBox();
+  if (box1) {
+    await bar.dragTo(bar, { targetPosition: { x: box1.x + 50, y: box1.y + 50 } });
+    const box2 = await chromeWin.boundingBox();
+    expect(box2 && box1 && box2.x !== box1.x).toBeTruthy();
+  }
+
+  // snap using keyboard
+  await termWin.click();
+  await page.keyboard.press('Meta+ArrowLeft');
+  const snapBox = await termWin.boundingBox();
+  const viewport = page.viewportSize();
+  if (snapBox && viewport) {
+    expect(Math.round(snapBox.x)).toBe(0);
+    expect(Math.round(snapBox.width)).toBeCloseTo(viewport.width / 2, 1);
+  }
+
+  // keyboard navigation via Alt+Tab
+  await page.keyboard.down('Alt');
+  await page.keyboard.press('Tab');
+  await page.keyboard.up('Alt');
+  await expect(chromeWin).toHaveAttribute('aria-selected', 'true');
+
+  // dialog focus retention
+  await chromeWin.click();
+  const dialogPromise = page.waitForEvent('dialog');
+  await page.evaluate(() => alert('hi'));
+  const dialog = await dialogPromise;
+  await dialog.accept();
+  await expect(chromeWin).toHaveAttribute('aria-selected', 'true');
+});


### PR DESCRIPTION
## Summary
- document local and CI test workflows in CONTRIBUTING
- add deterministic seeded tests for 2048 and Sudoku
- exercise window manager interactions with new Playwright spec
- run `yarn smoke` as part of verify script

## Testing
- `node --version` *(fails: command not found)*
- `yarn test __tests__/game2048.property.test.ts __tests__/sudoku.property.test.ts` *(fails: command not found)*
- `npx playwright test tests/desktop/window-manager.spec.ts` *(fails: command not found)*
- `yarn smoke` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be76068c148328b70ff97fc13a1c50