### PR TITLE
feat: add theme-color meta for PWA

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <meta name="theme-color" content="#1793d1" media="(prefers-color-scheme: light)" />
+        <meta name="theme-color" content="#bb86fc" media="(prefers-color-scheme: dark)" />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
- add app router layout with theme-color meta tags for light and dark schemes

## Testing
- `npx eslint app/layout.tsx`
- `yarn test app/layout.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c37ac95a6c8328ae7ca51cd7f99bf1