### PR TITLE
feat: add decorative dots to window titlebar

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -684,6 +684,16 @@ export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
             onKeyDown={onKeyDown}
             onBlur={onBlur}
         >
+            <svg
+                className={`${styles.topBarDots} absolute left-3 h-2 w-6`}
+                viewBox="0 0 24 6"
+                fill="currentColor"
+                aria-hidden="true"
+            >
+                <circle cx="3" cy="3" r="3" />
+                <circle cx="12" cy="3" r="3" />
+                <circle cx="21" cy="3" r="3" />
+            </svg>
             <div className="flex justify-center w-full text-sm font-bold">{title}</div>
         </div>
     )

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -7,3 +7,14 @@
   height: calc(100% + 10px);
   width: calc(100% - 10px);
 }
+
+.topBarDots {
+  opacity: 0.2;
+  pointer-events: none;
+}
+
+@media (prefers-contrast: more), (forced-colors: active) {
+  .topBarDots {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add low-contrast three-dot SVG to window title bar
- hide decorative dots for high-contrast or forced-color modes
- ensure dots ignore pointer events

## Testing
- `node_modules/.bin/eslint components/base/window.js components/base/window.module.css`
- `node_modules/.bin/jest components/base/window.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c39e81b0a083289d93f6ee9ecc8097