### PR TITLE
feat: highlight snap slots during drag

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -118,6 +118,41 @@ describe('Window snapping preview', () => {
   });
 });
 
+describe('Snap slot highlighting', () => {
+  it('shows snap slots while dragging and clears on stop', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    act(() => {
+      ref.current!.changeCursorToMove();
+    });
+
+    expect(screen.getByTestId('snap-slot-left')).toBeInTheDocument();
+    expect(screen.getByTestId('snap-slot-right')).toBeInTheDocument();
+    expect(screen.getByTestId('snap-slot-top')).toBeInTheDocument();
+
+    act(() => {
+      ref.current!.handleStop();
+    });
+
+    expect(screen.queryByTestId('snap-slot-left')).toBeNull();
+    expect(screen.queryByTestId('snap-slot-right')).toBeNull();
+    expect(screen.queryByTestId('snap-slot-top')).toBeNull();
+  });
+});
+
 describe('Window snapping finalize and release', () => {
   it('snaps window on drag stop near left edge', () => {
     const ref = React.createRef<Window>();
@@ -199,7 +234,12 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({
+        key: 'ArrowDown',
+        altKey: true,
+        preventDefault: () => {},
+        stopPropagation: () => {}
+      } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -614,10 +614,26 @@ export class Window extends Component {
     render() {
         return (
             <>
+                {this.state.grabbed && (
+                    <>
+                        <div
+                            data-testid="snap-slot-left"
+                            className="fixed inset-y-0 left-0 w-1/2 border border-blue-400/40 bg-blue-400/10 pointer-events-none z-40"
+                        />
+                        <div
+                            data-testid="snap-slot-right"
+                            className="fixed inset-y-0 right-0 w-1/2 border border-blue-400/40 bg-blue-400/10 pointer-events-none z-40"
+                        />
+                        <div
+                            data-testid="snap-slot-top"
+                            className="fixed inset-x-0 top-0 h-1/2 border border-blue-400/40 bg-blue-400/10 pointer-events-none z-40"
+                        />
+                    </>
+                )}
                 {this.state.snapPreview && (
                     <div
                         data-testid="snap-preview"
-                        className="fixed border-2 border-dashed border-white bg-white bg-opacity-10 pointer-events-none z-40 transition-opacity"
+                        className="fixed border-2 border-blue-400/70 bg-blue-400/20 pointer-events-none z-50 transition-opacity"
                         style={{ left: this.state.snapPreview.left, top: this.state.snapPreview.top, width: this.state.snapPreview.width, height: this.state.snapPreview.height }}
                     />
                 )}


### PR DESCRIPTION
## Summary
- show potential snap areas with tinted overlays and borders while dragging
- clear overlays on drag cancel and cover with tests

## Testing
- `yarn test __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c388dfaa7c832883a4d8cafa6bfbfe