### PR TITLE
Handle invalid RNG state during deserialization

### DIFF
--- a/apps/games/__tests__/rng.test.ts
+++ b/apps/games/__tests__/rng.test.ts
@@ -1,0 +1,37 @@
+import seedrandom from 'seedrandom';
+import { random, reset, serialize, deserialize } from '../rng';
+
+describe('rng.deserialize', () => {
+  afterEach(() => {
+    reset();
+  });
+
+  it('restores RNG from a valid state string', () => {
+    reset('seed');
+    random();
+    random();
+    const state = serialize();
+    const next = random();
+    reset('other');
+    random();
+    deserialize(state);
+    expect(random()).toBe(next);
+  });
+
+  it('resets RNG when state is invalid JSON', () => {
+    reset('seed');
+    random();
+    deserialize('not-json');
+    const expected = seedrandom('', { state: true })();
+    expect(random()).toBe(expected);
+  });
+
+  it('resets RNG when parsed state is missing fields', () => {
+    reset('seed');
+    random();
+    const malformed = JSON.stringify({ foo: 'bar' });
+    deserialize(malformed);
+    const expected = seedrandom('', { state: true })();
+    expect(random()).toBe(expected);
+  });
+});

--- a/apps/games/rng.ts
+++ b/apps/games/rng.ts
@@ -15,9 +15,25 @@ export const serialize = (): string => {
 };
 
 export const deserialize = (state: string): void => {
-  rng = seedrandom('', {
-    state: JSON.parse(state) as seedrandom.State.Arc4,
-  });
+  try {
+    const parsed = JSON.parse(state);
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'i' in parsed &&
+      'j' in parsed &&
+      'S' in parsed
+    ) {
+      rng = seedrandom('', {
+        state: parsed as seedrandom.State.Arc4,
+      });
+      return;
+    }
+  } catch {
+    // fall through to reset below
+  }
+
+  rng = seedrandom('', { state: true });
 };
 
 const rngApi = { random, reset, serialize, deserialize };


### PR DESCRIPTION
## Summary
- make RNG deserialization robust by catching JSON parse errors and validating state
- add tests covering valid and invalid RNG state strings

## Testing
- `npx jest apps/games/__tests__/rng.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1532a10608328a23335d4e35a52c7