### PR TITLE
[ui] add :has() menu/search highlights with fallbacks

### DIFF
--- a/assets/css/kali-components.css
+++ b/assets/css/kali-components.css
@@ -1,0 +1,10 @@
+.menu-btn:has(+ .active),
+.menu-btn-active {
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.1);
+}
+
+.appmenu:has(.search input:focus),
+.appmenu-search-focus {
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.1);
+}
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -8,6 +8,7 @@ import '../styles/globals.css';
 import '../styles/index.css';
 import '../styles/resume-print.css';
 import '../styles/print.css';
+import '../assets/css/kali-components.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
@@ -16,6 +17,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { supportsCSSHas } from '../utils/feature';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -143,6 +145,42 @@ function MyApp(props) {
       if (OriginalNotification) {
         window.Notification = OriginalNotification;
       }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (supportsCSSHas()) return;
+    const observers = [];
+
+    document.querySelectorAll('.menu-btn').forEach((btn) => {
+      const sibling = btn.nextElementSibling;
+      if (!sibling) return;
+      const toggle = () => {
+        btn.classList.toggle('menu-btn-active', sibling.classList.contains('active'));
+      };
+      const observer = new MutationObserver(toggle);
+      observer.observe(sibling, { attributes: true, attributeFilter: ['class'] });
+      observers.push(observer);
+      toggle();
+    });
+
+    const handlers = [];
+    document.querySelectorAll('.appmenu').forEach((menu) => {
+      const input = menu.querySelector('.search input');
+      if (!input) return;
+      const focus = () => menu.classList.add('appmenu-search-focus');
+      const blur = () => menu.classList.remove('appmenu-search-focus');
+      input.addEventListener('focus', focus);
+      input.addEventListener('blur', blur);
+      handlers.push({ input, focus, blur });
+    });
+
+    return () => {
+      observers.forEach((o) => o.disconnect());
+      handlers.forEach(({ input, focus, blur }) => {
+        input.removeEventListener('focus', focus);
+        input.removeEventListener('blur', blur);
+      });
     };
   }, []);
 

--- a/utils/feature.ts
+++ b/utils/feature.ts
@@ -4,3 +4,8 @@ export const hasOffscreenCanvas = (): boolean =>
   typeof HTMLCanvasElement !== 'undefined' &&
   typeof HTMLCanvasElement.prototype.transferControlToOffscreen === 'function';
 
+export const supportsCSSHas = (): boolean =>
+  typeof CSS !== 'undefined' &&
+  typeof CSS.supports === 'function' &&
+  CSS.supports('selector(:has(*))');
+


### PR DESCRIPTION
## Summary
- highlight menu button when sibling active and app menu when search input focused
- add fallback classes and JS when CSS :has() unsupported

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in tetris, missing display name)*
- `yarn test` *(fails: e.preventDefault is not a function; Unable to find role="alert"; TypeError: Cannot read properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68c506e705bc8328ac581a6b39260428