### PR TITLE
[accessibility] improve high contrast styling

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -530,3 +530,13 @@ textarea:focus-visible {
     color: #000 !important;
 }
 
+@media (prefers-contrast: more), (forced-colors: active) {
+    :root {
+        --color-border: color-mix(in srgb, var(--color-border) 30%, var(--color-text) 70%);
+    }
+
+    body {
+        font-weight: 600;
+    }
+}
+

--- a/tests/high-contrast.spec.ts
+++ b/tests/high-contrast.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test('high contrast mode increases border visibility and text weight', async ({ page }) => {
+  await page.emulateMedia({ forcedColors: 'active' });
+  await page.goto('/');
+
+  const bodyFontWeight = await page.evaluate(() => getComputedStyle(document.body).fontWeight);
+  expect(parseInt(bodyFontWeight, 10)).toBeGreaterThanOrEqual(600);
+
+  const borderColor = await page.evaluate(() => {
+    const div = document.createElement('div');
+    div.style.border = '1px solid var(--color-border)';
+    document.body.appendChild(div);
+    return getComputedStyle(div).borderTopColor;
+  });
+  expect(borderColor).not.toBe('rgb(42, 46, 54)');
+});


### PR DESCRIPTION
## Summary
- enhance high-contrast mode by bolding text and boosting border color
- add Playwright test to ensure contrast adjustments apply

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in tetris)*
- `yarn test` *(fails: window, nmapNse, Modal tests)*
- `npx playwright test` *(fails: missing browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f2644d6c8328bed172acf9d7ab6c