### PR TITLE
docs: add usage example for PipPortal component

### DIFF
--- a/docs/pip-portal.md
+++ b/docs/pip-portal.md
@@ -11,14 +11,19 @@ hook to open or close the PiP window.
 ```tsx
 import PipPortalProvider, { usePipPortal } from '../components/common/PipPortal';
 
+function Timer({ label }: { label: string }) {
+  return <div className="p-2">{label}: 00:30</div>;
+}
+
 function HudButton() {
   const { open, close } = usePipPortal();
 
   return (
     <div>
+      {/* `label` sets the text displayed before the timer value */}
       <button
         onClick={() =>
-          open(<div className="p-2">Timer: 00:30</div>)
+          open(<Timer label="Elapsed" />)
         }
       >
         Show Timer


### PR DESCRIPTION
## Summary
- expand PipPortal docs with a Timer example
- note Timer `label` property via JSX comment

## Testing
- `yarn test` *(fails: eslint-plugin-no-dupe-app-imports not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68c15b0988d0832896738349450418c1