### PR TITLE
Use static apps config import in search index

### DIFF
--- a/lib/search.ts
+++ b/lib/search.ts
@@ -64,7 +64,7 @@ async function buildIndex() {
 
   // Platform slugs from apps.config
   try {
-    const apps = (await import(path.join(process.cwd(), 'apps.config.js'))).default as any[];
+    const apps = (await import('../apps.config.js')).default as any[];
     for (const app of apps) {
       idx.add({
         id: `app-${app.id}`,


### PR DESCRIPTION
## Summary
- import apps.config.js using a static path in search index builder

## Testing
- `yarn lint` *(fails: A control must be associated with a text label etc.)*
- `yarn test` *(fails: missing Playwright browsers and Chrome binary)*
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68bf2395ed448328854a68d988918930