### PR TITLE
fix: ensure shuffle swap uses non-null cards

### DIFF
--- a/apps/games/solitaire/logic.ts
+++ b/apps/games/solitaire/logic.ts
@@ -31,7 +31,11 @@ export const createDeck = (): Card[] => {
 const shuffle = (deck: Card[]) => {
   for (let i = deck.length - 1; i > 0; i -= 1) {
     const j = Math.floor(random() * (i + 1));
-    [deck[i], deck[j]] = [deck[j], deck[i]];
+    // With `noUncheckedIndexedAccess` enabled, index access on `deck` can
+    // return `undefined`. However, during shuffle both `i` and `j` are within
+    // bounds, so the cards are guaranteed to exist. Use non-null assertions to
+    // satisfy the type checker.
+    [deck[i], deck[j]] = [deck[j]!, deck[i]!];
   }
 };
 


### PR DESCRIPTION
## Summary
- fix TypeScript compilation error in solitaire shuffle by using non-null assertions when swapping deck cards

## Testing
- `yarn test apps/games/solitaire --passWithNoTests`
- `yarn typecheck` *(fails: Type 'Tower | undefined' is not assignable to type 'Tower')*


------
https://chatgpt.com/codex/tasks/task_e_68bfffbd6c1483288c214cfcb407d1a5