### PR TITLE
fix: resolve compile-time module errors

### DIFF
--- a/apps/wireshark/components/PcapViewer.tsx
+++ b/apps/wireshark/components/PcapViewer.tsx
@@ -165,12 +165,6 @@ const parsePcapNg = (buf: ArrayBuffer): Packet[] => {
 };
 
 const parseWithWasm = async (buf: ArrayBuffer): Promise<Packet[]> => {
-  try {
-    // Attempt to load wasm parser via its JS wrapper; fall back to JS parsing
-    await import('https://unpkg.com/pcap.js@latest/pcap.js');
-  } catch {
-    // Ignore errors and use JS parser
-  }
   const magic = new DataView(buf).getUint32(0, false);
   return magic === 0x0a0d0d0a ? parsePcapNg(buf) : parsePcap(buf);
 };

--- a/components/ToolbarIcons.tsx
+++ b/components/ToolbarIcons.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export const MinimizeIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg width="10" height="10" viewBox="0 0 10 10" {...props}>
+    <rect x="1" y="5" width="8" height="1" fill="currentColor" />
+  </svg>
+);
+
+export const MaximizeIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg width="10" height="10" viewBox="0 0 10 10" {...props}>
+    <rect x="1" y="1" width="8" height="8" fill="none" stroke="currentColor" strokeWidth="1" />
+  </svg>
+);
+
+export const CloseIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg width="10" height="10" viewBox="0 0 10 10" {...props}>
+    <line x1="1" y1="1" x2="9" y2="9" stroke="currentColor" strokeWidth="1" />
+    <line x1="9" y1="1" x2="1" y2="9" stroke="currentColor" strokeWidth="1" />
+  </svg>
+);
+
+export default { CloseIcon, MaximizeIcon, MinimizeIcon };

--- a/components/apps/chess.js
+++ b/components/apps/chess.js
@@ -338,7 +338,7 @@ const ChessGame = () => {
 
   useEffect(() => {
     if (!isBrowser()) return;
-    import("stockfish")
+    import("stockfish/src/stockfish-nnue-16-single.js")
       .then(() => setHasStockfish(true))
       .catch(() => setHasStockfish(false));
   }, []);


### PR DESCRIPTION
## Summary
- add ToolbarIcons with basic SVG icons
- fix stockfish import path in chess app
- drop remote pcap.js import in Wireshark viewer

## Testing
- `yarn typecheck` *(fails: workers/sudokuSolver.ts type errors)*
- `yarn test` *(fails: missing Chrome binary and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0dba72fc8328890439ef34f9ed34