### PR TITLE
chore: disallow mdx imports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,13 @@
    yarn dev
    ```
 
+## Lint
+- Run ESLint before committing:
+  ```bash
+  yarn lint
+  ```
+- `.mdx` files must not be imported in code.
+
 ## Tests
 - **Unit tests**:
   ```bash

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,7 @@ const config = [
       'import/no-anonymous-default-export': 'off',
       'import/no-cycle': 'warn',
       'import/no-unresolved': 'error',
+      'no-restricted-imports': ['error', { patterns: ['**/*.mdx'] }],
     },
   }),
 ];

--- a/pages/get-kali.tsx
+++ b/pages/get-kali.tsx
@@ -5,17 +5,6 @@ import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
 import ImageWizard from '../components/downloads/ImageWizard';
 
-import * as Installer from '../content/get-kali/installer.mdx';
-import * as VMs from '../content/get-kali/vms.mdx';
-import * as ARM from '../content/get-kali/arm.mdx';
-import * as Mobile from '../content/get-kali/mobile.mdx';
-import * as Cloud from '../content/get-kali/cloud.mdx';
-import * as Containers from '../content/get-kali/containers.mdx';
-import * as Live from '../content/get-kali/live.mdx';
-import * as WSL from '../content/get-kali/wsl.mdx';
-import * as WinKex from '../content/get-kali/win-kex.mdx';
-import * as Purple from '../content/get-kali/purple.mdx';
-import * as Docs from '../content/get-kali/docs.mdx';
 
 const badgeIcons: Record<string, string> = {
   aws: '/icons/providers/aws.svg',
@@ -32,21 +21,74 @@ type Platform = {
 };
 
 const platforms: Platform[] = [
-  { slug: 'installer', ...(Installer as any) },
-  { slug: 'virtual-machines', ...(VMs as any) },
-  { slug: 'arm', ...(ARM as any) },
-  { slug: 'mobile', ...(Mobile as any) },
-  { slug: 'cloud', ...(Cloud as any) },
-  { slug: 'containers', ...(Containers as any) },
-  { slug: 'live', ...(Live as any) },
-  { slug: 'wsl', ...(WSL as any) },
+  {
+    slug: 'installer',
+    title: 'Installer',
+    summary: 'Full-featured ISO for bare-metal installation.',
+    badges: ['amd64', 'arm64'],
+  },
+  {
+    slug: 'virtual-machines',
+    title: 'Virtual Machines',
+    summary: 'Pre-built images for VMware and VirtualBox.',
+    badges: ['vmware', 'virtualbox'],
+  },
+  {
+    slug: 'arm',
+    title: 'ARM',
+    summary: 'Images for ARM-based single-board computers.',
+    badges: ['arm', 'arm64'],
+  },
+  {
+    slug: 'mobile',
+    title: 'Mobile (NetHunter)',
+    summary: 'Kali NetHunter for Android devices.',
+    badges: ['android'],
+  },
+  {
+    slug: 'cloud',
+    title: 'Cloud',
+    summary: 'Images for AWS, Azure, and other cloud providers.',
+    badges: ['aws', 'azure', 'gcp'],
+  },
+  {
+    slug: 'containers',
+    title: 'Containers',
+    summary: 'Docker and LXC/LXD container images.',
+    badges: ['docker', 'lxc'],
+  },
+  {
+    slug: 'live',
+    title: 'Live',
+    summary: 'Bootable live system with optional persistence.',
+    badges: ['usb'],
+  },
+  {
+    slug: 'wsl',
+    title: 'WSL',
+    summary: 'Kali Linux for Windows Subsystem for Linux.',
+    badges: ['wsl'],
+  },
   {
     slug: 'win-kex',
+    title: 'Win-KeX',
+    summary: 'Graphical desktop experience for Kali on WSL.',
+    badges: ['wsl'],
     url: 'https://www.kali.org/docs/wsl/win-kex/',
-    ...(WinKex as any),
   },
-  { slug: 'purple', ...(Purple as any) },
-  { slug: 'docs', url: 'https://www.kali.org/docs/', ...(Docs as any) },
+  {
+    slug: 'purple',
+    title: 'Kali Purple',
+    summary: 'Security operations-focused Kali variant.',
+    badges: ['soc'],
+  },
+  {
+    slug: 'docs',
+    title: 'Documentation',
+    summary: 'Official Kali Linux guides and tutorials.',
+    badges: ['docs'],
+    url: 'https://www.kali.org/docs/',
+  },
 ];
 
 const GetKali: React.FC = () => (


### PR DESCRIPTION
## Summary
- ban `.mdx` module imports in ESLint
- inline Get Kali platform metadata instead of importing MDX
- note MDX import restriction in contributing guide

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `npx eslint pages/get-kali.tsx`
- `yarn test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68bf70d1b2d8832897255aa81db66a15