### PR TITLE
feat: add terminal prompt presets

### DIFF
--- a/__tests__/terminal-prompt.test.tsx
+++ b/__tests__/terminal-prompt.test.tsx
@@ -1,0 +1,77 @@
+jest.mock(
+  '@xterm/xterm',
+  () => ({
+    Terminal: jest.fn().mockImplementation(() => ({
+      open: jest.fn(),
+      focus: jest.fn(),
+      loadAddon: jest.fn(),
+      write: jest.fn(),
+      writeln: jest.fn(),
+      onData: jest.fn(),
+      onKey: jest.fn(),
+      onPaste: jest.fn(),
+      dispose: jest.fn(),
+      clear: jest.fn(),
+      options: {},
+      buffer: { active: { viewportY: 0, baseY: 0 } },
+    })),
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  '@xterm/addon-fit',
+  () => ({
+    FitAddon: jest.fn().mockImplementation(() => ({ fit: jest.fn() })),
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  '@xterm/addon-search',
+  () => ({
+    SearchAddon: jest.fn().mockImplementation(() => ({ findNext: jest.fn() })),
+  }),
+  { virtual: true },
+);
+
+jest.mock('@xterm/xterm/css/xterm.css', () => ({}), { virtual: true });
+
+import React, { act } from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import Terminal from '../apps/terminal';
+
+const TerminalMock: any = require('@xterm/xterm').Terminal;
+
+describe('terminal prompt presets', () => {
+  const openApp = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('uses stored preset on mount', async () => {
+    window.localStorage.setItem('terminal:prompt', JSON.stringify('Simple'));
+    render(<Terminal openApp={openApp} />);
+    await act(async () => {});
+    const write = TerminalMock.mock.results[0].value.write;
+    expect(write).toHaveBeenCalledWith(expect.stringContaining('$ '));
+  });
+
+  it('allows switching preset via settings menu', async () => {
+    const { unmount } = render(<Terminal openApp={openApp} />);
+    await act(async () => {});
+    fireEvent.click(screen.getByLabelText('Prompt settings'));
+    fireEvent.click(screen.getByText('Simple'));
+    expect(window.localStorage.getItem('terminal:prompt')).toBe(
+      JSON.stringify('Simple'),
+    );
+    unmount();
+    render(<Terminal openApp={openApp} />);
+    await act(async () => {});
+    const write = TerminalMock.mock.results[TerminalMock.mock.results.length - 1].value.write;
+    expect(write).toHaveBeenCalledWith(expect.stringContaining('$ '));
+  });
+});
+

--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -12,6 +12,8 @@ jest.mock(
       onPaste: jest.fn(),
       dispose: jest.fn(),
       clear: jest.fn(),
+      options: {},
+      buffer: { active: { viewportY: 0, baseY: 0 } },
     })),
   }),
   { virtual: true }

--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -1,26 +1,79 @@
 'use client';
 
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useState } from 'react';
+import {
+  PROMPT_PRESETS,
+  PromptPreset,
+  usePromptPreset,
+} from '../state';
 
 export type TerminalContainerProps = React.HTMLAttributes<HTMLDivElement>;
 
+const CogIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    width={16}
+    height={16}
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <circle cx={12} cy={12} r={3} />
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.06a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.06a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.06a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+  </svg>
+);
+
 const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
-  ({ style, className = '', ...props }, ref) => (
-    <div
-      ref={ref}
-      data-testid="xterm-container"
-      className={className}
-      style={{
-        background: 'var(--kali-bg)',
-        fontFamily: 'monospace',
-        fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
-        lineHeight: 1.4,
-        whiteSpace: 'pre',
-        ...style,
-      }}
-      {...props}
-    />
-  ),
+  ({ style, className = '', ...props }, ref) => {
+    const [preset, setPreset] = usePromptPreset();
+    const [open, setOpen] = useState(false);
+    return (
+      <div className="relative">
+        <div
+          ref={ref}
+          data-testid="xterm-container"
+          className={className}
+          style={{
+            background: 'var(--kali-bg)',
+            fontFamily: 'monospace',
+            fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
+            lineHeight: 1.4,
+            whiteSpace: 'pre',
+            ...style,
+          }}
+          {...props}
+        />
+        <button
+          aria-label="Prompt settings"
+          onClick={() => setOpen((o) => !o)}
+          className="absolute top-1 right-1 z-10 p-1 bg-black/50 rounded"
+        >
+          <CogIcon />
+        </button>
+        {open && (
+          <div className="absolute top-6 right-1 z-20 bg-gray-800 text-white border border-gray-700 rounded text-xs">
+            {Object.keys(PROMPT_PRESETS).map((key) => (
+              <button
+                key={key}
+                className={`block w-full text-left px-2 py-1 hover:bg-gray-700 ${
+                  preset === key ? 'bg-gray-700' : ''
+                }`}
+                onClick={() => {
+                  setPreset(key as PromptPreset);
+                  setOpen(false);
+                }}
+              >
+                {key}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  },
 );
 
 Terminal.displayName = 'Terminal';

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -13,6 +13,7 @@ import usePersistentState from '../../hooks/usePersistentState';
 import commandRegistry, { CommandContext } from './commands';
 import TerminalContainer from './components/Terminal';
 import { exoOpen } from '../../src/lib/exo-open';
+import { usePromptPreset, PROMPT_PRESETS } from './state';
 
 const CopyIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg
@@ -99,6 +100,7 @@ const hexToRgba = (hex: string, alpha: number) => {
 
 const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(
   ({ openApp, scheme = 'Kali-Dark', opacity = 1, onSettingsChange }, ref) => {
+  const [promptPreset] = usePromptPreset();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<any>(null);
   const fitRef = useRef<any>(null);
@@ -189,10 +191,10 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(
 
   const prompt = useCallback(() => {
     if (termRef.current) {
-      termRef.current.write('┌──(🦊 kali)\r\n└─❯ ');
+      termRef.current.write(PROMPT_PRESETS[promptPreset]);
       renderHint();
     }
-  }, [renderHint]);
+  }, [renderHint, promptPreset]);
 
   const handleCopy = () => {
     navigator.clipboard.writeText(contentRef.current).catch(() => {});

--- a/apps/terminal/state.ts
+++ b/apps/terminal/state.ts
@@ -1,0 +1,31 @@
+import usePersistentState from '../../hooks/usePersistentState';
+
+export const PROMPT_PRESETS = {
+  Kali: '┌──(🦊 kali)\r\n└─❯ ',
+  Simple: '$ ',
+} as const;
+
+export type PromptPreset = keyof typeof PROMPT_PRESETS;
+
+const PROMPT_KEY = 'terminal:prompt';
+
+export function usePromptPreset() {
+  return usePersistentState<PromptPreset>(
+    PROMPT_KEY,
+    'Kali',
+    (v): v is PromptPreset => v in PROMPT_PRESETS,
+  );
+}
+
+export function loadPromptPreset(): PromptPreset {
+  try {
+    const stored = window.localStorage.getItem(PROMPT_KEY);
+    if (stored && stored in PROMPT_PRESETS) {
+      return stored as PromptPreset;
+    }
+  } catch {
+    // ignore
+  }
+  return 'Kali';
+}
+


### PR DESCRIPTION
## Summary
- allow switching terminal prompt through a gear menu
- persist selected prompt preset
- test prompt persistence and selection

## Testing
- `yarn test __tests__/terminal-prompt.test.tsx __tests__/terminal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf304d76808328ae23ec355c64fbef