### PR TITLE
refactor: guard theme script

### DIFF
--- a/public/theme.js
+++ b/public/theme.js
@@ -1,24 +1,31 @@
-import { isBrowser } from '@/utils/env';
+
 (function () {
   var THEME_KEY = 'app:theme';
+  var darkThemes = ['dark', 'neon', 'matrix', 'kali-dark'];
+
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
+
   try {
     var stored = null;
-    if (isBrowser() && typeof window.localStorage !== 'undefined') {
+    if (typeof window.localStorage !== 'undefined') {
       stored = window.localStorage.getItem(THEME_KEY);
     }
 
-    var prefersDark = false;
-    if (isBrowser() && typeof window.matchMedia === 'function') {
-      prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    }
+    var prefersDark =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var theme = stored || (prefersDark ? 'kali-dark' : 'kali-light');
 
-    var theme = stored || (prefersDark ? 'dark' : 'default');
     document.documentElement.dataset.theme = theme;
-    var darkThemes = ['dark', 'neon', 'matrix', 'kali-dark'];
-    document.documentElement.classList.toggle('dark', darkThemes.includes(theme));
+    document.documentElement.classList.toggle(
+      'dark',
+      darkThemes.includes(theme)
+    );
   } catch (e) {
     console.error('Failed to apply theme', e);
-    document.documentElement.dataset.theme = 'default';
-    document.documentElement.classList.remove('dark');
+    document.documentElement.dataset.theme = 'kali-dark';
+    document.documentElement.classList.add('dark');
   }
 })();


### PR DESCRIPTION
## Summary
- wrap theme loader in a self-invoking function that guards browser APIs
- default theme to `kali-dark`/`kali-light` using `prefers-color-scheme`
- fall back to `kali-dark` and add `dark` class on failure

## Testing
- `yarn lint public/theme.js` *(fails: numerous existing lint errors across repository)*
- `npx eslint public/theme.js --no-ignore && echo 'eslint ok'`


------
https://chatgpt.com/codex/tasks/task_e_68c129b0af688328ba5100b61500d425