### PR TITLE
feat: add accent toggle

### DIFF
--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -19,6 +19,7 @@ class MyDocument extends Document {
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
           <script nonce={nonce} src="/theme.js" />
+          <script nonce={nonce} src="/assets/js/kali-ui.js" />
         </Head>
         <body>
           <Main />

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -24,17 +24,27 @@ const AppsPage = () => {
 
   return (
     <div className="p-4">
-      <label htmlFor="app-search" className="sr-only">
-        Search apps
-      </label>
-      <input
-        id="app-search"
-        type="search"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        placeholder="Search apps"
-        className="mb-4 w-full rounded border p-2"
-      />
+      <div className="mb-4 flex items-center gap-2">
+        <label htmlFor="app-search" className="sr-only">
+          Search apps
+        </label>
+        <input
+          id="app-search"
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search apps"
+          className="flex-1 rounded border p-2"
+        />
+        <button
+          type="button"
+          data-accent-toggle
+          aria-label="toggle accent color"
+          className="rounded border p-2"
+        >
+          🎨
+        </button>
+      </div>
       <div
         id="app-grid"
         tabIndex="-1"

--- a/public/assets/js/kali-ui.js
+++ b/public/assets/js/kali-ui.js
@@ -1,0 +1,34 @@
+(function () {
+  const ACCENT_KEY = 'kali:accent';
+  const root = document.documentElement;
+  const defaultAccent = getComputedStyle(root).getPropertyValue('--color-accent').trim();
+  const altAccent = getComputedStyle(root).getPropertyValue('--accent-2').trim();
+
+  function applyAccent(color) {
+    root.style.setProperty('--color-accent', color);
+    try {
+      localStorage.setItem(ACCENT_KEY, color === altAccent ? 'purple' : 'default');
+    } catch (_) {
+      /* ignore */
+    }
+  }
+
+  try {
+    const stored = localStorage.getItem(ACCENT_KEY);
+    if (stored === 'purple') {
+      applyAccent(altAccent);
+    }
+  } catch (_) {
+    /* ignore */
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.querySelector('[data-accent-toggle]');
+    if (!btn) return;
+    btn.addEventListener('click', () => {
+      const current = getComputedStyle(root).getPropertyValue('--color-accent').trim();
+      const next = current === altAccent ? defaultAccent : altAccent;
+      applyAccent(next);
+    });
+  });
+})();

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -9,6 +9,7 @@
   --color-primary: #1793d1; /* kali blue accent */
   --color-secondary: #1a1f26; /* complementary dark */
   --color-accent: #1793d1; /* accent matches primary */
+  --accent-2: #805ad5; /* alternate accent */
   /* Utility colors */
   --color-muted: #2a2e36; /* muted surfaces */
   --color-surface: #1a1f26; /* panel surfaces */


### PR DESCRIPTION
## Summary
- add accent color toggle script with persistence
- expose toggle button in apps page header
- define alternate accent variable and load script

## Testing
- `yarn lint` *(fails: Unexpected global 'document', Component definition is missing display name)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c46d3696b48328a15a76fcca436c06