### PR TITLE
chore: specify node runtime in vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,10 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "nodejs22.x" },
-    "app/api/**/route.{js,ts}": { "runtime": "nodejs22.x" }
+    "nodeVersion": { "range": "22.x" },
+    "pages/api/**/*.js": { "runtime": "nodejs22.x" },
+    "pages/api/**/*.ts": { "runtime": "nodejs22.x" },
+    "app/api/**/route.js": { "runtime": "nodejs22.x" },
+    "app/api/**/route.ts": { "runtime": "nodejs22.x" }
   }
 }


### PR DESCRIPTION
## Summary
- declare Node 22 runtime for all API routes in vercel.json

## Testing
- `apt-get update`
- `apt-get install -y nodejs npm` *(fails: pnpm not installed / heavy dependency chain)*


------
https://chatgpt.com/codex/tasks/task_e_68bf0bfef1048328bfc4ca1ee254fab3