### PR TITLE
fix @types/react lock entry

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3957,7 +3957,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:19.1.12, @types/react@npm:>=16.9.11":
+"@types/react@npm:19.1.12":
   version: 19.1.12
   resolution: "@types/react@npm:19.1.12"
   dependencies:


### PR DESCRIPTION
## Summary
- update yarn.lock @types/react entry to resolve immutable install error

## Testing
- `yarn install --immutable`
- `yarn test` *(fails: Missing allowlist entries, cannot find Chrome binary, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf118c1f808328911d1f1765c6d151