### PR TITLE
Add status pill and tests

### DIFF
--- a/__tests__/system-status.test.tsx
+++ b/__tests__/system-status.test.tsx
@@ -1,0 +1,67 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import SystemStatus from '../components/status/SystemStatus';
+
+const originalFetch = global.fetch;
+
+describe('SystemStatus', () => {
+  const setNavigatorOnLine = (value: boolean) => {
+    Object.defineProperty(window.navigator, 'onLine', {
+      configurable: true,
+      value,
+    });
+  };
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+    setNavigatorOnLine(true);
+  });
+
+  test('displays status from API', async () => {
+    setNavigatorOnLine(true);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: 'All Systems Operational' }),
+    } as any);
+
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <SystemStatus />
+      </SWRConfig>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('All Systems Operational')).toBeInTheDocument(),
+    );
+    const link = screen.getByRole('link', { name: 'All Systems Operational' });
+    expect(link).toHaveAttribute('href', 'https://status.kali.org/');
+  });
+
+  test('shows offline when navigator is offline', () => {
+    setNavigatorOnLine(false);
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <SystemStatus />
+      </SWRConfig>,
+    );
+    expect(screen.getByText('Offline')).toBeInTheDocument();
+  });
+
+  test('handles fetch error gracefully', async () => {
+    setNavigatorOnLine(true);
+    global.fetch = jest.fn().mockRejectedValue(new Error('fail'));
+
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <SystemStatus />
+      </SWRConfig>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('Status Unavailable')).toBeInTheDocument(),
+    );
+  });
+});
+

--- a/components/status/SystemStatus.tsx
+++ b/components/status/SystemStatus.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import useSWR from 'swr';
+
+interface StatusResponse {
+  status?: string;
+  message?: string;
+  indicator?: string;
+  [key: string]: any;
+}
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error('Network response was not ok');
+  }
+  return res.json() as Promise<StatusResponse>;
+};
+
+export default function SystemStatus() {
+  const [offline, setOffline] = useState(
+    typeof navigator !== 'undefined' ? !navigator.onLine : false,
+  );
+
+  useEffect(() => {
+    const update = () => setOffline(!navigator.onLine);
+    window.addEventListener('online', update);
+    window.addEventListener('offline', update);
+    return () => {
+      window.removeEventListener('online', update);
+      window.removeEventListener('offline', update);
+    };
+  }, []);
+
+  const { data, error } = useSWR<StatusResponse>(
+    offline ? null : 'https://status.kali.org/api/status.json',
+    fetcher,
+  );
+
+  let text = 'Loading…';
+  let color = 'bg-gray-500';
+
+  if (offline) {
+    text = 'Offline';
+  } else if (error) {
+    text = 'Status Unavailable';
+  } else if (data) {
+    const indicator = (data.indicator || data.status || '').toLowerCase();
+    text = data.message || data.status || 'Unknown';
+    if (['critical', 'major', 'down', 'danger', 'outage'].some((s) => indicator.includes(s))) {
+      color = 'bg-red-600';
+    } else if (
+      ['minor', 'degraded', 'warning', 'maintenance'].some((s) => indicator.includes(s))
+    ) {
+      color = 'bg-yellow-500';
+    } else {
+      color = 'bg-green-600';
+    }
+  }
+
+  return (
+    <Link
+      href="https://status.kali.org/"
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`inline-block rounded-full px-3 py-1 text-xs text-white ${color}`}
+    >
+      {text}
+    </Link>
+  );
+}
+

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -7,6 +7,7 @@ import { baseMetadata } from "../lib/metadata";
 import ReleaseNotesModal from "../components/ReleaseNotesModal";
 import Header from "../components/layout/Header";
 import Footer from "../components/layout/Footer";
+import SystemStatus from "../components/status/SystemStatus";
 
 export const metadata = baseMetadata;
 
@@ -40,6 +41,9 @@ export default function Home({ desktops }) {
     <>
       <Header />
       <main className="p-4">
+        <div className="mb-4">
+          <SystemStatus />
+        </div>
         <h1 className="mb-4 text-2xl font-bold sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl 2xl:text-7xl">
           Choose the desktop you prefer
         </h1>


### PR DESCRIPTION
## Summary
- add SystemStatus component using SWR to show service status
- surface status pill on homepage
- test SystemStatus for online, offline, and error scenarios

## Testing
- `yarn test __tests__/system-status.test.tsx`
- `npx eslint components/status/SystemStatus.tsx pages/index.jsx __tests__/system-status.test.tsx` *(warn: File ignored because no matching configuration was supplied)*

------
https://chatgpt.com/codex/tasks/task_e_68bf304881848328959837ff71cfb58a