### PR TITLE
feat(desktop): enable icon rename

### DIFF
--- a/components/desktop/DesktopIcon.tsx
+++ b/components/desktop/DesktopIcon.tsx
@@ -1,0 +1,128 @@
+import React, { useState, useRef, useEffect } from 'react';
+import Image from 'next/image';
+
+interface DesktopIconProps {
+    name: string;
+    id: string;
+    icon: string;
+    openApp: (id: string) => void;
+    disabled?: boolean;
+    displayName?: string;
+    prefetch?: () => void;
+}
+
+const DesktopIcon: React.FC<DesktopIconProps> = ({ name, id, icon, openApp, disabled, displayName, prefetch }) => {
+    const [launching, setLaunching] = useState(false);
+    const [dragging, setDragging] = useState(false);
+    const [prefetched, setPrefetched] = useState(false);
+    const [isRenaming, setIsRenaming] = useState(false);
+    const [caption, setCaption] = useState(displayName || name);
+    const [tempName, setTempName] = useState(displayName || name);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const handleDragStart = () => setDragging(true);
+    const handleDragEnd = () => setDragging(false);
+
+    const open = () => {
+        if (disabled) return;
+        setLaunching(true);
+        setTimeout(() => setLaunching(false), 300);
+        openApp(id);
+    };
+
+    const handlePrefetch = () => {
+        if (!prefetched && typeof prefetch === 'function') {
+            prefetch();
+            setPrefetched(true);
+        }
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (isRenaming) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            open();
+        } else if (e.key === 'F2') {
+            e.preventDefault();
+            setTempName(caption);
+            setIsRenaming(true);
+        }
+    };
+
+    useEffect(() => {
+        if (isRenaming && inputRef.current) {
+            inputRef.current.focus();
+            inputRef.current.select();
+        }
+    }, [isRenaming]);
+
+    const commitRename = () => {
+        const newName = tempName.trim();
+        if (newName) {
+            setCaption(newName);
+        }
+        setIsRenaming(false);
+    };
+
+    const cancelRename = () => {
+        setTempName(caption);
+        setIsRenaming(false);
+    };
+
+    const handleRenameKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            if (tempName.trim()) {
+                commitRename();
+            }
+        } else if (e.key === 'Escape') {
+            e.preventDefault();
+            cancelRename();
+        }
+    };
+
+    return (
+        <div
+            role="button"
+            aria-label={caption}
+            aria-disabled={disabled}
+            data-context="app"
+            data-app-id={id}
+            draggable={!isRenaming}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            className={(launching ? ' app-icon-launch ' : '') + (dragging ? ' opacity-70 ' : '') +
+                ' p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active '}
+            id={'app-' + id}
+            onDoubleClick={open}
+            onKeyDown={handleKeyDown}
+            tabIndex={disabled ? -1 : 0}
+            onMouseEnter={handlePrefetch}
+            onFocus={handlePrefetch}
+        >
+            <Image
+                width={40}
+                height={40}
+                className="mb-1 w-10"
+                src={icon.replace('./', '/')}
+                alt={'Kali ' + caption}
+                sizes="40px"
+            />
+            {isRenaming ? (
+                <input
+                    ref={inputRef}
+                    value={tempName}
+                    onChange={(e) => setTempName(e.target.value)}
+                    onBlur={commitRename}
+                    onKeyDown={handleRenameKey}
+                    className="w-full text-center text-xs text-black"
+                />
+            ) : (
+                caption
+            )}
+        </div>
+    );
+};
+
+export default DesktopIcon;
+

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -10,7 +10,7 @@ const BackgroundImage = dynamic(
 import SideBar from './side_bar';
 import apps, { games } from '../../apps.config';
 import Window from '../base/window';
-import UbuntuApp from '../base/ubuntu_app';
+import DesktopIcon from '../desktop/DesktopIcon';
 import AllApplications from '../screen/all-applications'
 import ShortcutSelector from '../screen/shortcut-selector'
 import WindowSwitcher from '../screen/window-switcher'
@@ -447,7 +447,7 @@ export class Desktop extends Component {
                 }
 
                 appsJsx.push(
-                    <UbuntuApp key={app.id} {...props} />
+                    <DesktopIcon key={app.id} {...props} />
                 );
             }
         });


### PR DESCRIPTION
## Summary
- add DesktopIcon component with inline rename UI and F2 shortcut
- render DesktopIcon for desktop apps

## Testing
- `yarn test __tests__/window.test.tsx` (fails: TypeError: e.preventDefault is not a function)
- `yarn test __tests__/nmapNse.test.tsx` (fails: Unable to find role="alert")


------
https://chatgpt.com/codex/tasks/task_e_68c37a95e3048328a2cdfd254ae26001