### PR TITLE
feat: add warm-tone overlay

### DIFF
--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -12,6 +12,9 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const [warmTone, setWarmTone] = usePersistentState('qs-warm-tone', false);
+  const [warmStart, setWarmStart] = usePersistentState('qs-warm-start', '19:00');
+  const [warmEnd, setWarmEnd] = usePersistentState('qs-warm-end', '07:00');
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -20,6 +23,33 @@ const QuickSettings = ({ open }: Props) => {
   useEffect(() => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
+
+  useEffect(() => {
+    const applyWarmTone = () => {
+      if (!warmTone) {
+        document.documentElement.classList.remove('warm-tone');
+        return;
+      }
+
+      const [startH, startM] = warmStart.split(':').map(Number);
+      const [endH, endM] = warmEnd.split(':').map(Number);
+      const start = startH * 60 + startM;
+      const end = endH * 60 + endM;
+      const now = new Date();
+      const current = now.getHours() * 60 + now.getMinutes();
+
+      const active =
+        start < end
+          ? current >= start && current < end
+          : current >= start || current < end;
+
+      document.documentElement.classList.toggle('warm-tone', active);
+    };
+
+    applyWarmTone();
+    const id = setInterval(applyWarmTone, 60 * 1000);
+    return () => clearInterval(id);
+  }, [warmTone, warmStart, warmEnd]);
 
   return (
     <div
@@ -44,13 +74,45 @@ const QuickSettings = ({ open }: Props) => {
         <span>Network</span>
         <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
       </div>
-      <div className="px-4 flex justify-between">
+      <div className="px-4 pb-2 flex justify-between">
         <span>Reduced motion</span>
         <input
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
         />
+      </div>
+      <div className="px-4 pb-2 flex justify-between">
+        <span>Warm tone</span>
+        <input
+          type="checkbox"
+          checked={warmTone}
+          onChange={() => setWarmTone(!warmTone)}
+        />
+      </div>
+      <div className="px-4 pb-2">
+        <div className="flex justify-between pb-2">
+          <label htmlFor="warm-start" className="mr-2">
+            Start
+          </label>
+          <input
+            id="warm-start"
+            type="time"
+            value={warmStart}
+            onChange={(e) => setWarmStart(e.target.value)}
+          />
+        </div>
+        <div className="flex justify-between">
+          <label htmlFor="warm-end" className="mr-2">
+            End
+          </label>
+          <input
+            id="warm-end"
+            type="time"
+            value={warmEnd}
+            onChange={(e) => setWarmEnd(e.target.value)}
+          />
+        </div>
       </div>
     </div>
   );

--- a/styles/index.css
+++ b/styles/index.css
@@ -399,6 +399,16 @@ dialog {
     list-style: "🌟";
 }
 
+html.warm-tone::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background: rgba(255, 153, 51, 0.15);
+    mix-blend-mode: multiply;
+    z-index: 9999;
+}
+
 .list-arrow {
     list-style: "⇀";
 }


### PR DESCRIPTION
## Summary
- allow scheduling a warm-tone overlay from quick settings
- overlay applies with mix-blend-mode and respects local time

## Testing
- `yarn lint` (fails: A control must be associated with a text label)
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` (fails: releases snap with Alt+ArrowDown restoring size; copies example output to clipboard)


------
https://chatgpt.com/codex/tasks/task_e_68c37a9c3b608328b10cbb5ddbfd0ef3