### PR TITLE
Guard ExposureExplainer index access

### DIFF
--- a/apps/mimikatz/components/ExposureExplainer.tsx
+++ b/apps/mimikatz/components/ExposureExplainer.tsx
@@ -66,6 +66,8 @@ const ExposureExplainer: React.FC = () => {
     return () => clearInterval(timer);
   }, []);
 
+  const currentStep = steps[index] ?? steps[0];
+
   return (
     <div className="text-white p-4">
       <div className="bg-yellow-400 text-black text-center font-bold mb-4">
@@ -83,8 +85,8 @@ const ExposureExplainer: React.FC = () => {
           </div>
         ))}
       </div>
-      <h3 className="text-lg font-bold text-center mb-2">{steps[index].title}</h3>
-      <p className="text-center max-w-md mx-auto mb-4">{steps[index].description}</p>
+      <h3 className="text-lg font-bold text-center mb-2">{currentStep.title}</h3>
+      <p className="text-center max-w-md mx-auto mb-4">{currentStep.description}</p>
       <div className="flex justify-center space-x-2">
         {steps.map((_, i) => (
           <button


### PR DESCRIPTION
## Summary
- prevent undefined step access in ExposureExplainer by defaulting to the first step

## Testing
- `yarn tsc -p tsconfig.json --noEmit` *(fails: Element implicitly has an 'any' type, etc.)*
- `yarn test` *(fails: ReferenceError: displayYouTube is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fee6513c83288d1cdd29115cb087