### PR TITLE
feat: add screenshot selection overlay

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -72,6 +72,7 @@ const QuoteApp = createDynamicApp('quote', 'Quote');
 const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery');
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
+const ScreenshotApp = createDynamicApp('screenshot', 'Screenshot');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
@@ -165,6 +166,7 @@ const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
+const displayScreenshot = createDisplay(ScreenshotApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 
@@ -266,6 +268,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayInputLab,
+  },
+  {
+    id: 'screenshot',
+    title: 'Screenshot',
+    icon: '/themes/Yaru/apps/screen-recorder.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayScreenshot,
   },
 ];
 

--- a/apps/screenshot/index.tsx
+++ b/apps/screenshot/index.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import html2canvas from 'html2canvas';
+
+interface Selection {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export default function Screenshot() {
+  const [start, setStart] = useState<{ x: number; y: number } | null>(null);
+  const [selection, setSelection] = useState<Selection | null>(null);
+  const [image, setImage] = useState<string | null>(null);
+  const [showGuide, setShowGuide] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      if (!localStorage.getItem('screenshot-guide-shown')) {
+        setShowGuide(true);
+        localStorage.setItem('screenshot-guide-shown', '1');
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setStart(null);
+        setSelection(null);
+        setImage(null);
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, []);
+
+  const onMouseDown = (e: React.MouseEvent) => {
+    if (image) return;
+    setStart({ x: e.clientX, y: e.clientY });
+    setSelection({ x: e.clientX, y: e.clientY, w: 0, h: 0 });
+  };
+
+  const onMouseMove = (e: React.MouseEvent) => {
+    if (!start) return;
+    const x = Math.min(e.clientX, start.x);
+    const y = Math.min(e.clientY, start.y);
+    const w = Math.abs(e.clientX - start.x);
+    const h = Math.abs(e.clientY - start.y);
+    setSelection({ x, y, w, h });
+  };
+
+  const onMouseUp = async () => {
+    if (!start || !selection) return;
+    try {
+      const canvas = await html2canvas(document.body, { useCORS: true });
+      const crop = document.createElement('canvas');
+      crop.width = selection.w;
+      crop.height = selection.h;
+      const ctx = crop.getContext('2d');
+      if (ctx) {
+        ctx.drawImage(
+          canvas,
+          selection.x,
+          selection.y,
+          selection.w,
+          selection.h,
+          0,
+          0,
+          selection.w,
+          selection.h,
+        );
+        setImage(crop.toDataURL('image/png'));
+      }
+    } catch (err) {
+      console.error('Failed to capture screenshot', err);
+    } finally {
+      setStart(null);
+      setSelection(null);
+    }
+  };
+
+  const copyImage = async () => {
+    if (!image) return;
+    try {
+      const blob = await (await fetch(image)).blob();
+      await navigator.clipboard?.write([
+        new ClipboardItem({ 'image/png': blob }),
+      ]);
+    } catch (err) {
+      console.error('Copy failed', err);
+    }
+  };
+
+  const downloadImage = () => {
+    if (!image) return;
+    const a = document.createElement('a');
+    a.href = image;
+    a.download = 'screenshot.png';
+    a.click();
+  };
+
+  return (
+    <div className="w-full h-full relative select-none">
+      {!image && (
+        <div
+          className="absolute inset-0 cursor-crosshair"
+          onMouseDown={onMouseDown}
+          onMouseMove={onMouseMove}
+          onMouseUp={onMouseUp}
+        >
+          {showGuide && (
+            <div className="absolute top-2 left-1/2 -translate-x-1/2 bg-black/70 text-white px-2 py-1 rounded text-sm">
+              Drag to select area. Press Esc to cancel.
+            </div>
+          )}
+          {selection && (
+            <div
+              className="absolute border-2 border-blue-500 bg-blue-400/20"
+              style={{
+                left: selection.x,
+                top: selection.y,
+                width: selection.w,
+                height: selection.h,
+              }}
+            />
+          )}
+        </div>
+      )}
+      {image && (
+        <div className="w-full h-full flex flex-col items-center justify-center gap-2 bg-black/80">
+          <img src={image} alt="Screenshot preview" className="max-w-full max-h-[80vh]" />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={copyImage}
+              className="px-3 py-1 bg-blue-600 text-white rounded"
+            >
+              Copy
+            </button>
+            <button
+              type="button"
+              onClick={downloadImage}
+              className="px-3 py-1 bg-green-600 text-white rounded"
+            >
+              Download
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Screenshot app that captures a selected screen region
- allow copying or downloading captured images and show one-time usage tips
- register the Screenshot app in utilities list

## Testing
- `npx eslint apps/screenshot/index.tsx && echo 'Lint passed'`
- `yarn test apps/screenshot/index.tsx` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c37abafc148328999eb6b836b8fe1f