### PR TITLE
feat: add theme toggle component

### DIFF
--- a/components/ui/ThemeToggle.tsx
+++ b/components/ui/ThemeToggle.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { getTheme, setTheme, isDarkTheme } from '../../utils/theme';
+
+/**
+ * Toggle between light and dark themes.
+ * Applies theme by updating the <html> element's dataset and class list.
+ * Respects system preference on first load and persists choice in localStorage.
+ */
+const ThemeToggle = () => {
+  const [theme, setThemeState] = useState<string>(() => getTheme());
+
+  useEffect(() => {
+    setTheme(theme);
+  }, [theme]);
+
+  const handleToggle = () => {
+    setThemeState(isDarkTheme(theme) ? 'default' : 'dark');
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleToggle}
+      className="underline"
+      aria-label="Toggle theme"
+    >
+      {isDarkTheme(theme) ? 'Light mode' : 'Dark mode'}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
+import ThemeToggle from '../components/ui/ThemeToggle';
 
 const Ubuntu = dynamic(
   () =>
@@ -37,6 +38,17 @@ const App = () => (
     <Ubuntu />
     <BetaBadge />
     <InstallButton />
+    <footer className="absolute bottom-2 left-0 w-full flex items-center justify-center gap-4 text-xs text-ubt-grey">
+      <a
+        href="https://github.com/unnippillil/kali-linux-portfolio"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline"
+      >
+        Source
+      </a>
+      <ThemeToggle />
+    </footer>
   </>
 );
 


### PR DESCRIPTION
## Summary
- add reusable ThemeToggle component that syncs theme with `<html>`
- expose theme toggle in footer on home page

## Testing
- `npx jest __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size; NmapNSEApp › copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68c34950133c8328b510775104e57071