### PR TITLE
Add keyboard controls for window snap preview

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -160,6 +160,86 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.height).toBe(96.3);
   });
 
+  it('snaps window with Enter key when preview is visible', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 5,
+      top: 10,
+      right: 105,
+      bottom: 110,
+      width: 100,
+      height: 100,
+      x: 5,
+      y: 10,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+    act(() => {
+      ref.current!.handleKeyDown({ key: 'Enter', preventDefault() {}, stopPropagation() {} } as any);
+    });
+
+    expect(ref.current!.state.snapped).toBe('left');
+  });
+
+  it('cancels snap preview with Escape key', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 5,
+      top: 10,
+      right: 105,
+      bottom: 110,
+      width: 100,
+      height: 100,
+      x: 5,
+      y: 10,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+    act(() => {
+      ref.current!.handleKeyDown({ key: 'Escape', preventDefault() {}, stopPropagation() {} } as any);
+    });
+
+    expect(ref.current!.state.snapPreview).toBeNull();
+    expect(ref.current!.state.snapPosition).toBeNull();
+    expect(ref.current!.state.snapped).toBeNull();
+  });
+
   it('releases snap with Alt+ArrowDown restoring size', () => {
     const ref = React.createRef<Window>();
     render(
@@ -199,7 +279,7 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true, preventDefault() {}, stopPropagation() {} } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -519,6 +519,19 @@ export class Window extends Component {
     }
 
     handleKeyDown = (e) => {
+        if (this.state.snapPosition) {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.handleStop();
+                return;
+            } else if (e.key === 'Escape') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.setState({ snapPreview: null, snapPosition: null });
+                return;
+            }
+        }
         if (e.key === 'Escape') {
             this.closeWindow();
         } else if (e.key === 'Tab') {


### PR DESCRIPTION
## Summary
- allow pressing Enter to confirm snapping when preview is shown
- allow pressing Escape to cancel the snap preview without snapping
- test keyboard snap confirmation and cancellation

## Testing
- `yarn test __tests__/window.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c388d46b0c8328aa8f7eaf90af36f8