### PR TITLE
Remove duplicate jest path mapping and ignore legacy tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,11 +8,11 @@ const customJestConfig = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
     '^@xterm/xterm/css/xterm.css$': '<rootDir>/__mocks__/styleMock.js',
-    '^@/(.*)$': '<rootDir>/$1',
   },
   testPathIgnorePatterns: [
     '<rootDir>/playwright/',
     '<rootDir>/__tests__/playwright/',
+    '<rootDir>/__tests__/legacy/',
     '<rootDir>/tests/',
   ],
 };


### PR DESCRIPTION
## Summary
- remove duplicate `@` moduleNameMapper entry
- ignore legacy tests in Jest config

## Testing
- `yarn test` *(fails: eslint-plugin-no-dupe-app-imports missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c12f9da4e4832898c52480d280403f