### PR TITLE
feat: add optional tab bar to window

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -6,6 +6,7 @@ import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
+import Tabs from '../Tabs';
 import styles from './window.module.css';
 
 export class Window extends Component {
@@ -659,6 +660,14 @@ export class Window extends Component {
                             allowMaximize={this.props.allowMaximize !== false}
                             pip={() => this.props.screen(this.props.addFolder, this.props.openApp)}
                         />
+                        {this.props.tabs && this.props.tabs.length > 0 && (
+                            <Tabs
+                                tabs={this.props.tabs}
+                                active={this.props.activeTab}
+                                onChange={this.props.onTabChange}
+                                className="w-full bg-ub-window-title text-white border-b border-black border-opacity-40 flex-shrink-0"
+                            />
+                        )}
                         {(this.id === "settings"
                             ? <Settings />
                             : <WindowMainScreen screen={this.props.screen} title={this.props.title}


### PR DESCRIPTION
## Summary
- allow windows to show a lightweight tab bar when provided tabs
- style tab bar to keep outer border continuous

## Testing
- `npm test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/reconng.test.tsx 2>&1 | tail -n 20`
- `npm test __tests__/window.test.tsx 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c39e9a659c8328a7f52ad8145f6f35