### PR TITLE
feat: add sticky toc and markdown anchors

### DIFF
--- a/__tests__/sticky-toc.test.tsx
+++ b/__tests__/sticky-toc.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, act } from '@testing-library/react';
+import StickyTOC from '../components/docs/StickyTOC';
+import { renderMarkdown } from '../lib/markdown';
+
+// Utility to mock IntersectionObserver and expose the callback
+class IO {
+  callback: IntersectionObserverCallback;
+  constructor(cb: IntersectionObserverCallback) {
+    this.callback = cb;
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() { return []; }
+}
+
+describe('StickyTOC', () => {
+  let observer: IO;
+  beforeEach(() => {
+    // @ts-ignore
+    global.IntersectionObserver = jest.fn((cb) => {
+      observer = new IO(cb);
+      return observer;
+    });
+  });
+
+  it('highlights active section when intersecting', () => {
+    const md = `# Title\n\n## One\n\nText\n\n## Two\n`;
+    const { html, headings } = renderMarkdown(md);
+
+    const { container } = render(
+      <>
+        <div dangerouslySetInnerHTML={{ __html: html }} />
+        <StickyTOC headings={headings} />
+      </>
+    );
+
+    const secondHeading = container.querySelector(`#${headings[2].id}`) as Element;
+    act(() => {
+      observer.callback([{ target: secondHeading, isIntersecting: true } as IntersectionObserverEntry]);
+    });
+
+    expect(screen.getByRole('link', { name: 'Two' })).toHaveClass('font-bold');
+  });
+});

--- a/components/docs/StickyTOC.tsx
+++ b/components/docs/StickyTOC.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import type { Heading } from '@/lib/markdown';
+
+interface Props {
+  headings: Heading[];
+}
+
+/**
+ * StickyTOC renders a table of contents and highlights the currently
+ * active section using an IntersectionObserver.
+ */
+const StickyTOC: React.FC<Props> = ({ headings }) => {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (headings.length === 0) return;
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setActiveId(entry.target.id);
+        }
+      });
+    }, { rootMargin: '0px 0px -70% 0px' });
+
+    headings.forEach((h) => {
+      const el = document.getElementById(h.id);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, [headings]);
+
+  return (
+    <nav aria-label="Table of contents" className="sticky top-0">
+      <ul>
+        {headings.map((h) => (
+          <li key={h.id} style={{ marginLeft: `${(h.level - 1) * 16}px` }}>
+            <a
+              href={`#${h.id}`}
+              className={activeId === h.id ? 'font-bold text-blue-600' : ''}
+              aria-current={activeId === h.id ? 'true' : undefined}
+            >
+              {h.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+};
+
+export default StickyTOC;

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,0 +1,42 @@
+export interface Heading {
+  id: string;
+  text: string;
+  level: number;
+}
+
+function slugify(text: string, counts: Record<string, number>) {
+  const base = text
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-');
+  const count = counts[base] || 0;
+  counts[base] = count + 1;
+  return count ? `${base}-${count}` : base;
+}
+
+/**
+ * Very small markdown renderer that supports headings and paragraphs and
+ * injects id anchors on headings so a table of contents can link to them.
+ */
+export function renderMarkdown(markdown: string): { html: string; headings: Heading[] } {
+  const lines = markdown.split(/\n+/);
+  const headings: Heading[] = [];
+  const html: string[] = [];
+  const counts: Record<string, number> = {};
+
+  for (const line of lines) {
+    const match = /^(#{1,6})\s+(.*)$/.exec(line);
+    if (match) {
+      const level = match[1].length;
+      const text = match[2].trim();
+      const id = slugify(text, counts);
+      headings.push({ id, text, level });
+      html.push(`<h${level} id="${id}">${text}</h${level}>`);
+    } else if (line.trim() !== '') {
+      html.push(`<p>${line}</p>`);
+    }
+  }
+
+  return { html: html.join('\n'), headings };
+}


### PR DESCRIPTION
## Summary
- add lightweight markdown renderer that injects heading anchor ids
- implement StickyTOC with IntersectionObserver based scrollspy
- test active section highlighting for StickyTOC

## Testing
- `npx eslint lib/markdown.ts components/docs/StickyTOC.tsx __tests__/sticky-toc.test.tsx`
- `yarn test __tests__/sticky-toc.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf3845acbc832886ac117031a1653d