### PR TITLE
fix: handle undefined workspace

### DIFF
--- a/apps/recon-ng/components/ModulePlanner.tsx
+++ b/apps/recon-ng/components/ModulePlanner.tsx
@@ -28,7 +28,7 @@ const ModulePlanner: React.FC = () => {
   const [plan, setPlan] = usePersistentState<string[]>('reconng-plan', []);
   const [workspace, setWorkspace] = usePersistentState<string>(
     'reconng-workspace',
-    WORKSPACES[0],
+    WORKSPACES[0] ?? 'default',
   );
   const [log, setLog] = useState('');
 


### PR DESCRIPTION
## Summary
- ensure ModulePlanner uses a defined workspace when initializing state

## Testing
- `npx eslint apps/recon-ng/components/ModulePlanner.tsx && echo 'eslint passed'`
- `npx jest __tests__/csp.test.ts` *(fails: Missing allowlist entries for external domains)*

------
https://chatgpt.com/codex/tasks/task_e_68c1581f37d483288055095ff1937622