### PR TITLE
Add terminal option for desktop folders

### DIFF
--- a/components/context-menus/desktop-menu.tsx
+++ b/components/context-menus/desktop-menu.tsx
@@ -1,54 +1,75 @@
-import React, { useState, useEffect } from 'react'
-import logger from '../../utils/logger'
+import React, { useState, useEffect } from 'react';
+import logger from '../../utils/logger';
+import apps from '../../apps.config';
 
-function DesktopMenu(props) {
+interface DesktopMenuProps {
+    active: boolean;
+    openApp: (id: string) => void;
+    addNewFolder: () => void;
+    openShortcutSelector: () => void;
+    clearSession: () => void;
+    /** ID of the app/folder that triggered the menu */
+    contextApp?: string | null;
+}
 
-    const [isFullScreen, setIsFullScreen] = useState(false)
+function DesktopMenu(props: DesktopMenuProps) {
+    const [isFullScreen, setIsFullScreen] = useState(false);
 
     useEffect(() => {
         document.addEventListener('fullscreenchange', checkFullScreen);
         return () => {
             document.removeEventListener('fullscreenchange', checkFullScreen);
         };
-    }, [])
-
+    }, []);
 
     const openTerminal = () => {
-        props.openApp("terminal");
-    }
+        if (props.contextApp && props.contextApp.startsWith('new-folder-')) {
+            const folder = apps.find(a => a.id === props.contextApp);
+            const terminal = apps.find(a => a.id === 'terminal');
+            if (folder && terminal) {
+                const termId = `terminal-${props.contextApp}`;
+                if (!apps.find(a => a.id === termId)) {
+                    apps.push({ ...terminal, id: termId, title: folder.title });
+                }
+                props.openApp(termId);
+                return;
+            }
+        }
+        props.openApp('terminal');
+    };
 
     const openSettings = () => {
-        props.openApp("settings");
-    }
+        props.openApp('settings');
+    };
 
     const checkFullScreen = () => {
         if (document.fullscreenElement) {
-            setIsFullScreen(true)
+            setIsFullScreen(true);
         } else {
-            setIsFullScreen(false)
+            setIsFullScreen(false);
         }
-    }
+    };
 
     const goFullScreen = () => {
         // make website full screen
         try {
             if (document.fullscreenElement) {
-                document.exitFullscreen()
+                document.exitFullscreen();
             } else {
-                document.documentElement.requestFullscreen()
+                document.documentElement.requestFullscreen();
             }
         }
         catch (e) {
-            logger.error(e)
+            logger.error(e);
         }
-    }
+    };
 
     return (
         <div
             id="desktop-menu"
             role="menu"
             aria-label="Desktop context menu"
-            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
         >
             <button
                 onClick={props.addNewFolder}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -246,11 +246,19 @@ export class Desktop extends Component {
                 this.showContextMenu(e, "desktop");
                 break;
             case "app":
-                ReactGA.event({
-                    category: `Context Menu`,
-                    action: `Opened App Context Menu`
-                });
-                this.setState({ context_app: appId }, () => this.showContextMenu(e, "app"));
+                if (appId && appId.startsWith('new-folder-')) {
+                    ReactGA.event({
+                        category: `Context Menu`,
+                        action: `Opened Folder Context Menu`
+                    });
+                    this.setState({ context_app: appId }, () => this.showContextMenu(e, "desktop"));
+                } else {
+                    ReactGA.event({
+                        category: `Context Menu`,
+                        action: `Opened App Context Menu`
+                    });
+                    this.setState({ context_app: appId }, () => this.showContextMenu(e, "app"));
+                }
                 break;
             case "taskbar":
                 ReactGA.event({
@@ -912,6 +920,7 @@ export class Desktop extends Component {
                     addNewFolder={this.addNewFolder}
                     openShortcutSelector={this.openShortcutSelector}
                     clearSession={() => { this.props.clearSession(); window.location.reload(); }}
+                    contextApp={this.state.context_app}
                 />
                 <DefaultMenu active={this.state.context_menus.default} onClose={this.hideAllContextMenu} />
                 <AppMenu


### PR DESCRIPTION
## Summary
- allow opening a Terminal when right-clicking desktop folders
- give the new terminal window the folder name as its title
- treat folder icons as desktop context menu targets

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, installButton.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c37a9970ac8328bafe1e5291b3a529