### PR TITLE
feat: add rtl locale support

### DIFF
--- a/__tests__/rtl-locale.test.tsx
+++ b/__tests__/rtl-locale.test.tsx
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react';
+import useLocale from '../hooks/useLocale';
+
+describe('useLocale', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('dir');
+  });
+
+  test('applies rtl direction when locale is rtl', () => {
+    const original = Intl.DateTimeFormat;
+    // @ts-ignore overriding for test
+    Intl.DateTimeFormat = jest.fn().mockReturnValue({
+      resolvedOptions: () => ({ locale: 'ar' }),
+    });
+
+    const { result } = renderHook(() => useLocale());
+
+    expect(result.current.locale).toBe('ar');
+    expect(result.current.dir).toBe('rtl');
+    expect(document.documentElement.getAttribute('dir')).toBe('rtl');
+
+    Intl.DateTimeFormat = original;
+  });
+
+  test('defaults to ltr direction', () => {
+    const original = Intl.DateTimeFormat;
+    // @ts-ignore overriding for test
+    Intl.DateTimeFormat = jest.fn().mockReturnValue({
+      resolvedOptions: () => ({ locale: 'en-US' }),
+    });
+
+    const { result } = renderHook(() => useLocale());
+
+    expect(result.current.dir).toBe('ltr');
+    expect(document.documentElement.getAttribute('dir')).toBe('ltr');
+
+    Intl.DateTimeFormat = original;
+  });
+});

--- a/components/desktop/TopPanel.tsx
+++ b/components/desktop/TopPanel.tsx
@@ -18,7 +18,7 @@ interface Props {
  */
 export default function TopPanel({ title }: Props) {
   return (
-    <header className="flex items-center justify-between w-full bg-ub-grey text-ubt-grey h-8 md:h-6 lg:h-8 px-2 md:px-1 lg:px-2 text-sm md:text-xs lg:text-sm sticky top-0 z-40">
+    <header className="flex items-center justify-between w-full bg-ub-grey text-ubt-grey h-8 md:h-6 lg:h-8 px-2 md:px-1 lg:px-2 text-sm md:text-xs lg:text-sm sticky top-0 z-40 rtl:flex-row-reverse">
       {/* App menu */}
       <div className="flex items-center">
         <WhiskerMenu />
@@ -34,7 +34,7 @@ export default function TopPanel({ title }: Props) {
       </div>
 
       {/* System indicators */}
-      <div className="flex items-center space-x-2 md:space-x-1 lg:space-x-2" aria-label="System indicators">
+      <div className="flex items-center space-x-2 md:space-x-1 lg:space-x-2 rtl:flex-row-reverse rtl:space-x-reverse" aria-label="System indicators">
         <div className="hidden sm:block">
           <PanelClock />
         </div>

--- a/components/menu/HelpMenu.tsx
+++ b/components/menu/HelpMenu.tsx
@@ -33,16 +33,16 @@ const HelpMenu: React.FC = () => {
         Help
       </button>
       {open && (
-        <div
-          ref={menuRef}
-          className="absolute left-0 mt-1 z-50 bg-ub-grey text-white shadow-lg p-2"
-          tabIndex={-1}
-        >
-          <button
-            type="button"
-            className="block px-2 py-1 text-left hover:underline"
-            onClick={showTour}
+          <div
+            ref={menuRef}
+            className="absolute left-0 mt-1 z-50 bg-ub-grey text-white shadow-lg p-2 rtl:left-auto rtl:right-0"
+            tabIndex={-1}
           >
+            <button
+              type="button"
+              className="block px-2 py-1 text-left hover:underline rtl:text-right"
+              onClick={showTour}
+            >
             Show Welcome Tour
           </button>
         </div>

--- a/components/menu/MegaMenu.tsx
+++ b/components/menu/MegaMenu.tsx
@@ -55,7 +55,7 @@ export default function MegaMenu() {
 
   return (
     <div className="relative" onMouseEnter={handleMenuEnter} onMouseLeave={handleMenuLeave}>
-      <ul className="flex gap-4">
+        <ul className="flex gap-4 rtl:flex-row-reverse">
         {SECTIONS.map((section, idx) => (
           <li
             key={section.label}
@@ -66,7 +66,7 @@ export default function MegaMenu() {
               {section.label}
             </button>
             {active === idx && (
-              <div className="absolute left-0 top-full mt-1 bg-ub-grey text-white shadow-lg p-4">
+                <div className="absolute left-0 top-full mt-1 bg-ub-grey text-white shadow-lg p-4 rtl:left-auto rtl:right-0">
                 <ul className="grid gap-2 sm:grid-cols-2">
                   {section.links.map((link) => (
                     <li key={link.href}>

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -122,14 +122,14 @@ const WhiskerMenu: React.FC = () => {
         onClick={() => setOpen(o => !o)}
         className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
       >
-        <Icon name="menu" className="inline mr-1 w-4 h-4" />
+        <Icon name="menu" className="inline mr-1 w-4 h-4 rtl:ml-1 rtl:mr-0" />
         Applications
       </button>
       {open && (
-        <div
-          ref={menuRef}
-          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
-          tabIndex={-1}
+          <div
+            ref={menuRef}
+            className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg rtl:left-auto rtl:right-0"
+            tabIndex={-1}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node)) {
               setOpen(false);
@@ -140,7 +140,7 @@ const WhiskerMenu: React.FC = () => {
             {CATEGORIES.map(cat => (
               <button
                 key={cat.id}
-                className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
+                className={`text-left px-2 py-1 rounded mb-1 rtl:text-right ${category === cat.id ? 'bg-gray-700' : ''}`}
                 onClick={() => setCategory(cat.id)}
               >
                 {cat.label}

--- a/hooks/useLocale.ts
+++ b/hooks/useLocale.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+
+export type TextDirection = 'ltr' | 'rtl';
+
+interface LocaleInfo {
+  locale: string;
+  dir: TextDirection;
+}
+
+function detectLocale(): LocaleInfo {
+  const { locale } = new Intl.DateTimeFormat().resolvedOptions();
+  let dir: TextDirection = 'ltr';
+  try {
+    // @ts-ignore - Intl.Locale may not be in older typings
+    const intlLocale = new Intl.Locale(locale);
+    dir = intlLocale?.textInfo?.direction || 'ltr';
+  } catch {
+    // Fallback for environments without Intl.Locale
+    const rtlLangs = ['ar', 'he', 'fa', 'ur'];
+    dir = rtlLangs.some((code) => locale.startsWith(code)) ? 'rtl' : 'ltr';
+  }
+  return { locale, dir };
+}
+
+export default function useLocale() {
+  const [state, setState] = useState<LocaleInfo>(() => detectLocale());
+
+  useEffect(() => {
+    setState(detectLocale());
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('dir', state.dir);
+  }, [state.dir]);
+
+  return state;
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -26,6 +26,7 @@ import NotificationCenter from '../components/common/NotificationCenter';
 import HighContrastToggle from '../components/common/HighContrastToggle';
 import { Workbox } from 'workbox-window';
 import Toast from '../components/ui/Toast';
+import useLocale from '../hooks/useLocale';
 
 
 let SpeedInsights = () => null;
@@ -45,6 +46,7 @@ function MyApp(props) {
   const [updateReady, setUpdateReady] = useState(false);
   const wbRef = useRef(null);
 
+  useLocale();
   useReportWebVitals();
 
   useEffect(() => {

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,6 +1,7 @@
 @import './globals.css';
 @import './whisker.css';
 @import './colors-alt.css';
+@import './rtl.css';
 
 :root {
     --color-bg: #0f1317;

--- a/styles/rtl.css
+++ b/styles/rtl.css
@@ -1,0 +1,8 @@
+/* RTL-specific utility classes */
+html[dir="rtl"] .rtl\:flex-row-reverse { flex-direction: row-reverse; }
+html[dir="rtl"] .rtl\:space-x-reverse > :not([hidden]) ~ :not([hidden]) { --tw-space-x-reverse: 1; }
+html[dir="rtl"] .rtl\:text-right { text-align: right; }
+html[dir="rtl"] .rtl\:left-auto { left: auto; }
+html[dir="rtl"] .rtl\:right-0 { right: 0; }
+html[dir="rtl"] .rtl\:ml-1 { margin-left: 0.25rem; }
+html[dir="rtl"] .rtl\:mr-0 { margin-right: 0; }


### PR DESCRIPTION
## Summary
- implement locale hook with Intl and apply dir="rtl" when appropriate
- mirror TopPanel and menus for RTL layouts
- add RTL utility styles and tests

## Testing
- `npm test __tests__/rtl-locale.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf384bb9348328acf038e111e87f79