### PR TITLE
Add pinned app entries for system tools

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -1,11 +1,11 @@
-import { createDynamicApp, createDisplay } from './utils/createDynamicApp';
+import { createDynamicApp, createDisplay } from "./utils/createDynamicApp";
 
 /**
  * @typedef {import('./types/app').AppMetadata} AppMetadata
  */
 
 export const chromeDefaultTiles = [
-  { title: 'Example', url: 'https://example.com' },
+  { title: "Example", url: "https://example.com" },
 ];
 
 // TODO: restore YouTube (youtube)
@@ -106,126 +106,147 @@ export const chromeDefaultTiles = [
 // TODO: restore Contact (contact)
 // TODO: restore Gigolo (gigolo)
 
-const TerminalApp = createDynamicApp('terminal', 'Terminal');
-const VsCodeApp = createDynamicApp('vscode', 'VsCode');
-const CalculatorApp = createDynamicApp('calculator', 'Calculator');
-const ConverterApp = createDynamicApp('converter', 'Converter');
-const TicTacToeApp = createDynamicApp('tictactoe', 'Tic Tac Toe');
-const ChessApp = createDynamicApp('chess', 'Chess');
+const TerminalApp = createDynamicApp("terminal", "Terminal");
+const VsCodeApp = createDynamicApp("vscode", "Visual Studio Code");
+const CalcApp = createDynamicApp("calc", "Calculator");
+const ConverterApp = createDynamicApp("converter", "Converter");
+const TicTacToeApp = createDynamicApp("tictactoe", "Tic Tac Toe");
+const ChessApp = createDynamicApp("chess", "Chess");
 // Classic four-in-a-row game
-const ConnectFourApp = createDynamicApp('connect-four', 'Connect Four');
-const HangmanApp = createDynamicApp('hangman', 'Hangman');
-const FroggerApp = createDynamicApp('frogger', 'Frogger');
-const FlappyBirdApp = createDynamicApp('flappy-bird', 'Flappy Bird');
-const SnakeApp = createDynamicApp('snake', 'Snake');
-const MemoryApp = createDynamicApp('memory', 'Memory');
+const ConnectFourApp = createDynamicApp("connect-four", "Connect Four");
+const HangmanApp = createDynamicApp("hangman", "Hangman");
+const FroggerApp = createDynamicApp("frogger", "Frogger");
+const FlappyBirdApp = createDynamicApp("flappy-bird", "Flappy Bird");
+const SnakeApp = createDynamicApp("snake", "Snake");
+const MemoryApp = createDynamicApp("memory", "Memory");
 // Classic puzzle where players clear a minefield.
-const MinesweeperApp = createDynamicApp('minesweeper', 'Minesweeper');
-const PongApp = createDynamicApp('pong', 'Pong');
-const PacmanApp = createDynamicApp('pacman', 'Pacman');
-const CarRacerApp = createDynamicApp('car-racer', 'Car Racer');
-const LaneRunnerApp = createDynamicApp('lane-runner', 'Lane Runner');
-const PlatformerApp = createDynamicApp('platformer', 'Platformer');
-const BattleshipApp = createDynamicApp('battleship', 'Battleship');
-const CheckersApp = createDynamicApp('checkers', 'Checkers');
-const ReversiApp = createDynamicApp('reversi', 'Reversi');
-const SimonApp = createDynamicApp('simon', 'Simon');
-const SokobanApp = createDynamicApp('sokoban', 'Sokoban');
+const MinesweeperApp = createDynamicApp("minesweeper", "Minesweeper");
+const PongApp = createDynamicApp("pong", "Pong");
+const PacmanApp = createDynamicApp("pacman", "Pacman");
+const CarRacerApp = createDynamicApp("car-racer", "Car Racer");
+const LaneRunnerApp = createDynamicApp("lane-runner", "Lane Runner");
+const PlatformerApp = createDynamicApp("platformer", "Platformer");
+const BattleshipApp = createDynamicApp("battleship", "Battleship");
+const CheckersApp = createDynamicApp("checkers", "Checkers");
+const ReversiApp = createDynamicApp("reversi", "Reversi");
+const SimonApp = createDynamicApp("simon", "Simon");
+const SokobanApp = createDynamicApp("sokoban", "Sokoban");
 // Use the enhanced TypeScript implementation of Solitaire that supports
 // draw-3 mode, hints, animations, and auto-complete.
-const SolitaireApp = createDynamicApp('solitaire/index', 'Solitaire');
-const TowerDefenseApp = createDynamicApp('tower-defense', 'Tower Defense');
-const WordSearchApp = createDynamicApp('word-search', 'Word Search');
-const WordleApp = createDynamicApp('wordle', 'Wordle');
-const BlackjackApp = createDynamicApp('blackjack', 'Blackjack');
-const BreakoutApp = createDynamicApp('breakout', 'Breakout');
-const AsteroidsApp = createDynamicApp('asteroids', 'Asteroids');
-const SudokuApp = createDynamicApp('sudoku', 'Sudoku');
-const SpaceInvadersApp = createDynamicApp('space-invaders', 'Space Invaders');
-const NonogramApp = createDynamicApp('nonogram', 'Nonogram');
-const TetrisApp = createDynamicApp('tetris', 'Tetris');
-const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
-const FileExplorerApp = createDynamicApp('file-explorer', 'Files');
-const RistrettoApp = createDynamicApp('ristretto', 'Image Viewer');
-const Radare2App = createDynamicApp('radare2', 'Radare2');
-const AboutAlexApp = createDynamicApp('About', 'About Alex');
-const PowerApp = createDynamicApp('power', 'Power Settings');
+const SolitaireApp = createDynamicApp("solitaire/index", "Solitaire");
+const TowerDefenseApp = createDynamicApp("tower-defense", "Tower Defense");
+const WordSearchApp = createDynamicApp("word-search", "Word Search");
+const WordleApp = createDynamicApp("wordle", "Wordle");
+const BlackjackApp = createDynamicApp("blackjack", "Blackjack");
+const BreakoutApp = createDynamicApp("breakout", "Breakout");
+const AsteroidsApp = createDynamicApp("asteroids", "Asteroids");
+const SudokuApp = createDynamicApp("sudoku", "Sudoku");
+const SpaceInvadersApp = createDynamicApp("space-invaders", "Space Invaders");
+const NonogramApp = createDynamicApp("nonogram", "Nonogram");
+const TetrisApp = createDynamicApp("tetris", "Tetris");
+const CandyCrushApp = createDynamicApp("candy-crush", "Candy Crush");
+const FileExplorerApp = createDynamicApp("file-explorer", "Files");
+const RistrettoApp = createDynamicApp("ristretto", "Image Viewer");
+const Radare2App = createDynamicApp("radare2", "Radare2");
+const AboutAlexApp = createDynamicApp("About", "About Alex");
+const PowerApp = createDynamicApp("power", "Power Settings");
 
-const XApp = createDynamicApp('x', 'X');
-const SpotifyApp = createDynamicApp('spotify', 'Spotify');
-const SettingsApp = createDynamicApp('settings', 'Settings');
-const ChromeApp = createDynamicApp('chrome', 'Chrome');
-const GeditApp = createDynamicApp('gedit', 'Gedit');
-const MousepadApp = createDynamicApp('mousepad', 'Mousepad Preferences');
-const TodoistApp = createDynamicApp('todoist', 'Todoist');
-const WeatherApp = createDynamicApp('weather', 'Weather');
-const ClipboardManagerApp = createDynamicApp('clipboard_manager', 'Clipboard Manager');
-const FigletApp = createDynamicApp('figlet', 'Figlet');
-const ResourceMonitorApp = createDynamicApp('resource_monitor', 'Resource Monitor');
-const ScreenRecorderApp = createDynamicApp('screen-recorder', 'Screen Recorder');
-const TaskManagerApp = createDynamicApp('task_manager', 'Task Manager');
-const NiktoApp = createDynamicApp('nikto', 'Nikto');
+const XApp = createDynamicApp("x", "X");
+const SpotifyApp = createDynamicApp("spotify", "Spotify");
+const SettingsApp = createDynamicApp("settings", "Settings");
+const ChromeApp = createDynamicApp("chrome", "Google Chrome");
+const GeditApp = createDynamicApp("gedit", "Gedit");
+const MousepadApp = createDynamicApp("mousepad", "Mousepad Preferences");
+const TodoistApp = createDynamicApp("todoist", "Todoist");
+const WeatherApp = createDynamicApp("weather", "Weather");
+const ClipboardManagerApp = createDynamicApp(
+  "clipboard_manager",
+  "Clipboard Manager",
+);
+const FigletApp = createDynamicApp("figlet", "Figlet");
+const ResourceMonitorApp = createDynamicApp(
+  "resource_monitor",
+  "Resource Monitor",
+);
+const ScreenRecorderApp = createDynamicApp(
+  "screen-recorder",
+  "Screen Recorder",
+);
+const TaskManagerApp = createDynamicApp("task_manager", "Task Manager");
+const NiktoApp = createDynamicApp("nikto", "Nikto");
 
-const QrApp = createDynamicApp('qr', 'QR Tool');
-const AsciiArtApp = createDynamicApp('ascii_art', 'ASCII Art');
-const QuoteApp = createDynamicApp('quote', 'Quote');
-const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery');
-const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
-const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
-const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
-const BraseroApp = createDynamicApp('brasero', 'Brasero');
+const QrApp = createDynamicApp("qr", "QR Tool");
+const AsciiArtApp = createDynamicApp("ascii_art", "ASCII Art");
+const QuoteApp = createDynamicApp("quote", "Quote");
+const ProjectGalleryApp = createDynamicApp(
+  "project-gallery",
+  "Project Gallery",
+);
+const WeatherWidgetApp = createDynamicApp("weather_widget", "Weather Widget");
+const InputLabApp = createDynamicApp("input-lab", "Input Lab");
+const GhidraApp = createDynamicApp("ghidra", "Ghidra");
+const BraseroApp = createDynamicApp("brasero", "Brasero");
 
-const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
-const TrashApp = createDynamicApp('trash', 'Trash');
-const SerialTerminalApp = createDynamicApp('serial-terminal', 'Serial Terminal');
+const StickyNotesApp = createDynamicApp("sticky_notes", "Sticky Notes");
+const TrashApp = createDynamicApp("trash", "Trash");
+const SerialTerminalApp = createDynamicApp(
+  "serial-terminal",
+  "Serial Terminal",
+);
 
+const NetworkConnectionsApp = createDynamicApp(
+  "network/connections",
+  "Network Connections",
+);
+const BleSensorApp = createDynamicApp("ble-sensor", "BLE Sensor");
+const BluetoothApp = createDynamicApp("bluetooth", "Bluetooth");
+const DsniffApp = createDynamicApp("dsniff", "dsniff");
+const BeefApp = createDynamicApp("beef", "BeEF");
+const MetasploitApp = createDynamicApp("metasploit", "Metasploit");
+const NetworkManagerApp = createDynamicApp(
+  "network-manager",
+  "Network Manager",
+);
 
-const NetworkConnectionsApp = createDynamicApp('network/connections', 'Network Connections');
-const BleSensorApp = createDynamicApp('ble-sensor', 'BLE Sensor');
-const BluetoothApp = createDynamicApp('bluetooth', 'Bluetooth');
-const DsniffApp = createDynamicApp('dsniff', 'dsniff');
-const BeefApp = createDynamicApp('beef', 'BeEF');
-const MetasploitApp = createDynamicApp('metasploit', 'Metasploit');
-const NetworkManagerApp = createDynamicApp('network-manager', 'Network Manager');
+const AutopsyApp = createDynamicApp("autopsy", "Autopsy");
+const PluginManagerApp = createDynamicApp("plugin-manager", "Plugin Manager");
+const PanelProfilesApp = createDynamicApp("panel-profiles", "Panel Profiles");
 
-const AutopsyApp = createDynamicApp('autopsy', 'Autopsy');
-const PluginManagerApp = createDynamicApp('plugin-manager', 'Plugin Manager');
-const PanelProfilesApp = createDynamicApp('panel-profiles', 'Panel Profiles');
+const GomokuApp = createDynamicApp("gomoku", "Gomoku");
+const PinballApp = createDynamicApp("pinball", "Pinball");
+const VolatilityApp = createDynamicApp("volatility", "Volatility");
 
-const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
-const PinballApp = createDynamicApp('pinball', 'Pinball');
-const VolatilityApp = createDynamicApp('volatility', 'Volatility');
+const KismetApp = createDynamicApp("kismet", "Kismet");
 
-const KismetApp = createDynamicApp('kismet', 'Kismet');
-
-const HashcatApp = createDynamicApp('hashcat', 'Hashcat');
-const MsfPostApp = createDynamicApp('metasploit-post', 'Metasploit Post');
-const EvidenceVaultApp = createDynamicApp('evidence-vault', 'Evidence Vault');
-const MimikatzApp = createDynamicApp('mimikatz', 'Mimikatz');
-const MimikatzOfflineApp = createDynamicApp('mimikatz/offline', 'Mimikatz Offline');
-const EttercapApp = createDynamicApp('ettercap', 'Ettercap');
-const ReaverApp = createDynamicApp('reaver', 'Reaver');
-const HydraApp = createDynamicApp('hydra', 'Hydra');
-const JohnApp = createDynamicApp('john', 'John the Ripper');
-const NessusApp = createDynamicApp('nessus', 'Nessus');
-const NmapNSEApp = createDynamicApp('nmap-nse', 'Nmap NSE');
-const OpenVASApp = createDynamicApp('openvas', 'OpenVAS');
-const ReconNGApp = createDynamicApp('reconng', 'Recon-ng');
-const KaliToolsApp = createDynamicApp('kali-tools', 'Kali Tools');
-const SecurityToolsApp = createDynamicApp('security-tools', 'Security Tools');
-const KaliTweaksApp = createDynamicApp('kali-tweaks', 'Kali Tweaks');
-const SSHApp = createDynamicApp('ssh', 'SSH Command Builder');
-const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
-const HtmlRewriteApp = createDynamicApp('html-rewriter', 'HTML Rewriter');
-const ContactApp = createDynamicApp('contact', 'Contact');
-const GigoloApp = createDynamicApp('gigolo', 'Gigolo');
-
-
-
+const HashcatApp = createDynamicApp("hashcat", "Hashcat");
+const MsfPostApp = createDynamicApp("metasploit-post", "Metasploit Post");
+const EvidenceVaultApp = createDynamicApp("evidence-vault", "Evidence Vault");
+const MimikatzApp = createDynamicApp("mimikatz", "Mimikatz");
+const MimikatzOfflineApp = createDynamicApp(
+  "mimikatz/offline",
+  "Mimikatz Offline",
+);
+const EttercapApp = createDynamicApp("ettercap", "Ettercap");
+const ReaverApp = createDynamicApp("reaver", "Reaver");
+const HydraApp = createDynamicApp("hydra", "Hydra");
+const JohnApp = createDynamicApp("john", "John the Ripper");
+const NessusApp = createDynamicApp("nessus", "Nessus");
+const NmapNSEApp = createDynamicApp("nmap-nse", "Nmap NSE");
+const OpenVASApp = createDynamicApp("openvas", "OpenVAS");
+const ReconNGApp = createDynamicApp("reconng", "Recon-ng");
+const KaliToolsApp = createDynamicApp("kali-tools", "Kali Tools");
+const SecurityToolsApp = createDynamicApp("security-tools", "Security Tools");
+const KaliTweaksApp = createDynamicApp("kali-tweaks", "Kali Tweaks");
+const SSHApp = createDynamicApp("ssh", "SSH Command Builder");
+const HTTPApp = createDynamicApp("http", "HTTP Request Builder");
+const HtmlRewriteApp = createDynamicApp("html-rewriter", "HTML Rewriter");
+const ContactApp = createDynamicApp("contact", "Contact");
+const GigoloApp = createDynamicApp("gigolo", "Gigolo");
 
 const displayTerminal = createDisplay(TerminalApp);
+const displayChrome = createDisplay(ChromeApp);
 const displayVsCode = createDisplay(VsCodeApp);
-const displayCalculator = createDisplay(CalculatorApp);
+const displayCalc = createDisplay(CalcApp);
 const displayConverter = createDisplay(ConverterApp);
 const displayTicTacToe = createDisplay(TicTacToeApp);
 const displayChess = createDisplay(ChessApp);
@@ -267,7 +288,6 @@ const displayPower = createDisplay(PowerApp);
 const displayX = createDisplay(XApp);
 const displaySpotify = createDisplay(SpotifyApp);
 const displaySettings = createDisplay(SettingsApp);
-const displayChrome = createDisplay(ChromeApp);
 const displayGedit = createDisplay(GeditApp);
 const displayMousepad = createDisplay(MousepadApp);
 const displayTodoist = createDisplay(TodoistApp);
@@ -336,72 +356,72 @@ const displayKismet = createDisplay(KismetApp);
 /** @type {AppMetadata[]} */
 const utilityList = [
   {
-    id: 'qr',
-    title: 'QR Tool',
-    icon: '/themes/Yaru/apps/qr.svg',
+    id: "qr",
+    title: "QR Tool",
+    icon: "/themes/Yaru/apps/qr.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayQr,
   },
   {
-    id: 'ascii-art',
-    title: 'ASCII Art',
-    icon: '/themes/Yaru/apps/gedit.png',
+    id: "ascii-art",
+    title: "ASCII Art",
+    icon: "/themes/Yaru/apps/gedit.png",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayAsciiArt,
   },
   {
-    id: 'clipboard-manager',
-    title: 'Clipboard Manager',
-    icon: '/themes/Yaru/apps/gedit.png',
+    id: "clipboard-manager",
+    title: "Clipboard Manager",
+    icon: "/themes/Yaru/apps/gedit.png",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayClipboardManager,
   },
   {
-    id: 'figlet',
-    title: 'Figlet',
-    icon: '/themes/Yaru/apps/gedit.png',
+    id: "figlet",
+    title: "Figlet",
+    icon: "/themes/Yaru/apps/gedit.png",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayFiglet,
   },
   {
-    id: 'quote',
-    title: 'Quote',
-    icon: '/themes/Yaru/apps/quote.svg',
+    id: "quote",
+    title: "Quote",
+    icon: "/themes/Yaru/apps/quote.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayQuote,
   },
   {
-    id: 'project-gallery',
-    title: 'Project Gallery',
-    icon: '/themes/Yaru/apps/project-gallery.svg',
+    id: "project-gallery",
+    title: "Project Gallery",
+    icon: "/themes/Yaru/apps/project-gallery.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayProjectGallery,
   },
   {
-    id: 'brasero',
-    title: 'Brasero',
-    icon: '/themes/Yaru/apps/brasero.svg',
+    id: "brasero",
+    title: "Brasero",
+    icon: "/themes/Yaru/apps/brasero.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayBrasero,
   },
   {
-    id: 'input-lab',
-    title: 'Input Lab',
-    icon: '/themes/Yaru/apps/input-lab.svg',
+    id: "input-lab",
+    title: "Input Lab",
+    icon: "/themes/Yaru/apps/input-lab.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -420,27 +440,27 @@ export const gameDefaults = {
 // Games list used for the "Games" folder on the desktop
 const gameList = [
   {
-    id: 'asteroids',
-    title: 'Asteroids',
-    icon: '/themes/Yaru/apps/asteroids.svg',
+    id: "asteroids",
+    title: "Asteroids",
+    icon: "/themes/Yaru/apps/asteroids.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayAsteroids,
   },
   {
-    id: 'battleship',
-    title: 'Battleship',
-    icon: '/themes/Yaru/apps/battleship.svg',
+    id: "battleship",
+    title: "Battleship",
+    icon: "/themes/Yaru/apps/battleship.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayBattleship,
   },
   {
-    id: 'blackjack',
-    title: 'Blackjack',
-    icon: '/themes/Yaru/apps/blackjack.svg',
+    id: "blackjack",
+    title: "Blackjack",
+    icon: "/themes/Yaru/apps/blackjack.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -448,45 +468,45 @@ const gameList = [
     ...gameDefaults,
   },
   {
-    id: 'breakout',
-    title: 'Breakout',
-    icon: '/themes/Yaru/apps/breakout.svg',
+    id: "breakout",
+    title: "Breakout",
+    icon: "/themes/Yaru/apps/breakout.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayBreakout,
   },
   {
-    id: 'car-racer',
-    title: 'Car Racer',
-    icon: '/themes/Yaru/apps/car-racer.svg',
+    id: "car-racer",
+    title: "Car Racer",
+    icon: "/themes/Yaru/apps/car-racer.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayCarRacer,
   },
   {
-    id: 'lane-runner',
-    title: 'Lane Runner',
-    icon: '/themes/Yaru/apps/car-racer.svg',
+    id: "lane-runner",
+    title: "Lane Runner",
+    icon: "/themes/Yaru/apps/car-racer.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayLaneRunner,
   },
   {
-    id: 'checkers',
-    title: 'Checkers',
-    icon: '/themes/Yaru/apps/checkers.svg',
+    id: "checkers",
+    title: "Checkers",
+    icon: "/themes/Yaru/apps/checkers.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayCheckers,
   },
   {
-    id: 'chess',
-    title: 'Chess',
-    icon: '/themes/Yaru/apps/chess.svg',
+    id: "chess",
+    title: "Chess",
+    icon: "/themes/Yaru/apps/chess.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -494,126 +514,126 @@ const gameList = [
   },
   // Simple placeholder implementation
   {
-    id: 'connect-four',
-    title: 'Connect Four',
-    icon: '/themes/Yaru/apps/connect-four.svg',
+    id: "connect-four",
+    title: "Connect Four",
+    icon: "/themes/Yaru/apps/connect-four.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayConnectFour,
   },
   {
-    id: 'frogger',
-    title: 'Frogger',
-    icon: '/themes/Yaru/apps/frogger.svg',
+    id: "frogger",
+    title: "Frogger",
+    icon: "/themes/Yaru/apps/frogger.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayFrogger,
   },
   {
-    id: 'hangman',
-    title: 'Hangman',
-    icon: '/themes/Yaru/apps/hangman.svg',
+    id: "hangman",
+    title: "Hangman",
+    icon: "/themes/Yaru/apps/hangman.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayHangman,
   },
   {
-    id: 'memory',
-    title: 'Memory',
-    icon: '/themes/Yaru/apps/memory.svg',
+    id: "memory",
+    title: "Memory",
+    icon: "/themes/Yaru/apps/memory.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayMemory,
   },
   {
-    id: 'minesweeper',
-    title: 'Minesweeper',
-    icon: '/themes/Yaru/apps/minesweeper.svg',
+    id: "minesweeper",
+    title: "Minesweeper",
+    icon: "/themes/Yaru/apps/minesweeper.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayMinesweeper,
   },
   {
-    id: 'pacman',
-    title: 'Pacman',
-    icon: '/themes/Yaru/apps/pacman.svg',
+    id: "pacman",
+    title: "Pacman",
+    icon: "/themes/Yaru/apps/pacman.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayPacman,
   },
   {
-    id: 'platformer',
-    title: 'Platformer',
-    icon: '/themes/Yaru/apps/platformer.svg',
+    id: "platformer",
+    title: "Platformer",
+    icon: "/themes/Yaru/apps/platformer.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayPlatformer,
   },
   {
-    id: 'pong',
-    title: 'Pong',
-    icon: '/themes/Yaru/apps/pong.svg',
+    id: "pong",
+    title: "Pong",
+    icon: "/themes/Yaru/apps/pong.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayPong,
   },
   {
-    id: 'reversi',
-    title: 'Reversi',
-    icon: '/themes/Yaru/apps/reversi.svg',
+    id: "reversi",
+    title: "Reversi",
+    icon: "/themes/Yaru/apps/reversi.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayReversi,
   },
   {
-    id: 'simon',
-    title: 'Simon',
-    icon: '/themes/Yaru/apps/simon.svg',
+    id: "simon",
+    title: "Simon",
+    icon: "/themes/Yaru/apps/simon.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displaySimon,
   },
   {
-    id: 'snake',
-    title: 'Snake',
-    icon: '/themes/Yaru/apps/snake.svg',
+    id: "snake",
+    title: "Snake",
+    icon: "/themes/Yaru/apps/snake.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displaySnake,
   },
   {
-    id: 'sokoban',
-    title: 'Sokoban',
-    icon: '/themes/Yaru/apps/sokoban.svg',
+    id: "sokoban",
+    title: "Sokoban",
+    icon: "/themes/Yaru/apps/sokoban.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displaySokoban,
   },
   {
-    id: 'solitaire',
-    title: 'Solitaire',
-    icon: '/themes/Yaru/apps/solitaire.svg',
+    id: "solitaire",
+    title: "Solitaire",
+    icon: "/themes/Yaru/apps/solitaire.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displaySolitaire,
   },
   {
-    id: 'tictactoe',
-    title: 'Tic Tac Toe',
-    icon: '/themes/Yaru/apps/tictactoe.svg',
+    id: "tictactoe",
+    title: "Tic Tac Toe",
+    icon: "/themes/Yaru/apps/tictactoe.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -621,99 +641,99 @@ const gameList = [
     ...gameDefaults,
   },
   {
-    id: 'tetris',
-    title: 'Tetris',
-    icon: '/themes/Yaru/apps/tetris.svg',
+    id: "tetris",
+    title: "Tetris",
+    icon: "/themes/Yaru/apps/tetris.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayTetris,
   },
   {
-    id: 'tower-defense',
-    title: 'Tower Defense',
-    icon: '/themes/Yaru/apps/tower-defense.svg',
+    id: "tower-defense",
+    title: "Tower Defense",
+    icon: "/themes/Yaru/apps/tower-defense.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayTowerDefense,
   },
   {
-    id: 'word-search',
-    title: 'Word Search',
-    icon: '/themes/Yaru/apps/word-search.svg',
+    id: "word-search",
+    title: "Word Search",
+    icon: "/themes/Yaru/apps/word-search.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayWordSearch,
   },
   {
-    id: 'wordle',
-    title: 'Wordle',
-    icon: '/themes/Yaru/apps/wordle.svg',
+    id: "wordle",
+    title: "Wordle",
+    icon: "/themes/Yaru/apps/wordle.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayWordle,
   },
   {
-    id: 'nonogram',
-    title: 'Nonogram',
-    icon: '/themes/Yaru/apps/nonogram.svg',
+    id: "nonogram",
+    title: "Nonogram",
+    icon: "/themes/Yaru/apps/nonogram.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayNonogram,
   },
   {
-    id: 'space-invaders',
-    title: 'Space Invaders',
-    icon: '/themes/Yaru/apps/space-invaders.svg',
+    id: "space-invaders",
+    title: "Space Invaders",
+    icon: "/themes/Yaru/apps/space-invaders.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displaySpaceInvaders,
   },
   {
-    id: 'sudoku',
-    title: 'Sudoku',
-    icon: '/themes/Yaru/apps/sudoku.svg',
+    id: "sudoku",
+    title: "Sudoku",
+    icon: "/themes/Yaru/apps/sudoku.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displaySudoku,
   },
   {
-    id: 'flappy-bird',
-    title: 'Flappy Bird',
-    icon: '/themes/Yaru/apps/flappy-bird.svg',
+    id: "flappy-bird",
+    title: "Flappy Bird",
+    icon: "/themes/Yaru/apps/flappy-bird.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayFlappyBird,
   },
   {
-    id: 'candy-crush',
-    title: 'Candy Crush',
-    icon: '/themes/Yaru/apps/candy-crush.svg',
+    id: "candy-crush",
+    title: "Candy Crush",
+    icon: "/themes/Yaru/apps/candy-crush.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayCandyCrush,
   },
   {
-    id: 'gomoku',
-    title: 'Gomoku',
-    icon: '/themes/Yaru/apps/gomoku.svg',
+    id: "gomoku",
+    title: "Gomoku",
+    icon: "/themes/Yaru/apps/gomoku.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayGomoku,
   },
   {
-    id: 'pinball',
-    title: 'Pinball',
-    icon: '/themes/Yaru/apps/pinball.svg',
+    id: "pinball",
+    title: "Pinball",
+    icon: "/themes/Yaru/apps/pinball.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -724,13 +744,12 @@ const gameList = [
 /** @type {AppMetadata[]} */
 export const games = gameList.map((game) => ({ ...gameDefaults, ...game }));
 
-
 /** @type {AppMetadata[]} */
 const apps = [
   {
-    id: 'terminal',
-    title: 'Terminal',
-    icon: '/themes/Yaru/apps/bash.png',
+    id: "terminal",
+    title: "Terminal",
+    icon: "/themes/Yaru/apps/bash.png",
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -738,9 +757,9 @@ const apps = [
   },
   {
     // VSCode app uses a Stack iframe, so no editor dependencies are required
-    id: 'vscode',
-    title: 'Visual Studio Code',
-    icon: '/themes/Yaru/apps/vscode.png',
+    id: "vscode",
+    title: "Visual Studio Code",
+    icon: "/themes/Yaru/apps/vscode.png",
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -749,324 +768,343 @@ const apps = [
     defaultHeight: 85,
   },
   {
-    id: 'x',
-    title: 'X',
-    icon: '/themes/Yaru/apps/x.png',
+    id: "chrome",
+    title: "Google Chrome",
+    icon: "/themes/Yaru/apps/chrome.png",
+    disabled: false,
+    favourite: true,
+    desktop_shortcut: false,
+    screen: displayChrome,
+  },
+  {
+    id: "calc",
+    title: "Calculator",
+    icon: "/themes/Yaru/apps/calc.png",
+    disabled: false,
+    favourite: true,
+    desktop_shortcut: false,
+    screen: displayCalc,
+  },
+  {
+    id: "x",
+    title: "X",
+    icon: "/themes/Yaru/apps/x.png",
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
     screen: displayX,
   },
   {
-    id: 'spotify',
-    title: 'Spotify',
-    icon: '/themes/Yaru/apps/spotify.svg',
+    id: "spotify",
+    title: "Spotify",
+    icon: "/themes/Yaru/apps/spotify.svg",
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
     screen: displaySpotify,
   },
   {
-    id: 'beef',
-    title: 'BeEF',
-    icon: '/themes/Yaru/apps/beef.svg',
+    id: "beef",
+    title: "BeEF",
+    icon: "/themes/Yaru/apps/beef.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayBeef,
   },
   {
-    id: 'about',
-    title: 'About Alex',
-    icon: '/themes/Yaru/system/user-home.png',
+    id: "about",
+    title: "About Alex",
+    icon: "/themes/Yaru/system/user-home.png",
     disabled: false,
     favourite: true,
     desktop_shortcut: true,
     screen: displayAboutAlex,
   },
   {
-    id: 'settings',
-    title: 'Settings',
-    icon: '/themes/Yaru/apps/gnome-control-center.png',
+    id: "settings",
+    title: "Settings",
+    icon: "/themes/Yaru/apps/gnome-control-center.png",
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
     screen: displaySettings,
   },
   {
-    id: 'power',
-    title: 'Power',
-    icon: '/themes/Yaru/status/power-button.svg',
+    id: "power",
+    title: "Power",
+    icon: "/themes/Yaru/status/power-button.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayPower,
   },
   {
-    id: 'files',
-    title: 'Files',
-    icon: '/themes/Yaru/system/folder.png',
+    id: "files",
+    title: "Files",
+    icon: "/themes/Yaru/system/folder.png",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayFileExplorer,
   },
   {
-    id: 'ristretto',
-    title: 'Image Viewer',
-    icon: '/themes/Yaru/apps/ristretto.svg',
+    id: "ristretto",
+    title: "Image Viewer",
+    icon: "/themes/Yaru/apps/ristretto.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayRistretto,
   },
   {
-    id: 'resource-monitor',
-    title: 'Resource Monitor',
-    icon: '/themes/Yaru/apps/resource-monitor.svg',
+    id: "resource-monitor",
+    title: "Resource Monitor",
+    icon: "/themes/Yaru/apps/resource-monitor.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayResourceMonitor,
   },
   {
-    id: 'task-manager',
-    title: 'Task Manager',
-    icon: '/themes/Yaru/apps/resource-monitor.svg',
+    id: "task-manager",
+    title: "Task Manager",
+    icon: "/themes/Yaru/apps/resource-monitor.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayTaskManager,
   },
   {
-    id: 'screen-recorder',
-    title: 'Screen Recorder',
-    icon: '/themes/Yaru/apps/screen-recorder.svg',
+    id: "screen-recorder",
+    title: "Screen Recorder",
+    icon: "/themes/Yaru/apps/screen-recorder.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayScreenRecorder,
   },
   {
-    id: 'ettercap',
-    title: 'Ettercap',
-    icon: '/themes/Yaru/apps/ettercap.svg',
+    id: "ettercap",
+    title: "Ettercap",
+    icon: "/themes/Yaru/apps/ettercap.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayEttercap,
   },
   {
-    id: 'ble-sensor',
-    title: 'BLE Sensor',
-    icon: '/themes/Yaru/apps/bluetooth.svg',
+    id: "ble-sensor",
+    title: "BLE Sensor",
+    icon: "/themes/Yaru/apps/bluetooth.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayBleSensor,
   },
   {
-    id: 'bluetooth',
-    title: 'Bluetooth',
-    icon: '/themes/Yaru/apps/bluetooth.svg',
+    id: "bluetooth",
+    title: "Bluetooth",
+    icon: "/themes/Yaru/apps/bluetooth.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayBluetooth,
   },
   {
-    id: 'metasploit',
-    title: 'Metasploit',
-    icon: '/themes/Yaru/apps/metasploit.svg',
+    id: "metasploit",
+    title: "Metasploit",
+    icon: "/themes/Yaru/apps/metasploit.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayMetasploit,
   },
   {
-    id: 'network/connections',
-    title: 'Network Connections',
-    icon: '/themes/Yaru/status/network-wireless-signal-good-symbolic.svg',
+    id: "network/connections",
+    title: "Network Connections",
+    icon: "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayNetworkConnections,
   },
   {
-    id: 'todoist',
-    title: 'Todoist',
-    icon: '/themes/Yaru/apps/todoist.png',
+    id: "todoist",
+    title: "Todoist",
+    icon: "/themes/Yaru/apps/todoist.png",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayTodoist,
   },
   {
-    id: 'sticky_notes',
-    title: 'Sticky Notes',
-    icon: '/themes/Yaru/apps/gedit.png',
+    id: "sticky_notes",
+    title: "Sticky Notes",
+    icon: "/themes/Yaru/apps/gedit.png",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayStickyNotes,
   },
   {
-    id: 'trash',
-    title: 'Trash',
-    icon: '/themes/Yaru/status/user-trash-symbolic.svg',
+    id: "trash",
+    title: "Trash",
+    icon: "/themes/Yaru/status/user-trash-symbolic.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: true,
     screen: displayTrash,
   },
   {
-    id: 'mousepad',
-    title: 'Mousepad Preferences',
-    icon: '/themes/Yaru/apps/gedit.png',
+    id: "mousepad",
+    title: "Mousepad Preferences",
+    icon: "/themes/Yaru/apps/gedit.png",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayMousepad,
   },
   {
-    id: 'gedit',
-    title: 'Contact Me',
-    icon: '/themes/Yaru/apps/gedit.png',
+    id: "gedit",
+    title: "Contact Me",
+    icon: "/themes/Yaru/apps/gedit.png",
     disabled: false,
     favourite: false,
     desktop_shortcut: true,
     screen: displayGedit,
   },
   {
-    id: 'converter',
-    title: 'Converter',
+    id: "converter",
+    title: "Converter",
 
-    icon: '/themes/Yaru/apps/calc.png',
+    icon: "/themes/Yaru/apps/calc.png",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayConverter,
   },
   {
-    id: 'kismet',
-    title: 'Kismet',
-    icon: '/themes/Yaru/apps/kismet.svg',
+    id: "kismet",
+    title: "Kismet",
+    icon: "/themes/Yaru/apps/kismet.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayKismet,
   },
   {
-    id: 'nikto',
-    title: 'Nikto',
-    icon: '/themes/Yaru/apps/nikto.svg',
+    id: "nikto",
+    title: "Nikto",
+    icon: "/themes/Yaru/apps/nikto.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayNikto,
   },
   {
-    id: 'autopsy',
-    title: 'Autopsy',
-    icon: '/themes/Yaru/apps/autopsy.svg',
+    id: "autopsy",
+    title: "Autopsy",
+    icon: "/themes/Yaru/apps/autopsy.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayAutopsy,
   },
-    {
-      id: 'plugin-manager',
-      title: 'Plugin Manager',
-      icon: '/themes/Yaru/apps/project-gallery.svg',
-      disabled: false,
-      favourite: false,
-      desktop_shortcut: false,
-      screen: displayPluginManager,
-    },
-    {
-      id: 'panel-profiles',
-      title: 'Panel Profiles',
-      icon: '/themes/Yaru/apps/project-gallery.svg',
-      disabled: false,
-      favourite: false,
-      desktop_shortcut: false,
-      screen: displayPanelProfiles,
-    },
-    {    id: 'reaver',
-      title: 'Reaver',
-    icon: '/themes/Yaru/apps/reaver.svg',
+  {
+    id: "plugin-manager",
+    title: "Plugin Manager",
+    icon: "/themes/Yaru/apps/project-gallery.svg",
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayPluginManager,
+  },
+  {
+    id: "panel-profiles",
+    title: "Panel Profiles",
+    icon: "/themes/Yaru/apps/project-gallery.svg",
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayPanelProfiles,
+  },
+  {
+    id: "reaver",
+    title: "Reaver",
+    icon: "/themes/Yaru/apps/reaver.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayReaver,
   },
   {
-    id: 'nessus',
-    title: 'Nessus',
-    icon: '/themes/Yaru/apps/nessus.svg',
+    id: "nessus",
+    title: "Nessus",
+    icon: "/themes/Yaru/apps/nessus.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayNessus,
   },
   {
-    id: 'ghidra',
-    title: 'Ghidra',
-    icon: '/themes/Yaru/apps/ghidra.svg',
+    id: "ghidra",
+    title: "Ghidra",
+    icon: "/themes/Yaru/apps/ghidra.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayGhidra,
   },
   {
-    id: 'gigolo',
-    title: 'Gigolo',
-    icon: '/themes/Yaru/apps/ftp.svg',
+    id: "gigolo",
+    title: "Gigolo",
+    icon: "/themes/Yaru/apps/ftp.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayGigolo,
   },
   {
-    id: 'mimikatz',
-    title: 'Mimikatz',
-    icon: '/themes/Yaru/apps/mimikatz.svg',
+    id: "mimikatz",
+    title: "Mimikatz",
+    icon: "/themes/Yaru/apps/mimikatz.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayMimikatz,
   },
   {
-    id: 'mimikatz/offline',
-    title: 'Mimikatz Offline',
-    icon: '/themes/Yaru/apps/mimikatz.svg',
+    id: "mimikatz/offline",
+    title: "Mimikatz Offline",
+    icon: "/themes/Yaru/apps/mimikatz.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayMimikatzOffline,
   },
   {
-    id: 'ssh',
-    title: 'SSH Builder',
-    icon: '/themes/Yaru/apps/ssh.svg',
+    id: "ssh",
+    title: "SSH Builder",
+    icon: "/themes/Yaru/apps/ssh.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displaySSH,
   },
   {
-    id: 'http',
-    title: 'HTTP Builder',
-    icon: '/themes/Yaru/apps/http.svg',
+    id: "http",
+    title: "HTTP Builder",
+    icon: "/themes/Yaru/apps/http.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayHTTP,
   },
   {
-    id: 'html-rewriter',
-    title: 'HTML Rewriter',
-    icon: '/themes/Yaru/apps/project-gallery.svg',
+    id: "html-rewriter",
+    title: "HTML Rewriter",
+    icon: "/themes/Yaru/apps/project-gallery.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -1075,9 +1113,9 @@ const apps = [
   ...(process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY
     ? [
         {
-          id: 'contact',
-          title: 'Contact',
-          icon: '/themes/Yaru/apps/project-gallery.svg',
+          id: "contact",
+          title: "Contact",
+          icon: "/themes/Yaru/apps/project-gallery.svg",
           disabled: false,
           favourite: false,
           desktop_shortcut: false,
@@ -1086,167 +1124,166 @@ const apps = [
       ]
     : []),
   {
-    id: 'hydra',
-    title: 'Hydra',
-    icon: '/themes/Yaru/apps/hydra.svg',
+    id: "hydra",
+    title: "Hydra",
+    icon: "/themes/Yaru/apps/hydra.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayHydra,
   },
   {
-    id: 'nmap-nse',
-    title: 'Nmap NSE',
-    icon: '/themes/Yaru/apps/nmap-nse.svg',
+    id: "nmap-nse",
+    title: "Nmap NSE",
+    icon: "/themes/Yaru/apps/nmap-nse.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayNmapNSE,
   },
   {
-    id: 'weather',
-    title: 'Weather',
-    icon: '/themes/Yaru/apps/weather.svg',
+    id: "weather",
+    title: "Weather",
+    icon: "/themes/Yaru/apps/weather.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayWeather,
   },
   {
-    id: 'weather-widget',
-    title: 'Weather Widget',
-    icon: '/themes/Yaru/apps/weather.svg',
+    id: "weather-widget",
+    title: "Weather Widget",
+    icon: "/themes/Yaru/apps/weather.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayWeatherWidget,
   },
   {
-    id: 'serial-terminal',
-    title: 'Serial Terminal',
-    icon: '/themes/Yaru/apps/bash.png',
+    id: "serial-terminal",
+    title: "Serial Terminal",
+    icon: "/themes/Yaru/apps/bash.png",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displaySerialTerminal,
   },
   {
-    id: 'radare2',
-    title: 'Radare2',
-    icon: '/themes/Yaru/apps/radare2.svg',
+    id: "radare2",
+    title: "Radare2",
+    icon: "/themes/Yaru/apps/radare2.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayRadare2,
   },
   {
-    id: 'volatility',
-    title: 'Volatility',
-    icon: '/themes/Yaru/apps/volatility.svg',
+    id: "volatility",
+    title: "Volatility",
+    icon: "/themes/Yaru/apps/volatility.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayVolatility,
   },
   {
-    id: 'hashcat',
-    title: 'Hashcat',
-    icon: '/themes/Yaru/apps/hashcat.svg',
+    id: "hashcat",
+    title: "Hashcat",
+    icon: "/themes/Yaru/apps/hashcat.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayHashcat,
   },
   {
-    id: 'metasploit-post',
-    title: 'Metasploit Post',
-    icon: '/themes/Yaru/apps/msf-post.svg',
+    id: "metasploit-post",
+    title: "Metasploit Post",
+    icon: "/themes/Yaru/apps/msf-post.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayMsfPost,
   },
   {
-    id: 'evidence-vault',
-    title: 'Evidence Vault',
-    icon: '/themes/Yaru/apps/project-gallery.svg',
+    id: "evidence-vault",
+    title: "Evidence Vault",
+    icon: "/themes/Yaru/apps/project-gallery.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayEvidenceVault,
   },
   {
-    id: 'dsniff',
-    title: 'dsniff',
-    icon: '/themes/Yaru/apps/dsniff.svg',
+    id: "dsniff",
+    title: "dsniff",
+    icon: "/themes/Yaru/apps/dsniff.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayDsniff,
   },
   {
-    id: 'network-manager',
-    title: 'Network Manager',
-    icon: '/themes/Yaru/apps/resource-monitor.svg',
+    id: "network-manager",
+    title: "Network Manager",
+    icon: "/themes/Yaru/apps/resource-monitor.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayNetworkManager,
   },
   {
-    id: 'john',
-    title: 'John the Ripper',
-    icon: '/themes/Yaru/apps/john.svg',
+    id: "john",
+    title: "John the Ripper",
+    icon: "/themes/Yaru/apps/john.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayJohn,
   },
   {
-    id: 'openvas',
-    title: 'OpenVAS',
-    icon: '/themes/Yaru/apps/openvas.svg',
+    id: "openvas",
+    title: "OpenVAS",
+    icon: "/themes/Yaru/apps/openvas.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayOpenVAS,
   },
   {
-    id: 'recon-ng',
-    title: 'Recon-ng',
-    icon: '/themes/Yaru/apps/reconng.svg',
+    id: "recon-ng",
+    title: "Recon-ng",
+    icon: "/themes/Yaru/apps/reconng.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayReconNG,
   },
   {
-    id: 'kali-tools',
-    title: 'Kali Tools',
-    icon: '/themes/Yaru/apps/project-gallery.svg',
+    id: "kali-tools",
+    title: "Kali Tools",
+    icon: "/themes/Yaru/apps/project-gallery.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayKaliTools,
   },
   {
-    id: 'security-tools',
-    title: 'Security Tools',
-    icon: '/themes/Yaru/apps/project-gallery.svg',
+    id: "security-tools",
+    title: "Security Tools",
+    icon: "/themes/Yaru/apps/project-gallery.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displaySecurityTools,
   },
   {
-    id: 'kali-tweaks',
-    title: 'Kali Tweaks',
-    icon: '/themes/Yaru/apps/project-gallery.svg',
+    id: "kali-tweaks",
+    title: "Kali Tweaks",
+    icon: "/themes/Yaru/apps/project-gallery.svg",
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
     screen: displayKaliTweaks,
-
   },
 ];
 


### PR DESCRIPTION
## Summary
- add dynamic app definitions and displays for Terminal, Google Chrome, Visual Studio Code, and Calculator
- expose new apps in the configuration with icons, pinned favourites, and display hooks

## Testing
- `yarn test apps.config.js --passWithNoTests`
- `yarn lint apps.config.js` *(fails: A control must be associated with a text label, no-duplicate-filenames errors in unrelated files)*
- `npx eslint apps.config.js`
- `npx prettier apps.config.js -c`


------
https://chatgpt.com/codex/tasks/task_e_68c2520822a08328ac8b457c21ea9591