### PR TITLE
[ui] animate accent on section entry

### DIFF
--- a/__tests__/sectionAccent.test.tsx
+++ b/__tests__/sectionAccent.test.tsx
@@ -1,0 +1,45 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import useSectionAccent from '../hooks/useSectionAccent';
+
+describe('useSectionAccent', () => {
+  it('updates --accent when section enters view', () => {
+    const observers: any[] = [];
+    class IntersectionObserverMock {
+      callback: any;
+      elements: Element[] = [];
+      constructor(cb: any) {
+        this.callback = cb;
+        observers.push(this);
+      }
+      observe(el: Element) {
+        this.elements.push(el);
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    // @ts-ignore
+    global.IntersectionObserver = IntersectionObserverMock;
+
+    const TestComponent = () => {
+      useSectionAccent();
+      return (
+        <>
+          <section data-accent="#111111">One</section>
+          <section data-accent="#222222">Two</section>
+        </>
+      );
+    };
+
+    render(<TestComponent />);
+
+    const observer = observers[0];
+    // simulate the second section entering the viewport
+    observer.callback([
+      { target: observer.elements[1], isIntersecting: true },
+    ]);
+
+    expect(document.documentElement.style.getPropertyValue('--accent'))
+      .toBe('#222222');
+  });
+});

--- a/hooks/useSectionAccent.ts
+++ b/hooks/useSectionAccent.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+
+/**
+ * Observes all <section> elements with a `data-accent` attribute and
+ * updates the `--accent` CSS variable on the root element whenever a
+ * section becomes visible in the viewport. The color transition is
+ * handled via CSS using the `@property` rule for `--accent`.
+ */
+export default function useSectionAccent() {
+  useEffect(() => {
+    const sections = Array.from(
+      document.querySelectorAll<HTMLElement>('section[data-accent]'),
+    );
+    if (sections.length === 0) return;
+
+    const root = document.documentElement;
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          const color = (entry.target as HTMLElement).dataset.accent;
+          if (color) {
+            root.style.setProperty('--accent', color);
+          }
+        }
+      });
+    }, {
+      threshold: 0.6,
+    });
+
+    sections.forEach((sec) => observer.observe(sec));
+
+    return () => observer.disconnect();
+  }, []);
+}
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,6 +11,7 @@ import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import useSectionAccent from '../hooks/useSectionAccent';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
@@ -28,6 +29,7 @@ const ubuntu = Ubuntu({
 function MyApp(props) {
   const { Component, pageProps } = props;
 
+  useSectionAccent();
 
   useEffect(() => {
     if (typeof window !== 'undefined' && typeof window.initA2HS === 'function') {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,5 +1,11 @@
 @import './tokens.css';
 
+@property --accent {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #1793d1;
+}
+
 /* Accessible theme color palette meeting WCAG AA contrast ratios */
 :root {
   /* Base colors */
@@ -20,6 +26,8 @@
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   accent-color: var(--color-control-accent);
+  --accent: var(--color-accent);
+  transition: --accent 150ms linear;
 }
 
 /* Dark theme */


### PR DESCRIPTION
## Summary
- allow sections to declare data-accent and animate the `--accent` CSS variable when visible
- wire global hook so pages update accent color on section entry
- add test covering section accent behavior

## Testing
- `npx eslint hooks/useSectionAccent.ts pages/_app.jsx styles/globals.css __tests__/sectionAccent.test.tsx`
- `yarn test __tests__/sectionAccent.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c4f251d4148328b1e43bfd985807b8