### PR TITLE
refactor: derive default workspace constant

### DIFF
--- a/apps/recon-ng/components/ModulePlanner.tsx
+++ b/apps/recon-ng/components/ModulePlanner.tsx
@@ -18,6 +18,7 @@ const MODULES: Record<string, ModuleDef> = {
 
 const moduleNames = Object.keys(MODULES);
 const WORKSPACES = ['default', 'testing', 'production'] as const;
+const DEFAULT_WORKSPACE = WORKSPACES.at(0) ?? 'default';
 
 const ForceGraph2D = dynamic(
   () => import('react-force-graph').then((mod) => mod.ForceGraph2D),
@@ -28,7 +29,7 @@ const ModulePlanner: React.FC = () => {
   const [plan, setPlan] = usePersistentState<string[]>('reconng-plan', []);
   const [workspace, setWorkspace] = usePersistentState<string>(
     'reconng-workspace',
-    WORKSPACES[0] ?? 'default',
+    DEFAULT_WORKSPACE,
   );
   const [log, setLog] = useState('');
 


### PR DESCRIPTION
## Summary
- refactor ModulePlanner to derive a default workspace constant and use it when initializing persistent state

## Testing
- `yarn typecheck` *(fails: eslint-plugin-no-dupe-app-imports: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*
- `./node_modules/.bin/jest apps/recon-ng/components/ModulePlanner.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c15aa9c57883289f1c724f7e355072