### PR TITLE
chore: remove deprecated vercel analytics

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "analytics": { "source": "auto" },
   "speedInsights": { "source": "auto" },
   "functions": {
     "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.21" },


### PR DESCRIPTION
## Summary
- remove deprecated analytics option from `vercel.json`

## Testing
- `npx eslint vercel.json`
- `yarn test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68bf443e32188328b699f3f9585df183