### PR TITLE
Handle missing style defaults in Posterizer

### DIFF
--- a/apps/quote/components/Posterizer.tsx
+++ b/apps/quote/components/Posterizer.tsx
@@ -40,14 +40,16 @@ const STYLES = [
 export default function Posterizer({ quote }: { quote: Quote | null }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [styleIndex, setStyleIndex] = useState(0);
-  const [bg, setBg] = useState<string>(STYLES[0].bg);
-  const [fg, setFg] = useState<string>(STYLES[0].fg);
-  const [font, setFont] = useState<string>(STYLES[0].font);
+  const DEFAULT_STYLE =
+    STYLES[0] ?? ({ name: 'Classic', bg: '#000000', fg: '#ffffff', font: 'serif' } as const);
+  const [bg, setBg] = useState<string>(DEFAULT_STYLE.bg);
+  const [fg, setFg] = useState<string>(DEFAULT_STYLE.fg);
+  const [font, setFont] = useState<string>(DEFAULT_STYLE.font);
 
   const cycleStyle = () => {
     const next = (styleIndex + 1) % STYLES.length;
     setStyleIndex(next);
-    const s = STYLES[next];
+    const s = STYLES[next] ?? DEFAULT_STYLE;
     setBg(s.bg);
     setFg(s.fg);
     setFont(s.font);
@@ -113,15 +115,31 @@ export default function Posterizer({ quote }: { quote: Quote | null }) {
 
   return (
     <div className="flex flex-col items-center gap-2 w-full">
-      <canvas ref={canvasRef} width={600} height={400} className="border" />
+      <canvas
+        ref={canvasRef}
+        width={600}
+        height={400}
+        className="border"
+        aria-label="Quote preview"
+      />
       <div className="flex flex-wrap gap-2 justify-center">
         <label className="flex items-center gap-1">
           BG
-          <input type="color" value={bg} onChange={(e) => setBg(e.target.value)} />
+          <input
+            type="color"
+            value={bg}
+            onChange={(e) => setBg(e.target.value)}
+            aria-label="Background color"
+          />
         </label>
         <label className="flex items-center gap-1">
           FG
-          <input type="color" value={fg} onChange={(e) => setFg(e.target.value)} />
+          <input
+            type="color"
+            value={fg}
+            onChange={(e) => setFg(e.target.value)}
+            aria-label="Foreground color"
+          />
         </label>
         <input
           type="text"
@@ -129,6 +147,7 @@ export default function Posterizer({ quote }: { quote: Quote | null }) {
           onChange={(e) => setFont(e.target.value)}
           className="px-2 py-1 rounded text-black"
           placeholder="Font"
+          aria-label="Font"
         />
         <span className={accessible ? 'text-green-400' : 'text-red-400'}>
           Contrast: {ratio.toFixed(2)}
@@ -139,7 +158,7 @@ export default function Posterizer({ quote }: { quote: Quote | null }) {
         >
           Next Style
         </button>
-        <span>Style: {STYLES[styleIndex].name}</span>
+        <span>Style: {STYLES[styleIndex]?.name ?? DEFAULT_STYLE.name}</span>
         <button
           className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
           onClick={download}


### PR DESCRIPTION
## Summary
- Guard Posterizer style lookups with a fallback and add accessible labels

## Testing
- `npx eslint apps/quote/components/Posterizer.tsx`
- `yarn test apps/quote --passWithNoTests`
- `yarn typecheck` *(fails: Type ... not assignable to type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c13385004c8328a4588efededaedf9