### PR TITLE
test: drawer search and theme persistence

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
   testMatch: /.*\.spec\.ts/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    ignoreHTTPSErrors: true,
   },
 });

--- a/tests/drawer-theme.spec.ts
+++ b/tests/drawer-theme.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+test('drawer search and theme persistence', async ({ page }) => {
+  await page.goto('/');
+
+  // Ensure menu is ready then open drawer with Meta key and search
+  await page.waitForSelector('button:has-text("Applications")');
+  await page.evaluate(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Meta', metaKey: true }));
+  });
+  const searchInput = page.locator('input[placeholder="Search"]');
+  await expect(searchInput).toBeVisible();
+  await searchInput.fill('proj');
+  await expect(page.getByText('Project Gallery', { exact: true })).toBeVisible();
+  await page.keyboard.press('Escape');
+
+  // Cycle theme three times
+  await page.locator('#status-bar').click();
+  const themeButton = page.getByRole('button', { name: /^Theme/ });
+  await expect(themeButton).toBeVisible();
+  for (let i = 0; i < 3; i++) {
+    await themeButton.click();
+  }
+
+  // Reload and verify dark theme persists
+  await page.reload();
+  await expect(page.locator('html')).toHaveClass(/dark/);
+
+  await page.locator('#status-bar').click();
+  await expect(page.getByRole('button', { name: /Theme Dark/ })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- ignore HTTPS issues in Playwright config
- add Playwright test for drawer search and theme persistence

## Testing
- `npx playwright install`
- `BASE_URL=https://unnippillil.com npx playwright test tests/drawer-theme.spec.ts` *(fails: waiting for locator('button:has-text("Applications")') to be visible)*

------
https://chatgpt.com/codex/tasks/task_e_68c4757e7d2c8328bdf4befa338e4e05