### PR TITLE
feat: add policy index grid

### DIFF
--- a/components/policy/PolicyIndex.tsx
+++ b/components/policy/PolicyIndex.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { policies } from "../../data/policies";
+
+const PolicyIndex: React.FC = () => (
+  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+    {policies.map((p) => (
+      <div key={p.href} className="space-y-1">
+        <a
+          href={p.href}
+          className="text-blue-500 hover:underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {p.label}
+        </a>
+        <p className="text-xs text-gray-500">
+          Last updated: {p.updated} · Author: {p.author}
+        </p>
+      </div>
+    ))}
+  </div>
+);
+
+export default PolicyIndex;

--- a/data/policies.ts
+++ b/data/policies.ts
@@ -1,0 +1,69 @@
+export interface PolicyLink {
+  label: string;
+  href: string;
+  author: string;
+  updated: string;
+}
+
+export const policies: PolicyLink[] = [
+  {
+    label: "Cookie Policy",
+    href: "https://www.kali.org/docs/policy/cookie/",
+    author: "Offensive Security",
+    updated: "2024-05-01",
+  },
+  {
+    label: "Kali Linux EULA",
+    href: "https://www.kali.org/docs/policy/eula/",
+    author: "Offensive Security",
+    updated: "2024-05-01",
+  },
+  {
+    label: "Kali Linux Network Service Policy",
+    href: "https://www.kali.org/docs/policy/kali-linux-network-service-policy/",
+    author: "Offensive Security",
+    updated: "2024-05-01",
+  },
+  {
+    label: "Kali Linux Open Source Policy",
+    href: "https://www.kali.org/docs/policy/kali-linux-open-source-policy/",
+    author: "Offensive Security",
+    updated: "2024-05-01",
+  },
+  {
+    label: "Kali Linux Trademark Policy",
+    href: "https://www.kali.org/docs/policy/trademark/",
+    author: "Offensive Security",
+    updated: "2024-05-01",
+  },
+  {
+    label: "Kali Linux Update Policies",
+    href: "https://www.kali.org/docs/policy/kali-linux-security-update-policies/",
+    author: "Offensive Security",
+    updated: "2024-05-01",
+  },
+  {
+    label: "Kali Linux User Policy",
+    href: "https://www.kali.org/docs/policy/kali-linux-user-policy/",
+    author: "Offensive Security",
+    updated: "2024-05-01",
+  },
+  {
+    label: "Kali's Relationship With Debian",
+    href: "https://www.kali.org/docs/policy/kali-linux-relationship-with-debian/",
+    author: "Offensive Security",
+    updated: "2024-05-01",
+  },
+  {
+    label: "Penetration Testing Tools Policy",
+    href: "https://www.kali.org/docs/policy/penetration-testing-tools-policy/",
+    author: "Offensive Security",
+    updated: "2024-05-01",
+  },
+  {
+    label: "Privacy Policy",
+    href: "https://www.kali.org/docs/policy/privacy/",
+    author: "Offensive Security",
+    updated: "2024-05-01",
+  },
+];

--- a/pages/legal.tsx
+++ b/pages/legal.tsx
@@ -1,75 +1,6 @@
 import React from "react";
 import PolicyPage from "../components/PolicyPage";
-
-interface PolicyLink {
-  label: string;
-  href: string;
-  author: string;
-  updated: string;
-}
-
-const policies: PolicyLink[] = [
-  {
-    label: "Cookie Policy",
-    href: "https://www.kali.org/docs/policy/cookie/",
-    author: "Offensive Security",
-    updated: "2024-05-01",
-  },
-  {
-    label: "Kali Linux EULA",
-    href: "https://www.kali.org/docs/policy/eula/",
-    author: "Offensive Security",
-    updated: "2024-05-01",
-  },
-  {
-    label: "Kali Linux Network Service Policy",
-    href: "https://www.kali.org/docs/policy/kali-linux-network-service-policy/",
-    author: "Offensive Security",
-    updated: "2024-05-01",
-  },
-  {
-    label: "Kali Linux Open Source Policy",
-    href: "https://www.kali.org/docs/policy/kali-linux-open-source-policy/",
-    author: "Offensive Security",
-    updated: "2024-05-01",
-  },
-  {
-    label: "Kali Linux Trademark Policy",
-    href: "https://www.kali.org/docs/policy/trademark/",
-    author: "Offensive Security",
-    updated: "2024-05-01",
-  },
-  {
-    label: "Kali Linux Update Policies",
-    href: "https://www.kali.org/docs/policy/kali-linux-security-update-policies/",
-    author: "Offensive Security",
-    updated: "2024-05-01",
-  },
-  {
-    label: "Kali Linux User Policy",
-    href: "https://www.kali.org/docs/policy/kali-linux-user-policy/",
-    author: "Offensive Security",
-    updated: "2024-05-01",
-  },
-  {
-    label: "Kali's Relationship With Debian",
-    href: "https://www.kali.org/docs/policy/kali-linux-relationship-with-debian/",
-    author: "Offensive Security",
-    updated: "2024-05-01",
-  },
-  {
-    label: "Penetration Testing Tools Policy",
-    href: "https://www.kali.org/docs/policy/penetration-testing-tools-policy/",
-    author: "Offensive Security",
-    updated: "2024-05-01",
-  },
-  {
-    label: "Privacy Policy",
-    href: "https://www.kali.org/docs/policy/privacy/",
-    author: "Offensive Security",
-    updated: "2024-05-01",
-  },
-];
+import PolicyIndex from "../components/policy/PolicyIndex";
 
 const LegalPage: React.FC = () => (
   <PolicyPage
@@ -77,23 +8,7 @@ const LegalPage: React.FC = () => (
     author="Portfolio Maintainer"
     updated="2024-09-07"
   >
-    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8">
-      {policies.map((p) => (
-        <div key={p.href} className="space-y-1">
-          <a
-            href={p.href}
-            className="text-blue-500 underline"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {p.label}
-          </a>
-          <p className="text-xs text-gray-500">
-            Last updated: {p.updated} · Author: {p.author}
-          </p>
-        </div>
-      ))}
-    </div>
+    <PolicyIndex />
     <p className="text-xs text-gray-500">
       This portfolio is an independent project and is not affiliated with or
       endorsed by Kali Linux, Offensive Security, or any of their subsidiaries.


### PR DESCRIPTION
## Summary
- add policy grid component with responsive layout
- centralize policy metadata in a data file
- wire legal page to new policy index

## Testing
- `npx eslint data/policies.ts components/policy/PolicyIndex.tsx pages/legal.tsx`
- `yarn test` *(fails: browserType.launch executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68be7cbbc7348328b4bde6639ff1138b