### PR TITLE
feat: add text to ascii tool

### DIFF
--- a/__tests__/textToAscii.test.tsx
+++ b/__tests__/textToAscii.test.tsx
@@ -1,0 +1,10 @@
+import { render, fireEvent } from '@testing-library/react';
+import TextToAscii from '../components/apps/text_to_ascii';
+
+test('converts text to ASCII codes', () => {
+  const { container } = render(<TextToAscii />);
+  const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+  fireEvent.change(textarea, { target: { value: 'ABC' } });
+  const pre = container.querySelector('pre');
+  expect(pre?.textContent).toBe('65 66 67');
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -168,6 +168,7 @@ const NiktoApp = createDynamicApp('nikto', 'Nikto');
 
 const QrApp = createDynamicApp('qr', 'QR Tool');
 const AsciiArtApp = createDynamicApp('ascii_art', 'ASCII Art');
+const TextToAsciiApp = createDynamicApp('text-to-ascii', 'Text to ASCII');
 const QuoteApp = createDynamicApp('quote', 'Quote');
 const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery');
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
@@ -281,6 +282,7 @@ const displayNikto = createDisplay(NiktoApp);
 
 const displayQr = createDisplay(QrApp);
 const displayAsciiArt = createDisplay(AsciiArtApp);
+const displayTextToAscii = createDisplay(TextToAsciiApp);
 const displayQuote = createDisplay(QuoteApp);
 const displayProjectGallery = createDisplay(ProjectGalleryApp);
 const displayTrash = createDisplay(TrashApp);
@@ -352,6 +354,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayAsciiArt,
+  },
+  {
+    id: 'text-to-ascii',
+    title: 'Text to ASCII',
+    icon: '/themes/Yaru/apps/gedit.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayTextToAscii,
   },
   {
     id: 'clipboard-manager',

--- a/apps/text-to-ascii/index.tsx
+++ b/apps/text-to-ascii/index.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+
+const TextToAscii = () => {
+  const [text, setText] = useState('');
+  const ascii = text
+    .split('')
+    .map((ch) => ch.charCodeAt(0))
+    .join(' ');
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(ascii);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-2 bg-ub-cool-grey text-white h-full overflow-auto">
+      <textarea
+        className="w-full p-2 rounded text-black"
+        placeholder="Enter text"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <button
+        type="button"
+        onClick={copy}
+        className="px-2 py-1 bg-blue-600 rounded"
+      >
+        Copy
+      </button>
+      <pre className="p-2 bg-black text-green-500 rounded min-h-[3rem] whitespace-pre-wrap break-all">{ascii}</pre>
+    </div>
+  );
+};
+
+export default TextToAscii;
+

--- a/components/apps/text_to_ascii/index.tsx
+++ b/components/apps/text_to_ascii/index.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../apps/text-to-ascii';

--- a/pages/apps/text-to-ascii.jsx
+++ b/pages/apps/text-to-ascii.jsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const TextToAsciiPage = dynamic(() => import('../../apps/text-to-ascii'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default TextToAsciiPage;


### PR DESCRIPTION
## Summary
- add Text to ASCII conversion app with copy feature
- expose new page and register app in config
- cover conversion logic with test

## Testing
- `yarn test __tests__/textToAscii.test.tsx __tests__/asciiArt.test.tsx` *(fails: sourcemap-codec missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb58108608328a15a8cca80823f75