### PR TITLE
feat: add section anchors and scroll nav

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
+import Script from 'next/script';
 
 const Ubuntu = dynamic(
   () =>
@@ -34,9 +35,32 @@ const App = () => (
       Skip to content
     </a>
     <Meta />
+    <header>
+      <nav className="wswitch">
+        <a href="#about">About</a>
+        <a href="#projects">Projects</a>
+        <a href="#blog">Blog</a>
+        <a href="#contact">Contact</a>
+      </nav>
+    </header>
+    <main>
+      <section id="about">
+        <h2>About</h2>
+      </section>
+      <section id="projects">
+        <h2>Projects</h2>
+      </section>
+      <section id="blog">
+        <h2>Blog</h2>
+      </section>
+      <section id="contact">
+        <h2>Contact</h2>
+      </section>
+    </main>
     <Ubuntu />
     <BetaBadge />
     <InstallButton />
+    <Script src="/kali-ui.js" strategy="lazyOnload" />
   </>
 );
 

--- a/public/kali-ui.js
+++ b/public/kali-ui.js
@@ -1,0 +1,38 @@
+(function () {
+  function init() {
+    const links = document.querySelectorAll('.wswitch a');
+    if (!links.length) return;
+    const sections = Array.from(links).map((link) => {
+      const id = link.getAttribute('href').replace('#', '');
+      return document.getElementById(id);
+    });
+    function update() {
+      let current = null;
+      sections.forEach((section) => {
+        if (!section) return;
+        const rect = section.getBoundingClientRect();
+        if (
+          rect.top <= window.innerHeight / 2 &&
+          rect.bottom >= window.innerHeight / 2
+        ) {
+          current = section.id;
+        }
+      });
+      links.forEach((link) => {
+        const href = link.getAttribute('href').replace('#', '');
+        if (href === current) {
+          link.setAttribute('aria-current', 'true');
+        } else {
+          link.removeAttribute('aria-current');
+        }
+      });
+    }
+    window.addEventListener('scroll', update, { passive: true });
+    update();
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- add header navigation with anchors to about, projects, blog and contact sections
- include matching sections and lazy load kali-ui script
- introduce kali-ui.js to highlight active section link while scrolling

## Testing
- `npx eslint -c eslint.config.mjs pages/index.jsx public/kali-ui.js`
- `yarn test --passWithNoTests pages/index.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68c46d32c40483289884cef2117b0418