### PR TITLE
Restore marketing home page and release notes modal

### DIFF
--- a/components/ReleaseNotesModal.tsx
+++ b/components/ReleaseNotesModal.tsx
@@ -1,0 +1,67 @@
+import React, { useMemo } from 'react';
+import Image from 'next/image';
+import Modal from '@/components/base/Modal';
+import posts from '@/data/kali-blog.json';
+
+interface ReleaseNotesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function ReleaseNotesModal({ isOpen, onClose }: ReleaseNotesModalProps) {
+  const latest = useMemo(() => {
+    return posts
+      .filter(p => p.title.includes('Release'))
+      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())[0];
+  }, []);
+
+  if (!latest) return null;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+    >
+      <div className="window-shadow bg-ub-cool-grey rounded-md w-96 border border-black">
+        <div className="flex items-center bg-ub-window-title text-white h-11 rounded-t-md">
+          <div className="flex-1 text-center font-bold">Release Notes</div>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="m-1 bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 active:bg-opacity-80 rounded-full flex justify-center items-center h-6 w-6 focus-visible:outline focus-visible:outline-2 focus-visible:outline-white focus-visible:outline-offset-2 transition-colors"
+          >
+            <Image
+              src="/themes/Yaru/window/window-close-symbolic.svg"
+              alt="Close"
+              width={16}
+              height={16}
+              className="h-4 w-4"
+            />
+          </button>
+        </div>
+        <div className="p-4 text-sm">
+          <p className="mb-4">{latest.title}</p>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300"
+            >
+              Dismiss
+            </button>
+            <a
+              href={latest.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+            >
+              Read More
+            </a>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/content/desktops.json
+++ b/content/desktops.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Xfce",
+    "image": "/wallpapers/wall-1.webp",
+    "blurhash": "U56RyHITRhtSDhx^t7WA8^axWBWAMwRPWBof",
+    "default": true
+  },
+  {
+    "name": "GNOME",
+    "image": "/wallpapers/wall-2.webp",
+    "blurhash": "UI3-*1kXU[kDkEf6f6flaJfRaKe.kXfladad"
+  },
+  {
+    "name": "KDE",
+    "image": "/wallpapers/wall-3.webp",
+    "blurhash": "UmDJYURjM|of_4WAa#of?daxj?j]%hoLaxj]"
+  }
+]

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,124 @@
-import dynamic from "next/dynamic";
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import type { GetStaticProps } from "next";
+import { XMLParser } from "fast-xml-parser";
+import desktopsData from "../content/desktops.json";
 import { baseMetadata } from "../lib/metadata";
+import ReleaseNotesModal from "../components/ReleaseNotesModal";
+import Header from "../components/layout/Header";
+import Footer from "../components/layout/Footer";
 
 export const metadata = baseMetadata;
 
-const Ubuntu = dynamic(() => import("../components/screen/ubuntu"), {
-  ssr: false,
-});
-
-export default function Home() {
-  return <Ubuntu />;
+interface Desktop {
+  name: string;
+  image: string;
+  blurhash: string;
+  default?: boolean;
 }
 
+interface DesktopWithData extends Omit<Desktop, "blurhash"> {
+  blurDataURL: string;
+}
+
+interface Post {
+  title: string;
+  link: string;
+  date: string;
+}
+
+interface HomeProps {
+  desktops: DesktopWithData[];
+  posts: Post[];
+}
+
+async function blurHashToDataURL(blurhash: string) {
+  const { decode } = await import("blurhash");
+  const { PNG } = await import("pngjs");
+  const pixels = decode(blurhash, 32, 32);
+  const png = new PNG({ width: 32, height: 32 });
+  png.data = Buffer.from(pixels);
+  return `data:image/png;base64,${PNG.sync.write(png).toString("base64")}`;
+}
+
+export const getStaticProps: GetStaticProps<HomeProps> = async () => {
+  const desktops = await Promise.all(
+    (desktopsData as Desktop[]).map(async (d) => ({
+      ...d,
+      blurDataURL: await blurHashToDataURL(d.blurhash),
+    }))
+  );
+
+    try {
+      const rssRes = await fetch("https://www.kali.org/rss.xml");
+      const rssText = await rssRes.text();
+      const parser = new XMLParser();
+      const rss = parser.parse(rssText);
+      const items = rss?.rss?.channel?.item ?? [];
+      const arr = Array.isArray(items) ? items : [items];
+      const posts: Post[] = arr
+        .filter((i) => i && i.title)
+        .map((i: any) => ({
+          title: i.title,
+          link: i.link,
+          date: i.pubDate,
+        }));
+
+      return { props: { desktops, posts }, revalidate: 7200 };
+    } catch {
+      return { props: { desktops, posts: [] }, revalidate: 7200 };
+    }
+  };
+
+export default function Home({ desktops }: HomeProps) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    setOpen(true);
+  }, []);
+
+  return (
+    <>
+      <Header />
+      <main className="p-4">
+        <h1 className="mb-4 text-2xl font-bold sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl 2xl:text-7xl">
+          Choose the desktop you prefer
+        </h1>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+          {desktops.map((d) => (
+            <div
+              key={d.name}
+              className="relative text-center"
+              aria-label={
+                d.default
+                  ? `${d.name} desktop environment (default)`
+                  : `${d.name} desktop environment`
+              }
+            >
+              {d.default && (
+                <span
+                  aria-hidden="true"
+                  className="absolute right-2 top-2 rounded bg-muted px-1.5 py-0.5 text-xs text-text"
+                >
+                  Default
+                </span>
+              )}
+              <Image
+                src={d.image}
+                alt={d.name}
+                width={320}
+                height={200}
+                placeholder="blur"
+                blurDataURL={d.blurDataURL}
+                className="rounded"
+              />
+              <p className="mt-2 text-sm sm:text-base md:text-lg">{d.name}</p>
+            </div>
+          ))}
+        </div>
+        <ReleaseNotesModal isOpen={open} onClose={() => setOpen(false)} />
+      </main>
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Reintroduce the desktop-selection marketing page and release notes modal, returning the UI to the prior Ubuntu-style layout.
- Add back ReleaseNotesModal component and desktops list removed by PR #5611.

## Testing
- `npx eslint pages/index.tsx components/ReleaseNotesModal.tsx`
- `yarn test --passWithNoTests components/ReleaseNotesModal.tsx pages/index.tsx`
- `yarn lint` *(fails: 471 errors)*
- `pnpm typecheck` *(fails: TypeScript errors)*


------
https://chatgpt.com/codex/tasks/task_e_68c259b540288328ad2e5b6c3cef2d3c