### PR TITLE
Add CSP allowlist and stabilize terminal theme init

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,12 @@ These external domains are whitelisted in the default CSP. Update this list when
 | `*.twimg.com` | Twitter asset CDN |
 | `*.x.com` | X (Twitter) domain equivalents |
 | `*.google.com` | Google services and Chrome app favicons |
+| `platform.twitter.com` | Twitter widgets |
+| `syndication.twitter.com` | Twitter syndication |
+| `cdn.syndication.twimg.com` | Twitter CDN |
+| `www.youtube.com` | YouTube embeds |
+| `www.google.com` | Google services |
+| `www.gstatic.com` | Google static assets |
 | `example.com` | Chrome app demo origin |
 | `openweathermap.org` | Weather widget images |
 | `ghchart.rshah.org` | GitHub contribution charts |

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -408,9 +408,13 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(
       container?.addEventListener('contextmenu', handleLinkContext);
       const preset = TERMINAL_THEMES[scheme as keyof typeof TERMINAL_THEMES];
       const bg = hexToRgba(preset.background, opacity);
-      term.options.theme = { ...preset, background: bg };
-      container.style.backgroundColor = bg;
-      container.style.color = preset.foreground;
+      if (term?.options) {
+        term.options.theme = { ...preset, background: bg };
+      }
+      if (container) {
+        container.style.backgroundColor = bg;
+        container.style.color = preset.foreground;
+      }
       if (opfsSupported) {
         dirRef.current = await getDir('terminal');
         const existing = await readFile('history.txt', dirRef.current || undefined);

--- a/next.config.js
+++ b/next.config.js
@@ -17,7 +17,19 @@ try {
 } catch {}
 
 
+const ContentSecurityPolicy = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
+  "connect-src 'self' https://platform.twitter.com https://vercel.live https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://sdk.scdn.co https://example.com https://*.twimg.com https://*.google.com https://open.spotify.com",
+  "img-src 'self' data: blob: https://stackblitz.com https://platform.twitter.com https://vercel.live https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://sdk.scdn.co https://example.com https://*.twimg.com https://*.google.com https://www.youtube-nocookie.com https://open.spotify.com https://react.dev",
+  "frame-src 'self' https://stackblitz.com https://platform.twitter.com https://vercel.live https://www.youtube.com https://www.youtube-nocookie.com https://open.spotify.com",
+].join('; ');
+
 const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: ContentSecurityPolicy,
+  },
   {
     key: 'X-Content-Type-Options',
     value: 'nosniff',


### PR DESCRIPTION
## Summary
- add comprehensive Content-Security-Policy allowlist and header configuration
- document newly allowed CSP domains in README
- guard terminal theme initialization against missing options

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npx jest __tests__/csp.test.ts`
- `npx jest __tests__/a11y.cli.test.ts` *(fails: cannot find Chrome binary)*
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68bf9224bc448328928a1026ae0ce4b2