### PR TITLE
fix: handle string indexing safely

### DIFF
--- a/apps/calculator/components/GraphPanel.tsx
+++ b/apps/calculator/components/GraphPanel.tsx
@@ -16,7 +16,7 @@ function tokenize(expr: string): Token[] {
   const tokens: Token[] = [];
   let i = 0;
   while (i < expr.length) {
-    const ch = expr[i];
+    const ch = expr.charAt(i);
     if (/\s/.test(ch)) {
       i += 1;
       continue;
@@ -30,8 +30,8 @@ function tokenize(expr: string): Token[] {
       let num = '-';
       const start = i;
       i += 1;
-      while (i < expr.length && /[0-9.]/.test(expr[i])) {
-        num += expr[i];
+      while (i < expr.length && /[0-9.]/.test(expr.charAt(i))) {
+        num += expr.charAt(i);
         i += 1;
       }
       tokens.push({ type: 'number', value: num, start });
@@ -41,8 +41,8 @@ function tokenize(expr: string): Token[] {
       let num = ch;
       const start = i;
       i += 1;
-      while (i < expr.length && /[0-9.]/.test(expr[i])) {
-        num += expr[i];
+      while (i < expr.length && /[0-9.]/.test(expr.charAt(i))) {
+        num += expr.charAt(i);
         i += 1;
       }
       tokens.push({ type: 'number', value: num, start });
@@ -52,7 +52,7 @@ function tokenize(expr: string): Token[] {
       const start = i;
       const id = expr.slice(i).match(/^[A-Za-z]+/)! [0];
       i += id.length;
-      if (expr[i] === '(') tokens.push({ type: 'func', value: id, start });
+      if (expr.charAt(i) === '(') tokens.push({ type: 'func', value: id, start });
       else tokens.push({ type: 'id', value: id, start });
       continue;
     }


### PR DESCRIPTION
## Summary
- prevent undefined char reads when tokenizing expressions in GraphPanel

## Testing
- `yarn tsc --noEmit` (fails: Type 'undefined' cannot be used as an index type)
- `yarn test apps/calculator/components/GraphPanel.tsx` (fails: No tests found, exiting with code 1)


------
https://chatgpt.com/codex/tasks/task_e_68bf5e29829483289b63eed6846f6986