### PR TITLE
feat: add desktop app switcher overlay

### DIFF
--- a/__tests__/app-switcher.test.tsx
+++ b/__tests__/app-switcher.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import Desktop from '../src/components/desktop/Desktop';
+import { registerWindow, reset, getActiveWindow } from '../lib/window-manager';
+
+jest.mock('../src/components/desktop/Dock', () => () => <div />);
+jest.mock('../src/components/desktop/DesktopContextMenu', () => () => null);
+jest.mock('../src/components/desktop/HotCorner', () => () => null);
+jest.mock('../src/components/panel/Panel', () => () => <div />);
+
+describe('AppSwitcher', () => {
+  beforeEach(() => {
+    reset();
+    registerWindow({ id: 'one', title: 'One' });
+    registerWindow({ id: 'two', title: 'Two' });
+  });
+
+  it('cycles through windows and activates on release', () => {
+    render(<Desktop />);
+
+    fireEvent.keyDown(window, { key: 'Alt' });
+    expect(screen.getByTestId('app-switcher')).toBeInTheDocument();
+    let items = screen.getAllByRole('listitem');
+    expect(items[0]).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(window, { key: 'Tab' });
+    items = screen.getAllByRole('listitem');
+    expect(items[1]).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyUp(window, { key: 'Alt' });
+    expect(screen.queryByTestId('app-switcher')).not.toBeInTheDocument();
+    expect(getActiveWindow()).toBe('two');
+  });
+});

--- a/lib/window-manager.ts
+++ b/lib/window-manager.ts
@@ -1,0 +1,47 @@
+export interface AppWindow {
+  id: string;
+  title: string;
+}
+
+let windows: AppWindow[] = [];
+let activeId: string | null = null;
+
+const listeners = new Set<() => void>();
+
+function emit() {
+  listeners.forEach((l) => l());
+}
+
+export function getWindows() {
+  return windows;
+}
+
+export function registerWindow(win: AppWindow) {
+  windows.push(win);
+  emit();
+}
+
+export function unregisterWindow(id: string) {
+  windows = windows.filter((w) => w.id !== id);
+  emit();
+}
+
+export function activateWindow(id: string) {
+  activeId = id;
+  emit();
+}
+
+export function getActiveWindow() {
+  return activeId;
+}
+
+export function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function reset() {
+  windows = [];
+  activeId = null;
+  emit();
+}

--- a/src/components/desktop/AppSwitcher.tsx
+++ b/src/components/desktop/AppSwitcher.tsx
@@ -1,0 +1,29 @@
+import React, { useSyncExternalStore } from 'react';
+import { getWindows, subscribe, AppWindow } from '@/lib/window-manager';
+
+interface Props {
+  index: number;
+}
+
+export default function AppSwitcher({ index }: Props) {
+  const windows = useSyncExternalStore(subscribe, getWindows, getWindows) as AppWindow[];
+  if (!windows.length) return null;
+  return (
+    <div
+      data-testid="app-switcher"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    >
+      <ul className="bg-ub-grey text-white p-4 rounded">
+        {windows.map((w, i) => (
+          <li
+            key={w.id}
+            aria-selected={i === index}
+            className={`px-3 py-1 rounded ${i === index ? 'bg-ub-orange text-black' : ''}`}
+          >
+            {w.title}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add basic window manager store
- display running apps with new AppSwitcher overlay
- handle Alt+Tab in Desktop to activate selected window
- cover overlay behaviour with integration test

## Testing
- `pnpm typecheck` *(fails: workers/terminal-worker.ts etc.)*
- `yarn test __tests__/app-switcher.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf303c12a0832892b6d38db6499389