### PR TITLE
fix: ensure figlet worker horizontal layout type

### DIFF
--- a/apps/figlet/worker.ts
+++ b/apps/figlet/worker.ts
@@ -48,7 +48,7 @@ self.onmessage = (e: MessageEvent<any>) => {
     const rendered = figlet.textSync(normalized, {
       font: font as FontName,
       width,
-      horizontalLayout: layout as FigletOptions['horizontalLayout'],
+      horizontalLayout: layout as FigletOptions['horizontalLayout'] & string,
     });
   self.postMessage({ type: 'render', output: rendered });
 };


### PR DESCRIPTION
## Summary
- avoid undefined assignment when passing horizontalLayout to figlet

## Testing
- `yarn test apps/figlet` *(fails: No tests found, exiting with code 1)*
- `yarn run build` *(fails: Argument of type 'number | undefined' is not assignable to parameter of type 'number' in apps/games/battleship/ai.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc38f7ca48328b219956b614ff89b