### PR TITLE
feat: add Kali navigation labels and improve focus styles

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import { getNavLabels } from '@/src/config/nav';
 
 type AppMeta = {
   id: string;
@@ -27,6 +28,7 @@ const WhiskerMenu: React.FC = () => {
   const [highlight, setHighlight] = useState(0);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const labels = getNavLabels();
 
   const allApps: AppMeta[] = apps as any;
   const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
@@ -37,7 +39,7 @@ const WhiskerMenu: React.FC = () => {
     } catch {
       return [];
     }
-  }, [allApps, open]);
+  }, [allApps]);
   const utilityApps: AppMeta[] = utilities as any;
   const gameApps: AppMeta[] = games as any;
 
@@ -120,7 +122,7 @@ const WhiskerMenu: React.FC = () => {
         ref={buttonRef}
         type="button"
         onClick={() => setOpen(o => !o)}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        className="pl-3 pr-3 transition duration-100 ease-in-out border-b-2 border-transparent py-1"
       >
         <Image
           src="/themes/Yaru/status/decompiler-symbolic.svg"
@@ -129,7 +131,7 @@ const WhiskerMenu: React.FC = () => {
           height={16}
           className="inline mr-1"
         />
-        Applications
+        {labels.applications}
       </button>
       {open && (
         <div
@@ -155,8 +157,9 @@ const WhiskerMenu: React.FC = () => {
           </div>
           <div className="p-3">
             <input
-              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20"
               placeholder="Search"
+              aria-label="Search applications"
               value={query}
               onChange={e => setQuery(e.target.value)}
               autoFocus

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -4,6 +4,7 @@ import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import { getNavLabels } from '@/src/config/nav';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -13,8 +14,9 @@ export default class Navbar extends Component {
 		};
 	}
 
-	render() {
-		return (
+        render() {
+                const labels = getNavLabels();
+                return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
@@ -22,7 +24,7 @@ export default class Navbar extends Component {
                                 <WhiskerMenu />
                                 <div
                                         className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                                'pl-2 pr-2 text-xs md:text-sm transition duration-100 ease-in-out border-b-2 border-transparent py-1'
                                         }
                                 >
                                         <Clock />
@@ -30,12 +32,12 @@ export default class Navbar extends Component {
                                 <button
                                         type="button"
                                         id="status-bar"
-                                        aria-label="System status"
+                                        aria-label={labels.status}
                                         onClick={() => {
                                                 this.setState({ status_card: !this.state.status_card });
                                         }}
                                         className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
+                                                'relative pr-3 pl-3 transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
                                         }
                                 >
                                         <Status />

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -1,0 +1,23 @@
+export type NavLabelSet = {
+  applications: string;
+  status: string;
+};
+
+const DEFAULT_LABELS: NavLabelSet = {
+  applications: 'Applications',
+  status: 'System status'
+};
+
+const KALI_LABELS: NavLabelSet = {
+  applications: 'Kali Apps',
+  status: 'Kali system status'
+};
+
+export function getNavLabels(theme?: string): NavLabelSet {
+  const currentTheme =
+    theme || (typeof document !== 'undefined' ? document.documentElement.getAttribute('data-theme') : undefined);
+  if (currentTheme === 'kali') {
+    return KALI_LABELS;
+  }
+  return DEFAULT_LABELS;
+}


### PR DESCRIPTION
## Summary
- load Kali-specific navigation labels based on `data-theme`
- apply navigation config in menu and navbar
- expose visible focus styles and labelled search input

## Testing
- `npm run lint` *(fails: Unexpected global 'document', Component definition is missing display name)*
- `npm run build`
- `npm run ping` *(fails: Missing script "ping")*

------
https://chatgpt.com/codex/tasks/task_e_68c34c7763688328b3b4df907b652beb