### PR TITLE
fix: guard playlist quotes

### DIFF
--- a/apps/quote/index.tsx
+++ b/apps/quote/index.tsx
@@ -115,7 +115,8 @@ export default function QuoteApp() {
         setPlaylist(ids);
         const first = ids[0];
         if (first !== undefined) {
-          setCurrent(quotes[first]);
+          const firstQuote = quotes[first];
+          if (firstQuote) setCurrent(firstQuote);
         }
       }
     }


### PR DESCRIPTION
## Summary
- safeguard playlist initialization by verifying quoted index exists

## Testing
- `npx tsc -p tsconfig.json` *(fails: Object is possibly 'undefined' in various files)*

------
https://chatgpt.com/codex/tasks/task_e_68c13cd0aff883288cf402b230ca57c5