### PR TITLE
style: add keyboard tag styling and use in docs

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -2,7 +2,7 @@
 
 ## Windowing System
 - `components/desktop/Window.tsx` – resizable, draggable window component with snap preview and z-index focus management.
-- `src/wm/WindowSwitcher.tsx` – Alt+Tab overlay for switching windows.
+- `src/wm/WindowSwitcher.tsx` – <kbd>Alt</kbd>+<kbd>Tab</kbd> overlay for switching windows.
 - `src/wm/placement.ts`, `src/wm/keybindingManager.ts` – helpers for window placement and keyboard shortcuts.
 
 ## Dynamic App Loader

--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ See `.env.local.example` for the full list.
 
 ## App Finder
 
-- Press **Ctrl+Space** to open a compact run dialog.
+ - Press <kbd>Ctrl</kbd>+<kbd>Space</kbd> to open a compact run dialog.
 - The expanded view organizes results into categories and favorites.
 - Drag a search result onto the panel to create a launcher.
-- Press **Esc** to close the finder.
+ - Press <kbd>Esc</kbd> to close the finder.
 
 ---
 

--- a/docs/TASKS_UI_POLISH.md
+++ b/docs/TASKS_UI_POLISH.md
@@ -23,7 +23,7 @@ This document tracks UI polish tasks for the Kali/Ubuntu inspired desktop experi
    - **Where:** desktop drag controller.
 
 5. **Keyboard window management**
-   - **Accept:** Alt+Tab app switcher, Alt+\` intra-app cycling, Super+Arrow tiling.
+     - **Accept:** <kbd>Alt</kbd>+<kbd>Tab</kbd> app switcher, <kbd>Alt</kbd>+<kbd>`</kbd> intra-app cycling, <kbd>Super</kbd>+<kbd>Arrow</kbd> tiling.
    - **Where:** desktop keymap handler.
 
 6. **Remember window positions per app**
@@ -51,14 +51,14 @@ This document tracks UI polish tasks for the Kali/Ubuntu inspired desktop experi
     - **Where:** window chrome.
 
 12. **Workspaces (virtual desktops) MVP**
-    - **Accept:** Shortcut Ctrl+Super+Left/Right cycles 2–3 workspaces; windows are scoped.
+     - **Accept:** Shortcut <kbd>Ctrl</kbd>+<kbd>Super</kbd>+<kbd>Left</kbd>/<kbd>Right</kbd> cycles 2–3 workspaces; windows are scoped.
     - **Where:** desktop state machine.
 
 13. **Window min size constraints**
     - **Accept:** Apps cannot resize below content-fit minimums; aspect guard keeps within ~1.6:1 golden ratio band for dialogs.
     - **Where:** window constraints.
 
-14. **Alt-Tab overlay polish**
+14. **<kbd>Alt</kbd>+<kbd>Tab</kbd> overlay polish**
     - **Accept:** Smooth 150–200 ms fade and scale in, row of app icons with labels.
     - **Where:** overlay component; follow motion ranges.
 
@@ -175,7 +175,7 @@ This document tracks UI polish tasks for the Kali/Ubuntu inspired desktop experi
 ## E) Accessibility
 
 41. **Keyboard-first navigation**
-    - **Accept:** Full desktop and app grid operable by keyboard (Tab, Arrow, Enter, Escape), with visible focus.
+     - **Accept:** Full desktop and app grid operable by keyboard (<kbd>Tab</kbd>, <kbd>Arrow</kbd>, <kbd>Enter</kbd>, <kbd>Escape</kbd>), with visible focus.
     - **Where:** focus management in desktop and window components.
 
 42. **ARIA for window chrome**

--- a/docs/keyboard-only-test-plan.md
+++ b/docs/keyboard-only-test-plan.md
@@ -3,21 +3,21 @@
 ## Resizing
 1. Open any window.
 2. Focus the window.
-3. Hold **Shift** and press arrow keys:
-   - **Shift + ArrowRight** increases width.
-   - **Shift + ArrowLeft** decreases width.
-   - **Shift + ArrowDown** increases height.
-   - **Shift + ArrowUp** decreases height.
+3. Hold <kbd>Shift</kbd> and press arrow keys:
+   - <kbd>Shift</kbd>+<kbd>ArrowRight</kbd> increases width.
+   - <kbd>Shift</kbd>+<kbd>ArrowLeft</kbd> decreases width.
+   - <kbd>Shift</kbd>+<kbd>ArrowDown</kbd> increases height.
+   - <kbd>Shift</kbd>+<kbd>ArrowUp</kbd> decreases height.
 4. Verify the window resizes accordingly.
 
 ## Snapping
-1. With the window focused, press arrow keys with **Alt**:
-   - **Alt + ArrowLeft** snaps the window to the left half of the screen.
-   - **Alt + ArrowRight** snaps it to the right half.
-   - **Alt + ArrowUp** snaps it to the top half.
-   - **Alt + ArrowDown** restores the window to its previous size and position.
+1. With the window focused, press arrow keys with <kbd>Alt</kbd>:
+   - <kbd>Alt</kbd>+<kbd>ArrowLeft</kbd> snaps the window to the left half of the screen.
+   - <kbd>Alt</kbd>+<kbd>ArrowRight</kbd> snaps it to the right half.
+   - <kbd>Alt</kbd>+<kbd>ArrowUp</kbd> snaps it to the top half.
+   - <kbd>Alt</kbd>+<kbd>ArrowDown</kbd> restores the window to its previous size and position.
 
 ## Focus
-1. After resizing or snapping, press **Tab** to move focus inside the window.
-2. Continue pressing **Tab** to confirm focus can leave the window and is not trapped.
-3. Shift+Tab moves focus backward as expected.
+1. After resizing or snapping, press <kbd>Tab</kbd> to move focus inside the window.
+2. Continue pressing <kbd>Tab</kbd> to confirm focus can leave the window and is not trapped.
+3. <kbd>Shift</kbd>+<kbd>Tab</kbd> moves focus backward as expected.

--- a/public/docs/apps/terminal.md
+++ b/public/docs/apps/terminal.md
@@ -1,7 +1,7 @@
 # Terminal Help
 
-This terminal emulates basic shell commands. Type commands and press Enter to execute.
+This terminal emulates basic shell commands. Type commands and press <kbd>Enter</kbd> to execute.
 
-- Use arrow keys to navigate history.
-- Press `Ctrl+C` to cancel a running command.
+- Use <kbd>ArrowUp</kbd>/<kbd>ArrowDown</kbd> to navigate history.
+- Press <kbd>Ctrl</kbd>+<kbd>C</kbd> to cancel a running command.
 - The `help` command lists available commands.

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -118,6 +118,24 @@
   }
 }
 
+/* Keyboard key styling */
+kbd {
+  display: inline-block;
+  padding: 0 var(--space-1);
+  font-family: var(--font-family-mono, monospace);
+  font-size: 0.85em;
+  border: 1px solid var(--color-ubt-cool-grey);
+  border-radius: var(--radius-sm);
+  background: var(--color-ubt-grey);
+  color: var(--color-ub-grey);
+}
+
+.high-contrast kbd {
+  background: var(--color-bg);
+  color: var(--color-text);
+  border-color: var(--color-text);
+}
+
 /* Optional high contrast via media query */
 @media (prefers-contrast: more) {
   :root {


### PR DESCRIPTION
## Summary
- style `<kbd>` element with theme-aware colors
- use `<kbd>` tags for key instructions in docs

## Testing
- `yarn lint` *(fails: process terminated)*
- `yarn test` *(fails: browser binaries missing and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68be7cbe3bcc8328970b93e7c3a7d529