### PR TITLE
feat: add window variant border colors

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -612,6 +612,16 @@ export class Window extends Component {
     }
 
     render() {
+        const variant = this.props["data-variant"];
+        const borderMap = {
+            info: "var(--win-border-info)",
+            warning: "var(--win-border-warning)",
+            error: "var(--win-border-error)",
+        };
+        const style = { width: `${this.state.width}%`, height: `${this.state.height}%` };
+        if (variant && borderMap[variant]) {
+            style.borderColor = borderMap[variant];
+        }
         return (
             <>
                 {this.state.snapPreview && (
@@ -634,7 +644,8 @@ export class Window extends Component {
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
                 >
                     <div
-                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
+                        data-variant={variant}
+                        style={style}
                         className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
                         role="dialog"

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,5 +1,11 @@
 @import './globals.css';
 
+:root {
+    --win-border-info: var(--game-color-secondary);
+    --win-border-warning: var(--game-color-warning);
+    --win-border-error: var(--game-color-danger);
+}
+
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
 }


### PR DESCRIPTION
## Summary
- add info, warning, and error window border tokens
- apply border colors via `data-variant` mapping in window component

## Testing
- `npx eslint components/base/window.js -f json`
- `yarn test __tests__/window.test.tsx` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size)*

------
https://chatgpt.com/codex/tasks/task_e_68c39e7e41308328ba0ef3b65bf3256c