### PR TITLE
style: add borders and focus outlines for controls

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,6 +14,7 @@
   --color-surface: #1a1f26; /* panel surfaces */
   --color-inverse: #000000; /* inverse of text */
   --color-border: #2a2e36; /* subtle borders */
+  --panel-border: var(--color-border);
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
   --color-focus-ring: var(--color-accent);

--- a/styles/index.css
+++ b/styles/index.css
@@ -16,9 +16,18 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
     min-height: var(--hit-area);
 }
 
+input,
+select,
+button {
+    border: 1px solid var(--panel-border);
+    border-radius: 6px;
+}
+
 a:focus-visible,
-button:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
+button:focus-visible,
+input:focus-visible,
+select:focus-visible {
+    outline: var(--focus-outline-width) solid var(--color-accent) !important;
     outline-offset: 2px;
 }
 


### PR DESCRIPTION
## Summary
- add global `--panel-border` variable
- style input/select/button with panel borders and rounded corners
- highlight focused form controls with accent outline

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c475720b10832884559e0fb9273a2a