### PR TITLE
chore: enforce Yarn 4 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,5 +194,5 @@
     "workbox-build@npm:7.1.1": "npm:workbox-build@7.3.0",
     "three-bmfont-text": "npm:three-bmfont-text@^3.0.1"
   },
-  "packageManager": "yarn@1.22.22"
+  "packageManager": "yarn@4.9.2"
 }


### PR DESCRIPTION
## Summary
- use Yarn 4.9.2 via package.json `packageManager`

## Testing
- `yarn test` *(fails: eslint-plugin-no-dupe-app-imports: This package doesn't seem to be present in your lockfile)*
- `npm test` *(fails: multiple test failures; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68c1001da07083288889c5e2a2d1f08d