### PR TITLE
Add aria labels to icon buttons

### DIFF
--- a/apps/chrome/components/AddressBar.tsx
+++ b/apps/chrome/components/AddressBar.tsx
@@ -77,6 +77,7 @@ export default function AddressBar({ url, onNavigate }: Props) {
         onClick={goBack}
         disabled={index <= 0}
         className="px-2 border rounded"
+        aria-label="Back"
       >
         ◀
       </button>
@@ -85,6 +86,7 @@ export default function AddressBar({ url, onNavigate }: Props) {
         onClick={goForward}
         disabled={index >= history.length - 1}
         className="px-2 border rounded"
+        aria-label="Forward"
       >
         ▶
       </button>

--- a/apps/hashcat/index.tsx
+++ b/apps/hashcat/index.tsx
@@ -274,6 +274,7 @@ const Hashcat: React.FC = () => {
                 type="button"
                 onClick={() => removeDictionary(d)}
                 className="ml-1"
+                aria-label={`Remove dictionary ${d}`}
               >
                 ×
               </button>

--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -411,13 +411,25 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
 
   return (
     <div ref={containerRef} className="relative" tabIndex={0}>
-      <button className="absolute left-4 bottom-4" {...bind('left')}>
+      <button
+        className="absolute left-4 bottom-4"
+        {...bind('left')}
+        aria-label="Move left"
+      >
         ◀
       </button>
-      <button className="absolute left-20 bottom-4" {...bind('right')}>
+      <button
+        className="absolute left-20 bottom-4"
+        {...bind('right')}
+        aria-label="Move right"
+      >
         ▶
       </button>
-      <button className="absolute right-4 bottom-4" {...bind('jump')}>
+      <button
+        className="absolute right-4 bottom-4"
+        {...bind('jump')}
+        aria-label="Jump"
+      >
         ⇧
       </button>
       <div className="absolute top-4 left-4 bg-white bg-opacity-80 p-2 rounded text-xs space-y-1">

--- a/apps/quote/components/PlaylistBuilder.tsx
+++ b/apps/quote/components/PlaylistBuilder.tsx
@@ -146,6 +146,7 @@ export default function PlaylistBuilder({ quotes, playlist, setPlaylist }: Playl
                   <button
                     onClick={() => deletePlaylist(name)}
                     className="px-2 py-1 bg-gray-700 rounded"
+                    aria-label={`Delete playlist ${name}`}
                   >
                     ✕
                   </button>
@@ -170,6 +171,7 @@ export default function PlaylistBuilder({ quotes, playlist, setPlaylist }: Playl
                 setPlaylist(playlist.filter((_, j) => j !== idx))
               }
               className="px-2 py-1 bg-gray-700 rounded"
+              aria-label="Remove quote"
             >
               ✕
             </button>

--- a/apps/radare2/components/GraphView.tsx
+++ b/apps/radare2/components/GraphView.tsx
@@ -190,6 +190,7 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
             backgroundColor: "var(--r2-surface)",
             border: "1px solid var(--r2-border)",
           }}
+          aria-label="Zoom in"
         >
           +
         </button>
@@ -200,6 +201,7 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
             backgroundColor: "var(--r2-surface)",
             border: "1px solid var(--r2-border)",
           }}
+          aria-label="Zoom out"
         >
           -
         </button>
@@ -210,6 +212,7 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
             backgroundColor: "var(--r2-surface)",
             border: "1px solid var(--r2-border)",
           }}
+          aria-label="Pan up"
         >
           ↑
         </button>
@@ -220,6 +223,7 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
             backgroundColor: "var(--r2-surface)",
             border: "1px solid var(--r2-border)",
           }}
+          aria-label="Pan down"
         >
           ↓
         </button>
@@ -230,6 +234,7 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
             backgroundColor: "var(--r2-surface)",
             border: "1px solid var(--r2-border)",
           }}
+          aria-label="Pan left"
         >
           ←
         </button>
@@ -240,6 +245,7 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
             backgroundColor: "var(--r2-surface)",
             border: "1px solid var(--r2-border)",
           }}
+          aria-label="Pan right"
         >
           →
         </button>

--- a/apps/spotify/components/MoodTuner.tsx
+++ b/apps/spotify/components/MoodTuner.tsx
@@ -110,6 +110,7 @@ const MoodTuner = () => {
               onClick={previous}
               title="Prev (P)"
               className="w-8 h-8 flex items-center justify-center"
+              aria-label="Previous track"
             >
               ⏮<span className="sr-only">(P)</span>
             </button>
@@ -117,6 +118,7 @@ const MoodTuner = () => {
               onClick={togglePlay}
               title="Play/Pause (Space)"
               className="w-8 h-8 flex items-center justify-center"
+              aria-label={isPlaying ? 'Pause' : 'Play'}
             >
               {isPlaying ? "⏸" : "▶"}
               <span className="sr-only">(Space)</span>
@@ -125,6 +127,7 @@ const MoodTuner = () => {
               onClick={next}
               title="Next (N)"
               className="w-8 h-8 flex items-center justify-center"
+              aria-label="Next track"
             >
               ⏭<span className="sr-only">(N)</span>
             </button>

--- a/apps/spotify/index.tsx
+++ b/apps/spotify/index.tsx
@@ -160,6 +160,7 @@ const SpotifyApp = () => {
             title="Previous"
             disabled={!queue.length}
             className="w-9 h-9 flex items-center justify-center"
+            aria-label="Previous track"
           >
             ⏮
           </button>
@@ -168,6 +169,7 @@ const SpotifyApp = () => {
             title="Play/Pause"
             disabled={!queue.length}
             className="w-9 h-9 flex items-center justify-center"
+            aria-label="Play/Pause"
           >
             ⏯
           </button>
@@ -176,6 +178,7 @@ const SpotifyApp = () => {
             title="Next"
             disabled={!queue.length}
             className="w-9 h-9 flex items-center justify-center"
+            aria-label="Next track"
           >
             ⏭
           </button>

--- a/apps/x/index.tsx
+++ b/apps/x/index.tsx
@@ -364,6 +364,7 @@ export default function XTimeline() {
                     type="button"
                     onClick={() => removeScheduled(t.id)}
                     className="ml-2 px-2 py-1 rounded bg-[var(--color-muted)] text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+                    aria-label="Remove scheduled item"
                   >
                     ×
                   </button>

--- a/components/apps/chrome/index.tsx
+++ b/components/apps/chrome/index.tsx
@@ -536,9 +536,24 @@ const Chrome: React.FC = () => {
           <div key={i} className="flex flex-col items-center">
             {editingTiles && (
               <div className="mb-1 space-x-1">
-                <button onClick={() => moveTile(i, -1)}>↑</button>
-                <button onClick={() => moveTile(i, 1)}>↓</button>
-                <button onClick={() => removeTile(i)}>×</button>
+                <button
+                  onClick={() => moveTile(i, -1)}
+                  aria-label="Move tile up"
+                >
+                  ↑
+                </button>
+                <button
+                  onClick={() => moveTile(i, 1)}
+                  aria-label="Move tile down"
+                >
+                  ↓
+                </button>
+                <button
+                  onClick={() => removeTile(i)}
+                  aria-label="Remove tile"
+                >
+                  ×
+                </button>
               </div>
             )}
             {(() => {

--- a/components/apps/space-invaders.js
+++ b/components/apps/space-invaders.js
@@ -842,6 +842,7 @@ const SpaceInvaders = () => {
             className="bg-gray-700 px-4 py-2 rounded"
             onTouchStart={touchStart('left')}
             onTouchEnd={touchEnd('left')}
+            aria-label="Move left"
           >
             ◀
           </button>
@@ -849,6 +850,7 @@ const SpaceInvaders = () => {
             className="bg-gray-700 px-4 py-2 rounded"
             onTouchStart={touchStart('fire')}
             onTouchEnd={touchEnd('fire')}
+            aria-label="Fire"
           >
             🔥
           </button>
@@ -856,6 +858,7 @@ const SpaceInvaders = () => {
             className="bg-gray-700 px-4 py-2 rounded"
             onTouchStart={touchStart('right')}
             onTouchEnd={touchEnd('right')}
+            aria-label="Move right"
           >
             ▶
           </button>

--- a/components/apps/spotify.jsx
+++ b/components/apps/spotify.jsx
@@ -61,9 +61,9 @@ export default function SpotifyApp() {
     <div className="h-full w-full flex flex-col items-center justify-center gap-4 bg-black bg-opacity-30 text-white">
       <p>Spotify player connected.</p>
       <div className="flex gap-4">
-        <button onClick={() => player.previousTrack()}>⏮</button>
-        <button onClick={() => player.togglePlay()}>⏯</button>
-        <button onClick={() => player.nextTrack()}>⏭</button>
+        <button onClick={() => player.previousTrack()} aria-label="Previous track">⏮</button>
+        <button onClick={() => player.togglePlay()} aria-label="Play/Pause">⏯</button>
+        <button onClick={() => player.nextTrack()} aria-label="Next track">⏭</button>
       </div>
     </div>
   ) : (
@@ -71,9 +71,9 @@ export default function SpotifyApp() {
       <p>Sample tracks (CC‑licensed)</p>
       <audio ref={audioRef} src={SAMPLE_TRACKS[index].url} onEnded={nextSample} />
       <div className="flex gap-4">
-        <button onClick={prevSample}>⏮</button>
-        <button onClick={toggleSample}>⏯</button>
-        <button onClick={nextSample}>⏭</button>
+        <button onClick={prevSample} aria-label="Previous sample">⏮</button>
+        <button onClick={toggleSample} aria-label="Play/Pause sample">⏯</button>
+        <button onClick={nextSample} aria-label="Next sample">⏭</button>
       </div>
       <p className="text-xs">{SAMPLE_TRACKS[index].title}</p>
     </div>


### PR DESCRIPTION
## Summary
- add `aria-label` to icon-only buttons across the app
- improve accessibility for controls in Chrome, Spotify, games and utilities

## Testing
- `yarn lint` *(fails: Unexpected global 'document'; Component definition missing display name)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c47568a5488328b759f1ec318d541f