### PR TITLE
Add alt text for Next.js images

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -75,12 +75,10 @@ export default function Footer() {
           >
             <Image
               src={link.icon}
-              alt=""
+              alt={link.label}
               width={24}
               height={24}
-              aria-hidden="true"
             />
-            <span className="sr-only">{link.label}</span>
           </a>
         ))}
       </footer>

--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -109,7 +109,7 @@ export class SideBarApp extends Component {
                     height={28}
                     className="w-7"
                     src={this.props.icon.replace('./', '/')}
-                    alt="Ubuntu App Icon"
+                    alt={this.props.title}
                     sizes="28px"
                 />
                 <Image
@@ -117,7 +117,8 @@ export class SideBarApp extends Component {
                     height={28}
                     className={(this.state.scaleImage ? " scale " : "") + " scalable-app-icon w-7 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"}
                     src={this.props.icon.replace('./', '/')}
-                    alt=""
+                    alt={this.props.title}
+                    aria-hidden="true"
                     sizes="28px"
                 />
                 {

--- a/components/panel/GenMon.tsx
+++ b/components/panel/GenMon.tsx
@@ -115,7 +115,7 @@ export default function GenMon({ code, interval = 60 }: GenMonProps) {
       {icon && (
         <Image
           src={icon}
-          alt=""
+          alt="Status icon"
           className="w-4 h-4"
           width={16}
           height={16}

--- a/components/panel/taskbar/TaskList.tsx
+++ b/components/panel/taskbar/TaskList.tsx
@@ -91,7 +91,7 @@ const TaskList: React.FC<TaskListProps> = ({ apps, onMinimizeWindow }) => {
           {app.icon ? (
             <Image
               src={app.icon}
-              alt=""
+              alt={app.title}
               className="max-w-full max-h-full"
               width={rowSize}
               height={rowSize}

--- a/components/platforms/PlatformCard.tsx
+++ b/components/platforms/PlatformCard.tsx
@@ -9,7 +9,7 @@ interface PlatformCardProps {
 export default function PlatformCard({ title, bullets, thumbnail }: PlatformCardProps) {
   return (
     <div className="flex gap-4 rounded border p-4">
-      <Image src={thumbnail} alt="" width={64} height={64} className="rounded" />
+      <Image src={thumbnail} alt={`${title} icon`} width={64} height={64} className="rounded" />
       <div className="space-y-2">
         <h3 className="font-bold">{title}</h3>
         <ul className="list-disc list-inside text-sm space-y-1">

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -76,7 +76,7 @@ export default function Taskbar(props) {
                     height={24}
                     className="w-5 h-5 transition-transform duration-200 ease-out group-hover:scale-110"
                     src={app.icon.replace('./', '/')}
-                    alt=""
+                    alt={app.title}
                     sizes="24px"
                 />
                 <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -149,7 +149,7 @@ const AppsPage = () => {
                 {app.icon && (
                   <Image
                     src={app.icon}
-                    alt=""
+                    alt={app.title}
                     width={48}
                     height={48}
                     sizes="48px"


### PR DESCRIPTION
## Summary
- add descriptive alt text to various Next.js `<Image>` components
- annotate decorative duplicates with aria-hidden
- label social icons with alt text

## Testing
- `yarn lint` *(fails: --workspace-root may only be used inside a workspace)*
- `yarn test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68bf70d6246c83289181c7d9cf21953a