### PR TITLE
fix iteration compile errors in game logic

### DIFF
--- a/apps/games/battleship/ai.ts
+++ b/apps/games/battleship/ai.ts
@@ -94,7 +94,7 @@ function randomLayout(
 
   const allCells = new Set<number>();
   layout.forEach((sh) => sh.cells.forEach((c) => allCells.add(c)));
-  for (const h of hits) {
+  for (const h of Array.from(hits)) {
     if (!allCells.has(h)) return null;
   }
 

--- a/workers/sudokuSolver.ts
+++ b/workers/sudokuSolver.ts
@@ -79,7 +79,8 @@ const eliminate = (
   if (values[s]!.length === 0) return false;
   if (values[s]!.length === 1) {
     const d2 = values[s]!;
-    for (const s2 of peers[s] ?? []) {
+    const peerList = peers[s] ? Array.from(peers[s]!) : [];
+    for (const s2 of peerList) {
       const res = eliminate(values, s2, d2, steps);
       if (!res) return false;
     }


### PR DESCRIPTION
## Summary
- avoid iterating sets directly in Battleship AI to support lower JS targets
- normalize peer iteration in sudoku solver to a plain array

## Testing
- `npm test __tests__/battleship-logic.test.ts __tests__/battleship-ai.test.js __tests__/sudokuSolver.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c060d594988328a3dd3c0f7e7dae70