### PR TITLE
Add timed splash overlay before desktop loads

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { ReactNode, useEffect, useState } from "react";
+import Splash from "../components/overlays/Splash";
+import "../styles/index.css";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  const [showDesktop, setShowDesktop] = useState(false);
+  const [showSplash, setShowSplash] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setShowDesktop(true);
+      setTimeout(() => setShowSplash(false), 300);
+    }, 900);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <html lang="en">
+      <body>
+        {showDesktop && children}
+        {showSplash && <Splash fading={showDesktop} />}
+      </body>
+    </html>
+  );
+}

--- a/components/overlays/Splash.tsx
+++ b/components/overlays/Splash.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+interface SplashProps {
+  fading?: boolean;
+}
+
+export default function Splash({ fading }: SplashProps) {
+  return <div className={fading ? "splash-screen splash-screen--hide" : "splash-screen"} />;
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -38,6 +38,36 @@ button:focus-visible {
     scroll-behavior: auto !important;
 }
 
+/* Splash screen overlay */
+.splash-screen {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--color-bg);
+    z-index: 10000;
+}
+
+.splash-screen--hide {
+    animation: splash-fade 300ms forwards;
+}
+
+@keyframes splash-fade {
+    to {
+        opacity: 0;
+        visibility: hidden;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .splash-screen--hide {
+        animation: none;
+        opacity: 0;
+        visibility: hidden;
+    }
+}
+
 /* Top NavBar styling */
 
 .top-arrow-up {


### PR DESCRIPTION
## Summary
- Gate desktop rendering in new `app/layout.tsx` and show splash screen for 900 ms with fade-out
- Introduce `components/overlays/Splash.tsx` full-viewport overlay component
- Define splash overlay styles and reduced-motion guard in `styles/index.css`

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: e.preventDefault is not a function, Unable to find role="alert", Cannot read properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68c37a8ccdf88328b4742bec1eadcf11