### PR TITLE
feat: enable vercel analytics and speed insights

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,24 @@
+# Performance Monitoring
+
+This project leverages Vercel's Web Analytics and Speed Insights to track usage and monitor page performance.
+
+## Analytics
+
+`pages/_app.jsx` includes the `<Analytics />` component from `@vercel/analytics/react` to capture anonymous usage metrics. Events for `/admin` and `/private` routes and any email metadata are filtered before sending.
+
+## Speed Insights
+
+The `<SpeedInsights />` component from `@vercel/speed-insights/next` is dynamically loaded in production to measure Core Web Vitals.
+
+## Configuration
+
+Analytics and Speed Insights are enabled in `vercel.json`:
+
+```json
+{
+  "analytics": { "source": "auto" },
+  "speedInsights": { "source": "auto" }
+}
+```
+
+Ensure these features are also enabled in your Vercel project settings to collect data for deployments.

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -4,7 +4,7 @@
 
 import { isBrowser } from '@/utils/env';
 import { useEffect, useRef, useState } from 'react';
-import { Analytics } from '@vercel/analytics/next';
+import { Analytics } from '@vercel/analytics/react';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -256,20 +256,15 @@ function MyApp(props) {
                       onClose={() => setUpdateReady(false)}
                     />
                   )}
-                  {process.env.VERCEL_ANALYTICS_ID && (
-                    <>
-                      <Analytics
-                        beforeSend={(e) => {
-                          if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                          const evt = e;
-                          if (evt.metadata?.email) delete evt.metadata.email;
-                          return e;
-                        }}
-                      />
-
-                      <SpeedInsights />
-                    </>
-                  )}
+                  <Analytics
+                    beforeSend={(e) => {
+                      if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                      const evt = e;
+                      if (evt.metadata?.email) delete evt.metadata.email;
+                      return e;
+                    }}
+                  />
+                  <SpeedInsights />
                 </NotificationCenter>
               </PipPortalProvider>
             </TrayProvider>

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
+  "analytics": { "source": "auto" },
+  "speedInsights": { "source": "auto" },
   "functions": {
     "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.21" },
     "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.21" }


### PR DESCRIPTION
## Summary
- add Vercel Analytics and Speed Insights components in `_app`
- enable analytics and speed insights in `vercel.json`
- document performance monitoring setup

## Testing
- `npx eslint pages/_app.jsx vercel.json docs/performance.md`
- `yarn test __tests__/speed-insights.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf38488c2083289aefdfa8c977ddf7