### PR TITLE
fix sudoku shuffle typing

### DIFF
--- a/apps/games/sudoku/index.ts
+++ b/apps/games/sudoku/index.ts
@@ -18,7 +18,9 @@ const shuffle = <T>(arr: T[], rng: () => number): T[] => {
   const a = arr.slice();
   for (let i = a.length - 1; i > 0; i--) {
     const j = Math.floor(rng() * (i + 1));
-    [a[i], a[j]] = [a[j], a[i]];
+    const tmp = a[i]!;
+    a[i] = a[j]!;
+    a[j] = tmp;
   }
   return a;
 };


### PR DESCRIPTION
## Summary
- fix type error in sudoku shuffle by replacing destructuring swap with explicit variable

## Testing
- `yarn typecheck` *(fails: Type 'HTMLButtonElement | null' is not assignable to type 'void | (() => VoidOrUndefinedOnly)' in src/components/settings/AutostartManager.tsx, etc.)*
- `yarn test apps/games/sudoku` *(fails: No tests found)*
- `yarn lint apps/games/sudoku/index.ts` *(fails: File with base name 'game-loop.worker' has multiple extensions)*

------
https://chatgpt.com/codex/tasks/task_e_68c052fe121c8328a3a630b3bc961c6a