### PR TITLE
Add center snap zone for window snapping

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -80,6 +80,44 @@ describe('Window snapping preview', () => {
     expect(screen.getByTestId('snap-preview')).toBeInTheDocument();
   });
 
+  it('shows preview when dragged near vertical midline', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    const width = window.innerWidth;
+    // Simulate being near the vertical center
+    winEl.getBoundingClientRect = () => ({
+      left: width / 2 - 50,
+      top: 100,
+      right: width / 2 + 50,
+      bottom: 200,
+      width: 100,
+      height: 100,
+      x: width / 2 - 50,
+      y: 100,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+
+    expect(screen.getByTestId('snap-preview')).toBeInTheDocument();
+  });
+
   it('hides preview when away from edge', () => {
     const ref = React.createRef<Window>();
     render(
@@ -160,6 +198,48 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.height).toBe(96.3);
   });
 
+  it('snaps window on drag stop near vertical midline', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    const width = window.innerWidth;
+    winEl.getBoundingClientRect = () => ({
+      left: width / 2 - 50,
+      top: 100,
+      right: width / 2 + 50,
+      bottom: 200,
+      width: 100,
+      height: 100,
+      x: width / 2 - 50,
+      y: 100,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+    act(() => {
+      ref.current!.handleStop();
+    });
+
+    expect(ref.current!.state.snapped).toBe('center');
+    expect(ref.current!.state.width).toBe(50);
+    expect(ref.current!.state.height).toBe(96.3);
+  });
+
   it('releases snap with Alt+ArrowDown restoring size', () => {
     const ref = React.createRef<Window>();
     render(
@@ -199,7 +279,12 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({
+        key: 'ArrowDown',
+        altKey: true,
+        preventDefault() {},
+        stopPropagation() {},
+      } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -273,6 +273,10 @@ export class Window extends Component {
             newWidth = 100.2;
             newHeight = 50;
             transform = 'translate(-1pt,-2pt)';
+        } else if (position === 'center') {
+            newWidth = 50;
+            newHeight = 96.3;
+            transform = `translate(${window.innerWidth / 4}px,-2pt)`;
         }
         const r = document.querySelector("#" + this.id);
         if (r && transform) {
@@ -330,6 +334,10 @@ export class Window extends Component {
         else if (rect.top <= threshold) {
             snap = { left: '0', top: '0', width: '100%', height: '50%' };
             this.setState({ snapPreview: snap, snapPosition: 'top' });
+        }
+        else if (Math.abs((rect.left + rect.width / 2) - window.innerWidth / 2) <= threshold) {
+            snap = { left: '25%', top: '0', width: '50%', height: '100%' };
+            this.setState({ snapPreview: snap, snapPosition: 'center' });
         }
         else {
             if (this.state.snapPreview) this.setState({ snapPreview: null, snapPosition: null });
@@ -586,6 +594,7 @@ export class Window extends Component {
 
     snapWindow = (pos) => {
         this.focusWindow();
+        this.setWinowsPosition();
         const { width, height } = this.state;
         let newWidth = width;
         let newHeight = height;
@@ -598,12 +607,22 @@ export class Window extends Component {
             newWidth = 50;
             newHeight = 96.3;
             transform = `translate(${window.innerWidth / 2}px,-2pt)`;
+        } else if (pos === 'top') {
+            newWidth = 100.2;
+            newHeight = 50;
+            transform = 'translate(-1pt,-2pt)';
+        } else if (pos === 'center') {
+            newWidth = 50;
+            newHeight = 96.3;
+            transform = `translate(${window.innerWidth / 4}px,-2pt)`;
         }
         const node = document.getElementById(this.id);
         if (node && transform) {
             node.style.transform = transform;
         }
         this.setState({
+            snapPreview: null,
+            snapPosition: null,
             snapped: pos,
             lastSize: { width, height },
             width: newWidth,


### PR DESCRIPTION
## Summary
- allow windows to snap to a centered vertical midline with preview highlight
- support snapping to the center in window snap logic
- test preview and snapping for new midline zone

## Testing
- `npx eslint components/base/window.js __tests__/window.test.tsx`
- `yarn test __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c39e9064c08328a764598a39a8154c