### PR TITLE
fix: guard array indexing in quote app

### DIFF
--- a/apps/quote/components/Posterizer.tsx
+++ b/apps/quote/components/Posterizer.tsx
@@ -37,14 +37,13 @@ const STYLES = [
   { name: 'Retro', bg: '#1e3a8a', fg: '#fef3c7', font: 'monospace' },
 ] as const;
 
-const DEFAULT_STYLE = STYLES[0]!;
-
 export default function Posterizer({ quote }: { quote: Quote | null }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [styleIndex, setStyleIndex] = useState(0);
-  const [bg, setBg] = useState<string>(DEFAULT_STYLE.bg);
-  const [fg, setFg] = useState<string>(DEFAULT_STYLE.fg);
-  const [font, setFont] = useState<string>(DEFAULT_STYLE.font);
+  const initial = STYLES[0] ?? { bg: '#000000', fg: '#ffffff', font: 'serif' };
+  const [bg, setBg] = useState<string>(initial.bg);
+  const [fg, setFg] = useState<string>(initial.fg);
+  const [font, setFont] = useState<string>(initial.font);
 
 
   const cycleStyle = () => {
@@ -143,7 +142,6 @@ export default function Posterizer({ quote }: { quote: Quote | null }) {
             value={fg}
             onChange={(e) => setFg(e.target.value)}
             aria-label="Foreground color"
-
           />
         </label>
         <input
@@ -151,8 +149,8 @@ export default function Posterizer({ quote }: { quote: Quote | null }) {
           value={font}
           onChange={(e) => setFont(e.target.value)}
           className="px-2 py-1 rounded text-black"
-          placeholder="Font"          aria-label="Font"
-
+          placeholder="Font"
+          aria-label="Font"
         />
         <span className={accessible ? 'text-green-400' : 'text-red-400'}>
           Contrast: {ratio.toFixed(2)}

--- a/apps/quote/index.tsx
+++ b/apps/quote/index.tsx
@@ -111,7 +111,7 @@ export default function QuoteApp() {
         .split(',')
         .map((n) => parseInt(n, 10))
         .filter((n) => !Number.isNaN(n) && n >= 0 && n < quotes.length);
-      if (ids.length > 0) {
+      if (ids.length) {
         setPlaylist(ids);
         const first = ids[0];
         if (first !== undefined) {
@@ -192,7 +192,6 @@ export default function QuoteApp() {
 
   useEffect(() => {
     changeQuote();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filtered]);
 
   useEffect(() => {
@@ -411,7 +410,13 @@ export default function QuoteApp() {
           )}
           <label className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded cursor-pointer">
             Import
-            <input type="file" accept="application/json" className="hidden" onChange={importQuotes} />
+            <input
+              type="file"
+              accept="application/json"
+              className="hidden"
+              onChange={importQuotes}
+              aria-label="Import quotes"
+            />
           </label>
         </div>
         {posterize && (
@@ -425,17 +430,20 @@ export default function QuoteApp() {
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search"
             className="px-2 py-1 rounded text-black"
+            aria-label="Search quotes"
           />
           <input
             value={authorFilter}
             onChange={(e) => setAuthorFilter(e.target.value)}
             placeholder="Author"
             className="px-2 py-1 rounded text-black"
+            aria-label="Author filter"
           />
           <select
             value={category}
             onChange={(e) => setCategory(e.target.value)}
             className="px-2 py-1 rounded text-black"
+            aria-label="Category"
           >
             <option value="">All Categories</option>
             {categories.map((cat) => (
@@ -466,6 +474,7 @@ export default function QuoteApp() {
               type="checkbox"
               checked={loop}
               onChange={(e) => setLoop(e.target.checked)}
+              aria-label="Loop playlist"
             />
             <span>Loop</span>
           </label>
@@ -474,6 +483,7 @@ export default function QuoteApp() {
               type="checkbox"
               checked={shuffle}
               onChange={(e) => setShuffle(e.target.checked)}
+              aria-label="Shuffle playlist"
             />
             <span>Shuffle</span>
           </label>


### PR DESCRIPTION
## Summary
- safely access playlist index by checking for undefined before reading
- initialize posterizer colors with default fallback when style array is empty
- label quote app inputs for accessibility to satisfy lint rules

## Testing
- `npx eslint apps/quote/index.tsx apps/quote/components/Posterizer.tsx`
- `yarn typecheck` *(fails: Type '(el: HTMLButtonElement | null) => HTMLButtonElement | null' is not assignable to type '(instance: HTMLButtonElement | null) => void | (() => VoidOrUndefinedOnly)'.)*
- `yarn test apps/quote` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c13d55f2d483289671b72709becd2b