### PR TITLE
fix: guard undo prev state

### DIFF
--- a/apps/sokoban/engine.ts
+++ b/apps/sokoban/engine.ts
@@ -152,8 +152,8 @@ export function move(state: State, dirKey: DirectionKey): State {
 }
 
 export function undo(state: State): State {
-  if (!state.history.length) return state;
   const prev = state.history[state.history.length - 1];
+  if (!prev) return state;
   const boxes = new Set(prev.boxes);
   const restored: State = {
     ...state,


### PR DESCRIPTION
## Summary
- handle empty history in Sokoban undo logic

## Testing
- `yarn test __tests__/sokoban.test.ts`
- `yarn typecheck` *(fails: Type errors in AutostartManager.tsx and menu utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a1e744788328beae457db13430eb