### PR TITLE
fix: guard against missing loot artifacts

### DIFF
--- a/apps/metasploit/components/LootViewer.tsx
+++ b/apps/metasploit/components/LootViewer.tsx
@@ -22,8 +22,15 @@ const LootViewer: React.FC = () => {
     (v): v is string[] => Array.isArray(v) && v.every((x) => typeof x === 'string'),
   );
 
-  const artifact = artifacts[index];
   const total = artifacts.length;
+  const artifact = artifacts[index];
+  if (!artifact) {
+    return (
+      <div className="p-4 text-sm bg-ub-grey flex flex-col gap-2">
+        <p>No artifacts available.</p>
+      </div>
+    );
+  }
   const isFavorite = favorites.includes(artifact.id);
 
   const prev = () => setIndex((i) => (i === 0 ? total - 1 : i - 1));


### PR DESCRIPTION
## Summary
- avoid crash when selecting out-of-range metasploit loot by rendering fallback message

## Testing
- `yarn lint apps/metasploit/components/LootViewer.tsx` *(fails: Cannot find package '@eslint/eslintrc')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest' and 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68c0fa7139ec83288aca3771bf57afba