### PR TITLE
[ui] stabilize gallery placeholders

### DIFF
--- a/apps/project-gallery/pages/index.tsx
+++ b/apps/project-gallery/pages/index.tsx
@@ -275,7 +275,7 @@ export default function ProjectGalleryPage() {
                 key={i}
                 className="h-72 flex flex-col border rounded overflow-hidden animate-pulse"
               >
-                <div className="w-full h-40 bg-gray-300" />
+                <div className="w-full aspect-video bg-gray-300" />
                 <div className="p-2 space-y-2 flex-1">
                   <div className="h-4 bg-gray-300 rounded w-3/4" />
                   <div className="h-3 bg-gray-300 rounded w-1/2" />


### PR DESCRIPTION
## Summary
- guard project gallery image placeholders with aspect-ratio to limit layout shifts

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f25aa36c8328afe496dbba76a304