### PR TITLE
chore: stub stockfish node modules

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -97,6 +97,9 @@ function configureWebpack(config, { isServer }) {
     ...(config.resolve.fallback || {}),
     module: false,
     async_hooks: false,
+    fs: false,
+    worker_threads: false,
+    readline: false,
   };
   config.resolve.alias = {
     ...(config.resolve.alias || {}),


### PR DESCRIPTION
## Summary
- prevent stockfish from trying to bundle server-only modules by stubbing `fs`, `worker_threads` and `readline` in webpack config

## Testing
- `yarn test __tests__/blackjack.test.ts`
- `yarn build` *(fails: [WebpackInjectManifest] 'cacheId' property is not expected to be here)*

------
https://chatgpt.com/codex/tasks/task_e_68bf189fffd08328a85a589c5c9dc405