### PR TITLE
feat(terminal): add apt update command

### DIFF
--- a/__tests__/apt-update.test.ts
+++ b/__tests__/apt-update.test.ts
@@ -1,0 +1,35 @@
+import aptUpdate from '../apps/terminal/commands/apt-update';
+import type { CommandContext } from '../apps/terminal/commands';
+
+const createCtx = () => {
+  const lines: string[] = [];
+  const ctx: CommandContext = {
+    writeLine: (t: string) => lines.push(t),
+    files: {},
+    history: [],
+    aliases: {},
+    setAlias: () => {},
+    runWorker: async () => {},
+  };
+  return { ctx, lines };
+};
+
+describe('apt-update command', () => {
+  it('emits progress and completion', async () => {
+    const { ctx, lines } = createCtx();
+    const ctrl = aptUpdate('', ctx);
+    await ctrl.finished;
+    expect(lines[0]).toMatch(/Hit:1/);
+    expect(lines.some((l) => l.includes('\x1b[32m['))).toBe(true);
+    expect(lines.at(-1)).toBe('All packages are up to date.');
+  });
+
+  it('can be canceled', async () => {
+    const { ctx, lines } = createCtx();
+    const ctrl = aptUpdate('', ctx);
+    ctrl.cancel();
+    await expect(ctrl.finished).rejects.toThrow('canceled');
+    expect(lines).not.toContain('All packages are up to date.');
+  });
+});
+

--- a/apps/terminal/commands/apt-update.ts
+++ b/apps/terminal/commands/apt-update.ts
@@ -1,0 +1,44 @@
+import type { CommandContext } from './types';
+import type { ScriptController } from '../utils/scriptRunner';
+
+const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
+export default function aptUpdate(_args: string, ctx: CommandContext): ScriptController {
+  let aborted = false;
+  const cancel = () => {
+    aborted = true;
+  };
+
+  const finished = (async () => {
+    const stages = [
+      'Hit:1 http://http.kali.org/kali kali-rolling InRelease',
+      'Get:2 http://http.kali.org/kali kali-rolling/main amd64 Packages [15.2 MB]',
+      'Fetched 15.2 MB in 1s (15.2 MB/s)',
+      'Reading package lists... Done',
+      'Building dependency tree... Done',
+      'Reading state information... Done',
+    ];
+
+    for (const line of stages) {
+      if (aborted) throw new Error('canceled');
+      ctx.writeLine(line);
+      await sleep(20);
+    }
+
+    const total = 20;
+    for (let i = 0; i <= total; i++) {
+      if (aborted) throw new Error('canceled');
+      const pct = Math.round((i / total) * 100);
+      const filled = '#'.repeat(i);
+      const empty = '-'.repeat(total - i);
+      ctx.writeLine(`\x1b[32m[${filled}${empty}] ${pct}%\x1b[0m`);
+      await sleep(20);
+    }
+
+    if (aborted) throw new Error('canceled');
+    ctx.writeLine('All packages are up to date.');
+  })();
+
+  return { cancel, finished };
+}
+

--- a/apps/terminal/commands/index.ts
+++ b/apps/terminal/commands/index.ts
@@ -1,4 +1,5 @@
 import type { CommandHandler, CommandContext } from './types';
+import aptUpdate from './apt-update';
 
 async function man(args: string, ctx: CommandContext) {
   const name = args.trim();
@@ -91,11 +92,30 @@ function neofetch(_args: string, ctx: CommandContext) {
   ctx.writeLine(`${c2}Theme: Undercover (${variant})${reset}`);
 }
 
+async function apt(args: string, ctx: CommandContext) {
+  const sub = args.trim();
+  if (sub === 'update') {
+    const ctrl = aptUpdate('', ctx);
+    try {
+      await ctrl.finished;
+    } catch (e: any) {
+      if (e?.message === 'canceled') {
+        ctx.writeLine('\x1b[31mOperation canceled\x1b[0m');
+      } else {
+        throw e;
+      }
+    }
+  } else {
+    ctx.writeLine('Usage: apt update');
+  }
+}
+
 const registry: Record<string, CommandHandler> = {
   man,
   history,
   alias,
   neofetch,
+  apt,
   cat: (args, ctx) => ctx.runWorker(`cat ${args}`),
   grep: (args, ctx) => ctx.runWorker(`grep ${args}`),
   jq: (args, ctx) => ctx.runWorker(`jq ${args}`),


### PR DESCRIPTION
## Summary
- add cancellable `apt update` terminal command with colored progress bars
- hook command into terminal registry
- test staged output and cancelation

## Testing
- `yarn test __tests__/apt-update.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf304ec378832884da3da52ec222f0