### PR TITLE
Add Kali component CSS

### DIFF
--- a/assets/css/kali-components.css
+++ b/assets/css/kali-components.css
@@ -1,0 +1,74 @@
+:root {
+  --kali-panel: var(--color-surface);
+}
+
+.kali-panel {
+  background: var(--kali-panel);
+  color: var(--color-text);
+  display: flex;
+  align-items: center;
+  height: 2.5rem;
+  padding: 0 var(--space-4);
+}
+
+.appmenu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  min-width: 12rem;
+  background: var(--kali-panel);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) 0;
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--color-inverse), transparent 80%);
+  z-index: 1000;
+}
+
+.appmenu a {
+  display: block;
+  padding: var(--space-2) var(--space-4);
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.appmenu a:hover,
+.appmenu a:focus {
+  background: var(--color-muted);
+}
+
+.terminal {
+  background: var(--color-inverse);
+  color: var(--color-terminal);
+  font-family: 'Ubuntu Mono', monospace;
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--color-terminal), transparent 50%);
+}
+
+/* Utility classes */
+.flex-center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.draggable {
+  cursor: move;
+}
+
+.select-none {
+  user-select: none;
+}
+
+.hidden {
+  display: none;
+}
+
+/* Wallpaper hook */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background: var(--wallpaper, url('/wallpapers/default.jpg')) center/cover no-repeat;
+}


### PR DESCRIPTION
## Summary
- add `kali-components.css` with panel, app menu, terminal, utility, and wallpaper styles

## Testing
- `npx eslint assets/css/kali-components.css` (warn: file ignored)
- `yarn test --passWithNoTests` (fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68c46d2e5bf88328a58e7c21176e4bde