### PR TITLE
chore: normalize line endings

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -40,8 +40,8 @@ jobs:
         run: yarn export
       - run: touch ./out/.nojekyll
 
-      - name: Deploy to Github-Pages 
+      - name: Deploy to Github-Pages
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
-          branch: gh-pages 
-          folder: out 
+          branch: gh-pages
+          folder: out

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kali Linux Portfolio 
+# Kali Linux Portfolio
 
 A desktop-style portfolio built with Next.js and Tailwind that emulates a Kali/Ubuntu UI with windows, a dock, context menus, and a rich catalog of **security-tool simulations**, **utilities**, and **retro games**. This README is tailored for a professional full-stack engineer preparing **production deployment** and ongoing maintenance.
 
@@ -564,4 +564,3 @@ The calculator supports a subset of math.js expressions with the following featu
 - The previous answer is accessible via `Ans`.
 
 Invalid syntax is highlighted in the calculator input, selecting the character where parsing failed.
-


### PR DESCRIPTION
## Summary
- remove trailing spaces in GitHub Pages deploy workflow
- clean README top and bottom lines and ensure LF line endings

## Testing
- `npx eslint README.md .github/workflows/gh-deploy.yml`
- `git diff --check`


------
https://chatgpt.com/codex/tasks/task_e_68bf70bba75083289e23fbb51d14a5fe