### PR TITLE
feat: add Kali theme token CSS

### DIFF
--- a/assets/css/kali-tokens.css
+++ b/assets/css/kali-tokens.css
@@ -1,0 +1,71 @@
+/* Kali theme tokens */
+:root,
+[data-theme="dark"] {
+  color-scheme: dark;
+  --color-bg: #0f1317;
+  --color-text: #f5f5f5;
+  --color-primary: #1793d1;
+  --color-secondary: #1a1f26;
+  --color-accent: #1793d1;
+  --color-muted: #2a2e36;
+  --color-surface: #1a1f26;
+  --color-inverse: #000000;
+  --color-border: #2a2e36;
+  --color-focus-ring: var(--color-accent);
+  --color-selection: var(--color-accent);
+  --color-control-accent: var(--color-accent);
+  accent-color: var(--color-control-accent);
+}
+
+/* Light theme */
+[data-theme="light"] {
+  color-scheme: light;
+  --color-bg: #ffffff;
+  --color-text: #0f1317;
+  --color-primary: #1793d1;
+  --color-secondary: #f5f5f5;
+  --color-accent: #1793d1;
+  --color-muted: #e0e0e0;
+  --color-surface: #ffffff;
+  --color-inverse: #ffffff;
+  --color-border: #cccccc;
+  --color-focus-ring: var(--color-accent);
+  --color-selection: var(--color-accent);
+  --color-control-accent: var(--color-accent);
+  accent-color: var(--color-control-accent);
+}
+
+/* Undercover theme */
+[data-theme="undercover"] {
+  color-scheme: light;
+  --color-bg: #f0f0f0;
+  --color-text: #1a1a1a;
+  --color-primary: #0063b1;
+  --color-secondary: #e5e5e5;
+  --color-accent: #0063b1;
+  --color-muted: #c8c8c8;
+  --color-surface: #ffffff;
+  --color-inverse: #ffffff;
+  --color-border: #d0d0d0;
+  --color-focus-ring: var(--color-accent);
+  --color-selection: var(--color-accent);
+  --color-control-accent: var(--color-accent);
+  accent-color: var(--color-control-accent);
+}
+
+/* Base element rules */
+html,
+body {
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+::selection {
+  background: var(--color-selection);
+  color: var(--color-inverse);
+}
+
+*:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- add theme token CSS variables for Kali dark, light, and undercover modes
- define base html/body styles for color application

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window.test.tsx: e.preventDefault is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c46d2e7dd08328bf7ab85f1aface73