### PR TITLE
fix: guard against empty lines in Tic Tac Toe logic

### DIFF
--- a/apps/games/tictactoe/logic.ts
+++ b/apps/games/tictactoe/logic.ts
@@ -28,7 +28,9 @@ export const checkWinner = (
 ): { winner: Player | 'draw' | null; line: number[] } => {
   const lines = generateLines(size);
   for (const line of lines) {
-    const [first, ...rest] = line;
+    const first = line[0];
+    if (first === undefined) continue;
+    const rest = line.slice(1);
     const val = board[first];
     if (val && rest.every((idx) => board[idx] === val)) {
       const winner = misere ? (val === 'X' ? 'O' : 'X') : val;


### PR DESCRIPTION
## Summary
- avoid indexing the board with undefined line positions in tic tac toe winner check

## Testing
- `yarn test __tests__/tictactoe.test.ts`
- `yarn tsc --noEmit apps/games/tictactoe/logic.ts --skipLibCheck`


------
https://chatgpt.com/codex/tasks/task_e_68c060bd2abc83288049902c51cccece