### PR TITLE
style: adjust window titlebar for small screens

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -530,3 +530,19 @@ textarea:focus-visible {
     color: #000 !important;
 }
 
+@media (max-width: 640px) {
+    :root {
+        --win-titlebar-height: 48px;
+    }
+
+    .opened-window .bg-ub-window-title {
+        height: var(--win-titlebar-height);
+    }
+
+    button[aria-label^="Window"] {
+        width: 32px;
+        height: 32px;
+        min-width: 24px;
+        min-height: 24px;
+    }
+}


### PR DESCRIPTION
## Summary
- ensure mobile windows use 48px titlebar height
- enlarge window control buttons to 32×32 with at least 24×24 hit area

## Testing
- `yarn a11y` *(fails: [WCAG2AA.Principle2.Guideline2_4.2_4_1.G1,G123,G124.NoSuchID] This link points to a named anchor "app-grid" within the document, but no anchor exists with that name. (#__next > div > a:nth-child(1)))*

------
https://chatgpt.com/codex/tasks/task_e_68c39ea114e48328ba08ee2acb1ebc87