### PR TITLE
feat: apply theme token in quick settings

### DIFF
--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -15,15 +15,16 @@ const QuickSettings = ({ open }: Props) => {
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
+    document.documentElement.setAttribute('data-theme', theme);
   }, [theme]);
 
   useEffect(() => {
-    document.documentElement.classList.toggle('reduce-motion', reduceMotion);
+    document.documentElement.classList.toggle('reduced-motion', reduceMotion);
   }, [reduceMotion]);
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      className={`absolute rounded-md py-4 top-9 right-3 shadow border bg-[var(--color-surface)] text-[var(--color-text)] border-[var(--color-border)] ${
         open ? '' : 'hidden'
       }`}
     >
@@ -37,16 +38,30 @@ const QuickSettings = ({ open }: Props) => {
         </button>
       </div>
       <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
+        <label htmlFor="qs-sound">Sound</label>
+        <input
+          id="qs-sound"
+          aria-label="Sound"
+          type="checkbox"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+        />
       </div>
       <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+        <label htmlFor="qs-network">Network</label>
+        <input
+          id="qs-network"
+          aria-label="Network"
+          type="checkbox"
+          checked={online}
+          onChange={() => setOnline(!online)}
+        />
       </div>
       <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
+        <label htmlFor="qs-reduced-motion">Reduced motion</label>
         <input
+          id="qs-reduced-motion"
+          aria-label="Reduced motion"
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}


### PR DESCRIPTION
## Summary
- set `data-theme` attribute when toggling theme in QuickSettings
- switch panel colors to design tokens for AA contrast
- label QuickSettings checkboxes for accessibility

## Testing
- `yarn lint components/ui/QuickSettings.tsx` *(fails: Unexpected global 'document' ...)*
- `yarn test --passWithNoTests` *(fails: window snapping finalize and release, NmapNSEApp, Modal closes tests)*
- `yarn typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c3586256708328b85cde25aadfe249