### PR TITLE
fix router profile state

### DIFF
--- a/apps/reaver/components/RouterProfiles.tsx
+++ b/apps/reaver/components/RouterProfiles.tsx
@@ -42,7 +42,8 @@ interface RouterProfilesProps {
 const STORAGE_KEY = 'reaver-router-profile';
 
 const RouterProfiles: React.FC<RouterProfilesProps> = ({ onChange }) => {
-  const [selected, setSelected] = useState<RouterProfile>(ROUTER_PROFILES[0]);
+  // ROUTER_PROFILES always contains at least one entry, default to the first
+  const [selected, setSelected] = useState<RouterProfile>(ROUTER_PROFILES[0]!);
 
   // Load persisted profile on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary
- default router profile state to a non-null value to satisfy strict indexing rules

## Testing
- `yarn test apps/reaver/components/RouterProfiles.test.tsx` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c13f50158083288682f6a40bff8b1e