### PR TITLE
Respect reduced motion for width/height transitions

### DIFF
--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -627,7 +627,9 @@ export default function Todoist() {
           </button>
         </div>
         <div
-          className={`transition-[max-height] duration-300 overflow-hidden px-2 ${isEditing ? 'max-h-20' : 'max-h-0'}`}
+          className={`overflow-hidden px-2 ${
+            !prefersReducedMotion.current ? 'transition-[max-height] duration-300' : ''
+          } ${isEditing ? 'max-h-20' : 'max-h-0'}`}
         >
           {isEditing && (
             <input

--- a/styles/index.css
+++ b/styles/index.css
@@ -27,6 +27,7 @@ button:focus-visible {
         animation-duration: 0.01ms !important;
         animation-iteration-count: 1 !important;
         transition-duration: 0.01ms !important;
+        transition-property: opacity, background-color, color, border-color, text-decoration-color, fill, stroke, box-shadow, transform !important;
         scroll-behavior: auto !important;
     }
 }
@@ -35,6 +36,7 @@ button:focus-visible {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+    transition-property: opacity, background-color, color, border-color, text-decoration-color, fill, stroke, box-shadow, transform !important;
     scroll-behavior: auto !important;
 }
 


### PR DESCRIPTION
## Summary
- Restrict transitions under `prefers-reduced-motion` to non-size properties
- Avoid Todoist task editor height animations when reduced motion is enabled

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, reconng.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c388d9486c8328ada5f3aa72aa1f00