### PR TITLE
feat: add kali hero break

### DIFF
--- a/src/components/Hero/hero.css
+++ b/src/components/Hero/hero.css
@@ -1,0 +1,25 @@
+.hero-title br {
+  display: none;
+}
+
+[data-theme='kali'] .hero-title br {
+  display: block;
+}
+
+/* Reserve space to avoid layout shift when the theme toggles */
+@media (min-width: 768px) {
+  .hero-title {
+    min-height: calc(2 * 1em * 1.2);
+  }
+}
+
+/* On narrow screens allow natural wrapping and hide forced break */
+@media (max-width: 767px) {
+  .hero-title {
+    white-space: normal;
+    min-height: 0;
+  }
+  [data-theme='kali'] .hero-title br {
+    display: none;
+  }
+}

--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import './hero.css';
+
+/**
+ * Hero heading renders a line break between words when the document theme is `kali`.
+ * The break is only shown on screens `>=768px` to keep natural wrapping on mobile.
+ */
+export default function Hero() {
+  return (
+    <h1 className="hero-title text-4xl font-bold leading-tight md:text-6xl">
+      Kali
+      <br />
+      Linux
+    </h1>
+  );
+}


### PR DESCRIPTION
## Summary
- support line break in Hero heading when `data-theme="kali"`
- add CSS to reserve space and allow mobile wrapping

## Testing
- `npm run lint` *(fails: Unexpected global 'document')*
- `npm run build`
- `npm run ping` *(fails: Missing script "ping")*

------
https://chatgpt.com/codex/tasks/task_e_68c34c796e3c8328be5e33d1ee1d7fd1