### PR TITLE
fix: ensure layout passed to figlet is non-nullable

### DIFF
--- a/apps/figlet/worker.ts
+++ b/apps/figlet/worker.ts
@@ -48,7 +48,7 @@ self.onmessage = (e: MessageEvent<any>) => {
     const rendered = figlet.textSync(normalized, {
       font: font as FontName,
       width,
-      horizontalLayout: layout as FigletOptions['horizontalLayout'],
+      horizontalLayout: layout as NonNullable<FigletOptions['horizontalLayout']>,
     });
   self.postMessage({ type: 'render', output: rendered });
 };


### PR DESCRIPTION
## Summary
- fix TypeScript error in figlet worker by ensuring horizontalLayout is non-nullable

## Testing
- `npx tsc --pretty false --noEmit --skipLibCheck apps/figlet/worker.ts`
- `yarn tsc` *(fails: Element implicitly has an 'any' type because expression of type '"X-GNOME-Autostart-enabled"' can't be used to index type '{ Name: string; }'.)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc3e0fb908328b9d241d0217c7c29