### PR TITLE
feat: add install options list

### DIFF
--- a/pages/install/[category].tsx
+++ b/pages/install/[category].tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+
+const TITLES: Record<string, string> = {
+  'bare-metal': 'Bare Metal',
+  vms: 'VMs',
+  arm: 'ARM',
+  cloud: 'Cloud',
+  containers: 'Containers',
+  wsl: 'WSL',
+};
+
+export default function InstallCategory() {
+  const router = useRouter();
+  const { category } = router.query;
+  if (typeof category !== 'string' || !TITLES[category]) {
+    return (
+      <main className="p-4">
+        <p>Unknown category.</p>
+        <Link href="/install" className="underline">
+          Back to options
+        </Link>
+      </main>
+    );
+  }
+  const title = TITLES[category];
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl">{title}</h1>
+      <p>
+        More information about {title} installation coming soon.
+      </p>
+      <Link href="/install" className="underline">
+        Back to options
+      </Link>
+    </main>
+  );
+}
+

--- a/pages/install/index.tsx
+++ b/pages/install/index.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from 'next/link';
+
+const options = [
+  { id: 'bare-metal', label: 'Bare Metal' },
+  { id: 'vms', label: 'VMs' },
+  { id: 'arm', label: 'ARM' },
+  { id: 'cloud', label: 'Cloud' },
+  { id: 'containers', label: 'Containers' },
+  { id: 'wsl', label: 'WSL' },
+];
+
+export default function InstallOptions() {
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl mb-4">Installation Options</h1>
+      <ul className="space-y-2">
+        {options.map((opt) => (
+          <li
+            key={opt.id}
+            className="flex items-center justify-between border p-2 rounded"
+          >
+            <span>{opt.label}</span>
+            <Link href={`/install/${opt.id}`}>
+              <button className="bg-ubt-blue text-white px-3 py-1 rounded">
+                Learn More
+              </button>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add installation options page listing Bare Metal, VMs, ARM, Cloud, Containers, WSL with internal links
- provide dynamic route for installation category details

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: window snap behavior and nmap NSE app tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c3586b5c048328ab6aa1f9dabd6ca8