### PR TITLE
feat: ensure font display swap

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -22,6 +22,7 @@ import { Ubuntu } from 'next/font/google';
 const ubuntu = Ubuntu({
   subsets: ['latin'],
   weight: ['300', '400', '500', '700'],
+  display: 'swap',
 });
 
 


### PR DESCRIPTION
## Summary
- ensure Ubuntu font uses swap display

## Testing
- `npx eslint pages/_app.jsx`
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: e.preventDefault is not a function; Unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68c47579ddd48328be84c3b9bfeefa11