### PR TITLE
feat: add layout tokens

### DIFF
--- a/apps/About/index.tsx
+++ b/apps/About/index.tsx
@@ -32,7 +32,7 @@ function LinkedInIcon({ className }: { className?: string }) {
 export default function AboutPage() {
   return (
     <div className="min-h-screen w-full bg-[var(--kali-bg)] text-sm">
-      <div className="max-w-screen-md mx-auto my-4 sm:my-8 p-4 sm:p-6">
+      <div className="mx-auto my-4 sm:my-8 p-4 sm:p-6 max-w-[var(--content-max)]">
         <section className="flex items-center mb-8">
           <Image
             src="/images/logos/bitmoji.png"

--- a/apps/calculator/styles.css
+++ b/apps/calculator/styles.css
@@ -71,7 +71,7 @@ body {
   border-radius: 4px;
   font-size: 1rem;
   cursor: pointer;
-  min-height: 48px;
+  min-height: var(--panel-height);
   transition: transform 150ms;
 }
 

--- a/assets/css/kali-tokens.css
+++ b/assets/css/kali-tokens.css
@@ -1,0 +1,5 @@
+:root {
+  --panel-height: 48px;
+  --navbar-gap: 8px;
+  --content-max: 1200px;
+}

--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -41,7 +41,7 @@ export default function ModuleCard({
         <h3 className="font-bold">{highlight(module.name, query)}</h3>
         <p className="text-sm">{highlight(module.description, query)}</p>
       </div>
-      <div className="flex flex-col gap-2 items-center">
+      <div className="flex flex-col items-center gap-[var(--navbar-gap)]">
         <Image
           src="/themes/Yaru/status/about.svg"
           alt="Details"

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -37,7 +37,7 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
             <div
               aria-label="accent-color-picker"
               role="radiogroup"
-              className="flex gap-2 mt-1"
+              className="flex gap-[var(--navbar-gap)] mt-1"
             >
               {ACCENT_OPTIONS.map((c) => (
                 <button

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -56,6 +56,9 @@
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;
+  --panel-height: 48px;
+  --navbar-gap: 8px;
+  --content-max: 1200px;
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;


### PR DESCRIPTION
## Summary
- define panel height, navbar gap, and content max tokens for Kali styles
- use new layout tokens in calculator buttons, settings drawer, module card, and about page container
- expose tokens via shared tokens stylesheet

## Testing
- `yarn test` (fails: window.test.tsx, nmapNse.test.tsx)

------
https://chatgpt.com/codex/tasks/task_e_68c47555d2e88328a51ce23c420bf482