### PR TITLE
fix hangman engine word selection

### DIFF
--- a/apps/hangman/engine.ts
+++ b/apps/hangman/engine.ts
@@ -32,8 +32,8 @@ export const createGame = (opts?: GameOptions): HangmanGame => {
   let hints: number | undefined;
   if (typeof opts === 'string') word = opts;
   else if (opts) ({ word, category, hints } = opts);
-  const dict = category ? DICTIONARIES[category] || allWords() : allWords();
-  const chosen = word || dict[Math.floor(Math.random() * dict.length)];
+  const dict = category ? DICTIONARIES[category] ?? allWords() : allWords();
+  const chosen = word ?? dict[Math.floor(Math.random() * dict.length)]!;
   return {
     word: chosen,
     guessed: [],


### PR DESCRIPTION
## Summary
- ensure Hangman engine always picks a string by using nullish coalescing and a non-null assertion

## Testing
- `yarn typecheck` *(fails: Type errors in unrelated files)*
- `yarn test __tests__/hangman.test.ts __tests__/replay.test.ts __tests__/hangmanGuessPool.test.ts __tests__/dailyLeaderboard.test.ts`
- `yarn lint apps/hangman/engine.ts` *(fails: Lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b64599c08328bbb4bd8c8216826e