### PR TITLE
Load compiled worker scripts

### DIFF
--- a/apps/timer_stopwatch/main.js
+++ b/apps/timer_stopwatch/main.js
@@ -53,7 +53,7 @@ function updateBreakDisplay() {
 }
 
 function startTimerWorker(tick) {
-  timerWorker = new Worker(new URL('../../workers/timer.worker.ts', import.meta.url));
+  timerWorker = new Worker(new URL('../../workers/timer.worker.js', import.meta.url));
   timerWorker.onmessage = () => {
     timerRemaining = Math.max(0, Math.ceil((timerEndTime - Date.now()) / 1000));
     tick();
@@ -164,7 +164,7 @@ function loadStopwatchState() {
 function startWatch() {
   if (stopwatchWorker || typeof Worker !== 'function') return;
   stopwatchStartTime = Date.now() - stopwatchElapsed * 1000;
-  stopwatchWorker = new Worker(new URL('../../workers/timer.worker.ts', import.meta.url));
+  stopwatchWorker = new Worker(new URL('../../workers/timer.worker.js', import.meta.url));
   stopwatchWorker.onmessage = () => {
     stopwatchElapsed = Math.floor((Date.now() - stopwatchStartTime) / 1000);
     updateStopwatchDisplay();

--- a/components/apps/Games/common/canvas/index.tsx
+++ b/components/apps/Games/common/canvas/index.tsx
@@ -34,7 +34,7 @@ const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       // Prefer OffscreenCanvas with a worker when supported
       if (typeof Worker === 'function' && hasOffscreenCanvas()) {
         const worker = new Worker(
-          new URL('../../../../../workers/game-loop.worker.ts', import.meta.url)
+          new URL('../../../../../workers/game-loop.worker.js', import.meta.url)
         );
         workerRef.current = worker;
         const offscreen = canvas.transferControlToOffscreen();

--- a/components/apps/qr_tool/index.tsx
+++ b/components/apps/qr_tool/index.tsx
@@ -30,7 +30,7 @@ const QRTool: React.FC = () => {
       typeof Worker === 'function'
     ) {
       workerRef.current = new Worker(
-        new URL('../../../workers/qrEncode.worker.ts', import.meta.url),
+        new URL('../../../workers/qrEncode.worker.js', import.meta.url),
       );
     }
     return workerRef.current;

--- a/components/panel/Timer.tsx
+++ b/components/panel/Timer.tsx
@@ -57,7 +57,7 @@ export default function Timer() {
     setRemaining(totalSeconds);
     setRunning(true);
     workerRef.current = new Worker(
-      new URL("../../workers/timer.worker.ts", import.meta.url)
+      new URL("../../workers/timer.worker.js", import.meta.url)
     );
     workerRef.current.onmessage = () => {
       const left = Math.max(

--- a/components/simulator/index.tsx
+++ b/components/simulator/index.tsx
@@ -30,7 +30,7 @@ const Simulator: React.FC = () => {
 
   useEffect(() => {
     const worker = new Worker(
-      new URL('../../workers/simulatorParser.worker.ts', import.meta.url),
+      new URL('../../workers/simulatorParser.worker.js', import.meta.url),
     );
     workerRef.current = worker;
     worker.onmessage = (e: MessageEvent<SimulatorParserResponse>) => {

--- a/workers/game-loop.worker.js
+++ b/workers/game-loop.worker.js
@@ -1,0 +1,73 @@
+let canvas;
+let ctx = null;
+let width = 0;
+let height = 0;
+let x = 0;
+let dir = 1;
+let last = 0;
+
+function raf(cb) {
+  const rAF = self.requestAnimationFrame;
+  if (typeof rAF === 'function') return rAF(cb);
+  return self.setTimeout(() => cb(performance.now()), 16);
+}
+
+function start() {
+  last = performance.now();
+  raf(loop);
+}
+
+function loop(now) {
+  const dt = (now - last) / 1000;
+  last = now;
+  update(dt);
+  draw();
+  raf(loop);
+}
+
+function update(dt) {
+  x += dir * dt * 100;
+  if (x < 0) {
+    x = 0;
+    dir = 1;
+  } else if (x > width - 20) {
+    x = width - 20;
+    dir = -1;
+  }
+}
+
+function draw() {
+  if (!ctx) return;
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = '#0f0';
+  ctx.fillRect(x, height / 2 - 10, 20, 20);
+}
+
+self.onmessage = (e) => {
+  const { type } = e.data || {};
+  if (type === 'init') {
+    canvas = e.data.canvas;
+    width = e.data.width;
+    height = e.data.height;
+    const dpr = e.data.dpr || 1;
+    ctx = canvas.getContext('2d');
+    if (ctx) {
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+    start();
+  } else if (type === 'resize') {
+    width = e.data.width;
+    height = e.data.height;
+    const dpr = e.data.dpr || 1;
+    if (canvas && ctx) {
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+  }
+};
+
+export {};
+

--- a/workers/qrEncode.worker.js
+++ b/workers/qrEncode.worker.js
@@ -1,0 +1,16 @@
+import QRCode from 'qrcode';
+
+self.onmessage = async ({ data }) => {
+  const { text, opts } = data;
+  try {
+    const value = text || ' ';
+    const png = await QRCode.toDataURL(value, opts);
+    const svg = await QRCode.toString(value, { ...opts, type: 'svg' });
+    self.postMessage({ png, svg });
+  } catch {
+    self.postMessage({ png: '', svg: '' });
+  }
+};
+
+export {};
+

--- a/workers/simulatorParser.worker.js
+++ b/workers/simulatorParser.worker.js
@@ -1,0 +1,37 @@
+let cancelled = false;
+
+self.onmessage = ({ data }) => {
+  if (data.action === 'parse') {
+    cancelled = false;
+    const lines = data.text.split(/\r?\n/);
+    const total = lines.length;
+    const start = Date.now();
+    const parsed = [];
+    for (let i = 0; i < lines.length; i++) {
+      if (cancelled) {
+        self.postMessage({ type: 'cancelled' });
+        return;
+      }
+      const line = lines[i];
+      const [key, ...rest] = line.split(':');
+      parsed.push({
+        line: i + 1,
+        key: key.trim(),
+        value: rest.join(':').trim(),
+        raw: line,
+      });
+      if (i % 100 === 0) {
+        const progress = (i + 1) / total;
+        const elapsed = Date.now() - start;
+        const eta = progress > 0 ? (elapsed * (1 - progress)) / progress : 0;
+        self.postMessage({ type: 'progress', progress, eta });
+      }
+    }
+    self.postMessage({ type: 'done', parsed });
+  } else if (data.action === 'cancel') {
+    cancelled = true;
+  }
+};
+
+export {};
+

--- a/workers/timer.worker.js
+++ b/workers/timer.worker.js
@@ -1,0 +1,21 @@
+let intervalId = null;
+
+self.onmessage = ({ data }) => {
+  if (data.action === 'start') {
+    const { interval } = data;
+    if (typeof interval === 'number') {
+      if (intervalId !== null) {
+        clearInterval(intervalId);
+      }
+      intervalId = self.setInterval(() => self.postMessage('tick'), interval);
+    }
+  } else if (data.action === 'stop') {
+    if (intervalId !== null) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  }
+};
+
+export {};
+


### PR DESCRIPTION
## Summary
- use type-only import for simulator worker
- load `.worker.js` instead of `.worker.ts`
- add JavaScript worker implementations

## Testing
- `npm run lint -- components/panel/Timer.tsx components/apps/qr_tool/index.tsx components/simulator/index.tsx components/apps/Games/common/canvas/index.tsx apps/timer_stopwatch/main.js workers/game-loop.worker.js workers/qrEncode.worker.js workers/simulatorParser.worker.js workers/timer.worker.js`
- `npm test` *(fails: TypeError in apps/terminal/index.tsx and CSP allowlist issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bf70d8afd883288a10f29a48f46db8