### PR TITLE
Guard nonogram helpers against undefined grid access

### DIFF
--- a/apps/games/nonogram/hints.ts
+++ b/apps/games/nonogram/hints.ts
@@ -10,14 +10,18 @@ export interface Hint {
 export const revealRandomCell = (grid: Grid, solution: Grid): Hint | null => {
   const candidates: { i: number; j: number }[] = [];
   for (let i = 0; i < solution.length; i++) {
-    for (let j = 0; j < solution[i].length; j++) {
-      if (solution[i][j] === 1 && grid[i][j] !== 1) {
+    const solRow = solution[i];
+    const gridRow = grid[i];
+    if (!solRow || !gridRow) continue;
+    for (let j = 0; j < solRow.length; j++) {
+      if (solRow[j] === 1 && gridRow[j] !== 1) {
         candidates.push({ i, j });
       }
     }
   }
   if (!candidates.length) return null;
   const pick = candidates[Math.floor(Math.random() * candidates.length)];
+  if (!pick) return null;
   return { i: pick.i, j: pick.j, value: 1 };
 };
 

--- a/apps/games/nonogram/logic.ts
+++ b/apps/games/nonogram/logic.ts
@@ -20,7 +20,9 @@ export const lineToClues = (line: Cell[]): number[] => {
 // Generate all patterns for a clue in a line of given length
 export const generateLinePatterns = (clue: Clue, length: number): Cell[][] => {
   if (clue.length === 0) return [Array(length).fill(0)];
-  const [first, ...rest] = clue;
+  const first = clue[0];
+  const rest = clue.slice(1);
+  if (first === undefined) return [];
   const patterns: Cell[][] = [];
   for (let offset = 0; offset <= length - first; offset++) {
     const head: Cell[] = Array(offset).fill(0).concat(Array(first).fill(1));
@@ -50,11 +52,16 @@ export const findForcedCellsInLine = (
   line: Cell[]
 ): { index: number; value: Cell }[] => {
   const solutions = getPossibleLineSolutions(clue, line);
-  if (!solutions.length) return [];
+  const base = solutions[0];
+  if (!base) return [];
   const forced: { index: number; value: Cell }[] = [];
   for (let i = 0; i < line.length; i++) {
-    const val = solutions[0][i];
-    if (solutions.every((s) => s[i] === val) && line[i] === 0) {
+    const val = base[i];
+    if (
+      val !== undefined &&
+      solutions.every((s) => s[i] === val) &&
+      line[i] === 0
+    ) {
       forced.push({ index: i, value: (val ? 1 : -1) as Cell });
     }
   }
@@ -68,17 +75,23 @@ export const findHint = (
   grid: Grid
 ): { i: number; j: number; value: 1 } | null => {
   for (let i = 0; i < rows.length; i++) {
-    const forced = findForcedCellsInLine(rows[i], grid[i]).filter(
-      (f) => f.value === 1
-    );
-    if (forced.length) return { i, j: forced[0].index, value: 1 };
+    const clue = rows[i];
+    const row = grid[i];
+    if (!clue || !row) continue;
+    const forced = findForcedCellsInLine(clue, row).filter((f) => f.value === 1);
+    const firstForced = forced[0];
+    if (firstForced) return { i, j: firstForced.index, value: 1 };
   }
   for (let j = 0; j < cols.length; j++) {
-    const col = grid.map((row) => row[j]);
-    const forced = findForcedCellsInLine(cols[j], col).filter(
-      (f) => f.value === 1
-    );
-    if (forced.length) return { i: forced[0].index, j, value: 1 };
+    const clue = cols[j];
+    if (!clue) continue;
+    const col: Cell[] = grid
+      .map((row) => row[j])
+      .filter((v): v is Cell => v !== undefined);
+    if (col.length !== grid.length) continue;
+    const forced = findForcedCellsInLine(clue, col).filter((f) => f.value === 1);
+    const firstForced = forced[0];
+    if (firstForced) return { i: firstForced.index, j, value: 1 };
   }
   return null;
 };
@@ -96,11 +109,16 @@ export const checkContradictions = (
   rows: Clue[],
   cols: Clue[]
 ): { rows: boolean[]; cols: boolean[] } => {
-  const rowContradictions = rows.map((clue, i) =>
-    evaluateLine(grid[i], clue).contradiction
-  );
+  const rowContradictions = rows.map((clue, i) => {
+    const row = grid[i];
+    if (!row) return false;
+    return evaluateLine(row, clue).contradiction;
+  });
   const colContradictions = cols.map((clue, j) => {
-    const column = grid.map((row) => row[j]);
+    const column: Cell[] = grid
+      .map((row) => row[j])
+      .filter((v): v is Cell => v !== undefined);
+    if (column.length !== grid.length) return false;
     return evaluateLine(column, clue).contradiction;
   });
   return { rows: rowContradictions, cols: colContradictions };
@@ -109,6 +127,7 @@ export const checkContradictions = (
 // Toggle a cross mark on the grid
 export const toggleCross = (grid: Grid, r: number, c: number): Grid => {
   const g = grid.map((row) => row.slice());
+  if (!g[r] || g[r][c] === undefined) return g;
   g[r][c] = g[r][c] === -1 ? 0 : -1;
   return g;
 };
@@ -121,28 +140,36 @@ export const autoFill = (grid: Grid, rows: Clue[], cols: Clue[]): Grid => {
     changed = false;
     rows.forEach((clue, i) => {
       const line = g[i];
+      if (!line) return;
       const solutions = getPossibleLineSolutions(clue, line);
       if (solutions.length === 1) {
-        solutions[0].forEach((val, j) => {
-          const newVal = (val ? 1 : -1) as Cell;
-          if (g[i][j] !== newVal) {
-            g[i][j] = newVal;
-            changed = true;
-          }
-        });
+        const sol = solutions[0];
+        if (sol)
+          sol.forEach((val, j) => {
+            const newVal = (val ? 1 : -1) as Cell;
+            if (line[j] !== newVal) {
+              line[j] = newVal;
+              changed = true;
+            }
+          });
       }
     });
     cols.forEach((clue, j) => {
-      const col = g.map((row) => row[j]);
+      const col: Cell[] = g
+        .map((row) => row[j])
+        .filter((v): v is Cell => v !== undefined);
+      if (col.length !== g.length) return;
       const solutions = getPossibleLineSolutions(clue, col);
       if (solutions.length === 1) {
-        solutions[0].forEach((val, i) => {
-          const newVal = (val ? 1 : -1) as Cell;
-          if (g[i][j] !== newVal) {
-            g[i][j] = newVal;
-            changed = true;
-          }
-        });
+        const sol = solutions[0];
+        if (sol)
+          sol.forEach((val, i) => {
+            const newVal = (val ? 1 : -1) as Cell;
+            if (g[i] && g[i][j] !== newVal) {
+              g[i][j] = newVal;
+              changed = true;
+            }
+          });
       }
     });
   }

--- a/apps/games/nonogram/packs.ts
+++ b/apps/games/nonogram/packs.ts
@@ -1,4 +1,4 @@
-import { lineToClues, Grid, Clue } from './logic';
+import { lineToClues, Grid, Clue, Cell } from './logic';
 
 export interface Puzzle {
   name: string;
@@ -25,7 +25,9 @@ export const parsePack = (raw: string): Puzzle[] => {
     const width = grid[0]?.length || 0;
     const cols: Clue[] = [];
     for (let c = 0; c < width; c++) {
-      const col = grid.map((row) => row[c]);
+      const col: Cell[] = grid
+        .map((row) => row[c])
+        .filter((v): v is Cell => v !== undefined);
       cols.push(lineToClues(col));
     }
     return { name: `Puzzle ${idx + 1}`, rows, cols, grid };
@@ -53,7 +55,9 @@ export const loadPackFromJSON = (raw: string): PuzzlePack => {
     const width = grid[0]?.length || 0;
     const cols: Clue[] = [];
     for (let c = 0; c < width; c++) {
-      const col = grid.map((row) => row[c]);
+      const col: Cell[] = grid
+        .map((row) => row[c])
+        .filter((v): v is Cell => v !== undefined);
       cols.push(lineToClues(col));
     }
     return { name: p.name || `Puzzle ${idx + 1}`, rows, cols, grid };


### PR DESCRIPTION
## Summary
- handle undefined rows and picks in nonogram hint helper
- add safe guards throughout nonogram logic helpers
- filter undefined cells when parsing nonogram puzzle packs

## Testing
- `yarn eslint apps/games/nonogram/hints.ts`
- `yarn eslint apps/games/nonogram/logic.ts`
- `yarn eslint apps/games/nonogram/packs.ts`
- `yarn test apps/games/nonogram --passWithNoTests`
- `CI=1 yarn build` *(fails: Type error: Type 'Card | undefined' is not assignable to type 'Card' in apps/games/solitaire/logic.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcfe0fa28832894f4fc94ab6b6378