### PR TITLE
feat: add dragon watermark style and docs

### DIFF
--- a/__tests__/watermark.test.ts
+++ b/__tests__/watermark.test.ts
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('watermark styles', () => {
+  test('exports dragon watermark class', () => {
+    const cssPath = path.join(__dirname, '..', 'styles', 'watermarks.css');
+    const css = fs.readFileSync(cssPath, 'utf8');
+    expect(css).toMatch(/\.dragon-watermark\s*\{/);
+  });
+});

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,18 @@
+# Theming
+
+## Watermarks
+
+Use the `.dragon-watermark` utility to place a subtle dragon image behind content.
+
+```html
+<h1 class="dragon-watermark">Dragon Heading</h1>
+```
+
+## Heading Contrast
+
+Watermarks and other decorative backgrounds must not reduce text readability.
+Headings should retain sufficient contrast against the background:
+- 4.5:1 ratio for normal text
+- 3:1 ratio for large headings (≥24px or bold 19px)
+
+Adjust the foreground color if the watermark lowers contrast below these guidelines.

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,6 +1,7 @@
 @import './globals.css';
 @import './whisker.css';
 @import './colors-alt.css';
+@import './watermarks.css';
 
 :root {
     --color-bg: #0f1317;

--- a/styles/watermarks.css
+++ b/styles/watermarks.css
@@ -1,0 +1,6 @@
+.dragon-watermark {
+  background: url('/images/dragon-watermark.png') no-repeat center;
+  background-size: contain;
+  opacity: 0.05;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- add `.dragon-watermark` utility for subtle background image
- document watermark usage and heading contrast in theming guide
- test for watermark class presence

## Testing
- `npx eslint __tests__/watermark.test.ts`
- `yarn test __tests__/watermark.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf3040476083289f9e3fbbc9f1828f