### PR TITLE
feat(2048): surface daily seed and share results

### DIFF
--- a/__tests__/daily2048Seed.test.tsx
+++ b/__tests__/daily2048Seed.test.tsx
@@ -1,5 +1,6 @@
 import { render, waitFor } from '@testing-library/react';
 import Page2048 from '../apps/2048';
+import { ToastProvider } from '../components/ui/ToastProvider';
 import { getDailySeed } from '../utils/dailySeed';
 
 jest.mock('react-ga4', () => ({ event: jest.fn() }));
@@ -7,14 +8,22 @@ jest.mock('../utils/dailySeed');
 
 test('daily seed produces identical starting boards', async () => {
   (getDailySeed as jest.Mock).mockResolvedValue('abcd');
-  const { container: c1 } = render(<Page2048 />);
+  const { container: c1 } = render(
+    <ToastProvider>
+      <Page2048 />
+    </ToastProvider>,
+  );
   await waitFor(() => {
     const cells = Array.from(c1.querySelectorAll('.grid > div > div'));
     expect(cells.filter((el) => el.textContent).length).toBe(2);
   });
   const board1 = Array.from(c1.querySelectorAll('.grid > div > div')).map((el) => el.textContent);
 
-  const { container: c2 } = render(<Page2048 />);
+  const { container: c2 } = render(
+    <ToastProvider>
+      <Page2048 />
+    </ToastProvider>,
+  );
   await waitFor(() => {
     const cells = Array.from(c2.querySelectorAll('.grid > div > div'));
     expect(cells.filter((el) => el.textContent).length).toBe(2);

--- a/apps/2048/index.tsx
+++ b/apps/2048/index.tsx
@@ -3,7 +3,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import ReactGA from 'react-ga4';
 import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
-import { getDailySeed } from '../../utils/dailySeed';
+import { getDailySeed, currentDateString } from '../../utils/dailySeed';
+import copyToClipboard from '../../utils/clipboard';
+import useToast from '../../hooks/useToast';
 import { isBrowser } from '@/utils/env';
 
 const SIZE = 4;
@@ -133,12 +135,14 @@ const Page2048 = () => {
   const [won, setWon] = useState(false);
   const [lost, setLost] = useState(false);
   const [history, setHistory] = useState<number[][][]>([]);
+  const [seedStr, setSeedStr] = useState('');
+  const toast = useToast();
 
   useEffect(() => {
     let mounted = true;
     (async () => {
-      const seedStr = await getDailySeed('2048');
-      const seed = hashSeed(seedStr);
+      const s = await getDailySeed('2048');
+      const seed = hashSeed(s);
       const rand = mulberry32(seed);
       const b = Array.from({ length: SIZE }, () => Array(SIZE).fill(0));
       addRandomTile(b, rand);
@@ -147,6 +151,7 @@ const Page2048 = () => {
       setBoard(b);
       rngRef.current = rand;
       seedRef.current = seed;
+      setSeedStr(s);
     })();
     return () => {
       mounted = false;
@@ -231,6 +236,14 @@ const Page2048 = () => {
     resetTimer();
   }, [resetTimer]);
 
+  const handleShare = useCallback(async () => {
+    const date = currentDateString();
+    const url = `${window.location.origin}${window.location.pathname}?seed=${seedStr}`;
+    const summary = `2048 ${date} Score:${highest} Moves:${moves.length} Seed:${seedStr} ${url}`;
+    const ok = await copyToClipboard(summary);
+    toast(ok ? 'Copied to clipboard!' : 'Copy failed');
+  }, [seedStr, highest, moves, toast]);
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
@@ -305,6 +318,17 @@ const Page2048 = () => {
           Close
         </button>
         {hard && <div className="ml-2">{timer}</div>}
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="px-4 py-2 bg-gray-700 rounded">Score: {highest}</div>
+        <div className="px-4 py-2 bg-gray-700 rounded">Moves: {moves.length}</div>
+        <div className="px-4 py-2 bg-gray-700 rounded">Seed: {seedStr}</div>
+        <button
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          onClick={handleShare}
+        >
+          Share
+        </button>
       </div>
       <div className="grid w-full max-w-sm grid-cols-4 gap-2">
         {board.map((row, rIdx) =>


### PR DESCRIPTION
## Summary
- show daily seed next to score in 2048
- add share button that copies score, moves, date, and seed link
- toast feedback after copying

## Testing
- `yarn test __tests__/daily2048Seed.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bf2e4ae72c83288faef8c956bd7245