### PR TITLE
feat: clamp windows around reserved regions

### DIFF
--- a/utils/reservedRegions.ts
+++ b/utils/reservedRegions.ts
@@ -1,0 +1,28 @@
+import { publish, subscribe } from './pubsub';
+
+export interface ReservedRegion {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+}
+
+const regions = new Map<string, ReservedRegion>();
+
+export function addReservedRegion(id: string, rect: ReservedRegion) {
+  regions.set(id, rect);
+  publish('reserved-regions', Array.from(regions.values()));
+}
+
+export function removeReservedRegion(id: string) {
+  regions.delete(id);
+  publish('reserved-regions', Array.from(regions.values()));
+}
+
+export function getReservedRegions(): ReservedRegion[] {
+  return Array.from(regions.values());
+}
+
+export function subscribeReservedRegions(cb: (regions: ReservedRegion[]) => void) {
+  return subscribe('reserved-regions', cb as any);
+}


### PR DESCRIPTION
## Summary
- add reserved region registry and pubsub helpers
- ensure windows avoid reserved regions, updating as popovers appear or disappear
- test window clamping around reserved regions

## Testing
- `yarn test __tests__/window.test.tsx`
- `npx eslint components/base/window.js utils/reservedRegions.ts __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c39e958f8083289bb7dc09cf2dd5de