### PR TITLE
Add releases page listing versions from JSON

### DIFF
--- a/pages/releases.tsx
+++ b/pages/releases.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface Release {
+  title: string;
+  date: string;
+}
+
+export default function Releases() {
+  const [releases, setReleases] = useState<Release[]>([]);
+
+  useEffect(() => {
+    fetch('/data/releases.json')
+      .then((res) => res.json())
+      .then((data: Release[]) => setReleases(data))
+      .catch(() => {
+        /* ignore */
+      });
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-ub-cool-grey text-white p-4">
+      <h1 className="text-2xl font-bold mb-4">Releases</h1>
+      <ul className="space-y-2">
+        {releases.map((r) => (
+          <li key={r.title} className="flex justify-between">
+            <span>{r.title}</span>
+            <span className="text-sm text-gray-400">{r.date}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/public/data/releases.json
+++ b/public/data/releases.json
@@ -1,0 +1,4 @@
+[
+  { "title": "Initial Release", "date": "2024-01-01" },
+  { "title": "Feature Update", "date": "2024-03-15" }
+]


### PR DESCRIPTION
## Summary
- add static releases page listing titles and dates
- store release info in public/data/releases.json

## Testing
- `yarn eslint pages/releases.tsx`
- `yarn test` *(fails: TypeError e.preventDefault is not a function in window.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c3586b4f348328b17938273533fd86