### PR TITLE
feat: theme tokens for menus and toasts

### DIFF
--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -110,7 +110,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
             item.onSelect();
             setOpen(false);
           }}
-          className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+          className="w-full text-left cursor-default py-0.5 mb-1.5 context-menu-item"
         >
           {item.label}
         </button>

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -35,7 +35,7 @@ function AppMenu(props) {
                 onClick={handlePin}
                 role="menuitem"
                 aria-label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full text-left cursor-default py-0.5 mb-1.5 context-menu-item"
             >
                 <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
             </button>

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -30,7 +30,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Linkedin"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full block cursor-default py-0.5 mb-1.5 context-menu-item"
             >
                 <span className="ml-5">🙋‍♂️</span> <span className="ml-2">Follow on <strong>Linkedin</strong></span>
             </a>
@@ -40,7 +40,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Github"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full block cursor-default py-0.5 mb-1.5 context-menu-item"
             >
                 <span className="ml-5">🤝</span> <span className="ml-2">Follow on <strong>Github</strong></span>
             </a>
@@ -50,7 +50,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Contact Me"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full block cursor-default py-0.5 mb-1.5 context-menu-item"
             >
                 <span className="ml-5">📥</span> <span className="ml-2">Contact Me</span>
             </a>
@@ -60,7 +60,7 @@ function DefaultMenu(props) {
                 onClick={() => { localStorage.clear(); window.location.reload() }}
                 role="menuitem"
                 aria-label="Reset Kali Linux"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full text-left cursor-default py-0.5 mb-1.5 context-menu-item"
             >
                 <span className="ml-5">🧹</span> <span className="ml-2">Reset Kali Linux</span>
             </button>

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -55,7 +55,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="New Folder"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left py-0.5 mb-1.5 context-menu-item"
             >
                 <span className="ml-5">New Folder</span>
             </button>
@@ -64,16 +64,16 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Create Shortcut"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left py-0.5 mb-1.5 context-menu-item"
             >
                 <span className="ml-5">Create Shortcut...</span>
             </button>
             <Devider />
-            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 mb-1.5 text-gray-400 context-menu-item">
                 <span className="ml-5">Paste</span>
             </div>
             <Devider />
-            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 mb-1.5 text-gray-400 context-menu-item">
                 <span className="ml-5">Show Desktop in Files</span>
             </div>
             <button
@@ -81,7 +81,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Open in Terminal"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left py-0.5 mb-1.5 context-menu-item"
             >
                 <span className="ml-5">Open in Terminal</span>
             </button>
@@ -91,12 +91,12 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Change Background"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left py-0.5 mb-1.5 context-menu-item"
             >
                 <span className="ml-5">Change Background...</span>
             </button>
             <Devider />
-            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 mb-1.5 text-gray-400 context-menu-item">
                 <span className="ml-5">Display Settings</span>
             </div>
             <button
@@ -104,7 +104,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Settings"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left py-0.5 mb-1.5 context-menu-item"
             >
                 <span className="ml-5">Settings</span>
             </button>
@@ -114,7 +114,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label={isFullScreen ? "Exit Full Screen" : "Enter Full Screen"}
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left py-0.5 mb-1.5 context-menu-item"
             >
                 <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
             </button>
@@ -124,7 +124,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Clear Session"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left py-0.5 mb-1.5 context-menu-item"
             >
                 <span className="ml-5">Clear Session</span>
             </button>

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -37,7 +37,7 @@ function TaskbarMenu(props) {
                 onClick={handleMinimize}
                 role="menuitem"
                 aria-label={props.minimized ? 'Restore Window' : 'Minimize Window'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full text-left cursor-default py-0.5 mb-1.5 context-menu-item"
             >
                 <span className="ml-5">{props.minimized ? 'Restore' : 'Minimize'}</span>
             </button>
@@ -46,7 +46,7 @@ function TaskbarMenu(props) {
                 onClick={handleClose}
                 role="menuitem"
                 aria-label="Close Window"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full text-left cursor-default py-0.5 mb-1.5 context-menu-item"
             >
                 <span className="ml-5">Close</span>
             </button>

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -32,7 +32,11 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform text-white px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      style={{
+        background: 'var(--kali-toast, #111827)',
+        border: '1px solid var(--kali-toast-border, #374151)',
+      }}
     >
       <span>{message}</span>
       {onAction && actionLabel && (

--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,13 @@ body{
     color: var(--color-text);
 }
 
+[data-theme="kali"] {
+    --kali-menu: color-mix(in srgb, var(--color-bg), transparent 60%);
+    --kali-menu-hover: color-mix(in srgb, var(--color-bg), transparent 45%);
+    --kali-toast: color-mix(in srgb, var(--color-bg), transparent 60%);
+    --kali-toast-border: color-mix(in srgb, var(--color-bg), transparent 40%);
+}
+
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
     min-width: var(--hit-area);
     min-height: var(--hit-area);
@@ -367,7 +374,7 @@ dialog {
 /* Context Menu & Panels */
 .context-menu-bg,
 .windowMainScreen {
-    background-color: color-mix(in srgb, var(--color-bg), transparent 15%); /* Fallback for unsupported browsers */
+    background-color: var(--kali-menu, color-mix(in srgb, var(--color-bg), transparent 15%));
 }
 
 @supports ((-webkit-backdrop-filter: blur(0)) or (backdrop-filter: blur(0))) {
@@ -375,8 +382,12 @@ dialog {
     .windowMainScreen {
         -webkit-backdrop-filter: blur(10px);
         backdrop-filter: blur(10px);
-        background-color: color-mix(in srgb, var(--color-bg), transparent 60%);
+        background-color: var(--kali-menu, color-mix(in srgb, var(--color-bg), transparent 60%));
     }
+}
+
+.context-menu-item:hover {
+    background-color: var(--kali-menu-hover, #374151);
 }
 
 .emoji-list>li {


### PR DESCRIPTION
## Summary
- add Kali theme CSS variables for menus and toast UI
- apply new tokens to context menu items and toast component

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: e.preventDefault is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c37aa8f3a083288cf60a61cf694626