### PR TITLE
Add Hydra wordlist tool and hashcat app page

### DIFF
--- a/apps/hydra/index.tsx
+++ b/apps/hydra/index.tsx
@@ -4,6 +4,7 @@ import React, { useRef } from 'react';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
 import HydraApp from '../../components/apps/hydra';
 import StrategyTrainer from './components/StrategyTrainer';
+import WordlistAtelier from './components/WordlistAtelier';
 
 const HydraPreview: React.FC = () => {
   const countRef = useRef(1);
@@ -21,6 +22,7 @@ const HydraPreview: React.FC = () => {
     <div className="min-h-screen bg-gray-900 text-white">
       <TabbedWindow initialTabs={[createTab()]} onNewTab={createTab} />
       <StrategyTrainer />
+      <WordlistAtelier />
     </div>
   );
 };

--- a/pages/apps/hashcat.jsx
+++ b/pages/apps/hashcat.jsx
@@ -1,0 +1,11 @@
+import dynamic from 'next/dynamic';
+
+const Hashcat = dynamic(() => import('../../apps/hashcat'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function HashcatPage() {
+  return <Hashcat />;
+}
+

--- a/pages/apps/hydra.jsx
+++ b/pages/apps/hydra.jsx
@@ -1,0 +1,11 @@
+import dynamic from 'next/dynamic';
+
+const Hydra = dynamic(() => import('../../apps/hydra'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function HydraPage() {
+  return <Hydra />;
+}
+


### PR DESCRIPTION
## Summary
- add WordlistAtelier to Hydra preview for generating wordlists
- expose Hashcat and Hydra apps via dynamic pages

## Testing
- `npx esbuild pages/apps/john.jsx pages/apps/hashcat.jsx pages/apps/hydra.jsx --bundle --loader:.js=jsx --outdir=/tmp/build`
- `yarn test __tests__/hashcat.test.tsx __tests__/hydra.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bfb588803883289c68aa0125a3c8f2