### PR TITLE
Define YouTube app display function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Use explicit `@vercel/node` runtime version to satisfy Vercel build requirements.
+- Define YouTube display function in app configuration to resolve missing reference errors.
 
 ## [2.1.0] - 2025-09-03
 ### Added

--- a/apps.config.js
+++ b/apps.config.js
@@ -153,6 +153,7 @@ const PowerApp = createDynamicApp('power', 'Power Settings');
 
 const XApp = createDynamicApp('x', 'X');
 const SpotifyApp = createDynamicApp('spotify', 'Spotify');
+const YouTubeApp = createDynamicApp('youtube', 'YouTube');
 const SettingsApp = createDynamicApp('settings', 'Settings');
 const ChromeApp = createDynamicApp('chrome', 'Chrome');
 const GeditApp = createDynamicApp('gedit', 'Gedit');
@@ -266,6 +267,7 @@ const displayPower = createDisplay(PowerApp);
 
 const displayX = createDisplay(XApp);
 const displaySpotify = createDisplay(SpotifyApp);
+const displayYouTube = createDisplay(YouTubeApp);
 const displaySettings = createDisplay(SettingsApp);
 const displayChrome = createDisplay(ChromeApp);
 const displayGedit = createDisplay(GeditApp);


### PR DESCRIPTION
## Summary
- add missing `YouTubeApp` dynamic app and corresponding display in config
- document fix in CHANGELOG

## Testing
- `yarn test __tests__/appImport.test.ts __tests__/apps.smoke.test.tsx __tests__/zorder.test.tsx` *(fails: dynamic app imports -> missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc5bd917c83288902c01a5db729d4