### PR TITLE
feat: add window context menu

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -7,6 +7,7 @@ import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
 import styles from './window.module.css';
+import WindowMenu from '../context-menus/window-menu';
 
 export class Window extends Component {
     constructor(props) {
@@ -37,6 +38,7 @@ export class Window extends Component {
         this._usageTimeout = null;
         this._uiExperiments = process.env.NEXT_PUBLIC_UI_EXPERIMENTS === 'true';
         this._menuOpener = null;
+        this.titleBarRef = React.createRef();
     }
 
     componentDidMount() {
@@ -525,40 +527,40 @@ export class Window extends Component {
             this.focusWindow();
         } else if (e.altKey) {
             if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.unsnapWindow();
             } else if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('left');
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('right');
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('top');
             }
             this.focusWindow();
         } else if (e.shiftKey) {
             const step = 1;
             if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ width: Math.max(prev.width - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ width: Math.min(prev.width + step, 100) }), this.resizeBoundries);
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ height: Math.max(prev.height - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ height: Math.min(prev.height + step, 100) }), this.resizeBoundries);
             }
             this.focusWindow();
@@ -645,6 +647,7 @@ export class Window extends Component {
                         {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} />}
                         {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}
                         <WindowTopBar
+                            ref={this.titleBarRef}
                             title={this.props.title}
                             onKeyDown={this.handleTitleBarKeyDown}
                             onBlur={this.releaseGrab}
@@ -666,6 +669,13 @@ export class Window extends Component {
                                 openApp={this.props.openApp} />)}
                     </div>
                 </Draggable >
+                <WindowMenu
+                    targetRef={this.titleBarRef}
+                    onMinimize={this.minimizeWindow}
+                    onMaximize={this.state.maximized ? this.restoreWindow : this.maximizeWindow}
+                    onClose={this.closeWindow}
+                    maximized={this.state.maximized}
+                />
             </>
         )
     }
@@ -674,9 +684,10 @@ export class Window extends Component {
 export default Window
 
 // Window's title bar
-export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
+export const WindowTopBar = React.forwardRef(function WindowTopBar({ title, onKeyDown, onBlur, grabbed }, ref) {
     return (
         <div
+            ref={ref}
             className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
             tabIndex={0}
             role="button"
@@ -687,7 +698,7 @@ export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
             <div className="flex justify-center w-full text-sm font-bold">{title}</div>
         </div>
     )
-}
+});
 
 // Window's Borders
 export class WindowYBorder extends Component {

--- a/components/context-menus/window-menu.tsx
+++ b/components/context-menus/window-menu.tsx
@@ -1,0 +1,154 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+
+interface WindowMenuProps {
+  targetRef: React.RefObject<HTMLElement>;
+  onMinimize: () => void;
+  onMaximize: () => void;
+  onClose: () => void;
+  maximized: boolean;
+}
+
+const WindowMenu: React.FC<WindowMenuProps> = ({
+  targetRef,
+  onMinimize,
+  onMaximize,
+  onClose,
+  maximized,
+}) => {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState({ x: 0, y: 0 });
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useFocusTrap(menuRef as React.RefObject<HTMLElement>, open);
+  useRovingTabIndex(menuRef as React.RefObject<HTMLElement>, open, 'vertical');
+
+  useEffect(() => {
+    const node = targetRef.current;
+    if (!node) return;
+
+    const openMenu = (x: number, y: number) => {
+      setPos({ x, y });
+      setOpen(true);
+      requestAnimationFrame(() => {
+        const menu = menuRef.current;
+        if (!menu) return;
+        const { offsetWidth, offsetHeight } = menu;
+        let newX = x;
+        let newY = y;
+        if (newX + offsetWidth > window.innerWidth) newX = Math.max(0, newX - offsetWidth);
+        if (newY + offsetHeight > window.innerHeight) newY = Math.max(0, newY - offsetHeight);
+        setPos({ x: newX, y: newY });
+      });
+    };
+
+    const handleContextMenu = (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      openMenu(e.pageX, e.pageY);
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.shiftKey && e.key === 'F10') {
+        e.preventDefault();
+        const rect = node.getBoundingClientRect();
+        openMenu(rect.left, rect.bottom);
+      }
+    };
+
+    node.addEventListener('contextmenu', handleContextMenu);
+    node.addEventListener('keydown', handleKeyDown);
+    return () => {
+      node.removeEventListener('contextmenu', handleContextMenu);
+      node.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [targetRef]);
+
+  useEffect(() => {
+    if (open) {
+      window.dispatchEvent(new CustomEvent('context-menu-open'));
+    } else {
+      window.dispatchEvent(new CustomEvent('context-menu-close'));
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open]);
+
+  const handleMinimize = () => {
+    onMinimize();
+    setOpen(false);
+  };
+
+  const handleMaximize = () => {
+    onMaximize();
+    setOpen(false);
+  };
+
+  const handleClose = () => {
+    onClose();
+    setOpen(false);
+  };
+
+  if (!open) return null;
+
+  const menu = (
+    <div
+      role="menu"
+      ref={menuRef}
+      aria-hidden={!open}
+      style={{ left: pos.x, top: pos.y }}
+      className="cursor-default w-40 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm"
+    >
+      <button
+        type="button"
+        role="menuitem"
+        aria-label="Minimize Window"
+        onClick={handleMinimize}
+        className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+      >
+        <span className="ml-5">Minimize</span>
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        aria-label={maximized ? 'Restore Window' : 'Maximize Window'}
+        onClick={handleMaximize}
+        className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+      >
+        <span className="ml-5">{maximized ? 'Restore' : 'Maximize'}</span>
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        aria-label="Close Window"
+        onClick={handleClose}
+        className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+      >
+        <span className="ml-5">Close</span>
+      </button>
+    </div>
+  );
+
+  return createPortal(menu, document.body);
+};
+
+export default WindowMenu;
+


### PR DESCRIPTION
## Summary
- add WindowMenu component to handle title bar context menu actions
- wire up Window component with new menu and keyboard-friendly title bar

## Testing
- `npx eslint components/base/window.js components/context-menus/window-menu.tsx`
- `yarn test __tests__/window.test.tsx`
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c35854f0b8832892434e37541a27c0