### PR TITLE
feat: add dock orientation toggle

### DIFF
--- a/components/dock/Dock.tsx
+++ b/components/dock/Dock.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import SideBar from "../screen/side_bar";
+import Taskbar from "../screen/taskbar";
+import usePersistentState from "../../hooks/usePersistentState";
+
+export type DockOrientation = "bottom" | "left";
+
+/**
+ * Dock component that renders either the bottom taskbar or the left sidebar
+ * based on the persisted orientation setting.
+ */
+const Dock = (props: any) => {
+  const [orientation] = usePersistentState<DockOrientation>(
+    "dock-orientation",
+    "bottom",
+    (v): v is DockOrientation => v === "bottom" || v === "left",
+  );
+
+  return orientation === "left" ? <SideBar {...props} /> : <Taskbar {...props} />;
+};
+
+export default Dock;

--- a/components/panels/QuickSettings.tsx
+++ b/components/panels/QuickSettings.tsx
@@ -12,6 +12,11 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const [orientation, setOrientation] = usePersistentState<'bottom' | 'left'>(
+    'dock-orientation',
+    'bottom',
+    (v): v is 'bottom' | 'left' => v === 'bottom' || v === 'left',
+  );
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -38,15 +43,35 @@ const QuickSettings = ({ open }: Props) => {
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
+        <input
+          aria-label="Sound"
+          type="checkbox"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+        />
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+        <input
+          aria-label="Network"
+          type="checkbox"
+          checked={online}
+          onChange={() => setOnline(!online)}
+        />
+      </div>
+      <div className="px-4 pb-2 flex justify-between">
+        <span>Dock position</span>
+        <button
+          className="px-2 py-0.5 border rounded"
+          onClick={() => setOrientation(orientation === 'bottom' ? 'left' : 'bottom')}
+        >
+          {orientation === 'bottom' ? 'Bottom' : 'Left'}
+        </button>
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>
         <input
+          aria-label="Reduced motion"
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
-import QuickSettings from '../ui/QuickSettings';
+import QuickSettings from '../panels/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
 
 export default class Navbar extends Component {


### PR DESCRIPTION
## Summary
- add Dock component that switches between bottom taskbar and left sidebar
- expose dock position setting in Quick Settings panel
- label Quick Settings toggles for accessibility

## Testing
- `npx eslint components/dock/Dock.tsx components/panels/QuickSettings.tsx components/screen/navbar.js`
- `yarn test Dock QuickSettings --passWithNoTests`
- `npx tsc --jsx react --noEmit components/dock/Dock.tsx components/panels/QuickSettings.tsx` *(fails: 'React' refers to a UMD global)*

------
https://chatgpt.com/codex/tasks/task_e_68c3585b0c8883288a184d5f0573738c