### PR TITLE
fix: handle missing year in timeline

### DIFF
--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -29,11 +29,12 @@ const ScrollableTimeline: React.FC = () => {
 
   const milestonesByYear = useMemo(() => {
     return milestones.reduce<Record<string, GroupedMilestone[]>>((acc, m) => {
-      // m.date is expected to be in the format YYYY-MM. If the month
-      // portion is missing for any reason, default to an empty string so the
+      // m.date is expected to be in the format YYYY-MM. If the month portion
+      // is missing for any reason, default to an empty string so the
       // GroupedMilestone type requirement is satisfied and the UI gracefully
       // handles the missing data instead of causing a type error.
       const [year, month = ''] = m.date.split('-');
+      if (!year) return acc;
       const entry: GroupedMilestone = { ...m, month };
       (acc[year] = acc[year] || []).push(entry);
       return acc;


### PR DESCRIPTION
## Summary
- avoid indexing milestones with undefined year

## Testing
- `yarn typecheck`
- `yarn test` *(fails: Missing Chromes, modules, and other env-related issues)*
- `yarn build` *(terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8ee0b8d88328b71276d954747883