### PR TITLE
Fix slideRow return type in 2048 game logic

### DIFF
--- a/apps/games/_2048/logic.ts
+++ b/apps/games/_2048/logic.ts
@@ -43,6 +43,13 @@ export const slide = (row: number[]) => {
   return { row: newRow, score, merges };
 };
 
+export const slideRow = (
+  row: number[],
+): { row: number[]; merged: number[] } => {
+  const { row: newRow, merges } = slide(row);
+  return { row: newRow, merged: merges };
+};
+
 export const transpose = (board: Board) =>
   board[0].map((_, c) => board.map((row) => row[c]));
 


### PR DESCRIPTION
## Summary
- expose `slideRow` helper returning new row and merge indices for 2048

## Testing
- `yarn tsc apps/games/_2048/logic.ts --pretty false --noEmit` *(fails: Module 'seedrandom' can only be default-imported using 'esModuleInterop'; 'cytoscape' has no exported member 'Stylesheet')*

------
https://chatgpt.com/codex/tasks/task_e_68bf585b95c0832893182f7c845beb30