### PR TITLE
Handle undefined latest counts in Nessus trend chart

### DIFF
--- a/apps/nessus/components/TrendChart.tsx
+++ b/apps/nessus/components/TrendChart.tsx
@@ -124,7 +124,7 @@ export default function TrendChart() {
               {severities.map((sev, i) => {
                 const barWidth = width / severities.length - 4;
                 const x = i * (barWidth + 4);
-                const barHeight = (latest.counts[sev] / max) * height;
+                const barHeight = ((latest?.counts[sev] ?? 0) / max) * height;
                 const y = height - barHeight;
                 return (
                   <rect


### PR DESCRIPTION
## Summary
- guard against missing `latest` severity counts in TrendChart summary bars

## Testing
- `npx eslint apps/nessus/components/TrendChart.tsx` (fails: A control must be associated with a text label)
- `npx jest apps/nessus/components/TrendChart.tsx --passWithNoTests`
- `npx tsc --noEmit apps/nessus/components/TrendChart.tsx` (fails: Module '@types/react/index' can only be default-imported using the 'esModuleInterop' flag and other JSX related errors)


------
https://chatgpt.com/codex/tasks/task_e_68c1ae1ab7208328a5ea46a132c19e48