### PR TITLE
feat(menu): parse URL hash to open app menu

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -67,6 +67,22 @@ const WhiskerMenu: React.FC = () => {
   }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps]);
 
   useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const hash = window.location.hash;
+    if (hash === '#menu' || hash.startsWith('#menu?')) {
+      setOpen(true);
+      const query = hash.split('?')[1];
+      if (query) {
+        const params = new URLSearchParams(query);
+        const cat = params.get('cat');
+        if (cat && CATEGORIES.some(c => c.id === cat)) {
+          setCategory(cat);
+        }
+      }
+    }
+  }, []);
+
+  useEffect(() => {
     if (!open) return;
     setHighlight(0);
   }, [open, category, query]);
@@ -133,6 +149,7 @@ const WhiskerMenu: React.FC = () => {
       </button>
       {open && (
         <div
+          id="appmenu"
           ref={menuRef}
           className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
           tabIndex={-1}


### PR DESCRIPTION
## Summary
- open WhiskerMenu when URL hash contains `#menu`
- support `#menu?cat=NAME` to select a menu category on load

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c4755f3210832884808d24bdf8d35b