### PR TITLE
safeguard undefined file in slideshow

### DIFF
--- a/apps/settings/components/BackgroundSlideshow.tsx
+++ b/apps/settings/components/BackgroundSlideshow.tsx
@@ -38,6 +38,7 @@ export default function BackgroundSlideshow() {
     }
     const run = () => {
       const file = selected[indexRef.current % selected.length];
+      if (!file) return;
       const base = file.replace(/\.[^.]+$/, '');
       setWallpaper(base);
       indexRef.current = (indexRef.current + 1) % selected.length;


### PR DESCRIPTION
## Summary
- avoid accessing wallpaper base name if file is undefined in slideshow

## Testing
- `npx eslint apps/settings/components/BackgroundSlideshow.tsx`
- `yarn test apps/settings/components/BackgroundSlideshow.tsx --passWithNoTests`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bf8896804c8328bc5f5027de3923bb