### PR TITLE
fix: guard posterizer default styles

### DIFF
--- a/apps/quote/components/Posterizer.tsx
+++ b/apps/quote/components/Posterizer.tsx
@@ -40,14 +40,15 @@ const STYLES = [
 export default function Posterizer({ quote }: { quote: Quote | null }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [styleIndex, setStyleIndex] = useState(0);
-  const [bg, setBg] = useState<string>(STYLES[0].bg);
-  const [fg, setFg] = useState<string>(STYLES[0].fg);
-  const [font, setFont] = useState<string>(STYLES[0].font);
+  const [bg, setBg] = useState<string>(STYLES[0]?.bg ?? '#000000');
+  const [fg, setFg] = useState<string>(STYLES[0]?.fg ?? '#ffffff');
+  const [font, setFont] = useState<string>(STYLES[0]?.font ?? 'serif');
 
   const cycleStyle = () => {
     const next = (styleIndex + 1) % STYLES.length;
     setStyleIndex(next);
     const s = STYLES[next];
+    if (!s) return;
     setBg(s.bg);
     setFg(s.fg);
     setFont(s.font);
@@ -113,15 +114,31 @@ export default function Posterizer({ quote }: { quote: Quote | null }) {
 
   return (
     <div className="flex flex-col items-center gap-2 w-full">
-      <canvas ref={canvasRef} width={600} height={400} className="border" />
+      <canvas
+        ref={canvasRef}
+        width={600}
+        height={400}
+        className="border"
+        aria-label="Quote preview"
+      />
       <div className="flex flex-wrap gap-2 justify-center">
         <label className="flex items-center gap-1">
           BG
-          <input type="color" value={bg} onChange={(e) => setBg(e.target.value)} />
+          <input
+            type="color"
+            value={bg}
+            onChange={(e) => setBg(e.target.value)}
+            aria-label="Background color"
+          />
         </label>
         <label className="flex items-center gap-1">
           FG
-          <input type="color" value={fg} onChange={(e) => setFg(e.target.value)} />
+          <input
+            type="color"
+            value={fg}
+            onChange={(e) => setFg(e.target.value)}
+            aria-label="Foreground color"
+          />
         </label>
         <input
           type="text"
@@ -129,6 +146,7 @@ export default function Posterizer({ quote }: { quote: Quote | null }) {
           onChange={(e) => setFont(e.target.value)}
           className="px-2 py-1 rounded text-black"
           placeholder="Font"
+          aria-label="Font"
         />
         <span className={accessible ? 'text-green-400' : 'text-red-400'}>
           Contrast: {ratio.toFixed(2)}


### PR DESCRIPTION
## Summary
- avoid undefined style references in Posterizer by adding defaults and checks
- improve accessibility with ARIA labels for canvas and color/font inputs

## Testing
- `yarn lint apps/quote/components/Posterizer.tsx` *(fails: repository-wide lint reports numerous existing errors)*
- `yarn eslint apps/quote/components/Posterizer.tsx`
- `yarn test __tests__/posterizerStyles.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c134307ad08328921fbbe53ced1e98