### PR TITLE
fix: guard 2048 tile placement

### DIFF
--- a/apps/2048/engine.ts
+++ b/apps/2048/engine.ts
@@ -61,7 +61,8 @@ export const addRandomTile = (board: Board, rand: () => number): Board => {
   if (empty.length === 0) return board.map((row) => [...row]);
   const [r, c] = empty[Math.floor(rand() * empty.length)]!;
   const newBoard = board.map((row) => [...row]);
-  const rowAt = newBoard[r]!;
+  const rowAt = newBoard[r];
+  if (!rowAt) return newBoard;
   rowAt[c] = rand() < 0.9 ? 2 : 4;
   return newBoard;
 };


### PR DESCRIPTION
## Summary
- guard 2048 tile placement by ensuring selected row exists before writing

## Testing
- `npx eslint apps/2048/engine.ts`
- `yarn test apps/2048/__tests__/engine.test.ts`
- `npx tsc --skipLibCheck --noEmit apps/2048/engine.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf4b92b1548328916902c860cdf60f