### PR TITLE
Fix result array update in metasploit-post app

### DIFF
--- a/apps/metasploit-post/index.tsx
+++ b/apps/metasploit-post/index.tsx
@@ -214,10 +214,13 @@ const MetasploitPost: React.FC = () => {
 
   const runModule = (mod: ModuleEntry) => {
     const result = { title: mod.path, output: mod.sampleOutput };
-    setResults((prev) => ({
-      ...prev,
-      [activeTab]: [...prev[activeTab], result],
-    }));
+    setResults((prev) => {
+      const items = prev[activeTab] ?? [];
+      return {
+        ...prev,
+        [activeTab]: [...items, result],
+      };
+    });
     setSelected(mod);
     animateSteps();
   };


### PR DESCRIPTION
## Summary
- handle undefined tab results when recording module output

## Testing
- `yarn test apps/metasploit-post` *(fails: jest: not found)*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest', 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68c0f887d17c832898cf494dc6be31f7