### PR TITLE
Add focus-visible outlines to window controls

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -755,7 +755,7 @@ export function WindowEditButtons(props) {
             <button
                 type="button"
                 aria-label="Window minimize"
-                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                className={`mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6 ${styles.windowControlButton}`}
                 onClick={props.minimize}
             >
                 <NextImage
@@ -773,7 +773,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window restore"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className={`mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6 ${styles.windowControlButton}`}
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -789,7 +789,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window maximize"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className={`mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6 ${styles.windowControlButton}`}
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -807,7 +807,7 @@ export function WindowEditButtons(props) {
                 type="button"
                 id={`close-${props.id}`}
                 aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
+                className={`mx-1 cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6 ${styles.windowControlButton}`}
                 onClick={props.close}
             >
                 <NextImage

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -7,3 +7,7 @@
   height: calc(100% + 10px);
   width: calc(100% - 10px);
 }
+
+.windowControlButton:focus-visible {
+  outline: 2px solid var(--win-border-focus);
+}


### PR DESCRIPTION
## Summary
- highlight minimize, maximize, and close controls when focused via keyboard
- style window control buttons with a focus-visible outline variable

## Testing
- `yarn lint`
- `yarn test __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c388ca16f48328a3c382b27efea399