### PR TITLE
feat: add terminal session recording

### DIFF
--- a/__tests__/terminal-recording.test.tsx
+++ b/__tests__/terminal-recording.test.tsx
@@ -1,0 +1,45 @@
+import React, { act, createRef } from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import Terminal from '../apps/terminal/components/Terminal';
+import ReplayPlayer from '../components/terminal/ReplayPlayer';
+
+describe('terminal recording', () => {
+  it('captures input and output', () => {
+    const ref = createRef<any>();
+    render(<Terminal ref={ref} />);
+    act(() => ref.current.startRecording());
+    act(() => {
+      ref.current.recordInput('hello');
+      ref.current.recordOutput('world');
+    });
+    const events = ref.current.getRecording();
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({ type: 'input', data: 'hello' });
+    expect(events[1]).toMatchObject({ type: 'output', data: 'world' });
+  });
+
+  it('replays a session', () => {
+    jest.useFakeTimers();
+    const events = [
+      { type: 'output', data: 'welcome', timestamp: 0 },
+      { type: 'input', data: 'ls', timestamp: 1000 },
+      { type: 'output', data: 'file', timestamp: 1500 },
+    ];
+    const { getByTestId } = render(<ReplayPlayer events={events} />);
+    fireEvent.click(getByTestId('play'));
+    act(() => {
+      jest.advanceTimersByTime(0);
+    });
+    expect(getByTestId('replay-output').textContent).toBe('welcome');
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(getByTestId('replay-output').textContent).toContain('> ls');
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(getByTestId('replay-output').textContent).toContain('file');
+    jest.useRealTimers();
+  });
+});
+

--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -1,26 +1,70 @@
 'use client';
 
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import SessionRecorder, {
+  SessionEvent,
+} from '../../../lib/session-recorder';
 
 export type TerminalContainerProps = React.HTMLAttributes<HTMLDivElement>;
 
-const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
-  ({ style, className = '', ...props }, ref) => (
-    <div
-      ref={ref}
-      data-testid="xterm-container"
-      className={className}
-      style={{
-        background: 'var(--kali-bg)',
-        fontFamily: 'monospace',
-        fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
-        lineHeight: 1.4,
-        whiteSpace: 'pre',
-        ...style,
-      }}
-      {...props}
-    />
-  ),
+export interface TerminalRecorderHandle extends HTMLDivElement {
+  startRecording: () => void;
+  stopRecording: () => void;
+  recordInput: (data: string) => void;
+  recordOutput: (data: string) => void;
+  getRecording: () => SessionEvent[];
+}
+
+const Terminal = forwardRef<TerminalRecorderHandle, TerminalContainerProps>(
+  ({ style, className = '', ...props }, ref) => {
+    const divRef = useRef<HTMLDivElement>(null);
+    const recorderRef = useRef<SessionRecorder | null>(null);
+
+    const startRecording = () => {
+      recorderRef.current = new SessionRecorder();
+    };
+
+    const stopRecording = () => {
+      recorderRef.current?.download();
+    };
+
+    const recordInput = (data: string) => {
+      recorderRef.current?.recordInput(data);
+    };
+
+    const recordOutput = (data: string) => {
+      recorderRef.current?.recordOutput(data);
+    };
+
+    const getRecording = () => recorderRef.current?.getEvents() ?? [];
+
+    useImperativeHandle(ref, () =>
+      Object.assign(divRef.current as HTMLDivElement, {
+        startRecording,
+        stopRecording,
+        recordInput,
+        recordOutput,
+        getRecording,
+      }),
+    );
+
+    return (
+      <div
+        ref={divRef}
+        data-testid="xterm-container"
+        className={className}
+        style={{
+          background: 'var(--kali-bg)',
+          fontFamily: 'monospace',
+          fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
+          lineHeight: 1.4,
+          whiteSpace: 'pre',
+          ...style,
+        }}
+        {...props}
+      />
+    );
+  },
 );
 
 Terminal.displayName = 'Terminal';

--- a/components/terminal/ReplayPlayer.tsx
+++ b/components/terminal/ReplayPlayer.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useRef, useState } from 'react';
+import type { SessionEvent } from '../../lib/session-recorder';
+
+interface ReplayPlayerProps {
+  events: SessionEvent[];
+}
+
+export default function ReplayPlayer({ events }: ReplayPlayerProps) {
+  const [index, setIndex] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const timer = useRef<NodeJS.Timeout>();
+
+  useEffect(() => {
+    if (!playing) return;
+    if (index >= events.length) {
+      setPlaying(false);
+      return;
+    }
+    const delay =
+      index === 0
+        ? 0
+        : events[index].timestamp - events[index - 1].timestamp;
+    timer.current = setTimeout(() => setIndex((i) => i + 1), delay);
+    return () => clearTimeout(timer.current);
+  }, [playing, index, events]);
+
+  const content = events
+    .slice(0, index)
+    .map((e) => (e.type === 'input' ? `> ${e.data}` : e.data))
+    .join('\n');
+
+  const togglePlay = () => setPlaying((p) => !p);
+  const reset = () => {
+    setPlaying(false);
+    setIndex(0);
+  };
+
+  return (
+    <div>
+      <pre data-testid="replay-output">{content}</pre>
+      <div>
+        <button onClick={togglePlay} data-testid="play">
+          {playing ? 'Pause' : 'Play'}
+        </button>
+        <button onClick={reset} data-testid="reset">
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/lib/session-recorder.ts
+++ b/lib/session-recorder.ts
@@ -1,0 +1,40 @@
+export type SessionEvent = {
+  type: 'input' | 'output';
+  data: string;
+  timestamp: number;
+};
+
+export default class SessionRecorder {
+  private events: SessionEvent[] = [];
+
+  private record(type: 'input' | 'output', data: string) {
+    this.events.push({ type, data, timestamp: Date.now() });
+  }
+
+  recordInput(data: string) {
+    this.record('input', data);
+  }
+
+  recordOutput(data: string) {
+    this.record('output', data);
+  }
+
+  getEvents() {
+    return this.events;
+  }
+
+  toJSON() {
+    return JSON.stringify(this.events);
+  }
+
+  download(filename = 'terminal-session.json') {
+    const blob = new Blob([this.toJSON()], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+}
+


### PR DESCRIPTION
## Summary
- record terminal input and output and save sessions as JSON
- replay saved terminal sessions with playback controls
- test terminal session recording and replay

## Testing
- `yarn test __tests__/terminal-recording.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf304e0d788328937ee611aee1b559