### PR TITLE
Refactor navbar into sticky Kali panel

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,47 +1,56 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Image from 'next/image';
 import Clock from '../util-components/clock';
-import Status from '../util-components/status';
-import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import { useTheme } from '../../hooks/useTheme';
 
-export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+export default function Navbar(props) {
+  const { theme, setTheme } = useTheme();
 
-	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
-                                </div>
-                                <WhiskerMenu />
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-                                        }
-                                >
-                                        <Clock />
-                                </div>
-                                <button
-                                        type="button"
-                                        id="status-bar"
-                                        aria-label="System status"
-                                        onClick={() => {
-                                                this.setState({ status_card: !this.state.status_card });
-                                        }}
-                                        className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-                                        }
-                                >
-                                        <Status />
-                                        <QuickSettings open={this.state.status_card} />
-                                </button>
-			</div>
-		);
-	}
+  const quickLaunch = [
+    { href: '/terminal', icon: '/themes/kali/panel/terminal.svg', label: 'Terminal' },
+    { href: '/browser', icon: '/themes/kali/panel/browser.svg', label: 'Browser' },
+    { href: '/files', icon: '/themes/kali/panel/files.svg', label: 'Files' }
+  ];
+
+  return (
+    <div className="kali-panel sticky top-0 z-50 grid grid-cols-[auto_auto_1fr_auto_auto] items-center w-full bg-[var(--panel)] border-b border-[var(--panel-border)] backdrop-blur bg-opacity-80 shadow-md text-ubt-grey text-sm select-none">
+      <WhiskerMenu />
+      <div className="flex items-center gap-2 px-2">
+        {quickLaunch.map(link => (
+          <a key={link.href} href={link.href} className="p-1 rounded hover:bg-white/10">
+            <Image src={link.icon} alt={link.label} width={16} height={16} className="w-4 h-4" />
+          </a>
+        ))}
+      </div>
+      <div className="flex justify-center gap-1">
+        {[1, 2, 3, 4].map(n => (
+          <a
+            key={n}
+            data-ws={n}
+            href={`#ws-${n}`}
+            className="px-2 py-1 rounded hover:bg-white/10 text-xs"
+          >
+            {n}
+          </a>
+        ))}
+      </div>
+      <button
+        aria-label="Toggle theme"
+        onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+        className="mx-2 px-2 py-1 rounded-full hover:bg-white/10"
+      >
+        <Image
+          src={theme === 'dark' ? '/themes/kali/panel/sun.svg' : '/themes/kali/panel/moon.svg'}
+          alt="Theme"
+          width={16}
+          height={16}
+          className="w-4 h-4"
+        />
+      </button>
+      <span className="px-2">
+        <Clock />
+      </span>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- replace legacy `main-navbar-vp` bar with sticky `kali-panel` grid container
- add menu button, quick-launch links, workspace selectors, theme toggle chip, and clock span
- switch icon paths to new Kali panel assets and use panel variables for styling

## Testing
- `yarn test` *(fails: window snapping finalize and nmapNSE tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c4697f2b10832882462b748ba1f6f5