### PR TITLE
Add copyable hash row for download tiles

### DIFF
--- a/components/get-kali/HashRow.tsx
+++ b/components/get-kali/HashRow.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+interface HashRowProps {
+  hash: string;
+}
+
+export default function HashRow({ hash }: HashRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const truncated = `${hash.slice(0, 12)}…`;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(hash);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // ignore clipboard errors
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2 text-xs font-mono">
+      <code
+        tabIndex={0}
+        onFocus={() => setExpanded(true)}
+        onBlur={() => setExpanded(false)}
+        className="break-all focus:outline-none"
+      >
+        {expanded ? hash : truncated}
+      </code>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="rounded bg-gray-200 px-1 py-px text-[10px] hover:bg-gray-300 focus:outline-none"
+        aria-label="Copy SHA256 hash"
+      >
+        {copied ? 'Copied!' : 'Copy'}
+      </button>
+    </div>
+  );
+}
+

--- a/pages/platforms/cloud.tsx
+++ b/pages/platforms/cloud.tsx
@@ -1,5 +1,14 @@
 import React from 'react';
 import Callout from '../../components/ui/Callout';
+import HashRow from '../../components/get-kali/HashRow';
+
+const downloads = [
+  {
+    label: 'Kali Cloud Image',
+    href: '#',
+    hash: 'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
+  },
+];
 
 const CloudPage: React.FC = () => (
   <main className="p-4 space-y-4">
@@ -10,6 +19,16 @@ const CloudPage: React.FC = () => (
       <li>🌐 Reliable internet connection</li>
       <li>💾 Instance with at least 20 GB storage</li>
     </ul>
+    <section className="grid gap-4 sm:grid-cols-2">
+      {downloads.map((d) => (
+        <div key={d.label} className="border rounded p-4 flex flex-col">
+          <a href={d.href} className="text-blue-500 hover:underline mb-2">
+            {d.label}
+          </a>
+          {d.hash && <HashRow hash={d.hash} />}
+        </div>
+      ))}
+    </section>
     <Callout variant="readDocs">
       <p>
         Read the{' '}

--- a/pages/platforms/usb-live.tsx
+++ b/pages/platforms/usb-live.tsx
@@ -1,5 +1,14 @@
 import React from 'react';
 import Callout from '../../components/ui/Callout';
+import HashRow from '../../components/get-kali/HashRow';
+
+const downloads = [
+  {
+    label: 'Kali Live USB Image',
+    href: '#',
+    hash: '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff',
+  },
+];
 
 const USBLivePage: React.FC = () => (
   <main className="p-4 space-y-4">
@@ -10,6 +19,16 @@ const USBLivePage: React.FC = () => (
       <li>🖥️ BIOS/UEFI that supports booting from USB</li>
       <li>🌐 Internet connection for updates</li>
     </ul>
+    <section className="grid gap-4 sm:grid-cols-2">
+      {downloads.map((d) => (
+        <div key={d.label} className="border rounded p-4 flex flex-col">
+          <a href={d.href} className="text-blue-500 hover:underline mb-2">
+            {d.label}
+          </a>
+          {d.hash && <HashRow hash={d.hash} />}
+        </div>
+      ))}
+    </section>
     <Callout variant="readDocs">
       <p>
         Create a persistent live USB by following the{' '}

--- a/pages/platforms/vmware.tsx
+++ b/pages/platforms/vmware.tsx
@@ -1,5 +1,14 @@
 import React from 'react';
 import Callout from '../../components/ui/Callout';
+import HashRow from '../../components/get-kali/HashRow';
+
+const downloads = [
+  {
+    label: 'Kali VMware 64-bit',
+    href: '#',
+    hash: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+  },
+];
 
 const VMwarePage: React.FC = () => (
   <main className="p-4 space-y-4">
@@ -10,6 +19,16 @@ const VMwarePage: React.FC = () => (
       <li>💾 At least 20 GB free disk space</li>
       <li>🐏 4 GB RAM or more</li>
     </ul>
+    <section className="grid gap-4 sm:grid-cols-2">
+      {downloads.map((d) => (
+        <div key={d.label} className="border rounded p-4 flex flex-col">
+          <a href={d.href} className="text-blue-500 hover:underline mb-2">
+            {d.label}
+          </a>
+          {d.hash && <HashRow hash={d.hash} />}
+        </div>
+      ))}
+    </section>
     <Callout variant="readDocs">
       <p>
         For setup instructions, read the{' '}


### PR DESCRIPTION
## Summary
- add `HashRow` component that truncates SHA256, expands on focus and supports copy with feedback
- show hash row for available images on VMware, Cloud and USB Live download tiles

## Testing
- `yarn test` *(fails: missing modules, allowlist entries, and Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68be7ca82684832891eaec465274a919