### PR TITLE
Guard worker initialization for SSR

### DIFF
--- a/components/FixturesLoader.tsx
+++ b/components/FixturesLoader.tsx
@@ -11,6 +11,7 @@ export default function FixturesLoader({ onData }: LoaderProps) {
   const [worker, setWorker] = useState<Worker | null>(null);
 
   useEffect(() => {
+    if (typeof Worker === 'undefined') return;
     const w = new Worker(new URL('../workers/fixturesParser.ts', import.meta.url));
     w.onmessage = (e) => {
       const { type, payload } = e.data;


### PR DESCRIPTION
## Summary
- avoid server-side errors by guarding worker creation in FixturesLoader

## Testing
- `npx eslint components/FixturesLoader.tsx && echo 'Lint OK'`
- `yarn test components/FixturesLoader.tsx --passWithNoTests`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68bf70da4c648328bff67168286bed04