### PR TITLE
feat: add terminal theme switching with persistence

### DIFF
--- a/__tests__/terminal-themes.test.tsx
+++ b/__tests__/terminal-themes.test.tsx
@@ -1,0 +1,71 @@
+jest.mock(
+  '@xterm/xterm',
+  () => ({
+    Terminal: jest.fn().mockImplementation(() => ({
+      open: jest.fn(),
+      focus: jest.fn(),
+      loadAddon: jest.fn(),
+      write: jest.fn(),
+      writeln: jest.fn(),
+      onData: jest.fn(),
+      onKey: jest.fn(),
+      onPaste: jest.fn(),
+      dispose: jest.fn(),
+      clear: jest.fn(),
+      options: {},
+    })),
+  }),
+  { virtual: true },
+);
+jest.mock(
+  '@xterm/addon-fit',
+  () => ({
+    FitAddon: jest.fn().mockImplementation(() => ({ fit: jest.fn() })),
+  }),
+  { virtual: true },
+);
+jest.mock(
+  '@xterm/addon-search',
+  () => ({
+    SearchAddon: jest.fn().mockImplementation(() => ({ findNext: jest.fn() })),
+  }),
+  { virtual: true },
+);
+jest.mock('@xterm/xterm/css/xterm.css', () => ({}), { virtual: true });
+
+import React, { act } from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import TerminalTabs from '../apps/terminal/tabs';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe('Terminal theme switching', () => {
+  it('applies and persists selected theme', async () => {
+    const { getByLabelText, getByText, container, unmount } = render(
+      <TerminalTabs />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    fireEvent.click(getByLabelText('Settings'));
+    fireEvent.change(getByLabelText('Color Scheme'), {
+      target: { value: 'Dracula' },
+    });
+    fireEvent.click(getByText('Apply'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(window.localStorage.getItem('terminal-theme')).toBe('"Dracula"');
+
+    unmount();
+    const { getByLabelText: getByLabelText2 } = render(<TerminalTabs />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    fireEvent.click(getByLabelText2('Settings'));
+    const select = getByLabelText2('Color Scheme') as HTMLSelectElement;
+    expect(select.value).toBe('Dracula');
+  });
+});

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -13,6 +13,7 @@ import usePersistentState from '../../hooks/usePersistentState';
 import commandRegistry, { CommandContext } from './commands';
 import TerminalContainer from './components/Terminal';
 import { exoOpen } from '../../src/lib/exo-open';
+import { TERMINAL_THEMES } from './themes';
 
 const CopyIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg
@@ -80,13 +81,6 @@ export interface TerminalHandle {
 const files: Record<string, string> = {
   'README.md': 'Welcome to the web terminal.\nThis is a fake file used for demos.',
 };
-
-const THEME_PRESETS = {
-  'Kali-Dark': { background: '#0f1317', foreground: '#f5f5f5' },
-  'Kali-Light': { background: '#f5f5f5', foreground: '#0f1317' },
-  Solarized: { background: '#002b36', foreground: '#839496' },
-  Dracula: { background: '#282a36', foreground: '#f8f8f2' },
-} as const;
 
 const hexToRgba = (hex: string, alpha: number) => {
   const sanitized = hex.replace('#', '');
@@ -238,13 +232,9 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(
 
   useEffect(() => {
     if (!termRef.current || !containerRef.current) return;
-    const preset = THEME_PRESETS[scheme as keyof typeof THEME_PRESETS];
+    const preset = TERMINAL_THEMES[scheme as keyof typeof TERMINAL_THEMES];
     const bg = hexToRgba(preset.background, opacity);
-    termRef.current.options.theme = {
-      background: bg,
-      foreground: preset.foreground,
-      cursor: preset.foreground,
-    };
+    termRef.current.options.theme = { ...preset, background: bg };
     containerRef.current.style.backgroundColor = bg;
     containerRef.current.style.color = preset.foreground;
   }, [scheme, opacity]);
@@ -416,13 +406,9 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(
       const textarea = term.textarea;
       textarea?.addEventListener('paste', handlePasteEvent);
       container?.addEventListener('contextmenu', handleLinkContext);
-      const preset = THEME_PRESETS[scheme as keyof typeof THEME_PRESETS];
+      const preset = TERMINAL_THEMES[scheme as keyof typeof TERMINAL_THEMES];
       const bg = hexToRgba(preset.background, opacity);
-      term.options.theme = {
-        background: bg,
-        foreground: preset.foreground,
-        cursor: preset.foreground,
-      };
+      term.options.theme = { ...preset, background: bg };
       container.style.backgroundColor = bg;
       container.style.color = preset.foreground;
       if (opfsSupported) {
@@ -610,7 +596,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(
                 value={settingsScheme}
                 onChange={(e) => setSettingsScheme(e.target.value)}
               >
-                {Object.keys(THEME_PRESETS).map((name) => (
+                {Object.keys(TERMINAL_THEMES).map((name) => (
                   <option key={name} value={name}>
                     {name}
                   </option>

--- a/apps/terminal/state.ts
+++ b/apps/terminal/state.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import usePersistentState from '../../hooks/usePersistentState';
+import { TERMINAL_THEMES, type TerminalThemeName } from './themes';
+
+const isThemeName = (v: unknown): v is TerminalThemeName =>
+  typeof v === 'string' && v in TERMINAL_THEMES;
+
+export function useTerminalTheme() {
+  return usePersistentState<TerminalThemeName>(
+    'terminal-theme',
+    'Kali-Dark',
+    isThemeName,
+  );
+}

--- a/apps/terminal/tabs/index.tsx
+++ b/apps/terminal/tabs/index.tsx
@@ -3,16 +3,21 @@
 import React, { useCallback, useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../../components/ui/TabbedWindow';
 import Terminal, { TerminalProps } from '..';
+import { useTerminalTheme } from '../state';
+import type { TerminalThemeName } from '../themes';
 
 const TerminalTabs: React.FC<TerminalProps> = ({ openApp }) => {
   const countRef = useRef(1);
-  const [scheme, setScheme] = useState('Kali-Dark');
+  const [scheme, setScheme] = useTerminalTheme();
   const [opacity, setOpacity] = useState(1);
 
-  const handleSettingsChange = useCallback((s: string, o: number) => {
-    setScheme(s);
-    setOpacity(o);
-  }, []);
+  const handleSettingsChange = useCallback(
+    (s: string, o: number) => {
+      setScheme(s as TerminalThemeName);
+      setOpacity(o);
+    },
+    [setScheme],
+  );
 
   const createTab = useCallback((): TabDefinition => {
     const id = Date.now().toString();

--- a/apps/terminal/themes.ts
+++ b/apps/terminal/themes.ts
@@ -1,0 +1,26 @@
+import type { ITheme } from '@xterm/xterm';
+
+export const TERMINAL_THEMES: Record<string, ITheme> = {
+  'Kali-Dark': {
+    background: '#0f1317',
+    foreground: '#f5f5f5',
+    cursor: '#f5f5f5',
+  },
+  'Kali-Light': {
+    background: '#f5f5f5',
+    foreground: '#0f1317',
+    cursor: '#0f1317',
+  },
+  Solarized: {
+    background: '#002b36',
+    foreground: '#839496',
+    cursor: '#839496',
+  },
+  Dracula: {
+    background: '#282a36',
+    foreground: '#f8f8f2',
+    cursor: '#f8f8f2',
+  },
+};
+
+export type TerminalThemeName = keyof typeof TERMINAL_THEMES;


### PR DESCRIPTION
## Summary
- provide themed color palettes for xterm.js
- persist terminal color scheme selection
- test terminal theme switching and persistence

## Testing
- `yarn test __tests__/terminal-themes.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bf384300ac8328bbe7ad16e70e5081