### PR TITLE
fix: ensure mathjs imports typed

### DIFF
--- a/apps/calculator/utils/parser.ts
+++ b/apps/calculator/utils/parser.ts
@@ -1,7 +1,7 @@
 import { isBrowser } from '@/utils/env';
-import { create, all } from 'mathjs';
+import { create, all, FactoryFunctionMap } from 'mathjs';
 
-const math = create(all);
+const math = create(all as FactoryFunctionMap);
 
 export interface EvalOptions {
   /** Base for numeric literals and result formatting */


### PR DESCRIPTION
## Summary
- fix mathjs create by importing FactoryFunctionMap and casting

## Testing
- `npx eslint apps/calculator/utils/parser.ts`
- `npx tsc -p tsconfig.json --noEmit` *(fails: many existing type errors unrelated to change)*
- `npx jest apps/calculator/utils/parser.ts --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bf63c9ad1883288b20f0df726dd0b7