### PR TITLE
feat: add version label to tool header

### DIFF
--- a/components/tools/ToolHeader.tsx
+++ b/components/tools/ToolHeader.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+interface ToolHeaderProps {
+  name: string;
+  version?: string;
+  updated?: string;
+  badges?: React.ReactNode;
+}
+
+export default function ToolHeader({
+  name,
+  version,
+  updated,
+  badges,
+}: ToolHeaderProps) {
+  return (
+    <header className="mb-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <h1 className="text-2xl font-bold">{name}</h1>
+        {version && (
+          <span className="inline-block rounded bg-info/20 px-2 py-1 text-xs font-semibold text-info">
+            v{version}
+          </span>
+        )}
+        {updated && (
+          <span className="inline-block rounded bg-info/20 px-2 py-1 text-xs font-semibold text-info">
+            Updated {updated}
+          </span>
+        )}
+        {badges}
+      </div>
+    </header>
+  );
+}
+

--- a/pages/tools/[slug].tsx
+++ b/pages/tools/[slug].tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import tools from '../../data/tools.json';
 import copyToClipboard from '../../utils/clipboard';
+import ToolHeader from '../../components/tools/ToolHeader';
 
 interface ToolCommand {
   label?: string;
@@ -21,6 +22,7 @@ interface Tool {
   commands: ToolCommand[];
   upstream: string;
   related?: string[];
+  updated?: string;
 }
 
 interface Props {
@@ -39,7 +41,11 @@ export default function ToolPage({ tool }: Props) {
 
   return (
     <div className="p-4 max-w-3xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">{tool.name}</h1>
+      <ToolHeader
+        name={tool.name}
+        version={tool.packages?.[0]?.version}
+        updated={tool.updated}
+      />
       <p className="mb-6">{tool.summary}</p>
 
       {tool.packages?.length > 0 && (


### PR DESCRIPTION
## Summary
- add ToolHeader component with version and updated badges
- use ToolHeader in tool detail page

## Testing
- `yarn test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*


------
https://chatgpt.com/codex/tasks/task_e_68be7cb6f2b48328a1dc920f25387cb1