### PR TITLE
Restore CSP allowlist and align Nmap NSE tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ These external domains are whitelisted in the default CSP. Update this list when
 | `*.twimg.com` | Twitter asset CDN |
 | `*.x.com` | X (Twitter) domain equivalents |
 | `*.google.com` | Google services and Chrome app favicons |
+| `www.gstatic.com` | Google static assets |
 | `example.com` | Chrome app demo origin |
 | `openweathermap.org` | Weather widget images |
 | `ghchart.rshah.org` | GitHub contribution charts |
@@ -289,6 +290,7 @@ These external domains are whitelisted in the default CSP. Update this list when
 | `cdn.jsdelivr.net` | Math.js library |
 | `cdnjs.cloudflare.com` | PDF.js worker |
 | `stackblitz.com` | StackBlitz IDE embeds |
+| `www.youtube.com` | YouTube embeds and scripts |
 | `www.youtube-nocookie.com` | YouTube video embeds (privacy-enhanced) |
 | `open.spotify.com` | Spotify embeds |
 | `react.dev` | React documentation embeds |

--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -46,9 +46,8 @@ describe('NmapNSEApp', () => {
 
     render(<NmapNSEApp />);
     await waitFor(() => expect(mockFetch).toHaveBeenCalled());
-    await userEvent.click(
-      screen.getByRole('button', { name: /copy command/i })
-    );
+    const btn = screen.getByRole('button', { name: /nmap/i });
+    await userEvent.click(btn);
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('nmap')
     );
@@ -82,7 +81,7 @@ describe('NmapNSEApp', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Sample output')
     );
-    expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
+    expect(await screen.findByRole('status')).toHaveTextContent(/copied/i);
 
     mockFetch.mockRestore();
   });

--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,21 @@ try {
 } catch {}
 
 
+const ContentSecurityPolicy = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+  "img-src 'self' https: data:",
+  "style-src 'self'",
+  "font-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://sdk.scdn.co",
+  "connect-src 'self' https://example.com https://*.twitter.com https://*.twimg.com https://*.x.com https://*.google.com https://stackblitz.com",
+  "frame-src 'self' https://vercel.live https://stackblitz.com https://*.google.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com https://react.dev https://example.com",
+  "frame-ancestors 'self'",
+  "upgrade-insecure-requests",
+].join('; ');
+
 const securityHeaders = [
   {
     key: 'X-Content-Type-Options',
@@ -39,6 +54,10 @@ const securityHeaders = [
   {
     key: 'Strict-Transport-Security',
     value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'Content-Security-Policy',
+    value: ContentSecurityPolicy,
   },
 ];
 


### PR DESCRIPTION
## Summary
- reinstate Content Security Policy with updated external domains
- document new CSP domains in README
- adjust Nmap NSE clipboard tests to reflect current UI and toast role

## Testing
- `yarn test __tests__/nmapNse.test.tsx`
- `yarn test __tests__/csp.test.ts`
- `yarn test` *(fails: missing modules/playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1084dce08328b02578da8907214f