### PR TITLE
feat: add trust banner

### DIFF
--- a/components/home/TrustBanner.tsx
+++ b/components/home/TrustBanner.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+export default function TrustBanner() {
+  return (
+    <div className="mb-4 rounded border border-blue-400 bg-blue-50 p-4 text-blue-800">
+      <p>
+        Ensure you are on an{" "}
+        <a
+          href="https://www.kali.org/docs/introduction/download-official-kali-linux-images/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          official Kali site
+        </a>{" "}
+        and verify downloads with our{" "}
+        <a
+          href="https://www.kali.org/docs/introduction/download-validation/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          checksum instructions
+        </a>.
+      </p>
+    </div>
+  );
+}

--- a/pages/get-kali.tsx
+++ b/pages/get-kali.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Callout from '../components/ui/Callout';
+import TrustBanner from '../components/home/TrustBanner';
 
 import * as Installer from '../content/get-kali/installer.mdx';
 import * as VMs from '../content/get-kali/vms.mdx';
@@ -47,6 +48,7 @@ const platforms: Platform[] = [
 
 const GetKali: React.FC = () => (
   <main className="p-4">
+    <TrustBanner />
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {platforms.map(({ slug, title, summary, badges, url }) => (
         <div key={slug} className="border rounded p-4 flex flex-col">

--- a/pages/get-kali/index.tsx
+++ b/pages/get-kali/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import Link from 'next/link';
 import Callout from '../../components/ui/Callout';
+import TrustBanner from '../../components/home/TrustBanner';
 
 const GetKali: React.FC = () => (
   <main className="p-4">
+    <TrustBanner />
     <div className="mb-6 flex items-center justify-between rounded bg-purple-600 p-4 text-white">
       <span className="text-lg">New to Kali Linux? Learn how to get started.</span>
       <Link href="/install-options" className="rounded bg-white px-4 py-2 font-semibold text-purple-700 hover:bg-purple-50">

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import desktopsData from "../content/desktops.json";
 import { baseMetadata } from "../lib/metadata";
 import ReleaseNotesModal from "../components/ReleaseNotesModal";
+import TrustBanner from "../components/home/TrustBanner";
 
 export const metadata = baseMetadata;
 
@@ -36,6 +37,7 @@ export default function Home({ desktops }) {
 
   return (
     <main className="p-4">
+      <TrustBanner />
       <h1 className="mb-4 text-2xl font-bold sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl 2xl:text-7xl">
         Choose the desktop you prefer
       </h1>


### PR DESCRIPTION
## Summary
- add TrustBanner component linking to official Kali site list and checksum doc
- display trust banner on Home and Get Kali pages

## Testing
- `yarn test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68be7ca280c483288f1d4b7e27b948bd