### PR TITLE
feat: color-code tool categories with accessible hues

### DIFF
--- a/components/tools/ToolCard.tsx
+++ b/components/tools/ToolCard.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+import { getCategoryStyle } from '@/data/categoryColors';
+
+interface ToolCardProps {
+  name: string;
+  category: string;
+  children?: ReactNode;
+}
+
+export default function ToolCard({ name, category, children }: ToolCardProps) {
+  const style = getCategoryStyle(category);
+  return (
+    <div className="rounded border p-4" style={style}>
+      <h3 className="font-semibold mb-2">{name}</h3>
+      {children && <div className="text-sm">{children}</div>}
+    </div>
+  );
+}

--- a/components/tools/ToolTable.tsx
+++ b/components/tools/ToolTable.tsx
@@ -1,0 +1,32 @@
+import { getCategoryStyle } from '@/data/categoryColors';
+
+export interface ToolTableRow {
+  id: string;
+  name: string;
+  category: string;
+}
+
+interface ToolTableProps {
+  tools: ToolTableRow[];
+}
+
+export default function ToolTable({ tools }: ToolTableProps) {
+  return (
+    <table className="w-full border-collapse">
+      <thead>
+        <tr>
+          <th className="p-2 text-left">Tool</th>
+          <th className="p-2 text-left">Category</th>
+        </tr>
+      </thead>
+      <tbody>
+        {tools.map((tool) => (
+          <tr key={tool.id} style={getCategoryStyle(tool.category)}>
+            <td className="p-2 font-medium">{tool.name}</td>
+            <td className="p-2">{tool.category}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/data/categoryColors.ts
+++ b/data/categoryColors.ts
@@ -1,0 +1,20 @@
+import type { CSSProperties } from "react";
+
+export const categoryHues: Record<string, number> = {
+  'information-gathering': 212,
+  'password-attacks': 0,
+};
+
+const DEFAULT_HUE = 210;
+
+export function getCategoryStyle(id: string): CSSProperties {
+  const hue = categoryHues[id] ?? DEFAULT_HUE;
+  return {
+    // Light background ensures readable contrast against dark text
+    backgroundColor: `hsl(${hue} 60% 90%)`,
+    borderColor: `hsl(${hue} 60% 70%)`,
+    color: '#000',
+  };
+}
+
+export default categoryHues;

--- a/pages/tools/categories/[category].tsx
+++ b/pages/tools/categories/[category].tsx
@@ -4,6 +4,7 @@ import categories, { ToolCategory } from '../../../data/tool-categories';
 import toolData from '../../../data/tools.json';
 import Hero from '../../../components/ui/Hero';
 import CommandChip from '../../../components/ui/CommandChip';
+import ToolCard from '../../../components/tools/ToolCard';
 
 interface ToolInfo {
   id: string;
@@ -24,11 +25,10 @@ export default function CategoryPage({ category, tools }: CategoryPageProps) {
         <h2 className="text-xl font-semibold mb-4">Popular Tools</h2>
         <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
           {tools.map((tool) => (
-            <li key={tool.id} className="border rounded p-4 space-y-2">
-              <h3 className="font-semibold">
-                <Link href={`/tools/${tool.id}`}>{tool.name}</Link>
-              </h3>
-              {tool.install && <CommandChip command={tool.install} />}
+            <li key={tool.id}>
+              <ToolCard name={tool.name} category={category.id}>
+                {tool.install && <CommandChip command={tool.install} />}
+              </ToolCard>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- map tool categories to hues and provide accessible styles
- introduce ToolCard and ToolTable components using category hues
- tint category page tool cards according to category

## Testing
- `npm test` *(fails: dynamic imports missing, browser binaries unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68be7caf83f883288af985b6e9808eee