### PR TITLE
feat: add global focus ring

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -73,7 +73,7 @@ html[data-theme='matrix'] {
   color: var(--color-inverse);
 }
 
-*:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
+.focus-ring {
+  outline: var(--focus-outline-width) solid var(--color-focus-ring) !important;
   outline-offset: 2px;
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -16,10 +16,12 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
     min-height: var(--hit-area);
 }
 
+button:focus-visible,
 a:focus-visible,
-button:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
-    outline-offset: 2px;
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+    @apply focus-ring;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -508,14 +510,6 @@ pre {
     font-family: monospace;
     line-height: 1.2;
 }
-
-/* Visible focus rings for copy buttons and text areas */
-button:focus-visible,
-textarea:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color);
-    outline-offset: 2px;
-}
-
 /* Enable scroll snapping for gallery containers */
 .gallery-container {
     scroll-snap-type: x mandatory;


### PR DESCRIPTION
## Summary
- define reusable `.focus-ring` class with accent outline
- apply consistent focus styling to buttons, links, and form controls

## Testing
- `yarn lint 2>&1 | tail -n 20` *(fails: 571 errors, 7 warnings)*
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/Modal.test.tsx --maxWorkers=2` *(fails: 2 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c47570148c8328ba42e784197d7a2f