### PR TITLE
Track last eight app launches with clearable history

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -27,6 +27,7 @@ const WhiskerMenu: React.FC = () => {
   const [highlight, setHighlight] = useState(0);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const [recentVersion, setRecentVersion] = useState(0);
 
   const allApps: AppMeta[] = apps as any;
   const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
@@ -37,7 +38,7 @@ const WhiskerMenu: React.FC = () => {
     } catch {
       return [];
     }
-  }, [allApps, open]);
+  }, [allApps, open, recentVersion]);
   const utilityApps: AppMeta[] = utilities as any;
   const gameApps: AppMeta[] = games as any;
 
@@ -74,6 +75,11 @@ const WhiskerMenu: React.FC = () => {
   const openSelectedApp = (id: string) => {
     window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
     setOpen(false);
+  };
+
+  const clearRecent = () => {
+    safeLocalStorage?.setItem('recentApps', JSON.stringify([]));
+    setRecentVersion(v => v + 1);
   };
 
   useEffect(() => {
@@ -154,13 +160,24 @@ const WhiskerMenu: React.FC = () => {
             ))}
           </div>
           <div className="p-3">
-            <input
-              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
-              placeholder="Search"
-              value={query}
-              onChange={e => setQuery(e.target.value)}
-              autoFocus
-            />
+            <div className="mb-3 flex items-center">
+              <input
+                className="w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+                placeholder="Search"
+                aria-label="Search applications"
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                autoFocus
+              />
+              {category === 'recent' && recentApps.length > 0 && (
+                <button
+                  className="ml-2 px-2 py-1 text-sm bg-gray-700 rounded"
+                  onClick={clearRecent}
+                >
+                  Clear
+                </button>
+              )}
+            </div>
             <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
               {currentApps.map((app, idx) => (
                 <div key={app.id} className={idx === highlight ? 'ring-2 ring-ubb-orange' : ''}>

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -639,9 +639,10 @@ export class Desktop extends Component {
 
             let recentApps = [];
             try { recentApps = JSON.parse(safeLocalStorage?.getItem('recentApps') || '[]'); } catch (e) { recentApps = []; }
-            recentApps = recentApps.filter(id => id !== objId);
             recentApps.unshift(objId);
-            recentApps = recentApps.slice(0, 10);
+            if (recentApps.length > 8) {
+                recentApps = recentApps.slice(0, 8);
+            }
             safeLocalStorage?.setItem('recentApps', JSON.stringify(recentApps));
 
             setTimeout(() => {
@@ -839,7 +840,7 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                      <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} aria-label="Folder name" />
                 </div>
                 <div className="flex">
                     <button


### PR DESCRIPTION
## Summary
- Maintain a circular buffer of the last eight app launches in `recentApps`
- Expose recent app history in the menu and allow clearing via new button

## Testing
- `yarn eslint components/menu/WhiskerMenu.tsx components/screen/desktop.js` (warned)
- `yarn test` *(fails: TypeError: Cannot read properties of null (reading '_origin'))*

------
https://chatgpt.com/codex/tasks/task_e_68c3585dfd8883288b2520f47b5a89d3