### PR TITLE
chore: use yarn typegen and typecheck in pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": "20.x"
   },
   "simple-git-hooks": {
-    "pre-commit": "pnpm -w typecheck && tsc --noEmit -p packages/*"
+    "pre-commit": "yarn typegen && yarn typecheck"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.9",


### PR DESCRIPTION
## Summary
- run `yarn typegen` and `yarn typecheck` on pre-commit

## Testing
- `npx simple-git-hooks`
- `git commit -am "test pre-commit"` *(fails: tsc diagnostics)*

------
https://chatgpt.com/codex/tasks/task_e_68c100969c4483288b5190c4e13b9471