### PR TITLE
Persist WhiskerMenu category selection

### DIFF
--- a/__tests__/whiskerMenu.test.tsx
+++ b/__tests__/whiskerMenu.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import WhiskerMenu from '../components/menu/WhiskerMenu';
+
+jest.mock('next/image', () => (props: any) => <img {...props} alt={props.alt || ''} />);
+
+jest.mock('../components/base/ubuntu_app', () => ({ name, openApp }: any) => (
+  <button onClick={openApp}>{name}</button>
+));
+
+describe('WhiskerMenu category persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('saves selected category and restores on open', () => {
+    const { unmount } = render(<WhiskerMenu />);
+
+    fireEvent.click(screen.getByRole('button', { name: /applications/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Games' }));
+
+    expect(window.localStorage.getItem('kali:lastCat')).toBe('games');
+
+    fireEvent.click(screen.getByRole('button', { name: /applications/i }));
+    unmount();
+
+    render(<WhiskerMenu />);
+    fireEvent.click(screen.getByRole('button', { name: /applications/i }));
+    const gamesBtn = document.querySelector('button[data-cat="games"]');
+    expect(gamesBtn?.className).toContain('bg-gray-700');
+  });
+});
+

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -68,6 +68,14 @@ const WhiskerMenu: React.FC = () => {
 
   useEffect(() => {
     if (!open) return;
+    const lastCat = safeLocalStorage?.getItem('kali:lastCat');
+    if (lastCat && CATEGORIES.some(c => c.id === lastCat)) {
+      setCategory(lastCat);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
     setHighlight(0);
   }, [open, category, query]);
 
@@ -146,8 +154,12 @@ const WhiskerMenu: React.FC = () => {
             {CATEGORIES.map(cat => (
               <button
                 key={cat.id}
+                data-cat={cat.id}
                 className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
-                onClick={() => setCategory(cat.id)}
+                onClick={() => {
+                  setCategory(cat.id);
+                  safeLocalStorage?.setItem('kali:lastCat', cat.id);
+                }}
               >
                 {cat.label}
               </button>


### PR DESCRIPTION
## Summary
- Persist selected application drawer category in `localStorage`
- Restore saved category when the drawer opens
- Add tests for category persistence

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c4755e7e1483288e0e2ecdbea7df49