### PR TITLE
fix: handle unit initialization and rate lookups

### DIFF
--- a/apps/converter/index.tsx
+++ b/apps/converter/index.tsx
@@ -96,9 +96,10 @@ export default function Converter() {
   useEffect(() => {
     const data = rates[active as Domain];
     const units = Object.keys(data);
-    if (units.length) {
-      setFromUnit(units[0]);
-      setToUnit(units[1] || units[0]);
+    const first = units[0];
+    if (first !== undefined) {
+      setFromUnit(first);
+      setToUnit(units[1] ?? first);
     }
     setFromValue("");
     setToValue("");
@@ -127,7 +128,13 @@ export default function Converter() {
       return;
     }
     const data = rates[active as Domain];
-    const result = (n * data[toUnit]) / data[fromUnit];
+    const toRate = data[toUnit];
+    const fromRate = data[fromUnit];
+    if (toRate === undefined || fromRate === undefined) {
+      setToValue("");
+      return;
+    }
+    const result = (n * toRate) / fromRate;
     const out = result.toString();
     setToValue(out);
     addHistory(val, fromUnit, out, toUnit);
@@ -140,8 +147,14 @@ export default function Converter() {
       setFromValue("");
       return;
     }
-    const data = rates[active];
-    const result = (n * data[fromUnit]) / data[toUnit];
+    const data = rates[active as Domain];
+    const fromRate = data[fromUnit];
+    const toRate = data[toUnit];
+    if (fromRate === undefined || toRate === undefined) {
+      setFromValue("");
+      return;
+    }
+    const result = (n * fromRate) / toRate;
     const out = result.toString();
     setFromValue(out);
     addHistory(out, fromUnit, val, toUnit);


### PR DESCRIPTION
## Summary
- guard against undefined units when initializing converter
- add undefined checks for conversion rates

## Testing
- `yarn run build` *(fails: Argument of type '{ id: number; protocol?: string; host?: string; path?: string; }[]' is not assignable to parameter of type 'SetStateAction<{ protocol: string; host: string; path: string; }[]>' in apps/dsniff/components/StressSandbox.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7ab181688328a9246e93c41502e4