### PR TITLE
[ui] offset anchor jump for headings

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,15 @@ body{
     color: var(--color-text);
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    scroll-margin-top: var(--panel-height);
+}
+
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
     min-width: var(--hit-area);
     min-height: var(--hit-area);


### PR DESCRIPTION
## Summary
- add panel-height scroll margin to all heading levels so anchored navigation reveals full titles

## Testing
- `yarn lint` *(fails: A control must be associated with a text label, etc.)*
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/flappyBird.test.tsx` *(fails: Window snapping finalize and release, NmapNSEApp copies example output to clipboard)*
- `node -e "const {chromium}=require('playwright');(async()=>{const browser=await chromium.launch();const page=await browser.newPage();await page.setContent('<style>:root{--panel-height:50px;}h2{scroll-margin-top:var(--panel-height);}body{margin:0;height:2000px;}</style><a id=\\"link\\" href=\\"#target\\">go</a><h2 id=\\"target\\" style=\\"margin-top:1000px\\">Target</h2>');await page.click('#link');await page.waitForTimeout(100);const box=await page.locator('#target').boundingBox();console.log(box.y);await browser.close();})();"`


------
https://chatgpt.com/codex/tasks/task_e_68c4f25faee083289560222b4fb41720