### PR TITLE
fix: add fallback BSSID for DeauthWalkthrough

### DIFF
--- a/apps/kismet/components/DeauthWalkthrough.tsx
+++ b/apps/kismet/components/DeauthWalkthrough.tsx
@@ -14,7 +14,11 @@ interface Frame {
 // indexing returns `undefined` when out of bounds (especially under
 // `noUncheckedIndexedAccess`), safeguard the `bssid` extraction with optional
 // chaining and a fallback.
-const targetBssid = capture[0]?.bssid ?? '';
+// Provide a human-friendly fallback when the capture array is empty. Using an
+// obviously invalid BSSID makes it easier to spot missing data during
+// development while still satisfying TypeScript's strict null checks.
+const FALLBACK_BSSID = '00:00:00:00:00:00';
+const targetBssid = capture[0]?.bssid ?? FALLBACK_BSSID;
 
 const frames: Frame[] = [
   { seq: 1, src: targetBssid, dst: '11:22:33:44:55:66', type: 'Data' },


### PR DESCRIPTION
## Summary
- handle possibly undefined capture entry by falling back to explicit BSSID value

## Testing
- `yarn run build` *(fails: next not found)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f536e68c8328b84433d1cbf01f4a