### PR TITLE
feat(home): add release ticker

### DIFF
--- a/components/home/ReleaseTicker.tsx
+++ b/components/home/ReleaseTicker.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import releases from '../../public/data/releases.json';
+
+interface ReleaseEntry {
+  version: string;
+  date: string;
+  notes?: string;
+}
+
+const formatter = new Intl.DateTimeFormat('en-GB', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+});
+
+export default function ReleaseTicker() {
+  const [items, setItems] = useState<ReleaseEntry[]>([]);
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    setItems(releases as ReleaseEntry[]);
+  }, []);
+
+  useEffect(() => {
+    if (!items.length) return;
+    const id = setInterval(() => {
+      setIndex((prev) => (prev + 1) % items.length);
+    }, 5000);
+    return () => clearInterval(id);
+  }, [items]);
+
+  if (!items.length) return null;
+
+  const current = items[index];
+
+  return (
+    <div className="absolute bottom-12 left-1/2 transform -translate-x-1/2 bg-ub-cool-grey bg-opacity-90 text-white text-sm px-4 py-1 rounded shadow">
+      <span className="whitespace-nowrap">
+        {`v${current.version} - ${formatter.format(new Date(current.date))}`}
+      </span>
+    </div>
+  );
+}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -23,6 +23,7 @@ import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { useSnapSetting } from '../../hooks/usePersistentState';
+import ReleaseTicker from '../home/ReleaseTicker';
 
 export class Desktop extends Component {
     constructor() {
@@ -901,6 +902,9 @@ export class Desktop extends Component {
                     openApp={this.openApp}
                     minimize={this.hasMinimised}
                 />
+
+                {/* Release Ticker */}
+                <ReleaseTicker />
 
                 {/* Desktop Apps */}
                 {this.renderDesktopApps()}

--- a/public/data/releases.json
+++ b/public/data/releases.json
@@ -1,0 +1,17 @@
+[
+  {
+    "version": "2.1.0",
+    "date": "2025-09-03",
+    "notes": "Added safe copy script and integrated into build process."
+  },
+  {
+    "version": "2.0.0",
+    "date": "2025-04-18",
+    "notes": "Major upgrade with new features."
+  },
+  {
+    "version": "1.9.0",
+    "date": "2024-12-10",
+    "notes": "Improved performance and bug fixes."
+  }
+]


### PR DESCRIPTION
## Summary
- add ReleaseTicker component to show recent releases
- store release info in static json
- render ticker on desktop home screen

## Testing
- `npx eslint . --max-warnings=0`
- `yarn test` *(fails: Window snapping finalize and release — releases snap with Alt+ArrowDown restoring size; NmapNSEApp copies example output to clipboard; Modal closes when Escape pressed globally)*

------
https://chatgpt.com/codex/tasks/task_e_68c37ac3ecdc8328a8e3f037b599b8b6