### PR TITLE
feat: highlight selection and focus for Kali theme

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -77,3 +77,13 @@ html[data-theme='matrix'] {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
+
+html[data-theme='kali'] ::selection {
+  background: var(--color-accent);
+  color: var(--color-inverse);
+}
+
+html[data-theme='kali'] *:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- make selection background use Kali accent color
- outline focus-visible elements with Kali accent

## Testing
- `npx eslint styles/globals.css`
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/niktoPage.test.tsx --silent` *(fails: 2 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c349521c8c8328b85be9a20008ffed