### PR TITLE
feat: add empty state illustrations

### DIFF
--- a/components/apps/security-tools/index.js
+++ b/components/apps/security-tools/index.js
@@ -135,6 +135,7 @@ export default function SecurityTools() {
             value={query}
             onChange={e => setQuery(e.target.value)}
             placeholder="Search all tools"
+            aria-label="Search all tools"
             className="w-full mb-2 p-1 text-black text-xs"
           />
           {query ? (
@@ -192,7 +193,7 @@ export default function SecurityTools() {
           )}
             {!hasResults && (
               <EmptyState
-                icon={<span>🔍</span>}
+                variant="search"
                 headline="No results"
                 helperText="Try refining your query"
               />
@@ -245,9 +246,19 @@ export default function SecurityTools() {
             {active === 'yara' && (
             <div>
               <p className="text-xs mb-2">Simplified YARA tester using sample text. Pattern matching is simulated.</p>
-              <textarea value={yaraRule} onChange={e=>setYaraRule(e.target.value)} className="w-full h-24 text-black p-1" />
+              <textarea
+                aria-label="YARA rule"
+                value={yaraRule}
+                onChange={e=>setYaraRule(e.target.value)}
+                className="w-full h-24 text-black p-1"
+              />
               <div className="text-xs mt-2 mb-1">Sample file:</div>
-              <textarea value={sampleText} readOnly className="w-full h-24 text-black p-1" />
+              <textarea
+                aria-label="Sample file"
+                value={sampleText}
+                readOnly
+                className="w-full h-24 text-black p-1"
+              />
               <button onClick={runYara} className="mt-2 px-2 py-1 bg-ub-green text-black text-xs">Scan</button>
               {yaraResult && <div className="mt-2 text-xs">{yaraResult}</div>}
             </div>

--- a/components/apps/vscode.jsx
+++ b/components/apps/vscode.jsx
@@ -96,7 +96,7 @@ export default function VsCodeWrapper({ openApp }) {
               {items.length === 0 && (
                 <li className="py-8">
                   <EmptyState
-                    icon={<span>🔍</span>}
+                    variant="search"
                     headline="No results"
                     helperText="Try another search"
                   />

--- a/components/panel/WeatherPopover.tsx
+++ b/components/panel/WeatherPopover.tsx
@@ -47,6 +47,7 @@ export default function WeatherPopover({
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search location"
+          aria-label="Search location"
           className="w-full mb-1 px-2 py-1 bg-gray-700 rounded text-sm"
         />
         {query && (
@@ -66,7 +67,7 @@ export default function WeatherPopover({
             {filtered.length === 0 && (
               <li className="p-4">
                 <EmptyState
-                  icon={<span>📍</span>}
+                  variant="search"
                   headline="No results"
                   helperText="Try another location"
                 />

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,23 +1,73 @@
 import React from 'react';
 
+type EmptyStateVariant = 'default' | 'search' | 'error';
+
 interface EmptyStateProps {
   icon?: React.ReactNode;
+  variant?: EmptyStateVariant;
   headline: string;
   helperText?: string;
   className?: string;
 }
 
+const illustrations: Record<EmptyStateVariant, React.ReactNode> = {
+  default: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+      <line x1="7" y1="8" x2="17" y2="8" />
+      <line x1="7" y1="12" x2="17" y2="12" />
+      <line x1="7" y1="16" x2="13" y2="16" />
+    </svg>
+  ),
+  search: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="11" cy="11" r="7" />
+      <line x1="16" y1="16" x2="20" y2="20" />
+    </svg>
+  ),
+  error: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  ),
+};
+
 export default function EmptyState({
   icon,
+  variant = 'default',
   headline,
   helperText,
   className = '',
 }: EmptyStateProps) {
+  const illustration = icon ?? illustrations[variant];
   return (
     <div className={`flex flex-col items-center text-center ${className}`.trim()}>
-      {icon && (
+      {illustration && (
         <div className="text-4xl mb-2 text-muted" aria-hidden="true">
-          {icon}
+          {illustration}
         </div>
       )}
       <h3 className="font-semibold text-text">{headline}</h3>

--- a/components/ui/SearchOverlay.tsx
+++ b/components/ui/SearchOverlay.tsx
@@ -116,7 +116,7 @@ export default function SearchOverlay({ open, onClose }: SearchOverlayProps) {
           {query && results.length === 0 && (
             <li className="py-8">
               <EmptyState
-                icon={<span>🔍</span>}
+                variant="search"
                 headline="No results"
                 helperText="Try a different search term"
               />

--- a/src/plugins/Dictionary.tsx
+++ b/src/plugins/Dictionary.tsx
@@ -83,7 +83,7 @@ export default function Dictionary() {
             {loading && <p>Loading...</p>}
             {error && (
               <EmptyState
-                icon={<span>📖</span>}
+                variant="search"
                 headline={error}
                 helperText="Try another word"
               />


### PR DESCRIPTION
## Summary
- add variant-based illustrations for EmptyState component
- reuse EmptyState across search and fetch-driven views
- improve accessibility with labeled search controls

## Testing
- `npx eslint components/ui/EmptyState.tsx components/ui/SearchOverlay.tsx components/panel/WeatherPopover.tsx components/apps/vscode.jsx components/apps/security-tools/index.js src/plugins/Dictionary.tsx`
- `yarn test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68be7cb4884c8328864e41f28089ef98