### PR TITLE
Guard browser globals for SSR safety

### DIFF
--- a/apps/chrome/components/AddressBar.tsx
+++ b/apps/chrome/components/AddressBar.tsx
@@ -46,14 +46,18 @@ export default function AddressBar({ url, onNavigate }: Props) {
     if (index <= 0) return;
     const newIndex = index - 1;
     setIndex(newIndex);
-    onNavigate(history[newIndex]);
+    if (history[newIndex]) {
+      onNavigate(history[newIndex]);
+    }
   };
 
   const goForward = () => {
     if (index >= history.length - 1) return;
     const newIndex = index + 1;
     setIndex(newIndex);
-    onNavigate(history[newIndex]);
+    if (history[newIndex]) {
+      onNavigate(history[newIndex]);
+    }
   };
 
   const addBookmark = () => {
@@ -93,6 +97,7 @@ export default function AddressBar({ url, onNavigate }: Props) {
         value={input}
         onChange={(e) => setInput(e.target.value)}
         onKeyDown={(e) => e.key === 'Enter' && go()}
+        aria-label="Address bar"
       />
       <button type="button" onClick={go} className="px-2 border rounded">
         Go

--- a/apps/ettercap/components/FilterEditor.tsx
+++ b/apps/ettercap/components/FilterEditor.tsx
@@ -57,9 +57,11 @@ export default function FilterEditor() {
   );
 
   const saveSample = () => {
-    const name = window.prompt('Sample name');
-    if (!name) return;
-    setSamples((s) => [...s, { name, code: filterText }]);
+    if (typeof window !== 'undefined') {
+      const name = window.prompt('Sample name');
+      if (!name) return;
+      setSamples((s) => [...s, { name, code: filterText }]);
+    }
   };
 
   return (
@@ -89,6 +91,7 @@ export default function FilterEditor() {
         className="w-full h-32 border p-2 font-mono"
         value={filterText}
         onChange={(e) => setFilterText(e.target.value)}
+        aria-label="Filter code"
       />
       <div className="grid grid-cols-2 gap-4">
         <div>

--- a/apps/input-lab/index.tsx
+++ b/apps/input-lab/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { isBrowser } from '@/utils/env';
 import React, { useEffect, useState } from 'react';
 import { evaluate } from 'mathjs';
 
@@ -30,29 +29,32 @@ export default function InputLab() {
   };
 
   const exportLog = () => {
-    const blob = new Blob([JSON.stringify(eventLog, null, 2)], {
-      type: 'application/json',
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'input-lab-log.json';
-    a.click();
-    URL.revokeObjectURL(url);
+    if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+      const blob = new Blob([JSON.stringify(eventLog, null, 2)], {
+        type: 'application/json',
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'input-lab-log.json';
+      a.click();
+      URL.revokeObjectURL(url);
+    }
   };
 
   // Load saved text on mount
   useEffect(() => {
-    if (!isBrowser()) return;
-    const saved = window.localStorage.getItem(SAVE_KEY);
-    if (saved) setText(saved);
+    if (typeof window !== 'undefined') {
+      const saved = window.localStorage.getItem(SAVE_KEY);
+      if (saved) setText(saved);
+    }
   }, []);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const val = e.target.value;
     setText(val);
     setError('');
-    if (isBrowser()) {
+    if (typeof window !== 'undefined') {
       window.localStorage.setItem(SAVE_KEY, val);
     }
   };

--- a/apps/weather/components/Alerts.tsx
+++ b/apps/weather/components/Alerts.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect } from "react";
 import usePersistentState from "../../../hooks/usePersistentState";
-import { isBrowser } from '@/utils/env';
 
 interface AlertsProps {
   latitude: number;
@@ -30,7 +29,7 @@ const Alerts = ({ latitude, longitude }: AlertsProps) => {
   );
 
   useEffect(() => {
-    if (!enabled || !isBrowser()) return;
+    if (!enabled || typeof window === "undefined") return;
     if ("Notification" in window && Notification.permission === "default") {
       void Notification.requestPermission();
     }
@@ -74,7 +73,7 @@ const Alerts = ({ latitude, longitude }: AlertsProps) => {
     const handleFocus = () => start();
     const handleBlur = () => stop();
 
-    if (document.hasFocus()) start();
+    if (typeof document !== "undefined" && document.hasFocus()) start();
 
     window.addEventListener("focus", handleFocus);
     window.addEventListener("blur", handleBlur);
@@ -88,35 +87,38 @@ const Alerts = ({ latitude, longitude }: AlertsProps) => {
 
   return (
     <div className="space-y-2 p-2">
-      <label className="flex items-center space-x-2">
-        <input
-          type="checkbox"
-          checked={enabled}
-          onChange={(e) => setEnabled(e.target.checked)}
-        />
-        <span>Enable alerts</span>
-      </label>
-      <div className="flex space-x-4">
-        <label className="flex items-center space-x-1">
-          <span>Low</span>
+        <label className="flex items-center space-x-2">
           <input
-            type="number"
-            value={low}
-            onChange={(e) => setLow(Number(e.target.value))}
-            className="w-16 text-black"
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            aria-label="Enable alerts"
           />
+          <span>Enable alerts</span>
         </label>
-        <label className="flex items-center space-x-1">
-          <span>High</span>
-          <input
-            type="number"
-            value={high}
-            onChange={(e) => setHigh(Number(e.target.value))}
-            className="w-16 text-black"
-          />
-        </label>
+        <div className="flex space-x-4">
+          <label className="flex items-center space-x-1">
+            <span>Low</span>
+            <input
+              type="number"
+              value={low}
+              onChange={(e) => setLow(Number(e.target.value))}
+              className="w-16 text-black"
+              aria-label="Low temperature"
+            />
+          </label>
+          <label className="flex items-center space-x-1">
+            <span>High</span>
+            <input
+              type="number"
+              value={high}
+              onChange={(e) => setHigh(Number(e.target.value))}
+              className="w-16 text-black"
+              aria-label="High temperature"
+            />
+          </label>
+        </div>
       </div>
-    </div>
   );
 };
 

--- a/utils/clipboard.ts
+++ b/utils/clipboard.ts
@@ -1,8 +1,8 @@
 export const copyToClipboard = async (text: string): Promise<boolean> => {
   try {
-    if (navigator?.clipboard?.writeText) {
+    if (typeof window !== 'undefined' && navigator?.clipboard?.writeText) {
       await navigator.clipboard.writeText(text);
-    } else {
+    } else if (typeof window !== 'undefined' && typeof document !== 'undefined') {
       const textarea = document.createElement('textarea');
       textarea.value = text;
       textarea.style.position = 'fixed';


### PR DESCRIPTION
## Summary
- wrap browser-only APIs in `if (typeof window !== 'undefined')`
- label form controls to satisfy lint rules
- avoid undefined history entries in AddressBar navigation

## Testing
- `npx eslint apps/ettercap/components/FilterEditor.tsx apps/weather/components/Alerts.tsx apps/input-lab/index.tsx utils/clipboard.ts apps/chrome/components/AddressBar.tsx`
- `yarn test` *(fails: Missing modules, TypeError: Cannot set properties of undefined)*
- `yarn build` *(fails: AttachmentCarousel.tsx - 'file' is possibly 'undefined')*

------
https://chatgpt.com/codex/tasks/task_e_68bf70c3e2fc83288781fa39e4792335