### PR TITLE
test: add 2048 game Playwright coverage

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests',
-  testMatch: /.*\.spec\.(ts|tsx)/,
+  // Run Playwright specs from both the main tests directory and the
+  // standalone `playwright` folder used for lighter integration tests.
+  testDir: '.',
+  testMatch: /(?:tests|playwright)\/.*\.spec\.(ts|tsx)/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
     headless: true,

--- a/playwright/2048.spec.ts
+++ b/playwright/2048.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect, Page } from '@playwright/test';
+
+// Helper to read the board as an array of cell texts
+async function getBoard(page: Page) {
+  return page.locator('.grid > div > div').allTextContents();
+}
+
+test.describe('2048 game', () => {
+  test('responds to keyboard moves', async ({ page }) => {
+    await page.goto('/apps/2048');
+    const before = await getBoard(page);
+    await page.keyboard.press('ArrowRight');
+    await expect.poll(async () => getBoard(page)).not.toEqual(before);
+  });
+
+  test('supports swipe gestures', async ({ page }) => {
+    await page.goto('/apps/2048');
+    const before = await getBoard(page);
+    // simulate swipe left
+    await page.dispatchEvent('body', 'touchstart', { touches: [{ clientX: 200, clientY: 200 }] });
+    await page.dispatchEvent('body', 'touchend', { changedTouches: [{ clientX: 100, clientY: 200 }] });
+    await expect.poll(async () => getBoard(page)).not.toEqual(before);
+  });
+
+  test('undo and restart work', async ({ page }) => {
+    await page.goto('/apps/2048');
+    const initial = await getBoard(page);
+    await page.keyboard.press('ArrowUp');
+    const moved = await getBoard(page);
+    await page.getByRole('button', { name: /undo/i }).click();
+    await expect.poll(async () => getBoard(page)).toEqual(initial);
+    await page.getByRole('button', { name: /restart|reset/i }).click();
+    await expect
+      .poll(async () => (await getBoard(page)).filter((v) => v.trim()).length)
+      .toBe(2);
+  });
+
+  test('hard mode times out the game', async ({ page }) => {
+    await page.goto('/apps/2048');
+    await page.getByLabel('Hard').check();
+    await page.waitForTimeout(4000);
+    await expect(page.getByText('Game over')).toBeVisible();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Playwright spec verifying 2048 game controls
- include keyboard, swipe, undo, restart, and hard mode timeout checks
- adjust Playwright config to run specs from `playwright` folder

## Testing
- `npx playwright test playwright/2048.spec.ts` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2e4c33d88328b76a7f1f74bb6a5a