### PR TITLE
feat: enable lazy loading for images

### DIFF
--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -77,6 +77,8 @@ const BadgeList = ({ badges, className = '' }) => {
                 src={badge.src}
                 alt={badge.alt}
                 title={badge.description || badge.label}
+                loading="lazy"
+                decoding="async"
               />
             </button>
           ))}

--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -130,6 +130,8 @@ const ScrollableTimeline: React.FC = () => {
                         src={first.image}
                         alt={first.title}
                         className="w-full h-32 object-cover mb-2 rounded"
+                        loading="lazy"
+                        decoding="async"
                       />
                       <p className="text-sm md:text-base mb-2">{first.title}</p>
                       {renderTags(first.tags)}
@@ -159,6 +161,8 @@ const ScrollableTimeline: React.FC = () => {
                       src={m.image}
                       alt={m.title}
                       className="w-full h-32 object-cover mb-2 rounded"
+                      loading="lazy"
+                      decoding="async"
                     />
                     <p className="text-sm md:text-base">{m.title}</p>
                   </a>

--- a/components/YouTubePlayer.js
+++ b/components/YouTubePlayer.js
@@ -220,6 +220,7 @@ export default function YouTubePlayer({ videoId }) {
                 src={`https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`}
                 alt="YouTube video thumbnail"
                 loading="lazy"
+                decoding="async"
                 className="absolute inset-0 w-full h-full object-cover"
               />
               <svg

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -20,6 +20,8 @@ export default function LockScreen(props) {
                 src={`/wallpapers/${wallpaper}.webp`}
                 alt=""
                 className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+                loading="lazy"
+                decoding="async"
             />
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
                 <div className=" text-7xl">

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -42,6 +42,8 @@ export default function BackgroundImage() {
                 src={`/wallpapers/${wallpaper}.webp`}
                 alt=""
                 className="w-full h-full object-cover"
+                loading="lazy"
+                decoding="async"
             />
             {needsOverlay && (
                 <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- add async lazy-loading to badge list images
- ensure timeline and background images defer loading
- lazy load lock-screen wallpaper and YouTube previews

## Testing
- `npm run lint` *(fails: Unknown env config)*
- `npm test` *(fails: e.preventDefault is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c3587969148328827d8b04f03416e9