### PR TITLE
chore: keep _app global styles only

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -50,11 +50,6 @@ function MyApp(props) {
   useReportWebVitals();
 
   useEffect(() => {
-    void import('@xterm/xterm/css/xterm.css');
-    void import('leaflet/dist/leaflet.css');
-  }, []);
-
-  useEffect(() => {
     if (isBrowser() && typeof window.initA2HS === 'function') {
       window.initA2HS();
     }


### PR DESCRIPTION
## Summary
- ensure pages/_app.jsx starts with use client and only imports global CSS
- drop module-specific CSS imports for xterm and leaflet

## Testing
- `pnpm -w typecheck` *(fails: --workspace-root may only be used inside a workspace)*
- `yarn lint pages/_app.jsx` *(fails: 501 problems (500 errors, 1 warning))*
- `yarn test __tests__/terminal.test.tsx` *(fails: TypeError: Cannot set properties of undefined (setting 'theme'))*


------
https://chatgpt.com/codex/tasks/task_e_68bf70c6ea508328b5436c17a35ae771