### PR TITLE
Add global navigation panel

### DIFF
--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -21,6 +21,7 @@ class MyDocument extends Document {
           <script nonce={nonce} src="/theme.js" />
         </Head>
         <body>
+          <header className="kali-panel" role="navigation" aria-label="Global"></header>
           <Main />
           <NextScript nonce={nonce} />
         </body>

--- a/styles/index.css
+++ b/styles/index.css
@@ -40,6 +40,15 @@ button:focus-visible {
 
 /* Top NavBar styling */
 
+/* Sticky global navigation panel */
+.kali-panel {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: var(--color-surface);
+    padding: var(--space-2) var(--space-4);
+}
+
 .top-arrow-up {
     border-inline-start: 5px solid transparent;
     border-inline-end: 5px solid transparent;


### PR DESCRIPTION
## Summary
- add global `kali-panel` header with navigation role and aria label
- style header as sticky panel so content flows beneath it

## Testing
- `yarn lint` *(fails: Unexpected global 'document' and other lint errors)*
- `CI=true yarn test` *(fails: window and nmapNSE tests among others)*

------
https://chatgpt.com/codex/tasks/task_e_68c46d2f97408328a1fda0044183215a