### PR TITLE
Guard pinball collision support from undefined

### DIFF
--- a/apps/pinball/index.tsx
+++ b/apps/pinball/index.tsx
@@ -130,12 +130,13 @@ export default function Pinball() {
     Events.on(engine, "collisionStart", (evt) => {
       evt.pairs.forEach((pair) => {
         const bodies = [pair.bodyA, pair.bodyB];
-        if (bodies.includes(ball) && bodies.includes(leftFlipper)) {
-          const { x, y } = pair.collision.supports[0];
+        const support = pair.collision.supports[0];
+        if (support && bodies.includes(ball) && bodies.includes(leftFlipper)) {
+          const { x, y } = support;
           sparksRef.current.push({ x, y, life: 1 });
         }
-        if (bodies.includes(ball) && bodies.includes(rightFlipper)) {
-          const { x, y } = pair.collision.supports[0];
+        if (support && bodies.includes(ball) && bodies.includes(rightFlipper)) {
+          const { x, y } = support;
           sparksRef.current.push({ x, y, life: 1 });
         }
         if (bodies.includes(ball) && bodies.includes(leftLane)) {


### PR DESCRIPTION
## Summary
- avoid accessing collision supports when undefined in pinball

## Testing
- `yarn test apps/pinball --passWithNoTests`
- `npx eslint apps/pinball/index.tsx`
- `npx tsc -p tsconfig.json --noEmit` *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c12bd4fe0c832881f76b5f27c49061