### PR TITLE
fix: adjust dynamic app imports

### DIFF
--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
-import { logEvent } from './analytics';
-import ErrorBoundary from '../components/core/ErrorBoundary';
+import { logEvent } from '@/utils/analytics';
+import ErrorBoundary from '@/components/core/ErrorBoundary';
 
-const APP_DIR = '../apps';
+const APP_DIR = '@/apps';
 
 export const createDynamicApp = (id, title) => {
   const DynamicApp = dynamic(
@@ -12,26 +12,26 @@ export const createDynamicApp = (id, title) => {
         let mod;
         try {
           mod = await import(
-            /* webpackInclude: /\.(js|jsx|ts|tsx)$/,
-               webpackExclude: /\.test\.(js|jsx|ts|tsx)$/,
-               webpackChunkName: "[request]",
-               webpackPrefetch: true */ `../apps/${id}`
+            /* webpackInclude: /\.(js|jsx|ts|tsx)$/, 
+               webpackExclude: /\.test\.(js|jsx|ts|tsx)$/, 
+               webpackChunkName: "[request]", 
+               webpackPrefetch: true */ `@/apps/${id}`
           );
         } catch {
           try {
             mod = await import(
-              /* webpackInclude: /\.(js|jsx|ts|tsx)$/,
-                 webpackExclude: /\.test\.(js|jsx|ts|tsx)$/,
-                 webpackChunkName: "[request]",
-                 webpackPrefetch: true */ `../apps/${id}/index`
+              /* webpackInclude: /\.(js|jsx|ts|tsx)$/, 
+                 webpackExclude: /\.test\.(js|jsx|ts|tsx)$/, 
+                 webpackChunkName: "[request]", 
+                 webpackPrefetch: true */ `@/apps/${id}/index`
             );
           } catch {
             try {
               mod = await import(
-                /* webpackInclude: /\.(js|jsx|ts|tsx)$/,
-                   webpackExclude: /\.test\.(js|jsx|ts|tsx)$/,
-                   webpackChunkName: "[request]",
-                   webpackPrefetch: true */ `../apps/${id.replace('_', '-')}`
+                /* webpackInclude: /\.(js|jsx|ts|tsx)$/, 
+                   webpackExclude: /\.test\.(js|jsx|ts|tsx)$/, 
+                   webpackChunkName: "[request]", 
+                   webpackPrefetch: true */ `@/apps/${id.replace('_', '-')}`
               );
             } catch {
               console.warn(


### PR DESCRIPTION
## Summary
- update createDynamicApp to load apps via root alias

## Testing
- `yarn test __tests__/appLoadError.test.tsx`
- `npx eslint utils/createDynamicApp.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf76c8d66c8328842012f137797cbc