### PR TITLE
feat: add duplicate export guard

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -1259,8 +1259,5 @@ const apps = [
   },
 ];
 
-export const utilities = [];
-export const gameDefaults = { defaultWidth: 50, defaultHeight: 60 };
-export const games = [];
 
 export default apps;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:gamepad": "tsc -p tsconfig.gamepad.json && node --import tsx/esm scripts/safe-copy.mjs",
     "typegen": "next typegen",
-    "prebuild": "rm -rf .next && yarn typegen && yarn build:gamepad",
+    "prebuild": "rm -rf .next && yarn typegen && yarn build:gamepad && node scripts/check-duplicate-exports.mjs",
     "dev": "next dev",
     "dev:turbo": "next dev --turbo",
     "build": "node scripts/build.mjs",

--- a/scripts/check-duplicate-exports.mjs
+++ b/scripts/check-duplicate-exports.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const targetFile = path.resolve(__dirname, '../apps.config.js');
+
+const content = readFileSync(targetFile, 'utf8');
+const regex = /export const\s+(\w+)/g;
+const counts = new Map();
+let match;
+while ((match = regex.exec(content)) !== null) {
+  const name = match[1];
+  counts.set(name, (counts.get(name) || 0) + 1);
+}
+const duplicates = [...counts.entries()].filter(([, count]) => count > 1);
+if (duplicates.length > 0) {
+  console.error('Duplicate export const declarations detected in apps.config.js:');
+  for (const [name, count] of duplicates) {
+    console.error(` - ${name} (x${count})`);
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add script to detect duplicate `export const` declarations in `apps.config.js`
- run duplicate export check during `prebuild`
- clean redundant exports from `apps.config.js`

## Testing
- `node scripts/check-duplicate-exports.mjs`
- `yarn prebuild`
- `yarn build` *(fails: killed after starting Next.js build due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbce000d88328ad7275cfa697d73d