### PR TITLE
feat: add release timeline component

### DIFF
--- a/components/kali/ReleaseTimeline.tsx
+++ b/components/kali/ReleaseTimeline.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+
+interface Release {
+  title: string;
+  link: string;
+  date: string; // ISO date string
+}
+
+const ReleaseTimeline: React.FC = () => {
+  const [releases, setReleases] = useState<Release[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/kali-releases.json');
+        if (!res.ok) throw new Error('Failed to fetch local release data');
+        const data: Release[] = await res.json();
+        data.sort(
+          (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+        );
+        setReleases(data);
+      } catch (err) {
+        console.error('Failed to fetch release data', err);
+      }
+    };
+    load();
+  }, []);
+
+  if (releases.length === 0) {
+    return <p className="text-center text-sm text-gray-400">Loading releases...</p>;
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <ol className="relative border-l border-gray-700">
+        {releases.map((r) => (
+          <li key={r.link} className="mb-10 ml-4">
+            <div className="absolute w-3 h-3 bg-ubt-blue rounded-full mt-1.5 -left-1.5 border border-white" />
+            <time
+              className="mb-1 text-sm leading-none text-gray-400"
+              dateTime={r.date}
+            >
+              {new Date(r.date).toLocaleDateString(undefined, {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+              })}
+            </time>
+            <h3 className="text-lg font-semibold text-white">{r.title}</h3>
+            <a
+              href={r.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-ubt-blue hover:underline"
+            >
+              Read more ↗
+            </a>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+};
+
+export default ReleaseTimeline;

--- a/public/kali-releases.json
+++ b/public/kali-releases.json
@@ -1,0 +1,32 @@
+[
+  {
+    "title": "Kali Linux 2025.2 Release (Kali Menu Refresh, BloodHound CE & CARsenal)",
+    "link": "https://www.kali.org/blog/kali-linux-2025-2-release/",
+    "date": "2025-06-13"
+  },
+  {
+    "title": "Kali Linux 2025.1a Release (2025 Theme, & Raspberry Pi)",
+    "link": "https://www.kali.org/blog/kali-linux-2025-1-release/",
+    "date": "2025-03-19"
+  },
+  {
+    "title": "Kali Linux 2024.4 Release (Python 3.12, Goodbye i386, Raspberry Pi Imager & Kali NetHunter)",
+    "link": "https://www.kali.org/blog/kali-linux-2024-4-release/",
+    "date": "2024-12-16"
+  },
+  {
+    "title": "Kali Linux 2024.3 Release (Multiple transitions)",
+    "link": "https://www.kali.org/blog/kali-linux-2024-3-release/",
+    "date": "2024-09-11"
+  },
+  {
+    "title": "Kali Linux 2024.2 Release (t64, GNOME 46 & Community Packages)",
+    "link": "https://www.kali.org/blog/kali-linux-2024-2-release/",
+    "date": "2024-06-05"
+  },
+  {
+    "title": "Kali Linux 2024.1 Release (Micro Mirror)",
+    "link": "https://www.kali.org/blog/kali-linux-2024-1-release/",
+    "date": "2024-02-28"
+  }
+]


### PR DESCRIPTION
## Summary
- add `ReleaseTimeline` component for Kali releases
- load release data from local JSON feed and render in a responsive timeline
- include sample `kali-releases.json` dataset

## Testing
- `yarn test --passWithNoTests components/kali/ReleaseTimeline.tsx`
- `npx eslint components/kali/ReleaseTimeline.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68be7cc85d4083289b570f91ffb93799