### PR TITLE
Ensure client directives for hook-based app index files

### DIFF
--- a/apps/password_generator/index.tsx
+++ b/apps/password_generator/index.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { useState } from 'react';
 
 const LOWER = 'abcdefghijklmnopqrstuvwxyz';

--- a/apps/sokoban/index.tsx
+++ b/apps/sokoban/index.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { logEvent, logGameStart, logGameEnd, logGameError } from '../../utils/analytics';
 import { LEVEL_PACKS, LevelPack, parseLevels } from './levels';

--- a/apps/word_search/index.tsx
+++ b/apps/word_search/index.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { useEffect, useState, useRef } from 'react';
 import { z } from 'zod';
 import { useRouter } from 'next/router';


### PR DESCRIPTION
## Summary
- add `use client` directive to password generator, sokoban, and word search app index files to support hooks on the client

## Testing
- `npx eslint apps/password_generator/index.tsx apps/sokoban/index.tsx apps/word_search/index.tsx`
- `yarn test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell; Command failed: npx axe ... --exit 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bf70d3a70c8328995153b26018feca