### PR TITLE
Add release highlight mini panel

### DIFF
--- a/__tests__/ReleaseHighlight.test.tsx
+++ b/__tests__/ReleaseHighlight.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import ReleaseHighlight from "@/components/home/ReleaseHighlight";
+
+jest.mock("@/data/kali-blog.json", () => [
+  {
+    title: "Kali Linux 2025.2 Release",
+    link: "https://example.com/2025.2",
+    date: "2025-06-13",
+  },
+  {
+    title: "Kali Linux 2025.1 Release",
+    link: "https://example.com/2025.1",
+    date: "2025-03-19",
+  },
+]);
+
+describe("ReleaseHighlight", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders latest release and dismisses", async () => {
+    render(<ReleaseHighlight />);
+    const link = await screen.findByRole("link", {
+      name: /kali linux 2025.2 release/i,
+    });
+    expect(link).toHaveAttribute("href", "https://example.com/2025.2");
+
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("link", {
+          name: /kali linux 2025.2 release/i,
+        }),
+      ).toBeNull(),
+    );
+    expect(localStorage.getItem("release-highlight-dismissed")).toBe(
+      "https://example.com/2025.2",
+    );
+  });
+});
+

--- a/components/home/ReleaseHighlight.tsx
+++ b/components/home/ReleaseHighlight.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useMemo, useState } from "react";
+import posts from "@/data/kali-blog.json";
+
+const STORAGE_KEY = "release-highlight-dismissed";
+
+interface Post {
+  title: string;
+  link: string;
+  date: string;
+}
+
+export default function ReleaseHighlight() {
+  const [visible, setVisible] = useState(false);
+
+  const latest = useMemo(() => {
+    return (posts as Post[])
+      .filter((p) => p.title.includes("Release"))
+      .sort(
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+      )[0];
+  }, []);
+
+  useEffect(() => {
+    if (!latest) return;
+    if (typeof window === "undefined") return;
+    const dismissed = localStorage.getItem(STORAGE_KEY);
+    if (dismissed !== latest.link) {
+      setVisible(true);
+    }
+  }, [latest]);
+
+  const dismiss = () => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem(STORAGE_KEY, latest.link);
+    }
+    setVisible(false);
+  };
+
+  if (!latest || !visible) return null;
+
+  return (
+    <div className="Surface rounded p-4 flex items-start justify-between">
+      <div className="flex-1">
+        <h3 className="text-lg font-semibold mb-1">Latest Release</h3>
+        <a
+          href={latest.link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-blue-600 hover:underline"
+        >
+          {latest.title}
+        </a>
+      </div>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={dismiss}
+        className="ml-4 text-gray-500 hover:text-gray-700"
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- display latest release highlight on home page with link to notes
- persist dismiss state in localStorage and add unit test

## Testing
- `yarn test __tests__/ReleaseHighlight.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be7c9bf2f4832896b695fe76417ed8