### PR TITLE
Add corner snapping and Super+Arrow support

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -63,13 +63,13 @@ describe('Window snapping preview', () => {
     // Simulate being near the left edge
     winEl.getBoundingClientRect = () => ({
       left: 5,
-      top: 10,
+      top: 50,
       right: 105,
-      bottom: 110,
+      bottom: 150,
       width: 100,
       height: 100,
       x: 5,
-      y: 10,
+      y: 50,
       toJSON: () => {}
     });
 
@@ -138,13 +138,13 @@ describe('Window snapping finalize and release', () => {
     const winEl = document.getElementById('test-window')!;
     winEl.getBoundingClientRect = () => ({
       left: 5,
-      top: 10,
+      top: 50,
       right: 105,
-      bottom: 110,
+      bottom: 150,
       width: 100,
       height: 100,
       x: 5,
-      y: 10,
+      y: 50,
       toJSON: () => {}
     });
 
@@ -158,6 +158,47 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
     expect(ref.current!.state.width).toBe(50);
     expect(ref.current!.state.height).toBe(96.3);
+  });
+
+  it('snaps window on drag stop near top-left corner', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 5,
+      top: 5,
+      right: 105,
+      bottom: 105,
+      width: 100,
+      height: 100,
+      x: 5,
+      y: 5,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+    act(() => {
+      ref.current!.handleStop();
+    });
+
+    expect(ref.current!.state.snapped).toBe('top-left');
+    expect(ref.current!.state.width).toBe(50);
+    expect(ref.current!.state.height).toBeCloseTo(48.1);
   });
 
   it('releases snap with Alt+ArrowDown restoring size', () => {
@@ -179,13 +220,13 @@ describe('Window snapping finalize and release', () => {
     const winEl = document.getElementById('test-window')!;
     winEl.getBoundingClientRect = () => ({
       left: 5,
-      top: 10,
+      top: 50,
       right: 105,
-      bottom: 110,
+      bottom: 150,
       width: 100,
       height: 100,
       x: 5,
-      y: 10,
+      y: 50,
       toJSON: () => {}
     });
 
@@ -199,7 +240,7 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true, preventDefault() {}, stopPropagation() {} } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();
@@ -226,13 +267,13 @@ describe('Window snapping finalize and release', () => {
     const winEl = document.getElementById('test-window')!;
     winEl.getBoundingClientRect = () => ({
       left: 5,
-      top: 10,
+      top: 50,
       right: 105,
-      bottom: 110,
+      bottom: 150,
       width: 100,
       height: 100,
       x: 5,
-      y: 10,
+      y: 50,
       toJSON: () => {}
     });
 
@@ -252,6 +293,43 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBeNull();
     expect(ref.current!.state.width).toBe(60);
     expect(ref.current!.state.height).toBe(85);
+  });
+});
+
+describe('Window Super+Arrow snapping', () => {
+  it('snaps to corners using Super+Arrow keys', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    act(() => {
+      ref.current!.handleSuperArrow({ detail: 'ArrowLeft' } as any);
+    });
+    act(() => {
+      ref.current!.handleSuperArrow({ detail: 'ArrowUp' } as any);
+    });
+
+    expect(ref.current!.state.snapped).toBe('top-left');
+
+    act(() => {
+      ref.current!.handleSuperArrow({ detail: 'ArrowRight' } as any);
+    });
+    act(() => {
+      ref.current!.handleSuperArrow({ detail: 'ArrowDown' } as any);
+    });
+
+    expect(ref.current!.state.snapped).toBe('bottom-right');
   });
 });
 

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -255,39 +255,6 @@ export class Window extends Component {
         }
     }
 
-    snapWindow = (position) => {
-        this.setWinowsPosition();
-        const { width, height } = this.state;
-        let newWidth = width;
-        let newHeight = height;
-        let transform = '';
-        if (position === 'left') {
-            newWidth = 50;
-            newHeight = 96.3;
-            transform = 'translate(-1pt,-2pt)';
-        } else if (position === 'right') {
-            newWidth = 50;
-            newHeight = 96.3;
-            transform = `translate(${window.innerWidth / 2}px,-2pt)`;
-        } else if (position === 'top') {
-            newWidth = 100.2;
-            newHeight = 50;
-            transform = 'translate(-1pt,-2pt)';
-        }
-        const r = document.querySelector("#" + this.id);
-        if (r && transform) {
-            r.style.transform = transform;
-        }
-        this.setState({
-            snapPreview: null,
-            snapPosition: null,
-            snapped: position,
-            lastSize: { width, height },
-            width: newWidth,
-            height: newHeight
-        }, this.resizeBoundries);
-    }
-
     checkOverlap = () => {
         var r = document.querySelector("#" + this.id);
         var rect = r.getBoundingClientRect();
@@ -319,7 +286,23 @@ export class Window extends Component {
         var rect = r.getBoundingClientRect();
         const threshold = 30;
         let snap = null;
-        if (rect.left <= threshold) {
+        if (rect.left <= threshold && rect.top <= threshold) {
+            snap = { left: '0', top: '0', width: '50%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'top-left' });
+        }
+        else if (rect.right >= window.innerWidth - threshold && rect.top <= threshold) {
+            snap = { left: '50%', top: '0', width: '50%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'top-right' });
+        }
+        else if (rect.left <= threshold && rect.bottom >= window.innerHeight - threshold) {
+            snap = { left: '0', top: '50%', width: '50%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'bottom-left' });
+        }
+        else if (rect.right >= window.innerWidth - threshold && rect.bottom >= window.innerHeight - threshold) {
+            snap = { left: '50%', top: '50%', width: '50%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'bottom-right' });
+        }
+        else if (rect.left <= threshold) {
             snap = { left: '0', top: '0', width: '50%', height: '100%' };
             this.setState({ snapPreview: snap, snapPosition: 'left' });
         }
@@ -568,15 +551,19 @@ export class Window extends Component {
     handleSuperArrow = (e) => {
         const key = e.detail;
         if (key === 'ArrowLeft') {
-            if (this.state.snapped === 'left') this.unsnapWindow();
+            if (['left', 'top-left', 'bottom-left'].includes(this.state.snapped)) this.unsnapWindow();
             else this.snapWindow('left');
         } else if (key === 'ArrowRight') {
-            if (this.state.snapped === 'right') this.unsnapWindow();
+            if (['right', 'top-right', 'bottom-right'].includes(this.state.snapped)) this.unsnapWindow();
             else this.snapWindow('right');
         } else if (key === 'ArrowUp') {
-            this.maximizeWindow();
+            if (this.state.snapped === 'left' || this.state.snapped === 'bottom-left') this.snapWindow('top-left');
+            else if (this.state.snapped === 'right' || this.state.snapped === 'bottom-right') this.snapWindow('top-right');
+            else this.maximizeWindow();
         } else if (key === 'ArrowDown') {
-            if (this.state.maximized) {
+            if (this.state.snapped === 'left' || this.state.snapped === 'top-left') this.snapWindow('bottom-left');
+            else if (this.state.snapped === 'right' || this.state.snapped === 'top-right') this.snapWindow('bottom-right');
+            else if (this.state.maximized) {
                 this.restoreWindow();
             } else if (this.state.snapped) {
                 this.unsnapWindow();
@@ -586,6 +573,7 @@ export class Window extends Component {
 
     snapWindow = (pos) => {
         this.focusWindow();
+        this.setWinowsPosition();
         const { width, height } = this.state;
         let newWidth = width;
         let newHeight = height;
@@ -598,6 +586,26 @@ export class Window extends Component {
             newWidth = 50;
             newHeight = 96.3;
             transform = `translate(${window.innerWidth / 2}px,-2pt)`;
+        } else if (pos === 'top') {
+            newWidth = 100.2;
+            newHeight = 50;
+            transform = 'translate(-1pt,-2pt)';
+        } else if (pos === 'top-left') {
+            newWidth = 50;
+            newHeight = 48.1;
+            transform = 'translate(-1pt,-2pt)';
+        } else if (pos === 'top-right') {
+            newWidth = 50;
+            newHeight = 48.1;
+            transform = `translate(${window.innerWidth / 2}px,-2pt)`;
+        } else if (pos === 'bottom-left') {
+            newWidth = 50;
+            newHeight = 48.1;
+            transform = `translate(-1pt,${window.innerHeight / 2 - 2}px)`;
+        } else if (pos === 'bottom-right') {
+            newWidth = 50;
+            newHeight = 48.1;
+            transform = `translate(${window.innerWidth / 2}px,${window.innerHeight / 2 - 2}px)`;
         }
         const node = document.getElementById(this.id);
         if (node && transform) {
@@ -605,6 +613,8 @@ export class Window extends Component {
         }
         this.setState({
             snapped: pos,
+            snapPreview: null,
+            snapPosition: null,
             lastSize: { width, height },
             width: newWidth,
             height: newHeight


### PR DESCRIPTION
## Summary
- support snapping windows to four corners via drag and Super+Arrow keys
- cover corner snapping with tests

## Testing
- `yarn test __tests__/window.test.tsx`
- `yarn test` *(fails: Unable to find role="alert" in `__tests__/nmapNse.test.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68c388dc5cb08328be0304d32cd8fe11