### PR TITLE
ci: run typegen and perf checks in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           node-version: 20.x
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - run: yarn typegen
       - run: yarn typecheck
 
   test:
@@ -115,9 +116,7 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
-
-validate-apps:
-
+  validate-apps:
     runs-on: ubuntu-latest
     needs: install
     steps:
@@ -127,8 +126,7 @@ validate-apps:
           node-version: 20.x
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: npm run validate:apps
-
+      - run: yarn validate:apps
 
   vercel-preview:
     runs-on: ubuntu-latest
@@ -170,6 +168,7 @@ validate-apps:
           cache: yarn
       - run: yarn install --immutable --immutable-cache
       - run: ANALYZE=true yarn build
+      - run: yarn perf:check
       - name: Enforce bundle budgets
         run: yarn check-budgets
       - run: yarn export


### PR DESCRIPTION
## Summary
- run `yarn typegen` before type checking
- switch validate apps script to `yarn`
- add `yarn perf:check` prior to bundle budget enforcement

## Testing
- `npx prettier .github/workflows/ci.yml --check`

------
https://chatgpt.com/codex/tasks/task_e_68c1001f52308328a93ce04719be17d1