### PR TITLE
feat(desktop): remember split layouts for app pairs

### DIFF
--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -82,7 +82,7 @@ describe('NmapNSEApp', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Sample output')
     );
-    expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
+    expect(await screen.findByRole('status')).toHaveTextContent(/copied/i);
 
     mockFetch.mockRestore();
   });

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -199,7 +199,12 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({
+        key: 'ArrowDown',
+        altKey: true,
+        preventDefault: () => {},
+        stopPropagation: () => {},
+      } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();
@@ -252,6 +257,53 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBeNull();
     expect(ref.current!.state.width).toBe(60);
     expect(ref.current!.state.height).toBe(85);
+  });
+
+  it('invokes onSnap callback on snap and unsnap', () => {
+    const ref = React.createRef<Window>();
+    const onSnap = jest.fn();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        onSnap={onSnap}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 5,
+      top: 10,
+      right: 105,
+      bottom: 110,
+      width: 100,
+      height: 100,
+      x: 5,
+      y: 10,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+    act(() => {
+      ref.current!.handleStop();
+    });
+
+    expect(onSnap).toHaveBeenLastCalledWith('left');
+
+    act(() => {
+      ref.current!.unsnapWindow();
+    });
+
+    expect(onSnap).toHaveBeenLastCalledWith(null);
   });
 });
 

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -244,14 +244,18 @@ export class Window extends Component {
                 r.style.transform = `translate(${x},${y})`;
             }
         }
+        const callback = () => {
+            this.resizeBoundries();
+            if (this.props.onSnap) this.props.onSnap(null);
+        };
         if (this.state.lastSize) {
             this.setState({
                 width: this.state.lastSize.width,
                 height: this.state.lastSize.height,
                 snapped: null
-            }, this.resizeBoundries);
+            }, callback);
         } else {
-            this.setState({ snapped: null }, this.resizeBoundries);
+            this.setState({ snapped: null }, callback);
         }
     }
 
@@ -285,7 +289,10 @@ export class Window extends Component {
             lastSize: { width, height },
             width: newWidth,
             height: newHeight
-        }, this.resizeBoundries);
+        }, () => {
+            this.resizeBoundries();
+            if (this.props.onSnap) this.props.onSnap(position);
+        });
     }
 
     checkOverlap = () => {
@@ -608,7 +615,10 @@ export class Window extends Component {
             lastSize: { width, height },
             width: newWidth,
             height: newHeight
-        }, this.resizeBoundries);
+        }, () => {
+            this.resizeBoundries();
+            if (this.props.onSnap) this.props.onSnap(pos);
+        });
     }
 
     render() {


### PR DESCRIPTION
## Summary
- record snap positions for window pairs and reuse on reopen
- notify desktop of window snap changes via new `onSnap` callback
- update tests for snap callback and nmap output copy toast

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c388df0a7c83288b0f75e66860da55