### PR TITLE
feat: add translucent top panel

### DIFF
--- a/__tests__/panel-translucency.test.tsx
+++ b/__tests__/panel-translucency.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import TopPanel from '../components/desktop/TopPanel';
+
+jest.mock('../components/menu/WhiskerMenu', () => () => <div />);
+jest.mock('../components/util-components/PanelClock', () => () => <div />);
+jest.mock('../components/util-components/status', () => () => <div />);
+
+describe('TopPanel translucency', () => {
+  it('applies blur with translucent background when supported', () => {
+    const { container } = render(<TopPanel title="Test" />);
+    const header = container.querySelector('header');
+    expect(header).not.toBeNull();
+    const className = header!.className;
+    expect(className).toContain('bg-ub-grey');
+    expect(className).toContain('supports-[backdrop-filter:blur(8px)]:backdrop-blur');
+    expect(className).toContain('supports-[backdrop-filter:blur(8px)]:opacity-90');
+    expect(className).toContain('supports-[backdrop-filter:blur(8px)]:bg-opacity-90');
+  });
+});

--- a/components/desktop/TopPanel.tsx
+++ b/components/desktop/TopPanel.tsx
@@ -18,7 +18,7 @@ interface Props {
  */
 export default function TopPanel({ title }: Props) {
   return (
-    <header className="flex items-center justify-between w-full bg-ub-grey text-ubt-grey h-8 md:h-6 lg:h-8 px-2 md:px-1 lg:px-2 text-sm md:text-xs lg:text-sm sticky top-0 z-40">
+    <header className="flex items-center justify-between w-full bg-ub-grey supports-[backdrop-filter:blur(8px)]:bg-opacity-90 supports-[backdrop-filter:blur(8px)]:backdrop-blur supports-[backdrop-filter:blur(8px)]:opacity-90 text-ubt-grey h-8 md:h-6 lg:h-8 px-2 md:px-1 lg:px-2 text-sm md:text-xs lg:text-sm sticky top-0 z-40">
       {/* App menu */}
       <div className="flex items-center">
         <WhiskerMenu />


### PR DESCRIPTION
## Summary
- apply backdrop blur and 90% opacity to TopPanel with solid fallback
- test TopPanel translucency class names

## Testing
- `yarn test __tests__/panel-translucency.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf3043cbac8328b67e75871a83fc3f