### PR TITLE
Adjust window gap based on wallpaper luminance

### DIFF
--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -33,6 +33,13 @@ export default function BackgroundImage() {
             const lum = 0.2126 * toLinear(avgR) + 0.7152 * toLinear(avgG) + 0.0722 * toLinear(avgB);
             const contrast = (1.05) / (lum + 0.05); // white text luminance is 1
             setNeedsOverlay(contrast < 4.5);
+
+            // Adjust window gap based on wallpaper luminance
+            const baseGap = 8; // px
+            const gap = baseGap + (lum - 0.5) * 4; // slight +/- adjustment
+            requestAnimationFrame(() => {
+                document.documentElement.style.setProperty('--win-gap', `${gap}px`);
+            });
         };
     }, [wallpaper]);
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -56,6 +56,8 @@
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;
+  /* Default gap between windows */
+  --win-gap: 8px;
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;


### PR DESCRIPTION
## Summary
- tune window spacing by deriving `--win-gap` from wallpaper luminance
- define default `--win-gap` design token for window spacing

## Testing
- `npx eslint components/util-components/background-image.js styles/tokens.css`
- `npx jest __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/Modal.test.tsx` *(fails: TypeError: e.preventDefault is not a function; Unable to find role="alert")*


------
https://chatgpt.com/codex/tasks/task_e_68c39e9642288328af17b3b20c977e10