### PR TITLE
feat: add window gap setting slider

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -21,6 +21,8 @@ export default function Settings() {
     setWallpaper,
     density,
     setDensity,
+    winGap,
+    setWinGap,
     reducedMotion,
     setReducedMotion,
     fontScale,
@@ -79,6 +81,7 @@ export default function Settings() {
       if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
+      if (parsed.winGap !== undefined) setWinGap(parsed.winGap);
       if (parsed.theme !== undefined) setTheme(parsed.theme);
     } catch (err) {
       console.error("Invalid settings", err);
@@ -100,6 +103,7 @@ export default function Settings() {
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
+    setWinGap(defaults.winGap);
     setTheme("default");
   };
 
@@ -149,6 +153,24 @@ export default function Settings() {
                 />
               ))}
             </div>
+          </div>
+          <div className="flex justify-center my-4">
+            <label htmlFor="win-gap" className="mr-2 text-ubt-grey">Window gap:</label>
+            <input
+              id="win-gap"
+              type="range"
+              min="0"
+              max="16"
+              step="1"
+              value={winGap}
+              onChange={(e) =>
+                setWinGap(
+                  Math.max(0, Math.min(16, parseInt(e.target.value, 10)))
+                )
+              }
+              className="ubuntu-slider"
+              aria-label="Window gap"
+            />
           </div>
           <div className="flex justify-center my-4">
             <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -491,12 +491,31 @@ export class Desktop extends Component {
     }
 
     updateWindowPosition = (id, x, y) => {
-        const snap = this.props.snapEnabled
-            ? (v) => Math.round(v / 8) * 8
+        const gap = Math.max(0, Math.min(16, this.props.winGap || 0));
+        const snap = this.props.snapEnabled && gap > 0
+            ? (v) => Math.round(v / gap) * gap
             : (v) => v;
         this.setState(prev => ({
             window_positions: { ...prev.window_positions, [id]: { x: snap(x), y: snap(y) } }
         }), this.saveSession);
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.winGap !== this.props.winGap) {
+            const gap = Math.max(0, Math.min(16, this.props.winGap || 0));
+            if (this.props.snapEnabled && gap > 0) {
+                this.setState(prev => {
+                    const updated = {};
+                    for (const [id, pos] of Object.entries(prev.window_positions)) {
+                        updated[id] = {
+                            x: Math.round(pos.x / gap) * gap,
+                            y: Math.round(pos.y / gap) * gap,
+                        };
+                    }
+                    return { window_positions: updated };
+                }, this.saveSession);
+            }
+        }
     }
 
     saveSession = () => {

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -7,6 +7,7 @@ import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
+import { SettingsContext } from '../hooks/useSettings';
 
 export default class Ubuntu extends Component {
 	constructor() {
@@ -127,8 +128,16 @@ export default class Ubuntu extends Component {
 					turnOn={this.turnOn}
 				/>
 				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
-			</div>
-		);
-	}
+                                <SettingsContext.Consumer>
+                                        {({ winGap }) => (
+                                                <Desktop
+                                                        bg_image_name={this.state.bg_image_name}
+                                                        changeBackgroundImage={this.changeBackgroundImage}
+                                                        winGap={winGap}
+                                                />
+                                        )}
+                                </SettingsContext.Consumer>
+                        </div>
+                );
+        }
 }

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getWinGap as loadWinGap,
+  setWinGap as saveWinGap,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -63,6 +65,7 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  winGap: number;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +77,7 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setWinGap: (value: number) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +92,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  winGap: defaults.winGap,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +104,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setWinGap: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -112,6 +118,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [winGap, setWinGap] = useState<number>(defaults.winGap);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +134,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setWinGap(await loadWinGap());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +244,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    const gap = Math.min(16, Math.max(0, winGap));
+    document.documentElement.style.setProperty('--win-gap', `${gap}px`);
+    saveWinGap(gap);
+  }, [winGap]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -250,6 +264,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        winGap,
         setAccent,
         setWallpaper,
         setDensity,
@@ -261,6 +276,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setWinGap,
       }}
     >
       {children}

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -59,6 +59,8 @@
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;
+  /* Window gap */
+  --win-gap: 8px;
 }
 
 /* High contrast theme */

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  winGap: 8,
 };
 
 export async function getAccent() {
@@ -69,6 +70,18 @@ export async function getFontScale() {
 export async function setFontScale(scale) {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem('font-scale', String(scale));
+}
+
+export async function getWinGap() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.winGap;
+  const stored = window.localStorage.getItem('win-gap');
+  return stored ? parseInt(stored, 10) : DEFAULT_SETTINGS.winGap;
+}
+
+export async function setWinGap(value) {
+  if (typeof window === 'undefined') return;
+  const clamped = Math.max(0, Math.min(16, value));
+  window.localStorage.setItem('win-gap', String(clamped));
 }
 
 export async function getHighContrast() {
@@ -137,6 +150,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('win-gap');
 }
 
 export async function exportSettings() {
@@ -151,6 +165,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    winGap,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +177,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getWinGap(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +191,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    winGap,
     theme,
   });
 }
@@ -199,6 +216,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    winGap,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +229,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (winGap !== undefined) await setWinGap(winGap);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add window gap variable and persistence
- expose window gap slider in settings with clamping
- snap desktop windows using configurable gap

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c388de258c832882d8cdf57a7dc2b9