### PR TITLE
feat: add wallpaper gradient overlays

### DIFF
--- a/__tests__/gradient-mask.test.ts
+++ b/__tests__/gradient-mask.test.ts
@@ -1,0 +1,25 @@
+import { gradientFromColor } from '../lib/wallpaper';
+import { contrastRatio } from '../components/apps/Games/common/theme';
+
+const extractHex = (gradient: string): string => {
+  const match = gradient.match(/rgba\((\d+),\s*(\d+),\s*(\d+)/);
+  if (!match) throw new Error('no color');
+  const [r, g, b] = match.slice(1).map(Number);
+  return `#${r.toString(16).padStart(2, '0')}${g
+    .toString(16)
+    .padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+};
+
+describe('wallpaper gradient mask', () => {
+  test('provides contrast for light images', () => {
+    const grad = gradientFromColor('#f5f5f5');
+    const color = extractHex(grad);
+    expect(contrastRatio('#ffffff', color)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  test('retains contrast for dark images', () => {
+    const grad = gradientFromColor('#222222');
+    const color = extractHex(grad);
+    expect(contrastRatio('#ffffff', color)).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/components/ui/Hero.tsx
+++ b/components/ui/Hero.tsx
@@ -13,7 +13,7 @@ interface HeroProps {
 
 export default function Hero({ title, summary, meta }: HeroProps) {
   return (
-    <section className="flex flex-col gap-6 md:flex-row md:gap-4">
+    <section className="wallpaper-gradient flex flex-col gap-6 md:flex-row md:gap-4">
       <div className="flex-1 space-y-4">
         <h1 className="text-3xl font-bold">{title}</h1>
         <ul className="list-disc list-inside space-y-2">

--- a/lib/wallpaper.ts
+++ b/lib/wallpaper.ts
@@ -1,0 +1,78 @@
+import { contrastRatio } from '../components/apps/Games/common/theme';
+
+interface RGB { r: number; g: number; b: number }
+
+const hexToRgb = (hex: string): RGB => {
+  const clean = hex.replace('#', '');
+  const num = parseInt(clean, 16);
+  return {
+    r: (num >> 16) & 0xff,
+    g: (num >> 8) & 0xff,
+    b: num & 0xff,
+  };
+};
+
+const rgbToHex = ({ r, g, b }: RGB): string =>
+  `#${r.toString(16).padStart(2, '0')}${g
+    .toString(16)
+    .padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+
+// Rough dominant color extraction by averaging sampled pixels
+export const getDominantColor = async (src: string): Promise<string> => {
+  const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image();
+    image.crossOrigin = 'Anonymous';
+    image.onload = () => resolve(image);
+    image.onerror = reject;
+    image.src = src;
+  });
+
+  const canvas = document.createElement('canvas');
+  canvas.width = img.width;
+  canvas.height = img.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return '#000000';
+  ctx.drawImage(img, 0, 0);
+  const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+  let r = 0,
+    g = 0,
+    b = 0,
+    count = 0;
+  for (let i = 0; i < data.length; i += 40) {
+    r += data[i];
+    g += data[i + 1];
+    b += data[i + 2];
+    count++;
+  }
+  r = Math.round(r / count);
+  g = Math.round(g / count);
+  b = Math.round(b / count);
+  return rgbToHex({ r, g, b });
+};
+
+const darkenUntilContrast = (hex: string, target = 4.5): RGB => {
+  let color = hexToRgb(hex);
+  const toHex = () => rgbToHex(color);
+  while (contrastRatio('#ffffff', toHex()) < target) {
+    color = {
+      r: Math.max(0, Math.floor(color.r * 0.9)),
+      g: Math.max(0, Math.floor(color.g * 0.9)),
+      b: Math.max(0, Math.floor(color.b * 0.9)),
+    };
+  }
+  return color;
+};
+
+export const gradientFromColor = (hex: string): string => {
+  const { r, g, b } = darkenUntilContrast(hex);
+  return `linear-gradient(to top, rgba(${r}, ${g}, ${b}, 0.8) 0%, rgba(${r}, ${g}, ${b}, 0) 60%)`;
+};
+
+export const applyWallpaperGradient = async (
+  src: string,
+  el: HTMLElement = document.documentElement,
+): Promise<void> => {
+  const color = await getDominantColor(src);
+  el.style.setProperty('--wallpaper-gradient', gradientFromColor(color));
+};
+

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,6 +1,7 @@
 @import './globals.css';
 @import './whisker.css';
 @import './colors-alt.css';
+@import './wallpaper-gradients.css';
 
 :root {
     --color-bg: #0f1317;

--- a/styles/wallpaper-gradients.css
+++ b/styles/wallpaper-gradients.css
@@ -1,0 +1,5 @@
+.wallpaper-gradient {
+  background-image: var(--wallpaper-gradient);
+  background-repeat: no-repeat;
+  background-size: cover;
+}


### PR DESCRIPTION
## Summary
- compute wallpaper dominant color and derive gradient mask
- add wallpaper-gradient utility CSS and apply to hero sections
- test gradient mask ensures text contrast

## Testing
- `yarn eslint lib/wallpaper.ts components/ui/Hero.tsx __tests__/gradient-mask.test.ts`
- `yarn test __tests__/gradient-mask.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf30457f6883289d4ffb6419fb0f99