### PR TITLE
feat: add tray popover management

### DIFF
--- a/components/panels/TrayGroup.tsx
+++ b/components/panels/TrayGroup.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import React, { useState, useRef, useEffect, ReactElement } from 'react';
+import { createPortal } from 'react-dom';
+
+interface TrayItem {
+  /** Unique id for the tray button */
+  id: string;
+  /** Button element to render in the tray */
+  button: ReactElement;
+  /** Popover element shown when the tray is active */
+  popover?: ReactElement;
+}
+
+interface TrayGroupProps {
+  items: TrayItem[];
+}
+
+/**
+ * Renders a group of tray buttons and manages their popovers.
+ * Each popover is rendered in a portal and closes on Escape or
+ * when clicking outside of it.
+ */
+const TrayGroup: React.FC<TrayGroupProps> = ({ items }) => {
+  const [openId, setOpenId] = useState<string | null>(null);
+  const buttonRefs = useRef<Record<string, HTMLElement | null>>({});
+  const popoverRefs = useRef<Record<string, HTMLElement | null>>({});
+
+  useEffect(() => {
+    if (!openId) return;
+
+    const handleClick = (e: MouseEvent) => {
+      const btn = buttonRefs.current[openId];
+      const pop = popoverRefs.current[openId];
+      const target = e.target as Node;
+      if (btn?.contains(target) || pop?.contains(target)) return;
+      setOpenId(null);
+    };
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpenId(null);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [openId]);
+
+  const portalTarget = typeof document !== 'undefined' ? document.body : null;
+
+  return (
+    <>
+      <div className="flex items-center">
+        {items.map((item) => (
+          <button
+            key={item.id}
+            ref={(el) => (buttonRefs.current[item.id] = el)}
+            onClick={() => setOpenId(openId === item.id ? null : item.id)}
+            aria-haspopup={item.popover ? 'true' : undefined}
+            aria-expanded={openId === item.id}
+            className="relative"
+          >
+            {item.button}
+          </button>
+        ))}
+      </div>
+      {portalTarget &&
+        items.map((item) => {
+          if (!item.popover || openId !== item.id) return null;
+          return createPortal(
+            <div ref={(el) => (popoverRefs.current[item.id] = el)}>{item.popover}</div>,
+            portalTarget
+          );
+        })}
+    </>
+  );
+};
+
+export default TrayGroup;
+

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,47 +1,34 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import TrayGroup from '../panels/TrayGroup';
 
-export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
-
-	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
-                                </div>
-                                <WhiskerMenu />
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+export default function Navbar() {
+        return (
+                <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                        <div className="pl-3 pr-1">
+                                <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
+                        </div>
+                        <WhiskerMenu />
+                        <div
+                                className={
+                                        'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                }
+                        >
+                                <Clock />
+                        </div>
+                        <TrayGroup
+                                items={[
+                                        {
+                                                id: 'quick-settings',
+                                                button: <Status />,
+                                                popover: <QuickSettings open />
                                         }
-                                >
-                                        <Clock />
-                                </div>
-                                <button
-                                        type="button"
-                                        id="status-bar"
-                                        aria-label="System status"
-                                        onClick={() => {
-                                                this.setState({ status_card: !this.state.status_card });
-                                        }}
-                                        className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-                                        }
-                                >
-                                        <Status />
-                                        <QuickSettings open={this.state.status_card} />
-                                </button>
-			</div>
-		);
-	}
+                                ]}
+                        />
+                </div>
+        );
 }


### PR DESCRIPTION
## Summary
- build TrayGroup component to handle tray buttons and portal popovers
- integrate TrayGroup on navbar for quick settings access

## Testing
- `node_modules/.bin/eslint components/panels/TrayGroup.tsx components/screen/navbar.js`
- `node_modules/.bin/jest components/panels/TrayGroup.tsx components/screen/navbar.js --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c3584d9d648328bbb070d4b4b57760