### PR TITLE
feat: add Undercover toggle to quick settings

### DIFF
--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useTheme } from '../../hooks/useTheme';
+import {
+  getUndercover,
+  setUndercover as setUndercoverTheme,
+} from '../../utils/theme';
 
 interface Props {
   open: boolean;
@@ -13,6 +17,7 @@ interface Props {
 const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
   const { theme, setTheme } = useTheme();
   const isDark = theme === 'dark';
+  const [undercover, setUndercover] = useState(getUndercover());
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState(
@@ -21,6 +26,7 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
   );
 
   const toggleTheme = () => setTheme(isDark ? 'light' : 'dark');
+  const toggleUndercover = () => setUndercover((u) => !u);
   const toggleSound = () => setSound((s) => !s);
   const toggleOnline = () => setOnline((o) => !o);
   const toggleReduceMotion = () => setReduceMotion((r) => !r);
@@ -28,6 +34,10 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
   useEffect(() => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
+
+  useEffect(() => {
+    setUndercoverTheme(undercover);
+  }, [undercover]);
 
   return (
     <div
@@ -43,6 +53,15 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
           <span>Theme</span>
           <span>{isDark ? 'Dark' : 'Light'}</span>
         </button>
+      </div>
+      <div className="px-4 pb-2 flex justify-between">
+        <span>Undercover mode</span>
+        <input
+          type="checkbox"
+          checked={undercover}
+          onChange={toggleUndercover}
+          aria-label="Undercover mode"
+        />
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Sound</span>

--- a/tests/ui/undercover-tooltip.spec.tsx
+++ b/tests/ui/undercover-tooltip.spec.tsx
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test.describe('Undercover tooltip', () => {
   test('mentions Windows-like theme and docs link', async ({ page }) => {
     await page.goto('/');
-    const trigger = page.getByLabel(/undercover/i);
+    const trigger = page.getByLabel(/undercover/i).first();
     await trigger.hover();
     const tooltip = page.getByRole('tooltip');
     await expect(tooltip).toContainText('Windows-like theme');


### PR DESCRIPTION
## Summary
- add Undercover mode toggle with persistence in Quick Settings
- fix Undercover tooltip test to target navbar button

## Testing
- `npx playwright test tests/ui/undercover-tooltip.spec.tsx` *(fails: Host system is missing dependencies to run browsers)*
- `npm test` *(fails: multiple Jest tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf303e26c083289b8fafd6f3cf529d