### PR TITLE
fix: guard undefined modules in ModulePlanner

### DIFF
--- a/apps/recon-ng/components/ModulePlanner.tsx
+++ b/apps/recon-ng/components/ModulePlanner.tsx
@@ -88,6 +88,7 @@ const ModulePlanner: React.FC = () => {
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
         {moduleNames.map((m) => {
           const mod = MODULES[m];
+          if (!mod) return null;
           const active = plan.includes(m);
           return (
             <div


### PR DESCRIPTION
## Summary
- safely handle undefined modules in Recon-ng ModulePlanner

## Testing
- `yarn typecheck` *(fails: Type '(el: HTMLButtonElement | null) => HTMLButtonElement | null' is not assignable to type '(instance: HTMLButtonElement | null) => void | (() => VoidOrUndefinedOnly).' and several other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c15bce415883289b0c6dd0cb3df9bd