### PR TITLE
feat: add keyboard shortcut modal

### DIFF
--- a/__tests__/shortcut-modal.test.tsx
+++ b/__tests__/shortcut-modal.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ShortcutModal from '../components/keyboard/ShortcutModal';
+import Desktop from '../src/components/desktop/Desktop';
+import Terminal from '../apps/terminal/components/Terminal';
+
+jest.mock('../src/components/panel/Panel', () => () => <div>panel</div>);
+jest.mock('../src/components/desktop/Dock', () => () => <div>dock</div>);
+jest.mock('../src/components/desktop/HotCorner', () => () => null);
+jest.mock('../src/components/desktop/DesktopContextMenu', () => () => null);
+
+describe('ShortcutModal', () => {
+  it('renders shortcuts, traps focus, and closes with Escape', () => {
+    const onClose = jest.fn();
+    render(<ShortcutModal isOpen onClose={onClose} />);
+    expect(screen.getByText('xfce4-appfinder')).toBeInTheDocument();
+    const close = screen.getByRole('button', { name: /close/i });
+    close.focus();
+    fireEvent.keyDown(close, { key: 'Tab' });
+    expect(close).toHaveFocus();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('opens from Desktop with ? key', () => {
+    render(<Desktop />);
+    fireEvent.keyDown(window, { key: '?' });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('opens from Terminal with ? key', () => {
+    render(<Terminal />);
+    fireEvent.keyDown(window, { key: '?' });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});
+

--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -1,26 +1,48 @@
 'use client';
 
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
+import ShortcutModal from '@/components/keyboard/ShortcutModal';
 
 export type TerminalContainerProps = React.HTMLAttributes<HTMLDivElement>;
 
 const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
-  ({ style, className = '', ...props }, ref) => (
-    <div
-      ref={ref}
-      data-testid="xterm-container"
-      className={className}
-      style={{
-        background: 'var(--kali-bg)',
-        fontFamily: 'monospace',
-        fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
-        lineHeight: 1.4,
-        whiteSpace: 'pre',
-        ...style,
-      }}
-      {...props}
-    />
-  ),
+  ({ style, className = '', ...props }, ref) => {
+    const [showShortcuts, setShowShortcuts] = useState(false);
+
+    useEffect(() => {
+      const handler = (e: KeyboardEvent) => {
+        if (e.key === '?') {
+          e.preventDefault();
+          setShowShortcuts(true);
+        }
+      };
+      window.addEventListener('keydown', handler);
+      return () => window.removeEventListener('keydown', handler);
+    }, []);
+
+    return (
+      <>
+        <div
+          ref={ref}
+          data-testid="xterm-container"
+          className={className}
+          style={{
+            background: 'var(--kali-bg)',
+            fontFamily: 'monospace',
+            fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
+            lineHeight: 1.4,
+            whiteSpace: 'pre',
+            ...style,
+          }}
+          {...props}
+        />
+        <ShortcutModal
+          isOpen={showShortcuts}
+          onClose={() => setShowShortcuts(false)}
+        />
+      </>
+    );
+  },
 );
 
 Terminal.displayName = 'Terminal';

--- a/components/keyboard/ShortcutModal.tsx
+++ b/components/keyboard/ShortcutModal.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import Modal from '@/components/base/Modal';
+import shortcuts from '@/data/xfce4/default-shortcuts.json';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function ShortcutModal({ isOpen, onClose }: Props) {
+  const titleId = 'shortcut-modal-title';
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      ariaLabelledby={titleId}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+    >
+      <div className="window-shadow bg-ub-cool-grey rounded-md w-80 max-h-[80vh] overflow-auto border border-black p-4">
+        <h2 id={titleId} className="text-lg font-bold mb-2">
+          Keyboard Shortcuts
+        </h2>
+        <ul className="space-y-1 mb-4">
+          {shortcuts.map((s) => (
+            <li key={s.command} className="flex justify-between px-2 py-1">
+              <span className="flex-1 mr-2">{s.command}</span>
+              <span className="font-mono">{s.keys}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="text-right">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-2 py-1 bg-ub-orange text-white rounded text-sm"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+

--- a/src/components/desktop/Desktop.tsx
+++ b/src/components/desktop/Desktop.tsx
@@ -3,6 +3,7 @@ import DesktopContextMenu from './DesktopContextMenu';
 import Dock from './Dock';
 import Panel from '../panel/Panel';
 import HotCorner from './HotCorner';
+import ShortcutModal from '@/components/keyboard/ShortcutModal';
 
 export interface DesktopIcon {
   id: string;
@@ -34,6 +35,7 @@ export const Desktop: React.FC = () => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [icons, setIcons] = useState<DesktopIcon[]>([]);
   const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
 
   // Example icons for demonstration
   useEffect(() => {
@@ -56,35 +58,52 @@ export const Desktop: React.FC = () => {
     setIcons((prev) => arrangeIconsToGrid(prev, width));
   }, []);
 
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === '?') {
+        e.preventDefault();
+        setShortcutsOpen(true);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
   return (
-    <div
-      ref={containerRef}
-      className="relative w-full h-full overflow-hidden"
-      onContextMenu={handleContextMenu}
-      onClick={closeMenu}
-    >
-      <div className="absolute top-0 left-0 right-0 z-50">
-        <Panel />
-      </div>
-      {icons.map((icon) => (
-        <div
-          key={icon.id}
-          className="absolute text-center text-xs text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
-          style={{ left: icon.x, top: icon.y, width: 80 }}
-          tabIndex={0}
-        >
-          <div className="h-16 w-16 rounded bg-black bg-opacity-20" />
-          <div>{icon.title}</div>
+    <>
+      <div
+        ref={containerRef}
+        className="relative w-full h-full overflow-hidden"
+        onContextMenu={handleContextMenu}
+        onClick={closeMenu}
+      >
+        <div className="absolute top-0 left-0 right-0 z-50">
+          <Panel />
         </div>
-      ))}
-      <Dock />
-      <HotCorner />
-      <DesktopContextMenu
-        position={menuPos}
-        onClose={closeMenu}
-        onArrange={handleArrange}
+        {icons.map((icon) => (
+          <div
+            key={icon.id}
+            className="absolute text-center text-xs text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
+            style={{ left: icon.x, top: icon.y, width: 80 }}
+            tabIndex={0}
+          >
+            <div className="h-16 w-16 rounded bg-black bg-opacity-20" />
+            <div>{icon.title}</div>
+          </div>
+        ))}
+        <Dock />
+        <HotCorner />
+        <DesktopContextMenu
+          position={menuPos}
+          onClose={closeMenu}
+          onArrange={handleArrange}
+        />
+      </div>
+      <ShortcutModal
+        isOpen={shortcutsOpen}
+        onClose={() => setShortcutsOpen(false)}
       />
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- implement ShortcutModal to display window manager shortcuts
- hook '?' key in Desktop and Terminal to toggle modal
- add focused modal unit tests

## Testing
- `yarn test __tests__/shortcut-modal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf3842ed488328b4d88e057786265e