### PR TITLE
feat: add compact Kali header

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -6,17 +6,36 @@ import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+        constructor() {
+                super();
+                this.state = {
+                        status_card: false,
+                        compact: false,
+                };
+                this.handleScroll = this.handleScroll.bind(this);
+        }
+
+        componentDidMount() {
+                window.addEventListener('scroll', this.handleScroll, { passive: true });
+                this.handleScroll();
+        }
+
+        componentWillUnmount() {
+                window.removeEventListener('scroll', this.handleScroll);
+        }
+
+        handleScroll() {
+                const isKali = document.documentElement.dataset.theme === 'kali';
+                const compact = isKali && window.scrollY > 8;
+                if (compact !== this.state.compact) {
+                        this.setState({ compact });
+                }
+        }
 
 	render() {
 		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
+                        <div className={`header main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50 ${this.state.compact ? 'header--compact' : ''}`}>
+                                <div className="pl-3 pr-1 header__logo">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
                                 <WhiskerMenu />

--- a/styles/index.css
+++ b/styles/index.css
@@ -40,6 +40,30 @@ button:focus-visible {
 
 /* Top NavBar styling */
 
+.header {
+    height: 48px;
+    transition: height 120ms ease;
+}
+
+.header__logo {
+    transition: transform 120ms ease;
+}
+
+.header--compact {
+    height: 40px;
+}
+
+.header--compact .header__logo {
+    transform: scale(0.85);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .header,
+    .header__logo {
+        transition: none;
+    }
+}
+
 .top-arrow-up {
     border-inline-start: 5px solid transparent;
     border-inline-end: 5px solid transparent;


### PR DESCRIPTION
## Summary
- toggle compact header class on scroll only for the Kali theme
- animate header height and logo with reduced‑motion guard

## Testing
- `npm run lint`
- `npm run build`
- `npm run ping` *(fails: Missing script "ping")*

------
https://chatgpt.com/codex/tasks/task_e_68c34c768f44832899bebc388b2951d5