### PR TITLE
feat: support system color scheme

### DIFF
--- a/apps/clipboard_manager/index.html
+++ b/apps/clipboard_manager/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html lang="en">
+<html data-theme="" lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="color-scheme" content="light dark" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Clipboard Manager</title>

--- a/apps/color_picker/index.html
+++ b/apps/color_picker/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html lang="en">
+<html data-theme="" lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="color-scheme" content="light dark" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Color Picker</title>
   <link rel="stylesheet" href="index.css">

--- a/apps/timer_stopwatch/index.html
+++ b/apps/timer_stopwatch/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html lang="en">
+<html data-theme="" lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="color-scheme" content="light dark" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Timer & Stopwatch</title>
   <link rel="stylesheet" href="index.css">

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -13,8 +13,9 @@ class MyDocument extends Document {
   render() {
     const { nonce } = this.props;
     return (
-      <Html lang="en" data-csp-nonce={nonce}>
+      <Html data-theme="" lang="en" data-csp-nonce={nonce}>
         <Head>
+          <meta name="color-scheme" content="light dark" />
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />


### PR DESCRIPTION
## Summary
- declare light/dark color scheme via meta tag
- provide empty data-theme attribute for initial paint
- apply color scheme defaults to static app HTML pages

## Testing
- `yarn test` *(fails: e.preventDefault is not a function; unable to find role="alert")*
- `yarn lint pages/_document.jsx apps/timer_stopwatch/index.html apps/color_picker/index.html apps/clipboard_manager/index.html` *(fails: Unexpected global 'document')*

------
https://chatgpt.com/codex/tasks/task_e_68c4755386c08328b0c70d80e6adae55