### PR TITLE
feat: add image download wizard

### DIFF
--- a/__tests__/image-wizard.test.tsx
+++ b/__tests__/image-wizard.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ImageWizard from '../components/downloads/ImageWizard';
+
+describe('ImageWizard', () => {
+  test('walks through steps and shows recommendation with docs link', async () => {
+    render(<ImageWizard />);
+
+    // Step 1: platform
+    expect(
+      screen.getByText(/How do you plan to run Kali\?/i)
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText(/Virtual Machine/i));
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    // Step 2: desktop
+    expect(
+      screen.getByText(/Choose a desktop environment/i)
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText(/GNOME/i));
+    await userEvent.click(screen.getByRole('button', { name: /finish/i }));
+
+    // Result
+    expect(
+      screen.getByText(/virtual machine image/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/non-authoritative recommendation/i)
+    ).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /documentation/i });
+    expect(link).toHaveAttribute('href', 'https://www.kali.org/docs/');
+  });
+});

--- a/components/downloads/ImageWizard.tsx
+++ b/components/downloads/ImageWizard.tsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+
+const platforms = ['Bare Metal', 'Virtual Machine', 'WSL'];
+const desktops = ['GNOME', 'XFCE', 'KDE'];
+
+function getRecommendation(platform: string, desktop: string) {
+  if (platform === 'Virtual Machine') {
+    return `Use the Kali ${desktop} virtual machine image.`;
+  }
+  if (platform === 'WSL') {
+    return `Use Kali ${desktop} on WSL.`;
+  }
+  return `Use the Kali ${desktop} installer image.`;
+}
+
+export default function ImageWizard() {
+  const [step, setStep] = useState(0);
+  const [platform, setPlatform] = useState('');
+  const [desktop, setDesktop] = useState('');
+
+  const nextDisabled =
+    (step === 0 && !platform) ||
+    (step === 1 && !desktop);
+
+  const next = () => {
+    if (step < 2) {
+      setStep(step + 1);
+    }
+  };
+
+  const prev = () => {
+    if (step > 0) {
+      setStep(step - 1);
+    }
+  };
+
+  const reset = () => {
+    setStep(0);
+    setPlatform('');
+    setDesktop('');
+  };
+
+  return (
+    <div className="mb-8">
+      {step === 0 && (
+        <fieldset>
+          <legend className="mb-2 font-medium">How do you plan to run Kali?</legend>
+          <ul className="space-y-2">
+            {platforms.map((p) => (
+              <li key={p}>
+                <label className="flex items-center space-x-2">
+                  <input
+                    type="radio"
+                    name="platform"
+                    value={p}
+                    checked={platform === p}
+                    onChange={() => setPlatform(p)}
+                  />
+                  <span>{p}</span>
+                </label>
+              </li>
+            ))}
+          </ul>
+        </fieldset>
+      )}
+
+      {step === 1 && (
+        <fieldset>
+          <legend className="mb-2 font-medium">Choose a desktop environment</legend>
+          <ul className="space-y-2">
+            {desktops.map((d) => (
+              <li key={d}>
+                <label className="flex items-center space-x-2">
+                  <input
+                    type="radio"
+                    name="desktop"
+                    value={d}
+                    checked={desktop === d}
+                    onChange={() => setDesktop(d)}
+                  />
+                  <span>{d}</span>
+                </label>
+              </li>
+            ))}
+          </ul>
+        </fieldset>
+      )}
+
+      {step === 2 && (
+        <div className="p-4 border rounded">
+          <p className="font-semibold">{getRecommendation(platform, desktop)}</p>
+          <p className="text-sm mt-2">
+            This is a non-authoritative recommendation. For details, see{' '}
+            <a
+              href="https://www.kali.org/docs/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline text-blue-600"
+            >
+              the documentation
+            </a>
+            .
+          </p>
+          <button
+            onClick={reset}
+            className="mt-4 px-4 py-2 bg-blue-600 text-white rounded"
+          >
+            Start over
+          </button>
+        </div>
+      )}
+
+      {step < 2 && (
+        <div className="mt-4 flex justify-between">
+          <button
+            onClick={prev}
+            disabled={step === 0}
+            className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
+          >
+            Back
+          </button>
+          <button
+            onClick={next}
+            disabled={nextDisabled}
+            className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+          >
+            {step === 1 ? 'Finish' : 'Next'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/pages/get-kali.tsx
+++ b/pages/get-kali.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Callout from '../components/ui/Callout';
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
+import ImageWizard from '../components/downloads/ImageWizard';
 
 import * as Installer from '../content/get-kali/installer.mdx';
 import * as VMs from '../content/get-kali/vms.mdx';
@@ -51,6 +52,7 @@ const GetKali: React.FC = () => (
   <>
     <Header />
     <main className="p-4">
+      <ImageWizard />
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {platforms.map(({ slug, title, summary, badges, url }) => (
           <div key={slug} className="border rounded p-4 flex flex-col">


### PR DESCRIPTION
## Summary
- add ImageWizard component for step-by-step image guidance
- surface wizard on Get Kali page
- test wizard flow and docs link

## Testing
- `pnpm -w typecheck` *(fails: --workspace-root may only be used inside a workspace)*
- `yarn test __tests__/image-wizard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf304a0c308328aeeb14b5c91ac8e0