### PR TITLE
Update workspace hash and section scroll offset

### DIFF
--- a/pages/module-workspace.tsx
+++ b/pages/module-workspace.tsx
@@ -105,14 +105,15 @@ const ModuleWorkspace: React.FC = () => {
     <div className="p-4 space-y-4 bg-ub-cool-grey text-white min-h-screen">
       <section className="space-y-2">
         <h1 className="text-xl font-semibold">Workspaces</h1>
-        <div className="flex gap-2">
-          <input
-            value={newWorkspace}
-            onChange={(e) => setNewWorkspace(e.target.value)}
-            placeholder="New workspace"
-            className="p-1 rounded text-black"
-          />
-          <button
+          <div className="flex gap-2">
+            <input
+              value={newWorkspace}
+              onChange={(e) => setNewWorkspace(e.target.value)}
+              placeholder="New workspace"
+              aria-label="New workspace name"
+              className="p-1 rounded text-black"
+            />
+            <button
             onClick={addWorkspace}
             className="px-2 py-1 bg-ub-orange rounded text-black"
           >
@@ -123,7 +124,12 @@ const ModuleWorkspace: React.FC = () => {
           {workspaces.map((ws) => (
             <button
               key={ws}
-              onClick={() => setCurrentWorkspace(ws)}
+              onClick={() => {
+                setCurrentWorkspace(ws);
+                if (typeof window !== 'undefined') {
+                  window.location.hash = encodeURIComponent(ws);
+                }
+              }}
               className={`px-2 py-1 rounded ${
                 currentWorkspace === ws ? 'bg-blue-600' : 'bg-gray-700'
               }`}
@@ -173,15 +179,16 @@ const ModuleWorkspace: React.FC = () => {
               <h2 className="font-semibold">Command Composer</h2>
               {selected.options.map((opt) => (
                 <div key={opt.name}>
-                  <label className="block text-sm">
-                    {opt.name} {opt.required ? '*' : ''}
-                    <input
-                      value={optionValues[opt.name]}
-                      onChange={(e) =>
-                        setOptionValues({
-                          ...optionValues,
-                          [opt.name]: e.target.value,
-                        })
+                    <label className="block text-sm">
+                      {opt.name} {opt.required ? '*' : ''}
+                      <input
+                        value={optionValues[opt.name]}
+                        aria-label={opt.name}
+                        onChange={(e) =>
+                          setOptionValues({
+                            ...optionValues,
+                            [opt.name]: e.target.value,
+                          })
                       }
                       className="mt-1 w-full p-1 rounded text-black"
                     />

--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,10 @@ body{
     color: var(--color-text);
 }
 
+section {
+    scroll-margin-top: var(--panel-height);
+}
+
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
     min-width: var(--hit-area);
     min-height: var(--hit-area);


### PR DESCRIPTION
## Summary
- update module workspace buttons to set `location.hash`
- offset anchored sections with `scroll-margin-top`

## Testing
- `npx eslint pages/module-workspace.tsx styles/index.css`
- `yarn test` *(fails: act warnings and missing env credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68c4756f1eb0832889853e27c4ab2daa