### PR TITLE
chore(test): move Clipman test to legacy

### DIFF
--- a/__tests__/legacy/Clipman.case.test.tsx
+++ b/__tests__/legacy/Clipman.case.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
-import Clipman, { CLIPMAN_STORAGE_KEY } from '../src/plugins/Clipman';
+import Clipman, { CLIPMAN_STORAGE_KEY } from '../../src/plugins/Clipman';
 
 let original: string | null;
 


### PR DESCRIPTION
## Summary
- move `Clipman.test.tsx` to `__tests__/legacy` and update import path

## Testing
- `npm test -- __tests__/legacy/Clipman.case.test.tsx`
- `pnpm typecheck` *(fails: numerous TS errors)*


------
https://chatgpt.com/codex/tasks/task_e_68c1311da10c83289465b9cb51d97d91