### PR TITLE
feat: highlight default desktop option

### DIFF
--- a/__tests__/desktopDefaultBadge.test.tsx
+++ b/__tests__/desktopDefaultBadge.test.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import Home from "../pages/index.jsx";
+
+describe("Choose your desktop row", () => {
+  test("marks Xfce as the default desktop environment", () => {
+    const placeholder = "data:image/png;base64,abc";
+    const desktops = [
+      {
+        name: "Xfce",
+        image: "/xfce.png",
+        blurDataURL: placeholder,
+        default: true,
+      },
+      { name: "GNOME", image: "/gnome.png", blurDataURL: placeholder },
+    ];
+
+    render(<Home desktops={desktops} />);
+    const xfceCard = screen.getByLabelText(
+      /Xfce desktop environment \(default\)/i,
+      { selector: "div" },
+    );
+    expect(within(xfceCard).getByText(/Default/i)).toBeInTheDocument();
+  });
+});

--- a/content/desktops.json
+++ b/content/desktops.json
@@ -2,7 +2,8 @@
   {
     "name": "Xfce",
     "image": "/wallpapers/wall-1.webp",
-    "blurhash": "U56RyHITRhtSDhx^t7WA8^axWBWAMwRPWBof"
+    "blurhash": "U56RyHITRhtSDhx^t7WA8^axWBWAMwRPWBof",
+    "default": true
   },
   {
     "name": "GNOME",

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -22,16 +22,34 @@ export async function getStaticProps() {
 }
 
 /**
- * @param {{ desktops: { name: string; image: string; blurDataURL: string }[] }} props
+ * @param {{ desktops: { name: string; image: string; blurDataURL: string; default?: boolean }[] }} props
  * @returns {JSX.Element}
  */
 export default function Home({ desktops }) {
   return (
     <main className="p-4">
-      <h1 className="mb-4 text-2xl font-bold sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl 2xl:text-7xl">Choose the desktop you prefer</h1>
+      <h1 className="mb-4 text-2xl font-bold sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl 2xl:text-7xl">
+        Choose the desktop you prefer
+      </h1>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
         {desktops.map((d) => (
-          <div key={d.name} className="text-center">
+          <div
+            key={d.name}
+            className="relative text-center"
+            aria-label={
+              d.default
+                ? `${d.name} desktop environment (default)`
+                : `${d.name} desktop environment`
+            }
+          >
+            {d.default && (
+              <span
+                aria-hidden="true"
+                className="absolute right-2 top-2 rounded bg-muted px-1.5 py-0.5 text-xs text-text"
+              >
+                Default
+              </span>
+            )}
             <Image
               src={d.image}
               alt={d.name}


### PR DESCRIPTION
## Summary
- add `default` marker for Xfce in desktop data
- show subtle "Default" badge on Xfce card with accessible label
- test desktop row accessibility for default badge

## Testing
- `yarn lint pages/index.jsx __tests__/desktopDefaultBadge.test.tsx` *(fails: A control must be associated with a text label, etc.)*
- `yarn typecheck` *(fails: workers/... Type errors)*
- `yarn test __tests__/desktopDefaultBadge.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be6aa5ecc48328adfb72bbe0ac56e1