### PR TITLE
Add community page with breadcrumb navigation

### DIFF
--- a/__tests__/community-page.test.tsx
+++ b/__tests__/community-page.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CommunityPage from '../pages/community';
+import links from '../content/community-links.json';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+describe('CommunityPage', () => {
+  it('renders community links, breadcrumbs and disclaimer', () => {
+    render(<CommunityPage />);
+
+    expect(screen.getByText(/unofficial/i)).toBeInTheDocument();
+    const nav = screen.getByRole('navigation', { name: /breadcrumb/i });
+    expect(nav).toBeInTheDocument();
+    expect(nav).toHaveTextContent('Home');
+    expect(nav).toHaveTextContent('Community');
+
+    for (const link of links as { name: string; url: string }[]) {
+      const el = screen.getByRole('link', { name: link.name });
+      expect(el).toHaveAttribute('href', link.url);
+    }
+  });
+});

--- a/content/community-links.json
+++ b/content/community-links.json
@@ -1,0 +1,5 @@
+[
+  { "name": "Kali Linux Forums", "url": "https://forums.kali.org/" },
+  { "name": "Kali Linux Discord", "url": "https://discord.gg/kali-linux" },
+  { "name": "Kali Linux Reddit", "url": "https://www.reddit.com/r/Kalilinux/" }
+]

--- a/pages/community.tsx
+++ b/pages/community.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import Breadcrumbs from '../components/ui/Breadcrumbs';
+import { useRouter } from 'next/router';
+import communityLinks from '../content/community-links.json';
+
+interface CommunityLink {
+  name: string;
+  url: string;
+}
+
+const CommunityPage: React.FC = () => {
+  const router = useRouter();
+  const path = [{ name: 'Home' }, { name: 'Community' }];
+
+  const handleNavigate = (index: number) => {
+    if (index === 0) {
+      router.push('/');
+    }
+  };
+
+  return (
+    <div className="p-8 max-w-3xl mx-auto">
+      <Breadcrumbs path={path} onNavigate={handleNavigate} />
+      <h1 className="text-2xl font-bold mt-4 mb-4">Community</h1>
+      <p className="text-xs text-gray-500 mb-6">
+        This is an unofficial community page and is not affiliated with or endorsed
+        by Kali Linux, Offensive Security, or any related entities.
+      </p>
+      <ul className="list-disc list-inside space-y-2">
+        {(communityLinks as CommunityLink[]).map((link, idx) => (
+          <li key={idx}>
+            <a
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-400 hover:underline"
+            >
+              {link.name}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default CommunityPage;


### PR DESCRIPTION
## Summary
- add community page displaying links from JSON content with Breadcrumbs navigation
- note project is unofficial
- test community page rendering

## Testing
- `yarn test __tests__/community-page.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf304bd968832884b3ef5c6b50b010