### PR TITLE
chore: pin Yarn 1.22.22 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,8 +190,7 @@
     "@rollup/plugin-replace": "^6.0.2",
     "workbox-build@npm:7.1.0": "npm:workbox-build@7.3.0",
     "workbox-build@npm:7.1.1": "npm:workbox-build@7.3.0",
-
     "three-bmfont-text": "npm:three-bmfont-text@^3.0.1"
   },
-  "packageManager": "yarn@4.9.2"
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
## Summary
- ensure repository uses Yarn 1.22.22 via packageManager field

## Testing
- `yarn test __tests__/csp.test.ts` *(fails: Missing allowlist entries for multiple domains)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb55326788328adcb154d3fb29cc7