### PR TITLE
feat: add window mosaic layout

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -53,6 +53,7 @@ export class Window extends Component {
         window.addEventListener('context-menu-close', this.removeInertBackground);
         const root = document.getElementById(this.id);
         root?.addEventListener('super-arrow', this.handleSuperArrow);
+        root?.addEventListener('set-bounds', this.handleSetBounds);
         if (this._uiExperiments) {
             this.scheduleUsageCheck();
         }
@@ -66,6 +67,7 @@ export class Window extends Component {
         window.removeEventListener('context-menu-close', this.removeInertBackground);
         const root = document.getElementById(this.id);
         root?.removeEventListener('super-arrow', this.handleSuperArrow);
+        root?.removeEventListener('set-bounds', this.handleSetBounds);
         if (this._usageTimeout) {
             clearTimeout(this._usageTimeout);
         }
@@ -525,40 +527,40 @@ export class Window extends Component {
             this.focusWindow();
         } else if (e.altKey) {
             if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.unsnapWindow();
             } else if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('left');
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('right');
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('top');
             }
             this.focusWindow();
         } else if (e.shiftKey) {
             const step = 1;
             if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ width: Math.max(prev.width - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ width: Math.min(prev.width + step, 100) }), this.resizeBoundries);
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ height: Math.max(prev.height - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ height: Math.min(prev.height + step, 100) }), this.resizeBoundries);
             }
             this.focusWindow();
@@ -582,6 +584,17 @@ export class Window extends Component {
                 this.unsnapWindow();
             }
         }
+    }
+
+    handleSetBounds = (e) => {
+        const { x, y, width, height } = e.detail || {};
+        const node = document.getElementById(this.id);
+        if (node) {
+            node.style.transform = `translate(${x}px, ${y}px)`;
+        }
+        const w = (width / window.innerWidth) * 100;
+        const h = (height / window.innerHeight) * 100;
+        this.setState({ width: w, height: h }, this.resizeBoundries);
     }
 
     snapWindow = (pos) => {

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -85,6 +85,26 @@ function DesktopMenu(props) {
             >
                 <span className="ml-5">Open in Terminal</span>
             </button>
+            <button
+                onClick={props.mosaicWindows}
+                type="button"
+                role="menuitem"
+                aria-label="Mosaic Windows"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
+                <span className="ml-5">Mosaic Windows</span>
+            </button>
+            {props.canUndoMosaic && (
+                <button
+                    onClick={props.undoMosaic}
+                    type="button"
+                    role="menuitem"
+                    aria-label="Undo Mosaic"
+                    className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                >
+                    <span className="ml-5">Undo Mosaic</span>
+                </button>
+            )}
             <Devider />
             <button
                 onClick={openSettings}


### PR DESCRIPTION
## Summary
- add mosaic window layout with BSP partitioning and undo support
- expose set-bounds event for windows to resize and move programmatically
- add context menu and hotkeys for mosaic/undo actions

## Testing
- `yarn test` *(fails: Unable to find role="alert" in __tests__/nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c39e918c9c8328979a7ccf45d7cde0