### PR TITLE
feat: add terminal copy button

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -146,6 +146,35 @@ function MyApp(props) {
     };
   }, []);
 
+  useEffect(() => {
+    const addButtons = () => {
+      document.querySelectorAll('.terminal .titlebar').forEach((bar) => {
+        if (bar.querySelector('button[data-copy-target]')) return;
+        const terminal = bar.closest('.terminal');
+        const screen = terminal?.querySelector('.screen');
+        if (!screen) return;
+        if (!screen.id) {
+          screen.id = `terminal-screen-${Math.random().toString(36).slice(2, 9)}`;
+        }
+        const button = document.createElement('button');
+        button.textContent = 'Copy';
+        button.setAttribute('data-copy-target', `#${screen.id}`);
+        button.addEventListener('click', async () => {
+          try {
+            await navigator.clipboard.writeText(screen.textContent || '');
+            const original = button.textContent;
+            button.textContent = 'Copied';
+            setTimeout(() => {
+              button.textContent = original;
+            }, 2000);
+          } catch {}
+        });
+        bar.appendChild(button);
+      });
+    };
+    addButtons();
+  }, [Component]);
+
   return (
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />


### PR DESCRIPTION
## Summary
- auto-insert copy button into terminal titlebars that copies nearest screen text
- button shows 'Copied' after copying

## Testing
- `yarn lint pages/_app.jsx` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: __tests__/window.test.tsx, __tests__/nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c4756d88648328a71a762b129fb616