### PR TITLE
Account for safe areas when maximizing windows

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,6 +20,10 @@
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   accent-color: var(--color-control-accent);
+  --safe-area-top: env(safe-area-inset-top);
+  --safe-area-bottom: env(safe-area-inset-bottom);
+  --safe-area-left: env(safe-area-inset-left);
+  --safe-area-right: env(safe-area-inset-right);
 }
 
 /* Dark theme */


### PR DESCRIPTION
## Summary
- compute available viewport excluding panels, dock, and safe areas
- maximize windows within the available rectangle to avoid hidden borders
- expose CSS safe-area variables for runtime calculations

## Testing
- `yarn lint` *(fails: Unexpected global 'document', Component definition is missing display name)*
- `yarn test` *(fails: TypeError: e.preventDefault is not a function, Unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68c388e3d28483289ae7f4f63e7d854b