### PR TITLE
feat: add undercover work theme toggle

### DIFF
--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -8,13 +8,21 @@ interface Props {
 }
 
 const QuickSettings = ({ open }: Props) => {
-  const [theme, setTheme] = usePersistentState('qs-theme', 'light');
+  const [theme, setTheme] = usePersistentState<'light' | 'dark' | 'work'>(
+    'qs-theme',
+    'light',
+    (v): v is 'light' | 'dark' | 'work' =>
+      typeof v === 'string' && ['light', 'dark', 'work'].includes(v),
+  );
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
+    const dataTheme =
+      theme === 'work' ? 'undercover' : theme === 'light' ? 'default' : theme;
+    document.documentElement.dataset.theme = dataTheme;
   }, [theme]);
 
   useEffect(() => {
@@ -30,24 +38,39 @@ const QuickSettings = ({ open }: Props) => {
       <div className="px-4 pb-2">
         <button
           className="w-full flex justify-between"
-          onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+          onClick={() =>
+            setTheme(theme === 'light' ? 'dark' : theme === 'dark' ? 'work' : 'light')
+          }
         >
           <span>Theme</span>
-          <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
+          <span>
+            {theme === 'light' ? 'Light' : theme === 'dark' ? 'Dark' : 'Work'}
+          </span>
         </button>
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
+        <input
+          type="checkbox"
+          aria-label="Toggle sound"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+        />
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+        <input
+          type="checkbox"
+          aria-label="Toggle network"
+          checked={online}
+          onChange={() => setOnline(!online)}
+        />
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>
         <input
           type="checkbox"
+          aria-label="Toggle reduced motion"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
         />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -68,6 +68,21 @@ html[data-theme='matrix'] {
 
 }
 
+/* Undercover theme */
+html[data-theme='undercover'] {
+  --color-bg: #f3f4f6;
+  --color-text: #1f2937;
+  --color-primary: #2563eb;
+  --color-secondary: #e5e7eb;
+  --color-accent: #2563eb;
+  --color-muted: #d1d5db;
+  --color-surface: #ffffff;
+  --color-inverse: #ffffff;
+  --color-border: #d1d5db;
+  --color-terminal: #111827;
+  --color-dark: #ffffff;
+}
+
 ::selection {
   background: var(--color-selection);
   color: var(--color-inverse);


### PR DESCRIPTION
## Summary
- enable quick switching between light, dark, and work themes
- define CSS variables for new undercover work theme

## Testing
- `npx eslint components/ui/QuickSettings.tsx styles/globals.css`
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: "Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size", "NmapNSEApp › copies example output to clipboard")*


------
https://chatgpt.com/codex/tasks/task_e_68c34955ff7483289231b79e9dbc1c43