### PR TITLE
feat(nav): add kali navigation links

### DIFF
--- a/components/menu/KaliNav.tsx
+++ b/components/menu/KaliNav.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+const links = [
+  { href: "https://www.kali.org/get-kali/", label: "Get Kali" },
+  { href: "https://www.kali.org/blog/", label: "Blog" },
+  { href: "https://www.kali.org/docs/", label: "Documentation" },
+  { href: "https://www.kali.org/community/", label: "Community" },
+  { href: "https://www.kali.org/developers/", label: "Developers" },
+  { href: "https://www.kali.org/about/", label: "About" },
+];
+
+const KaliNav: React.FC = () => (
+  <nav className="flex space-x-2">
+    {links.map((link) => (
+      <a
+        key={link.href}
+        href={link.href}
+        className="px-2 py-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] rounded"
+        tabIndex={0}
+      >
+        {link.label}
+      </a>
+    ))}
+  </nav>
+);
+
+export default KaliNav;

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
-import Image from 'next/image';
-import UbuntuApp from '../base/ubuntu_app';
-import apps, { utilities, games } from '../../apps.config';
-import { safeLocalStorage } from '../../utils/safeStorage';
+import React, { useState, useEffect, useRef, useMemo } from "react";
+import Image from "next/image";
+import UbuntuApp from "../base/ubuntu_app";
+import apps, { utilities, games } from "../../apps.config";
+import { safeLocalStorage } from "../../utils/safeStorage";
 
 type AppMeta = {
   id: string;
@@ -13,27 +13,34 @@ type AppMeta = {
 };
 
 const CATEGORIES = [
-  { id: 'all', label: 'All' },
-  { id: 'favorites', label: 'Favorites' },
-  { id: 'recent', label: 'Recent' },
-  { id: 'utilities', label: 'Utilities' },
-  { id: 'games', label: 'Games' }
+  { id: "all", label: "All" },
+  { id: "favorites", label: "Favorites" },
+  { id: "recent", label: "Recent" },
+  { id: "utilities", label: "Utilities" },
+  { id: "games", label: "Games" },
 ];
 
 const WhiskerMenu: React.FC = () => {
   const [open, setOpen] = useState(false);
-  const [category, setCategory] = useState('all');
-  const [query, setQuery] = useState('');
+  const [category, setCategory] = useState("all");
+  const [query, setQuery] = useState("");
   const [highlight, setHighlight] = useState(0);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
   const allApps: AppMeta[] = apps as any;
-  const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
+  const favoriteApps = useMemo(
+    () => allApps.filter((a) => a.favourite),
+    [allApps],
+  );
   const recentApps = useMemo(() => {
     try {
-      const ids: string[] = JSON.parse(safeLocalStorage?.getItem('recentApps') || '[]');
-      return ids.map(id => allApps.find(a => a.id === id)).filter(Boolean) as AppMeta[];
+      const ids: string[] = JSON.parse(
+        safeLocalStorage?.getItem("recentApps") || "[]",
+      );
+      return ids
+        .map((id) => allApps.find((a) => a.id === id))
+        .filter(Boolean) as AppMeta[];
     } catch {
       return [];
     }
@@ -44,16 +51,16 @@ const WhiskerMenu: React.FC = () => {
   const currentApps = useMemo(() => {
     let list: AppMeta[];
     switch (category) {
-      case 'favorites':
+      case "favorites":
         list = favoriteApps;
         break;
-      case 'recent':
+      case "recent":
         list = recentApps;
         break;
-      case 'utilities':
+      case "utilities":
         list = utilityApps;
         break;
-      case 'games':
+      case "games":
         list = gameApps;
         break;
       default:
@@ -61,10 +68,18 @@ const WhiskerMenu: React.FC = () => {
     }
     if (query) {
       const q = query.toLowerCase();
-      list = list.filter(a => a.title.toLowerCase().includes(q));
+      list = list.filter((a) => a.title.toLowerCase().includes(q));
     }
     return list;
-  }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps]);
+  }, [
+    category,
+    query,
+    allApps,
+    favoriteApps,
+    recentApps,
+    utilityApps,
+    gameApps,
+  ]);
 
   useEffect(() => {
     if (!open) return;
@@ -72,46 +87,49 @@ const WhiskerMenu: React.FC = () => {
   }, [open, category, query]);
 
   const openSelectedApp = (id: string) => {
-    window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
+    window.dispatchEvent(new CustomEvent("open-app", { detail: id }));
     setOpen(false);
   };
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Meta' && !e.ctrlKey && !e.shiftKey && !e.altKey) {
+      if (e.key === "Meta" && !e.ctrlKey && !e.shiftKey && !e.altKey) {
         e.preventDefault();
-        setOpen(o => !o);
+        setOpen((o) => !o);
         return;
       }
       if (!open) return;
-      if (e.key === 'Escape') {
+      if (e.key === "Escape") {
         setOpen(false);
-      } else if (e.key === 'ArrowDown') {
+      } else if (e.key === "ArrowDown") {
         e.preventDefault();
-        setHighlight(h => Math.min(h + 1, currentApps.length - 1));
-      } else if (e.key === 'ArrowUp') {
+        setHighlight((h) => Math.min(h + 1, currentApps.length - 1));
+      } else if (e.key === "ArrowUp") {
         e.preventDefault();
-        setHighlight(h => Math.max(h - 1, 0));
-      } else if (e.key === 'Enter') {
+        setHighlight((h) => Math.max(h - 1, 0));
+      } else if (e.key === "Enter") {
         e.preventDefault();
         const app = currentApps[highlight];
         if (app) openSelectedApp(app.id);
       }
     };
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
   }, [open, currentApps, highlight]);
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
       if (!open) return;
       const target = e.target as Node;
-      if (!menuRef.current?.contains(target) && !buttonRef.current?.contains(target)) {
+      if (
+        !menuRef.current?.contains(target) &&
+        !buttonRef.current?.contains(target)
+      ) {
         setOpen(false);
       }
     };
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
   }, [open]);
 
   return (
@@ -119,8 +137,8 @@ const WhiskerMenu: React.FC = () => {
       <button
         ref={buttonRef}
         type="button"
-        onClick={() => setOpen(o => !o)}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        onClick={() => setOpen((o) => !o)}
+        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] rounded"
       >
         <Image
           src="/themes/Yaru/status/decompiler-symbolic.svg"
@@ -143,10 +161,10 @@ const WhiskerMenu: React.FC = () => {
           }}
         >
           <div className="flex flex-col bg-gray-800 p-2">
-            {CATEGORIES.map(cat => (
+            {CATEGORIES.map((cat) => (
               <button
                 key={cat.id}
-                className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
+                className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? "bg-gray-700" : ""}`}
                 onClick={() => setCategory(cat.id)}
               >
                 {cat.label}
@@ -157,13 +175,17 @@ const WhiskerMenu: React.FC = () => {
             <input
               className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
               placeholder="Search"
+              aria-label="Search applications"
               value={query}
-              onChange={e => setQuery(e.target.value)}
+              onChange={(e) => setQuery(e.target.value)}
               autoFocus
             />
             <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
               {currentApps.map((app, idx) => (
-                <div key={app.id} className={idx === highlight ? 'ring-2 ring-ubb-orange' : ''}>
+                <div
+                  key={app.id}
+                  className={idx === highlight ? "ring-2 ring-ubb-orange" : ""}
+                >
                   <UbuntuApp
                     id={app.id}
                     icon={app.icon}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,47 +1,59 @@
-import React, { Component } from 'react';
-import Image from 'next/image';
-import Clock from '../util-components/clock';
-import Status from '../util-components/status';
-import QuickSettings from '../ui/QuickSettings';
-import WhiskerMenu from '../menu/WhiskerMenu';
+import React, { Component } from "react";
+import Image from "next/image";
+import Clock from "../util-components/clock";
+import Status from "../util-components/status";
+import QuickSettings from "../ui/QuickSettings";
+import WhiskerMenu from "../menu/WhiskerMenu";
+import KaliNav from "../menu/KaliNav";
+import { SettingsContext } from "../../hooks/useSettings";
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+  static contextType = SettingsContext;
 
-	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
-                                </div>
-                                <WhiskerMenu />
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-                                        }
-                                >
-                                        <Clock />
-                                </div>
-                                <button
-                                        type="button"
-                                        id="status-bar"
-                                        aria-label="System status"
-                                        onClick={() => {
-                                                this.setState({ status_card: !this.state.status_card });
-                                        }}
-                                        className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-                                        }
-                                >
-                                        <Status />
-                                        <QuickSettings open={this.state.status_card} />
-                                </button>
-			</div>
-		);
-	}
+  constructor() {
+    super();
+    this.state = {
+      status_card: false,
+    };
+  }
+
+  render() {
+    const { theme } = this.context;
+    return (
+      <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+        <div className="pl-3 pr-1">
+          <Image
+            src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg"
+            alt="network icon"
+            width={16}
+            height={16}
+            className="w-4 h-4"
+          />
+        </div>
+        <WhiskerMenu />
+        {theme === "kali" && <KaliNav />}
+        <div
+          className={
+            "pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+          }
+        >
+          <Clock />
+        </div>
+        <button
+          type="button"
+          id="status-bar"
+          aria-label="System status"
+          onClick={() => {
+            this.setState({ status_card: !this.state.status_card });
+          }}
+          className={
+            "relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 "
+          }
+        >
+          <Status />
+          <QuickSettings open={this.state.status_card} />
+        </button>
+      </div>
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- add Kali top navigation links with focus-visible styles
- wire navbar to show Kali links when theme is 'kali'
- improve WhiskerMenu accessibility with focus rings and labeled search

## Testing
- `npx eslint components/screen/navbar.js components/menu/KaliNav.tsx components/menu/WhiskerMenu.tsx`
- `yarn lint components/screen/navbar.js components/menu/KaliNav.tsx components/menu/WhiskerMenu.tsx` *(fails: Unexpected global 'document' etc.)*
- `yarn test` *(fails: Window snapping finalize and release; NmapNSEApp copies example output to clipboard; modal traps focus)*

------
https://chatgpt.com/codex/tasks/task_e_68c3494e3e7c83288a7a07872538ca6e