### PR TITLE
test: add axe color contrast check

### DIFF
--- a/tests/axe-color-contrast.spec.ts
+++ b/tests/axe-color-contrast.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+test("homepage has no color-contrast violations in kali theme", async ({
+  page,
+}) => {
+  await page.goto("/?theme=kali");
+  const results = await new AxeBuilder({ page })
+    .withRules("color-contrast")
+    .analyze();
+  expect(results.violations).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary
- add Playwright test that checks home page has no axe color-contrast violations in kali theme

## Testing
- `BASE_URL=https://unnippillil.com npx playwright test tests/axe-color-contrast.spec.ts` *(fails: page.goto net::ERR_CERT_AUTHORITY_INVALID)*

------
https://chatgpt.com/codex/tasks/task_e_68c3495791748328b4f026a8c55a6c5a