### PR TITLE
feat(module-workspace): persist window gap per workspace

### DIFF
--- a/__tests__/moduleWorkspaceStore.test.tsx
+++ b/__tests__/moduleWorkspaceStore.test.tsx
@@ -24,4 +24,33 @@ describe('ModuleWorkspace key-value store', () => {
     expect(stored).toBeDefined();
     expect(stored).toContain('port-scan TARGET=host');
   });
+
+  it('persists window gap per workspace', () => {
+    render(<ModuleWorkspace />);
+
+    fireEvent.change(screen.getByPlaceholderText('New workspace'), {
+      target: { value: 'ws1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    fireEvent.change(screen.getByLabelText('Window gap'), {
+      target: { value: '10' },
+    });
+
+    fireEvent.change(screen.getByPlaceholderText('New workspace'), {
+      target: { value: 'ws2' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    fireEvent.change(screen.getByLabelText('Window gap'), {
+      target: { value: '20' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'ws1' }));
+
+    expect(screen.getByLabelText('Window gap')).toHaveValue('10');
+    expect(
+      document.documentElement.style.getPropertyValue('--win-gap'),
+    ).toBe('10px');
+  });
 });


### PR DESCRIPTION
## Summary
- persist `--win-gap` value per workspace and apply on switch
- expose window gap slider in ModuleWorkspace UI
- test window gap persistence across workspaces

## Testing
- `yarn lint pages/module-workspace.tsx __tests__/moduleWorkspaceStore.test.tsx` (fails: Unexpected global 'document', component missing display name)
- `yarn test moduleWorkspaceStore.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c39e9395c083289e4b8ee23569e50e