### PR TITLE
Add density-based menu item heights

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -232,7 +232,7 @@ export default function Settings() {
               onChange={(e) => setDensity(e.target.value as any)}
               className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
             >
-              <option value="regular">Regular</option>
+              <option value="regular">Comfortable</option>
               <option value="compact">Compact</option>
             </select>
           </div>

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -95,7 +95,7 @@ export function Settings() {
                     onChange={(e) => setDensity(e.target.value)}
                     className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
                 >
-                    <option value="regular">Regular</option>
+                    <option value="regular">Comfortable</option>
                     <option value="compact">Compact</option>
                 </select>
             </div>

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -110,7 +110,8 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
             item.onSelect();
             setOpen(false);
           }}
-          className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+          className="w-full text-left cursor-default hover:bg-gray-700 mb-1.5 flex items-center whitespace-normal break-words"
+          style={{ minHeight: 'var(--menu-item-height)' }}
         >
           {item.label}
         </button>

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -35,9 +35,10 @@ function AppMenu(props) {
                 onClick={handlePin}
                 role="menuitem"
                 aria-label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full text-left cursor-default hover:bg-gray-700 mb-1.5 flex items-center"
+                style={{ minHeight: 'var(--menu-item-height)' }}
             >
-                <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
+                <span className="ml-5 flex-1 whitespace-normal break-words">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
             </button>
         </div>
     )

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -30,9 +30,10 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Linkedin"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full block cursor-default hover:bg-gray-700 mb-1.5 flex items-center"
+                style={{ minHeight: 'var(--menu-item-height)' }}
             >
-                <span className="ml-5">🙋‍♂️</span> <span className="ml-2">Follow on <strong>Linkedin</strong></span>
+                <span className="ml-5">🙋‍♂️</span> <span className="ml-2 flex-1 whitespace-normal break-words">Follow on <strong>Linkedin</strong></span>
             </a>
             <a
                 rel="noopener noreferrer"
@@ -40,9 +41,10 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Github"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full block cursor-default hover:bg-gray-700 mb-1.5 flex items-center"
+                style={{ minHeight: 'var(--menu-item-height)' }}
             >
-                <span className="ml-5">🤝</span> <span className="ml-2">Follow on <strong>Github</strong></span>
+                <span className="ml-5">🤝</span> <span className="ml-2 flex-1 whitespace-normal break-words">Follow on <strong>Github</strong></span>
             </a>
             <a
                 rel="noopener noreferrer"
@@ -50,9 +52,10 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Contact Me"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full block cursor-default hover:bg-gray-700 mb-1.5 flex items-center"
+                style={{ minHeight: 'var(--menu-item-height)' }}
             >
-                <span className="ml-5">📥</span> <span className="ml-2">Contact Me</span>
+                <span className="ml-5">📥</span> <span className="ml-2 flex-1 whitespace-normal break-words">Contact Me</span>
             </a>
             <Devider />
             <button
@@ -60,9 +63,10 @@ function DefaultMenu(props) {
                 onClick={() => { localStorage.clear(); window.location.reload() }}
                 role="menuitem"
                 aria-label="Reset Kali Linux"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full text-left cursor-default hover:bg-gray-700 mb-1.5 flex items-center"
+                style={{ minHeight: 'var(--menu-item-height)' }}
             >
-                <span className="ml-5">🧹</span> <span className="ml-2">Reset Kali Linux</span>
+                <span className="ml-5">🧹</span> <span className="ml-2 flex-1 whitespace-normal break-words">Reset Kali Linux</span>
             </button>
         </div>
     )

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -55,35 +55,38 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="New Folder"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 flex items-center"
+                style={{ minHeight: 'var(--menu-item-height)' }}
             >
-                <span className="ml-5">New Folder</span>
+                <span className="ml-5 flex-1 whitespace-normal break-words">New Folder</span>
             </button>
             <button
                 onClick={props.openShortcutSelector}
                 type="button"
                 role="menuitem"
                 aria-label="Create Shortcut"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 flex items-center"
+                style={{ minHeight: 'var(--menu-item-height)' }}
             >
-                <span className="ml-5">Create Shortcut...</span>
+                <span className="ml-5 flex-1 whitespace-normal break-words">Create Shortcut...</span>
             </button>
             <Devider />
-            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Paste</span>
+            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400 flex items-center" style={{ minHeight: 'var(--menu-item-height)' }}>
+                <span className="ml-5 flex-1 whitespace-normal break-words">Paste</span>
             </div>
             <Devider />
-            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Show Desktop in Files</span>
+            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400 flex items-center" style={{ minHeight: 'var(--menu-item-height)' }}>
+                <span className="ml-5 flex-1 whitespace-normal break-words">Show Desktop in Files</span>
             </div>
             <button
                 onClick={openTerminal}
                 type="button"
                 role="menuitem"
                 aria-label="Open in Terminal"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 flex items-center"
+                style={{ minHeight: 'var(--menu-item-height)' }}
             >
-                <span className="ml-5">Open in Terminal</span>
+                <span className="ml-5 flex-1 whitespace-normal break-words">Open in Terminal</span>
             </button>
             <Devider />
             <button
@@ -91,22 +94,24 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Change Background"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 flex items-center"
+                style={{ minHeight: 'var(--menu-item-height)' }}
             >
-                <span className="ml-5">Change Background...</span>
+                <span className="ml-5 flex-1 whitespace-normal break-words">Change Background...</span>
             </button>
             <Devider />
-            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Display Settings</span>
+            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400 flex items-center" style={{ minHeight: 'var(--menu-item-height)' }}>
+                <span className="ml-5 flex-1 whitespace-normal break-words">Display Settings</span>
             </div>
             <button
                 onClick={openSettings}
                 type="button"
                 role="menuitem"
                 aria-label="Settings"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 flex items-center"
+                style={{ minHeight: 'var(--menu-item-height)' }}
             >
-                <span className="ml-5">Settings</span>
+                <span className="ml-5 flex-1 whitespace-normal break-words">Settings</span>
             </button>
             <Devider />
             <button
@@ -114,9 +119,10 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label={isFullScreen ? "Exit Full Screen" : "Enter Full Screen"}
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 flex items-center"
+                style={{ minHeight: 'var(--menu-item-height)' }}
             >
-                <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
+                <span className="ml-5 flex-1 whitespace-normal break-words">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
             </button>
             <Devider />
             <button
@@ -124,9 +130,10 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Clear Session"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 flex items-center"
+                style={{ minHeight: 'var(--menu-item-height)' }}
             >
-                <span className="ml-5">Clear Session</span>
+                <span className="ml-5 flex-1 whitespace-normal break-words">Clear Session</span>
             </button>
         </div>
     )

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -37,18 +37,20 @@ function TaskbarMenu(props) {
                 onClick={handleMinimize}
                 role="menuitem"
                 aria-label={props.minimized ? 'Restore Window' : 'Minimize Window'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full text-left cursor-default hover:bg-gray-700 mb-1.5 flex items-center"
+                style={{ minHeight: 'var(--menu-item-height)' }}
             >
-                <span className="ml-5">{props.minimized ? 'Restore' : 'Minimize'}</span>
+                <span className="ml-5 flex-1 whitespace-normal break-words">{props.minimized ? 'Restore' : 'Minimize'}</span>
             </button>
             <button
                 type="button"
                 onClick={handleClose}
                 role="menuitem"
                 aria-label="Close Window"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full text-left cursor-default hover:bg-gray-700 mb-1.5 flex items-center"
+                style={{ minHeight: 'var(--menu-item-height)' }}
             >
-                <span className="ml-5">Close</span>
+                <span className="ml-5 flex-1 whitespace-normal break-words">Close</span>
             </button>
         </div>
     );

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -165,6 +165,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         '--space-4': '1rem',
         '--space-5': '1.5rem',
         '--space-6': '2rem',
+        '--menu-item-height': 'var(--menu-item-height-comfortable)',
       },
       compact: {
         '--space-1': '0.125rem',
@@ -173,6 +174,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         '--space-4': '0.75rem',
         '--space-5': '1rem',
         '--space-6': '1.5rem',
+        '--menu-item-height': 'var(--menu-item-height-compact)',
       },
     };
     const vars = spacing[density];

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,5 +1,12 @@
 @import './globals.css';
 
+:root {
+    /* Menu item heights */
+    --menu-item-height-comfortable: 32px;
+    --menu-item-height-compact: 24px;
+    --menu-item-height: var(--menu-item-height-comfortable);
+}
+
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
 }


### PR DESCRIPTION
## Summary
- define CSS variables for comfortable and compact menu item heights
- apply menu height variable across context menus and ensure long labels wrap
- expose "Comfortable" density option and persist selected menu item height

## Testing
- `npx jest __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/Modal.test.tsx` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c37aac02ac8328b56b4ff264b05387