### PR TITLE
[ui] add onboarding tour

### DIFF
--- a/__tests__/desktopTour.test.tsx
+++ b/__tests__/desktopTour.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DesktopTour from '../components/ui/DesktopTour';
+
+jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+
+describe('DesktopTour', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('saves flag when skipped', async () => {
+    render(<DesktopTour />);
+    const skip = await screen.findByRole('button', { name: /skip/i });
+    fireEvent.click(skip);
+    expect(localStorage.getItem('kali:tourDone')).toBe('true');
+  });
+});
+

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -31,6 +31,7 @@ const WhiskerMenu: React.FC = () => {
   const allApps: AppMeta[] = apps as any;
   const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
   const recentApps = useMemo(() => {
+    if (!open) return [];
     try {
       const ids: string[] = JSON.parse(safeLocalStorage?.getItem('recentApps') || '[]');
       return ids.map(id => allApps.find(a => a.id === id)).filter(Boolean) as AppMeta[];
@@ -117,6 +118,7 @@ const WhiskerMenu: React.FC = () => {
   return (
     <div className="relative">
       <button
+        id="whisker-menu-button"
         ref={buttonRef}
         type="button"
         onClick={() => setOpen(o => !o)}
@@ -153,14 +155,15 @@ const WhiskerMenu: React.FC = () => {
               </button>
             ))}
           </div>
-          <div className="p-3">
-            <input
-              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
-              placeholder="Search"
-              value={query}
-              onChange={e => setQuery(e.target.value)}
-              autoFocus
-            />
+            <div className="p-3">
+              <input
+                className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+                placeholder="Search"
+                aria-label="Search apps"
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                autoFocus
+              />
             <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
               {currentApps.map((app, idx) => (
                 <div key={app.id} className={idx === highlight ? 'ring-2 ring-ubb-orange' : ''}>

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -23,6 +23,7 @@ import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { useSnapSetting } from '../../hooks/usePersistentState';
+import DesktopTour from '../ui/DesktopTour';
 
 export class Desktop extends Component {
     constructor() {
@@ -838,8 +839,8 @@ export class Desktop extends Component {
         return (
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
-                    <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <label htmlFor="folder-name-input">New folder name</label>
+                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" aria-label="New folder name" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
                 </div>
                 <div className="flex">
                     <button
@@ -966,6 +967,8 @@ export class Desktop extends Component {
                         windows={this.state.switcherWindows}
                         onSelect={this.selectWindow}
                         onClose={this.closeWindowSwitcher} /> : null}
+
+                <DesktopTour />
 
             </main>
         )

--- a/components/ui/DesktopTour.tsx
+++ b/components/ui/DesktopTour.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import Tour from '@rc-component/tour';
+import { safeLocalStorage } from '../../utils/safeStorage';
+
+const TOUR_KEY = 'kali:tourDone';
+
+const DesktopTour = () => {
+  const [open, setOpen] = useState(false);
+  const [current, setCurrent] = useState(0);
+
+  useEffect(() => {
+    if (safeLocalStorage?.getItem(TOUR_KEY) !== 'true') {
+      setOpen(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    if (current === 0) {
+      document.getElementById('whisker-menu-button')?.click();
+    } else if (current === 1) {
+      const status = document.getElementById('status-bar');
+      if (status && !document.getElementById('qs-theme-toggle')) {
+        status.click();
+      }
+    } else if (current === 2) {
+      const status = document.getElementById('status-bar');
+      if (document.getElementById('qs-theme-toggle')) {
+        status?.click();
+      }
+      document.getElementById('whisker-menu-button')?.click();
+    }
+  }, [open, current]);
+
+  const finish = () => {
+    safeLocalStorage?.setItem(TOUR_KEY, 'true');
+    setOpen(false);
+  };
+
+  const steps = [
+    {
+      title: 'Open the drawer',
+      description: 'Use the Applications menu to launch apps.',
+      target: () => document.getElementById('whisker-menu-button'),
+    },
+    {
+      title: 'Switch theme',
+      description: 'Toggle between light and dark modes.',
+      target: () => document.getElementById('qs-theme-toggle'),
+    },
+    {
+      title: 'Navigate workspaces',
+      description: 'Press Ctrl+Super+←/→ to cycle workspaces.',
+      target: () => document.getElementById('desktop'),
+    },
+  ];
+
+  if (!open) return null;
+
+  return (
+    <Tour
+      open
+      steps={steps}
+      current={current}
+      onChange={setCurrent}
+      onClose={finish}
+      renderPanel={(props, idx) => (
+        <div>
+          <div className="font-bold mb-2">{props.title}</div>
+          {props.description && <div className="mb-3">{props.description}</div>}
+          <div className="flex justify-between">
+            <button onClick={finish}>Skip</button>
+            <div className="space-x-2">
+              {idx > 0 && <button onClick={props.onPrev}>Prev</button>}
+              <button onClick={idx === steps.length - 1 ? finish : props.onNext}>
+                {idx === steps.length - 1 ? 'Done' : 'Next'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    />
+  );
+};
+
+export default DesktopTour;
+

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -29,6 +29,7 @@ const QuickSettings = ({ open }: Props) => {
     >
       <div className="px-4 pb-2">
         <button
+          id="qs-theme-toggle"
           className="w-full flex justify-between"
           onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
         >
@@ -38,16 +39,27 @@ const QuickSettings = ({ open }: Props) => {
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
+        <input
+          type="checkbox"
+          aria-label="Toggle sound"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+        />
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+        <input
+          type="checkbox"
+          aria-label="Toggle network"
+          checked={online}
+          onChange={() => setOnline(!online)}
+        />
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>
         <input
           type="checkbox"
+          aria-label="Toggle reduced motion"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
         />


### PR DESCRIPTION
## Summary
- add initial desktop tour showing app drawer, theme toggle, and workspace tip
- allow skipping the tour and mark completion via `kali:tourDone`
- test to ensure tour completion flag saves

## Testing
- `npx eslint components/menu/WhiskerMenu.tsx components/ui/QuickSettings.tsx components/ui/DesktopTour.tsx components/screen/desktop.js __tests__/desktopTour.test.tsx`
- `yarn test` *(fails: window snapping finalize and release, NmapNSEApp, ReconNG app)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f246b6ec83289391ac24f1e98e36