### PR TITLE
[ui] add hero demo windows setting

### DIFF
--- a/__tests__/HeroDemoWindows.test.tsx
+++ b/__tests__/HeroDemoWindows.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import HeroDemoWindows from '../components/HeroDemoWindows';
+import { SettingsContext } from '../hooks/useSettings';
+
+jest.mock('react-draggable', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+describe('HeroDemoWindows', () => {
+  it('does not render when disabled', () => {
+    render(
+      <SettingsContext.Provider value={{ heroDemos: false } as any}>
+        <HeroDemoWindows />
+      </SettingsContext.Provider>
+    );
+    expect(screen.queryByText(/Demo Terminal/)).toBeNull();
+  });
+
+  it('renders windows when enabled', () => {
+    render(
+      <SettingsContext.Provider value={{ heroDemos: true } as any}>
+        <HeroDemoWindows />
+      </SettingsContext.Provider>
+    );
+    expect(screen.getByText(/Demo Terminal/)).toBeInTheDocument();
+  });
+});

--- a/components/HeroDemoWindows.tsx
+++ b/components/HeroDemoWindows.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Draggable from "react-draggable";
+import { useSettings } from "../hooks/useSettings";
+
+export default function HeroDemoWindows() {
+  const { heroDemos } = useSettings();
+  if (!heroDemos) return null;
+  return (
+    <div className="fixed top-4 left-4 space-y-4 pointer-events-none z-50">
+      <Draggable handle=".drag-handle">
+        <div className="pointer-events-auto w-64 bg-ub-cool-grey text-white rounded shadow-lg select-text">
+          <div className="drag-handle bg-ub-window-title px-2 py-1 cursor-move rounded-t select-none">
+            Demo Terminal
+          </div>
+          <pre className="p-2 text-xs">
+$ echo "Kali rules"
+Kali rules
+          </pre>
+        </div>
+      </Draggable>
+      <Draggable handle=".drag-handle">
+        <div className="pointer-events-auto w-60 bg-ub-cool-grey text-white rounded shadow-lg select-text">
+          <div className="drag-handle bg-ub-window-title px-2 py-1 cursor-move rounded-t select-none">
+            Welcome
+          </div>
+          <div className="p-2 text-sm">
+            Drag these windows around. Text inside can be selected.
+          </div>
+        </div>
+      </Draggable>
+    </div>
+  );
+}

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { getUnlockedThemes } from '../utils/theme';
 import { useSettings, ACCENT_OPTIONS } from '../hooks/useSettings';
+import ToggleSwitch from './ToggleSwitch';
 
 interface Props {
   highScore?: number;
@@ -9,7 +10,7 @@ interface Props {
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const unlocked = getUnlockedThemes(highScore);
-  const { accent, setAccent, theme, setTheme } = useSettings();
+  const { accent, setAccent, theme, setTheme, heroDemos, setHeroDemos } = useSettings();
 
   return (
     <div>
@@ -51,6 +52,14 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
                 />
               ))}
             </div>
+          </label>
+          <label className="flex items-center justify-between mt-2">
+            <span>Hero demo windows</span>
+            <ToggleSwitch
+              ariaLabel="toggle-hero-demos"
+              checked={heroDemos}
+              onChange={setHeroDemos}
+            />
           </label>
         </div>
       )}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getHeroDemos as loadHeroDemos,
+  setHeroDemos as saveHeroDemos,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +64,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  heroDemos: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +76,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setHeroDemos: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +91,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  heroDemos: defaults.heroDemos,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +103,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setHeroDemos: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +118,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [heroDemos, setHeroDemos] = useState<boolean>(defaults.heroDemos);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +134,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setHeroDemos(await loadHeroDemos());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +244,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveHeroDemos(heroDemos);
+  }, [heroDemos]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +261,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        heroDemos,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +273,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setHeroDemos,
         setTheme,
       }}
     >

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
+import HeroDemoWindows from '../components/HeroDemoWindows';
 
 const Ubuntu = dynamic(
   () =>
@@ -36,6 +37,7 @@ const App = () => (
     <Meta />
     <Ubuntu />
     <BetaBadge />
+    <HeroDemoWindows />
     <InstallButton />
   </>
 );

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  heroDemos: true,
 };
 
 export async function getAccent() {
@@ -102,6 +103,17 @@ export async function setHaptics(value) {
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+export async function getHeroDemos() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.heroDemos;
+  const val = window.localStorage.getItem('hero-demos');
+  return val === null ? DEFAULT_SETTINGS.heroDemos : val === 'true';
+}
+
+export async function setHeroDemos(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('hero-demos', value ? 'true' : 'false');
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -137,6 +149,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('hero-demos');
 }
 
 export async function exportSettings() {
@@ -151,6 +164,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    heroDemos,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +176,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getHeroDemos(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +190,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    heroDemos,
     theme,
   });
 }
@@ -199,6 +215,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    heroDemos,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +228,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (heroDemos !== undefined) await setHeroDemos(heroDemos);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- introduce draggable hero demo windows gated by user setting
- persist `heroDemos` preference and expose toggle in settings drawer

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window snapping and NmapNSE tests)*
- `yarn test __tests__/HeroDemoWindows.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c4f24d8d0c8328a6bbbf126aef0c69