### PR TITLE
Add window manager and game seed tests with smoke CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,22 @@ jobs:
           path: test-results/**/*.zip
           if-no-files-found: ignore
 
+  smoke:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: npx playwright install --with-deps
+      - run: |
+          yarn dev &
+          npx wait-on http://localhost:3000
+      - run: yarn smoke
+
   pa11y:
     runs-on: ubuntu-latest
     needs: install
@@ -143,6 +159,7 @@ validate-apps:
       - typecheck
       - test
       - e2e
+      - smoke
       - security
       - verify
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+## Running locally
+
+```bash
+yarn install
+yarn dev
+```
+
+In another terminal run the full check suite:
+
+```bash
+yarn lint
+yarn typecheck
+yarn test
+npx playwright test
+yarn smoke
+```
+
+`yarn smoke` requires a dev server listening on `http://localhost:3000` and loads each `/apps/*` route headlessly to ensure there are no runtime errors.
+
+## Continuous Integration
+
+The CI workflow runs linting, type checks, unit tests, Playwright end-to-end specs and the smoke suite. To emulate CI locally run:
+
+```bash
+yarn lint && yarn typecheck && yarn test && npx playwright test && yarn smoke
+```

--- a/__tests__/game2048.winCondition.test.ts
+++ b/__tests__/game2048.winCondition.test.ts
@@ -1,0 +1,25 @@
+import { Board, moveLeft, addRandomTile } from '../apps/games/_2048/logic';
+import { reset } from '../apps/games/rng';
+
+describe('2048 win condition', () => {
+  test('merging 1024 tiles yields 2048', () => {
+    const board: Board = [
+      [1024, 1024, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ];
+    const { board: moved, score } = moveLeft(board);
+    expect(moved[0][0]).toBe(2048);
+    expect(score).toBe(2048);
+  });
+
+  test.each([1, 2, 3, 4, 5])('random tiles deterministic (seed %d)', (seed) => {
+    reset(seed.toString());
+    const board: Board = Array.from({ length: 4 }, () => Array(4).fill(0));
+    addRandomTile(board);
+    addRandomTile(board);
+    const tiles = board.flat().filter((n) => n !== 0);
+    tiles.forEach((v) => expect([2, 4]).toContain(v));
+  });
+});

--- a/__tests__/sudoku.winCondition.test.ts
+++ b/__tests__/sudoku.winCondition.test.ts
@@ -1,0 +1,19 @@
+import { generateSudoku, SIZE } from '../apps/games/sudoku';
+import { solve } from '../workers/sudokuSolver';
+
+describe('sudoku win condition', () => {
+  const seeds = [0, 1, 2, 3, 4];
+
+  test.each(seeds)('puzzle solvable and unique (seed %d)', (seed) => {
+    const { puzzle, solution } = generateSudoku('easy', seed);
+    const solved = solve(puzzle.map((r) => r.slice())).solution;
+    expect(solved).toEqual(solution);
+
+    for (let i = 0; i < SIZE; i++) {
+      const row = new Set(solution[i]);
+      const col = new Set(solution.map((r) => r[i]));
+      expect(row.size).toBe(SIZE);
+      expect(col.size).toBe(SIZE);
+    }
+  });
+});

--- a/tests/e2e/window-manager.spec.ts
+++ b/tests/e2e/window-manager.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('window manager', () => {
+  test('multi-window interactions and focus', async ({ page }) => {
+    await page.goto('/');
+
+    // Launch terminal
+    await page.locator('nav [aria-label="Show Applications"]').click();
+    await page.locator('#app-terminal').click();
+
+    // Launch gedit
+    await page.locator('nav [aria-label="Show Applications"]').click();
+    await page.locator('#app-gedit').click();
+
+    const terminal = page.locator('[data-app-id="terminal"]');
+    const gedit = page.locator('[data-app-id="gedit"]');
+
+    // z-index ordering: gedit on top after launch
+    const zTerminal = await terminal.evaluate(el => Number(getComputedStyle(el).zIndex));
+    const zGedit = await gedit.evaluate(el => Number(getComputedStyle(el).zIndex));
+    expect(zGedit).toBeGreaterThan(zTerminal);
+
+    // Bring terminal to front
+    await terminal.click();
+    const zTerminalFront = await terminal.evaluate(el => Number(getComputedStyle(el).zIndex));
+    const zGeditBack = await gedit.evaluate(el => Number(getComputedStyle(el).zIndex));
+    expect(zTerminalFront).toBeGreaterThan(zGeditBack);
+
+    // Drag gedit window
+    const header = gedit.locator('button').first();
+    const startBox = await gedit.boundingBox();
+    const headerBox = await header.boundingBox();
+    if (headerBox) {
+      await page.mouse.move(headerBox.x + headerBox.width / 2, headerBox.y + headerBox.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(headerBox.x + headerBox.width / 2 + 100, headerBox.y + headerBox.height / 2 + 100);
+      await page.mouse.up();
+    }
+    const movedBox = await gedit.boundingBox();
+    if (startBox && movedBox) {
+      expect(movedBox.x).toBeGreaterThan(startBox.x + 50);
+    }
+
+    // Snap left via keyboard and restore
+    await gedit.focus();
+    await page.keyboard.down('Alt');
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.up('Alt');
+    let style = await gedit.getAttribute('style');
+    expect(style).toContain('width: 50%');
+
+    await page.keyboard.down('Alt');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.up('Alt');
+
+    // Keyboard navigation between windows
+    await page.keyboard.down('Alt');
+    await page.keyboard.press('Tab');
+    await page.keyboard.up('Alt');
+    await expect(terminal).not.toHaveClass(/notFocused/);
+    await expect(gedit).toHaveClass(/notFocused/);
+
+    // Opening a context menu should not steal focus
+    await terminal.click({ button: 'right' });
+    await expect(terminal).not.toHaveClass(/notFocused/);
+    await page.keyboard.press('Escape');
+    await expect(terminal).not.toHaveClass(/notFocused/);
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright spec covering window z-index, drag, snap, and focus handling
- add deterministic 2048 and Sudoku tests
- run `yarn smoke` in CI and document contribution workflow

## Testing
- `yarn test __tests__/game2048.winCondition.test.ts __tests__/sudoku.winCondition.test.ts`
- `npx wait-on http://localhost:3000 && npx playwright test tests/e2e/window-manager.spec.ts --trace on` *(failed: could not reach dev server)*
- `yarn smoke` *(failed: could not reach dev server)*

------
https://chatgpt.com/codex/tasks/task_e_68be75fc79cc83288c8fd68e19e6fd4f