### PR TITLE
feat: accent outline for active elements

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -530,3 +530,9 @@ textarea:focus-visible {
     color: #000 !important;
 }
 
+@media (prefers-reduced-motion: no-preference) {
+    [data-active="true"] {
+        box-shadow: 0 0 0 2px color-mix(in oklab, var(--win-accent) 30%, transparent);
+    }
+}
+


### PR DESCRIPTION
## Summary
- highlight active elements with an accent-colored box shadow

## Testing
- `yarn test` *(fails: e.preventDefault is not a function, unable to find role="alert")*


------
https://chatgpt.com/codex/tasks/task_e_68c39e79f10c8328ab51a717ff2eac93