### PR TITLE
Specify Vercel runtime version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use explicit `@vercel/node` runtime version to satisfy Vercel build requirements.
 
 ## [2.1.0] - 2025-09-03
 ### Added

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" },
-    "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" }
+    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.21" },
+    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.21" }
   }
 }


### PR DESCRIPTION
## Summary
- pin `@vercel/node` runtime version for API routes
- document runtime pin in changelog

## Testing
- `yarn test` *(fails: browserType.launch: Executable doesn't exist; run `yarn playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0c4490a083289da209fcb99d0694