### PR TITLE
feat: add avatar component and about pages

### DIFF
--- a/components/ui/Avatar.tsx
+++ b/components/ui/Avatar.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+
+export interface AvatarProps {
+  src?: string;
+  name?: string;
+  size?: number;
+  className?: string;
+}
+
+function hashCode(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash << 5) - hash + str.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+export default function Avatar({
+  src,
+  name = '',
+  size = 64,
+  className = '',
+}: AvatarProps) {
+  const [error, setError] = useState(false);
+
+  if (src && !error) {
+    return (
+      <img
+        src={src}
+        alt={name}
+        width={size}
+        height={size}
+        onError={() => setError(true)}
+        className={`rounded-full object-cover bg-muted ${className}`}
+        style={{ width: size, height: size }}
+      />
+    );
+  }
+
+  const hash = hashCode(name);
+  const color = `hsl(${hash % 360}, 70%, 50%)`;
+  const cell = size / 5;
+  const blocks: JSX.Element[] = [];
+  for (let y = 0; y < 5; y++) {
+    for (let x = 0; x < 3; x++) {
+      if ((hash >> (x + y * 3)) & 1) {
+        const px = x * cell;
+        const py = y * cell;
+        blocks.push(<rect key={`${x}-${y}`} x={px} y={py} width={cell} height={cell} />);
+        const mx = (4 - x) * cell;
+        blocks.push(<rect key={`${4 - x}-${y}`} x={mx} y={py} width={cell} height={cell} />);
+      }
+    }
+  }
+
+  return (
+    <div
+      className={`flex items-center justify-center rounded-full bg-muted text-text overflow-hidden ${className}`}
+      style={{ width: size, height: size }}
+    >
+      {name ? (
+        <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} fill={color}>
+          {blocks}
+        </svg>
+      ) : (
+        <span className="text-sm">?</span>
+      )}
+    </div>
+  );
+}
+

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -1,0 +1,15 @@
+import Avatar from '../../components/ui/Avatar';
+
+export default function AboutPage() {
+  return (
+    <div className="p-8 max-w-3xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">About</h1>
+      <div className="flex items-center space-x-4">
+        <Avatar src="/images/logos/bitmoji.png" name="Alex" size={80} />
+        <p>
+          This project showcases the Kali Linux portfolio and the people working behind the scenes.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/pages/about/team.tsx
+++ b/pages/about/team.tsx
@@ -1,0 +1,23 @@
+import Avatar from '../../components/ui/Avatar';
+
+const team = [
+  { name: 'Alex', src: '/images/logos/bitmoji.png' },
+  { name: 'Taylor' },
+  { name: 'Jordan' },
+];
+
+export default function TeamPage() {
+  return (
+    <div className="p-8 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-6">Team</h1>
+      <ul className="space-y-4">
+        {team.map((member) => (
+          <li key={member.name} className="flex items-center space-x-4">
+            <Avatar src={member.src} name={member.name} size={64} />
+            <span className="font-medium">{member.name}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Avatar component that renders image or generated identicon
- show avatars on new About and Team pages

## Testing
- `npx eslint components/ui/Avatar.tsx pages/about/index.tsx pages/about/team.tsx`
- `npx jest __tests__/aboutAccessibility.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be7c73b628832880baa0281215f0a9