### PR TITLE
fix(sokoban): guard coordinate parsing

### DIFF
--- a/apps/sokoban/engine.ts
+++ b/apps/sokoban/engine.ts
@@ -112,8 +112,9 @@ export function isDeadlockPosition(state: State, pos: Position): boolean {
 function computeDeadlocks(state: State): Set<string> {
   const d = new Set<string>();
   state.boxes.forEach((b) => {
-    const [x, y] = b.split(',').map(Number);
-    const pos = { x, y };
+    const [xStr, yStr] = b.split(',');
+    if (xStr === undefined || yStr === undefined) return;
+    const pos: Position = { x: Number(xStr), y: Number(yStr) };
     if (isDeadlockPosition(state, pos)) d.add(b);
   });
   return d;


### PR DESCRIPTION
## Summary
- avoid passing undefined coordinates when checking box deadlocks

## Testing
- `pnpm -w typecheck` *(fails: --workspace-root may only be used inside a workspace)*
- `yarn test __tests__/sokoban.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c19e4b39f48328a9b7f66052e37297