### PR TITLE
refactor: defer browser api usage

### DIFF
--- a/lib/theme-store.ts
+++ b/lib/theme-store.ts
@@ -1,8 +1,8 @@
-import { useSyncExternalStore } from 'react';
+import { useEffect, useSyncExternalStore } from 'react';
 
 const STORAGE_KEY = 'app:theme';
 
-let theme = (typeof window !== 'undefined' && window.localStorage.getItem(STORAGE_KEY)) || 'default';
+let theme = 'default';
 const listeners = new Set<() => void>();
 
 export const getTheme = () => theme;
@@ -25,4 +25,13 @@ export const subscribe = (fn: () => void) => {
   return () => listeners.delete(fn);
 };
 
-export const useTheme = () => useSyncExternalStore(subscribe, getTheme);
+export const useTheme = () => {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      setTheme(stored);
+    }
+  }, []);
+  return useSyncExternalStore(subscribe, getTheme);
+};

--- a/utils/qrStorage.ts
+++ b/utils/qrStorage.ts
@@ -7,13 +7,13 @@ const FILE_NAME = 'qr-scans.json';
 
 const getStorage = (): StorageManager => navigator.storage;
 
-const opfsSupported =
+const isOpfsSupported = (): boolean =>
   isBrowser() && 'storage' in navigator && Boolean(getStorage().getDirectory);
 
 let directoryHandlePromise: Promise<FileSystemDirectoryHandle | null> | null = null;
 const getDirectoryHandle = (): Promise<FileSystemDirectoryHandle | null> => {
   if (directoryHandlePromise) return directoryHandlePromise;
-  if (!opfsSupported) {
+  if (!isOpfsSupported()) {
     directoryHandlePromise = Promise.resolve(null);
   } else {
     directoryHandlePromise = getStorage()


### PR DESCRIPTION
## Summary
- move theme initialization into a client-side effect
- compute OPFS support lazily to avoid navigator at module scope

## Testing
- `yarn test lib/theme-store.ts utils/qrStorage.ts`
- `npx eslint lib/theme-store.ts utils/qrStorage.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf70c5bd5883288d882c2f819b7d24