### PR TITLE
Guard against undefined year in ScrollableTimeline

### DIFF
--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -32,8 +32,10 @@ const ScrollableTimeline: React.FC = () => {
       // m.date is expected to be in the format YYYY-MM. If the month
       // portion is missing for any reason, default to an empty string so the
       // GroupedMilestone type requirement is satisfied and the UI gracefully
-      // handles the missing data instead of causing a type error.
+      // handles the missing data. If the year is missing entirely we skip the
+      // entry to avoid indexing the accumulator with `undefined`.
       const [year, month = ''] = m.date.split('-');
+      if (!year) return acc;
       const entry: GroupedMilestone = { ...m, month };
       (acc[year] = acc[year] || []).push(entry);
       return acc;


### PR DESCRIPTION
## Summary
- skip milestones without a year when grouping timeline data to prevent undefined index errors

## Testing
- `npx eslint components/ScrollableTimeline.tsx`
- `yarn typecheck`
- `yarn test ScrollableTimeline`
- `yarn lint` *(fails: App 'radare2' imported from both 'apps/radare2' and 'components/apps/radare2' no-dupe-app-imports/no-dupe-app-imports and other pre-existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8ef6935c8328b996b558c1341422