### PR TITLE
Add safe-area padding to panels and snapped windows

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -634,7 +634,18 @@ export class Window extends Component {
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
                 >
                     <div
-                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
+                        style={{
+                            width: `${this.state.width}%`,
+                            height: `${this.state.height}%`,
+                            ...(this.state.snapped
+                                ? {
+                                      paddingTop: 'env(safe-area-inset-top)',
+                                      paddingRight: 'env(safe-area-inset-right)',
+                                      paddingBottom: 'env(safe-area-inset-bottom)',
+                                      paddingLeft: 'env(safe-area-inset-left)',
+                                  }
+                                : {}),
+                        }}
                         className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
                         role="dialog"

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -14,8 +14,15 @@ export default class Navbar extends Component {
 	}
 
 	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                return (
+                        <div
+                                className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50"
+                                style={{
+                                        paddingTop: 'env(safe-area-inset-top)',
+                                        paddingLeft: 'env(safe-area-inset-left)',
+                                        paddingRight: 'env(safe-area-inset-right)',
+                                }}
+                        >
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -16,7 +16,15 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div
+            className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40"
+            role="toolbar"
+            style={{
+                paddingBottom: 'env(safe-area-inset-bottom)',
+                paddingLeft: 'env(safe-area-inset-left)',
+                paddingRight: 'env(safe-area-inset-right)',
+            }}
+        >
             {runningApps.map(app => (
                 <button
                     key={app.id}


### PR DESCRIPTION
## Summary
- add `safe-area-inset` padding to top and bottom panels
- ensure snapped windows respect device safe areas

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: e.preventDefault is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c388eb0d0c83288c05581738c99432