### PR TITLE
feat: add kali theme fallbacks

### DIFF
--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -17,16 +17,16 @@ export const isDarkTheme = (theme: string): boolean =>
   DARK_THEMES.includes(theme as (typeof DARK_THEMES)[number]);
 
 export const getTheme = (): string => {
-  if (!isBrowser()) return 'default';
+  if (!isBrowser()) return 'kali-dark';
   try {
     const stored = window.localStorage.getItem(THEME_KEY);
     if (stored && stored !== 'undercover') return stored;
     const prefersDark = window.matchMedia?.(
       '(prefers-color-scheme: dark)'
     ).matches;
-    return prefersDark ? 'dark' : 'default';
+    return prefersDark ? 'kali-dark' : 'kali-light';
   } catch {
-    return 'default';
+    return 'kali-dark';
   }
 };
 


### PR DESCRIPTION
## Summary
- use Kali-specific themes in theme detection
- default to `kali-dark` when detection fails

## Testing
- `npx eslint utils/theme.ts`
- `npx jest utils/theme.ts --passWithNoTests`
- `npx tsc --noEmit utils/theme.ts` *(fails: Cannot find module '@/utils/env'; cytoscape stylesheet types)*

------
https://chatgpt.com/codex/tasks/task_e_68c129b0cc8883289771d16445a106d9