### PR TITLE
fix: remove invalid nodeVersion range in vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
+    "nodeVersion": 18,
     "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.21" },
     "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.21" }
   }


### PR DESCRIPTION
## Summary
- specify `nodeVersion` without invalid `range` property to satisfy Vercel schema validation

## Testing
- `yarn test` *(fails: Playwright browser not installed; missing Chrome binary; axe CLI failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf110169c48328a228640cdf0cd5fd