### PR TITLE
Add dim overlay when window maximized

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -839,7 +839,7 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <input aria-label="New folder name" className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
                 </div>
                 <div className="flex">
                     <button
@@ -876,6 +876,10 @@ export class Desktop extends Component {
                 >
                     {this.renderWindows()}
                 </div>
+
+                {this.state.hideSideBar && (
+                    <div className="desktop-overlay" aria-hidden="true" />
+                )}
 
                 {/* Background Image */}
                 <BackgroundImage />

--- a/styles/index.css
+++ b/styles/index.css
@@ -110,6 +110,14 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     -moz-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
 }
 
+.desktop-overlay {
+    position: absolute;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    pointer-events: none;
+    z-index: 10;
+}
+
 .closed-window {
     animation: closeWindow 200ms 1 forwards;
 }


### PR DESCRIPTION
## Summary
- Dim desktop with overlay when side bar hides after maximizing a window
- Style the overlay to cover the desktop

## Testing
- `npx eslint components/screen/desktop.js styles/index.css`
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/reconng.test.tsx --runInBand --silent` *(fails: 2 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c358665554832882a749a9c4425e58