### PR TITLE
feat: add tool header link pills

### DIFF
--- a/components/tools/ToolHeader.tsx
+++ b/components/tools/ToolHeader.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+interface ToolHeaderProps {
+  id: string;
+  name: string;
+  description: string;
+  upstream?: string;
+}
+
+const badgeClass =
+  'inline-block rounded bg-gray-200 px-2 py-1 text-xs font-semibold text-gray-800 dark:bg-gray-700 dark:text-gray-100';
+
+interface LinkPillProps {
+  href: string;
+  children: React.ReactNode;
+}
+
+const LinkPill = ({ href, children }: LinkPillProps) => (
+  <a href={href} target="_blank" rel="noopener noreferrer" className={badgeClass}>
+    {children}
+  </a>
+);
+
+export default function ToolHeader({
+  id,
+  name,
+  description,
+  upstream,
+}: ToolHeaderProps) {
+  const repoUrl = upstream ?? `https://gitlab.com/kalilinux/packages/${id}`;
+  const manUrl = `https://manpages.debian.org/unstable/${id}/${id}.1.en.html`;
+
+  return (
+    <header className="space-y-2">
+      <h1 className="text-2xl font-bold">{name}</h1>
+      <p>{description}</p>
+      <div className="flex flex-wrap gap-2">
+        <LinkPill href={repoUrl}>Upstream Repo</LinkPill>
+        <LinkPill href={manUrl}>Man Page</LinkPill>
+      </div>
+    </header>
+  );
+}
+

--- a/pages/tools/[tool].tsx
+++ b/pages/tools/[tool].tsx
@@ -1,4 +1,5 @@
 import CommandChip from '@/components/CommandChip';
+import ToolHeader from '@/components/tools/ToolHeader';
 import toolData from '@/data/tool-details.json';
 import { GetStaticPaths, GetStaticProps } from 'next';
 
@@ -15,14 +16,14 @@ interface ToolInfo {
 }
 
 interface ToolPageProps {
+  id: string;
   tool: ToolInfo;
 }
 
-export default function ToolPage({ tool }: ToolPageProps) {
+export default function ToolPage({ id, tool }: ToolPageProps) {
   return (
     <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">{tool.name}</h1>
-      <p>{tool.description}</p>
+      <ToolHeader id={id} name={tool.name} description={tool.description} />
       {tool.commands.length > 0 && (
         <section>
           <h2 className="text-xl font-semibold mb-2">Commands</h2>
@@ -68,5 +69,5 @@ export const getStaticPaths: GetStaticPaths = async () => {
 export const getStaticProps: GetStaticProps<ToolPageProps> = async ({ params }) => {
   const id = params?.tool as string;
   const tool = tools[id];
-  return { props: { tool } };
+  return { props: { id, tool } };
 };


### PR DESCRIPTION
## Summary
- add reusable LinkPill badge component for tool headers
- show upstream repository and man page links
- integrate new header into tool pages

## Testing
- `npx eslint components/tools/ToolHeader.tsx pages/tools/[tool].tsx && echo 'eslint: no issues found'`
- `yarn test --passWithNoTests ToolHeader`

------
https://chatgpt.com/codex/tasks/task_e_68be7cb1e0cc8328966d23bc87fc718f