### PR TITLE
feat(terminal): cyan prompt and stable cursor

### DIFF
--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -18,7 +18,17 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
         ...style,
       }}
       {...props}
-    />
+    >
+      {/* Initial styles to avoid flash before xterm.css loads */}
+      <style>{`
+        .xterm .xterm-cursor {
+          animation: none;
+        }
+        .xterm-screen, .xterm-viewport {
+          background: transparent;
+        }
+      `}</style>
+    </div>
   ),
 );
 

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -146,7 +146,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
   contextRef.current.writeLine = writeLine;
 
   const prompt = useCallback(() => {
-    if (termRef.current) termRef.current.write('$ ');
+    if (termRef.current) termRef.current.write('\x1b[36m$ \x1b[0m');
   }, []);
 
   const handleCopy = () => {
@@ -300,7 +300,8 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
       await import('@xterm/xterm/css/xterm.css');
       if (disposed) return;
       const term = new XTerm({
-        cursorBlink: true,
+        cursorBlink: false,
+        cursorStyle: 'block',
         scrollback: 1000,
         cols: 80,
         rows: 24,

--- a/styles/index.css
+++ b/styles/index.css
@@ -170,7 +170,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .xterm .xterm-cursor {
-    animation: cursor-pulse 1s steps(2) infinite;
+    animation: none;
 }
 
 dialog {
@@ -191,17 +191,6 @@ dialog {
     }
 }
 
-@keyframes cursor-pulse {
-    0% { opacity: 1; }
-    50% { opacity: 0.2; }
-    100% { opacity: 1; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .xterm .xterm-cursor {
-        animation: none;
-    }
-}
 
 @keyframes scaleAppImage {
     from {


### PR DESCRIPTION
## Summary
- color terminal prompt cyan
- switch to block cursor with blinking disabled
- add initial CSS to prevent xterm flash

## Testing
- `yarn lint` (fails: Unexpected global 'document')
- `yarn build`
- `ping -c 1 127.0.0.1`


------
https://chatgpt.com/codex/tasks/task_e_68c34c8a56a08328b1ba5a8ee30b60e9