### PR TITLE
feat: add workspace switcher with persistence

### DIFF
--- a/__tests__/workspace-switcher.test.tsx
+++ b/__tests__/workspace-switcher.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import WorkspaceSwitcher from '../components/util-components/WorkspaceSwitcher';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+test('cycles workspaces with keyboard controls', () => {
+  render(<WorkspaceSwitcher />);
+  const ws1 = screen.getByRole('tab', { name: 'Workspace 1' });
+  ws1.focus();
+
+  fireEvent.keyDown(ws1, { key: 'ArrowRight' });
+  const ws2 = screen.getByRole('tab', { name: 'Workspace 2' });
+  expect(ws2).toHaveAttribute('aria-selected', 'true');
+  expect(ws2).toHaveFocus();
+
+  fireEvent.keyDown(ws2, { key: 'ArrowRight' });
+  const ws3 = screen.getByRole('tab', { name: 'Workspace 3' });
+  fireEvent.keyDown(ws3, { key: 'ArrowRight' });
+  const ws4 = screen.getByRole('tab', { name: 'Workspace 4' });
+  fireEvent.keyDown(ws4, { key: 'ArrowRight' });
+  const ws1Again = screen.getByRole('tab', { name: 'Workspace 1' });
+  expect(ws1Again).toHaveAttribute('aria-selected', 'true');
+  expect(ws1Again).toHaveFocus();
+
+  fireEvent.keyDown(ws1Again, { key: 'ArrowLeft' });
+  const ws4Again = screen.getByRole('tab', { name: 'Workspace 4' });
+  expect(ws4Again).toHaveAttribute('aria-selected', 'true');
+  expect(ws4Again).toHaveFocus();
+
+  fireEvent.keyDown(ws4Again, { key: 'Home' });
+  const ws1Home = screen.getByRole('tab', { name: 'Workspace 1' });
+  expect(ws1Home).toHaveAttribute('aria-selected', 'true');
+  expect(ws1Home).toHaveFocus();
+
+  fireEvent.keyDown(ws1Home, { key: 'End' });
+  const ws4End = screen.getByRole('tab', { name: 'Workspace 4' });
+  expect(ws4End).toHaveAttribute('aria-selected', 'true');
+  expect(ws4End).toHaveFocus();
+});
+
+test('persists active workspace via localStorage', async () => {
+  const { unmount } = render(<WorkspaceSwitcher />);
+  const ws3 = screen.getByRole('tab', { name: 'Workspace 3' });
+  fireEvent.click(ws3);
+  expect(ws3).toHaveAttribute('aria-selected', 'true');
+  unmount();
+
+  render(<WorkspaceSwitcher />);
+  await waitFor(() =>
+    expect(screen.getByRole('tab', { name: 'Workspace 3' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+  );
+});

--- a/components/desktop/TopPanel.tsx
+++ b/components/desktop/TopPanel.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import WhiskerMenu from "../menu/WhiskerMenu";
 import PanelClock from "../util-components/PanelClock";
 import Status from "../util-components/status";
+import WorkspaceSwitcher from "../util-components/WorkspaceSwitcher";
 
 interface Props {
   /** Optional title shown in the center of the panel */
@@ -35,6 +36,7 @@ export default function TopPanel({ title }: Props) {
 
       {/* System indicators */}
       <div className="flex items-center space-x-2 md:space-x-1 lg:space-x-2" aria-label="System indicators">
+        <WorkspaceSwitcher />
         <div className="hidden sm:block">
           <PanelClock />
         </div>

--- a/components/util-components/WorkspaceSwitcher.tsx
+++ b/components/util-components/WorkspaceSwitcher.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useRef, useState, KeyboardEvent } from 'react';
+import { getWorkspace, setWorkspace } from '../../lib/workspace-store';
+
+const WORKSPACES = 4;
+
+export default function WorkspaceSwitcher() {
+  const [active, setActive] = useState(0);
+  const refs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  useEffect(() => {
+    setActive(getWorkspace());
+  }, []);
+
+  useEffect(() => {
+    setWorkspace(active);
+  }, [active]);
+
+  const activate = (idx: number) => {
+    setActive(idx);
+    refs.current[idx]?.focus();
+  };
+
+  const handleKey = (e: KeyboardEvent<HTMLButtonElement>, idx: number) => {
+    let next = idx;
+    switch (e.key) {
+      case 'ArrowRight':
+        next = (idx + 1) % WORKSPACES;
+        break;
+      case 'ArrowLeft':
+        next = (idx + WORKSPACES - 1) % WORKSPACES;
+        break;
+      case 'Home':
+        next = 0;
+        break;
+      case 'End':
+        next = WORKSPACES - 1;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    activate(next);
+  };
+
+  return (
+    <div role="tablist" aria-label="Workspaces" className="flex space-x-1">
+      {Array.from({ length: WORKSPACES }, (_, i) => (
+        <button
+          key={i}
+          role="tab"
+          aria-label={`Workspace ${i + 1}`}
+          aria-selected={i === active}
+          tabIndex={i === active ? 0 : -1}
+          ref={(el) => (refs.current[i] = el)}
+          onClick={() => activate(i)}
+          onKeyDown={(e) => handleKey(e, i)}
+          className={`w-2 h-2 rounded-full ${
+            i === active ? 'bg-ubt-blue' : 'bg-ubt-grey'
+          }`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/lib/workspace-store.ts
+++ b/lib/workspace-store.ts
@@ -1,0 +1,13 @@
+const KEY = 'active-workspace';
+
+export function getWorkspace(): number {
+  if (typeof window === 'undefined') return 0;
+  const raw = window.localStorage.getItem(KEY);
+  const idx = parseInt(raw ?? '', 10);
+  return isNaN(idx) ? 0 : idx;
+}
+
+export function setWorkspace(idx: number) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(KEY, String(idx));
+}


### PR DESCRIPTION
## Summary
- add WorkspaceSwitcher component with keyboard navigation and focus management
- persist active workspace via localStorage
- integrate workspace switcher into top panel and test cycling/persistence

## Testing
- `yarn test __tests__/workspace-switcher.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bf3037dadc83289924f28bf0ac17b5