### PR TITLE
feat: add Kali dots to window titlebar

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -675,6 +675,9 @@ export default Window
 
 // Window's title bar
 export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
+    const showKaliDots =
+        typeof document !== "undefined" &&
+        document.documentElement.dataset.appearance === "kali";
     return (
         <div
             className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
@@ -684,6 +687,20 @@ export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
             onKeyDown={onKeyDown}
             onBlur={onBlur}
         >
+            {showKaliDots && (
+                <svg
+                    width="18"
+                    height="4"
+                    viewBox="0 0 18 4"
+                    className="absolute left-3 top-1/2 -translate-y-1/2 kali-titlebar-dots"
+                    aria-hidden="true"
+                    focusable="false"
+                >
+                    <circle cx="2" cy="2" r="2" fill="currentColor" />
+                    <circle cx="9" cy="2" r="2" fill="currentColor" />
+                    <circle cx="16" cy="2" r="2" fill="currentColor" />
+                </svg>
+            )}
             <div className="flex justify-center w-full text-sm font-bold">{title}</div>
         </div>
     )

--- a/styles/index.css
+++ b/styles/index.css
@@ -530,3 +530,14 @@ textarea:focus-visible {
     color: #000 !important;
 }
 
+/* Hide Kali titlebar dots in high contrast modes */
+.high-contrast .kali-titlebar-dots {
+    display: none;
+}
+
+@media (prefers-contrast: more), (forced-colors: active) {
+    .kali-titlebar-dots {
+        display: none;
+    }
+}
+


### PR DESCRIPTION
## Summary
- show a three-dot SVG at the start of window titlebars when appearance is set to Kali
- hide Kali titlebar dots in high contrast modes

## Testing
- `npx eslint components/base/window.js styles/index.css`
- `yarn test` *(fails: TypeError: e.preventDefault is not a function; Unable to find role="alert"; Cannot read properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68c388cfdfdc8328833983f0d4c74138