### PR TITLE
refactor: remove spread fragments in Next config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -56,6 +56,13 @@ const buildId =
 
 const precacheManifest = require('./precache-manifest.json');
 
+const additionalManifestEntries = [
+  // Precache the main shell and tools index so they are instantly available offline
+  { url: '/', revision: buildId },
+  { url: '/apps', revision: buildId },
+];
+precacheManifest.forEach((entry) => additionalManifestEntries.push(entry));
+
 const withPWA = require('@ducanh2912/next-pwa').default({
   dest: 'public',
   sw: 'service-worker.js',
@@ -68,13 +75,7 @@ const withPWA = require('@ducanh2912/next-pwa').default({
   },
   workboxOptions: {
     swSrc: 'sw.ts',
-    additionalManifestEntries: [
-      // Precache the main shell and tools index so they are instantly available offline
-      { url: '/', revision: buildId },
-      { url: '/apps', revision: buildId },
-      // Include core static assets generated in the manifest
-      ...precacheManifest,
-    ],
+    additionalManifestEntries,
   },
 });
 
@@ -97,23 +98,31 @@ function configureWebpack(config, { isServer }) {
   config.experiments.asyncWebAssembly = true;
   // Prevent bundling of server-only modules in the browser
   config.resolve = config.resolve || {};
-  config.resolve.fallback = {
-    ...(config.resolve.fallback || {}),
-    module: false,
-    async_hooks: false,
-    fs: false,
-    worker_threads: false,
-    readline: false,
-  };
-  config.resolve.alias = {
-    ...(config.resolve.alias || {}),
-    'react-dom$': require('path').resolve(__dirname, 'lib/react-dom-shim.js'),
-  };
+  config.resolve.fallback = Object.assign(
+    {},
+    config.resolve.fallback,
+    {
+      module: false,
+      async_hooks: false,
+      fs: false,
+      worker_threads: false,
+      readline: false,
+    }
+  );
+  config.resolve.alias = Object.assign(
+    {},
+    config.resolve.alias,
+    {
+      'react-dom$': require('path').resolve(
+        __dirname,
+        'lib/react-dom-shim.js'
+      ),
+    }
+  );
   if (isProd) {
-    config.optimization = {
-      ...(config.optimization || {}),
+    config.optimization = Object.assign({}, config.optimization, {
       mangleExports: false,
-    };
+    });
   }
   return config;
 }
@@ -123,7 +132,7 @@ function configureWebpack(config, { isServer }) {
 module.exports = withBundleAnalyzer(
   withExportImages(
     withPWA({
-      ...(isStaticExport && { output: 'export' }),
+      output: isStaticExport ? 'export' : undefined,
       env: { NEXT_PUBLIC_BUILD_ID: buildId },
       serverExternalPackages: [
         '@supabase/supabase-js',
@@ -172,98 +181,101 @@ module.exports = withBundleAnalyzer(
       ];
     },
     // Apply security headers only in production.
-    ...(isProd
-      ? {
-          async headers() {
-            return [
-              {
-                source: '/',
-                headers: [
-                  {
-                    key: 'Link',
-                    value: '</wallpapers/wall-1.webp>; rel=preload; as=image',
-                  },
-                ],
-              },
-              {
-                source: '/:path*',
-                headers: [
-                  {
-                    key: 'Link',
-                    value: '<https://fonts.googleapis.com>; rel=preconnect; crossorigin',
-                  },
-                  {
-                    key: 'Link',
-                    value: '<https://fonts.gstatic.com>; rel=preconnect; crossorigin',
-                  },
-                ],
-              },
-              {
-                source: '/_next/static/:path*',
-                headers: [
-                  {
-                    key: 'Cache-Control',
-                    value: 'public, max-age=31536000, immutable',
-                  },
-                ],
-              },
-              {
-                source: '/(.*)',
-                headers: securityHeaders,
-              },
-              ...precacheManifest.map(({ url }) => ({
-                source: url,
-                headers: [
-                  {
-                    key: 'Cache-Control',
-                    value: 'public, max-age=31536000, immutable',
-                  },
-                ],
-              })),
-              {
-                source: '/manifest.webmanifest',
-                headers: [
-                  {
-                    key: 'Content-Type',
-                    value: 'application/manifest+json',
-                  },
-                  {
-                    key: 'Cache-Control',
-                    value: 'public, max-age=0, must-revalidate',
-                  },
-                ],
-              },
-              {
-                source: '/service-worker.js',
-                headers: [
-                  {
-                    key: 'Cache-Control',
-                    value: 'public, max-age=0, must-revalidate',
-                  },
-                ],
-              },
-              {
-                source: '/fonts/:path*',
-                headers: [
-                  {
-                    key: 'Cache-Control',
-                    value: 'public, max-age=31536000, immutable',
-                  },
-                ],
-              },
-              {
-                source: '/images/:path*',
-                headers: [
-                  {
-                    key: 'Cache-Control',
-                    value: 'public, max-age=31536000, immutable',
-                  },
-                ],
-              },
-            ];
-          },
+    headers: isProd
+      ? async () => {
+          const result = [
+            {
+              source: '/',
+              headers: [
+                {
+                  key: 'Link',
+                  value: '</wallpapers/wall-1.webp>; rel=preload; as=image',
+                },
+              ],
+            },
+            {
+              source: '/:path*',
+              headers: [
+                {
+                  key: 'Link',
+                  value: '<https://fonts.googleapis.com>; rel=preconnect; crossorigin',
+                },
+                {
+                  key: 'Link',
+                  value: '<https://fonts.gstatic.com>; rel=preconnect; crossorigin',
+                },
+              ],
+            },
+            {
+              source: '/_next/static/:path*',
+              headers: [
+                {
+                  key: 'Cache-Control',
+                  value: 'public, max-age=31536000, immutable',
+                },
+              ],
+            },
+            {
+              source: '/(.*)',
+              headers: securityHeaders,
+            },
+          ];
+          precacheManifest.forEach(({ url }) => {
+            result.push({
+              source: url,
+              headers: [
+                {
+                  key: 'Cache-Control',
+                  value: 'public, max-age=31536000, immutable',
+                },
+              ],
+            });
+          });
+          result.push(
+            {
+              source: '/manifest.webmanifest',
+              headers: [
+                {
+                  key: 'Content-Type',
+                  value: 'application/manifest+json',
+                },
+                {
+                  key: 'Cache-Control',
+                  value: 'public, max-age=0, must-revalidate',
+                },
+              ],
+            },
+            {
+              source: '/service-worker.js',
+              headers: [
+                {
+                  key: 'Cache-Control',
+                  value: 'public, max-age=0, must-revalidate',
+                },
+              ],
+            },
+            {
+              source: '/fonts/:path*',
+              headers: [
+                {
+                  key: 'Cache-Control',
+                  value: 'public, max-age=31536000, immutable',
+                },
+              ],
+            },
+            {
+              source: '/images/:path*',
+              headers: [
+                {
+                  key: 'Cache-Control',
+                  value: 'public, max-age=31536000, immutable',
+                },
+              ],
+            }
+          );
+          return result;
         }
-      : {}),
+      : undefined,
     })
   )
 );


### PR DESCRIPTION
## Summary
- eliminate literal spread syntax in next.config.js
- explicit manifest entry assembly and Object.assign-based webpack merges
- consolidate PWA export chain without ... fragments

## Testing
- `node -e "require('./next.config.js')"`
- `yarn build` *(fails: Argument of type 'string | undefined' is not assignable to parameter of type 'string' in apps/chrome/components/AddressBar.tsx:49:16)*


------
https://chatgpt.com/codex/tasks/task_e_68bf70b4098883288e4567bd67b209a8