### PR TITLE
fix vercel config schema

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "nodeVersion": "22.x",
     "pages/api/**/*.{js,ts}": { "runtime": "nodejs22.x" },
     "app/api/**/route.{js,ts}": { "runtime": "nodejs22.x" }
   }


### PR DESCRIPTION
## Summary
- remove unsupported `functions.nodeVersion` field

## Testing
- `npx eslint vercel.json` *(warn: File ignored because no matching configuration was supplied)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0511daec832895ffbd882ee585e4