### PR TITLE
fix(gamepad): guard against undefined buttons

### DIFF
--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -118,8 +118,8 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
       for (const gp of pads) {
         if (!gp) continue;
         for (let i = 0; i < gp.buttons.length; i++) {
-          if (gp.buttons[i]?.pressed) {
-
+          const button = gp.buttons[i];
+          if (button?.pressed) {
             setPadMap((prev) => ({ ...prev, [waiting.action]: i }));
             setWaiting(null);
             return;


### PR DESCRIPTION
## Summary
- avoid undefined button access during gamepad remapping

## Testing
- `yarn tsc -p tsconfig.json --noEmit` *(fails: Type 'null' is not assignable to type 'void | (() => VoidOrUndefinedOnly)' and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c115ab7cf88328bd523911b721194d