### PR TITLE
Render utility apps as mobile sheets on mobile

### DIFF
--- a/components/base/UtilitySheet.tsx
+++ b/components/base/UtilitySheet.tsx
@@ -1,0 +1,86 @@
+import React, { useState, useRef, useEffect } from 'react';
+import Modal from './Modal';
+
+interface UtilitySheetProps {
+  id: string;
+  title: string;
+  screen: (addFolder: any, openApp: any) => React.ReactNode;
+  addFolder: (id: string) => void;
+  openApp: (id: string) => void;
+  closed: (id: string) => void;
+  focus: (id: string) => void;
+}
+
+const UtilitySheet: React.FC<UtilitySheetProps> = ({
+  id,
+  title,
+  screen,
+  addFolder,
+  openApp,
+  closed,
+  focus,
+}) => {
+  const [open, setOpen] = useState(true);
+  const [snap, setSnap] = useState(0.5);
+  const startY = useRef(0);
+  const startSnap = useRef(0.5);
+
+  useEffect(() => {
+    setSnap(0.5);
+  }, []);
+
+  const handleClose = () => {
+    setOpen(false);
+    closed(id);
+  };
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    startY.current = e.clientY;
+    startSnap.current = snap;
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', onPointerUp);
+  };
+
+  const onPointerMove = (e: PointerEvent) => {
+    const delta = startY.current - e.clientY;
+    const next = startSnap.current + delta / window.innerHeight;
+    const clamped = Math.min(0.9, Math.max(0.5, next));
+    setSnap(clamped);
+  };
+
+  const onPointerUp = () => {
+    window.removeEventListener('pointermove', onPointerMove);
+    window.removeEventListener('pointerup', onPointerUp);
+    setSnap((prev) => (prev < 0.7 ? 0.5 : 0.9));
+  };
+
+  return (
+    <Modal isOpen={open} onClose={handleClose}>
+      <div className="fixed inset-0 z-50" onMouseDown={() => focus(id)}>
+        <div
+          className="absolute inset-0 bg-black/50"
+          onClick={handleClose}
+          aria-hidden="true"
+        />
+        <div
+          className="absolute bottom-0 left-0 right-0 bg-ub-cool-grey text-white rounded-t-lg shadow-lg flex flex-col"
+          style={{ height: `${snap * 100}vh` }}
+          role="dialog"
+          aria-label={title}
+        >
+          <div
+            className="p-2 cursor-grab active:cursor-grabbing touch-none"
+            onPointerDown={onPointerDown}
+          >
+            <div className="w-12 h-1.5 bg-gray-500 rounded-full mx-auto" />
+          </div>
+          <div className="flex-1 overflow-y-auto">
+            {screen(addFolder, openApp)}
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default UtilitySheet;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -8,7 +8,8 @@ const BackgroundImage = dynamic(
     { ssr: false }
 );
 import SideBar from './side_bar';
-import apps, { games } from '../../apps.config';
+import apps, { games, utilities } from '../../apps.config';
+import UtilitySheet from '../base/UtilitySheet';
 import Window from '../base/window';
 import UbuntuApp from '../base/ubuntu_app';
 import AllApplications from '../screen/all-applications'
@@ -456,11 +457,11 @@ export class Desktop extends Component {
 
     renderWindows = () => {
         let windowsJsx = [];
-        apps.forEach((app, index) => {
+        const isMobile = typeof window !== 'undefined' && window.matchMedia('(max-width: 640px)').matches;
+        apps.forEach((app) => {
             if (this.state.closed_windows[app.id] === false) {
-
                 const pos = this.state.window_positions[app.id];
-                const props = {
+                const common = {
                     title: app.title,
                     id: app.id,
                     screen: app.screen,
@@ -468,6 +469,10 @@ export class Desktop extends Component {
                     closed: this.closeApp,
                     openApp: this.openApp,
                     focus: this.focus,
+                };
+
+                const windowProps = {
+                    ...common,
                     isFocused: this.state.focused_windows[app.id],
                     hideSideBar: this.hideSideBar,
                     hasMinimised: this.hasMinimised,
@@ -480,11 +485,14 @@ export class Desktop extends Component {
                     initialY: pos ? pos.y : undefined,
                     onPositionChange: (x, y) => this.updateWindowPosition(app.id, x, y),
                     snapEnabled: this.props.snapEnabled,
-                }
+                };
 
-                windowsJsx.push(
-                    <Window key={app.id} {...props} />
-                )
+                const isUtility = utilities.some(u => u.id === app.id);
+                if (isUtility && isMobile) {
+                    windowsJsx.push(<UtilitySheet key={app.id} {...common} />);
+                } else {
+                    windowsJsx.push(<Window key={app.id} {...windowProps} />);
+                }
             }
         });
         return windowsJsx;
@@ -838,8 +846,8 @@ export class Desktop extends Component {
         return (
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
-                    <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <label htmlFor="folder-name-input">New folder name</label>
+                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} aria-label="New folder name" />
                 </div>
                 <div className="flex">
                     <button


### PR DESCRIPTION
## Summary
- Add `UtilitySheet` modal with drag snap points at 50% and 90%
- Use `UtilitySheet` for utility apps when viewport is mobile
- Disable background interaction while a utility sheet is open

## Testing
- `npx eslint components/base/UtilitySheet.tsx components/screen/desktop.js`
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c39ea180c88328a35e7f62015ade51