### PR TITLE
chore: update yarn packageManager to 4.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,5 +194,5 @@
     "workbox-build@npm:7.1.1": "npm:workbox-build@7.3.0",
     "three-bmfont-text": "npm:three-bmfont-text@^3.0.1"
   },
-  "packageManager": "yarn@1.22.22"
+  "packageManager": "yarn@4.9.2"
 }


### PR DESCRIPTION
## Summary
- keep packageManager in sync with yarn 4 lockfile by upgrading to `yarn@4.9.2`

## Testing
- `pnpm typecheck` *(fails: 'AutostartEntry' type errors)*
- `npx jest __tests__/blackjack.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c129b25c148328b1b0ae852e944252