### PR TITLE
feat: load wallpaper after DOM ready with gradient fallback

### DIFF
--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -20,9 +20,15 @@ class MyDocument extends Document {
           <meta name="theme-color" content="#0f1317" />
           <script nonce={nonce} src="/theme.js" />
         </Head>
-        <body>
+        <body style={{ background: 'linear-gradient(#0f1317,#1a1f26)' }}>
           <Main />
           <NextScript nonce={nonce} />
+          <script
+            nonce={nonce}
+            dangerouslySetInnerHTML={{
+              __html: `document.addEventListener('DOMContentLoaded',function(){var wp=localStorage.getItem('bg-image')||'wall-2';document.body.style.setProperty('--wp-image','url(/wallpapers/' + wp + '.webp)');document.body.classList.add('wp-ready');});`,
+            }}
+          />
         </body>
       </Html>
     );

--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,23 @@ body{
     color: var(--color-text);
 }
 
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+body.wp-ready::before {
+    background-image: var(--wp-image);
+    opacity: 1;
+}
+
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
     min-width: var(--hit-area);
     min-height: var(--hit-area);


### PR DESCRIPTION
## Summary
- add minimal inline gradient background to `<body>`
- load persisted wallpaper via `body::before` once DOM is ready

## Testing
- `npx eslint pages/_document.jsx styles/index.css`
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: 2)*

------
https://chatgpt.com/codex/tasks/task_e_68c475656ec883289709e769b921e8ad