### PR TITLE
Fix gamepad input types in phaser matter

### DIFF
--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -302,9 +302,9 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
         if (gamepad && gamepad.total > 0) {
           const pad = gamepad.getPad(0);
           const pm = padMapRef.current;
-          ctrl.left = pad.buttons[pm.left]?.pressed;
-          ctrl.right = pad.buttons[pm.right]?.pressed;
-          const jp = pad.buttons[pm.jump]?.pressed;
+          ctrl.left = pad.buttons[pm.left]?.pressed ?? false;
+          ctrl.right = pad.buttons[pm.right]?.pressed ?? false;
+          const jp = pad.buttons[pm.jump]?.pressed ?? false;
           if (jp && !this.padJumpWasPressed) {
             ctrl.jumpPressed = true;
             ctrl.jumpHeld = true;


### PR DESCRIPTION
## Summary
- default undefined gamepad button states to false in phaser matter scene

## Testing
- `yarn run build` *(fails: Object is possibly 'undefined' in apps/pinball/index.tsx)*
- `yarn test apps/phaser_matter --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c1233ba5a88328b4b7f890f5f7a731