### PR TITLE
fix: handle undefined attachment in carousel

### DIFF
--- a/apps/contact/components/AttachmentCarousel.tsx
+++ b/apps/contact/components/AttachmentCarousel.tsx
@@ -29,6 +29,7 @@ const AttachmentCarousel: React.FC<AttachmentCarouselProps> = ({
   if (!attachments.length) return null;
 
   const file = attachments[index];
+  if (!file) return null;
   const url = urls[index];
   const isImage = file.type.startsWith('image/');
 


### PR DESCRIPTION
## Summary
- prevent crash when current attachment is undefined

## Testing
- `yarn test apps/contact/components/AttachmentCarousel.tsx --passWithNoTests`
- `./node_modules/.bin/eslint apps/contact/components/AttachmentCarousel.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf76db36cc832896efd02dc3c9cd33