### PR TITLE
[i18n] add client-side locale swapping

### DIFF
--- a/components/BetaBadge.jsx
+++ b/components/BetaBadge.jsx
@@ -5,7 +5,7 @@ export default function BetaBadge() {
       type="button"
       className="fixed bottom-4 right-4 rounded bg-yellow-500/90 px-2 py-1 text-xs font-semibold text-black"
     >
-      Beta
+      <span data-i18n="beta">Beta</span>
     </button>
   );
 }

--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -28,7 +28,7 @@ const InstallButton: React.FC = () => {
       onClick={handleInstall}
       className="fixed bottom-4 right-4 bg-ubt-blue text-white px-3 py-1 rounded"
     >
-      Install
+      <span data-i18n="install">Install</span>
     </button>
   );
 };

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -19,6 +19,7 @@ class MyDocument extends Document {
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
           <script nonce={nonce} src="/theme.js" />
+          <script nonce={nonce} src="/kali-ui.js" />
         </Head>
         <body>
           <Main />

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -10,7 +10,11 @@ const Ubuntu = dynamic(
     }),
   {
     ssr: false,
-    loading: () => <p>Loading Ubuntu...</p>,
+    loading: () => (
+      <p>
+        <span data-i18n="loadingUbuntu">Loading Ubuntu...</span>
+      </p>
+    ),
   }
 );
 const InstallButton = dynamic(
@@ -21,7 +25,13 @@ const InstallButton = dynamic(
     }),
   {
     ssr: false,
-    loading: () => <p>Loading install options...</p>,
+    loading: () => (
+      <p>
+        <span data-i18n="loadingInstallOptions">
+          Loading install options...
+        </span>
+      </p>
+    ),
   }
 );
 
@@ -31,7 +41,7 @@ const InstallButton = dynamic(
 const App = () => (
   <>
     <a href="#window-area" className="sr-only focus:not-sr-only">
-      Skip to content
+      <span data-i18n="skipToContent">Skip to content</span>
     </a>
     <Meta />
     <Ubuntu />

--- a/public/assets/i18n/en.json
+++ b/public/assets/i18n/en.json
@@ -1,0 +1,7 @@
+{
+  "skipToContent": "Skip to content",
+  "loadingUbuntu": "Loading Ubuntu...",
+  "loadingInstallOptions": "Loading install options...",
+  "install": "Install",
+  "beta": "Beta"
+}

--- a/public/kali-ui.js
+++ b/public/kali-ui.js
@@ -1,0 +1,40 @@
+/* eslint-env browser */
+(function () {
+  const I18N_PATH = '/assets/i18n/';
+  const DEFAULT_LOCALE = 'en';
+  let translations = {};
+
+  function applyTranslations(root = document) {
+    root.querySelectorAll('[data-i18n]').forEach((el) => {
+      const key = el.getAttribute('data-i18n');
+      if (key && Object.prototype.hasOwnProperty.call(translations, key)) {
+        el.textContent = translations[key];
+      }
+    });
+  }
+
+  async function loadLocale(locale) {
+    const res = await fetch(`${I18N_PATH}${locale}.json`);
+    translations = await res.json();
+    applyTranslations();
+  }
+
+  window.setLocale = async function (locale) {
+    await loadLocale(locale);
+    try {
+      window.localStorage.setItem('locale', locale);
+    } catch (e) {
+      // ignore storage errors
+    }
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    let locale = DEFAULT_LOCALE;
+    try {
+      locale = window.localStorage.getItem('locale') || DEFAULT_LOCALE;
+    } catch (e) {
+      locale = DEFAULT_LOCALE;
+    }
+    loadLocale(locale);
+  });
+})();


### PR DESCRIPTION
## Summary
- add English locale file
- load translations and expose `setLocale` helper
- mark UI labels with `data-i18n` hooks

## Testing
- `nvm install && nvm use`
- `yarn lint` *(fails: no-top-level-window violations in tetris, display-name rule)*
- `yarn test` *(fails: window snapping test TypeError, nmapNse alert not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f23fee788328a6f0a28035e10688