### PR TITLE
feat: improve tic tac toe accessibility

### DIFF
--- a/components/apps/tictactoe.js
+++ b/components/apps/tictactoe.js
@@ -20,6 +20,7 @@ const TicTacToe = () => {
   const [ai, setAi] = useState(null);
   const [status, setStatus] = useState('Choose X or O');
   const [winLine, setWinLine] = useState(null);
+  const [ariaMessage, setAriaMessage] = useState('');
   const [stats, setStats] = useState(() => {
     if (!isBrowser()) return {};
     try {
@@ -59,6 +60,7 @@ const TicTacToe = () => {
     setAi(null);
     setStatus('Choose X or O');
     setWinLine(null);
+    setAriaMessage('');
   }, [size, mode]);
 
   const startGame = (p) => {
@@ -68,6 +70,7 @@ const TicTacToe = () => {
     setBoard(createBoard(size));
     setStatus(`${SKINS[skin][p]}'s turn`);
     setWinLine(null);
+    setAriaMessage('');
   };
 
   const handleClick = (idx) => {
@@ -83,6 +86,7 @@ const TicTacToe = () => {
     const { winner, line } = checkWinner(board, size, mode === 'misere');
     if (winner) {
       setStatus(winner === 'draw' ? 'Draw' : `${SKINS[skin][winner]} wins`);
+      setAriaMessage(winner === player ? 'You win' : 'Game over');
       setWinLine(line);
       if (winner === 'draw') recordResult('draw');
       else if (winner === player) recordResult('win');
@@ -138,11 +142,16 @@ const TicTacToe = () => {
   if (player === null) {
     return (
       <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4">
+        <p className="sr-only">
+          Use Tab to move through settings and choose your mark. When the board appears, tab through the squares and press Enter or
+          Space to place your symbol. Get three in a row to win.
+        </p>
+        <div aria-live="polite" className="sr-only">{ariaMessage}</div>
         <div className="mb-4">Size:
           <select
             value={size}
             onChange={(e) => setSize(parseInt(e.target.value, 10))}
-            className="bg-gray-700 rounded p-1 ml-2"
+            className="bg-gray-700 rounded p-1 ml-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white"
           >
             <option value={3}>3×3</option>
             <option value={4}>4×4</option>
@@ -152,7 +161,7 @@ const TicTacToe = () => {
           <select
             value={mode}
             onChange={(e) => setMode(e.target.value)}
-            className="bg-gray-700 rounded p-1 ml-2"
+            className="bg-gray-700 rounded p-1 ml-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white"
           >
             <option value="classic">Classic</option>
             <option value="misere">Misère (three-in-a-row loses)</option>
@@ -162,7 +171,7 @@ const TicTacToe = () => {
           <select
             value={level}
             onChange={(e) => setLevel(e.target.value)}
-            className="bg-gray-700 rounded p-1 ml-2"
+            className="bg-gray-700 rounded p-1 ml-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white"
           >
             <option value="easy">Easy</option>
             <option value="medium">Medium</option>
@@ -173,7 +182,7 @@ const TicTacToe = () => {
           <select
             value={skin}
             onChange={(e) => setSkin(e.target.value)}
-            className="bg-gray-700 rounded p-1 ml-2"
+            className="bg-gray-700 rounded p-1 ml-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white"
           >
             {Object.keys(SKINS).map((k) => (
               <option key={k} value={k}>
@@ -185,13 +194,13 @@ const TicTacToe = () => {
         <div className="mb-4">Choose X or O</div>
         <div className="flex space-x-4">
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-yellow-400"
             onClick={() => startGame('X')}
           >
             {currentSkin.X}
           </button>
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-yellow-400"
             onClick={() => startGame('O')}
           >
             {currentSkin.O}
@@ -209,6 +218,10 @@ const TicTacToe = () => {
 
   return (
     <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4">
+      <p className="sr-only">
+        Use Tab to move focus across the grid and press Enter or Space to place your mark. Get three in a row to win.
+      </p>
+      <div aria-live="polite" className="sr-only">{ariaMessage}</div>
       <div className="mb-2" aria-live="polite">
         {status}
       </div>
@@ -220,7 +233,7 @@ const TicTacToe = () => {
           {board.map((cell, idx) => (
             <button
               key={idx}
-              className="w-full h-full flex items-center justify-center bg-gray-700 text-5xl"
+              className="w-full h-full flex items-center justify-center bg-gray-700 text-5xl focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-yellow-400"
               onClick={() => handleClick(idx)}
             >
               {cell ? currentSkin[cell] : ''}
@@ -257,23 +270,25 @@ const TicTacToe = () => {
       </div>
       <div className="flex space-x-4 mt-4">
         <button
-          className="px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded"
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-300"
           onClick={() => {
             setBoard(createBoard(size));
             setStatus(`${currentSkin[player]}'s turn`);
             setWinLine(null);
+            setAriaMessage('');
           }}
         >
           Restart
         </button>
         <button
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-yellow-400"
           onClick={() => {
             setPlayer(null);
             setAi(null);
             setBoard(createBoard(size));
             setStatus('Choose X or O');
             setWinLine(null);
+            setAriaMessage('');
           }}
         >
           Reset


### PR DESCRIPTION
## Summary
- announce win or game over with aria-live message
- add screen reader instructions
- add focus styles for keyboard navigation

## Testing
- `npx eslint components/apps/tictactoe.js && echo "lint passed"`
- `npx jest __tests__/liveRegion.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf2e4f24d88328807c184b0c18042f