### PR TITLE
fix: ensure terminal scripts entries are typed

### DIFF
--- a/apps/terminal/components/Scripts.tsx
+++ b/apps/terminal/components/Scripts.tsx
@@ -122,12 +122,14 @@ const Scripts = ({ runCommand }: ScriptsProps) => {
           onChange={(e) => setName(e.target.value)}
           placeholder="script name"
           className="w-full border p-1"
+          aria-label="script name"
         />
         <textarea
           value={code}
           onChange={(e) => setCode(e.target.value)}
           placeholder={"echo hello\nsleep 1000\necho done"}
           className="w-full border p-1 h-32"
+          aria-label="script code"
         />
         <button
           onClick={save}
@@ -145,8 +147,7 @@ const Scripts = ({ runCommand }: ScriptsProps) => {
         )}
       </div>
       <ul className="space-y-1">
-        {Object.keys(scripts).map((n) => {
-          const entry = scripts[n];
+        {Object.entries(scripts).map(([n, entry]) => {
           const data: ScriptEntry =
             typeof entry === 'string' ? { code: entry } : entry;
           const presets = data.presets || {};


### PR DESCRIPTION
## Summary
- handle terminal script entries safely when listing presets
- add labels for script name and code inputs

## Testing
- `node_modules/.bin/eslint apps/terminal/components/Scripts.tsx`
- `node_modules/.bin/tsc -p tsconfig.json --noEmit` *(fails: Type '(el: HTMLButtonElement | null) => HTMLButtonElement | null' is not assignable to type '(instance: HTMLButtonElement | null) => void | (() => VoidOrUndefinedOnly)'.)*
- `node_modules/.bin/jest apps/terminal/components/Scripts.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c20a1176f083289878bd7b06086138