### PR TITLE
feat: adjust window snapping for dock

### DIFF
--- a/__tests__/Modal.test.tsx
+++ b/__tests__/Modal.test.tsx
@@ -3,6 +3,17 @@ import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Modal from '../components/base/Modal';
 
+beforeEach(() => {
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    },
+    writable: true,
+  });
+});
+
 test('modal traps focus, disables background, and restores opener focus', async () => {
   const root = document.createElement('div');
   root.setAttribute('id', '__next');

--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -82,7 +82,7 @@ describe('NmapNSEApp', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Sample output')
     );
-    expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
+    expect(await screen.findByRole('status')).toHaveTextContent(/copied/i);
 
     mockFetch.mockRestore();
   });

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -157,7 +157,10 @@ describe('Window snapping finalize and release', () => {
 
     expect(ref.current!.state.snapped).toBe('left');
     expect(ref.current!.state.width).toBe(50);
-    expect(ref.current!.state.height).toBe(96.3);
+    const dock = document.querySelector('[aria-label="Dock"]');
+    const bottom = dock ? dock.getBoundingClientRect().height : 0;
+    const expectedHeight = ((window.innerHeight - bottom) / window.innerHeight) * 100;
+    expect(ref.current!.state.height).toBeCloseTo(expectedHeight);
   });
 
   it('releases snap with Alt+ArrowDown restoring size', () => {
@@ -199,7 +202,12 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({
+        key: 'ArrowDown',
+        altKey: true,
+        preventDefault: () => {},
+        stopPropagation: () => {},
+      } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();


### PR DESCRIPTION
## Summary
- compute dock offsets to keep snapped window layouts symmetric
- update window snapping preview and logic to respect dock position
- fix related tests for dynamic snap sizing and clipboard toast roles

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68c388e2b6d483289640418d6b129a4f