### PR TITLE
[ui] expose design tokens to JS

### DIFF
--- a/assets/data/tokens.json
+++ b/assets/data/tokens.json
@@ -1,0 +1,61 @@
+{
+  "colors": {
+    "ubGrey": "#0f1317",
+    "ubWarmGrey": "#7d7f83",
+    "ubCoolGrey": "#1a1f26",
+    "ubOrange": "#1793d1",
+    "ubLiteAbrgn": "#22262c",
+    "ubMedAbrgn": "#1b1f24",
+    "ubDrkAbrgn": "#13171b",
+    "ubWindowTitle": "#0c0f12",
+    "ubGeditDark": "#021B33",
+    "ubGeditLight": "#003B70",
+    "ubGeditDarker": "#010D1A",
+    "ubtGrey": "#F6F6F5",
+    "ubtWarmGrey": "#AEA79F",
+    "ubtCoolGrey": "#333333",
+    "ubtBlue": "#62A0EA",
+    "ubtGreen": "#73D216",
+    "ubtGeditOrange": "#F39A21",
+    "ubtGeditBlue": "#50B6C6",
+    "ubtGeditDark": "#003B70",
+    "ubBorderOrange": "#1793d1",
+    "ubDarkGrey": "#2a2e36",
+    "bg": "#0f1317",
+    "text": "#F5F5F5"
+  },
+  "game": {
+    "secondary": "#1d4ed8",
+    "success": "#15803d",
+    "warning": "#d97706",
+    "danger": "#b91c1c"
+  },
+  "spacing": {
+    "1": "0.25rem",
+    "2": "0.5rem",
+    "3": "0.75rem",
+    "4": "1rem",
+    "5": "1.5rem",
+    "6": "2rem"
+  },
+  "radius": {
+    "sm": "2px",
+    "md": "4px",
+    "lg": "8px",
+    "round": "9999px"
+  },
+  "motion": {
+    "fast": "150ms",
+    "medium": "300ms",
+    "slow": "500ms"
+  },
+  "fonts": {
+    "familyBase": "'Ubuntu', sans-serif",
+    "multiplier": "1"
+  },
+  "hitArea": "32px",
+  "focus": {
+    "outlineColor": "var(--color-ubt-blue)",
+    "outlineWidth": "2px"
+  }
+}

--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Head from 'next/head';
 import { getCspNonce } from '../../utils/csp';
+import tokens from '../../utils/tokens';
 
 export default function Meta() {
     const nonce = getCspNonce();
@@ -20,7 +21,7 @@ export default function Meta() {
             <meta name="language" content="English" />
             <meta name="category" content="16" />
             <meta name="viewport" content="width=device-width, initial-scale=1" />
-            <meta name="theme-color" content="#0f1317" />
+            <meta name="theme-color" content={tokens.colors.bg} />
 
             {/* Search Engine */}
             <meta name="image" content="images/logos/fevicon.png" />

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
+import tokens from '../../utils/tokens';
 
 export function Settings() {
     const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
@@ -180,7 +181,7 @@ export function Settings() {
             <div className="flex justify-center my-4">
                 <div
                     className="p-4 rounded transition-colors duration-300 motion-reduce:transition-none"
-                    style={{ backgroundColor: '#0f1317', color: '#ffffff' }}
+                    style={{ backgroundColor: tokens.colors.bg, color: tokens.colors.text }}
                 >
                     <p className="mb-2 text-center">Preview</p>
                     <button

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -23,11 +23,12 @@ import {
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+import tokens from '../utils/tokens';
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
 export const ACCENT_OPTIONS = [
-  '#1793d1', // kali blue (default)
+  tokens.colors.ubOrange, // kali blue (default)
   '#e53e3e', // red
   '#d97706', // orange
   '#38a169', // green
@@ -159,20 +160,20 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const spacing: Record<Density, Record<string, string>> = {
       regular: {
-        '--space-1': '0.25rem',
-        '--space-2': '0.5rem',
-        '--space-3': '0.75rem',
-        '--space-4': '1rem',
-        '--space-5': '1.5rem',
-        '--space-6': '2rem',
+        '--space-1': tokens.spacing['1'],
+        '--space-2': tokens.spacing['2'],
+        '--space-3': tokens.spacing['3'],
+        '--space-4': tokens.spacing['4'],
+        '--space-5': tokens.spacing['5'],
+        '--space-6': tokens.spacing['6'],
       },
       compact: {
-        '--space-1': '0.125rem',
-        '--space-2': '0.25rem',
-        '--space-3': '0.5rem',
-        '--space-4': '0.75rem',
-        '--space-5': '1rem',
-        '--space-6': '1.5rem',
+        '--space-1': `calc(${tokens.spacing['1']} / 2)`,
+        '--space-2': `calc(${tokens.spacing['2']} / 2)`,
+        '--space-3': `calc(${tokens.spacing['3']} / 2)`,
+        '--space-4': `calc(${tokens.spacing['4']} / 2)`,
+        '--space-5': `calc(${tokens.spacing['5']} / 2)`,
+        '--space-6': `calc(${tokens.spacing['6']} / 2)`,
       },
     };
     const vars = spacing[density];

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,4 +1,5 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import tokens from '../utils/tokens';
 
 class MyDocument extends Document {
   /**
@@ -17,7 +18,7 @@ class MyDocument extends Document {
         <Head>
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
-          <meta name="theme-color" content="#0f1317" />
+          <meta name="theme-color" content={tokens.colors.bg} />
           <script nonce={nonce} src="/theme.js" />
         </Head>
         <body>

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -2,9 +2,10 @@
 
 import { get, set, del } from 'idb-keyval';
 import { getTheme, setTheme } from './theme';
+import tokens from './tokens';
 
 const DEFAULT_SETTINGS = {
-  accent: '#1793d1',
+  accent: tokens.colors.ubOrange,
   wallpaper: 'wall-2',
   density: 'regular',
   reducedMotion: false,

--- a/utils/tokens.ts
+++ b/utils/tokens.ts
@@ -1,0 +1,3 @@
+import tokens from '../assets/data/tokens.json';
+
+export default tokens;


### PR DESCRIPTION
## Summary
- add `assets/data/tokens.json` with shared design tokens
- map tokens in JS and hook into settings defaults and spacing
- replace hard-coded theme colors with token references

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window snapping finalize and release; NmapNSEApp copies example output to clipboard; modal closes when Escape pressed globally)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f253f59483289d1ea2fb020607ef