### PR TITLE
feat: add font tokens for kali theme

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,10 @@ body{
     color: var(--color-text);
 }
 
+pre, code, kbd, samp {
+    font-family: var(--font-family-code);
+}
+
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
     min-width: var(--hit-area);
     min-height: var(--hit-area);

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -53,12 +53,21 @@
 
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
+  --font-family-code: ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;
+  --kali-font-family-base: Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
+  --kali-font-family-code: var(--font-family-code);
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;
+}
+
+/* Kali theme */
+.kali {
+  --font-family-base: var(--kali-font-family-base);
+  --font-family-code: var(--kali-font-family-code);
 }
 
 /* High contrast theme */


### PR DESCRIPTION
## Summary
- add kali base and code font tokens using Inter and a shared monospace stack
- apply monospace font to code-related elements

## Testing
- `yarn lint` (fails: A control must be associated with a text label)
- `yarn test` (fails: window.test.tsx, nmapNse.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68c3494cd94c832888f02faff09ada38