### PR TITLE
chore: mark password generator as client component

### DIFF
--- a/apps/password_generator/index.tsx
+++ b/apps/password_generator/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState } from 'react';
 
 const LOWER = 'abcdefghijklmnopqrstuvwxyz';


### PR DESCRIPTION
## Summary
- mark password generator app as client component

## Testing
- `yarn build` (fails: Argument of type 'string | undefined' is not assignable to parameter of type 'string')


------
https://chatgpt.com/codex/tasks/task_e_68bf70d2173c8328a9f1304e0c3c4f03