### PR TITLE
feat: add on-screen display for volume and brightness

### DIFF
--- a/__tests__/osd-display.test.tsx
+++ b/__tests__/osd-display.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import OsdDisplay from '../components/osd/OsdDisplay';
+
+jest.useFakeTimers();
+
+describe('OsdDisplay', () => {
+  beforeEach(() => {
+    jest.clearAllTimers();
+  });
+
+  test('responds to volumechange events', () => {
+    render(<OsdDisplay />);
+    act(() => {
+      window.dispatchEvent(new CustomEvent('volumechange', { detail: { value: 30 } }));
+    });
+    const progress = screen.getByTestId('progress');
+    expect(progress.style.width).toBe('30%');
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  test('responds to brightnesschange events', () => {
+    render(<OsdDisplay />);
+    act(() => {
+      window.dispatchEvent(new CustomEvent('brightnesschange', { detail: { value: 70 } }));
+    });
+    const progress = screen.getByTestId('progress');
+    expect(progress.style.width).toBe('70%');
+  });
+});
+

--- a/components/osd/OsdDisplay.tsx
+++ b/components/osd/OsdDisplay.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface OSDState {
+  type: 'volume' | 'brightness';
+  value: number;
+}
+
+function clamp(value: number) {
+  return Math.max(0, Math.min(100, value));
+}
+
+export default function OsdDisplay() {
+  const [state, setState] = useState<OSDState | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const createHandler = (type: OSDState['type']) => (e: Event) => {
+      const detail = (e as CustomEvent<{ value: number }>).detail;
+      const value = clamp(Number(detail?.value));
+      setState({ type, value });
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => setState(null), 1000);
+    };
+
+    const volumeHandler = createHandler('volume');
+    const brightnessHandler = createHandler('brightness');
+    window.addEventListener('volumechange', volumeHandler as EventListener);
+    window.addEventListener('brightnesschange', brightnessHandler as EventListener);
+    return () => {
+      window.removeEventListener('volumechange', volumeHandler as EventListener);
+      window.removeEventListener('brightnesschange', brightnessHandler as EventListener);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  if (!state) return null;
+
+  const label = state.type === 'volume' ? 'Volume' : 'Brightness';
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-black/80 text-white px-4 py-3 rounded transition-opacity duration-300 motion-reduce:transition-none"
+    >
+      <div className="text-sm mb-1">{label}</div>
+      <div className="w-40 h-2 bg-gray-700 rounded">
+        <div data-testid="progress" className="h-full bg-white" style={{ width: `${state.value}%` }} />
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add centered OSD component that reacts to `volumechange` and `brightnesschange` events
- respect reduced motion preferences using CSS transitions
- test volume and brightness OSD behavior

## Testing
- `npm test -- __tests__/osd-display.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bf3042b5308328bad7426aa1de7deb