### PR TITLE
fix: skip git hooks in CI to allow Vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
     "verify:all": "node --import tsx/esm scripts/verify.mjs",
     "validate:apps": "node --import tsx/esm scripts/validate-apps.mjs",
-    "postinstall": "simple-git-hooks"
+    "postinstall": "if [ \"$CI\" != \"true\" ]; then simple-git-hooks; fi"
   },
   "engines": {
     "node": "20.x"


### PR DESCRIPTION
## Summary
- avoid running simple-git-hooks during CI installs to prevent missing dev deps on Vercel

## Testing
- `yarn test --bail` *(fails: Test Suites: 1 failed, 14 passed, 15 of 213 total)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0d4472348328b1aba86e96cc80df