### PR TITLE
Add NewsStrip to landing page and static news data

### DIFF
--- a/__tests__/newsStrip.test.tsx
+++ b/__tests__/newsStrip.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import NewsStrip from '../components/landing/NewsStrip';
+
+describe('NewsStrip', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve([
+          {
+            title: 'Example news item that is fairly long to test truncation',
+            url: 'https://example.com',
+          },
+        ]),
+    }) as any;
+  });
+
+  test('renders links that open in a new tab', async () => {
+    render(<NewsStrip />);
+    const link = await screen.findByRole('link');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/components/landing/NewsStrip.tsx
+++ b/components/landing/NewsStrip.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+
+interface NewsItem {
+  title: string;
+  url: string;
+}
+
+const truncate = (text: string, length = 80) =>
+  text.length > length ? `${text.slice(0, length - 1)}…` : text;
+
+const NewsStrip: React.FC = () => {
+  const [items, setItems] = useState<NewsItem[]>([]);
+
+  useEffect(() => {
+    let mounted = true;
+    fetch('/data/news.json')
+      .then((res) => res.json())
+      .then((data: NewsItem[]) => {
+        if (mounted) setItems(data);
+      })
+      .catch(() => setItems([]));
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (!items.length) return null;
+
+  return (
+    <div className="bg-gray-800 text-sm text-gray-100">
+      <ul className="flex overflow-x-auto space-x-4 p-2">
+        {items.map((item) => (
+          <li key={item.url}>
+            <a
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:underline"
+            >
+              {truncate(item.title)}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default NewsStrip;

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -24,6 +24,17 @@ const InstallButton = dynamic(
     loading: () => <p>Loading install options...</p>,
   }
 );
+const NewsStrip = dynamic(
+  () =>
+    import('../components/landing/NewsStrip').catch((err) => {
+      console.error('Failed to load NewsStrip component', err);
+      throw err;
+    }),
+  {
+    ssr: false,
+    loading: () => <p>Loading news...</p>,
+  }
+);
 
 /**
  * @returns {JSX.Element}
@@ -37,6 +48,7 @@ const App = () => (
     <Ubuntu />
     <BetaBadge />
     <InstallButton />
+    <NewsStrip />
   </>
 );
 

--- a/public/data/news.json
+++ b/public/data/news.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "Kali Linux 2024.1 Released with New Tools and Enhancements",
+    "url": "https://www.kali.org/blog/kali-linux-2024-1-release/"
+  },
+  {
+    "title": "Offensive Security Announces Kali Purple, a Defensive Security Platform",
+    "url": "https://www.kali.org/blog/kali-purple-preview/"
+  },
+  {
+    "title": "Kali Linux Adds Experimental Cloud Images for ARM",
+    "url": "https://www.kali.org/blog/experimental-cloud-images/"
+  }
+]


### PR DESCRIPTION
## Summary
- add static news data under `public/data` and component to display it
- integrate `NewsStrip` into landing page
- include unit test verifying links open in new tab

## Testing
- `yarn test __tests__/newsStrip.test.tsx`
- `npx eslint components/landing/NewsStrip.tsx pages/index.jsx __tests__/newsStrip.test.tsx` (warning: File ignored because no matching configuration was supplied for `pages/index.jsx`)


------
https://chatgpt.com/codex/tasks/task_e_68c3494f84e48328b5c59da09fa5a44c