### PR TITLE
[a11y] label icon buttons and hide decorative svgs

### DIFF
--- a/components/PopularModules.tsx
+++ b/components/PopularModules.tsx
@@ -108,6 +108,7 @@ const PopularModules: React.FC = () => {
         stroke="currentColor"
         viewBox="0 0 24 24"
         aria-hidden="true"
+        focusable="false"
       >
         <path
           strokeLinecap="round"
@@ -124,6 +125,7 @@ const PopularModules: React.FC = () => {
         stroke="currentColor"
         viewBox="0 0 24 24"
         aria-hidden="true"
+        focusable="false"
       >
         <path
           strokeLinecap="round"
@@ -146,6 +148,7 @@ const PopularModules: React.FC = () => {
         stroke="currentColor"
         viewBox="0 0 24 24"
         aria-hidden="true"
+        focusable="false"
       >
         <path
           strokeLinecap="round"
@@ -162,6 +165,7 @@ const PopularModules: React.FC = () => {
         stroke="currentColor"
         viewBox="0 0 24 24"
         aria-hidden="true"
+        focusable="false"
       >
         <path
           strokeLinecap="round"

--- a/components/YouTubePlayer.js
+++ b/components/YouTubePlayer.js
@@ -228,6 +228,8 @@ export default function YouTubePlayer({ videoId }) {
                 height="48"
                 viewBox="0 0 68 48"
                 className="relative z-10"
+                aria-hidden="true"
+                focusable="false"
               >
                 <path
                   className="ytp-large-play-button-bg"

--- a/components/apps/Games/common/VirtualPad.tsx
+++ b/components/apps/Games/common/VirtualPad.tsx
@@ -16,12 +16,28 @@ export default function VirtualPad({ onDirection, onButton }: PadProps) {
   return (
     <div className="virtual-pad">
       <div className="dpad">
-        <button className="up" onPointerDown={handleDir(0, -1)} />
+        <button
+          className="up"
+          aria-label="Up"
+          onPointerDown={handleDir(0, -1)}
+        />
         <div className="middle">
-          <button className="left" onPointerDown={handleDir(-1, 0)} />
-          <button className="right" onPointerDown={handleDir(1, 0)} />
+          <button
+            className="left"
+            aria-label="Left"
+            onPointerDown={handleDir(-1, 0)}
+          />
+          <button
+            className="right"
+            aria-label="Right"
+            onPointerDown={handleDir(1, 0)}
+          />
         </div>
-        <button className="down" onPointerDown={handleDir(0, 1)} />
+        <button
+          className="down"
+          aria-label="Down"
+          onPointerDown={handleDir(0, 1)}
+        />
       </div>
       <div className="actions">
         <button className="btn-a" onPointerDown={handleBtn('A')}>


### PR DESCRIPTION
## Summary
- add aria-labels to virtual gamepad directional controls
- hide decorative SVGs from screen readers

## Testing
- `yarn lint` (fails: Unexpected global 'document')
- `yarn test` (fails: e.preventDefault is not a function)
- `yarn a11y`


------
https://chatgpt.com/codex/tasks/task_e_68c4f2655b288328ad1b152a97fdafab