### PR TITLE
feat: auto toggle high contrast based on wallpaper

### DIFF
--- a/components/settings/WallpaperManager.tsx
+++ b/components/settings/WallpaperManager.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSettings } from "../../hooks/useSettings";
+
+async function calculateLuminance(src: string): Promise<number> {
+  const response = await fetch(src);
+  const blob = await response.blob();
+  const bitmap = await createImageBitmap(blob);
+  const canvas = new OffscreenCanvas(1, 1);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return 0;
+  ctx.drawImage(bitmap, 0, 0, 1, 1);
+  const { data } = ctx.getImageData(0, 0, 1, 1);
+  const [r, g, b] = data;
+  const toLinear = (c: number) => {
+    c /= 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+}
+
+export default function WallpaperManager() {
+  const { wallpaper, highContrast, setHighContrast } = useSettings();
+  const cache = useRef<Record<string, number>>({});
+
+  useEffect(() => {
+    let active = true;
+    const analyze = async () => {
+      let lum = cache.current[wallpaper];
+      if (lum === undefined) {
+        lum = await calculateLuminance(`/wallpapers/${wallpaper}.webp`);
+        cache.current[wallpaper] = lum;
+      }
+      if (!active) return;
+      const contrast = 1.05 / (lum + 0.05);
+      const shouldHighContrast = contrast < 4.5;
+      if (shouldHighContrast !== highContrast) {
+        setHighContrast(shouldHighContrast);
+      }
+    };
+    analyze().catch((err) => console.error("Wallpaper analysis failed", err));
+    return () => {
+      active = false;
+    };
+  }, [wallpaper, highContrast, setHighContrast]);
+
+  return null;
+}
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -14,6 +14,7 @@ import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
+import WallpaperManager from '../components/settings/WallpaperManager';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
@@ -157,6 +158,7 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
+          <WallpaperManager />
           <PipPortalProvider>
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />


### PR DESCRIPTION
## Summary
- switch to high contrast token set when wallpaper brightness fails contrast check
- compute wallpaper luminance via offscreen canvas and cache per wallpaper
- mount wallpaper manager to apply brightness-based theme logic globally

## Testing
- `yarn lint` *(fails: Unexpected global 'document' and missing display name)*
- `yarn test` *(fails: e.preventDefault is not a function; Unable to find role="alert"; TypeError reading '_origin')*

------
https://chatgpt.com/codex/tasks/task_e_68c37aaf8ea0832885f31085e5b5560e