### PR TITLE
[terminal] confirm large copy operations

### DIFF
--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -150,7 +150,11 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
   }, []);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(contentRef.current).catch(() => {});
+    const text = contentRef.current;
+    if (text.length > 5000 && !window.confirm('Copy large output to clipboard?')) {
+      return;
+    }
+    navigator.clipboard.writeText(text).catch(() => {});
   };
 
   const handlePaste = async () => {


### PR DESCRIPTION
## Summary
- prompt before copying terminal output larger than 5000 characters
- test copy handler confirmation logic

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test __tests__/terminal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c4f2473f808328b8a2f3c790635ea3