### PR TITLE
feat: add segmented theme toggle

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -4,6 +4,7 @@ import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import ThemeToggle from '../../src/components/ThemeToggle';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -41,7 +42,10 @@ export default class Navbar extends Component {
                                         <Status />
                                         <QuickSettings open={this.state.status_card} />
                                 </button>
-			</div>
-		);
-	}
+                                <div className="pr-3">
+                                        <ThemeToggle />
+                                </div>
+                        </div>
+                );
+        }
 }

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
+import ThemeToggle from '../../src/components/ThemeToggle';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
@@ -16,32 +17,37 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => (
-                <button
-                    key={app.id}
-                    type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
-                    onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
-                    />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
-                </button>
-            ))}
+        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center justify-between z-40" role="toolbar">
+            <div className="flex items-center">
+                {runningApps.map(app => (
+                    <button
+                        key={app.id}
+                        type="button"
+                        aria-label={app.title}
+                        data-context="taskbar"
+                        data-app-id={app.id}
+                        onClick={() => handleClick(app)}
+                        className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
+                            'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                    >
+                        <Image
+                            width={24}
+                            height={24}
+                            className="w-5 h-5"
+                            src={app.icon.replace('./', '/')}
+                            alt=""
+                            sizes="24px"
+                        />
+                        <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                        {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
+                            <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
+                        )}
+                    </button>
+                ))}
+            </div>
+            <div className="pr-2">
+                <ThemeToggle />
+            </div>
         </div>
     );
 }

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,20 +2,16 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import ThemeToggle from '../../src/components/ThemeToggle';
 
 interface Props {
   open: boolean;
 }
 
 const QuickSettings = ({ open }: Props) => {
-  const [theme, setTheme] = usePersistentState('qs-theme', 'light');
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
-
-  useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark');
-  }, [theme]);
 
   useEffect(() => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
@@ -28,25 +24,30 @@ const QuickSettings = ({ open }: Props) => {
       }`}
     >
       <div className="px-4 pb-2">
-        <button
-          className="w-full flex justify-between"
-          onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-        >
-          <span>Theme</span>
-          <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
-        </button>
+        <ThemeToggle />
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
+        <input
+          aria-label="Toggle sound"
+          type="checkbox"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+        />
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+        <input
+          aria-label="Toggle network"
+          type="checkbox"
+          checked={online}
+          onChange={() => setOnline(!online)}
+        />
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>
         <input
+          aria-label="Toggle reduced motion"
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useSettings } from '../../hooks/useSettings';
+
+/** Segmented theme toggle with labeled options */
+export default function ThemeToggle() {
+  const { theme, setTheme } = useSettings();
+  const options = [
+    { label: 'Light', value: 'default' },
+    { label: 'Dark', value: 'dark' },
+  ];
+
+  return (
+    <div
+      role="group"
+      aria-label="Theme"
+      className="inline-flex rounded-md border border-ubt-cool-grey overflow-hidden"
+    >
+      {options.map((opt, idx) => (
+        <button
+          key={opt.value}
+          type="button"
+          aria-pressed={theme === opt.value}
+          onClick={() => setTheme(opt.value)}
+          className={`min-w-[44px] min-h-[44px] px-3 py-2 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)] ${
+            theme === opt.value
+              ? 'bg-ubt-grey text-white'
+              : 'bg-ub-cool-grey text-ubt-grey'
+          } ${idx > 0 ? 'border-l border-ubt-cool-grey' : ''}`}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- implement accessible segmented ThemeToggle component
- use ThemeToggle within QuickSettings panel
- surface ThemeToggle in navbar and taskbar for header/footer access

## Testing
- `npx eslint components/screen/navbar.js components/screen/taskbar.js components/ui/QuickSettings.tsx src/components/ThemeToggle.tsx`
- `npx jest src/components/ThemeToggle.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c34c87dbf8832891f6b496c8e0f599