### PR TITLE
feat: add tiling layout toggle

### DIFF
--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -120,6 +120,16 @@ function DesktopMenu(props) {
             </button>
             <Devider />
             <button
+                onClick={props.toggleTileWindows}
+                type="button"
+                role="menuitem"
+                aria-label="Tile Windows"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
+                <span className="ml-5">Tile Windows</span>
+            </button>
+            <Devider />
+            <button
                 onClick={props.clearSession}
                 type="button"
                 role="menuitem"


### PR DESCRIPTION
## Summary
- add desktop context menu button to tile/untile windows
- implement binary space partition tiling algorithm and layout restoration

## Testing
- `npm test` *(fails: window snapping finalize, NmapNSEApp copies output, modal focus trapping)*

------
https://chatgpt.com/codex/tasks/task_e_68c388ddcbf48328ae4ed561573321be