### PR TITLE
chore: remove unused ESLint config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,7 +1,0 @@
-module.exports = {
-  extends: ['next/core-web-vitals'],
-  rules: {
-    '@next/next/no-page-custom-font': 'off',
-    '@next/next/no-img-element': 'off',
-  },
-};


### PR DESCRIPTION
## Summary
- remove legacy `.eslintrc.cjs` so the repo relies on the flat config

## Testing
- `pnpm -w typecheck` *(fails: --workspace-root may only be used inside a workspace)*
- `yarn eslint .` *(fails: 500 problems (500 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68bf70bdad6c8328a5ae5cd8398b919e