### PR TITLE
feat: add copy accessibility hints to terminal

### DIFF
--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -11,6 +11,7 @@ import React, {
 import useOPFS from '../../hooks/useOPFS';
 import commandRegistry, { CommandContext } from './commands';
 import TerminalContainer from './components/Terminal';
+import Hints from '../../components/apps/Terminal/Hints';
 
 const CopyIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg
@@ -500,6 +501,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
             <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-4 bg-gradient-to-t from-black" />
           )}
         </div>
+        <Hints />
       </div>
     </div>
   );

--- a/components/apps/Terminal/Hints.tsx
+++ b/components/apps/Terminal/Hints.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Displays keyboard hints for the terminal and announces copy events
+ * for screen reader users via an ARIA live region.
+ */
+export default function Hints() {
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    const handleCopy = () => {
+      setMessage('Copied to clipboard');
+      clearTimeout(timer);
+      timer = setTimeout(() => setMessage(''), 2000);
+    };
+
+    window.addEventListener('copy', handleCopy);
+    return () => {
+      window.removeEventListener('copy', handleCopy);
+      clearTimeout(timer);
+    };
+  }, []);
+
+  return (
+    <div className="p-2 text-xs text-gray-400">
+      <p>
+        Press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> to copy,{' '}
+        <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>V</kbd> to paste.
+      </p>
+      <div aria-live="polite" className="sr-only">
+        {message}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Terminal `Hints` component with keyboard shortcuts and aria-live copy feedback
- render hints in terminal app

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c35872932083289bf93f9779f12e8b