### PR TITLE
fix: guard step access in exposure explainer

### DIFF
--- a/apps/mimikatz/components/ExposureExplainer.tsx
+++ b/apps/mimikatz/components/ExposureExplainer.tsx
@@ -58,6 +58,7 @@ const steps: Step[] = [
 
 const ExposureExplainer: React.FC = () => {
   const [index, setIndex] = useState(0);
+  const currentStep = steps[index];
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -65,6 +66,10 @@ const ExposureExplainer: React.FC = () => {
     }, 4000);
     return () => clearInterval(timer);
   }, []);
+
+  if (!currentStep) {
+    return null;
+  }
 
   return (
     <div className="text-white p-4">
@@ -83,8 +88,8 @@ const ExposureExplainer: React.FC = () => {
           </div>
         ))}
       </div>
-      <h3 className="text-lg font-bold text-center mb-2">{steps[index].title}</h3>
-      <p className="text-center max-w-md mx-auto mb-4">{steps[index].description}</p>
+      <h3 className="text-lg font-bold text-center mb-2">{currentStep.title}</h3>
+      <p className="text-center max-w-md mx-auto mb-4">{currentStep.description}</p>
       <div className="flex justify-center space-x-2">
         {steps.map((_, i) => (
           <button


### PR DESCRIPTION
## Summary
- handle undefined step indexes in ExposureExplainer component

## Testing
- `npx eslint apps/mimikatz/components/ExposureExplainer.tsx`
- `npx tsc --noEmit -p tsconfig.json` *(fails: Type 'HTMLButtonElement | null' is not assignable to type...)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fedace848328af6a44c2c30bf94e