### PR TITLE
Add workspace anchor navigation

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,47 +1,67 @@
-import React, { Component } from 'react';
+"use client";
+
+import React, { useState } from 'react';
 import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import useScrollSpy from '../../hooks/useScrollSpy';
 
-export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+export default function Navbar() {
+  const [statusCard, setStatusCard] = useState(false);
+  const activeId = useScrollSpy(['about', 'projects', 'blog', 'contact']);
 
-	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
-                                </div>
-                                <WhiskerMenu />
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-                                        }
-                                >
-                                        <Clock />
-                                </div>
-                                <button
-                                        type="button"
-                                        id="status-bar"
-                                        aria-label="System status"
-                                        onClick={() => {
-                                                this.setState({ status_card: !this.state.status_card });
-                                        }}
-                                        className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-                                        }
-                                >
-                                        <Status />
-                                        <QuickSettings open={this.state.status_card} />
-                                </button>
-			</div>
-		);
-	}
+  return (
+    <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+      <div className="pl-3 pr-1">
+        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
+      </div>
+      <nav className="flex">
+        <a
+          href="#about"
+          className={`wswitch px-1 ${activeId === 'about' ? 'text-ubt-green' : ''}`}
+          aria-current={activeId === 'about' ? 'page' : undefined}
+        >
+          1
+        </a>
+        <a
+          href="#projects"
+          className={`wswitch px-1 ${activeId === 'projects' ? 'text-ubt-green' : ''}`}
+          aria-current={activeId === 'projects' ? 'page' : undefined}
+        >
+          2
+        </a>
+        <a
+          href="#blog"
+          className={`wswitch px-1 ${activeId === 'blog' ? 'text-ubt-green' : ''}`}
+          aria-current={activeId === 'blog' ? 'page' : undefined}
+        >
+          3
+        </a>
+        <a
+          href="#contact"
+          className={`wswitch px-1 ${activeId === 'contact' ? 'text-ubt-green' : ''}`}
+          aria-current={activeId === 'contact' ? 'page' : undefined}
+        >
+          4
+        </a>
+      </nav>
+      <WhiskerMenu />
+      <div className="pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1">
+        <Clock />
+      </div>
+      <button
+        type="button"
+        id="status-bar"
+        aria-label="System status"
+        onClick={() => setStatusCard(!statusCard)}
+        className="relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 "
+      >
+        <Status />
+        <QuickSettings open={statusCard} />
+      </button>
+    </div>
+  );
 }
+

--- a/hooks/useScrollSpy.js
+++ b/hooks/useScrollSpy.js
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+
+export default function useScrollSpy(ids = [], offset = 0) {
+  const [activeId, setActiveId] = useState('');
+
+  useEffect(() => {
+    const onScroll = () => {
+      let current = '';
+      for (const id of ids) {
+        const el = document.getElementById(id);
+        if (!el) continue;
+        const rect = el.getBoundingClientRect();
+        if (rect.top <= offset && rect.bottom > offset) {
+          current = id;
+          break;
+        }
+      }
+      setActiveId(current);
+    };
+
+    window.addEventListener('scroll', onScroll);
+    onScroll();
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [ids, offset]);
+
+  return activeId;
+}
+

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -34,9 +34,16 @@ const App = () => (
       Skip to content
     </a>
     <Meta />
-    <Ubuntu />
-    <BetaBadge />
-    <InstallButton />
+    <main>
+      <Ubuntu />
+      <BetaBadge />
+      <InstallButton />
+      {/* Section anchors for workspace navigation */}
+      <section id="about" />
+      <section id="projects" />
+      <section id="blog" />
+      <section id="contact" />
+    </main>
   </>
 );
 


### PR DESCRIPTION
## Summary
- add about, projects, blog, and contact section anchors to the homepage
- convert navbar to function component with workspace links 1–4 and scroll spy
- implement `useScrollSpy` hook for active workspace tracking

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js, component definition missing display name in utils/createDynamicApp.js)*
- `yarn test` *(fails: Window snapping finalize and release: TypeError e.preventDefault is not a function; NmapNSEApp copies example output to clipboard: Unable to find role="alert"; TypeError: Cannot read properties of null (reading '_origin'))*


------
https://chatgpt.com/codex/tasks/task_e_68c46981741c8328a9cd4832edd245f1