### PR TITLE
[ui] focus search on slash key

### DIFF
--- a/public/kali-ui.js
+++ b/public/kali-ui.js
@@ -1,0 +1,29 @@
+(function () {
+  function findSearchInput() {
+    var selectors = [
+      '.all-apps-anim input',
+      '.window-switcher input',
+    ];
+    for (var i = 0; i < selectors.length; i++) {
+      var el = document.querySelector(selectors[i]);
+      if (el) return el;
+    }
+    return null;
+  }
+
+  function handleSlash(e) {
+    if (e.key !== '/' || e.ctrlKey || e.metaKey || e.altKey) return;
+    var active = document.activeElement;
+    if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)) return;
+    var input = findSearchInput();
+    if (!input) return;
+    e.preventDefault();
+    input.focus();
+    input.value = '';
+    try {
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    } catch (e) {}
+  }
+
+  window.addEventListener('keydown', handleSlash);
+})();


### PR DESCRIPTION
## Summary
- focus drawer or palette search when pressing `/`
- clear existing query and prevent default browser quick-find

## Testing
- `npx eslint public/kali-ui.js`
- `yarn test` *(fails: e.preventDefault is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c506f207d48328a07dfd4b8c2d224f