### PR TITLE
feat: auto tile terminal and editor

### DIFF
--- a/__tests__/editorTerminalSplit.test.ts
+++ b/__tests__/editorTerminalSplit.test.ts
@@ -1,0 +1,35 @@
+import { Desktop } from '../components/screen/desktop';
+
+describe('arrangeEditorTerminal', () => {
+  it('tiles terminal and editor when enabled', () => {
+    const desktop: any = new Desktop();
+    desktop.props = { editorTerminalSplit: true, snapEnabled: true };
+    desktop.windowRefs = {
+      terminal: { snapWindow: jest.fn() },
+      vscode: { snapWindow: jest.fn() },
+    };
+    desktop.state = {
+      ...desktop.state,
+      closed_windows: { terminal: false, vscode: false },
+    };
+    desktop.arrangeEditorTerminal();
+    expect(desktop.windowRefs.terminal.snapWindow).toHaveBeenCalledWith('left', 38);
+    expect(desktop.windowRefs.vscode.snapWindow).toHaveBeenCalledWith('right', 62);
+  });
+
+  it('respects setting to disable tiling', () => {
+    const desktop: any = new Desktop();
+    desktop.props = { editorTerminalSplit: false, snapEnabled: true };
+    desktop.windowRefs = {
+      terminal: { snapWindow: jest.fn() },
+      vscode: { snapWindow: jest.fn() },
+    };
+    desktop.state = {
+      ...desktop.state,
+      closed_windows: { terminal: false, vscode: false },
+    };
+    desktop.arrangeEditorTerminal();
+    expect(desktop.windowRefs.terminal.snapWindow).not.toHaveBeenCalled();
+    expect(desktop.windowRefs.vscode.snapWindow).not.toHaveBeenCalled();
+  });
+});

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,9 +1,11 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
+import { useTerminalEditorSplitSetting } from '../../hooks/usePersistentState';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
     const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const [editorTerminalSplit, setEditorTerminalSplit] = useTerminalEditorSplitSetting();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -175,6 +177,17 @@ export function Settings() {
                         className="mr-2"
                     />
                     Pong Spin
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={editorTerminalSplit}
+                        onChange={(e) => setEditorTerminalSplit(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Tile Editor & Terminal
                 </label>
             </div>
             <div className="flex justify-center my-4">

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -584,20 +584,17 @@ export class Window extends Component {
         }
     }
 
-    snapWindow = (pos) => {
+    snapWindow = (pos, widthPercent = 50) => {
         this.focusWindow();
         const { width, height } = this.state;
-        let newWidth = width;
-        let newHeight = height;
+        const newWidth = widthPercent;
+        const newHeight = 96.3;
         let transform = '';
         if (pos === 'left') {
-            newWidth = 50;
-            newHeight = 96.3;
             transform = 'translate(-1pt,-2pt)';
         } else if (pos === 'right') {
-            newWidth = 50;
-            newHeight = 96.3;
-            transform = `translate(${window.innerWidth / 2}px,-2pt)`;
+            const offset = window.innerWidth * (1 - widthPercent / 100);
+            transform = `translate(${offset}px,-2pt)`;
         }
         const node = document.getElementById(this.id);
         if (node && transform) {

--- a/hooks/usePersistentState.js
+++ b/hooks/usePersistentState.js
@@ -49,3 +49,10 @@ export const useSnapSetting = () =>
     true,
     (value) => typeof value === "boolean",
   );
+
+export const useTerminalEditorSplitSetting = () =>
+  usePersistentState(
+    "terminal-editor-split",
+    true,
+    (value) => typeof value === "boolean",
+  );

--- a/hooks/usePersistentState.ts
+++ b/hooks/usePersistentState.ts
@@ -60,3 +60,10 @@ export const useSnapSetting = () =>
     true,
     (v): v is boolean => typeof v === 'boolean',
   );
+
+export const useTerminalEditorSplitSetting = () =>
+  usePersistentState<boolean>(
+    'terminal-editor-split',
+    true,
+    (v): v is boolean => typeof v === 'boolean',
+  );


### PR DESCRIPTION
## Summary
- auto tile terminal and editor windows into 62/38 split
- add setting to disable editor/terminal auto tiling
- make snapWindow accept custom width

## Testing
- `npx eslint hooks/usePersistentState.ts hooks/usePersistentState.js components/base/window.js components/screen/desktop.js __tests__/editorTerminalSplit.test.ts`
- `yarn test __tests__/editorTerminalSplit.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c39e9f820c8328b92ced182d7b4a45