### PR TITLE
[terminal] build palette link list when idle

### DIFF
--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -100,6 +100,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
   });
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [paletteInput, setPaletteInput] = useState('');
+  const [paletteLinks, setPaletteLinks] = useState<string[]>([]);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const { supported: opfsSupported, getDir, readFile, writeFile, deleteFile } =
     useOPFS();
@@ -144,6 +145,24 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
   );
 
   contextRef.current.writeLine = writeLine;
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handle = 'requestIdleCallback' in window
+      ? (window as any).requestIdleCallback(() => {
+          setPaletteLinks(Object.keys(registryRef.current));
+        })
+      : window.setTimeout(() => {
+          setPaletteLinks(Object.keys(registryRef.current));
+        }, 0);
+    return () => {
+      if ('cancelIdleCallback' in window) {
+        (window as any).cancelIdleCallback(handle);
+      } else {
+        clearTimeout(handle);
+      }
+    };
+  }, []);
 
   const prompt = useCallback(() => {
     if (termRef.current) termRef.current.write('$ ');
@@ -423,7 +442,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
               }}
             />
             <ul className="max-h-40 overflow-y-auto">
-              {Object.keys(registryRef.current)
+              {paletteLinks
                 .filter((c) => c.startsWith(paletteInput))
                 .map((c) => (
                   <li key={c} className="text-white">


### PR DESCRIPTION
## Summary
- build terminal palette link list with `requestIdleCallback` to defer heavy work until idle

## Testing
- `yarn lint` *(fails: A control must be associated with a text label ...)*
- `yarn test` *(fails: window snapping finalize and release; nmap NSE app; modal closes when Escape pressed)*
- `yarn smoke` *(fails: Playwright browser executable missing)*
- `npx playwright test` *(fails: 8 failed, 33 did not run)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f24cdc708328a4320ed5e894f3aa