### PR TITLE
fix checkers board indexing safety

### DIFF
--- a/apps/checkers/index.tsx
+++ b/apps/checkers/index.tsx
@@ -20,7 +20,10 @@ const getAllMovesNoForce = (board: Board, color: 'red' | 'black'): Move[] => {
   let result: Move[] = [];
   for (let r = 0; r < 8; r++) {
     for (let c = 0; c < 8; c++) {
-      if (board[r][c]?.color === color) {
+      // With `noUncheckedIndexedAccess`, array indexing is considered unsafe
+      // and may return `undefined`. Optional chaining ensures we only access
+      // piece properties when both the row and cell exist.
+      if (board[r]?.[c]?.color === color) {
         const moves = getPieceMoves(board, r, c, false);
         if (moves.length) result = result.concat(moves);
       }
@@ -129,7 +132,8 @@ export default function CheckersPage() {
   }, [board]);
 
   const selectPiece = (r: number, c: number) => {
-    const piece = board[r][c];
+    // Guard against out-of-bounds access when using strict array indexing.
+    const piece = board[r]?.[c];
     if (winner || !piece || piece.color !== turn) return;
     const filtered = getSelectableMoves(board, r, c, rule === 'forced');
     if (filtered.length) {
@@ -165,7 +169,10 @@ export default function CheckersPage() {
     const count = positionCounts.current.get(currentKey) || 0;
     if (count <= 1) positionCounts.current.delete(currentKey);
     else positionCounts.current.set(currentKey, count - 1);
-    const prev = history[history.length - 1];
+    // `history` is checked for length above, but `noUncheckedIndexedAccess`
+    // still treats the indexed element as possibly undefined. Assert
+    // existence with `!` to satisfy the compiler.
+    const prev = history[history.length - 1]!;
     setBoard(prev.board);
     setTurn(prev.turn);
     setNoCapture(prev.noCapture);

--- a/components/apps/checkers/engine.ts
+++ b/components/apps/checkers/engine.ts
@@ -47,7 +47,9 @@ export const getPieceMoves = (
   c: number,
   enforceCapture = true,
 ): Move[] => {
-  const piece = board[r][c];
+  // With `noUncheckedIndexedAccess`, array indices may return `undefined`.
+  // Optional chaining guards against out-of-bounds access when compiling.
+  const piece = board[r]?.[c];
   if (!piece) return [];
   const dirs = [...directions[piece.color]];
   if (piece.king) {
@@ -59,13 +61,13 @@ export const getPieceMoves = (
     const r1 = r + dr;
     const c1 = c + dc;
     if (!inBounds(r1, c1)) continue;
-    const target = board[r1][c1];
+    const target = board[r1]?.[c1];
     if (!target) {
       moves.push({ from: [r, c], to: [r1, c1] });
     } else if (target.color !== piece.color) {
       const r2 = r + dr * 2;
       const c2 = c + dc * 2;
-      if (inBounds(r2, c2) && !board[r2][c2]) {
+      if (inBounds(r2, c2) && !board[r2]?.[c2]) {
         captures.push({ from: [r, c], to: [r2, c2], captured: [r1, c1] });
       }
     }
@@ -81,7 +83,7 @@ export const getAllMoves = (
   let result: Move[] = [];
   for (let r = 0; r < 8; r++) {
     for (let c = 0; c < 8; c++) {
-      if (board[r][c]?.color === color) {
+      if (board[r]?.[c]?.color === color) {
         const moves = getPieceMoves(board, r, c, enforceCapture);
         if (moves.length) result = result.concat(moves);
       }
@@ -129,7 +131,7 @@ export const boardToBitboards = (board: Board) => {
   let kings = 0n;
   for (let r = 0; r < 8; r++) {
     for (let c = 0; c < 8; c++) {
-      const piece = board[r][c];
+      const piece = board[r]?.[c];
       if (!piece) continue;
       const bit = 1n << BigInt((7 - r) * 8 + c);
       if (piece.color === 'red') red |= bit;


### PR DESCRIPTION
## Summary
- safeguard 2D board access with optional chaining
- handle history indexing with non-null assertion in undo
- update engine helpers to respect `noUncheckedIndexedAccess`

## Testing
- `yarn test apps/checkers` *(fails: No tests found)*
- `yarn typecheck` *(fails: workers/sudokuSolver.ts: Type 'undefined' cannot be used as an index type; workers/terminal-worker.ts: Object is possibly 'undefined')*
- `yarn build` *(fails: apps/chrome/components/AddressBar.tsx: Argument of type 'string | undefined' is not assignable to parameter of type 'string')*


------
https://chatgpt.com/codex/tasks/task_e_68bf68682cd08328a8855db883917e70