### PR TITLE
ui: add container queries for app grid

### DIFF
--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -76,7 +76,10 @@ export default function AppGrid({ openApp }) {
     if (index >= data.items.length) return null;
     const app = data.items[index];
     return (
-      <div style={{ ...style, display: 'flex', justifyContent: 'center', alignItems: 'center', padding: 12 }}>
+      <div
+        style={{ ...style, display: 'flex', justifyContent: 'center', alignItems: 'center' }}
+        className="terminal"
+      >
         <UbuntuApp
           id={app.id}
           icon={app.icon}
@@ -96,7 +99,7 @@ export default function AppGrid({ openApp }) {
         value={query}
         onChange={(e) => setQuery(e.target.value)}
       />
-      <div className="w-full flex-1 h-[70vh] outline-none" onKeyDown={handleKeyDown}>
+      <div className="cq w-full flex-1 h-[70vh] outline-none" onKeyDown={handleKeyDown}>
         <AutoSizer>
           {({ height, width }) => {
             const columnCount = getColumnCount(width);
@@ -111,7 +114,7 @@ export default function AppGrid({ openApp }) {
                 rowCount={rowCount}
                 rowHeight={112}
                 width={width}
-                className="scroll-smooth"
+                className="kali-grid scroll-smooth"
               >
                 {(props) => <Cell {...props} data={{ items: filtered, columnCount }} />}
               </Grid>

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -41,15 +41,16 @@ class AllApplications extends React.Component {
     renderApps = () => {
         const apps = this.state.apps || [];
         return apps.map((app) => (
-            <UbuntuApp
-                key={app.id}
-                name={app.title}
-                id={app.id}
-                icon={app.icon}
-                openApp={() => this.openApp(app.id)}
-                disabled={app.disabled}
-                prefetch={app.screen?.prefetch}
-            />
+            <div key={app.id} className="terminal">
+                <UbuntuApp
+                    name={app.title}
+                    id={app.id}
+                    icon={app.icon}
+                    openApp={() => this.openApp(app.id)}
+                    disabled={app.disabled}
+                    prefetch={app.screen?.prefetch}
+                />
+            </div>
         ));
     };
 
@@ -62,8 +63,10 @@ class AllApplications extends React.Component {
                     value={this.state.query}
                     onChange={this.handleChange}
                 />
-                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
-                    {this.renderApps()}
+                <div className="cq">
+                    <div className="kali-grid grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
+                        {this.renderApps()}
+                    </div>
                 </div>
             </div>
         );

--- a/components/screen/shortcut-selector.js
+++ b/components/screen/shortcut-selector.js
@@ -41,15 +41,16 @@ class ShortcutSelector extends React.Component {
     renderApps = () => {
         const apps = this.state.apps || [];
         return apps.map((app) => (
-            <UbuntuApp
-                key={app.id}
-                name={app.title}
-                id={app.id}
-                icon={app.icon}
-                openApp={() => this.selectApp(app.id)}
-                disabled={app.disabled}
-                prefetch={app.screen?.prefetch}
-            />
+            <div key={app.id} className="terminal">
+                <UbuntuApp
+                    name={app.title}
+                    id={app.id}
+                    icon={app.icon}
+                    openApp={() => this.selectApp(app.id)}
+                    disabled={app.disabled}
+                    prefetch={app.screen?.prefetch}
+                />
+            </div>
         ));
     };
 
@@ -62,8 +63,10 @@ class ShortcutSelector extends React.Component {
                     value={this.state.query}
                     onChange={this.handleChange}
                 />
-                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
-                    {this.renderApps()}
+                <div className="cq">
+                    <div className="kali-grid grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
+                        {this.renderApps()}
+                    </div>
                 </div>
                 <button
                     className="mb-8 px-4 py-2 rounded bg-black bg-opacity-20 text-white"

--- a/styles/index.css
+++ b/styles/index.css
@@ -530,3 +530,20 @@ textarea:focus-visible {
     color: #000 !important;
 }
 
+/* Container query utilities */
+.cq {
+    container-type: inline-size;
+}
+
+.kali-grid > .terminal > div {
+    padding: 0.25rem;
+    font-size: 0.75rem;
+}
+
+@container (min-width: 520px) {
+    .kali-grid > .terminal > div {
+        padding: 1rem;
+        font-size: 0.875rem;
+    }
+}
+


### PR DESCRIPTION
## Summary
- wrap app grids in `.cq` containers
- switch `.kali-grid > .terminal` spacing to `@container` queries
- tune padding and font size at `min-width: 520px`

## Testing
- `yarn lint` *(fails: Unexpected global 'document' etc.)*
- `yarn test` *(fails: e.preventDefault is not a function, Unable to find role="alert", Cannot read properties of null)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68c4f2394ef483288d0b98324fa45685