### PR TITLE
[search] use Fuse for fuzzy app lookup

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -38,6 +38,7 @@ export class UbuntuApp extends Component {
                 aria-disabled={this.props.disabled}
                 data-context="app"
                 data-app-id={this.props.id}
+                data-keywords={this.props.keywords}
                 draggable
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import Fuse from 'fuse.js';
 
 type AppMeta = {
   id: string;
@@ -10,6 +11,7 @@ type AppMeta = {
   icon: string;
   disabled?: boolean;
   favourite?: boolean;
+  keywords?: string;
 };
 
 const CATEGORIES = [
@@ -60,8 +62,12 @@ const WhiskerMenu: React.FC = () => {
         list = allApps;
     }
     if (query) {
-      const q = query.toLowerCase();
-      list = list.filter(a => a.title.toLowerCase().includes(q));
+      const fuse = new Fuse(list, {
+        keys: ['title', 'keywords'],
+        threshold: 0.3,
+        ignoreLocation: true,
+      });
+      list = fuse.search(query).map(r => r.item);
     }
     return list;
   }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps]);
@@ -164,12 +170,13 @@ const WhiskerMenu: React.FC = () => {
             <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
               {currentApps.map((app, idx) => (
                 <div key={app.id} className={idx === highlight ? 'ring-2 ring-ubb-orange' : ''}>
-                  <UbuntuApp
+                <UbuntuApp
                     id={app.id}
                     icon={app.icon}
                     name={app.title}
                     openApp={() => openSelectedApp(app.id)}
                     disabled={app.disabled}
+                    keywords={app.keywords}
                   />
                 </div>
               ))}

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import UbuntuApp from '../base/ubuntu_app';
+import Fuse from 'fuse.js';
 
 class AllApplications extends React.Component {
     constructor() {
@@ -23,12 +24,15 @@ class AllApplications extends React.Component {
     handleChange = (e) => {
         const value = e.target.value;
         const { unfilteredApps } = this.state;
-        const apps =
-            value === '' || value === null
-                ? unfilteredApps
-                : unfilteredApps.filter((app) =>
-                      app.title.toLowerCase().includes(value.toLowerCase())
-                  );
+        let apps = unfilteredApps;
+        if (value) {
+            const fuse = new Fuse(unfilteredApps, {
+                keys: ['title', 'keywords'],
+                threshold: 0.3,
+                ignoreLocation: true,
+            });
+            apps = fuse.search(value).map(r => r.item);
+        }
         this.setState({ query: value, apps });
     };
 
@@ -49,6 +53,7 @@ class AllApplications extends React.Component {
                 openApp={() => this.openApp(app.id)}
                 disabled={app.disabled}
                 prefetch={app.screen?.prefetch}
+                keywords={app.keywords}
             />
         ));
     };

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "dompurify": "^3.2.6",
     "fast-xml-parser": "^4.3.5",
     "figlet": "^1.8.2",
+    "fuse.js": "^7.1.0",
     "hash-wasm": "^4.12.0",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7640,6 +7640,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fuse.js@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "fuse.js@npm:7.1.0"
+  checksum: 10c0/c0d1b1d192a4bdf3eade897453ddd28aff96b70bf3e49161a45880f9845ebaee97265595db633776700a5bcf8942223c752754a848d70c508c3c9fd997faad1e
+  languageName: node
+  linkType: hard
+
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -13911,6 +13918,7 @@ __metadata:
     fast-glob: "npm:^3.3.3"
     fast-xml-parser: "npm:^4.3.5"
     figlet: "npm:^1.8.2"
+    fuse.js: "npm:^7.1.0"
     hash-wasm: "npm:^4.12.0"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"


### PR DESCRIPTION
## Summary
- add Fuse.js dependency for fuzzy search
- switch app listings to Fuse-based fuzzy matching across titles and keywords
- expose `data-keywords` attribute on UbuntuApp tiles

## Testing
- `yarn lint` *(fails: Unexpected global 'document' etc.)*
- `yarn test` *(fails: window snapping finalize and release; NmapNSEApp copies example output; modal closes when Escape pressed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f23b18cc8328b27ebc1f9ef833d8