### PR TITLE
fix: handle undefined loot artifact

### DIFF
--- a/apps/metasploit/components/LootViewer.tsx
+++ b/apps/metasploit/components/LootViewer.tsx
@@ -23,11 +23,11 @@ const LootViewer: React.FC = () => {
   );
 
   const total = artifacts.length;
+  const artifact = artifacts[index];
 
   if (!artifact) {
     return null;
   }
-
 
   const isFavorite = favorites.includes(artifact.id);
 


### PR DESCRIPTION
## Summary
- prevent accessing undefined loot artifact

## Testing
- `yarn test apps/metasploit/components/TargetEmulator.test.tsx`
- `yarn run build` *(fails: Object is possibly 'undefined' in apps/mimikatz/components/ExposureExplainer.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fbf603408328be647c3cf0e6bb02