### PR TITLE
feat: add togglable cyan accent

### DIFF
--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -12,6 +12,7 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const [accent, setAccent] = usePersistentState('qs-accent', 'blue');
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -20,6 +21,10 @@ const QuickSettings = ({ open }: Props) => {
   useEffect(() => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('accent-cyan', accent === 'cyan');
+  }, [accent]);
 
   return (
     <div
@@ -34,6 +39,15 @@ const QuickSettings = ({ open }: Props) => {
         >
           <span>Theme</span>
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
+        </button>
+      </div>
+      <div className="px-4 pb-2">
+        <button
+          className="w-full flex justify-between"
+          onClick={() => setAccent(accent === 'blue' ? 'cyan' : 'blue')}
+        >
+          <span>Accent</span>
+          <span>{accent === 'blue' ? 'Blue' : 'Cyan'}</span>
         </button>
       </div>
       <div className="px-4 pb-2 flex justify-between">

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,5 +1,16 @@
 @import './globals.css';
 
+/* Alternate accent palette for greener cyan tone */
+html.accent-cyan {
+    --color-primary: #00c9a7;
+    --color-accent: #00c9a7;
+    --color-focus-ring: var(--color-accent);
+    --color-selection: var(--color-accent);
+    --color-control-accent: var(--color-accent);
+    --color-ub-orange: var(--color-accent);
+    accent-color: var(--color-control-accent);
+}
+
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
 }


### PR DESCRIPTION
## Summary
- allow toggling between blue and greener cyan accent in Quick Settings with persistence
- provide CSS accent-cyan variables overriding accent color

## Testing
- `yarn lint` (fails: Unexpected global 'document')
- `yarn test` (fails: window and nmapNse tests)

------
https://chatgpt.com/codex/tasks/task_e_68c35864aadc832880f436f3ae5bb06e