### PR TITLE
Center utility windows

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -199,7 +199,12 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({
+        key: 'ArrowDown',
+        altKey: true,
+        preventDefault() {},
+        stopPropagation() {},
+      } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();
@@ -404,5 +409,66 @@ describe('Window overlay inert behaviour', () => {
 
     document.body.removeChild(root);
     document.body.removeChild(opener);
+  });
+});
+
+describe('Utility window sizing', () => {
+  const originalWidth = window.innerWidth;
+  const originalHeight = window.innerHeight;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1000, writable: true });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800, writable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalWidth, writable: true });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalHeight, writable: true });
+  });
+
+  it('sizes and centers utility windows', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="util-window"
+        title="Util"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        utility
+        ref={ref}
+      />
+    );
+    const winEl = document.getElementById('util-window')!;
+    expect(winEl.style.width).toBe('42%');
+    expect(winEl.style.height).toBe('40%');
+    expect(ref.current!.startX).toBe(290);
+    expect(ref.current!.startY).toBe(240);
+  });
+
+  it('ignores sizing for tabbed terminal', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="terminal"
+        title="Terminal"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        utility
+        ref={ref}
+      />
+    );
+    const winEl = document.getElementById('terminal')!;
+    expect(winEl.style.width).toBe('60%');
+    expect(winEl.style.height).toBe('85%');
+    expect(ref.current!.startX).toBe(60);
+    expect(ref.current!.startY).toBe(10);
   });
 });

--- a/apps.config.js
+++ b/apps.config.js
@@ -212,6 +212,7 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayQr,
+    utility: true,
   },
   {
     id: 'ascii-art',
@@ -221,6 +222,7 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayAsciiArt,
+    utility: true,
   },
   {
     id: 'clipboard-manager',
@@ -230,6 +232,7 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayClipboardManager,
+    utility: true,
   },
   {
     id: 'figlet',
@@ -239,6 +242,7 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayFiglet,
+    utility: true,
   },
   {
     id: 'quote',
@@ -248,6 +252,7 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayQuote,
+    utility: true,
   },
   {
     id: 'project-gallery',
@@ -257,6 +262,7 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayProjectGallery,
+    utility: true,
   },
   {
     id: 'input-lab',
@@ -266,6 +272,7 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayInputLab,
+    utility: true,
   },
 ];
 
@@ -625,6 +632,7 @@ const apps = [
     favourite: true,
     desktop_shortcut: false,
     screen: displayTerminal,
+    utility: true,
   },
   {
     // VSCode app uses a Stack iframe, so no editor dependencies are required
@@ -960,6 +968,7 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displaySerialTerminal,
+    utility: true,
   },
   {
     id: 'radare2',

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -14,14 +14,26 @@ export class Window extends Component {
         this.id = null;
         const isPortrait =
             typeof window !== "undefined" && window.innerHeight > window.innerWidth;
+        const isUtility =
+            typeof window !== "undefined" && props.utility && props.id !== 'terminal';
+        const utilityWidth = 420;
+        const utilityHeight = 320;
+        const widthPercent = isUtility
+            ? (utilityWidth / window.innerWidth) * 100
+            : props.defaultWidth || (isPortrait ? 90 : 60);
+        const heightPercent = isUtility
+            ? (utilityHeight / window.innerHeight) * 100
+            : props.defaultHeight || 85;
         this.startX =
             props.initialX ??
-            (isPortrait ? window.innerWidth * 0.05 : 60);
-        this.startY = props.initialY ?? 10;
+            (isUtility
+                ? (window.innerWidth - utilityWidth) / 2
+                : (isPortrait ? window.innerWidth * 0.05 : 60));
+        this.startY = props.initialY ?? (isUtility ? (window.innerHeight - utilityHeight) / 2 : 10);
         this.state = {
             cursorType: "cursor-default",
-            width: props.defaultWidth || (isPortrait ? 90 : 60),
-            height: props.defaultHeight || 85,
+            width: widthPercent,
+            height: heightPercent,
             closed: false,
             maximized: false,
             parentSize: {
@@ -75,6 +87,16 @@ export class Window extends Component {
         if (this.props.defaultHeight && this.props.defaultWidth) {
             this.setState(
                 { height: this.props.defaultHeight, width: this.props.defaultWidth },
+                this.resizeBoundries
+            );
+            return;
+        }
+
+        if (this.props.utility && this.props.id !== 'terminal') {
+            const widthPercent = (420 / window.innerWidth) * 100;
+            const heightPercent = (320 / window.innerHeight) * 100;
+            this.setState(
+                { width: widthPercent, height: heightPercent },
                 this.resizeBoundries
             );
             return;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -480,6 +480,7 @@ export class Desktop extends Component {
                     initialY: pos ? pos.y : undefined,
                     onPositionChange: (x, y) => this.updateWindowPosition(app.id, x, y),
                     snapEnabled: this.props.snapEnabled,
+                    utility: app.utility,
                 }
 
                 windowsJsx.push(


### PR DESCRIPTION
## Summary
- Flag utility apps in registry
- Center non-terminal utility windows at 420x320
- Cover utility sizing with unit tests

## Testing
- `yarn test __tests__/window.test.tsx`
- `yarn test __tests__/apps.smoke.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c388e5334883288dcb7da3dafe5b29