### PR TITLE
fix: handle undefined channel counts in ChannelChart

### DIFF
--- a/apps/kismet/components/ChannelChart.tsx
+++ b/apps/kismet/components/ChannelChart.tsx
@@ -39,7 +39,7 @@ const ChannelChart: React.FC = () => {
     return chs;
   }, [band, channelCounts]);
 
-  const maxCount = Math.max(1, ...channels.map((c) => channelCounts[c]));
+  const maxCount = Math.max(1, ...channels.map((c) => channelCounts[c] ?? 0));
 
   return (
     <div className="text-white">
@@ -60,7 +60,7 @@ const ChannelChart: React.FC = () => {
       </div>
       <div className="flex items-end h-40 space-x-1" aria-live="polite">
         {channels.map((c) => {
-          const count = channelCounts[c];
+          const count = channelCounts[c] ?? 0;
           const color = c <= bandRanges['2.4GHz'][1] ? 'bg-blue-600' : 'bg-green-600';
           return (
             <div key={c} className="flex flex-col items-center">


### PR DESCRIPTION
## Summary
- handle undefined channel counts in ChannelChart to prevent build failures

## Testing
- `npx eslint apps/kismet/components/ChannelChart.tsx`
- `yarn build` *(fails: Type error in DeauthWalkthrough.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c0edfe63bc8328896f47dd682f1204