### PR TITLE
fix: ensure mathjs dependency map is defined

### DIFF
--- a/apps/calculator/components/GraphPanel.tsx
+++ b/apps/calculator/components/GraphPanel.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { create, all } from 'mathjs';
+import { create, all, type FactoryFunctionMap } from 'mathjs';
 
-const math = create(all);
+// mathjs `all` can be undefined in type definitions, assert the map exists
+const math = create(all as FactoryFunctionMap);
 
 type Token = {
   type: 'number' | 'id' | 'func' | 'operator' | 'paren' | 'comma';
@@ -324,6 +325,13 @@ export default function GraphPanel({
     };
   }, []);
 
-  return <canvas ref={canvasRef} width={width} height={height} />;
-}
+    return (
+      <canvas
+        ref={canvasRef}
+        width={width}
+        height={height}
+        aria-label="graph"
+      />
+    );
+  }
 


### PR DESCRIPTION
## Summary
- cast mathjs `all` factory map to avoid undefined type error
- add accessible label for graph canvas

## Testing
- `npx eslint apps/calculator/components/GraphPanel.tsx`
- `yarn test __tests__/csp.test.ts` *(fails: Missing allowlist entries for many domains)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5bd10a888328883527efb1bd720d