### PR TITLE
feat: add Dragon menu and improve focus styles

### DIFF
--- a/components/menus/DragonMenu.tsx
+++ b/components/menus/DragonMenu.tsx
@@ -1,0 +1,92 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import Image from 'next/image';
+import UbuntuApp from '../base/ubuntu_app';
+import apps, { utilities, games } from '../../apps.config';
+import { safeLocalStorage } from '../../utils/safeStorage';
+
+type AppMeta = {
+  id: string;
+  title: string;
+  icon: string;
+  disabled?: boolean;
+  favourite?: boolean;
+};
+
+const STORAGE_KEY = 'dragon-menu-category';
+
+const DragonMenu: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const [category, setCategory] = useState('favorites');
+
+  useEffect(() => {
+    const last = safeLocalStorage?.getItem(STORAGE_KEY);
+    if (last) setCategory(last);
+  }, []);
+
+  useEffect(() => {
+    safeLocalStorage?.setItem(STORAGE_KEY, category);
+  }, [category]);
+
+  const allApps: AppMeta[] = apps as any;
+  const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
+  const categories = [
+    { id: 'favorites', label: 'Favorites', apps: favoriteApps },
+    { id: 'utilities', label: 'Utilities', apps: utilities as AppMeta[] },
+    { id: 'games', label: 'Games', apps: games as AppMeta[] },
+  ];
+
+  const current = categories.find(c => c.id === category) ?? categories[0];
+
+  const openApp = (id: string) => {
+    window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        aria-label="Applications"
+        onClick={() => setOpen(o => !o)}
+        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+      >
+        <Image
+          src="/themes/Yaru/status/icons8-kali-linux.svg"
+          alt="Menu"
+          width={16}
+          height={16}
+          className="inline"
+        />
+      </button>
+      {open && (
+        <div className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg">
+          <div className="flex flex-col bg-gray-800 p-2">
+            {categories.map(cat => (
+              <button
+                key={cat.id}
+                className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
+                onClick={() => setCategory(cat.id)}
+              >
+                {cat.label}
+              </button>
+            ))}
+          </div>
+          <div className="p-3 grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
+            {current.apps.map(app => (
+              <UbuntuApp
+                key={app.id}
+                id={app.id}
+                icon={app.icon}
+                name={app.title}
+                openApp={() => openApp(app.id)}
+                disabled={app.disabled}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DragonMenu;

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -4,6 +4,7 @@ import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import DragonMenu from '../menus/DragonMenu';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -16,6 +17,7 @@ export default class Navbar extends Component {
 	render() {
 		return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                                <DragonMenu />
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>

--- a/styles/index.css
+++ b/styles/index.css
@@ -18,7 +18,7 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
 
 a:focus-visible,
 button:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
+    outline: var(--focus-outline-width) solid var(--color-focus-ring) !important;
     outline-offset: 2px;
 }
 
@@ -512,9 +512,9 @@ pre {
 /* Visible focus rings for copy buttons and text areas */
 button:focus-visible,
 textarea:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline: var(--focus-outline-width) solid var(--color-focus-ring);
     outline-offset: 2px;
-}
+ }
 
 /* Enable scroll snapping for gallery containers */
 .gallery-container {


### PR DESCRIPTION
## Summary
- add DragonMenu component listing Favorites, Utilities, and Games, persisting last category
- show DragonMenu as leftmost button in navbar
- unify focus outlines with theme tokens

## Testing
- `yarn lint components/menus/DragonMenu.tsx components/screen/navbar.js styles/index.css` *(fails: A control must be associated with a text label, etc.)*
- `yarn test` *(fails: Window snapping finalize and release, NmapNSEApp copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68c3584c52308328b67d284e3eef42c2