### PR TITLE
Preserve terminal buffer per tab

### DIFF
--- a/apps/terminal/tabs/index.tsx
+++ b/apps/terminal/tabs/index.tsx
@@ -2,17 +2,37 @@
 
 import React, { useRef } from 'react';
 import TabbedWindow, { TabDefinition } from '../../../components/ui/TabbedWindow';
-import Terminal, { TerminalProps } from '..';
+import Terminal, { TerminalProps, TerminalHandle } from '..';
 
 const TerminalTabs: React.FC<TerminalProps> = ({ openApp }) => {
   const countRef = useRef(1);
+  // Keep a ref to each terminal instance so we can query its content when a tab
+  // is deactivated. We also track a buffer map keyed by tab ID to restore
+  // previous output if the tab is ever re-mounted.
+  const tabRefs = useRef<Record<string, React.RefObject<TerminalHandle>>>({});
+  const buffers = useRef<Record<string, string>>({});
 
   const createTab = (): TabDefinition => {
     const id = Date.now().toString();
+    const ref = React.createRef<TerminalHandle>();
+    tabRefs.current[id] = ref;
     return {
       id,
       title: `Session ${countRef.current++}`,
-      content: <Terminal openApp={openApp} />,
+      content: (
+        <Terminal
+          ref={ref}
+          openApp={openApp}
+          initialContent={buffers.current[id]}
+        />
+      ),
+      onDeactivate: () => {
+        buffers.current[id] = ref.current?.getContent() || '';
+      },
+      onClose: () => {
+        delete tabRefs.current[id];
+        delete buffers.current[id];
+      },
     };
   };
 


### PR DESCRIPTION
## Summary
- track and restore terminal output for each tab
- allow terminal component to accept initial content for buffer restoration

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c3587130ec83288c037f84d5686c0e