### PR TITLE
feat: use Inter and Fira Code fonts

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -35,10 +35,10 @@ class MyDocument extends Document<Props> {
           <link
             rel="preload"
             as="style"
-            href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Fira+Code:wght@400;600&display=swap"
           />
           <link
-            href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Fira+Code:wght@400;600&display=swap"
             rel="stylesheet"
           />
           <script nonce={nonce} src="/theme.js" async />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -261,3 +261,11 @@ thead th {
     white-space: nowrap;
   }
 }
+
+.font-ubuntu {
+  font-family: 'Inter', 'Cantarell', 'Ubuntu', system-ui, -apple-system, 'Segoe UI', 'Noto Sans', Arial, sans-serif;
+}
+
+.font-mono {
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}


### PR DESCRIPTION
## Summary
- load Inter and Fira Code via Google Fonts
- add utility classes for sans and monospace fonts

## Testing
- `npx eslint pages/_document.tsx`
- `npx jest pages/_document.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c129b192bc8328a67a4ec2f4aa760f