### PR TITLE
refactor: update test import path

### DIFF
--- a/__tests__/desktopDefaultBadge.test.tsx
+++ b/__tests__/desktopDefaultBadge.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, within } from "@testing-library/react";
-import Home from "../pages/index.jsx";
+import Home from "../pages/index";
 
 describe("Choose your desktop row", () => {
   test("marks Xfce as the default desktop environment", () => {


### PR DESCRIPTION
## Summary
- update desktop default badge test to import pages/index without extension

## Testing
- `pnpm -w typecheck` *(fails: --workspace-root may only be used inside a workspace)*
- `yarn test` *(fails: Missing environment variables, Playwright browsers not installed)*
- `yarn test __tests__/desktopDefaultBadge.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c12f9d0a7c83289e965d4f16cc5d50