### PR TITLE
fix modal focus retrieval

### DIFF
--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -70,8 +70,9 @@ const Modal: React.FC<ModalProps> = ({
         if (e.key !== 'Tab') return;
         const elements = modalRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
         if (!elements || elements.length === 0) return;
-        const first = elements[0];
-        const last = elements[elements.length - 1];
+        const first = elements.item(0);
+        const last = elements.item(elements.length - 1);
+        if (!first || !last) return;
         const current = document.activeElement as HTMLElement;
         if (!e.shiftKey && current === last) {
             e.preventDefault();


### PR DESCRIPTION
## Summary
- use `item()` to retrieve first and last focusable elements in modal
- guard against missing elements before focusing

## Testing
- `yarn test Modal`
- `yarn lint components/base/Modal.tsx` *(fails: eslint-plugin-no-dupe-app-imports: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ae16bcf88328a27408595d342edb