### PR TITLE
Use CSS variables for window border radius

### DIFF
--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -116,6 +116,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
             ref={modalRef}
             onKeyDown={handleKeyDown}
             tabIndex={-1}
+            style={{ borderRadius: 'var(--win-radius-tight)' }}
         >
             {children}
         </div>,

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -612,6 +612,16 @@ export class Window extends Component {
     }
 
     render() {
+        const radius = this.props.modal ? 'var(--win-radius-tight)' : 'var(--win-radius)';
+        const style = {
+            width: `${this.state.width}%`,
+            height: `${this.state.height}%`,
+            borderRadius: this.state.maximized ? 0 : radius,
+        };
+        if (!this.props.modal) {
+            style.borderBottomLeftRadius = 0;
+            style.borderBottomRightRadius = 0;
+        }
         return (
             <>
                 {this.state.snapPreview && (
@@ -634,8 +644,8 @@ export class Window extends Component {
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
                 >
                     <div
-                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        style={style}
+                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300" : "") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}
@@ -649,6 +659,7 @@ export class Window extends Component {
                             onKeyDown={this.handleTitleBarKeyDown}
                             onBlur={this.releaseGrab}
                             grabbed={this.state.grabbed}
+                            radius={this.state.maximized ? 0 : radius}
                         />
                         <WindowEditButtons
                             minimize={this.minimizeWindow}
@@ -674,15 +685,16 @@ export class Window extends Component {
 export default Window
 
 // Window's title bar
-export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
+export function WindowTopBar({ title, onKeyDown, onBlur, grabbed, radius }) {
     return (
         <div
-            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
+            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none flex items-center h-11"}
             tabIndex={0}
             role="button"
             aria-grabbed={grabbed}
             onKeyDown={onKeyDown}
             onBlur={onBlur}
+            style={{ borderTopLeftRadius: radius, borderTopRightRadius: radius }}
         >
             <div className="flex justify-center w-full text-sm font-bold">{title}</div>
         </div>

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -45,6 +45,9 @@
   --radius-md: 4px;
   --radius-lg: 8px;
   --radius-round: 9999px;
+  /* Window radius */
+  --win-radius: var(--radius-lg);
+  --win-radius-tight: var(--radius-md);
 
   /* Motion durations */
   --motion-fast: 150ms;


### PR DESCRIPTION
## Summary
- add `--win-radius` and `--win-radius-tight` CSS variables for window corner control
- refactor window component to consume CSS radius variables
- apply tighter radius variable to modal wrapper

## Testing
- `yarn lint components/base/window.js components/base/Modal.tsx styles/tokens.css` *(fails: many existing jsx-a11y/control-has-associated-label errors)*
- `yarn test __tests__/Modal.test.tsx __tests__/window.test.tsx` *(fails: e.preventDefault is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c388c5122c832881097465d7a150cc