### PR TITLE
fix postinstall script simple-git-hooks resolution

### DIFF
--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,5 +1,9 @@
 import { execSync } from 'node:child_process';
 
 if (process.env.CI !== 'true') {
-  execSync('simple-git-hooks', { stdio: 'inherit' });
+  // When invoked directly via `node scripts/postinstall.mjs` the
+  // `simple-git-hooks` binary from `node_modules/.bin` may not be on the PATH
+  // which causes the previous command to fail. Using `npx` ensures we resolve
+  // the local package correctly regardless of how the script is executed.
+  execSync('npx simple-git-hooks', { stdio: 'inherit' });
 }


### PR DESCRIPTION
## Summary
- resolve `simple-git-hooks` path in postinstall script using `npx`

## Testing
- `node scripts/postinstall.mjs`
- `yarn test` *(fails: workspace has failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bf70bd088c832893ab114b2cd39e7a