### PR TITLE
Add Kali UI assets and color scheme meta to Document

### DIFF
--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -18,10 +18,15 @@ class MyDocument extends Document {
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
+          <meta name="color-scheme" content="light dark" />
+          <link rel="preload" href="assets/css/kali-tokens.css" as="style" />
+          <link rel="stylesheet" href="assets/css/kali-tokens.css" />
+          <link rel="stylesheet" href="assets/css/kali-components.css" />
           <script nonce={nonce} src="/theme.js" />
         </Head>
         <body>
           <Main />
+          <script nonce={nonce} src="assets/js/kali-ui.js" defer></script>
           <NextScript nonce={nonce} />
         </body>
       </Html>


### PR DESCRIPTION
## Summary
- preload and load Kali CSS token and component styles globally
- add light/dark color-scheme meta tag
- include Kali UI script in document body

## Testing
- `npx eslint pages/_document.jsx` *(warns: File ignored because no matching configuration was supplied)*
- `CI=1 yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: 2 failed, 2 total)*

------
https://chatgpt.com/codex/tasks/task_e_68c46d2f6b2c83288306f238563508d8