### PR TITLE
Respect save-data preference

### DIFF
--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -6,8 +6,10 @@ import { useSettings } from '../../hooks/useSettings';
 export default function BackgroundImage() {
     const { wallpaper } = useSettings();
     const [needsOverlay, setNeedsOverlay] = useState(false);
+    const saveData = typeof navigator !== 'undefined' && navigator.connection?.saveData;
 
     useEffect(() => {
+        if (saveData) return;
         const img = new Image();
         img.src = `/wallpapers/${wallpaper}.webp`;
         img.onload = () => {
@@ -34,7 +36,17 @@ export default function BackgroundImage() {
             const contrast = (1.05) / (lum + 0.05); // white text luminance is 1
             setNeedsOverlay(contrast < 4.5);
         };
-    }, [wallpaper]);
+    }, [wallpaper, saveData]);
+
+    if (saveData) {
+        return (
+            <div
+                className="absolute -z-10 top-0 right-0 overflow-hidden h-full w-full"
+                style={{ backgroundColor: 'var(--color-bg)' }}
+                aria-hidden="true"
+            />
+        );
+    }
 
     return (
         <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -146,6 +146,20 @@ function MyApp(props) {
     };
   }, []);
 
+  useEffect(() => {
+    const connection = navigator.connection;
+    if (connection?.saveData) {
+      document.body.style.backgroundImage = 'none';
+      const images = document.querySelectorAll('img');
+      images.forEach((img) => {
+        const isCritical = img.getAttribute('data-critical') === 'true';
+        if (!isCritical && img.getAttribute('loading') !== 'eager') {
+          img.loading = 'lazy';
+        }
+      });
+    }
+  }, []);
+
   return (
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />


### PR DESCRIPTION
## Summary
- Avoid wallpaper download when `navigator.connection.saveData` is enabled
- Defer non-critical image loading when save-data is active

## Testing
- `yarn lint` *(fails: A control must be associated with a text label ... )*
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c475782b1c8328b27c8dc4fd000e7c