### PR TITLE
fix: handle empty board in 2048 transpose

### DIFF
--- a/apps/2048/index.tsx
+++ b/apps/2048/index.tsx
@@ -40,8 +40,10 @@ const slideRow = (row: number[]) => {
   return newRow;
 };
 
-const transpose = (board: number[][]) =>
-  board.length === 0 ? [] : board[0].map((_, c) => board.map((row) => row[c]));
+const transpose = (board: number[][]): number[][] => {
+  if (board.length === 0) return [];
+  return board[0].map((_, c) => board.map((row) => row[c]));
+};
 const flip = (board: number[][]) => board.map((row) => [...row].reverse());
 
 const moveLeft = (board: number[][]) => board.map((row) => slideRow(row));


### PR DESCRIPTION
## Summary
- prevent TypeScript undefined error in 2048 transpose by returning early for empty boards

## Testing
- `yarn typecheck` *(fails: workers/sudokuSolver.ts: Type 'undefined' cannot be used as an index type, workers/terminal-worker.ts: Object is possibly 'undefined', etc.)*
- `yarn test apps/2048 --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68bf281c58988328ae060842b4f63b9a