### PR TITLE
fix: guard playlist index

### DIFF
--- a/apps/quote/index.tsx
+++ b/apps/quote/index.tsx
@@ -111,9 +111,12 @@ export default function QuoteApp() {
         .split(',')
         .map((n) => parseInt(n, 10))
         .filter((n) => !Number.isNaN(n) && n >= 0 && n < quotes.length);
-      if (ids.length) {
+      if (ids.length > 0) {
         setPlaylist(ids);
-        setCurrent(quotes[ids[0]]);
+        const first = ids[0];
+        if (first !== undefined) {
+          setCurrent(quotes[first]);
+        }
       }
     }
   }, [quotes]);


### PR DESCRIPTION
## Summary
- safely select first quote from playlist parameter to avoid undefined index errors

## Testing
- `yarn lint apps/quote/index.tsx` *(fails: eslint-plugin-no-dupe-app-imports missing)*
- `yarn test apps/quote/index.tsx` *(fails: eslint-plugin-no-dupe-app-imports missing)*
- `yarn build` *(fails: eslint-plugin-no-dupe-app-imports missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c13831898483288e21671edeb3ad59