### PR TITLE
feat: add window shadow tokens

### DIFF
--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -116,6 +116,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
             ref={modalRef}
             onKeyDown={handleKeyDown}
             tabIndex={-1}
+            className="modal-window"
         >
             {children}
         </div>,

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -635,7 +635,19 @@ export class Window extends Component {
                 >
                     <div
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        className={
+                            this.state.cursorType +
+                            " " +
+                            (this.state.closed ? " closed-window " : "") +
+                            (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") +
+                            (this.props.minimized ? " opacity-0 invisible duration-200 " : "") +
+                            (this.state.grabbed ? " opacity-70 " : "") +
+                            (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") +
+                            (this.props.isFocused
+                                ? " z-30 window-shadow "
+                                : " z-20 inactive-window notFocused ") +
+                            " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute border-black border-opacity-40 border border-t-0 flex flex-col"
+                        }
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}

--- a/styles/index.css
+++ b/styles/index.css
@@ -105,9 +105,21 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .window-shadow {
-    box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -webkit-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -moz-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+    box-shadow: var(--win-shadow-2);
+    -webkit-box-shadow: var(--win-shadow-2);
+    -moz-box-shadow: var(--win-shadow-2);
+}
+
+.inactive-window {
+    box-shadow: var(--win-shadow-1);
+    -webkit-box-shadow: var(--win-shadow-1);
+    -moz-box-shadow: var(--win-shadow-1);
+}
+
+.modal-window {
+    box-shadow: var(--win-shadow-3);
+    -webkit-box-shadow: var(--win-shadow-3);
+    -moz-box-shadow: var(--win-shadow-3);
 }
 
 .closed-window {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -51,6 +51,12 @@
   --motion-medium: 300ms;
   --motion-slow: 500ms;
 
+  /* Window shadows */
+  --win-shadow-0: none;
+  --win-shadow-1: 0 2px 4px color-mix(in srgb, var(--color-inverse), transparent 85%);
+  --win-shadow-2: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+  --win-shadow-3: 2px 8px 20px 6px color-mix(in srgb, var(--color-inverse), transparent 75%);
+
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
   --font-multiplier: 1;


### PR DESCRIPTION
## Summary
- add window shadow tokens to design system
- apply shadow tokens for active, inactive, and modal windows

## Testing
- `npx jest` (fails: window.test.tsx, nmapNse.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68c388c904748328a0487f7a22338b61