### PR TITLE
feat: add 24-hour clock option

### DIFF
--- a/apps/ettercap/index.tsx
+++ b/apps/ettercap/index.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import FilterEditor from './components/FilterEditor';
 import LogPane, { LogEntry } from './components/LogPane';
 import ArpDiagram from './components/ArpDiagram';
+import { useSettings } from '../../hooks/useSettings';
 
 const MODES = ['Unified', 'Sniff', 'ARP'];
 
@@ -11,17 +12,18 @@ export default function EttercapPage() {
   const [mode, setMode] = useState('Unified');
   const [started, setStarted] = useState(false);
   const [logs, setLogs] = useState<LogEntry[]>([]);
+  const { twentyFourHour } = useSettings();
 
   useEffect(() => {
     if (!started) return;
     const id = setInterval(() => {
       const levels: LogEntry['level'][] = ['info', 'warn', 'error'];
       const level = levels[Math.floor(Math.random() * levels.length)];
-      const message = `Sample ${level} message ${new Date().toLocaleTimeString()}`;
+      const message = `Sample ${level} message ${new Date().toLocaleTimeString([], twentyFourHour ? { hour12: false } : undefined)}`;
       setLogs((l) => [...l, { id: Date.now(), level, message }]);
     }, 2000);
     return () => clearInterval(id);
-  }, [started]);
+  }, [started, twentyFourHour]);
 
   return (
     <div className="p-4">

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -31,6 +31,7 @@ export default function Settings() {
     setHaptics,
     theme,
     setTheme,
+    setTwentyFourHour,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -101,6 +102,7 @@ export default function Settings() {
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
     setTheme("default");
+    setTwentyFourHour(defaults.twentyFourHour);
   };
 
   const [showKeymap, setShowKeymap] = useState(false);

--- a/apps/weather_widget/main.js
+++ b/apps/weather_widget/main.js
@@ -52,9 +52,11 @@ function convertTemp(celsius) {
 }
 
 function formatTime(timestamp) {
+  const use24h = safeLocalStorage?.getItem('24h-time') === 'true';
   return new Date(timestamp * 1000).toLocaleTimeString([], {
     hour: '2-digit',
     minute: '2-digit',
+    hour12: !use24h,
   });
 }
 

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -9,7 +9,7 @@ interface Props {
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const unlocked = getUnlockedThemes(highScore);
-  const { accent, setAccent, theme, setTheme } = useSettings();
+  const { accent, setAccent, theme, setTheme, twentyFourHour, setTwentyFourHour } = useSettings();
 
   return (
     <div>
@@ -51,6 +51,15 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
                 />
               ))}
             </div>
+          </label>
+          <label className="flex items-center gap-2 mt-2">
+            <input
+              type="checkbox"
+              aria-label="toggle-24h-time"
+              checked={twentyFourHour}
+              onChange={(e) => setTwentyFourHour(e.target.checked)}
+            />
+            24-hour clock
           </label>
         </div>
       )}

--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -5,6 +5,7 @@ import KeywordSearchPanel from './KeywordSearchPanel';
 import demoArtifacts from './data/sample-artifacts.json';
 import ReportExport from '../../../apps/autopsy/components/ReportExport';
 import demoCase from '../../../apps/autopsy/data/case.json';
+import { useSettings } from '../../../hooks/useSettings';
 
 const escapeFilename = (str = '') =>
   str
@@ -22,6 +23,7 @@ function Timeline({ events, onSelect }) {
   const workerRef = useRef(null);
   const positionsRef = useRef([]);
   const [sorted, setSorted] = useState([]);
+  const { twentyFourHour } = useSettings();
   const MIN_ZOOM = 1 / (24 * 60); // 1 pixel per day
   const MAX_ZOOM = 60; // 60 pixels per minute
   const [zoom, setZoom] = useState(1 / 60); // start at 1 pixel per hour
@@ -139,11 +141,12 @@ function Timeline({ events, onSelect }) {
         if (tickMinutes >= 1440) {
           label = date.toLocaleDateString();
         } else if (tickMinutes >= 60) {
-          label = date.toLocaleTimeString([], { hour: '2-digit' });
+          label = date.toLocaleTimeString([], { hour: '2-digit', hour12: !twentyFourHour });
         } else {
           label = date.toLocaleTimeString([], {
             hour: '2-digit',
             minute: '2-digit',
+            hour12: !twentyFourHour,
           });
         }
         ctx.fillText(label, x + 2, height / 2 + 25);
@@ -193,7 +196,7 @@ function Timeline({ events, onSelect }) {
     } else {
       requestAnimationFrame(render);
     }
-  }, [sorted, zoom]);
+  }, [sorted, zoom, twentyFourHour]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -283,11 +286,9 @@ function Timeline({ events, onSelect }) {
           />
           <datalist id="timeline-day-markers">
             {dayMarkers.map((m) => (
-              <option
-                key={m.day}
-                value={m.idx}
-                label={new Date(m.day).toLocaleDateString()}
-              />
+              <option key={m.day} value={m.idx}>
+                {new Date(m.day).toLocaleDateString()}
+              </option>
             ))}
           </datalist>
           {hoverIndex !== null && sorted[hoverIndex] && (
@@ -598,6 +599,7 @@ function Autopsy({ initialArtifacts = null }) {
           value={caseName}
           onChange={(e) => setCaseName(e.target.value)}
           placeholder="Case name"
+          aria-label="Case name"
           className="flex-grow bg-ub-grey text-white px-2 py-1 rounded"
         />
         <button
@@ -644,6 +646,7 @@ function Autopsy({ initialArtifacts = null }) {
         <textarea
           readOnly
           value={analysis}
+          aria-label="Analysis output"
           className="bg-ub-grey text-xs text-white p-2 rounded resize-none"
         />
       )}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getTwentyFourHour as loadTwentyFourHour,
+  setTwentyFourHour as saveTwentyFourHour,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +64,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  twentyFourHour: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +76,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setTwentyFourHour: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +91,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  twentyFourHour: defaults.twentyFourHour,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +103,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setTwentyFourHour: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +118,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [twentyFourHour, setTwentyFourHour] = useState<boolean>(defaults.twentyFourHour);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +134,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setTwentyFourHour(await loadTwentyFourHour());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +244,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveTwentyFourHour(twentyFourHour);
+  }, [twentyFourHour]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +261,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        twentyFourHour,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +273,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setTwentyFourHour,
         setTheme,
       }}
     >

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  twentyFourHour: false,
 };
 
 export async function getAccent() {
@@ -102,6 +103,16 @@ export async function setHaptics(value) {
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+export async function getTwentyFourHour() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.twentyFourHour;
+  return window.localStorage.getItem('24h-time') === 'true';
+}
+
+export async function setTwentyFourHour(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('24h-time', value ? 'true' : 'false');
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -137,6 +148,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('24h-time');
 }
 
 export async function exportSettings() {
@@ -151,6 +163,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    twentyFourHour,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +175,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getTwentyFourHour(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +189,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    twentyFourHour,
     theme,
   });
 }
@@ -199,6 +214,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    twentyFourHour,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +227,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (twentyFourHour !== undefined) await setTwentyFourHour(twentyFourHour);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add 24-hour clock setting persisted in settings store
- expose toggle in Settings drawer and apply setting across apps

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `npx eslint apps/ettercap/index.tsx apps/settings/index.tsx apps/weather_widget/main.js components/SettingsDrawer.tsx components/apps/autopsy/index.js hooks/useSettings.tsx utils/settingsStore.js`
- `yarn test` *(fails: Window snapping finalize and release releases snap with Alt+ArrowDown restoring size, NmapNSEApp copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68c47562afb88328b0fd28dc3ccbb879