### PR TITLE
Handle missing alias names in terminal command

### DIFF
--- a/apps/terminal/commands/index.ts
+++ b/apps/terminal/commands/index.ts
@@ -29,11 +29,13 @@ function alias(args: string, ctx: CommandContext) {
     Object.entries(ctx.aliases).forEach(([k, v]) => ctx.writeLine(`${k}='${v}'`));
     return;
   }
-  const [name, value] = args.split('=');
+  const [rawName = '', value] = args.split('=');
+  const name = rawName.trim();
+  if (!name) return;
   if (value) {
-    ctx.setAlias(name.trim(), value.trim());
+    ctx.setAlias(name, value.trim());
   } else {
-    const existing = ctx.aliases[name.trim()];
+    const existing = ctx.aliases[name];
     if (existing) ctx.writeLine(`${name}='${existing}'`);
   }
 }


### PR DESCRIPTION
## Summary
- avoid undefined alias names in terminal by validating name before usage

## Testing
- `yarn run build` *(fails: eslint-plugin-no-dupe-app-imports missing)*
- `yarn test` *(fails: eslint-plugin-no-dupe-app-imports missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c207087c488328a1237fbaaf5f4009