### PR TITLE
ci: add build validation job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: 20.x
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: yarn typecheck
+      - run: yarn typegen && yarn typecheck
 
   test:
     runs-on: ubuntu-latest
@@ -115,9 +115,7 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
-
-validate-apps:
-
+  build:
     runs-on: ubuntu-latest
     needs: install
     steps:
@@ -127,7 +125,14 @@ validate-apps:
           node-version: 20.x
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: npm run validate:apps
+      - run: yarn build
+      - run: yarn perf:check
+      - run: yarn check-budgets
+      - run: |
+          yarn start &
+          npx wait-on http://localhost:3000
+      - run: yarn smoke
+      - run: yarn validate:apps
 
 
   vercel-preview:
@@ -161,6 +166,7 @@ validate-apps:
       - e2e
       - smoke
       - security
+      - build
       - verify
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- run typegen before typecheck
- add build job running smoke, validate apps, perf and budget checks
- gate export on new build job

## Testing
- `yarn lint .github/workflows/ci.yml` *(fails: File ignored because no matching configuration was supplied; ✖ 494 problems (493 errors, 1 warning))*

------
https://chatgpt.com/codex/tasks/task_e_68c10099fcc48328bfa88198aab408ac