### PR TITLE
Add wallpaper manifest and offline wallpaper categories

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
+import WallpaperManager from "../../components/settings/WallpaperManager";
 import {
   resetSettings,
   defaults,
@@ -42,18 +43,7 @@ export default function Settings() {
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
 
-  const wallpapers = [
-    "wall-1",
-    "wall-2",
-    "wall-3",
-    "wall-4",
-    "wall-5",
-    "wall-6",
-    "wall-7",
-    "wall-8",
-  ];
-
-  const changeBackground = (name: string) => setWallpaper(name);
+  
 
   const handleExport = async () => {
     const data = await exportSettingsData();
@@ -151,54 +141,9 @@ export default function Settings() {
             </div>
           </div>
           <div className="flex justify-center my-4">
-            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>
-            <input
-              id="wallpaper-slider"
-              type="range"
-              min="0"
-              max={wallpapers.length - 1}
-              step="1"
-              value={wallpapers.indexOf(wallpaper)}
-              onChange={(e) =>
-                changeBackground(wallpapers[parseInt(e.target.value, 10)])
-              }
-              className="ubuntu-slider"
-              aria-label="Wallpaper"
-            />
-          </div>
-          <div className="flex justify-center my-4">
             <BackgroundSlideshow />
           </div>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
-            {wallpapers.map((name) => (
-              <div
-                key={name}
-                role="button"
-                aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
-                aria-pressed={name === wallpaper}
-                tabIndex={0}
-                onClick={() => changeBackground(name)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    changeBackground(name);
-                  }
-                }}
-                className={
-                  (name === wallpaper
-                    ? " border-yellow-700 "
-                    : " border-transparent ") +
-                  " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"
-                }
-                style={{
-                  backgroundImage: `url(/wallpapers/${name}.webp)`,
-                  backgroundSize: "cover",
-                  backgroundRepeat: "no-repeat",
-                  backgroundPosition: "center center",
-                }}
-              ></div>
-            ))}
-          </div>
+          <WallpaperManager />
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
             <button
               onClick={handleReset}

--- a/components/settings/WallpaperManager.tsx
+++ b/components/settings/WallpaperManager.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import { useSettings } from "../../hooks/useSettings";
+
+type ManifestEntry = {
+  name: string;
+  categories: string[];
+};
+
+type Manifest = {
+  categories: string[];
+  wallpapers: ManifestEntry[];
+};
+
+const STORAGE_KEY = "wallpaper-category";
+
+export default function WallpaperManager() {
+  const { wallpaper, setWallpaper } = useSettings();
+  const [manifest, setManifest] = useState<Manifest | null>(null);
+  const [category, setCategory] = useState<string>("");
+
+  useEffect(() => {
+    const loadManifest = async () => {
+      try {
+        const res = await fetch("/wallpapers/manifest.json", { cache: "force-cache" });
+        const data: Manifest = await res.json();
+        setManifest(data);
+        const saved = localStorage.getItem(STORAGE_KEY);
+        if (saved && data.categories.includes(saved)) {
+          setCategory(saved);
+        } else if (data.categories.length > 0) {
+          setCategory(data.categories[0]);
+        }
+      } catch (err) {
+        console.error("Failed to load wallpaper manifest", err);
+      }
+    };
+    loadManifest();
+  }, []);
+
+  useEffect(() => {
+    if (category) {
+      localStorage.setItem(STORAGE_KEY, category);
+    }
+  }, [category]);
+
+  if (!manifest) return null;
+
+  const filtered = manifest.wallpapers.filter(
+    (w) => !category || w.categories.includes(category)
+  );
+
+  return (
+    <>
+      <div className="flex justify-center my-4">
+        <label className="mr-2 text-ubt-grey">Category:</label>
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+        >
+          {manifest.categories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
+        {filtered.map(({ name }) => (
+          <div
+            key={name}
+            role="button"
+            aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
+            aria-pressed={name === wallpaper}
+            tabIndex={0}
+            onClick={() => setWallpaper(name)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                setWallpaper(name);
+              }
+            }}
+            className={(name === wallpaper ? " border-yellow-700 " : " border-transparent ") +
+              " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"}
+            style={{
+              backgroundImage: `url(/wallpapers/${name}.webp)`,
+              backgroundSize: "cover",
+              backgroundRepeat: "no-repeat",
+              backgroundPosition: "center center",
+            }}
+          ></div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/public/wallpapers/manifest.json
+++ b/public/wallpapers/manifest.json
@@ -1,0 +1,13 @@
+{
+  "categories": ["Dark", "Light", "Abstract", "Community"],
+  "wallpapers": [
+    { "name": "wall-1", "categories": ["Dark"] },
+    { "name": "wall-2", "categories": ["Dark"] },
+    { "name": "wall-3", "categories": ["Light"] },
+    { "name": "wall-4", "categories": ["Light"] },
+    { "name": "wall-5", "categories": ["Abstract"] },
+    { "name": "wall-6", "categories": ["Abstract"] },
+    { "name": "wall-7", "categories": ["Community"] },
+    { "name": "wall-8", "categories": ["Community"] }
+  ]
+}


### PR DESCRIPTION
## Summary
- add wallpaper manifest with Dark, Light, Abstract, Community groupings
- introduce WallpaperManager with offline category filter and persistence
- integrate WallpaperManager into settings page

## Testing
- `npx eslint components/settings/WallpaperManager.tsx apps/settings/index.tsx && echo "ESLint passed"`
- `npx jest components/settings/WallpaperManager.tsx apps/settings/index.tsx --findRelatedTests --passWithNoTests`
- `npx tsc --noEmit && echo "Typecheck passed"`


------
https://chatgpt.com/codex/tasks/task_e_68c37ab0f9fc83289e7b0af6c12ab1bb