### PR TITLE
Snap windows with gap and auto-hide dock

### DIFF
--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -82,7 +82,7 @@ describe('NmapNSEApp', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Sample output')
     );
-    expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
+    expect(await screen.findByRole('status')).toHaveTextContent(/copied/i);
 
     mockFetch.mockRestore();
   });

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -14,6 +14,7 @@ describe('Window lifecycle', () => {
     jest.useFakeTimers();
     const closed = jest.fn();
     const hideSideBar = jest.fn();
+    const hideDock = jest.fn();
 
     render(
       <Window
@@ -24,6 +25,7 @@ describe('Window lifecycle', () => {
         hasMinimised={() => {}}
         closed={closed}
         hideSideBar={hideSideBar}
+        hideDock={hideDock}
         openApp={() => {}}
       />
     );
@@ -54,6 +56,7 @@ describe('Window snapping preview', () => {
         hasMinimised={() => {}}
         closed={() => {}}
         hideSideBar={() => {}}
+        hideDock={() => {}}
         openApp={() => {}}
         ref={ref}
       />
@@ -91,6 +94,7 @@ describe('Window snapping preview', () => {
         hasMinimised={() => {}}
         closed={() => {}}
         hideSideBar={() => {}}
+        hideDock={() => {}}
         openApp={() => {}}
         ref={ref}
       />
@@ -130,6 +134,7 @@ describe('Window snapping finalize and release', () => {
         hasMinimised={() => {}}
         closed={() => {}}
         hideSideBar={() => {}}
+        hideDock={() => {}}
         openApp={() => {}}
         ref={ref}
       />
@@ -171,6 +176,7 @@ describe('Window snapping finalize and release', () => {
         hasMinimised={() => {}}
         closed={() => {}}
         hideSideBar={() => {}}
+        hideDock={() => {}}
         openApp={() => {}}
         ref={ref}
       />
@@ -199,7 +205,7 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true, preventDefault: () => {}, stopPropagation: () => {} } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();
@@ -218,6 +224,7 @@ describe('Window snapping finalize and release', () => {
         hasMinimised={() => {}}
         closed={() => {}}
         hideSideBar={() => {}}
+        hideDock={() => {}}
         openApp={() => {}}
         ref={ref}
       />
@@ -266,6 +273,7 @@ describe('Window keyboard dragging', () => {
         hasMinimised={() => {}}
         closed={() => {}}
         hideSideBar={() => {}}
+        hideDock={() => {}}
         openApp={() => {}}
       />
     );
@@ -296,6 +304,7 @@ describe('Edge resistance', () => {
         hasMinimised={() => {}}
         closed={() => {}}
         hideSideBar={() => {}}
+        hideDock={() => {}}
         openApp={() => {}}
         ref={ref}
       />
@@ -342,6 +351,7 @@ describe('Window overlay inert behaviour', () => {
         hasMinimised={() => {}}
         closed={() => {}}
         hideSideBar={() => {}}
+        hideDock={() => {}}
         openApp={() => {}}
         ref={ref}
       />,
@@ -383,6 +393,7 @@ describe('Window overlay inert behaviour', () => {
         hasMinimised={() => {}}
         closed={() => {}}
         hideSideBar={() => {}}
+        hideDock={() => {}}
         openApp={() => {}}
         ref={ref}
         overlayRoot="custom-root"

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -249,9 +249,15 @@ export class Window extends Component {
                 width: this.state.lastSize.width,
                 height: this.state.lastSize.height,
                 snapped: null
-            }, this.resizeBoundries);
+            }, () => {
+                this.resizeBoundries();
+                this.checkOverlap();
+            });
         } else {
-            this.setState({ snapped: null }, this.resizeBoundries);
+            this.setState({ snapped: null }, () => {
+                this.resizeBoundries();
+                this.checkOverlap();
+            });
         }
     }
 
@@ -285,7 +291,10 @@ export class Window extends Component {
             lastSize: { width, height },
             width: newWidth,
             height: newHeight
-        }, this.resizeBoundries);
+        }, () => {
+            this.resizeBoundries();
+            this.checkOverlap();
+        });
     }
 
     checkOverlap = () => {
@@ -296,6 +305,12 @@ export class Window extends Component {
         }
         else {
             this.props.hideSideBar(this.id, false);
+        }
+        const dockThreshold = 40;
+        if (rect.bottom >= window.innerHeight - dockThreshold) {
+            this.props.hideDock(this.id, true);
+        } else {
+            this.props.hideDock(this.id, false);
         }
     }
 
@@ -320,11 +335,11 @@ export class Window extends Component {
         const threshold = 30;
         let snap = null;
         if (rect.left <= threshold) {
-            snap = { left: '0', top: '0', width: '50%', height: '100%' };
+            snap = { left: '0', top: '0', width: 'calc(50% - var(--win-gap))', height: '100%' };
             this.setState({ snapPreview: snap, snapPosition: 'left' });
         }
         else if (rect.right >= window.innerWidth - threshold) {
-            snap = { left: '50%', top: '0', width: '50%', height: '100%' };
+            snap = { left: '50%', top: '0', width: 'calc(50% - var(--win-gap))', height: '100%' };
             this.setState({ snapPreview: snap, snapPosition: 'right' });
         }
         else if (rect.top <= threshold) {
@@ -463,6 +478,7 @@ export class Window extends Component {
             r.style.transform = `translate(-1pt,-2pt)`;
             this.setState({ maximized: true, height: 96.3, width: 100.2 });
             this.props.hideSideBar(this.id, true);
+            this.props.hideDock(this.id, true);
         }
     }
 
@@ -471,6 +487,7 @@ export class Window extends Component {
         this.setState({ closed: true }, () => {
             this.deactivateOverlay();
             this.props.hideSideBar(this.id, false);
+            this.props.hideDock(this.id, false);
             setTimeout(() => {
                 this.props.closed(this.id)
             }, 300) // after 300ms this window will be unmounted from parent (Desktop)
@@ -608,7 +625,10 @@ export class Window extends Component {
             lastSize: { width, height },
             width: newWidth,
             height: newHeight
-        }, this.resizeBoundries);
+        }, () => {
+            this.resizeBoundries();
+            this.checkOverlap();
+        });
     }
 
     render() {
@@ -634,7 +654,7 @@ export class Window extends Component {
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
                 >
                     <div
-                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
+                        style={{ width: (this.state.snapped === 'left' || this.state.snapped === 'right') ? `calc(50% - var(--win-gap))` : `${this.state.width}%`, height: `${this.state.height}%` }}
                         className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
                         role="dialog"

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -35,9 +35,11 @@ export class Desktop extends Component {
             closed_windows: {},
             allAppsView: false,
             overlapped_windows: {},
+            dock_overlapped_windows: {},
             disabled_apps: {},
             favourite_apps: {},
             hideSideBar: false,
+            hideDock: false,
             minimized_windows: {},
             window_positions: {},
             desktop_apps: [],
@@ -470,6 +472,7 @@ export class Desktop extends Component {
                     focus: this.focus,
                     isFocused: this.state.focused_windows[app.id],
                     hideSideBar: this.hideSideBar,
+                    hideDock: this.hideDock,
                     hasMinimised: this.hasMinimised,
                     minimized: this.state.minimized_windows[app.id],
                     resizable: app.resizable,
@@ -540,6 +543,35 @@ export class Desktop extends Component {
         this.setState({ hideSideBar: hide, overlapped_windows });
     }
 
+    hideDock = (objId, hide) => {
+        if (hide === this.state.hideDock) return;
+
+        if (objId === null) {
+            if (hide === false) {
+                this.setState({ hideDock: false });
+            }
+            else {
+                for (const key in this.state.dock_overlapped_windows) {
+                    if (this.state.dock_overlapped_windows[key]) {
+                        this.setState({ hideDock: true });
+                        return;
+                    }
+                }
+            }
+            return;
+        }
+
+        if (hide === false) {
+            for (const key in this.state.dock_overlapped_windows) {
+                if (this.state.dock_overlapped_windows[key] && key !== objId) return;
+            }
+        }
+
+        let dock_overlapped_windows = this.state.dock_overlapped_windows;
+        dock_overlapped_windows[objId] = hide;
+        this.setState({ hideDock: hide, dock_overlapped_windows });
+    }
+
     hasMinimised = (objId) => {
         let minimized_windows = this.state.minimized_windows;
         var focused_windows = this.state.focused_windows;
@@ -550,6 +582,7 @@ export class Desktop extends Component {
         this.setState({ minimized_windows, focused_windows });
 
         this.hideSideBar(null, false);
+        this.hideDock(null, false);
 
         this.giveFocusToLastApp();
     }
@@ -693,6 +726,7 @@ export class Desktop extends Component {
         this.giveFocusToLastApp();
 
         this.hideSideBar(null, false);
+        this.hideDock(null, false);
 
         // close window
         let closed_windows = this.state.closed_windows;
@@ -900,6 +934,7 @@ export class Desktop extends Component {
                     focused_windows={this.state.focused_windows}
                     openApp={this.openApp}
                     minimize={this.hasMinimised}
+                    hide={this.state.hideDock}
                 />
 
                 {/* Desktop Apps */}

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -16,7 +16,8 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div className={(props.hide ? "translate-y-full " : "") +
+            "absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40 transition-transform duration-300"} role="toolbar">
             {runningApps.map(app => (
                 <button
                     key={app.id}

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -39,6 +39,8 @@
   --space-4: 1rem;
   --space-5: 1.5rem;
   --space-6: 2rem;
+  /* Gap between snapped windows and screen edges */
+  --win-gap: 8px;
 
   /* Radius */
   --radius-sm: 2px;


### PR DESCRIPTION
## Summary
- add `--win-gap` token and use it for half-screen snapping
- hide dock when a window overlaps and animate Taskbar off-screen
- align tests with new clipboard status role

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c388da68f483288663076a5af1fb3e