### PR TITLE
Add fallback panel background for unsupported backdrop filter

### DIFF
--- a/assets/css/kali-components.css
+++ b/assets/css/kali-components.css
@@ -1,0 +1,5 @@
+@supports not (backdrop-filter: blur(6px)) {
+  .kali-panel {
+    background: rgba(12, 14, 18, 0.95);
+  }
+}


### PR DESCRIPTION
## Summary
- Add CSS fallback for `.kali-panel` when `backdrop-filter` is unsupported and ensure 95% opacity

## Testing
- `yarn test` *(fails: `window.test.tsx`, `nmapNse.test.tsx`, `Modal.test.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68c475549bf4832894909968283888d6