### PR TITLE
chore(frogger): ensure level config always defined

### DIFF
--- a/apps/games/frogger/levels.ts
+++ b/apps/games/frogger/levels.ts
@@ -66,5 +66,5 @@ export const LEVELS: LaneConfiguration[] = [
 ];
 
 export const getLevelConfig = (level: number): LaneConfiguration =>
-  LEVELS[(level - 1) % LEVELS.length];
+  LEVELS[(level - 1) % LEVELS.length] ?? LEVELS[0];
 


### PR DESCRIPTION
## Summary
- prevent undefined configs in Frogger's `getLevelConfig`

## Testing
- `yarn tsc apps/games/frogger/levels.ts --noEmit --skipLibCheck`
- `yarn eslint apps/games/frogger/levels.ts`
- `yarn test apps/games/frogger --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bfcc2feae08328bacb9881874712d6