### PR TITLE
Add wallpaper opacity and blur controls

### DIFF
--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { getUnlockedThemes } from '../utils/theme';
 import { useSettings, ACCENT_OPTIONS } from '../hooks/useSettings';
 
@@ -10,6 +10,16 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const unlocked = getUnlockedThemes(highScore);
   const { accent, setAccent, theme, setTheme } = useSettings();
+  const [opacity, setOpacity] = useState(1);
+  const [blur, setBlur] = useState(0);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--wp-opacity', String(opacity));
+  }, [opacity]);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--wp-blur', `${blur}px`);
+  }, [blur]);
 
   return (
     <div>
@@ -51,6 +61,30 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
                 />
               ))}
             </div>
+          </label>
+          <label>
+            Wallpaper Opacity
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              value={opacity}
+              onChange={(e) => setOpacity(parseFloat(e.target.value))}
+              aria-label="wallpaper-opacity"
+            />
+          </label>
+          <label>
+            Wallpaper Blur
+            <input
+              type="range"
+              min="0"
+              max="20"
+              step="1"
+              value={blur}
+              onChange={(e) => setBlur(parseFloat(e.target.value))}
+              aria-label="wallpaper-blur"
+            />
           </label>
         </div>
       )}

--- a/styles/index.css
+++ b/styles/index.css
@@ -9,6 +9,18 @@ body{
     font-display: swap;
     background-color: var(--color-bg);
     color: var(--color-text);
+    --wp-opacity: 1;
+    --wp-blur: 0px;
+}
+
+body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    opacity: var(--wp-opacity);
+    filter: blur(var(--wp-blur));
+    z-index: -1;
 }
 
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {


### PR DESCRIPTION
## Summary
- add sliders in settings drawer for wallpaper opacity and blur
- apply `--wp-opacity` and `--wp-blur` CSS variables to body pseudo element

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `CI=1 yarn test` *(fails: e.preventDefault is not a function in window.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c47565fe608328902aac00a02eb37a