### PR TITLE
Clamp modal content width

### DIFF
--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -116,6 +116,11 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
             ref={modalRef}
             onKeyDown={handleKeyDown}
             tabIndex={-1}
+            style={{
+                width: 'fit-content',
+                maxWidth: 'min(720px, 90vw)',
+                overflowX: 'hidden'
+            }}
         >
             {children}
         </div>,


### PR DESCRIPTION
## Summary
- Constrain modal windows to `min(720px, 90vw)` and hide horizontal overflow for better mobile experience

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c388e60e24832897b5759595b83bc9