### PR TITLE
fix: ensure figlet layout type

### DIFF
--- a/apps/figlet/worker.ts
+++ b/apps/figlet/worker.ts
@@ -48,7 +48,7 @@ self.onmessage = (e: MessageEvent<any>) => {
     const rendered = figlet.textSync(normalized, {
       font: font as FontName,
       width,
-      horizontalLayout: layout as FigletOptions['horizontalLayout'],
+      horizontalLayout: layout as NonNullable<FigletOptions['horizontalLayout']>,
     });
   self.postMessage({ type: 'render', output: rendered });
 };


### PR DESCRIPTION
## Summary
- ensure figlet worker passes strict optional property checks

## Testing
- `yarn test apps/figlet/worker.ts --passWithNoTests`
- `npx eslint apps/figlet/worker.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bfc363fb408328b3ac6ee7bc7e8019