### PR TITLE
[ui] add Alt+Tab window switcher

### DIFF
--- a/__tests__/window-switcher.test.tsx
+++ b/__tests__/window-switcher.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import WindowSwitcher from '../components/screen/window-switcher';
+
+describe('WindowSwitcher', () => {
+  const windows = [
+    { id: 'one', title: 'One' },
+    { id: 'two', title: 'Two' },
+    { id: 'three', title: 'Three' },
+  ];
+
+  it('navigates with arrow keys and selects with Enter', () => {
+    const onSelect = jest.fn();
+    render(<WindowSwitcher windows={windows} onSelect={onSelect} onClose={() => {}} />);
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    fireEvent.keyDown(window, { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledWith('two');
+  });
+
+  it('selects current window on Alt release', () => {
+    const onSelect = jest.fn();
+    render(<WindowSwitcher windows={windows} onSelect={onSelect} onClose={() => {}} />);
+
+    fireEvent.keyDown(window, { key: 'Tab' });
+    fireEvent.keyUp(window, { key: 'Alt' });
+
+    expect(onSelect).toHaveBeenCalledWith('two');
+  });
+});
+

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -211,11 +211,25 @@ export class Desktop extends Component {
         this.focus(windows[next]);
     }
 
-    openWindowSwitcher = () => {
-        const windows = this.app_stack
-            .filter(id => this.state.closed_windows[id] === false)
-            .map(id => apps.find(a => a.id === id))
-            .filter(Boolean);
+    openWindowSwitcher = async () => {
+        const windows = [];
+        for (const id of this.app_stack) {
+            if (this.state.closed_windows[id] === false) {
+                const appMeta = apps.find(a => a.id === id);
+                if (appMeta) {
+                    let image = null;
+                    const node = document.getElementById(id);
+                    if (node) {
+                        try {
+                            image = await toPng(node);
+                        } catch (e) {
+                            // ignore thumbnail errors
+                        }
+                    }
+                    windows.push({ ...appMeta, image });
+                }
+            }
+        }
         if (windows.length) {
             this.setState({ showWindowSwitcher: true, switcherWindows: windows });
         }
@@ -839,7 +853,7 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} aria-label="Folder name" />
                 </div>
                 <div className="flex">
                     <button

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -1,22 +1,12 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 
 export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
-  const [query, setQuery] = useState('');
   const [selected, setSelected] = useState(0);
-  const inputRef = useRef(null);
-
-  const filtered = windows.filter((w) =>
-    w.title.toLowerCase().includes(query.toLowerCase())
-  );
-
-  useEffect(() => {
-    inputRef.current?.focus();
-  }, []);
 
   useEffect(() => {
     const handleKeyUp = (e) => {
       if (e.key === 'Alt') {
-        const win = filtered[selected];
+        const win = windows[selected];
         if (win && typeof onSelect === 'function') {
           onSelect(win.id);
         } else if (typeof onClose === 'function') {
@@ -26,57 +16,54 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
     };
     window.addEventListener('keyup', handleKeyUp);
     return () => window.removeEventListener('keyup', handleKeyUp);
-  }, [filtered, selected, onSelect, onClose]);
+  }, [windows, selected, onSelect, onClose]);
 
-  const handleKeyDown = (e) => {
-    if (e.key === 'Tab') {
-      e.preventDefault();
-      const len = filtered.length;
-      if (!len) return;
-      const dir = e.shiftKey ? -1 : 1;
-      setSelected((selected + dir + len) % len);
-    } else if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      const len = filtered.length;
-      if (!len) return;
-      setSelected((selected + 1) % len);
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      const len = filtered.length;
-      if (!len) return;
-      setSelected((selected - 1 + len) % len);
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      if (typeof onClose === 'function') onClose();
-    }
-  };
-
-  const handleChange = (e) => {
-    setQuery(e.target.value);
-    setSelected(0);
-  };
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Tab' || e.key === 'ArrowRight') {
+        e.preventDefault();
+        const len = windows.length;
+        if (!len) return;
+        const dir = e.shiftKey && e.key === 'Tab' ? -1 : 1;
+        setSelected((selected + dir + len) % len);
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        const len = windows.length;
+        if (!len) return;
+        setSelected((selected - 1 + len) % len);
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        const win = windows[selected];
+        if (win && typeof onSelect === 'function') onSelect(win.id);
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        if (typeof onClose === 'function') onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [windows, selected, onSelect, onClose]);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 text-white">
-      <div className="bg-ub-grey p-4 rounded w-3/4 md:w-1/3">
-        <input
-          ref={inputRef}
-          value={query}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          className="w-full mb-4 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
-          placeholder="Search windows"
-        />
-        <ul>
-          {filtered.map((w, i) => (
-            <li
-              key={w.id}
-              className={`px-2 py-1 rounded ${i === selected ? 'bg-ub-orange text-black' : ''}`}
-            >
-              {w.title}
-            </li>
-          ))}
-        </ul>
+      <div className="flex space-x-4">
+        {windows.map((w, i) => (
+          <div
+            key={w.id}
+            className={`flex flex-col items-center p-2 rounded ${
+              i === selected ? 'bg-ub-orange text-black' : 'bg-ub-grey'
+            }`}
+          >
+            {w.image || w.icon ? (
+              <img
+                src={w.image || w.icon}
+                alt={w.title}
+                className="h-24 w-32 object-cover"
+              />
+            ) : null}
+            <span className="mt-2 text-sm text-center w-32 truncate">{w.title}</span>
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace Alt+Tab search with horizontal window switcher overlay
- capture window thumbnails and navigate via arrows or Enter
- add unit tests for window switcher behavior

## Testing
- `npx eslint components/screen/window-switcher.js components/screen/desktop.js __tests__/window-switcher.test.tsx`
- `npx jest __tests__/window-switcher.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c50711515c8328a197c0bb0ba96311