### PR TITLE
Add navigator and iframe type extensions and replace ts-ignore

### DIFF
--- a/__tests__/autopsy.test.tsx
+++ b/__tests__/autopsy.test.tsx
@@ -45,7 +45,7 @@ describe('Autopsy plugins and timeline', () => {
         this.onload && this.onload({ target: { result: buffer } });
       }
     }
-    // @ts-ignore
+    // @ts-expect-error mock FileReader
     global.FileReader = FileReaderMock;
   });
 

--- a/__tests__/flappyBird.test.tsx
+++ b/__tests__/flappyBird.test.tsx
@@ -4,7 +4,7 @@ import FlappyBird from '../components/apps/flappy-bird';
 
 beforeAll(() => {
   // Minimal ResizeObserver mock for the test environment
-  // @ts-ignore
+  // @ts-expect-error ResizeObserver not in JSDOM
   global.ResizeObserver = class {
     observe() {}
     unobserve() {}

--- a/__tests__/gameAudioNodes.test.ts
+++ b/__tests__/gameAudioNodes.test.ts
@@ -26,9 +26,9 @@ describe('game audio node manager', () => {
       close = close;
     }
 
-    // @ts-ignore
+    // @ts-expect-error AudioContext mock
     window.AudioContext = MockAudioContext as any;
-    // @ts-ignore
+    // @ts-expect-error AudioContext mock
     window.webkitAudioContext = MockAudioContext as any;
   });
 

--- a/__tests__/hydra.test.tsx
+++ b/__tests__/hydra.test.tsx
@@ -14,7 +14,7 @@ describe('Hydra wordlists', () => {
         if (this.onload) this.onload({ target: { result: 'user\n' } });
       }
     }
-    // @ts-ignore
+    // @ts-expect-error Mock FileReader for tests
     global.FileReader = MockFileReader;
 
     const file = new File(['user\n'], 'users.txt', { type: 'text/plain' });
@@ -59,7 +59,7 @@ describe('Hydra pause and resume', () => {
 
   it('pauses and resumes cracking progress', async () => {
     let runResolve: Function = () => {};
-    // @ts-ignore
+    // @ts-expect-error Mock fetch for tests
     global.fetch = jest.fn((url, options) => {
       if (options && options.body && options.body.includes('action')) {
         return Promise.resolve({ json: async () => ({}) });
@@ -113,7 +113,7 @@ describe('Hydra session restore', () => {
 
   it('resumes attack from saved session', async () => {
     let runResolve: Function = () => {};
-    // @ts-ignore
+    // @ts-expect-error Mock fetch for tests
     global.fetch = jest.fn((url, options) => {
       if (options && options.body && options.body.includes('resume')) {
         return Promise.resolve({ json: async () => ({ output: '' }) });

--- a/__tests__/hydraStepper.test.tsx
+++ b/__tests__/hydraStepper.test.tsx
@@ -5,7 +5,7 @@ import Stepper from '../components/apps/hydra/Stepper';
 describe('Hydra Stepper', () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    // @ts-ignore
+    // @ts-expect-error JSDOM lacks matchMedia
     window.matchMedia = window.matchMedia || function () {
       return {
         matches: false,
@@ -13,7 +13,7 @@ describe('Hydra Stepper', () => {
         removeListener: () => {},
       };
     };
-    // @ts-ignore
+    // @ts-expect-error JSDOM stub
     window.requestAnimationFrame = (cb: any) => cb();
   });
 

--- a/__tests__/metasploit.test.tsx
+++ b/__tests__/metasploit.test.tsx
@@ -4,7 +4,7 @@ import MetasploitApp from '../components/apps/metasploit';
 
 describe.skip('Metasploit app', () => {
   beforeEach(() => {
-    // @ts-ignore
+    // @ts-expect-error Mock fetch
     global.fetch = jest.fn(() =>
       Promise.resolve({
         json: () => Promise.resolve({ loot: [], notes: [] }),
@@ -56,7 +56,7 @@ describe.skip('Metasploit app', () => {
   });
 
   it('toggles loot viewer', async () => {
-    // @ts-ignore
+    // @ts-expect-error Mock fetch
     global.fetch = jest.fn(() =>
       Promise.resolve({
         json: () =>

--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -41,7 +41,7 @@ describe('NmapNSEApp', () => {
         })
       );
     const writeText = jest.fn();
-    // @ts-ignore
+    // @ts-expect-error clipboard mock
     navigator.clipboard = { writeText };
 
     render(<NmapNSEApp />);
@@ -70,7 +70,7 @@ describe('NmapNSEApp', () => {
         })
       );
     const writeText = jest.fn();
-    // @ts-ignore
+    // @ts-expect-error clipboard mock
     navigator.clipboard = { writeText };
 
     render(<NmapNSEApp />);

--- a/__tests__/openvas.test.tsx
+++ b/__tests__/openvas.test.tsx
@@ -13,10 +13,10 @@ describe('OpenVASApp', () => {
 
     const notificationMock: any = jest.fn();
     (notificationMock as any).permission = 'granted';
-    // @ts-ignore
+    // @ts-expect-error mock Notification
     global.Notification = notificationMock;
 
-    // @ts-ignore
+    // @ts-expect-error mock URL
     global.URL.createObjectURL = jest.fn(() => 'blob:summary');
     localStorage.clear();
   });

--- a/__tests__/passwordGenerator.test.tsx
+++ b/__tests__/passwordGenerator.test.tsx
@@ -13,7 +13,7 @@ describe('PasswordGenerator', () => {
 
   it('copies password to clipboard', async () => {
     const writeText = jest.fn().mockResolvedValue(undefined);
-    // @ts-ignore
+    // @ts-expect-error clipboard mock
     Object.assign(navigator, { clipboard: { writeText } });
     const { getByText, getByTestId } = render(<PasswordGenerator />);
     fireEvent.click(getByText('Generate'));

--- a/__tests__/player.test.ts
+++ b/__tests__/player.test.ts
@@ -11,9 +11,9 @@ describe('audio player pooling', () => {
         this.state = 'running';
       }
     }
-    // @ts-ignore
+    // @ts-expect-error AudioContext mock
     window.AudioContext = MockAudioContext as any;
-    // @ts-ignore
+    // @ts-expect-error AudioContext mock
     window.webkitAudioContext = MockAudioContext as any;
     Object.defineProperty(window.HTMLMediaElement.prototype, 'pause', {
       configurable: true,

--- a/__tests__/playwright/fallbacks.spec.ts
+++ b/__tests__/playwright/fallbacks.spec.ts
@@ -6,7 +6,7 @@ test.describe('browser API fallbacks', () => {
   test('falls back when OffscreenCanvas is unsupported', async ({ browser }) => {
     const context = await browser.newContext();
     await context.addInitScript(() => {
-      // @ts-ignore
+      // @ts-expect-error force unsupported
       delete window.OffscreenCanvas;
     });
     const page = await context.newPage();
@@ -47,7 +47,7 @@ test.describe('browser API fallbacks', () => {
     const context = await browser.newContext();
     await context.addInitScript(() => {
       Object.defineProperty(document, 'pictureInPictureEnabled', { value: false });
-      // @ts-ignore
+      // @ts-expect-error force unsupported
       delete HTMLVideoElement.prototype.requestPictureInPicture;
     });
     const page = await context.newPage();

--- a/__tests__/qr_tool.test.tsx
+++ b/__tests__/qr_tool.test.tsx
@@ -19,7 +19,7 @@ describe('QRTool generator', () => {
       }
       terminate() {}
     }
-    // @ts-ignore
+    // @ts-expect-error Worker not in Node
     global.Worker = MockWorker;
   });
 

--- a/__tests__/reducedMotion.test.tsx
+++ b/__tests__/reducedMotion.test.tsx
@@ -9,7 +9,7 @@ describe('prefers-reduced-motion handling', () => {
   });
 
   test('detects system preference via media query', async () => {
-    // @ts-ignore
+    // @ts-expect-error mock matchMedia
     window.matchMedia = jest.fn().mockImplementation((query) => ({
       matches: query.includes('reduced-motion'),
       addEventListener: jest.fn(),

--- a/__tests__/rtl-locale.test.tsx
+++ b/__tests__/rtl-locale.test.tsx
@@ -8,7 +8,7 @@ describe('useLocale', () => {
 
   test('applies rtl direction when locale is rtl', () => {
     const original = Intl.DateTimeFormat;
-    // @ts-ignore overriding for test
+    // @ts-expect-error overriding for test
     Intl.DateTimeFormat = jest.fn().mockReturnValue({
       resolvedOptions: () => ({ locale: 'ar' }),
     });
@@ -24,7 +24,7 @@ describe('useLocale', () => {
 
   test('defaults to ltr direction', () => {
     const original = Intl.DateTimeFormat;
-    // @ts-ignore overriding for test
+    // @ts-expect-error overriding for test
     Intl.DateTimeFormat = jest.fn().mockReturnValue({
       resolvedOptions: () => ({ locale: 'en-US' }),
     });

--- a/__tests__/saveSlots.test.ts
+++ b/__tests__/saveSlots.test.ts
@@ -2,9 +2,9 @@ import 'fake-indexeddb/auto';
 
 // Provide a lightweight structuredClone polyfill for fake-indexeddb
 // in environments where it is missing.
-// @ts-ignore
+// @ts-expect-error structuredClone missing in Node
 if (typeof globalThis.structuredClone !== 'function') {
-  // @ts-ignore
+  // @ts-expect-error structuredClone missing in Node
   globalThis.structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
 }
 

--- a/__tests__/scrollableTimeline.test.tsx
+++ b/__tests__/scrollableTimeline.test.tsx
@@ -10,7 +10,7 @@ beforeAll(() => {
     unobserve() {}
     takeRecords() { return []; }
   }
-  // @ts-ignore
+  // @ts-expect-error IntersectionObserver not in JSDOM
   global.IntersectionObserver = IntersectionObserverMock;
 });
 

--- a/__tests__/sticky-toc.test.tsx
+++ b/__tests__/sticky-toc.test.tsx
@@ -17,7 +17,7 @@ class IO {
 describe('StickyTOC', () => {
   let observer: IO;
   beforeEach(() => {
-    // @ts-ignore
+    // @ts-expect-error mock IntersectionObserver
     global.IntersectionObserver = jest.fn((cb) => {
       observer = new IO(cb);
       return observer;

--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -67,11 +67,11 @@ describe('theme persistence and unlocking', () => {
 
   test('defaults to system preference when no stored theme', () => {
     // simulate dark mode preference
-    // @ts-ignore
+    // @ts-expect-error mock matchMedia
     window.matchMedia = jest.fn().mockReturnValue({ matches: true });
     expect(getTheme()).toBe('dark');
     // simulate light mode preference
-    // @ts-ignore
+    // @ts-expect-error mock matchMedia
     window.matchMedia = jest.fn().mockReturnValue({ matches: false });
     expect(getTheme()).toBe('default');
   });

--- a/components/apps/chrome/index.tsx
+++ b/components/apps/chrome/index.tsx
@@ -779,7 +779,6 @@ const Chrome: React.FC = () => {
               title={activeTab.url}
               className="w-full h-full"
               sandbox={SANDBOX_FLAGS.join(' ')}
-              // @ts-ignore - CSP is a valid attribute but not in the React types
               csp={CSP}
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; geolocation; gyroscope; picture-in-picture; microphone; camera"
               referrerPolicy="no-referrer"

--- a/components/apps/project-gallery.tsx
+++ b/components/apps/project-gallery.tsx
@@ -45,7 +45,6 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
       /* ignore */
     }
     try {
-      // @ts-ignore - OPFS not yet in TypeScript libs
       const root = await navigator.storage?.getDirectory();
       const handle = await root?.getFileHandle(STORAGE_FILE);
       const file = await handle?.getFile();
@@ -71,7 +70,6 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
       /* ignore */
     }
     try {
-      // @ts-ignore - OPFS not yet in TypeScript libs
       const root = await navigator.storage?.getDirectory();
       const handle = await root?.getFileHandle(STORAGE_FILE, { create: true });
       const writable = await handle?.createWritable();

--- a/components/pwa/InstallPrompt.tsx
+++ b/components/pwa/InstallPrompt.tsx
@@ -29,7 +29,6 @@ export default function InstallPrompt() {
     if (localStorage.getItem(STORAGE_KEY)) return;
     const isStandalone =
       window.matchMedia('(display-mode: standalone)').matches ||
-      // @ts-ignore - iOS Safari
       (navigator.standalone === true);
     if (isStandalone) return;
 

--- a/docs/type-debt.md
+++ b/docs/type-debt.md
@@ -1,0 +1,23 @@
+# TypeScript Expect Error Log
+
+This document tracks usages of `@ts-expect-error` and the rationale behind them.
+
+- `jest.setup.ts` – Polyfills DOM APIs missing in the Jest environment.
+- `__tests__/hydraStepper.test.tsx` – Stubs `matchMedia` and `requestAnimationFrame` for JSDOM.
+- `__tests__/flappyBird.test.tsx` – Provides a `ResizeObserver` mock.
+- `__tests__/hydra.test.tsx` – Mocks `FileReader` and `fetch`.
+- `__tests__/themePersistence.test.ts` – Mocks `matchMedia` for theme preference tests.
+- `__tests__/qr_tool.test.tsx` – Mocks the `Worker` constructor.
+- `__tests__/playwright/fallbacks.spec.ts` – Deletes APIs to simulate unsupported features.
+- `__tests__/scrollableTimeline.test.tsx` – Mocks `IntersectionObserver`.
+- `__tests__/rtl-locale.test.tsx` – Overrides `Intl.DateTimeFormat` for locale testing.
+- `__tests__/saveSlots.test.ts` – Polyfills `structuredClone` in Node.
+- `__tests__/openvas.test.tsx` – Mocks `Notification` and `URL.createObjectURL`.
+- `__tests__/reducedMotion.test.tsx` – Mocks `matchMedia` for reduced-motion preference.
+- `__tests__/metasploit.test.tsx` – Mocks `fetch` responses.
+- `__tests__/autopsy.test.tsx` – Mocks `FileReader`.
+- `__tests__/nmapNse.test.tsx` – Mocks `navigator.clipboard`.
+- `__tests__/player.test.ts` – Mocks `AudioContext` implementations.
+- `__tests__/sticky-toc.test.tsx` – Mocks `IntersectionObserver`.
+- `__tests__/gameAudioNodes.test.ts` – Mocks `AudioContext` implementations.
+- `__tests__/passwordGenerator.test.tsx` – Mocks `navigator.clipboard`.

--- a/hooks/useLocale.ts
+++ b/hooks/useLocale.ts
@@ -11,7 +11,6 @@ function detectLocale(): LocaleInfo {
   const { locale } = new Intl.DateTimeFormat().resolvedOptions();
   let dir: TextDirection = 'ltr';
   try {
-    // @ts-ignore - Intl.Locale may not be in older typings
     const intlLocale = new Intl.Locale(locale);
     dir = intlLocale?.textInfo?.direction || 'ltr';
   } catch {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -3,11 +3,11 @@ import '@testing-library/jest-dom';
 
 // Provide TextEncoder/TextDecoder in the test environment
 if (!global.TextEncoder) {
-  // @ts-ignore
+  // @ts-expect-error Polyfill for test environment
   global.TextEncoder = TextEncoder;
 }
 if (!global.TextDecoder) {
-  // @ts-ignore
+  // @ts-expect-error Polyfill for test environment
   global.TextDecoder = TextDecoder as any;
 }
 
@@ -28,14 +28,14 @@ class LocalStorageMock {
   }
 }
 const localStorageMock = new LocalStorageMock();
-// @ts-ignore
+// @ts-expect-error Polyfill for test environment
 if (!global.localStorage) {
-  // @ts-ignore
+  // @ts-expect-error Polyfill for test environment
   global.localStorage = localStorageMock;
 }
-// @ts-ignore
+// @ts-expect-error Polyfill for test environment
 if (typeof window !== 'undefined' && !window.localStorage) {
-  // @ts-ignore
+  // @ts-expect-error Polyfill for test environment
   window.localStorage = localStorageMock;
 }
 
@@ -46,21 +46,21 @@ class IntersectionObserverMock {
   unobserve() {}
   disconnect() {}
 }
-// @ts-ignore
+// @ts-expect-error Polyfill for test environment
 if (!global.IntersectionObserver) {
-  // @ts-ignore
+  // @ts-expect-error Polyfill for test environment
   global.IntersectionObserver = IntersectionObserverMock;
 }
-// @ts-ignore
+// @ts-expect-error Polyfill for test environment
 if (typeof window !== 'undefined' && !window.IntersectionObserver) {
-  // @ts-ignore
+  // @ts-expect-error Polyfill for test environment
   window.IntersectionObserver = IntersectionObserverMock;
 }
 
 // matchMedia mock for components expecting it
-// @ts-ignore
+// @ts-expect-error Polyfill for test environment
 if (typeof window !== 'undefined' && !window.matchMedia) {
-  // @ts-ignore
+  // @ts-expect-error Polyfill for test environment
   window.matchMedia = () => ({
     matches: false,
     addListener: () => {},
@@ -72,15 +72,15 @@ if (typeof window !== 'undefined' && !window.matchMedia) {
 }
 
 // Provide a stub for fetch so tests can spy on it
-// @ts-ignore
+// @ts-expect-error Polyfill for test environment
 if (!global.fetch) {
-  // @ts-ignore
+  // @ts-expect-error Polyfill for test environment
   global.fetch = () => Promise.reject(new Error('fetch not implemented'));
 }
 
 // Canvas mock for tests relying on 2D context
 if (typeof HTMLCanvasElement !== 'undefined') {
-  // @ts-ignore
+  // @ts-expect-error Polyfill for test environment
   HTMLCanvasElement.prototype.getContext = () => ({
     fillRect: () => {},
     clearRect: () => {},

--- a/src/apps/appfinder/AppFinder.tsx
+++ b/src/apps/appfinder/AppFinder.tsx
@@ -73,7 +73,9 @@ function parseDesktopFile(contents: string): DesktopEntry | null {
     }
   }
   if (!data.Name || !data.Exec) return null;
-  return { name: data.Name, exec: data.Exec, icon: data.Icon };
+  const entry: DesktopEntry = { name: data.Name, exec: data.Exec };
+  if (data.Icon) entry.icon = data.Icon;
+  return entry;
 }
 
 // Resolve a command to open a directory using the user's preferred file

--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -26,7 +26,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
     <Modal
       isOpen={open}
       onClose={onCancel}
-      ariaLabelledby={title ? headingId : undefined}
+      {...(title ? { ariaLabelledby: headingId } : {})}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
     >
       <div className="bg-gray-800 text-white p-4 rounded shadow-lg w-80 max-w-full">

--- a/src/components/desktop/DesktopContextMenu.tsx
+++ b/src/components/desktop/DesktopContextMenu.tsx
@@ -45,8 +45,8 @@ export const DesktopContextMenu: React.FC<DesktopContextMenuProps> = ({
   onClearSession,
 }) => {
   const menuRef = useRef<HTMLDivElement>(null);
-  useFocusTrap(menuRef, !!position);
-  useRovingTabIndex(menuRef, !!position, 'vertical');
+  useFocusTrap(menuRef as unknown as React.RefObject<HTMLElement>, !!position);
+  useRovingTabIndex(menuRef as unknown as React.RefObject<HTMLElement>, !!position, 'vertical');
 
   useEffect(() => {
     if (position && menuRef.current) {
@@ -73,7 +73,7 @@ export const DesktopContextMenu: React.FC<DesktopContextMenuProps> = ({
     <div
       role="menu"
       aria-label="Desktop context menu"
-      ref={menuRef}
+        ref={menuRef}
       onKeyDown={handleKeyDown}
       className="absolute z-50 w-52 cursor-default select-none rounded border border-gray-700 bg-gray-800 text-sm text-white shadow-lg"
       style={{ top: position.y, left: position.x }}

--- a/src/components/notifications/Notifier.tsx
+++ b/src/components/notifications/Notifier.tsx
@@ -37,10 +37,10 @@ export const Notifier: React.FC<{ children?: React.ReactNode }> = ({ children })
   }, []);
 
   useEffect(() => {
-    if (!current && queue.length > 0) {
-      setCurrent(queue[0]);
-      setQueue(q => q.slice(1));
-    }
+      if (!current && queue.length > 0) {
+        setCurrent(queue[0]!);
+        setQueue(q => q.slice(1));
+      }
   }, [queue, current]);
 
   useEffect(() => {

--- a/src/components/panel/Panel.tsx
+++ b/src/components/panel/Panel.tsx
@@ -90,7 +90,7 @@ export default function Panel() {
     setPlugins((prev) => {
       const updated = [...prev];
       const [item] = updated.splice(from, 1);
-      updated.splice(to, 0, item);
+      updated.splice(to, 0, item!);
       return updated;
     });
   };

--- a/src/components/panel/PowerMenu.tsx
+++ b/src/components/panel/PowerMenu.tsx
@@ -102,7 +102,9 @@ export default function PowerMenu({ index, move, innerRef, focused, onFocus }: P
         >
           <button
             role="menuitem"
-            ref={(el) => (itemRefs.current[0] = el)}
+            ref={(el) => {
+              itemRefs.current[0] = el;
+            }}
             onKeyDown={handleItemKey}
             onClick={() => {
               setOpen(false);
@@ -115,7 +117,9 @@ export default function PowerMenu({ index, move, innerRef, focused, onFocus }: P
           </button>
           <button
             role="menuitem"
-            ref={(el) => (itemRefs.current[1] = el)}
+            ref={(el) => {
+              itemRefs.current[1] = el;
+            }}
             onKeyDown={handleItemKey}
             onClick={() => {
               setOpen(false);
@@ -128,7 +132,9 @@ export default function PowerMenu({ index, move, innerRef, focused, onFocus }: P
           </button>
           <button
             role="menuitem"
-            ref={(el) => (itemRefs.current[2] = el)}
+            ref={(el) => {
+              itemRefs.current[2] = el;
+            }}
             onKeyDown={handleItemKey}
             onClick={() => {
               setOpen(false);

--- a/src/components/settings/AutostartManager.tsx
+++ b/src/components/settings/AutostartManager.tsx
@@ -20,7 +20,7 @@ const AutostartManager: React.FC = () => {
   const updateEntry = (index: number, change: Partial<AutostartEntry>) => {
     setEntries((prev) => {
       const next = [...prev];
-      next[index] = { ...next[index], ...change };
+      next[index] = { ...next[index], ...change } as AutostartEntry;
       return next;
     });
   };

--- a/src/lib/autostart.ts
+++ b/src/lib/autostart.ts
@@ -56,7 +56,7 @@ export async function readAutostart(): Promise<AutostartEntry[]> {
  */
 export async function saveAutostartEntry(entry: AutostartEntry): Promise<void> {
   const { file, data, name, enabled, delay } = entry;
-  const updated = { ...data, Name: name };
+  const updated: Record<string, any> = { ...data, Name: name };
   updated["X-GNOME-Autostart-enabled"] = enabled;
   if (typeof delay === "number") {
     updated["X-GNOME-Autostart-Delay"] = delay;

--- a/src/lib/menu/desktopEntry.ts
+++ b/src/lib/menu/desktopEntry.ts
@@ -21,7 +21,8 @@ const parseIni = (text: string): Record<string, Record<string, string>> => {
     if (!line || line.startsWith('#')) continue;
     const section = line.match(/^\[(.+)]$/);
     if (section) {
-      current = result[section[1]] = {};
+      const key = section[1];
+      if (key) current = result[key] = {};
       continue;
     }
     if (!current) continue;
@@ -43,15 +44,17 @@ export const parseDesktopEntry = async (file: string): Promise<DesktopEntry | nu
     const text = await fs.readFile(file, 'utf8');
     const data = parseIni(text)['Desktop Entry'];
     if (!data) return null;
-    return {
-      type: data.Type,
+    const entry: DesktopEntry = {
       name: data.Name || path.basename(file),
-      exec: data.Exec,
-      icon: data.Icon,
-      categories: data.Categories ? data.Categories.split(';').filter(Boolean) : undefined,
       terminal: data.Terminal === 'true',
       noDisplay: data.NoDisplay === 'true',
     };
+    if (data.Type) entry.type = data.Type;
+    if (data.Exec) entry.exec = data.Exec;
+    if (data.Icon) entry.icon = data.Icon;
+    if (data.Categories)
+      entry.categories = data.Categories.split(';').filter(Boolean);
+    return entry;
   } catch {
     return null;
   }

--- a/src/lib/menu/garcon.ts
+++ b/src/lib/menu/garcon.ts
@@ -70,13 +70,11 @@ export const loadMenu = async (): Promise<MenuCategory[]> => {
       if (item.desktop) {
         const entry: DesktopEntry | null = await parseDesktopEntry(item.desktop);
         if (entry && !entry.noDisplay) {
-          parsedItems.push({
-            id: item.id || entry.name,
-            name: entry.name,
-            icon: entry.icon,
-            exec: entry.exec,
-            categories: entry.categories,
-          });
+          const parsed: MenuItem = { id: item.id || entry.name, name: entry.name };
+          if (entry.icon) parsed.icon = entry.icon;
+          if (entry.exec) parsed.exec = entry.exec;
+          if (entry.categories) parsed.categories = entry.categories;
+          parsedItems.push(parsed);
         }
       } else {
         parsedItems.push(item);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "dom.iterable", "esnext", "es2020.intl"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,

--- a/types/navigator.d.ts
+++ b/types/navigator.d.ts
@@ -1,0 +1,16 @@
+export {};
+
+declare global {
+  interface Navigator {
+    /** Indicates if the app is launched in standalone mode (iOS). */
+    standalone?: boolean;
+  }
+
+  interface StorageManager {
+    /**
+     * Origin Private File System root access.
+     * https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/getDirectory
+     */
+    getDirectory(): Promise<FileSystemDirectoryHandle>;
+  }
+}

--- a/types/react-dom.d.ts
+++ b/types/react-dom.d.ts
@@ -1,1 +1,13 @@
+import 'react';
+
 declare module 'react-dom';
+
+declare module 'react' {
+  interface IframeHTMLAttributes<T> extends React.HTMLAttributes<T> {
+    /**
+     * Content Security Policy for the iframe.
+     * https://developer.mozilla.org/docs/Web/HTML/Element/iframe#attr-csp
+     */
+    csp?: string;
+  }
+}


### PR DESCRIPTION
## Summary
- add custom navigator typings for standalone mode and OPFS
- allow `<iframe>` to set `csp` via React typings and clean up usage
- switch remaining `@ts-ignore` to `@ts-expect-error` and document debt

## Testing
- `yarn typecheck` *(fails: Type 'string | undefined' is not assignable to type 'string', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c10097c67483289afa6708ac579a7a