### PR TITLE
refactor: use NodeList item with non-null assertions

### DIFF
--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -168,14 +168,14 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
     prevFocus.current = document.activeElement as HTMLElement | null;
     const selectors =
       'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])';
-    const focusables = Array.from(
-      overlayRef.current.querySelectorAll<HTMLElement>(selectors),
+    const focusables = overlayRef.current.querySelectorAll<HTMLElement>(
+      selectors,
     );
-    focusables[0]?.focus();
+    focusables.item(0)?.focus();
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === "Tab" && focusables.length > 0) {
-        const first = focusables[0];
-        const last = focusables[focusables.length - 1];
+        const first = focusables.item(0)!;
+        const last = focusables.item(focusables.length - 1)!;
         if (e.shiftKey) {
           if (document.activeElement === first) {
             e.preventDefault();


### PR DESCRIPTION
## Summary
- Use NodeList `item()` to access first and last focusable elements
- Replace array indexing with non-null assertions for focus management

## Testing
- `yarn test` *(fails: global search finds platform slugs, missing Playwright browsers, undefined displayYouTube, and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ae179d5c8328be056e4a2746c4fc