### PR TITLE
feat: add terminal theme with blinking cursor

### DIFF
--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -11,6 +11,7 @@ import React, {
 import useOPFS from '../../hooks/useOPFS';
 import commandRegistry, { CommandContext } from './commands';
 import TerminalContainer from './components/Terminal';
+import terminalTheme, { PROMPT } from '../../components/apps/Terminal/theme';
 
 const CopyIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg
@@ -146,7 +147,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
   contextRef.current.writeLine = writeLine;
 
   const prompt = useCallback(() => {
-    if (termRef.current) termRef.current.write('$ ');
+    if (termRef.current) termRef.current.write(PROMPT);
   }, []);
 
   const handleCopy = () => {
@@ -300,7 +301,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
       await import('@xterm/xterm/css/xterm.css');
       if (disposed) return;
       const term = new XTerm({
-        cursorBlink: true,
+        ...terminalTheme,
         scrollback: 1000,
         cols: 80,
         rows: 24,
@@ -407,6 +408,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
           <div className="mt-10 w-80 bg-gray-800 p-4 rounded">
             <input
               autoFocus
+              aria-label="Command palette input"
               className="w-full mb-2 bg-black text-white p-2"
               value={paletteInput}
               onChange={(e) => setPaletteInput(e.target.value)}

--- a/components/apps/Terminal/theme.ts
+++ b/components/apps/Terminal/theme.ts
@@ -1,0 +1,17 @@
+import type { ITerminalOptions } from '@xterm/xterm';
+
+// Styled prompt with ANSI colors: bright green for user/host and path, reset before input
+export const PROMPT = '\x1b[1;32mkali@web:~$\x1b[0m ';
+
+// Terminal theme options, including cursor style and blinking
+const theme: ITerminalOptions = {
+  cursorBlink: true,
+  theme: {
+    background: 'var(--kali-bg)',
+    foreground: '#C5C8C6',
+    cursor: '#C5C8C6',
+    cursorAccent: '#000000',
+  },
+};
+
+export default theme;


### PR DESCRIPTION
## Summary
- add centralized theme for Terminal with colored prompt and blinking cursor
- apply theme in terminal initialization

## Testing
- `npx eslint components/apps/Terminal/theme.ts apps/terminal/index.tsx`
- `npm test __tests__/terminal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c3587185088328be462e329927e766