### PR TITLE
Add overshoot animation on resize respecting motion preferences

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -530,3 +530,31 @@ textarea:focus-visible {
     color: #000 !important;
 }
 
+/* Overshoot animation when resize constraints are exceeded */
+.resize-overshoot {
+    animation: resizeOvershoot 120ms ease-out;
+}
+
+@keyframes resizeOvershoot {
+    0% {
+        width: var(--overshoot-width);
+        height: var(--overshoot-height);
+    }
+
+    60% {
+        width: calc(var(--overshoot-width) + 2%);
+        height: calc(var(--overshoot-height) + 2%);
+    }
+
+    100% {
+        width: var(--overshoot-width);
+        height: var(--overshoot-height);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .resize-overshoot {
+        animation: none;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `resizeOvershoot` keyframe and helper class in `styles/index.css`
- trigger overshoot animation when window resizing exceeds min/max size in `components/base/window.js`
- bypass animation when `prefers-reduced-motion` is set

## Testing
- `npx eslint components/base/window.js styles/index.css`
- `npx jest components/base/window.test.js` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c39e8aeb188328902cc8ca39531ef3