### PR TITLE
feat: add tertiary and ghost button variants

### DIFF
--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,6 +1,12 @@
 import type { ButtonHTMLAttributes, CSSProperties } from "react";
 
-export type ButtonVariant = "default" | "primary" | "secondary" | "danger";
+export type ButtonVariant =
+  | "default"
+  | "primary"
+  | "secondary"
+  | "tertiary"
+  | "ghost"
+  | "danger";
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
@@ -18,6 +24,15 @@ const variantStyles: Record<ButtonVariant, CSSProperties> = {
   secondary: {
     "--btn-bg": "var(--color-secondary)",
     "--btn-text": "var(--color-text)",
+  },
+  tertiary: {
+    "--btn-bg": "var(--color-tertiary)",
+    "--btn-text": "var(--color-text)",
+  },
+  ghost: {
+    "--btn-bg": "transparent",
+    "--btn-text": "var(--color-primary)",
+    border: "1px solid transparent",
   },
   danger: {
     "--btn-bg": "var(--game-color-danger)",

--- a/pages/get-kali.tsx
+++ b/pages/get-kali.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import Callout from '../components/ui/Callout';
+import Header from '../components/layout/Header';
+import Footer from '../components/layout/Footer';
 
 import * as Installer from '../content/get-kali/installer.mdx';
 import * as VMs from '../content/get-kali/vms.mdx';
@@ -46,58 +48,62 @@ const platforms: Platform[] = [
 ];
 
 const GetKali: React.FC = () => (
-  <main className="p-4">
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {platforms.map(({ slug, title, summary, badges, url }) => (
-        <div key={slug} className="border rounded p-4 flex flex-col">
-          <h2 className="text-xl font-semibold mb-2">{title}</h2>
-          <p className="mb-4">{summary}</p>
-          {badges?.length > 0 && (
-            <ul className="flex flex-wrap gap-2 mb-4">
-              {badges.map((badge) => {
-                const icon = badgeIcons[badge];
-                return (
-                  <li key={badge} className="flex items-center justify-center">
-                    {icon ? (
-                      <img src={icon} alt={badge} className="h-6 w-6" />
-                    ) : (
-                      <span className="bg-gray-200 text-gray-800 px-2 py-1 rounded text-xs">
-                        {badge}
-                      </span>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-          <a
-            href={url ?? `https://www.kali.org/get-kali/#kali-${slug}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-500 hover:underline mt-auto"
-          >
-            Learn more
-          </a>
-        </div>
-      ))}
-    </div>
-    <div className="mt-6">
-      <Callout variant="verifyDownload">
-        <p>
-          Verify downloads using signatures or hashes.{' '}
-          <a
-            href="https://www.kali.org/docs/introduction/download-validation/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            Verification instructions
-          </a>
-          .
-        </p>
-      </Callout>
-    </div>
-  </main>
+  <>
+    <Header />
+    <main className="p-4">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {platforms.map(({ slug, title, summary, badges, url }) => (
+          <div key={slug} className="border rounded p-4 flex flex-col">
+            <h2 className="text-xl font-semibold mb-2">{title}</h2>
+            <p className="mb-4">{summary}</p>
+            {badges?.length > 0 && (
+              <ul className="flex flex-wrap gap-2 mb-4">
+                {badges.map((badge) => {
+                  const icon = badgeIcons[badge];
+                  return (
+                    <li key={badge} className="flex items-center justify-center">
+                      {icon ? (
+                        <img src={icon} alt={badge} className="h-6 w-6" />
+                      ) : (
+                        <span className="bg-gray-200 text-gray-800 px-2 py-1 rounded text-xs">
+                          {badge}
+                        </span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+            <a
+              href={url ?? `https://www.kali.org/get-kali/#kali-${slug}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-500 hover:underline mt-auto"
+            >
+              Learn more
+            </a>
+          </div>
+        ))}
+      </div>
+      <div className="mt-6">
+        <Callout variant="verifyDownload">
+          <p>
+            Verify downloads using signatures or hashes{' '}
+            <a
+              href="https://www.kali.org/docs/introduction/download-validation/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              Verification instructions
+            </a>
+            .
+          </p>
+        </Callout>
+      </div>
+    </main>
+    <Footer />
+  </>
 );
 
 export default GetKali;

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -5,6 +5,8 @@ import { useEffect, useState } from "react";
 import desktopsData from "../content/desktops.json";
 import { baseMetadata } from "../lib/metadata";
 import ReleaseNotesModal from "../components/ReleaseNotesModal";
+import Header from "../components/layout/Header";
+import Footer from "../components/layout/Footer";
 
 export const metadata = baseMetadata;
 
@@ -35,10 +37,12 @@ export default function Home({ desktops }) {
   }, []);
 
   return (
-    <main className="p-4">
-      <h1 className="mb-4 text-2xl font-bold sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl 2xl:text-7xl">
-        Choose the desktop you prefer
-      </h1>
+    <>
+      <Header />
+      <main className="p-4">
+        <h1 className="mb-4 text-2xl font-bold sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl 2xl:text-7xl">
+          Choose the desktop you prefer
+        </h1>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
         {desktops.map((d) => (
           <div
@@ -72,6 +76,8 @@ export default function Home({ desktops }) {
         ))}
       </div>
       <ReleaseNotesModal isOpen={open} onClose={() => setOpen(false)} />
-    </main>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -25,6 +25,10 @@
   --color-ub-dark-grey: #2a2e36;
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
+  --color-primary: #1793d1;
+  --color-secondary: #1a1f26;
+  --color-tertiary: #374151;
+  --color-ghost: transparent;
 
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
@@ -91,6 +95,8 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --color-tertiary: #ffffff;
+  --color-ghost: transparent;
 }
 
 /* Dyslexia-friendly fonts */
@@ -130,5 +136,7 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+    --color-tertiary: #ffffff;
+    --color-ghost: transparent;
   }
 }


### PR DESCRIPTION
## Summary
- add tertiary and ghost variants to Button component
- introduce contrast-friendly color tokens for tertiary and ghost
- wrap Home and Get-Kali pages with Header and Footer to supply landmark roles

## Testing
- `npm test` *(fails: Missing allowlist entries; Node.js v18 errors)*
- `npm run lint` *(fails: hangs due to workspace requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68be7c6e06748328801a49075655d816