### PR TITLE
feat: add kali accent ramp and hover states

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -1,5 +1,52 @@
 @import './globals.css';
 
+html[data-theme="kali"] {
+    --kali-accent-50: color-mix(in oklch, #1793d1 10%, white);
+    --kali-accent-100: color-mix(in oklch, #1793d1 20%, white);
+    --kali-accent-200: color-mix(in oklch, #1793d1 30%, white);
+    --kali-accent-300: color-mix(in oklch, #1793d1 40%, white);
+    --kali-accent-400: color-mix(in oklch, #1793d1 50%, white);
+    --kali-accent-500: #1793d1;
+    --kali-accent-600: color-mix(in oklch, #1793d1 90%, black);
+    --kali-accent-700: color-mix(in oklch, #1793d1 80%, black);
+    --kali-accent-800: color-mix(in oklch, #1793d1 70%, black);
+    --kali-accent-900: color-mix(in oklch, #1793d1 60%, black);
+
+    --color-primary: var(--kali-accent-500);
+    --color-accent: var(--kali-accent-500);
+    --color-focus-ring: var(--kali-accent-600);
+    --color-selection: var(--kali-accent-200);
+    --color-control-accent: var(--kali-accent-500);
+    accent-color: var(--color-control-accent);
+}
+
+html[data-theme="kali"] a {
+    color: var(--kali-accent-500);
+    transition: color 0.2s;
+}
+
+html[data-theme="kali"] a:hover {
+    color: var(--kali-accent-600);
+}
+
+html[data-theme="kali"] a:active {
+    color: var(--kali-accent-700);
+}
+
+html[data-theme="kali"] button {
+    background-color: var(--kali-accent-500);
+    color: var(--color-text);
+    transition: background-color 0.2s;
+}
+
+html[data-theme="kali"] button:hover {
+    background-color: var(--kali-accent-600);
+}
+
+html[data-theme="kali"] button:active {
+    background-color: var(--kali-accent-700);
+}
+
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
 }


### PR DESCRIPTION
## Summary
- generate OKLCH-based `--kali-accent-*` scale
- wire buttons/links to adjacent ramp steps for hover and active states
- map Kali theme colors to new accent ramp

## Testing
- `yarn lint styles/index.css` (fails: Unexpected global 'document')
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` (fails: 2 failed, 2 total)


------
https://chatgpt.com/codex/tasks/task_e_68c37aaabbb48328a7e9a6d9885b252d