### PR TITLE
feat: add overlay switcher

### DIFF
--- a/components/overlays/Switcher.tsx
+++ b/components/overlays/Switcher.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+
+interface WindowInfo {
+  id: string;
+  title: string;
+  icon?: string;
+}
+
+interface SwitcherProps {
+  windows: WindowInfo[];
+  onSelect?: (id: string) => void;
+  onClose?: () => void;
+}
+
+export default function Switcher({ windows, onSelect, onClose }: SwitcherProps) {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    setIndex(0);
+  }, [windows]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.repeat) return;
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        const len = windows.length;
+        if (!len) return;
+        const dir = e.shiftKey ? -1 : 1;
+        setIndex((i) => (i + dir + len) % len);
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        const len = windows.length;
+        if (!len) return;
+        setIndex((i) => (i + 1) % len);
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        const len = windows.length;
+        if (!len) return;
+        setIndex((i) => (i - 1 + len) % len);
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose?.();
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (['Alt', 'Meta', 'Control'].includes(e.key)) {
+        const win = windows[index];
+        if (win) {
+          onSelect?.(win.id);
+        } else {
+          onClose?.();
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [windows, index, onSelect, onClose]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 text-white">
+      <div className="flex space-x-4">
+        {windows.map((w, i) => (
+          <div
+            key={w.id}
+            className={`flex flex-col items-center px-3 py-2 rounded ${
+              i === index ? 'bg-ub-orange text-black' : ''
+            }`}
+          >
+            {w.icon && (
+              <img
+                src={w.icon}
+                alt=""
+                className="h-12 w-12 mb-1 object-contain"
+              />
+            )}
+            <span className="text-sm whitespace-nowrap">{w.title}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -13,7 +13,7 @@ import Window from '../base/window';
 import UbuntuApp from '../base/ubuntu_app';
 import AllApplications from '../screen/all-applications'
 import ShortcutSelector from '../screen/shortcut-selector'
-import WindowSwitcher from '../screen/window-switcher'
+import Switcher from '../overlays/Switcher'
 import DesktopMenu from '../context-menus/desktop-menu';
 import DefaultMenu from '../context-menus/default';
 import AppMenu from '../context-menus/app-menu';
@@ -147,6 +147,7 @@ export class Desktop extends Component {
     }
 
     handleGlobalShortcut = (e) => {
+        if (e.repeat) return;
         if (e.altKey && e.key === 'Tab') {
             e.preventDefault();
             if (!this.state.showWindowSwitcher) {
@@ -155,10 +156,6 @@ export class Desktop extends Component {
         } else if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'v') {
             e.preventDefault();
             this.openApp('clipboard-manager');
-        }
-        else if (e.altKey && e.key === 'Tab') {
-            e.preventDefault();
-            this.cycleApps(e.shiftKey ? -1 : 1);
         }
         else if (e.altKey && (e.key === '`' || e.key === '~')) {
             e.preventDefault();
@@ -962,7 +959,7 @@ export class Desktop extends Component {
                         onClose={() => this.setState({ showShortcutSelector: false })} /> : null}
 
                 { this.state.showWindowSwitcher ?
-                    <WindowSwitcher
+                    <Switcher
                         windows={this.state.switcherWindows}
                         onSelect={this.selectWindow}
                         onClose={this.closeWindowSwitcher} /> : null}


### PR DESCRIPTION
## Summary
- add overlay switcher component showing open windows in focus order
- ignore key repeat and close on modifier release
- wire switcher into desktop shortcuts

## Testing
- `yarn test` *(fails: Window snapping finalize and release, nmapNSEApp copies example output to clipboard, ReconNG app stores API keys in localStorage)*

------
https://chatgpt.com/codex/tasks/task_e_68c35852dce88328a55c760561f252a4