### PR TITLE
Refactor docs TOC builder for safer section linking

### DIFF
--- a/pages/docs/[topic].tsx
+++ b/pages/docs/[topic].tsx
@@ -38,8 +38,9 @@ export default function DocPage({ html, toc, title, topic }: DocProps) {
   const sections: TocSection[] = toc.reduce((acc: TocSection[], item) => {
     if (item.depth === 2) {
       acc.push({ id: item.id, text: item.text, children: [] });
-    } else if (item.depth === 3 && acc.length > 0) {
-      acc[acc.length - 1].children.push(item);
+    } else if (item.depth === 3) {
+      const last = acc.at(-1);
+      if (last) last.children.push(item);
     }
     return acc;
   }, []);


### PR DESCRIPTION
## Summary
- refactor docs TOC reducer to use `acc.at(-1)` instead of index access
- guard against missing sections before pushing children

## Testing
- `npx eslint pages/docs/'[topic].tsx'`
- `yarn test --passWithNoTests pages/docs/'[topic].tsx'`
- `yarn typecheck` *(fails: eslint-plugin-no-dupe-app-imports: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ae1bdd108328a968518a70df1415