### PR TITLE
feat: add lock screen wallpaper configuration

### DIFF
--- a/apps/settings/components/WallpaperManager.tsx
+++ b/apps/settings/components/WallpaperManager.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect } from 'react';
+import ToggleSwitch from '../../../components/ToggleSwitch';
+import { useSettings } from '../../../hooks/useSettings';
+
+const wallpapers = [
+  'wall-1',
+  'wall-2',
+  'wall-3',
+  'wall-4',
+  'wall-5',
+  'wall-6',
+  'wall-7',
+  'wall-8',
+];
+
+export default function WallpaperManager() {
+  const {
+    wallpaper,
+    lockWallpaper,
+    setLockWallpaper,
+    lockSameAsDesktop,
+    setLockSameAsDesktop,
+    lockBlur,
+    setLockBlur,
+  } = useSettings();
+
+  useEffect(() => {
+    if (lockSameAsDesktop) {
+      setLockWallpaper(wallpaper);
+    }
+  }, [lockSameAsDesktop, wallpaper, setLockWallpaper]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-center my-4 items-center">
+        <label className="mr-2 text-ubt-grey">Lock same as desktop</label>
+        <ToggleSwitch
+          ariaLabel="Lock wallpaper same as desktop"
+          checked={lockSameAsDesktop}
+          onChange={setLockSameAsDesktop}
+        />
+      </div>
+      {!lockSameAsDesktop && (
+        <div className="flex justify-center my-4">
+          <label htmlFor="lock-wallpaper-slider" className="mr-2 text-ubt-grey">
+            Lock Wallpaper:
+          </label>
+          <input
+            id="lock-wallpaper-slider"
+            type="range"
+            min="0"
+            max={wallpapers.length - 1}
+            step="1"
+            value={wallpapers.indexOf(lockWallpaper)}
+            onChange={(e) =>
+              setLockWallpaper(wallpapers[parseInt(e.target.value, 10)])
+            }
+            className="ubuntu-slider"
+            aria-label="Lock screen wallpaper"
+          />
+        </div>
+      )}
+      <div className="flex justify-center my-4">
+        <label htmlFor="lock-blur" className="mr-2 text-ubt-grey">
+          Blur intensity:
+        </label>
+        <input
+          id="lock-blur"
+          type="range"
+          min="0"
+          max="20"
+          value={lockBlur}
+          onChange={(e) => setLockBlur(parseInt(e.target.value, 10))}
+          className="ubuntu-slider"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
+import WallpaperManager from "./components/WallpaperManager";
 import {
   resetSettings,
   defaults,
@@ -169,6 +170,7 @@ export default function Settings() {
           <div className="flex justify-center my-4">
             <BackgroundSlideshow />
           </div>
+          <WallpaperManager />
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
             {wallpapers.map((name) => (
               <div

--- a/components/overlays/LockScreen.tsx
+++ b/components/overlays/LockScreen.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect } from 'react';
+import Clock from '../util-components/clock';
+import { useSettings } from '../../hooks/useSettings';
+
+interface Props {
+  isLocked: boolean;
+  unLockScreen: () => void;
+}
+
+export default function LockScreen({ isLocked, unLockScreen }: Props) {
+  const { wallpaper, lockWallpaper, lockSameAsDesktop, lockBlur } = useSettings();
+
+  useEffect(() => {
+    if (!isLocked) return;
+    window.addEventListener('click', unLockScreen);
+    window.addEventListener('keypress', unLockScreen);
+    return () => {
+      window.removeEventListener('click', unLockScreen);
+      window.removeEventListener('keypress', unLockScreen);
+    };
+  }, [isLocked, unLockScreen]);
+
+  const bg = lockSameAsDesktop ? wallpaper : lockWallpaper;
+
+  return (
+    <div
+      id="ubuntu-lock-screen"
+      style={{ zIndex: '100', contentVisibility: 'auto' }}
+      className={(isLocked ? ' visible translate-y-0 ' : ' invisible -translate-y-full ') + ' absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen'}
+    >
+      <img
+        src={`/wallpapers/${bg}.webp`}
+        alt=""
+        className="absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500"
+        style={{ filter: isLocked ? `blur(${lockBlur}px)` : 'none' }}
+      />
+      <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
+        <div className=" text-7xl">
+          <Clock onlyTime={true} />
+        </div>
+        <div className="mt-4 text-xl font-medium">
+          <Clock onlyDay={true} />
+        </div>
+        <div className=" mt-16 text-base">
+          Click or Press a key to unlock
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -3,7 +3,7 @@
 import React, { Component } from 'react';
 import BootingScreen from './screen/booting_screen';
 import Desktop from './screen/desktop';
-import LockScreen from './screen/lock_screen';
+import LockScreen from './overlays/LockScreen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
@@ -116,11 +116,10 @@ export default class Ubuntu extends Component {
 	render() {
 		return (
 			<div className="w-screen h-screen overflow-hidden" id="monitor-screen">
-				<LockScreen
-					isLocked={this.state.screen_locked}
-					bgImgName={this.state.bg_image_name}
-					unLockScreen={this.unLockScreen}
-				/>
+                                <LockScreen
+                                        isLocked={this.state.screen_locked}
+                                        unLockScreen={this.unLockScreen}
+                                />
 				<BootingScreen
 					visible={this.state.booting_screen}
 					isShutDown={this.state.shutDownScreen}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -4,6 +4,12 @@ import {
   setAccent as saveAccent,
   getWallpaper as loadWallpaper,
   setWallpaper as saveWallpaper,
+  getLockWallpaper as loadLockWallpaper,
+  setLockWallpaper as saveLockWallpaper,
+  getLockSameAsDesktop as loadLockSameAsDesktop,
+  setLockSameAsDesktop as saveLockSameAsDesktop,
+  getLockBlur as loadLockBlur,
+  setLockBlur as saveLockBlur,
   getDensity as loadDensity,
   setDensity as saveDensity,
   getReducedMotion as loadReducedMotion,
@@ -54,6 +60,9 @@ const shadeColor = (color: string, percent: number): string => {
 interface SettingsContextValue {
   accent: string;
   wallpaper: string;
+  lockWallpaper: string;
+  lockSameAsDesktop: boolean;
+  lockBlur: number;
   density: Density;
   reducedMotion: boolean;
   fontScale: number;
@@ -65,6 +74,9 @@ interface SettingsContextValue {
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
+  setLockWallpaper: (wallpaper: string) => void;
+  setLockSameAsDesktop: (value: boolean) => void;
+  setLockBlur: (value: number) => void;
   setDensity: (density: Density) => void;
   setReducedMotion: (value: boolean) => void;
   setFontScale: (value: number) => void;
@@ -79,6 +91,9 @@ interface SettingsContextValue {
 export const SettingsContext = createContext<SettingsContextValue>({
   accent: defaults.accent,
   wallpaper: defaults.wallpaper,
+  lockWallpaper: defaults.lockWallpaper,
+  lockSameAsDesktop: defaults.lockSameAsDesktop,
+  lockBlur: defaults.lockBlur,
   density: defaults.density as Density,
   reducedMotion: defaults.reducedMotion,
   fontScale: defaults.fontScale,
@@ -90,6 +105,9 @@ export const SettingsContext = createContext<SettingsContextValue>({
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
+  setLockWallpaper: () => {},
+  setLockSameAsDesktop: () => {},
+  setLockBlur: () => {},
   setDensity: () => {},
   setReducedMotion: () => {},
   setFontScale: () => {},
@@ -104,6 +122,9 @@ export const SettingsContext = createContext<SettingsContextValue>({
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [accent, setAccent] = useState<string>(defaults.accent);
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
+  const [lockWallpaper, setLockWallpaper] = useState<string>(defaults.lockWallpaper);
+  const [lockSameAsDesktop, setLockSameAsDesktop] = useState<boolean>(defaults.lockSameAsDesktop);
+  const [lockBlur, setLockBlur] = useState<number>(defaults.lockBlur);
   const [density, setDensity] = useState<Density>(defaults.density as Density);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
@@ -119,6 +140,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     (async () => {
       setAccent(await loadAccent());
       setWallpaper(await loadWallpaper());
+      setLockWallpaper(await loadLockWallpaper());
+      setLockSameAsDesktop(await loadLockSameAsDesktop());
+      setLockBlur(await loadLockBlur());
       setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
       setFontScale(await loadFontScale());
@@ -155,6 +179,24 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     saveWallpaper(wallpaper);
   }, [wallpaper]);
+
+  useEffect(() => {
+    if (lockSameAsDesktop) {
+      setLockWallpaper(wallpaper);
+    }
+  }, [wallpaper, lockSameAsDesktop]);
+
+  useEffect(() => {
+    saveLockWallpaper(lockWallpaper);
+  }, [lockWallpaper]);
+
+  useEffect(() => {
+    saveLockSameAsDesktop(lockSameAsDesktop);
+  }, [lockSameAsDesktop]);
+
+  useEffect(() => {
+    saveLockBlur(lockBlur);
+  }, [lockBlur]);
 
   useEffect(() => {
     const spacing: Record<Density, Record<string, string>> = {
@@ -241,6 +283,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       value={{
         accent,
         wallpaper,
+        lockWallpaper,
+        lockSameAsDesktop,
+        lockBlur,
         density,
         reducedMotion,
         fontScale,
@@ -252,6 +297,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         theme,
         setAccent,
         setWallpaper,
+        setLockWallpaper,
+        setLockSameAsDesktop,
+        setLockBlur,
         setDensity,
         setReducedMotion,
         setFontScale,

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -6,6 +6,9 @@ import { getTheme, setTheme } from './theme';
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
   wallpaper: 'wall-2',
+  lockWallpaper: 'wall-2',
+  lockSameAsDesktop: true,
+  lockBlur: 5,
   density: 'regular',
   reducedMotion: false,
   fontScale: 1,
@@ -34,6 +37,38 @@ export async function getWallpaper() {
 export async function setWallpaper(wallpaper) {
   if (typeof window === 'undefined') return;
   await set('bg-image', wallpaper);
+}
+
+export async function getLockWallpaper() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.lockWallpaper;
+  return (await get('lock-bg-image')) || DEFAULT_SETTINGS.lockWallpaper;
+}
+
+export async function setLockWallpaper(wallpaper) {
+  if (typeof window === 'undefined') return;
+  await set('lock-bg-image', wallpaper);
+}
+
+export async function getLockSameAsDesktop() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.lockSameAsDesktop;
+  const stored = await get('lock-use-desktop');
+  return stored === undefined ? DEFAULT_SETTINGS.lockSameAsDesktop : stored;
+}
+
+export async function setLockSameAsDesktop(value) {
+  if (typeof window === 'undefined') return;
+  await set('lock-use-desktop', value);
+}
+
+export async function getLockBlur() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.lockBlur;
+  const stored = await get('lock-blur');
+  return typeof stored === 'number' ? stored : DEFAULT_SETTINGS.lockBlur;
+}
+
+export async function setLockBlur(value) {
+  if (typeof window === 'undefined') return;
+  await set('lock-blur', value);
 }
 
 export async function getDensity() {
@@ -128,6 +163,9 @@ export async function resetSettings() {
   await Promise.all([
     del('accent'),
     del('bg-image'),
+    del('lock-bg-image'),
+    del('lock-use-desktop'),
+    del('lock-blur'),
   ]);
   window.localStorage.removeItem('density');
   window.localStorage.removeItem('reduced-motion');
@@ -143,6 +181,9 @@ export async function exportSettings() {
   const [
     accent,
     wallpaper,
+    lockWallpaper,
+    lockSameAsDesktop,
+    lockBlur,
     density,
     reducedMotion,
     fontScale,
@@ -154,6 +195,9 @@ export async function exportSettings() {
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
+    getLockWallpaper(),
+    getLockSameAsDesktop(),
+    getLockBlur(),
     getDensity(),
     getReducedMotion(),
     getFontScale(),
@@ -167,6 +211,9 @@ export async function exportSettings() {
   return JSON.stringify({
     accent,
     wallpaper,
+    lockWallpaper,
+    lockSameAsDesktop,
+    lockBlur,
     density,
     reducedMotion,
     fontScale,
@@ -191,6 +238,9 @@ export async function importSettings(json) {
   const {
     accent,
     wallpaper,
+    lockWallpaper,
+    lockSameAsDesktop,
+    lockBlur,
     density,
     reducedMotion,
     fontScale,
@@ -203,6 +253,10 @@ export async function importSettings(json) {
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
+  if (lockWallpaper !== undefined) await setLockWallpaper(lockWallpaper);
+  if (lockSameAsDesktop !== undefined)
+    await setLockSameAsDesktop(lockSameAsDesktop);
+  if (lockBlur !== undefined) await setLockBlur(lockBlur);
   if (density !== undefined) await setDensity(density);
   if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
   if (fontScale !== undefined) await setFontScale(fontScale);


### PR DESCRIPTION
## Summary
- support separate lock screen wallpaper and blur settings
- add lock screen wallpaper manager with same-as-desktop toggle
- blur lock screen background based on user preference

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c37ab66aac83289f89160d67e5e599