### PR TITLE
Add captions to developer menu

### DIFF
--- a/components/kali/Header.tsx
+++ b/components/kali/Header.tsx
@@ -5,6 +5,7 @@ import StatusPill from './StatusPill';
 interface NavItem {
   label: string;
   href?: string;
+  caption?: string;
   children?: NavItem[];
 }
 
@@ -19,18 +20,26 @@ const Header: React.FC = () => (
                 <summary className="cursor-pointer list-none">{item.label}</summary>
                 <ul className="mt-2 space-y-1">
                   {item.children.map((child) => (
-                    <li key={child.label}>
-                      <a href={child.href} className="hover:underline">
+                    <li key={child.label} className="space-y-1">
+                      <a href={child.href} className="hover:underline block">
                         {child.label}
                       </a>
+                      {child.caption && (
+                        <p className="text-xs text-gray-400">{child.caption}</p>
+                      )}
                     </li>
                   ))}
                 </ul>
               </details>
             ) : (
-              <a href={item.href} className="hover:underline">
-                {item.label}
-              </a>
+              <div className="space-y-1">
+                <a href={item.href} className="hover:underline block">
+                  {item.label}
+                </a>
+                {item.caption && (
+                  <p className="text-xs text-gray-400">{item.caption}</p>
+                )}
+              </div>
             )}
           </li>
         ))}

--- a/data/ia.json
+++ b/data/ia.json
@@ -15,11 +15,11 @@
       {"label": "Download Mirrors", "href": "https://http.kali.org/README?mirrorlist"}
     ]},
     {"label": "Developers", "children": [
-      {"label": "Git Repositories", "href": "https://gitlab.com/kalilinux"},
-      {"label": "Packages", "href": "https://pkg.kali.org/"},
-      {"label": "Auto Package Test", "href": "https://autopkgtest.kali.org/"},
-      {"label": "Bug Tracker", "href": "https://bugs.kali.org/"},
-      {"label": "Kali NetHunter Stats", "href": "https://nethunter.kali.org/"}
+      {"label": "Git Repositories", "href": "https://gitlab.com/kalilinux", "caption": "Browse Kali Linux source code"},
+      {"label": "Packages", "href": "https://pkg.kali.org/", "caption": "Track Kali packages"},
+      {"label": "Auto Package Test", "href": "https://autopkgtest.kali.org/", "caption": "Continuous integration results"},
+      {"label": "Bug Tracker", "href": "https://bugs.kali.org/", "caption": "Report and monitor issues"},
+      {"label": "Kali NetHunter Stats", "href": "https://nethunter.kali.org/", "caption": "Statistics for NetHunter"}
     ]},
     {"label": "About", "children": [
       {"label": "Kali Linux Overview", "href": "https://www.kali.org/features/"},


### PR DESCRIPTION
## Summary
- add caption metadata for developer menu entries
- render menu captions beneath header links

## Testing
- `yarn eslint components/kali/Header.tsx data/ia.json`
- `yarn test` *(fails: Missing allowlist entries & module import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be7c7887c08328bc0597052fe62065