### PR TITLE
feat: add letter rail navigation

### DIFF
--- a/components/tools/LetterRail.tsx
+++ b/components/tools/LetterRail.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface LetterRailProps {
+  letters: string[];
+  grouped: Record<string, unknown[]>;
+}
+
+const LetterRail = ({ letters, grouped }: LetterRailProps) => {
+  const [active, setActive] = useState<string | null>(null);
+
+  useEffect(() => {
+    const onScroll = () => {
+      const midpoint = window.scrollY + window.innerHeight / 2;
+      let current: string | null = null;
+      for (const letter of letters) {
+        const el = document.getElementById(`section-${letter}`);
+        if (el) {
+          const top = el.offsetTop;
+          const bottom = top + el.offsetHeight;
+          if (midpoint >= top && midpoint < bottom) {
+            current = letter;
+            break;
+          }
+        }
+      }
+      setActive(current);
+    };
+
+    onScroll();
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [letters, grouped]);
+
+  const handleClick = (letter: string) => {
+    const el = document.getElementById(`section-${letter}`);
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  return (
+    <nav aria-label="Alphabet navigation" className="fixed right-2 top-1/2 -translate-y-1/2">
+      <ul className="flex flex-col items-center space-y-1">
+        {letters.map((letter) => {
+          const disabled = !grouped[letter];
+          const classes = `h-6 w-6 text-xs ${disabled
+            ? 'cursor-default text-gray-400'
+            : active === letter
+              ? 'font-bold text-blue-600'
+              : 'text-blue-600 hover:underline'}`;
+          return (
+            <li key={letter}>
+              <button
+                type="button"
+                aria-label={`Jump to ${letter} section`}
+                aria-disabled={disabled}
+                disabled={disabled}
+                onClick={() => !disabled && handleClick(letter)}
+                className={classes}
+              >
+                {letter}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+};
+
+export default LetterRail;
+

--- a/pages/apps/kali-tools/index.jsx
+++ b/pages/apps/kali-tools/index.jsx
@@ -1,6 +1,7 @@
 import Head from 'next/head';
 import { useMemo, useState } from 'react';
 import tools from '../../../data/kali-tools.json';
+import LetterRail from '../../../components/tools/LetterRail';
 
 const letters = Array.from({ length: 26 }, (_, i) =>
   String.fromCharCode(65 + i),
@@ -29,11 +30,6 @@ const KaliToolsPage = () => {
     name: tool.name,
     url: `https://www.kali.org/tools/${tool.id}/`,
   }));
-
-  const handleScroll = (letter) => {
-    const el = document.getElementById(`section-${letter}`);
-    if (el) el.scrollIntoView({ behavior: 'smooth' });
-  };
 
   return (
     <>
@@ -80,34 +76,7 @@ const KaliToolsPage = () => {
             </section>
           ) : null,
         )}
-        <nav
-          aria-label="Alphabet navigation"
-          className="fixed right-2 top-1/2 -translate-y-1/2"
-        >
-          <ul className="flex flex-col items-center space-y-1">
-            {letters.map((letter) => {
-              const disabled = !grouped[letter];
-              return (
-                <li key={letter}>
-                  <button
-                    type="button"
-                    aria-label={`Jump to ${letter} section`}
-                    aria-disabled={disabled}
-                    disabled={disabled}
-                    onClick={() => !disabled && handleScroll(letter)}
-                    className={`h-6 w-6 text-xs ${
-                      disabled
-                        ? 'cursor-default text-gray-400'
-                        : 'text-blue-600 hover:underline'
-                    }`}
-                  >
-                    {letter}
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
-        </nav>
+        <LetterRail letters={letters} grouped={grouped} />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- add reusable `LetterRail` component that smooth scrolls to anchors and highlights active letter
- integrate `LetterRail` into Kali tools page for right-side alphabet navigation

## Testing
- `yarn lint components/tools/LetterRail.tsx pages/apps/kali-tools/index.jsx` (fails: repo has existing lint errors)
- `yarn test components/tools/LetterRail.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be7cadf6b48328ad3807c64c074b6c