### PR TITLE
feat: add skip to content link

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -159,7 +159,9 @@ function MyApp(props) {
         <SettingsProvider>
           <PipPortalProvider>
             <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
+            <main id="main">
+              <Component {...pageProps} />
+            </main>
             <ShortcutOverlay />
             <Analytics
               beforeSend={(e) => {

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -21,6 +21,9 @@ class MyDocument extends Document {
           <script nonce={nonce} src="/theme.js" />
         </Head>
         <body>
+          <a href="#main" className="skip">
+            Skip to content
+          </a>
           <Main />
           <NextScript nonce={nonce} />
         </body>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -77,3 +77,24 @@ html[data-theme='matrix'] {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
+
+.skip {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip:focus {
+  left: 0;
+  top: 0;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  padding: 0.5rem;
+  background: var(--color-inverse);
+  color: var(--color-text);
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- add a visually hidden "Skip to content" link for accessibility
- wrap main app content in `<main id="main">`
- style skip link to appear on focus only

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: TypeError: e.preventDefault is not a function, Unable to find role="alert")*
- `yarn lint pages/_document.jsx pages/_app.jsx styles/globals.css` *(fails: 581 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c475741f14832890f5108522c125b8