### PR TITLE
chore: document type suppressions and replace ts-ignore

### DIFF
--- a/__tests__/autopsy.test.tsx
+++ b/__tests__/autopsy.test.tsx
@@ -45,7 +45,7 @@ describe('Autopsy plugins and timeline', () => {
         this.onload && this.onload({ target: { result: buffer } });
       }
     }
-    // @ts-ignore
+    // @ts-expect-error FileReader not defined in Node tests
     global.FileReader = FileReaderMock;
   });
 

--- a/__tests__/flappyBird.test.tsx
+++ b/__tests__/flappyBird.test.tsx
@@ -4,7 +4,7 @@ import FlappyBird from '../components/apps/flappy-bird';
 
 beforeAll(() => {
   // Minimal ResizeObserver mock for the test environment
-  // @ts-ignore
+  // @ts-expect-error ResizeObserver not available in tests
   global.ResizeObserver = class {
     observe() {}
     unobserve() {}

--- a/__tests__/gameAudioNodes.test.ts
+++ b/__tests__/gameAudioNodes.test.ts
@@ -26,9 +26,9 @@ describe('game audio node manager', () => {
       close = close;
     }
 
-    // @ts-ignore
+    // @ts-expect-error Web Audio API not available in JSDOM
     window.AudioContext = MockAudioContext as any;
-    // @ts-ignore
+    // @ts-expect-error Web Audio API not available in JSDOM
     window.webkitAudioContext = MockAudioContext as any;
   });
 

--- a/__tests__/hydra.test.tsx
+++ b/__tests__/hydra.test.tsx
@@ -14,7 +14,7 @@ describe('Hydra wordlists', () => {
         if (this.onload) this.onload({ target: { result: 'user\n' } });
       }
     }
-    // @ts-ignore
+    // @ts-expect-error FileReader not defined in Node tests
     global.FileReader = MockFileReader;
 
     const file = new File(['user\n'], 'users.txt', { type: 'text/plain' });
@@ -59,7 +59,7 @@ describe('Hydra pause and resume', () => {
 
   it('pauses and resumes cracking progress', async () => {
     let runResolve: Function = () => {};
-    // @ts-ignore
+    // @ts-expect-error fetch not in Node tests
     global.fetch = jest.fn((url, options) => {
       if (options && options.body && options.body.includes('action')) {
         return Promise.resolve({ json: async () => ({}) });
@@ -113,7 +113,7 @@ describe('Hydra session restore', () => {
 
   it('resumes attack from saved session', async () => {
     let runResolve: Function = () => {};
-    // @ts-ignore
+    // @ts-expect-error fetch not in Node tests
     global.fetch = jest.fn((url, options) => {
       if (options && options.body && options.body.includes('resume')) {
         return Promise.resolve({ json: async () => ({ output: '' }) });

--- a/__tests__/hydraStepper.test.tsx
+++ b/__tests__/hydraStepper.test.tsx
@@ -5,7 +5,7 @@ import Stepper from '../components/apps/hydra/Stepper';
 describe('Hydra Stepper', () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    // @ts-ignore
+    // @ts-expect-error matchMedia missing in JSDOM
     window.matchMedia = window.matchMedia || function () {
       return {
         matches: false,
@@ -13,7 +13,7 @@ describe('Hydra Stepper', () => {
         removeListener: () => {},
       };
     };
-    // @ts-ignore
+    // @ts-expect-error requestAnimationFrame not in Node tests
     window.requestAnimationFrame = (cb: any) => cb();
   });
 

--- a/__tests__/metasploit.test.tsx
+++ b/__tests__/metasploit.test.tsx
@@ -4,7 +4,7 @@ import MetasploitApp from '../components/apps/metasploit';
 
 describe.skip('Metasploit app', () => {
   beforeEach(() => {
-    // @ts-ignore
+    // @ts-expect-error fetch not in Node tests
     global.fetch = jest.fn(() =>
       Promise.resolve({
         json: () => Promise.resolve({ loot: [], notes: [] }),
@@ -56,7 +56,7 @@ describe.skip('Metasploit app', () => {
   });
 
   it('toggles loot viewer', async () => {
-    // @ts-ignore
+    // @ts-expect-error fetch not in Node tests
     global.fetch = jest.fn(() =>
       Promise.resolve({
         json: () =>

--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -41,7 +41,7 @@ describe('NmapNSEApp', () => {
         })
       );
     const writeText = jest.fn();
-    // @ts-ignore
+    // @ts-expect-error Clipboard API not available in tests
     navigator.clipboard = { writeText };
 
     render(<NmapNSEApp />);
@@ -70,7 +70,7 @@ describe('NmapNSEApp', () => {
         })
       );
     const writeText = jest.fn();
-    // @ts-ignore
+    // @ts-expect-error Clipboard API not available in tests
     navigator.clipboard = { writeText };
 
     render(<NmapNSEApp />);

--- a/__tests__/openvas.test.tsx
+++ b/__tests__/openvas.test.tsx
@@ -13,10 +13,10 @@ describe('OpenVASApp', () => {
 
     const notificationMock: any = jest.fn();
     (notificationMock as any).permission = 'granted';
-    // @ts-ignore
+    // @ts-expect-error Notification API not in Node tests
     global.Notification = notificationMock;
 
-    // @ts-ignore
+    // @ts-expect-error URL.createObjectURL missing in JSDOM
     global.URL.createObjectURL = jest.fn(() => 'blob:summary');
     localStorage.clear();
   });

--- a/__tests__/passwordGenerator.test.tsx
+++ b/__tests__/passwordGenerator.test.tsx
@@ -13,7 +13,7 @@ describe('PasswordGenerator', () => {
 
   it('copies password to clipboard', async () => {
     const writeText = jest.fn().mockResolvedValue(undefined);
-    // @ts-ignore
+    // @ts-expect-error Clipboard API not available in tests
     Object.assign(navigator, { clipboard: { writeText } });
     const { getByText, getByTestId } = render(<PasswordGenerator />);
     fireEvent.click(getByText('Generate'));

--- a/__tests__/player.test.ts
+++ b/__tests__/player.test.ts
@@ -11,9 +11,9 @@ describe('audio player pooling', () => {
         this.state = 'running';
       }
     }
-    // @ts-ignore
+    // @ts-expect-error Web Audio API not available in JSDOM
     window.AudioContext = MockAudioContext as any;
-    // @ts-ignore
+    // @ts-expect-error Web Audio API not available in JSDOM
     window.webkitAudioContext = MockAudioContext as any;
     Object.defineProperty(window.HTMLMediaElement.prototype, 'pause', {
       configurable: true,

--- a/__tests__/playwright/fallbacks.spec.ts
+++ b/__tests__/playwright/fallbacks.spec.ts
@@ -6,7 +6,7 @@ test.describe('browser API fallbacks', () => {
   test('falls back when OffscreenCanvas is unsupported', async ({ browser }) => {
     const context = await browser.newContext();
     await context.addInitScript(() => {
-      // @ts-ignore
+      // @ts-expect-error OffscreenCanvas not in older types
       delete window.OffscreenCanvas;
     });
     const page = await context.newPage();
@@ -47,7 +47,7 @@ test.describe('browser API fallbacks', () => {
     const context = await browser.newContext();
     await context.addInitScript(() => {
       Object.defineProperty(document, 'pictureInPictureEnabled', { value: false });
-      // @ts-ignore
+      // @ts-expect-error PiP API not in JSDOM
       delete HTMLVideoElement.prototype.requestPictureInPicture;
     });
     const page = await context.newPage();

--- a/__tests__/qr_tool.test.tsx
+++ b/__tests__/qr_tool.test.tsx
@@ -19,7 +19,7 @@ describe('QRTool generator', () => {
       }
       terminate() {}
     }
-    // @ts-ignore
+    // @ts-expect-error Worker not defined in Node tests
     global.Worker = MockWorker;
   });
 

--- a/__tests__/reducedMotion.test.tsx
+++ b/__tests__/reducedMotion.test.tsx
@@ -9,7 +9,7 @@ describe('prefers-reduced-motion handling', () => {
   });
 
   test('detects system preference via media query', async () => {
-    // @ts-ignore
+    // @ts-expect-error matchMedia missing in JSDOM
     window.matchMedia = jest.fn().mockImplementation((query) => ({
       matches: query.includes('reduced-motion'),
       addEventListener: jest.fn(),

--- a/__tests__/rtl-locale.test.tsx
+++ b/__tests__/rtl-locale.test.tsx
@@ -8,7 +8,7 @@ describe('useLocale', () => {
 
   test('applies rtl direction when locale is rtl', () => {
     const original = Intl.DateTimeFormat;
-    // @ts-ignore overriding for test
+    // @ts-expect-error override Intl in test
     Intl.DateTimeFormat = jest.fn().mockReturnValue({
       resolvedOptions: () => ({ locale: 'ar' }),
     });
@@ -24,7 +24,7 @@ describe('useLocale', () => {
 
   test('defaults to ltr direction', () => {
     const original = Intl.DateTimeFormat;
-    // @ts-ignore overriding for test
+    // @ts-expect-error override Intl in test
     Intl.DateTimeFormat = jest.fn().mockReturnValue({
       resolvedOptions: () => ({ locale: 'en-US' }),
     });

--- a/__tests__/saveSlots.test.ts
+++ b/__tests__/saveSlots.test.ts
@@ -1,10 +1,9 @@
 import 'fake-indexeddb/auto';
 
-// Provide a lightweight structuredClone polyfill for fake-indexeddb
-// in environments where it is missing.
-// @ts-ignore
+// Provide a lightweight structuredClone polyfill for environments lacking it
+// @ts-expect-error structuredClone not yet typed in Node
 if (typeof globalThis.structuredClone !== 'function') {
-  // @ts-ignore
+  // @ts-expect-error assign polyfill for structuredClone
   globalThis.structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
 }
 

--- a/__tests__/scrollableTimeline.test.tsx
+++ b/__tests__/scrollableTimeline.test.tsx
@@ -10,7 +10,7 @@ beforeAll(() => {
     unobserve() {}
     takeRecords() { return []; }
   }
-  // @ts-ignore
+  // @ts-expect-error IntersectionObserver missing in Node
   global.IntersectionObserver = IntersectionObserverMock;
 });
 

--- a/__tests__/sticky-toc.test.tsx
+++ b/__tests__/sticky-toc.test.tsx
@@ -17,7 +17,7 @@ class IO {
 describe('StickyTOC', () => {
   let observer: IO;
   beforeEach(() => {
-    // @ts-ignore
+    // @ts-expect-error IntersectionObserver missing in Node
     global.IntersectionObserver = jest.fn((cb) => {
       observer = new IO(cb);
       return observer;

--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -67,11 +67,11 @@ describe('theme persistence and unlocking', () => {
 
   test('defaults to system preference when no stored theme', () => {
     // simulate dark mode preference
-    // @ts-ignore
+    // @ts-expect-error matchMedia not in JSDOM
     window.matchMedia = jest.fn().mockReturnValue({ matches: true });
     expect(getTheme()).toBe('dark');
     // simulate light mode preference
-    // @ts-ignore
+    // @ts-expect-error matchMedia not in JSDOM
     window.matchMedia = jest.fn().mockReturnValue({ matches: false });
     expect(getTheme()).toBe('default');
   });

--- a/components/apps/chrome/index.tsx
+++ b/components/apps/chrome/index.tsx
@@ -779,7 +779,7 @@ const Chrome: React.FC = () => {
               title={activeTab.url}
               className="w-full h-full"
               sandbox={SANDBOX_FLAGS.join(' ')}
-              // @ts-ignore - CSP is a valid attribute but not in the React types
+              // @ts-expect-error CSP attribute not yet typed in React
               csp={CSP}
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; geolocation; gyroscope; picture-in-picture; microphone; camera"
               referrerPolicy="no-referrer"

--- a/components/apps/project-gallery.tsx
+++ b/components/apps/project-gallery.tsx
@@ -45,7 +45,7 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
       /* ignore */
     }
     try {
-      // @ts-ignore - OPFS not yet in TypeScript libs
+      // @ts-expect-error OPFS not yet in TypeScript libs
       const root = await navigator.storage?.getDirectory();
       const handle = await root?.getFileHandle(STORAGE_FILE);
       const file = await handle?.getFile();
@@ -71,7 +71,7 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
       /* ignore */
     }
     try {
-      // @ts-ignore - OPFS not yet in TypeScript libs
+      // @ts-expect-error OPFS not yet in TypeScript libs
       const root = await navigator.storage?.getDirectory();
       const handle = await root?.getFileHandle(STORAGE_FILE, { create: true });
       const writable = await handle?.createWritable();

--- a/components/pwa/InstallPrompt.tsx
+++ b/components/pwa/InstallPrompt.tsx
@@ -29,7 +29,7 @@ export default function InstallPrompt() {
     if (localStorage.getItem(STORAGE_KEY)) return;
     const isStandalone =
       window.matchMedia('(display-mode: standalone)').matches ||
-      // @ts-ignore - iOS Safari
+      // @ts-expect-error standalone not in Navigator types
       (navigator.standalone === true);
     if (isStandalone) return;
 

--- a/docs/type-debt.md
+++ b/docs/type-debt.md
@@ -1,0 +1,29 @@
+# Type Suppression Debt
+
+Each entry tracks a `@ts-expect-error` added to work around missing or incomplete type definitions. These should be revisited and removed once proper types are available.
+
+| File | Reason | Owner | Planned Removal |
+| --- | --- | --- | --- |
+| jest.setup.ts | Web API stubs for Jest (TextEncoder, localStorage, IntersectionObserver, matchMedia, fetch, Canvas) | @kali-maintainers | 2025-01-01 |
+| __tests__/autopsy.test.tsx | FileReader not defined in Node tests | @kali-maintainers | 2025-01-01 |
+| __tests__/reducedMotion.test.tsx | matchMedia missing in JSDOM | @kali-maintainers | 2025-01-01 |
+| __tests__/saveSlots.test.ts | structuredClone polyfill lacks types | @kali-maintainers | 2025-01-01 |
+| components/apps/chrome/index.tsx | CSP attribute not typed in React | @kali-maintainers | 2025-01-01 |
+| components/apps/project-gallery.tsx | OPFS APIs not in TypeScript libs | @kali-maintainers | 2025-01-01 |
+| __tests__/player.test.ts | Web Audio API missing in JSDOM | @kali-maintainers | 2025-01-01 |
+| __tests__/openvas.test.tsx | Notification and URL APIs missing in Node | @kali-maintainers | 2025-01-01 |
+| __tests__/qr_tool.test.tsx | Worker not defined in Node tests | @kali-maintainers | 2025-01-01 |
+| __tests__/playwright/fallbacks.spec.ts | OffscreenCanvas and PiP APIs not typed | @kali-maintainers | 2025-01-01 |
+| __tests__/passwordGenerator.test.tsx | Clipboard API not available in tests | @kali-maintainers | 2025-01-01 |
+| __tests__/rtl-locale.test.tsx | Override of Intl.DateTimeFormat | @kali-maintainers | 2025-01-01 |
+| components/pwa/InstallPrompt.tsx | navigator.standalone not in Navigator types | @kali-maintainers | 2025-01-01 |
+| __tests__/gameAudioNodes.test.ts | Web Audio API missing in JSDOM | @kali-maintainers | 2025-01-01 |
+| hooks/useLocale.ts | Intl.Locale not yet in libs | @kali-maintainers | 2025-01-01 |
+| __tests__/hydraStepper.test.tsx | matchMedia and requestAnimationFrame missing | @kali-maintainers | 2025-01-01 |
+| __tests__/sticky-toc.test.tsx | IntersectionObserver missing in Node | @kali-maintainers | 2025-01-01 |
+| __tests__/themePersistence.test.ts | matchMedia missing in JSDOM | @kali-maintainers | 2025-01-01 |
+| __tests__/nmapNse.test.tsx | Clipboard API not available in tests | @kali-maintainers | 2025-01-01 |
+| __tests__/metasploit.test.tsx | fetch not defined in Node tests | @kali-maintainers | 2025-01-01 |
+| __tests__/scrollableTimeline.test.tsx | IntersectionObserver missing in Node | @kali-maintainers | 2025-01-01 |
+| __tests__/flappyBird.test.tsx | ResizeObserver not in JSDOM | @kali-maintainers | 2025-01-01 |
+| __tests__/hydra.test.tsx | FileReader and fetch not defined in Node tests | @kali-maintainers | 2025-01-01 |

--- a/hooks/useLocale.ts
+++ b/hooks/useLocale.ts
@@ -11,7 +11,7 @@ function detectLocale(): LocaleInfo {
   const { locale } = new Intl.DateTimeFormat().resolvedOptions();
   let dir: TextDirection = 'ltr';
   try {
-    // @ts-ignore - Intl.Locale may not be in older typings
+    // @ts-expect-error Intl.Locale may not exist in older libs
     const intlLocale = new Intl.Locale(locale);
     dir = intlLocale?.textInfo?.direction || 'ltr';
   } catch {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -3,11 +3,11 @@ import '@testing-library/jest-dom';
 
 // Provide TextEncoder/TextDecoder in the test environment
 if (!global.TextEncoder) {
-  // @ts-ignore
+  // @ts-expect-error Missing TextEncoder in Jest environment
   global.TextEncoder = TextEncoder;
 }
 if (!global.TextDecoder) {
-  // @ts-ignore
+  // @ts-expect-error Missing TextDecoder in Jest environment
   global.TextDecoder = TextDecoder as any;
 }
 
@@ -28,14 +28,14 @@ class LocalStorageMock {
   }
 }
 const localStorageMock = new LocalStorageMock();
-// @ts-ignore
+// @ts-expect-error Node globals lack localStorage
 if (!global.localStorage) {
-  // @ts-ignore
+  // @ts-expect-error Assign mock localStorage to global
   global.localStorage = localStorageMock;
 }
-// @ts-ignore
+// @ts-expect-error window missing localStorage in JSDOM
 if (typeof window !== 'undefined' && !window.localStorage) {
-  // @ts-ignore
+  // @ts-expect-error Assign mock localStorage to window
   window.localStorage = localStorageMock;
 }
 
@@ -46,21 +46,21 @@ class IntersectionObserverMock {
   unobserve() {}
   disconnect() {}
 }
-// @ts-ignore
+// @ts-expect-error JSDOM missing IntersectionObserver
 if (!global.IntersectionObserver) {
-  // @ts-ignore
+  // @ts-expect-error Assign mock IntersectionObserver
   global.IntersectionObserver = IntersectionObserverMock;
 }
-// @ts-ignore
+// @ts-expect-error JSDOM window missing IntersectionObserver
 if (typeof window !== 'undefined' && !window.IntersectionObserver) {
-  // @ts-ignore
+  // @ts-expect-error Assign mock IntersectionObserver to window
   window.IntersectionObserver = IntersectionObserverMock;
 }
 
 // matchMedia mock for components expecting it
-// @ts-ignore
+// @ts-expect-error JSDOM lacks matchMedia
 if (typeof window !== 'undefined' && !window.matchMedia) {
-  // @ts-ignore
+  // @ts-expect-error Provide mock matchMedia
   window.matchMedia = () => ({
     matches: false,
     addListener: () => {},
@@ -72,15 +72,15 @@ if (typeof window !== 'undefined' && !window.matchMedia) {
 }
 
 // Provide a stub for fetch so tests can spy on it
-// @ts-ignore
+// @ts-expect-error Node test environment lacks fetch
 if (!global.fetch) {
-  // @ts-ignore
+  // @ts-expect-error Assign mock fetch
   global.fetch = () => Promise.reject(new Error('fetch not implemented'));
 }
 
 // Canvas mock for tests relying on 2D context
 if (typeof HTMLCanvasElement !== 'undefined') {
-  // @ts-ignore
+  // @ts-expect-error JSDOM Canvas API incomplete
   HTMLCanvasElement.prototype.getContext = () => ({
     fillRect: () => {},
     clearRect: () => {},


### PR DESCRIPTION
## Summary
- replace `@ts-ignore` with `@ts-expect-error` and explain missing Web APIs
- track type suppressions in `docs/type-debt.md`

## Testing
- `npm test` *(fails: ReferenceError: displayYouTube is not defined, missing Playwright browsers, ESLint config errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c100200fa48328a9d46bcada3acd30