### PR TITLE
Fix figlet types and react-window import for stable build

### DIFF
--- a/apps/ascii-art/index.tsx
+++ b/apps/ascii-art/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback, ChangeEvent } from 'react';
-import figlet from 'figlet';
+import figlet, { FontName } from 'figlet';
 import Standard from 'figlet/importable-fonts/Standard.js';
 import Slant from 'figlet/importable-fonts/Slant.js';
 import Big from 'figlet/importable-fonts/Big.js';
@@ -69,7 +69,7 @@ const AsciiArtApp = () => {
   const [tab, setTab] = useState<'text' | 'image'>('text');
   const [text, setText] = useState('');
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
-  const [font, setFont] = useState<figlet.Fonts>('Standard');
+  const [font, setFont] = useState<FontName>('Standard');
   const [output, setOutput] = useState('');
   const [fgColor, setFgColor] = useState('#00ff00');
   const [bgColor, setBgColor] = useState('#000000');
@@ -92,7 +92,7 @@ const AsciiArtApp = () => {
     if (!router.isReady) return;
     const { t, f, b, c } = router.query;
     if (typeof t === 'string') setText(t);
-      if (typeof f === 'string' && fontList.includes(f)) setFont(f as figlet.Fonts);
+      if (typeof f === 'string' && fontList.includes(f)) setFont(f as FontName);
     if (typeof b === 'string') {
       const br = parseFloat(b);
       if (!Number.isNaN(br) && br >= -1 && br <= 1) setBrightness(br);
@@ -258,7 +258,7 @@ const AsciiArtApp = () => {
           />
           <select
             value={font}
-            onChange={(e) => setFont(e.target.value as figlet.Fonts)}
+            onChange={(e) => setFont(e.target.value as FontName)}
             className="px-2 py-1 text-black rounded"
           >
             {fontList.map((f) => (

--- a/apps/figlet/worker.ts
+++ b/apps/figlet/worker.ts
@@ -1,4 +1,5 @@
-import figlet from 'figlet';
+import figlet, { FontName } from 'figlet';
+import type { KerningMethods } from 'figlet/dist/types/figlet-types';
 // Fonts are loaded dynamically from the main thread. This keeps the worker
 // lightweight and allows only the fonts that are actually used to be loaded.
 
@@ -11,7 +12,7 @@ function isMonospace(name: string) {
   let width: number | undefined;
   for (const ch of chars) {
     const glyph = strip(
-      figlet.textSync(ch, { font: name as figlet.Fonts }).split('\n'),
+      figlet.textSync(ch, { font: name as FontName }).split('\n'),
     );
     const w = glyph.reduce((m, line) => Math.max(m, line.length), 0);
     if (width === undefined) width = w;
@@ -25,7 +26,7 @@ self.onmessage = (e: MessageEvent<any>) => {
     const { name, data } = e.data as { name: string; data: string };
     try {
       figlet.parseFont(name, data);
-      const preview = figlet.textSync('Figlet', { font: name as figlet.Fonts });
+      const preview = figlet.textSync('Figlet', { font: name as FontName });
       const mono = isMonospace(name);
       self.postMessage({ type: 'font', font: name, preview, mono });
     } catch {
@@ -46,9 +47,9 @@ self.onmessage = (e: MessageEvent<any>) => {
     .map((line) => line.trim())
     .join('\n');
   const rendered = figlet.textSync(normalized, {
-    font: font as figlet.Fonts,
+    font: font as FontName,
     width,
-    horizontalLayout: layout as figlet.KerningMethods,
+    horizontalLayout: layout as KerningMethods,
   });
   self.postMessage({ type: 'render', output: rendered });
 };

--- a/components/apps/windowed-list.tsx
+++ b/components/apps/windowed-list.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import AutoSizer from "react-virtualized-auto-sizer";
-import { FixedSizeList as List } from "react-window";
+import { List } from "react-window";
 
 export interface WindowedListProps<T> {
   items: T[];


### PR DESCRIPTION
## Summary
- import `FontName` types from figlet and update figlet worker
- use `List` from `react-window` to match v2 API

## Testing
- `yarn build`
- `yarn test` *(fails: window snapping e.preventDefault not a function, panel power menu TypeError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c274cc045883289a4192c54c1be9b7