### PR TITLE
Add fonts preconnect hints

### DIFF
--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -17,6 +17,8 @@ class MyDocument extends Document {
         <Head>
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+          <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
           <meta name="theme-color" content="#0f1317" />
           <script nonce={nonce} src="/theme.js" />
         </Head>


### PR DESCRIPTION
## Summary
- add resource hints for fonts.gstatic.com in the document head

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c4757addfc8328a95ad68277487d90