### PR TITLE
[ui] add vim-style navigation for drawer and palette

### DIFF
--- a/assets/js/kali-ui.js
+++ b/assets/js/kali-ui.js
@@ -1,0 +1,43 @@
+(function () {
+  const vimMap = {
+    h: 'ArrowLeft',
+    j: 'ArrowDown',
+    k: 'ArrowUp',
+    l: 'ArrowRight',
+  };
+
+  function isOverlayActive() {
+    return Boolean(
+      document.querySelector('.kali-drawer.active, .kali-palette.active')
+    );
+  }
+
+  document.addEventListener('keydown', (e) => {
+    const arrow = vimMap[e.key];
+    if (!arrow || !isOverlayActive()) return;
+
+    const grid = document.querySelector('.kali-grid');
+    const drawer = document.querySelector('.kali-drawer');
+    if (
+      !document.activeElement.closest('.kali-grid') &&
+      !document.activeElement.closest('.kali-drawer')
+    ) {
+      if (grid) {
+        const firstLink = grid.querySelector('a');
+        firstLink?.focus();
+      } else if (drawer) {
+        const firstItem = drawer.querySelector(
+          'li a, li button, .drawer-item'
+        );
+        firstItem?.focus();
+      }
+    }
+
+    e.preventDefault();
+    const evt = new KeyboardEvent('keydown', {
+      key: arrow,
+      bubbles: true,
+    });
+    document.activeElement.dispatchEvent(evt);
+  });
+})();


### PR DESCRIPTION
## Summary
- support `h`, `j`, `k`, `l` keys to navigate app grid or drawer when overlays are active

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js; Component definition is missing display name in utils/createDynamicApp.js)*
- `yarn test` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size; NmapNSEApp › copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68c506f175648328b15cc01c13e7172b