### PR TITLE
fix phaser matter compile errors

### DIFF
--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -292,7 +292,7 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
         );
       }
 
-      update(time: number, delta: number) {
+      override update(time: number, delta: number) {
         const ctrl = controls.current;
         const speed = 5;
         const fixedDelta = Math.min(delta, 1000 / 60);
@@ -302,8 +302,8 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
         if (gamepad && gamepad.total > 0) {
           const pad = gamepad.getPad(0);
           const pm = padMapRef.current;
-          ctrl.left = pad.buttons[pm.left]?.pressed;
-          ctrl.right = pad.buttons[pm.right]?.pressed;
+          ctrl.left = !!pad.buttons[pm.left]?.pressed;
+          ctrl.right = !!pad.buttons[pm.right]?.pressed;
           const jp = pad.buttons[pm.jump]?.pressed;
           if (jp && !this.padJumpWasPressed) {
             ctrl.jumpPressed = true;
@@ -311,7 +311,7 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
           } else if (!jp) {
             ctrl.jumpHeld = false;
           }
-          this.padJumpWasPressed = jp;
+          this.padJumpWasPressed = !!jp;
         }
 
         if (ctrl.left) this.player.setVelocityX(-speed);


### PR DESCRIPTION
## Summary
- fix TypeScript override requirement in Phaser Matter scene
- normalize gamepad button state to booleans

## Testing
- `yarn test __tests__/phaserMatter.test.ts`
- `yarn typecheck` *(fails: Type 'HTMLButtonElement | null' is not assignable to type 'void | (() => VoidOrUndefinedOnly)'*

------
https://chatgpt.com/codex/tasks/task_e_68c120fc6a9c83289568e58f56126d3c