### PR TITLE
feat: add vertical snap regions

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -119,11 +119,11 @@ describe('Window snapping preview', () => {
 });
 
 describe('Window snapping finalize and release', () => {
-  it('snaps window on drag stop near left edge', () => {
-    const ref = React.createRef<Window>();
-    render(
-      <Window
-        id="test-window"
+    it('snaps window on drag stop near left edge', () => {
+      const ref = React.createRef<Window>();
+      render(
+        <Window
+          id="test-window"
         title="Test"
         screen={() => <div>content</div>}
         focus={() => {}}
@@ -156,9 +156,91 @@ describe('Window snapping finalize and release', () => {
     });
 
     expect(ref.current!.state.snapped).toBe('left');
-    expect(ref.current!.state.width).toBe(50);
-    expect(ref.current!.state.height).toBe(96.3);
-  });
+      expect(ref.current!.state.width).toBe(50);
+      expect(ref.current!.state.height).toBe(96.3);
+    });
+
+    it('snaps window on drag stop near top edge with gaps', () => {
+      const ref = React.createRef<Window>();
+      render(
+        <Window
+          id="test-window"
+          title="Test"
+          screen={() => <div>content</div>}
+          focus={() => {}}
+          hasMinimised={() => {}}
+          closed={() => {}}
+          hideSideBar={() => {}}
+          openApp={() => {}}
+          ref={ref}
+        />
+      );
+
+      const winEl = document.getElementById('test-window')!;
+      winEl.getBoundingClientRect = () => ({
+        left: 40,
+        top: 5,
+        right: 140,
+        bottom: 105,
+        width: 100,
+        height: 100,
+        x: 40,
+        y: 5,
+        toJSON: () => {}
+      });
+
+      act(() => {
+        ref.current!.handleDrag();
+      });
+      act(() => {
+        ref.current!.handleStop();
+      });
+
+      expect(ref.current!.state.snapped).toBe('top');
+      expect(ref.current!.state.width).toBeCloseTo(100.2);
+      expect(ref.current!.state.height).toBeCloseTo(96.3 / 2);
+    });
+
+    it('snaps window on drag stop near bottom edge with gaps', () => {
+      const ref = React.createRef<Window>();
+      render(
+        <Window
+          id="test-window"
+          title="Test"
+          screen={() => <div>content</div>}
+          focus={() => {}}
+          hasMinimised={() => {}}
+          closed={() => {}}
+          hideSideBar={() => {}}
+          openApp={() => {}}
+          ref={ref}
+        />
+      );
+
+      const winEl = document.getElementById('test-window')!;
+      winEl.getBoundingClientRect = () => ({
+        left: 40,
+        top: window.innerHeight - 110,
+        right: 140,
+        bottom: window.innerHeight - 10,
+        width: 100,
+        height: 100,
+        x: 40,
+        y: window.innerHeight - 110,
+        toJSON: () => {}
+      });
+
+      act(() => {
+        ref.current!.handleDrag();
+      });
+      act(() => {
+        ref.current!.handleStop();
+      });
+
+      expect(ref.current!.state.snapped).toBe('bottom');
+      expect(ref.current!.state.width).toBeCloseTo(100.2);
+      expect(ref.current!.state.height).toBeCloseTo(96.3 / 2);
+    });
 
   it('releases snap with Alt+ArrowDown restoring size', () => {
     const ref = React.createRef<Window>();
@@ -199,7 +281,7 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true, preventDefault: () => {}, stopPropagation: () => {} } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -258,21 +258,28 @@ export class Window extends Component {
     snapWindow = (position) => {
         this.setWinowsPosition();
         const { width, height } = this.state;
+        const maxHeightPercent = 96.3;
+        const halfHeightPercent = maxHeightPercent / 2;
+        const halfHeightPx = (window.innerHeight * maxHeightPercent / 100) / 2;
         let newWidth = width;
         let newHeight = height;
         let transform = '';
         if (position === 'left') {
             newWidth = 50;
-            newHeight = 96.3;
+            newHeight = maxHeightPercent;
             transform = 'translate(-1pt,-2pt)';
         } else if (position === 'right') {
             newWidth = 50;
-            newHeight = 96.3;
+            newHeight = maxHeightPercent;
             transform = `translate(${window.innerWidth / 2}px,-2pt)`;
         } else if (position === 'top') {
             newWidth = 100.2;
-            newHeight = 50;
+            newHeight = halfHeightPercent;
             transform = 'translate(-1pt,-2pt)';
+        } else if (position === 'bottom') {
+            newWidth = 100.2;
+            newHeight = halfHeightPercent;
+            transform = `translate(-1pt,${halfHeightPx - 2}px)`;
         }
         const r = document.querySelector("#" + this.id);
         if (r && transform) {
@@ -318,6 +325,8 @@ export class Window extends Component {
         if (!r) return;
         var rect = r.getBoundingClientRect();
         const threshold = 30;
+        const maxHeightPercent = 96.3;
+        const halfHeightPx = (window.innerHeight * maxHeightPercent / 100) / 2;
         let snap = null;
         if (rect.left <= threshold) {
             snap = { left: '0', top: '0', width: '50%', height: '100%' };
@@ -328,8 +337,12 @@ export class Window extends Component {
             this.setState({ snapPreview: snap, snapPosition: 'right' });
         }
         else if (rect.top <= threshold) {
-            snap = { left: '0', top: '0', width: '100%', height: '50%' };
+            snap = { left: '0', top: '0', width: '100%', height: `${halfHeightPx}px` };
             this.setState({ snapPreview: snap, snapPosition: 'top' });
+        }
+        else if (rect.bottom >= window.innerHeight - threshold) {
+            snap = { left: '0', top: `${halfHeightPx}px`, width: '100%', height: `${halfHeightPx}px` };
+            this.setState({ snapPreview: snap, snapPosition: 'bottom' });
         }
         else {
             if (this.state.snapPreview) this.setState({ snapPreview: null, snapPosition: null });
@@ -582,33 +595,6 @@ export class Window extends Component {
                 this.unsnapWindow();
             }
         }
-    }
-
-    snapWindow = (pos) => {
-        this.focusWindow();
-        const { width, height } = this.state;
-        let newWidth = width;
-        let newHeight = height;
-        let transform = '';
-        if (pos === 'left') {
-            newWidth = 50;
-            newHeight = 96.3;
-            transform = 'translate(-1pt,-2pt)';
-        } else if (pos === 'right') {
-            newWidth = 50;
-            newHeight = 96.3;
-            transform = `translate(${window.innerWidth / 2}px,-2pt)`;
-        }
-        const node = document.getElementById(this.id);
-        if (node && transform) {
-            node.style.transform = transform;
-        }
-        this.setState({
-            snapped: pos,
-            lastSize: { width, height },
-            width: newWidth,
-            height: newHeight
-        }, this.resizeBoundries);
     }
 
     render() {


### PR DESCRIPTION
## Summary
- snap windows to top or bottom halves, accounting for gaps and portrait layouts
- preview bottom snap regions during drag
- test top and bottom snap behavior

## Testing
- `yarn test __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c39e9000fc8328aff16bafd31d3037