### PR TITLE
fix: guard top card access in solitaire logic

### DIFF
--- a/apps/games/solitaire/logic.ts
+++ b/apps/games/solitaire/logic.ts
@@ -1,6 +1,6 @@
-import { random } from '../rng';
+import { random } from "../rng";
 
-export type Suit = '♠' | '♥' | '♦' | '♣';
+export type Suit = "♠" | "♥" | "♦" | "♣";
 
 export interface Card {
   suit: Suit;
@@ -13,10 +13,10 @@ export interface GameState {
   waste: Card[];
   foundations: Record<Suit, Card[]>;
   tableau: Card[][];
-  drawMode: 'draw1' | 'draw3';
+  drawMode: "draw1" | "draw3";
 }
 
-const suits: Suit[] = ['♠', '♥', '♦', '♣'];
+const suits: Suit[] = ["♠", "♥", "♦", "♣"];
 
 export const createDeck = (): Card[] => {
   const deck: Card[] = [];
@@ -34,11 +34,10 @@ const shuffle = (deck: Card[]) => {
     const tmp = deck[i]!;
     deck[i] = deck[j]!;
     deck[j] = tmp;
-
   }
 };
 
-export const initGame = (drawMode: 'draw1' | 'draw3' = 'draw1'): GameState => {
+export const initGame = (drawMode: "draw1" | "draw3" = "draw1"): GameState => {
   const deck = createDeck();
   shuffle(deck);
   const tableau: Card[][] = [];
@@ -55,17 +54,17 @@ export const initGame = (drawMode: 'draw1' | 'draw3' = 'draw1'): GameState => {
     stock: deck.map((c) => ({ ...c, faceDown: true })),
     waste: [],
     foundations: {
-      '♠': [],
-      '♥': [],
-      '♦': [],
-      '♣': [],
+      "♠": [],
+      "♥": [],
+      "♦": [],
+      "♣": [],
     },
     tableau,
     drawMode,
   };
 };
 
-export const setDrawMode = (state: GameState, mode: 'draw1' | 'draw3') => {
+export const setDrawMode = (state: GameState, mode: "draw1" | "draw3") => {
   if (state.drawMode === mode) return;
   state.drawMode = mode;
   state.stock = [...state.stock, ...state.waste.reverse()].map((c) => ({
@@ -76,14 +75,17 @@ export const setDrawMode = (state: GameState, mode: 'draw1' | 'draw3') => {
 };
 
 export const toggleDrawMode = (state: GameState) =>
-  setDrawMode(state, state.drawMode === 'draw1' ? 'draw3' : 'draw1');
+  setDrawMode(state, state.drawMode === "draw1" ? "draw3" : "draw1");
 
 export const draw = (state: GameState) => {
   if (state.stock.length === 0) {
     state.stock = state.waste.reverse().map((c) => ({ ...c, faceDown: true }));
     state.waste = [];
   }
-  const count = Math.min(state.drawMode === 'draw1' ? 1 : 3, state.stock.length);
+  const count = Math.min(
+    state.drawMode === "draw1" ? 1 : 3,
+    state.stock.length,
+  );
   for (let i = 0; i < count; i += 1) {
     const card = state.stock.shift()!;
     card.faceDown = false;
@@ -91,33 +93,41 @@ export const draw = (state: GameState) => {
   }
 };
 
-const cardColor = (suit: Suit) => (suit === '♥' || suit === '♦' ? 'red' : 'black');
+const cardColor = (suit: Suit) =>
+  suit === "♥" || suit === "♦" ? "red" : "black";
 
 export const canMoveToFoundation = (card: Card, foundation: Card[]) => {
   if (card.faceDown) return false;
   if (foundation.length === 0) return card.rank === 1;
-  const top = foundation[foundation.length - 1]!; // length checked above
+  const top = foundation[foundation.length - 1];
+  if (!top) return false;
   return top.suit === card.suit && top.rank + 1 === card.rank;
 };
 
 export const canMoveToTableau = (card: Card, pile: Card[]) => {
   if (card.faceDown) return false;
   if (pile.length === 0) return card.rank === 13;
-  const top = pile[pile.length - 1]!; // length checked above
-  if (top.faceDown) return false;
-  return cardColor(top.suit) !== cardColor(card.suit) && top.rank === card.rank + 1;
+  const top = pile[pile.length - 1];
+  if (!top || top.faceDown) return false;
+  return (
+    cardColor(top.suit) !== cardColor(card.suit) && top.rank === card.rank + 1
+  );
 };
 
 export const getAutoMoves = (state: GameState) => {
-  const moves: { from: 'waste' | 'tableau'; fromIndex: number; card: Card }[] = [];
+  const moves: { from: "waste" | "tableau"; fromIndex: number; card: Card }[] =
+    [];
   const wasteTop = state.waste[0];
-  if (wasteTop && canMoveToFoundation(wasteTop, state.foundations[wasteTop.suit])) {
-    moves.push({ from: 'waste', fromIndex: 0, card: wasteTop });
+  if (
+    wasteTop &&
+    canMoveToFoundation(wasteTop, state.foundations[wasteTop.suit])
+  ) {
+    moves.push({ from: "waste", fromIndex: 0, card: wasteTop });
   }
   state.tableau.forEach((pile, idx) => {
     const card = pile[pile.length - 1];
     if (card && canMoveToFoundation(card, state.foundations[card.suit])) {
-      moves.push({ from: 'tableau', fromIndex: idx, card });
+      moves.push({ from: "tableau", fromIndex: idx, card });
     }
   });
   return moves;
@@ -125,9 +135,9 @@ export const getAutoMoves = (state: GameState) => {
 
 export const applyMoveToFoundation = (
   state: GameState,
-  move: { from: 'waste' | 'tableau'; fromIndex: number; card: Card },
+  move: { from: "waste" | "tableau"; fromIndex: number; card: Card },
 ) => {
-  if (move.from === 'waste') {
+  if (move.from === "waste") {
     state.waste.shift();
   } else {
     state.tableau[move.fromIndex].pop();
@@ -174,9 +184,23 @@ export const getHint = (state: GameState): string | null => {
 };
 
 export const rankToString = (rank: number) => {
-  const map = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+  const map = [
+    "A",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+    "10",
+    "J",
+    "Q",
+    "K",
+  ];
   return map[rank - 1];
 };
 
-export const cardToString = (card: Card) => `${rankToString(card.rank)}${card.suit}`;
-
+export const cardToString = (card: Card) =>
+  `${rankToString(card.rank)}${card.suit}`;


### PR DESCRIPTION
## Summary
- avoid undefined top card errors in solitaire foundations and tableau moves

## Testing
- `npx tsc --esModuleInterop --skipLibCheck --lib es2020,dom --module commonjs --noEmit apps/games/solitaire/logic.ts apps/games/rng.ts && echo 'TS compilation passed'`


------
https://chatgpt.com/codex/tasks/task_e_68c04dac50048328970aebcd035cc378