### PR TITLE
feat: add toast provider and hook

### DIFF
--- a/__tests__/toast.test.tsx
+++ b/__tests__/toast.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { toast } from '../hooks/useToast';
+import ToastProvider from '../components/notifications/ToastProvider';
+
+const setup = () => {
+  render(
+    <ToastProvider>
+      <div />
+    </ToastProvider>,
+  );
+};
+
+test('shows and auto-dismisses toast', () => {
+  jest.useFakeTimers();
+  setup();
+  act(() => {
+    toast('Hello', { duration: 1000 });
+  });
+  const status = screen.getByRole('status');
+  expect(status).toHaveAttribute('aria-live', 'polite');
+  expect(status).toHaveTextContent('Hello');
+  act(() => {
+    jest.advanceTimersByTime(1300);
+  });
+  expect(screen.queryByText('Hello')).not.toBeInTheDocument();
+});
+
+test('allows manual dismissal', () => {
+  jest.useFakeTimers();
+  setup();
+  act(() => {
+    toast('Bye', { duration: 10000 });
+  });
+  const btn = screen.getByRole('button', { name: /dismiss/i });
+  act(() => {
+    btn.click();
+  });
+  expect(screen.queryByText('Bye')).not.toBeInTheDocument();
+});

--- a/hooks/useToast.ts
+++ b/hooks/useToast.ts
@@ -1,12 +1,14 @@
 import { useContext } from 'react';
-import { ToastContext } from '../components/ui/ToastProvider';
+import { ToastContext, toast as externalToast, ToastFn } from '../components/notifications/ToastProvider';
 
-export const useToast = () => {
+export const useToast = (): ToastFn => {
   const ctx = useContext(ToastContext);
   if (!ctx) {
     throw new Error('useToast must be used within ToastProvider');
   }
   return ctx.toast;
 };
+
+export const toast: ToastFn = externalToast;
 
 export default useToast;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -26,6 +26,7 @@ import NotificationCenter from '../components/common/NotificationCenter';
 import HighContrastToggle from '../components/common/HighContrastToggle';
 import { Workbox } from 'workbox-window';
 import Toast from '../components/ui/Toast';
+import ToastProvider from '../components/notifications/ToastProvider';
 
 
 let SpeedInsights = () => null;
@@ -244,33 +245,35 @@ function MyApp(props) {
             <HighContrastToggle />
             <TrayProvider>
               <PipPortalProvider>
-                <NotificationCenter>
-                  <div aria-live="polite" id="live-region" />
-                  <Component {...pageProps} />
-                  <ShortcutOverlay />
-                  {updateReady && (
-                    <Toast
-                      message="Update available"
-                      actionLabel="Reload"
-                      onAction={() => wbRef.current?.messageSkipWaiting()}
-                      onClose={() => setUpdateReady(false)}
-                    />
-                  )}
-                  {process.env.VERCEL_ANALYTICS_ID && (
-                    <>
-                      <Analytics
-                        beforeSend={(e) => {
-                          if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                          const evt = e;
-                          if (evt.metadata?.email) delete evt.metadata.email;
-                          return e;
-                        }}
+                <ToastProvider>
+                  <NotificationCenter>
+                    <div aria-live="polite" id="live-region" />
+                    <Component {...pageProps} />
+                    <ShortcutOverlay />
+                    {updateReady && (
+                      <Toast
+                        message="Update available"
+                        actionLabel="Reload"
+                        onAction={() => wbRef.current?.messageSkipWaiting()}
+                        onClose={() => setUpdateReady(false)}
                       />
+                    )}
+                    {process.env.VERCEL_ANALYTICS_ID && (
+                      <>
+                        <Analytics
+                          beforeSend={(e) => {
+                            if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                            const evt = e;
+                            if (evt.metadata?.email) delete evt.metadata.email;
+                            return e;
+                          }}
+                        />
 
-                      <SpeedInsights />
-                    </>
-                  )}
-                </NotificationCenter>
+                        <SpeedInsights />
+                      </>
+                    )}
+                  </NotificationCenter>
+                </ToastProvider>
               </PipPortalProvider>
             </TrayProvider>
           </SettingsProvider>

--- a/src/pwa/a2hs.ts
+++ b/src/pwa/a2hs.ts
@@ -1,4 +1,5 @@
 import { isBrowser } from '@/utils/env';
+import { toast } from '@/hooks/useToast';
 interface BeforeInstallPromptEvent extends Event {
   readonly platforms: string[];
   readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
@@ -22,6 +23,11 @@ export async function showA2HS() {
   const promptEvent = deferredPrompt;
   deferredPrompt = null;
   await promptEvent.prompt();
-  await promptEvent.userChoice;
+  const { outcome } = await promptEvent.userChoice;
+  if (outcome === 'accepted') {
+    toast('App installed');
+  } else {
+    toast('Install dismissed');
+  }
   return true;
 }

--- a/utils/clipboard.ts
+++ b/utils/clipboard.ts
@@ -1,3 +1,5 @@
+import { toast } from '../hooks/useToast';
+
 export const copyToClipboard = async (text: string): Promise<boolean> => {
   try {
     if (navigator?.clipboard?.writeText) {
@@ -13,8 +15,10 @@ export const copyToClipboard = async (text: string): Promise<boolean> => {
       document.execCommand('copy');
       document.body.removeChild(textarea);
     }
+    toast('Copied to clipboard');
     return true;
   } catch {
+    toast('Failed to copy');
     return false;
   }
 };


### PR DESCRIPTION
## Summary
- add ToastProvider with aria-live polite and external toast fn
- expose useToast hook and toast helper
- show toasts on copy-to-clipboard and PWA install
- cover behavior with tests

## Testing
- `yarn test __tests__/toast.test.tsx`
- `npx eslint components/notifications/ToastProvider.tsx hooks/useToast.ts src/pwa/a2hs.ts utils/clipboard.ts pages/_app.jsx __tests__/toast.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf303b65ec832881516349a5473088