### PR TITLE
Ensure router profiles array typed as non-empty

### DIFF
--- a/apps/reaver/components/RouterProfiles.tsx
+++ b/apps/reaver/components/RouterProfiles.tsx
@@ -14,7 +14,7 @@ export interface RouterProfile {
   lockDuration: number;
 }
 
-export const ROUTER_PROFILES: RouterProfile[] = [
+export const ROUTER_PROFILES: [RouterProfile, ...RouterProfile[]] = [
   {
     id: 'generic',
     label: 'Generic (no lockout)',
@@ -50,7 +50,6 @@ const RouterProfiles: React.FC<RouterProfilesProps> = ({ onChange }) => {
     const profile = ROUTER_PROFILES.find((p) => p.id === stored) || ROUTER_PROFILES[0];
     setSelected(profile);
     onChange(profile);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
## Summary
- type `ROUTER_PROFILES` as a non-empty tuple to satisfy `useState` initialization
- drop an obsolete `react-hooks/exhaustive-deps` override

## Testing
- `npx tsc --noEmit --jsx react-jsx --esModuleInterop --skipLibCheck apps/reaver/components/RouterProfiles.tsx`
- `npx eslint apps/reaver/components/RouterProfiles.tsx`
- `yarn test apps/reaver --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c1401d858883289c30ce47885dc492