### PR TITLE
[a11y] show focus ring only during keyboard use

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "dompurify": "^3.2.6",
     "fast-xml-parser": "^4.3.5",
     "figlet": "^1.8.2",
+    "focus-visible": "^5.2.1",
     "hash-wasm": "^4.12.0",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -10,6 +10,7 @@ import '../styles/resume-print.css';
 import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
+import 'focus-visible';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -73,7 +73,17 @@ html[data-theme='matrix'] {
   color: var(--color-inverse);
 }
 
-*:focus-visible {
+/* Show focus outlines only during keyboard navigation */
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.js-focus-visible :focus:not(.focus-visible) {
+  outline: none;
+}
+
+*:focus-visible,
+.focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -17,7 +17,9 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
 }
 
 a:focus-visible,
-button:focus-visible {
+button:focus-visible,
+a.focus-visible,
+button.focus-visible {
     outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
     outline-offset: 2px;
 }
@@ -511,7 +513,9 @@ pre {
 
 /* Visible focus rings for copy buttons and text areas */
 button:focus-visible,
-textarea:focus-visible {
+textarea:focus-visible,
+button.focus-visible,
+textarea.focus-visible {
     outline: var(--focus-outline-width) solid var(--focus-outline-color);
     outline-offset: 2px;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7460,6 +7460,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"focus-visible@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "focus-visible@npm:5.2.1"
+  checksum: 10c0/1c0e4e8b22be8684a664acc340efd6a41aafb560ce09979186a1c934de321ce8d6a3d7175c946aab1c87409b0e10f623274d7ce7d42ff16a0e4dc862fa151623
+  languageName: node
+  linkType: hard
+
 "follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.6":
   version: 1.15.11
   resolution: "follow-redirects@npm:1.15.11"
@@ -13911,6 +13918,7 @@ __metadata:
     fast-glob: "npm:^3.3.3"
     fast-xml-parser: "npm:^4.3.5"
     figlet: "npm:^1.8.2"
+    focus-visible: "npm:^5.2.1"
     hash-wasm: "npm:^4.12.0"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"


### PR DESCRIPTION
## Summary
- import `focus-visible` polyfill to support keyboard-only focus styling
- hide mouse-triggered focus rings and apply custom outlines via CSS
- extend focus styles for anchor and form elements to support polyfill

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*
- `npx playwright test` *(fails: apps smoke tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f26015088328bc8394ff80b8c70f