### PR TITLE
feat: add high contrast data attribute

### DIFF
--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -193,7 +193,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [fontScale]);
 
   useEffect(() => {
-    document.documentElement.classList.toggle('high-contrast', highContrast);
+    if (highContrast) {
+      document.documentElement.setAttribute('data-contrast', 'high');
+    } else {
+      document.documentElement.removeAttribute('data-contrast');
+    }
     saveHighContrast(highContrast);
   }, [highContrast]);
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -526,7 +526,17 @@ textarea:focus-visible {
 }
 
 /* High contrast overrides */
-.high-contrast .bg-ub-orange {
+[data-contrast="high"] {
+    color: var(--color-text);
+}
+
+[data-contrast="high"] *,
+[data-contrast="high"] *::before,
+[data-contrast="high"] *::after {
+    border-color: color-mix(in srgb, currentColor, transparent 15%);
+}
+
+[data-contrast="high"] .bg-ub-orange {
     color: #000 !important;
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -62,7 +62,7 @@
 }
 
 /* High contrast theme */
-.high-contrast {
+[data-contrast="high"] {
   --color-bg: #000000;
   --color-text: #ffffff;
   --color-ub-grey: #000000;
@@ -76,6 +76,7 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --color-border: #ffffff;
 }
 
 /* Dyslexia-friendly fonts */


### PR DESCRIPTION
## Summary
- toggle `[data-contrast="high"]` on the root element from settings
- bump text contrast and border visibility when high contrast mode is active

## Testing
- `npx eslint hooks/useSettings.tsx styles/index.css styles/tokens.css`
- `npx jest themePersistence.test.ts` *(fails: TypeError Cannot read properties of null (reading '_origin'))*

------
https://chatgpt.com/codex/tasks/task_e_68c4757797788328833bad72358d48d6