### PR TITLE
feat: add desktop route

### DIFF
--- a/__tests__/home-desktop-link.test.tsx
+++ b/__tests__/home-desktop-link.test.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import Home from "../pages/index";
+
+describe("Home page desktop link", () => {
+  it("links to the desktop page", () => {
+    render(<Home desktops={[]} posts={[]} />);
+    const link = screen.getByRole("link", { name: /launch desktop/i });
+    expect(link).toHaveAttribute("href", "/desktop");
+  });
+});

--- a/pages/desktop.tsx
+++ b/pages/desktop.tsx
@@ -1,0 +1,9 @@
+import dynamic from "next/dynamic";
+
+const UbuntuScreen = dynamic(() => import("../components/screen/ubuntu"), {
+  ssr: false,
+});
+
+export default function DesktopPage() {
+  return <UbuntuScreen />;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import type { GetStaticProps } from "next";
 import { XMLParser } from "fast-xml-parser";
@@ -84,6 +85,11 @@ export default function Home({ desktops }: HomeProps) {
         <h1 className="mb-4 text-2xl font-bold sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl 2xl:text-7xl">
           Choose the desktop you prefer
         </h1>
+        <p className="mb-4">
+          <Link href="/desktop" className="underline">
+            Launch desktop
+          </Link>
+        </p>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
           {desktops.map((d) => (
             <div

--- a/pages/undercover.tsx
+++ b/pages/undercover.tsx
@@ -13,7 +13,7 @@ export default function UndercoverDisclaimer() {
         in during public use while avoiding trademarked assets.
       </p>
       <p>
-        <Link href="/">Return to desktop</Link>
+        <Link href="/desktop">Return to desktop</Link>
       </p>
     </main>
   );


### PR DESCRIPTION
## Summary
- add `/desktop` page rendering Ubuntu screen
- link home page and undercover disclaimer to new desktop route
- test desktop link on home page

## Testing
- `yarn test __tests__/home-desktop-link.test.tsx __tests__/desktopDefaultBadge.test.tsx __tests__/ubuntu.test.tsx`
- `yarn lint` *(fails: A control must be associated with a text label; file base name has multiple extensions)*

------
https://chatgpt.com/codex/tasks/task_e_68c2524e95788328be31611ac675ad8a