### PR TITLE
feat: add density wrappers

### DIFF
--- a/components/ResultViewer.tsx
+++ b/components/ResultViewer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useEffect } from 'react';
+import DensityWrapper from './ui/DensityWrapper';
 
 interface ViewerProps {
   data: any[];
@@ -50,6 +51,7 @@ export default function ResultViewer({ data }: ViewerProps) {
   };
 
   return (
+    <DensityWrapper>
     <div className="text-xs" aria-label="result viewer">
       <div role="tablist" className="mb-2 flex">
         <button role="tab" aria-selected={tab === 'raw'} onClick={() => setTab('raw')} className="px-2 py-1 bg-ub-cool-grey text-white mr-2">
@@ -120,6 +122,7 @@ export default function ResultViewer({ data }: ViewerProps) {
         </svg>
       )}
     </div>
+    </DensityWrapper>
   );
 }
 

--- a/components/settings/KeyboardShortcuts.tsx
+++ b/components/settings/KeyboardShortcuts.tsx
@@ -1,4 +1,5 @@
 import { useState, ChangeEvent } from 'react';
+import DensityWrapper from '../ui/DensityWrapper';
 
 interface Shortcut {
   id: number;
@@ -81,6 +82,7 @@ const KeyboardShortcuts = () => {
   };
 
   return (
+    <DensityWrapper>
     <div>
       {warning && (
         <div role="alert" className="text-red-500 mb-2">
@@ -125,6 +127,7 @@ const KeyboardShortcuts = () => {
         </label>
       </div>
     </div>
+    </DensityWrapper>
   );
 };
 

--- a/components/ui/DensityWrapper.tsx
+++ b/components/ui/DensityWrapper.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+import { SettingsContext } from '@/hooks/useSettings';
+import { useContext } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function DensityWrapper({ children }: Props) {
+  const { density } = useContext(SettingsContext);
+  const className = density === 'compact' ? 'ui-dense' : 'ui-cozy';
+  return <div className={className}>{children}</div>;
+}

--- a/pages/apps/kali-tools/index.jsx
+++ b/pages/apps/kali-tools/index.jsx
@@ -1,6 +1,7 @@
 import Head from 'next/head';
 import { useMemo, useState } from 'react';
 import tools from '../../../data/kali-tools.json';
+import DensityWrapper from '../../../components/ui/DensityWrapper';
 
 const letters = Array.from({ length: 26 }, (_, i) =>
   String.fromCharCode(65 + i),
@@ -48,6 +49,7 @@ const KaliToolsPage = () => {
           }}
         />
       </Head>
+      <DensityWrapper>
       <div className="relative p-4">
         <label htmlFor="tool-search" className="sr-only">
           Search tools
@@ -64,14 +66,14 @@ const KaliToolsPage = () => {
           grouped[letter] ? (
             <section key={letter} id={`section-${letter}`} className="mb-8">
               <h2 className="mb-2 text-xl font-bold">{letter}</h2>
-              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+              <div className="tools-grid grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
                 {grouped[letter].map((tool) => (
                   <a
                     key={tool.id}
                     href={`https://www.kali.org/tools/${tool.id}/`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
+                    className="tools-card flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
                   >
                     <span>{tool.name}</span>
                   </a>
@@ -109,6 +111,7 @@ const KaliToolsPage = () => {
           </ul>
         </nav>
       </div>
+      </DensityWrapper>
     </>
   );
 };

--- a/pages/tools/index.tsx
+++ b/pages/tools/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, KeyboardEvent, ChangeEvent } from "react";
 import tools from "../../data/kali-tools.json";
 import Pagination from "../../components/ui/Pagination";
+import DensityWrapper from "../../components/ui/DensityWrapper";
 
 const PAGE_SIZE_OPTIONS = [30, 60, 90];
 const COLUMNS = 3; // used for keyboard navigation
@@ -51,16 +52,17 @@ export default function ToolsPage() {
   };
 
   return (
-    <div className="p-4">
-      <ul
-        className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6"
-        onKeyDown={handleKeyDown}
-      >
-        {pageTools.map((tool, i) => (
-          <li key={tool.id}>
+    <DensityWrapper>
+      <div className="p-4">
+        <ul
+          className="tools-grid grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6"
+          onKeyDown={handleKeyDown}
+        >
+          {pageTools.map((tool, i) => (
+            <li key={tool.id}>
             <a
               href={`https://www.kali.org/tools/${tool.id}/`}
-              className="block rounded border p-4 focus:outline-none focus:ring"
+              className="tools-card block rounded border p-4 focus:outline-none focus:ring"
               ref={(el) => {
                 itemRefs.current[i] = el;
               }}
@@ -90,13 +92,13 @@ export default function ToolsPage() {
             </a>
           </li>
         ))}
-      </ul>
-      <div className="mt-4 flex flex-col items-center gap-4 sm:flex-row sm:justify-between">
-        <div className="flex items-center gap-2">
-          <label htmlFor="page-size" className="text-sm">
-            Results per page:
-          </label>
-          <select
+        </ul>
+        <div className="mt-4 flex flex-col items-center gap-4 sm:flex-row sm:justify-between">
+          <div className="flex items-center gap-2">
+            <label htmlFor="page-size" className="text-sm">
+              Results per page:
+            </label>
+            <select
             id="page-size"
             value={pageSize}
             onChange={handlePageSizeChange}
@@ -114,7 +116,8 @@ export default function ToolsPage() {
           totalPages={pageCount}
           onPageChange={setPage}
         />
+        </div>
       </div>
-    </div>
+    </DensityWrapper>
   );
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -745,3 +745,47 @@ textarea:focus-visible {
     box-shadow: 0 0 0 4px rgba(251,191,36,0.9);
     border-radius: 4px;
 }
+
+/* Density utility classes */
+.ui-cozy {
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 1.5rem;
+    --space-6: 2rem;
+}
+
+.ui-dense {
+    --space-1: 0.125rem;
+    --space-2: 0.25rem;
+    --space-3: 0.5rem;
+    --space-4: 0.75rem;
+    --space-5: 1rem;
+    --space-6: 1.5rem;
+}
+
+.ui-cozy .p-4 { padding: var(--space-4); }
+.ui-dense .p-4 { padding: var(--space-2); }
+
+.ui-cozy .mt-4 { margin-top: var(--space-4); }
+.ui-dense .mt-4 { margin-top: var(--space-2); }
+
+.ui-cozy .gap-4 { gap: var(--space-4); }
+.ui-dense .gap-4 { gap: var(--space-2); }
+
+.ui-cozy .px-2 { padding-left: var(--space-2); padding-right: var(--space-2); }
+.ui-dense .px-2 { padding-left: var(--space-1); padding-right: var(--space-1); }
+
+.ui-cozy table th,
+.ui-cozy table td { padding: var(--space-4); }
+
+.ui-dense table th,
+.ui-dense table td { padding: var(--space-2); }
+
+.ui-cozy .tools-grid { gap: var(--space-4); }
+.ui-dense .tools-grid { gap: var(--space-2); }
+
+.ui-cozy .tools-card { padding: var(--space-4); }
+.ui-dense .tools-card { padding: var(--space-2); }
+


### PR DESCRIPTION
## Summary
- add CSS utilities `.ui-dense` and `.ui-cozy` for density spacing
- wrap tools pages and tables with `DensityWrapper`
- ensure result viewer and keyboard shortcuts respect density

## Testing
- `yarn test` *(fails: cannot find Chrome binary; missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68be7c7453448328a4868dbaf6c74830