### PR TITLE
Fade in window controls on hover

### DIFF
--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -38,13 +38,22 @@ export default function VsCode() {
           className="flex items-center justify-end gap-2 px-2 py-1 border-b border-black/20"
           style={{ backgroundColor: kaliTheme.background }}
         >
-          <button aria-label="Minimize">
+          <button
+            aria-label="Minimize"
+            className="opacity-0 transition-opacity hover:opacity-100 focus:opacity-100"
+          >
             <MinimizeIcon />
           </button>
-          <button aria-label="Maximize">
+          <button
+            aria-label="Maximize"
+            className="opacity-0 transition-opacity hover:opacity-100 focus:opacity-100"
+          >
             <MaximizeIcon />
           </button>
-          <button aria-label="Close">
+          <button
+            aria-label="Close"
+            className="opacity-0 transition-opacity hover:opacity-100 focus:opacity-100"
+          >
             <CloseIcon />
           </button>
         </div>

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -755,7 +755,7 @@ export function WindowEditButtons(props) {
             <button
                 type="button"
                 aria-label="Window minimize"
-                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                className="mx-1 opacity-0 transition-opacity bg-white bg-opacity-0 hover:bg-opacity-10 focus:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6 hover:opacity-100 focus:opacity-100"
                 onClick={props.minimize}
             >
                 <NextImage
@@ -773,7 +773,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window restore"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className="mx-1 opacity-0 transition-opacity bg-white bg-opacity-0 hover:bg-opacity-10 focus:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6 hover:opacity-100 focus:opacity-100"
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -789,7 +789,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window maximize"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className="mx-1 opacity-0 transition-opacity bg-white bg-opacity-0 hover:bg-opacity-10 focus:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6 hover:opacity-100 focus:opacity-100"
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -807,7 +807,7 @@ export function WindowEditButtons(props) {
                 type="button"
                 id={`close-${props.id}`}
                 aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
+                className="mx-1 focus:outline-none cursor-default opacity-0 transition-opacity bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 focus:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6 hover:opacity-100 focus:opacity-100"
                 onClick={props.close}
             >
                 <NextImage


### PR DESCRIPTION
## Summary
- Hide window minimize/maximize/close buttons until hovered or focused
- Apply the same hover behavior to VS Code app buttons

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/Modal.test.tsx` *(fails: window test, nmapNse test)*

------
https://chatgpt.com/codex/tasks/task_e_68c39e9bfa2c8328b82eeddf1bb27d41