### PR TITLE
feat: add rc-drawer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "prettier": "^3.6.2",
     "prop-types": "^15.8.1",
     "qrcode": "^1.5.4",
+    "rc-drawer": "^7.1.0",
     "rc-virtual-list": "3.19.1",
     "react": "19.1.1",
     "react-activity-calendar": "^2.7.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12047,7 +12047,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-drawer@npm:~7.3.0":
+"rc-drawer@npm:^7.1.0, rc-drawer@npm:~7.3.0":
   version: 7.3.0
   resolution: "rc-drawer@npm:7.3.0"
   dependencies:
@@ -14843,6 +14843,7 @@ __metadata:
     prettier: "npm:^3.6.2"
     prop-types: "npm:^15.8.1"
     qrcode: "npm:^1.5.4"
+    rc-drawer: "npm:^7.1.0"
     rc-virtual-list: "npm:3.19.1"
     react: "npm:19.1.1"
     react-activity-calendar: "npm:^2.7.13"


### PR DESCRIPTION
## Summary
- add rc-drawer package for drawer components

## Testing
- `yarn install`
- `pnpm -w typecheck` (fails: --workspace-root may only be used inside a workspace)
- `yarn test` (fails: ReferenceError: nextConfig is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68bfab4a7e808328b02960350310035a