### PR TITLE
feat: add badge component and use in header

### DIFF
--- a/components/kali/Header.tsx
+++ b/components/kali/Header.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ia from '../../data/ia.json';
 import StatusPill from './StatusPill';
+import Badge from '../ui/Badge';
 
 interface NavItem {
   label: string;
@@ -16,7 +17,9 @@ const Header: React.FC = () => (
           <li key={item.label} className="relative">
             {item.children ? (
               <details>
-                <summary className="cursor-pointer list-none">{item.label}</summary>
+                <summary className="cursor-pointer list-none">
+                  <Badge>{item.label}</Badge>
+                </summary>
                 <ul className="mt-2 space-y-1">
                   {item.children.map((child) => (
                     <li key={child.label}>

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -1,0 +1,12 @@
+import type { HTMLAttributes } from "react";
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {}
+
+export default function Badge({ className = "", ...props }: BadgeProps) {
+  return (
+    <span
+      className={`inline-block rounded-full bg-[var(--color-primary)] px-2 py-0.5 text-xs font-semibold text-[var(--color-inverse)] ${className}`}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable pill-shaped `Badge` component
- show category badges in navigation header groups

## Testing
- `yarn test components/kali/Header.tsx components/ui/Badge.tsx --passWithNoTests`
- `npx eslint components/ui/Badge.tsx components/kali/Header.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be7c6c52f08328947cb53591504e96