### PR TITLE
fix: guard grouped reducer

### DIFF
--- a/apps/nikto/index.tsx
+++ b/apps/nikto/index.tsx
@@ -43,7 +43,7 @@ const NiktoPage: React.FC = () => {
 
   const grouped = useMemo(() => {
     return findings.reduce<Record<string, NiktoFinding[]>>((acc, f) => {
-      const list = acc[f.severity] ?? (acc[f.severity] = []);
+      const list = (acc[f.severity] ??= []);
       list.push(f);
       return acc;
     }, {});


### PR DESCRIPTION
## Summary
- ensure Nikto scan findings group initializer exists before pushing

## Testing
- `npx eslint apps/nikto/index.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c105204c688328a0892a0e99f70b2b