### PR TITLE
feat: add reusable button component

### DIFF
--- a/components/GitHubStars.js
+++ b/components/GitHubStars.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import usePersistentState from '../hooks/usePersistentState';
+import Button from '@/components/ui/Button';
 
 const GitHubStars = ({ user, repo }) => {
   const ref = useRef(null);
@@ -50,13 +51,14 @@ const GitHubStars = ({ user, repo }) => {
       ) : (
         <>
           <span>⭐ {stars}</span>
-          <button
+          <Button
             onClick={fetchStars}
             aria-label="Refresh star count"
-            className="ml-2 text-gray-400 hover:text-white"
+            variant="secondary"
+            className="ml-2"
           >
             ↻
-          </button>
+          </Button>
         </>
       )}
     </div>

--- a/components/HelpPanel.tsx
+++ b/components/HelpPanel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import DOMPurify from 'dompurify';
 import { marked } from 'marked';
+import Button from '@/components/ui/Button';
 
 interface HelpPanelProps {
   appId: string;
@@ -50,15 +51,16 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
 
   return (
     <>
-      <button
+      <Button
         type="button"
         aria-label="Help"
         aria-expanded={open}
         onClick={toggle}
-        className="fixed top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+        variant="secondary"
+        className="fixed top-2 right-2 z-40 rounded-full w-11 h-11 p-0"
       >
         ?
-      </button>
+      </Button>
       {open && (
         <div
           className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-start justify-end p-4"

--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { trackEvent } from '@/lib/analytics-client';
 import { showA2HS } from '@/src/pwa/a2hs';
+import Button from '@/components/ui/Button';
 
 const InstallButton: React.FC = () => {
   const [visible, setVisible] = useState(false);
@@ -24,12 +25,9 @@ const InstallButton: React.FC = () => {
   if (!visible) return null;
 
   return (
-    <button
-      onClick={handleInstall}
-      className="fixed bottom-4 right-4 bg-ubt-blue text-white px-3 py-1 rounded"
-    >
+    <Button onClick={handleInstall} className="fixed bottom-4 right-4">
       Install
-    </button>
+    </Button>
   );
 };
 

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import React from 'react';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+}
+
+const baseClasses =
+  'inline-flex items-center justify-center font-medium rounded transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 min-h-[44px] min-w-[44px] px-4 py-2';
+
+const variantClasses: Record<string, string> = {
+  primary:
+    'bg-[var(--color-accent)] text-white border border-[var(--color-accent)] hover:shadow-[0_0_8px_var(--color-accent)]',
+  secondary:
+    'border border-[var(--color-accent)] text-[var(--color-accent)] hover:shadow-[0_0_8px_var(--color-accent)]',
+};
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = 'primary', className = '', ...props }, ref) => {
+    const classes = `${baseClasses} ${variantClasses[variant]} ${className}`.trim();
+    return <button ref={ref} className={classes} {...props} />;
+  }
+);
+
+Button.displayName = 'Button';
+
+export default Button;


### PR DESCRIPTION
## Summary
- add `Button` component with primary and secondary variants
- use new Button in install prompt, help panel, and GitHub star counter

## Testing
- `npx eslint components/ui/Button.tsx components/InstallButton.tsx components/HelpPanel.tsx components/GitHubStars.js`
- `yarn typecheck`
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c349519d6c8328979f14458879e70f