### PR TITLE
feat: update portfolio meta tags

### DIFF
--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -7,11 +7,11 @@ export default function Meta() {
     return (
         <Head>
             {/* Primary Meta Tags */}
-             <title>Alex Unnippillil&apos;s Portfolio </title>
+             <title>Alex Unnippillil&apos;s Kali-style Desktop Portfolio</title>
             <meta charSet="utf-8" />
-            <meta name="title" content="Alex Patel Portfolio - Computer Engineering Student" />
+            <meta name="title" content="Alex Unnippillil's Kali-style Desktop Portfolio" />
             <meta name="description"
-                content="Alex Unnippillil Personal Portfolio Website" />
+                content="Explore Alex Unnippillil's Kali-style desktop portfolio showcasing projects and skills." />
             <meta name="author" content="Alex Unnippillil" />
             <meta name="keywords"
                 content="Alex Unnippillil, Unnippillil's portfolio, linux, kali portfolio, alex unnippillil portfolio, alex computer, alex unnippillil, alex linux, alex unnippillil kali portfolio" />
@@ -25,23 +25,23 @@ export default function Meta() {
             {/* Search Engine */}
             <meta name="image" content="images/logos/fevicon.png" />
             {/* Schema.org for Google */}
-            <meta itemProp="name" content="Alex Unnippillil Portfolio " />
+            <meta itemProp="name" content="Alex Unnippillil's Kali-style Desktop Portfolio" />
             <meta itemProp="description"
-                content="Alex Unnippillil Personal Portfolio Website" />
+                content="Explore Alex Unnippillil's Kali-style desktop portfolio showcasing projects and skills." />
             <meta itemProp="image" content="images/logos/fevicon.png" />
             {/* Twitter */}
             <meta name="twitter:card" content="summary" />
-            <meta name="twitter:title" content="Alex Unnippillil Personal Portfolio Website" />
+            <meta name="twitter:title" content="Alex Unnippillil's Kali-style Desktop Portfolio" />
             <meta name="twitter:description"
-                content="Alex Unnippillil Personal Portfolio Website" />
+                content="Explore Alex Unnippillil's Kali-style desktop portfolio showcasing projects and skills." />
             <meta name="twitter:site" content="alexunnippillil" />
             <meta name="twitter:creator" content="unnippillil" />
-            <meta name="twitter:image:src" content="images/logos/logo_1024.png" />
+            <meta name="twitter:image:src" content="https://unnippillil.com/images/hero.png" />
             {/* Open Graph general (Facebook, Pinterest & Google+) */}
-            <meta name="og:title" content="Alex Unnippillil Personal Portfolio Website " />
+            <meta name="og:title" content="Alex Unnippillil's Kali-style Desktop Portfolio" />
             <meta name="og:description"
-                content="Alex Unnippillil Personal Portfolio Website. ." />
-            <meta name="og:image" content="https://unnippillil.com/images/logos/logo_1200.png" />
+                content="Explore Alex Unnippillil's Kali-style desktop portfolio showcasing projects and skills." />
+            <meta name="og:image" content="https://unnippillil.com/images/hero.png" />
             <meta name="og:url" content="https://unnippillil.com/" />
             <meta name="og:site_name" content="Alex Unnippillil Personal Portfolio" />
             <meta name="og:locale" content="en_CA" />


### PR DESCRIPTION
## Summary
- reference Kali-style desktop portfolio in default SEO title and description
- point Open Graph and Twitter images to new hero artwork

## Testing
- `yarn test __tests__/window.test.tsx`
- `yarn lint components/SEO/Meta.js` *(fails: Unexpected global 'document')*

------
https://chatgpt.com/codex/tasks/task_e_68c349586b948328b3eed579347d4a17