### PR TITLE
feat: prevent context menu overflow

### DIFF
--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useRef, useEffect } from 'react';
-import useFocusTrap from '../../hooks/useFocusTrap';
-import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+import React, { useState, useRef, useEffect } from "react";
+import useFocusTrap from "../../hooks/useFocusTrap";
+import useRovingTabIndex from "../../hooks/useRovingTabIndex";
 
 export interface MenuItem {
   label: React.ReactNode;
@@ -25,12 +25,29 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
   const [pos, setPos] = useState({ x: 0, y: 0 });
   const menuRef = useRef<HTMLDivElement>(null);
 
+  const openMenuAt = (pageX: number, pageY: number) => {
+    setPos({ x: pageX, y: pageY });
+    setOpen(true);
+    requestAnimationFrame(() => {
+      const menu = menuRef.current;
+      if (!menu) return;
+      const rect = menu.getBoundingClientRect();
+      let x = pageX;
+      let y = pageY;
+      if (rect.right > window.innerWidth) {
+        x = pageX - rect.width;
+      }
+      if (rect.bottom > window.innerHeight) {
+        y = pageY - rect.height;
+      }
+      if (x !== pageX || y !== pageY) {
+        setPos({ x: Math.max(0, x), y: Math.max(0, y) });
+      }
+    });
+  };
+
   useFocusTrap(menuRef as React.RefObject<HTMLElement>, open);
-  useRovingTabIndex(
-    menuRef as React.RefObject<HTMLElement>,
-    open,
-    'vertical',
-  );
+  useRovingTabIndex(menuRef as React.RefObject<HTMLElement>, open, "vertical");
 
   useEffect(() => {
     const node = targetRef.current;
@@ -38,33 +55,31 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
 
     const handleContextMenu = (e: MouseEvent) => {
       e.preventDefault();
-      setPos({ x: e.pageX, y: e.pageY });
-      setOpen(true);
+      openMenuAt(e.pageX, e.pageY);
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.shiftKey && e.key === 'F10') {
+      if (e.shiftKey && e.key === "F10") {
         e.preventDefault();
         const rect = node.getBoundingClientRect();
-        setPos({ x: rect.left, y: rect.bottom });
-        setOpen(true);
+        openMenuAt(rect.left + window.scrollX, rect.bottom + window.scrollY);
       }
     };
 
-    node.addEventListener('contextmenu', handleContextMenu);
-    node.addEventListener('keydown', handleKeyDown);
+    node.addEventListener("contextmenu", handleContextMenu);
+    node.addEventListener("keydown", handleKeyDown);
 
     return () => {
-      node.removeEventListener('contextmenu', handleContextMenu);
-      node.removeEventListener('keydown', handleKeyDown);
+      node.removeEventListener("contextmenu", handleContextMenu);
+      node.removeEventListener("keydown", handleKeyDown);
     };
   }, [targetRef]);
 
   useEffect(() => {
     if (open) {
-      window.dispatchEvent(new CustomEvent('context-menu-open'));
+      window.dispatchEvent(new CustomEvent("context-menu-open"));
     } else {
-      window.dispatchEvent(new CustomEvent('context-menu-close'));
+      window.dispatchEvent(new CustomEvent("context-menu-close"));
     }
   }, [open]);
 
@@ -78,17 +93,17 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
     };
 
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
+      if (e.key === "Escape") {
         setOpen(false);
       }
     };
 
-    document.addEventListener('mousedown', handleClick);
-    document.addEventListener('keydown', handleEscape);
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleEscape);
 
     return () => {
-      document.removeEventListener('mousedown', handleClick);
-      document.removeEventListener('keydown', handleEscape);
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleEscape);
     };
   }, [open]);
 
@@ -98,8 +113,10 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
       ref={menuRef}
       aria-hidden={!open}
       style={{ left: pos.x, top: pos.y }}
-      className={(open ? 'block ' : 'hidden ') +
-        'cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+      className={
+        (open ? "block " : "hidden ") +
+        "cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm"
+      }
     >
       {items.map((item, i) => (
         <button
@@ -120,4 +137,3 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
 };
 
 export default ContextMenu;
-


### PR DESCRIPTION
## Summary
- compute context menu coordinates on open
- flip menu when near viewport edges to avoid overflow

## Testing
- `npx eslint components/common/ContextMenu.tsx`
- `yarn test --passWithNoTests components/common/ContextMenu.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c39e9c7e088328a9a5e5746368e300