### PR TITLE
refactor: replace deep relative imports with alias

### DIFF
--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react'
-import useFocusTrap from '../../hooks/useFocusTrap'
-import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+import useFocusTrap from '@/hooks/useFocusTrap'
+import useRovingTabIndex from '@/hooks/useRovingTabIndex'
 
 function AppMenu(props) {
     const menuRef = useRef(null)

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react'
-import useFocusTrap from '../../hooks/useFocusTrap'
-import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+import useFocusTrap from '@/hooks/useFocusTrap'
+import useRovingTabIndex from '@/hooks/useRovingTabIndex'
 
 function DefaultMenu(props) {
     const menuRef = useRef(null)

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react'
-import logger from '../../utils/logger'
+import logger from '@/utils/logger'
 import PolicyKitPrompt from '../common/PolicyKitPrompt'
-import useFocusTrap from '../../hooks/useFocusTrap'
-import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+import useFocusTrap from '@/hooks/useFocusTrap'
+import useRovingTabIndex from '@/hooks/useRovingTabIndex'
 
 function DesktopMenu(props) {
 

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
-import useFocusTrap from '../../hooks/useFocusTrap';
-import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+import useFocusTrap from '@/hooks/useFocusTrap';
+import useRovingTabIndex from '@/hooks/useRovingTabIndex';
 
 function TaskbarMenu(props) {
     const menuRef = useRef(null);

--- a/components/context-menus/window-menu.js
+++ b/components/context-menus/window-menu.js
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
-import useFocusTrap from '../../hooks/useFocusTrap';
-import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+import useFocusTrap from '@/hooks/useFocusTrap';
+import useRovingTabIndex from '@/hooks/useRovingTabIndex';
 
 function WindowMenu(props) {
     const menuRef = useRef(null);

--- a/components/ui/CodeBlock.tsx
+++ b/components/ui/CodeBlock.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import copyToClipboard from "../../utils/clipboard";
+import copyToClipboard from "@/utils/clipboard";
 
 interface CodeBlockProps extends React.HTMLAttributes<HTMLPreElement> {
   children: React.ReactNode;

--- a/components/ui/ContextMenu.tsx
+++ b/components/ui/ContextMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
-import useFocusTrap from "../../hooks/useFocusTrap";
-import useRovingTabIndex from "../../hooks/useRovingTabIndex";
+import useFocusTrap from "@/hooks/useFocusTrap";
+import useRovingTabIndex from "@/hooks/useRovingTabIndex";
 
 export interface ContextMenuItem {
   /** Text label displayed for the menu item. */

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import usePersistentState from '../../hooks/usePersistentState';
+import usePersistentState from '@/hooks/usePersistentState';
 import { useEffect, useState } from 'react';
-import { useTheme } from '../../hooks/useTheme';
+import { useTheme } from '@/hooks/useTheme';
 import {
   getUndercover,
   setUndercover as setUndercoverTheme,
-} from '../../utils/theme';
+} from '@/utils/theme';
 
 interface Props {
   open: boolean;

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { kaliTheme } from '../../styles/themes/kali';
+import { kaliTheme } from '@/styles/themes/kali';
 
 interface ToastProps {
   message: string;

--- a/components/ui/ToastProvider.tsx
+++ b/components/ui/ToastProvider.tsx
@@ -5,7 +5,7 @@ import React, {
   useState,
   ReactNode,
 } from 'react';
-import { kaliTheme } from '../../styles/themes/kali';
+import { kaliTheme } from '@/styles/themes/kali';
 
 interface ToastItem {
   id: number;

--- a/components/ui/VideoPlayer.tsx
+++ b/components/ui/VideoPlayer.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import PipPortalProvider, { usePipPortal } from "../common/PipPortal";
-import useWakeLockOnFullscreen from "../../hooks/useWakeLockOnFullscreen";
+import useWakeLockOnFullscreen from "@/hooks/useWakeLockOnFullscreen";
 import { isBrowser } from '@/utils/env';
 
 interface VideoPlayerProps {

--- a/components/ui/WallpaperPicker.tsx
+++ b/components/ui/WallpaperPicker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { useSettings } from "../../hooks/useSettings";
+import { useSettings } from "@/hooks/useSettings";
 
 const WALLPAPERS = [
   "wall-1",


### PR DESCRIPTION
## Summary
- use `@/` alias in UI components to replace deep relative imports
- switch context menu components to `@/` imports for hooks and utilities

## Testing
- `npm test` *(fails: Cannot set properties of undefined)*
- `npm run build` *(fails: Cannot find module 'figlet' from 'apps/ascii-art/index.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68bf70cb822c8328b15a83dfe20d1f65