### PR TITLE
feat: add global search component

### DIFF
--- a/__tests__/global-search.test.tsx
+++ b/__tests__/global-search.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import GlobalSearch from '../components/search/GlobalSearch';
+
+jest.useFakeTimers();
+
+describe('GlobalSearch component', () => {
+  it('shows results for query', async () => {
+    render(<GlobalSearch open onClose={() => {}} />);
+    const input = screen.getByRole('textbox', { name: /search query/i });
+    fireEvent.change(input, { target: { value: 'gobuster' } });
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    const link = await screen.findByRole('link', { name: /gobuster/i });
+    expect(link).toBeInTheDocument();
+  });
+
+  it('navigates with arrow keys', async () => {
+    const searchFn = jest.fn(async () => [
+      { id: '1', title: 'First', url: '#', section: 'content' },
+      { id: '2', title: 'Second', url: '#', section: 'content' },
+    ]);
+    render(<GlobalSearch open onClose={() => {}} searchFn={searchFn} />);
+    const input = screen.getByRole('textbox', { name: /search query/i });
+    fireEvent.change(input, { target: { value: 'test' } });
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    let links = await screen.findAllByRole('link');
+    expect(links[0]).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    links = await screen.findAllByRole('link');
+    expect(links[1]).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(document, { key: 'ArrowUp' });
+    links = await screen.findAllByRole('link');
+    expect(links[0]).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/components/search/GlobalSearch.tsx
+++ b/components/search/GlobalSearch.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { searchAll, SearchDoc } from '../../lib/search-index';
+
+interface GlobalSearchProps {
+  open: boolean;
+  onClose: () => void;
+  searchFn?: (query: string) => Promise<SearchDoc[]>;
+}
+
+export default function GlobalSearch({ open, onClose, searchFn = searchAll }: GlobalSearchProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SearchDoc[]>([]);
+  const [active, setActive] = useState(0);
+
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setResults([]);
+      setActive(0);
+      inputRef.current?.focus();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!query) {
+      setResults([]);
+      return;
+    }
+    const handle = setTimeout(() => {
+      searchFn(query).then((res) => {
+        setResults(res);
+        setActive(0);
+      });
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActive((a) => (a + 1) % (results.length || 1));
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActive((a) => (a - 1 + results.length) % (results.length || 1));
+      }
+      if (e.key === 'Enter') {
+        const r = results[active];
+        if (r) window.location.href = r.url;
+      }
+    };
+    if (open) {
+      document.addEventListener('keydown', onKey);
+      return () => document.removeEventListener('keydown', onKey);
+    }
+  }, [open, results, active, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 bg-black/70 p-4 flex flex-col"
+    >
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        aria-label="Search query"
+        className="p-2 rounded"
+        placeholder="Search..."
+      />
+      <ul className="mt-4 overflow-y-auto">
+        {results.map((r, i) => (
+          <li key={r.id}>
+            <a
+              href={r.url}
+              aria-selected={i === active}
+              className={`block px-2 py-1 rounded ${
+                i === active ? 'bg-white/20 text-white' : 'text-white'
+              }`}
+            >
+              {r.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/lib/search-index.ts
+++ b/lib/search-index.ts
@@ -1,0 +1,116 @@
+import fs from 'fs';
+import path from 'path';
+import { Document } from 'flexsearch';
+
+export interface SearchDoc {
+  id: string;
+  title: string;
+  url: string;
+  section: 'content' | 'tools';
+}
+
+let index: Document<SearchDoc> | null = null;
+
+function indexContent(dir: string, idx: Document<SearchDoc>, prefix = '') {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    const rel = path.join(prefix, entry.name);
+    if (entry.isDirectory()) {
+      indexContent(full, idx, rel);
+    } else if (entry.isFile()) {
+      if (entry.name.endsWith('.mdx')) {
+        const mdx = fs.readFileSync(full, 'utf8');
+        const m = mdx.match(/export const title\s*=\s*['"]([^'"]+)['"]/);
+        const title = m ? m[1] : entry.name.replace(/\.mdx$/, '');
+        const slug = '/' + rel.replace(/\.mdx$/, '').split(path.sep).join('/');
+        idx.add({
+          id: `content-${slug}`,
+          title,
+          url: slug,
+          section: 'content',
+        });
+      } else if (entry.name.endsWith('.json')) {
+        try {
+          const data = JSON.parse(fs.readFileSync(full, 'utf8'));
+          const slug = '/' + rel.replace(/\.json$/, '').split(path.sep).join('/');
+          if (Array.isArray(data)) {
+            for (const item of data) {
+              const title = item.title || item.name;
+              if (title) {
+                idx.add({
+                  id: `content-${slug}-${title}`,
+                  title,
+                  url: slug,
+                  section: 'content',
+                });
+              }
+            }
+          } else {
+            const title = data.title || data.name;
+            if (title) {
+              idx.add({
+                id: `content-${slug}`,
+                title,
+                url: slug,
+                section: 'content',
+              });
+            }
+          }
+        } catch {
+          // ignore invalid json
+        }
+      }
+    }
+  }
+}
+
+async function buildIndex() {
+  const idx = new Document<SearchDoc>({
+    document: {
+      id: 'id',
+      index: ['title'],
+      tag: 'section',
+      store: ['title', 'url', 'section'],
+    },
+    tokenize: 'forward',
+    cache: 100,
+  });
+
+  const contentDir = path.join(process.cwd(), 'content');
+  if (fs.existsSync(contentDir)) {
+    indexContent(contentDir, idx);
+  }
+
+  const toolsPath = path.join(process.cwd(), 'data', 'tools.json');
+  if (fs.existsSync(toolsPath)) {
+    const tools = JSON.parse(fs.readFileSync(toolsPath, 'utf8')) as { id: string; name: string }[];
+    for (const tool of tools) {
+      idx.add({
+        id: `tool-${tool.id}`,
+        title: tool.name,
+        url: `https://www.kali.org/tools/${tool.id}/`,
+        section: 'tools',
+      });
+    }
+  }
+
+  index = idx;
+  return idx;
+}
+
+export async function getSearchIndex() {
+  return index || buildIndex();
+}
+
+export async function searchAll(query: string) {
+  const idx = await getSearchIndex();
+  const results = idx.search(query, { enrich: true }) as any[];
+  const docs: SearchDoc[] = [];
+  for (const result of results) {
+    for (const r of result.result) {
+      if (r.doc) docs.push(r.doc as SearchDoc);
+    }
+  }
+  return docs;
+}


### PR DESCRIPTION
## Summary
- index MDX content and tools data in `lib/search-index.ts`
- add `GlobalSearch` overlay component with debounced input and keyboard navigation
- test search results and keyboard navigation

## Testing
- `yarn test __tests__/global-search.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf3843ca508328801383163ab6e2c8