### PR TITLE
feat: add mirror integrity card to Get Kali page

### DIFF
--- a/components/get-kali/MirrorIntegrity.tsx
+++ b/components/get-kali/MirrorIntegrity.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import Callout from '../ui/Callout';
+
+export default function MirrorIntegrity() {
+  return (
+    <div className="space-y-4">
+      <Callout variant="mirrorInfo">
+        <p>
+          Downloads are automatically served from the nearest mirror for better performance. View the{' '}
+          <a
+            href="https://http.kali.org/README.mirrorlist"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            full mirror list
+          </a>
+          .
+        </p>
+      </Callout>
+      <Callout variant="verifyDownload">
+        <p>
+          Download images securely by verifying signatures or hashes.{' '}
+          <a
+            href="https://www.kali.org/docs/introduction/download-images-securely/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            Learn how
+          </a>
+          .
+        </p>
+      </Callout>
+    </div>
+  );
+}
+

--- a/pages/get-kali.tsx
+++ b/pages/get-kali.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Callout from '../components/ui/Callout';
+import MirrorIntegrity from '../components/get-kali/MirrorIntegrity';
 
 import * as Installer from '../content/get-kali/installer.mdx';
 import * as VMs from '../content/get-kali/vms.mdx';
@@ -82,22 +82,10 @@ const GetKali: React.FC = () => (
       ))}
     </div>
     <div className="mt-6">
-      <Callout variant="verifyDownload">
-        <p>
-          Verify downloads using signatures or hashes.{' '}
-          <a
-            href="https://www.kali.org/docs/introduction/download-validation/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            Verification instructions
-          </a>
-          .
-        </p>
-      </Callout>
+      <MirrorIntegrity />
     </div>
   </main>
 );
 
 export default GetKali;
+

--- a/pages/get-kali/index.tsx
+++ b/pages/get-kali/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
-import Callout from '../../components/ui/Callout';
+import MirrorIntegrity from '../../components/get-kali/MirrorIntegrity';
 
 const GetKali: React.FC = () => (
   <main className="p-4">
@@ -25,7 +25,7 @@ const GetKali: React.FC = () => (
       </div>
       <div className="flex flex-col rounded border p-4">
         <h2 className="mb-2 text-xl font-semibold">USB Live</h2>
-        <p className="mb-4">Boot from a portable USB drive and run Kali without touching your system&apos;s disk.</p>
+        <p className="mb-4">Boot from a portable USB drive and run Kali without touching your system's disk.</p>
         <a
           href="https://www.kali.org/get-kali/#kali-live"
           target="_blank"
@@ -54,35 +54,7 @@ const GetKali: React.FC = () => (
       </div>
     </div>
     <div className="mt-6">
-      <Callout variant="mirrorInfo">
-        <p>
-          Downloads are automatically served from the nearest mirror for better
-          performance. View the{' '}
-          <a
-            href="https://http.kali.org/README.mirrorlist"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            full mirror list
-          </a>
-          .
-        </p>
-      </Callout>
-      <Callout variant="verifyDownload">
-        <p>
-          Verify downloads using signatures or hashes.{' '}
-          <a
-            href="https://www.kali.org/docs/introduction/download-validation/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            Verification instructions
-          </a>
-          .
-        </p>
-      </Callout>
+      <MirrorIntegrity />
     </div>
   </main>
 );


### PR DESCRIPTION
## Summary
- add MirrorIntegrity component with mirror list and secure download links
- display MirrorIntegrity card near download sections on Get Kali pages

## Testing
- `yarn test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68be7ca6528c8328beecdea82ccd9a61