### PR TITLE
feat: add Kali landing hero

### DIFF
--- a/components/landing/KaliHero.tsx
+++ b/components/landing/KaliHero.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+const KaliHero: React.FC = () => (
+  <section className="kali-hero">
+    <div className="kali-hero__content">
+      <h1 className="kali-hero__title">Kali Linux</h1>
+      <p className="kali-hero__tagline">The most advanced penetration testing distribution</p>
+      <div className="kali-hero__actions">
+        <a
+          href="https://www.kali.org/get-kali/"
+          className="kali-hero__btn"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Get Kali
+        </a>
+        <a
+          href="https://www.kali.org/docs/"
+          className="kali-hero__btn"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Documentation
+        </a>
+      </div>
+    </div>
+  </section>
+);
+
+export default KaliHero;
+

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,8 @@
 import dynamic from 'next/dynamic';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
+import KaliHero from '../components/landing/KaliHero';
+import { useRouter } from 'next/router';
 
 const Ubuntu = dynamic(
   () =>
@@ -28,16 +30,26 @@ const InstallButton = dynamic(
 /**
  * @returns {JSX.Element}
  */
-const App = () => (
-  <>
-    <a href="#window-area" className="sr-only focus:not-sr-only">
-      Skip to content
-    </a>
-    <Meta />
-    <Ubuntu />
-    <BetaBadge />
-    <InstallButton />
-  </>
-);
+const App = () => {
+  const { query } = useRouter();
+  const isKali = query.theme === 'kali';
+  return (
+    <>
+      <a href="#window-area" className="sr-only focus:not-sr-only">
+        Skip to content
+      </a>
+      <Meta />
+      {isKali ? (
+        <KaliHero />
+      ) : (
+        <>
+          <Ubuntu />
+          <BetaBadge />
+          <InstallButton />
+        </>
+      )}
+    </>
+  );
+};
 
 export default App;

--- a/styles/index.css
+++ b/styles/index.css
@@ -530,3 +530,58 @@ textarea:focus-visible {
     color: #000 !important;
 }
 
+/* Kali landing hero */
+.kali-hero {
+    position: relative;
+    padding: 5rem 1rem;
+    text-align: center;
+    color: #fff;
+    background: linear-gradient(135deg, #0a0f2d, #123c69);
+    overflow: hidden;
+}
+
+.kali-hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: url('/themes/Yaru/status/icons8-kali-linux.svg') center/60% no-repeat;
+    opacity: 0.05;
+    pointer-events: none;
+}
+
+.kali-hero__content {
+    position: relative;
+    z-index: 1;
+}
+
+.kali-hero__title {
+    font-size: 3rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+}
+
+.kali-hero__tagline {
+    font-size: 1.25rem;
+    margin-bottom: 2rem;
+}
+
+.kali-hero__actions {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+}
+
+.kali-hero__btn {
+    padding: 0.75rem 1.5rem;
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 0.375rem;
+    color: #fff;
+    text-decoration: none;
+    transition: background 0.2s ease;
+}
+
+.kali-hero__btn:hover,
+.kali-hero__btn:focus {
+    background: rgba(0, 0, 0, 0.5);
+}
+


### PR DESCRIPTION
## Summary
- add KaliHero landing component with tagline and links
- show KaliHero on index when theme=kali
- style KaliHero with gradient background and dragon watermark

## Testing
- `npx eslint pages/index.jsx components/landing/KaliHero.tsx styles/index.css`
- `yarn lint components/landing/KaliHero.tsx pages/index.jsx styles/index.css` *(fails: Unexpected global 'document' in unrelated files)*
- `yarn test` *(fails: Window snapping finalize and release test; Nmap NSE App clipboard test)*

------
https://chatgpt.com/codex/tasks/task_e_68c3494dc24c832884e67aa96b82a34e