### PR TITLE
feat: add status chip indicator

### DIFF
--- a/components/kali/Header.tsx
+++ b/components/kali/Header.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ia from '../../data/ia.json';
-import StatusPill from './StatusPill';
+import { StatusChip } from './StatusPill';
 
 interface NavItem {
   label: string;
@@ -35,7 +35,7 @@ const Header: React.FC = () => (
           </li>
         ))}
         <li className="ml-auto">
-          <StatusPill />
+          <StatusChip />
         </li>
       </ul>
     </nav>

--- a/pages/api/status.ts
+++ b/pages/api/status.ts
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.status(200).json({ status: { indicator: 'operational' } });
+}


### PR DESCRIPTION
## Summary
- add reusable `useStatus` hook with `StatusChip` component to show status color in header
- wire `StatusChip` into Kali header
- stub `/api/status` endpoint for local status fetching

## Testing
- `yarn eslint components/kali/StatusPill.tsx components/kali/Header.tsx pages/api/status.ts && echo 'eslint:ok'`
- `yarn test __tests__/StatusIndicators.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68be7c7761748328b743d84ba03bd13e