### PR TITLE
style(docs): tighten mdx typography

### DIFF
--- a/pages/docs/[topic].tsx
+++ b/pages/docs/[topic].tsx
@@ -5,6 +5,7 @@ import { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
 import { marked } from 'marked';
 import { useEffect, useState } from 'react';
+import '@/styles/docs.css';
 
 interface TocItem {
   id: string;
@@ -137,7 +138,10 @@ export default function DocPage({ html, toc, title, topic }: DocProps) {
             ))}
           </div>
         </nav>
-        <article className="prose flex-1" dangerouslySetInnerHTML={{ __html: html }} />
+        <article
+          className="prose docs-content flex-1"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
       </div>
     </>
   );

--- a/styles/docs.css
+++ b/styles/docs.css
@@ -1,0 +1,38 @@
+/* Documentation specific overrides to match official docs */
+.docs-content {
+  font-family: var(--font-family-base, system-ui, sans-serif);
+}
+
+.docs-content ul,
+.docs-content ol {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+  padding-left: 1.25em;
+}
+
+.docs-content li + li {
+  margin-top: 0.25em;
+}
+
+.docs-content pre {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  padding: 0.75em 1em;
+  line-height: 1.4;
+  font-size: 0.9em;
+}
+
+.docs-content code {
+  font-family: var(--font-family-mono, monospace);
+}
+
+.docs-content blockquote {
+  margin: 1rem 0;
+  padding: 0.5rem 1rem;
+  border-left: 4px solid var(--color-primary);
+  background-color: var(--color-surface);
+}
+
+.docs-content blockquote > :last-child {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
## Summary
- add global docs typography overrides
- scope new styles via docs-content class

## Testing
- `npx eslint pages/docs/[topic].tsx`
- `npm test` *(fails: TypeError Cannot set properties of undefined (setting 'theme'))*

------
https://chatgpt.com/codex/tasks/task_e_68be7cb822b08328976c704529531322