### PR TITLE
feat(2048): add swipe controls

### DIFF
--- a/apps/2048/index.tsx
+++ b/apps/2048/index.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import ReactGA from 'react-ga4';
+import { useSwipeable } from 'react-swipeable';
 import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
 import { getDailySeed } from '../../utils/dailySeed';
 import { isBrowser } from '@/utils/env';
@@ -202,6 +203,13 @@ const Page2048 = () => {
     [board, won, lost, highest, boardType, resetTimer]
   );
 
+  const swipeHandlers = useSwipeable({
+    onSwipedLeft: () => handleMove('ArrowLeft'),
+    onSwipedRight: () => handleMove('ArrowRight'),
+    onSwipedUp: () => handleMove('ArrowUp'),
+    onSwipedDown: () => handleMove('ArrowDown'),
+  });
+
   const handleUndo = useCallback(() => {
     setHistory((h) => {
       if (!h.length) return h;
@@ -281,7 +289,7 @@ const Page2048 = () => {
   }, [won, lost, moves, boardType, hard, highest]);
 
   return (
-    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+    <div {...swipeHandlers} className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
       <div className="flex space-x-2">
         <button className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded" onClick={restart}>
           Restart

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "react-ga4": "^2.1.0",
     "react-github-calendar": "^4.5.9",
     "react-leaflet": "^5.0.0",
+    "react-swipeable": "^7.0.2",
     "react-transition-group": "^4.4.5",
     "react-virtualized-auto-sizer": "^1.0.26",
     "react-window": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12715,6 +12715,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-swipeable@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "react-swipeable@npm:7.0.2"
+  peerDependencies:
+    react: ^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc
+  checksum: 10c0/cca3ec9e6321f73d187a8ac4beece2ad8cce1f4efa0215de93e2635492e7c514ccbc30311bb0e88bafb79d302916550603cdcd44ac81054a8c0f6679b18eb04d
+  languageName: node
+  linkType: hard
+
 "react-transition-group@npm:^4.4.5":
   version: 4.4.5
   resolution: "react-transition-group@npm:4.4.5"
@@ -14847,6 +14856,7 @@ __metadata:
     react-ga4: "npm:^2.1.0"
     react-github-calendar: "npm:^4.5.9"
     react-leaflet: "npm:^5.0.0"
+    react-swipeable: "npm:^7.0.2"
     react-transition-group: "npm:^4.4.5"
     react-virtualized-auto-sizer: "npm:^1.0.26"
     react-window: "npm:^2.0.2"


### PR DESCRIPTION
## Summary
- add `react-swipeable` dependency
- enable swipe gestures for 2048 game

## Testing
- `yarn test apps/2048 --passWithNoTests`
- `npx eslint apps/2048/index.tsx` *(fails: A control must be associated with a text label)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2e55c9b883289c28e5a721b1b8ec