### PR TITLE
feat: announce filtered app count

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -151,10 +151,10 @@ function MyApp(props) {
       <Script src="/a2hs.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
         <a
-          href="#app-grid"
+          href="#appList"
           className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
         >
-          Skip to app grid
+          Skip to app list
         </a>
         <SettingsProvider>
           <PipPortalProvider>

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -36,7 +36,7 @@ const AppsPage = () => {
         className="mb-4 w-full rounded border p-2"
       />
       <div
-        id="app-grid"
+        id="appList"
         tabIndex="-1"
         className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
       >
@@ -60,6 +60,9 @@ const AppsPage = () => {
             <span className="mt-2">{app.title}</span>
           </Link>
         ))}
+      </div>
+      <div id="menuStatus" aria-live="polite" className="sr-only">
+        {`${filteredApps.length} result${filteredApps.length === 1 ? '' : 's'} found`}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- make app list id `appList`
- announce filter result count for apps
- update skip link target

## Testing
- `yarn lint` *(fails: Unexpected global 'document', Component definition is missing display name)*
- `yarn test` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size, NmapNSEApp › copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68c4755c6c3c83288c2f6dc269641ff3