### PR TITLE
fix: handle missing year in timeline

### DIFF
--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -45,7 +45,12 @@ const ScrollableTimeline: React.FC = () => {
 
   const monthItems = useMemo(() => {
     if (!selectedYear) return [] as GroupedMilestone[];
-    return milestonesByYear[selectedYear].sort((a, b) => a.month.localeCompare(b.month));
+    // If the selected year doesn't exist in the milestones map, default to an
+    // empty array to prevent runtime errors. Spread into a new array before
+    // sorting to avoid mutating the original data structure.
+    return [...(milestonesByYear[selectedYear] ?? [])].sort((a, b) =>
+      a.month.localeCompare(b.month),
+    );
   }, [milestonesByYear, selectedYear]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- guard against undefined selectedYear in ScrollableTimeline

## Testing
- `yarn test __tests__/scrollableTimeline.test.tsx`
- `yarn typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68bf915ae884832895f1e8f1941a06d2