### PR TITLE
feat(kali): add release pill to header

### DIFF
--- a/components/kali/Header.tsx
+++ b/components/kali/Header.tsx
@@ -8,38 +8,57 @@ interface NavItem {
   children?: NavItem[];
 }
 
-const Header: React.FC = () => (
-  <header className="border-b border-gray-700 p-4">
-    <nav aria-label="Main navigation">
-      <ul className="flex flex-wrap items-center gap-4">
-        {(ia as any).header.map((item: NavItem) => (
-          <li key={item.label} className="relative">
-            {item.children ? (
-              <details>
-                <summary className="cursor-pointer list-none">{item.label}</summary>
-                <ul className="mt-2 space-y-1">
-                  {item.children.map((child) => (
-                    <li key={child.label}>
-                      <a href={child.href} className="hover:underline">
-                        {child.label}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </details>
-            ) : (
-              <a href={item.href} className="hover:underline">
-                {item.label}
+const badgeBase = 'inline-block rounded px-2 py-1 text-xs font-semibold';
+const badgeVariants: Record<'info', string> = {
+  info: 'bg-blue-600 text-white',
+};
+
+const Header: React.FC = () => {
+  const release = (ia as any).releasePill;
+
+  return (
+    <header className="border-b border-gray-700 p-4">
+      <nav aria-label="Main navigation">
+        <ul className="flex flex-wrap items-center gap-4">
+          {(ia as any).header.map((item: NavItem) => (
+            <li key={item.label} className="relative">
+              {item.children ? (
+                <details>
+                  <summary className="cursor-pointer list-none">{item.label}</summary>
+                  <ul className="mt-2 space-y-1">
+                    {item.children.map((child) => (
+                      <li key={child.label}>
+                        <a href={child.href} className="hover:underline">
+                          {child.label}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+              ) : (
+                <a href={item.href} className="hover:underline">
+                  {item.label}
+                </a>
+              )}
+            </li>
+          ))}
+          <li className="ml-auto flex items-center gap-2">
+            {release?.enabled && (
+              <a
+                href={release.href}
+                className={`${badgeBase} ${badgeVariants.info}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {release.label}
               </a>
             )}
+            <StatusPill />
           </li>
-        ))}
-        <li className="ml-auto">
-          <StatusPill />
-        </li>
-      </ul>
-    </nav>
-  </header>
-);
+        </ul>
+      </nav>
+    </header>
+  );
+};
 
 export default Header;

--- a/data/ia.json
+++ b/data/ia.json
@@ -96,5 +96,10 @@
       {"label": "Newsletter", "href": "https://www.kali.org/newsletter/"},
       {"label": "RSS", "href": "https://www.kali.org/rss.xml"}
     ]
+  },
+  "releasePill": {
+    "enabled": true,
+    "href": "https://www.kali.org/blog/kali-linux-2025-2-release/",
+    "label": "2025.2 Released"
   }
 }


### PR DESCRIPTION
## Summary
- show release announcement pill in header when configured
- add release pill metadata to ia.json

## Testing
- `yarn eslint components/kali/Header.tsx`
- `yarn test components/kali/Header.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be7c7628308328b7d882c5bd484449