### PR TITLE
Add checksum utility app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -72,6 +72,7 @@ const QuoteApp = createDynamicApp('quote', 'Quote');
 const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery');
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
+const ChecksumsApp = createDynamicApp('checksums', 'Checksums');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
@@ -165,6 +166,7 @@ const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
+const displayChecksums = createDisplay(ChecksumsApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 
@@ -266,6 +268,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayInputLab,
+  },
+  {
+    id: 'checksums',
+    title: 'Checksums',
+    icon: '/themes/Yaru/apps/hashcat.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayChecksums,
   },
 ];
 

--- a/apps/checksums/index.css
+++ b/apps/checksums/index.css
@@ -1,0 +1,5 @@
+body { font-family: sans-serif; margin: 1rem; display: flex; flex-direction: column; }
+textarea { width: 100%; margin-bottom: 0.5rem; }
+#input { height: 100px; }
+#output { height: 2.5rem; }
+button { width: fit-content; margin-bottom: 0.5rem; }

--- a/apps/checksums/index.html
+++ b/apps/checksums/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Checksums</title>
+  <link rel="stylesheet" href="index.css">
+</head>
+<body>
+  <h1>Checksums</h1>
+  <textarea id="input" placeholder="Enter text"></textarea>
+  <button id="compute">Compute SHA-256</button>
+  <textarea id="output" readonly placeholder="Hash will appear here"></textarea>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/apps/checksums/main.js
+++ b/apps/checksums/main.js
@@ -1,0 +1,26 @@
+/* eslint-env browser */
+if (isBrowser) {
+  const input = document.getElementById('input');
+  const output = document.getElementById('output');
+  const button = document.getElementById('compute');
+
+  if (!window.crypto?.subtle) {
+    output.value = 'Web Crypto API not supported.';
+    button.disabled = true;
+  } else {
+    button.addEventListener('click', async () => {
+      const encoder = new TextEncoder();
+      const data = encoder.encode(input.value);
+      try {
+        const hashBuffer = await window.crypto.subtle.digest('SHA-256', data);
+        const hashArray = Array.from(new Uint8Array(hashBuffer));
+        const hashHex = hashArray
+          .map((b) => b.toString(16).padStart(2, '0'))
+          .join('');
+        output.value = hashHex;
+      } catch (err) {
+        output.value = 'Error computing hash';
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Build Web Crypto-based SHA-256 checksum app with textarea input and output
- Integrate Checksums utility into app configuration

## Testing
- `npx eslint apps.config.js apps/checksums`
- `npx jest apps/checksums --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c37ac0201483289f384e1e25d244e6