### PR TITLE
feat: expand window via edge double-click

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -198,9 +198,14 @@ describe('Window snapping finalize and release', () => {
 
     expect(ref.current!.state.snapped).toBe('left');
 
-    act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
-    });
+      act(() => {
+        ref.current!.handleKeyDown({
+          key: 'ArrowDown',
+          altKey: true,
+          preventDefault: () => {},
+          stopPropagation: () => {}
+        } as any);
+      });
 
     expect(ref.current!.state.snapped).toBeNull();
     expect(ref.current!.state.width).toBe(60);
@@ -319,6 +324,50 @@ describe('Edge resistance', () => {
     });
 
     expect(winEl.style.transform).toBe('translate(0px, 0px)');
+  });
+});
+
+describe('Edge double-click expansion', () => {
+  it('expands width when double-clicking side edge', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const edge = screen.getByTestId('window-y-border');
+    fireEvent.doubleClick(edge);
+    expect(ref.current!.state.width).toBe(100.2);
+  });
+
+  it('expands height when double-clicking top/bottom edge', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const edge = screen.getByTestId('window-x-border');
+    fireEvent.doubleClick(edge);
+    expect(ref.current!.state.height).toBe(96.3);
   });
 });
 

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -221,6 +221,27 @@ export class Window extends Component {
         this.setState({ width: widthPercent }, this.resizeBoundries);
     }
 
+    expandWidth = () => {
+        const node = document.getElementById(this.id);
+        if (!node) return;
+        const match = /translate\(([-\d.]+)px,\s*([-\d.]+)px\)/.exec(node.style.transform);
+        const y = match ? `${match[2]}px` : '0px';
+        node.style.transform = `translate(-1pt, ${y})`;
+        this.setState({ width: 100.2 }, () => {
+            this.resizeBoundries();
+            this.checkOverlap();
+        });
+    }
+
+    expandHeight = () => {
+        const node = document.getElementById(this.id);
+        if (!node) return;
+        const match = /translate\(([-\d.]+)px,\s*([-\d.]+)px\)/.exec(node.style.transform);
+        const x = match ? `${match[1]}px` : '0px';
+        node.style.transform = `translate(${x}, -2pt)`;
+        this.setState({ height: 96.3 }, this.resizeBoundries);
+    }
+
     setWinowsPosition = () => {
         var r = document.querySelector("#" + this.id);
         if (!r) return;
@@ -642,8 +663,8 @@ export class Window extends Component {
                         tabIndex={0}
                         onKeyDown={this.handleKeyDown}
                     >
-                        {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} />}
-                        {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}
+                        {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} expand={this.expandWidth} />}
+                        {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} expand={this.expandHeight} />}
                         <WindowTopBar
                             title={this.props.title}
                             onKeyDown={this.handleTitleBarKeyDown}
@@ -702,9 +723,11 @@ export class WindowYBorder extends Component {
     render() {
             return (
                 <div
+                    data-testid="window-y-border"
                     className={`${styles.windowYBorder} cursor-[e-resize] border-transparent border-1 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2`}
                     onDragStart={(e) => { e.dataTransfer.setDragImage(this.trpImg, 0, 0) }}
                     onDrag={this.props.resize}
+                    onDoubleClick={this.props.expand}
                 ></div>
             )
         }
@@ -721,9 +744,11 @@ export class WindowXBorder extends Component {
     render() {
             return (
                 <div
+                    data-testid="window-x-border"
                     className={`${styles.windowXBorder} cursor-[n-resize] border-transparent border-1 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2`}
                     onDragStart={(e) => { e.dataTransfer.setDragImage(this.trpImg, 0, 0) }}
                     onDrag={this.props.resize}
+                    onDoubleClick={this.props.expand}
                 ></div>
             )
         }


### PR DESCRIPTION
## Summary
- add horizontal and vertical expansion on window edge double-click
- test double-click behaviour for window borders

## Testing
- `yarn test __tests__/window.test.tsx`
- `npx eslint components/base/window.js __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c39e8516588328bbb575c5a59b8a19