### PR TITLE
[ui] sync theme settings across tabs

### DIFF
--- a/__tests__/settingsStore.test.ts
+++ b/__tests__/settingsStore.test.ts
@@ -1,0 +1,20 @@
+import { setAccent, getAccent, resetSettings } from '../utils/settingsStore';
+
+describe('settingsStore accent sync', () => {
+  beforeEach(async () => {
+    window.localStorage.clear();
+    await resetSettings();
+  });
+
+  test('setAccent stores value in localStorage', async () => {
+    await setAccent('#ff0000');
+    expect(window.localStorage.getItem('accent')).toBe('#ff0000');
+    expect(await getAccent()).toBe('#ff0000');
+  });
+
+  test('resetSettings clears accent from localStorage', async () => {
+    await setAccent('#00ff00');
+    await resetSettings();
+    expect(window.localStorage.getItem('accent')).toBeNull();
+  });
+});

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -149,6 +149,7 @@ function MyApp(props) {
   return (
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />
+      <Script src="/kali-ui.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
         <a
           href="#app-grid"

--- a/public/kali-ui.js
+++ b/public/kali-ui.js
@@ -1,0 +1,50 @@
+/* eslint-env browser */
+(function () {
+  var THEME_KEY = 'app:theme';
+  var CONTRAST_KEY = 'high-contrast';
+  var ACCENT_KEY = 'accent';
+  var darkThemes = ['dark', 'neon', 'matrix'];
+
+  function shadeColor(color, percent) {
+    var f = parseInt(color.slice(1), 16);
+    var t = percent < 0 ? 0 : 255;
+    var p = Math.abs(percent);
+    var R = f >> 16;
+    var G = (f >> 8) & 0x00ff;
+    var B = f & 0x0000ff;
+    var newR = Math.round((t - R) * p) + R;
+    var newG = Math.round((t - G) * p) + G;
+    var newB = Math.round((t - B) * p) + B;
+    return '#' + (0x1000000 + newR * 0x10000 + newG * 0x100 + newB).toString(16).slice(1);
+  }
+
+  function applyAccent(accent) {
+    if (!accent) return;
+    var border = shadeColor(accent, -0.2);
+    var vars = {
+      '--color-ub-orange': accent,
+      '--color-ub-border-orange': border,
+      '--color-primary': accent,
+      '--color-accent': accent,
+      '--color-focus-ring': accent,
+      '--color-selection': accent,
+      '--color-control-accent': accent,
+    };
+    Object.keys(vars).forEach(function (key) {
+      document.documentElement.style.setProperty(key, vars[key]);
+    });
+  }
+
+  window.addEventListener('storage', function (e) {
+    if (e.key === THEME_KEY && e.newValue) {
+      document.documentElement.dataset.theme = e.newValue;
+      document.documentElement.classList.toggle('dark', darkThemes.includes(e.newValue));
+    }
+    if (e.key === CONTRAST_KEY) {
+      document.documentElement.classList.toggle('high-contrast', e.newValue === 'true');
+    }
+    if (e.key === ACCENT_KEY && e.newValue) {
+      applyAccent(e.newValue);
+    }
+  });
+})();

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -24,6 +24,9 @@ export async function getAccent() {
 export async function setAccent(accent) {
   if (typeof window === 'undefined') return;
   await set('accent', accent);
+  try {
+    window.localStorage.setItem('accent', accent);
+  } catch {}
 }
 
 export async function getWallpaper() {
@@ -129,6 +132,9 @@ export async function resetSettings() {
     del('accent'),
     del('bg-image'),
   ]);
+  try {
+    window.localStorage.removeItem('accent');
+  } catch {}
   window.localStorage.removeItem('density');
   window.localStorage.removeItem('reduced-motion');
   window.localStorage.removeItem('font-scale');


### PR DESCRIPTION
## Summary
- listen for theme, contrast, and accent storage changes in kali-ui.js
- broadcast accent updates via localStorage and reset handling
- add regression test for accent sync and load new script in _app

## Testing
- `npx eslint pages/_app.jsx utils/settingsStore.js __tests__/settingsStore.test.ts public/kali-ui.js`
- `yarn test` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size; NmapNSEApp › copies example output to clipboard)*
- `yarn test __tests__/settingsStore.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c4f24451ec8328802c44436ee00646