### PR TITLE
feat: highlight window during drag

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -194,9 +194,20 @@ export class Window extends Component {
             this.unsnapWindow();
         }
         this.setState({ cursorType: "cursor-move", grabbed: true })
+
+        const root = document.getElementById(this.id);
+        if (root) {
+            root.setAttribute('data-dragging', 'true');
+            root.style.outline = `2px solid var(--win-accent)`;
+        }
     }
 
     changeCursorToDefault = () => {
+        const root = document.getElementById(this.id);
+        if (root) {
+            root.removeAttribute('data-dragging');
+            root.style.outline = '';
+        }
         this.setState({ cursorType: "cursor-default", grabbed: false })
     }
 


### PR DESCRIPTION
## Summary
- add outline and data-dragging attribute while window is dragged
- clear outline and attribute when drag stops

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx)*
- `npx eslint components/base/window.js -f json`


------
https://chatgpt.com/codex/tasks/task_e_68c39e8095ec83288752963bd4ee6190