### PR TITLE
feat: add mobile bottom sheet for utility apps

### DIFF
--- a/__tests__/bottomSheet.test.tsx
+++ b/__tests__/bottomSheet.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import BottomSheet from '../components/base/BottomSheet';
+
+jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+
+describe('BottomSheet', () => {
+  it('sets inert attribute on root when open', () => {
+    document.body.innerHTML = '<div id="__next"></div>';
+    const root = document.getElementById('__next')!;
+    render(
+      <BottomSheet
+        id="test"
+        title="Test"
+        screen={() => <div>content</div>}
+        addFolder={() => {}}
+        openApp={() => {}}
+        closed={() => {}}
+      />,
+      { container: root }
+    );
+    expect(root.hasAttribute('inert')).toBe(true);
+  });
+});
+

--- a/apps.config.js
+++ b/apps.config.js
@@ -212,6 +212,7 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayQr,
+    utility: true,
   },
   {
     id: 'ascii-art',
@@ -221,6 +222,7 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayAsciiArt,
+    utility: true,
   },
   {
     id: 'clipboard-manager',
@@ -230,6 +232,7 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayClipboardManager,
+    utility: true,
   },
   {
     id: 'figlet',
@@ -239,6 +242,7 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayFiglet,
+    utility: true,
   },
   {
     id: 'quote',
@@ -248,6 +252,7 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayQuote,
+    utility: true,
   },
   {
     id: 'project-gallery',
@@ -257,6 +262,7 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayProjectGallery,
+    utility: true,
   },
   {
     id: 'input-lab',
@@ -266,6 +272,7 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayInputLab,
+    utility: true,
   },
 ];
 

--- a/components/base/BottomSheet.tsx
+++ b/components/base/BottomSheet.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import React, { useState, useRef } from 'react';
+import Modal from './Modal';
+
+interface BottomSheetProps {
+    id: string;
+    title: string;
+    screen: (addFolder: any, openApp: (id: string) => void) => React.ReactNode;
+    addFolder: any;
+    openApp: (id: string) => void;
+    closed: (id: string) => void;
+}
+
+const BottomSheet: React.FC<BottomSheetProps> = ({ id, title, screen, addFolder, openApp, closed }) => {
+    const [height, setHeight] = useState(50);
+    const startY = useRef(0);
+    const startHeight = useRef(50);
+
+    const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+        startY.current = e.clientY;
+        startHeight.current = height;
+        window.addEventListener('pointermove', onPointerMove);
+        window.addEventListener('pointerup', onPointerUp);
+    };
+
+    const onPointerMove = (e: PointerEvent) => {
+        const delta = startY.current - e.clientY;
+        const newHeight = Math.min(100, Math.max(25, startHeight.current + (delta / window.innerHeight) * 100));
+        setHeight(newHeight);
+    };
+
+    const onPointerUp = () => {
+        window.removeEventListener('pointermove', onPointerMove);
+        window.removeEventListener('pointerup', onPointerUp);
+        setHeight(h => (h > 75 ? 100 : 50));
+    };
+
+    const handleClose = () => {
+        closed(id);
+    };
+
+    return (
+        <Modal isOpen={true} onClose={handleClose}>
+            <div className="fixed inset-0 flex items-end justify-center">
+                <div className="absolute inset-0 bg-black/50" onClick={handleClose} />
+                <div
+                    className="relative w-full bg-ub-grey text-white rounded-t-md shadow-lg flex flex-col"
+                    style={{ height: `${height}vh` }}
+                >
+                    <div
+                        className="p-2 flex justify-between items-center cursor-grab touch-none"
+                        onPointerDown={onPointerDown}
+                    >
+                        <span>{title}</span>
+                        <button onClick={handleClose} aria-label="Close">
+                            ×
+                        </button>
+                    </div>
+                    <div className="flex-1 overflow-auto">
+                        {screen(addFolder, openApp)}
+                    </div>
+                </div>
+            </div>
+        </Modal>
+    );
+};
+
+export default BottomSheet;
+

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -10,6 +10,7 @@ const BackgroundImage = dynamic(
 import SideBar from './side_bar';
 import apps, { games } from '../../apps.config';
 import Window from '../base/window';
+import BottomSheet from '../base/BottomSheet';
 import UbuntuApp from '../base/ubuntu_app';
 import AllApplications from '../screen/all-applications'
 import ShortcutSelector from '../screen/shortcut-selector'
@@ -456,7 +457,8 @@ export class Desktop extends Component {
 
     renderWindows = () => {
         let windowsJsx = [];
-        apps.forEach((app, index) => {
+        const isMobile = typeof window !== 'undefined' && window.innerWidth < 640;
+        apps.forEach((app) => {
             if (this.state.closed_windows[app.id] === false) {
 
                 const pos = this.state.window_positions[app.id];
@@ -482,9 +484,23 @@ export class Desktop extends Component {
                     snapEnabled: this.props.snapEnabled,
                 }
 
-                windowsJsx.push(
-                    <Window key={app.id} {...props} />
-                )
+                if (isMobile && app.utility) {
+                    windowsJsx.push(
+                        <BottomSheet
+                            key={app.id}
+                            id={app.id}
+                            title={app.title}
+                            screen={app.screen}
+                            addFolder={this.addToDesktop}
+                            closed={this.closeApp}
+                            openApp={this.openApp}
+                        />
+                    );
+                } else {
+                    windowsJsx.push(
+                        <Window key={app.id} {...props} />
+                    );
+                }
             }
         });
         return windowsJsx;


### PR DESCRIPTION
## Summary
- render utility apps as bottom sheet on mobile
- flag utilities in app config for mobile detection
- add test ensuring background is inert while sheet is open

## Testing
- `yarn test bottomSheet.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c388e956448328ad2aa615ea48a91e