### PR TITLE
feat: add NetHunter edition tile

### DIFF
--- a/components/get-kali/NetHunterTile.tsx
+++ b/components/get-kali/NetHunterTile.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+interface Edition {
+  name: string;
+  description: string;
+  tone: 'info' | 'warning' | 'danger';
+  href: string;
+}
+
+const editions: Edition[] = [
+  {
+    name: 'Rootless',
+    description: 'Run NetHunter in Termux without root access.',
+    tone: 'info',
+    href: 'https://www.kali.org/docs/nethunter/nethunter-rootless/',
+  },
+  {
+    name: 'Lite',
+    description: 'Essential tools for rooted devices with minimal footprint.',
+    tone: 'warning',
+    href: 'https://www.kali.org/docs/nethunter/',
+  },
+  {
+    name: 'Full',
+    description: 'Complete experience with Wi-Fi injection and HID attacks.',
+    tone: 'danger',
+    href: 'https://www.kali.org/docs/nethunter/',
+  },
+];
+
+const toneClasses: Record<Edition['tone'], string> = {
+  info: 'bg-info text-black',
+  warning: 'bg-warning text-black',
+  danger: 'bg-danger text-black',
+};
+
+export interface NetHunterTileProps {
+  variant?: 'grid' | 'list';
+}
+
+const NetHunterTile: React.FC<NetHunterTileProps> = ({ variant = 'grid' }) => {
+  const containerClass =
+    variant === 'list' ? 'space-y-4' : 'grid gap-4 md:grid-cols-3';
+  return (
+    <div className={containerClass}>
+      {editions.map(({ name, description, tone, href }) => (
+        <div key={name} className="border rounded p-4 flex flex-col">
+          <span
+            className={`self-start rounded px-2 py-1 text-xs font-semibold ${toneClasses[tone]}`}
+          >
+            {name}
+          </span>
+          <p className="mt-2 mb-4">{description}</p>
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-auto text-blue-500 hover:underline"
+          >
+            Documentation
+          </a>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default NetHunterTile;
+

--- a/pages/nethunter.tsx
+++ b/pages/nethunter.tsx
@@ -1,37 +1,10 @@
 import React from 'react';
-
-const editions = [
-  {
-    name: 'Rootless',
-    icon: '📱',
-    description: 'Run NetHunter in Termux without root access.',
-  },
-  {
-    name: 'Lite',
-    icon: '🌟',
-    description: 'Essential tools for rooted devices with minimal footprint.',
-  },
-  {
-    name: 'Full',
-    icon: '🛠️',
-    description: 'Complete experience with Wi-Fi injection and HID attacks.',
-  },
-];
+import NetHunterTile from '../components/get-kali/NetHunterTile';
 
 const Nethunter: React.FC = () => (
   <main className="p-4">
     <h1 className="text-2xl font-bold mb-4">Kali NetHunter</h1>
-    <div className="grid gap-4 md:grid-cols-3">
-      {editions.map(({ name, icon, description }) => (
-        <div key={name} className="border rounded p-4 flex flex-col">
-          <div className="flex items-center mb-2">
-            <span className="text-2xl mr-2" aria-hidden>{icon}</span>
-            <h2 className="text-xl font-semibold">{name}</h2>
-          </div>
-          <p className="mb-4">{description}</p>
-        </div>
-      ))}
-    </div>
+    <NetHunterTile />
     <div className="mt-6 flex flex-col gap-4">
       <a
         href="https://www.kali.org/docs/nethunter/"


### PR DESCRIPTION
## Summary
- add NetHunterTile component listing editions with tone badges
- display tile on NetHunter page

## Testing
- `yarn test` *(fails: TypeError: Cannot set properties of undefined (setting 'theme'))*
- `npx eslint components/get-kali/NetHunterTile.tsx pages/nethunter.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68be7caa6c7c83289d2f8d6d03416595