### PR TITLE
Add stricter validation for calculator formulas

### DIFF
--- a/apps/calculator/formulas.ts
+++ b/apps/calculator/formulas.ts
@@ -20,7 +20,9 @@ export function useFormulas() {
 
 export function validateFormula(expr: string): boolean {
   try {
-    evaluate(expr);
+    const sanitized = expr.replace(/\s+/g, '');
+    if (/(?:[+\-*\/]{2,})/.test(sanitized)) return false;
+    evaluate(sanitized);
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- ensure calculator formula validator rejects expressions with consecutive operators

## Testing
- `npx eslint apps/calculator/formulas.ts`
- `yarn test __tests__/calculator.formulas.test.ts`
- `pnpm -w typecheck` *(fails: --workspace-root may only be used inside a workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1c7b128c8328baf1ae3892df7a2f