### PR TITLE
Add power menu overlay

### DIFF
--- a/components/overlays/PowerMenu.tsx
+++ b/components/overlays/PowerMenu.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useState, useEffect, useRef, KeyboardEvent } from 'react';
+import Modal from '../base/Modal';
+
+const isEditable = (el: HTMLElement) => {
+  const tag = el.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || (el as HTMLElement).isContentEditable;
+};
+
+export default function PowerMenu() {
+  const [open, setOpen] = useState(false);
+  const buttonsRef = useRef<Array<HTMLButtonElement | null>>([]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (isEditable(target)) return;
+      if (e.ctrlKey && e.altKey && e.key === 'Delete') {
+        e.preventDefault();
+        setOpen(true);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
+    e.preventDefault();
+    const nodes = buttonsRef.current.filter((b): b is HTMLButtonElement => Boolean(b));
+    if (nodes.length === 0) return;
+    const current = document.activeElement as HTMLButtonElement;
+    let index = nodes.indexOf(current);
+    if (index === -1) index = 0;
+    if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+      index = (index - 1 + nodes.length) % nodes.length;
+    } else if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+      index = (index + 1) % nodes.length;
+    }
+    nodes[index].focus();
+  };
+
+  return (
+    <Modal isOpen={open} onClose={() => setOpen(false)}>
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
+        onKeyDown={handleKeyDown}
+      >
+        <div className="bg-gray-800 text-white p-4 rounded space-y-2 min-w-[200px]">
+          <button
+            ref={(el) => (buttonsRef.current[0] = el)}
+            className="w-full px-4 py-2 bg-gray-700 rounded focus:outline-none focus:ring"
+            type="button"
+          >
+            Shut Down
+          </button>
+          <button
+            ref={(el) => (buttonsRef.current[1] = el)}
+            className="w-full px-4 py-2 bg-gray-700 rounded focus:outline-none focus:ring"
+            type="button"
+          >
+            Restart
+          </button>
+          <button
+            ref={(el) => (buttonsRef.current[2] = el)}
+            className="w-full px-4 py-2 bg-gray-700 rounded focus:outline-none focus:ring"
+            type="button"
+          >
+            Log out
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -12,6 +12,7 @@ import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
+import PowerMenu from '../components/overlays/PowerMenu';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
@@ -161,6 +162,7 @@ function MyApp(props) {
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />
             <ShortcutOverlay />
+            <PowerMenu />
             <Analytics
               beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;


### PR DESCRIPTION
## Summary
- add PowerMenu overlay with shut down, restart and log out options
- wire Ctrl+Alt+Delete shortcut and focus-trapped modal
- include PowerMenu in app layout

## Testing
- `yarn lint` (fails: Unexpected global 'document' in public/apps/tetris/main.js)
- `yarn test` (fails: e.preventDefault is not a function in window.test.tsx; Unable to find role="alert" in nmapNse.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68c37a90461483289573a41e827d3916