### PR TITLE
Add download verification page with checksum tools

### DIFF
--- a/__tests__/download-verification.test.tsx
+++ b/__tests__/download-verification.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import VerifyDownloadPage from '../pages/verify-download';
+
+jest.mock('../lib/hash-utils', () => ({
+  sha256File: jest.fn().mockResolvedValue('abc123'),
+}));
+
+describe('VerifyDownloadPage', () => {
+  it('computes checksum and verifies match', async () => {
+    render(<VerifyDownloadPage />);
+
+    expect(
+      screen.getByRole('heading', { name: /sha256 checksum/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /signature verification/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('expected-input'), {
+      target: { value: 'abc123' },
+    });
+
+    const file = new File(['hello'], 'hello.txt', { type: 'text/plain' });
+    fireEvent.change(screen.getByTestId('file-input'), {
+      target: { files: [file] },
+    });
+
+    expect(await screen.findByTestId('computed-hash')).toHaveTextContent(
+      'abc123',
+    );
+    expect(await screen.findByText(/hashes match/i)).toBeInTheDocument();
+  });
+});

--- a/lib/hash-utils.ts
+++ b/lib/hash-utils.ts
@@ -1,0 +1,13 @@
+export async function sha256File(file: Blob): Promise<string> {
+  const buffer = await file.arrayBuffer();
+  if (typeof crypto !== 'undefined' && crypto.subtle) {
+    const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
+    return Array.from(new Uint8Array(hashBuffer))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+  const { createHash } = await import('crypto');
+  const hash = createHash('sha256');
+  hash.update(Buffer.from(buffer));
+  return hash.digest('hex');
+}

--- a/pages/verify-download.tsx
+++ b/pages/verify-download.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import CodeBlock from '../components/ui/CodeBlock';
+import { sha256File } from '../lib/hash-utils';
+
+const VerifyDownloadPage: React.FC = () => {
+  const [expected, setExpected] = useState('');
+  const [computed, setComputed] = useState('');
+  const [match, setMatch] = useState<boolean | null>(null);
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const hash = await sha256File(file);
+    setComputed(hash);
+    setMatch(expected ? hash === expected.toLowerCase() : null);
+  };
+
+  const handleExpectedChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const value = e.target.value.trim().toLowerCase();
+    setExpected(value);
+    setMatch(computed ? computed === value : null);
+  };
+
+  return (
+    <div className="p-8 max-w-3xl mx-auto space-y-8">
+      <h1 className="text-2xl font-bold mb-4">Verify Download</h1>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">SHA256 Checksum</h2>
+        <p>
+          Select your downloaded file to compute its SHA256 checksum and compare
+          with the official value.
+        </p>
+        <CodeBlock className="p-4 bg-[var(--color-muted)] rounded">
+{`sha256sum kali-linux.iso`}
+        </CodeBlock>
+        <input
+          type="file"
+          onChange={handleFile}
+          data-testid="file-input"
+          className="block"
+        />
+        <input
+          type="text"
+          placeholder="Expected SHA256"
+          value={expected}
+          onChange={handleExpectedChange}
+          data-testid="expected-input"
+          className="border rounded p-2 w-full"
+        />
+        {computed && (
+          <p className="font-mono break-all">
+            Computed: <span data-testid="computed-hash">{computed}</span>
+          </p>
+        )}
+        {match !== null && (
+          <p className={match ? 'text-green-600' : 'text-red-600'}>
+            {match ? 'Hashes match' : 'Hashes do not match'}
+          </p>
+        )}
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Signature Verification</h2>
+        <p>Use the official signature file to verify your download with GPG.</p>
+        <CodeBlock className="p-4 bg-[var(--color-muted)] rounded">
+{`gpg --verify kali-linux.iso.sig kali-linux.iso`}
+        </CodeBlock>
+      </section>
+    </div>
+  );
+};
+
+export default VerifyDownloadPage;


### PR DESCRIPTION
## Summary
- add SHA256 and signature guidance page with checksum comparison
- implement hash utility for computing file SHA256
- test download verification workflow

## Testing
- `pnpm -w typecheck` *(fails: --workspace-root may only be used inside a workspace)*
- `yarn test __tests__/download-verification.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bf3048016c8328bf8e37fb85c1d350