### PR TITLE
[build] hash wallpapers for cache busting

### DIFF
--- a/apps/settings/components/BackgroundSlideshow.tsx
+++ b/apps/settings/components/BackgroundSlideshow.tsx
@@ -4,10 +4,11 @@ import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 import { useSettings } from '../../../hooks/useSettings';
+import wallpaperManifest from '../../../public/wallpapers-manifest.json';
 
 export default function BackgroundSlideshow() {
   const { setWallpaper } = useSettings();
-  const [available, setAvailable] = useState<string[]>([]);
+  const available = Object.values(wallpaperManifest);
   const [selected, setSelected] = usePersistentState<string[]>(
     'bg-slideshow-selected',
     [],
@@ -21,20 +22,13 @@ export default function BackgroundSlideshow() {
   const indexRef = useRef(0);
 
   useEffect(() => {
-    fetch('/api/wallpapers')
-      .then((res) => res.json())
-      .then((files: string[]) => setAvailable(files))
-      .catch(() => setAvailable([]));
-  }, []);
-
-  useEffect(() => {
     if (!playing || selected.length === 0) {
       if (timerRef.current) clearInterval(timerRef.current);
       return;
     }
     const run = () => {
       const file = selected[indexRef.current % selected.length];
-      const base = file.replace(/\.[^.]+$/, '');
+      const base = file.split('.')[0];
       setWallpaper(base);
       indexRef.current = (indexRef.current + 1) % selected.length;
     };
@@ -68,6 +62,7 @@ export default function BackgroundSlideshow() {
             />
             <input
               type="checkbox"
+              aria-label="select-wallpaper"
               checked={selected.includes(file)}
               onChange={() => toggle(file)}
             />
@@ -75,15 +70,16 @@ export default function BackgroundSlideshow() {
         ))}
       </div>
       <div className="flex items-center space-x-2">
-        <label htmlFor="interval">Interval (s):</label>
-        <input
-          id="interval"
-          type="number"
-          min={5}
-          value={Math.round(intervalMs / 1000)}
-          onChange={(e) => setIntervalMs(Number(e.target.value) * 1000)}
-          className="w-20 bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-        />
+          <label htmlFor="interval">Interval (s):</label>
+          <input
+            id="interval"
+            type="number"
+            aria-label="Interval in seconds"
+            min={5}
+            value={Math.round(intervalMs / 1000)}
+            onChange={(e) => setIntervalMs(Number(e.target.value) * 1000)}
+            className="w-20 bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+          />
       </div>
       <button
         onClick={() => setPlaying((p) => !p)}

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
+import wallpaperManifest from "../../public/wallpapers-manifest.json";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
   resetSettings,
@@ -42,16 +43,7 @@ export default function Settings() {
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
 
-  const wallpapers = [
-    "wall-1",
-    "wall-2",
-    "wall-3",
-    "wall-4",
-    "wall-5",
-    "wall-6",
-    "wall-7",
-    "wall-8",
-  ];
+  const wallpapers = Object.keys(wallpaperManifest);
 
   const changeBackground = (name: string) => setWallpaper(name);
 
@@ -115,7 +107,7 @@ export default function Settings() {
           <div
             className="md:w-2/5 w-2/3 h-1/3 m-auto my-4"
             style={{
-              backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
+              backgroundImage: `url(/wallpapers/${wallpaperManifest[wallpaper]})`,
               backgroundSize: "cover",
               backgroundRepeat: "no-repeat",
               backgroundPosition: "center center",
@@ -159,9 +151,9 @@ export default function Settings() {
               max={wallpapers.length - 1}
               step="1"
               value={wallpapers.indexOf(wallpaper)}
-              onChange={(e) =>
-                changeBackground(wallpapers[parseInt(e.target.value, 10)])
-              }
+                onChange={(e) =>
+                  changeBackground(wallpapers[parseInt(e.target.value, 10)])
+                }
               className="ubuntu-slider"
               aria-label="Wallpaper"
             />
@@ -191,7 +183,7 @@ export default function Settings() {
                   " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"
                 }
                 style={{
-                  backgroundImage: `url(/wallpapers/${name}.webp)`,
+                  backgroundImage: `url(/wallpapers/${wallpaperManifest[name]})`,
                   backgroundSize: "cover",
                   backgroundRepeat: "no-repeat",
                   backgroundPosition: "center center",

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
+import wallpaperManifest from '../../public/wallpapers-manifest.json';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
@@ -8,7 +9,7 @@ export function Settings() {
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
 
-    const wallpapers = ['wall-1', 'wall-2', 'wall-3', 'wall-4', 'wall-5', 'wall-6', 'wall-7', 'wall-8'];
+    const wallpapers = Object.keys(wallpaperManifest);
 
     const changeBackgroundImage = (e) => {
         const name = e.currentTarget.dataset.path;
@@ -57,7 +58,7 @@ export function Settings() {
 
     return (
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
-            <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
+            <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${wallpaperManifest[wallpaper]})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
             </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Theme:</label>
@@ -100,9 +101,11 @@ export function Settings() {
                 </select>
             </div>
             <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Font Size:</label>
+                <label htmlFor="font-size" className="mr-2 text-ubt-grey">Font Size:</label>
                 <input
+                    id="font-size"
                     type="range"
+                    aria-label="Font Size"
                     min="0.75"
                     max="1.5"
                     step="0.05"
@@ -115,6 +118,7 @@ export function Settings() {
                 <label className="mr-2 text-ubt-grey flex items-center">
                     <input
                         type="checkbox"
+                        aria-label="Reduced Motion"
                         checked={reducedMotion}
                         onChange={(e) => setReducedMotion(e.target.checked)}
                         className="mr-2"
@@ -126,6 +130,7 @@ export function Settings() {
                 <label className="mr-2 text-ubt-grey flex items-center">
                     <input
                         type="checkbox"
+                        aria-label="Large Hit Areas"
                         checked={largeHitAreas}
                         onChange={(e) => setLargeHitAreas(e.target.checked)}
                         className="mr-2"
@@ -137,6 +142,7 @@ export function Settings() {
                 <label className="mr-2 text-ubt-grey flex items-center">
                     <input
                         type="checkbox"
+                        aria-label="High Contrast"
                         checked={highContrast}
                         onChange={(e) => setHighContrast(e.target.checked)}
                         className="mr-2"
@@ -148,6 +154,7 @@ export function Settings() {
                 <label className="mr-2 text-ubt-grey flex items-center">
                     <input
                         type="checkbox"
+                        aria-label="Allow Network Requests"
                         checked={allowNetwork}
                         onChange={(e) => setAllowNetwork(e.target.checked)}
                         className="mr-2"
@@ -159,6 +166,7 @@ export function Settings() {
                 <label className="mr-2 text-ubt-grey flex items-center">
                     <input
                         type="checkbox"
+                        aria-label="Haptics"
                         checked={haptics}
                         onChange={(e) => setHaptics(e.target.checked)}
                         className="mr-2"
@@ -170,6 +178,7 @@ export function Settings() {
                 <label className="mr-2 text-ubt-grey flex items-center">
                     <input
                         type="checkbox"
+                        aria-label="Pong Spin"
                         checked={pongSpin}
                         onChange={(e) => setPongSpin(e.target.checked)}
                         className="mr-2"
@@ -214,7 +223,7 @@ export function Settings() {
                             }}
                             data-path={name}
                             className={((name === wallpaper) ? " border-yellow-700 " : " border-transparent ") + " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"}
-                            style={{ backgroundImage: `url(/wallpapers/${name}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}
+                            style={{ backgroundImage: `url(/wallpapers/${wallpaperManifest[name]})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}
                         ></div>
                     ))
                 }
@@ -261,6 +270,7 @@ export function Settings() {
             <input
                 type="file"
                 accept="application/json"
+                aria-label="Import settings"
                 ref={fileInput}
                 onChange={async (e) => {
                     const file = e.target.files && e.target.files[0];

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
+import wallpaperManifest from '../../public/wallpapers-manifest.json';
 
 export default function LockScreen(props) {
 
     const { wallpaper } = useSettings();
+    const file = wallpaperManifest[wallpaper] || `${wallpaper}.webp`;
 
     if (props.isLocked) {
         window.addEventListener('click', props.unLockScreen);
@@ -17,7 +19,7 @@ export default function LockScreen(props) {
             style={{ zIndex: "100", contentVisibility: 'auto' }}
             className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
             <img
-                src={`/wallpapers/${wallpaper}.webp`}
+                src={`/wallpapers/${file}`}
                 alt=""
                 className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
             />

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -2,14 +2,16 @@
 
 import React, { useEffect, useState } from 'react'
 import { useSettings } from '../../hooks/useSettings';
+import wallpaperManifest from '../../public/wallpapers-manifest.json';
 
 export default function BackgroundImage() {
     const { wallpaper } = useSettings();
     const [needsOverlay, setNeedsOverlay] = useState(false);
+    const file = wallpaperManifest[wallpaper] || `${wallpaper}.webp`;
 
     useEffect(() => {
         const img = new Image();
-        img.src = `/wallpapers/${wallpaper}.webp`;
+        img.src = `/wallpapers/${file}`;
         img.onload = () => {
             const canvas = document.createElement('canvas');
             canvas.width = img.width;
@@ -34,12 +36,12 @@ export default function BackgroundImage() {
             const contrast = (1.05) / (lum + 0.05); // white text luminance is 1
             setNeedsOverlay(contrast < 4.5);
         };
-    }, [wallpaper]);
+    }, [file]);
 
     return (
         <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
             <img
-                src={`/wallpapers/${wallpaper}.webp`}
+                src={`/wallpapers/${file}`}
                 alt=""
                 className="w-full h-full object-cover"
             />

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "homepage": "https://unnippillil.com/",
   "scripts": {
     "build:gamepad": "tsc -p tsconfig.gamepad.json",
-    "prebuild": "tsc -p tsconfig.gamepad.json",
+    "prebuild": "node scripts/hash-wallpapers.mjs && tsc -p tsconfig.gamepad.json",
     "dev": "next dev",
     "build": "next build",
     "postbuild": "node scripts/safe-copy.mjs",
     "start": "next start",
+    "preexport": "node scripts/hash-wallpapers.mjs && tsc -p tsconfig.gamepad.json",
     "export": "NEXT_PUBLIC_STATIC_EXPORT=true next build",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/pages/api/wallpapers.js
+++ b/pages/api/wallpapers.js
@@ -1,14 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import wallpapers from '../../public/wallpapers-manifest.json';
 
 export default function handler(req, res) {
-  const dir = path.join(process.cwd(), 'public', 'images', 'wallpapers');
-  try {
-    const files = fs
-      .readdirSync(dir)
-      .filter((file) => /\.(?:png|jpe?g|webp|gif)$/i.test(file));
-    res.status(200).json(files);
-  } catch {
-    res.status(200).json([]);
-  }
+  res.status(200).json(Object.values(wallpapers));
 }

--- a/public/wallpapers-manifest.json
+++ b/public/wallpapers-manifest.json
@@ -1,0 +1,10 @@
+{
+  "wall-1": "wall-1.webp",
+  "wall-2": "wall-2.webp",
+  "wall-3": "wall-3.webp",
+  "wall-4": "wall-4.webp",
+  "wall-5": "wall-5.webp",
+  "wall-6": "wall-6.webp",
+  "wall-7": "wall-7.webp",
+  "wall-8": "wall-8.webp"
+}

--- a/scripts/hash-wallpapers.mjs
+++ b/scripts/hash-wallpapers.mjs
@@ -1,0 +1,49 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { createHash } from 'crypto';
+
+const dirs = [
+  path.join(process.cwd(), 'public', 'wallpapers'),
+  path.join(process.cwd(), 'public', 'images', 'wallpapers'),
+];
+const manifestPath = path.join(process.cwd(), 'public', 'wallpapers-manifest.json');
+
+async function main() {
+  const manifest = {};
+  const baseDir = dirs[0];
+  const files = await fs.readdir(baseDir);
+
+  for (const file of files) {
+    const ext = path.extname(file);
+    const base = path.basename(file, ext);
+    const simpleBase = base.split('.')[0];
+
+    // Skip already hashed files
+    if (simpleBase !== base) {
+      manifest[simpleBase] = file;
+      continue;
+    }
+
+    const buf = await fs.readFile(path.join(baseDir, file));
+    const hash = createHash('md5').update(buf).digest('hex').slice(0, 8);
+    const hashedName = `${simpleBase}.${hash}${ext}`;
+    manifest[simpleBase] = hashedName;
+
+    for (const dir of dirs) {
+      const src = path.join(dir, file);
+      const dest = path.join(dir, hashedName);
+      try {
+        await fs.rename(src, dest);
+      } catch {
+        // ignore missing files in secondary directories
+      }
+    }
+  }
+
+  await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- hash wallpaper images and record filenames in a manifest
- load hashed wallpaper names from the manifest across desktop components
- generate hashes during prebuild and preexport

## Testing
- `npx eslint apps/settings/components/BackgroundSlideshow.tsx apps/settings/index.tsx components/apps/settings.js components/screen/lock_screen.js components/util-components/background-image.js pages/api/wallpapers.js scripts/hash-wallpapers.mjs`
- `yarn test` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f25c8a0c8328a84dd16a19aa2431