### PR TITLE
Allow undefined fileName in Evidence interface

### DIFF
--- a/apps/metasploit-post/index.tsx
+++ b/apps/metasploit-post/index.tsx
@@ -32,7 +32,7 @@ interface PrivNode {
 interface Evidence {
   id: number;
   note: string;
-  fileName?: string;
+  fileName?: string | undefined;
   tags: string[];
 }
 
@@ -118,7 +118,7 @@ const EvidenceVault: React.FC = () => {
     const entry: Evidence = {
       id: Date.now(),
       note,
-      ...(file ? { fileName: file.name } : {}),
+      fileName: file?.name,
       tags: tags.split(',').map((t) => t.trim()).filter(Boolean),
     };
     setItems((prev) => [...prev, entry]);


### PR DESCRIPTION
## Summary
- permit Evidence.fileName to be `string | undefined`
- add evidence entries directly using `file?.name`

## Testing
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest' and 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68c0f695ceb883288371945ff08234b7