### PR TITLE
docs: add icon guidelines and system icons

### DIFF
--- a/docs/design/icons.mdx
+++ b/docs/design/icons.mdx
@@ -1,0 +1,11 @@
+# Icon Design Rules
+
+Our system icon set supports two standard sizes: 24px and 20px.
+
+| Size | Stroke | Corner radius | Padding |
+|------|--------|---------------|---------|
+| 24px | 2px    | 2px           | 2px     |
+| 20px | 1.5px  | 1.5px         | 2px     |
+
+All icons live on a square canvas with the specified padding to keep strokes inside the box. 
+Use round line caps and joins for consistent appearance.

--- a/public/icons/system/check.svg
+++ b/public/icons/system/check.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>

--- a/public/icons/system/close.svg
+++ b/public/icons/system/close.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 6l12 12M6 18L18 6"/></svg>

--- a/public/icons/system/minus.svg
+++ b/public/icons/system/minus.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/></svg>

--- a/public/icons/system/plus.svg
+++ b/public/icons/system/plus.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>

--- a/public/icons/system/search.svg
+++ b/public/icons/system/search.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>


### PR DESCRIPTION
## Summary
- document stroke, corner radius, and padding rules for 24px and 20px icons
- add base SVG system icons (check, close, plus, minus, search)

## Testing
- `npx eslint docs/design/icons.mdx public/icons/system/*.svg`
- `yarn test` *(fails: Playwright browsers and Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_68be602214208328a57164dedc0e747f