### PR TITLE
Replace ellipsis placeholders in game UI

### DIFF
--- a/apps/sokoban/index.tsx
+++ b/apps/sokoban/index.tsx
@@ -362,33 +362,27 @@ const Sokoban: React.FC<SokobanProps> = ({ getDailySeed }) => {
   }, [state, index, packIndex, warnDir, handleReset, handleUndo, handleRedo]);
 
   const handleHint = useCallback(() => {
-    setHint('...');
-    setTimeout(() => {
-      const dir = findHint(state);
-      setHint(dir ? dir.replace('Arrow', '') : 'No hint');
-    }, 0);
+    const dir = findHint(state);
+    setHint(dir ? dir.replace('Arrow', '') : 'No hint');
   }, [state]);
   
   const keyPos = useCallback((p: Position) => `${p.x},${p.y}`, []);
 
   const handlePreview = useCallback(() => {
     setSolutionPath(new Set());
-    setStatus('...');
-    setTimeout(() => {
-      const sol = findSolution(state);
-      if (!sol) {
-        setStatus('No solution');
-        return;
-      }
-      const positions: string[] = [];
-      let st = state;
-      sol.forEach((dir) => {
-        st = move(st, dir);
-        positions.push(keyPos(st.player));
-      });
-      setSolutionPath(new Set(positions));
-      setStatus('');
-    }, 0);
+    const sol = findSolution(state);
+    if (!sol) {
+      setStatus('No solution');
+      return;
+    }
+    const positions: string[] = [];
+    let st = state;
+    sol.forEach((dir) => {
+      st = move(st, dir);
+      positions.push(keyPos(st.player));
+    });
+    setSolutionPath(new Set(positions));
+    setStatus('');
   }, [state, keyPos]);
 
   const cellStyle = useMemo(

--- a/public/apps/platformer/main.js
+++ b/public/apps/platformer/main.js
@@ -190,7 +190,7 @@ function pollRemap() {
 Object.keys(padButtons).forEach(a => {
   padButtons[a].addEventListener('click', () => {
     waitingPad = a;
-    padButtons[a].textContent = '...';
+    padButtons[a].textContent = 'Press a button';
     requestAnimationFrame(pollRemap);
   });
 });


### PR DESCRIPTION
## Summary
- compute Sokoban hints and previews directly instead of showing temporary ellipsis
- show descriptive text when remapping gamepad buttons in Platformer

## Testing
- `yarn test` *(fails: ConfigError: ESLint configuration ...)*
- `yarn build` *(fails: Identifier 'utilities' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb58c41d08328bb4f58f1b93ee328