### PR TITLE
test: verify additional routes

### DIFF
--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -44,7 +44,15 @@ const getPort = () =>
     process.on('exit', () => server.kill());
     await waitOn({ resources: [`http://localhost:${port}`], timeout: 60000 });
 
-    const routes = ['/', '/dummy-form', '/video-gallery', '/profile'];
+    const routes = [
+      '/',
+      '/dummy-form',
+      '/video-gallery',
+      '/profile',
+      '/popular-modules',
+      '/network-topology',
+      '/notes',
+    ];
     for (const route of routes) {
       const res = await fetch(`http://localhost:${port}${route}`);
       const header = res.headers.get('x-powered-by');


### PR DESCRIPTION
## Summary
- expand verify script to check /popular-modules, /network-topology, and /notes routes

## Testing
- `THEME=ubuntu ESLINT_USE_FLAT_CONFIG=false yarn verify:all` *(fails: yarn lint exited with code 1)*
- `THEME=kali ESLINT_USE_FLAT_CONFIG=false yarn verify:all` *(fails: yarn lint exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c3494a22bc8328b679e41c57afb020