### PR TITLE
Add Undercover light theme with Windows-like styling

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -23,7 +23,9 @@ describe('theme persistence and unlocking', () => {
 
   test('themes unlock at score milestones', () => {
     const unlocked = getUnlockedThemes(600);
-    expect(unlocked).toEqual(expect.arrayContaining(['default', 'neon', 'dark']));
+    expect(unlocked).toEqual(
+      expect.arrayContaining(['default', 'undercover', 'neon', 'dark'])
+    );
     expect(unlocked).not.toContain('matrix');
   });
 

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -129,6 +129,7 @@ export default function Settings() {
               className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
             >
               <option value="default">Default</option>
+              <option value="undercover">Undercover</option>
               <option value="dark">Dark</option>
               <option value="neon">Neon</option>
               <option value="matrix">Matrix</option>

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -67,6 +67,7 @@ export function Settings() {
                     className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
                 >
                     <option value="default">Default</option>
+                    <option value="undercover">Undercover</option>
                     <option value="dark">Dark</option>
                     <option value="neon">Neon</option>
                     <option value="matrix">Matrix</option>

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -60,6 +60,7 @@ export default function ThemeSettings() {
           className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
         >
           <option value="default">Default</option>
+          <option value="undercover">Undercover</option>
           <option value="dark">Dark</option>
           <option value="neon">Neon</option>
           <option value="matrix">Matrix</option>

--- a/public/themes/Undercover/apps/explorer.svg
+++ b/public/themes/Undercover/apps/explorer.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path d="M4 18h56v36H4z" fill="#e5e7eb" stroke="#94a3b8" stroke-width="2"/>
+  <path d="M4 18l8-10h18l8 10" fill="#cbd5e1" stroke="#94a3b8" stroke-width="2"/>
+</svg>

--- a/public/themes/Undercover/apps/settings.svg
+++ b/public/themes/Undercover/apps/settings.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="10" fill="none" stroke="#2563eb" stroke-width="6"/>
+  <g stroke="#2563eb" stroke-width="4" stroke-linecap="round">
+    <line x1="32" y1="4" x2="32" y2="14"/>
+    <line x1="32" y1="50" x2="32" y2="60"/>
+    <line x1="4" y1="32" x2="14" y2="32"/>
+    <line x1="50" y1="32" x2="60" y2="32"/>
+    <line x1="12" y1="12" x2="20" y2="20"/>
+    <line x1="44" y1="44" x2="52" y2="52"/>
+    <line x1="12" y1="52" x2="20" y2="44"/>
+    <line x1="44" y1="20" x2="52" y2="12"/>
+  </g>
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -68,6 +68,30 @@ html[data-theme='matrix'] {
 
 }
 
+/* Undercover theme - Windows-like light blues */
+html[data-theme='undercover'] {
+  --color-bg: #f3f4f6;
+  --color-text: #1e293b;
+  --color-primary: #3b82f6;
+  --color-secondary: #e5e7eb;
+  --color-accent: #2563eb;
+  --color-muted: #cbd5e1;
+  --color-surface: #ffffff;
+  --color-inverse: #ffffff;
+  --color-border: #cbd5e1;
+  --color-terminal: #008000;
+  --color-dark: #dbeafe;
+  --font-family-base: 'Segoe UI', 'Ubuntu', sans-serif;
+
+  /* Ubuntu token overrides for light theme */
+  --color-ub-grey: #f3f4f6;
+  --color-ub-cool-grey: #e5e7eb;
+  --color-ubt-grey: #1e293b;
+  --color-ubt-cool-grey: #94a3b8;
+  --color-ubt-blue: #60a5fa;
+  --color-ub-dark-grey: #94a3b8;
+}
+
 ::selection {
   background: var(--color-selection);
   color: var(--color-inverse);

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -3,6 +3,7 @@ export const THEME_KEY = 'app:theme';
 // Score required to unlock each theme
 export const THEME_UNLOCKS: Record<string, number> = {
   default: 0,
+  undercover: 0,
   neon: 100,
   dark: 500,
   matrix: 1000,


### PR DESCRIPTION
## Summary
- add `undercover` light theme with blue accents and Segoe UI font
- expose Undercover option in settings panels and unlock logic
- include initial Windows-style icon set

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c46983dad883288d179a6af3154281