### PR TITLE
feat: add skip links for desktop canvas and dock

### DIFF
--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -21,6 +21,8 @@ class MyDocument extends Document {
           <script nonce={nonce} src="/theme.js" />
         </Head>
         <body>
+          <a href="#desktop" className="skip-link">Skip to desktop canvas</a>
+          <a href="#dock" className="skip-link">Skip to dock</a>
           <Main />
           <NextScript nonce={nonce} />
         </body>

--- a/styles/index.css
+++ b/styles/index.css
@@ -22,6 +22,21 @@ button:focus-visible {
     outline-offset: 2px;
 }
 
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 0;
+    padding: 0.5rem 1rem;
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    z-index: 1000;
+    text-decoration: underline;
+}
+
+.skip-link:focus {
+    top: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after {
         animation-duration: 0.01ms !important;


### PR DESCRIPTION
## Summary
- add top-of-page skip links to reach desktop canvas and dock
- style skip links so they appear when focused via keyboard navigation

## Testing
- `npx eslint pages/_document.jsx styles/index.css`
- `npx jest __tests__/ubuntu.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c35874ea088328bd6d3ad21e1b3bac