### PR TITLE
Add cross-browser text selection styles

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,17 @@ body{
     color: var(--color-text);
 }
 
+/* Cross-browser text selection styling */
+::selection {
+    background: var(--color-selection);
+    color: var(--color-inverse);
+}
+
+::-moz-selection {
+    background: var(--color-selection);
+    color: var(--color-inverse);
+}
+
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
     min-width: var(--hit-area);
     min-height: var(--hit-area);


### PR DESCRIPTION
## Summary
- style text selection using CSS vars for Safari, Chromium, and Firefox

## Testing
- `yarn lint` (fails: many jsx-a11y errors)
- `yarn test` (fails: e.preventDefault is not a function in window.test.tsx and NmapNSEApp test missing role="alert")

------
https://chatgpt.com/codex/tasks/task_e_68c35863e3588328a3e9bce785be0734