### PR TITLE
fix autostart entry type assignment

### DIFF
--- a/apps/settings/session-startup/autostart.tsx
+++ b/apps/settings/session-startup/autostart.tsx
@@ -56,7 +56,11 @@ export default function AutostartSettings() {
   const updateUser = (idx: number, changes: Partial<Entry>) => {
     setUserEntries((prev) => {
       const next = [...prev];
-      next[idx] = { ...next[idx], ...changes };
+      // Merging in partial updates preserves required fields from the existing
+      // entry, but TypeScript loses this information when spreading the
+      // `changes` object (which marks all properties optional). Cast the
+      // result back to `Entry` to satisfy the type checker.
+      next[idx] = { ...next[idx], ...changes } as Entry;
       persist(next);
       return next;
     });


### PR DESCRIPTION
## Summary
- ensure merging user entry updates preserves required fields by casting to Entry

## Testing
- `yarn typecheck && echo 'typecheck succeeded'`
- `npx playwright test tests/e2e/autostart.spec.ts` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8a18b9788328b1260fdfbe2c1d67