### PR TITLE
feat: add usage hint to search overlay

### DIFF
--- a/components/ui/SearchOverlay.tsx
+++ b/components/ui/SearchOverlay.tsx
@@ -23,11 +23,22 @@ export default function SearchOverlay({ open, onClose }: SearchOverlayProps) {
   const nodeRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState('');
+  const [showHint, setShowHint] = useState(false);
 
   useEffect(() => {
     if (open) {
       setQuery('');
       inputRef.current?.focus();
+      if (typeof window !== 'undefined') {
+        const key = 'tool-search-hint-uses';
+        const uses = Number(window.localStorage.getItem(key) || '0');
+        if (uses < 2) {
+          setShowHint(true);
+          window.localStorage.setItem(key, String(uses + 1));
+        } else {
+          setShowHint(false);
+        }
+      }
     }
   }, [open]);
 
@@ -70,6 +81,23 @@ export default function SearchOverlay({ open, onClose }: SearchOverlayProps) {
         role="dialog"
         aria-modal="true"
       >
+        {showHint && (
+          <div
+            className="mb-3 flex justify-center gap-4 text-sm text-white/70"
+            aria-hidden="true"
+          >
+            <span>
+              <kbd className="rounded bg-white/20 px-1">↑</kbd>
+              <kbd className="ml-1 rounded bg-white/20 px-1">↓</kbd> to navigate
+            </span>
+            <span>
+              <kbd className="rounded bg-white/20 px-1">Enter</kbd> to open
+            </span>
+            <span>
+              <kbd className="rounded bg-white/20 px-1">Esc</kbd> to close
+            </span>
+          </div>
+        )}
         <input
           ref={inputRef}
           type="text"


### PR DESCRIPTION
## Summary
- add keyboard usage hint row to search overlay
- track hint display in localStorage to hide after two uses

## Testing
- `npx eslint components/ui/SearchOverlay.tsx`
- `npx jest __tests__/search.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68be7cb759fc8328995caa4bf70f7391