### PR TITLE
[ui] improve keyboard shortcut overlay

### DIFF
--- a/__tests__/ShortcutOverlay.test.tsx
+++ b/__tests__/ShortcutOverlay.test.tsx
@@ -25,4 +25,12 @@ describe('ShortcutOverlay', () => {
     expect(items[0]).toHaveAttribute('data-conflict', 'true');
     expect(items[1]).toHaveAttribute('data-conflict', 'true');
   });
+
+  it('closes with Escape key', () => {
+    render(<ShortcutOverlay />);
+    fireEvent.keyDown(window, { key: '?' });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- reuse modal component for keyboard shortcut overlay
- open shortcuts list with `?` and close using Esc
- add test covering Esc closure

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window snapping finalize and nmap NSE test)*
- `yarn test __tests__/ShortcutOverlay.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c4f240debc8328a32cb235c2fd9728