### PR TITLE
feat: add wallpapers info card

### DIFF
--- a/components/cards/WallpapersInfo.tsx
+++ b/components/cards/WallpapersInfo.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const WallpapersInfo: React.FC = () => (
+  <section className="p-4 rounded bg-ub-grey text-white">
+    <h2 className="text-xl font-bold mb-2">Wallpapers</h2>
+    <p>
+      Looking for fresh backgrounds? Download the official Kali Linux wallpapers from{' '}
+      <a
+        href="https://www.kali.org/docs/introduction/kali-linux-wallpaper/"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-ub-orange underline"
+      >
+        kali.org
+      </a>
+      .
+    </p>
+  </section>
+);
+
+export default WallpapersInfo;


### PR DESCRIPTION
## Summary
- add WallpapersInfo card with external link to Kali wallpapers

## Testing
- `yarn eslint components/cards/WallpapersInfo.tsx --max-warnings=0 -f json`
- `yarn lint components/cards/WallpapersInfo.tsx` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: window snapping finalize and release, NmapNSEApp copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68c3586e97888328bf3d50f17ac4770a