### PR TITLE
Add battery power management components

### DIFF
--- a/components/panels/TrayGroup.tsx
+++ b/components/panels/TrayGroup.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import usePersistentState from '../../hooks/usePersistentState';
+
+export type BatteryVariant = 'normal' | 'charging';
+
+const BatteryIcon = ({ percent, variant }: { percent: number; variant: BatteryVariant }) => {
+  const clamped = Math.max(0, Math.min(100, percent));
+  const innerWidth = (clamped / 100) * 16; // inner width within outer battery
+  const fill = clamped < 20 ? '#f87171' : 'currentColor';
+
+  return (
+    <svg
+      width="26"
+      height="14"
+      viewBox="0 0 26 14"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-label="battery"
+      className="text-current"
+    >
+      <rect
+        x="1"
+        y="1"
+        width="20"
+        height="12"
+        rx="2"
+        ry="2"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+      />
+      <rect x="3" y="3" width={innerWidth} height="8" fill={fill} />
+      <rect x="22" y="4" width="3" height="6" rx="1" ry="1" fill="currentColor" />
+      {variant === 'charging' && (
+        <polygon
+          points="12,3 9,7 12,7 10,11 15,6 12,6"
+          fill="#000"
+        />
+      )}
+    </svg>
+  );
+};
+
+const TrayGroup = () => {
+  const [percent] = usePersistentState<number>(
+    'battery-percent',
+    100,
+    (v): v is number => typeof v === 'number',
+  );
+  const [variant] = usePersistentState<BatteryVariant>(
+    'battery-variant',
+    'normal',
+    (v): v is BatteryVariant => v === 'normal' || v === 'charging',
+  );
+
+  return (
+    <div className="flex items-center gap-1" aria-label="battery-status">
+      <BatteryIcon percent={percent} variant={variant} />
+      <span className="text-sm">{percent}%</span>
+    </div>
+  );
+};
+
+export default TrayGroup;

--- a/components/settings/Power.tsx
+++ b/components/settings/Power.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+import Toast from '../ui/Toast';
+
+export type BatteryVariant = 'normal' | 'charging';
+
+const Power = () => {
+  const [percent, setPercent] = usePersistentState<number>(
+    'battery-percent',
+    100,
+    (v): v is number => typeof v === 'number',
+  );
+  const [variant, setVariant] = usePersistentState<BatteryVariant>(
+    'battery-variant',
+    'normal',
+    (v): v is BatteryVariant => v === 'normal' || v === 'charging',
+  );
+  const [toast, setToast] = useState('');
+
+  useEffect(() => {
+    if (percent < 20) {
+      setToast('Battery low');
+    }
+  }, [percent]);
+
+  return (
+    <div className="p-4 space-y-4">
+      <div>
+        <label htmlFor="battery-slider" className="block mb-1">
+          Battery: {percent}%
+        </label>
+        <input
+          id="battery-slider"
+          type="range"
+          min={0}
+          max={100}
+          value={percent}
+          onChange={(e) => setPercent(parseInt(e.target.value))}
+          className="w-full"
+          aria-label="battery percentage"
+        />
+      </div>
+      <div>
+        <label htmlFor="battery-variant" className="block mb-1">
+          Variant
+        </label>
+        <select
+          id="battery-variant"
+          value={variant}
+          onChange={(e) => setVariant(e.target.value as BatteryVariant)}
+          className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+        >
+          <option value="normal">Normal</option>
+          <option value="charging">Charging</option>
+        </select>
+      </div>
+      {toast && <Toast message={toast} onClose={() => setToast('')} />}
+    </div>
+  );
+};
+
+export default Power;


### PR DESCRIPTION
## Summary
- Add tray group component with battery icon and percentage display
- Provide power settings with persistent slider and warning toast

## Testing
- `npx eslint components/panels/TrayGroup.tsx components/settings/Power.tsx`
- `yarn lint components/panels/TrayGroup.tsx components/settings/Power.tsx` *(fails: A control must be associated with a text label and numerous project-wide lint errors)*
- `yarn test` *(fails: window snapping finalize and NmapNSE test errors, localStorage TypeError)*


------
https://chatgpt.com/codex/tasks/task_e_68c37a9b4d548328b24d476d6974cedd