### PR TITLE
chore: refine jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,12 +8,12 @@ const customJestConfig = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
     '^@xterm/xterm/css/xterm.css$': '<rootDir>/__mocks__/styleMock.js',
-    '^@/(.*)$': '<rootDir>/$1',
   },
   testPathIgnorePatterns: [
     '<rootDir>/playwright/',
     '<rootDir>/__tests__/playwright/',
     '<rootDir>/tests/',
+    '<rootDir>/__tests__/legacy/',
   ],
 };
 


### PR DESCRIPTION
## Summary
- remove duplicate alias entry in Jest config
- ignore legacy tests during test runs

## Testing
- `npx jest` *(fails: Missing environment variables and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1311ed67083288d444078ee685500