### PR TITLE
fix: handle undefined severity groups

### DIFF
--- a/apps/nikto/index.tsx
+++ b/apps/nikto/index.tsx
@@ -43,8 +43,8 @@ const NiktoPage: React.FC = () => {
 
   const grouped = useMemo(() => {
     return findings.reduce<Record<string, NiktoFinding[]>>((acc, f) => {
-      acc[f.severity] = acc[f.severity] || [];
-      acc[f.severity].push(f);
+      const list = acc[f.severity] ?? (acc[f.severity] = []);
+      list.push(f);
       return acc;
     }, {});
   }, [findings]);
@@ -119,42 +119,45 @@ const NiktoPage: React.FC = () => {
         Build a nikto command without running any scans. Data and reports are static and for learning only.
       </p>
       <form onSubmit={(e) => e.preventDefault()} className="grid gap-4 md:grid-cols-3">
-        <div>
-          <label htmlFor="nikto-host" className="block text-sm mb-1">
-            Host
-          </label>
-          <input
-            id="nikto-host"
-            className="w-full p-2 rounded text-black"
-            value={host}
-            onChange={(e) => setHost(e.target.value)}
-          />
-        </div>
-        <div>
-          <label htmlFor="nikto-port" className="block text-sm mb-1">
-            Port
-          </label>
-          <input
-            id="nikto-port"
-            type="number"
-            className="w-full p-2 rounded text-black"
-            value={port}
-            onChange={(e) => setPort(e.target.value)}
-          />
-        </div>
-        <div className="flex items-center mt-2">
-          <input
-            id="nikto-ssl"
-            type="checkbox"
-            className="mr-2"
-            checked={ssl}
-            onChange={(e) => setSsl(e.target.checked)}
-          />
-          <label htmlFor="nikto-ssl" className="text-sm">
-            SSL
-          </label>
-        </div>
-      </form>
+          <div>
+            <label htmlFor="nikto-host" className="block text-sm mb-1">
+              Host
+            </label>
+            <input
+              id="nikto-host"
+              aria-label="Host"
+              className="w-full p-2 rounded text-black"
+              value={host}
+              onChange={(e) => setHost(e.target.value)}
+            />
+          </div>
+          <div>
+            <label htmlFor="nikto-port" className="block text-sm mb-1">
+              Port
+            </label>
+            <input
+              id="nikto-port"
+              type="number"
+              aria-label="Port"
+              className="w-full p-2 rounded text-black"
+              value={port}
+              onChange={(e) => setPort(e.target.value)}
+            />
+          </div>
+          <div className="flex items-center mt-2">
+            <input
+              id="nikto-ssl"
+              aria-label="Enable SSL"
+              type="checkbox"
+              className="mr-2"
+              checked={ssl}
+              onChange={(e) => setSsl(e.target.checked)}
+            />
+            <label htmlFor="nikto-ssl" className="text-sm">
+              SSL
+            </label>
+          </div>
+        </form>
       <div>
         <h2 className="text-lg mb-2">Command Preview</h2>
         <CommandChip command={command} />


### PR DESCRIPTION
## Summary
- avoid pushing into undefined severity buckets when grouping Nikto findings
- add aria-labels to Nikto inputs for accessibility

## Testing
- `npx eslint apps/nikto/index.tsx`
- `yarn test apps/nikto --passWithNoTests`
- `npx tsc --noEmit --lib DOM,ES2020 --jsx react-jsx apps/nikto/index.tsx` *(fails: Module '@types/react' can only be default-imported using the 'esModuleInterop' flag)*

------
https://chatgpt.com/codex/tasks/task_e_68c1013777c48328922903fb3a3082fe