### PR TITLE
feat: add quick settings panel

### DIFF
--- a/__tests__/quick-settings.test.tsx
+++ b/__tests__/quick-settings.test.tsx
@@ -1,0 +1,26 @@
+import { render, fireEvent } from "@testing-library/react";
+import React from "react";
+import QuickSettings from "../components/panel/QuickSettings";
+
+describe("quick settings toggles", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("toggles and persists Wi-Fi setting", () => {
+    const { getByLabelText, unmount, rerender } = render(<QuickSettings />);
+    const openBtn = getByLabelText("Quick settings");
+    fireEvent.click(openBtn);
+    const wifi = getByLabelText("Wi-Fi");
+    expect(wifi).toHaveAttribute("aria-checked", "true");
+    fireEvent.click(wifi);
+    expect(wifi).toHaveAttribute("aria-checked", "false");
+    unmount();
+    const { getByLabelText: getByLabelText2 } = render(<QuickSettings />);
+    const openBtn2 = getByLabelText2("Quick settings");
+    fireEvent.click(openBtn2);
+    const wifi2 = getByLabelText2("Wi-Fi");
+    expect(wifi2).toHaveAttribute("aria-checked", "false");
+  });
+});
+

--- a/components/desktop/TopPanel.tsx
+++ b/components/desktop/TopPanel.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import WhiskerMenu from "../menu/WhiskerMenu";
 import PanelClock from "../util-components/PanelClock";
 import Status from "../util-components/status";
+import QuickSettings from "../panel/QuickSettings";
 
 interface Props {
   /** Optional title shown in the center of the panel */
@@ -39,6 +40,7 @@ export default function TopPanel({ title }: Props) {
           <PanelClock />
         </div>
         <Status />
+        <QuickSettings />
       </div>
     </header>
   );

--- a/components/panel/QuickSettings.tsx
+++ b/components/panel/QuickSettings.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import React, { useState } from "react";
+import ToggleSwitch from "../ToggleSwitch";
+import { useQuickSettings } from "@/lib/settings-store";
+
+export default function QuickSettings() {
+  const { settings, update } = useQuickSettings();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="relative">
+      <button
+        aria-label="Quick settings"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className="p-1 rounded hover:bg-ubc-icon-hover focus:outline-none focus:ring-2 focus:ring-ub-orange"
+      >
+        <span aria-hidden>⚙️</span>
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Quick settings"
+          className="absolute right-0 mt-2 w-48 bg-ub-grey text-white rounded shadow-lg p-3 transition-opacity motion-reduce:transition-none" 
+        >
+          <div className="flex items-center justify-between mb-2">
+            <span>Wi-Fi</span>
+            <ToggleSwitch
+              checked={settings.wifi}
+              onChange={(v) => update({ wifi: v })}
+              ariaLabel="Wi-Fi"
+            />
+          </div>
+          <div className="flex items-center justify-between mb-2">
+            <span>Bluetooth</span>
+            <ToggleSwitch
+              checked={settings.bluetooth}
+              onChange={(v) => update({ bluetooth: v })}
+              ariaLabel="Bluetooth"
+            />
+          </div>
+          <div className="mt-2">
+            <label htmlFor="brightness" className="block text-xs mb-1">
+              Brightness
+            </label>
+            <input
+              id="brightness"
+              type="range"
+              min={0}
+              max={100}
+              value={settings.brightness}
+              onChange={(e) => update({ brightness: Number(e.target.value) })}
+              className="w-full"
+              aria-label="Brightness"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/lib/settings-store.ts
+++ b/lib/settings-store.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect, useCallback } from "react";
+import { isBrowser } from "@/utils/env";
+
+export interface QuickSettingsState {
+  wifi: boolean;
+  bluetooth: boolean;
+  brightness: number;
+}
+
+const KEY = "quick-settings";
+
+const defaults: QuickSettingsState = {
+  wifi: true,
+  bluetooth: true,
+  brightness: 100,
+};
+
+function load(): QuickSettingsState {
+  if (!isBrowser()) return defaults;
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? { ...defaults, ...JSON.parse(raw) } : defaults;
+  } catch {
+    return defaults;
+  }
+}
+
+function save(state: QuickSettingsState) {
+  if (!isBrowser()) return;
+  try {
+    localStorage.setItem(KEY, JSON.stringify(state));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function useQuickSettings() {
+  const [settings, setSettings] = useState<QuickSettingsState>(() => load());
+
+  useEffect(() => {
+    save(settings);
+  }, [settings]);
+
+  const update = useCallback((patch: Partial<QuickSettingsState>) => {
+    setSettings((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  return { settings, update };
+}
+


### PR DESCRIPTION
## Summary
- add QuickSettings popover with Wi-Fi, Bluetooth toggles and brightness slider
- persist quick settings in localStorage
- mount QuickSettings on the desktop top panel

## Testing
- `node_modules/.bin/eslint components/panel/QuickSettings.tsx components/desktop/TopPanel.tsx lib/settings-store.ts __tests__/quick-settings.test.tsx`
- `npx jest __tests__/quick-settings.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bf303a51e48328b31731adca41c046