### PR TITLE
feat: add subtle hero gradient animation

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,30 @@ body{
     color: var(--color-text);
 }
 
+/* Subtle animated gradient for hero sections or page backgrounds */
+.hero-band {
+    background: linear-gradient(var(--hero-gradient-angle, 0deg), var(--color-primary), var(--color-secondary));
+    animation: hero-band-shift 90s linear infinite;
+}
+
+@keyframes hero-band-shift {
+    0% {
+        --hero-gradient-angle: 0deg;
+    }
+    50% {
+        --hero-gradient-angle: 180deg;
+    }
+    100% {
+        --hero-gradient-angle: 360deg;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .hero-band {
+        animation: none;
+    }
+}
+
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
     min-width: var(--hit-area);
     min-height: var(--hit-area);


### PR DESCRIPTION
## Summary
- animate hero band/background with a slow gradient shift
- disable gradient animation when user prefers reduced motion

## Testing
- `yarn lint` *(fails: Unexpected global 'document' and missing display name)*
- `yarn test` *(fails: window snapping test & NmapNSE clipboard test)*

------
https://chatgpt.com/codex/tasks/task_e_68c37ab4bf208328bab0d0cc3650b39e