### PR TITLE
feat: add kali theme tokens

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -68,6 +68,25 @@ html[data-theme='matrix'] {
 
 }
 
+/* Kali theme */
+html[data-theme='kali'] {
+  --color-bg: var(--kali-neutral);
+  --color-text: var(--kali-text);
+  --color-primary: var(--kali-accent);
+  --color-secondary: var(--kali-surface);
+  --color-accent: var(--kali-accent);
+  --color-muted: var(--kali-surface);
+  --color-surface: var(--kali-surface);
+  --color-inverse: var(--kali-neutral);
+  --color-border: var(--kali-surface);
+  --color-terminal: #00ff00;
+  --color-dark: var(--kali-neutral);
+  --color-focus-ring: var(--kali-accent);
+  --color-selection: var(--kali-accent);
+  --color-control-accent: var(--kali-accent);
+  accent-color: var(--color-control-accent);
+}
+
 ::selection {
   background: var(--color-selection);
   color: var(--color-inverse);

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -117,3 +117,11 @@
     --color-ub-border-orange: #ffff00;
   }
 }
+
+/* Kali theme tokens */
+:root {
+  --kali-neutral: #0f1317;
+  --kali-surface: #1a1f26;
+  --kali-text: #f5f5f5;
+  --kali-accent: #1793d1;
+}


### PR DESCRIPTION
## Summary
- define Kali color tokens for neutral, surface, text and accent
- map semantic CSS variables to Kali tokens when `data-theme="kali"`

## Testing
- `node - <<'NODE' ... NODE` (validate CSS variable updates)
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test __tests__/window.test.tsx` *(fails: e.preventDefault is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c3494c10e48328b6d4b0b6578a0f77