### PR TITLE
refactor: guard last hint positions

### DIFF
--- a/apps/word_search/index.tsx
+++ b/apps/word_search/index.tsx
@@ -397,15 +397,16 @@ const WordSearchInner: React.FC<WordSearchInnerProps> = ({ getDailySeed }) => {
 
   const useLastHint = () => {
     if (lastHints <= 0) return;
-    const remaining = placements.filter(
-      (p) =>
-        !found.has(p.word) &&
-        !hintCells.has(key(p.positions[p.positions.length - 1]))
-    );
+    const remaining = placements.filter((p) => {
+      const last = p.positions.at(-1);
+      return last ? !found.has(p.word) && !hintCells.has(key(last)) : false;
+    });
     if (!remaining.length) return;
     const target = remaining[Math.floor(Math.random() * remaining.length)];
+    const lastPos = target.positions.at(-1);
+    if (!lastPos) return;
     const newHints = new Set(hintCells);
-    newHints.add(key(target.positions[target.positions.length - 1]));
+    newHints.add(key(lastPos));
     setHintCells(newHints);
     setLastHints(lastHints - 1);
   };


### PR DESCRIPTION
## Summary
- handle missing last position when filtering last hints
- skip hint update if no last position

## Testing
- `npx eslint apps/word_search/index.tsx` *(fails: A control must be associated with a text label)*
- `npx jest apps/word_search --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c1ae15fb0c8328a729226b030b55ea