### PR TITLE
feat(snake): add attempt limit for food and obstacles

### DIFF
--- a/apps/games/__tests__/snake.test.ts
+++ b/apps/games/__tests__/snake.test.ts
@@ -1,0 +1,54 @@
+import { randomFood, randomObstacle, GRID_SIZE, type Point } from '../snake';
+
+describe('snake helpers', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('randomFood', () => {
+    it('returns a free point', () => {
+      const snake: Point[] = [{ x: 0, y: 0 }];
+      const obstacles: Point[] = [{ x: 1, y: 1 }];
+      const values = [0, 0, 0, 0, 0.9, 0.9];
+      jest.spyOn(Math, 'random').mockImplementation(() => values.shift()!);
+      const food = randomFood(snake, obstacles);
+      expect(food).toEqual({ x: 18, y: 18 });
+      expect([...snake, ...obstacles]).not.toContainEqual(food);
+    });
+
+    it('returns null when board is full', () => {
+      const snake: Point[] = [];
+      for (let x = 0; x < GRID_SIZE; x += 1) {
+        for (let y = 0; y < GRID_SIZE; y += 1) {
+          snake.push({ x, y });
+        }
+      }
+      expect(randomFood(snake)).toBeNull();
+    });
+  });
+
+  describe('randomObstacle', () => {
+    it('returns a free point', () => {
+      const snake: Point[] = [{ x: 0, y: 0 }];
+      const food: Point = { x: 1, y: 1 };
+      const obstacles: Point[] = [{ x: 2, y: 2 }];
+      const values = [0, 0, 0.05, 0.05, 0.1, 0.1, 0.9, 0.9];
+      jest.spyOn(Math, 'random').mockImplementation(() => values.shift()!);
+      const obstacle = randomObstacle(snake, food, obstacles);
+      expect(obstacle).toEqual({ x: 18, y: 18 });
+      expect([...snake, food, ...obstacles]).not.toContainEqual(obstacle);
+    });
+
+    it('returns null when no space available', () => {
+      const snake: Point[] = [];
+      for (let x = 0; x < GRID_SIZE; x += 1) {
+        for (let y = 0; y < GRID_SIZE; y += 1) {
+          if (x === 0 && y === 0) continue;
+          snake.push({ x, y });
+        }
+      }
+      const food: Point = { x: 0, y: 0 };
+      expect(randomObstacle(snake, food)).toBeNull();
+    });
+  });
+});

--- a/apps/games/snake.ts
+++ b/apps/games/snake.ts
@@ -8,37 +8,41 @@ export interface Point {
 export const randomFood = (
   snake: Point[],
   obstacles: Point[] = [],
-): Point => {
-  let pos: Point;
-  do {
-    pos = {
+  maxAttempts = 100,
+): Point | null => {
+  for (let i = 0; i < maxAttempts; i += 1) {
+    const pos = {
       x: Math.floor(Math.random() * GRID_SIZE),
       y: Math.floor(Math.random() * GRID_SIZE),
     };
-  } while (
-    snake.some((s) => s.x === pos.x && s.y === pos.y) ||
-    obstacles.some((o) => o.x === pos.x && o.y === pos.y)
-  );
-  return pos;
+    if (
+      !snake.some((s) => s.x === pos.x && s.y === pos.y) &&
+      !obstacles.some((o) => o.x === pos.x && o.y === pos.y)
+    )
+      return pos;
+  }
+  return null;
 };
 
 export const randomObstacle = (
   snake: Point[],
   food: Point,
   obstacles: Point[] = [],
-): Point => {
-  let pos: Point;
-  do {
-    pos = {
+  maxAttempts = 100,
+): Point | null => {
+  for (let i = 0; i < maxAttempts; i += 1) {
+    const pos = {
       x: Math.floor(Math.random() * GRID_SIZE),
       y: Math.floor(Math.random() * GRID_SIZE),
     };
-  } while (
-    snake.some((s) => s.x === pos.x && s.y === pos.y) ||
-    (food.x === pos.x && food.y === pos.y) ||
-    obstacles.some((o) => o.x === pos.x && o.y === pos.y)
-  );
-  return pos;
+    if (
+      !snake.some((s) => s.x === pos.x && s.y === pos.y) &&
+      !(food.x === pos.x && food.y === pos.y) &&
+      !obstacles.some((o) => o.x === pos.x && o.y === pos.y)
+    )
+      return pos;
+  }
+  return null;
 };
 
 export const generateObstacles = (
@@ -48,7 +52,9 @@ export const generateObstacles = (
 ): Point[] => {
   const obstacles: Point[] = [];
   for (let i = 0; i < count; i += 1) {
-    obstacles.push(randomObstacle(snake, food, obstacles));
+    const pos = randomObstacle(snake, food, obstacles);
+    if (!pos) break;
+    obstacles.push(pos);
   }
   return obstacles;
 };


### PR DESCRIPTION
## Summary
- prevent infinite loops by bounding randomFood/randomObstacle attempts
- handle full-board scenarios by returning `null`
- test normal and full-board behaviors for food and obstacle placement

## Testing
- `npm test -- apps/games/__tests__/snake.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c15327964083288d016ff1502b36cb