### PR TITLE
style: refine window root clipping

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -110,6 +110,14 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     -moz-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
 }
 
+.main-window {
+    background-clip: padding-box;
+}
+
+.main-window:focus-visible {
+    outline-offset: -1px;
+}
+
 .closed-window {
     animation: closeWindow 200ms 1 forwards;
 }


### PR DESCRIPTION
## Summary
- keep window outlines crisp by clipping background to padding box
- offset window outline inward when focused

## Testing
- `yarn lint` *(fails: Unexpected global 'document' and missing display name)*
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: e.preventDefault is not a function; Unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68c39e7cd3fc83288e44eb48b9b9d19c