### PR TITLE
feat: add purple theme preset

### DIFF
--- a/__tests__/theme-switcher.test.tsx
+++ b/__tests__/theme-switcher.test.tsx
@@ -1,0 +1,20 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import Appearance from '../components/settings/Appearance';
+import { getTheme, setTheme } from '../lib/theme-store';
+
+describe('theme switcher', () => {
+  beforeEach(() => {
+    document.documentElement.dataset.theme = '';
+    document.documentElement.className = '';
+    window.localStorage.clear();
+    setTheme('default');
+  });
+
+  test('selecting purple theme persists selection', () => {
+    render(<Appearance />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'purple' } });
+    expect(document.documentElement.dataset.theme).toBe('purple');
+    expect(window.localStorage.getItem('app:theme')).toBe('purple');
+    expect(getTheme()).toBe('purple');
+  });
+});

--- a/components/settings/Appearance.tsx
+++ b/components/settings/Appearance.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { setTheme, useTheme } from '@/lib/theme-store';
+import React from 'react';
+
+const PRESETS = [
+  { value: 'default', label: 'Default' },
+  { value: 'kali-dark', label: 'Kali Dark' },
+  { value: 'kali-light', label: 'Kali Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'neon', label: 'Neon' },
+  { value: 'matrix', label: 'Matrix' },
+  { value: 'purple', label: 'Purple' },
+];
+
+export default function Appearance() {
+  const theme = useTheme();
+  return (
+    <div className="flex justify-center my-4">
+      <label className="mr-2 text-ubt-grey">Theme:</label>
+      <select
+        value={theme}
+        onChange={(e) => setTheme(e.target.value)}
+        className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+      >
+        {PRESETS.map((p) => (
+          <option key={p.value} value={p.value}>
+            {p.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/lib/theme-store.ts
+++ b/lib/theme-store.ts
@@ -1,0 +1,28 @@
+import { useSyncExternalStore } from 'react';
+
+const STORAGE_KEY = 'app:theme';
+
+let theme = (typeof window !== 'undefined' && window.localStorage.getItem(STORAGE_KEY)) || 'default';
+const listeners = new Set<() => void>();
+
+export const getTheme = () => theme;
+
+export function setTheme(newTheme: string): void {
+  theme = newTheme;
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(STORAGE_KEY, newTheme);
+    document.documentElement.dataset.theme = newTheme;
+    document.documentElement.classList.toggle(
+      'dark',
+      ['dark', 'neon', 'matrix', 'kali-dark', 'purple'].includes(newTheme)
+    );
+  }
+  listeners.forEach((fn) => fn());
+}
+
+export const subscribe = (fn: () => void) => {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+};
+
+export const useTheme = () => useSyncExternalStore(subscribe, getTheme);

--- a/styles/themes/purple.css
+++ b/styles/themes/purple.css
@@ -1,0 +1,14 @@
+/* Purple theme design tokens */
+html[data-theme='purple'] {
+  --color-bg: #1b1039;
+  --color-text: #f5f5f5;
+  --color-primary: #805ad5;
+  --color-secondary: #120b26;
+  --color-accent: #805ad5;
+  --color-muted: #261b4d;
+  --color-surface: #1b1039;
+  --color-inverse: #ffffff;
+  --color-border: #433160;
+  --color-terminal: #00ff00;
+  --color-dark: #0d071a;
+}


### PR DESCRIPTION
## Summary
- add purple theme tokens and persistence
- add appearance selector with purple preset
- test theme selection persistence

## Testing
- `yarn test __tests__/theme-switcher.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf3041d9b883288bd49e1349460710