### PR TITLE
feat: add code ligature setting

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -29,6 +29,8 @@ export default function Settings() {
     setHighContrast,
     haptics,
     setHaptics,
+    codeLigatures,
+    setCodeLigatures,
     theme,
     setTheme,
   } = useSettings();
@@ -258,6 +260,14 @@ export default function Settings() {
               checked={haptics}
               onChange={setHaptics}
               ariaLabel="Haptics"
+            />
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Enable code ligatures:</span>
+            <ToggleSwitch
+              checked={codeLigatures}
+              onChange={setCodeLigatures}
+              ariaLabel="Enable code ligatures"
             />
           </div>
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -485,7 +485,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
         <div className="relative">
           <TerminalContainer
             ref={containerRef}
-            className="resize overflow-hidden font-mono"
+            className="terminal resize overflow-hidden font-mono"
             style={{
               width: '80ch',
               height: '24em',

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { getUnlockedThemes } from '../utils/theme';
 import { useSettings, ACCENT_OPTIONS } from '../hooks/useSettings';
+import ToggleSwitch from './ToggleSwitch';
 
 interface Props {
   highScore?: number;
@@ -9,7 +10,8 @@ interface Props {
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const unlocked = getUnlockedThemes(highScore);
-  const { accent, setAccent, theme, setTheme } = useSettings();
+  const { accent, setAccent, theme, setTheme, codeLigatures, setCodeLigatures } =
+    useSettings();
 
   return (
     <div>
@@ -51,6 +53,14 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
                 />
               ))}
             </div>
+          </label>
+          <label className="flex items-center gap-2 mt-4">
+            <ToggleSwitch
+              checked={codeLigatures}
+              onChange={setCodeLigatures}
+              ariaLabel="Enable code ligatures"
+            />
+            <span>Enable code ligatures</span>
           </label>
         </div>
       )}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getCodeLigatures as loadCodeLigatures,
+  setCodeLigatures as saveCodeLigatures,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +64,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  codeLigatures: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +76,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setCodeLigatures: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +91,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  codeLigatures: defaults.codeLigatures,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +103,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setCodeLigatures: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +118,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [codeLigatures, setCodeLigatures] = useState<boolean>(
+    defaults.codeLigatures,
+  );
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +136,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setCodeLigatures(await loadCodeLigatures());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +246,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    document.documentElement.classList.toggle('code-ligatures', codeLigatures);
+    saveCodeLigatures(codeLigatures);
+  }, [codeLigatures]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +264,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        codeLigatures,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +276,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setCodeLigatures,
         setTheme,
       }}
     >

--- a/styles/index.css
+++ b/styles/index.css
@@ -169,6 +169,11 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     background: transparent;
 }
 
+.code-ligatures .terminal .screen,
+.code-ligatures .terminal .xterm-screen {
+    font-variant-ligatures: contextual;
+}
+
 .xterm .xterm-cursor {
     animation: cursor-pulse 1s steps(2) infinite;
 }

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  codeLigatures: false,
 };
 
 export async function getAccent() {
@@ -102,6 +103,16 @@ export async function setHaptics(value) {
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+export async function getCodeLigatures() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.codeLigatures;
+  return window.localStorage.getItem('code-ligatures') === 'true';
+}
+
+export async function setCodeLigatures(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('code-ligatures', value ? 'true' : 'false');
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -137,6 +148,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('code-ligatures');
 }
 
 export async function exportSettings() {
@@ -151,6 +163,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    codeLigatures,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +175,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getCodeLigatures(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +189,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    codeLigatures,
     theme,
   });
 }
@@ -199,6 +214,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    codeLigatures,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +227,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (codeLigatures !== undefined) await setCodeLigatures(codeLigatures);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add persistent "Enable code ligatures" option
- allow toggling ligatures from Settings app and drawer
- apply contextual ligatures to terminal screens when enabled

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c4756b64dc83289799f0feb2e79477