### PR TITLE
feat: add lock screen overlay

### DIFF
--- a/__tests__/LockScreen.test.tsx
+++ b/__tests__/LockScreen.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import LockScreen from '../components/overlays/LockScreen';
+
+describe('LockScreen', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem('keymap');
+  });
+
+  it('toggles with Ctrl+L and restores focus on close', () => {
+    render(
+      <div>
+        <button>focus-me</button>
+        <LockScreen />
+      </div>
+    );
+    const btn = screen.getByText('focus-me');
+    btn.focus();
+    expect(document.activeElement).toBe(btn);
+
+    fireEvent.keyDown(window, { key: 'l', ctrlKey: true });
+    expect(screen.getByText(/Locked/)).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByText(/Locked/)).toBeNull();
+    expect(document.activeElement).toBe(btn);
+  });
+});

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -8,6 +8,7 @@ export interface Shortcut {
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
+  { description: 'Lock screen', keys: 'Ctrl+L' },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {

--- a/components/overlays/LockScreen.tsx
+++ b/components/overlays/LockScreen.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import useKeymap from '../../apps/settings/keymapRegistry';
+
+const LockScreen: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const prevFocusRef = useRef<HTMLElement | null>(null);
+  const { shortcuts } = useKeymap();
+
+  const lockKeys =
+    shortcuts.find((s) => s.description === 'Lock screen')?.keys || 'Ctrl+L';
+
+  const close = useCallback(() => {
+    setOpen(false);
+    prevFocusRef.current?.focus();
+    prevFocusRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      const isInput =
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable;
+      if (isInput) return;
+      const parts = [
+        e.ctrlKey ? 'Ctrl' : '',
+        e.altKey ? 'Alt' : '',
+        e.shiftKey ? 'Shift' : '',
+        e.metaKey ? 'Meta' : '',
+        e.key.length === 1 ? e.key.toUpperCase() : e.key,
+      ].filter(Boolean);
+      const combo = parts.join('+');
+      if (combo === lockKeys) {
+        e.preventDefault();
+        if (!open) {
+          prevFocusRef.current = document.activeElement as HTMLElement;
+          setOpen(true);
+          setTimeout(() => overlayRef.current?.focus(), 0);
+        } else {
+          close();
+        }
+      } else if (e.key === 'Escape' && open) {
+        e.preventDefault();
+        close();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [lockKeys, open, close]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleFocus = (e: FocusEvent) => {
+      if (
+        overlayRef.current &&
+        !overlayRef.current.contains(e.target as Node)
+      ) {
+        e.preventDefault();
+        overlayRef.current.focus();
+      }
+    };
+    document.addEventListener('focusin', handleFocus);
+    return () => document.removeEventListener('focusin', handleFocus);
+  }, [open]);
+
+  if (!open) return null;
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+    }
+  };
+
+  return (
+    <div
+      ref={overlayRef}
+      tabIndex={0}
+      role="dialog"
+      aria-modal="true"
+      onKeyDown={handleKeyDown}
+      className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/50"
+      style={{ backdropFilter: 'blur(10px)' }}
+    >
+      <p className="text-2xl text-white">Locked – Press Esc to unlock</p>
+    </div>
+  );
+};
+
+export default LockScreen;
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -14,6 +14,7 @@ import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
+import LockScreen from '../components/overlays/LockScreen';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
@@ -161,6 +162,7 @@ function MyApp(props) {
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />
             <ShortcutOverlay />
+            <LockScreen />
             <Analytics
               beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;


### PR DESCRIPTION
## Summary
- add LockScreen overlay with backdrop blur and focus trapping
- register Ctrl+L shortcut in keymap and mount overlay globally
- test lock screen toggle and focus restoration

## Testing
- `yarn lint components/overlays/LockScreen.tsx apps/settings/keymapRegistry.ts pages/_app.jsx __tests__/LockScreen.test.tsx` (fails: A control must be associated with a text label)
- `yarn test` (fails: e.preventDefault is not a function; Unable to find role="alert")

------
https://chatgpt.com/codex/tasks/task_e_68c37a8e3b7083288762a40edcd1999d