### PR TITLE
fix: avoid locale redirect loop

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -39,9 +39,11 @@ export function middleware(req: NextRequest | { headers: Headers; nextUrl?: URL;
       ?.split(',')[0]
       .split('-')[0];
     const locale = locales.includes(language ?? '') ? language! : defaultLocale;
-    return NextResponse.redirect(
-      new URL(`/${locale}${pathname}`, (req as any).url || 'http://localhost')
-    );
+    if (locale !== defaultLocale) {
+      return NextResponse.redirect(
+        new URL(`/${locale}${pathname}`, (req as any).url || 'http://localhost')
+      );
+    }
   }
 
   const n = nonce();


### PR DESCRIPTION
## Summary
- prevent infinite redirects when Accept-Language matches default locale

## Testing
- `yarn lint` *(fails: 471 errors)*
- `yarn test` *(fails: multiple failing tests; missing environment variables, module resolution, and Playwright browsers)*
- `yarn typecheck` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c2440e8da08328b2c507d83ada755a