### PR TITLE
fix: ensure router profile defaults

### DIFF
--- a/apps/reaver/components/RouterProfiles.tsx
+++ b/apps/reaver/components/RouterProfiles.tsx
@@ -48,10 +48,10 @@ const RouterProfiles: React.FC<RouterProfilesProps> = ({ onChange }) => {
   // Load persisted profile on mount
   useEffect(() => {
     const stored = window.localStorage.getItem(STORAGE_KEY);
-    const profile = ROUTER_PROFILES.find((p) => p.id === stored) || ROUTER_PROFILES[0];
+    const profile =
+      ROUTER_PROFILES.find((p) => p.id === stored) ?? ROUTER_PROFILES[0]!;
     setSelected(profile);
     onChange(profile);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
## Summary
- Ensure RouterProfiles defaults to a valid profile using nullish coalescing
- Remove unused ESLint disable directive

## Testing
- `npx eslint apps/reaver/components/RouterProfiles.tsx`
- `npx jest --passWithNoTests apps/reaver/components/RouterProfiles.tsx`
- `npx tsc --noEmit -p tsconfig.json` *(fails: existing TypeScript errors in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c1421ceefc8328b3707a5e58570266