### PR TITLE
chore: run pre-commit typecheck with yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": "20.x"
   },
   "simple-git-hooks": {
-    "pre-commit": "pnpm -w typecheck && tsc --noEmit -p packages/*"
+    "pre-commit": "yarn typecheck"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.9",


### PR DESCRIPTION
## Summary
- run pre-commit typecheck with yarn instead of pnpm

## Testing
- `yarn typecheck` *(fails: Type 'HTMLButtonElement | null' is not assignable to type 'void | (() => VoidOrUndefinedOnly)'...)*

------
https://chatgpt.com/codex/tasks/task_e_68c1001e687c83289479b735b426c443