### PR TITLE
chore: add @tinyhttp/cookie-signature dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.56.1",
     "@tailwindcss/typography": "^0.5.16",
+    "@tinyhttp/cookie-signature": "^4.1.0",
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
     "@vercel/toolbar": "^0.1.38",


### PR DESCRIPTION
## Summary
- add `@tinyhttp/cookie-signature` dependency

## Testing
- `yarn install` *(fails: No candidates found for @tinyhttp/cookie-signature@^4.1.0)*
- `yarn test` *(fails: ReferenceError: nextConfig is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bfab4c2ae88328aae120d099c76190