### PR TITLE
feat: respect reduced motion preferences

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -29,6 +29,35 @@ button:focus-visible {
         transition-duration: 0.01ms !important;
         scroll-behavior: auto !important;
     }
+
+    .motion-reduce,
+    .animateShow,
+    .closed-window,
+    .scalable-app-icon.scale,
+    .xterm .xterm-cursor,
+    .all-apps-anim,
+    .app-icon-launch,
+    .card,
+    .card.flipped,
+    .animate-deal,
+    .peek,
+    .chip,
+    .chip-pop,
+    .shuffle,
+    .shake,
+    .key-press,
+    .reveal,
+    .tile-pop,
+    .merge-ripple,
+    .score-pop,
+    .hangman-part,
+    .word-found {
+        transition: none !important;
+    }
+
+    .xterm .xterm-cursor {
+        animation: none !important;
+    }
 }
 
 .reduced-motion *, .reduced-motion *::before, .reduced-motion *::after {
@@ -197,11 +226,6 @@ dialog {
     100% { opacity: 1; }
 }
 
-@media (prefers-reduced-motion: reduce) {
-    .xterm .xterm-cursor {
-        animation: none;
-    }
-}
 
 @keyframes scaleAppImage {
     from {
@@ -338,23 +362,6 @@ dialog {
     animation: shuffleDeck 0.5s;
 }
 
-@media (prefers-reduced-motion: reduce) {
-    .card,
-    .chip {
-        transition: none;
-    }
-    .card.flipped {
-        transform: none;
-    }
-    .chip-pop,
-    .animate-deal,
-    .peek,
-    .shuffle {
-        animation: none;
-        transform: none;
-        opacity: 1;
-    }
-}
 
 @keyframes shuffleDeck {
     0% { transform: translateX(0); }


### PR DESCRIPTION
## Summary
- add `motion-reduce` utility to disable transitions when user prefers reduced motion
- ensure all CSS animations respect reduced-motion setting and stop terminal cursor blink

## Testing
- `npx eslint styles/index.css`
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*
- `yarn a11y` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c37ac659788328a2bc383378894d14