### PR TITLE
test(2048): cover engine helpers

### DIFF
--- a/apps/2048/__tests__/engine.test.ts
+++ b/apps/2048/__tests__/engine.test.ts
@@ -1,0 +1,70 @@
+import { slideRow, hasMoves, transpose } from '../engine';
+
+describe('slideRow', () => {
+  it('merges tiles and slides left', () => {
+    expect(slideRow([2, 0, 2, 0])).toEqual([4, 0, 0, 0]);
+  });
+
+  it('prevents double merges', () => {
+    expect(slideRow([2, 2, 2, 2])).toEqual([4, 4, 0, 0]);
+  });
+});
+
+describe('hasMoves', () => {
+  it('detects empty cells', () => {
+    const board = [
+      [2, 4, 8, 16],
+      [32, 64, 0, 128],
+      [256, 512, 1024, 2048],
+      [4, 2, 4, 2],
+    ];
+    expect(hasMoves(board)).toBe(true);
+  });
+
+  it('detects possible merges', () => {
+    const board = [
+      [2, 2, 4, 8],
+      [16, 32, 64, 128],
+      [256, 512, 1024, 2048],
+      [4, 8, 16, 32],
+    ];
+    expect(hasMoves(board)).toBe(true);
+  });
+
+  it('detects no moves left', () => {
+    const board = [
+      [2, 4, 8, 16],
+      [32, 64, 128, 256],
+      [512, 1024, 2, 4],
+      [8, 16, 32, 64],
+    ];
+    expect(hasMoves(board)).toBe(false);
+  });
+});
+
+describe('transpose', () => {
+  it('transposes a board', () => {
+    const board = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ];
+    expect(transpose(board)).toEqual([
+      [1, 4, 7],
+      [2, 5, 8],
+      [3, 6, 9],
+    ]);
+  });
+
+  it('is its own inverse', () => {
+    const board = [
+      [1, 2],
+      [3, 4],
+    ];
+    expect(transpose(transpose(board))).toEqual(board);
+  });
+
+  it('handles empty board', () => {
+    expect(transpose([])).toEqual([]);
+  });
+});

--- a/apps/2048/engine.ts
+++ b/apps/2048/engine.ts
@@ -1,0 +1,34 @@
+const SIZE = 4;
+
+export const slideRow = (row: number[]) => {
+  const arr = row.filter((n) => n !== 0);
+  for (let i = 0; i < arr.length - 1; i += 1) {
+    const current = arr[i]!;
+    const next = arr[i + 1]!;
+    if (current === next) {
+      arr[i] = current * 2;
+      arr[i + 1] = 0;
+    }
+  }
+  const newRow = arr.filter((n) => n !== 0);
+  while (newRow.length < SIZE) newRow.push(0);
+  return newRow;
+};
+
+export const transpose = (board: number[][]): number[][] => {
+  if (board.length === 0) return [];
+  return board[0].map((_, c) => board.map((row) => row[c]));
+};
+
+export const hasMoves = (board: number[][]) => {
+  for (let r = 0; r < SIZE; r += 1) {
+    for (let c = 0; c < SIZE; c += 1) {
+      if (board[r][c] === 0) return true;
+      if (c < SIZE - 1 && board[r][c] === board[r][c + 1]) return true;
+      if (r < SIZE - 1 && board[r][c] === board[r + 1][c]) return true;
+    }
+  }
+  return false;
+};
+
+export default { slideRow, transpose, hasMoves };


### PR DESCRIPTION
## Summary
- add standalone 2048 engine helpers and tests for slideRow, hasMoves, and transpose
- ensure transpose handles empty boards and is its own inverse

## Testing
- `npx jest apps/2048/__tests__/engine.test.ts --coverage`
- `yarn test` *(fails: module resolution issues, missing browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2e4b575c8328bcbf8ddbfbee14c2