### PR TITLE
feat: highlight active windows

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -634,8 +634,23 @@ export class Window extends Component {
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
                 >
                     <div
-                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        style={{
+                            width: `${this.state.width}%`,
+                            height: `${this.state.height}%`,
+                            '--win-border-inner': this.props.isFocused ? 'var(--win-accent)' : undefined,
+                        }}
+                        data-active={this.props.isFocused}
+                        className={
+                            this.state.cursorType +
+                            " " +
+                            (this.state.closed ? " closed-window " : "") +
+                            (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") +
+                            (this.props.minimized ? " opacity-0 invisible duration-200 " : "") +
+                            (this.state.grabbed ? " opacity-70 " : "") +
+                            (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") +
+                            (this.props.isFocused ? " z-30 " : " z-20 notFocused") +
+                            " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"
+                        }
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}

--- a/styles/index.css
+++ b/styles/index.css
@@ -105,9 +105,10 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .window-shadow {
-    box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -webkit-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -moz-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+    outline: var(--win-hairline) solid var(--win-border);
+    box-shadow: inset 0 0 0 1px var(--win-border-inner), 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+    -webkit-box-shadow: inset 0 0 0 1px var(--win-border-inner), 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+    -moz-box-shadow: inset 0 0 0 1px var(--win-border-inner), 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
 }
 
 .closed-window {


### PR DESCRIPTION
## Summary
- outline and inner border for windows
- active windows use accent inner shadow via `data-active`

## Testing
- `yarn eslint components/base/window.js styles/index.css`
- `yarn test components/base/window.js`

------
https://chatgpt.com/codex/tasks/task_e_68c39e799a108328a55f5bd11429e8b7