### PR TITLE
chore: dim inactive window chrome

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -94,7 +94,13 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .notFocused {
-    filter: brightness(90%);
+    /* filter removed to prevent dimming body content */
+}
+
+[data-active="false"] .bg-ub-window-title,
+[data-active="false"] [class*="windowYBorder"],
+[data-active="false"] [class*="windowXBorder"] {
+    filter: brightness(0.94) saturate(0.98);
 }
 
 .root,


### PR DESCRIPTION
## Summary
- prevent inactive windows from dimming body content
- dim only titlebar and window borders when inactive

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c39e7f518883289d99954c4d3af488