### PR TITLE
Handle optional gamepad buttons under strict TypeScript

### DIFF
--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -114,12 +114,14 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
     if (!waiting || waiting.device !== 'pad') return;
     // poll at 100ms intervals instead of every frame to reduce CPU
     const interval = setInterval(() => {
-      const pads = navigator.getGamepads ? navigator.getGamepads() : [];
-      for (const gp of pads) {
-        if (!gp) continue;
-        for (let i = 0; i < gp.buttons.length; i++) {
-          const button = gp.buttons[i];
-          if (button?.pressed) {
+      const pads = navigator.getGamepads
+        ? Array.from(navigator.getGamepads())
+        : [];
+      for (const gpMaybe of pads) {
+        if (!gpMaybe) continue;
+        for (const [i, btn] of gpMaybe.buttons.entries()) {
+          if (btn.pressed) {
+            if (!waiting) return;
             setPadMap((prev) => ({ ...prev, [waiting.action]: i }));
             setWaiting(null);
             return;


### PR DESCRIPTION
## Summary
- Safely iterate over gamepad buttons when remapping controls
- Guard `waiting` state before updating the pad map

## Testing
- `yarn eslint apps/phaser_matter/index.tsx`
- `yarn typecheck` *(fails: apps/metasploit/components/TargetEmulator.test.tsx(14,49): error TS2532: Object is possibly 'undefined'.)*
- `yarn test apps/phaser_matter/index.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c11728979c8328b6d169caa3dcab15