### PR TITLE
feat: highlight active windows

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -637,6 +637,7 @@ export class Window extends Component {
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
                         className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
+                        data-active={this.props.isFocused}
                         role="dialog"
                         aria-label={this.props.title}
                         tabIndex={0}

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -7,3 +7,13 @@
   height: calc(100% + 10px);
   width: calc(100% - 10px);
 }
+
+:global([data-active="true"]::before) {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 2px;
+  width: 100%;
+  background: var(--win-accent);
+}


### PR DESCRIPTION
## Summary
- flag window root with `data-active` and style an accent bar
- add CSS to display `var(--win-accent)` top border for active windows

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c388c50ad483288ae034730328cb8c