### PR TITLE
[ui] add inputmode and autocomplete

### DIFF
--- a/apps/ssh/index.tsx
+++ b/apps/ssh/index.tsx
@@ -35,6 +35,8 @@ const SSHBuilder: React.FC = () => {
             className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
             value={user}
             onChange={(e) => setUser(e.target.value)}
+            autoComplete="username"
+            inputMode="text"
           />
         </div>
         <div>
@@ -47,6 +49,8 @@ const SSHBuilder: React.FC = () => {
             className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
             value={host}
             onChange={(e) => setHost(e.target.value)}
+            autoComplete="off"
+            inputMode="text"
           />
         </div>
         <div>
@@ -59,6 +63,8 @@ const SSHBuilder: React.FC = () => {
             className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
             value={port}
             onChange={(e) => setPort(e.target.value)}
+            autoComplete="off"
+            inputMode="numeric"
           />
         </div>
       </form>

--- a/apps/weather_widget/index.tsx
+++ b/apps/weather_widget/index.tsx
@@ -16,13 +16,15 @@ export default function WeatherWidget() {
           id="city-search"
           placeholder="Search city"
           list="saved-cities"
+          autoComplete="off"
+          inputMode="text"
         />
         <datalist id="saved-cities"></datalist>
         <select id="unit-toggle">
           <option value="metric">°C</option>
           <option value="imperial">°F</option>
         </select>
-        <input type="text" id="api-key-input" placeholder="API Key (optional)" />
+        <input type="text" id="api-key-input" placeholder="API Key (optional)" autoComplete="off" inputMode="text" />
         <button id="save-api-key">Save</button>
         <button id="pin-city">Pin</button>
       </div>

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -153,18 +153,18 @@ export class Gedit extends Component {
                 <div className="relative flex-grow flex flex-col bg-ub-gedit-dark font-normal windowMainScreen">
                     <div className="absolute left-0 top-0 h-full px-2 bg-ub-gedit-darker"></div>
                     <div className="relative">
-                        <input id="sender-name" value={this.state.name} onChange={this.handleChange('name')} onBlur={this.handleBlur('name')} aria-invalid={nameInvalid} aria-describedby="name-status" className={`w-full text-ubt-gedit-orange focus:bg-ub-gedit-light outline-none font-medium text-sm pl-6 py-0.5 bg-transparent ${nameInvalid ? 'border border-red-500' : nameValid ? 'border border-emerald-500' : ''}`} placeholder="Your Email / Name :" spellCheck="false" autoComplete="off" type="text" />
+                        <input id="sender-name" value={this.state.name} onChange={this.handleChange('name')} onBlur={this.handleBlur('name')} aria-invalid={nameInvalid} aria-describedby="name-status" className={`w-full text-ubt-gedit-orange focus:bg-ub-gedit-light outline-none font-medium text-sm pl-6 py-0.5 bg-transparent ${nameInvalid ? 'border border-red-500' : nameValid ? 'border border-emerald-500' : ''}`} placeholder="Your Email / Name :" spellCheck="false" autoComplete="email" inputMode="email" type="text" />
                         <span className="absolute left-1 top-1/2 transform -translate-y-1/2 font-bold light text-sm text-ubt-gedit-blue">1</span>
                         <p id="name-status" className={`text-xs mt-1 ${nameInvalid ? 'text-red-400' : nameValid ? 'text-emerald-400' : 'sr-only'}`} aria-live="polite">
                             {nameInvalid ? 'Name must not be empty' : nameValid ? 'Looks good' : ''}
                         </p>
                     </div>
                     <div className="relative">
-                        <input id="sender-subject" value={this.state.subject} onChange={this.handleChange('subject')} className=" w-full my-1 text-ubt-gedit-blue focus:bg-ub-gedit-light gedit-subject outline-none text-sm font-normal pl-6 py-0.5 bg-transparent" placeholder="subject (may be a feedback for this website!)" spellCheck="false" autoComplete="off" type="text" />
+                        <input id="sender-subject" value={this.state.subject} onChange={this.handleChange('subject')} className=" w-full my-1 text-ubt-gedit-blue focus:bg-ub-gedit-light gedit-subject outline-none text-sm font-normal pl-6 py-0.5 bg-transparent" placeholder="subject (may be a feedback for this website!)" spellCheck="false" autoComplete="off" inputMode="text" type="text" />
                         <span className="absolute left-1 top-1/2 transform -translate-y-1/2 font-bold  text-sm text-ubt-gedit-blue">2</span>
                     </div>
                     <div className="relative flex-grow">
-                        <textarea id="sender-message" value={this.state.message} onChange={this.handleChange('message')} onBlur={this.handleBlur('message')} aria-invalid={messageInvalid} aria-describedby="message-status" className={`w-full gedit-message font-light text-sm resize-none h-full windowMainScreen outline-none tracking-wider pl-6 py-1 bg-transparent ${messageInvalid ? 'border border-red-500' : messageValid ? 'border border-emerald-500' : ''}`} placeholder="Message" spellCheck="false" autoComplete="none" type="text" />
+                        <textarea id="sender-message" value={this.state.message} onChange={this.handleChange('message')} onBlur={this.handleBlur('message')} aria-invalid={messageInvalid} aria-describedby="message-status" className={`w-full gedit-message font-light text-sm resize-none h-full windowMainScreen outline-none tracking-wider pl-6 py-1 bg-transparent ${messageInvalid ? 'border border-red-500' : messageValid ? 'border border-emerald-500' : ''}`} placeholder="Message" spellCheck="false" autoComplete="off" inputMode="text" type="text" />
                         <span className="absolute left-1 top-1 font-bold  text-sm text-ubt-gedit-blue">3</span>
                         <p id="message-status" className={`text-xs mt-1 ${messageInvalid ? 'text-red-400' : messageValid ? 'text-emerald-400' : 'sr-only'}`} aria-live="polite">
                             {messageInvalid ? 'Message must not be empty' : messageValid ? 'Looks good' : ''}


### PR DESCRIPTION
## Summary
- improve mobile experience by adding `inputmode`/`autocomplete` to contact and SSH forms
- clarify input modes in weather widget controls

## Testing
- `yarn lint` *(fails: Unexpected global 'document' and other errors)*
- `yarn test` *(fails: TypeError: Cannot read properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f25813ac8328802a1a59dbf3b828