### PR TITLE
feat: add footer theme switcher for docs

### DIFF
--- a/components/ThemeSwitcher.tsx
+++ b/components/ThemeSwitcher.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import ToggleSwitch from "./ToggleSwitch";
 
 const ALT_KEY = "alt-palette";
+const EVENT_NAME = "theme-change";
 
 export default function ThemeSwitcher() {
   const [enabled, setEnabled] = useState(false);
@@ -13,6 +14,12 @@ export default function ThemeSwitcher() {
     if (stored === "true") {
       setEnabled(true);
     }
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<boolean>).detail;
+      setEnabled(detail);
+    };
+    window.addEventListener(EVENT_NAME, handler);
+    return () => window.removeEventListener(EVENT_NAME, handler);
   }, []);
 
   useEffect(() => {
@@ -22,6 +29,7 @@ export default function ThemeSwitcher() {
       window.localStorage.removeItem(ALT_KEY);
     }
     document.documentElement.classList.toggle("alt-palette", enabled);
+    window.dispatchEvent(new CustomEvent(EVENT_NAME, { detail: enabled }));
   }, [enabled]);
 
   return (

--- a/pages/docs/[topic].tsx
+++ b/pages/docs/[topic].tsx
@@ -5,6 +5,7 @@ import { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
 import { marked } from 'marked';
 import { useEffect, useState } from 'react';
+import DocsLayout from './layout';
 
 interface TocItem {
   id: string;
@@ -62,14 +63,14 @@ export default function DocPage({ html, toc, title, topic }: DocProps) {
 
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://example.com';
 
-  return (
-    <>
-      <Head>
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
-              '@context': 'https://schema.org',
+    return (
+      <DocsLayout>
+        <Head>
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify({
+                '@context': 'https://schema.org',
               '@type': 'WebSite',
               url: siteUrl,
               name: 'Kali Linux Portfolio',
@@ -99,9 +100,9 @@ export default function DocPage({ html, toc, title, topic }: DocProps) {
             }),
           }}
         />
-      </Head>
-      <div className="flex flex-col lg:flex-row p-4">
-        <nav className="lg:w-1/4 lg:min-w-[12rem] lg:max-w-[20rem] lg:flex-shrink-0 lg:pr-4 lg:sticky lg:top-0">
+        </Head>
+        <div className="flex flex-col lg:flex-row p-4">
+          <nav className="lg:w-1/4 lg:min-w-[12rem] lg:max-w-[20rem] lg:flex-shrink-0 lg:pr-4 lg:sticky lg:top-0">
           <button
             className="lg:hidden mb-2 flex items-center"
             onClick={() => setShowToc((v) => !v)}
@@ -137,11 +138,11 @@ export default function DocPage({ html, toc, title, topic }: DocProps) {
             ))}
           </div>
         </nav>
-        <article className="prose flex-1" dangerouslySetInnerHTML={{ __html: html }} />
-      </div>
-    </>
-  );
-}
+          <article className="prose flex-1" dangerouslySetInnerHTML={{ __html: html }} />
+        </div>
+      </DocsLayout>
+    );
+  }
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const dir = path.join(process.cwd(), 'public', 'docs', 'seed');

--- a/pages/docs/layout.tsx
+++ b/pages/docs/layout.tsx
@@ -1,0 +1,16 @@
+import ThemeSwitcher from "@/components/ThemeSwitcher";
+import { ReactNode } from "react";
+
+export default function DocsLayout({ children }: { children?: ReactNode }) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <header className="p-4 flex justify-end">
+        <ThemeSwitcher />
+      </header>
+      <main className="flex-1">{children}</main>
+      <footer className="p-4 flex justify-center">
+        <ThemeSwitcher />
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add layout for docs with ThemeSwitcher in header and footer
- sync multiple ThemeSwitcher instances via custom `theme-change` event
- wrap docs topic pages with the new layout

## Testing
- `npx eslint components/ThemeSwitcher.tsx pages/docs/layout.tsx 'pages/docs/[topic].tsx'`
- `yarn test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68be7cba02dc8328918c329d9e438d37