### PR TITLE
chore: use passive touch listeners and memoize 2048 handlers

### DIFF
--- a/apps/2048/index.tsx
+++ b/apps/2048/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, useMemo } from 'react';
 import ReactGA from 'react-ga4';
 import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
 import { getDailySeed } from '../../utils/dailySeed';
@@ -251,17 +251,43 @@ const Page2048 = () => {
     return () => window.removeEventListener('keydown', onKey);
   }, [handleMove, restart, handleUndo]);
 
-  const close = () => {
+  const close = useCallback(() => {
     if (isBrowser()) {
       document.getElementById('close-2048')?.click();
     }
-  };
+  }, []);
 
-  const displayCell = (v: number) => {
-    if (v === 0) return '';
-    if (boardType === 'hex') return v.toString(16).toUpperCase();
-    return v;
-  };
+  const displayCell = useCallback(
+    (v: number) => {
+      if (v === 0) return '';
+      if (boardType === 'hex') return v.toString(16).toUpperCase();
+      return v;
+    },
+    [boardType]
+  );
+
+  const renderedBoard = useMemo(
+    () =>
+      board.map((row, rIdx) =>
+        row.map((cell, cIdx) => (
+          <div
+            key={`${rIdx}-${cIdx}`}
+            className={`w-full aspect-square ${
+              prefersReducedMotion ? '' : 'transition-transform transition-opacity'
+            }`}
+          >
+            <div
+              className={`h-full w-full flex items-center justify-center text-2xl font-bold rounded ${
+                cell ? tileColors[cell] || 'bg-gray-700' : 'bg-gray-800'
+              }`}
+            >
+              {displayCell(cell)}
+            </div>
+          </div>
+        ))
+      ),
+    [board, prefersReducedMotion, displayCell]
+  );
 
   useEffect(() => {
     if (won || lost) {
@@ -307,22 +333,7 @@ const Page2048 = () => {
         {hard && <div className="ml-2">{timer}</div>}
       </div>
       <div className="grid w-full max-w-sm grid-cols-4 gap-2">
-        {board.map((row, rIdx) =>
-          row.map((cell, cIdx) => (
-            <div
-              key={`${rIdx}-${cIdx}`}
-              className={`w-full aspect-square ${prefersReducedMotion ? '' : 'transition-transform transition-opacity'}`}
-            >
-              <div
-                className={`h-full w-full flex items-center justify-center text-2xl font-bold rounded ${
-                  cell ? tileColors[cell] || 'bg-gray-700' : 'bg-gray-800'
-                }`}
-              >
-                {displayCell(cell)}
-              </div>
-            </div>
-          ))
-        )}
+        {renderedBoard}
       </div>
       {(won || lost) && (
         <div className="mt-4 text-xl">{won ? 'You win!' : 'Game over'}</div>

--- a/components/apps/frogger.js
+++ b/components/apps/frogger.js
@@ -266,8 +266,8 @@ const Frogger = () => {
         else if (dy < -30) moveFrog(0, -1);
       }
     };
-    container?.addEventListener('touchstart', handleStart);
-    container?.addEventListener('touchend', handleEnd);
+    container?.addEventListener('touchstart', handleStart, { passive: true });
+    container?.addEventListener('touchend', handleEnd, { passive: true });
     return () => {
       container?.removeEventListener('touchstart', handleStart);
       container?.removeEventListener('touchend', handleEnd);

--- a/components/apps/pacman.js
+++ b/components/apps/pacman.js
@@ -707,7 +707,7 @@ const Pacman = () => {
 
     window.addEventListener('keydown', handleKey);
     canvas.addEventListener('touchstart', handleTouchStart, { passive: true });
-    canvas.addEventListener('touchend', handleTouchEnd);
+    canvas.addEventListener('touchend', handleTouchEnd, { passive: true });
 
     let id;
     const loop = () => {

--- a/components/apps/pong.js
+++ b/components/apps/pong.js
@@ -117,10 +117,10 @@ const PongInner = () => {
       controls.current.touchY = null;
       controls.current.touchY2 = null;
     };
-    canvas.addEventListener('touchstart', handleTouch);
-    canvas.addEventListener('touchmove', handleTouch);
-    canvas.addEventListener('touchend', endTouch);
-    canvas.addEventListener('touchcancel', endTouch);
+    canvas.addEventListener('touchstart', handleTouch, { passive: true });
+    canvas.addEventListener('touchmove', handleTouch, { passive: true });
+    canvas.addEventListener('touchend', endTouch, { passive: true });
+    canvas.addEventListener('touchcancel', endTouch, { passive: true });
     return () => {
       canvas.removeEventListener('touchstart', handleTouch);
       canvas.removeEventListener('touchmove', handleTouch);

--- a/components/apps/useGameControls.js
+++ b/components/apps/useGameControls.js
@@ -80,8 +80,8 @@ const useGameControls = (arg, gameId = 'default') => {
       }
     };
 
-    window.addEventListener('touchstart', start);
-    window.addEventListener('touchend', end);
+    window.addEventListener('touchstart', start, { passive: true });
+    window.addEventListener('touchend', end, { passive: true });
     return () => {
       window.removeEventListener('touchstart', start);
       window.removeEventListener('touchend', end);
@@ -162,9 +162,9 @@ const useGameControls = (arg, gameId = 'default') => {
       stateRef.current.hyperspace = false;
     };
 
-    canvas.addEventListener('touchstart', start);
-    canvas.addEventListener('touchmove', move);
-    canvas.addEventListener('touchend', end);
+    canvas.addEventListener('touchstart', start, { passive: true });
+    canvas.addEventListener('touchmove', move, { passive: true });
+    canvas.addEventListener('touchend', end, { passive: true });
     return () => {
       canvas.removeEventListener('touchstart', start);
       canvas.removeEventListener('touchmove', move);

--- a/public/apps/platformer/main.js
+++ b/public/apps/platformer/main.js
@@ -208,14 +208,20 @@ function setupMobile() {
     const el = document.getElementById(id);
     if (!el) return;
     const key = map[id];
-    el.addEventListener('touchstart', e => {
-      e.preventDefault();
-      keys[key] = true;
-    });
-    el.addEventListener('touchend', e => {
-      e.preventDefault();
-      keys[key] = false;
-    });
+    el.addEventListener(
+      'touchstart',
+      () => {
+        keys[key] = true;
+      },
+      { passive: true }
+    );
+    el.addEventListener(
+      'touchend',
+      () => {
+        keys[key] = false;
+      },
+      { passive: true }
+    );
   });
 }
 setupMobile();


### PR DESCRIPTION
## Summary
- mark touch event listeners passive to avoid scroll blocking
- memoize 2048 helpers and board rendering

## Testing
- `yarn test` *(fails: cannot find Chrome/Playwright and other missing modules)*
- `npx eslint apps/2048/index.tsx components/apps/useGameControls.js components/apps/pong.js components/apps/pacman.js components/apps/frogger.js public/apps/platformer/main.js` *(fails: A control must be associated with a text label)*
- `npx -y lighthouse https://example.com --quiet` *(fails: Chrome path not set)*
- `npx -y react-devtools` *(fails: package installation prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2e4d69b0832892de8850696fb9f7