### PR TITLE
feat: copy selection in terminal

### DIFF
--- a/__tests__/terminal-copy-on-select.test.tsx
+++ b/__tests__/terminal-copy-on-select.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import Terminal from '../apps/terminal/components/Terminal';
+import useToast from '../hooks/useToast';
+
+jest.mock('../hooks/useToast');
+
+describe('Terminal copy on select', () => {
+  const toast = jest.fn();
+  beforeEach(() => {
+    (useToast as jest.Mock).mockReturnValue(toast);
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+    });
+    toast.mockClear();
+  });
+
+  it('shows copy button on text selection and copies to clipboard', async () => {
+    const { getByTestId, getByRole, queryByRole } = render(
+      <Terminal>hello world</Terminal>,
+    );
+    const container = getByTestId('xterm-container');
+    const range = document.createRange();
+    range.selectNodeContents(container);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    fireEvent.mouseUp(container);
+
+    const button = getByRole('button', { name: /copy/i });
+    fireEvent.click(button);
+
+    await Promise.resolve();
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello world');
+    expect(toast).toHaveBeenCalledWith('Copied to clipboard');
+    await waitFor(() =>
+      expect(queryByRole('button', { name: /copy/i })).toBeNull(),
+    );
+  });
+
+  it('supports long press on touch devices', () => {
+    jest.useFakeTimers();
+    const { getByTestId, getByRole } = render(
+      <Terminal>touch text</Terminal>,
+    );
+    const container = getByTestId('xterm-container');
+    fireEvent.touchStart(container, {
+      touches: [{ clientX: 0, clientY: 0 }],
+    });
+
+    const range = document.createRange();
+    range.selectNodeContents(container);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+
+    const button = getByRole('button', { name: /copy/i });
+    expect(button).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+});

--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -1,26 +1,148 @@
 'use client';
 
-import React, { forwardRef } from 'react';
+import React, {
+  forwardRef,
+  useRef,
+  useState,
+  useImperativeHandle,
+  useCallback,
+} from 'react';
+import useToast from '../../../hooks/useToast';
 
 export type TerminalContainerProps = React.HTMLAttributes<HTMLDivElement>;
 
 const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
-  ({ style, className = '', ...props }, ref) => (
-    <div
-      ref={ref}
-      data-testid="xterm-container"
-      className={className}
-      style={{
-        background: 'var(--kali-bg)',
-        fontFamily: 'monospace',
-        fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
-        lineHeight: 1.4,
-        whiteSpace: 'pre',
-        ...style,
-      }}
-      {...props}
-    />
-  ),
+  ({ style, className = '', children, ...props }, ref) => {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    useImperativeHandle(ref, () => containerRef.current as HTMLDivElement, []);
+    const toast = useToast();
+    const [copyPos, setCopyPos] = useState<{ x: number; y: number } | null>(
+      null,
+    );
+    const selectionRef = useRef('');
+    const touchTimer = useRef<NodeJS.Timeout>();
+
+    const handleSelection = useCallback(
+      (event: MouseEvent | TouchEvent) => {
+        const selection = window.getSelection();
+        const text = selection?.toString().trim();
+        if (!text) {
+          setCopyPos(null);
+          return;
+        }
+        selectionRef.current = text;
+        const rect = containerRef.current?.getBoundingClientRect();
+        let clientX = 0;
+        let clientY = 0;
+        if ('touches' in event && event.touches[0]) {
+          clientX = event.touches[0].clientX;
+          clientY = event.touches[0].clientY;
+        } else if ('changedTouches' in event && event.changedTouches[0]) {
+          clientX = event.changedTouches[0].clientX;
+          clientY = event.changedTouches[0].clientY;
+        } else if ('clientX' in event) {
+          clientX = event.clientX;
+          clientY = event.clientY;
+        }
+        setCopyPos({
+          x: clientX - (rect?.left ?? 0),
+          y: clientY - (rect?.top ?? 0),
+        });
+      },
+      [],
+    );
+
+    const onMouseUp = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        handleSelection(e.nativeEvent);
+      },
+      [handleSelection],
+    );
+
+    const onTouchStart = useCallback(
+      (e: React.TouchEvent<HTMLDivElement>) => {
+        const touch = e.touches[0];
+        touchTimer.current = setTimeout(
+          () =>
+            handleSelection({
+              clientX: touch.clientX,
+              clientY: touch.clientY,
+            } as any),
+          500,
+        );
+      },
+      [handleSelection],
+    );
+
+    const clearTouchTimer = useCallback(() => {
+      if (touchTimer.current) {
+        clearTimeout(touchTimer.current);
+        touchTimer.current = undefined;
+      }
+    }, []);
+
+    const onTouchEnd = useCallback(
+      (e: React.TouchEvent<HTMLDivElement>) => {
+        clearTouchTimer();
+        handleSelection(e.nativeEvent);
+      },
+      [clearTouchTimer, handleSelection],
+    );
+
+    const onTouchMove = useCallback(() => {
+      clearTouchTimer();
+    }, [clearTouchTimer]);
+
+    const handleCopy = useCallback(() => {
+      navigator.clipboard
+        .writeText(selectionRef.current)
+        .then(() => toast('Copied to clipboard'))
+        .catch(() => {})
+        .finally(() => {
+          setCopyPos(null);
+          window.getSelection()?.removeAllRanges();
+        });
+    }, [toast]);
+
+    return (
+      <div
+        ref={containerRef}
+        data-testid="xterm-container"
+        className={className}
+        onMouseUp={onMouseUp}
+        onTouchStart={onTouchStart}
+        onTouchEnd={onTouchEnd}
+        onTouchMove={onTouchMove}
+        style={{
+          position: 'relative',
+          background: 'var(--kali-bg)',
+          fontFamily: 'monospace',
+          fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
+          lineHeight: 1.4,
+          whiteSpace: 'pre',
+          ...style,
+        }}
+        {...props}
+      >
+        {children}
+        {copyPos && (
+          <button
+            type="button"
+            aria-label="Copy"
+            data-testid="copy-selection-btn"
+            className="absolute px-2 py-1 text-sm border rounded"
+            style={{
+              top: copyPos.y,
+              left: copyPos.x,
+            }}
+            onClick={handleCopy}
+          >
+            Copy
+          </button>
+        )}
+      </div>
+    );
+  },
 );
 
 Terminal.displayName = 'Terminal';


### PR DESCRIPTION
## Summary
- show copy button when terminal text is selected
- integrate copy with toast notification and touch long-press
- add tests for copy-on-select behavior

## Testing
- `yarn test __tests__/terminal-copy-on-select.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf38437684832891082f9bdfee71c8