### PR TITLE
feat: add landmarks to document and skip link

### DIFF
--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -21,7 +21,14 @@ class MyDocument extends Document {
           <script nonce={nonce} src="/theme.js" />
         </Head>
         <body>
-          <Main />
+          <a href="#main-content" className="sr-only focus:not-sr-only">
+            Skip to content
+          </a>
+          <header />
+          <main id="main-content">
+            <Main />
+          </main>
+          <footer />
           <NextScript nonce={nonce} />
         </body>
       </Html>


### PR DESCRIPTION
## Summary
- ensure _document defines header, main, and footer landmarks
- add skip to content link for first-tab focus

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c34956bee48328952722a256bc08cd