### PR TITLE
style: improve code block rendering

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -502,11 +502,26 @@ dialog {
     background-color: var(--color-accent);
 }
 
-/* Ensure monospace layout for app outputs */
+/* Ensure monospace layout for app outputs and code blocks */
+textarea,
+pre,
+code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+pre,
+code {
+    caret-color: var(--color-accent);
+}
+
 textarea,
 pre {
-    font-family: monospace;
     line-height: 1.2;
+}
+
+pre {
+    overflow-x: auto;
+    max-width: 100%;
 }
 
 /* Visible focus rings for copy buttons and text areas */


### PR DESCRIPTION
## Summary
- ensure code blocks and inline code use a consistent monospace stack and accent-colored caret
- allow long `pre` lines to scroll horizontally instead of expanding layout

## Testing
- `yarn lint styles/index.css` *(fails: A control must be associated with a text label, etc.)*
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/reconng.test.tsx` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c34953c4b883288b16a27cae732a7a