### PR TITLE
Refine TitleBar typography and preload fonts

### DIFF
--- a/__tests__/titlebar-typography.test.tsx
+++ b/__tests__/titlebar-typography.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import TitleBar from '../components/window/TitleBar';
+
+describe('TitleBar typography', () => {
+  test('uses system font with custom letter spacing', () => {
+    const { getByTestId } = render(<TitleBar title="Demo" />);
+    const el = getByTestId('titlebar');
+    const style = getComputedStyle(el);
+    expect(style.fontFamily).toMatch(/system-ui/i);
+    expect(style.letterSpacing).toBe('0.05em');
+  });
+});

--- a/components/window/TitleBar.tsx
+++ b/components/window/TitleBar.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface TitleBarProps {
+  title: string;
+  onKeyDown?: React.KeyboardEventHandler<HTMLButtonElement>;
+  onBlur?: React.FocusEventHandler<HTMLButtonElement>;
+  grabbed?: boolean;
+}
+
+export default function TitleBar({ title, onKeyDown, onBlur, grabbed }: TitleBarProps) {
+  return (
+    <button
+      type="button"
+      className="relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"
+      tabIndex={0}
+      aria-grabbed={grabbed}
+      onKeyDown={onKeyDown}
+      onBlur={onBlur}
+    >
+      <div
+        data-testid="titlebar"
+        className="flex justify-center w-full text-sm font-bold"
+        style={{ fontFamily: 'system-ui', letterSpacing: '0.05em' }}
+      >
+        {title}
+      </div>
+    </button>
+  );
+}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -26,6 +26,17 @@ class MyDocument extends Document<Props> {
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link
+            rel="preconnect"
+            href="https://fonts.gstatic.com"
+            crossOrigin="anonymous"
+          />
+          <link
+            rel="preload"
+            as="style"
+            href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
+          />
           <link
             href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
             rel="stylesheet"


### PR DESCRIPTION
## Summary
- preload Ubuntu font resources in custom Document to avoid flash of unstyled text
- add dedicated TitleBar component with system-ui font and adjusted letter spacing
- add regression test asserting TitleBar typography

## Testing
- `yarn eslint components/window/TitleBar.tsx pages/_document.tsx __tests__/titlebar-typography.test.tsx && echo 'Lint succeeded'`
- `yarn test __tests__/titlebar-typography.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bf3045be8c8328bf4cc94bbc501a76