### PR TITLE
feat: add Wordlists card

### DIFF
--- a/__tests__/Wordlists.test.tsx
+++ b/__tests__/Wordlists.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Wordlists from '../components/cards/Wordlists';
+
+describe('Wordlists card', () => {
+  it('links to the official package page', () => {
+    render(<Wordlists />);
+    const link = screen.getByRole('link', { name: /official package page/i });
+    expect(link).toHaveAttribute('href', 'https://www.kali.org/tools/wordlists/');
+  });
+});

--- a/components/cards/Wordlists.tsx
+++ b/components/cards/Wordlists.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const Wordlists: React.FC = () => (
+  <section className="p-4 rounded bg-ub-grey text-white">
+    <h2 className="text-xl font-bold mb-2">Wordlists</h2>
+    <p className="text-sm mb-2">
+      Curated lists of common passwords for cracking and testing.
+    </p>
+    <a
+      href="https://www.kali.org/tools/wordlists/"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-ub-orange underline"
+    >
+      Official package page
+    </a>
+  </section>
+);
+
+export default Wordlists;


### PR DESCRIPTION
## Summary
- add Wordlists card component with link to official Kali package page
- test coverage for Wordlists card link

## Testing
- `npx eslint components/cards/Wordlists.tsx __tests__/Wordlists.test.tsx`
- `yarn test __tests__/Wordlists.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c3586e026c8328a771ed9a2763b6cf