### PR TITLE
Handle optional fileName in Evidence vault

### DIFF
--- a/apps/metasploit-post/index.tsx
+++ b/apps/metasploit-post/index.tsx
@@ -118,7 +118,7 @@ const EvidenceVault: React.FC = () => {
     const entry: Evidence = {
       id: Date.now(),
       note,
-      fileName: file?.name,
+      ...(file ? { fileName: file.name } : {}),
       tags: tags.split(',').map((t) => t.trim()).filter(Boolean),
     };
     setItems((prev) => [...prev, entry]);


### PR DESCRIPTION
## Summary
- avoid assigning `undefined` to `fileName` when adding evidence entries

## Testing
- `yarn lint apps/metasploit-post/index.tsx`
- `yarn typecheck` *(fails: numerous existing TS errors across unrelated files)*
- `yarn test` *(fails: multiple suites, e.g. missing env variables and undefined modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f4fda7bc832887fe7cefe55e3337