### PR TITLE
[metrics] add consent toggle and local tracking

### DIFF
--- a/__tests__/metrics.test.ts
+++ b/__tests__/metrics.test.ts
@@ -1,0 +1,26 @@
+import {
+  setMetricsConsent,
+  logFeatureUsage,
+  getMetricsCounts,
+  resetMetrics,
+} from '../utils/metrics';
+
+describe('metrics', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetMetrics();
+    setMetricsConsent(false);
+  });
+
+  test('does not log without consent', () => {
+    logFeatureUsage('test');
+    expect(getMetricsCounts()).toEqual({});
+  });
+
+  test('logs usage with consent', () => {
+    setMetricsConsent(true);
+    logFeatureUsage('test');
+    logFeatureUsage('test');
+    expect(getMetricsCounts()).toEqual({ test: 2 });
+  });
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -29,6 +29,8 @@ export default function Settings() {
     setHighContrast,
     haptics,
     setHaptics,
+    metricsConsent,
+    setMetricsConsent,
     theme,
     setTheme,
   } = useSettings();
@@ -272,6 +274,16 @@ export default function Settings() {
       )}
       {activeTab === "privacy" && (
         <>
+          <div className="flex justify-center my-4">
+            <span className="text-ubt-grey mr-2">
+              Allow usage metrics (stored locally)
+            </span>
+            <ToggleSwitch
+              checked={metricsConsent}
+              onChange={setMetricsConsent}
+              ariaLabel="Metrics consent"
+            />
+          </div>
           <div className="flex justify-center my-4 space-x-4">
             <button
               onClick={handleExport}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -23,6 +23,7 @@ import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { useSnapSetting } from '../../hooks/usePersistentState';
+import { logFeatureUsage } from '../../utils/metrics';
 
 export class Desktop extends Component {
     constructor() {
@@ -591,6 +592,8 @@ export class Desktop extends Component {
             action: `Opened ${objId} window`
         });
 
+        logFeatureUsage(`app:${objId}`);
+
         // if the app is disabled
         if (this.state.disabled_apps[objId]) return;
 
@@ -838,8 +841,8 @@ export class Desktop extends Component {
         return (
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
-                    <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <label htmlFor="folder-name-input">New folder name</label>
+                    <input aria-label="New folder name" className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
                 </div>
                 <div className="flex">
                     <button

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getMetricsConsent as loadMetricsConsent,
+  setMetricsConsent as saveMetricsConsent,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +64,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  metricsConsent: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +76,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setMetricsConsent: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +91,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  metricsConsent: defaults.metricsConsent,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +103,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setMetricsConsent: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +118,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [metricsConsent, setMetricsConsent] = useState<boolean>(
+    defaults.metricsConsent,
+  );
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +136,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setMetricsConsent(await loadMetricsConsent());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +246,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveMetricsConsent(metricsConsent);
+  }, [metricsConsent]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +263,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        metricsConsent,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +275,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setMetricsConsent,
         setTheme,
       }}
     >

--- a/pages/metrics.tsx
+++ b/pages/metrics.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { getMetricsCounts } from '../utils/metrics';
+
+export default function MetricsDebug() {
+  const [counts, setCounts] = useState<Record<string, number>>({});
+
+  useEffect(() => {
+    setCounts(getMetricsCounts());
+  }, []);
+
+  return (
+    <div className="p-4 text-white">
+      <h1 className="text-2xl mb-4">Usage Metrics</h1>
+      {Object.keys(counts).length === 0 ? (
+        <p>No metrics recorded.</p>
+      ) : (
+        <ul className="space-y-2">
+          {Object.entries(counts).map(([name, value]) => (
+            <li key={name}>
+              {name}: {value}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/utils/metrics.ts
+++ b/utils/metrics.ts
@@ -1,0 +1,37 @@
+import { safeLocalStorage } from './safeStorage';
+
+export const METRICS_CONSENT_KEY = 'metrics-consent';
+export const METRICS_COUNT_KEY = 'metrics-counts';
+
+export const getMetricsConsent = (): boolean =>
+  safeLocalStorage?.getItem(METRICS_CONSENT_KEY) === 'true';
+
+export const setMetricsConsent = (value: boolean): void => {
+  safeLocalStorage?.setItem(METRICS_CONSENT_KEY, value ? 'true' : 'false');
+};
+
+export const logFeatureUsage = (feature: string): void => {
+  if (!getMetricsConsent() || !safeLocalStorage) return;
+  let data: Record<string, number>;
+  try {
+    data = JSON.parse(safeLocalStorage.getItem(METRICS_COUNT_KEY) || '{}');
+  } catch {
+    data = {};
+  }
+  data[feature] = (data[feature] || 0) + 1;
+  safeLocalStorage.setItem(METRICS_COUNT_KEY, JSON.stringify(data));
+};
+
+export const getMetricsCounts = (): Record<string, number> => {
+  if (!safeLocalStorage) return {};
+  try {
+    return JSON.parse(safeLocalStorage.getItem(METRICS_COUNT_KEY) || '{}');
+  } catch {
+    return {};
+  }
+};
+
+export const resetMetrics = (): void => {
+  if (!safeLocalStorage) return;
+  safeLocalStorage.removeItem(METRICS_COUNT_KEY);
+};

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -2,6 +2,12 @@
 
 import { get, set, del } from 'idb-keyval';
 import { getTheme, setTheme } from './theme';
+import {
+  getMetricsConsent as loadMetricsConsent,
+  setMetricsConsent as saveMetricsConsent,
+  resetMetrics,
+  METRICS_CONSENT_KEY,
+} from './metrics';
 
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
@@ -14,6 +20,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  metricsConsent: false,
 };
 
 export async function getAccent() {
@@ -123,6 +130,16 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getMetricsConsent() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.metricsConsent;
+  return loadMetricsConsent();
+}
+
+export async function setMetricsConsent(value) {
+  if (typeof window === 'undefined') return;
+  saveMetricsConsent(value);
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +154,8 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem(METRICS_CONSENT_KEY);
+  resetMetrics();
 }
 
 export async function exportSettings() {
@@ -151,6 +170,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    metricsConsent,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +182,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getMetricsConsent(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +196,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    metricsConsent,
     theme,
   });
 }
@@ -199,6 +221,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    metricsConsent,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +234,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (metricsConsent !== undefined) await setMetricsConsent(metricsConsent);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add metrics utility for local usage tracking
- add metrics consent setting and toggle
- log app launches and expose metrics debug page

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `npx eslint utils/metrics.ts hooks/useSettings.tsx apps/settings/index.tsx components/screen/desktop.js pages/metrics.tsx __tests__/metrics.test.ts`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68c4f25e9048832894804a7c4ecf553d