### PR TITLE
chore: copy gamepad script during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "https://unnippillil.com/",
   "scripts": {
-    "build:gamepad": "tsc -p tsconfig.gamepad.json",
+    "build:gamepad": "tsc -p tsconfig.gamepad.json && node --import tsx/esm scripts/safe-copy.mjs",
     "typegen": "next typegen",
     "prebuild": "rm -rf .next && yarn typegen && yarn build:gamepad",
     "dev": "next dev",

--- a/scripts/safe-copy.mjs
+++ b/scripts/safe-copy.mjs
@@ -1,11 +1,11 @@
 import { access, mkdir, copyFile } from 'node:fs/promises';
 import { constants } from 'node:fs';
-import logger from '../utils/logger';
+import { dirname } from 'node:path';
+import loggerModule from '../utils/logger';
 
-
+const logger = loggerModule.default || loggerModule;
 const src = 'dist/utils/gamepad.js';
-const destDir = 'public/vendor';
-const dest = `${destDir}/gamepad.js`;
+const dest = 'public/vendor/gamepad.js';
 
 try {
   await access(src, constants.F_OK);
@@ -14,6 +14,7 @@ try {
   process.exit(0);
 }
 
-await mkdir(destDir, { recursive: true });
+await mkdir(dirname(dest), { recursive: true });
 await copyFile(src, dest);
 logger.info(`Copied ${src} to ${dest}`);
+


### PR DESCRIPTION
## Summary
- run safe-copy after gamepad TypeScript build
- make copy script more robust

## Testing
- `yarn test` *(fails: ReferenceError: nextConfig is not defined)*
- `node --import tsx/esm scripts/safe-copy.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68bfab4b2bc08328acd64fe2c1f25e72