### PR TITLE
fix: import figlet Fonts type

### DIFF
--- a/apps/ascii-art/index.tsx
+++ b/apps/ascii-art/index.tsx
@@ -3,6 +3,7 @@
 import { isBrowser } from '@/utils/env';
 import { useState, useEffect, useRef, useCallback, ChangeEvent } from 'react';
 import figlet from 'figlet';
+import type { Fonts } from 'figlet';
 import Standard from 'figlet/importable-fonts/Standard.js';
 import Slant from 'figlet/importable-fonts/Slant.js';
 import Big from 'figlet/importable-fonts/Big.js';
@@ -70,7 +71,7 @@ const AsciiArtApp = () => {
   const [tab, setTab] = useState<'text' | 'image'>('text');
   const [text, setText] = useState('');
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
-  const [font, setFont] = useState<figlet.Fonts>('Standard');
+  const [font, setFont] = useState<Fonts>('Standard');
   const [output, setOutput] = useState('');
   const [fgColor, setFgColor] = useState('#00ff00');
   const [bgColor, setBgColor] = useState('#000000');
@@ -93,7 +94,7 @@ const AsciiArtApp = () => {
     if (!router.isReady) return;
     const { t, f, b, c } = router.query;
     if (typeof t === 'string') setText(t);
-      if (typeof f === 'string' && fontList.includes(f)) setFont(f as figlet.Fonts);
+      if (typeof f === 'string' && fontList.includes(f)) setFont(f as Fonts);
     if (typeof b === 'string') {
       const br = parseFloat(b);
       if (!Number.isNaN(br) && br >= -1 && br <= 1) setBrightness(br);
@@ -259,7 +260,7 @@ const AsciiArtApp = () => {
           />
           <select
             value={font}
-            onChange={(e) => setFont(e.target.value as figlet.Fonts)}
+            onChange={(e) => setFont(e.target.value as Fonts)}
             className="px-2 py-1 text-black rounded"
           >
             {fontList.map((f) => (


### PR DESCRIPTION
## Summary
- import Fonts type from figlet for ascii art app
- use Fonts type for state and handlers

## Testing
- `npx eslint apps/ascii-art/index.tsx` (fails: A control must be associated with a text label)
- `yarn test apps/ascii-art` (fails: No tests found)
- `yarn typecheck` (fails: existing type errors in workers)


------
https://chatgpt.com/codex/tasks/task_e_68bf528053348328bb6a574f60e46917