### PR TITLE
docs: note next-pwa version and future serwist migration

### DIFF
--- a/PWA.md
+++ b/PWA.md
@@ -1,6 +1,6 @@
 # Progressive Web App
 
-This project uses `next-pwa` with a custom service worker (`sw.ts`) built via Workbox's `injectManifest` mode. The worker allows fine grained control over how each asset is cached so new deployments remain predictable while the site stays fast offline.
+This project uses `@ducanh2912/next-pwa` (currently `^10.2.9`) with a custom service worker (`sw.ts`) built via Workbox's `injectManifest` mode. The worker allows fine-grained control over how each asset is cached so new deployments remain predictable while the site stays fast offline. Upstream recommends migrating to `@serwist/next` when feasible, so monitor its guidance and switch when appropriate.
 
 ## Caching strategy
 


### PR DESCRIPTION
## Summary
- document current `@ducanh2912/next-pwa` usage and version
- mention upstream recommendation to migrate to `@serwist/next`

## Testing
- `yarn lint PWA.md` *(fails: Identifier 'utilities' has already been declared in apps.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb553aac48328a8bc1e47bdb232a7