### PR TITLE
fix: handle 2048 random tile selection

### DIFF
--- a/apps/2048/engine.ts
+++ b/apps/2048/engine.ts
@@ -57,7 +57,7 @@ export const addRandomTile = (board: Board, rand: () => number): Board => {
     }),
   );
   if (empty.length === 0) return board.map((row) => [...row]);
-  const [r, c] = empty[Math.floor(rand() * empty.length)];
+  const [r, c] = empty[Math.floor(rand() * empty.length)]!;
   const newBoard = board.map((row) => [...row]);
   newBoard[r][c] = rand() < 0.9 ? 2 : 4;
   return newBoard;


### PR DESCRIPTION
## Summary
- assert random empty cell selection to satisfy TS

## Testing
- `./node_modules/.bin/eslint apps/2048/engine.ts`
- `yarn test apps/2048`
- `yarn tsc apps/2048/engine.ts --noEmit` *(fails: 'cytoscape' has no exported member 'Stylesheet')*

------
https://chatgpt.com/codex/tasks/task_e_68bf48be0f648328a121e728d36a4dea