### PR TITLE
[desktop] add kiosk mode support

### DIFF
--- a/components/KioskHomeButton.tsx
+++ b/components/KioskHomeButton.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import React from 'react';
+import WhiskerMenu from './menu/WhiskerMenu';
+
+const KioskHomeButton: React.FC = () => (
+  <div className="fixed bottom-4 left-4 z-50">
+    <WhiskerMenu compact />
+  </div>
+);
+
+export default KioskHomeButton;
+

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -20,7 +20,7 @@ const CATEGORIES = [
   { id: 'games', label: 'Games' }
 ];
 
-const WhiskerMenu: React.FC = () => {
+const WhiskerMenu: React.FC<{ compact?: boolean }> = ({ compact = false }) => {
   const [open, setOpen] = useState(false);
   const [category, setCategory] = useState('all');
   const [query, setQuery] = useState('');
@@ -119,17 +119,26 @@ const WhiskerMenu: React.FC = () => {
       <button
         ref={buttonRef}
         type="button"
+        aria-label="Applications"
         onClick={() => setOpen(o => !o)}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        className={
+          compact
+            ? 'w-10 h-10 rounded-full bg-ub-grey flex items-center justify-center'
+            : 'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+        }
       >
         <Image
-          src="/themes/Yaru/status/decompiler-symbolic.svg"
+          src={
+            compact
+              ? '/themes/Yaru/status/chrome_home.svg'
+              : '/themes/Yaru/status/decompiler-symbolic.svg'
+          }
           alt="Menu"
           width={16}
           height={16}
-          className="inline mr-1"
+          className={compact ? 'w-4 h-4' : 'inline mr-1'}
         />
-        Applications
+        {!compact && 'Applications'}
       </button>
       {open && (
         <div

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -5,19 +5,20 @@ import BootingScreen from './screen/booting_screen';
 import Desktop from './screen/desktop';
 import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
+import KioskHomeButton from './KioskHomeButton';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
 
 export default class Ubuntu extends Component {
-	constructor() {
-		super();
-		this.state = {
-			screen_locked: false,
-			bg_image_name: 'wall-2',
-			booting_screen: true,
-			shutDownScreen: false
-		};
-	}
+        constructor(props) {
+                super(props);
+                this.state = {
+                        screen_locked: false,
+                        bg_image_name: 'wall-2',
+                        booting_screen: true,
+                        shutDownScreen: false
+                };
+        }
 
 	componentDidMount() {
 		this.getLocalData();
@@ -126,9 +127,12 @@ export default class Ubuntu extends Component {
 					isShutDown={this.state.shutDownScreen}
 					turnOn={this.turnOn}
 				/>
-				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
-			</div>
-		);
-	}
+                                {!this.props.kiosk && (
+                                        <Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
+                                )}
+                                <Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
+                                {this.props.kiosk && <KioskHomeButton />}
+                        </div>
+                );
+        }
 }

--- a/hooks/useKiosk.tsx
+++ b/hooks/useKiosk.tsx
@@ -1,0 +1,13 @@
+import { createContext, ReactNode, useContext } from 'react';
+import { useRouter } from 'next/router';
+
+const KioskContext = createContext(false);
+
+export function KioskProvider({ children }: { children: ReactNode }) {
+  const { query } = useRouter();
+  const isKiosk = query.kiosk === '1';
+  return <KioskContext.Provider value={isKiosk}>{children}</KioskContext.Provider>;
+}
+
+export const useKiosk = () => useContext(KioskContext);
+

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState, ReactNode, useRef } from 'react';
+import { useKiosk } from './useKiosk';
 import {
   getAccent as loadAccent,
   setAccent as saveAccent,
@@ -112,8 +113,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
-  const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [theme, setThemeState] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
+  const isKiosk = useKiosk();
 
   useEffect(() => {
     (async () => {
@@ -127,7 +129,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
-      setTheme(loadTheme());
+      setThemeState(loadTheme());
     })();
   }, []);
 
@@ -235,6 +237,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     saveHaptics(haptics);
   }, [haptics]);
+
+  const setTheme = (value: string) => {
+    if (isKiosk) return;
+    setThemeState(value);
+  };
 
   return (
     <SettingsContext.Provider

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,6 +11,7 @@ import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import { KioskProvider } from '../hooks/useKiosk';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
@@ -156,23 +157,25 @@ function MyApp(props) {
         >
           Skip to app grid
         </a>
-        <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+        <KioskProvider>
+          <SettingsProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
-        </SettingsProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </SettingsProvider>
+        </KioskProvider>
       </div>
     </ErrorBoundary>
 

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
+import { useKiosk } from '../hooks/useKiosk';
 
 const Ubuntu = dynamic(
   () =>
@@ -28,16 +29,19 @@ const InstallButton = dynamic(
 /**
  * @returns {JSX.Element}
  */
-const App = () => (
-  <>
-    <a href="#window-area" className="sr-only focus:not-sr-only">
-      Skip to content
-    </a>
-    <Meta />
-    <Ubuntu />
-    <BetaBadge />
-    <InstallButton />
-  </>
-);
+const App = () => {
+  const kiosk = useKiosk();
+  return (
+    <>
+      <a href="#window-area" className="sr-only focus:not-sr-only">
+        Skip to content
+      </a>
+      <Meta />
+      <Ubuntu kiosk={kiosk} />
+      <BetaBadge />
+      <InstallButton />
+    </>
+  );
+};
 
 export default App;


### PR DESCRIPTION
## Summary
- detect `kiosk=1` query param and provide kiosk context
- hide navbar, add floating home button, and lock theme when kiosk mode is active

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window snapping finalize and release / copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f243431083288f88ade594c42cb8