### PR TITLE
Add software center app with searchable install toggles

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -87,6 +87,7 @@ const MetasploitApp = createDynamicApp('metasploit', 'Metasploit');
 
 const AutopsyApp = createDynamicApp('autopsy', 'Autopsy');
 const PluginManagerApp = createDynamicApp('plugin-manager', 'Plugin Manager');
+const SoftwareCenterApp = createDynamicApp('software-center', 'Software Center');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
@@ -170,6 +171,7 @@ const displayGhidra = createDisplay(GhidraApp);
 
 const displayAutopsy = createDisplay(AutopsyApp);
 const displayPluginManager = createDisplay(PluginManagerApp);
+const displaySoftwareCenter = createDisplay(SoftwareCenterApp);
 
 const displayWireshark = createDisplay(WiresharkApp);
 const displayBleSensor = createDisplay(BleSensorApp);
@@ -835,6 +837,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayPluginManager,
+  },
+  {
+    id: 'software-center',
+    title: 'Software Center',
+    icon: '/themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displaySoftwareCenter,
   },
   {    id: 'reaver',
     title: 'Reaver',

--- a/apps/software-center/index.tsx
+++ b/apps/software-center/index.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+interface AppInfo {
+  id: string;
+  name: string;
+  category: string;
+}
+
+const APPS: AppInfo[] = [
+  { id: 'nmap', name: 'Nmap', category: 'Security' },
+  { id: 'wireshark', name: 'Wireshark', category: 'Security' },
+  { id: 'firefox', name: 'Firefox', category: 'Utility' },
+  { id: 'vim', name: 'Vim', category: 'Productivity' },
+  { id: 'gimp', name: 'GIMP', category: 'Graphics' },
+];
+
+export default function SoftwareCenter() {
+  const [query, setQuery] = useState('');
+  const [category, setCategory] = useState('');
+  const [installed, setInstalled] = useState<Record<string, boolean>>({});
+
+  const categories = useMemo(
+    () => Array.from(new Set(APPS.map((a) => a.category))),
+    []
+  );
+
+  const toggle = (id: string) => {
+    setInstalled((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const filtered = APPS.filter(
+    (app) =>
+      app.name.toLowerCase().includes(query.toLowerCase()) &&
+      (!category || app.category === category)
+  );
+
+  return (
+    <div className="p-4 text-white">
+      <h1 className="text-xl mb-4">Software Center</h1>
+      <div className="mb-4 flex flex-col sm:flex-row gap-2">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search"
+          aria-label="Search applications"
+          className="px-2 py-1 rounded text-black flex-1"
+        />
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          aria-label="Filter by category"
+          className="px-2 py-1 rounded text-black"
+        >
+          <option value="">All Categories</option>
+          {categories.map((cat) => (
+            <option key={cat} value={cat}>
+              {cat}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {filtered.map((app) => (
+          <div
+            key={app.id}
+            className="bg-gray-700 rounded p-4 flex flex-col items-start"
+          >
+            <h2 className="text-lg mb-1">{app.name}</h2>
+            <span className="text-sm mb-2 text-gray-300">{app.category}</span>
+            <button
+              onClick={() => toggle(app.id)}
+              className={`px-2 py-1 rounded text-white ${
+                installed[app.id]
+                  ? 'bg-red-700 hover:bg-red-600'
+                  : 'bg-blue-700 hover:bg-blue-600'
+              }`}
+            >
+              {installed[app.id] ? 'Remove' : 'Install'}
+            </button>
+          </div>
+        ))}
+        {!filtered.length && <p>No applications found.</p>}
+      </div>
+    </div>
+  );
+}
+

--- a/pages/apps/software-center.jsx
+++ b/pages/apps/software-center.jsx
@@ -1,0 +1,9 @@
+import dynamic from 'next/dynamic';
+
+const SoftwareCenterPage = dynamic(() => import('../../apps/software-center'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default SoftwareCenterPage;
+


### PR DESCRIPTION
## Summary
- add Software Center app showing grid of apps with install/remove toggles
- wire Software Center into app routing and configuration

## Testing
- `npx eslint apps/software-center/index.tsx pages/apps/software-center.jsx apps.config.js` *(fails: 580 problems across repo)*
- `yarn test apps/software-center --passWithNoTests`
- `npx tsc --jsx react-jsx --noEmit apps/software-center/index.tsx` *(fails: Stylesheet types missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c37ab7f04c83289c7c9ea477458c62