### PR TITLE
Enable keyboard navigation for app list

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -151,7 +151,7 @@ function MyApp(props) {
       <Script src="/a2hs.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
         <a
-          href="#app-grid"
+          href="#appList"
           className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
         >
           Skip to app grid

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -1,10 +1,12 @@
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import Link from 'next/link';
 
 const AppsPage = () => {
   const [apps, setApps] = useState([]);
   const [query, setQuery] = useState('');
+  const [index, setIndex] = useState(0);
+  const listRef = useRef(null);
 
   useEffect(() => {
     let isMounted = true;
@@ -22,6 +24,35 @@ const AppsPage = () => {
     (app) => !app.disabled && app.title.toLowerCase().includes(query.toLowerCase()),
   );
 
+  useEffect(() => {
+    const links = listRef.current?.querySelectorAll('li a');
+    if (!links || links.length === 0) return;
+    const safeIndex = Math.min(index, links.length - 1);
+    if (safeIndex !== index) {
+      setIndex(safeIndex);
+      return;
+    }
+    links.forEach((link, i) => {
+      link.tabIndex = i === safeIndex ? 0 : -1;
+    });
+    links[safeIndex]?.focus();
+  }, [index, filteredApps]);
+
+  const handleKeyDown = (e) => {
+    const links = listRef.current?.querySelectorAll('li a');
+    if (!links || links.length === 0) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setIndex((i) => Math.min(i + 1, links.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      links[index]?.click();
+    }
+  };
+
   return (
     <div className="p-4">
       <label htmlFor="app-search" className="sr-only">
@@ -35,32 +66,35 @@ const AppsPage = () => {
         placeholder="Search apps"
         className="mb-4 w-full rounded border p-2"
       />
-      <div
-        id="app-grid"
+      <ul
+        id="appList"
         tabIndex="-1"
-        className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
+        ref={listRef}
+        onKeyDown={handleKeyDown}
+        className="grid list-none grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
       >
         {filteredApps.map((app) => (
-          <Link
-            key={app.id}
-            href={`/apps/${app.id}`}
-            className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
-            aria-label={app.title}
-          >
-            {app.icon && (
-              <Image
-                src={app.icon}
-                alt=""
-                width={64}
-                height={64}
-                sizes="64px"
-                className="h-16 w-16"
-              />
-            )}
-            <span className="mt-2">{app.title}</span>
-          </Link>
+          <li key={app.id}>
+            <Link
+              href={`/apps/${app.id}`}
+              className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
+              aria-label={app.title}
+            >
+              {app.icon && (
+                <Image
+                  src={app.icon}
+                  alt=""
+                  width={64}
+                  height={64}
+                  sizes="64px"
+                  className="h-16 w-16"
+                />
+              )}
+              <span className="mt-2">{app.title}</span>
+            </Link>
+          </li>
         ))}
-      </div>
+      </ul>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add index-based keyboard navigation for apps list
- render app grid as list and update skip link target

## Testing
- `npx eslint pages/apps/index.jsx pages/_app.jsx` *(files ignored: no matching configuration)*
- `yarn test` *(failed: window snapping finalize and NmapNSEApp tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c4755deacc83288e4addadd2605a78