### PR TITLE
fix: guard undefined audio data in spotify visualizer

### DIFF
--- a/apps/spotify/Visualizer.tsx
+++ b/apps/spotify/Visualizer.tsx
@@ -24,7 +24,9 @@ export default function Visualizer({ analyser }: Props) {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       const barWidth = canvas.width / bufferLength;
       for (let i = 0; i < bufferLength; i++) {
-        const value = dataArray[i];
+        // With `noUncheckedIndexedAccess` enabled, direct indexing can yield
+        // `undefined`. Provide a safe fallback to keep the visualizer stable.
+        const value = dataArray[i] ?? 0;
         const barHeight = (value / 255) * canvas.height;
         ctx.fillStyle = `rgb(${value}, 100, 150)`;
         ctx.fillRect(i * barWidth, canvas.height - barHeight, barWidth - 1, barHeight);


### PR DESCRIPTION
## Summary
- handle potential undefined values when reading frequency data

## Testing
- `yarn typecheck` *(fails: Type '{ file?: string; name?: string; enabled?: boolean; delay?: number; data?: Record<string, any>; }' is not assignable to type 'AutostartEntry' ...)*
- `yarn test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cf7981d88328898dcfbae667db38