### PR TITLE
Add accessible skip link and landmark roles

### DIFF
--- a/__tests__/skip-links.test.tsx
+++ b/__tests__/skip-links.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import fs from 'fs';
+import path from 'path';
+import Header from '../components/layout/Header';
+import Footer from '../components/layout/Footer';
+import Home from '../pages/index.jsx';
+
+describe('skip link and landmarks', () => {
+  it('includes skip link in _app', () => {
+    const content = fs.readFileSync(path.join(__dirname, '../pages/_app.tsx'), 'utf8');
+    expect(content).toContain('<a href="#main" className="skip-link">Skip to content</a>');
+  });
+
+  it('renders nav, main and footer roles', () => {
+    render(
+      <>
+        <Header />
+        <Home desktops={[]} />
+        <Footer />
+      </>
+    );
+    expect(screen.getAllByRole('navigation').length).toBeGreaterThan(0);
+    const main = screen.getByRole('main');
+    expect(main).toHaveAttribute('id', 'main');
+    expect(screen.getAllByRole('contentinfo').length).toBeGreaterThan(0);
+  });
+});

--- a/components/kali/Header.tsx
+++ b/components/kali/Header.tsx
@@ -16,7 +16,7 @@ const Header: React.FC = () => (
       backdropFilter: 'blur(var(--blur-sm))',
     }}
   >
-    <nav aria-label="Main navigation">
+    <nav role="navigation" aria-label="Main navigation">
       <ul className="flex flex-wrap items-center gap-4">
         {(ia as any).header.map((item: NavItem) => (
           <li key={item.label} className="relative">

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -53,7 +53,7 @@ const sections = [
 
 export default function Footer() {
   return (
-    <footer className="bg-gray-900 text-gray-300 mt-16">
+    <footer role="contentinfo" className="bg-gray-900 text-gray-300 mt-16">
       <div className="max-w-screen-xl mx-auto px-4 py-8">
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-8">
           {sections.map((section) => (

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -14,7 +14,7 @@ export default function Header() {
       <Link href="/" className="p-4 hover:underline md:hidden">
         Home
       </Link>
-      <nav className="hidden md:flex gap-4 p-4 rtl:flex-row-reverse">
+      <nav role="navigation" className="hidden md:flex gap-4 p-4 rtl:flex-row-reverse">
         <Link href="/" className="hover:underline">
           Home
         </Link>

--- a/components/layout/MobileNav.tsx
+++ b/components/layout/MobileNav.tsx
@@ -92,7 +92,7 @@ export default function MobileNav({ className }: Props) {
               className="w-full p-2 rounded bg-gray-800"
             />
           </div>
-          <nav className="flex-1 overflow-y-auto" aria-label="Mobile navigation">
+          <nav role="navigation" className="flex-1 overflow-y-auto" aria-label="Mobile navigation">
             {filteredSections.map((section) => (
               <div key={section.label} className="p-4 border-b border-gray-800">
                 {section.children && section.children.length > 0 ? (

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,6 +14,7 @@ import '../styles/globals.css';
 import '../styles/index.css';
 import '../styles/resume-print.css';
 import '../styles/print.css';
+import '../styles/a11y.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
@@ -234,6 +235,7 @@ function MyApp(props) {
       <ErrorBoundary>
         <Script src="/a2hs.js" strategy="beforeInteractive" nonce={nonce} />
         <div>
+          <a href="#main" className="skip-link">Skip to content</a>
           <a
             href="#app-grid"
             className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -39,7 +39,7 @@ export default function Home({ desktops }) {
   return (
     <>
       <Header />
-      <main className="p-4">
+      <main id="main" role="main" className="p-4">
         <h1 className="mb-4 text-2xl font-bold sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl 2xl:text-7xl">
           Choose the desktop you prefer
         </h1>

--- a/styles/a11y.css
+++ b/styles/a11y.css
@@ -1,0 +1,14 @@
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: #fff;
+  color: #000;
+  padding: 0.5rem 1rem;
+  z-index: 100;
+  text-decoration: none;
+}
+
+.skip-link:focus {
+  top: 0;
+}


### PR DESCRIPTION
## Summary
- add global skip link for keyboard navigation
- ensure navigation, main, and footer elements expose landmark roles
- add styling and tests for skip link

## Testing
- `yarn test __tests__/skip-links.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bf384c2ed08328acdbd109df6172d6