### PR TITLE
Fix postinstall script for Yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
     "verify:all": "node --import tsx/esm scripts/verify.mjs",
     "validate:apps": "node --import tsx/esm scripts/validate-apps.mjs",
-    "postinstall": "if [ \"$CI\" != \"true\" ]; then simple-git-hooks; fi"
+    "postinstall": "node scripts/postinstall.mjs"
   },
   "engines": {
     "node": "20.x"

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,5 @@
+import { execSync } from 'node:child_process';
+
+if (process.env.CI !== 'true') {
+  execSync('simple-git-hooks', { stdio: 'inherit' });
+}


### PR DESCRIPTION
## Summary
- replace shell conditional in postinstall with Node script to support Yarn 4
- add `scripts/postinstall.mjs` that conditionally installs git hooks

## Testing
- `yarn postinstall`

------
https://chatgpt.com/codex/tasks/task_e_68bf149c307c83289b3630914aac1053