### PR TITLE
Adjust window title colors based on focus state

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -677,7 +677,7 @@ export default Window
 export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
     return (
         <div
-            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
+            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 w-full select-none rounded-b-none flex items-center h-11"}
             tabIndex={0}
             role="button"
             aria-grabbed={grabbed}

--- a/styles/index.css
+++ b/styles/index.css
@@ -93,8 +93,13 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     position: relative;
 }
 
-.notFocused {
-    filter: brightness(90%);
+/* Window focus state */
+.bg-ub-window-title {
+    color: var(--kali-text);
+}
+
+.notFocused .bg-ub-window-title {
+    color: var(--kali-muted);
 }
 
 .root,


### PR DESCRIPTION
## Summary
- remove brightness filter on unfocused windows and style title bar text to use theme variables
- drop hardcoded white title text so inactive windows appear muted

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: window snapping finalize and release test)*

------
https://chatgpt.com/codex/tasks/task_e_68c388d072088328a8c6f9c172f4d4b3