### PR TITLE
feat: add kali theme tokens

### DIFF
--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -61,6 +61,18 @@
   --focus-outline-width: 2px;
 }
 
+[data-theme="kali"] {
+  --kali-surface-0: var(--color-ub-grey);
+  --kali-surface-1: var(--color-ub-cool-grey);
+  --kali-surface-2: var(--color-ub-lite-abrgn);
+  --kali-surface-3: var(--color-ub-dark-grey);
+  --kali-border: var(--color-ub-border-orange);
+  --kali-accent: var(--color-ub-orange);
+  --kali-accent-weak: var(--color-ubt-blue);
+  --kali-text: var(--color-text);
+  --kali-muted: var(--color-ub-warm-grey);
+}
+
 /* High contrast theme */
 .high-contrast {
   --color-bg: #000000;


### PR DESCRIPTION
## Summary
- declare Kali theme CSS variables for surfaces, border, accent, and text colors

## Testing
- `npm run lint` *(fails: many jsx-a11y control-has-associated-label errors)*
- `npm run build` *(terminated after long run without completing)*
- `npm run ping` *(missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c34c7b5c4c83288f99298594c520c9