### PR TITLE
fix: guard row in 2048 addRandomTile

### DIFF
--- a/apps/2048/engine.ts
+++ b/apps/2048/engine.ts
@@ -61,8 +61,10 @@ export const addRandomTile = (board: Board, rand: () => number): Board => {
   if (empty.length === 0) return board.map((row) => [...row]);
   const [r, c] = empty[Math.floor(rand() * empty.length)]!;
   const newBoard = board.map((row) => [...row]);
-  const rowAt = newBoard[r]!;
-  rowAt[c] = rand() < 0.9 ? 2 : 4;
+  const rowAt = newBoard[r];
+  if (rowAt) {
+    rowAt[c] = rand() < 0.9 ? 2 : 4;
+  }
   return newBoard;
 };
 


### PR DESCRIPTION
## Summary
- guard against undefined row when adding a random tile in 2048 engine

## Testing
- `yarn typecheck` *(fails: workers/terminal-worker.ts(44,43): Object is possibly 'undefined')*
- `yarn test apps/2048/engine` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4b7d4f788328802e0ae9f7845b36