### PR TITLE
fix: mark Sokoban app as client component

### DIFF
--- a/apps/sokoban/index.tsx
+++ b/apps/sokoban/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { logEvent, logGameStart, logGameEnd, logGameError } from '../../utils/analytics';
 import { LEVEL_PACKS, LevelPack, parseLevels } from './levels';
@@ -462,7 +464,12 @@ const Sokoban: React.FC<SokobanProps> = ({ getDailySeed }) => {
             <option key={i} value={i}>{`Level ${i + 1}`}</option>
           ))}
         </select>
-        <input type="file" accept=".txt,.sas" onChange={handleFile} />
+         <input
+            type="file"
+            accept=".txt,.sas"
+            onChange={handleFile}
+            aria-label="upload level file"
+          />
         <button
           type="button"
           onClick={() => setShowLevels(true)}


### PR DESCRIPTION
## Summary
- add `'use client'` directive to Sokoban app entry
- label file input for accessibility

## Testing
- `npx eslint apps/sokoban/index.tsx`
- `npx jest apps/sokoban --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bf70d1dae48328b828a6e0f7b8d991