### PR TITLE
Centralize Kali URL configuration

### DIFF
--- a/apps/mimikatz/index.tsx
+++ b/apps/mimikatz/index.tsx
@@ -3,8 +3,9 @@
 import React, { useState } from 'react';
 import MimikatzApp from '../../components/apps/mimikatz';
 import ExposureExplainer from './components/ExposureExplainer';
+import { KALI_SITES } from '@/src/config/kaliSites';
 
-const disclaimerUrl = 'https://www.kali.org/docs/policy/disclaimer/';
+const disclaimerUrl = `${KALI_SITES.BASE}/docs/policy/disclaimer/`;
 
 const MimikatzPage: React.FC = () => {
   const [confirmed, setConfirmed] = useState(false);

--- a/components/WorkflowCard.tsx
+++ b/components/WorkflowCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { KALI_SITES } from '@/src/config/kaliSites';
 
 interface Step {
   title: string;
@@ -9,7 +10,7 @@ interface Step {
 const steps: Step[] = [
   {
     title: 'Reconnaissance',
-    link: 'https://www.kali.org/tools/nmap/',
+    link: `${KALI_SITES.BASE}/tools/nmap/`,
     description: 'Discover and map targets.'
   },
   {

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,11 +10,11 @@ const customJestConfig = {
     '^@xterm/xterm/css/xterm.css$': '<rootDir>/__mocks__/styleMock.js',
     '^@/(.*)$': '<rootDir>/$1',
   },
-  testPathIgnorePatterns: [
-    '<rootDir>/playwright/',
-    '<rootDir>/__tests__/playwright/',
-    '<rootDir>/tests/',
-  ],
+    testPathIgnorePatterns: [
+      '<rootDir>/playwright/',
+      '<rootDir>/__tests__/playwright/',
+      '<rootDir>/tests/apps.smoke.spec.ts',
+    ],
 };
 
 module.exports = createJestConfig(customJestConfig);

--- a/pages/security-education.tsx
+++ b/pages/security-education.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import WorkflowCard from '../components/WorkflowCard';
 import { WindowMainScreen } from '../components/base/window';
+import { KALI_SITES } from '@/src/config/kaliSites';
 
 interface FrameProps {
   title: string;
@@ -36,12 +37,12 @@ const SecurityEducation = () => (
         <div className="grid gap-4 p-4 md:grid-cols-2">
           <InfoFrame
             title="What"
-            link="https://www.kali.org/docs/introduction/what-is-kali-linux/"
+            link={`${KALI_SITES.BASE}/docs/introduction/what-is-kali-linux/`}
             description="Overview of Kali Linux and its purpose."
           />
           <InfoFrame
             title="Why"
-            link="https://www.kali.org/docs/introduction/should-i-use-kali-linux/"
+            link={`${KALI_SITES.BASE}/docs/introduction/should-i-use-kali-linux/`}
             description="Reasons to use Kali Linux for authorized security assessments."
           />
           <InfoFrame

--- a/src/config/kaliSites.ts
+++ b/src/config/kaliSites.ts
@@ -1,0 +1,5 @@
+export const KALI_SITES = {
+  BASE: 'https://www.kali.org',
+};
+
+export const allowedDomains = Object.values(KALI_SITES);

--- a/tests/outboundLinks.test.ts
+++ b/tests/outboundLinks.test.ts
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+import fg from 'fast-glob';
+import { allowedDomains } from '@/src/config/kaliSites';
+
+describe('Outbound links', () => {
+  it('uses configured Kali domains only', () => {
+    const root = path.join(__dirname, '..');
+    const files = fg.sync(['**/*.{ts,tsx,js,jsx}', '!node_modules/**', '!src/config/kaliSites.ts'], {
+      cwd: root,
+    });
+    const offenders: string[] = [];
+    const domain = allowedDomains[0];
+    for (const file of files) {
+      const content = fs.readFileSync(path.join(root, file), 'utf8');
+      if (content.includes(domain)) {
+        offenders.push(file);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- centralize Kali domain configuration in `src/config/kaliSites.ts`
- replace hard-coded kali.org links with config references
- add unit test to ensure Kali links come from config

## Testing
- `npm run lint` *(fails: A control must be associated with a text label)*
- `CI=1 npm run build`
- `npm test`
- `npm test tests/outboundLinks.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c34c78e9008328b7733ea4c39663ab