### PR TITLE
Add responsive breadcrumbs component

### DIFF
--- a/__tests__/breadcrumbs.test.tsx
+++ b/__tests__/breadcrumbs.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import Breadcrumbs from '@/components/navigation/Breadcrumbs';
+
+describe('Breadcrumbs', () => {
+  const items = [
+    { href: '/', label: 'Home' },
+    { href: '/docs', label: 'Docs' },
+    { href: '/docs/page', label: 'Page' },
+  ];
+
+  it('renders links and marks current page', () => {
+    render(<Breadcrumbs items={items} />);
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/');
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute('href', '/docs');
+    const current = screen.getByText('Page');
+    expect(current.tagName).toBe('SPAN');
+    expect(current).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('is hidden on small screens via classes', () => {
+    const { container } = render(<Breadcrumbs items={items} />);
+    expect(container.firstChild).toHaveClass('hidden');
+  });
+});

--- a/components/navigation/Breadcrumbs.tsx
+++ b/components/navigation/Breadcrumbs.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+
+export interface BreadcrumbItem {
+  href: string;
+  label: string;
+}
+
+interface BreadcrumbsProps {
+  items: BreadcrumbItem[];
+  className?: string;
+}
+
+export default function Breadcrumbs({ items, className = '' }: BreadcrumbsProps) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={`hidden md:block text-sm text-gray-600 dark:text-gray-300 ${className}`}
+    >
+      <ol className="flex flex-wrap items-center gap-2">
+        {items.map((item, idx) => (
+          <li key={item.href} className="flex items-center gap-2">
+            {idx > 0 && <span>/</span>}
+            {idx === items.length - 1 ? (
+              <span aria-current="page">{item.label}</span>
+            ) : (
+              <Link href={item.href} className="hover:underline">
+                {item.label}
+              </Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/layouts/DocsLayout.tsx
+++ b/layouts/DocsLayout.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+import Breadcrumbs, { BreadcrumbItem } from '@/components/navigation/Breadcrumbs';
+
+interface DocsLayoutProps {
+  items: BreadcrumbItem[];
+  children: ReactNode;
+}
+
+export default function DocsLayout({ items, children }: DocsLayoutProps) {
+  return (
+    <div className="p-4">
+      <Breadcrumbs items={items} />
+      {children}
+    </div>
+  );
+}

--- a/pages/docs/[topic].tsx
+++ b/pages/docs/[topic].tsx
@@ -6,6 +6,7 @@ import Head from 'next/head';
 import { marked } from 'marked';
 import { useEffect, useState } from 'react';
 import '@/styles/docs.css';
+import DocsLayout from '@/layouts/DocsLayout';
 
 interface TocItem {
   id: string;
@@ -62,6 +63,10 @@ export default function DocPage({ html, toc, title, topic }: DocProps) {
   };
 
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://example.com';
+  const breadcrumbs = [
+    { href: '/docs', label: 'Docs' },
+    { href: `/docs/${topic}`, label: title },
+  ];
 
   return (
     <>
@@ -101,8 +106,9 @@ export default function DocPage({ html, toc, title, topic }: DocProps) {
           }}
         />
       </Head>
-      <div className="flex flex-col lg:flex-row p-4">
-        <nav className="lg:w-1/4 lg:min-w-[12rem] lg:max-w-[20rem] lg:flex-shrink-0 lg:pr-4 lg:sticky lg:top-0">
+      <DocsLayout items={breadcrumbs}>
+        <div className="flex flex-col lg:flex-row">
+          <nav className="lg:w-1/4 lg:min-w-[12rem] lg:max-w-[20rem] lg:flex-shrink-0 lg:pr-4 lg:sticky lg:top-0">
           <button
             className="lg:hidden mb-2 flex items-center"
             onClick={() => setShowToc((v) => !v)}
@@ -137,12 +143,13 @@ export default function DocPage({ html, toc, title, topic }: DocProps) {
               </div>
             ))}
           </div>
-        </nav>
-        <article
-          className="prose docs-content flex-1"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      </div>
+          </nav>
+          <article
+            className="prose docs-content flex-1"
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+        </div>
+      </DocsLayout>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add Breadcrumbs navigation component with responsive visibility
- integrate breadcrumbs into docs via new DocsLayout
- test breadcrumb rendering and visibility

## Testing
- `yarn test __tests__/breadcrumbs.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf3844e28c8328a1a33f1569661e32