### PR TITLE
feat: improve high-contrast window borders

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -110,6 +110,15 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     -moz-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
 }
 
+html[data-theme="kali"][data-contrast="high"] .window-shadow {
+    border-width: 2px;
+    border-top-width: 0;
+    border-color: var(--color-border);
+    box-shadow: none;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+}
+
 .closed-window {
     animation: closeWindow 200ms 1 forwards;
 }


### PR DESCRIPTION
## Summary
- bump window border to 2px and remove shadows in Kali high-contrast mode

## Testing
- `npx eslint styles/index.css` *(warn: File ignored because no matching configuration was supplied)*
- `yarn test styles/index.css` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c388c656488328b0750ca6663d6275