### PR TITLE
feat: add multi-timezone clock popover

### DIFF
--- a/components/panels/ClockPopover.tsx
+++ b/components/panels/ClockPopover.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import settings from "../../data/settings.json";
+
+interface Settings {
+  extraTimeZones?: string[];
+}
+
+const extras: string[] = (settings as Settings).extraTimeZones?.slice(0, 2) || [];
+
+function formatTime(date: Date, timeZone?: string) {
+  return date.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone,
+  });
+}
+
+export default function ClockPopover() {
+  const [now, setNow] = useState<Date>(() => new Date());
+
+  useEffect(() => {
+    const update = () => setNow(new Date());
+    const id = setInterval(update, 60 * 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="p-4 text-ubt-grey">
+      <div suppressHydrationWarning>
+        {formatTime(now)} <span className="ml-2 text-xs">Local</span>
+      </div>
+      {extras.map((tz) => (
+        <div key={tz} suppressHydrationWarning>
+          {formatTime(now, tz)} <span className="ml-2 text-xs">{tz}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/data/settings.json
+++ b/data/settings.json
@@ -1,0 +1,3 @@
+{
+  "extraTimeZones": ["Europe/London", "Asia/Tokyo"]
+}


### PR DESCRIPTION
## Summary
- display local and additional time zones from settings JSON
- show all clocks in 24-hour format and refresh every minute

## Testing
- `yarn test` *(fails: window, nmapNse, flappyBird)*
- `yarn lint components/panels/ClockPopover.tsx` *(no output, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c37a9aa0d48328b441a53f95f0d8db