### PR TITLE
Add security attributes to external links

### DIFF
--- a/apps/wireshark/components/PcapViewer.tsx
+++ b/apps/wireshark/components/PcapViewer.tsx
@@ -326,7 +326,7 @@ const PcapViewer: React.FC<PcapViewerProps> = ({ showLegend = true }) => {
         <a
           href="https://wiki.wireshark.org/SampleCaptures"
           target="_blank"
-          rel="noreferrer"
+          rel="noopener noreferrer"
           className="text-xs underline"
         >
           Sample sources

--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -464,7 +464,7 @@ function HashcatApp() {
             className="underline"
             href="https://hashcat.net/wiki/doku.php?id=wordlists"
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
           >
             hashcat.net
           </a>

--- a/components/apps/openvas/feed-status-card.js
+++ b/components/apps/openvas/feed-status-card.js
@@ -14,7 +14,7 @@ const FeedStatusCard = () => {
       <p className="text-sm">VTs: {feed.vtCount.toLocaleString()}</p>
       <p className="text-sm">Last Update: {feed.lastUpdate}</p>
       <p className="text-xs text-gray-400 mt-2">
-        Data based on <a href={feed.docs} className="underline" target="_blank" rel="noreferrer">Greenbone docs</a> (canned demo)
+        Data based on <a href={feed.docs} className="underline" target="_blank" rel="noopener noreferrer">Greenbone docs</a> (canned demo)
       </p>
     </div>
   );

--- a/components/apps/radare2/GuideOverlay.js
+++ b/components/apps/radare2/GuideOverlay.js
@@ -83,7 +83,7 @@ export default function GuideOverlay({ onClose }) {
             href="/demo-data/radare2/tutorial/basic.r2"
             className="underline"
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
           >
             View script
           </a>


### PR DESCRIPTION
## Summary
- ensure Wireshark sample capture link opens safely in a new tab
- harden Radare2 guide overlay and hashcat docs link
- update OpenVAS feed card external doc link with noopener noreferrer

## Testing
- `yarn lint` *(fails: Unexpected global 'document'; Component definition is missing display name)*
- `yarn test` *(fails: window snapping finalize and release releases snap with Alt+ArrowDown restoring size; copies example output to clipboard)*
- `npx -y lighthouse http://localhost:3000 --only-audits=external-anchors-use-rel-noopener --chrome-flags="--headless" --quiet` *(fails: The CHROME_PATH environment variable must be set to a Chrome/Chromium executable)*

------
https://chatgpt.com/codex/tasks/task_e_68c34958041483288911ebbf20c15e8a