### PR TITLE
fix: use supported node runtime

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@
 - [ ] No new `use client` without justification
 - [ ] Browser-only APIs isolated in client modules
 - [ ] `.d.ts` added/updated for Web API gaps
-- [ ] Tested on Node 22 locally; Vercel target 22.x
+- [ ] Tested on Node 20 locally; Vercel target 20.x

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "postinstall": "simple-git-hooks"
   },
   "engines": {
-    "node": "22.x"
+    "node": "20.x"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm -w typecheck && tsc --noEmit -p packages/*"

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "nodejs22.x" },
-    "app/api/**/route.{js,ts}": { "runtime": "nodejs22.x" }
+    "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" },
+    "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" }
   }
 }


### PR DESCRIPTION
## Summary
- use Node.js 20 runtime in Vercel config
- align package.json and PR template with Node.js 20

## Testing
- `yarn test` *(fails: browserType.launch: Executable doesn't exist...)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0ae5cd408328a6430a2174459345