### PR TITLE
refactor: move Clipman storage to localStorage

### DIFF
--- a/src/plugins/clipman.json
+++ b/src/plugins/clipman.json
@@ -1,7 +1,0 @@
-{
-  "history": [],
-  "settings": {
-    "syncSelections": false,
-    "persistOnExit": false
-  }
-}


### PR DESCRIPTION
## Summary
- replace fs/path-based storage with localStorage in Clipman plugin
- adjust Clipman tests for localStorage persistence
- remove unused clipman.json file

## Testing
- `yarn eslint --no-ignore src/plugins/Clipman.tsx __tests__/Clipman.test.tsx && echo "lint OK"`
- `yarn test __tests__/Clipman.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bf70c27b108328b0b8fdde25c23e11