### PR TITLE
feat: inline SVG icons in panel status area

### DIFF
--- a/components/util-components/small_arrow.js
+++ b/components/util-components/small_arrow.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './small_arrow.module.css';
 
-export default function SmallArrow({ angle = 'up' }) {
+export default function SmallArrow({ angle = 'up', className = '', ...props }) {
     const rotations = {
         up: '',
         down: 'rotate-180',
@@ -9,5 +9,5 @@ export default function SmallArrow({ angle = 'up' }) {
         right: 'rotate-90',
     };
 
-    return <div className={`${styles.arrow} ${rotations[angle] ?? ''}`}></div>;
+    return <div {...props} className={`${styles.arrow} ${rotations[angle] ?? ''} ${className}`}></div>;
 }

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,9 +1,74 @@
 import React, { useEffect, useState } from "react";
-import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
 
-const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
+const WifiOn = (props) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <path d="M5 12.55a11 11 0 0 1 14.08 0" />
+    <path d="M1.42 9a16 16 0 0 1 21.16 0" />
+    <path d="M8.53 16.11a6 6 0 0 1 6.95 0" />
+    <line x1="12" y1="20" x2="12.01" y2="20" />
+  </svg>
+);
+
+const WifiOff = (props) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <line x1="1" y1="1" x2="23" y2="23" />
+    <path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55" />
+    <path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39" />
+    <path d="M10.71 5.05A16 16 0 0 1 22.58 9" />
+    <path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88" />
+    <path d="M8.53 16.11a6 6 0 0 1 6.95 0" />
+    <line x1="12" y1="20" x2="12.01" y2="20" />
+  </svg>
+);
+
+const Volume = (props) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+    <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
+    <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+  </svg>
+);
+
+const Battery = (props) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <rect x="1" y="6" width="18" height="12" rx="2" ry="2" />
+    <line x1="23" y1="13" x2="23" y2="11" />
+  </svg>
+);
 
 export default function Status() {
   const { allowNetwork } = useSettings();
@@ -39,45 +104,28 @@ export default function Status() {
   }, []);
 
   return (
-    <div className="flex justify-center items-center">
+    <div className="panel-right flex justify-center items-center">
       <span
         className="mx-1.5 relative"
         title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}
       >
-        <Image
-          width={16}
-          height={16}
-          src={online ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"}
-          alt={online ? "online" : "offline"}
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
+        {online ? (
+          <WifiOn aria-hidden="true" className="inline status-symbol w-4 h-4" />
+        ) : (
+          <WifiOff aria-hidden="true" className="inline status-symbol w-4 h-4" />
+        )}
         {!allowNetwork && (
           <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
         )}
       </span>
       <span className="mx-1.5">
-        <Image
-          width={16}
-          height={16}
-          src={VOLUME_ICON}
-          alt="volume"
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
+        <Volume aria-hidden="true" className="inline status-symbol w-4 h-4" />
       </span>
       <span className="mx-1.5">
-        <Image
-          width={16}
-          height={16}
-          src="/themes/Yaru/status/battery-good-symbolic.svg"
-          alt="ubuntu battry"
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
+        <Battery aria-hidden="true" className="inline status-symbol w-4 h-4" />
       </span>
       <span className="mx-1">
-        <SmallArrow angle="down" className=" status-symbol" />
+        <SmallArrow angle="down" className="status-symbol" aria-hidden="true" />
       </span>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace panel status images with inline SVG icons and mark them aria-hidden
- allow SmallArrow component to forward props for accessibility

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, installButton.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c47561e9d88328afe97d84415fa1cc