### PR TITLE
fix: handle undefined value in visualizer

### DIFF
--- a/apps/spotify/Visualizer.tsx
+++ b/apps/spotify/Visualizer.tsx
@@ -24,7 +24,7 @@ export default function Visualizer({ analyser }: Props) {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       const barWidth = canvas.width / bufferLength;
       for (let i = 0; i < bufferLength; i++) {
-        const value = dataArray[i];
+        const value = dataArray[i] ?? 0;
         const barHeight = (value / 255) * canvas.height;
         ctx.fillStyle = `rgb(${value}, 100, 150)`;
         ctx.fillRect(i * barWidth, canvas.height - barHeight, barWidth - 1, barHeight);
@@ -33,6 +33,14 @@ export default function Visualizer({ analyser }: Props) {
     draw();
   }, [analyser]);
 
-  return <canvas ref={canvasRef} width={300} height={100} className="w-full h-24" />;
+  return (
+    <canvas
+      ref={canvasRef}
+      width={300}
+      height={100}
+      className="w-full h-24"
+      aria-label="audio visualizer"
+    />
+  );
 }
 


### PR DESCRIPTION
## Summary
- avoid undefined values in Spotify visualizer
- add accessibility label to canvas

## Testing
- `npx eslint apps/spotify/Visualizer.tsx`
- `npx jest apps/spotify --passWithNoTests`
- `npx tsc -p tsconfig.json --noEmit` *(fails: TS errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c1adec24308328a29eae28db722b81