### PR TITLE
fix nikto findings grouping undefined value

### DIFF
--- a/apps/nikto/index.tsx
+++ b/apps/nikto/index.tsx
@@ -43,8 +43,8 @@ const NiktoPage: React.FC = () => {
 
   const grouped = useMemo(() => {
     return findings.reduce<Record<string, NiktoFinding[]>>((acc, f) => {
-      const list = acc[f.severity] ?? (acc[f.severity] = []);
-      list.push(f);
+      const severity = f.severity;
+      (acc[severity] ??= []).push(f);
       return acc;
     }, {});
   }, [findings]);


### PR DESCRIPTION
## Summary
- fix grouping of Nikto findings to avoid accessing undefined array slot

## Testing
- `npx eslint apps/nikto/index.tsx`
- `yarn test apps/nikto/index.tsx` *(fails: No tests found)*
- `yarn tsc -p tsconfig.json --noEmit` *(fails: types in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c104133ea88328a3774f0d1054f394