### PR TITLE
feat(window): allow pinning windows above others

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -199,7 +199,7 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true, preventDefault: () => {}, stopPropagation: () => {} } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();
@@ -319,6 +319,34 @@ describe('Edge resistance', () => {
     });
 
     expect(winEl.style.transform).toBe('translate(0px, 0px)');
+  });
+});
+
+describe('Always on top flag', () => {
+  it('toggles state and moves window to overlay root', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    expect(ref.current!.state.alwaysOnTop).toBe(false);
+    act(() => {
+      ref.current!.toggleAlwaysOnTop();
+    });
+    expect(ref.current!.state.alwaysOnTop).toBe(true);
+    const overlay = document.getElementById('window-overlay-root');
+    expect(overlay).not.toBeNull();
+    expect(overlay!.contains(document.getElementById('test-window'))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- add `alwaysOnTop` flag to window state and overlay root rendering
- allow toggling pin state from title bar context menu
- ensure portal keeps pinned windows above others without altering focus

## Testing
- `yarn test __tests__/window.test.tsx`
- `yarn test` *(fails: Unable to find role="alert" in __tests__/nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c37aa35b9483289cf99025303b1f5b