### PR TITLE
refactor: use next image for local assets

### DIFF
--- a/components/apps/reversi.js
+++ b/components/apps/reversi.js
@@ -1,5 +1,6 @@
 import { isBrowser } from '@/utils/env';
 import React, { useState, useRef, useEffect, useCallback } from 'react';
+import Image from 'next/image';
 import {
   SIZE,
   DIRECTIONS,
@@ -415,7 +416,7 @@ const Reversi = () => {
           onClick={reset}
           aria-label="Reset"
         >
-          <img src="/themes/Yaru/status/chrome_refresh.svg" width="24" height="24" alt="" />
+          <Image src="/themes/Yaru/status/chrome_refresh.svg" width={24} height={24} alt="" />
         </button>
         <button
           className="w-6 h-6 bg-gray-700 hover:bg-gray-600 rounded flex items-center justify-center disabled:opacity-50"

--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -1,5 +1,6 @@
 import { isBrowser } from '@/utils/env';
 import React, { useEffect, useRef, useState, useCallback } from 'react';
+import Image from 'next/image';
 import * as chrono from 'chrono-node';
 import { RRule } from 'rrule';
 import { parseRecurring } from '../../apps/todoist/utils/recurringParser';
@@ -673,7 +674,7 @@ export default function Todoist() {
         </h2>
         {filtered.length === 0 ? (
           <div className="flex flex-col items-center text-gray-500 mt-3">
-            <img src="/empty-tasks.svg" alt="" className="w-16 h-16 mb-1.5" />
+            <Image src="/empty-tasks.svg" alt="" className="mb-1.5" width={64} height={64} />
             <span className="text-sm">No tasks</span>
           </div>
         ) : (

--- a/components/home/KaliEverywhere.tsx
+++ b/components/home/KaliEverywhere.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import SectionDivider from "../ui/SectionDivider";
 
 interface Platform {
@@ -8,6 +9,8 @@ interface Platform {
     src: string;
     href: string;
     alt: string;
+    width: number;
+    height: number;
   };
 }
 
@@ -35,6 +38,8 @@ const platforms: Platform[] = [
       src: "/badges/containers.svg",
       href: "https://www.kali.org/docs/containers",
       alt: "Containers badge",
+      width: 120,
+      height: 20,
     },
   },
   {
@@ -60,6 +65,8 @@ const platforms: Platform[] = [
       src: "/badges/wsl.svg",
       href: "https://aka.ms/wslstorepage",
       alt: "WSL badge",
+      width: 80,
+      height: 20,
     },
   },
 ];
@@ -80,7 +87,12 @@ export default function KaliEverywhere() {
             <p className="text-sm text-muted">{p.description}</p>
             {p.badge && (
               <a href={p.badge.href} target="_blank" rel="noopener" className="mt-2">
-                <img src={p.badge.src} alt={p.badge.alt} className="h-6" />
+                <Image
+                  src={p.badge.src}
+                  alt={p.badge.alt}
+                  width={p.badge.width}
+                  height={p.badge.height}
+                />
               </a>
             )}
           </div>

--- a/pages/get-kali/index.tsx
+++ b/pages/get-kali/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 import Callout from '../../components/ui/Callout';
 
 const GetKali: React.FC = () => (
@@ -39,9 +40,9 @@ const GetKali: React.FC = () => (
         <h2 className="mb-2 text-xl font-semibold">Cloud</h2>
         <p className="mb-4">Deploy Kali on popular cloud providers for on-demand access from anywhere.</p>
         <div className="mb-4 flex gap-2">
-          <img src="/icons/providers/aws.svg" alt="AWS" className="h-6 w-6" />
-          <img src="/icons/providers/azure.svg" alt="Azure" className="h-6 w-6" />
-          <img src="/icons/providers/gcp.svg" alt="GCP" className="h-6 w-6" />
+          <Image src="/icons/providers/aws.svg" alt="AWS" className="h-6 w-6" width={24} height={24} />
+          <Image src="/icons/providers/azure.svg" alt="Azure" className="h-6 w-6" width={24} height={24} />
+          <Image src="/icons/providers/gcp.svg" alt="GCP" className="h-6 w-6" width={24} height={24} />
         </div>
         <a
           href="https://www.kali.org/get-kali/#kali-cloud"


### PR DESCRIPTION
## Summary
- replace image tags referencing local files with Next.js Image in Get Kali page
- switch Reversi and Todoist apps to Next.js Image for local icons
- enhance Kali Everywhere badges with explicit dimensions and Next.js Image

## Testing
- `npm run lint -- pages/get-kali/index.tsx components/apps/reversi.js components/apps/todoist.js components/home/KaliEverywhere.tsx`
- `npm test` *(fails: Missing allowlist entries in __tests__/csp.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bf70d6a9d48328b04e6795ff93f530