### PR TITLE
[ci] add oversized image check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,18 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn test --coverage
 
+  images:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn check:images
+
   security:
     runs-on: ubuntu-latest
     needs: install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: check-images
+        name: Check oversized images
+        entry: node scripts/check-images.js
+        language: node
+        pass_filenames: false

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import noTopLevelWindow from './eslint-plugin-no-top-level-window/index.js';
 const compat = new FlatCompat();
 
 const config = [
-  { ignores: ['components/apps/Chrome/index.tsx'] },
+  { ignores: ['components/apps/Chrome/index.tsx', 'public/apps/**'] },
   {
     plugins: {
       'no-top-level-window': noTopLevelWindow,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "module-report": "node scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
+    "check:images": "node scripts/check-images.js",
     "verify:all": "node scripts/verify.mjs"
   },
   "engines": {

--- a/scripts/check-images.js
+++ b/scripts/check-images.js
@@ -1,0 +1,49 @@
+const path = require('path');
+const fg = require('fast-glob');
+const sharp = require('sharp');
+
+const IMAGE_DIR = path.join(__dirname, '..', 'public');
+const PATTERN = '**/*.{png,jpg,jpeg,webp}';
+
+async function getImages() {
+  return fg(PATTERN, { cwd: IMAGE_DIR, onlyFiles: true });
+}
+
+function baseKey(file) {
+  const parsed = path.parse(file);
+  const base = parsed.name.split('@')[0].split('-')[0];
+  return path.join(parsed.dir, base);
+}
+
+async function checkImages() {
+  const files = await getImages();
+  const groups = new Map();
+  for (const file of files) {
+    const key = baseKey(file);
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(file);
+  }
+
+  const oversized = [];
+  for (const file of files) {
+    const metadata = await sharp(path.join(IMAGE_DIR, file)).metadata();
+    if (metadata.width && metadata.width > 2000) {
+      const key = baseKey(file);
+      if ((groups.get(key) || []).length === 1) {
+        oversized.push(`${file} (${metadata.width}px)`);
+      }
+    }
+  }
+
+  if (oversized.length) {
+    console.error('Oversized images without responsive variants:');
+    for (const img of oversized) {
+      console.error(` - ${img}`);
+    }
+    process.exit(1);
+  } else {
+    console.log('No oversized images without responsive variants found.');
+  }
+}
+
+checkImages();


### PR DESCRIPTION
## Summary
- enforce oversized image policy via new check-images script
- wire check into pre-commit and CI workflow
- ignore public app scripts during lint

## Testing
- `node scripts/check-images.js`
- `yarn lint` *(fails: multiple accessibility and display-name errors)*
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/Modal.test.tsx` *(fails: 2 failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c506fe467883289f3d758507ab7c5e