### PR TITLE
feat: improve mobile navigation

### DIFF
--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -55,14 +55,14 @@ class AllApplications extends React.Component {
 
     render() {
         return (
-            <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
+            <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim w-screen h-screen">
                 <input
                     className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
                     placeholder="Search"
                     value={this.state.query}
                     onChange={this.handleChange}
                 />
-                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
+                <div className="all-apps-grid grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 pb-10 place-items-center">
                     {this.renderApps()}
                 </div>
             </div>

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,4 +1,5 @@
 @import './globals.css';
+@import './kali-components.css';
 
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);

--- a/styles/kali-components.css
+++ b/styles/kali-components.css
@@ -1,0 +1,28 @@
+/* Responsive adjustments for Kali portfolio components */
+
+html, body {
+  overflow-x: hidden;
+}
+
+/* Collapse quick-launch bar to essential controls on small screens */
+@media (max-width: 640px) {
+  .main-navbar-vp > * {
+    display: none;
+  }
+  .main-navbar-vp > :nth-child(2),
+  .main-navbar-vp > :nth-child(3),
+  .main-navbar-vp > :nth-child(4) {
+    display: flex;
+  }
+}
+
+/* App drawer occupies full viewport and stacks cards in a single column */
+@media (max-width: 640px) {
+  .all-apps-anim {
+    width: 100vw;
+    height: 100vh;
+  }
+  .all-apps-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -55,7 +55,7 @@
   --font-family-base: 'Ubuntu', sans-serif;
   --font-multiplier: 1;
   /* Minimum interactive target size */
-  --hit-area: 32px;
+  --hit-area: 40px;
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;


### PR DESCRIPTION
## Summary
- collapse quick-launch to menu button, theme chip, and clock on small screens
- ensure app drawer fills viewport and stacks apps vertically
- bump default tap target size to 40px

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, reconng.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c46d358ab88328800f94aaebc6850e