### PR TITLE
fix(nikto): initialize severity groups

### DIFF
--- a/apps/nikto/index.tsx
+++ b/apps/nikto/index.tsx
@@ -43,8 +43,7 @@ const NiktoPage: React.FC = () => {
 
   const grouped = useMemo(() => {
     return findings.reduce<Record<string, NiktoFinding[]>>((acc, f) => {
-      const list = acc[f.severity] ?? (acc[f.severity] = []);
-      list.push(f);
+      (acc[f.severity] ??= []).push(f);
       return acc;
     }, {});
   }, [findings]);


### PR DESCRIPTION
## Summary
- ensure severity arrays are initialized before pushing

## Testing
- `npx eslint apps/nikto/index.tsx`
- `yarn test apps/nikto/index.tsx --passWithNoTests`
- `yarn typecheck` *(fails: Type 'HTMLButtonElement | null' is not assignable to type 'void | (() => VoidOrUndefinedOnly)')*

------
https://chatgpt.com/codex/tasks/task_e_68c10546176c832887dbaa09d7c81f5e