### PR TITLE
refactor: use Array.at for undo history

### DIFF
--- a/components/apps/checkers/index.tsx
+++ b/components/apps/checkers/index.tsx
@@ -286,8 +286,8 @@ const Checkers = () => {
   };
 
   const undo = () => {
-    if (!history.length) return;
-    const prev = history[history.length - 1];
+    const prev = history.at(-1);
+    if (!prev) return;
     setFuture([{ board, turn, no: noCapture, move: lastMove }, ...future]);
     setBoard(prev.board);
     setTurn(prev.turn as 'red' | 'black');


### PR DESCRIPTION
## Summary
- use `history.at(-1)` for undo stack
- guard against missing history entry in undo

## Testing
- `yarn test __tests__/checkers.validator.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1ae1849408328b41c743783b69423