### PR TITLE
Add onboarding tour for key desktop elements

### DIFF
--- a/components/overlays/Onboarding.tsx
+++ b/components/overlays/Onboarding.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import Tour, { type TourStepProps } from '@rc-component/tour';
+import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
+
+const STORAGE_KEY = 'onboarding-complete';
+
+const steps: TourStepProps[] = [
+  {
+    title: 'Dock',
+    description: 'Your favorite apps live here.',
+    target: () => document.querySelector('nav[aria-label="Dock"]') as HTMLElement,
+  },
+  {
+    title: 'Launcher',
+    description: 'Open the app launcher to explore all applications.',
+    target: () =>
+      document.querySelector('nav[aria-label="Dock"] img[alt="Ubuntu view app"]') as HTMLElement,
+  },
+  {
+    title: 'Terminal',
+    description: 'Access the Terminal from the dock.',
+    target: () =>
+      document.querySelector('nav[aria-label="Dock"] [aria-label="Terminal"]') as HTMLElement,
+  },
+];
+
+export default function Onboarding() {
+  const [open, setOpen] = useState(false);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!window.localStorage.getItem(STORAGE_KEY)) {
+      setOpen(true);
+    }
+  }, []);
+
+  const handleFinish = () => {
+    setOpen(false);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, '1');
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <Tour
+      open={open}
+      onClose={handleFinish}
+      onFinish={handleFinish}
+      steps={steps}
+      mask
+      animated={!prefersReducedMotion}
+    />
+  );
+}
+

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -23,6 +23,7 @@ import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { useSnapSetting } from '../../hooks/usePersistentState';
+import Onboarding from '../overlays/Onboarding';
 
 export class Desktop extends Component {
     constructor() {
@@ -839,7 +840,7 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                      <input aria-label="Folder name" className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
                 </div>
                 <div className="flex">
                     <button
@@ -966,6 +967,8 @@ export class Desktop extends Component {
                         windows={this.state.switcherWindows}
                         onSelect={this.selectWindow}
                         onClose={this.closeWindowSwitcher} /> : null}
+
+                <Onboarding />
 
             </main>
         )


### PR DESCRIPTION
## Summary
- add onboarding tooltip tour guiding users through dock, launcher and terminal
- remember tour completion with localStorage and disable animations when users prefer reduced motion
- integrate onboarding into desktop and label folder name input

## Testing
- `npx eslint components/overlays/Onboarding.tsx components/screen/desktop.js`
- `yarn test Onboarding` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c37a929388832895e91b8709322ed1