### PR TITLE
feat: add release banner

### DIFF
--- a/components/common/ReleaseBanner.tsx
+++ b/components/common/ReleaseBanner.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface BannerData {
+  show: boolean;
+  message: string;
+}
+
+const STORAGE_KEY = 'release-banner-dismissed';
+
+export default function ReleaseBanner() {
+  const [data, setData] = useState<BannerData | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(STORAGE_KEY) === 'true') {
+        setDismissed(true);
+      }
+    } catch {
+      /* ignore */
+    }
+
+    fetch('/release-banner.json')
+      .then((res) => res.json())
+      .then((json) => setData(json))
+      .catch(() => setData(null));
+  }, []);
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    try {
+      localStorage.setItem(STORAGE_KEY, 'true');
+    } catch {
+      /* ignore */
+    }
+  };
+
+  if (!data || !data.show || dismissed) return null;
+
+  return (
+    <div className="bg-ub-yellow text-black p-2 text-xs flex justify-between items-center">
+      <span>{data.message}</span>
+      <button
+        onClick={handleDismiss}
+        className="ml-4 px-2 py-1 bg-ub-grey text-black"
+        type="button"
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import ReleaseBanner from '../components/common/ReleaseBanner';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -156,6 +157,7 @@ function MyApp(props) {
         >
           Skip to app grid
         </a>
+        <ReleaseBanner />
         <SettingsProvider>
           <PipPortalProvider>
             <div aria-live="polite" id="live-region" />

--- a/public/release-banner.json
+++ b/public/release-banner.json
@@ -1,0 +1,4 @@
+{
+  "show": true,
+  "message": "Check out our latest release!"
+}


### PR DESCRIPTION
## Summary
- add release banner component that fetches `/release-banner.json`, shows when enabled, and can be dismissed
- load new component in global app layout
- seed `public/release-banner.json`

## Testing
- `yarn lint` *(fails: Unexpected global 'document' etc., 578 problems)*
- `yarn build` *(fails: terminated after long runtime)*
- `ping -c 1 127.0.0.1`


------
https://chatgpt.com/codex/tasks/task_e_68c34c87221c832896662775ec1f6dfb