### PR TITLE
Use SVG sprite for folder icons

### DIFF
--- a/assets/icons/sprite.svg
+++ b/assets/icons/sprite.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <symbol id="folder" viewBox="0 0 24 24">
+    <path fill="currentColor" d="M3 7a2 2 0 0 1 2-2h4l2 2h6a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z" />
+  </symbol>
+</svg>

--- a/components/apps/autopsy/KeywordSearchPanel.js
+++ b/components/apps/autopsy/KeywordSearchPanel.js
@@ -15,7 +15,11 @@ const typeIcons = {
   Document: '📄',
   Image: '🖼️',
   Log: '📜',
-  File: '📁',
+  File: (
+    <svg className="i">
+      <use href="#folder" />
+    </svg>
+  ),
   Registry: '🗃️',
 };
 
@@ -43,14 +47,15 @@ function KeywordSearchPanel({ keyword, setKeyword, artifacts, onSelect }) {
 
   return (
     <>
-      <div className="flex space-x-2">
-        <input
-          type="text"
-          value={keyword}
-          onChange={(e) => setKeyword(e.target.value)}
-          placeholder="Keyword search"
-          className="flex-grow bg-ub-grey text-white px-2 py-1 rounded"
-        />
+        <div className="flex space-x-2">
+          <input
+            type="text"
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            placeholder="Keyword search"
+            aria-label="Keyword search"
+            className="flex-grow bg-ub-grey text-white px-2 py-1 rounded"
+          />
         <button
           onClick={exportHits}
           className="bg-ub-orange px-2 py-1 rounded text-sm text-black"
@@ -68,7 +73,11 @@ function KeywordSearchPanel({ keyword, setKeyword, artifacts, onSelect }) {
           >
             <div className="flex items-center font-bold">
               <span className="mr-1" aria-hidden="true">
-                {typeIcons[a.type] || '📁'}
+                {typeIcons[a.type] || (
+                  <svg className="i">
+                    <use href="#folder" />
+                  </svg>
+                )}
               </span>
               <span
                 dangerouslySetInnerHTML={{ __html: highlight(a.name) }}

--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -281,15 +281,13 @@ function Timeline({ events, onSelect }) {
             className="w-full"
             aria-label="Timeline scrub bar"
           />
-          <datalist id="timeline-day-markers">
-            {dayMarkers.map((m) => (
-              <option
-                key={m.day}
-                value={m.idx}
-                label={new Date(m.day).toLocaleDateString()}
-              />
-            ))}
-          </datalist>
+            <datalist id="timeline-day-markers">
+              {dayMarkers.map((m) => (
+                <option key={m.day} value={m.idx}>
+                  {new Date(m.day).toLocaleDateString()}
+                </option>
+              ))}
+            </datalist>
           {hoverIndex !== null && sorted[hoverIndex] && (
             <div
               className="absolute -top-10 bg-ub-grey text-xs p-1 rounded"
@@ -553,7 +551,15 @@ function Autopsy({ initialArtifacts = null }) {
     return (
       <div key={node.name} className="pl-2">
         <div className="flex items-center h-8">
-          <span className="mr-1">{isFolder ? '📁' : '📄'}</span>
+          <span className="mr-1">
+            {isFolder ? (
+              <svg className="i">
+                <use href="#folder" />
+              </svg>
+            ) : (
+              '📄'
+            )}
+          </span>
           {isFolder ? (
             <span className="font-bold">{node.name}</span>
           ) : (
@@ -592,14 +598,15 @@ function Autopsy({ initialArtifacts = null }) {
         className="sr-only"
         dangerouslySetInnerHTML={{ __html: announcement }}
       />
-      <div className="flex space-x-2">
-        <input
-          type="text"
-          value={caseName}
-          onChange={(e) => setCaseName(e.target.value)}
-          placeholder="Case name"
-          className="flex-grow bg-ub-grey text-white px-2 py-1 rounded"
-        />
+        <div className="flex space-x-2">
+          <input
+            type="text"
+            value={caseName}
+            onChange={(e) => setCaseName(e.target.value)}
+            placeholder="Case name"
+            aria-label="Case name"
+            className="flex-grow bg-ub-grey text-white px-2 py-1 rounded"
+          />
         <button
           onClick={createCase}
           className="bg-ub-orange px-3 py-1 rounded"
@@ -640,13 +647,14 @@ function Autopsy({ initialArtifacts = null }) {
           </div>
         </div>
       )}
-      {analysis && (
-        <textarea
-          readOnly
-          value={analysis}
-          className="bg-ub-grey text-xs text-white p-2 rounded resize-none"
-        />
-      )}
+        {analysis && (
+          <textarea
+            readOnly
+            value={analysis}
+            aria-label="Analysis output"
+            className="bg-ub-grey text-xs text-white p-2 rounded resize-none"
+          />
+        )}
       {artifacts.length > 0 && (
         <div className="space-y-2">
           <div className="flex flex-wrap gap-2">

--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -43,7 +43,11 @@ const protocolIcons = {
   HTTP: '🌐',
   HTTPS: '🔒',
   ARP: '🔁',
-  FTP: '📁',
+  FTP: (
+    <svg className="i">
+      <use href="#folder" />
+    </svg>
+  ),
   SSH: '🔐',
 };
 
@@ -583,14 +587,15 @@ const Dsniff = () => {
           </button>
         ))}
       </div>
-      <div className="mb-2">
-        <input
-          className="w-full text-black p-1"
-          placeholder="Search logs"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-        />
-      </div>
+        <div className="mb-2">
+          <input
+            className="w-full text-black p-1"
+            placeholder="Search logs"
+            aria-label="Search logs"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
       <div className="mb-2">
         <div className="flex space-x-2 mb-2">
           <select
@@ -601,12 +606,13 @@ const Dsniff = () => {
             <option value="host">host</option>
             <option value="protocol">protocol</option>
           </select>
-          <input
-            className="flex-1 text-black p-1"
-            placeholder="Value"
-            value={newValue}
-            onChange={(e) => setNewValue(e.target.value)}
-          />
+            <input
+              className="flex-1 text-black p-1"
+              placeholder="Value"
+              aria-label="Value"
+              value={newValue}
+              onChange={(e) => setNewValue(e.target.value)}
+            />
           <button
             className="bg-ub-blue text-white px-2"
             onClick={addFilter}


### PR DESCRIPTION
## Summary
- add `assets/icons/sprite.svg` with reusable folder symbol
- replace folder emoji with `<svg>` sprite icon across dsniff and autopsy components
- add missing aria-labels to satisfy lint

## Testing
- `npx eslint components/apps/autopsy/index.js components/apps/autopsy/KeywordSearchPanel.js components/apps/dsniff/index.js`
- `yarn test components/apps/dsniff/index.js components/apps/autopsy/index.js components/apps/autopsy/KeywordSearchPanel.js --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c4756863908328a08edf64b1c4af3e