### PR TITLE
feat: add wallpaper picker component

### DIFF
--- a/__tests__/wallpaper-picker.test.tsx
+++ b/__tests__/wallpaper-picker.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import WallpaperPicker from '../components/settings/WallpaperPicker';
+import { getWallpaper } from '../lib/wallpaper';
+import wallpapers from '../content/wallpapers.json';
+
+jest.mock('next/image', () => (props: any) => <img {...props} alt={props.alt || ''} />);
+
+describe('WallpaperPicker', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.style.removeProperty('--background-image');
+  });
+
+  test('renders options with lazy-loaded thumbnails', () => {
+    render(<WallpaperPicker />);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(wallpapers.length);
+    const img = screen.getAllByRole('img')[0] as HTMLImageElement;
+    expect(img.getAttribute('loading')).toBe('lazy');
+  });
+
+  test('persists selected wallpaper', async () => {
+    render(<WallpaperPicker />);
+    const buttons = screen.getAllByRole('button');
+    await userEvent.click(buttons[1]);
+    expect(getWallpaper()).toBe(wallpapers[1]);
+    expect(window.localStorage.getItem('wallpaper')).toBe(wallpapers[1]);
+    expect(
+      document.documentElement.style.getPropertyValue('--background-image')
+    ).toBe(`url(${wallpapers[1]})`);
+  });
+});

--- a/components/settings/WallpaperPicker.tsx
+++ b/components/settings/WallpaperPicker.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import wallpapers from '@/content/wallpapers.json';
+import { getWallpaper, setWallpaper } from '@/lib/wallpaper';
+
+const WallpaperPicker = () => {
+  const [current, setCurrent] = useState<string>(getWallpaper());
+
+  useEffect(() => {
+    setWallpaper(current);
+  }, [current]);
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center">
+      {wallpapers.map((src) => {
+        const name = src.replace('/wallpapers/', '').replace(/\.[^.]+$/, '');
+        return (
+          <button
+            key={src}
+            type="button"
+            aria-label={`Select ${name.replace('wall-', 'wallpaper ')}`}
+            aria-pressed={current === src}
+            onClick={() => setCurrent(src)}
+            className={`m-2 md:m-4 border-4 border-opacity-80 overflow-hidden ${
+              current === src ? 'border-yellow-700' : 'border-transparent'
+            }`}
+          >
+            <Image
+              src={src}
+              alt={`Preview of ${name}`}
+              width={320}
+              height={180}
+              loading="lazy"
+              className="object-cover w-full h-full"
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default WallpaperPicker;

--- a/content/wallpapers.json
+++ b/content/wallpapers.json
@@ -1,0 +1,10 @@
+[
+  "/wallpapers/wall-1.webp",
+  "/wallpapers/wall-2.webp",
+  "/wallpapers/wall-3.webp",
+  "/wallpapers/wall-4.webp",
+  "/wallpapers/wall-5.webp",
+  "/wallpapers/wall-6.webp",
+  "/wallpapers/wall-7.webp",
+  "/wallpapers/wall-8.webp"
+]

--- a/lib/wallpaper.ts
+++ b/lib/wallpaper.ts
@@ -1,0 +1,20 @@
+import wallpapers from '@/content/wallpapers.json';
+
+const STORAGE_KEY = 'wallpaper';
+
+export function listWallpapers(): string[] {
+  return wallpapers;
+}
+
+export function getWallpaper(): string {
+  if (typeof window === 'undefined') return wallpapers[0];
+  return window.localStorage.getItem(STORAGE_KEY) || wallpapers[0];
+}
+
+export function setWallpaper(src: string): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, src);
+  document.documentElement.style.setProperty('--background-image', `url(${src})`);
+}
+
+export const DEFAULT_WALLPAPER = wallpapers[0];


### PR DESCRIPTION
## Summary
- add wallpapers list and wallpaper persistence helper
- build settings wallpaper picker with cached lazy-loaded thumbnails
- test wallpaper picker selection and persistence

## Testing
- `yarn test __tests__/wallpaper-picker.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf303f5d388328895f15c0ca63ed62