### PR TITLE
feat: update theme tokens

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,78 +2,50 @@
 
 /* Accessible theme color palette meeting WCAG AA contrast ratios */
 :root {
-  /* Base colors */
-  --color-bg: #0f1317; /* kali background */
-  --color-text: #f5f5f5; /* text on dark backgrounds */
-  /* Brand accents */
-  --color-primary: #1793d1; /* kali blue accent */
-  --color-secondary: #1a1f26; /* complementary dark */
-  --color-accent: #1793d1; /* accent matches primary */
-  /* Utility colors */
-  --color-muted: #2a2e36; /* muted surfaces */
-  --color-surface: #1a1f26; /* panel surfaces */
-  --color-inverse: #000000; /* inverse of text */
-  --color-border: #2a2e36; /* subtle borders */
-  --color-terminal: #00ff00; /* terminal green */
-  --color-dark: #0c0f12; /* card back */
-  --color-focus-ring: var(--color-accent);
-  --color-selection: var(--color-accent);
-  --color-control-accent: var(--color-accent);
-  accent-color: var(--color-control-accent);
+  --bg: #0f1317;
+  --surface: #1a1f26;
+  --panel: #0c0f12;
+  --panel-border: #2a2e36;
+  --text: #f5f5f5;
+  --muted: #2a2e36;
+  --accent: #1793d1;
+  --accent-2: #00ff00;
+  --radius: 4px;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.4);
 }
 
-/* Dark theme */
-html[data-theme='dark'] {
-  --color-bg: #000000;
-  --color-text: #e5e5e5;
-  --color-primary: #1e88e5;
-  --color-secondary: #121212;
-  --color-accent: #bb86fc;
-  --color-muted: #1f1f1f;
-  --color-surface: #121212;
-  --color-inverse: #ffffff;
-  --color-border: #333333;
-  --color-terminal: #00ff00;
-  --color-dark: #0a0a0a;
+:root[data-theme="light"] {
+  --bg: #f5f5f5;
+  --surface: #ffffff;
+  --panel: #e0e0e0;
+  --panel-border: #d0d0d0;
+  --text: #0f1317;
+  --muted: #7d7f83;
+  --accent: #1793d1;
+  --accent-2: #00aa00;
+  --radius: 4px;
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
-/* Neon theme */
-html[data-theme='neon'] {
-  --color-bg: #000000;
-  --color-text: #ffffff;
-  --color-primary: #39ff14;
-  --color-secondary: #1a1a1a;
-  --color-accent: #ff00ff;
-  --color-muted: #222222;
-  --color-surface: #111111;
-  --color-inverse: #ffffff;
-  --color-border: #333333;
-  --color-terminal: #39ff14;
-  --color-dark: #000000;
-}
-
-/* Matrix theme */
-html[data-theme='matrix'] {
-  --color-bg: #000000;
-  --color-text: #00ff00;
-  --color-primary: #00ff00;
-  --color-secondary: #001100;
-  --color-accent: #00ff00;
-  --color-muted: #003300;
-  --color-surface: #001100;
-  --color-inverse: #ffffff;
-  --color-border: #003300;
-  --color-terminal: #00ff00;
-  --color-dark: #000000;
-
+:root[data-theme="undercover"] {
+  --bg: #f2f2f2;
+  --surface: #ffffff;
+  --panel: #dcdcdc;
+  --panel-border: #c0c0c0;
+  --text: #000000;
+  --muted: #666666;
+  --accent: #0078d7;
+  --accent-2: #005a9e;
+  --radius: 4px;
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 ::selection {
-  background: var(--color-selection);
-  color: var(--color-inverse);
+  background: var(--accent);
+  color: var(--bg);
 }
 
 *:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- replace global color variables with Kali token set
- add light and undercover data-theme variants
- simplify selection and focus rules

## Testing
- `npm test` *(fails: Window snapping finalize and release releases snap with Alt+ArrowDown restoring size)*
- `npm run lint` *(failed: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c4697e751c83289b4e72ee808ff5a2