### PR TITLE
feat: add system monitor app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -73,6 +73,7 @@ const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery')
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
+const SystemMonitorApp = createDynamicApp('system-monitor', 'System Monitor');
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
 const TrashApp = createDynamicApp('trash', 'Trash');
@@ -165,6 +166,7 @@ const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
+const displaySystemMonitor = createDisplay(SystemMonitorApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 
@@ -709,6 +711,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayResourceMonitor,
+  },
+  {
+    id: 'system-monitor',
+    title: 'System Monitor',
+    icon: '/themes/Yaru/apps/system-monitor.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displaySystemMonitor,
   },
   {
     id: 'screen-recorder',

--- a/apps/system-monitor/index.tsx
+++ b/apps/system-monitor/index.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+
+// Simple seeded PRNG (mulberry32)
+function createPRNG(seed: number) {
+  return function () {
+    seed |= 0;
+    seed = (seed + 0x6D2B79F5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const MAX_POINTS = 60;
+
+function drawChart(
+  canvas: HTMLCanvasElement | null,
+  values: number[],
+  color: string,
+  label: string,
+  maxVal: number,
+) {
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  const w = canvas.width;
+  const h = canvas.height;
+  ctx.clearRect(0, 0, w, h);
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  values.forEach((v, i) => {
+    const x = (i / (values.length - 1 || 1)) * w;
+    const y = h - (v / maxVal) * h;
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  });
+  ctx.stroke();
+  const latest = values[values.length - 1] || 0;
+  ctx.fillStyle = '#ffffff';
+  ctx.font = '12px sans-serif';
+  ctx.fillText(`${label}: ${latest.toFixed(1)}`, 4, 12);
+}
+
+export default function SystemMonitorApp() {
+  const cpuRef = useRef<HTMLCanvasElement>(null);
+  const ramRef = useRef<HTMLCanvasElement>(null);
+  const netRef = useRef<HTMLCanvasElement>(null);
+
+  const cpuRand = useRef(createPRNG(1)).current;
+  const ramRand = useRef(createPRNG(2)).current;
+  const netRand = useRef(createPRNG(3)).current;
+
+  const dataRef = useRef({ cpu: [] as number[], ram: [] as number[], net: [] as number[] });
+  const lastFrame = useRef(0);
+  const [paused, setPaused] = useState(false);
+
+  useEffect(() => {
+    let raf: number;
+    const animate = (time: number) => {
+      if (time - lastFrame.current >= 1000 / 60) {
+        lastFrame.current = time;
+        if (!paused && !document.hidden) {
+          const push = (arr: number[], v: number) => {
+            arr.push(v);
+            if (arr.length > MAX_POINTS) arr.shift();
+          };
+          push(dataRef.current.cpu, cpuRand() * 100);
+          push(dataRef.current.ram, ramRand() * 100);
+          push(dataRef.current.net, netRand() * 1000);
+          drawChart(cpuRef.current, dataRef.current.cpu, '#ff5555', 'CPU %', 100);
+          drawChart(ramRef.current, dataRef.current.ram, '#55ff55', 'RAM %', 100);
+          drawChart(netRef.current, dataRef.current.net, '#5599ff', 'Net kB/s', 1000);
+        }
+      }
+      raf = requestAnimationFrame(animate);
+    };
+    raf = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(raf);
+  }, [paused]);
+
+  // Ensure animation pauses when tab is hidden
+  useEffect(() => {
+    const handleVis = () => {
+      if (document.hidden) {
+        // no-op: animate loop checks document.hidden
+      }
+    };
+    document.addEventListener('visibilitychange', handleVis);
+    return () => document.removeEventListener('visibilitychange', handleVis);
+  }, []);
+
+  return (
+    <div className="h-full w-full bg-ub-cool-grey text-white flex flex-col">
+      <div className="p-2">
+        <button
+          onClick={() => setPaused((p) => !p)}
+          className="px-2 py-1 bg-ub-dark-grey rounded"
+        >
+          {paused ? 'Resume' : 'Pause'}
+        </button>
+      </div>
+      <div className="flex-1 flex items-center justify-evenly p-4 gap-4">
+        <canvas
+          ref={cpuRef}
+          width={300}
+          height={100}
+          role="img"
+          aria-label="CPU usage chart"
+          className="bg-ub-dark-grey"
+        />
+        <canvas
+          ref={ramRef}
+          width={300}
+          height={100}
+          role="img"
+          aria-label="RAM usage chart"
+          className="bg-ub-dark-grey"
+        />
+        <canvas
+          ref={netRef}
+          width={300}
+          height={100}
+          role="img"
+          aria-label="Network chart"
+          className="bg-ub-dark-grey"
+        />
+      </div>
+    </div>
+  );
+}
+

--- a/public/themes/Yaru/apps/system-monitor.svg
+++ b/public/themes/Yaru/apps/system-monitor.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect x="8" y="20" width="48" height="24" rx="3" ry="3" fill="#222" stroke="#000" stroke-width="2"/>
+  <rect x="10" y="22" width="40" height="20" fill="#4ade80"/>
+  <rect x="56" y="26" width="4" height="12" fill="#000"/>
+</svg>


### PR DESCRIPTION
## Summary
- add system monitor app with seeded random CPU, RAM, and network charts
- pause updates when hidden and allow manual pause/resume
- register app and icon in configuration

## Testing
- `npm test` *(fails: window, nmapNse, Modal)*

------
https://chatgpt.com/codex/tasks/task_e_68c37ab9f2788328917b4b1b082d69a0