### PR TITLE
Ensure gamepad controls default to false

### DIFF
--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -302,9 +302,9 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
         if (gamepad && gamepad.total > 0) {
           const pad = gamepad.getPad(0);
           const pm = padMapRef.current;
-          ctrl.left = pad.buttons[pm.left]?.pressed ?? false;
-          ctrl.right = pad.buttons[pm.right]?.pressed ?? false;
-          const jp = pad.buttons[pm.jump]?.pressed ?? false;
+          ctrl.left = !!pad.buttons[pm.left]?.pressed;
+          ctrl.right = !!pad.buttons[pm.right]?.pressed;
+          const jp = !!pad.buttons[pm.jump]?.pressed;
           if (jp && !this.padJumpWasPressed) {
             ctrl.jumpPressed = true;
             ctrl.jumpHeld = true;


### PR DESCRIPTION
## Summary
- Coerce gamepad button states to booleans in Phaser Matter integration to avoid `undefined` values

## Testing
- `yarn build` *(fails: Object is possibly 'undefined' in apps/pinball/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c125835b708328999dcc24b3f68b94