### PR TITLE
fix: guard optional rule set in RulesSandbox

### DIFF
--- a/apps/hashcat/components/RulesSandbox.tsx
+++ b/apps/hashcat/components/RulesSandbox.tsx
@@ -76,7 +76,8 @@ const RulesSandbox: React.FC<Props> = ({ savedSets, onChange, setRuleSet }) => {
 
   const load = (key: string) => {
     setName(key);
-    setRules(savedSets[key].join('\n'));
+    // Guard against undefined rule sets to satisfy TypeScript's strict null checks
+    setRules(savedSets[key]?.join('\n') ?? '');
   };
 
   const remove = (key: string) => {


### PR DESCRIPTION
## Summary
- prevent undefined rule sets from causing compile errors in RulesSandbox component

## Testing
- `yarn typecheck` *(fails: Element implicitly has an 'any' type because expression of type '"X-GNOME-Autostart-enabled"' can't be used to index type '{ Name: string; }'.)*
- `yarn test` *(fails: Missing environment variables NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d5b438288328b3d66bff5f31081f