### PR TITLE
[security] centralize trusted origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Defined in `next.config.js`. See [CSP External Domains](#csp-external-domains) f
 
 ### CSP External Domains
 
-These external domains are whitelisted in the default CSP. Update this list whenever `next.config.js` changes.
+These external domains are whitelisted in the default CSP. `security/trusted-origins.json` is the source of truth; update it whenever domains change.
 
 | Domain | Purpose |
 | --- | --- |
@@ -252,10 +252,16 @@ These external domains are whitelisted in the default CSP. Update this list when
 | `cdn.jsdelivr.net` | Math.js library |
 | `cdnjs.cloudflare.com` | PDF.js worker |
 | `stackblitz.com` | StackBlitz IDE embeds |
+| `vscode.dev` | VS Code IDE embeds |
+| `ghbtns.com` | GitHub buttons |
+| `todoist.com` | Todoist embeds |
 | `www.youtube.com` | YouTube IFrame API |
 | `www.youtube-nocookie.com` | YouTube video embeds (privacy-enhanced) |
 | `open.spotify.com` | Spotify embeds |
 | `vercel.live` | Vercel toolbar |
+| `www.gstatic.com` | Google static assets |
+| `fonts.googleapis.com` | Google Fonts stylesheet |
+| `fonts.gstatic.com` | Google Fonts assets |
 
 **Notes for prod hardening**
 - Review `connect-src` and `frame-src` to ensure only required domains are present for your deployment.

--- a/components/ExternalFrame.js
+++ b/components/ExternalFrame.js
@@ -1,12 +1,18 @@
 import React, { useEffect, useState } from 'react';
 import Head from 'next/head';
+import trustedOrigins from '../security/trusted-origins.json';
 
-const ALLOWLIST = ['https://vscode.dev', 'https://stackblitz.com'];
+const ALLOWLIST = trustedOrigins.origins;
+
+const matches = (origin, allowed) =>
+  allowed.includes('*')
+    ? origin.endsWith(allowed.replace('*.', ''))
+    : origin === allowed;
 
 const isAllowed = (src) => {
   try {
-    const url = new URL(src);
-    return ALLOWLIST.some((allowed) => url.href.startsWith(allowed));
+    const { origin } = new URL(src);
+    return ALLOWLIST.some((allowed) => matches(origin, allowed));
   } catch {
     return false;
   }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server';
+import trustedOrigins from './security/trusted-origins.json';
 
 function nonce() {
   const arr = new Uint8Array(16);
@@ -8,14 +9,15 @@ function nonce() {
 
 export function middleware(req: NextRequest) {
   const n = nonce();
+  const trusted = trustedOrigins.origins.join(' ');
   const csp = [
     "default-src 'self'",
     "img-src 'self' https: data:",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
-    `script-src 'self' 'unsafe-inline' 'nonce-${n}' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com`,
-    "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://stackblitz.com",
-    "frame-src 'self' https://vercel.live https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
+    `script-src 'self' 'unsafe-inline' 'nonce-${n}' ${trusted}`,
+    `connect-src 'self' ${trusted}`,
+    `frame-src 'self' ${trusted}`,
     "frame-ancestors 'self'",
     "object-src 'none'",
     "base-uri 'self'",

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,10 @@
 // Security headers configuration for Next.js.
 // Allows external badges and same-origin PDF embedding.
-// Update README (section "CSP External Domains") when editing domains below.
+// External domains are sourced from security/trusted-origins.json.
 
 const { validateServerEnv: validateEnv } = require('./lib/validate.js');
+const { origins: trustedOrigins } = require('./security/trusted-origins.json');
+const trusted = trustedOrigins.join(' ');
 
 const ContentSecurityPolicy = [
   "default-src 'self'",
@@ -21,11 +23,11 @@ const ContentSecurityPolicy = [
   // Restrict fonts to same origin
   "font-src 'self'",
   // External scripts required for embedded timelines
-  "script-src 'self' 'unsafe-inline' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
+  `script-src 'self' 'unsafe-inline' ${trusted}`,
   // Allow outbound connections for embeds and the in-browser Chrome app
-  "connect-src 'self' https://example.com https://developer.mozilla.org https://en.wikipedia.org https://www.google.com https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
+  `connect-src 'self' ${trusted}`,
   // Allow iframes from specific providers so the Chrome and StackBlitz apps can load allowed content
-  "frame-src 'self' https://vercel.live https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com https://example.com https://developer.mozilla.org https://en.wikipedia.org",
+  `frame-src 'self' ${trusted}`,
 
   // Allow this site to embed its own resources (resume PDF)
   "frame-ancestors 'self'",

--- a/security/trusted-origins.json
+++ b/security/trusted-origins.json
@@ -1,0 +1,27 @@
+{
+  "origins": [
+    "https://vercel.live",
+    "https://platform.twitter.com",
+    "https://syndication.twitter.com",
+    "https://cdn.syndication.twimg.com",
+    "https://*.twitter.com",
+    "https://*.x.com",
+    "https://www.youtube.com",
+    "https://www.youtube-nocookie.com",
+    "https://www.google.com",
+    "https://*.google.com",
+    "https://www.gstatic.com",
+    "https://fonts.googleapis.com",
+    "https://fonts.gstatic.com",
+    "https://cdn.jsdelivr.net",
+    "https://cdnjs.cloudflare.com",
+    "https://stackblitz.com",
+    "https://vscode.dev",
+    "https://open.spotify.com",
+    "https://ghbtns.com",
+    "https://todoist.com",
+    "https://example.com",
+    "https://developer.mozilla.org",
+    "https://en.wikipedia.org"
+  ]
+}


### PR DESCRIPTION
## Summary
- add security/trusted-origins.json as source of truth for external domains
- generate CSP headers from trusted origins list
- reuse trusted origins for iframe and Chrome app allowlists

## Testing
- `yarn lint` *(fails: Unexpected global 'document' and missing display name)*
- `yarn test` *(fails: e.preventDefault is not a function and TypeError: Cannot read properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68c5070480b48328960ac50242dfabaf