### PR TITLE
feat: add cloud provider icons and download grid

### DIFF
--- a/components/get-kali/DownloadGrid.tsx
+++ b/components/get-kali/DownloadGrid.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const providers = [
+  { name: 'AWS', icon: '/icons/cloud/aws.svg' },
+  { name: 'Azure', icon: '/icons/cloud/azure.svg' },
+  { name: 'GCP', icon: '/icons/cloud/gcp.svg' }
+];
+
+export default function DownloadGrid() {
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      {providers.map((p) => (
+        <div key={p.name} className="flex flex-col items-center text-sm">
+          <img src={p.icon} alt={`${p.name} icon`} width={32} height={32} />
+          <span className="mt-2">{p.name}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/public/icons/cloud/aws.svg
+++ b/public/icons/cloud/aws.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="4" fill="#FF9900"/>
+  <path d="M8 22 L16 10 L24 22 Z" fill="#fff"/>
+</svg>

--- a/public/icons/cloud/azure.svg
+++ b/public/icons/cloud/azure.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="4" fill="#0078D4"/>
+  <polygon points="8,24 16,8 24,24" fill="#fff"/>
+</svg>

--- a/public/icons/cloud/gcp.svg
+++ b/public/icons/cloud/gcp.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="4" fill="#4285F4"/>
+  <circle cx="16" cy="16" r="8" fill="#fff"/>
+</svg>


### PR DESCRIPTION
## Summary
- add simplified AWS, Azure, and GCP pictograms
- display cloud provider grid with normalized icon sizes

## Testing
- `npx eslint components/get-kali/DownloadGrid.tsx`
- `npm test -- --passWithNoTests DownloadGrid`


------
https://chatgpt.com/codex/tasks/task_e_68be7caac4088328848cc6ad40e89ea0