### PR TITLE
fix: guard top card lookup in solitaire

### DIFF
--- a/apps/games/solitaire/logic.ts
+++ b/apps/games/solitaire/logic.ts
@@ -97,14 +97,14 @@ const cardColor = (suit: Suit) => (suit === '♥' || suit === '♦' ? 'red' : 'b
 export const canMoveToFoundation = (card: Card, foundation: Card[]) => {
   if (card.faceDown) return false;
   if (foundation.length === 0) return card.rank === 1;
-  const top = foundation[foundation.length - 1];
+  const top = foundation[foundation.length - 1]!; // length checked above
   return top.suit === card.suit && top.rank + 1 === card.rank;
 };
 
 export const canMoveToTableau = (card: Card, pile: Card[]) => {
   if (card.faceDown) return false;
   if (pile.length === 0) return card.rank === 13;
-  const top = pile[pile.length - 1];
+  const top = pile[pile.length - 1]!; // length checked above
   if (top.faceDown) return false;
   return cardColor(top.suit) !== cardColor(card.suit) && top.rank === card.rank + 1;
 };


### PR DESCRIPTION
## Summary
- ensure top card exists when checking foundation or tableau moves in solitaire logic

## Testing
- `yarn typecheck` *(fails: Type 'null' is not assignable to type 'void | (() => VoidOrUndefinedOnly).')*
- `yarn test __tests__/solitaireLogic.test.ts __tests__/solitaireEngine.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c040d986748328848310415170b15c