### PR TITLE
feat(word-search): add client directive

### DIFF
--- a/apps/word_search/index.tsx
+++ b/apps/word_search/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useState, useRef } from 'react';
 import { z } from 'zod';
 import { useRouter } from 'next/router';


### PR DESCRIPTION
## Summary
- mark word search app as client component

## Testing
- `npx eslint apps/word_search/index.tsx` *(fails: A control must be associated with a text label)*
- `yarn test apps/word_search --passWithNoTests`
- `npx tsc --noEmit apps/word_search/index.tsx` *(fails: Cannot find module '../../components/apps/wordle_words.json' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bf70d2bd708328bf38ab10c635af8a