### PR TITLE
feat: add section divider component

### DIFF
--- a/components/home/DesktopEnvs.tsx
+++ b/components/home/DesktopEnvs.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import SectionDivider from "../ui/SectionDivider";
 
 interface DesktopEnv {
   name: string;
@@ -13,19 +14,22 @@ const desktopEnvs: DesktopEnv[] = [
 
 export default function DesktopEnvs() {
   return (
-    <div className="grid gap-4 sm:grid-cols-3">
-      {desktopEnvs.map((env) => (
-        <div key={env.name} className="Surface rounded p-4 text-center">
-          <Image
-            src={env.image}
-            alt={env.name}
-            width={128}
-            height={128}
-            className="mx-auto mb-2 h-24 w-24 object-contain"
-          />
-          <h3 className="text-lg font-semibold">{env.name}</h3>
-        </div>
-      ))}
-    </div>
+    <>
+      <div className="grid gap-4 sm:grid-cols-3">
+        {desktopEnvs.map((env) => (
+          <div key={env.name} className="Surface rounded p-4 text-center">
+            <Image
+              src={env.image}
+              alt={env.name}
+              width={128}
+              height={128}
+              className="mx-auto mb-2 h-24 w-24 object-contain"
+            />
+            <h3 className="text-lg font-semibold">{env.name}</h3>
+          </div>
+        ))}
+      </div>
+      <SectionDivider className="my-8" />
+    </>
   );
 }

--- a/components/home/KaliEverywhere.tsx
+++ b/components/home/KaliEverywhere.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import SectionDivider from "../ui/SectionDivider";
 
 interface Platform {
   icon: string;
@@ -51,20 +51,23 @@ const platforms: Platform[] = [
 
 export default function KaliEverywhere() {
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-      {platforms.map((p) => (
-        <div
-          key={p.title}
-          className="flex flex-col items-center p-4 border rounded text-center bg-white"
-        >
-          <div className="text-4xl mb-2" aria-hidden>
-            {p.icon}
+    <>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {platforms.map((p) => (
+          <div
+            key={p.title}
+            className="Surface flex flex-col items-center rounded p-4 text-center"
+          >
+            <div className="mb-2 text-4xl" aria-hidden>
+              {p.icon}
+            </div>
+            <h3 className="font-semibold">{p.title}</h3>
+            <p className="text-sm text-muted">{p.description}</p>
           </div>
-          <h3 className="font-semibold">{p.title}</h3>
-          <p className="text-sm text-gray-600">{p.description}</p>
-        </div>
-      ))}
-    </div>
+        ))}
+      </div>
+      <SectionDivider className="my-8" />
+    </>
   );
 }
 

--- a/components/ui/SectionDivider.tsx
+++ b/components/ui/SectionDivider.tsx
@@ -1,0 +1,18 @@
+interface SectionDividerProps {
+  className?: string;
+}
+
+export default function SectionDivider({ className = "" }: SectionDividerProps) {
+  return (
+    <div className={`w-full overflow-hidden ${className}`}>
+      <svg
+        viewBox="0 0 100 10"
+        preserveAspectRatio="none"
+        className="h-6 w-full text-border"
+        aria-hidden
+      >
+        <path d="M0 0 L50 10 L100 0 L100 10 L0 10 Z" fill="currentColor" />
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable SectionDivider component with responsive SVG divider
- insert dividers and theme-friendly colors in home sections

## Testing
- `npx eslint components/home/DesktopEnvs.tsx components/home/KaliEverywhere.tsx components/ui/SectionDivider.tsx`
- `npx tsc --noEmit --jsx react-jsx --skipLibCheck components/home/DesktopEnvs.tsx components/home/KaliEverywhere.tsx components/ui/SectionDivider.tsx`
- `npx jest components/home/DesktopEnvs.tsx components/home/KaliEverywhere.tsx components/ui/SectionDivider.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be7c6d48bc83289ca792ab09f3289a