### PR TITLE
Restore Ettercap spoofing components

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -89,7 +89,6 @@ export const chromeDefaultTiles = [
 // TODO: restore Evidence Vault (evidence-vault)
 // TODO: restore Mimikatz (mimikatz)
 // TODO: restore Mimikatz Offline (mimikatz/offline)
-// TODO: restore Ettercap (ettercap)
 // TODO: restore Reaver (reaver)
 // TODO: restore Hydra (hydra)
 // TODO: restore John the Ripper (john)

--- a/pages/apps/ettercap.jsx
+++ b/pages/apps/ettercap.jsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const Ettercap = dynamic(() => import('../../apps/ettercap'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function EttercapPage() {
+  return <Ettercap />;
+}

--- a/pages/spoofing.tsx
+++ b/pages/spoofing.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import dynamic from 'next/dynamic';
 import { baseMetadata } from '../lib/metadata';
 
 export const metadata = baseMetadata;
@@ -22,23 +23,9 @@ const ToolTile = ({ title, link, children }: TileProps) => (
   </a>
 );
 
-const ArpDiagram = () => (
-  <svg viewBox="0 0 300 120" className="w-full h-32">
-    <defs>
-      <marker id="arrow-arp" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto" markerUnits="strokeWidth">
-        <path d="M0,0 L0,6 L9,3 z" fill="#4ade80" />
-      </marker>
-    </defs>
-    <rect x="10" y="40" width="80" height="40" fill="#1f2937" stroke="#4ade80" />
-    <text x="50" y="65" fill="white" textAnchor="middle">Victim</text>
-    <rect x="110" y="40" width="80" height="40" fill="#1f2937" stroke="#4ade80" />
-    <text x="150" y="65" fill="white" textAnchor="middle">Attacker</text>
-    <rect x="210" y="40" width="80" height="40" fill="#1f2937" stroke="#4ade80" />
-    <text x="250" y="65" fill="white" textAnchor="middle">Gateway</text>
-    <line x1="90" y1="60" x2="110" y2="60" stroke="#4ade80" strokeWidth="2" markerEnd="url(#arrow-arp)" />
-    <line x1="190" y1="60" x2="210" y2="60" stroke="#4ade80" strokeWidth="2" markerEnd="url(#arrow-arp)" />
-  </svg>
-);
+const ArpDiagram = dynamic(() => import('@/apps/ettercap/components/ArpDiagram'), {
+  ssr: false,
+});
 
 const DnsDiagram = () => (
   <svg viewBox="0 0 300 160" className="w-full h-40">


### PR DESCRIPTION
## Summary
- add dedicated page to load Ettercap app with ARP diagram and filter editor
- reuse Ettercap's interactive ARP diagram on spoofing overview page
- clean registry comments to reflect restored Ettercap app

## Testing
- `yarn test` *(fails: sourcemap-codec missing in lockfile)*
- `yarn lint` *(fails: sourcemap-codec missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb5800bb883288b08c84d7ceee10f