### PR TITLE
fix: resolve TypeScript errors

### DIFF
--- a/src/apps/appfinder/AppFinder.tsx
+++ b/src/apps/appfinder/AppFinder.tsx
@@ -73,7 +73,9 @@ function parseDesktopFile(contents: string): DesktopEntry | null {
     }
   }
   if (!data.Name || !data.Exec) return null;
-  return { name: data.Name, exec: data.Exec, icon: data.Icon };
+  const entry: DesktopEntry = { name: data.Name, exec: data.Exec };
+  if (data.Icon) entry.icon = data.Icon;
+  return entry;
 }
 
 // Resolve a command to open a directory using the user's preferred file

--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -26,7 +26,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
     <Modal
       isOpen={open}
       onClose={onCancel}
-      ariaLabelledby={title ? headingId : undefined}
+      {...(title ? { ariaLabelledby: headingId } : {})}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
     >
       <div className="bg-gray-800 text-white p-4 rounded shadow-lg w-80 max-w-full">

--- a/src/components/desktop/DesktopContextMenu.tsx
+++ b/src/components/desktop/DesktopContextMenu.tsx
@@ -45,8 +45,8 @@ export const DesktopContextMenu: React.FC<DesktopContextMenuProps> = ({
   onClearSession,
 }) => {
   const menuRef = useRef<HTMLDivElement>(null);
-  useFocusTrap(menuRef, !!position);
-  useRovingTabIndex(menuRef, !!position, 'vertical');
+  useFocusTrap(menuRef as React.RefObject<HTMLElement>, !!position);
+  useRovingTabIndex(menuRef as React.RefObject<HTMLElement>, !!position, 'vertical');
 
   useEffect(() => {
     if (position && menuRef.current) {

--- a/src/components/notifications/Notifier.tsx
+++ b/src/components/notifications/Notifier.tsx
@@ -38,7 +38,7 @@ export const Notifier: React.FC<{ children?: React.ReactNode }> = ({ children })
 
   useEffect(() => {
     if (!current && queue.length > 0) {
-      setCurrent(queue[0]);
+      setCurrent(queue[0]!);
       setQueue(q => q.slice(1));
     }
   }, [queue, current]);

--- a/src/components/panel/Panel.tsx
+++ b/src/components/panel/Panel.tsx
@@ -90,7 +90,7 @@ export default function Panel() {
     setPlugins((prev) => {
       const updated = [...prev];
       const [item] = updated.splice(from, 1);
-      updated.splice(to, 0, item);
+      updated.splice(to, 0, item!);
       return updated;
     });
   };

--- a/src/components/panel/PowerMenu.tsx
+++ b/src/components/panel/PowerMenu.tsx
@@ -102,7 +102,9 @@ export default function PowerMenu({ index, move, innerRef, focused, onFocus }: P
         >
           <button
             role="menuitem"
-            ref={(el) => (itemRefs.current[0] = el)}
+            ref={(el) => {
+              itemRefs.current[0] = el;
+            }}
             onKeyDown={handleItemKey}
             onClick={() => {
               setOpen(false);
@@ -115,7 +117,9 @@ export default function PowerMenu({ index, move, innerRef, focused, onFocus }: P
           </button>
           <button
             role="menuitem"
-            ref={(el) => (itemRefs.current[1] = el)}
+            ref={(el) => {
+              itemRefs.current[1] = el;
+            }}
             onKeyDown={handleItemKey}
             onClick={() => {
               setOpen(false);
@@ -128,7 +132,9 @@ export default function PowerMenu({ index, move, innerRef, focused, onFocus }: P
           </button>
           <button
             role="menuitem"
-            ref={(el) => (itemRefs.current[2] = el)}
+            ref={(el) => {
+              itemRefs.current[2] = el;
+            }}
             onKeyDown={handleItemKey}
             onClick={() => {
               setOpen(false);

--- a/src/components/settings/AutostartManager.tsx
+++ b/src/components/settings/AutostartManager.tsx
@@ -20,7 +20,7 @@ const AutostartManager: React.FC = () => {
   const updateEntry = (index: number, change: Partial<AutostartEntry>) => {
     setEntries((prev) => {
       const next = [...prev];
-      next[index] = { ...next[index], ...change };
+      next[index] = { ...next[index], ...change } as AutostartEntry;
       return next;
     });
   };

--- a/src/lib/autostart.ts
+++ b/src/lib/autostart.ts
@@ -56,7 +56,7 @@ export async function readAutostart(): Promise<AutostartEntry[]> {
  */
 export async function saveAutostartEntry(entry: AutostartEntry): Promise<void> {
   const { file, data, name, enabled, delay } = entry;
-  const updated = { ...data, Name: name };
+  const updated: Record<string, unknown> = { ...data, Name: name };
   updated["X-GNOME-Autostart-enabled"] = enabled;
   if (typeof delay === "number") {
     updated["X-GNOME-Autostart-Delay"] = delay;

--- a/src/lib/menu/desktopEntry.ts
+++ b/src/lib/menu/desktopEntry.ts
@@ -21,7 +21,7 @@ const parseIni = (text: string): Record<string, Record<string, string>> => {
     if (!line || line.startsWith('#')) continue;
     const section = line.match(/^\[(.+)]$/);
     if (section) {
-      current = result[section[1]] = {};
+      current = result[section[1]!] = {};
       continue;
     }
     if (!current) continue;
@@ -43,15 +43,20 @@ export const parseDesktopEntry = async (file: string): Promise<DesktopEntry | nu
     const text = await fs.readFile(file, 'utf8');
     const data = parseIni(text)['Desktop Entry'];
     if (!data) return null;
-    return {
-      type: data.Type,
+
+    const entry: DesktopEntry = {
       name: data.Name || path.basename(file),
-      exec: data.Exec,
-      icon: data.Icon,
-      categories: data.Categories ? data.Categories.split(';').filter(Boolean) : undefined,
       terminal: data.Terminal === 'true',
       noDisplay: data.NoDisplay === 'true',
     };
+
+    if (data.Type) entry.type = data.Type;
+    if (data.Exec) entry.exec = data.Exec;
+    if (data.Icon) entry.icon = data.Icon;
+    if (data.Categories)
+      entry.categories = data.Categories.split(';').filter(Boolean);
+
+    return entry;
   } catch {
     return null;
   }

--- a/src/lib/menu/garcon.ts
+++ b/src/lib/menu/garcon.ts
@@ -70,13 +70,14 @@ export const loadMenu = async (): Promise<MenuCategory[]> => {
       if (item.desktop) {
         const entry: DesktopEntry | null = await parseDesktopEntry(item.desktop);
         if (entry && !entry.noDisplay) {
-          parsedItems.push({
+          const parsed: MenuItem = {
             id: item.id || entry.name,
             name: entry.name,
-            icon: entry.icon,
-            exec: entry.exec,
-            categories: entry.categories,
-          });
+          };
+          if (entry.icon) parsed.icon = entry.icon;
+          if (entry.exec) parsed.exec = entry.exec;
+          if (entry.categories) parsed.categories = entry.categories;
+          parsedItems.push(parsed);
         }
       } else {
         parsedItems.push(item);


### PR DESCRIPTION
## Summary
- fix merging of autostart entries and type safe updates
- parse desktop entries and menu items without undefined fields
- clean up refs and non-null checks to satisfy strict TypeScript settings

## Testing
- `yarn tsc` *(fails: pages/docs/[topic].tsx(188,3): Type '(text: any, level: any) => string' is not assignable to type '({ tokens, depth }: Heading) => string'.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f082ddf88328a3a60f7534a8158b