### PR TITLE
feat: add Kali watermark for hero sections

### DIFF
--- a/public/assets/kali-watermark.svg
+++ b/public/assets/kali-watermark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" fill="none">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="96" font-family="sans-serif" fill="currentColor" fill-opacity="0.05">KALI</text>
+</svg>

--- a/styles/index.css
+++ b/styles/index.css
@@ -530,3 +530,23 @@ textarea:focus-visible {
     color: #000 !important;
 }
 
+
+@media (prefers-contrast: no-more) {
+  html[data-theme='default'] .hero,
+  html[data-theme='default'] .feature,
+  html[data-theme='default'] .features {
+    position: relative;
+  }
+
+  html[data-theme='default'] .hero::before,
+  html[data-theme='default'] .feature::before,
+  html[data-theme='default'] .features::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: url('/assets/kali-watermark.svg') center/60% no-repeat;
+    opacity: 0.05;
+    pointer-events: none;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add SVG watermark asset for Kali theme
- layer watermark behind hero and feature sections when contrast preference is `no-more`

## Testing
- `npx eslint styles/index.css`
- `npx tsc --noEmit` *(failed: no output)*
- `yarn lint` *(failed: hung)*
- `yarn test` *(failed: no log)*

------
https://chatgpt.com/codex/tasks/task_e_68c34c7ae88c83288c37eff1ff48334a