### PR TITLE
fix: guard hangman hint selection

### DIFF
--- a/apps/hangman/engine.ts
+++ b/apps/hangman/engine.ts
@@ -60,7 +60,7 @@ export const useHint = (game: HangmanGame): string | null => {
     .filter((l) => !game.guessed.includes(l));
   if (remaining.length === 0) return null;
   const unique = Array.from(new Set(remaining));
-  const reveal = unique[Math.floor(Math.random() * unique.length)];
+  const reveal = unique[Math.floor(Math.random() * unique.length)]!;
   game.guessed.push(reveal);
   game.hints -= 1;
   return reveal;


### PR DESCRIPTION
## Summary
- ensure hint reveal is always a string in hangman engine

## Testing
- `npx eslint apps/hangman/engine.ts`
- `yarn test apps/hangman/engine.ts --passWithNoTests`
- `yarn tsc apps/hangman/engine.ts --noEmit` *(fails: Cannot find module './family.json' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c0cdfb32508328837bfe1a3deb350c