### PR TITLE
Add wrappers and pages for classic games

### DIFF
--- a/apps/flappy-bird/index.tsx
+++ b/apps/flappy-bird/index.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../components/apps/flappy-bird';

--- a/apps/frogger/index.tsx
+++ b/apps/frogger/index.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../components/apps/frogger';

--- a/apps/memory/index.tsx
+++ b/apps/memory/index.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../components/apps/memory';

--- a/apps/snake/index.tsx
+++ b/apps/snake/index.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../components/apps/snake';

--- a/pages/apps/flappy-bird.jsx
+++ b/pages/apps/flappy-bird.jsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const FlappyBird = dynamic(() => import('../../apps/flappy-bird'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default FlappyBird;

--- a/pages/apps/frogger.jsx
+++ b/pages/apps/frogger.jsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const Frogger = dynamic(() => import('../../apps/frogger'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default Frogger;

--- a/pages/apps/memory.jsx
+++ b/pages/apps/memory.jsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const Memory = dynamic(() => import('../../apps/memory'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default Memory;

--- a/pages/apps/snake.jsx
+++ b/pages/apps/snake.jsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const Snake = dynamic(() => import('../../apps/snake'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default Snake;

--- a/scripts/smoke-all-apps.mjs
+++ b/scripts/smoke-all-apps.mjs
@@ -14,13 +14,17 @@ const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 
   // Add new app routes here to include them in smoke tests
     const routes = [
-      '/apps/ascii-art',
-      '/apps/autopsy',
+    '/apps/ascii-art',
+    '/apps/autopsy',
     '/apps/beef',
     '/apps/blackjack',
     '/apps/calculator',
     '/apps/checkers',
     '/apps/connect-four',
+    '/apps/flappy-bird',
+    '/apps/frogger',
+    '/apps/memory',
+    '/apps/snake',
     '/apps/contact',
     '/apps/converter',
     '/apps/figlet',


### PR DESCRIPTION
## Summary
- add Next.js wrappers for Frogger, Flappy Bird, Memory, and Snake apps
- expose new game routes and include them in smoke tests

## Testing
- `node -e "require('esbuild').transformSync(require('fs').readFileSync('components/apps/frogger.js','utf8'), {loader:'jsx'})"`
- `node -e "require('esbuild').transformSync(require('fs').readFileSync('components/apps/flappy-bird.js','utf8'), {loader:'jsx'})"`
- `node -e "require('esbuild').transformSync(require('fs').readFileSync('components/apps/memory.js','utf8'), {loader:'jsx'})"`
- `node -e "require('esbuild').transformSync(require('fs').readFileSync('components/apps/snake.js','utf8'), {loader:'jsx'})"`
- `node --import tsx/esm scripts/validate-apps.mjs` *(fails: Missing route for dynamic app: pong, pacman, lane-runner, platformer, reversi, wordle, breakout, asteroids, tetris, candy-crush, file-explorer, ristretto, gedit, screen-recorder, task_manager, serial-terminal, ble-sensor, etc.)*
- `yarn eslint apps/frogger/index.tsx apps/flappy-bird/index.tsx apps/snake/index.tsx apps/memory/index.tsx pages/apps/frogger.jsx pages/apps/flappy-bird.jsx pages/apps/snake.jsx pages/apps/memory.jsx scripts/smoke-all-apps.mjs` *(fails: sourcemap-codec@npm:^1.4.8 missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb58b966c83288e956d27bd55df5d