### PR TITLE
feat: add functional logger and settings persistence tests

### DIFF
--- a/__tests__/loggerPersistence.test.ts
+++ b/__tests__/loggerPersistence.test.ts
@@ -1,0 +1,33 @@
+import logger, { setLogLevel, createLogger, getLogLevel } from '../utils/logger';
+
+describe('logger', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+    localStorage.clear();
+    setLogLevel('info');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('respects log level and persists', () => {
+    setLogLevel('error');
+    logger.info('hello');
+    expect(console.info).not.toHaveBeenCalled();
+    logger.error('oops');
+    expect(console.error).toHaveBeenCalled();
+    expect(JSON.parse(localStorage.getItem('log-level')!)).toBe('error');
+    expect(getLogLevel()).toBe('error');
+  });
+
+  it('creates prefixed logger', () => {
+    const custom = createLogger('prefix');
+    custom.info('message');
+    expect(console.info).toHaveBeenCalledWith('prefix', 'message');
+  });
+});

--- a/__tests__/persistent.test.ts
+++ b/__tests__/persistent.test.ts
@@ -1,0 +1,19 @@
+import { loadFromStorage, saveToStorage } from '../utils/persistent';
+
+describe('persistent storage helpers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('saves and loads values', () => {
+    saveToStorage('foo', { bar: 1 });
+    const val = loadFromStorage('foo', { bar: 0 });
+    expect(val).toEqual({ bar: 1 });
+  });
+
+  it('returns fallback when validator fails', () => {
+    localStorage.setItem('foo', JSON.stringify('nope'));
+    const val = loadFromStorage('foo', 42, (v): v is number => typeof v === 'number');
+    expect(val).toBe(42);
+  });
+});


### PR DESCRIPTION
## Summary
- add configurable logger that persists log level to local storage and supports namespaced loggers
- add tests validating logger behavior and storage helpers

## Testing
- `yarn test __tests__/loggerPersistence.test.ts __tests__/persistent.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bfb58ed7048328b2bf0bbb653ab3a2