### PR TITLE
Close app menu on backdrop click

### DIFF
--- a/public/kali-ui.js
+++ b/public/kali-ui.js
@@ -1,0 +1,11 @@
+/* eslint-env browser */
+(function () {
+  var appmenu = document.getElementById('appmenu');
+  if (!appmenu) return;
+
+  appmenu.addEventListener('click', function (event) {
+    if (!event.target.closest('.appmenu-shell')) {
+      appmenu.close();
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- close `#appmenu` when clicking outside `.appmenu-shell`

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c4755b10d88328b94a049b657ab89b