### PR TITLE
[nessus] trap focus in drawer

### DIFF
--- a/__tests__/nessus-report.test.tsx
+++ b/__tests__/nessus-report.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import NessusReport from '../pages/nessus-report';
 
 describe('Nessus sample report', () => {
@@ -46,5 +47,16 @@ describe('Nessus sample report', () => {
     const rows = screen.getAllByRole('row');
     expect(rows.length).toBe(2); // header + 1 finding
     expect(screen.getByText('Weak SSH Cipher')).toBeInTheDocument();
+  });
+
+  test('keeps focus trapped in drawer', async () => {
+    render(<NessusReport />);
+    fireEvent.click(screen.getByText('Weak SSH Cipher'));
+    const closeBtn = screen.getByText('Close');
+    expect(closeBtn).toHaveFocus();
+    await userEvent.tab();
+    expect(closeBtn).toHaveFocus();
+    await userEvent.tab({ shift: true });
+    expect(closeBtn).toHaveFocus();
   });
 });

--- a/pages/nessus-report.tsx
+++ b/pages/nessus-report.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useRef, useEffect } from 'react';
 import data from '../components/apps/nessus/sample-report.json';
 
 const severityColors: Record<string, string> = {
@@ -29,6 +29,20 @@ const NessusReport: React.FC = () => {
   const [host, setHost] = useState<string>('All');
   const [family, setFamily] = useState<string>('All');
   const [findings, setFindings] = useState<Finding[]>(data as Finding[]);
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (selected) {
+      closeRef.current?.focus();
+    }
+  }, [selected]);
+
+  const handleDialogKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      closeRef.current?.focus();
+    }
+  };
 
   const hosts = useMemo(
     () => Array.from(new Set(findings.map((f) => f.host))).sort(),
@@ -163,6 +177,7 @@ const NessusReport: React.FC = () => {
           accept=".json"
           className="text-black p-1 rounded"
           onChange={handleFile}
+          aria-label="Import report"
         />
         <label htmlFor="severity-filter" className="text-sm">
           Filter severity
@@ -281,9 +296,11 @@ const NessusReport: React.FC = () => {
       {selected && (
         <div
           role="dialog"
+          onKeyDown={handleDialogKey}
           className="fixed top-0 right-0 h-full w-80 bg-gray-800 p-4 overflow-auto shadow-lg"
         >
           <button
+            ref={closeRef}
             type="button"
             onClick={() => setSelected(null)}
             className="mb-2 text-sm bg-red-600 px-2 py-1 rounded"


### PR DESCRIPTION
## Summary
- ensure Nessus report drawer traps focus when open
- test that focus cannot escape the drawer via tabbing

## Testing
- `npx eslint pages/nessus-report.tsx __tests__/nessus-report.test.tsx`
- `yarn test __tests__/nessus-report.test.tsx`
- `yarn test` *(fails: e.preventDefault is not a function in window.test.tsx; Unable to find role="alert" in nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f2630b648328b01ad6ab7b8c48b4