### PR TITLE
Add contrast accessibility test for Kali theme

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testMatch: /.*\.(?:spec|test)\.ts/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/tests/contrast.test.ts
+++ b/tests/contrast.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+const routes = ['/', '/apps'];
+
+for (const route of routes) {
+  test(`kali theme has no AA contrast issues on ${route}`, async ({ page }) => {
+    await page.goto(route);
+    await page.locator('html').evaluate((el) => el.setAttribute('data-theme', 'kali'));
+    const results = await new AxeBuilder({ page })
+      .withRules(['color-contrast'])
+      .withTags(['wcag2aa'])
+      .analyze();
+    expect(results.violations).toHaveLength(0);
+  });
+}


### PR DESCRIPTION
## Summary
- run axe-core contrast checks for pages under Kali theme
- allow Playwright test files ending with .test.ts

## Testing
- `npx eslint tests/contrast.test.ts playwright.config.ts && echo 'lint passed'`
- `yarn build` *(fails: Next.js build was interrupted)*
- `npx playwright test tests/contrast.test.ts` *(fails: missing system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c34c8933c48328bb76720d233f6352