### PR TITLE
fix posterizer default style reference

### DIFF
--- a/apps/quote/components/Posterizer.tsx
+++ b/apps/quote/components/Posterizer.tsx
@@ -37,7 +37,7 @@ const STYLES = [
   { name: 'Retro', bg: '#1e3a8a', fg: '#fef3c7', font: 'monospace' },
 ] as const;
 
-const DEFAULT_STYLE = STYLES[0]!;
+const DEFAULT_STYLE = STYLES[0];
 
 export default function Posterizer({ quote }: { quote: Quote | null }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -50,7 +50,7 @@ export default function Posterizer({ quote }: { quote: Quote | null }) {
   const cycleStyle = () => {
     const next = (styleIndex + 1) % STYLES.length;
     setStyleIndex(next);
-    const s = STYLES[next]!;
+    const s = STYLES[next] ?? DEFAULT_STYLE;
 
     setBg(s.bg);
     setFg(s.fg);


### PR DESCRIPTION
## Summary
- provide DEFAULT_STYLE constant for poster generator
- ensure style cycling falls back to DEFAULT_STYLE

## Testing
- `yarn run build` *(fails: Creating an optimized production build ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c13723b8f88328bce8c40bd0a9e12e