### PR TITLE
chore: remove yarn path configuration

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,3 @@
-yarnPath: .yarn/releases/yarn-4.9.2.cjs
 nodeLinker: node-modules
 
 packageExtensions:


### PR DESCRIPTION
## Summary
- remove local Yarn path so Corepack-managed or global Yarn is used

## Testing
- `corepack enable`
- `yarn --version`
- `yarn test` *(fails: Playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf988e4ac08328af887bad848d9f15