### PR TITLE
Add hook coverage and asset loader reset

### DIFF
--- a/__tests__/useAssetLoader.test.ts
+++ b/__tests__/useAssetLoader.test.ts
@@ -1,0 +1,73 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import useAssetLoader from '../hooks/useAssetLoader';
+
+describe('useAssetLoader', () => {
+  afterEach(() => {
+    // Cleanup mocks to avoid leaking between tests
+    // @ts-ignore
+    delete global.Image;
+    // @ts-ignore
+    delete global.Audio;
+  });
+
+  test('resolves when all assets load', async () => {
+    class MockImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      set src(_src: string) {
+        setTimeout(() => {
+          this.onload && this.onload();
+        }, 0);
+      }
+    }
+    class MockAudio {
+      oncanplaythrough: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      src = '';
+      load() {
+        setTimeout(() => {
+          this.oncanplaythrough && this.oncanplaythrough();
+        }, 0);
+      }
+    }
+    // @ts-ignore
+    global.Image = MockImage;
+    // @ts-ignore
+    global.Audio = MockAudio;
+
+    const { result } = renderHook(() =>
+      useAssetLoader({ images: ['a.png'], sounds: ['a.mp3'] }),
+    );
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe(false);
+  });
+
+  test('reports error when an asset fails to load', async () => {
+    class MockImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      set src(src: string) {
+        setTimeout(() => {
+          if (src.includes('bad')) {
+            this.onerror && this.onerror();
+          } else {
+            this.onload && this.onload();
+          }
+        }, 0);
+      }
+    }
+    // @ts-ignore
+    global.Image = MockImage;
+    // @ts-ignore - no audio loading for this test
+    global.Audio = function () {};
+
+    const { result } = renderHook(() =>
+      useAssetLoader({ images: ['bad.png'] }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe(true);
+  });
+});

--- a/__tests__/useSession.test.ts
+++ b/__tests__/useSession.test.ts
@@ -1,0 +1,58 @@
+import { renderHook, act } from '@testing-library/react';
+import useSession from '../hooks/useSession';
+
+describe('useSession', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('open and close windows', () => {
+    const { result } = renderHook(() => useSession());
+    act(() =>
+      result.current.dispatch({
+        type: 'open',
+        win: { id: 'one', x: 0, y: 0 },
+      }),
+    );
+    expect(result.current.session.windows).toHaveLength(1);
+
+    act(() => result.current.dispatch({ type: 'close', id: 'one' }));
+    expect(result.current.session.windows).toHaveLength(0);
+  });
+
+  test('move and snap windows', () => {
+    const { result } = renderHook(() => useSession());
+    act(() =>
+      result.current.dispatch({
+        type: 'open',
+        win: { id: 'a', x: 0, y: 0 },
+      }),
+    );
+    act(() =>
+      result.current.dispatch({ type: 'move', id: 'a', x: 10, y: 20 }),
+    );
+    expect(result.current.session.windows[0]).toMatchObject({ x: 10, y: 20 });
+
+    act(() =>
+      result.current.dispatch({ type: 'snap', id: 'a', snap: 'left' }),
+    );
+    expect(result.current.session.windows[0].snap).toBe('left');
+  });
+
+  test('reset session clears storage', () => {
+    const { result } = renderHook(() => useSession());
+    act(() =>
+      result.current.dispatch({
+        type: 'open',
+        win: { id: 'a', x: 0, y: 0 },
+      }),
+    );
+    expect(result.current.session.windows).toHaveLength(1);
+
+    act(() => result.current.resetSession());
+    expect(result.current.session.windows).toHaveLength(0);
+    const stored = window.localStorage.getItem('desktop-session');
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(String(stored)).windows).toEqual([]);
+  });
+});

--- a/__tests__/useTray.test.tsx
+++ b/__tests__/useTray.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { TrayProvider, useTray } from '../hooks/useTray';
+
+describe('useTray', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TrayProvider>{children}</TrayProvider>
+  );
+
+  test('registers and unregisters icons', () => {
+    const { result } = renderHook(() => useTray(), { wrapper });
+
+    act(() => result.current.register({ id: 'one', legacy: '/1.svg' }));
+    act(() => result.current.register({ id: 'two', legacy: '/2.svg' }));
+    expect(result.current.icons.map((i) => i.id)).toEqual(['one', 'two']);
+
+    // registering with existing id updates the icon rather than duplicating
+    act(() => result.current.register({ id: 'one', legacy: '/1b.svg' }));
+    expect(result.current.icons).toHaveLength(2);
+    expect(result.current.icons.find((i) => i.id === 'one')?.legacy).toBe(
+      '/1b.svg',
+    );
+
+    act(() => result.current.unregister('one'));
+    expect(result.current.icons.map((i) => i.id)).toEqual(['two']);
+  });
+});

--- a/hooks/useAssetLoader.ts
+++ b/hooks/useAssetLoader.ts
@@ -22,6 +22,9 @@ export default function useAssetLoader(
 
   useEffect(() => {
     let cancelled = false;
+    // Whenever the list of assets changes start a new loading cycle.
+    // Reset the state so consumers can show loading indicators again.
+    setState({ loading: true, error: false });
 
     const loadImage = (src: string) => new Promise<void>((resolve, reject) => {
       const img = new Image();


### PR DESCRIPTION
## Summary
- reset asset loader state when asset lists change
- add tests for desktop session and tray hooks
- test asset loader state transitions

## Testing
- `npx jest --runTestsByPath __tests__/useSession.test.ts`
- `npx jest --runTestsByPath __tests__/useTray.test.tsx`
- `npx jest --runTestsByPath __tests__/useAssetLoader.test.ts --runInBand` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb58dd1d883288ed4b855e82cdfb6