### PR TITLE
fix dynamic import warning in search index

### DIFF
--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,12 +1,12 @@
-import fs from 'fs';
-import path from 'path';
-import { Document } from 'flexsearch';
+import fs from "fs";
+import path from "path";
+import { Document } from "flexsearch";
 
 export interface SearchDoc {
   id: string;
   title: string;
   url: string;
-  section: 'docs' | 'tools' | 'platforms';
+  section: "docs" | "tools" | "platforms";
 }
 
 let index: Document<SearchDoc> | null = null;
@@ -14,63 +14,68 @@ let index: Document<SearchDoc> | null = null;
 async function buildIndex() {
   const idx = new Document<SearchDoc>({
     document: {
-      id: 'id',
-      index: ['title'],
-      tag: 'section',
-      store: ['title', 'url', 'section'],
+      id: "id",
+      index: ["title"],
+      tag: "section",
+      store: ["title", "url", "section"],
     },
-    tokenize: 'forward',
+    tokenize: "forward",
     cache: 100,
   });
 
   // Docs headings
-  const docsDir = path.join(process.cwd(), 'public', 'docs', 'seed');
+  const docsDir = path.join(process.cwd(), "public", "docs", "seed");
   if (fs.existsSync(docsDir)) {
-    const files = fs.readdirSync(docsDir).filter((f) => f.endsWith('.md'));
+    const files = fs.readdirSync(docsDir).filter((f) => f.endsWith(".md"));
     for (const file of files) {
-      const topic = file.replace(/\.md$/, '');
-      const md = fs.readFileSync(path.join(docsDir, file), 'utf8');
+      const topic = file.replace(/\.md$/, "");
+      const md = fs.readFileSync(path.join(docsDir, file), "utf8");
       const headingRegex = /^#{2,3}\s+(.*)$/gm;
       let m: RegExpExecArray | null;
       while ((m = headingRegex.exec(md)) !== null) {
         const text = m[1].trim();
         const slug = text
           .toLowerCase()
-          .replace(/[^a-z0-9]+/g, '-')
-          .replace(/^-+|-+$/g, '');
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-+|-+$/g, "");
         idx.add({
           id: `doc-${topic}#${slug}`,
           title: text,
           url: `/docs/${topic}#${slug}`,
-          section: 'docs',
+          section: "docs",
         });
       }
     }
   }
 
   // Tool names
-  const toolsPath = path.join(process.cwd(), 'data', 'kali-tools.json');
+  const toolsPath = path.join(process.cwd(), "data", "kali-tools.json");
   if (fs.existsSync(toolsPath)) {
-    const tools = JSON.parse(fs.readFileSync(toolsPath, 'utf8')) as { id: string; name: string }[];
+    const tools = JSON.parse(fs.readFileSync(toolsPath, "utf8")) as {
+      id: string;
+      name: string;
+    }[];
     for (const tool of tools) {
       idx.add({
         id: `tool-${tool.id}`,
         title: tool.name,
         url: `https://www.kali.org/tools/${tool.id}/`,
-        section: 'tools',
+        section: "tools",
       });
     }
   }
 
   // Platform slugs from apps.config
   try {
-    const apps = (await import(path.join(process.cwd(), 'apps.config.js'))).default as any[];
+    // Use a static import path so bundlers can resolve the dependency without
+    // emitting a "critical dependency" warning for dynamic expressions.
+    const apps = (await import("../apps.config.js")).default as any[];
     for (const app of apps) {
       idx.add({
         id: `app-${app.id}`,
         title: app.title,
         url: `/apps/${app.id}`,
-        section: 'platforms',
+        section: "platforms",
       });
     }
   } catch {


### PR DESCRIPTION
## Summary
- avoid Webpack critical dependency warning by using a static import for `apps.config.js`

## Testing
- `npx eslint lib/search.ts`
- `npx jest lib/search.ts --passWithNoTests`
- `npx tsc -p tsconfig.json --noEmit` *(fails: TypeScript errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68bf22f28c748328861c884a078e3e3b