### PR TITLE
fix: handle undefined item in john app

### DIFF
--- a/apps/john/index.tsx
+++ b/apps/john/index.tsx
@@ -77,14 +77,14 @@ const JohnApp: React.FC = () => {
         setHashes((prev) => {
           const next = [...prev];
           const item = next[idx];
-          if (item.status !== 'pending') {
+          if (!item || item.status !== 'pending') {
             clearInterval(intervals[idx]);
             return next;
           }
           item.progress = Math.min(item.progress + step, 100);
           if (item.progress === 100) {
-            if (PASSWORDS[item.hash]) {
-              const pw = PASSWORDS[item.hash];
+            const pw = PASSWORDS[item.hash];
+            if (pw !== undefined) {
               item.status = 'cracked';
               item.password = pw;
               item.strength = getStrength(pw);
@@ -197,6 +197,7 @@ const JohnApp: React.FC = () => {
               type="number"
               min={1}
               max={5}
+              aria-label="Length"
               value={incLength}
               onChange={(e) => setIncLength(parseInt(e.target.value, 10) || 1)}
               className="w-16 text-black px-1 py-0.5 rounded"


### PR DESCRIPTION
## Summary
- prevent undefined access in John hash cracking intervals
- label incremental length input for accessibility

## Testing
- `npx eslint apps/john/index.tsx`
- `yarn test apps/john --passWithNoTests`
- `yarn build` *(fails: apps/kismet/components/ChannelChart.tsx:42:32 Type error: Argument of type 'number | undefined' is not assignable to parameter of type 'number')*


------
https://chatgpt.com/codex/tasks/task_e_68c0d9bb95308328ba68a0818f2e219d