### PR TITLE
fix(appfinder): ensure desktop entries have both key and value

### DIFF
--- a/src/apps/appfinder/AppFinder.tsx
+++ b/src/apps/appfinder/AppFinder.tsx
@@ -63,9 +63,13 @@ function parseDesktopFile(contents: string): DesktopEntry | null {
     }
     if (!inEntry) continue;
     const m = line.match(/^([^=]+)=(.*)$/);
-    if (m) {
-      const [, key, value] = m;
+    if (m && m[1] && m[2]) {
+      const key = m[1];
+      const value = m[2];
       data[key.trim()] = value.trim();
+    } else {
+      // Skip lines without a valid key/value pair
+      continue;
     }
   }
   if (!data.Name || !data.Exec) return null;


### PR DESCRIPTION
## Summary
- skip malformed lines in AppFinder desktop file parser when key/value pair missing

## Testing
- `npx eslint src/apps/appfinder/AppFinder.tsx` (file ignored by ESLint rules)
- `yarn test src/apps/appfinder/AppFinder.tsx --passWithNoTests`
- `pnpm typecheck` (fails: argument type errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_68bf82a92dd48328bbf7fa0fce6afd14