### PR TITLE
fix: correct hot corner hook imports

### DIFF
--- a/src/components/desktop/HotCorner.tsx
+++ b/src/components/desktop/HotCorner.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
-import usePersistentState from '../../hooks/usePersistentState';
-import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
+import usePersistentState from '../../../hooks/usePersistentState';
+import usePrefersReducedMotion from '../../../hooks/usePrefersReducedMotion';
 
 const HINT_KEY = 'hot-corner-hint';
 


### PR DESCRIPTION
## Summary
- fix HotCorner imports to use root-level persistent state and reduced-motion hooks

## Testing
- `yarn lint src/components/desktop/HotCorner.tsx` *(fails: no-dupe-app-imports and many other lint errors)*
- `yarn typecheck` *(fails: 1500+ TS errors, e.g. 'm' is possibly undefined in components/apps/solitaire/index.tsx)*
- `yarn test __tests__/reducedMotion.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf70ca0ff08328a08ccc11bdea126b