### PR TITLE
fix calculator parser typing

### DIFF
--- a/apps/calculator/utils/parser.ts
+++ b/apps/calculator/utils/parser.ts
@@ -1,5 +1,5 @@
 import { isBrowser } from '@/utils/env';
-import { create, all, FactoryFunctionMap } from 'mathjs';
+import { create, all, type FactoryFunctionMap } from 'mathjs';
 
 const math = create(all as FactoryFunctionMap);
 


### PR DESCRIPTION
## Summary
- ensure mathjs FactoryFunctionMap is imported as a type

## Testing
- `yarn tsc -p tsconfig.json --noEmit` *(fails: workers/sudokuSolver.ts(234,16): error TS2538: Type 'undefined' cannot be used as an index type., ...)*
- `yarn test apps/calculator/utils/parser.test.ts --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bf6e85f37483289acce7a480953ac8