### PR TITLE
style: unify focus outline for interactive elements

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -16,9 +16,9 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
     min-height: var(--hit-area);
 }
 
-a:focus-visible,
-button:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
+/* Consistent focus rings for interactive elements */
+:is(a, button, [role="button"], input, textarea, select, summary, [tabindex]):focus-visible {
+    outline: var(--focus-outline-width) solid var(--color-focus-ring) !important;
     outline-offset: 2px;
 }
 
@@ -507,13 +507,6 @@ textarea,
 pre {
     font-family: monospace;
     line-height: 1.2;
-}
-
-/* Visible focus rings for copy buttons and text areas */
-button:focus-visible,
-textarea:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color);
-    outline-offset: 2px;
 }
 
 /* Enable scroll snapping for gallery containers */


### PR DESCRIPTION
## Summary
- apply a consistent focus ring to links, buttons, inputs and other interactive elements

## Testing
- `yarn lint` *(fails: Unexpected global 'document' and missing display name)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c35875a2388328ab6ec2a6cc71a726