### PR TITLE
fix: guard alias name

### DIFF
--- a/apps/terminal/commands/index.ts
+++ b/apps/terminal/commands/index.ts
@@ -30,6 +30,10 @@ function alias(args: string, ctx: CommandContext) {
     return;
   }
   const [name, value] = args.split('=');
+  if (!name) {
+    ctx.writeLine("usage: alias name='value'");
+    return;
+  }
   if (value) {
     ctx.setAlias(name.trim(), value.trim());
   } else {


### PR DESCRIPTION
## Summary
- guard against missing alias name in terminal command

## Testing
- `npx eslint apps/terminal/commands/index.ts`
- `npx tsc --noEmit -p tsconfig.json` *(fails: numerous type errors in unrelated files)*
- `npx jest apps/terminal/commands/index.ts --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c207798ba08328a358716a567028a1