### PR TITLE
Clamp window position within safe viewport bounds

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,6 +20,12 @@
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   accent-color: var(--color-control-accent);
+
+  /* Safe area insets */
+  --sat: env(safe-area-inset-top);
+  --sar: env(safe-area-inset-right);
+  --sab: env(safe-area-inset-bottom);
+  --sal: env(safe-area-inset-left);
 }
 
 /* Dark theme */


### PR DESCRIPTION
## Summary
- expose safe-area insets via CSS variables
- clamp window transforms after drag or resize using dock and safe-area insets
- ensure drag edge resistance and bounds respect insets

## Testing
- `yarn test __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c388d7a0048328b73ad74f40eeb3a9