### PR TITLE
feat: add theme detection script

### DIFF
--- a/assets/js/kali-ui.js
+++ b/assets/js/kali-ui.js
@@ -1,0 +1,14 @@
+(function () {
+  const THEME_KEY = 'app:theme';
+  try {
+    const storedTheme = window.localStorage.getItem(THEME_KEY);
+    if (storedTheme) {
+      document.documentElement.dataset.theme = storedTheme;
+      return;
+    }
+  } catch (e) {
+    // Ignore localStorage errors
+  }
+  const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  document.documentElement.dataset.theme = prefersDark ? 'dark' : 'light';
+})();


### PR DESCRIPTION
## Summary
- add theme detection script with localStorage and prefers-color-scheme fallback

## Testing
- `yarn lint` *(fails: Unexpected global 'document' no-top-level-window/no-top-level-window-or-document)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c475542bfc832894911ad6edd07cc3