### PR TITLE
feat: add blur and shadow tokens

### DIFF
--- a/components/kali/Header.tsx
+++ b/components/kali/Header.tsx
@@ -9,7 +9,13 @@ interface NavItem {
 }
 
 const Header: React.FC = () => (
-  <header className="border-b border-gray-700 p-4">
+  <header
+    className="border-b border-gray-700 p-4"
+    style={{
+      boxShadow: 'var(--shadow-sm)',
+      backdropFilter: 'blur(var(--blur-sm))',
+    }}
+  >
     <nav aria-label="Main navigation">
       <ul className="flex flex-wrap items-center gap-4">
         {(ia as any).header.map((item: NavItem) => (
@@ -17,7 +23,13 @@ const Header: React.FC = () => (
             {item.children ? (
               <details>
                 <summary className="cursor-pointer list-none">{item.label}</summary>
-                <ul className="mt-2 space-y-1">
+                <ul
+                  className="mt-2 space-y-1"
+                  style={{
+                    boxShadow: 'var(--shadow-lg)',
+                    backdropFilter: 'blur(var(--blur-sm))',
+                  }}
+                >
                   {item.children.map((child) => (
                     <li key={child.label}>
                       <a href={child.href} className="hover:underline">

--- a/components/layout/DocMegaMenu.tsx
+++ b/components/layout/DocMegaMenu.tsx
@@ -23,7 +23,11 @@ export default function DocMegaMenu({ onClose }: DocMegaMenuProps) {
   return (
     <div
       ref={ref}
-      className="fixed left-0 top-12 z-50 w-full bg-white shadow-lg p-4 rtl:left-auto rtl:right-0"
+      className="fixed left-0 top-12 z-50 w-full bg-white p-4 rtl:left-auto rtl:right-0"
+      style={{
+        boxShadow: 'var(--shadow-lg)',
+        backdropFilter: 'blur(var(--blur-sm))',
+      }}
     >
       <ul className="grid gap-2 sm:grid-cols-2">
         <li>

--- a/components/ui/SearchOverlay.tsx
+++ b/components/ui/SearchOverlay.tsx
@@ -67,6 +67,7 @@ export default function SearchOverlay({ open, onClose }: SearchOverlayProps) {
       <div
         ref={nodeRef}
         className="fixed inset-0 bg-black/70 flex flex-col p-4"
+        style={{ backdropFilter: 'blur(var(--blur-lg))' }}
         role="dialog"
         aria-modal="true"
       >
@@ -74,6 +75,7 @@ export default function SearchOverlay({ open, onClose }: SearchOverlayProps) {
           ref={inputRef}
           type="text"
           className="w-full p-3 text-lg rounded"
+          style={{ boxShadow: 'var(--shadow-sm)' }}
           placeholder="Search..."
           value={query}
           aria-label="Search query"

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -51,6 +51,17 @@
   --motion-medium: 300ms;
   --motion-slow: 500ms;
 
+  /* Blur */
+  --blur-sm: 4px;
+  --blur-md: 8px;
+  --blur-lg: 16px;
+
+  /* Shadows */
+  --shadow-color: color-mix(in srgb, var(--color-inverse), transparent 80%);
+  --shadow-sm: 0 1px 2px var(--shadow-color);
+  --shadow-md: 0 4px 6px var(--shadow-color);
+  --shadow-lg: 0 8px 12px var(--shadow-color);
+
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
   --font-multiplier: 1;


### PR DESCRIPTION
## Summary
- add blur and shadow CSS variables to token library
- apply shared blur and shadow styles to header, mega menu, and search overlay

## Testing
- `npm test` *(fails: appImport.test.ts, terminal.test.tsx and others)*

------
https://chatgpt.com/codex/tasks/task_e_68be7c6c98488328b0d5a85bb0815c6a