### PR TITLE
feat: add releases timeline page

### DIFF
--- a/__tests__/release-timeline.test.tsx
+++ b/__tests__/release-timeline.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import Timeline from '../components/releases/Timeline';
+
+const mockReleases = [
+  { title: 'Release 1', link: 'https://example.com/1', pubDate: '2025-01-01' },
+  { title: 'Release 2', link: 'https://example.com/2', pubDate: '2025-02-01' },
+];
+
+describe('Release Timeline', () => {
+  it('renders release items with correct links', () => {
+    render(<Timeline releases={mockReleases} />);
+    mockReleases.forEach((r) => {
+      const link = screen.getByText(r.title).closest('a');
+      expect(link).toHaveAttribute('href', r.link);
+    });
+  });
+});

--- a/components/releases/Timeline.tsx
+++ b/components/releases/Timeline.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export interface ReleaseItem {
+  title: string;
+  link: string;
+  pubDate: string;
+}
+
+interface TimelineProps {
+  releases: ReleaseItem[];
+}
+
+const Timeline: React.FC<TimelineProps> = ({ releases }) => (
+  <ol className="relative ml-4 border-l border-gray-700">
+    {releases.map((release) => (
+      <li key={release.link} className="mb-10 ml-4">
+        <div className="absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full border border-gray-900 bg-ubt-blue" />
+        <time className="mb-1 block text-sm text-gray-400">
+          {new Date(release.pubDate).toDateString()}
+        </time>
+        <a
+          href={release.link}
+          target="_blank"
+          rel="noreferrer"
+          className="text-lg font-semibold text-ubt-blue hover:underline"
+        >
+          {release.title}
+        </a>
+      </li>
+    ))}
+  </ol>
+);
+
+export default Timeline;

--- a/pages/releases.tsx
+++ b/pages/releases.tsx
@@ -1,0 +1,35 @@
+import { GetStaticProps } from 'next';
+import { XMLParser } from 'fast-xml-parser';
+import Timeline, { ReleaseItem } from '../components/releases/Timeline';
+
+interface ReleasesPageProps {
+  releases: ReleaseItem[];
+}
+
+export default function ReleasesPage({ releases }: ReleasesPageProps) {
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Kali Linux Releases</h1>
+      <Timeline releases={releases} />
+    </main>
+  );
+}
+
+export const getStaticProps: GetStaticProps<ReleasesPageProps> = async () => {
+  const res = await fetch('https://www.kali.org/rss.xml');
+  const xml = await res.text();
+  const parser = new XMLParser();
+  const parsed = parser.parse(xml);
+  const items = Array.isArray(parsed.rss.channel.item)
+    ? parsed.rss.channel.item
+    : [parsed.rss.channel.item];
+  const releases: ReleaseItem[] = items.map((item: any) => ({
+    title: item.title as string,
+    link: item.link as string,
+    pubDate: item.pubDate as string,
+  }));
+  return {
+    props: { releases },
+    revalidate: 7200,
+  };
+};


### PR DESCRIPTION
## Summary
- fetch Kali RSS feed at build-time and expose releases page with ISR
- implement releases timeline component
- test timeline rendering

## Testing
- `npx eslint components/releases/Timeline.tsx pages/releases.tsx __tests__/release-timeline.test.tsx`
- `npx jest __tests__/release-timeline.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bf30470ea48328bec662b35394ade6