### PR TITLE
Limit window dragging to empty titlebar areas

### DIFF
--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -20,7 +20,7 @@ export default function Tabs<T extends string>({
   className = "",
 }: TabsProps<T>) {
   return (
-    <div role="tablist" className={`flex ${className}`.trim()}>
+    <div role="tablist" className={`flex ${className}`.trim()} data-drag="true">
       {tabs.map((t) => (
         <button
           key={t.id}
@@ -31,6 +31,7 @@ export default function Tabs<T extends string>({
           className={`px-4 py-2 focus:outline-none ${
             active === t.id ? "bg-ub-orange text-white" : "text-ubt-grey"
           }`}
+          data-drag="false"
         >
           {t.label}
         </button>

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -683,8 +683,9 @@ export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
             aria-grabbed={grabbed}
             onKeyDown={onKeyDown}
             onBlur={onBlur}
+            data-drag="true"
         >
-            <div className="flex justify-center w-full text-sm font-bold">{title}</div>
+            <div className="flex justify-center w-full text-sm font-bold" data-drag="true">{title}</div>
         </div>
     )
 }
@@ -741,6 +742,7 @@ export function WindowEditButtons(props) {
                     aria-label="Window pin"
                     className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
                     onClick={togglePin}
+                    data-drag="false"
                 >
                     <NextImage
                         src="/themes/Yaru/window/window-pin-symbolic.svg"
@@ -757,6 +759,7 @@ export function WindowEditButtons(props) {
                 aria-label="Window minimize"
                 className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
                 onClick={props.minimize}
+                data-drag="false"
             >
                 <NextImage
                     src="/themes/Yaru/window/window-minimize-symbolic.svg"
@@ -775,6 +778,7 @@ export function WindowEditButtons(props) {
                             aria-label="Window restore"
                             className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
                             onClick={props.maximize}
+                            data-drag="false"
                         >
                             <NextImage
                                 src="/themes/Yaru/window/window-restore-symbolic.svg"
@@ -791,6 +795,7 @@ export function WindowEditButtons(props) {
                             aria-label="Window maximize"
                             className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
                             onClick={props.maximize}
+                            data-drag="false"
                         >
                             <NextImage
                                 src="/themes/Yaru/window/window-maximize-symbolic.svg"
@@ -809,6 +814,7 @@ export function WindowEditButtons(props) {
                 aria-label="Window close"
                 className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
                 onClick={props.close}
+                data-drag="false"
             >
                 <NextImage
                     src="/themes/Yaru/window/window-close-symbolic.svg"

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -168,7 +168,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
       tabIndex={0}
       onKeyDown={onKeyDown}
     >
-      <div className="flex flex-shrink-0 bg-gray-800 text-white text-sm overflow-x-auto">
+      <div className="flex flex-shrink-0 bg-gray-800 text-white text-sm overflow-x-auto" data-drag="true">
         {tabs.map((t, i) => (
           <div
             key={t.id}
@@ -180,6 +180,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
             onDragOver={handleDragOver(i)}
             onDrop={handleDrop(i)}
             onClick={() => setActive(t.id)}
+            data-drag="false"
           >
             <span className="max-w-[150px]">{middleEllipsis(t.title)}</span>
             {t.closable !== false && tabs.length > 1 && (
@@ -190,6 +191,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
                   closeTab(t.id);
                 }}
                 aria-label="Close Tab"
+                data-drag="false"
               >
                 ×
               </button>
@@ -201,6 +203,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
             className="px-2 py-1 bg-gray-800 hover:bg-gray-700"
             onClick={addTab}
             aria-label="New Tab"
+            data-drag="false"
           >
             +
           </button>


### PR DESCRIPTION
## Summary
- allow dragging from title text and blank titlebar gaps
- prevent dragging when interacting with window controls and tab buttons

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js; Component definition missing display name in utils/createDynamicApp.js)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c388ccaf688328910d654d3e0cd26c