### PR TITLE
terminal: support rtl command palette

### DIFF
--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -404,7 +404,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
     <div className="relative h-full w-full">
       {paletteOpen && (
         <div className="absolute inset-0 bg-black bg-opacity-75 flex items-start justify-center z-10">
-          <div className="mt-10 w-80 bg-gray-800 p-4 rounded">
+          <div className="mt-10 w-80 bg-gray-800 p-4 rounded command-palette">
             <input
               autoFocus
               className="w-full mb-2 bg-black text-white p-2"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -77,3 +77,15 @@ html[data-theme='matrix'] {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
+
+/* RTL support for terminal command palette */
+[dir="rtl"] .command-palette {
+  direction: rtl;
+}
+[dir="rtl"] .command-palette input {
+  text-align: right;
+}
+[dir="rtl"] .command-palette ul {
+  direction: rtl;
+  text-align: right;
+}


### PR DESCRIPTION
## Summary
- enable RTL-aware styling for terminal command palette
- right-align command palette input and results in RTL layouts

## Testing
- `yarn lint` *(fails: Unexpected global 'document', Component definition is missing display name)*
- `yarn test` *(fails: Window snapping finalize and release, NmapNSEApp copies example output to clipboard, getDensity errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f241ec748328ba4959f304a3d891