### PR TITLE
Add Nonogram puzzle game with page integration

### DIFF
--- a/games/nonogram/components/Board.tsx
+++ b/games/nonogram/components/Board.tsx
@@ -7,16 +7,26 @@ interface BoardProps {
   rows: Clue[];
   cols: Clue[];
   solution: Grid;
+  /** Current state of the puzzle grid. */
+  grid: Grid;
+  /**
+   * Notify parent components when the grid state changes. The provided grid is
+   * a deep copy and can be used directly as new state.
+   */
+  onChange: (grid: Grid) => void;
 }
 
 type Cell = -1 | 0 | 1;
 
-const Board: React.FC<BoardProps> = ({ rows, cols, solution }) => {
+const Board: React.FC<BoardProps> = ({
+  rows,
+  cols,
+  solution,
+  grid,
+  onChange,
+}) => {
   const height = rows.length;
   const width = cols.length;
-  const [grid, setGrid] = useState<Grid>(
-    () => Array.from({ length: height }, () => Array(width).fill(0) as Cell[])
-  );
   const [mode, setMode] = useState<"fill" | "cross">("fill");
   const [errorCell, setErrorCell] = useState<{ i: number; j: number } | null>(
     null
@@ -24,21 +34,19 @@ const Board: React.FC<BoardProps> = ({ rows, cols, solution }) => {
   const [zoom, setZoom] = useState(1);
 
   const toggleCell = (i: number, j: number) => {
-    setGrid((g) => {
-      const ng = g.map((row) => row.slice()) as Grid;
-      const current = ng[i][j];
-      const next: Cell =
-        mode === "fill" ? (current === 1 ? 0 : 1) : current === -1 ? 0 : -1;
-      ng[i][j] = next;
-      if (
-        (next === 1 && solution[i][j] !== 1) ||
-        (next === -1 && solution[i][j] === 1)
-      ) {
-        setErrorCell({ i, j });
-        setTimeout(() => setErrorCell(null), 300);
-      }
-      return ng;
-    });
+    const ng = grid.map((row) => row.slice()) as Grid;
+    const current = ng[i][j];
+    const next: Cell =
+      mode === "fill" ? (current === 1 ? 0 : 1) : current === -1 ? 0 : -1;
+    ng[i][j] = next;
+    if (
+      (next === 1 && solution[i][j] !== 1) ||
+      (next === -1 && solution[i][j] === 1)
+    ) {
+      setErrorCell({ i, j });
+      setTimeout(() => setErrorCell(null), 300);
+    }
+    onChange(ng);
   };
 
   const total = solution.reduce(

--- a/games/nonogram/components/PngImport.tsx
+++ b/games/nonogram/components/PngImport.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import type { Clue, Grid } from "../../../apps/games/nonogram/logic";
 import { lineToClues } from "../../../apps/games/nonogram/logic";
 import Board from "./Board";
@@ -87,6 +87,15 @@ const dataToPuzzle = (data: ByteArray, width: number, height: number) => {
 const PngImport: React.FC = () => {
   const [puzzle, setPuzzle] = useState<ParsedPuzzle | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [grid, setGrid] = useState<Grid>([]);
+
+  useEffect(() => {
+    if (puzzle) {
+      const h = puzzle.rows.length;
+      const w = puzzle.cols.length;
+      setGrid(Array.from({ length: h }, () => Array(w).fill(0)) as Grid);
+    }
+  }, [puzzle]);
 
   const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -111,7 +120,13 @@ const PngImport: React.FC = () => {
       {error && <p className="text-red-600 mt-2">{error}</p>}
       {puzzle && (
         <div className="mt-4">
-          <Board rows={puzzle.rows} cols={puzzle.cols} solution={puzzle.grid} />
+          <Board
+            rows={puzzle.rows}
+            cols={puzzle.cols}
+            solution={puzzle.grid}
+            grid={grid}
+            onChange={setGrid}
+          />
         </div>
       )}
     </div>

--- a/games/nonogram/index.tsx
+++ b/games/nonogram/index.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import GameShell from "../../components/games/GameShell";
+import Board from "./components/Board";
+import HintSystem from "./components/HintSystem";
+import { loadPackFromJSON } from "../../apps/games/nonogram/packs";
+import samplePack from "../../apps/games/nonogram/sample-pack.json";
+import { loadProgress, saveProgress } from "../../apps/games/nonogram/progress";
+import type { Grid } from "../../apps/games/nonogram/logic";
+
+const pack = loadPackFromJSON(JSON.stringify(samplePack));
+
+const NonogramGame: React.FC = () => {
+  const [index, setIndex] = useState(0);
+  const puzzle = pack.puzzles[index];
+  const [grid, setGrid] = useState<Grid>(() =>
+    Array.from({ length: puzzle.rows.length }, () =>
+      Array(puzzle.cols.length).fill(0)
+    ) as Grid
+  );
+  const [hintsUsed, setHintsUsed] = useState(0);
+
+  useEffect(() => {
+    const progress = loadProgress(puzzle.name);
+    if (progress) {
+      setGrid(progress.grid);
+      setHintsUsed(progress.hintsUsed);
+    } else {
+      setGrid(
+        Array.from({ length: puzzle.rows.length }, () =>
+          Array(puzzle.cols.length).fill(0)
+        ) as Grid
+      );
+      setHintsUsed(0);
+    }
+  }, [index, puzzle]);
+
+  const handleGridChange = (g: Grid) => {
+    setGrid(g);
+    saveProgress(puzzle.name, { grid: g, hintsUsed });
+  };
+
+  const handleHint = (hint: { i: number; j: number; value: 1 }) => {
+    const ng = grid.map((row) => row.slice()) as Grid;
+    ng[hint.i][hint.j] = hint.value;
+    const newHints = hintsUsed + 1;
+    setHintsUsed(newHints);
+    saveProgress(puzzle.name, { grid: ng, hintsUsed: newHints });
+    setGrid(ng);
+  };
+
+  const settings = (
+    <div className="space-y-2">
+      <label className="flex items-center gap-2">
+        <span>Puzzle</span>
+        <select
+          value={index}
+          onChange={(e) => setIndex(parseInt(e.target.value, 10))}
+        >
+          {pack.puzzles.map((p, i) => (
+            <option key={p.name} value={i}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+
+  return (
+    <GameShell game="nonogram" settings={settings}>
+      <div className="space-y-4">
+        <Board
+          rows={puzzle.rows}
+          cols={puzzle.cols}
+          solution={puzzle.grid}
+          grid={grid}
+          onChange={handleGridChange}
+        />
+        <HintSystem
+          rows={puzzle.rows}
+          cols={puzzle.cols}
+          grid={grid}
+          solution={puzzle.grid}
+          maxHints={3}
+          onHint={handleHint}
+        />
+      </div>
+    </GameShell>
+  );
+};
+
+export default NonogramGame;
+

--- a/pages/games/nonogram/index.tsx
+++ b/pages/games/nonogram/index.tsx
@@ -1,0 +1,42 @@
+import dynamic from 'next/dynamic';
+import Head from 'next/head';
+
+const Nonogram = dynamic(() => import('../../../games/nonogram'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function NonogramPage() {
+  return (
+    <>
+      <Head>
+        <title>Nonogram Game</title>
+        <meta
+          name="description"
+          content="Solve Nonogram puzzles directly in your browser."
+        />
+        <meta property="og:title" content="Nonogram Game" />
+        <meta
+          property="og:description"
+          content="Solve Nonogram puzzles directly in your browser."
+        />
+        <meta
+          property="og:image"
+          content="https://unnippillil.com/images/wallpapers/wall-1.webp"
+        />
+        <meta property="twitter:card" content="summary_large_image" />
+        <meta property="twitter:title" content="Nonogram Game" />
+        <meta
+          property="twitter:description"
+          content="Solve Nonogram puzzles directly in your browser."
+        />
+        <meta
+          property="twitter:image"
+          content="https://unnippillil.com/images/wallpapers/wall-1.webp"
+        />
+      </Head>
+      <Nonogram />
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Refactor Nonogram board to accept external grid state and emit changes
- Add Nonogram puzzle game component with hint system and progress saving
- Expose Nonogram game via new `/games/nonogram` page

## Testing
- `npm test __tests__/nonogramGame.test.ts`
- `npm test __tests__/nonogram.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bfb58772a48328bbfcf1c1a18dfa1f