### PR TITLE
feat: add code block copy utility

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+interface CodeBlockProps {
+  children: string;
+}
+
+export default function CodeBlock({ children }: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(children);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <pre className="p-2">
+        <code>{children}</code>
+      </pre>
+      <button
+        type="button"
+        onClick={copy}
+        className="absolute top-2 right-2 border px-2 py-1 text-xs bg-white"
+        aria-label="Copy code"
+      >
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  );
+}

--- a/src/styles/kali.css
+++ b/src/styles/kali.css
@@ -1,0 +1,10 @@
+pre, code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  line-height: 1.25;
+}
+
+pre {
+  overflow: auto;
+  border: 1px solid #e5e7eb;
+  padding: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- style pre/code elements with monospace fonts and borders
- add CodeBlock component with copy-to-clipboard button

## Testing
- `npm run lint` *(fails: A control must be associated with a text label, etc.)*
- `npm run build`
- `npm test` *(fails: Unable to find role="alert", TypeError: e.preventDefault is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c34c7cba708328abdbd55ebfd528d0