### PR TITLE
Add milestone summaries to timeline cards

### DIFF
--- a/__tests__/scrollableTimeline.test.tsx
+++ b/__tests__/scrollableTimeline.test.tsx
@@ -20,10 +20,18 @@ describe('ScrollableTimeline', () => {
     // Initially shows years
     const year = screen.getByText('2012');
     expect(year).toBeInTheDocument();
+    // Summary for first milestone is visible
+    expect(
+      screen.getByText('Started nuclear engineering studies at Ontario Tech.')
+    ).toBeInTheDocument();
 
     // Clicking a year zooms to month view
     fireEvent.click(year);
     expect(screen.getByText('2012-09')).toBeInTheDocument();
+    // Summary persists in month view
+    expect(
+      screen.getByText('Started nuclear engineering studies at Ontario Tech.')
+    ).toBeInTheDocument();
     expect(screen.getByText('Back to years')).toBeInTheDocument();
   });
 });

--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -9,6 +9,7 @@ import rawMilestones from '../data/milestones.json';
 interface Milestone {
   date: string; // YYYY-MM
   title: string;
+  summary: string;
   image: string;
   link: string;
   tags: string[];
@@ -123,20 +124,21 @@ const ScrollableTimeline: React.FC = () => {
                         setView('month');
                         setSelectedYear(year);
                       }}
-                      className="text-left w-full focus:outline-none"
-                    >
-                      <div className="text-ubt-blue font-bold text-lg mb-2">{year}</div>
-                      <img
-                        src={first.image}
-                        alt={first.title}
-                        className="w-full h-32 object-cover mb-2 rounded"
-                      />
-                      <p className="text-sm md:text-base mb-2">{first.title}</p>
-                      {renderTags(first.tags)}
-                    </button>
-                  </li>
-                );
-              })
+                    className="text-left w-full focus:outline-none"
+                  >
+                    <div className="text-ubt-blue font-bold text-lg mb-2">{year}</div>
+                    <img
+                      src={first.image}
+                      alt={first.title}
+                      className="w-full h-32 object-cover mb-2 rounded"
+                    />
+                    <p className="text-sm md:text-base">{first.title}</p>
+                    <p className="text-xs text-gray-400 mb-2 truncate">{first.summary}</p>
+                    {renderTags(first.tags)}
+                  </button>
+                </li>
+              );
+            })
             : monthItems.map((m, index) => (
                 <li
                   key={`${selectedYear}-${m.month}`}
@@ -161,6 +163,7 @@ const ScrollableTimeline: React.FC = () => {
                       className="w-full h-32 object-cover mb-2 rounded"
                     />
                     <p className="text-sm md:text-base">{m.title}</p>
+                    <p className="text-xs text-gray-400 truncate">{m.summary}</p>
                   </a>
                   {renderTags(m.tags)}
                 </li>

--- a/data/milestones.json
+++ b/data/milestones.json
@@ -2,6 +2,7 @@
   {
     "date": "2012-09",
     "title": "Began Nuclear Engineering at Ontario Tech.",
+    "summary": "Started nuclear engineering studies at Ontario Tech.",
     "image": "https://via.placeholder.com/150",
     "link": "https://ontariotechu.ca/",
     "tags": ["education", "nuclear"]
@@ -9,6 +10,7 @@
   {
     "date": "2016-06",
     "title": "Graduated with B. Eng.",
+    "summary": "Completed Bachelor of Engineering degree.",
     "image": "https://via.placeholder.com/150",
     "link": "https://ontariotechu.ca/",
     "tags": ["graduation", "education"]
@@ -16,6 +18,7 @@
   {
     "date": "2020-01",
     "title": "Started Networking and I.T. Security program.",
+    "summary": "Enrolled in networking and IT security program.",
     "image": "https://via.placeholder.com/150",
     "link": "https://example.com/networking",
     "tags": ["education", "security"]
@@ -23,6 +26,7 @@
   {
     "date": "2021-03",
     "title": "Completed first capture-the-flag competition.",
+    "summary": "Participated in and completed first CTF event.",
     "image": "https://via.placeholder.com/150",
     "link": "https://example.com/ctf",
     "tags": ["ctf", "competition"]
@@ -30,6 +34,7 @@
   {
     "date": "2023-07",
     "title": "Built portfolio showcasing 20+ security projects.",
+    "summary": "Created portfolio highlighting numerous security projects.",
     "image": "https://via.placeholder.com/150",
     "link": "https://example.com/portfolio",
     "tags": ["portfolio", "projects"]
@@ -37,6 +42,7 @@
   {
     "date": "2024-04",
     "title": "Graduated with BIT in Networking and I.T. Security.",
+    "summary": "Earned BIT in networking and IT security.",
     "image": "https://via.placeholder.com/150",
     "link": "https://example.com/bit",
     "tags": ["graduation", "security"]


### PR DESCRIPTION
## Summary
- add concise `summary` field to milestone dataset
- render date, title, and one-line summary on timeline cards
- verify timeline displays summary in tests

## Testing
- `yarn test __tests__/scrollableTimeline.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c358701da08328b732c38bca891a84