### PR TITLE
feat: add greeter overlay

### DIFF
--- a/components/overlays/Greeter.tsx
+++ b/components/overlays/Greeter.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
+
+const Greeter: React.FC = () => {
+  const [hidden, setHidden] = useState(false);
+  const usernameRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    usernameRef.current?.focus();
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setHidden(true);
+    const desktop = document.getElementById('window-area');
+    if (desktop) {
+      desktop.setAttribute('tabindex', '-1');
+      (desktop as HTMLElement).focus();
+    }
+  };
+
+  if (hidden) return null;
+
+  return (
+    <div
+      id="greeter-overlay"
+      className="absolute inset-0 z-[100] flex flex-col items-center justify-center bg-black bg-opacity-90"
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col items-center gap-4"
+        aria-label="login"
+      >
+        <Image
+          src="/themes/Yaru/system/user-desktop.png"
+          alt=""
+          width={96}
+          height={96}
+          className="rounded-full"
+        />
+        <input
+          ref={usernameRef}
+          name="username"
+          aria-label="Username"
+          className="rounded px-2 py-1"
+        />
+        <input
+          type="password"
+          name="password"
+          aria-label="Password"
+          className="rounded px-2 py-1"
+        />
+        <button type="submit" className="mt-2 rounded bg-blue-600 px-4 py-2 text-white">
+          Log In
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default Greeter;
+

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -5,6 +5,7 @@ import BootingScreen from './screen/booting_screen';
 import Desktop from './screen/desktop';
 import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
+import Greeter from './overlays/Greeter';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
 
@@ -116,16 +117,17 @@ export default class Ubuntu extends Component {
 	render() {
 		return (
 			<div className="w-screen h-screen overflow-hidden" id="monitor-screen">
-				<LockScreen
-					isLocked={this.state.screen_locked}
-					bgImgName={this.state.bg_image_name}
-					unLockScreen={this.unLockScreen}
-				/>
-				<BootingScreen
-					visible={this.state.booting_screen}
-					isShutDown={this.state.shutDownScreen}
-					turnOn={this.turnOn}
-				/>
+                                <Greeter />
+                                <LockScreen
+                                        isLocked={this.state.screen_locked}
+                                        bgImgName={this.state.bg_image_name}
+                                        unLockScreen={this.unLockScreen}
+                                />
+                                <BootingScreen
+                                        visible={this.state.booting_screen}
+                                        isShutDown={this.state.shutDownScreen}
+                                        turnOn={this.turnOn}
+                                />
 				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
 				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
 			</div>


### PR DESCRIPTION
## Summary
- add Greeter overlay with avatar, username, and password inputs
- integrate Greeter into Ubuntu render flow

## Testing
- `yarn test` *(fails: e.preventDefault is not a function; unable to find role="alert"; localStorage origin error)*

------
https://chatgpt.com/codex/tasks/task_e_68c37a8eccc483289a8d6c5e7438370c