### PR TITLE
feat: add attention pulse animation

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -146,6 +146,47 @@ function MyApp(props) {
     };
   }, []);
 
+  useEffect(() => {
+    const prefersReducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)'
+    ).matches;
+
+    const handle = (el) => {
+      const reset = () => {
+        el.setAttribute('data-attention', 'false');
+      };
+      if (prefersReducedMotion) {
+        reset();
+        return;
+      }
+      el.addEventListener('animationend', reset, { once: true });
+    };
+
+    document.querySelectorAll('[data-attention="true"]').forEach(handle);
+
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((m) => {
+        if (
+          m.type === 'attributes' &&
+          m.attributeName === 'data-attention' &&
+          m.target.getAttribute('data-attention') === 'true'
+        ) {
+          handle(m.target);
+        }
+      });
+    });
+
+    if (document.body) {
+      observer.observe(document.body, {
+        attributes: true,
+        subtree: true,
+        attributeFilter: ['data-attention'],
+      });
+    }
+
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />

--- a/styles/index.css
+++ b/styles/index.css
@@ -530,3 +530,26 @@ textarea:focus-visible {
     color: #000 !important;
 }
 
+/* Attention shadow pulse */
+[data-attention="true"] {
+    animation: attention-shadow-pulse 1s ease-out;
+}
+
+@keyframes attention-shadow-pulse {
+    0% {
+        box-shadow: 0 0 0 0 var(--color-primary);
+    }
+    70% {
+        box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-primary), transparent);
+    }
+    100% {
+        box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-primary), transparent);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    [data-attention="true"] {
+        animation: none;
+    }
+}
+


### PR DESCRIPTION
## Summary
- animate elements with `data-attention="true"` using a temporary shadow pulse
- auto-reset `data-attention` after animation runs
- honor `prefers-reduced-motion` by disabling the pulse

## Testing
- `yarn lint pages/_app.jsx` *(fails: A control must be associated with a text label)*
- `yarn test --passWithNoTests` *(fails: TypeError: Cannot read properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68c39e9b783c8328a2e2323d30dda17e