### PR TITLE
feat: capture global shortcuts without focus

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -87,13 +87,13 @@ export class Desktop extends Component {
         this.checkForAppShortcuts();
         this.updateTrashIcon();
         window.addEventListener('trash-change', this.updateTrashIcon);
-        document.addEventListener('keydown', this.handleGlobalShortcut);
+        window.addEventListener('keydown', this.handleGlobalShortcut, true);
         window.addEventListener('open-app', this.handleOpenAppEvent);
     }
 
     componentWillUnmount() {
         this.removeContextListeners();
-        document.removeEventListener('keydown', this.handleGlobalShortcut);
+        window.removeEventListener('keydown', this.handleGlobalShortcut, true);
         window.removeEventListener('trash-change', this.updateTrashIcon);
         window.removeEventListener('open-app', this.handleOpenAppEvent);
     }


### PR DESCRIPTION
## Summary
- listen for Alt+Tab and other desktop shortcuts on the `window` to work even when no app window is focused

## Testing
- `yarn test` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size; NmapNSEApp › copies example output to clipboard; modal traps focus, disables background, and restores opener focus)*

------
https://chatgpt.com/codex/tasks/task_e_68c358764738832887cc33a073a82238