### PR TITLE
Add documentation-style About page

### DIFF
--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import Head from 'next/head';
+import { useTheme } from '../hooks/useTheme';
+import { isDarkTheme } from '../utils/theme';
+import '../styles/docs.css';
+
+export default function AboutPage() {
+  const { theme, setTheme } = useTheme();
+  const toggleTheme = () => {
+    const next = isDarkTheme(theme) ? 'default' : 'dark';
+    setTheme(next);
+  };
+
+  return (
+    <div className="docs-container">
+      <Head>
+        <title>About</title>
+      </Head>
+      <main className="docs-content">
+        <h1>About This Portfolio</h1>
+        <p>
+          This project showcases security-focused modules and experiments inspired by
+          Kali Linux. It aims to provide practical examples and educational
+          resources.
+        </p>
+      </main>
+      <footer className="docs-footer">
+        <button onClick={toggleTheme}>
+          {isDarkTheme(theme) ? 'Switch to Light Theme' : 'Switch to Dark Theme'}
+        </button>
+      </footer>
+    </div>
+  );
+}

--- a/styles/docs.css
+++ b/styles/docs.css
@@ -1,0 +1,41 @@
+.docs-container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  max-width: 65ch;
+  margin: 0 auto;
+  padding: 2rem;
+  line-height: 1.7;
+}
+
+.docs-content {
+  flex: 1;
+}
+
+.docs-content h1 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.docs-content p {
+  margin-bottom: 1rem;
+}
+
+.docs-footer {
+  border-top: 1px solid #e5e7eb;
+  padding-top: 1rem;
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.docs-footer button {
+  padding: 0.5rem 1rem;
+  border: 1px solid currentColor;
+  border-radius: 0.375rem;
+  background: transparent;
+  cursor: pointer;
+}
+
+.dark .docs-footer {
+  border-color: #4b5563;
+}


### PR DESCRIPTION
## Summary
- add about page with documentation-like layout and footer theme toggle
- create docs.css to style documentation pages

## Testing
- `npm test` *(fails: window.test.tsx TypeError e.preventDefault, nmapNse.test.tsx unable to find role="alert", jsdom localStorage error)*

------
https://chatgpt.com/codex/tasks/task_e_68c3586fb52483288607c77c75aa12e2