### PR TITLE
feat: improve theme loading and image performance

### DIFF
--- a/apps/autopsy/components/CaseWalkthrough.tsx
+++ b/apps/autopsy/components/CaseWalkthrough.tsx
@@ -21,7 +21,7 @@ const renderNode = (node: FileNode): React.ReactNode => {
       <div key={node.name} className="ml-4">
         <div className="flex items-center font-semibold">
           {node.thumbnail && (
-            <img src={node.thumbnail} alt="" className="w-4 h-4 mr-1" />
+            <img loading="lazy" src={node.thumbnail} alt="" className="w-4 h-4 mr-1" />
           )}
           {node.name}
         </div>
@@ -36,7 +36,7 @@ const renderNode = (node: FileNode): React.ReactNode => {
   return (
     <div key={node.name} className="ml-4 flex items-center">
       {node.thumbnail && (
-        <img src={node.thumbnail} alt="" className="w-4 h-4 mr-1" />
+        <img loading="lazy" src={node.thumbnail} alt="" className="w-4 h-4 mr-1" />
       )}
       {node.name}
     </div>
@@ -56,7 +56,7 @@ const CaseWalkthrough: React.FC = () => {
         <ul className="space-y-2">
           {timeline.map((item, idx) => (
             <li key={idx} className="flex items-center text-sm">
-              <img src={item.thumbnail} alt="" className="w-6 h-6 mr-2" />
+              <img loading="lazy" src={item.thumbnail} alt="" className="w-6 h-6 mr-2" />
               <span>
                 {new Date(item.timestamp).toLocaleString()} – {item.event}
               </span>

--- a/apps/beef/index.tsx
+++ b/apps/beef/index.tsx
@@ -38,12 +38,12 @@ const BeefPage: React.FC = () => {
           <h1 className="text-xl">BeEF Demo</h1>
         </div>
         <div className="flex gap-2">
-          <img
+          <img loading="lazy"
             src="/themes/Yaru/window/window-minimize-symbolic.svg"
             alt="minimize"
             className="w-6 h-6"
           />
-          <img
+          <img loading="lazy"
             src="/themes/Yaru/window/window-close-symbolic.svg"
             alt="close"
             className="w-6 h-6"

--- a/apps/chrome/index.tsx
+++ b/apps/chrome/index.tsx
@@ -140,7 +140,7 @@ export default function ChromeApp() {
           <ForwardIcon />
         </button>
         {favicon && (
-          <img src={favicon} alt="favicon" width={16} height={16} />
+          <img loading="lazy" src={favicon} alt="favicon" width={16} height={16} />
         )}
         {url && (
           <div className="flex items-center space-x-1 bg-gray-200 rounded-full px-2 py-1 text-xs">

--- a/apps/contact/components/AttachmentCarousel.tsx
+++ b/apps/contact/components/AttachmentCarousel.tsx
@@ -39,7 +39,7 @@ const AttachmentCarousel: React.FC<AttachmentCarouselProps> = ({
     <div className="mt-6">
       <div className="relative">
         {isImage ? (
-          <img src={url} alt={file.name} className="max-h-48 object-contain" />
+          <img loading="lazy" src={url} alt={file.name} className="max-h-48 object-contain" />
         ) : (
           <div className="p-3 bg-gray-800 rounded">{file.name}</div>
         )}

--- a/apps/figlet/index.tsx
+++ b/apps/figlet/index.tsx
@@ -490,7 +490,7 @@ const FigletApp: React.FC = () => {
           className="p-1 bg-green-700 hover:bg-green-600 rounded"
           aria-label="Export PNG"
         >
-          <img
+          <img loading="lazy"
             src="/themes/Yaru/actions/document-save-as-png-symbolic.svg"
             alt=""
             className="w-6 h-6"
@@ -501,7 +501,7 @@ const FigletApp: React.FC = () => {
           className="p-1 bg-yellow-700 hover:bg-yellow-600 rounded"
           aria-label="Export SVG"
         >
-          <img
+          <img loading="lazy"
             src="/themes/Yaru/actions/document-save-as-svg-symbolic.svg"
             alt=""
             className="w-6 h-6"

--- a/apps/nmap-nse/index.tsx
+++ b/apps/nmap-nse/index.tsx
@@ -115,7 +115,7 @@ const NmapNSE: React.FC = () => {
   return (
     <div className="flex flex-col h-full min-h-screen bg-gray-900 text-white">
       <header className="flex items-center gap-2 p-2 bg-gray-800">
-        <img
+        <img loading="lazy"
           src="/themes/Yaru/apps/radar-symbolic.svg"
           alt="Radar"
           className="w-5 h-5"

--- a/apps/project-gallery/pages/index.tsx
+++ b/apps/project-gallery/pages/index.tsx
@@ -290,7 +290,7 @@ export default function ProjectGalleryPage() {
                 aria-label={`${p.title}: ${p.description}`}
               >
                 <div className="w-full aspect-video overflow-hidden">
-                  <img src={p.thumbnail} alt={p.title} className="w-full h-full object-cover" />
+                  <img loading="lazy" src={p.thumbnail} alt={p.title} className="w-full h-full object-cover" />
                 </div>
                 <div className="p-2 flex-1">
                   <h3 className="font-semibold text-base line-clamp-2">{p.title}</h3>

--- a/apps/qr/components/Scan.tsx
+++ b/apps/qr/components/Scan.tsx
@@ -49,7 +49,7 @@ const Scan: React.FC<Props> = ({ onResult }) => {
       className="w-full h-full relative flex items-center justify-center border-2 border-dashed border-gray-500 text-gray-400"
     >
       {preview ? (
-        <img src={preview} alt="Dropped" className="max-w-full max-h-full" />
+        <img loading="lazy" src={preview} alt="Dropped" className="max-w-full max-h-full" />
       ) : (
         <p>Drop image</p>
       )}

--- a/apps/spotify/index.tsx
+++ b/apps/spotify/index.tsx
@@ -226,7 +226,7 @@ const SpotifyApp = () => {
         <div className="mt-2">
           <div className="relative w-32 aspect-square mb-2 shadow-lg overflow-hidden">
             {currentTrack.cover ? (
-              <img
+              <img loading="lazy"
                 src={currentTrack.cover}
                 alt={currentTrack.title}
                 className="w-full h-full object-cover"

--- a/apps/trash/index.tsx
+++ b/apps/trash/index.tsx
@@ -182,7 +182,7 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
       </div>
       <div className="flex-1 overflow-auto">
         <div className="flex flex-col items-center justify-center mt-12 space-y-1.5">
-          <img
+          <img loading="lazy"
             src={items.length ? FULL_ICON : EMPTY_ICON}
             alt={items.length ? 'Full trash' : 'Empty trash'}
             className="h-16 w-16 opacity-60"
@@ -198,7 +198,7 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
                 onClick={() => setSelected(idx)}
                 className={`flex items-center h-9 px-1 cursor-pointer ${selected === idx ? 'bg-ub-drk-abrgn' : ''}`}
               >
-                <img
+                <img loading="lazy"
                   src={item.icon || DEFAULT_ICON}
                   alt=""
                   className="h-4 w-4 mr-2"

--- a/apps/weather_widget/index.tsx
+++ b/apps/weather_widget/index.tsx
@@ -30,7 +30,7 @@ export default function WeatherWidget() {
       <div id="weather" className="weather">
         <div className="temp">--°C</div>
         <div className="feels-like">Feels like --°C</div>
-        <img className="icon" src="" alt="Weather icon" />
+        <img loading="lazy" className="icon" src="" alt="Weather icon" />
         <div className="forecast">Loading...</div>
         <div className="daily"></div>
         <div className="sunrise">Sunrise: --</div>

--- a/apps/weather_widget/main.js
+++ b/apps/weather_widget/main.js
@@ -79,7 +79,7 @@ function renderWeather(data) {
         dailyEl.innerHTML = data.forecast
           .map(
             (d) =>
-              `<div class="day"><img class="forecast-icon animated-icon" src="https://openweathermap.org/img/wn/${d.icon}.png" alt="${d.condition}"><div>${d.day} ${Math.round(
+              `<div class="day"><img loading="lazy" class="forecast-icon animated-icon" src="https://openweathermap.org/img/wn/${d.icon}.png" alt="${d.condition}"><div>${d.day} ${Math.round(
                 convertTemp(d.tempC)
               )}°${unit === 'metric' ? 'C' : 'F'}</div></div>`
           )

--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -73,7 +73,7 @@ const BadgeList = ({ badges, className = '' }) => {
               }}
               aria-label={badge.label}
             >
-              <img
+              <img loading="lazy"
                 src={badge.src}
                 alt={badge.alt}
                 title={badge.description || badge.label}

--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -126,7 +126,7 @@ const ScrollableTimeline: React.FC = () => {
                       className="text-left w-full focus:outline-none"
                     >
                       <div className="text-ubt-blue font-bold text-lg mb-2">{year}</div>
-                      <img
+                      <img loading="lazy"
                         src={first.image}
                         alt={first.title}
                         className="w-full h-32 object-cover mb-2 rounded"
@@ -155,7 +155,7 @@ const ScrollableTimeline: React.FC = () => {
                     rel="noopener noreferrer"
                     className="block mb-2"
                   >
-                    <img
+                    <img loading="lazy"
                       src={m.image}
                       alt={m.title}
                       className="w-full h-32 object-cover mb-2 rounded"

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -358,7 +358,7 @@ const SkillSection = ({ title, badges }: { title: string; badges: { src: string;
       />
       <div className="flex flex-wrap justify-center items-start w-full mt-2">
         {filteredBadges.map((badge) => (
-          <img
+          <img loading="lazy"
             key={badge.alt}
             className="m-1 cursor-pointer"
             src={badge.src}

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -310,7 +310,7 @@ const SkillSection = ({ title, badges }) => {
       />
       <div className="flex flex-wrap justify-center items-start w-full mt-2">
         {filteredBadges.map(badge => (
-          <img
+          <img loading="lazy"
             key={badge.alt}
             className="m-1 cursor-pointer"
             src={badge.src}
@@ -373,7 +373,7 @@ function Skills({ skills }) {
       <div className="w-full md:w-10/12 flex flex-col items-center mt-8">
         <div className="font-bold text-sm md:text-base mb-2 text-center">GitHub Contributions</div>
         <div className="bg-ub-gedit-light bg-opacity-20 p-1 md:p-2 rounded-md shadow-md">
-          <img
+          <img loading="lazy"
             src="https://ghchart.rshah.org/Alex-Unnippillil"
             alt="Alex Unnippillil's GitHub contribution graph"
             className="w-full rounded"

--- a/components/apps/ascii_art/index.js
+++ b/components/apps/ascii_art/index.js
@@ -550,7 +550,7 @@ export default function AsciiArt() {
         </button>
       </div>
       {imgSrc && !typingMode && (
-        <img
+        <img loading="lazy"
           src={imgSrc}
           alt="original image preview"
           className="max-h-48 mb-2 object-contain"

--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -773,7 +773,7 @@ function Autopsy({ initialArtifacts = null }) {
                     </pre>
                   )}
                   {previewTab === 'image' && selectedFile.imageUrl && (
-                    <img
+                    <img loading="lazy"
                       src={selectedFile.imageUrl}
                       alt={selectedFile.name}
                       className="max-w-full h-auto"

--- a/components/apps/bluetooth/index.tsx
+++ b/components/apps/bluetooth/index.tsx
@@ -129,7 +129,7 @@ const BluetoothApp: React.FC = () => {
                   key={d.address}
                   className="flex flex-col items-center rounded bg-gray-800 p-[6px]"
                 >
-                  <img
+                  <img loading="lazy"
                     src="/themes/Yaru/status/emblem-system-symbolic.svg"
                     alt=""
                     className="h-16 w-16"

--- a/components/apps/camera.tsx
+++ b/components/apps/camera.tsx
@@ -124,7 +124,7 @@ const CameraApp: React.FC = () => {
         </button>
       </div>
       {snapshot && (
-        <img
+        <img loading="lazy"
           src={snapshot}
           alt="Snapshot"
           className="max-w-full border border-gray-700 rounded"

--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -572,7 +572,7 @@ const CarRacer = () => {
                 onClick={() => setSkin(s.key)}
                 className={`border-2 ${skin === s.key ? 'border-white' : 'border-transparent'}`}
               >
-                <img
+                <img loading="lazy"
                   src={skinAssets[s.key]?.src || s.src}
                   alt={s.label}
                   className="h-12 w-8"

--- a/components/apps/chrome/AddressBar.tsx
+++ b/components/apps/chrome/AddressBar.tsx
@@ -251,7 +251,7 @@ const AddressBar: React.FC<AddressBarProps> = ({
                 onContextMenu={(e) => openContext(e, s)}
               >
                 {fav && fav.favicon && (
-                  <img src={fav.favicon} alt="" className="w-4 h-4 mr-2" />
+                  <img loading="lazy" src={fav.favicon} alt="" className="w-4 h-4 mr-2" />
                 )}
                 <span className="truncate">{s}</span>
               </li>

--- a/components/apps/chrome/index.tsx
+++ b/components/apps/chrome/index.tsx
@@ -545,7 +545,7 @@ const Chrome: React.FC = () => {
               try {
                 const origin = new URL(t.url).origin;
                 return (
-                  <img
+                  <img loading="lazy"
                     src={`https://www.google.com/s2/favicons?sz=64&domain_url=${origin}`}
                     alt=""
                     className="w-8 h-8 mb-1"
@@ -731,7 +731,7 @@ const Chrome: React.FC = () => {
                 const origin = new URL(t.url).origin;
                 const src = favicons[origin];
                 return src ? (
-                  <img
+                  <img loading="lazy"
                     src={src}
                     alt=""
                     className="w-4 h-4 mr-1 flex-shrink-0"

--- a/components/apps/hydra/index.js
+++ b/components/apps/hydra/index.js
@@ -450,7 +450,7 @@ const HydraApp = () => {
                 service === m.value ? 'bg-blue-600' : 'bg-gray-700'
               }`}
             >
-              <img src={m.icon} alt={m.label} className="w-6 h-6 mr-2" />
+              <img loading="lazy" src={m.icon} alt={m.label} className="w-6 h-6 mr-2" />
               <span>{m.label}</span>
             </div>
           ))}
@@ -647,7 +647,7 @@ const HydraApp = () => {
         onAttemptChange={handleAttempt}
       />
       <div className="mt-4 flex items-center gap-2">
-        <img
+        <img loading="lazy"
           src="/themes/Yaru/status/changes-prevent-symbolic.svg"
           alt="credentials"
           className="w-5 h-5"

--- a/components/apps/memory.js
+++ b/components/apps/memory.js
@@ -329,7 +329,7 @@ const MemoryBoard = ({ player, themePacks, onWin }) => {
                     } ${reduceMotion.current ? '' : 'transition-colors duration-300'}`}
                   >
                     {card.image ? (
-                      <img src={card.image} alt="" className="w-3/4 h-3/4 object-contain" />
+                      <img loading="lazy" src={card.image} alt="" className="w-3/4 h-3/4 object-contain" />
                     ) : (
                       <span className={`text-4xl ${card.color || ''}`}>{card.value}</span>
                     )}

--- a/components/apps/openvas/index.js
+++ b/components/apps/openvas/index.js
@@ -638,7 +638,7 @@ const OpenVASApp = () => {
           aria-label="Download summary"
           className="inline-flex items-center mt-2 p-2 bg-blue-600 rounded"
         >
-          <img src="/themes/Yaru/status/download.svg" alt="" className="w-4 h-4" />
+          <img loading="lazy" src="/themes/Yaru/status/download.svg" alt="" className="w-4 h-4" />
         </a>
       )}
       <footer className="mt-4 text-xs text-gray-400">

--- a/components/apps/qr/index.tsx
+++ b/components/apps/qr/index.tsx
@@ -140,7 +140,7 @@ const QRScanner: React.FC = () => {
       {result && (
         <div className="flex items-center gap-2 p-2 bg-white text-black rounded-md w-full max-w-sm">
           {preview && (
-            <img
+            <img loading="lazy"
               src={preview}
               alt="QR preview"
               className="w-32 h-32 rounded-md border"

--- a/components/apps/qr_tool/index.tsx
+++ b/components/apps/qr_tool/index.tsx
@@ -177,7 +177,7 @@ const QRTool: React.FC = () => {
             SVG
           </button>
         </div>
-        {png && <img src={png} alt="QR preview" className="h-48 w-48 bg-white" />}
+        {png && <img loading="lazy" src={png} alt="QR preview" className="h-48 w-48 bg-white" />}
       </div>
       <div className="space-y-2">
         <label htmlFor="qr-csv" className="block">
@@ -201,7 +201,7 @@ const QRTool: React.FC = () => {
           <div className="grid grid-cols-2 gap-4 pt-2 sm:grid-cols-3">
             {batch.map((item) => (
               <div key={item.name} className="flex flex-col items-center space-y-1">
-                <img src={item.png} alt={item.name} className="w-32 h-32 bg-white" />
+                <img loading="lazy" src={item.png} alt={item.name} className="w-32 h-32 bg-white" />
                 <div className="text-center text-xs break-all">{item.name}</div>
                 <div className="flex gap-1">
                   <button

--- a/components/apps/radare2/index.js
+++ b/components/apps/radare2/index.js
@@ -108,7 +108,7 @@ const Radare2 = ({ initialData = {} }) => {
     >
       {showGuide && <GuideOverlay onClose={() => setShowGuide(false)} />}
       <div className="flex gap-2 mb-2 flex-wrap items-center">
-        <img
+        <img loading="lazy"
           src="/themes/Yaru/apps/radare2.svg"
           alt="Radare2 badge"
           className="w-12 h-12"

--- a/components/apps/reversi.js
+++ b/components/apps/reversi.js
@@ -414,7 +414,7 @@ const Reversi = () => {
           onClick={reset}
           aria-label="Reset"
         >
-          <img src="/themes/Yaru/status/chrome_refresh.svg" width="24" height="24" alt="" />
+          <img loading="lazy" src="/themes/Yaru/status/chrome_refresh.svg" width="24" height="24" alt="" />
         </button>
         <button
           className="w-6 h-6 bg-gray-700 hover:bg-gray-600 rounded flex items-center justify-center disabled:opacity-50"

--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -672,7 +672,7 @@ export default function Todoist() {
         </h2>
         {filtered.length === 0 ? (
           <div className="flex flex-col items-center text-gray-500 mt-3">
-            <img src="/empty-tasks.svg" alt="" className="w-16 h-16 mb-1.5" />
+            <img loading="lazy" src="/empty-tasks.svg" alt="" className="w-16 h-16 mb-1.5" />
             <span className="text-sm">No tasks</span>
           </div>
         ) : (

--- a/components/apps/trash/index.tsx
+++ b/components/apps/trash/index.tsx
@@ -143,9 +143,9 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
             className={`m-2 border p-1 w-32 cursor-pointer ${selected === idx ? 'bg-ub-drk-abrgn' : ''}`}
           >
             {item.image ? (
-              <img src={item.image} alt={item.title} className="h-20 w-full object-cover" />
+              <img loading="lazy" src={item.image} alt={item.title} className="h-20 w-full object-cover" />
             ) : item.icon ? (
-              <img src={item.icon} alt={item.title} className="h-20 w-20 mx-auto object-contain" />
+              <img loading="lazy" src={item.icon} alt={item.title} className="h-20 w-20 mx-auto object-contain" />
             ) : null}
             <p className="text-center text-xs truncate mt-1" title={item.title}>
               {item.title}

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -125,7 +125,7 @@ function Sidebar({
             className="mb-[6px] cursor-pointer"
             onClick={() => onPlay(v)}
           >
-            <img src={v.thumbnail} alt="" className="h-24 w-full rounded object-cover" />
+            <img loading="lazy" src={v.thumbnail} alt="" className="h-24 w-full rounded object-cover" />
             <div>{v.title}</div>
           </div>
         ))}
@@ -145,7 +145,7 @@ function Sidebar({
             tabIndex={0}
             onKeyDown={(e) => handleKey(i, e)}
           >
-            <img src={v.thumbnail} alt="" className="h-24 w-full rounded object-cover" />
+            <img loading="lazy" src={v.thumbnail} alt="" className="h-24 w-full rounded object-cover" />
             <div>{v.name || v.title}</div>
           </div>
         ))}
@@ -225,7 +225,7 @@ function VirtualGrid({
             >
               <div className="cursor-pointer" onClick={() => onPlay(v)}>
                 <div className="relative">
-                  <img
+                  <img loading="lazy"
                     src={v.thumbnail}
                     alt={v.title}
                     className="h-[162px] w-full rounded object-cover"

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -16,7 +16,7 @@ export default function LockScreen(props) {
             id="ubuntu-lock-screen"
             style={{ zIndex: "100", contentVisibility: 'auto' }}
             className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
-            <img
+            <img loading="lazy"
                 src={`/wallpapers/${wallpaper}.webp`}
                 alt=""
                 className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -38,7 +38,7 @@ export default function BackgroundImage() {
 
     return (
         <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
-            <img
+            <img loading="lazy"
                 src={`/wallpapers/${wallpaper}.webp`}
                 alt=""
                 className="w-full h-full object-cover"

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -17,8 +17,9 @@ class MyDocument extends Document {
         <Head>
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
+          <link rel="preload" href="/styles/tokens.css" as="style" />
           <meta name="theme-color" content="#0f1317" />
-          <script nonce={nonce} src="/theme.js" />
+          <script nonce={nonce} src="/kali-ui.js" />
         </Head>
         <body>
           <Main />

--- a/public/kali-ui.js
+++ b/public/kali-ui.js
@@ -1,6 +1,15 @@
-(function () {
+;(function () {
   var THEME_KEY = 'app:theme';
   try {
+    var head = document.head;
+    if (head) {
+      var tokens = document.createElement('link');
+      tokens.rel = 'preload';
+      tokens.href = '/styles/tokens.css';
+      tokens.as = 'style';
+      head.appendChild(tokens);
+    }
+
     var stored = null;
     if (typeof window !== 'undefined' && typeof window.localStorage !== 'undefined') {
       stored = window.localStorage.getItem(THEME_KEY);


### PR DESCRIPTION
## Summary
- preload token stylesheet and initialize theme based on `prefers-color-scheme`
- defer offscreen image loading using native `loading="lazy"`

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: e.preventDefault is not a function; Unable to find role="alert")*
- `yarn test __tests__/taskbar.test.tsx`
- `yarn lint` *(times out)*

------
https://chatgpt.com/codex/tasks/task_e_68c46d3621b48328aa063233d3850460