### PR TITLE
feat(theme): add purple palette

### DIFF
--- a/components/ui/ThemeSwitcher.tsx
+++ b/components/ui/ThemeSwitcher.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { kaliTheme } from "@/styles/themes/kali";
+
+const STORAGE_KEY = "purple-palette";
+
+export default function ThemeSwitcher() {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored === "true") setEnabled(true);
+  }, []);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (enabled) {
+      const { button, link, badge } = kaliTheme.purple;
+      root.style.setProperty("--color-primary", button);
+      root.style.setProperty("--color-accent", link);
+      root.style.setProperty("--color-link", link);
+      root.style.setProperty("--color-badge-bg", badge.background);
+      root.style.setProperty("--color-badge-text", badge.text);
+      window.localStorage.setItem(STORAGE_KEY, "true");
+    } else {
+      root.style.removeProperty("--color-primary");
+      root.style.removeProperty("--color-accent");
+      root.style.removeProperty("--color-link");
+      root.style.removeProperty("--color-badge-bg");
+      root.style.removeProperty("--color-badge-text");
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, [enabled]);
+
+  return (
+    <button
+      type="button"
+      className="btn"
+      onClick={() => setEnabled(!enabled)}
+      aria-pressed={enabled}
+      aria-label="Toggle purple palette"
+    >
+      {enabled ? "Default Palette" : "Purple Palette"}
+    </button>
+  );
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -147,6 +147,18 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
     outline-offset: var(--focus-outline-offset);
 }
 
+a {
+    color: var(--color-link);
+}
+
+.badge {
+    background-color: var(--color-badge-bg);
+    color: var(--color-badge-text);
+    border-radius: var(--radius-sm);
+    padding: 0.125rem 0.25rem;
+    font-weight: 500;
+}
+
 a:focus-visible,
 button:focus-visible,
 input:focus-visible,

--- a/styles/themes/kali.ts
+++ b/styles/themes/kali.ts
@@ -8,6 +8,14 @@ export const kaliTheme = {
     text: 'var(--toast-text)',
     border: 'var(--toast-border)',
   },
+  purple: {
+    button: 'var(--purple-button)',
+    link: 'var(--purple-link)',
+    badge: {
+      background: 'var(--purple-badge-bg)',
+      text: 'var(--purple-badge-text)',
+    },
+  },
 };
 
 export type KaliTheme = typeof kaliTheme;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -26,6 +26,26 @@
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
 
+  /* Accent defaults */
+  --color-link: var(--color-primary);
+  --color-badge-bg: var(--color-primary);
+  --color-badge-text: var(--color-inverse);
+
+  /* Purple palette */
+  --color-purple-100: #f3e8ff;
+  --color-purple-200: #e9d5ff;
+  --color-purple-300: #d8b4fe;
+  --color-purple-400: #c084fc;
+  --color-purple-500: #a855f7;
+  --color-purple-600: #9333ea;
+  --color-purple-700: #7e22ce;
+  --color-purple-800: #6b21a8;
+  --color-purple-900: #581c87;
+  --purple-button: var(--color-purple-600);
+  --purple-link: var(--color-purple-400);
+  --purple-badge-bg: var(--color-purple-700);
+  --purple-badge-text: #ffffff;
+
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
   --game-color-success: #15803d;


### PR DESCRIPTION
## Summary
- add purple color tokens and accent defaults
- extend kali theme with purple palette and badge/link variables
- allow toggling a purple preset that updates button, link and badge colors

## Testing
- `yarn test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell; run `yarn playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68be7c6b87d88328b56ebd24dbb30af8