### PR TITLE
feat: add terminal card component

### DIFF
--- a/apps/project-gallery/pages/index.tsx
+++ b/apps/project-gallery/pages/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useMemo, useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 import FilterChip from '../components/FilterChip';
+import TerminalCard from '../../../components/terminal/TerminalCard';
 
 const TagIcon = () => (
   <svg
@@ -205,6 +206,7 @@ export default function ProjectGalleryPage() {
 
   return (
     <div className="p-4 space-y-4 text-black">
+      <TerminalCard title="Projects" content="Browse my work" />
       <div className="flex flex-wrap gap-2 items-center">
         <input
           type="text"
@@ -283,32 +285,11 @@ export default function ProjectGalleryPage() {
               </div>
             ))
           : filtered.map((p) => (
-              <div
+              <TerminalCard
                 key={p.id}
-                tabIndex={0}
-                className="group relative h-72 flex flex-col border rounded overflow-hidden transition-transform transition-opacity duration-300 hover:scale-105 hover:opacity-90 focus:scale-105 focus:opacity-90 focus:outline-none"
-                aria-label={`${p.title}: ${p.description}`}
-              >
-                <div className="w-full aspect-video overflow-hidden">
-                  <img src={p.thumbnail} alt={p.title} className="w-full h-full object-cover" />
-                </div>
-                <div className="p-2 flex-1">
-                  <h3 className="font-semibold text-base line-clamp-2">{p.title}</h3>
-                  <p className="text-sm">{p.description}</p>
-                </div>
-                <div className="absolute inset-0 opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 group-hover:pointer-events-auto group-focus-within:pointer-events-auto transition-opacity bg-black/60 text-white flex flex-col">
-                  <div className="p-2 flex flex-wrap gap-1">
-                    {p.tags.map((t) => (
-                      <span key={t} className="bg-white text-black rounded px-1 text-xs">
-                        {t}
-                      </span>
-                    ))}
-                  </div>
-                  <div className="mt-auto p-2 text-right">
-                    <button className="bg-blue-600 text-white px-4 h-10 rounded">Launch</button>
-                  </div>
-                </div>
-              </div>
+                title={p.title}
+                content={p.description}
+              />
             ))}
       </div>
     </div>

--- a/components/terminal/TerminalCard.tsx
+++ b/components/terminal/TerminalCard.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface TerminalCardProps {
+  title: string;
+  content: string;
+}
+
+const TerminalCard: React.FC<TerminalCardProps> = ({ title, content }) => {
+  return (
+    <div className="terminal">
+      <div className="titlebar">
+        <span className="winbtn" />
+        <span className="winbtn" />
+        <span className="winbtn" />
+        <span className="title">{title}</span>
+      </div>
+      <div className="screen">
+        <pre>{content}</pre>
+      </div>
+    </div>
+  );
+};
+
+export default TerminalCard;

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,8 +1,9 @@
 import ScrollableTimeline from '../components/ScrollableTimeline';
+import TerminalCard from '../components/terminal/TerminalCard';
 
 const ProfilePage = () => (
-  <main className="min-h-screen p-4 bg-gray-900 text-white">
-    <h1 className="mb-4 text-2xl">Timeline</h1>
+  <main className="min-h-screen p-4 bg-gray-900 text-white space-y-4">
+    <TerminalCard title="Timeline" content="Explore professional milestones" />
     <ScrollableTimeline />
   </main>
 );

--- a/styles/index.css
+++ b/styles/index.css
@@ -530,3 +530,40 @@ textarea:focus-visible {
     color: #000 !important;
 }
 
+
+/* Terminal card styles */
+.terminal {
+    border-radius: 0.375rem;
+    overflow: hidden;
+    background: #2d2d2d;
+    color: #e5e5e5;
+    font-family: monospace;
+    box-shadow: 0 0 6px rgba(0,0,0,0.2);
+}
+.titlebar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    background: #3b3b3b;
+}
+.titlebar .title {
+    margin-left: 0.5rem;
+}
+.winbtn {
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 9999px;
+    display: inline-block;
+}
+.titlebar .winbtn:nth-child(1) { background: #ff5f56; }
+.titlebar .winbtn:nth-child(2) { background: #ffbd2e; }
+.titlebar .winbtn:nth-child(3) { background: #27c93f; }
+.screen {
+    background: #000;
+    padding: 0.5rem;
+    overflow-x: auto;
+}
+.screen pre {
+    font-family: monospace;
+}


### PR DESCRIPTION
## Summary
- style new terminal window elements
- add reusable TerminalCard component with titlebar and preformatted content
- swap hero and project list cards to use TerminalCard

## Testing
- `yarn test __tests__/window.test.tsx __tests__/Modal.test.tsx` *(fails: e.preventDefault is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c46981bcf48328ab8cd6e521cd2837