### PR TITLE
Refactor Nonogram test data to remove ellipsis placeholder

### DIFF
--- a/__tests__/nonogramGame.test.ts
+++ b/__tests__/nonogramGame.test.ts
@@ -19,15 +19,15 @@ describe('games/nonogram logic', () => {
   });
 
   test('loads puzzles from packs', () => {
-    const raw = `
-#..
-##.
-...
-
-.#.
-###
-.#.
-`;
+    const raw = [
+      '#..',
+      '##.',
+      '...',
+      '',
+      '.#.',
+      '###',
+      '.#.',
+    ].join('\n');
     const puzzles = parsePack(raw);
     expect(puzzles).toHaveLength(2);
     expect(puzzles[0].rows).toEqual([[1], [2], []]);


### PR DESCRIPTION
## Summary
- refactor Nonogram pack loading test to build puzzle data from an array and eliminate bare ellipsis lines

## Testing
- `npx eslint .` *(fails: A control must be associated with a text label, duplicate-filenames errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf988a2f84832893690755524700c1