### PR TITLE
Refine About menu and support nested header nav

### DIFF
--- a/components/kali/Header.tsx
+++ b/components/kali/Header.tsx
@@ -8,30 +8,34 @@ interface NavItem {
   children?: NavItem[];
 }
 
+const renderNavItem = (item: NavItem): React.ReactNode => {
+  if (item.children) {
+    return (
+      <details>
+        <summary className="cursor-pointer list-none">{item.label}</summary>
+        <ul className="mt-2 space-y-1 pl-4">
+          {item.children.map((child) => (
+            <li key={child.label}>{renderNavItem(child)}</li>
+          ))}
+        </ul>
+      </details>
+    );
+  }
+
+  return (
+    <a href={item.href ?? '#'} className="hover:underline">
+      {item.label}
+    </a>
+  );
+};
+
 const Header: React.FC = () => (
   <header className="border-b border-gray-700 p-4">
     <nav aria-label="Main navigation">
       <ul className="flex flex-wrap items-center gap-4">
         {(ia as any).header.map((item: NavItem) => (
           <li key={item.label} className="relative">
-            {item.children ? (
-              <details>
-                <summary className="cursor-pointer list-none">{item.label}</summary>
-                <ul className="mt-2 space-y-1">
-                  {item.children.map((child) => (
-                    <li key={child.label}>
-                      <a href={child.href} className="hover:underline">
-                        {child.label}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </details>
-            ) : (
-              <a href={item.href} className="hover:underline">
-                {item.label}
-              </a>
-            )}
+            {renderNavItem(item)}
           </li>
         ))}
         <li className="ml-auto">

--- a/data/ia.json
+++ b/data/ia.json
@@ -22,13 +22,10 @@
       {"label": "Kali NetHunter Stats", "href": "https://nethunter.kali.org/"}
     ]},
     {"label": "About", "children": [
-      {"label": "Kali Linux Overview", "href": "https://www.kali.org/features/"},
-      {"label": "Press Pack", "href": "https://gitlab.com/kalilinux/documentation/press-pack/-/archive/main/press-pack-main.zip"},
-      {"label": "Wallpapers", "href": "https://www.kali.org/wallpapers/"},
-      {"label": "Kali Swag Store", "href": "https://offsec.usa.dowlis.com/kali/view-all.html"},
-      {"label": "Meet The Kali Team", "href": "https://www.kali.org/about-us/"},
-      {"label": "Partnerships", "href": "https://www.kali.org/partnerships/"},
-      {"label": "Contact Us", "href": "https://www.kali.org/contact/"}
+      {"label": "Overview", "href": "https://www.kali.org/features/"},
+      {"label": "Wallpapers", "href": "/wallpapers"},
+      {"label": "Contact", "href": "https://www.kali.org/contact/"},
+      {"label": "Store", "href": "#"}
     ]}
   ],
   "footer": {


### PR DESCRIPTION
## Summary
- streamline About section to overview, local wallpapers, contact, and placeholder store
- render header navigation recursively to match updated hierarchy

## Testing
- `yarn test` *(fails: Cannot set properties of undefined (setting 'theme'))*

------
https://chatgpt.com/codex/tasks/task_e_68be7c8045788328b1593804c9814ba1