### PR TITLE
fix: guard against missing 2048 board row

### DIFF
--- a/apps/2048/engine.ts
+++ b/apps/2048/engine.ts
@@ -59,7 +59,9 @@ export const addRandomTile = (board: Board, rand: () => number): Board => {
   if (empty.length === 0) return board.map((row) => [...row]);
   const [r, c] = empty[Math.floor(rand() * empty.length)]!;
   const newBoard = board.map((row) => [...row]);
-  newBoard[r][c] = rand() < 0.9 ? 2 : 4;
+  const row = newBoard[r];
+  if (!row) return newBoard;
+  row[c] = rand() < 0.9 ? 2 : 4;
   return newBoard;
 };
 


### PR DESCRIPTION
## Summary
- handle possibly undefined row when adding random tile to 2048 board

## Testing
- `yarn test apps/2048/__tests__/engine.test.ts`
- `yarn tsc -p tsconfig.json --noEmit` *(fails: 'ExpirationPlugin' is not assignable to type 'WorkboxPlugin', plus many other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4a757c048328bf24960c187d6f7f