### PR TITLE
fix: remove unsupported speedInsights property

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "speedInsights": { "source": "auto" },
   "functions": {
     "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.21" },
     "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.21" }


### PR DESCRIPTION
## Summary
- remove unsupported `speedInsights` setting from `vercel.json`

## Testing
- `npx eslint vercel.json`
- `yarn test vercel.json --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bf452ce0588328b0c3a1a168fa3a5f