### PR TITLE
feat: add skip link to header

### DIFF
--- a/__tests__/ia.test.tsx
+++ b/__tests__/ia.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Header from '../components/kali/Header';
 import Footer from '../components/kali/Footer';
 import ia from '../data/ia.json';
@@ -9,6 +10,14 @@ describe('IA navigation', () => {
     (ia as any).header.forEach((item: any) => {
       expect(screen.getByText(item.label)).toBeInTheDocument();
     });
+  });
+
+  test('skip link is first tabbable element', async () => {
+    render(<Header />);
+    await userEvent.tab();
+    const skip = screen.getByText(/skip to main content/i);
+    expect(skip).toHaveFocus();
+    expect(skip).toHaveAttribute('href', '#main-content');
   });
 
   test('footer renders groups and social links from ia.json', () => {

--- a/components/kali/Header.tsx
+++ b/components/kali/Header.tsx
@@ -9,7 +9,13 @@ interface NavItem {
 }
 
 const Header: React.FC = () => (
-  <header className="border-b border-gray-700 p-4">
+  <header className="relative border-b border-gray-700 p-4">
+    <a
+      href="#main-content"
+      className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-full focus:mt-2 focus:rounded focus:bg-black focus:px-4 focus:py-2 focus:text-white"
+    >
+      Skip to main content
+    </a>
     <nav aria-label="Main navigation">
       <ul className="flex flex-wrap items-center gap-4">
         {(ia as any).header.map((item: NavItem) => (


### PR DESCRIPTION
## Summary
- add visually-hidden skip link that appears on focus and anchors to main content
- ensure keyboard navigation lands on skip link first
- test skip link tab order

## Testing
- `yarn test __tests__/ia.test.tsx`
- `npx eslint components/kali/Header.tsx __tests__/ia.test.tsx`
- `pnpm -w typecheck` *(fails: --workspace-root may only be used inside a workspace)*
- `npx tsc --noEmit -p tsconfig.json` *(fails: numerous TS errors in unrelated files)*


------
https://chatgpt.com/codex/tasks/task_e_68be7c8495d08328985580b43d605355