### PR TITLE
feat: add font support

### DIFF
--- a/apps/ascii-art/index.tsx
+++ b/apps/ascii-art/index.tsx
@@ -251,7 +251,7 @@ const AsciiArtApp = () => {
             ref={textAreaRef}
             rows={1}
             className="px-2 py-1 text-black rounded resize-none overflow-hidden font-mono leading-none"
-            style={{ fontFamily: 'monospace', lineHeight: '1', fontSize: `${fontSize}px` }}
+            style={{ fontFamily: 'var(--font-fira-code), monospace', lineHeight: '1', fontSize: `${fontSize}px` }}
             placeholder="Enter text"
             value={text}
             onChange={(e) => setText(e.target.value)}

--- a/apps/calculator/styles.css
+++ b/apps/calculator/styles.css
@@ -1,5 +1,5 @@
 body {
-  font-family: Arial, sans-serif;
+  font-family: var(--font-inter), sans-serif;
   background: var(--color-bg);
   height: 100vh;
   display: flex;
@@ -93,7 +93,7 @@ body {
 }
 
 .button-grid .btn {
-  font-family: monospace;
+  font-family: var(--font-fira-code), monospace;
 }
 
 

--- a/apps/figlet/components/FontDropdown.tsx
+++ b/apps/figlet/components/FontDropdown.tsx
@@ -91,7 +91,11 @@ const FontDropdown: React.FC<Props> = ({ fonts, value, onChange }) => {
               role="option"
               aria-selected={value === f.name}
               className={`cursor-pointer px-2 ${i === active ? 'bg-blue-600' : ''}`}
-              style={{ height: '24px', lineHeight: '24px', fontFamily: 'monospace' }}
+              style={{
+                height: '24px',
+                lineHeight: '24px',
+                fontFamily: 'var(--font-fira-code), monospace',
+              }}
               onMouseEnter={() => setActive(i)}
               onMouseDown={(e) => {
                 e.preventDefault();

--- a/apps/quote/components/Posterizer.tsx
+++ b/apps/quote/components/Posterizer.tsx
@@ -34,7 +34,7 @@ const contrastRatio = (c1: string, c2: string) => {
 const STYLES = [
   { name: 'Classic', bg: '#000000', fg: '#ffffff', font: 'serif' },
   { name: 'Inverted', bg: '#ffffff', fg: '#000000', font: 'sans-serif' },
-  { name: 'Retro', bg: '#1e3a8a', fg: '#fef3c7', font: 'monospace' },
+  { name: 'Retro', bg: '#1e3a8a', fg: '#fef3c7', font: '"Fira Code", monospace' },
 ];
 
 export default function Posterizer({ quote }: { quote: Quote | null }) {

--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -12,7 +12,7 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
       className={`text-white ${className}`}
       style={{
         background: 'var(--kali-bg)',
-        fontFamily: 'monospace',
+        fontFamily: 'var(--font-fira-code), monospace',
         fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
         lineHeight: 1.4,
         ...style,

--- a/apps/timer_stopwatch/index.css
+++ b/apps/timer_stopwatch/index.css
@@ -1,5 +1,5 @@
 body {
-  font-family: sans-serif;
+  font-family: var(--font-inter), sans-serif;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -9,7 +9,7 @@ body {
 }
 .display {
   font-size: 4rem;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-fira-code), monospace;
   margin: 20px 0;
 }
 button {
@@ -35,7 +35,7 @@ li {
   margin: 2px 0;
   padding: 5px 10px;
   border-radius: 4px;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-fira-code), monospace;
 }
 .hidden {
   display:none;

--- a/apps/timer_stopwatch/styles.css
+++ b/apps/timer_stopwatch/styles.css
@@ -1,5 +1,5 @@
 body {
-  font-family: sans-serif;
+  font-family: var(--font-inter), sans-serif;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -9,7 +9,7 @@ body {
 }
 .display {
   font-size: 4rem;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-fira-code), monospace;
   margin: 20px 0;
 }
 button {
@@ -52,7 +52,7 @@ li {
   margin: 2px 0;
   padding: 5px 10px;
   border-radius: 4px;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-fira-code), monospace;
 }
 
 @container (max-width: 300px) {

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -17,11 +17,18 @@ import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
-import { Ubuntu } from 'next/font/google';
+import { Inter, Fira_Code } from 'next/font/google';
 
-const ubuntu = Ubuntu({
+const inter = Inter({
   subsets: ['latin'],
   weight: ['300', '400', '500', '700'],
+  variable: '--font-inter',
+});
+
+const firaCode = Fira_Code({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '700'],
+  variable: '--font-fira-code',
 });
 
 
@@ -149,7 +156,7 @@ function MyApp(props) {
   return (
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />
-      <div className={ubuntu.className}>
+      <div className={`${inter.className} ${inter.variable} ${firaCode.variable}`}>
         <a
           href="#app-grid"
           className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"

--- a/styles/index.css
+++ b/styles/index.css
@@ -504,8 +504,12 @@ dialog {
 
 /* Ensure monospace layout for app outputs */
 textarea,
-pre {
-    font-family: monospace;
+pre,
+code,
+kbd,
+samp,
+.font-mono {
+    font-family: var(--font-fira-code), monospace;
     line-height: 1.2;
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -52,7 +52,7 @@
   --motion-slow: 500ms;
 
   /* Fonts */
-  --font-family-base: 'Ubuntu', sans-serif;
+  --font-family-base: var(--font-inter), sans-serif;
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -38,7 +38,9 @@ module.exports = {
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
       },
       fontFamily: {
-        ubuntu: ['Ubuntu', 'sans-serif'],
+        ubuntu: ['var(--font-inter)', 'sans-serif'],
+        sans: ['var(--font-inter)', 'sans-serif'],
+        mono: ['var(--font-fira-code)', 'monospace'],
       },
       minWidth: {
         '0': '0',


### PR DESCRIPTION
## Summary
- switch app to Inter sans-serif and make Fira Code available via `next/font`
- apply Fira Code to terminal UI and any monospace elements
- map Tailwind font families to new Inter/Fira Code variables

## Testing
- `npm run lint` *(fails: A control must be associated with a text label)*
- `npm test` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size)*

------
https://chatgpt.com/codex/tasks/task_e_68c46985c6048328b189a24b8a33cc7f