### PR TITLE
Handle undefined target in DeauthWalkthrough

### DIFF
--- a/apps/kismet/components/DeauthWalkthrough.tsx
+++ b/apps/kismet/components/DeauthWalkthrough.tsx
@@ -10,14 +10,18 @@ interface Frame {
   type: string;
 }
 
-const target = capture[0];
+// The capture data is expected to contain at least one entry, but since array
+// indexing returns `undefined` when out of bounds (especially under
+// `noUncheckedIndexedAccess`), safeguard the `bssid` extraction with optional
+// chaining and a fallback.
+const targetBssid = capture[0]?.bssid ?? '';
 
 const frames: Frame[] = [
-  { seq: 1, src: target.bssid, dst: '11:22:33:44:55:66', type: 'Data' },
-  { seq: 2, src: target.bssid, dst: '11:22:33:44:55:66', type: 'Data' },
-  { seq: 3, src: target.bssid, dst: 'FF:FF:FF:FF:FF:FF', type: 'Deauth' },
-  { seq: 4, src: target.bssid, dst: 'FF:FF:FF:FF:FF:FF', type: 'Deauth' },
-  { seq: 5, src: target.bssid, dst: '11:22:33:44:55:66', type: 'Data' },
+  { seq: 1, src: targetBssid, dst: '11:22:33:44:55:66', type: 'Data' },
+  { seq: 2, src: targetBssid, dst: '11:22:33:44:55:66', type: 'Data' },
+  { seq: 3, src: targetBssid, dst: 'FF:FF:FF:FF:FF:FF', type: 'Deauth' },
+  { seq: 4, src: targetBssid, dst: 'FF:FF:FF:FF:FF:FF', type: 'Deauth' },
+  { seq: 5, src: targetBssid, dst: '11:22:33:44:55:66', type: 'Data' },
 ];
 
 const DeauthWalkthrough: React.FC = () => {


### PR DESCRIPTION
## Summary
- Safeguard kismet DeauthWalkthrough against missing capture entries

## Testing
- `npx eslint apps/kismet/components/DeauthWalkthrough.tsx`
- `yarn typecheck` *(fails: Type 'HTMLButtonElement | null' is not assignable to type 'void | (() => VoidOrUndefinedOnly)' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f2325d3c8328815e54a61be8ed43