### PR TITLE
refactor: type global fetch proxy flag

### DIFF
--- a/lib/fetchProxy.ts
+++ b/lib/fetchProxy.ts
@@ -51,9 +51,9 @@ function notify(type: 'start' | 'end', record: FetchLog) {
   }
 }
 
-if (typeof globalThis.fetch === 'function' && !(globalThis as any).__fetchProxyInstalled) {
+if (typeof globalThis.fetch === 'function' && !globalThis.__fetchProxyInstalled) {
   const originalFetch = globalThis.fetch.bind(globalThis);
-  (globalThis as any).__fetchProxyInstalled = true;
+  globalThis.__fetchProxyInstalled = true;
 
   globalThis.fetch = async (
     input: RequestInfo | URL,
@@ -81,7 +81,7 @@ if (typeof globalThis.fetch === 'function' && !(globalThis as any).__fetchProxyI
     notify('start', record);
 
     try {
-      const response = await originalFetch(input as any, init);
+      const response = await originalFetch(input, init);
       const end = now();
       record.endTime = end;
       record.duration = end - record.startTime;
@@ -102,8 +102,8 @@ if (typeof globalThis.fetch === 'function' && !(globalThis as any).__fetchProxyI
       if (contentLength) {
         finalize(Number(contentLength));
       } else if (
-        typeof (response as any).clone === 'function' &&
-        typeof (response as any).arrayBuffer === 'function'
+        typeof response.clone === 'function' &&
+        typeof response.arrayBuffer === 'function'
       ) {
         try {
           response

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
       "jest",
       "node",
       "./types/file-system-access",
-      "./types/web-bluetooth"
+      "./types/web-bluetooth",
+      "./types/fetch-proxy"
     ],
     "baseUrl": ".",
     "paths": {

--- a/types/fetch-proxy.d.ts
+++ b/types/fetch-proxy.d.ts
@@ -1,0 +1,6 @@
+export {};
+
+declare global {
+  var __fetchProxyInstalled: boolean | undefined;
+}
+


### PR DESCRIPTION
## Summary
- declare optional global flag to mark fetch proxy installation
- register the fetch proxy declaration in tsconfig
- remove `any` casts from `lib/fetchProxy`

## Testing
- `yarn test lib/fetchProxy.ts --passWithNoTests`
- `yarn typecheck` *(fails: TypeScript errors in unrelated files)*


------
https://chatgpt.com/codex/tasks/task_e_68c10020eb74832881d6bcb6e7a7fb2c