### PR TITLE
feat: add tooltip copy feedback for commands

### DIFF
--- a/components/CommandChip.tsx
+++ b/components/CommandChip.tsx
@@ -1,3 +1,3 @@
 'use client';
 
-export { default } from './ui/CommandChip';
+export { default, type CommandChipProps } from './ui/CommandChip';

--- a/components/ui/CommandChip.tsx
+++ b/components/ui/CommandChip.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 
-interface CommandChipProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface CommandChipProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   command: string;
 }
 
@@ -30,14 +30,23 @@ export default function CommandChip({ command, className = '', ...props }: Comma
     <button
       type="button"
       onClick={copy}
-      className={`inline-flex items-center gap-1 rounded-full border border-gray-600 bg-black px-2 py-1 font-mono text-green-400 text-sm ${className}`}
+      className={`group relative inline-flex items-center gap-1 rounded-full border border-gray-600 bg-black px-2 py-1 font-mono text-green-400 text-sm ${className}`}
       aria-label={`Copy ${command}`}
-      title="Copy command"
+      title={copied ? 'Copied!' : 'Copy command'}
       {...props}
     >
       <span className="select-all">$ {command}</span>
       <CopyIcon className="h-4 w-4" />
-      {copied && <span className="ml-1 text-xs text-gray-400">Copied</span>}
+      <span
+        role="tooltip"
+        className={`pointer-events-none absolute -top-7 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-gray-700 px-2 py-1 text-xs text-white transition-opacity ${
+          copied
+            ? 'opacity-100'
+            : 'opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100'
+        }`}
+      >
+        {copied ? 'Copied!' : 'Copy'}
+      </span>
     </button>
   );
 }

--- a/pages/tools/[slug].tsx
+++ b/pages/tools/[slug].tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import tools from '../../data/tools.json';
-import copyToClipboard from '../../utils/clipboard';
+import CommandChip from '@/components/CommandChip';
 
 interface ToolCommand {
   label?: string;
@@ -28,10 +28,6 @@ interface Props {
 }
 
 export default function ToolPage({ tool }: Props) {
-  const handleCopy = (cmd: string) => {
-    copyToClipboard(cmd);
-  };
-
   const relatedTools = (tool.related ?? [])
     .map((slug) => tools.find((t) => t.id === slug))
     .filter((t): t is Tool => Boolean(t))
@@ -59,18 +55,10 @@ export default function ToolPage({ tool }: Props) {
       {tool.commands?.length > 0 && (
         <section className="mb-6">
           <h2 className="text-xl font-semibold mb-2">Commands</h2>
-          <ul className="space-y-2">
+          <ul className="flex flex-wrap gap-2">
             {tool.commands.map((c, i) => (
-              <li key={i} className="flex items-center gap-2">
-                <code className="flex-1 bg-gray-100 dark:bg-gray-800 rounded px-2 py-1 text-sm">
-                  {c.cmd}
-                </code>
-                <button
-                  onClick={() => handleCopy(c.cmd)}
-                  className="px-2 py-1 text-sm border rounded"
-                >
-                  Copy
-                </button>
+              <li key={i}>
+                <CommandChip command={c.cmd} />
               </li>
             ))}
           </ul>

--- a/pages/tools/categories/[category].tsx
+++ b/pages/tools/categories/[category].tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import categories, { ToolCategory } from '../../../data/tool-categories';
 import toolData from '../../../data/tools.json';
 import Hero from '../../../components/ui/Hero';
-import CommandChip from '../../../components/ui/CommandChip';
+import CommandChip from '@/components/CommandChip';
 
 interface ToolInfo {
   id: string;


### PR DESCRIPTION
## Summary
- add tooltip with copy-to-clipboard feedback to `CommandChip`
- avoid layout shift for copy feedback
- reuse `CommandChip` on tool detail pages

## Testing
- `yarn test --passWithNoTests components/ui/CommandChip.tsx pages/tools/[slug].tsx pages/tools/categories/[category].tsx`
- `npx eslint components/ui/CommandChip.tsx pages/tools/[slug].tsx pages/tools/categories/[category].tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be7cb0d6a883289393d779b2e9669d