### PR TITLE
[desktop] support meta key shortcuts

### DIFF
--- a/__tests__/desktopMetaShortcut.test.ts
+++ b/__tests__/desktopMetaShortcut.test.ts
@@ -1,0 +1,37 @@
+import { Desktop } from '../components/screen/desktop';
+
+describe('desktop settings shortcut', () => {
+  const originalNavigator = navigator;
+
+  const setPlatform = (platform: string) => {
+    Object.defineProperty(window, 'navigator', {
+      value: { platform },
+      configurable: true,
+    });
+  };
+
+  afterEach(() => {
+    Object.defineProperty(window, 'navigator', {
+      value: originalNavigator,
+      configurable: true,
+    });
+  });
+
+  test('Cmd+, opens settings on mac', () => {
+    setPlatform('MacIntel');
+    const desktop = new Desktop();
+    desktop.openApp = jest.fn();
+    const event = new KeyboardEvent('keydown', { metaKey: true, key: ',' });
+    desktop.handleGlobalShortcut(event);
+    expect(desktop.openApp).toHaveBeenCalledWith('settings');
+  });
+
+  test('Win+, opens settings on windows', () => {
+    setPlatform('Win32');
+    const desktop = new Desktop();
+    desktop.openApp = jest.fn();
+    const event = new KeyboardEvent('keydown', { metaKey: true, key: ',' });
+    desktop.handleGlobalShortcut(event);
+    expect(desktop.openApp).toHaveBeenCalledWith('settings');
+  });
+});

--- a/__tests__/metaKey.test.ts
+++ b/__tests__/metaKey.test.ts
@@ -1,0 +1,33 @@
+import { getMetaKeyLabel, isMetaKey } from '../utils/metaKey';
+
+describe('meta key detection', () => {
+  const originalNavigator = navigator;
+
+  const setPlatform = (platform: string) => {
+    Object.defineProperty(window, 'navigator', {
+      value: { platform },
+      configurable: true,
+    });
+  };
+
+  afterEach(() => {
+    Object.defineProperty(window, 'navigator', {
+      value: originalNavigator,
+      configurable: true,
+    });
+  });
+
+  test('mac meta key label', () => {
+    setPlatform('MacIntel');
+    expect(getMetaKeyLabel()).toBe('Meta');
+    const e = new KeyboardEvent('keydown', { metaKey: true });
+    expect(isMetaKey(e)).toBe(true);
+  });
+
+  test('windows meta key label', () => {
+    setPlatform('Win32');
+    expect(getMetaKeyLabel()).toBe('Win');
+    const e = new KeyboardEvent('keydown', { metaKey: true });
+    expect(isMetaKey(e)).toBe(true);
+  });
+});

--- a/apps/settings/components/KeymapOverlay.tsx
+++ b/apps/settings/components/KeymapOverlay.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import useKeymap from '../keymapRegistry';
+import { getMetaKeyLabel } from '../../../utils/metaKey';
 
 interface KeymapOverlayProps {
   open: boolean;
@@ -13,7 +14,7 @@ const formatEvent = (e: KeyboardEvent) => {
     e.ctrlKey ? 'Ctrl' : '',
     e.altKey ? 'Alt' : '',
     e.shiftKey ? 'Shift' : '',
-    e.metaKey ? 'Meta' : '',
+    e.metaKey ? getMetaKeyLabel() : '',
     e.key.length === 1 ? e.key.toUpperCase() : e.key,
   ];
   return parts.filter(Boolean).join('+');

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -1,4 +1,5 @@
 import usePersistentState from '../../hooks/usePersistentState';
+import { getMetaKeyLabel } from '../../utils/metaKey';
 
 export interface Shortcut {
   description: string;
@@ -7,7 +8,10 @@ export interface Shortcut {
 
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
-  { description: 'Open settings', keys: 'Ctrl+,' },
+  {
+    description: 'Open settings',
+    keys: `${getMetaKeyLabel()}+,`,
+  },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {

--- a/components/common/ShortcutOverlay.tsx
+++ b/components/common/ShortcutOverlay.tsx
@@ -2,13 +2,14 @@
 
 import React, { useEffect, useState, useCallback } from 'react';
 import useKeymap from '../../apps/settings/keymapRegistry';
+import { getMetaKeyLabel } from '../../utils/metaKey';
 
 const formatEvent = (e: KeyboardEvent) => {
   const parts = [
     e.ctrlKey ? 'Ctrl' : '',
     e.altKey ? 'Alt' : '',
     e.shiftKey ? 'Shift' : '',
-    e.metaKey ? 'Meta' : '',
+    e.metaKey ? getMetaKeyLabel() : '',
     e.key.length === 1 ? e.key.toUpperCase() : e.key,
   ];
   return parts.filter(Boolean).join('+');

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -23,6 +23,7 @@ import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { useSnapSetting } from '../../hooks/usePersistentState';
+import { isMetaKey } from '../../utils/metaKey';
 
 export class Desktop extends Component {
     constructor() {
@@ -164,7 +165,11 @@ export class Desktop extends Component {
             e.preventDefault();
             this.cycleAppWindows(e.shiftKey ? -1 : 1);
         }
-        else if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
+        else if (isMetaKey(e) && e.key === ',') {
+            e.preventDefault();
+            this.openApp('settings');
+        }
+        else if (isMetaKey(e) && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
             e.preventDefault();
             const id = this.getFocusedWindowId();
             if (id) {

--- a/utils/metaKey.ts
+++ b/utils/metaKey.ts
@@ -1,0 +1,6 @@
+export const isMac = () =>
+  typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+
+export const getMetaKeyLabel = () => (isMac() ? 'Meta' : 'Win');
+
+export const isMetaKey = (e: KeyboardEvent) => e.metaKey;


### PR DESCRIPTION
## Summary
- add meta key helper with OS-aware label
- show proper meta key names in shortcut drawers
- enable Meta/Win + comma to open settings

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f24557b88328aca3dfd840d11b71