### PR TITLE
feat: snap move and resize to 4 or 8px grid

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -201,8 +201,8 @@ export class Window extends Component {
     }
 
     snapToGrid = (value) => {
-        if (!this.props.snapEnabled) return value;
-        return Math.round(value / 8) * 8;
+        const grid = this.props.snapEnabled ? 8 : 4;
+        return Math.round(value / grid) * grid;
     }
 
     handleVerticleResize = () => {
@@ -371,6 +371,7 @@ export class Window extends Component {
         if (snapPos) {
             this.snapWindow(snapPos);
         } else {
+            this.setWinowsPosition();
             this.setState({ snapPreview: null, snapPosition: null });
         }
     }
@@ -624,7 +625,7 @@ export class Window extends Component {
                 <Draggable
                     axis="both"
                     handle=".bg-ub-window-title"
-                    grid={this.props.snapEnabled ? [8, 8] : [1, 1]}
+                    grid={[this.props.snapEnabled ? 8 : 4, this.props.snapEnabled ? 8 : 4]}
                     scale={1}
                     onStart={this.changeCursorToMove}
                     onStop={this.handleStop}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -491,9 +491,8 @@ export class Desktop extends Component {
     }
 
     updateWindowPosition = (id, x, y) => {
-        const snap = this.props.snapEnabled
-            ? (v) => Math.round(v / 8) * 8
-            : (v) => v;
+        const grid = this.props.snapEnabled ? 8 : 4;
+        const snap = (v) => Math.round(v / grid) * grid;
         this.setState(prev => ({
             window_positions: { ...prev.window_positions, [id]: { x: snap(x), y: snap(y) } }
         }), this.saveSession);


### PR DESCRIPTION
## Summary
- snap window movement and resizing to 4px or 8px grid
- ensure window position finalizes on drag stop
- persist snapped positions using configurable grid size

## Testing
- `npm test` *(fails: Window snapping finalize and release, NmapNSEApp copies example output to clipboard, jsdom localStorage error)*

------
https://chatgpt.com/codex/tasks/task_e_68c388d680948328b5391c3273afae33