### PR TITLE
feat: add release tip component

### DIFF
--- a/components/get-kali/ReleaseTip.tsx
+++ b/components/get-kali/ReleaseTip.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Link from 'next/link';
+import Callout from '../ui/Callout';
+
+export default function ReleaseTip() {
+  return (
+    <Callout variant="readDocs">
+      <p>
+        Kali uses a rolling release model. Quarterly versions are just fresh snapshots
+        of the latest packages. Install once and keep updating to stay current.{' '}
+        <Link
+          href="https://www.kali.org/docs/policy/release-policy/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          Learn more
+        </Link>
+        .
+      </p>
+    </Callout>
+  );
+}


### PR DESCRIPTION
## Summary
- add release policy callout component

## Testing
- `npx eslint components/get-kali/ReleaseTip.tsx`
- `yarn test components/get-kali/ReleaseTip.tsx --passWithNoTests`
- `yarn tsc components/get-kali/ReleaseTip.tsx --noEmit` *(fails: Module '@types/react/index' can only be default-imported using the 'esModuleInterop' flag)*

------
https://chatgpt.com/codex/tasks/task_e_68be7cacc47083289e71a00dfd6d3369