### PR TITLE
chore: mark eslint plugin workspaces as private

### DIFF
--- a/eslint-plugin-no-dupe-app-imports/package.json
+++ b/eslint-plugin-no-dupe-app-imports/package.json
@@ -1,5 +1,6 @@
 {
   "name": "eslint-plugin-no-dupe-app-imports",
   "version": "1.0.0",
+  "private": true,
   "main": "index.js"
 }

--- a/eslint-plugin-no-duplicate-filenames/package.json
+++ b/eslint-plugin-no-duplicate-filenames/package.json
@@ -1,5 +1,6 @@
 {
   "name": "eslint-plugin-no-duplicate-filenames",
   "version": "1.0.0",
+  "private": true,
   "main": "index.js"
 }

--- a/eslint-plugin-no-top-level-window/package.json
+++ b/eslint-plugin-no-top-level-window/package.json
@@ -1,5 +1,6 @@
 {
   "name": "eslint-plugin-no-top-level-window",
   "version": "1.0.0",
+  "private": true,
   "main": "index.js"
 }


### PR DESCRIPTION
## Summary
- mark ESLint plugin workspace packages as private to avoid workspace warnings and accidental publish

## Testing
- `yarn test eslint-plugin-no-dupe-app-imports/index.js --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bfc1e482808328a9304181e042f79c