### PR TITLE
Add Kali theme divider utility

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -837,8 +837,12 @@ export class WindowMainScreen extends Component {
         }, 3000);
     }
     render() {
+        const isKali = typeof document !== 'undefined' && document.documentElement.dataset.theme === 'kali';
+        const base = "w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen";
+        const divider = isKali ? " kali-divider overflow-x-hidden" : "";
+        const themeBg = this.state.setDarkBg ? " bg-ub-drk-abrgn " : " bg-ub-cool-grey";
         return (
-            <div className={"w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen" + (this.state.setDarkBg ? " bg-ub-drk-abrgn " : " bg-ub-cool-grey")}>
+            <div className={base + divider + themeBg}>
                 {this.props.screen(this.props.addFolder, this.props.openApp)}
             </div>
         )

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -8,6 +8,7 @@ import '../styles/globals.css';
 import '../styles/index.css';
 import '../styles/resume-print.css';
 import '../styles/print.css';
+import '../src/styles/kali.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';

--- a/src/styles/kali.css
+++ b/src/styles/kali.css
@@ -1,0 +1,9 @@
+/* Kali theme specific utilities */
+
+.kali-divider {
+  /* Create a diagonal cut from top-right to bottom-left */
+  clip-path: polygon(0 0, 100% 0, 100% calc(100% - 2rem), 0% 100%);
+  /* Prevent clipped content from overflowing horizontally */
+  overflow-x: hidden;
+}
+


### PR DESCRIPTION
## Summary
- add `kali-divider` utility with diagonal clip-path
- load Kali CSS globally
- apply divider to window section when Kali theme active

## Testing
- `npm run lint` *(fails: A control must be associated with a text label, Unexpected global 'document', etc)*
- `npm run build`
- `npm run ping` *(fails: Missing script "ping")*

------
https://chatgpt.com/codex/tasks/task_e_68c34c7a5b048328862ca3210aec709c