### PR TITLE
feat: add tictactoe worker and page

### DIFF
--- a/apps/tictactoe/index.tsx
+++ b/apps/tictactoe/index.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+import TicTacToeApp from '../../components/apps/tictactoe';
+
+export default TicTacToeApp;

--- a/workers/tictactoe.worker.js
+++ b/workers/tictactoe.worker.js
@@ -1,0 +1,9 @@
+import { minimax } from '../apps/games/tictactoe/logic';
+
+self.onmessage = (e) => {
+  const { board, player, size, misere } = e.data;
+  const { index } = minimax(board.slice(), player, size, misere);
+  self.postMessage({ index });
+};
+
+export {};

--- a/workers/tictactoe.worker.ts
+++ b/workers/tictactoe.worker.ts
@@ -1,0 +1,16 @@
+import { minimax, Board, Player } from '../apps/games/tictactoe/logic';
+
+type Request = {
+  board: Board;
+  player: Player;
+  size: number;
+  misere: boolean;
+};
+
+self.onmessage = (e: MessageEvent<Request>) => {
+  const { board, player, size, misere } = e.data;
+  const { index } = minimax(board.slice(), player, size, misere);
+  (self as any).postMessage({ index });
+};
+
+export {};


### PR DESCRIPTION
## Summary
- add web worker using minimax engine for tic tac toe AI
- wire React tic tac toe UI to worker and expose app page

## Testing
- `npx tsc workers/tictactoe.worker.ts --target ES2020 --module ESNext --outDir workers --lib es2020,webworker --skipLibCheck`
- `yarn test __tests__/tictactoe.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bfb57da5408328a703680f5d3b0859