### PR TITLE
Fix timeline month type handling

### DIFF
--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -29,7 +29,11 @@ const ScrollableTimeline: React.FC = () => {
 
   const milestonesByYear = useMemo(() => {
     return milestones.reduce<Record<string, GroupedMilestone[]>>((acc, m) => {
-      const [year, month] = m.date.split('-');
+      // m.date is expected to be in the format YYYY-MM. If the month
+      // portion is missing for any reason, default to an empty string so the
+      // GroupedMilestone type requirement is satisfied and the UI gracefully
+      // handles the missing data instead of causing a type error.
+      const [year, month = ''] = m.date.split('-');
       const entry: GroupedMilestone = { ...m, month };
       (acc[year] = acc[year] || []).push(entry);
       return acc;


### PR DESCRIPTION
## Summary
- prevent undefined month values from breaking timeline grouping

## Testing
- `yarn typecheck`
- `yarn test __tests__/scrollableTimeline.test.tsx`
- `yarn lint components/ScrollableTimeline.tsx` *(fails: numerous existing repo lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8c7915f883289d57092707f7eedb