### PR TITLE
fix: avoid undefined in shuffle

### DIFF
--- a/apps/games/solitaire/logic.ts
+++ b/apps/games/solitaire/logic.ts
@@ -31,7 +31,9 @@ export const createDeck = (): Card[] => {
 const shuffle = (deck: Card[]) => {
   for (let i = deck.length - 1; i > 0; i -= 1) {
     const j = Math.floor(random() * (i + 1));
-    [deck[i], deck[j]] = [deck[j], deck[i]];
+    const tmp = deck[i]!;
+    deck[i] = deck[j]!;
+    deck[j] = tmp;
   }
 };
 


### PR DESCRIPTION
## Summary
- handle possible undefined cards when shuffling solitaire deck

## Testing
- `pnpm typecheck` *(fails: numerous TS errors)*
- `yarn test` *(fails: multiple failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68bfffb01778832898b79f725338ba0f