### PR TITLE
Remove nmconnection .ts import

### DIFF
--- a/scripts/generate-nmconnection-previews.ts
+++ b/scripts/generate-nmconnection-previews.ts
@@ -1,6 +1,6 @@
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { join, basename } from 'node:path';
-import { toKeyfile, NMConnection } from '../utils/nmconnection.ts';
+import { toKeyfile, NMConnection } from '../utils/nmconnection';
 import logger from '../utils/logger';
 
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
+    "allowImportingTsExtensions": false,
     "isolatedModules": true,
     // Next.js handles the JSX transform internally; preserve JSX for its compiler
     "jsx": "preserve",


### PR DESCRIPTION
## Summary
- import nmconnection utility without `.ts` extension
- disallow `.ts` extensions in TypeScript imports

## Testing
- `npm test` *(fails: Missing allowlist entries; Playwright browser missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf82a875948328a38fa5de37f2a6ec