### PR TITLE
refactor: use namespace React imports in ts files

### DIFF
--- a/__tests__/sensors.spec.ts
+++ b/__tests__/sensors.spec.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import BleSensor from '../components/apps/ble-sensor';
 

--- a/__tests__/weather.spec.ts
+++ b/__tests__/weather.spec.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import WeatherWidget from '../apps/weather_widget';
 

--- a/utils/pointer.ts
+++ b/utils/pointer.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 // Helper to normalize pointer events for both mouse and touch
 // Returns props that can be spread onto an element to handle both


### PR DESCRIPTION
## Summary
- replace default React import with namespace import in TypeScript tests and utility

## Testing
- `npm test -- __tests__/sensors.spec.ts __tests__/weather.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bf70e1a3c483289192d59393e9b940