### PR TITLE
Add footer trademark attribution for Kali Linux

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,21 @@
+"use client";
+import React from "react";
+
+export default function Footer() {
+  return (
+    <footer className="w-full bg-ub-grey text-ubt-grey text-center text-[14px] p-4">
+      <p>
+        Kali Linux is a trademark of OffSec Services Limited. This site is a personal portfolio and not affiliated with or endorsed by Kali Linux or OffSec.{' '}
+        <a
+          href="https://www.offsec.com/kali-linux/trademark-policy/"
+          className="underline text-ubt-blue"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Trademark policy
+        </a>
+        .
+      </p>
+    </footer>
+  );
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import Footer from '../components/Footer';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -161,6 +162,7 @@ function MyApp(props) {
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />
             <ShortcutOverlay />
+            <Footer />
             <Analytics
               beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;


### PR DESCRIPTION
## Summary
- add global footer with Kali Linux trademark attribution and OffSec policy link
- render footer across pages so text stays at least 14px on mobile

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, reconng.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c349594c948328b321185f61d9f026