### PR TITLE
feat: add window chrome styling with rounded borders

### DIFF
--- a/__tests__/window-chrome.test.tsx
+++ b/__tests__/window-chrome.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Window from '../components/window/Window';
+
+describe('Window chrome', () => {
+  it('uses new class names and renders controls', () => {
+    const { container } = render(
+      <Window>
+        <div>content</div>
+      </Window>
+    );
+    const win = container.querySelector('.window');
+    expect(win).toBeInTheDocument();
+    const controls = container.querySelectorAll('.window-control');
+    expect(controls).toHaveLength(3);
+  });
+});

--- a/components/window/Window.tsx
+++ b/components/window/Window.tsx
@@ -217,8 +217,14 @@ const Window = forwardRef<{ handleDrag: () => void; handleStop: () => void; hand
             ref={nodeRef}
             tabIndex={0}
             onKeyDown={handleKeyDown}
+            className="window"
             style={{ width: `${width}%`, height: `${height}%` }}
           >
+            <div className="window-controls">
+              <button type="button" className="window-control" aria-label="close window" />
+              <button type="button" className="window-control" aria-label="minimize window" />
+              <button type="button" className="window-control" aria-label="maximize window" />
+            </div>
             {children}
           </div>
         </Draggable>

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,6 +1,7 @@
 @import './globals.css';
 @import './whisker.css';
 @import './colors-alt.css';
+@import './window.css';
 
 :root {
     --color-bg: #0f1317;

--- a/styles/window.css
+++ b/styles/window.css
@@ -1,0 +1,51 @@
+/* Window styles */
+
+.window {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.window-controls {
+  display: flex;
+  gap: var(--space-1);
+  justify-content: flex-end;
+  padding: var(--space-1);
+  background: var(--color-secondary);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.window-control {
+  width: var(--hit-area);
+  height: var(--hit-area);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-muted);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background-color var(--motion-fast);
+}
+
+.window-control:hover {
+  background: color-mix(in srgb, var(--color-muted), var(--color-inverse) 10%);
+}
+
+/* Undercover mode adjustments */
+html[data-undercover='true'] .window-controls {
+  background: var(--color-surface);
+}
+
+html[data-undercover='true'] .window-control {
+  background: var(--color-muted);
+}
+
+html[data-undercover='true'] .window-control:hover {
+  background: color-mix(in srgb, var(--color-muted), var(--color-inverse) 10%);
+}


### PR DESCRIPTION
## Summary
- style windows with 8px border-radius and subtle border
- add window chrome controls with hover styles and theme tokens
- cover new chrome with dedicated test

## Testing
- `npx jest __tests__/window-chrome.test.tsx __tests__/window.new.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bf303bfa108328a0647657a7b63f27