### PR TITLE
refactor: export Next config via variable

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -120,9 +120,7 @@ function configureWebpack(config, { isServer }) {
   return config;
 }
 
-
-
-module.exports = withBundleAnalyzer(
+const nextConfig = withBundleAnalyzer(
   withExportImages({
     output: isStaticExport ? 'export' : undefined,
     serverExternalPackages: [
@@ -266,6 +264,5 @@ module.exports = withBundleAnalyzer(
       : undefined,
   })
 );
-
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- assign Next.js config to `nextConfig` using `withBundleAnalyzer(withExportImages())`
- export configuration via `module.exports = nextConfig`

## Testing
- `npm test -- next.config.js --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bfab4743488328a70b506582c879c6