### PR TITLE
feat: implement lock screen overlay

### DIFF
--- a/__tests__/lock-screen.test.tsx
+++ b/__tests__/lock-screen.test.tsx
@@ -1,0 +1,25 @@
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import LockScreen from '@/components/screen/LockScreen';
+
+jest.mock('@/lib/wallpaper', () => ({
+  useWallpaper: () => 'test-wallpaper.webp',
+}));
+
+describe('LockScreen', () => {
+  it('renders blurred wallpaper', () => {
+    const { getByAltText } = render(<LockScreen open onClose={() => {}} />);
+    const img = getByAltText('');
+    expect(img).toHaveAttribute('src', 'test-wallpaper.webp');
+    expect(img.className).toContain('blur');
+  });
+
+  it('focuses input and closes on ESC', () => {
+    const onClose = jest.fn();
+    const { getByLabelText } = render(<LockScreen open onClose={onClose} />);
+    const input = getByLabelText('Password');
+    expect(input).toHaveFocus();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/components/screen/LockScreen.tsx
+++ b/components/screen/LockScreen.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import React, { useEffect, useRef } from 'react';
+import { useWallpaper } from '@/lib/wallpaper';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function LockScreen({ open, onClose }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const wallpaper = useWallpaper();
+
+  useEffect(() => {
+    if (open) {
+      inputRef.current?.focus();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+      role="dialog"
+      aria-modal="true"
+    >
+      <img
+        src={wallpaper}
+        alt=""
+        className="absolute inset-0 w-full h-full object-cover blur-lg"
+      />
+      <form
+        onSubmit={(e) => e.preventDefault()}
+        className="relative z-10"
+      >
+        <input
+          ref={inputRef}
+          type="password"
+          aria-label="Password"
+          className="px-4 py-2 rounded bg-black/60 text-white focus:outline-none"
+        />
+      </form>
+    </div>
+  );
+}

--- a/lib/wallpaper.ts
+++ b/lib/wallpaper.ts
@@ -1,0 +1,9 @@
+import { useSettings } from '@/hooks/useSettings';
+
+/**
+ * Provides the current wallpaper URL based on user settings.
+ */
+export function useWallpaper(): string {
+  const { wallpaper } = useSettings();
+  return `/wallpapers/${wallpaper}.webp`;
+}

--- a/src/components/panel/PowerMenu.tsx
+++ b/src/components/panel/PowerMenu.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 import { usePanelPreferences } from './PanelPreferences';
+import LockScreen from '@/components/screen/LockScreen';
 
 interface Props {
   index: number;
@@ -35,6 +36,7 @@ export default function PowerMenu({ index, move, innerRef, focused, onFocus }: P
   drag(drop(ref));
 
   const [open, setOpen] = useState(false);
+  const [lockedScreen, setLockedScreen] = useState(false);
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
   useEffect(() => {
@@ -119,6 +121,18 @@ export default function PowerMenu({ index, move, innerRef, focused, onFocus }: P
             onKeyDown={handleItemKey}
             onClick={() => {
               setOpen(false);
+              setLockedScreen(true);
+            }}
+            className="px-2 py-1 text-left hover:bg-gray-700"
+          >
+            Lock
+          </button>
+          <button
+            role="menuitem"
+            ref={(el) => (itemRefs.current[2] = el)}
+            onKeyDown={handleItemKey}
+            onClick={() => {
+              setOpen(false);
               logOut();
               ref.current?.focus();
             }}
@@ -128,7 +142,7 @@ export default function PowerMenu({ index, move, innerRef, focused, onFocus }: P
           </button>
           <button
             role="menuitem"
-            ref={(el) => (itemRefs.current[2] = el)}
+            ref={(el) => (itemRefs.current[3] = el)}
             onKeyDown={handleItemKey}
             onClick={() => {
               setOpen(false);
@@ -141,6 +155,13 @@ export default function PowerMenu({ index, move, innerRef, focused, onFocus }: P
           </button>
         </div>
       )}
+      <LockScreen
+        open={lockedScreen}
+        onClose={() => {
+          setLockedScreen(false);
+          ref.current?.focus();
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create LockScreen overlay using wallpaper and password input
- add lock option in PowerMenu to launch LockScreen
- test LockScreen behavior and focus

## Testing
- `yarn test __tests__/lock-screen.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf303d48888328b68b6a0ba61f0152