### PR TITLE
[pages] add terminal-style 404 page

### DIFF
--- a/__tests__/404.test.tsx
+++ b/__tests__/404.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NotFoundPage from '../pages/404';
+
+jest.mock('../components/ubuntu', () => function Ubuntu() {
+  return <div />;
+});
+jest.mock('../components/BetaBadge', () => function BetaBadge() {
+  return <div />;
+});
+jest.mock('../components/InstallButton', () => function InstallButton() {
+  return <div />;
+});
+
+describe('404 page', () => {
+  it('renders command not found message and help link', () => {
+    render(<NotFoundPage />);
+    expect(screen.getByText(/command not found/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /help/i })).toBeInTheDocument();
+  });
+});

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,67 @@
+import dynamic from 'next/dynamic';
+import { useCallback } from 'react';
+import Meta from '../components/SEO/Meta';
+import BetaBadge from '../components/BetaBadge';
+
+const Ubuntu = dynamic(
+  () =>
+    import('../components/ubuntu').catch((err) => {
+      console.error('Failed to load Ubuntu component', err);
+      throw err;
+    }),
+  {
+    ssr: false,
+    loading: () => <p>Loading Ubuntu...</p>,
+  },
+);
+
+const InstallButton = dynamic(
+  () =>
+    import('../components/InstallButton').catch((err) => {
+      console.error('Failed to load InstallButton component', err);
+      throw err;
+    }),
+  {
+    ssr: false,
+    loading: () => <p>Loading install options...</p>,
+  },
+);
+
+const NotFoundPage = () => {
+  const openHelp = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    window.dispatchEvent(new CustomEvent('open-app', { detail: 'terminal' }));
+    setTimeout(() => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { ctrlKey: true, shiftKey: true, key: 'p' }),
+      );
+    }, 100);
+  }, []);
+
+  return (
+    <>
+      <a href="#window-area" className="sr-only focus:not-sr-only">
+        Skip to content
+      </a>
+      <Meta title="404: command not found" />
+      <Ubuntu />
+      <BetaBadge />
+      <InstallButton />
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+        <p className="text-white text-lg">
+          command not found. Try{' '}
+          <button
+            type="button"
+            onClick={openHelp}
+            className="underline pointer-events-auto"
+          >
+            help
+          </button>
+          .
+        </p>
+      </div>
+    </>
+  );
+};
+
+export default NotFoundPage;

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>command not found</title>
+  <style>
+    body { display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; background: #000; color: #fff; font-family: sans-serif; }
+    a { color: #4ea1ff; }
+  </style>
+</head>
+<body>
+  <p>command not found. Try <a href="#" id="help-link">help</a>.</p>
+  <script>
+    document.getElementById('help-link').addEventListener('click', function(e) {
+      e.preventDefault();
+      window.dispatchEvent(new CustomEvent('open-app', { detail: 'terminal' }));
+      setTimeout(function() {
+        window.dispatchEvent(new KeyboardEvent('keydown', { ctrlKey: true, shiftKey: true, key: 'p' }));
+      }, 100);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show `command not found` on unknown routes
- provide link to open terminal command palette
- add plain fallback `public/404.html`

## Testing
- `yarn lint` (fails: Unexpected global 'document')
- `yarn test` (fails: e.preventDefault is not a function)


------
https://chatgpt.com/codex/tasks/task_e_68c4f23d8610832881dd942458ce3764