### PR TITLE
[blog] add tag filtering with query params

### DIFF
--- a/__tests__/blog.test.tsx
+++ b/__tests__/blog.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import BlogPage from '../pages/blog';
+
+describe('BlogPage', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/blog');
+  });
+
+  it('filters posts and updates query params', () => {
+    render(<BlogPage />);
+    expect(screen.getByText('Intro to Kali Tools')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'guide' }));
+    expect(screen.queryByText('UI/UX Notes')).not.toBeInTheDocument();
+    expect(window.location.search).toBe('?tag=guide');
+  });
+
+  it('restores posts on back navigation', () => {
+    render(<BlogPage />);
+    fireEvent.click(screen.getByRole('button', { name: 'guide' }));
+    expect(window.location.search).toBe('?tag=guide');
+    act(() => {
+      window.history.pushState({}, '', '/blog');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+    expect(window.location.search).toBe('');
+    expect(screen.getByText('UI/UX Notes')).toBeInTheDocument();
+  });
+});

--- a/data/blog-posts.json
+++ b/data/blog-posts.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": 1,
+    "title": "Intro to Kali Tools",
+    "excerpt": "Getting started with the desktop-style Kali Linux portfolio.",
+    "tags": ["guide", "kali"]
+  },
+  {
+    "id": 2,
+    "title": "Building Custom Apps",
+    "excerpt": "How to extend the portfolio with new apps and plugins.",
+    "tags": ["development", "guide"]
+  },
+  {
+    "id": 3,
+    "title": "UI/UX Notes",
+    "excerpt": "Design decisions behind the Ubuntu-like interface.",
+    "tags": ["design"]
+  }
+]

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useMemo, useState } from 'react';
+import postsData from '../data/blog-posts.json';
+
+interface Post {
+  id: number;
+  title: string;
+  excerpt: string;
+  tags: string[];
+}
+
+const BlogPage = () => {
+  const posts = postsData as Post[];
+  const [activeTag, setActiveTag] = useState('');
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    setActiveTag(params.get('tag') || '');
+    const onPopState = () => {
+      const p = new URLSearchParams(window.location.search);
+      setActiveTag(p.get('tag') || '');
+    };
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
+
+  const allTags = useMemo(
+    () => Array.from(new Set(posts.flatMap((p) => p.tags))),
+    [posts]
+  );
+  const filtered = useMemo(
+    () => posts.filter((p) => !activeTag || p.tags.includes(activeTag)),
+    [posts, activeTag]
+  );
+
+  const toggleTag = (tag: string) => {
+    const next = tag === activeTag ? '' : tag;
+    const params = new URLSearchParams(window.location.search);
+    if (next) {
+      params.set('tag', next);
+    } else {
+      params.delete('tag');
+    }
+    const url = params.toString() ? `?${params.toString()}` : '';
+    window.history.pushState({}, '', url);
+    setActiveTag(next);
+  };
+
+  return (
+    <main className="p-4 bg-ub-cool-grey text-white min-h-screen">
+      <div className="flex flex-wrap gap-2 mb-4">
+        {allTags.map((t) => (
+          <button
+            key={t}
+            onClick={() => toggleTag(t)}
+            className={`px-3 py-1 rounded-full text-sm ${
+              activeTag === t ? 'bg-blue-500 text-white' : 'bg-gray-700'
+            }`}
+            aria-pressed={activeTag === t}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <ul className="space-y-4">
+        {filtered.map((post) => (
+          <li key={post.id} className="border border-gray-700 p-4 rounded">
+            <h2 className="text-xl font-semibold">{post.title}</h2>
+            <p className="text-sm">{post.excerpt}</p>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+};
+
+export default BlogPage;


### PR DESCRIPTION
## Summary
- add blog page with tag chips positioned above posts and query param sync
- record sample blog posts data
- test tag filtering and history state behavior

## Testing
- `npx eslint pages/blog.tsx __tests__/blog.test.tsx data/blog-posts.json`
- `yarn test __tests__/blog.test.tsx`
- `yarn lint` (fails: Unexpected global 'document')
- `yarn test` (fails: window.test.tsx, nmapNse.test.tsx, reconng.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68c4f26265ac8328bd4761bd9f48a6a9