### PR TITLE
feat: add tooltip component

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import Image from 'next/image';
 import { toCanvas } from 'html-to-image';
+import Tooltip from '../ui/Tooltip';
 
 export class SideBarApp extends Component {
     constructor() {
@@ -86,10 +87,12 @@ export class SideBarApp extends Component {
     };
 
     render() {
+        const tooltipId = `${this.props.id}-tooltip`;
         return (
             <button
                 type="button"
                 aria-label={this.props.title}
+                aria-describedby={tooltipId}
                 data-context="app"
                 data-app-id={this.props.id}
                 onClick={this.openApp}
@@ -98,6 +101,13 @@ export class SideBarApp extends Component {
                     this.setState({ showTitle: true });
                 }}
                 onMouseLeave={() => {
+                    this.setState({ showTitle: false, thumbnail: null });
+                }}
+                onFocus={() => {
+                    this.captureThumbnail();
+                    this.setState({ showTitle: true });
+                }}
+                onBlur={() => {
                     this.setState({ showTitle: false, thumbnail: null });
                 }}
                 className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
@@ -145,14 +155,12 @@ export class SideBarApp extends Component {
                         />
                     </div>
                 )}
-                <div
-                    className={
-                        (this.state.showTitle ? " visible " : " invisible ") +
-                        " w-max py-0.5 px-1.5 absolute top-1.5 left-full ml-3 m-1 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
-                    }
+                <Tooltip
+                    id={tooltipId}
+                    className={(this.state.showTitle ? " visible " : " invisible ") + " absolute top-1.5 left-full ml-3 m-1"}
                 >
                     {this.props.title}
-                </div>
+                </Tooltip>
             </button>
         );
     }

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import Image from 'next/image'
 import SideBarApp from '../base/side_bar_app';
+import Tooltip from '../ui/Tooltip';
 
 let renderApps = (props) => {
     let sideBarAppsJsx = [];
@@ -49,17 +50,29 @@ export default function SideBar(props) {
 export function AllApps(props) {
 
     const [title, setTitle] = useState(false);
+    const tooltipId = 'all-apps-tooltip';
 
     return (
         <div
             className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
             style={{ marginTop: 'auto' }}
+            role="button"
+            tabIndex={0}
+            aria-label="Show Applications"
+            aria-describedby={tooltipId}
             onMouseEnter={() => {
                 setTitle(true);
             }}
             onMouseLeave={() => {
                 setTitle(false);
             }}
+            onFocus={() => {
+                setTitle(true);
+            }}
+            onBlur={() => {
+                setTitle(false);
+            }}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); props.showApps(); } }}
             onClick={props.showApps}
         >
             <div className="relative">
@@ -71,14 +84,12 @@ export function AllApps(props) {
                     alt="Ubuntu view app"
                     sizes="28px"
                 />
-                <div
-                    className={
-                        (title ? " visible " : " invisible ") +
-                        " w-max py-0.5 px-1.5 absolute top-1 left-full ml-5 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
-                    }
+                <Tooltip
+                    id={tooltipId}
+                    className={(title ? " visible " : " invisible ") + " absolute top-1 left-full ml-5"}
                 >
                     Show Applications
-                </div>
+                </Tooltip>
             </div>
         </div>
     );

--- a/components/ui/Tooltip.tsx
+++ b/components/ui/Tooltip.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+interface TooltipProps {
+  children: React.ReactNode;
+  id?: string;
+  className?: string;
+}
+
+const Tooltip: React.FC<TooltipProps> = ({ children, id, className = '' }) => (
+  <div id={id} role="tooltip" className={`tooltip ${className}`}>{children}</div>
+);
+
+export default Tooltip;
+

--- a/styles/index.css
+++ b/styles/index.css
@@ -38,6 +38,18 @@ button:focus-visible {
     scroll-behavior: auto !important;
 }
 
+/* Tooltip component */
+.tooltip {
+    padding: 0.125rem 0.375rem;
+    font-size: 0.875rem;
+    color: var(--color-ubt-grey);
+    background-color: var(--color-ub-grey);
+    border: 1px solid rgba(156, 163, 175, 0.4);
+    border-radius: var(--radius-md);
+    pointer-events: none;
+    white-space: nowrap;
+}
+
 /* Top NavBar styling */
 
 .top-arrow-up {


### PR DESCRIPTION
## Summary
- add reusable Tooltip component with ARIA role
- show tooltips for dock icons and Show Applications button on hover or focus
- style tooltips for consistent appearance

## Testing
- `npm test` *(fails: Window snapping finalize and release releases snap with Alt+ArrowDown restoring size, NmapNSEApp copies example output to clipboard, TypeError: Cannot read properties of null (reading '_origin'))*

------
https://chatgpt.com/codex/tasks/task_e_68c4757582f88328b6322a219a9dfdd4