### PR TITLE
style: use outline focus ring

### DIFF
--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -33,7 +33,7 @@ export default function ModuleCard({
   return (
     <button
       onClick={() => onSelect(module)}
-      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
+      className={`focus-outline w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 ${
         selected ? 'bg-gray-100' : ''
       }`}
     >

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -102,7 +102,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
                 <button
                   role="menuitem"
                   tabIndex={-1}
-                  className="flex w-full items-center justify-between rounded-sm px-4 py-1 text-left hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
+                  className="focus-outline flex w-full items-center justify-between rounded-sm px-4 py-1 text-left hover:bg-gray-700"
                   onClick={(e) => {
                     if (item.submenu) {
                       const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -34,7 +34,7 @@ export default function Button({
   const variantStyle = variantStyles[variant];
   return (
     <button
-      className={`btn ${className}`}
+      className={`btn focus-outline ${className}`}
       style={{ ...variantStyle, ...style }}
       {...props}
     />

--- a/components/ui/SearchOverlay.tsx
+++ b/components/ui/SearchOverlay.tsx
@@ -93,7 +93,7 @@ export default function SearchOverlay({ open, onClose }: SearchOverlayProps) {
                     <li key={r.href}>
                       <a
                         href={r.href}
-                        className="flex items-center justify-between px-2 py-1 rounded hover:bg-white/10 focus:outline-none focus-visible:ring focus-visible:ring-white/50"
+                        className="focus-outline flex items-center justify-between px-2 py-1 rounded hover:bg-white/10"
                       >
                         <span>{r.title}</span>
                         <span className="flex gap-1">

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -49,7 +49,7 @@ const Toast: React.FC<ToastProps> = ({
       {onAction && actionLabel && (
         <button
           onClick={onAction}
-          className="ml-4 underline focus:outline-none"
+          className="ml-4 underline focus-outline"
         >
           {actionLabel}
         </button>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -172,7 +172,19 @@ html[data-theme='matrix'] {
 
 *:focus-visible {
   outline: var(--focus-outline-width) var(--focus-outline-style) var(--focus-outline-color);
-  outline-offset: 2px;
+  outline-offset: var(--focus-outline-offset);
+}
+
+.focus-outline:focus-visible {
+  outline: var(--focus-outline-width) var(--focus-outline-style) var(--focus-outline-color);
+  outline-offset: var(--focus-outline-offset);
+  transition: outline-offset var(--motion-fast);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .focus-outline:focus-visible {
+    transition: none;
+  }
 }
 
 .notification-center {

--- a/styles/index.css
+++ b/styles/index.css
@@ -142,11 +142,6 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
     transform: scale(0.98);
 }
 
-.btn:focus-visible {
-    outline: var(--focus-outline-width) var(--focus-outline-style) var(--focus-outline-color);
-    outline-offset: var(--focus-outline-offset);
-}
-
 a:focus-visible,
 button:focus-visible,
 input:focus-visible,

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -60,7 +60,7 @@
   --focus-outline-color: var(--color-accent);
   --focus-outline-width: 2px;
   --focus-outline-style: solid;
-  --focus-outline-offset: 2px;
+  --focus-outline-offset: 4px;
 }
 
 /* High contrast theme */
@@ -86,7 +86,7 @@
   --focus-outline-color: #ffff00;
   --focus-outline-width: 3px;
   --focus-outline-style: solid;
-  --focus-outline-offset: 3px;
+  --focus-outline-offset: 5px;
   --game-color-secondary: #ffff00;
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;


### PR DESCRIPTION
## Summary
- shift focus ring offset tokens so outlines sit outside existing shadows
- add shared `focus-outline` utility honoring reduced motion
- apply outline-based focus to buttons, cards, and menu items

## Testing
- `npx eslint components/ui/Button.tsx components/ModuleCard.tsx components/common/ContextMenu.tsx components/ui/Toast.tsx components/ui/SearchOverlay.tsx`
- `npx jest --findRelatedTests components/ui/Button.tsx components/ModuleCard.tsx components/common/ContextMenu.tsx components/ui/Toast.tsx components/ui/SearchOverlay.tsx` *(fails: Test Suites: 1 failed, 8 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68be7c70b33c83289bfc0bb9d09425da