### PR TITLE
Annotate utility apps and handle mobile sheets

### DIFF
--- a/apps/app-registry.ts
+++ b/apps/app-registry.ts
@@ -1,0 +1,12 @@
+import apps, { utilities } from '../apps.config';
+
+// Enhance the base apps list by annotating utility apps with metadata
+// needed by the window manager.
+export const appRegistry = apps.map(app => {
+  if (utilities.some(u => u.id === app.id)) {
+    return { ...app, utility: true, preferred: [420, 560] as [number, number] };
+  }
+  return app;
+});
+
+export default appRegistry;

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -71,25 +71,26 @@ export class Window extends Component {
         }
     }
 
-    setDefaultWindowDimenstion = () => {
-        if (this.props.defaultHeight && this.props.defaultWidth) {
-            this.setState(
-                { height: this.props.defaultHeight, width: this.props.defaultWidth },
-                this.resizeBoundries
-            );
-            return;
-        }
+      setDefaultWindowDimenstion = () => {
+          const isSheet = window.innerWidth < 640 || window.innerHeight > window.innerWidth;
+          if (this.props.defaultHeight && this.props.defaultWidth && !isSheet) {
+              this.setState(
+                  { height: this.props.defaultHeight, width: this.props.defaultWidth },
+                  this.resizeBoundries
+              );
+              return;
+          }
 
-        const isPortrait = window.innerHeight > window.innerWidth;
-        if (isPortrait) {
-            this.startX = window.innerWidth * 0.05;
-            this.setState({ height: 85, width: 90 }, this.resizeBoundries);
-        } else if (window.innerWidth < 640) {
-            this.setState({ height: 60, width: 85 }, this.resizeBoundries);
-        } else {
-            this.setState({ height: 85, width: 60 }, this.resizeBoundries);
-        }
-    }
+          const isPortrait = window.innerHeight > window.innerWidth;
+          if (isPortrait) {
+              this.startX = window.innerWidth * 0.05;
+              this.setState({ height: 85, width: 90 }, this.resizeBoundries);
+          } else if (window.innerWidth < 640) {
+              this.setState({ height: 60, width: 85 }, this.resizeBoundries);
+          } else {
+              this.setState({ height: 85, width: 60 }, this.resizeBoundries);
+          }
+      }
 
     resizeBoundries = () => {
         this.setState({


### PR DESCRIPTION
## Summary
- Annotate utility apps via `app-registry.ts` with `utility` flag and preferred dimensions
- Prevent default window dimensions from applying when rendered as mobile sheets

## Testing
- `npx eslint apps/app-registry.ts components/base/window.js`
- `yarn test apps/app-registry.ts components/base/window.js --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c39e9e3b348328aa909b56d87db807