### PR TITLE
feat: add tool category template

### DIFF
--- a/components/tools/CategoryLayout.tsx
+++ b/components/tools/CategoryLayout.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+
+interface CategoryLayoutProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function CategoryLayout({ children, className = '' }: CategoryLayoutProps) {
+  return <div className={`p-4 space-y-6 ${className}`}>{children}</div>;
+}
+

--- a/components/tools/ToolCard.tsx
+++ b/components/tools/ToolCard.tsx
@@ -1,0 +1,46 @@
+import React, { forwardRef } from 'react';
+
+interface ToolCardProps {
+  id: string;
+  name: string;
+  href?: string;
+}
+
+const badgeClass =
+  "inline-block rounded bg-gray-200 px-2 py-1 text-xs font-semibold text-gray-800 dark:bg-gray-700 dark:text-gray-100";
+
+const ToolCard = forwardRef<HTMLAnchorElement, ToolCardProps>(
+  ({ id, name, href = `https://www.kali.org/tools/${id}/` }, ref) => (
+    <a
+      href={href}
+      className="block rounded border p-4 focus:outline-none focus:ring"
+      ref={ref}
+    >
+      <h3 className="font-semibold text-base sm:text-lg md:text-xl">{name}</h3>
+      <div className="mt-2 flex flex-wrap gap-2">
+        <a
+          href={`https://gitlab.com/kalilinux/packages/${id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={badgeClass}
+        >
+          Source
+        </a>
+        <a
+          href={`https://www.kali.org/tools/${id}/`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={badgeClass}
+        >
+          Package
+        </a>
+        <span className={badgeClass}>{`$ apt install ${id}`}</span>
+      </div>
+    </a>
+  ),
+);
+
+ToolCard.displayName = 'ToolCard';
+
+export default ToolCard;
+

--- a/pages/tools/[category]/index.tsx
+++ b/pages/tools/[category]/index.tsx
@@ -1,14 +1,13 @@
 import { GetStaticPaths, GetStaticProps } from 'next';
-import Link from 'next/link';
-import categories, { ToolCategory } from '../../../data/tool-categories';
-import toolData from '../../../data/tools.json';
-import Hero from '../../../components/ui/Hero';
-import CommandChip from '../../../components/ui/CommandChip';
+import categories, { ToolCategory } from '@/data/tool-categories';
+import toolData from '@/data/tools.json';
+import Hero from '@/components/ui/Hero';
+import ToolCard from '@/components/tools/ToolCard';
+import CategoryLayout from '@/components/tools/CategoryLayout';
 
 interface ToolInfo {
   id: string;
   name: string;
-  install: string;
 }
 
 interface CategoryPageProps {
@@ -18,39 +17,34 @@ interface CategoryPageProps {
 
 export default function CategoryPage({ category, tools }: CategoryPageProps) {
   return (
-    <div className="p-4 space-y-6">
+    <CategoryLayout>
       <Hero title={category.name} summary={[category.intro]} />
       <section>
         <h2 className="text-xl font-semibold mb-4">Popular Tools</h2>
         <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
           {tools.map((tool) => (
-            <li key={tool.id} className="border rounded p-4 space-y-2">
-              <h3 className="font-semibold">
-                <Link href={`/tools/${tool.id}`}>{tool.name}</Link>
-              </h3>
-              {tool.install && <CommandChip command={tool.install} />}
+            <li key={tool.id}>
+              <ToolCard id={tool.id} name={tool.name} href={`/tools/${tool.id}`} />
             </li>
           ))}
         </ul>
       </section>
-    </div>
+    </CategoryLayout>
   );
 }
 
-export const getStaticPaths: GetStaticPaths = async () => {
-  return {
-    paths: categories.map((c) => ({ params: { category: c.id } })),
-    fallback: false,
-  };
-};
+export const getStaticPaths: GetStaticPaths = async () => ({
+  paths: categories.map((c) => ({ params: { category: c.id } })),
+  fallback: false,
+});
 
 export const getStaticProps: GetStaticProps<CategoryPageProps> = async ({ params }) => {
   const id = params?.category as string;
   const category = categories.find((c) => c.id === id)!;
   const tools: ToolInfo[] = category.tools.map((tid) => {
     const t = (toolData as any[]).find((tool) => tool.id === tid);
-    const install = t?.commands?.find((c: any) => c.label === 'Install')?.cmd || '';
-    return { id: tid, name: t?.name || tid, install };
+    return { id: tid, name: t?.name || tid };
   });
   return { props: { category, tools } };
 };
+

--- a/pages/tools/categories/index.tsx
+++ b/pages/tools/categories/index.tsx
@@ -1,19 +1,20 @@
 import Link from 'next/link';
-import categories from '../../../data/tool-categories';
+import categories from '@/data/tool-categories';
+import CategoryLayout from '@/components/tools/CategoryLayout';
 
 export default function ToolCategoriesIndex() {
   return (
-    <div className="p-4 space-y-4">
+    <CategoryLayout className="space-y-4">
       <h1 className="text-2xl font-bold">Tool Categories</h1>
       <ul className="list-disc list-inside space-y-2">
         {categories.map((cat) => (
           <li key={cat.id}>
-            <Link href={`/tools/categories/${cat.id}`} className="text-blue-600 underline">
+            <Link href={`/tools/${cat.id}`} className="text-blue-600 underline">
               {cat.name}
             </Link>
           </li>
         ))}
       </ul>
-    </div>
+    </CategoryLayout>
   );
 }

--- a/pages/tools/index.tsx
+++ b/pages/tools/index.tsx
@@ -1,12 +1,10 @@
 import { useState, useRef, KeyboardEvent, ChangeEvent } from "react";
 import tools from "../../data/kali-tools.json";
 import Pagination from "../../components/ui/Pagination";
+import ToolCard from "@/components/tools/ToolCard";
 
 const PAGE_SIZE_OPTIONS = [30, 60, 90];
 const COLUMNS = 3; // used for keyboard navigation
-
-const badgeClass =
-  "inline-block rounded bg-gray-200 px-2 py-1 text-xs font-semibold text-gray-800 dark:bg-gray-700 dark:text-gray-100";
 
 export default function ToolsPage() {
   const [page, setPage] = useState(0);
@@ -58,36 +56,13 @@ export default function ToolsPage() {
       >
         {pageTools.map((tool, i) => (
           <li key={tool.id}>
-            <a
-              href={`https://www.kali.org/tools/${tool.id}/`}
-              className="block rounded border p-4 focus:outline-none focus:ring"
+            <ToolCard
+              id={tool.id}
+              name={tool.name}
               ref={(el) => {
                 itemRefs.current[i] = el;
               }}
-            >
-              <h3 className="font-semibold text-base sm:text-lg md:text-xl">
-                {tool.name}
-              </h3>
-              <div className="mt-2 flex flex-wrap gap-2">
-                <a
-                  href={`https://gitlab.com/kalilinux/packages/${tool.id}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={badgeClass}
-                >
-                  Source
-                </a>
-                <a
-                  href={`https://www.kali.org/tools/${tool.id}/`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={badgeClass}
-                >
-                  Package
-                </a>
-                <span className={badgeClass}>{`$ apt install ${tool.id}`}</span>
-              </div>
-            </a>
+            />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- add reusable ToolCard and category layout components
- create dynamic tool category page with popular tools
- refactor listings to use shared layout and card

## Testing
- `yarn test --findRelatedTests components/tools/ToolCard.tsx components/tools/CategoryLayout.tsx pages/tools/index.tsx pages/tools/'[category]'/index.tsx pages/tools/categories/index.tsx --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68be7cb66e608328938fb379aba1b800