### PR TITLE
Fix crossfade TypeScript index type

### DIFF
--- a/apps/spotify/utils/crossfade.ts
+++ b/apps/spotify/utils/crossfade.ts
@@ -6,7 +6,7 @@ export default class CrossfadePlayer {
     null,
   ];
   private analyser: AnalyserNode | null = null;
-  private current = 0;
+  private current: 0 | 1 = 0;
   private startTime = 0;
 
   private ensureContext() {
@@ -36,7 +36,7 @@ export default class CrossfadePlayer {
       const res = await fetch(url);
       const arr = await res.arrayBuffer();
       const buffer = await ctx.decodeAudioData(arr);
-      const nextIndex = (this.current + 1) % 2;
+      const nextIndex: 0 | 1 = ((this.current + 1) % 2) as 0 | 1;
       const src = ctx.createBufferSource();
       src.buffer = buffer;
       src.connect(gains[nextIndex]);


### PR DESCRIPTION
## Summary
- narrow CrossfadePlayer tuple indices to `0 | 1`
- cast calculated index to satisfy TypeScript when selecting gains

## Testing
- `yarn build` *(fails: eslint-plugin-no-dupe-app-imports not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68c201f4002c8328bf9af343e367997d