### PR TITLE
style: add icon column to window titlebar

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -646,6 +646,7 @@ export class Window extends Component {
                         {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}
                         <WindowTopBar
                             title={this.props.title}
+                            icon={this.props.icon}
                             onKeyDown={this.handleTitleBarKeyDown}
                             onBlur={this.releaseGrab}
                             grabbed={this.state.grabbed}
@@ -674,17 +675,26 @@ export class Window extends Component {
 export default Window
 
 // Window's title bar
-export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
+export function WindowTopBar({ title, icon, onKeyDown, onBlur, grabbed }) {
     return (
         <div
-            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
+            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none grid grid-cols-[24px_1fr] items-center h-11"}
             tabIndex={0}
             role="button"
             aria-grabbed={grabbed}
             onKeyDown={onKeyDown}
             onBlur={onBlur}
         >
-            <div className="flex justify-center w-full text-sm font-bold">{title}</div>
+            {icon && (
+                <NextImage
+                    src={icon}
+                    alt=""
+                    width={24}
+                    height={24}
+                    className="self-center"
+                />
+            )}
+            <div className="text-sm font-bold leading-6">{title}</div>
         </div>
     )
 }

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -463,6 +463,7 @@ export class Desktop extends Component {
                 const props = {
                     title: app.title,
                     id: app.id,
+                    icon: app.icon,
                     screen: app.screen,
                     addFolder: this.addToDesktop,
                     closed: this.closeApp,


### PR DESCRIPTION
## Summary
- convert window title bar to grid with fixed icon column
- forward app icons so windows display them in the title bar

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: e.preventDefault is not a function; Unable to find role="alert")*
- `yarn lint components/base/window.js components/screen/desktop.js` *(fails: 571 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c388cc6acc8328895799684c29c9d8