### PR TITLE
fix: prevent undefined array access in 2048

### DIFF
--- a/apps/2048/index.tsx
+++ b/apps/2048/index.tsx
@@ -28,8 +28,10 @@ const hashSeed = (str: string): number => {
 const slideRow = (row: number[]) => {
   const arr = row.filter((n) => n !== 0);
   for (let i = 0; i < arr.length - 1; i += 1) {
-    if (arr[i] === arr[i + 1]) {
-      arr[i] *= 2;
+    const current = arr[i]!;
+    const next = arr[i + 1]!;
+    if (current === next) {
+      arr[i] = current * 2;
       arr[i + 1] = 0;
     }
   }


### PR DESCRIPTION
## Summary
- avoid potential undefined values when merging tiles in 2048

## Testing
- `yarn test apps/2048 --passWithNoTests`
- `yarn typecheck` *(fails: Type 'undefined' cannot be used as an index type in workers/sudokuSolver.ts, Object is possibly 'undefined' in workers/terminal-worker.ts, and related errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf238fede88328bd5d16916b77b62c