### PR TITLE
feat: track window focus state

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -56,6 +56,13 @@ export class Window extends Component {
         if (this._uiExperiments) {
             this.scheduleUsageCheck();
         }
+        this.updateActiveState(this.props.isFocused);
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.isFocused !== this.props.isFocused) {
+            this.updateActiveState(this.props.isFocused);
+        }
     }
 
     componentWillUnmount() {
@@ -69,6 +76,22 @@ export class Window extends Component {
         if (this._usageTimeout) {
             clearTimeout(this._usageTimeout);
         }
+    }
+
+    updateActiveState = (active) => {
+        const root = document.getElementById(this.id);
+        if (root) {
+            root.setAttribute('data-active', active ? 'true' : 'false');
+        }
+    }
+
+    handleRootFocus = () => {
+        this.updateActiveState(true);
+        this.focusWindow();
+    }
+
+    handleRootBlur = () => {
+        this.updateActiveState(false);
     }
 
     setDefaultWindowDimenstion = () => {
@@ -641,6 +664,8 @@ export class Window extends Component {
                         aria-label={this.props.title}
                         tabIndex={0}
                         onKeyDown={this.handleKeyDown}
+                        onFocus={this.handleRootFocus}
+                        onBlur={this.handleRootBlur}
                     >
                         {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} />}
                         {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}

--- a/styles/index.css
+++ b/styles/index.css
@@ -530,3 +530,13 @@ textarea:focus-visible {
     color: #000 !important;
 }
 
+html[data-theme="kali"] [data-active="true"] {
+    outline: 1px solid var(--win-border-active);
+    box-shadow: var(--win-shadow-1);
+}
+
+html[data-theme="kali"] [data-active="false"] {
+    outline: 1px solid var(--win-border-inactive);
+    box-shadow: none;
+}
+


### PR DESCRIPTION
## Summary
- add data-active attribute toggling to window root
- style active/inactive windows for kali theme

## Testing
- `npm test` *(fails: TypeError e.preventDefault is not a function; Unable to find role="alert"; TypeError: Cannot read properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68c388c41f5483289bdc6ff724eb53e2