### PR TITLE
feat: add locale redirect middleware

### DIFF
--- a/__tests__/middleware-csp.test.ts
+++ b/__tests__/middleware-csp.test.ts
@@ -19,7 +19,7 @@ describe('middleware CSP header', () => {
 
   it('includes nonce and allowed hosts', async () => {
     const server = createServer();
-    const res = await request(server).get('/');
+    const res = await request(server).get('/es').set('Accept-Language', 'es');
     server.close();
 
     const csp = res.headers['content-security-policy'];

--- a/__tests__/middleware-locale-redirect.test.ts
+++ b/__tests__/middleware-locale-redirect.test.ts
@@ -1,0 +1,25 @@
+/** @jest-environment node */
+import { NextRequest } from 'next/server';
+import { middleware } from '../middleware';
+
+describe('middleware locale redirect', () => {
+  function makeReq(lang: string) {
+    return new NextRequest('http://localhost/', {
+      headers: { 'accept-language': lang },
+    });
+  }
+
+  it('redirects to /en when Accept-Language is en', () => {
+    const req = makeReq('en');
+    const res = middleware(req);
+    expect(res.status).toBe(307);
+    expect(res.headers.get('Location')).toBe('http://localhost/en/');
+  });
+
+  it('redirects to /es when Accept-Language is es', () => {
+    const req = makeReq('es');
+    const res = middleware(req);
+    expect(res.status).toBe(307);
+    expect(res.headers.get('Location')).toBe('http://localhost/es/');
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -20,6 +20,15 @@ export function middleware(req: NextRequest | { headers: Headers; nextUrl?: URL;
   const shouldRedirect = Boolean((req as any).nextUrl);
   if (
     shouldRedirect &&
+    (pathname === `/${defaultLocale}` || pathname.startsWith(`/${defaultLocale}/`))
+  ) {
+    const newPath = pathname.replace(`/${defaultLocale}`, '') || '/';
+    return NextResponse.redirect(
+      new URL(newPath, (req as any).url || 'http://localhost')
+    );
+  }
+  if (
+    shouldRedirect &&
     !PUBLIC_FILE.test(pathname) &&
     !pathname.startsWith('/_next') &&
     !pathname.includes('/api') &&


### PR DESCRIPTION
## Summary
- handle default locale URLs by stripping `en` prefix
- redirect `/` to preferred locale
- cover locale detection in middleware tests

## Testing
- `yarn test __tests__/middleware-locale-redirect.test.ts __tests__/middleware-csp.test.ts __tests__/nosniff.test.ts __tests__/hsts.test.ts`
- `pnpm -w typecheck` *(fails: --workspace-root may only be used inside a workspace)*
- `yarn lint middleware.ts __tests__/middleware-locale-redirect.test.ts __tests__/middleware-csp.test.ts __tests__/nosniff.test.ts __tests__/hsts.test.ts` *(fails: 500 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bf70c85ad48328813a2df20f585e8c