### PR TITLE
fix: guard quote indexing

### DIFF
--- a/apps/quote/index.tsx
+++ b/apps/quote/index.tsx
@@ -115,7 +115,10 @@ export default function QuoteApp() {
         setPlaylist(ids);
         const first = ids[0];
         if (first !== undefined) {
-          setCurrent(quotes[first]);
+          const q = quotes[first];
+          if (q) {
+            setCurrent(q);
+          }
         }
       }
     }
@@ -134,9 +137,12 @@ export default function QuoteApp() {
         }
       } catch { /* ignore */ }
     }
-    const q = quotes[Math.floor(Math.random() * quotes.length)];
-    setDailyQuote(q);
-    localStorage.setItem('daily-quote', JSON.stringify({ date: today, quote: q }));
+    const idx = Math.floor(Math.random() * quotes.length);
+    const q = quotes[idx];
+    if (q) {
+      setDailyQuote(q);
+      localStorage.setItem('daily-quote', JSON.stringify({ date: today, quote: q }));
+    }
   }, [quotes]);
 
   const filtered = useMemo(() => {
@@ -169,7 +175,10 @@ export default function QuoteApp() {
       setCurrent(null);
       return;
     }
-    setCurrent(filtered[Math.floor(Math.random() * filtered.length)]);
+    const q = filtered[Math.floor(Math.random() * filtered.length)];
+    if (q) {
+      setCurrent(q);
+    }
   };
 
   const nextQuote = useCallback(() => {
@@ -178,7 +187,10 @@ export default function QuoteApp() {
       return;
     }
     const next = (currentIndex + 1) % filtered.length;
-    setCurrent(filtered[next]);
+    const q = filtered[next];
+    if (q) {
+      setCurrent(q);
+    }
   }, [filtered, currentIndex]);
 
   const prevQuote = useCallback(() => {
@@ -187,7 +199,10 @@ export default function QuoteApp() {
       return;
     }
     const prev = (currentIndex - 1 + filtered.length) % filtered.length;
-    setCurrent(filtered[prev]);
+    const q = filtered[prev];
+    if (q) {
+      setCurrent(q);
+    }
   }, [filtered, currentIndex]);
 
   useEffect(() => {
@@ -228,8 +243,11 @@ export default function QuoteApp() {
   useEffect(() => {
     if (!playOrder.length) return;
     const idx = playOrder[playIndex];
-    if (idx >= 0 && idx < quotes.length) {
-      setCurrent(quotes[idx]);
+    if (idx !== undefined && idx >= 0 && idx < quotes.length) {
+      const q = quotes[idx];
+      if (q) {
+        setCurrent(q);
+      }
     }
   }, [playIndex, playOrder, quotes]);
 
@@ -300,7 +318,12 @@ export default function QuoteApp() {
     setPlayOrder(order);
     setPlayIndex(0);
     const idx = order[0];
-    if (idx >= 0 && idx < quotes.length) setCurrent(quotes[idx]);
+    if (idx !== undefined && idx >= 0 && idx < quotes.length) {
+      const q = quotes[idx];
+      if (q) {
+        setCurrent(q);
+      }
+    }
     setPlaying(true);
   };
 


### PR DESCRIPTION
## Summary
- guard against undefined quote indexes when loading playlists and navigating quotes

## Testing
- `yarn install`
- `yarn build` *(fails: `apps/reaver/components/RouterProfiles.tsx:45:59 Argument of type 'RouterProfile | undefined'...`)*

------
https://chatgpt.com/codex/tasks/task_e_68c1392656e0832896a3e4b8c7777331