### PR TITLE
fix: handle undefined gamepad buttons

### DIFF
--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -118,7 +118,8 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
       for (const gp of pads) {
         if (!gp) continue;
         for (let i = 0; i < gp.buttons.length; i++) {
-          if (gp.buttons[i].pressed) {
+          const btn = gp.buttons[i];
+          if (btn?.pressed) {
             setPadMap((prev) => ({ ...prev, [waiting.action]: i }));
             setWaiting(null);
             return;


### PR DESCRIPTION
## Summary
- guard against undefined gamepad buttons when remapping controls

## Testing
- `yarn test` *(fails: ReferenceError: displayYouTube is not defined, missing Playwright browsers, etc.)*
- `yarn run build` *(fails: build process interrupted during optimized production build)*

------
https://chatgpt.com/codex/tasks/task_e_68c10ebbc2288328947326a15d902fe8