### PR TITLE
[error] add static 500 page

### DIFF
--- a/public/500.html
+++ b/public/500.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Server Error</title>
+  <style>
+    body { background-color: #0f1317; color: #F5F5F5; font-family: Ubuntu, sans-serif; display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; margin: 0; }
+    a { color: #1793d1; text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <h1>500 - Server Error</h1>
+  <p>Something went wrong.</p>
+  <a href="/">Retry</a>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,9 @@
   "functions": {
     "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
     "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
-  }
+  },
+  "routes": [
+    { "handle": "error" },
+    { "status": 500, "dest": "/500.html" }
+  ]
 }


### PR DESCRIPTION
## Summary
- add static `/500.html` error page with brand palette and retry link
- route server errors to the new page via `vercel.json`

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c4f23e0348832882507cc4e3e7ea17