### PR TITLE
feat: add accessible region sections

### DIFF
--- a/apps/About/index.tsx
+++ b/apps/About/index.tsx
@@ -33,7 +33,11 @@ export default function AboutPage() {
   return (
     <div className="min-h-screen w-full bg-[var(--kali-bg)] text-sm">
       <div className="max-w-screen-md mx-auto my-4 sm:my-8 p-4 sm:p-6">
-        <section className="flex items-center mb-8">
+        <section
+          role="region"
+          aria-labelledby="profile-title"
+          className="flex items-center mb-8"
+        >
           <Image
             src="/images/logos/bitmoji.png"
             alt="Alex Unnippillil"
@@ -43,7 +47,9 @@ export default function AboutPage() {
             priority
           />
           <div className="ml-4 flex-1 space-y-1.5">
-            <h1 className="text-xl font-bold">Alex Unnippillil</h1>
+            <h1 id="profile-title" className="text-xl font-bold">
+              Alex Unnippillil
+            </h1>
             <p className="text-gray-200">Cybersecurity Specialist</p>
           </div>
           <div className="ml-4 flex gap-3">

--- a/apps/autopsy/components/CaseWalkthrough.tsx
+++ b/apps/autopsy/components/CaseWalkthrough.tsx
@@ -51,8 +51,10 @@ const CaseWalkthrough: React.FC = () => {
 
   return (
     <div className="space-y-6">
-      <section>
-        <h2 className="text-lg font-bold mb-2">Timeline</h2>
+      <section role="region" aria-labelledby="timeline-title">
+        <h2 id="timeline-title" className="text-lg font-bold mb-2">
+          Timeline
+        </h2>
         <ul className="space-y-2">
           {timeline.map((item, idx) => (
             <li key={idx} className="flex items-center text-sm">
@@ -64,8 +66,10 @@ const CaseWalkthrough: React.FC = () => {
           ))}
         </ul>
       </section>
-      <section>
-        <h2 className="text-lg font-bold mb-2">File Tree</h2>
+      <section role="region" aria-labelledby="file-tree-title">
+        <h2 id="file-tree-title" className="text-lg font-bold mb-2">
+          File Tree
+        </h2>
         {renderNode(fileTree)}
       </section>
     </div>

--- a/apps/nessus/index.tsx
+++ b/apps/nessus/index.tsx
@@ -168,8 +168,10 @@ const Nessus: React.FC = () => {
     <div className="p-4 bg-gray-900 text-white min-h-screen space-y-6">
       <h1 className="text-2xl">Nessus Demo</h1>
 
-      <section>
-        <h2 className="text-xl mb-2">Plugin Feed</h2>
+      <section role="region" aria-labelledby="plugin-feed-title">
+        <h2 id="plugin-feed-title" className="text-xl mb-2">
+          Plugin Feed
+        </h2>
         <button
           type="button"
           onClick={() => setDrawerOpen(true)}
@@ -195,8 +197,10 @@ const Nessus: React.FC = () => {
         )}
       </section>
 
-      <section>
-        <h2 className="text-xl mb-2">Scan Comparison</h2>
+      <section role="region" aria-labelledby="scan-comparison-title">
+        <h2 id="scan-comparison-title" className="text-xl mb-2">
+          Scan Comparison
+        </h2>
         <div className="mb-2">
           {diff.changed.map((c) => (
             <div key={c.plugin}>
@@ -212,8 +216,10 @@ const Nessus: React.FC = () => {
         </div>
       </section>
 
-      <section>
-        <h2 className="text-xl mb-2">Executive Summary</h2>
+      <section role="region" aria-labelledby="executive-summary-title">
+        <h2 id="executive-summary-title" className="text-xl mb-2">
+          Executive Summary
+        </h2>
         <div ref={chartRef}>
           <SummaryDashboard summary={summary} trend={trend} />
         </div>
@@ -225,8 +231,8 @@ const Nessus: React.FC = () => {
           Export
         </button>
       </section>
-      <section>
-        <h2 className="text-xl mb-2">Trends</h2>
+      <section role="region" aria-labelledby="trends-title">
+        <h2 id="trends-title" className="text-xl mb-2">Trends</h2>
         <TrendChart />
       </section>
       <FiltersDrawer

--- a/apps/openvas/index.tsx
+++ b/apps/openvas/index.tsx
@@ -168,8 +168,10 @@ const OpenVASReport: React.FC = () => {
         </div>
       </div>
 
-      <section>
-        <h2 className="text-xl mb-2">Scan Overview</h2>
+      <section role="region" aria-labelledby="scan-overview-title">
+        <h2 id="scan-overview-title" className="text-xl mb-2">
+          Scan Overview
+        </h2>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mb-4">
           {Object.entries(riskSummary).map(([risk, count]) => (
             <div
@@ -190,8 +192,10 @@ const OpenVASReport: React.FC = () => {
         </svg>
       </section>
 
-      <section>
-        <h2 className="text-xl mb-2">Findings</h2>
+      <section role="region" aria-labelledby="findings-title">
+        <h2 id="findings-title" className="text-xl mb-2">
+          Findings
+        </h2>
         <table className="w-full text-left text-sm">
           <thead>
             <tr>

--- a/components/WorkflowCard.tsx
+++ b/components/WorkflowCard.tsx
@@ -25,8 +25,14 @@ const steps: Step[] = [
 ];
 
 const WorkflowCard: React.FC = () => (
-  <section className="p-4 rounded bg-ub-grey text-white">
-    <h2 className="text-xl font-bold mb-2">Workflow</h2>
+  <section
+    role="region"
+    aria-labelledby="workflow-title"
+    className="p-4 rounded bg-ub-grey text-white"
+  >
+    <h2 id="workflow-title" className="text-xl font-bold mb-2">
+      Workflow
+    </h2>
     <ul>
       {steps.map((s) => (
         <li key={s.title} className="mb-2">

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -275,8 +275,12 @@ function WorkerStatus() {
   }, []);
 
   return (
-    <section aria-labelledby="app-status-heading" className="mt-8 w-5/6 md:w-3/4">
-      <h2 id="app-status-heading" className="text-lg font-bold text-center">
+    <section
+      role="region"
+      aria-labelledby="app-status-title"
+      className="mt-8 w-5/6 md:w-3/4"
+    >
+      <h2 id="app-status-title" className="text-lg font-bold text-center">
         Worker App Availability
       </h2>
       <ul role="list" className="mt-2">

--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -64,8 +64,13 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
       {children}
       <div className="notification-center">
         {Object.entries(notifications).map(([appId, list]) => (
-          <section key={appId} className="notification-group">
-            <h3>{appId}</h3>
+          <section
+            key={appId}
+            role="region"
+            aria-labelledby={`${appId}-title`}
+            className="notification-group"
+          >
+            <h3 id={`${appId}-title`}>{appId}</h3>
             <ul>
               {list.map(n => (
                 <li key={n.id}>{n.message}</li>

--- a/components/game/GameSettingsPanel.jsx
+++ b/components/game/GameSettingsPanel.jsx
@@ -121,8 +121,8 @@ export default function GameSettingsPanel({
 
   return (
     <div className="game-settings-panel">
-      <section>
-        <h3>Controls</h3>
+      <section role="region" aria-labelledby="controls-title">
+        <h3 id="controls-title">Controls</h3>
         {Object.entries(keymap).map(([action, key]) => (
           <div key={action} className="flex gap-2 items-center">
             <span className="w-20 capitalize">{action}</span>
@@ -136,8 +136,8 @@ export default function GameSettingsPanel({
         </p>
       </section>
 
-      <section>
-        <h3>Gameplay</h3>
+      <section role="region" aria-labelledby="gameplay-title">
+        <h3 id="gameplay-title">Gameplay</h3>
         <label className="block">
           Speed:
           <input
@@ -155,8 +155,8 @@ export default function GameSettingsPanel({
         </button>
       </section>
 
-      <section>
-        <h3>Progress</h3>
+      <section role="region" aria-labelledby="progress-title">
+        <h3 id="progress-title">Progress</h3>
         <div className="flex gap-2">
           <button onClick={saveSnapshot}>Save Snapshot</button>
           <button onClick={loadSnapshotClick}>Load Snapshot</button>
@@ -167,8 +167,8 @@ export default function GameSettingsPanel({
         </div>
       </section>
 
-      <section>
-        <h3>Display</h3>
+      <section role="region" aria-labelledby="display-title">
+        <h3 id="display-title">Display</h3>
         <label className="block mb-2">
           Palette:
           <select
@@ -200,8 +200,8 @@ export default function GameSettingsPanel({
         </label>
       </section>
 
-      <section>
-        <h3>Input Latency</h3>
+      <section role="region" aria-labelledby="input-latency-title">
+        <h3 id="input-latency-title">Input Latency</h3>
         <button onClick={startLatencyTest}>Start Test</button>
         {latency !== null && <div>{latency.toFixed(0)} ms</div>}
       </section>

--- a/pages/module-workspace.tsx
+++ b/pages/module-workspace.tsx
@@ -103,8 +103,14 @@ const ModuleWorkspace: React.FC = () => {
 
   return (
     <div className="p-4 space-y-4 bg-ub-cool-grey text-white min-h-screen">
-      <section className="space-y-2">
-        <h1 className="text-xl font-semibold">Workspaces</h1>
+      <section
+        role="region"
+        aria-labelledby="workspaces-title"
+        className="space-y-2"
+      >
+        <h1 id="workspaces-title" className="text-xl font-semibold">
+          Workspaces
+        </h1>
         <div className="flex gap-2">
           <input
             value={newWorkspace}

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -36,8 +36,14 @@ export default function PostExploitation() {
     <>
       <Meta />
       <main className="mx-auto grid gap-4 p-4 md:grid-cols-2">
-        <section className="prose">
-          <h1>Metasploit Post-Exploitation Modules</h1>
+        <section
+          role="region"
+          aria-labelledby="post-exploitation-modules-title"
+          className="prose"
+        >
+          <h1 id="post-exploitation-modules-title">
+            Metasploit Post-Exploitation Modules
+          </h1>
           <p>
             Post-exploitation refers to any actions taken after a session is opened. Rapid7&apos;s{' '}
             <a

--- a/public/module-report.html
+++ b/public/module-report.html
@@ -11,8 +11,8 @@
 <body>
   <h1>Module Report</h1>
   
-  <section>
-    <h2>Port Scanner</h2>
+  <section role="region" aria-labelledby="port-scanner-title">
+    <h2 id="port-scanner-title">Port Scanner</h2>
     <p>Scans for open network ports</p>
     <h3>Logs</h3>
     <ul>
@@ -23,8 +23,8 @@
       <li>192.168.0.1: Ports 22,80 open</li><li>192.168.0.2: No open ports</li>
     </ul>
   </section>
-  <section>
-    <h2>Brute Force</h2>
+  <section role="region" aria-labelledby="brute-force-title">
+    <h2 id="brute-force-title">Brute Force</h2>
     <p>Attempts common passwords</p>
     <h3>Logs</h3>
     <ul>
@@ -35,8 +35,8 @@
       <li>admin@example.com: Login failed</li><li>root@example.com: Login failed</li>
     </ul>
   </section>
-  <section>
-    <h2>Vuln Check</h2>
+  <section role="region" aria-labelledby="vuln-check-title">
+    <h2 id="vuln-check-title">Vuln Check</h2>
     <p>Checks for known CVEs</p>
     <h3>Logs</h3>
     <ul>

--- a/public/offline.html
+++ b/public/offline.html
@@ -11,8 +11,8 @@
     <h1>Offline</h1>
     <p>You appear to be offline. Please check your connection.</p>
     <button id="retry">Retry</button>
-    <section>
-      <h2>Cached Apps</h2>
+    <section role="region" aria-labelledby="cached-apps-title">
+      <h2 id="cached-apps-title">Cached Apps</h2>
       <ul id="apps"></ul>
     </section>
   </main>

--- a/scripts/generate-module-report.mjs
+++ b/scripts/generate-module-report.mjs
@@ -28,8 +28,8 @@ function render(mods) {
   ${mods
     .map(
       (m) => `
-  <section>
-    <h2>${escapeHtml(m.name)}</h2>
+  <section role="region" aria-labelledby="${m.id}-title" id="${m.id}">
+    <h2 id="${m.id}-title">${escapeHtml(m.name)}</h2>
     <p>${escapeHtml(m.description)}</p>
     <h3>Logs</h3>
     <ul>


### PR DESCRIPTION
## Summary
- use `<section role="region" aria-labelledby="...">` for key layout sections
- provide matching heading IDs for accessible names
- update static and generated reports with labelled regions

## Testing
- `yarn lint` *(fails: Unexpected global 'document' and missing display name)*
- `yarn test` *(fails: e.preventDefault is not a function; Unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68c4757484248328808a024f8fa7650a