### PR TITLE
Reduce Kali mobile titlebar height

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -22,6 +22,17 @@ button:focus-visible {
     outline-offset: 2px;
 }
 
+@media (max-width:640px) {
+    html[data-theme="kali"] {
+        --win-mobile-titlebar-height: 40px;
+        --hit-area: 44px;
+    }
+
+    html[data-theme="kali"] .bg-ub-window-title {
+        height: var(--win-mobile-titlebar-height);
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after {
         animation-duration: 0.01ms !important;


### PR DESCRIPTION
## Summary
- Use `--win-mobile-titlebar-height` for window titlebars on small screens
- Ensure controls remain at least 44px tall in Kali theme

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, reconng.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c388e831508328880044709128fe9b