### PR TITLE
feat: add SHA256 copy button

### DIFF
--- a/src/components/DownloadCard.tsx
+++ b/src/components/DownloadCard.tsx
@@ -1,0 +1,38 @@
+import { useState, useRef, useEffect } from 'react';
+
+export interface DownloadCardProps {
+  sha256: string;
+}
+
+export default function DownloadCard({ sha256 }: DownloadCardProps) {
+  const [copied, setCopied] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(sha256);
+      setCopied(true);
+      timeoutRef.current = setTimeout(() => setCopied(false), 2000);
+    } finally {
+      buttonRef.current?.focus();
+    }
+  }
+
+  return (
+    <div className="download-card">
+      <div className="sha256-line">
+        <span>SHA256: {sha256}</span>
+        <button onClick={handleCopy} ref={buttonRef}>
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add DownloadCard component with SHA256 display and copy-to-clipboard button
- automatically revert copy label and restore focus

## Testing
- `npm run lint` *(fails: Unexpected global 'document' etc.)*
- `npm run build`
- `npm test` *(fails: window snapping test, nmap NSE copy test, modal focus test)*

------
https://chatgpt.com/codex/tasks/task_e_68c34c7fbcf08328b6806a4a26a175e3