### PR TITLE
feat: auto-resize dialogs based on content

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -199,7 +199,12 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({
+        key: 'ArrowDown',
+        altKey: true,
+        preventDefault: () => {},
+        stopPropagation: () => {}
+      } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();


### PR DESCRIPTION
## Summary
- expand Modal via ResizeObserver to fit content up to app-defined limits
- polyfill ResizeObserver and remove top-level window references in test setup
- adjust window test to use proper keyboard event stubs

## Testing
- `npx eslint components/base/Modal.tsx jest.setup.ts __tests__/window.test.tsx`
- `yarn test __tests__/Modal.test.tsx __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c39e9493bc832895eda5a65faaaf3b