### PR TITLE
feat: tighten event typings and BLE definitions

### DIFF
--- a/__tests__/scrollableTimeline.test.tsx
+++ b/__tests__/scrollableTimeline.test.tsx
@@ -12,6 +12,8 @@ beforeAll(() => {
   }
   // @ts-ignore
   global.IntersectionObserver = IntersectionObserverMock;
+  // Mock scrollTo as jsdom does not implement it
+  HTMLElement.prototype.scrollTo = function () {};
 });
 
 describe('ScrollableTimeline', () => {

--- a/__tests__/sensors.spec.ts
+++ b/__tests__/sensors.spec.ts
@@ -13,23 +13,28 @@ jest.mock('../utils/bleProfiles', () => ({
 describe('BleSensor error handling', () => {
   beforeEach(() => {
     window.confirm = jest.fn().mockReturnValue(true);
-    (navigator as any).bluetooth = {
-      requestDevice: jest
-        .fn()
-        .mockRejectedValueOnce(Object.assign(new Error('No devices found'), {
-          name: 'NotFoundError',
-        }))
-        .mockResolvedValueOnce({
-          id: 'dev1',
-          name: 'Device 1',
-          gatt: {
-            connect: jest.fn().mockResolvedValue({
-              getPrimaryServices: jest.fn().mockResolvedValue([]),
+    Object.defineProperty(navigator, 'bluetooth', {
+      configurable: true,
+      value: {
+        requestDevice: jest
+          .fn()
+          .mockRejectedValueOnce(
+            Object.assign(new Error('No devices found'), {
+              name: 'NotFoundError',
             }),
-          },
-          addEventListener: jest.fn(),
-        }),
-    };
+          )
+          .mockResolvedValueOnce({
+            id: 'dev1',
+            name: 'Device 1',
+            gatt: {
+              connect: jest.fn().mockResolvedValue({
+                getPrimaryServices: jest.fn().mockResolvedValue([]),
+              }),
+            },
+            addEventListener: jest.fn(),
+          }),
+      },
+    });
   });
 
   it('shows friendly error then connects on retry', async () => {

--- a/components/FixturesLoader.tsx
+++ b/components/FixturesLoader.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 
 interface LoaderProps {
-  onData: (rows: any[]) => void;
+  onData: (rows: Record<string, unknown>[]) => void;
 }
 
 export default function FixturesLoader({ onData }: LoaderProps) {

--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -9,8 +9,8 @@ const InstallButton: React.FC = () => {
 
   useEffect(() => {
     const handler = () => setVisible(true);
-    (window as any).addEventListener('a2hs:available', handler);
-    return () => (window as any).removeEventListener('a2hs:available', handler);
+    window.addEventListener<'a2hs:available'>('a2hs:available', handler);
+    return () => window.removeEventListener<'a2hs:available'>('a2hs:available', handler);
   }, []);
 
   const handleInstall = async () => {

--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -59,10 +59,7 @@ const ScrollableTimeline: React.FC = () => {
   }, [milestonesByYear, selectedYear]);
 
   useEffect(() => {
-    const container = containerRef.current as HTMLElement | null;
-    if (container && 'scrollTo' in container) {
-      (container as any).scrollTo({ left: 0 });
-    }
+    containerRef.current?.scrollTo({ left: 0 });
   }, [view, selectedYear]);
 
   useEffect(() => {

--- a/components/apps/ble-sensor.tsx
+++ b/components/apps/ble-sensor.tsx
@@ -12,9 +12,6 @@ import {
   CharacteristicData,
 } from '../../utils/bleProfiles';
 
-type BluetoothDevice = any;
-type BluetoothRemoteGATTServer = any;
-
 const MAX_RETRIES = 3;
 
 const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
@@ -72,7 +69,7 @@ const BleSensor: React.FC = () => {
     }
 
     try {
-      const device = await (navigator as any).bluetooth.requestDevice({
+      const device = await navigator.bluetooth.requestDevice({
         acceptAllDevices: true,
         optionalServices: ['battery_service', 'device_information'],
       });
@@ -98,7 +95,7 @@ const BleSensor: React.FC = () => {
       for (const service of primServices) {
           const chars = await service.getCharacteristics();
           const charData: CharacteristicData[] = await Promise.all(
-            chars.map(async (char: any) => {
+            chars.map(async (char: BluetoothRemoteGATTCharacteristic) => {
               try {
                 const val = await char.readValue();
                 let value = '';

--- a/components/apps/security-tools/index.tsx
+++ b/components/apps/security-tools/index.tsx
@@ -6,6 +6,24 @@ import ResultViewer from '../../ResultViewer';
 import ExplainerPane from '../../ExplainerPane';
 import EmptyState from '../../ui/EmptyState';
 
+type GenericRecord = Record<string, unknown>;
+interface SigmaRule extends GenericRecord {
+  id: string;
+  title: string;
+}
+interface MitreTechnique {
+  id: string;
+  name: string;
+}
+interface MitreTactic {
+  id: string;
+  name: string;
+  techniques: MitreTechnique[];
+}
+interface MitreData {
+  tactics: MitreTactic[];
+}
+
 const tabs = [
   { id: 'repeater', label: 'Repeater' },
   { id: 'suricata', label: 'Suricata Logs' },
@@ -20,21 +38,31 @@ export default function SecurityTools() {
   const [active, setActive] = useState('repeater');
   const [query, setQuery] = useState('');
   const [authorized, setAuthorized] = useState(false);
-  const [fixtureData, setFixtureData] = useState([]);
+  const [fixtureData, setFixtureData] = useState<GenericRecord[]>([]);
 
   // Logs, rules and fixtures
-  const [suricata, setSuricata] = useState([]);
-  const [zeek, setZeek] = useState([]);
-  const [sigma, setSigma] = useState([]);
-  const [mitre, setMitre] = useState({ tactics: [] });
+  const [suricata, setSuricata] = useState<GenericRecord[]>([]);
+  const [zeek, setZeek] = useState<GenericRecord[]>([]);
+  const [sigma, setSigma] = useState<SigmaRule[]>([]);
+  const [mitre, setMitre] = useState<MitreData>({ tactics: [] });
   const [sampleText, setSampleText] = useState('');
 
   useEffect(() => {
-    fetch('/fixtures/suricata.json').then(r => r.json()).then(setSuricata);
-    fetch('/fixtures/zeek.json').then(r => r.json()).then(setZeek);
-    fetch('/fixtures/sigma.json').then(r => r.json()).then(setSigma);
-    fetch('/fixtures/mitre.json').then(r => r.json()).then(setMitre);
-    fetch('/fixtures/yara_sample.txt').then(r => r.text()).then(setSampleText);
+    fetch('/fixtures/suricata.json')
+      .then((r) => r.json())
+      .then((d: GenericRecord[]) => setSuricata(d));
+    fetch('/fixtures/zeek.json')
+      .then((r) => r.json())
+      .then((d: GenericRecord[]) => setZeek(d));
+    fetch('/fixtures/sigma.json')
+      .then((r) => r.json())
+      .then((d: SigmaRule[]) => setSigma(d));
+    fetch('/fixtures/mitre.json')
+      .then((r) => r.json())
+      .then((d: MitreData) => setMitre(d));
+    fetch('/fixtures/yara_sample.txt')
+      .then((r) => r.text())
+      .then(setSampleText);
   }, []);
 
   const [yaraRule, setYaraRule] = useState('rule Demo { strings: $a = "MALWARE" condition: $a }');
@@ -83,7 +111,7 @@ export default function SecurityTools() {
     mitreResults.length ||
     (yaraMatch ? 1 : 0);
 
-  const tabButton = (t) => (
+  const tabButton = (t: { id: string; label: string }) => (
     <button
       key={t.id}
       onClick={() => setActive(t.id)}

--- a/docs/type-debt.md
+++ b/docs/type-debt.md
@@ -1,0 +1,3 @@
+# Type Debt
+
+- `types/global-window.d.ts`: The global `YT` and `twttr` properties are typed as `any` pending upstream type definitions for the YouTube and Twitter SDKs.

--- a/src/pwa/a2hs.ts
+++ b/src/pwa/a2hs.ts
@@ -1,5 +1,5 @@
 import { isBrowser } from '@/utils/env';
-interface BeforeInstallPromptEvent extends Event {
+export interface BeforeInstallPromptEvent extends Event {
   readonly platforms: string[];
   readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
   prompt(): Promise<void>;
@@ -13,7 +13,7 @@ export function initA2HS() {
     const event = e as BeforeInstallPromptEvent;
     event.preventDefault();
     deferredPrompt = event;
-    window.dispatchEvent(new Event('a2hs:available'));
+    window.dispatchEvent(new Event('a2hs:available') as CustomA2HSEvent);
   });
 }
 

--- a/types/global-window.d.ts
+++ b/types/global-window.d.ts
@@ -14,5 +14,11 @@ declare global {
       requestWindow: (options?: PictureInPictureWindowOptions) => Promise<Window>;
     };
   }
+
+  interface CustomA2HSEvent extends Event {}
+
+  interface WindowEventMap {
+    'a2hs:available': CustomA2HSEvent;
+  }
 }
 


### PR DESCRIPTION
## Summary
- add `CustomA2HSEvent` and declare `'a2hs:available'` on `WindowEventMap`
- clean up `InstallButton` & `a2hs` to use typed A2HS events
- replace Bluetooth `any` aliases with `web-bluetooth` types and remove `navigator as any`
- refactor `ResultViewer` to be generic and update fixtures loader/security tools
- switch `ScrollableTimeline` to `containerRef.current?.scrollTo`
- document remaining unavoidable `any`

## Testing
- `yarn test __tests__/installButton.test.tsx __tests__/scrollableTimeline.test.tsx __tests__/sensors.spec.ts`
- `yarn typecheck` *(fails: Type 'HTMLButtonElement | null' is not assignable to type 'void' and other existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c10098e3548328b0c11eeefa8490ef