### PR TITLE
feat: add Kali-only platform grid

### DIFF
--- a/public/icons/arm.svg
+++ b/public/icons/arm.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 0 0 2.25-2.25V6.75a2.25 2.25 0 0 0-2.25-2.25H6.75A2.25 2.25 0 0 0 4.5 6.75v10.5a2.25 2.25 0 0 0 2.25 2.25Zm.75-12h9v9h-9v-9Z"/>
+</svg>

--- a/public/icons/bare-metal.svg
+++ b/public/icons/bare-metal.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 14.25h13.5m-13.5 0a3 3 0 0 1-3-3m3 3a3 3 0 1 0 0 6h13.5a3 3 0 1 0 0-6m-16.5-3a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3m-19.5 0a4.5 4.5 0 0 1 .9-2.7L5.737 5.1a3.375 3.375 0 0 1 2.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 0 1 .9 2.7m0 0a3 3 0 0 1-3 3m0 3h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Zm-3 6h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Z"/>
+</svg>

--- a/public/icons/cloud.svg
+++ b/public/icons/cloud.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 15a4.5 4.5 0 0 0 4.5 4.5H18a3.75 3.75 0 0 0 1.332-7.257 3 3 0 0 0-3.758-3.848 5.25 5.25 0 0 0-10.233 2.33A4.502 4.502 0 0 0 2.25 15Z"/>
+</svg>

--- a/public/icons/container.svg
+++ b/public/icons/container.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"/>
+</svg>

--- a/public/icons/mobile.svg
+++ b/public/icons/mobile.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 1.5H8.25A2.25 2.25 0 0 0 6 3.75v16.5a2.25 2.25 0 0 0 2.25 2.25h7.5A2.25 2.25 0 0 0 18 20.25V3.75a2.25 2.25 0 0 0-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3"/>
+</svg>

--- a/public/icons/virtual-machine.svg
+++ b/public/icons/virtual-machine.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0V12a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 12V5.25"/>
+</svg>

--- a/public/icons/wsl.svg
+++ b/public/icons/wsl.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M3 8.25V18a2.25 2.25 0 0 0 2.25 2.25h13.5A2.25 2.25 0 0 0 21 18V8.25m-18 0V6a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 6v2.25m-18 0h18M5.25 6h.008v.008H5.25V6ZM7.5 6h.008v.008H7.5V6Zm2.25 0h.008v.008H9.75V6Z"/>
+</svg>

--- a/src/components/PlatformGrid.tsx
+++ b/src/components/PlatformGrid.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import Image from 'next/image';
+import { useTheme } from '@/hooks/useTheme';
+import { kaliTheme } from '@/styles/themes/kali';
+
+interface Platform {
+  key: string;
+  label: string;
+  icon: string;
+}
+
+const PLATFORMS: Platform[] = [
+  { key: 'arm', label: 'ARM', icon: '/icons/arm.svg' },
+  { key: 'bare-metal', label: 'Bare Metal', icon: '/icons/bare-metal.svg' },
+  { key: 'cloud', label: 'Cloud', icon: '/icons/cloud.svg' },
+  { key: 'virtual-machine', label: 'Virtual Machine', icon: '/icons/virtual-machine.svg' },
+  { key: 'wsl', label: 'WSL', icon: '/icons/wsl.svg' },
+  { key: 'mobile', label: 'Mobile', icon: '/icons/mobile.svg' },
+  { key: 'container', label: 'Container', icon: '/icons/container.svg' },
+];
+
+export default function PlatformGrid() {
+  const { theme } = useTheme();
+  if (theme !== 'kali') return null;
+
+  return (
+    <div
+      className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-7 gap-4"
+      style={{ backgroundColor: kaliTheme.background, color: kaliTheme.text }}
+    >
+      {PLATFORMS.map(({ key, label, icon }) => (
+        <div key={key} className="flex flex-col items-center text-center p-2">
+          <Image src={icon} alt={label} width={64} height={64} />
+          <span className="mt-2 text-sm md:text-base">{label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `PlatformGrid` component gated to the Kali theme and using a responsive grid
- include platform badge icons for ARM, bare metal, cloud, virtual machines, WSL, mobile and containers

## Testing
- `yarn test` *(fails: TypeError in window.snap and missing role alert)*
- `yarn lint` *(fails: Unexpected global 'document', missing display name)*
- `yarn typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c34c829a5c8328978e3d7eb95dcad5