### PR TITLE
Restrict image hosts and align security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,11 @@ These external domains are whitelisted in the default CSP. Update this list when
 | `*.x.com` | X (Twitter) domain equivalents |
 | `*.google.com` | Google services and Chrome app favicons |
 | `example.com` | Chrome app demo origin |
+| `opengraph.githubassets.com` | GitHub Open Graph images |
+| `raw.githubusercontent.com` | GitHub raw content |
+| `avatars.githubusercontent.com` | GitHub avatars |
+| `i.ytimg.com` | YouTube thumbnails |
+| `yt3.ggpht.com` | YouTube channel images |
 | `openweathermap.org` | Weather widget images |
 | `ghchart.rshah.org` | GitHub contribution charts |
 | `data.typeracer.com` | Typing race data |

--- a/__tests__/security-headers.test.ts
+++ b/__tests__/security-headers.test.ts
@@ -8,8 +8,10 @@ describe('security headers', () => {
     const headersList = await config.headers();
     const headerMap = Object.fromEntries(headersList.find((h: any) => h.source === '/(.*)').headers.map((h: any) => [h.key, h.value]));
     expect(headerMap['Permissions-Policy']).toBe(
-      'accelerometer=(), camera=(), microphone=(), geolocation=(), interest-cohort=(), fullscreen=(), payment=()'
+      'camera=(), microphone=(), geolocation=(), interest-cohort=()'
     );
-    expect(headerMap['Referrer-Policy']).toBe('no-referrer');
+    expect(headerMap['Referrer-Policy']).toBe(
+      'strict-origin-when-cross-origin'
+    );
   });
 });

--- a/middleware.ts
+++ b/middleware.ts
@@ -74,10 +74,13 @@ export function middleware(req: NextRequest | { headers: Headers; nextUrl?: URL;
       'max-age=63072000; includeSubDomains; preload'
     );
     res.headers.set('X-Content-Type-Options', 'nosniff');
-    res.headers.set('Referrer-Policy', 'same-origin');
+    res.headers.set(
+      'Referrer-Policy',
+      'strict-origin-when-cross-origin'
+    );
     res.headers.set(
       'Permissions-Policy',
-      'accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()'
+      'camera=(), microphone=(), geolocation=(), interest-cohort=()'
     );
   }
 

--- a/next.config.js
+++ b/next.config.js
@@ -24,12 +24,12 @@ const securityHeaders = [
   },
   {
     key: 'Referrer-Policy',
-    value: 'no-referrer',
+    value: 'strict-origin-when-cross-origin',
   },
   {
     key: 'Permissions-Policy',
     value:
-      'accelerometer=(), camera=(), microphone=(), geolocation=(), interest-cohort=(), fullscreen=(), payment=()',
+      'camera=(), microphone=(), geolocation=(), interest-cohort=()',
   },
   {
     // Allow same-origin framing so the PDF resume renders in an <object>
@@ -168,6 +168,18 @@ module.exports = withBundleAnalyzer(
         'data.typeracer.com',
         'images.credly.com',
         'staticmap.openstreetmap.de',
+      ],
+      remotePatterns: [
+        { protocol: 'https', hostname: 'opengraph.githubassets.com' },
+        { protocol: 'https', hostname: 'raw.githubusercontent.com' },
+        { protocol: 'https', hostname: 'avatars.githubusercontent.com' },
+        { protocol: 'https', hostname: 'i.ytimg.com' },
+        { protocol: 'https', hostname: 'yt3.ggpht.com' },
+        { protocol: 'https', hostname: 'openweathermap.org' },
+        { protocol: 'https', hostname: 'ghchart.rshah.org' },
+        { protocol: 'https', hostname: 'data.typeracer.com' },
+        { protocol: 'https', hostname: 'images.credly.com' },
+        { protocol: 'https', hostname: 'staticmap.openstreetmap.de' },
       ],
       localPatterns: [
         { pathname: '/themes/Yaru/apps/**' },

--- a/scripts/check-security-headers.mjs
+++ b/scripts/check-security-headers.mjs
@@ -29,7 +29,7 @@ if (xcto !== 'nosniff') {
 }
 
 const referrer = res.headers.get('referrer-policy');
-if (referrer !== 'no-referrer') {
+if (referrer !== 'strict-origin-when-cross-origin') {
   fail(`Invalid Referrer-Policy: ${referrer}`);
 }
 


### PR DESCRIPTION
## Summary
- restrict Next.js `images.remotePatterns` to explicit production hosts
- align `Permissions-Policy` and `Referrer-Policy` with production requirements
- document all external image domains in README

## Testing
- `npm test __tests__/remotePatterns.test.ts __tests__/security-headers.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bf9894c11c8328807b3c20eb7fe599