### PR TITLE
[window] snap drag end to grid

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -199,7 +199,7 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true, preventDefault: () => {}, stopPropagation: () => {} } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();
@@ -252,6 +252,31 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBeNull();
     expect(ref.current!.state.width).toBe(60);
     expect(ref.current!.state.height).toBe(85);
+  });
+
+  it('snaps position to 8px grid on drag stop', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+
+    act(() => {
+      ref.current!.handleStop({}, { node: winEl, x: 13, y: 7 } as any);
+    });
+
+    expect(winEl.style.transform).toBe('translate(16px, 8px)');
   });
 });
 

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -365,13 +365,25 @@ export class Window extends Component {
         this.checkSnapPreview();
     }
 
-    handleStop = () => {
+    handleStop = (_, data) => {
         this.changeCursorToDefault();
         const snapPos = this.state.snapPosition;
         if (snapPos) {
             this.snapWindow(snapPos);
         } else {
             this.setState({ snapPreview: null, snapPosition: null });
+            if (data && data.node) {
+                const grid = 8;
+                const maxX = this.state.parentSize.width;
+                const maxY = this.state.parentSize.height;
+                const snap = (value, max) => {
+                    const snapped = Math.round(value / grid) * grid;
+                    return Math.min(Math.max(0, snapped), max);
+                };
+                const x = snap(data.x, maxX);
+                const y = snap(data.y, maxY);
+                data.node.style.transform = `translate(${x}px, ${y}px)`;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- snap window position to 8px grid when dragging ends
- cover drag snapping with dedicated unit test

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `CI=1 yarn test __tests__/window.test.tsx`
- `CI=1 yarn test __tests__/nmapNse.test.tsx` *(fails: Unable to find role="alert")*


------
https://chatgpt.com/codex/tasks/task_e_68c4f24f74448328b275a27f0e01e1f0