### PR TITLE
fix: pin vercel runtime version

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" },
-    "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" }
+    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.21" },
+    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.21" }
   }
 }


### PR DESCRIPTION
## Summary
- pin @vercel/node runtime version for serverless functions

## Testing
- `npx eslint vercel.json`
- `yarn test __tests__/reportWebVitals.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bfc533e3608328a84dfc383ae68a15