### PR TITLE
Add Win-KeX tile component for WSL platform

### DIFF
--- a/components/platforms/WinKexTile.tsx
+++ b/components/platforms/WinKexTile.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface WinKexTileProps {
+  className?: string;
+}
+
+const features = [
+  'Full Kali desktop in a window',
+  'Seamless integration on Windows',
+  'Enhanced session with RDP'
+];
+
+export default function WinKexTile({ className = '' }: WinKexTileProps) {
+  return (
+    <div className={`border rounded p-4 flex flex-col ${className}`}>
+      <h3 className="font-semibold mb-2">Win-KeX</h3>
+      <ul className="list-disc list-inside text-sm space-y-1 mb-4">
+        {features.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+      <a
+        href="https://www.kali.org/docs/wsl/win-kex/"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-blue-500 hover:underline mt-auto"
+      >
+        Win-KeX documentation
+      </a>
+    </div>
+  );
+}

--- a/content/get-kali/wsl.mdx
+++ b/content/get-kali/wsl.mdx
@@ -1,5 +1,6 @@
 import MDXPageHeader from '../../components/ui/MDXPageHeader';
 import Admonition from '../../components/mdx/Admonition';
+import WinKexTile from '../../components/platforms/WinKexTile';
 
 <MDXPageHeader
   breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Get Kali', href: '/get-kali' }, { label: 'WSL' }]}
@@ -13,6 +14,8 @@ import Admonition from '../../components/mdx/Admonition';
   <a href="/wsl-prep" className="underline">WSL preparation docs</a>
   before installation.
 </Admonition>
+
+<WinKexTile />
 
 export const title = 'WSL';
 export const summary = 'Kali Linux for Windows Subsystem for Linux.';

--- a/data/features.ts
+++ b/data/features.ts
@@ -20,4 +20,9 @@ export const features: Feature[] = [
     blurb: 'Boot Kali from a portable USB drive and enable persistence.',
     href: '/platforms/usb-live',
   },
+  {
+    title: 'WSL',
+    blurb: 'Run Kali Linux on Windows Subsystem for Linux with Win-KeX.',
+    href: '/platforms/wsl',
+  },
 ];

--- a/pages/platforms/wsl.tsx
+++ b/pages/platforms/wsl.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Callout from '../../components/ui/Callout';
+import WinKexTile from '../../components/platforms/WinKexTile';
+
+const WSLPage: React.FC = () => (
+  <main className="p-4 space-y-4">
+    <h1 className="text-2xl font-semibold">WSL</h1>
+    <p>Run Kali on Windows Subsystem for Linux.</p>
+    <WinKexTile />
+    <Callout variant="readDocs">
+      <p>
+        Read the{' '}
+        <a
+          href="https://www.kali.org/docs/wsl/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          WSL documentation
+        </a>
+        {' '}for setup instructions.
+      </p>
+    </Callout>
+  </main>
+);
+
+export default WSLPage;


### PR DESCRIPTION
## Summary
- add Win-KeX tile component with key session features and docs link
- include Win-KeX tile on WSL get-kali content
- add dedicated WSL platform page and reference from features list

## Testing
- `yarn lint components/platforms/WinKexTile.tsx pages/platforms/wsl.tsx content/get-kali/wsl.mdx data/features.ts` (fails: Unable to resolve path to module '../components/ToolbarIcons', etc.)
- `yarn test components/platforms/WinKexTile.tsx pages/platforms/wsl.tsx content/get-kali/wsl.mdx data/features.ts` (fails: No tests found, exiting with code 1)


------
https://chatgpt.com/codex/tasks/task_e_68be7cc77d148328839cb0706810b79b