### PR TITLE
[perf] inline critical CSS and defer nonessential styles

### DIFF
--- a/styles/critical.css
+++ b/styles/critical.css
@@ -1,0 +1,11 @@
+/* Minimal critical CSS for initial render to avoid flash of unstyled content */
+:root {
+  --color-bg: #0f1317;
+  --color-text: #f5f5f5;
+}
+body {
+  margin: 0;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  font-family: sans-serif;
+}


### PR DESCRIPTION
## Summary
- inline minimal critical styles to prevent flash of unstyled content
- load other CSS asynchronously by marking stylesheet links as `media="print"` and switching to `all` on load

## Testing
- `npx eslint pages/_document.jsx styles/critical.css` (files ignored but command run)
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, reconng.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c50709c22c8328afb6824f0f55690f