### PR TITLE
feat: add accent color picker

### DIFF
--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -50,6 +50,13 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
                   style={{ backgroundColor: c }}
                 />
               ))}
+              <input
+                type="color"
+                aria-label="custom-accent"
+                value={accent}
+                onChange={(e) => setAccent(e.target.value)}
+                className="w-6 h-6 p-0 border-none bg-transparent"
+              />
             </div>
           </label>
         </div>

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -145,6 +145,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       '--color-focus-ring': accent,
       '--color-selection': accent,
       '--color-control-accent': accent,
+      '--accent': accent,
     };
     Object.entries(vars).forEach(([key, value]) => {
       document.documentElement.style.setProperty(key, value);

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -18,12 +18,13 @@ const DEFAULT_SETTINGS = {
 
 export async function getAccent() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
-  return (await get('accent')) || DEFAULT_SETTINGS.accent;
+  const stored = window.localStorage.getItem('accent');
+  return stored || DEFAULT_SETTINGS.accent;
 }
 
 export async function setAccent(accent) {
   if (typeof window === 'undefined') return;
-  await set('accent', accent);
+  window.localStorage.setItem('accent', accent);
 }
 
 export async function getWallpaper() {
@@ -125,10 +126,8 @@ export async function setAllowNetwork(value) {
 
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
-  await Promise.all([
-    del('accent'),
-    del('bg-image'),
-  ]);
+  await del('bg-image');
+  window.localStorage.removeItem('accent');
   window.localStorage.removeItem('density');
   window.localStorage.removeItem('reduced-motion');
   window.localStorage.removeItem('font-scale');


### PR DESCRIPTION
## Summary
- allow custom accent colors with new color input
- update root `--accent` variable and store choice in `localStorage`

## Testing
- `yarn test` *(fails: TypeError e.preventDefault is not a function; Unable to find role="alert")*


------
https://chatgpt.com/codex/tasks/task_e_68c47576e37083289064ac481edba9de