### PR TITLE
Add KaliEverywhere landing component

### DIFF
--- a/components/landing/KaliEverywhere.tsx
+++ b/components/landing/KaliEverywhere.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+interface Platform {
+  name: string;
+  href: string;
+}
+
+const platforms: Platform[] = [
+  { name: 'ARM', href: 'https://www.kali.org/get-kali/#kali-arm' },
+  { name: 'Bare Metal', href: 'https://www.kali.org/get-kali/#kali-bare-metal' },
+  { name: 'Cloud', href: 'https://www.kali.org/get-kali/#kali-cloud' },
+  { name: 'Containers', href: 'https://www.kali.org/get-kali/#kali-containers' },
+  { name: 'Virtual Machines', href: 'https://www.kali.org/get-kali/#kali-virtual-machines' },
+  { name: 'WSL', href: 'https://www.kali.org/get-kali/#kali-wsl' },
+];
+
+export default function KaliEverywhere() {
+  return (
+    <section aria-labelledby="kali-everywhere">
+      <h2 id="kali-everywhere" className="mb-4 text-xl font-bold">
+        Kali Everywhere
+      </h2>
+      <div className="overflow-x-auto md:overflow-visible">
+        <ul className="flex gap-4 md:flex-wrap">
+          {platforms.map(({ name, href }) => (
+            <li key={name} className="flex-none w-48">
+              <a
+                href={href}
+                className="block h-full p-4 rounded border border-[var(--color-border)] bg-[var(--color-surface)] hover:bg-[var(--color-muted)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
+              >
+                {name}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,8 @@
 import dynamic from 'next/dynamic';
+import { useRouter } from 'next/router';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
+import KaliEverywhere from '../components/landing/KaliEverywhere';
 
 const Ubuntu = dynamic(
   () =>
@@ -28,16 +30,22 @@ const InstallButton = dynamic(
 /**
  * @returns {JSX.Element}
  */
-const App = () => (
-  <>
-    <a href="#window-area" className="sr-only focus:not-sr-only">
-      Skip to content
-    </a>
-    <Meta />
-    <Ubuntu />
-    <BetaBadge />
-    <InstallButton />
-  </>
-);
+const App = () => {
+  const { query } = useRouter();
+  const theme = Array.isArray(query.theme) ? query.theme[0] : query.theme;
+
+  return (
+    <>
+      <a href="#window-area" className="sr-only focus:not-sr-only">
+        Skip to content
+      </a>
+      <Meta />
+      {theme === 'kali' && <KaliEverywhere />}
+      <Ubuntu />
+      <BetaBadge />
+      <InstallButton />
+    </>
+  );
+};
 
 export default App;


### PR DESCRIPTION
## Summary
- add KaliEverywhere component with cards for ARM, bare metal, cloud, containers, VMs, and WSL
- show KaliEverywhere on landing page when theme=kali

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c3494f10208328b5918ee145f3a8b1