### PR TITLE
feat: add DND gating for notifications

### DIFF
--- a/__tests__/notifications.test.tsx
+++ b/__tests__/notifications.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { NotificationsProvider, useNotifications } from '../store/notifications';
+
+describe('notifications store', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <NotificationsProvider>{children}</NotificationsProvider>
+  );
+
+  it('mutes toasts while DND active and restores on disable', () => {
+    const { result } = renderHook(() => useNotifications(), { wrapper });
+
+    act(() => result.current.toggleDnd());
+    act(() => result.current.push('hello'));
+
+    expect(result.current.notifications).toHaveLength(0);
+    expect(result.current.mutedCount).toBe(1);
+
+    act(() => result.current.toggleDnd());
+
+    expect(result.current.notifications).toHaveLength(1);
+    expect(result.current.mutedCount).toBe(0);
+  });
+});

--- a/components/panels/TrayGroup.tsx
+++ b/components/panels/TrayGroup.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useNotifications } from '../../store/notifications';
+
+/**
+ * TrayGroup shows a DND toggle and indicates the number of muted
+ * notifications while DND is active.
+ */
+const TrayGroup: React.FC = () => {
+  const { dnd, toggleDnd, mutedCount } = useNotifications();
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        aria-pressed={dnd}
+        onClick={toggleDnd}
+        className="relative px-2 py-1 bg-ub-grey text-black rounded"
+      >
+        {dnd ? 'DND On' : 'DND Off'}
+        {mutedCount > 0 && (
+          <span className="absolute -top-1 -right-1 bg-red-600 text-white text-xs rounded-full px-1">
+            {mutedCount}
+          </span>
+        )}
+      </button>
+    </div>
+  );
+};
+
+export default TrayGroup;

--- a/store/notifications.tsx
+++ b/store/notifications.tsx
@@ -1,0 +1,83 @@
+import React, { createContext, useCallback, useContext, useState } from 'react';
+
+export interface Notification {
+  id: string;
+  message: string;
+  date: number;
+}
+
+interface NotificationsStore {
+  notifications: Notification[];
+  /** number of notifications muted while DND is active */
+  mutedCount: number;
+  /** whether Do Not Disturb mode is active */
+  dnd: boolean;
+  /** push a new notification; will be muted when DND is on */
+  push: (message: string) => void;
+  /** remove all notifications and muted items */
+  clear: () => void;
+  /** toggle DND mode; flushing muted notifications when turning off */
+  toggleDnd: () => void;
+}
+
+export const NotificationsContext =
+  createContext<NotificationsStore | null>(null);
+
+export const NotificationsProvider: React.FC<{ children?: React.ReactNode }>
+  = ({ children }) => {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [muted, setMuted] = useState<Notification[]>([]);
+  const [dnd, setDnd] = useState(false);
+
+  const push = useCallback(
+    (message: string) => {
+      const n: Notification = {
+        id: `${Date.now()}-${Math.random()}`,
+        message,
+        date: Date.now(),
+      };
+      if (dnd) setMuted((prev) => [...prev, n]);
+      else setNotifications((prev) => [...prev, n]);
+    },
+    [dnd]
+  );
+
+  const clear = useCallback(() => {
+    setNotifications([]);
+    setMuted([]);
+  }, []);
+
+  const toggleDnd = useCallback(() => {
+    setDnd((prev) => {
+      const next = !prev;
+      if (prev && !next && muted.length > 0) {
+        setNotifications((n) => [...n, ...muted]);
+        setMuted([]);
+      }
+      return next;
+    });
+  }, [muted]);
+
+  const value: NotificationsStore = {
+    notifications,
+    mutedCount: muted.length,
+    dnd,
+    push,
+    clear,
+    toggleDnd,
+  };
+
+  return (
+    <NotificationsContext.Provider value={value}>
+      {children}
+    </NotificationsContext.Provider>
+  );
+};
+
+export const useNotifications = () => {
+  const ctx = useContext(NotificationsContext);
+  if (!ctx) throw new Error('useNotifications must be used within NotificationsProvider');
+  return ctx;
+};
+
+export default NotificationsProvider;


### PR DESCRIPTION
## Summary
- add notification store with DND support to mute toasts and queue messages
- provide TrayGroup component with toggle and badge for muted count
- cover notification behavior with a unit test

## Testing
- `yarn test __tests__/notifications.test.tsx`
- `yarn lint store/notifications.tsx components/panels/TrayGroup.tsx __tests__/notifications.test.tsx` *(fails: Unexpected global 'document' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c37a9db4f883288050738149b14a5a