### PR TITLE
fix: pin cookie-signature dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.56.1",
     "@tailwindcss/typography": "^0.5.16",
-    "@tinyhttp/cookie-signature": "^4.1.0",
+    "@tinyhttp/cookie-signature": "^1.3.0",
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
     "@vercel/toolbar": "^0.1.38",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3518,7 +3518,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tinyhttp/cookie-signature@npm:1.3.0":
+"@tinyhttp/cookie-signature@npm:1.3.0, @tinyhttp/cookie-signature@npm:^1.3.0":
   version: 1.3.0
   resolution: "@tinyhttp/cookie-signature@npm:1.3.0"
   checksum: 10c0/487534ce57bd449f79973e9e4de5aa057a67c817e5090ea614f22e562a4fb32e69f5540196b0b0d41b4482221f7e1300c301d3a615ca45ac1a54456fb6d27464
@@ -14765,6 +14765,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.6.4"
     "@testing-library/react": "npm:^16.3.0"
     "@testing-library/user-event": "npm:^14.6.1"
+    "@tinyhttp/cookie-signature": "npm:^1.3.0"
     "@types/canvas-confetti": "npm:^1"
     "@types/figlet": "npm:^1"
     "@types/howler": "npm:^2"
@@ -14883,7 +14884,7 @@ __metadata:
     workbox-precaching: "npm:^7.3.0"
     workbox-routing: "npm:^7.3.0"
     workbox-strategies: "npm:^7.3.0"
-
+    workbox-window: "npm:^7.3.0"
     ws: "npm:^8.18.0"
     zod: "npm:^3.23.8"
   languageName: unknown
@@ -15403,7 +15404,6 @@ __metadata:
   linkType: hard
 
 "workbox-core@npm:7.3.0, workbox-core@npm:^7.3.0":
-
   version: 7.3.0
   resolution: "workbox-core@npm:7.3.0"
   checksum: 10c0/b7dce640cd9665ed207f65f5b08a50e2e24e5599790c6ea4fec987539b9d2ef81765d8c5f94acfee3a8a45d5ade8e1a4ebd0b8847a1471302ef75a5b93c7bd04


### PR DESCRIPTION
## Summary
- pin @tinyhttp/cookie-signature to a published release to avoid install failure

## Testing
- `yarn install`
- `yarn test __tests__/apps.smoke.test.tsx` *(fails: Identifier 'utilities' has already been declared)*


------
https://chatgpt.com/codex/tasks/task_e_68bfaeaf831c832880c5010f84be3790