### PR TITLE
Add help cards page with terminal examples

### DIFF
--- a/__tests__/help-cards.test.tsx
+++ b/__tests__/help-cards.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HelpPage from '../pages/help';
+import helpCards from '../content/help-cards.json';
+
+describe('HelpCards', () => {
+  it('renders command examples using Terminal', () => {
+    render(<HelpPage />);
+
+    const terminals = screen.getAllByTestId('xterm-container');
+    expect(terminals).toHaveLength(helpCards.length);
+
+    helpCards.forEach((card) => {
+      card.commands.forEach((cmd) => {
+        expect(
+          screen.getByText((content) => content.includes(cmd))
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/components/help/HelpCards.tsx
+++ b/components/help/HelpCards.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import Terminal from '@/apps/terminal/components/Terminal';
+import helpCards from '@/content/help-cards.json';
+
+interface HelpCard {
+  title: string;
+  description: string;
+  commands: string[];
+}
+
+export default function HelpCards() {
+  const cards = helpCards as HelpCard[];
+
+  return (
+    <div className="grid gap-4">
+      {cards.map((card) => (
+        <div key={card.title} className="border rounded p-4 bg-white text-black dark:bg-gray-800 dark:text-white">
+          <h2 className="text-lg font-bold mb-2">{card.title}</h2>
+          <p className="mb-2">{card.description}</p>
+          <Terminal className="p-2 rounded bg-black text-green-500">
+            {card.commands.join('\n')}
+          </Terminal>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/content/help-cards.json
+++ b/content/help-cards.json
@@ -1,0 +1,12 @@
+[
+  {
+    "title": "Update System",
+    "description": "Update package lists and upgrade installed packages.",
+    "commands": ["sudo apt update", "sudo apt full-upgrade -y"]
+  },
+  {
+    "title": "Search for a Package",
+    "description": "Search the repositories for a package.",
+    "commands": ["apt-cache search <package>"]
+  }
+]

--- a/pages/help/index.tsx
+++ b/pages/help/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import HelpCards from '@/components/help/HelpCards';
+
+export default function HelpPage() {
+  return (
+    <div className="p-8 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-6">Helpful Commands</h1>
+      <HelpCards />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- display helpful command examples using new `HelpCards` component
- add `/help` route sourcing data from `content/help-cards.json`
- include tests for rendering of help cards

## Testing
- `npx eslint components/help/HelpCards.tsx pages/help/index.tsx __tests__/help-cards.test.tsx`
- `yarn test __tests__/help-cards.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf304c86b88328ab7fc89412ec5b07