### PR TITLE
[ui] add rtl layout support for panel and menus

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -134,7 +134,7 @@ const WhiskerMenu: React.FC = () => {
       {open && (
         <div
           ref={menuRef}
-          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
+          className="whisker-menu absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
           tabIndex={-1}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node)) {

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -57,7 +57,7 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 text-white">
+    <div className="wswitch fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 text-white">
       <div className="bg-ub-grey p-4 rounded w-3/4 md:w-1/3">
         <input
           ref={inputRef}

--- a/styles/index.css
+++ b/styles/index.css
@@ -530,3 +530,26 @@ textarea:focus-visible {
     color: #000 !important;
 }
 
+/* RTL layout adjustments */
+[dir="rtl"] .main-navbar-vp {
+    flex-direction: row-reverse;
+}
+
+[dir="rtl"] .whisker-menu {
+    flex-direction: row-reverse;
+    right: 0;
+    left: auto;
+}
+
+[dir="rtl"] .whisker-menu button {
+    text-align: right;
+}
+
+[dir="rtl"] [role="menu"] {
+    text-align: right;
+}
+
+[dir="rtl"] .wswitch {
+    flex-direction: row-reverse;
+}
+


### PR DESCRIPTION
## Summary
- add `[dir="rtl"]` rules to reverse navbar order and align menus
- enable Whisker menu and window switcher flipping via flex row-reverse

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/Modal.test.tsx` *(fails: e.preventDefault is not a function; unable to find role="alert")*
- `yarn smoke` *(fails: Playwright executable doesn't exist)*
- `npx playwright test` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f23f82ec8328ae1e05c95da50c52