### PR TITLE
refactor(api): use standard Response in route handlers

### DIFF
--- a/app/api/healthz/route.ts
+++ b/app/api/healthz/route.ts
@@ -1,6 +1,4 @@
-import { NextResponse } from 'next/server';
-
-export async function GET() {
-  return NextResponse.json({ ok: true });
+export function GET(): Response {
+  return Response.json({ ok: true });
 }
 

--- a/app/api/log-client-error/route.ts
+++ b/app/api/log-client-error/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { sign, unsign } from '@tinyhttp/cookie-signature';
 
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -50,11 +50,11 @@ function applyBackoff(req: NextRequest) {
   return { allowed, cookie };
 }
 
-export async function POST(req: NextRequest) {
+export async function POST(req: NextRequest): Promise<Response> {
   const { allowed, cookie } = applyBackoff(req);
   const headers = { 'Set-Cookie': cookie };
   if (!allowed) {
-    return NextResponse.json({ ok: false, code: 'rate_limit' }, { status: 429, headers });
+    return Response.json({ ok: false, code: 'rate_limit' }, { status: 429, headers });
   }
   let body: unknown;
   try {
@@ -64,5 +64,5 @@ export async function POST(req: NextRequest) {
   }
   const sanitized = sanitize(body);
   console.error('Client error:', sanitized);
-  return NextResponse.json({ ok: true }, { headers });
+  return Response.json({ ok: true }, { headers });
 }


### PR DESCRIPTION
## Summary
- ensure health check route uses web `Response`
- ensure client error logger route returns `Response`

## Testing
- `pnpm -w typecheck` *(fails: --workspace-root may only be used inside a workspace)*
- `yarn test __tests__/csp.test.ts` *(fails: Missing allowlist entries for multiple domains)*
- `yarn build` *(fails: Type error in apps/chrome/components/AddressBar.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bf70c801b48328912da2cc2d82e09d