### PR TITLE
fix luminance tuple to avoid undefined access

### DIFF
--- a/apps/quote/components/Posterizer.tsx
+++ b/apps/quote/components/Posterizer.tsx
@@ -16,11 +16,11 @@ const hexToRgb = (hex: string) => {
 };
 
 const luminance = ({ r, g, b }: { r: number; g: number; b: number }) => {
-  const a = [r, g, b].map((v) => {
+  const [rLum, gLum, bLum] = [r, g, b].map((v) => {
     const val = v / 255;
     return val <= 0.03928 ? val / 12.92 : Math.pow((val + 0.055) / 1.055, 2.4);
-  });
-  return a[0] * 0.2126 + a[1] * 0.7152 + a[2] * 0.0722;
+  }) as [number, number, number];
+  return rLum * 0.2126 + gLum * 0.7152 + bLum * 0.0722;
 };
 
 const contrastRatio = (c1: string, c2: string) => {


### PR DESCRIPTION
## Summary
- refactor luminance calculation in Posterizer to destructure mapped rgb values into a typed tuple to satisfy strict index checking

## Testing
- `node_modules/.bin/jest apps/quote/components/Posterizer.tsx` *(fails: No tests found)*
- `yarn typecheck` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68c12f996a50832881892893c79dde61