### PR TITLE
fix: handle missing loot artifacts

### DIFF
--- a/apps/metasploit/components/LootViewer.tsx
+++ b/apps/metasploit/components/LootViewer.tsx
@@ -24,10 +24,15 @@ const LootViewer: React.FC = () => {
 
   const artifact = artifacts[index];
   const total = artifacts.length;
-  const isFavorite = favorites.includes(artifact.id);
 
   const prev = () => setIndex((i) => (i === 0 ? total - 1 : i - 1));
   const next = () => setIndex((i) => (i === total - 1 ? 0 : i + 1));
+
+  if (!artifact) {
+    return null;
+  }
+
+  const isFavorite = favorites.includes(artifact.id);
   const toggleFavorite = () => {
     setFavorites((f) =>
       f.includes(artifact.id)


### PR DESCRIPTION
## Summary
- prevent undefined artifact access in Metasploit LootViewer component

## Testing
- `yarn lint apps/metasploit/components/LootViewer.tsx` *(fails: A control must be associated with a text label, duplicate filename errors)*
- `yarn test apps/metasploit/components/TargetEmulator.test.tsx`
- `yarn tsc apps/metasploit/components/LootViewer.tsx` *(fails: Cannot use JSX unless the '--jsx' flag is provided, missing module declarations)*
- `yarn build` *(fails: apps/mimikatz/components/ExposureExplainer.tsx - Object is possibly 'undefined')*

------
https://chatgpt.com/codex/tasks/task_e_68c0faa53ea48328805500cd75c67457