### PR TITLE
fix: handle empty board in transpose

### DIFF
--- a/apps/2048/index.tsx
+++ b/apps/2048/index.tsx
@@ -40,7 +40,8 @@ const slideRow = (row: number[]) => {
   return newRow;
 };
 
-const transpose = (board: number[][]) => board[0].map((_, c) => board.map((row) => row[c]));
+const transpose = (board: number[][]) =>
+  board.length === 0 ? [] : board[0].map((_, c) => board.map((row) => row[c]));
 const flip = (board: number[][]) => board.map((row) => [...row].reverse());
 
 const moveLeft = (board: number[][]) => board.map((row) => slideRow(row));


### PR DESCRIPTION
## Summary
- ensure 2048 board transpose safely handles empty input

## Testing
- `yarn typecheck` *(fails: workers/sudokuSolver.ts(234,16): Type 'undefined' cannot be used as an index type)*
- `yarn test apps/2048 --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bf26505fd08328b89dafb80d7fc271