### PR TITLE
Fix undefined board access in 2048 transpose

### DIFF
--- a/apps/2048/engine.ts
+++ b/apps/2048/engine.ts
@@ -19,8 +19,9 @@ export const flip = (board: Board): Board =>
   board.map((row) => [...row].reverse());
 
 export const transpose = (board: Board): Board => {
-  if (board.length === 0) return [];
-  return board[0].map((_, c) => board.map((row) => row[c]!));
+  const firstRow = board[0];
+  if (!firstRow) return [];
+  return firstRow.map((_, c) => board.map((row) => row[c]!));
 };
 
 export const moveLeft = (board: Board): Board =>


### PR DESCRIPTION
## Summary
- avoid `board[0]` undefined errors in 2048 engine's transpose

## Testing
- `yarn typecheck` *(fails: workers/sudokuSolver.ts(234,16): Type 'undefined' cannot be used as an index type)*
- `yarn test apps/2048/__tests__/engine.test.ts __tests__/2048.engine.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf417eb5148328a47dfe46de8ae008