### PR TITLE
fix: handle undefined collision supports in pinball

### DIFF
--- a/apps/pinball/index.tsx
+++ b/apps/pinball/index.tsx
@@ -132,12 +132,18 @@ export default function Pinball() {
       evt.pairs.forEach((pair) => {
         const bodies = [pair.bodyA, pair.bodyB];
         if (bodies.includes(ball) && bodies.includes(leftFlipper)) {
-          const { x, y } = pair.collision.supports[0];
-          sparksRef.current.push({ x, y, life: 1 });
+          const support = pair.collision.supports[0];
+          if (support) {
+            const { x, y } = support;
+            sparksRef.current.push({ x, y, life: 1 });
+          }
         }
         if (bodies.includes(ball) && bodies.includes(rightFlipper)) {
-          const { x, y } = pair.collision.supports[0];
-          sparksRef.current.push({ x, y, life: 1 });
+          const support = pair.collision.supports[0];
+          if (support) {
+            const { x, y } = support;
+            sparksRef.current.push({ x, y, life: 1 });
+          }
         }
         if (bodies.includes(ball) && bodies.includes(leftLane)) {
           laneGlowRef.current.left = true;


### PR DESCRIPTION
## Summary
- guard against missing collision supports when adding sparks

## Testing
- `npx jest apps/pinball/index.tsx --passWithNoTests`
- `yarn tsc apps/pinball/index.tsx --noEmit` *(fails: package not in lockfile)*
- `yarn lint apps/pinball/index.tsx` *(fails: package not in lockfile)*


------
https://chatgpt.com/codex/tasks/task_e_68c12ce70e1c8328ab6502ac29ce0a96