### PR TITLE
Add Work mode theme option with neutral palette

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -23,7 +23,9 @@ describe('theme persistence and unlocking', () => {
 
   test('themes unlock at score milestones', () => {
     const unlocked = getUnlockedThemes(600);
-    expect(unlocked).toEqual(expect.arrayContaining(['default', 'neon', 'dark']));
+    expect(unlocked).toEqual(
+      expect.arrayContaining(['default', 'work', 'neon', 'dark'])
+    );
     expect(unlocked).not.toContain('matrix');
   });
 
@@ -32,6 +34,8 @@ describe('theme persistence and unlocking', () => {
     expect(document.documentElement.classList.contains('dark')).toBe(true);
     setTheme('matrix');
     expect(document.documentElement.classList.contains('dark')).toBe(true);
+    setTheme('work');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
   });
 
   test('updates CSS variables without reload', () => {

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -129,6 +129,7 @@ export default function Settings() {
               className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
             >
               <option value="default">Default</option>
+              <option value="work">Work mode</option>
               <option value="dark">Dark</option>
               <option value="neon">Neon</option>
               <option value="matrix">Matrix</option>

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -6,6 +6,14 @@ interface Props {
   highScore?: number;
 }
 
+const THEME_LABELS: Record<string, string> = {
+  default: 'Default',
+  work: 'Work mode',
+  dark: 'Dark',
+  neon: 'Neon',
+  matrix: 'Matrix',
+};
+
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const unlocked = getUnlockedThemes(highScore);
@@ -27,7 +35,7 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
             >
               {unlocked.map((t) => (
                 <option key={t} value={t}>
-                  {t}
+                  {THEME_LABELS[t] ?? t}
                 </option>
               ))}
             </select>

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -67,6 +67,7 @@ export function Settings() {
                     className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
                 >
                     <option value="default">Default</option>
+                    <option value="work">Work mode</option>
                     <option value="dark">Dark</option>
                     <option value="neon">Neon</option>
                     <option value="matrix">Matrix</option>

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -60,6 +60,7 @@ export default function ThemeSettings() {
           className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
         >
           <option value="default">Default</option>
+          <option value="work">Work mode</option>
           <option value="dark">Dark</option>
           <option value="neon">Neon</option>
           <option value="matrix">Matrix</option>

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -61,6 +61,25 @@
   --focus-outline-width: 2px;
 }
 
+/* Work mode theme */
+html[data-theme='work'] {
+  --color-bg: #f5f5f5;
+  --color-text: #1a1a1a;
+  --color-primary: #4b5563;
+  --color-secondary: #e5e7eb;
+  --color-accent: #2563eb;
+  --color-muted: #d1d5db;
+  --color-surface: #ffffff;
+  --color-inverse: #ffffff;
+  --color-border: #d1d5db;
+  --color-terminal: #1a1a1a;
+  --color-dark: #e5e7eb;
+  --color-focus-ring: var(--color-accent);
+  --color-selection: var(--color-accent);
+  --color-control-accent: var(--color-accent);
+  accent-color: var(--color-control-accent);
+}
+
 /* High contrast theme */
 .high-contrast {
   --color-bg: #000000;

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -3,6 +3,7 @@ export const THEME_KEY = 'app:theme';
 // Score required to unlock each theme
 export const THEME_UNLOCKS: Record<string, number> = {
   default: 0,
+  work: 0,
   neon: 100,
   dark: 500,
   matrix: 1000,


### PR DESCRIPTION
## Summary
- add "Work mode" theme to settings UI and theme unlocks
- define neutral palette for `data-theme="work"`
- cover new theme behaviors in theme persistence tests

## Testing
- ⚠️ `yarn lint` *(failed: Unexpected global 'document' in public/apps/tetris/main.js)*
- ⚠️ `yarn test` *(window.test.tsx and nmapNse.test.tsx failing)*
- ✅ `yarn typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68c34c8aee7c8328b2e2cbbc2645023d