### PR TITLE
feat: add PWA install prompt banner

### DIFF
--- a/__tests__/install-banner.test.tsx
+++ b/__tests__/install-banner.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import InstallPrompt from '../components/pwa/InstallPrompt';
+
+describe('InstallPrompt', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('shows banner when beforeinstallprompt fires', async () => {
+    render(<InstallPrompt />);
+    const prompt = jest.fn().mockResolvedValue(undefined);
+    const event: any = new Event('beforeinstallprompt');
+    event.preventDefault = jest.fn();
+    event.prompt = prompt;
+    event.userChoice = Promise.resolve({ outcome: 'accepted', platform: 'test' });
+
+    await act(async () => {
+      window.dispatchEvent(event);
+    });
+
+    const button = await screen.findByRole('button', { name: /^install$/i });
+    await userEvent.click(button);
+    expect(prompt).toHaveBeenCalled();
+  });
+
+  test('dismiss stores flag and prevents future banners', async () => {
+    const { unmount } = render(<InstallPrompt />);
+    const event: any = new Event('beforeinstallprompt');
+    event.preventDefault = jest.fn();
+    event.prompt = jest.fn();
+    event.userChoice = Promise.resolve({ outcome: 'dismissed', platform: 'test' });
+
+    await act(async () => {
+      window.dispatchEvent(event);
+    });
+
+    const dismiss = await screen.findByLabelText(/dismiss install banner/i);
+    await userEvent.click(dismiss);
+    expect(localStorage.getItem('install-banner-dismissed')).toBe('1');
+    unmount();
+
+    render(<InstallPrompt />);
+    await act(async () => {
+      window.dispatchEvent(event);
+    });
+    expect(screen.queryByText(/install this app/i)).toBeNull();
+  });
+
+  test('shows iOS instructions', () => {
+    const ua = navigator.userAgent;
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'iPhone',
+      configurable: true,
+    });
+    render(<InstallPrompt />);
+    expect(
+      screen.getByText(/tap Share and Add to Home Screen/i)
+    ).toBeInTheDocument();
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: ua,
+      configurable: true,
+    });
+  });
+});
+

--- a/components/pwa/InstallPrompt.tsx
+++ b/components/pwa/InstallPrompt.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'install-banner-dismissed';
+
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+  prompt(): Promise<void>;
+}
+
+type PromptEvent = BeforeInstallPromptEvent;
+
+function getPlatform(): 'ios' | 'android' | 'other' {
+  const ua = navigator.userAgent || '';
+  if (/iphone|ipad|ipod/i.test(ua)) return 'ios';
+  if (/android/i.test(ua)) return 'android';
+  return 'other';
+}
+
+export default function InstallPrompt() {
+  const [visible, setVisible] = useState(false);
+  const [platform, setPlatform] = useState<'ios' | 'android' | 'other'>('other');
+  const [promptEvent, setPromptEvent] = useState<PromptEvent | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (localStorage.getItem(STORAGE_KEY)) return;
+    const isStandalone =
+      window.matchMedia('(display-mode: standalone)').matches ||
+      // @ts-ignore - iOS Safari
+      (navigator.standalone === true);
+    if (isStandalone) return;
+
+    const platform = getPlatform();
+    setPlatform(platform);
+
+    if (platform === 'ios') {
+      setVisible(true);
+      return;
+    }
+
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setPromptEvent(e as PromptEvent);
+      setVisible(true);
+    };
+    window.addEventListener('beforeinstallprompt', handler);
+    return () => window.removeEventListener('beforeinstallprompt', handler);
+  }, []);
+
+  const dismiss = () => {
+    localStorage.setItem(STORAGE_KEY, '1');
+    setVisible(false);
+  };
+
+  const install = async () => {
+    if (!promptEvent) return;
+    await promptEvent.prompt();
+    await promptEvent.userChoice;
+    dismiss();
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 inset-x-0 bg-ubt-blue text-white p-4 flex flex-col sm:flex-row items-center gap-2">
+      <p className="flex-1">
+        {platform === 'ios'
+          ? 'Install this app: tap Share and Add to Home Screen'
+          : 'Install this app for quick access'}
+      </p>
+      {promptEvent && (
+        <button
+          onClick={install}
+          className="bg-white text-ubt-blue px-3 py-1 rounded"
+        >
+          Install
+        </button>
+      )}
+      <button
+        onClick={dismiss}
+        aria-label="Dismiss install banner"
+        className="px-2"
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add install banner component that listens for `beforeinstallprompt`
- show OS-specific instructions and track dismissed state in localStorage
- add tests for banner behavior

## Testing
- `npm test __tests__/install-banner.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf384acce083288934d141e968e586