### PR TITLE
style: use font-based underline thickness

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,12 @@ body{
     color: var(--color-text);
 }
 
+a {
+    text-decoration-thickness: from-font;
+    text-underline-offset: 0.15em;
+    text-decoration-skip-ink: auto;
+}
+
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
     min-width: var(--hit-area);
     min-height: var(--hit-area);


### PR DESCRIPTION
## Summary
- use `text-decoration-thickness: from-font` for link underlines
- offset and skip ink to prevent layout shift

## Testing
- `npx eslint styles/index.css` (warn: File ignored because no matching configuration was supplied)
- `yarn test styles/index.css --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c35862ca388328bac03ecc7480e262