### PR TITLE
Use default style fallback in Posterizer

### DIFF
--- a/apps/quote/components/Posterizer.tsx
+++ b/apps/quote/components/Posterizer.tsx
@@ -50,7 +50,7 @@ export default function Posterizer({ quote }: { quote: Quote | null }) {
   const cycleStyle = () => {
     const next = (styleIndex + 1) % STYLES.length;
     setStyleIndex(next);
-    const s = STYLES[next]!;
+    const s = STYLES[next] ?? DEFAULT_STYLE;
 
     setBg(s.bg);
     setFg(s.fg);


### PR DESCRIPTION
## Summary
- ensure Posterizer cycles styles with a fallback default style

## Testing
- `yarn test apps/quote/components/Posterizer.tsx` *(no tests found)*
- `npx eslint apps/quote/components/Posterizer.tsx`
- `npx tsc apps/quote/components/Posterizer.tsx --noEmit --jsx react-jsx` *(missing cytoscape types)*

------
https://chatgpt.com/codex/tasks/task_e_68c136e398c08328a4a92d330ea15ef1