### PR TITLE
[ui] add skeleton placeholders

### DIFF
--- a/__tests__/blogList.test.tsx
+++ b/__tests__/blogList.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import BlogList from '../components/BlogList';
+
+jest.mock('../data/blog-posts.json', () => [
+  { id: 1, title: 'Test Post', summary: 'Summary', url: '#' },
+]);
+
+describe('BlogList', () => {
+  it('shows skeleton then loads posts', async () => {
+    render(<BlogList />);
+    expect(screen.getByTestId('blog-skeleton')).toBeInTheDocument();
+    const post = await screen.findByText('Test Post');
+    expect(post).toBeInTheDocument();
+  });
+});

--- a/components/BlogList.tsx
+++ b/components/BlogList.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+
+interface Post {
+  id: number;
+  title: string;
+  summary: string;
+  url: string;
+}
+
+const BlogList: React.FC = () => {
+  const [posts, setPosts] = useState<Post[] | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    import('../data/blog-posts.json').then((mod) => {
+      if (isMounted) {
+        setPosts(mod.default as Post[]);
+      }
+    });
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  if (!posts) {
+    return (
+      <ul data-testid="blog-skeleton" className="space-y-4">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <li key={idx} className="space-y-2">
+            <div className="skeleton h-5 w-3/4" />
+            <div className="skeleton h-4 w-full" />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  return (
+    <ul className="space-y-4">
+      {posts.map((p) => (
+        <li key={p.id} className="space-y-1">
+          <a
+            href={p.url}
+            className="text-ubt-blue hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {p.title}
+          </a>
+          <p className="text-sm">{p.summary}</p>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default BlogList;

--- a/data/blog-posts.json
+++ b/data/blog-posts.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": 1,
+    "title": "First Post",
+    "summary": "Intro to portfolio",
+    "url": "#"
+  },
+  {
+    "id": 2,
+    "title": "Second Post",
+    "summary": "Another update",
+    "url": "#"
+  },
+  {
+    "id": 3,
+    "title": "Third Post",
+    "summary": "More content",
+    "url": "#"
+  }
+]

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import BlogList from '../components/BlogList';
+
+const BlogPage = () => (
+  <main className="min-h-screen p-4 bg-gray-900 text-white">
+    <h1 className="mb-4 text-2xl">Blog</h1>
+    <BlogList />
+  </main>
+);
+
+export default BlogPage;

--- a/styles/index.css
+++ b/styles/index.css
@@ -38,6 +38,39 @@ button:focus-visible {
     scroll-behavior: auto !important;
 }
 
+/* Skeleton loading placeholders */
+.skeleton {
+    position: relative;
+    overflow: hidden;
+    background: color-mix(in srgb, var(--color-text), transparent 85%);
+}
+
+.skeleton::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    transform: translateX(-100%);
+    background: linear-gradient(
+        90deg,
+        transparent,
+        color-mix(in srgb, var(--color-inverse), transparent 70%),
+        transparent
+    );
+    animation: skeleton-shimmer 1.5s infinite;
+}
+
+@keyframes skeleton-shimmer {
+    to {
+        transform: translateX(100%);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .skeleton::after {
+        animation: none;
+    }
+}
+
 /* Top NavBar styling */
 
 .top-arrow-up {


### PR DESCRIPTION
## Summary
- add reusable skeleton styles with reduced-motion media query
- show skeletons for project gallery cards until content is ready
- add blog list component with loading skeletons

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `npx eslint components/BlogList.tsx pages/blog.tsx components/apps/project-gallery.tsx __tests__/blogList.test.tsx styles/index.css`
- `yarn test` *(fails: window snapping finalize and release, NmapNSEApp copies example output to clipboard, modal closes when Escape pressed globally)*
- `yarn test __tests__/blogList.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c4f25a1f008328ab591feb79e45a21