### PR TITLE
feat: add kali gradient to window titlebar

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -678,6 +678,15 @@ export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
     return (
         <div
             className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
+            style={
+                typeof document !== "undefined" &&
+                document.documentElement.dataset.theme === "kali"
+                    ? {
+                        backgroundImage:
+                            "repeating-linear-gradient(45deg, rgba(255,255,255,0.05) 0, rgba(255,255,255,0.05) 1px, transparent 1px, transparent 6px)"
+                    }
+                    : undefined
+            }
             tabIndex={0}
             role="button"
             aria-grabbed={grabbed}


### PR DESCRIPTION
## Summary
- add subtle repeating-linear-gradient overlay to window titlebar when using the Kali theme

## Testing
- `npx eslint components/base/window.js`
- `yarn test` *(fails: __tests__/window.test.tsx, __tests__/nmapNse.test.tsx, __tests__/Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c388c7a43c8328b91f02068983a6e0