### PR TITLE
Revert layout to whisker menu version

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
+import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
-import { Icon } from '../ui/Icon';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
 
@@ -122,14 +122,20 @@ const WhiskerMenu: React.FC = () => {
         onClick={() => setOpen(o => !o)}
         className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
       >
-        <Icon name="menu" className="inline mr-1 w-4 h-4 rtl:ml-1 rtl:mr-0" />
+        <Image
+          src="/themes/Yaru/status/decompiler-symbolic.svg"
+          alt="Menu"
+          width={16}
+          height={16}
+          className="inline mr-1"
+        />
         Applications
       </button>
       {open && (
-          <div
-            ref={menuRef}
-            className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg rtl:left-auto rtl:right-0"
-            tabIndex={-1}
+        <div
+          ref={menuRef}
+          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
+          tabIndex={-1}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node)) {
               setOpen(false);
@@ -140,7 +146,7 @@ const WhiskerMenu: React.FC = () => {
             {CATEGORIES.map(cat => (
               <button
                 key={cat.id}
-                className={`text-left px-2 py-1 rounded mb-1 rtl:text-right ${category === cat.id ? 'bg-gray-700' : ''}`}
+                className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
                 onClick={() => setCategory(cat.id)}
               >
                 {cat.label}
@@ -151,7 +157,6 @@ const WhiskerMenu: React.FC = () => {
             <input
               className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
               placeholder="Search"
-              aria-label="Search applications"
               value={query}
               onChange={e => setQuery(e.target.value)}
               autoFocus

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1,9 +1,7 @@
 "use client";
 
-import { isBrowser } from '@/utils/env';
 import React, { Component } from 'react';
 import dynamic from 'next/dynamic';
-import logger from '../../utils/logger';
 
 const BackgroundImage = dynamic(
     () => import('../util-components/background-image'),
@@ -16,21 +14,15 @@ import UbuntuApp from '../base/ubuntu_app';
 import AllApplications from '../screen/all-applications'
 import ShortcutSelector from '../screen/shortcut-selector'
 import WindowSwitcher from '../screen/window-switcher'
-import WorkspaceSwitcher from './workspace-switcher'
-import LauncherCreator from './launcher-creator'
 import DesktopMenu from '../context-menus/desktop-menu';
 import DefaultMenu from '../context-menus/default';
 import AppMenu from '../context-menus/app-menu';
 import Taskbar from './taskbar';
 import TaskbarMenu from '../context-menus/taskbar-menu';
-import WindowMenu from '../context-menus/window-menu';
 import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { useSnapSetting } from '../../hooks/usePersistentState';
-import { addRecentApp, getRecentApps } from '../../utils/recent';
-import osdService from '../../utils/osdService';
-import DesktopTour from '../welcome/DesktopTour';
 
 export class Desktop extends Component {
     constructor() {
@@ -38,12 +30,9 @@ export class Desktop extends Component {
         this.app_stack = [];
         this.initFavourite = {};
         this.allWindowClosed = false;
-        this.windowRefs = {};
         this.state = {
             focused_windows: {},
             closed_windows: {},
-            currentWorkspace: 0,
-            window_workspaces: {},
             allAppsView: false,
             overlapped_windows: {},
             disabled_apps: {},
@@ -52,23 +41,17 @@ export class Desktop extends Component {
             minimized_windows: {},
             window_positions: {},
             desktop_apps: [],
-            dock: [],
-            recentApps: getRecentApps(),
             context_menus: {
                 desktop: false,
                 default: false,
                 app: false,
                 taskbar: false,
-                window: false,
             },
             context_app: null,
             showNameBar: false,
             showShortcutSelector: false,
-            showLauncherCreator: false,
             showWindowSwitcher: false,
             switcherWindows: [],
-            showWorkspaceSwitcher: false,
-            switcherWorkspaces: [],
         }
     }
 
@@ -79,9 +62,17 @@ export class Desktop extends Component {
         this.fetchAppsData(() => {
             const session = this.props.session || {};
             const positions = {};
+            if (session.dock && session.dock.length) {
+                let favourite_apps = { ...this.state.favourite_apps };
+                session.dock.forEach(id => {
+                    favourite_apps[id] = true;
+                });
+                this.setState({ favourite_apps });
+            }
+
             if (session.windows && session.windows.length) {
-                session.windows.forEach(({ id, x, y, snap }) => {
-                    positions[id] = { x, y, snap };
+                session.windows.forEach(({ id, x, y }) => {
+                    positions[id] = { x, y };
                 });
                 this.setState({ window_positions: positions }, () => {
                     session.windows.forEach(({ id }) => this.openApp(id));
@@ -94,36 +85,15 @@ export class Desktop extends Component {
         this.setEventListeners();
         this.checkForNewFolders();
         this.checkForAppShortcuts();
-        this.checkForLaunchers();
         this.updateTrashIcon();
         window.addEventListener('trash-change', this.updateTrashIcon);
         document.addEventListener('keydown', this.handleGlobalShortcut);
-        document.addEventListener('mousedown', this.handleMouseShortcut);
         window.addEventListener('open-app', this.handleOpenAppEvent);
-
-        // Warm commonly used modules during idle periods so the first
-        // interaction is snappy even on a cold cache. Falling back to
-        // setTimeout ensures compatibility with environments lacking
-        // requestIdleCallback.
-        if (isBrowser()) {
-            const warmModules = () => {
-                import('../apps/terminal');
-                import('../../apps/terminal/tabs');
-                import('../apps/file-explorer');
-                import('../apps/settings');
-            };
-            if ('requestIdleCallback' in window) {
-                requestIdleCallback(warmModules);
-            } else {
-                setTimeout(warmModules, 0);
-            }
-        }
     }
 
     componentWillUnmount() {
         this.removeContextListeners();
         document.removeEventListener('keydown', this.handleGlobalShortcut);
-        document.removeEventListener('mousedown', this.handleMouseShortcut);
         window.removeEventListener('trash-change', this.updateTrashIcon);
         window.removeEventListener('open-app', this.handleOpenAppEvent);
     }
@@ -160,13 +130,6 @@ export class Desktop extends Component {
                 this.openApp("settings");
             });
         }
-        document.addEventListener('open-settings', (e) => {
-            const tab = e.detail && e.detail.tab;
-            if (tab) {
-                window.localStorage.setItem('settings-open-tab', tab);
-            }
-            this.openApp('settings');
-        });
     }
 
     setContextListeners = () => {
@@ -189,41 +152,17 @@ export class Desktop extends Component {
             if (!this.state.showWindowSwitcher) {
                 this.openWindowSwitcher();
             }
-        }
-        else if (e.altKey && e.key === 'F4') {
-            e.preventDefault();
-            const id = this.getFocusedWindowId();
-            if (id) this.closeApp(id);
-        }
-        else if (e.ctrlKey && e.altKey && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
-            e.preventDefault();
-            this.switchWorkspace(e.key === 'ArrowRight' ? 1 : -1);
-        }
-        else if (e.ctrlKey && e.altKey && e.key.toLowerCase() === 'w') {
-            e.preventDefault();
-            if (!this.state.showWorkspaceSwitcher) {
-                this.openWorkspaceSwitcher();
-            }
-        }
-        else if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'v') {
+        } else if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'v') {
             e.preventDefault();
             this.openApp('clipboard-manager');
+        }
+        else if (e.altKey && e.key === 'Tab') {
+            e.preventDefault();
+            this.cycleApps(e.shiftKey ? -1 : 1);
         }
         else if (e.altKey && (e.key === '`' || e.key === '~')) {
             e.preventDefault();
             this.cycleAppWindows(e.shiftKey ? -1 : 1);
-        }
-        else if (e.altKey && e.code === 'Space') {
-            e.preventDefault();
-            const id = this.getFocusedWindowId();
-            if (id) {
-                const node = document.getElementById(id);
-                if (node) {
-                    const rect = node.getBoundingClientRect();
-                    const fakeEvent = { pageX: rect.left, pageY: rect.top + rect.height };
-                    this.setState({ context_app: id }, () => this.showContextMenu(fakeEvent, 'window'));
-                }
-            }
         }
         else if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
             e.preventDefault();
@@ -231,15 +170,6 @@ export class Desktop extends Component {
             if (id) {
                 const event = new CustomEvent('super-arrow', { detail: e.key });
                 document.getElementById(id)?.dispatchEvent(event);
-            }
-        }
-    }
-
-    handleMouseShortcut = (e) => {
-        if (e.ctrlKey && e.altKey && e.button === 1) {
-            e.preventDefault();
-            if (!this.state.showWorkspaceSwitcher) {
-                this.openWorkspaceSwitcher();
             }
         }
     }
@@ -291,85 +221,6 @@ export class Desktop extends Component {
         }
     }
 
-    openWorkspaceSwitcher = () => {
-        const WORKSPACE_COUNT = 3;
-        let names = [];
-        try {
-            const stored = window.localStorage.getItem('workspaces');
-            if (stored) {
-                const parsed = JSON.parse(stored);
-                if (Array.isArray(parsed)) names = parsed;
-            }
-        } catch { /* ignore */ }
-        const workspaces = Array.from({ length: WORKSPACE_COUNT }, (_, i) => ({
-            id: i,
-            name: typeof names[i] === 'string' && names[i].trim() ? names[i] : `Workspace ${i + 1}`,
-        }));
-        this.setState({
-            showWorkspaceSwitcher: true,
-            switcherWorkspaces: workspaces,
-        });
-    }
-
-    switchWorkspace = (direction) => {
-        const WORKSPACE_COUNT = 3;
-        let nextWs = 0;
-        this.setState(prev => {
-            nextWs = (prev.currentWorkspace + direction + WORKSPACE_COUNT) % WORKSPACE_COUNT;
-            const closed_windows = { ...prev.closed_windows };
-            const focused_windows = { ...prev.focused_windows };
-            Object.keys(prev.window_workspaces).forEach(id => {
-                const same = prev.window_workspaces[id] === nextWs;
-                closed_windows[id] = !same;
-                if (!same) focused_windows[id] = false;
-            });
-            return { currentWorkspace: nextWs, closed_windows, focused_windows };
-        }, () => {
-            let name = `Workspace ${nextWs + 1}`;
-            try {
-                const stored = window.localStorage.getItem('workspaces');
-                if (stored) {
-                    const names = JSON.parse(stored);
-                    if (Array.isArray(names) && typeof names[nextWs] === 'string' && names[nextWs].trim()) {
-                        name = names[nextWs];
-                    }
-                }
-            } catch { /* ignore */ }
-            const message = `Workspace ${nextWs + 1} — ${name}`;
-            osdService.show(message, 1200);
-            this.giveFocusToLastApp();
-        });
-    }
-
-    goToWorkspace = (index) => {
-        const WORKSPACE_COUNT = 3;
-        const target = ((index % WORKSPACE_COUNT) + WORKSPACE_COUNT) % WORKSPACE_COUNT;
-        this.setState(prev => {
-            const closed_windows = { ...prev.closed_windows };
-            const focused_windows = { ...prev.focused_windows };
-            Object.keys(prev.window_workspaces).forEach(id => {
-                const same = prev.window_workspaces[id] === target;
-                closed_windows[id] = !same;
-                if (!same) focused_windows[id] = false;
-            });
-            return { currentWorkspace: target, closed_windows, focused_windows };
-        }, () => {
-            let name = `Workspace ${target + 1}`;
-            try {
-                const stored = window.localStorage.getItem('workspaces');
-                if (stored) {
-                    const names = JSON.parse(stored);
-                    if (Array.isArray(names) && typeof names[target] === 'string' && names[target].trim()) {
-                        name = names[target];
-                    }
-                }
-            } catch { /* ignore */ }
-            const message = `Workspace ${target + 1} — ${name}`;
-            osdService.show(message, 1200);
-            this.giveFocusToLastApp();
-        });
-    }
-
     closeWindowSwitcher = () => {
         this.setState({ showWindowSwitcher: false, switcherWindows: [] });
     }
@@ -377,16 +228,6 @@ export class Desktop extends Component {
     selectWindow = (id) => {
         this.setState({ showWindowSwitcher: false, switcherWindows: [] }, () => {
             this.openApp(id);
-        });
-    }
-
-    closeWorkspaceSwitcher = () => {
-        this.setState({ showWorkspaceSwitcher: false, switcherWorkspaces: [] });
-    }
-
-    selectWorkspace = (id) => {
-        this.setState({ showWorkspaceSwitcher: false, switcherWorkspaces: [] }, () => {
-            this.goToWorkspace(id);
         });
     }
 
@@ -418,13 +259,6 @@ export class Desktop extends Component {
                 });
                 this.setState({ context_app: appId }, () => this.showContextMenu(e, "taskbar"));
                 break;
-            case "window":
-                ReactGA.event({
-                    category: `Context Menu`,
-                    action: `Opened Window Context Menu`
-                });
-                this.setState({ context_app: appId }, () => this.showContextMenu(e, "window"));
-                break;
             default:
                 ReactGA.event({
                     category: `Context Menu`,
@@ -455,10 +289,6 @@ export class Desktop extends Component {
             case "taskbar":
                 ReactGA.event({ category: `Context Menu`, action: `Opened Taskbar Context Menu` });
                 this.setState({ context_app: appId }, () => this.showContextMenu(fakeEvent, "taskbar"));
-                break;
-            case "window":
-                ReactGA.event({ category: `Context Menu`, action: `Opened Window Context Menu` });
-                this.setState({ context_app: appId }, () => this.showContextMenu(fakeEvent, "window"));
                 break;
             default:
                 ReactGA.event({ category: `Context Menu`, action: `Opened Default Context Menu` });
@@ -513,23 +343,14 @@ export class Desktop extends Component {
     }
 
     fetchAppsData = (callback) => {
-        let pinnedApps = [];
-        try {
-            const stored = safeLocalStorage?.getItem('pinnedApps');
-            if (stored) {
-                pinnedApps = JSON.parse(stored);
-            } else if (this.props.session?.dock && this.props.session.dock.length) {
-                pinnedApps = this.props.session.dock;
-                safeLocalStorage?.setItem('pinnedApps', JSON.stringify(pinnedApps));
-            } else {
-                pinnedApps = apps.filter(app => app.favourite).map(app => app.id);
-                safeLocalStorage?.setItem('pinnedApps', JSON.stringify(pinnedApps));
-            }
-        } catch {
+        let pinnedApps = safeLocalStorage?.getItem('pinnedApps');
+        if (pinnedApps) {
+            pinnedApps = JSON.parse(pinnedApps);
+            apps.forEach(app => { app.favourite = pinnedApps.includes(app.id); });
+        } else {
             pinnedApps = apps.filter(app => app.favourite).map(app => app.id);
+            safeLocalStorage?.setItem('pinnedApps', JSON.stringify(pinnedApps));
         }
-        apps.forEach(app => { app.favourite = pinnedApps.includes(app.id); });
-
         let focused_windows = {}, closed_windows = {}, disabled_apps = {}, favourite_apps = {}, overlapped_windows = {}, minimized_windows = {};
         let desktop_apps = [];
         apps.forEach((app) => {
@@ -566,8 +387,7 @@ export class Desktop extends Component {
             favourite_apps,
             overlapped_windows,
             minimized_windows,
-            desktop_apps,
-            dock: pinnedApps
+            desktop_apps
         }, () => {
             if (typeof callback === 'function') callback();
         });
@@ -640,8 +460,6 @@ export class Desktop extends Component {
             if (this.state.closed_windows[app.id] === false) {
 
                 const pos = this.state.window_positions[app.id];
-                const index = this.app_stack.indexOf(app.id);
-                const zIndex = 100 + (index === -1 ? 0 : index);
                 const props = {
                     title: app.title,
                     id: app.id,
@@ -651,7 +469,6 @@ export class Desktop extends Component {
                     openApp: this.openApp,
                     focus: this.focus,
                     isFocused: this.state.focused_windows[app.id],
-                    zIndex,
                     hideSideBar: this.hideSideBar,
                     hasMinimised: this.hasMinimised,
                     minimized: this.state.minimized_windows[app.id],
@@ -661,32 +478,24 @@ export class Desktop extends Component {
                     defaultHeight: app.defaultHeight,
                     initialX: pos ? pos.x : undefined,
                     initialY: pos ? pos.y : undefined,
-                    initialSnap: pos ? pos.snap : undefined,
-                    onPositionChange: (x, y, snap) => this.updateWindowPosition(app.id, x, y, snap),
+                    onPositionChange: (x, y) => this.updateWindowPosition(app.id, x, y),
                     snapEnabled: this.props.snapEnabled,
                 }
 
                 windowsJsx.push(
-                    <Window
-                        key={app.id}
-                        ref={ref => { if (ref) this.windowRefs[app.id] = ref; }}
-                        {...props}
-                    />
+                    <Window key={app.id} {...props} />
                 )
             }
         });
         return windowsJsx;
     }
 
-    updateWindowPosition = (id, x, y, snapPos = null) => {
+    updateWindowPosition = (id, x, y) => {
         const snap = this.props.snapEnabled
             ? (v) => Math.round(v / 8) * 8
             : (v) => v;
         this.setState(prev => ({
-            window_positions: {
-                ...prev.window_positions,
-                [id]: { x: snap(x), y: snap(y), snap: snapPos }
-            }
+            window_positions: { ...prev.window_positions, [id]: { x: snap(x), y: snap(y) } }
         }), this.saveSession);
     }
 
@@ -696,10 +505,9 @@ export class Desktop extends Component {
         const windows = openWindows.map(id => ({
             id,
             x: this.state.window_positions[id] ? this.state.window_positions[id].x : 60,
-            y: this.state.window_positions[id] ? this.state.window_positions[id].y : 10,
-            snap: this.state.window_positions[id] ? this.state.window_positions[id].snap : null,
+            y: this.state.window_positions[id] ? this.state.window_positions[id].y : 10
         }));
-        const dock = this.state.dock;
+        const dock = Object.keys(this.state.favourite_apps).filter(id => this.state.favourite_apps[id]);
         this.props.setSession({ ...this.props.session, windows, dock });
     }
 
@@ -750,9 +558,8 @@ export class Desktop extends Component {
         // if there is atleast one app opened, give it focus
         if (!this.checkAllMinimised()) {
             for (const index in this.app_stack) {
-                const id = this.app_stack[index];
-                if (!this.state.closed_windows[id] && !this.state.minimized_windows[id]) {
-                    this.focus(id);
+                if (!this.state.minimized_windows[this.app_stack[index]]) {
+                    this.focus(this.app_stack[index]);
                     break;
                 }
             }
@@ -787,16 +594,6 @@ export class Desktop extends Component {
         // if the app is disabled
         if (this.state.disabled_apps[objId]) return;
 
-        const appMeta = apps.find(a => a.id === objId);
-        if (appMeta && appMeta.command) {
-            if (/^https?:\/\//.test(appMeta.command)) {
-                window.open(appMeta.command, '_blank');
-            } else if (appMeta.command !== objId) {
-                this.openApp(appMeta.command);
-            }
-            return;
-        }
-
         // if app is already open, focus it instead of spawning a new window
         if (this.state.closed_windows[objId] === false) {
             // if it's minimised, restore its last position
@@ -815,7 +612,6 @@ export class Desktop extends Component {
         } else {
             let closed_windows = this.state.closed_windows;
             let favourite_apps = this.state.favourite_apps;
-            let window_workspaces = this.state.window_workspaces;
             let frequentApps = [];
             try { frequentApps = JSON.parse(safeLocalStorage?.getItem('frequentApps') || '[]'); } catch (e) { frequentApps = []; }
             var currentApp = frequentApps.find(app => app.id === objId);
@@ -851,14 +647,11 @@ export class Desktop extends Component {
             setTimeout(() => {
                 favourite_apps[objId] = true; // adds opened app to sideBar
                 closed_windows[objId] = false; // openes app's window
-                window_workspaces[objId] = this.state.currentWorkspace;
-                this.setState({ closed_windows, favourite_apps, window_workspaces, allAppsView: false }, () => {
+                this.setState({ closed_windows, favourite_apps, allAppsView: false }, () => {
                     this.focus(objId);
                     this.saveSession();
                 });
                 this.app_stack.push(objId);
-                const recentApps = addRecentApp(objId);
-                this.setState({ recentApps });
             }, 200);
         }
     }
@@ -890,7 +683,6 @@ export class Desktop extends Component {
             icon: appMeta.icon,
             image,
             closedAt: now,
-            path: objId,
         });
         safeLocalStorage?.setItem('window-trash', JSON.stringify(trash));
         this.updateTrashIcon();
@@ -905,62 +697,54 @@ export class Desktop extends Component {
         // close window
         let closed_windows = this.state.closed_windows;
         let favourite_apps = this.state.favourite_apps;
-        let window_workspaces = { ...this.state.window_workspaces };
 
         if (this.initFavourite[objId] === false) favourite_apps[objId] = false; // if user default app is not favourite, remove from sidebar
         closed_windows[objId] = true; // closes the app's window
-        delete window_workspaces[objId];
 
-        this.setState({ closed_windows, favourite_apps, window_workspaces }, this.saveSession);
+        this.setState({ closed_windows, favourite_apps }, this.saveSession);
     }
 
     pinApp = (id) => {
-        let favourite_apps = { ...this.state.favourite_apps };
-        favourite_apps[id] = true;
-        this.initFavourite[id] = true;
-        const app = apps.find(a => a.id === id);
-        if (app) app.favourite = true;
-        const dock = this.state.dock.includes(id) ? [...this.state.dock] : [...this.state.dock, id];
-        safeLocalStorage?.setItem('pinnedApps', JSON.stringify(dock));
-        this.setState({ favourite_apps, dock }, () => { this.saveSession(); });
-        this.hideAllContextMenu();
+        let favourite_apps = { ...this.state.favourite_apps }
+        favourite_apps[id] = true
+        this.initFavourite[id] = true
+        const app = apps.find(a => a.id === id)
+        if (app) app.favourite = true
+        let pinnedApps = [];
+        try { pinnedApps = JSON.parse(safeLocalStorage?.getItem('pinnedApps') || '[]'); } catch (e) { pinnedApps = []; }
+        if (!pinnedApps.includes(id)) pinnedApps.push(id)
+        safeLocalStorage?.setItem('pinnedApps', JSON.stringify(pinnedApps))
+        this.setState({ favourite_apps }, () => { this.saveSession(); })
+        this.hideAllContextMenu()
     }
 
     unpinApp = (id) => {
-        let favourite_apps = { ...this.state.favourite_apps };
-        if (this.state.closed_windows[id]) favourite_apps[id] = false;
-        this.initFavourite[id] = false;
-        const app = apps.find(a => a.id === id);
-        if (app) app.favourite = false;
-        const dock = this.state.dock.filter(appId => appId !== id);
-        safeLocalStorage?.setItem('pinnedApps', JSON.stringify(dock));
-        this.setState({ favourite_apps, dock }, () => { this.saveSession(); });
-        this.hideAllContextMenu();
-    }
-
-    reorderDock = (dock) => {
-        safeLocalStorage?.setItem('pinnedApps', JSON.stringify(dock));
-        this.setState({ dock }, () => { this.saveSession(); });
+        let favourite_apps = { ...this.state.favourite_apps }
+        if (this.state.closed_windows[id]) favourite_apps[id] = false
+        this.initFavourite[id] = false
+        const app = apps.find(a => a.id === id)
+        if (app) app.favourite = false
+        let pinnedApps = [];
+        try { pinnedApps = JSON.parse(safeLocalStorage?.getItem('pinnedApps') || '[]'); } catch (e) { pinnedApps = []; }
+        pinnedApps = pinnedApps.filter(appId => appId !== id)
+        safeLocalStorage?.setItem('pinnedApps', JSON.stringify(pinnedApps))
+        this.setState({ favourite_apps }, () => { this.saveSession(); })
+        this.hideAllContextMenu()
     }
 
     focus = (objId) => {
-        // removes focus from all windows and gives focus to window with 'id = objId'
-        const focused_windows = { ...this.state.focused_windows };
+        // removes focus from all window and 
+        // gives focus to window with 'id = objId'
+        var focused_windows = this.state.focused_windows;
         focused_windows[objId] = true;
-        for (const key in focused_windows) {
-            if (key !== objId) {
-                focused_windows[key] = false;
+        for (let key in focused_windows) {
+            if (focused_windows.hasOwnProperty(key)) {
+                if (key !== objId) {
+                    focused_windows[key] = false;
+                }
             }
         }
-        this.setState({ focused_windows }, () => {
-            this.windowRefs[objId]?.focusSelf?.();
-        });
-
-        const index = this.app_stack.indexOf(objId);
-        if (index !== -1) {
-            this.app_stack.splice(index, 1);
-        }
-        this.app_stack.push(objId);
+        this.setState({ focused_windows });
     }
 
     addNewFolder = () => {
@@ -969,10 +753,6 @@ export class Desktop extends Component {
 
     openShortcutSelector = () => {
         this.setState({ showShortcutSelector: true });
-    }
-
-    openLauncherCreator = () => {
-        this.setState({ showLauncherCreator: true });
     }
 
     addShortcutToDesktop = (app_id) => {
@@ -1007,53 +787,6 @@ export class Desktop extends Component {
         }
     }
 
-    createLauncher = ({ name, comment, icon, command }) => {
-        const id = name.trim().replace(/\s+/g, '-').toLowerCase();
-        const finalIcon = icon || '/themes/Yaru/apps/bash.png';
-        apps.push({
-            id,
-            title: name,
-            icon: finalIcon,
-            comment,
-            command,
-            disabled: false,
-            favourite: false,
-            desktop_shortcut: true,
-            screen: () => { },
-        });
-        let launchers = [];
-        try { launchers = JSON.parse(safeLocalStorage?.getItem('custom_launchers') || '[]'); } catch (e) { launchers = []; }
-        launchers.push({ id, title: name, icon: finalIcon, comment, command });
-        safeLocalStorage?.setItem('custom_launchers', JSON.stringify(launchers));
-        this.setState({ showLauncherCreator: false }, this.updateAppsData);
-    }
-
-    checkForLaunchers = () => {
-        const stored = safeLocalStorage?.getItem('custom_launchers');
-        if (!stored) {
-            safeLocalStorage?.setItem('custom_launchers', JSON.stringify([]));
-            return;
-        }
-        try {
-            JSON.parse(stored).forEach(l => {
-                apps.push({
-                    id: l.id,
-                    title: l.title,
-                    icon: l.icon || '/themes/Yaru/apps/bash.png',
-                    comment: l.comment,
-                    command: l.command,
-                    disabled: false,
-                    favourite: false,
-                    desktop_shortcut: true,
-                    screen: () => { },
-                });
-            });
-            this.updateAppsData();
-        } catch (e) {
-            safeLocalStorage?.setItem('custom_launchers', JSON.stringify([]));
-        }
-    }
-
     updateTrashIcon = () => {
         let trash = [];
         try { trash = JSON.parse(safeLocalStorage?.getItem('window-trash') || '[]'); } catch (e) { trash = []; }
@@ -1062,17 +795,8 @@ export class Desktop extends Component {
             const icon = trash.length
                 ? '/themes/Yaru/status/user-trash-full-symbolic.svg'
                 : '/themes/Yaru/status/user-trash-symbolic.svg';
-            const count = trash.length;
-            let shouldUpdate = false;
             if (apps[appIndex].icon !== icon) {
                 apps[appIndex].icon = icon;
-                shouldUpdate = true;
-            }
-            if (apps[appIndex].tasks !== count) {
-                apps[appIndex].tasks = count;
-                shouldUpdate = true;
-            }
-            if (shouldUpdate) {
                 this.forceUpdate();
             }
         }
@@ -1115,7 +839,7 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} aria-label="Folder name" />
+                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
                 </div>
                 <div className="flex">
                     <button
@@ -1158,7 +882,6 @@ export class Desktop extends Component {
 
                 {/* Ubuntu Side Menu Bar */}
                 <SideBar apps={apps}
-                    dock={this.state.dock}
                     hide={this.state.hideSideBar}
                     hideSideBar={this.hideSideBar}
                     favourite_apps={this.state.favourite_apps}
@@ -1167,9 +890,7 @@ export class Desktop extends Component {
                     closed_windows={this.state.closed_windows}
                     focused_windows={this.state.focused_windows}
                     isMinimized={this.state.minimized_windows}
-                    openAppByAppId={this.openApp}
-                    reorderDock={this.reorderDock}
-                />
+                    openAppByAppId={this.openApp} />
 
                 {/* Taskbar */}
                 <Taskbar
@@ -1177,7 +898,6 @@ export class Desktop extends Component {
                     closed_windows={this.state.closed_windows}
                     minimized_windows={this.state.minimized_windows}
                     focused_windows={this.state.focused_windows}
-                    dock={this.state.dock}
                     openApp={this.openApp}
                     minimize={this.hasMinimised}
                 />
@@ -1188,11 +908,9 @@ export class Desktop extends Component {
                 {/* Context Menus */}
                 <DesktopMenu
                     active={this.state.context_menus.desktop}
-                    onClose={this.hideAllContextMenu}
                     openApp={this.openApp}
                     addNewFolder={this.addNewFolder}
                     openShortcutSelector={this.openShortcutSelector}
-                    openLauncherCreator={this.openLauncherCreator}
                     clearSession={() => { this.props.clearSession(); window.location.reload(); }}
                 />
                 <DefaultMenu active={this.state.context_menus.default} onClose={this.hideAllContextMenu} />
@@ -1201,9 +919,6 @@ export class Desktop extends Component {
                     pinned={this.initFavourite[this.state.context_app]}
                     pinApp={() => this.pinApp(this.state.context_app)}
                     unpinApp={() => this.unpinApp(this.state.context_app)}
-                    openMenuEditor={() => this.openApp('settings')}
-                    addToPanel={() => { const id = this.state.context_app; if (id) logger.info('Add to panel', id); }}
-                    addToDesktop={() => { const id = this.state.context_app; if (id) this.addShortcutToDesktop(id); }}
                     onClose={this.hideAllContextMenu}
                 />
                 <TaskbarMenu
@@ -1225,17 +940,6 @@ export class Desktop extends Component {
                     }}
                     onCloseMenu={this.hideAllContextMenu}
                 />
-                <WindowMenu
-                    active={this.state.context_menus.window}
-                    onMove={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.changeCursorToMove(); }}
-                    onResize={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.startResize(); }}
-                    onTop={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.toggleAlwaysOnTop(); }}
-                    onShade={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.toggleShade(); }}
-                    onStick={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.toggleStick(); }}
-                    onMaximize={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.maximizeWindow(); }}
-                    onClose={() => { const id = this.state.context_app; if (id) this.closeApp(id); }}
-                    onCloseMenu={this.hideAllContextMenu}
-                />
 
                 {/* Folder Input Name Bar */}
                 {
@@ -1248,7 +952,7 @@ export class Desktop extends Component {
                 { this.state.allAppsView ?
                     <AllApplications apps={apps}
                         games={games}
-                        recentApps={this.state.recentApps}
+                        recentApps={this.app_stack}
                         openApp={this.openApp} /> : null}
 
                 { this.state.showShortcutSelector ?
@@ -1257,25 +961,11 @@ export class Desktop extends Component {
                         onSelect={this.addShortcutToDesktop}
                         onClose={() => this.setState({ showShortcutSelector: false })} /> : null}
 
-                { this.state.showLauncherCreator ?
-                    <LauncherCreator
-                        onSave={this.createLauncher}
-                        onClose={() => this.setState({ showLauncherCreator: false })} /> : null}
-
                 { this.state.showWindowSwitcher ?
                     <WindowSwitcher
                         windows={this.state.switcherWindows}
                         onSelect={this.selectWindow}
                         onClose={this.closeWindowSwitcher} /> : null}
-
-                { this.state.showWorkspaceSwitcher ?
-                    <WorkspaceSwitcher
-                        workspaces={this.state.switcherWorkspaces}
-                        active={this.state.currentWorkspace}
-                        onSelect={this.selectWorkspace}
-                        onClose={this.closeWorkspaceSwitcher} /> : null}
-
-                <DesktopTour showAllApps={this.showAllApps} />
 
             </main>
         )

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,97 +1,47 @@
 import React, { Component } from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
-import PanelClock from '../util-components/PanelClock';
+import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
-import HelpMenu from '../menu/HelpMenu';
-import { getUndercover, setUndercover } from '../../utils/theme';
 
 export default class Navbar extends Component {
-  constructor() {
-    super();
-    this.state = {
-      status_card: false,
-      undercover: getUndercover(),
-      showTip: false,
-    };
-  }
+	constructor() {
+		super();
+		this.state = {
+			status_card: false
+		};
+	}
 
-  componentDidMount() {
-    setUndercover(this.state.undercover);
-  }
-
-  render() {
-    const toggleUndercover = () => {
-      const next = !this.state.undercover;
-      setUndercover(next);
-      this.setState({ undercover: next });
-    };
-
-    return (
-      <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-        <div className="pl-3 pr-1">
-          <Image
-            src={
-              this.state.undercover
-                ? '/themes/Undercover/status/network.svg'
-                : '/themes/Yaru/status/network-wireless-signal-good-symbolic.svg'
-            }
-            alt="network icon"
-            width={16}
-            height={16}
-            className="w-4 h-4"
-          />
-        </div>
-        <WhiskerMenu />
-        <HelpMenu />
-        <button
-          type="button"
-          aria-label="Undercover mode"
-          onClick={toggleUndercover}
-          onMouseEnter={() => this.setState({ showTip: true })}
-          onMouseLeave={() => this.setState({ showTip: false })}
-          className="relative p-2"
-        >
-          <Image
-            src="/themes/Undercover/system/undercover.svg"
-            alt="undercover toggle"
-            width={16}
-            height={16}
-          />
-          {this.state.showTip && (
-            <div
-              role="tooltip"
-              className="absolute right-0 mt-1 w-48 p-2 text-xs text-white bg-black rounded shadow-lg"
-            >
-              Undercover mode – Windows-like theme.{' '}
-              <Link href="/undercover" className="underline text-blue-300">
-                Read disclaimer
-              </Link>
-            </div>
-          )}
-        </button>
-        <div className="pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1">
-          <PanelClock />
-        </div>
-        <button
-          type="button"
-          id="status-bar"
-          aria-label="System status"
-          onClick={() => {
-            this.setState({ status_card: !this.state.status_card });
-          }}
-          className="relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 "
-        >
-          <Status />
-          <QuickSettings
-            open={this.state.status_card}
-            lockScreen={this.props.lockScreen}
-            logOut={this.props.logOut}
-          />
-        </button>
-      </div>
-    );
-  }
+	render() {
+		return (
+                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                                <div className="pl-3 pr-1">
+                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
+                                </div>
+                                <WhiskerMenu />
+                                <div
+                                        className={
+                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                        }
+                                >
+                                        <Clock />
+                                </div>
+                                <button
+                                        type="button"
+                                        id="status-bar"
+                                        aria-label="System status"
+                                        onClick={() => {
+                                                this.setState({ status_card: !this.state.status_card });
+                                        }}
+                                        className={
+                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
+                                        }
+                                >
+                                        <Status />
+                                        <QuickSettings open={this.state.status_card} />
+                                </button>
+			</div>
+		);
+	}
 }


### PR DESCRIPTION
## Summary
- restore WhiskerMenu and navbar layout from PR #4069
- roll back desktop screen to older layout implementation

## Testing
- `yarn test` *(fails: Cannot use import statement outside a module, missing browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68c2491ecc508328b60ac492fcbff6e5