### PR TITLE
feat(home): add desktop env cards with default badge

### DIFF
--- a/components/home/DesktopEnvs.tsx
+++ b/components/home/DesktopEnvs.tsx
@@ -3,10 +3,11 @@ import Image from "next/image";
 interface DesktopEnv {
   name: string;
   image: string;
+  isDefault?: boolean;
 }
 
 const desktopEnvs: DesktopEnv[] = [
-  { name: "Xfce", image: "/desktops/xfce.svg" },
+  { name: "Xfce", image: "/desktops/xfce.svg", isDefault: true },
   { name: "GNOME", image: "/desktops/gnome.svg" },
   { name: "KDE", image: "/desktops/kde.svg" },
 ];
@@ -15,13 +16,21 @@ export default function DesktopEnvs() {
   return (
     <div className="grid gap-4 sm:grid-cols-3">
       {desktopEnvs.map((env) => (
-        <div key={env.name} className="Surface rounded p-4 text-center">
+        <div
+          key={env.name}
+          className="relative flex flex-col items-center p-4 border rounded text-center bg-white"
+        >
+          {env.isDefault && (
+            <span className="absolute top-2 right-2 rounded bg-gray-200 px-2 py-0.5 text-[10px] font-medium text-gray-800 sm:text-xs">
+              default
+            </span>
+          )}
           <Image
             src={env.image}
             alt={env.name}
             width={128}
             height={128}
-            className="mx-auto mb-2 h-24 w-24 object-contain"
+            className="mb-2 h-24 w-24 object-contain"
           />
           <h3 className="text-lg font-semibold">{env.name}</h3>
         </div>


### PR DESCRIPTION
## Summary
- show GNOME and KDE desktop environment cards
- mark Xfce as the default environment with a subtle badge
- align desktop environment cards with shared card styling

## Testing
- `npx eslint components/home/DesktopEnvs.tsx`
- `yarn test DesktopEnvs --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be7c9376f48328834071da0b9ec612