### PR TITLE
feat(terminal): add quake-style global terminal

### DIFF
--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -8,6 +8,7 @@ export interface Shortcut {
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
+  { description: 'Toggle Quake terminal', keys: '`' },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {

--- a/apps/terminal/Quake.tsx
+++ b/apps/terminal/Quake.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import dynamic from 'next/dynamic';
+import useKeymap from '../settings/keymapRegistry';
+
+const Terminal = dynamic(() => import('./index'), { ssr: false });
+
+const formatEvent = (e: KeyboardEvent) => {
+  const parts = [
+    e.ctrlKey ? 'Ctrl' : '',
+    e.altKey ? 'Alt' : '',
+    e.shiftKey ? 'Shift' : '',
+    e.metaKey ? 'Meta' : '',
+    e.key.length === 1 ? e.key : e.key,
+  ];
+  return parts.filter(Boolean).join('+');
+};
+
+const Quake: React.FC = () => {
+  const { shortcuts } = useKeymap();
+  const [open, setOpen] = useState(false);
+  const [height, setHeight] = useState(() => {
+    if (typeof window === 'undefined') return 400;
+    const saved = window.sessionStorage.getItem('quake-height');
+    return saved ? parseInt(saved, 10) : 400;
+  });
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+
+  const toggle = useCallback(() => setOpen((o) => !o), []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable
+      )
+        return;
+      const key =
+        shortcuts.find((s) => s.description === 'Toggle Quake terminal')?.keys ||
+        '`';
+      if (formatEvent(e) === key) {
+        e.preventDefault();
+        toggle();
+      } else if (e.key === 'Escape' && open) {
+        e.preventDefault();
+        setOpen(false);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, toggle, shortcuts]);
+
+  useEffect(() => {
+    if (!open) return;
+    const el = wrapperRef.current?.querySelector(
+      '[data-testid="xterm-container"]',
+    ) as HTMLElement | null;
+    if (!el) return;
+    el.style.height = `${height}px`;
+    const observer = new ResizeObserver((entries) => {
+      const h = Math.round(entries[0].contentRect.height);
+      setHeight(h);
+      try {
+        window.sessionStorage.setItem('quake-height', String(h));
+      } catch {}
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [open, height]);
+
+  return (
+    <div
+      className={`fixed top-0 left-0 right-0 z-50 transform transition-transform duration-300 ${open ? 'translate-y-0' : '-translate-y-full pointer-events-none'}`}
+    >
+      <div ref={wrapperRef} className="mx-auto shadow-lg">
+        {open && <Terminal />}
+      </div>
+    </div>
+  );
+};
+
+export default Quake;
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -12,6 +12,7 @@ import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
+import Quake from '../apps/terminal/Quake';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
@@ -161,6 +162,7 @@ function MyApp(props) {
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />
             <ShortcutOverlay />
+            <Quake />
             <Analytics
               beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;


### PR DESCRIPTION
## Summary
- add Quake-style drop-down terminal toggled with backtick
- store terminal height per session
- expose Quake shortcut in keymap and wire into app layout

## Testing
- `npx eslint apps/terminal/Quake.tsx pages/_app.jsx apps/settings/keymapRegistry.ts`
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/Modal.test.tsx` *(fails: Window snapping finalize and release, NmapNSEApp copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68c37abd34908328ae0d02cb9490c682