### PR TITLE
Add platform badges for WSL and Containers

### DIFF
--- a/__tests__/platform-badges.test.tsx
+++ b/__tests__/platform-badges.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import KaliEverywhere from "../components/home/KaliEverywhere";
+
+test("renders WSL and Containers badges with correct links", () => {
+  render(<KaliEverywhere />);
+
+  const wslBadge = screen.getByRole("img", { name: /WSL badge/i });
+  expect(wslBadge).toBeInTheDocument();
+  const wslLink = wslBadge.closest("a");
+  expect(wslLink).toHaveAttribute("target", "_blank");
+  expect(wslLink).toHaveAttribute("rel", "noopener");
+
+  const containersBadge = screen.getByRole("img", { name: /Containers badge/i });
+  expect(containersBadge).toBeInTheDocument();
+  const containersLink = containersBadge.closest("a");
+  expect(containersLink).toHaveAttribute("target", "_blank");
+  expect(containersLink).toHaveAttribute("rel", "noopener");
+});

--- a/components/home/KaliEverywhere.tsx
+++ b/components/home/KaliEverywhere.tsx
@@ -4,6 +4,11 @@ interface Platform {
   icon: string;
   title: string;
   description: string;
+  badge?: {
+    src: string;
+    href: string;
+    alt: string;
+  };
 }
 
 const platforms: Platform[] = [
@@ -26,6 +31,11 @@ const platforms: Platform[] = [
     icon: "📦",
     title: "Containers",
     description: "Run Kali in Docker and other container platforms.",
+    badge: {
+      src: "/badges/containers.svg",
+      href: "https://www.kali.org/docs/containers",
+      alt: "Containers badge",
+    },
   },
   {
     icon: "📱",
@@ -46,6 +56,11 @@ const platforms: Platform[] = [
     icon: "🪟",
     title: "WSL",
     description: "Integrate Kali with Windows Subsystem for Linux.",
+    badge: {
+      src: "/badges/wsl.svg",
+      href: "https://aka.ms/wslstorepage",
+      alt: "WSL badge",
+    },
   },
 ];
 
@@ -63,6 +78,11 @@ export default function KaliEverywhere() {
             </div>
             <h3 className="font-semibold">{p.title}</h3>
             <p className="text-sm text-muted">{p.description}</p>
+            {p.badge && (
+              <a href={p.badge.href} target="_blank" rel="noopener" className="mt-2">
+                <img src={p.badge.src} alt={p.badge.alt} className="h-6" />
+              </a>
+            )}
           </div>
         ))}
       </div>

--- a/public/badges/containers.svg
+++ b/public/badges/containers.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="20" role="img" aria-label="Containers badge">
+  <rect width="120" height="20" fill="#0db7ed"/>
+  <text x="60" y="14" fill="#ffffff" font-family="sans-serif" font-size="12" text-anchor="middle">Containers</text>
+</svg>

--- a/public/badges/wsl.svg
+++ b/public/badges/wsl.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="20" role="img" aria-label="WSL badge">
+  <rect width="80" height="20" fill="#4a90e2"/>
+  <text x="40" y="14" fill="#ffffff" font-family="sans-serif" font-size="12" text-anchor="middle">WSL</text>
+</svg>


### PR DESCRIPTION
## Summary
- add simple WSL and Containers SVG badges
- show badges in KaliEverywhere cards with external links
- test for presence and link attributes of platform badges

## Testing
- `yarn test __tests__/platform-badges.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bf3046bb388328b3bcc8dd1b82d77b