### PR TITLE
fix(gamepad): guard against undefined buttons

### DIFF
--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -118,7 +118,7 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
       for (const gp of pads) {
         if (!gp) continue;
         for (let i = 0; i < gp.buttons.length; i++) {
-          if (gp.buttons[i].pressed) {
+          if (gp.buttons[i]?.pressed) {
             setPadMap((prev) => ({ ...prev, [waiting.action]: i }));
             setWaiting(null);
             return;


### PR DESCRIPTION
## Summary
- avoid accessing undefined gamepad buttons when remapping inputs

## Testing
- `yarn lint apps/phaser_matter/index.tsx` *(fails: A control must be associated with a text label, and other repo-wide lint errors)*
- `yarn test __tests__/phaserMatter.test.ts`
- `yarn tsc -p tsconfig.json --noEmit` *(fails: numerous type errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c11310d2008328b010bc59831b6bbe