### PR TITLE
fix: handle missing token in recurring parser

### DIFF
--- a/apps/todoist/utils/recurringParser.ts
+++ b/apps/todoist/utils/recurringParser.ts
@@ -38,7 +38,7 @@ export function parseRecurring(text: string, start: Date = new Date()): ParseRes
     freq = RRule.WEEKLY;
     byweekday = [RRule.SA, RRule.SU];
   } else {
-    const maybeNumber = parseInt(tokens[0], 10);
+    const maybeNumber = parseInt(tokens[0] || '', 10);
     if (!isNaN(maybeNumber)) {
       interval = maybeNumber;
       tokens.shift();
@@ -64,9 +64,10 @@ export function parseRecurring(text: string, start: Date = new Date()): ParseRes
         break;
       default:
         // handle specific days like Monday, Tuesday etc
-        if (DAY_MAP[unit]) {
+        const day = unit && DAY_MAP[unit];
+        if (day) {
           freq = RRule.WEEKLY;
-          byweekday = [DAY_MAP[unit]];
+          byweekday = [day];
         }
         break;
     }


### PR DESCRIPTION
## Summary
- handle undefined tokens in Todoist recurring parser
- guard weekday lookup to avoid undefined indexes

## Testing
- `yarn run build` *(fails: Type error in apps/tower-defense/index.tsx)*
- `npx tsc --pretty false apps/todoist/utils/recurringParser.ts` *(fails: '@types/react-cytoscapejs' missing `Stylesheet` export)*

------
https://chatgpt.com/codex/tasks/task_e_68c221d918dc832893473c0388ca8259