### PR TITLE
fix: add override to phaser update

### DIFF
--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -292,7 +292,7 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
         );
       }
 
-      update(time: number, delta: number) {
+      override update(time: number, delta: number) {
         const ctrl = controls.current;
         const speed = 5;
         const fixedDelta = Math.min(delta, 1000 / 60);


### PR DESCRIPTION
## Summary
- add missing `override` on phaser scene update method

## Testing
- `npx eslint apps/phaser_matter/index.tsx`
- `yarn test apps/phaser_matter --passWithNoTests`
- `npx tsc -p tsconfig.json --noEmit` *(fails: existing type errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c121da7e5083288c79116974391c39