### PR TITLE
fix: ensure grouping array exists

### DIFF
--- a/apps/nikto/index.tsx
+++ b/apps/nikto/index.tsx
@@ -43,8 +43,9 @@ const NiktoPage: React.FC = () => {
 
   const grouped = useMemo(() => {
     return findings.reduce<Record<string, NiktoFinding[]>>((acc, f) => {
-      acc[f.severity] = acc[f.severity] || [];
-      acc[f.severity].push(f);
+      const list = acc[f.severity] ?? [];
+      list.push(f);
+      acc[f.severity] = list;
       return acc;
     }, {});
   }, [findings]);


### PR DESCRIPTION
## Summary
- avoid undefined push when grouping Nikto findings by severity

## Testing
- `yarn lint apps/nikto/index.tsx` *(fails: Cannot find package '@eslint/eslintrc')*
- `yarn install` *(fails: took too long to resolve packages)*
- `yarn build` *(fails: network/dependency resolution issues)*
- `npx --yes --package typescript@5.8.2 --package @types/react@19.1.12 --package @types/node@20.16.0 tsc --noEmit apps/nikto/index.tsx` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c100bfc010832886ba1e8e89c96884