### PR TITLE
feat(settings): allow custom wallpaper upload

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
+import WallpaperManager from "../../components/settings/WallpaperManager";
 import {
   resetSettings,
   defaults,
@@ -52,8 +53,6 @@ export default function Settings() {
     "wall-7",
     "wall-8",
   ];
-
-  const changeBackground = (name: string) => setWallpaper(name);
 
   const handleExport = async () => {
     const data = await exportSettingsData();
@@ -115,7 +114,7 @@ export default function Settings() {
           <div
             className="md:w-2/5 w-2/3 h-1/3 m-auto my-4"
             style={{
-              backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
+              backgroundImage: `url(${wallpaper.startsWith("data:") ? wallpaper : `/wallpapers/${wallpaper}.webp`})`,
               backgroundSize: "cover",
               backgroundRepeat: "no-repeat",
               backgroundPosition: "center center",
@@ -158,9 +157,9 @@ export default function Settings() {
               min="0"
               max={wallpapers.length - 1}
               step="1"
-              value={wallpapers.indexOf(wallpaper)}
+              value={Math.max(wallpapers.indexOf(wallpaper), 0)}
               onChange={(e) =>
-                changeBackground(wallpapers[parseInt(e.target.value, 10)])
+                setWallpaper(wallpapers[parseInt(e.target.value, 10)])
               }
               className="ubuntu-slider"
               aria-label="Wallpaper"
@@ -169,36 +168,11 @@ export default function Settings() {
           <div className="flex justify-center my-4">
             <BackgroundSlideshow />
           </div>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
-            {wallpapers.map((name) => (
-              <div
-                key={name}
-                role="button"
-                aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
-                aria-pressed={name === wallpaper}
-                tabIndex={0}
-                onClick={() => changeBackground(name)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    changeBackground(name);
-                  }
-                }}
-                className={
-                  (name === wallpaper
-                    ? " border-yellow-700 "
-                    : " border-transparent ") +
-                  " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"
-                }
-                style={{
-                  backgroundImage: `url(/wallpapers/${name}.webp)`,
-                  backgroundSize: "cover",
-                  backgroundRepeat: "no-repeat",
-                  backgroundPosition: "center center",
-                }}
-              ></div>
-            ))}
-          </div>
+          <WallpaperManager
+            wallpapers={wallpapers}
+            selected={wallpaper}
+            onSelect={setWallpaper}
+          />
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
             <button
               onClick={handleReset}

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -17,7 +17,7 @@ export default function LockScreen(props) {
             style={{ zIndex: "100", contentVisibility: 'auto' }}
             className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
             <img
-                src={`/wallpapers/${wallpaper}.webp`}
+                src={wallpaper.startsWith('data:') ? wallpaper : `/wallpapers/${wallpaper}.webp`}
                 alt=""
                 className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
             />

--- a/components/settings/WallpaperManager.tsx
+++ b/components/settings/WallpaperManager.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { defaults } from "../../utils/settingsStore";
+
+interface Props {
+  wallpapers: string[];
+  selected: string;
+  onSelect: (wallpaper: string) => void;
+}
+
+/**
+ * Allows users to drag and drop a custom wallpaper image. The image is stored
+ * in localStorage as a data URL and surfaced alongside the default wallpaper
+ * choices. Users can remove the custom wallpaper which also clears stored
+ * data.
+ */
+export default function WallpaperManager({
+  wallpapers,
+  selected,
+  onSelect,
+}: Props) {
+  const STORAGE_KEY = "custom-wallpaper";
+  const [custom, setCustom] = useState<string | null>(null);
+
+  // Load custom wallpaper from storage on mount
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored) setCustom(stored);
+  }, []);
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files?.[0];
+    if (!file || !file.type.startsWith("image/")) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      window.localStorage.setItem(STORAGE_KEY, dataUrl);
+      setCustom(dataUrl);
+      onSelect(dataUrl);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleClear = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    window.localStorage.removeItem(STORAGE_KEY);
+    if (custom && selected === custom) {
+      onSelect(defaults.wallpaper);
+    }
+    setCustom(null);
+  };
+
+  return (
+    <div
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={handleDrop}
+      className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900"
+    >
+      {custom && (
+        <div
+          key="custom"
+          role="button"
+          aria-label="Select custom wallpaper"
+          aria-pressed={selected === custom}
+          tabIndex={0}
+          onClick={() => onSelect(custom)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onSelect(custom);
+            }
+          }}
+          className={
+            (selected === custom
+              ? " border-yellow-700 "
+              : " border-transparent ") +
+            " relative md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"
+          }
+          style={{
+            backgroundImage: `url(${custom})`,
+            backgroundSize: "cover",
+            backgroundRepeat: "no-repeat",
+            backgroundPosition: "center center",
+          }}
+        >
+          <button
+            onClick={handleClear}
+            aria-label="Remove custom wallpaper"
+            className="absolute top-1 right-1 bg-black/50 text-white rounded px-1"
+          >
+            ×
+          </button>
+        </div>
+      )}
+      {wallpapers.map((name) => (
+        <div
+          key={name}
+          role="button"
+          aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
+          aria-pressed={name === selected}
+          tabIndex={0}
+          onClick={() => onSelect(name)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onSelect(name);
+            }
+          }}
+          className={
+            (name === selected
+              ? " border-yellow-700 "
+              : " border-transparent ") +
+            " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"
+          }
+          style={{
+            backgroundImage: `url(/wallpapers/${name}.webp)`,
+            backgroundSize: "cover",
+            backgroundRepeat: "no-repeat",
+            backgroundPosition: "center center",
+          }}
+        ></div>
+      ))}
+    </div>
+  );
+}
+

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -9,7 +9,8 @@ export default function BackgroundImage() {
 
     useEffect(() => {
         const img = new Image();
-        img.src = `/wallpapers/${wallpaper}.webp`;
+        const src = wallpaper.startsWith('data:') ? wallpaper : `/wallpapers/${wallpaper}.webp`;
+        img.src = src;
         img.onload = () => {
             const canvas = document.createElement('canvas');
             canvas.width = img.width;
@@ -39,7 +40,7 @@ export default function BackgroundImage() {
     return (
         <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
             <img
-                src={`/wallpapers/${wallpaper}.webp`}
+                src={wallpaper.startsWith('data:') ? wallpaper : `/wallpapers/${wallpaper}.webp`}
                 alt=""
                 className="w-full h-full object-cover"
             />


### PR DESCRIPTION
## Summary
- enable custom wallpaper uploads with drag-and-drop manager
- support data URL wallpapers across settings, desktop, and lock screen

## Testing
- `npx eslint apps/settings/index.tsx components/screen/lock_screen.js components/util-components/background-image.js components/settings/WallpaperManager.tsx`
- `npx jest apps/settings/index.tsx components/settings/WallpaperManager.tsx components/util-components/background-image.js components/screen/lock_screen.js --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c37ab2abd8832886bfd69fc15d39d5