### PR TITLE
Improve navigation semantics and focus handling

### DIFF
--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -17,7 +17,7 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
         Settings
       </button>
       {open && (
-        <div role="dialog">
+        <div role="dialog" aria-modal="true">
           <label>
             Theme
             <select

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import UbuntuApp from '../base/ubuntu_app';
+import { trapFocus, releaseFocus } from '../../utils/kali-ui';
 
 class AllApplications extends React.Component {
     constructor() {
         super();
+        this.containerRef = React.createRef();
         this.state = {
             query: '',
             apps: [],
@@ -18,6 +20,11 @@ class AllApplications extends React.Component {
             if (!combined.some((app) => app.id === game.id)) combined.push(game);
         });
         this.setState({ apps: combined, unfilteredApps: combined });
+        trapFocus(this.containerRef.current);
+    }
+
+    componentWillUnmount() {
+        releaseFocus();
     }
 
     handleChange = (e) => {
@@ -55,8 +62,14 @@ class AllApplications extends React.Component {
 
     render() {
         return (
-            <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
+            <div
+                ref={this.containerRef}
+                role="dialog"
+                aria-modal="true"
+                className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim"
+            >
                 <input
+                    aria-label="Search applications"
                     className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
                     placeholder="Search"
                     value={this.state.query}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -14,8 +14,8 @@ export default class Navbar extends Component {
 	}
 
 	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                return (
+                        <nav role="navigation" aria-label="System panel" className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
@@ -41,7 +41,7 @@ export default class Navbar extends Component {
                                         <Status />
                                         <QuickSettings open={this.state.status_card} />
                                 </button>
-			</div>
-		);
+                        </nav>
+                );
 	}
 }

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -142,7 +142,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       '--color-ub-border-orange': border,
       '--color-primary': accent,
       '--color-accent': accent,
-      '--color-focus-ring': accent,
       '--color-selection': accent,
       '--color-control-accent': accent,
     };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,10 +16,10 @@
   --color-border: #2a2e36; /* subtle borders */
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
-  --color-focus-ring: var(--color-accent);
-  --color-selection: var(--color-accent);
-  --color-control-accent: var(--color-accent);
-  accent-color: var(--color-control-accent);
+  --accent: var(--color-accent);
+  --color-selection: var(--accent);
+  --color-control-accent: var(--accent);
+  accent-color: var(--accent);
 }
 
 /* Dark theme */
@@ -29,6 +29,7 @@ html[data-theme='dark'] {
   --color-primary: #1e88e5;
   --color-secondary: #121212;
   --color-accent: #bb86fc;
+  --accent: var(--color-accent);
   --color-muted: #1f1f1f;
   --color-surface: #121212;
   --color-inverse: #ffffff;
@@ -44,6 +45,7 @@ html[data-theme='neon'] {
   --color-primary: #39ff14;
   --color-secondary: #1a1a1a;
   --color-accent: #ff00ff;
+  --accent: var(--color-accent);
   --color-muted: #222222;
   --color-surface: #111111;
   --color-inverse: #ffffff;
@@ -59,6 +61,7 @@ html[data-theme='matrix'] {
   --color-primary: #00ff00;
   --color-secondary: #001100;
   --color-accent: #00ff00;
+  --accent: var(--color-accent);
   --color-muted: #003300;
   --color-surface: #001100;
   --color-inverse: #ffffff;
@@ -74,6 +77,6 @@ html[data-theme='matrix'] {
 }
 
 *:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -57,7 +57,7 @@
   /* Minimum interactive target size */
   --hit-area: 32px;
   /* Focus outline */
-  --focus-outline-color: var(--color-ubt-blue);
+  --focus-outline-color: var(--accent);
   --focus-outline-width: 2px;
 }
 

--- a/utils/kali-ui.js
+++ b/utils/kali-ui.js
@@ -1,0 +1,60 @@
+let previousActive;
+let trapContainer;
+
+function getFocusable(container) {
+  if (!container) return [];
+  const selectors = [
+    'a[href]',
+    'area[href]',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    'button:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])'
+  ];
+  return Array.from(container.querySelectorAll(selectors.join(',')));
+}
+
+export function trapFocus(container) {
+  if (!container) return;
+  trapContainer = container;
+  previousActive = document.activeElement;
+  const focusable = getFocusable(container);
+  if (focusable.length) {
+    focusable[0].focus();
+  }
+  container.addEventListener('keydown', handleKey);
+}
+
+function handleKey(e) {
+  if (e.key !== 'Tab' || !trapContainer) return;
+  const focusable = getFocusable(trapContainer);
+  if (focusable.length === 0) return;
+  const idx = focusable.indexOf(document.activeElement);
+  if (e.shiftKey) {
+    if (idx <= 0) {
+      e.preventDefault();
+      focusable[focusable.length - 1].focus();
+    }
+  } else {
+    if (idx === focusable.length - 1) {
+      e.preventDefault();
+      focusable[0].focus();
+    }
+  }
+}
+
+export function releaseFocus() {
+  if (trapContainer) {
+    trapContainer.removeEventListener('keydown', handleKey);
+    trapContainer = null;
+  }
+  if (previousActive && typeof previousActive.focus === 'function') {
+    previousActive.focus();
+  }
+  previousActive = null;
+}
+
+const focusUtils = { trapFocus, releaseFocus };
+
+export default focusUtils;


### PR DESCRIPTION
## Summary
- assign explicit navigation role to top panel
- add focus-trapped, modal app drawer with dialog semantics
- use accent tokens for focus outlines and utilities for trapping focus

## Testing
- `npx eslint components/screen/navbar.js components/screen/all-applications.js components/SettingsDrawer.tsx utils/kali-ui.js hooks/useSettings.tsx`
- `yarn test` *(fails: window snapping finalize & NmapNse tests)*


------
https://chatgpt.com/codex/tasks/task_e_68c46d352500832895e7dcc887140a45