### PR TITLE
feat: cycle snap widths for editor-sidecar layouts

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -199,7 +199,7 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true, preventDefault() {}, stopPropagation() {} } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();
@@ -252,6 +252,53 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBeNull();
     expect(ref.current!.state.width).toBe(60);
     expect(ref.current!.state.height).toBe(85);
+  });
+
+  it('cycles snap widths for left and right positions', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    act(() => {
+      ref.current!.handleKeyDown({ key: 'ArrowLeft', altKey: true, preventDefault() {}, stopPropagation() {} } as any);
+    });
+    expect(ref.current!.state.width).toBe(50);
+
+    act(() => {
+      ref.current!.handleKeyDown({ key: 'ArrowLeft', altKey: true, preventDefault() {}, stopPropagation() {} } as any);
+    });
+    expect(ref.current!.state.width).toBe(62);
+
+    act(() => {
+      ref.current!.handleKeyDown({ key: 'ArrowLeft', altKey: true, preventDefault() {}, stopPropagation() {} } as any);
+    });
+    expect(ref.current!.state.width).toBe(50);
+
+    act(() => {
+      ref.current!.handleKeyDown({ key: 'ArrowRight', altKey: true, preventDefault() {}, stopPropagation() {} } as any);
+    });
+    expect(ref.current!.state.width).toBe(50);
+
+    act(() => {
+      ref.current!.handleKeyDown({ key: 'ArrowRight', altKey: true, preventDefault() {}, stopPropagation() {} } as any);
+    });
+    expect(ref.current!.state.width).toBe(38);
+
+    act(() => {
+      ref.current!.handleKeyDown({ key: 'ArrowRight', altKey: true, preventDefault() {}, stopPropagation() {} } as any);
+    });
+    expect(ref.current!.state.width).toBe(50);
   });
 });
 

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -255,39 +255,6 @@ export class Window extends Component {
         }
     }
 
-    snapWindow = (position) => {
-        this.setWinowsPosition();
-        const { width, height } = this.state;
-        let newWidth = width;
-        let newHeight = height;
-        let transform = '';
-        if (position === 'left') {
-            newWidth = 50;
-            newHeight = 96.3;
-            transform = 'translate(-1pt,-2pt)';
-        } else if (position === 'right') {
-            newWidth = 50;
-            newHeight = 96.3;
-            transform = `translate(${window.innerWidth / 2}px,-2pt)`;
-        } else if (position === 'top') {
-            newWidth = 100.2;
-            newHeight = 50;
-            transform = 'translate(-1pt,-2pt)';
-        }
-        const r = document.querySelector("#" + this.id);
-        if (r && transform) {
-            r.style.transform = transform;
-        }
-        this.setState({
-            snapPreview: null,
-            snapPosition: null,
-            snapped: position,
-            lastSize: { width, height },
-            width: newWidth,
-            height: newHeight
-        }, this.resizeBoundries);
-    }
-
     checkOverlap = () => {
         var r = document.querySelector("#" + this.id);
         var rect = r.getBoundingClientRect();
@@ -568,11 +535,9 @@ export class Window extends Component {
     handleSuperArrow = (e) => {
         const key = e.detail;
         if (key === 'ArrowLeft') {
-            if (this.state.snapped === 'left') this.unsnapWindow();
-            else this.snapWindow('left');
+            this.snapWindow('left');
         } else if (key === 'ArrowRight') {
-            if (this.state.snapped === 'right') this.unsnapWindow();
-            else this.snapWindow('right');
+            this.snapWindow('right');
         } else if (key === 'ArrowUp') {
             this.maximizeWindow();
         } else if (key === 'ArrowDown') {
@@ -586,26 +551,38 @@ export class Window extends Component {
 
     snapWindow = (pos) => {
         this.focusWindow();
-        const { width, height } = this.state;
+        this.setWinowsPosition();
+        const { width, height, snapped, lastSize } = this.state;
         let newWidth = width;
         let newHeight = height;
         let transform = '';
         if (pos === 'left') {
-            newWidth = 50;
+            const cycle = [50, 62];
+            const idx = snapped === 'left' ? cycle.indexOf(width) : -1;
+            newWidth = cycle[(idx + 1) % cycle.length];
             newHeight = 96.3;
             transform = 'translate(-1pt,-2pt)';
         } else if (pos === 'right') {
-            newWidth = 50;
+            const cycle = [50, 38];
+            const idx = snapped === 'right' ? cycle.indexOf(width) : -1;
+            newWidth = cycle[(idx + 1) % cycle.length];
             newHeight = 96.3;
-            transform = `translate(${window.innerWidth / 2}px,-2pt)`;
+            const offset = window.innerWidth * ((100 - newWidth) / 100);
+            transform = `translate(${offset}px,-2pt)`;
+        } else if (pos === 'top') {
+            newWidth = 100.2;
+            newHeight = 50;
+            transform = 'translate(-1pt,-2pt)';
         }
         const node = document.getElementById(this.id);
         if (node && transform) {
             node.style.transform = transform;
         }
         this.setState({
+            snapPreview: null,
+            snapPosition: null,
             snapped: pos,
-            lastSize: { width, height },
+            lastSize: snapped ? lastSize : { width, height },
             width: newWidth,
             height: newHeight
         }, this.resizeBoundries);


### PR DESCRIPTION
## Summary
- add snap width cycling between 50/50 and 62/38
- streamline super+arrow behavior to always snap
- test snap width cycling

## Testing
- `yarn test __tests__/window.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c388db66d483289f94022f0a6e6599