### PR TITLE
feat: optimize analytics and preload assets

### DIFF
--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -12,12 +12,28 @@ class MyDocument extends Document {
 
   render() {
     const { nonce } = this.props;
+    const analyticsEnabled =
+      process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true';
     return (
       <Html lang="en" data-csp-nonce={nonce}>
         <Head>
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
+          {analyticsEnabled && (
+            <link
+              rel="preconnect"
+              href="https://vitals.vercel-analytics.com"
+              crossOrigin=""
+            />
+          )}
+          <link rel="preload" as="image" href="/wallpapers/wall-2.webp" />
+          <link
+            rel="preload"
+            as="image"
+            href="/themes/Yaru/status/icons8-kali-linux.svg"
+            type="image/svg+xml"
+          />
           <script nonce={nonce} src="/theme.js" />
         </Head>
         <body>


### PR DESCRIPTION
## Summary
- conditionally preconnect to Vercel Analytics when enabled
- preload hero wallpaper and Kali dragon silhouette assets

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, reconng.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c35878972c8328b29db25e3d4804e0