### PR TITLE
fix: handle optional gamepad buttons

### DIFF
--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -302,9 +302,9 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
         if (gamepad && gamepad.total > 0) {
           const pad = gamepad.getPad(0);
           const pm = padMapRef.current;
-          ctrl.left = pad.buttons[pm.left]?.pressed;
-          ctrl.right = pad.buttons[pm.right]?.pressed;
-          const jp = pad.buttons[pm.jump]?.pressed;
+          ctrl.left = pad.buttons[pm.left]?.pressed ?? false;
+          ctrl.right = pad.buttons[pm.right]?.pressed ?? false;
+          const jp = pad.buttons[pm.jump]?.pressed ?? false;
           if (jp && !this.padJumpWasPressed) {
             ctrl.jumpPressed = true;
             ctrl.jumpHeld = true;


### PR DESCRIPTION
## Summary
- guard against undefined gamepad button states in Phaser Matter demo

## Testing
- `yarn tsc --noEmit` *(fails: Type errors in other packages)*
- `yarn test` *(fails: missing env vars, Playwright browser, and other module issues)*
- `yarn build` *(incomplete: process interrupted while creating optimized build)*

------
https://chatgpt.com/codex/tasks/task_e_68c12497012883289e711861296dd8e9