### PR TITLE
Use fluid font sizes for headings

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,25 @@ body{
     color: var(--color-text);
 }
 
+h1 {
+    font-size: clamp(28px, 4vw, 44px);
+}
+h2 {
+    font-size: clamp(24px, 3.5vw, 36px);
+}
+h3 {
+    font-size: clamp(20px, 3vw, 32px);
+}
+h4 {
+    font-size: clamp(18px, 2.5vw, 28px);
+}
+h5 {
+    font-size: clamp(16px, 2vw, 24px);
+}
+h6 {
+    font-size: clamp(14px, 1.5vw, 20px);
+}
+
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
     min-width: var(--hit-area);
     min-height: var(--hit-area);


### PR DESCRIPTION
## Summary
- define responsive `h1`-`h6` font sizes via CSS `clamp`

## Testing
- `yarn eslint styles/index.css` *(warns: file ignored because no matching configuration was supplied)*
- `yarn test` *(fails: __tests__/window.test.tsx, __tests__/nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c4756b07208328b50c7161315ce0e6