### PR TITLE
chore(ui): restore classic shell, keep About Alex app

### DIFF
--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
+import { isBrowser } from '@/utils/env';
 
 interface ModalProps {
     isOpen: boolean;
@@ -11,6 +12,15 @@ interface ModalProps {
      * Defaults to the Next.js root (`__next`).
      */
     overlayRoot?: string | HTMLElement;
+    /**
+     * Optional id of a heading element that labels the dialog.
+     */
+    ariaLabelledby?: string;
+    /**
+     * Optional className applied to the dialog element, allowing styling such
+     * as positioning or background overlays.
+     */
+    className?: string;
 }
 
 const FOCUSABLE_SELECTORS = [
@@ -27,13 +37,20 @@ const FOCUSABLE_SELECTORS = [
     '[contenteditable]'
 ].join(',');
 
-const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot }) => {
+const Modal: React.FC<ModalProps> = ({
+    isOpen,
+    onClose,
+    children,
+    overlayRoot,
+    ariaLabelledby,
+    className,
+}) => {
     const modalRef = useRef<HTMLDivElement>(null);
     const triggerRef = useRef<HTMLElement | null>(null);
     const portalRef = useRef<HTMLDivElement | null>(null);
     const inertRootRef = useRef<HTMLElement | null>(null);
 
-    if (!portalRef.current && typeof document !== 'undefined') {
+    if (!portalRef.current && isBrowser()) {
         const el = document.createElement('div');
         portalRef.current = el;
         document.body.appendChild(el);
@@ -113,9 +130,11 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
         <div
             role="dialog"
             aria-modal="true"
+            aria-labelledby={ariaLabelledby}
             ref={modalRef}
             onKeyDown={handleKeyDown}
             tabIndex={-1}
+            className={className}
         >
             {children}
         </div>,

--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -101,7 +101,7 @@ export class SideBarApp extends Component {
                     this.setState({ showTitle: false, thumbnail: null });
                 }}
                 className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
-                    " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
+                    " group w-auto p-2 relative rounded m-1 hover:bg-white hover:bg-opacity-10 active:bg-white active:bg-opacity-20 cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-white focus-visible:outline-offset-2"}
                 id={"sidebar-" + this.props.id}
             >
                 <Image
@@ -109,7 +109,7 @@ export class SideBarApp extends Component {
                     height={28}
                     className="w-7"
                     src={this.props.icon.replace('./', '/')}
-                    alt="Ubuntu App Icon"
+                    alt={this.props.title}
                     sizes="28px"
                 />
                 <Image
@@ -117,13 +117,14 @@ export class SideBarApp extends Component {
                     height={28}
                     className={(this.state.scaleImage ? " scale " : "") + " scalable-app-icon w-7 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"}
                     src={this.props.icon.replace('./', '/')}
-                    alt=""
+                    alt={this.props.title}
+                    aria-hidden="true"
                     sizes="28px"
                 />
                 {
                     (
                         this.props.isClose[this.id] === false
-                            ? <div className=" w-2 h-1 absolute bottom-0 left-1/2 transform -translate-x-1/2 bg-white rounded-md"></div>
+                            ? <div className="w-2 h-1 absolute bottom-0 left-1/2 transform -translate-x-1/2 bg-white rounded-md opacity-80 transition-opacity group-hover:opacity-100 group-active:opacity-100 group-focus-visible:opacity-100"></div>
                             : null
                     )
                 }

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -1,10 +1,12 @@
 import React, { Component } from 'react'
 import Image from 'next/image'
+import prefetchDynamicImport from '../../utils/prefetchDynamicImport'
 
 export class UbuntuApp extends Component {
     constructor() {
         super();
         this.state = { launching: false, dragging: false, prefetched: false };
+        this.prefetchTimer = null;
     }
 
     handleDragStart = () => {
@@ -25,42 +27,67 @@ export class UbuntuApp extends Component {
 
     handlePrefetch = () => {
         if (!this.state.prefetched && typeof this.props.prefetch === 'function') {
-            this.props.prefetch();
+            prefetchDynamicImport(this.props.prefetch, `/apps/${this.props.id}.js`);
             this.setState({ prefetched: true });
         }
     }
 
+    startPrefetchTimer = () => {
+        if (this.state.prefetched || this.prefetchTimer) return;
+        this.prefetchTimer = setTimeout(() => {
+            this.prefetchTimer = null;
+            this.handlePrefetch();
+        }, 150);
+    }
+
+    clearPrefetchTimer = () => {
+        if (this.prefetchTimer) {
+            clearTimeout(this.prefetchTimer);
+            this.prefetchTimer = null;
+        }
+    }
+
+    componentWillUnmount() {
+        this.clearPrefetchTimer();
+    }
+
     render() {
         return (
-            <div
-                role="button"
+            <button
+                type="button"
                 aria-label={this.props.name}
-                aria-disabled={this.props.disabled}
+                disabled={this.props.disabled}
                 data-context="app"
                 data-app-id={this.props.id}
                 draggable
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
+                title={this.props.prefetch ? 'Prefetches on hover' : undefined}
                 className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                    " relative p-1 m-1 z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 border border-transparent rounded select-none w-20 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-colors "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
-                tabIndex={this.props.disabled ? -1 : 0}
-                onMouseEnter={this.handlePrefetch}
-                onFocus={this.handlePrefetch}
+                tabIndex={this.props.disabled ? -1 : (this.props.tabIndex ?? 0)}
+                onMouseEnter={this.startPrefetchTimer}
+                onMouseLeave={this.clearPrefetchTimer}
+                onFocus={(e) => { this.startPrefetchTimer(); this.props.onFocus && this.props.onFocus(e); }}
+                onBlur={this.clearPrefetchTimer}
             >
+                {this.props.prefetch && (
+                    <span className="sr-only">Prefetches resources on hover</span>
+                )}
                 <Image
-                    width={40}
-                    height={40}
-                    className="mb-1 w-10"
+                    width={32}
+                    height={32}
+                    className="mb-1 w-8"
                     src={this.props.icon.replace('./', '/')}
                     alt={"Kali " + this.props.name}
-                    sizes="40px"
+                    sizes="32px"
                 />
                 {this.props.displayName || this.props.name}
 
-            </div>
+            </button>
         )
     }
 }

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -1,5 +1,6 @@
 "use client";
 
+import { isBrowser } from '@/utils/env';
 import React, { Component } from 'react';
 import NextImage from 'next/image';
 import Draggable from 'react-draggable';
@@ -8,12 +9,25 @@ import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
 import styles from './window.module.css';
 
+// Simple debounce helper to limit how frequently handlers run
+const debounce = (fn, delay) => {
+    let timeout;
+    return (...args) => {
+        clearTimeout(timeout);
+        timeout = setTimeout(() => fn(...args), delay);
+    };
+};
+
 export class Window extends Component {
+    static defaultProps = {
+        isFocused: true,
+        zIndex: 1,
+    };
     constructor(props) {
         super(props);
         this.id = null;
         const isPortrait =
-            typeof window !== "undefined" && window.innerHeight > window.innerWidth;
+            isBrowser() && window.innerHeight > window.innerWidth;
         this.startX =
             props.initialX ??
             (isPortrait ? window.innerWidth * 0.05 : 60);
@@ -32,22 +46,33 @@ export class Window extends Component {
             snapPosition: null,
             snapped: null,
             lastSize: null,
+            prevBounds: null,
             grabbed: false,
+            alwaysOnTop: false,
+            shaded: false,
+            stuck: false,
+            resizing: false,
         }
         this._usageTimeout = null;
         this._uiExperiments = process.env.NEXT_PUBLIC_UI_EXPERIMENTS === 'true';
         this._menuOpener = null;
+        // Track the element that triggered this window so we can restore focus
+        this._opener = null;
+        this.rootRef = React.createRef();
     }
 
     componentDidMount() {
         this.id = this.props.id;
         this.setDefaultWindowDimenstion();
 
+        // Remember the currently focused element before this window takes focus
+        this._opener = document.activeElement;
+
         // google analytics
         ReactGA.send({ hitType: "pageview", page: `/${this.id}`, title: "Custom Title" });
 
         // on window resize, resize boundary
-        window.addEventListener('resize', this.resizeBoundries);
+        window.addEventListener('resize', this.debouncedResizeBoundries);
         // Listen for context menu events to toggle inert background
         window.addEventListener('context-menu-open', this.setInertBackground);
         window.addEventListener('context-menu-close', this.removeInertBackground);
@@ -56,12 +81,18 @@ export class Window extends Component {
         if (this._uiExperiments) {
             this.scheduleUsageCheck();
         }
+        if (this.props.initialSnap) {
+            this.snapWindow(this.props.initialSnap);
+        }
+
+        // Move focus into the window once it is mounted
+        this.focusSelf();
     }
 
     componentWillUnmount() {
         ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
-        window.removeEventListener('resize', this.resizeBoundries);
+        window.removeEventListener('resize', this.debouncedResizeBoundries);
         window.removeEventListener('context-menu-open', this.setInertBackground);
         window.removeEventListener('context-menu-close', this.removeInertBackground);
         const root = document.getElementById(this.id);
@@ -107,6 +138,8 @@ export class Window extends Component {
             }
         });
     }
+
+    debouncedResizeBoundries = debounce(this.resizeBoundries, 50);
 
     computeContentUsage = () => {
         const root = document.getElementById(this.id);
@@ -185,6 +218,10 @@ export class Window extends Component {
         this._menuOpener = null;
     }
 
+    focusSelf = () => {
+        this.rootRef.current?.focus();
+    }
+
     changeCursorToMove = () => {
         this.focusWindow();
         if (this.state.maximized) {
@@ -200,6 +237,38 @@ export class Window extends Component {
         this.setState({ cursorType: "cursor-default", grabbed: false })
     }
 
+    startResize = () => {
+        if (this.props.resizable === false) return;
+        this.focusWindow();
+        if (this.state.maximized) {
+            this.restoreWindow();
+        }
+        this.setState({ cursorType: "cursor-nwse-resize", resizing: true });
+    }
+
+    endResize = () => {
+        this.setState({ cursorType: "cursor-default", resizing: false });
+    }
+
+    toggleAlwaysOnTop = () => {
+        this.setState(prev => ({ alwaysOnTop: !prev.alwaysOnTop }));
+    }
+
+    toggleShade = () => {
+        this.setState(prev => {
+            if (prev.shaded) {
+                const height = prev.lastSize && prev.lastSize.height ? prev.lastSize.height : prev.height;
+                return { shaded: false, height };
+            } else {
+                return { shaded: true, lastSize: { ...prev.lastSize, height: prev.height }, height: 8 };
+            }
+        }, this.resizeBoundries);
+    }
+
+    toggleStick = () => {
+        this.setState(prev => ({ stuck: !prev.stuck }));
+    }
+
     snapToGrid = (value) => {
         if (!this.props.snapEnabled) return value;
         return Math.round(value / 8) * 8;
@@ -213,6 +282,8 @@ export class Window extends Component {
         this.setState({ height: heightPercent }, this.resizeBoundries);
     }
 
+    debouncedHandleVerticleResize = debounce(this.handleVerticleResize, 50);
+
     handleHorizontalResize = () => {
         if (this.props.resizable === false) return;
         const px = (this.state.width / 100) * window.innerWidth + 1;
@@ -220,6 +291,8 @@ export class Window extends Component {
         const widthPercent = snapped / window.innerWidth * 100;
         this.setState({ width: widthPercent }, this.resizeBoundries);
     }
+
+    debouncedHandleHorizontalResize = debounce(this.handleHorizontalResize, 50);
 
     setWinowsPosition = () => {
         var r = document.querySelector("#" + this.id);
@@ -230,33 +303,53 @@ export class Window extends Component {
         r.style.setProperty('--window-transform-x', x.toFixed(1).toString() + "px");
         r.style.setProperty('--window-transform-y', y.toFixed(1).toString() + "px");
         if (this.props.onPositionChange) {
-            this.props.onPositionChange(x, y);
+            this.props.onPositionChange(x, y, this.state.snapped);
         }
     }
 
     unsnapWindow = () => {
         if (!this.state.snapped) return;
+        const prev = this.state.prevBounds;
         var r = document.querySelector("#" + this.id);
         if (r) {
-            const x = r.style.getPropertyValue('--window-transform-x');
-            const y = r.style.getPropertyValue('--window-transform-y');
-            if (x && y) {
-                r.style.transform = `translate(${x},${y})`;
+            if (prev) {
+                const { x, y } = prev;
+                r.style.transform = `translate(${x}px,${y}px)`;
+            } else {
+                const x = r.style.getPropertyValue('--window-transform-x');
+                const y = r.style.getPropertyValue('--window-transform-y');
+                if (x && y) {
+                    r.style.transform = `translate(${x},${y})`;
+                }
             }
+        }
+        if (this.props.onPositionChange && prev) {
+            this.props.onPositionChange(prev.x, prev.y, null);
         }
         if (this.state.lastSize) {
             this.setState({
                 width: this.state.lastSize.width,
                 height: this.state.lastSize.height,
-                snapped: null
+                snapped: null,
+                prevBounds: null
             }, this.resizeBoundries);
         } else {
-            this.setState({ snapped: null }, this.resizeBoundries);
+            this.setState({ snapped: null, prevBounds: null }, this.resizeBoundries);
         }
     }
 
     snapWindow = (position) => {
-        this.setWinowsPosition();
+        this.focusWindow();
+        const r = document.querySelector("#" + this.id);
+        let prevBounds = null;
+        if (r) {
+            const rect = r.getBoundingClientRect();
+            const x = this.snapToGrid(rect.x);
+            const y = this.snapToGrid(rect.y - 32);
+            r.style.setProperty('--window-transform-x', x.toFixed(1).toString() + "px");
+            r.style.setProperty('--window-transform-y', y.toFixed(1).toString() + "px");
+            prevBounds = { x, y };
+        }
         const { width, height } = this.state;
         let newWidth = width;
         let newHeight = height;
@@ -273,10 +366,32 @@ export class Window extends Component {
             newWidth = 100.2;
             newHeight = 50;
             transform = 'translate(-1pt,-2pt)';
+        } else if (position === 'bottom') {
+            newWidth = 100.2;
+            newHeight = 50;
+            transform = `translate(-1pt,${window.innerHeight / 2}px)`;
+        } else if (position === 'top-left') {
+            newWidth = 50;
+            newHeight = 50;
+            transform = 'translate(-1pt,-2pt)';
+        } else if (position === 'top-right') {
+            newWidth = 50;
+            newHeight = 50;
+            transform = `translate(${window.innerWidth / 2}px,-2pt)`;
+        } else if (position === 'bottom-left') {
+            newWidth = 50;
+            newHeight = 50;
+            transform = `translate(-1pt,${window.innerHeight / 2}px)`;
+        } else if (position === 'bottom-right') {
+            newWidth = 50;
+            newHeight = 50;
+            transform = `translate(${window.innerWidth / 2}px,${window.innerHeight / 2}px)`;
         }
-        const r = document.querySelector("#" + this.id);
         if (r && transform) {
             r.style.transform = transform;
+        }
+        if (this.props.onPositionChange && prevBounds) {
+            this.props.onPositionChange(prevBounds.x, prevBounds.y, position);
         }
         this.setState({
             snapPreview: null,
@@ -284,7 +399,8 @@ export class Window extends Component {
             snapped: position,
             lastSize: { width, height },
             width: newWidth,
-            height: newHeight
+            height: newHeight,
+            prevBounds
         }, this.resizeBoundries);
     }
 
@@ -319,17 +435,41 @@ export class Window extends Component {
         var rect = r.getBoundingClientRect();
         const threshold = 30;
         let snap = null;
-        if (rect.left <= threshold) {
+        const nearLeft = rect.left <= threshold;
+        const nearRight = rect.right >= window.innerWidth - threshold;
+        const nearTop = rect.top <= threshold;
+        const nearBottom = rect.bottom >= window.innerHeight - threshold;
+        if (nearLeft && nearTop) {
+            snap = { left: '0', top: '0', width: '50%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'top-left' });
+        }
+        else if (nearRight && nearTop) {
+            snap = { left: '50%', top: '0', width: '50%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'top-right' });
+        }
+        else if (nearLeft && nearBottom) {
+            snap = { left: '0', top: '50%', width: '50%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'bottom-left' });
+        }
+        else if (nearRight && nearBottom) {
+            snap = { left: '50%', top: '50%', width: '50%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'bottom-right' });
+        }
+        else if (nearLeft) {
             snap = { left: '0', top: '0', width: '50%', height: '100%' };
             this.setState({ snapPreview: snap, snapPosition: 'left' });
         }
-        else if (rect.right >= window.innerWidth - threshold) {
+        else if (nearRight) {
             snap = { left: '50%', top: '0', width: '50%', height: '100%' };
             this.setState({ snapPreview: snap, snapPosition: 'right' });
         }
-        else if (rect.top <= threshold) {
+        else if (nearTop) {
             snap = { left: '0', top: '0', width: '100%', height: '50%' };
             this.setState({ snapPreview: snap, snapPosition: 'top' });
+        }
+        else if (nearBottom) {
+            snap = { left: '0', top: '50%', width: '100%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'bottom' });
         }
         else {
             if (this.state.snapPreview) this.setState({ snapPreview: null, snapPosition: null });
@@ -365,6 +505,8 @@ export class Window extends Component {
         this.checkSnapPreview();
     }
 
+    debouncedHandleDrag = debounce(this.handleDrag, 50);
+
     handleStop = () => {
         this.changeCursorToDefault();
         const snapPos = this.state.snapPosition;
@@ -377,6 +519,7 @@ export class Window extends Component {
 
     focusWindow = () => {
         this.props.focus(this.id);
+        this.focusSelf();
     }
 
     minimizeWindow = () => {
@@ -468,12 +611,21 @@ export class Window extends Component {
 
     closeWindow = () => {
         this.setWinowsPosition();
+        const prefersReducedMotion =
+            window.matchMedia &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        const delay = prefersReducedMotion ? 0 : 300;
         this.setState({ closed: true }, () => {
             this.deactivateOverlay();
             this.props.hideSideBar(this.id, false);
             setTimeout(() => {
-                this.props.closed(this.id)
-            }, 300) // after 300ms this window will be unmounted from parent (Desktop)
+                this.props.closed(this.id);
+                // Restore focus to the element that opened this window
+                if (this._opener && typeof this._opener.focus === 'function') {
+                    this._opener.focus();
+                }
+                this._opener = null;
+            }, delay); // skip delay when reduced motion is preferred
         });
     }
 
@@ -494,8 +646,8 @@ export class Window extends Component {
             else if (e.key === 'ArrowUp') dy = -step;
             else if (e.key === 'ArrowDown') dy = step;
             if (dx !== 0 || dy !== 0) {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 const node = document.getElementById(this.id);
                 if (node) {
                     const match = /translate\(([-\d.]+)px,\s*([-\d.]+)px\)/.exec(node.style.transform);
@@ -519,32 +671,19 @@ export class Window extends Component {
     }
 
     handleKeyDown = (e) => {
-        if (e.key === 'Escape') {
-            this.closeWindow();
-        } else if (e.key === 'Tab') {
-            this.focusWindow();
-        } else if (e.altKey) {
-            if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
-                this.unsnapWindow();
-            } else if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
-                this.snapWindow('left');
-            } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
-                this.snapWindow('right');
-            } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
-                this.snapWindow('top');
-            }
-            this.focusWindow();
-        } else if (e.shiftKey) {
+        if (this.state.snapPreview && e.key === 'Escape') {
+            e.preventDefault?.();
+            e.stopPropagation?.();
+            this.setState({ snapPreview: null, snapPosition: null });
+            return;
+        }
+        if (this.state.resizing) {
             const step = 1;
-            if (e.key === 'ArrowLeft') {
+            if (e.key === 'Enter' || e.key === 'Escape') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.endResize();
+            } else if (e.key === 'ArrowLeft') {
                 e.preventDefault();
                 e.stopPropagation();
                 this.setState(prev => ({ width: Math.max(prev.width - step, 20) }), this.resizeBoundries);
@@ -559,6 +698,51 @@ export class Window extends Component {
             } else if (e.key === 'ArrowDown') {
                 e.preventDefault();
                 e.stopPropagation();
+                this.setState(prev => ({ height: Math.min(prev.height + step, 100) }), this.resizeBoundries);
+            }
+            this.focusWindow();
+            return;
+        }
+        if (e.key === 'Escape') {
+            this.closeWindow();
+        } else if (e.key === 'Tab') {
+            this.focusWindow();
+        } else if (e.altKey) {
+            if (e.key === 'ArrowDown') {
+                e.preventDefault?.();
+                e.stopPropagation?.();
+                this.unsnapWindow();
+            } else if (e.key === 'ArrowLeft') {
+                e.preventDefault?.();
+                e.stopPropagation?.();
+                this.snapWindow('left');
+            } else if (e.key === 'ArrowRight') {
+                e.preventDefault?.();
+                e.stopPropagation?.();
+                this.snapWindow('right');
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault?.();
+                e.stopPropagation?.();
+                this.snapWindow('top');
+            }
+            this.focusWindow();
+        } else if (e.shiftKey) {
+            const step = 1;
+            if (e.key === 'ArrowLeft') {
+                e.preventDefault?.();
+                e.stopPropagation?.();
+                this.setState(prev => ({ width: Math.max(prev.width - step, 20) }), this.resizeBoundries);
+            } else if (e.key === 'ArrowRight') {
+                e.preventDefault?.();
+                e.stopPropagation?.();
+                this.setState(prev => ({ width: Math.min(prev.width + step, 100) }), this.resizeBoundries);
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault?.();
+                e.stopPropagation?.();
+                this.setState(prev => ({ height: Math.max(prev.height - step, 20) }), this.resizeBoundries);
+            } else if (e.key === 'ArrowDown') {
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ height: Math.min(prev.height + step, 100) }), this.resizeBoundries);
             }
             this.focusWindow();
@@ -584,33 +768,6 @@ export class Window extends Component {
         }
     }
 
-    snapWindow = (pos) => {
-        this.focusWindow();
-        const { width, height } = this.state;
-        let newWidth = width;
-        let newHeight = height;
-        let transform = '';
-        if (pos === 'left') {
-            newWidth = 50;
-            newHeight = 96.3;
-            transform = 'translate(-1pt,-2pt)';
-        } else if (pos === 'right') {
-            newWidth = 50;
-            newHeight = 96.3;
-            transform = `translate(${window.innerWidth / 2}px,-2pt)`;
-        }
-        const node = document.getElementById(this.id);
-        if (node && transform) {
-            node.style.transform = transform;
-        }
-        this.setState({
-            snapped: pos,
-            lastSize: { width, height },
-            width: newWidth,
-            height: newHeight
-        }, this.resizeBoundries);
-    }
-
     render() {
         return (
             <>
@@ -628,22 +785,35 @@ export class Window extends Component {
                     scale={1}
                     onStart={this.changeCursorToMove}
                     onStop={this.handleStop}
-                    onDrag={this.handleDrag}
+                    onDrag={this.debouncedHandleDrag}
                     allowAnyClick={false}
                     defaultPosition={{ x: this.startX, y: this.startY }}
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
                 >
                     <div
-                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        ref={this.rootRef}
+                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%`, zIndex: (this.props.zIndex || 0) + (this.state.alwaysOnTop ? 1000 : 0) }}
+                        className={
+                            this.state.cursorType + " " +
+                            (this.state.closed ? " closed-window " : "") +
+                            (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") +
+                            (this.props.minimized ? " opacity-0 invisible duration-200 " : "") +
+                            (this.state.grabbed ? " opacity-70 " : "") +
+                            (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") +
+                            (this.props.isFocused ? "" : " notFocused") +
+                            " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
+                        data-context="window"
+                        data-app-id={this.id}
                         role="dialog"
                         aria-label={this.props.title}
-                        tabIndex={0}
+                        aria-selected={this.props.isFocused}
+                        aria-hidden={!this.props.isFocused}
+                        tabIndex={this.props.isFocused ? 0 : -1}
                         onKeyDown={this.handleKeyDown}
                     >
-                        {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} />}
-                        {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}
+                        {this.props.resizable !== false && <WindowYBorder resize={this.debouncedHandleHorizontalResize} />}
+                        {this.props.resizable !== false && <WindowXBorder resize={this.debouncedHandleVerticleResize} />}
                         <WindowTopBar
                             title={this.props.title}
                             onKeyDown={this.handleTitleBarKeyDown}
@@ -659,7 +829,7 @@ export class Window extends Component {
                             allowMaximize={this.props.allowMaximize !== false}
                             pip={() => this.props.screen(this.props.addFolder, this.props.openApp)}
                         />
-                        {(this.id === "settings"
+                        {(!this.state.shaded) && (this.id === "settings"
                             ? <Settings />
                             : <WindowMainScreen screen={this.props.screen} title={this.props.title}
                                 addFolder={this.props.id === "terminal" ? this.props.addFolder : null}
@@ -676,16 +846,16 @@ export default Window
 // Window's title bar
 export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
     return (
-        <div
+        <button
+            type="button"
             className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
             tabIndex={0}
-            role="button"
             aria-grabbed={grabbed}
             onKeyDown={onKeyDown}
             onBlur={onBlur}
         >
             <div className="flex justify-center w-full text-sm font-bold">{title}</div>
-        </div>
+        </button>
     )
 }
 
@@ -732,7 +902,7 @@ export class WindowXBorder extends Component {
 // Window's Edit Buttons
 export function WindowEditButtons(props) {
     const { togglePin } = useDocPiP(props.pip || (() => null));
-    const pipSupported = typeof window !== 'undefined' && !!window.documentPictureInPicture;
+    const pipSupported = isBrowser() && !!window.documentPictureInPicture;
     return (
         <div className="absolute select-none right-0 top-0 mt-1 mr-1 flex justify-center items-center h-11 min-w-[8.25rem]">
             {pipSupported && props.pip && (
@@ -755,7 +925,7 @@ export function WindowEditButtons(props) {
             <button
                 type="button"
                 aria-label="Window minimize"
-                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 active:bg-opacity-20 rounded-full flex justify-center items-center h-6 w-6 cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-white focus-visible:outline-offset-2 transition-colors"
                 onClick={props.minimize}
             >
                 <NextImage
@@ -773,7 +943,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window restore"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 active:bg-opacity-20 rounded-full flex justify-center items-center h-6 w-6 cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-white focus-visible:outline-offset-2 transition-colors"
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -789,7 +959,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window maximize"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 active:bg-opacity-20 rounded-full flex justify-center items-center h-6 w-6 cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-white focus-visible:outline-offset-2 transition-colors"
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -807,7 +977,7 @@ export function WindowEditButtons(props) {
                 type="button"
                 id={`close-${props.id}`}
                 aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
+                className="mx-1 cursor-pointer bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 active:bg-opacity-80 rounded-full flex justify-center items-center h-6 w-6 focus-visible:outline focus-visible:outline-2 focus-visible:outline-white focus-visible:outline-offset-2 transition-colors"
                 onClick={props.close}
             >
                 <NextImage

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react'
-import useFocusTrap from '../../hooks/useFocusTrap'
-import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+import useFocusTrap from '@/hooks/useFocusTrap'
+import useRovingTabIndex from '@/hooks/useRovingTabIndex'
 
 function AppMenu(props) {
     const menuRef = useRef(null)
@@ -11,6 +11,21 @@ function AppMenu(props) {
         if (e.key === 'Escape') {
             props.onClose && props.onClose()
         }
+    }
+
+    const handleOpenMenuEditor = () => {
+        props.openMenuEditor && props.openMenuEditor()
+        props.onClose && props.onClose()
+    }
+
+    const handleAddToPanel = () => {
+        props.addToPanel && props.addToPanel()
+        props.onClose && props.onClose()
+    }
+
+    const handleAddToDesktop = () => {
+        props.addToDesktop && props.addToDesktop()
+        props.onClose && props.onClose()
     }
 
     const handlePin = () => {
@@ -25,6 +40,7 @@ function AppMenu(props) {
         <div
             id="app-menu"
             role="menu"
+            aria-label="App context menu"
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
@@ -32,15 +48,52 @@ function AppMenu(props) {
         >
             <button
                 type="button"
+                onClick={handleOpenMenuEditor}
+                role="menuitem"
+                aria-label="Open Menu Editor"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">Open Menu Editor</span>
+            </button>
+            <button
+                type="button"
+                onClick={handleAddToPanel}
+                role="menuitem"
+                aria-label="Add to Panel"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">Add to Panel</span>
+            </button>
+            <button
+                type="button"
+                onClick={handleAddToDesktop}
+                role="menuitem"
+                aria-label="Add to Desktop"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">Add to Desktop</span>
+            </button>
+            <Devider />
+            <button
+                type="button"
                 onClick={handlePin}
                 role="menuitem"
                 aria-label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
+                tabIndex={props.active ? 0 : -1}
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
             </button>
         </div>
     )
+}
+
+function Devider() {
+    return (
+        <div className="flex justify-center w-full">
+            <div className=" border-t border-gray-900 py-1 w-2/5"></div>
+        </div>
+    );
 }
 
 export default AppMenu

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react'
-import useFocusTrap from '../../hooks/useFocusTrap'
-import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+import useFocusTrap from '@/hooks/useFocusTrap'
+import useRovingTabIndex from '@/hooks/useRovingTabIndex'
 
 function DefaultMenu(props) {
     const menuRef = useRef(null)
@@ -17,6 +17,7 @@ function DefaultMenu(props) {
         <div
             id="default-menu"
             role="menu"
+            aria-label="Default context menu"
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
@@ -30,6 +31,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Linkedin"
+                tabIndex={props.active ? 0 : -1}
                 className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">🙋‍♂️</span> <span className="ml-2">Follow on <strong>Linkedin</strong></span>
@@ -40,6 +42,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Github"
+                tabIndex={props.active ? 0 : -1}
                 className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">🤝</span> <span className="ml-2">Follow on <strong>Github</strong></span>
@@ -50,6 +53,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Contact Me"
+                tabIndex={props.active ? 0 : -1}
                 className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">📥</span> <span className="ml-2">Contact Me</span>
@@ -60,6 +64,7 @@ function DefaultMenu(props) {
                 onClick={() => { localStorage.clear(); window.location.reload() }}
                 role="menuitem"
                 aria-label="Reset Kali Linux"
+                tabIndex={props.active ? 0 : -1}
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">🧹</span> <span className="ml-2">Reset Kali Linux</span>

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,9 +1,16 @@
-import React, { useState, useEffect } from 'react'
-import logger from '../../utils/logger'
+import React, { useState, useEffect, useRef } from 'react'
+import logger from '@/utils/logger'
+import PolicyKitPrompt from '../common/PolicyKitPrompt'
+import useFocusTrap from '@/hooks/useFocusTrap'
+import useRovingTabIndex from '@/hooks/useRovingTabIndex'
 
 function DesktopMenu(props) {
 
     const [isFullScreen, setIsFullScreen] = useState(false)
+    const [showRootPrompt, setShowRootPrompt] = useState(false)
+    const menuRef = useRef(null)
+    useFocusTrap(menuRef, props.active)
+    useRovingTabIndex(menuRef, props.active, 'vertical')
 
     useEffect(() => {
         document.addEventListener('fullscreenchange', checkFullScreen);
@@ -19,6 +26,10 @@ function DesktopMenu(props) {
 
     const openSettings = () => {
         props.openApp("settings");
+    }
+
+    const openRootPrompt = () => {
+        setShowRootPrompt(true)
     }
 
     const checkFullScreen = () => {
@@ -43,11 +54,20 @@ function DesktopMenu(props) {
         }
     }
 
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            props.onClose && props.onClose()
+        }
+    }
+
     return (
+        <>
         <div
             id="desktop-menu"
             role="menu"
             aria-label="Desktop context menu"
+            ref={menuRef}
+            onKeyDown={handleKeyDown}
             className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
         >
             <button
@@ -68,6 +88,15 @@ function DesktopMenu(props) {
             >
                 <span className="ml-5">Create Shortcut...</span>
             </button>
+            <button
+                onClick={props.openLauncherCreator}
+                type="button"
+                role="menuitem"
+                aria-label="Create Launcher"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
+                <span className="ml-5">Create Launcher...</span>
+            </button>
             <Devider />
             <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
                 <span className="ml-5">Paste</span>
@@ -76,6 +105,17 @@ function DesktopMenu(props) {
             <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
                 <span className="ml-5">Show Desktop in Files</span>
             </div>
+            <button
+                onClick={openRootPrompt}
+                type="button"
+                role="menuitem"
+                aria-label="Open as root"
+                title="Demo only: root access is not available"
+                aria-disabled="true"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400 cursor-not-allowed"
+            >
+                <span className="ml-5">Open as root</span>
+            </button>
             <button
                 onClick={openTerminal}
                 type="button"
@@ -129,6 +169,8 @@ function DesktopMenu(props) {
                 <span className="ml-5">Clear Session</span>
             </button>
         </div>
+        <PolicyKitPrompt open={showRootPrompt} onClose={() => setShowRootPrompt(false)} />
+        </>
     )
 }
 

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
-import useFocusTrap from '../../hooks/useFocusTrap';
-import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+import useFocusTrap from '@/hooks/useFocusTrap';
+import useRovingTabIndex from '@/hooks/useRovingTabIndex';
 
 function TaskbarMenu(props) {
     const menuRef = useRef(null);
@@ -27,6 +27,7 @@ function TaskbarMenu(props) {
         <div
             id="taskbar-menu"
             role="menu"
+            aria-label="Taskbar context menu"
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
@@ -37,6 +38,7 @@ function TaskbarMenu(props) {
                 onClick={handleMinimize}
                 role="menuitem"
                 aria-label={props.minimized ? 'Restore Window' : 'Minimize Window'}
+                tabIndex={props.active ? 0 : -1}
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">{props.minimized ? 'Restore' : 'Minimize'}</span>
@@ -46,6 +48,7 @@ function TaskbarMenu(props) {
                 onClick={handleClose}
                 role="menuitem"
                 aria-label="Close Window"
+                tabIndex={props.active ? 0 : -1}
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">Close</span>

--- a/components/context-menus/window-menu.js
+++ b/components/context-menus/window-menu.js
@@ -1,0 +1,42 @@
+import React, { useRef } from 'react';
+import useFocusTrap from '@/hooks/useFocusTrap';
+import useRovingTabIndex from '@/hooks/useRovingTabIndex';
+
+function WindowMenu(props) {
+    const menuRef = useRef(null);
+    useFocusTrap(menuRef, props.active);
+    useRovingTabIndex(menuRef, props.active, 'vertical');
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            props.onCloseMenu && props.onCloseMenu();
+        }
+    };
+
+    const wrap = (fn) => () => {
+        fn && fn();
+        props.onCloseMenu && props.onCloseMenu();
+    };
+
+    return (
+        <div
+            id="window-menu"
+            role="menu"
+            aria-label="Window context menu"
+            aria-hidden={!props.active}
+            ref={menuRef}
+            onKeyDown={handleKeyDown}
+            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-48 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm'}
+        >
+            <button type="button" aria-label="Move" onClick={wrap(props.onMove)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Move</span></button>
+            <button type="button" aria-label="Resize" onClick={wrap(props.onResize)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Resize</span></button>
+            <button type="button" aria-label="Always on top" onClick={wrap(props.onTop)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Always on top</span></button>
+            <button type="button" aria-label="Shade" onClick={wrap(props.onShade)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Shade</span></button>
+            <button type="button" aria-label="Stick" onClick={wrap(props.onStick)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Stick</span></button>
+            <button type="button" aria-label="Maximize" onClick={wrap(props.onMaximize)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Maximize</span></button>
+            <button type="button" aria-label="Close" onClick={wrap(props.onClose)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700"><span className="ml-5">Close</span></button>
+        </div>
+    );
+}
+
+export default WindowMenu;

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import UbuntuApp from '../base/ubuntu_app';
+// Fuse is quite large; load it dynamically only when needed
+let Fuse = null;
 
 class AllApplications extends React.Component {
     constructor() {
@@ -9,6 +11,8 @@ class AllApplications extends React.Component {
             apps: [],
             unfilteredApps: [],
         };
+        this.searchTimeout = null;
+        this.fuse = null;
     }
 
     componentDidMount() {
@@ -17,19 +21,51 @@ class AllApplications extends React.Component {
         games.forEach((game) => {
             if (!combined.some((app) => app.id === game.id)) combined.push(game);
         });
+        // Fuse will be loaded dynamically when a search is performed
         this.setState({ apps: combined, unfilteredApps: combined });
     }
 
+    componentWillUnmount() {
+        if (this.searchTimeout) clearTimeout(this.searchTimeout);
+    }
+
+    performSearch = async (value) => {
+        const { unfilteredApps } = this.state;
+        if (!value) {
+            this.setState({ apps: unfilteredApps });
+            return;
+        }
+        if (!this.fuse) {
+            const fuseModule = await import('fuse.js');
+            Fuse = fuseModule.default || fuseModule;
+            this.fuse = new Fuse(unfilteredApps, {
+                keys: ['title'],
+                includeScore: true,
+                threshold: 0.4,
+            });
+        } else {
+            this.fuse.setCollection(unfilteredApps);
+        }
+        const lower = value.toLowerCase();
+        const results = this.fuse.search(value).map((res) => {
+            const app = res.item;
+            let weight = 0;
+            if (app.favourite) weight += 3;
+            if (app.title.toLowerCase().startsWith(lower)) weight += 2;
+            return { app, score: res.score ?? 0, weight };
+        });
+        results.sort((a, b) => {
+            if (b.weight !== a.weight) return b.weight - a.weight;
+            return a.score - b.score;
+        });
+        this.setState({ apps: results.map((r) => r.app) });
+    };
+
     handleChange = (e) => {
         const value = e.target.value;
-        const { unfilteredApps } = this.state;
-        const apps =
-            value === '' || value === null
-                ? unfilteredApps
-                : unfilteredApps.filter((app) =>
-                      app.title.toLowerCase().includes(value.toLowerCase())
-                  );
-        this.setState({ query: value, apps });
+        this.setState({ query: value });
+        clearTimeout(this.searchTimeout);
+        this.searchTimeout = setTimeout(() => this.performSearch(value), 75);
     };
 
     openApp = (id) => {
@@ -38,9 +74,33 @@ class AllApplications extends React.Component {
         }
     };
 
+    renderRecentApps = () => {
+        const ids = this.props.recentApps || [];
+        const { unfilteredApps } = this.state;
+        const recent = ids
+            .map((id) => unfilteredApps.find((app) => app.id === id))
+            .filter(Boolean);
+        return recent.map((app) => (
+            <UbuntuApp
+                key={`recent-${app.id}`}
+                name={app.title}
+                id={app.id}
+                icon={app.icon}
+                openApp={() => this.openApp(app.id)}
+                disabled={app.disabled}
+                prefetch={app.screen?.prefetch}
+            />
+        ));
+    };
+
     renderApps = () => {
         const apps = this.state.apps || [];
-        return apps.map((app) => (
+        const exclude = new Set(this.props.recentApps || []);
+        const filtered =
+            this.state.query === ''
+                ? apps.filter((app) => !exclude.has(app.id))
+                : apps;
+        return filtered.map((app) => (
             <UbuntuApp
                 key={app.id}
                 name={app.title}
@@ -57,11 +117,20 @@ class AllApplications extends React.Component {
         return (
             <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
                 <input
+                    aria-label="Search"
                     className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
                     placeholder="Search"
                     value={this.state.query}
                     onChange={this.handleChange}
                 />
+                {!this.state.query && this.props.recentApps && this.props.recentApps.length ? (
+                    <>
+                        <h2 className="mb-4 text-white">Recently Used</h2>
+                        <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 mb-8 place-items-center">
+                            {this.renderRecentApps()}
+                        </div>
+                    </>
+                ) : null}
                 <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
                     {this.renderApps()}
                 </div>

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1,7 +1,9 @@
 "use client";
 
+import { isBrowser } from '@/utils/env';
 import React, { Component } from 'react';
 import dynamic from 'next/dynamic';
+import logger from '../../utils/logger';
 
 const BackgroundImage = dynamic(
     () => import('../util-components/background-image'),
@@ -14,15 +16,21 @@ import UbuntuApp from '../base/ubuntu_app';
 import AllApplications from '../screen/all-applications'
 import ShortcutSelector from '../screen/shortcut-selector'
 import WindowSwitcher from '../screen/window-switcher'
+import WorkspaceSwitcher from './workspace-switcher'
+import LauncherCreator from './launcher-creator'
 import DesktopMenu from '../context-menus/desktop-menu';
 import DefaultMenu from '../context-menus/default';
 import AppMenu from '../context-menus/app-menu';
 import Taskbar from './taskbar';
 import TaskbarMenu from '../context-menus/taskbar-menu';
+import WindowMenu from '../context-menus/window-menu';
 import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { useSnapSetting } from '../../hooks/usePersistentState';
+import { addRecentApp, getRecentApps } from '../../utils/recent';
+import osdService from '../../utils/osdService';
+import DesktopTour from '../welcome/DesktopTour';
 
 export class Desktop extends Component {
     constructor() {
@@ -30,9 +38,12 @@ export class Desktop extends Component {
         this.app_stack = [];
         this.initFavourite = {};
         this.allWindowClosed = false;
+        this.windowRefs = {};
         this.state = {
             focused_windows: {},
             closed_windows: {},
+            currentWorkspace: 0,
+            window_workspaces: {},
             allAppsView: false,
             overlapped_windows: {},
             disabled_apps: {},
@@ -41,17 +52,23 @@ export class Desktop extends Component {
             minimized_windows: {},
             window_positions: {},
             desktop_apps: [],
+            dock: [],
+            recentApps: getRecentApps(),
             context_menus: {
                 desktop: false,
                 default: false,
                 app: false,
                 taskbar: false,
+                window: false,
             },
             context_app: null,
             showNameBar: false,
             showShortcutSelector: false,
+            showLauncherCreator: false,
             showWindowSwitcher: false,
             switcherWindows: [],
+            showWorkspaceSwitcher: false,
+            switcherWorkspaces: [],
         }
     }
 
@@ -62,17 +79,9 @@ export class Desktop extends Component {
         this.fetchAppsData(() => {
             const session = this.props.session || {};
             const positions = {};
-            if (session.dock && session.dock.length) {
-                let favourite_apps = { ...this.state.favourite_apps };
-                session.dock.forEach(id => {
-                    favourite_apps[id] = true;
-                });
-                this.setState({ favourite_apps });
-            }
-
             if (session.windows && session.windows.length) {
-                session.windows.forEach(({ id, x, y }) => {
-                    positions[id] = { x, y };
+                session.windows.forEach(({ id, x, y, snap }) => {
+                    positions[id] = { x, y, snap };
                 });
                 this.setState({ window_positions: positions }, () => {
                     session.windows.forEach(({ id }) => this.openApp(id));
@@ -85,15 +94,36 @@ export class Desktop extends Component {
         this.setEventListeners();
         this.checkForNewFolders();
         this.checkForAppShortcuts();
+        this.checkForLaunchers();
         this.updateTrashIcon();
         window.addEventListener('trash-change', this.updateTrashIcon);
         document.addEventListener('keydown', this.handleGlobalShortcut);
+        document.addEventListener('mousedown', this.handleMouseShortcut);
         window.addEventListener('open-app', this.handleOpenAppEvent);
+
+        // Warm commonly used modules during idle periods so the first
+        // interaction is snappy even on a cold cache. Falling back to
+        // setTimeout ensures compatibility with environments lacking
+        // requestIdleCallback.
+        if (isBrowser()) {
+            const warmModules = () => {
+                import('../apps/terminal');
+                import('../../apps/terminal/tabs');
+                import('../apps/file-explorer');
+                import('../apps/settings');
+            };
+            if ('requestIdleCallback' in window) {
+                requestIdleCallback(warmModules);
+            } else {
+                setTimeout(warmModules, 0);
+            }
+        }
     }
 
     componentWillUnmount() {
         this.removeContextListeners();
         document.removeEventListener('keydown', this.handleGlobalShortcut);
+        document.removeEventListener('mousedown', this.handleMouseShortcut);
         window.removeEventListener('trash-change', this.updateTrashIcon);
         window.removeEventListener('open-app', this.handleOpenAppEvent);
     }
@@ -130,6 +160,13 @@ export class Desktop extends Component {
                 this.openApp("settings");
             });
         }
+        document.addEventListener('open-settings', (e) => {
+            const tab = e.detail && e.detail.tab;
+            if (tab) {
+                window.localStorage.setItem('settings-open-tab', tab);
+            }
+            this.openApp('settings');
+        });
     }
 
     setContextListeners = () => {
@@ -152,17 +189,41 @@ export class Desktop extends Component {
             if (!this.state.showWindowSwitcher) {
                 this.openWindowSwitcher();
             }
-        } else if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'v') {
+        }
+        else if (e.altKey && e.key === 'F4') {
+            e.preventDefault();
+            const id = this.getFocusedWindowId();
+            if (id) this.closeApp(id);
+        }
+        else if (e.ctrlKey && e.altKey && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
+            e.preventDefault();
+            this.switchWorkspace(e.key === 'ArrowRight' ? 1 : -1);
+        }
+        else if (e.ctrlKey && e.altKey && e.key.toLowerCase() === 'w') {
+            e.preventDefault();
+            if (!this.state.showWorkspaceSwitcher) {
+                this.openWorkspaceSwitcher();
+            }
+        }
+        else if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'v') {
             e.preventDefault();
             this.openApp('clipboard-manager');
-        }
-        else if (e.altKey && e.key === 'Tab') {
-            e.preventDefault();
-            this.cycleApps(e.shiftKey ? -1 : 1);
         }
         else if (e.altKey && (e.key === '`' || e.key === '~')) {
             e.preventDefault();
             this.cycleAppWindows(e.shiftKey ? -1 : 1);
+        }
+        else if (e.altKey && e.code === 'Space') {
+            e.preventDefault();
+            const id = this.getFocusedWindowId();
+            if (id) {
+                const node = document.getElementById(id);
+                if (node) {
+                    const rect = node.getBoundingClientRect();
+                    const fakeEvent = { pageX: rect.left, pageY: rect.top + rect.height };
+                    this.setState({ context_app: id }, () => this.showContextMenu(fakeEvent, 'window'));
+                }
+            }
         }
         else if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
             e.preventDefault();
@@ -170,6 +231,15 @@ export class Desktop extends Component {
             if (id) {
                 const event = new CustomEvent('super-arrow', { detail: e.key });
                 document.getElementById(id)?.dispatchEvent(event);
+            }
+        }
+    }
+
+    handleMouseShortcut = (e) => {
+        if (e.ctrlKey && e.altKey && e.button === 1) {
+            e.preventDefault();
+            if (!this.state.showWorkspaceSwitcher) {
+                this.openWorkspaceSwitcher();
             }
         }
     }
@@ -221,6 +291,85 @@ export class Desktop extends Component {
         }
     }
 
+    openWorkspaceSwitcher = () => {
+        const WORKSPACE_COUNT = 3;
+        let names = [];
+        try {
+            const stored = window.localStorage.getItem('workspaces');
+            if (stored) {
+                const parsed = JSON.parse(stored);
+                if (Array.isArray(parsed)) names = parsed;
+            }
+        } catch { /* ignore */ }
+        const workspaces = Array.from({ length: WORKSPACE_COUNT }, (_, i) => ({
+            id: i,
+            name: typeof names[i] === 'string' && names[i].trim() ? names[i] : `Workspace ${i + 1}`,
+        }));
+        this.setState({
+            showWorkspaceSwitcher: true,
+            switcherWorkspaces: workspaces,
+        });
+    }
+
+    switchWorkspace = (direction) => {
+        const WORKSPACE_COUNT = 3;
+        let nextWs = 0;
+        this.setState(prev => {
+            nextWs = (prev.currentWorkspace + direction + WORKSPACE_COUNT) % WORKSPACE_COUNT;
+            const closed_windows = { ...prev.closed_windows };
+            const focused_windows = { ...prev.focused_windows };
+            Object.keys(prev.window_workspaces).forEach(id => {
+                const same = prev.window_workspaces[id] === nextWs;
+                closed_windows[id] = !same;
+                if (!same) focused_windows[id] = false;
+            });
+            return { currentWorkspace: nextWs, closed_windows, focused_windows };
+        }, () => {
+            let name = `Workspace ${nextWs + 1}`;
+            try {
+                const stored = window.localStorage.getItem('workspaces');
+                if (stored) {
+                    const names = JSON.parse(stored);
+                    if (Array.isArray(names) && typeof names[nextWs] === 'string' && names[nextWs].trim()) {
+                        name = names[nextWs];
+                    }
+                }
+            } catch { /* ignore */ }
+            const message = `Workspace ${nextWs + 1} — ${name}`;
+            osdService.show(message, 1200);
+            this.giveFocusToLastApp();
+        });
+    }
+
+    goToWorkspace = (index) => {
+        const WORKSPACE_COUNT = 3;
+        const target = ((index % WORKSPACE_COUNT) + WORKSPACE_COUNT) % WORKSPACE_COUNT;
+        this.setState(prev => {
+            const closed_windows = { ...prev.closed_windows };
+            const focused_windows = { ...prev.focused_windows };
+            Object.keys(prev.window_workspaces).forEach(id => {
+                const same = prev.window_workspaces[id] === target;
+                closed_windows[id] = !same;
+                if (!same) focused_windows[id] = false;
+            });
+            return { currentWorkspace: target, closed_windows, focused_windows };
+        }, () => {
+            let name = `Workspace ${target + 1}`;
+            try {
+                const stored = window.localStorage.getItem('workspaces');
+                if (stored) {
+                    const names = JSON.parse(stored);
+                    if (Array.isArray(names) && typeof names[target] === 'string' && names[target].trim()) {
+                        name = names[target];
+                    }
+                }
+            } catch { /* ignore */ }
+            const message = `Workspace ${target + 1} — ${name}`;
+            osdService.show(message, 1200);
+            this.giveFocusToLastApp();
+        });
+    }
+
     closeWindowSwitcher = () => {
         this.setState({ showWindowSwitcher: false, switcherWindows: [] });
     }
@@ -228,6 +377,16 @@ export class Desktop extends Component {
     selectWindow = (id) => {
         this.setState({ showWindowSwitcher: false, switcherWindows: [] }, () => {
             this.openApp(id);
+        });
+    }
+
+    closeWorkspaceSwitcher = () => {
+        this.setState({ showWorkspaceSwitcher: false, switcherWorkspaces: [] });
+    }
+
+    selectWorkspace = (id) => {
+        this.setState({ showWorkspaceSwitcher: false, switcherWorkspaces: [] }, () => {
+            this.goToWorkspace(id);
         });
     }
 
@@ -259,6 +418,13 @@ export class Desktop extends Component {
                 });
                 this.setState({ context_app: appId }, () => this.showContextMenu(e, "taskbar"));
                 break;
+            case "window":
+                ReactGA.event({
+                    category: `Context Menu`,
+                    action: `Opened Window Context Menu`
+                });
+                this.setState({ context_app: appId }, () => this.showContextMenu(e, "window"));
+                break;
             default:
                 ReactGA.event({
                     category: `Context Menu`,
@@ -289,6 +455,10 @@ export class Desktop extends Component {
             case "taskbar":
                 ReactGA.event({ category: `Context Menu`, action: `Opened Taskbar Context Menu` });
                 this.setState({ context_app: appId }, () => this.showContextMenu(fakeEvent, "taskbar"));
+                break;
+            case "window":
+                ReactGA.event({ category: `Context Menu`, action: `Opened Window Context Menu` });
+                this.setState({ context_app: appId }, () => this.showContextMenu(fakeEvent, "window"));
                 break;
             default:
                 ReactGA.event({ category: `Context Menu`, action: `Opened Default Context Menu` });
@@ -343,14 +513,23 @@ export class Desktop extends Component {
     }
 
     fetchAppsData = (callback) => {
-        let pinnedApps = safeLocalStorage?.getItem('pinnedApps');
-        if (pinnedApps) {
-            pinnedApps = JSON.parse(pinnedApps);
-            apps.forEach(app => { app.favourite = pinnedApps.includes(app.id); });
-        } else {
+        let pinnedApps = [];
+        try {
+            const stored = safeLocalStorage?.getItem('pinnedApps');
+            if (stored) {
+                pinnedApps = JSON.parse(stored);
+            } else if (this.props.session?.dock && this.props.session.dock.length) {
+                pinnedApps = this.props.session.dock;
+                safeLocalStorage?.setItem('pinnedApps', JSON.stringify(pinnedApps));
+            } else {
+                pinnedApps = apps.filter(app => app.favourite).map(app => app.id);
+                safeLocalStorage?.setItem('pinnedApps', JSON.stringify(pinnedApps));
+            }
+        } catch {
             pinnedApps = apps.filter(app => app.favourite).map(app => app.id);
-            safeLocalStorage?.setItem('pinnedApps', JSON.stringify(pinnedApps));
         }
+        apps.forEach(app => { app.favourite = pinnedApps.includes(app.id); });
+
         let focused_windows = {}, closed_windows = {}, disabled_apps = {}, favourite_apps = {}, overlapped_windows = {}, minimized_windows = {};
         let desktop_apps = [];
         apps.forEach((app) => {
@@ -387,7 +566,8 @@ export class Desktop extends Component {
             favourite_apps,
             overlapped_windows,
             minimized_windows,
-            desktop_apps
+            desktop_apps,
+            dock: pinnedApps
         }, () => {
             if (typeof callback === 'function') callback();
         });
@@ -460,6 +640,8 @@ export class Desktop extends Component {
             if (this.state.closed_windows[app.id] === false) {
 
                 const pos = this.state.window_positions[app.id];
+                const index = this.app_stack.indexOf(app.id);
+                const zIndex = 100 + (index === -1 ? 0 : index);
                 const props = {
                     title: app.title,
                     id: app.id,
@@ -469,6 +651,7 @@ export class Desktop extends Component {
                     openApp: this.openApp,
                     focus: this.focus,
                     isFocused: this.state.focused_windows[app.id],
+                    zIndex,
                     hideSideBar: this.hideSideBar,
                     hasMinimised: this.hasMinimised,
                     minimized: this.state.minimized_windows[app.id],
@@ -478,24 +661,32 @@ export class Desktop extends Component {
                     defaultHeight: app.defaultHeight,
                     initialX: pos ? pos.x : undefined,
                     initialY: pos ? pos.y : undefined,
-                    onPositionChange: (x, y) => this.updateWindowPosition(app.id, x, y),
+                    initialSnap: pos ? pos.snap : undefined,
+                    onPositionChange: (x, y, snap) => this.updateWindowPosition(app.id, x, y, snap),
                     snapEnabled: this.props.snapEnabled,
                 }
 
                 windowsJsx.push(
-                    <Window key={app.id} {...props} />
+                    <Window
+                        key={app.id}
+                        ref={ref => { if (ref) this.windowRefs[app.id] = ref; }}
+                        {...props}
+                    />
                 )
             }
         });
         return windowsJsx;
     }
 
-    updateWindowPosition = (id, x, y) => {
+    updateWindowPosition = (id, x, y, snapPos = null) => {
         const snap = this.props.snapEnabled
             ? (v) => Math.round(v / 8) * 8
             : (v) => v;
         this.setState(prev => ({
-            window_positions: { ...prev.window_positions, [id]: { x: snap(x), y: snap(y) } }
+            window_positions: {
+                ...prev.window_positions,
+                [id]: { x: snap(x), y: snap(y), snap: snapPos }
+            }
         }), this.saveSession);
     }
 
@@ -505,9 +696,10 @@ export class Desktop extends Component {
         const windows = openWindows.map(id => ({
             id,
             x: this.state.window_positions[id] ? this.state.window_positions[id].x : 60,
-            y: this.state.window_positions[id] ? this.state.window_positions[id].y : 10
+            y: this.state.window_positions[id] ? this.state.window_positions[id].y : 10,
+            snap: this.state.window_positions[id] ? this.state.window_positions[id].snap : null,
         }));
-        const dock = Object.keys(this.state.favourite_apps).filter(id => this.state.favourite_apps[id]);
+        const dock = this.state.dock;
         this.props.setSession({ ...this.props.session, windows, dock });
     }
 
@@ -558,8 +750,9 @@ export class Desktop extends Component {
         // if there is atleast one app opened, give it focus
         if (!this.checkAllMinimised()) {
             for (const index in this.app_stack) {
-                if (!this.state.minimized_windows[this.app_stack[index]]) {
-                    this.focus(this.app_stack[index]);
+                const id = this.app_stack[index];
+                if (!this.state.closed_windows[id] && !this.state.minimized_windows[id]) {
+                    this.focus(id);
                     break;
                 }
             }
@@ -594,6 +787,16 @@ export class Desktop extends Component {
         // if the app is disabled
         if (this.state.disabled_apps[objId]) return;
 
+        const appMeta = apps.find(a => a.id === objId);
+        if (appMeta && appMeta.command) {
+            if (/^https?:\/\//.test(appMeta.command)) {
+                window.open(appMeta.command, '_blank');
+            } else if (appMeta.command !== objId) {
+                this.openApp(appMeta.command);
+            }
+            return;
+        }
+
         // if app is already open, focus it instead of spawning a new window
         if (this.state.closed_windows[objId] === false) {
             // if it's minimised, restore its last position
@@ -612,6 +815,7 @@ export class Desktop extends Component {
         } else {
             let closed_windows = this.state.closed_windows;
             let favourite_apps = this.state.favourite_apps;
+            let window_workspaces = this.state.window_workspaces;
             let frequentApps = [];
             try { frequentApps = JSON.parse(safeLocalStorage?.getItem('frequentApps') || '[]'); } catch (e) { frequentApps = []; }
             var currentApp = frequentApps.find(app => app.id === objId);
@@ -647,11 +851,14 @@ export class Desktop extends Component {
             setTimeout(() => {
                 favourite_apps[objId] = true; // adds opened app to sideBar
                 closed_windows[objId] = false; // openes app's window
-                this.setState({ closed_windows, favourite_apps, allAppsView: false }, () => {
+                window_workspaces[objId] = this.state.currentWorkspace;
+                this.setState({ closed_windows, favourite_apps, window_workspaces, allAppsView: false }, () => {
                     this.focus(objId);
                     this.saveSession();
                 });
                 this.app_stack.push(objId);
+                const recentApps = addRecentApp(objId);
+                this.setState({ recentApps });
             }, 200);
         }
     }
@@ -683,6 +890,7 @@ export class Desktop extends Component {
             icon: appMeta.icon,
             image,
             closedAt: now,
+            path: objId,
         });
         safeLocalStorage?.setItem('window-trash', JSON.stringify(trash));
         this.updateTrashIcon();
@@ -697,54 +905,62 @@ export class Desktop extends Component {
         // close window
         let closed_windows = this.state.closed_windows;
         let favourite_apps = this.state.favourite_apps;
+        let window_workspaces = { ...this.state.window_workspaces };
 
         if (this.initFavourite[objId] === false) favourite_apps[objId] = false; // if user default app is not favourite, remove from sidebar
         closed_windows[objId] = true; // closes the app's window
+        delete window_workspaces[objId];
 
-        this.setState({ closed_windows, favourite_apps }, this.saveSession);
+        this.setState({ closed_windows, favourite_apps, window_workspaces }, this.saveSession);
     }
 
     pinApp = (id) => {
-        let favourite_apps = { ...this.state.favourite_apps }
-        favourite_apps[id] = true
-        this.initFavourite[id] = true
-        const app = apps.find(a => a.id === id)
-        if (app) app.favourite = true
-        let pinnedApps = [];
-        try { pinnedApps = JSON.parse(safeLocalStorage?.getItem('pinnedApps') || '[]'); } catch (e) { pinnedApps = []; }
-        if (!pinnedApps.includes(id)) pinnedApps.push(id)
-        safeLocalStorage?.setItem('pinnedApps', JSON.stringify(pinnedApps))
-        this.setState({ favourite_apps }, () => { this.saveSession(); })
-        this.hideAllContextMenu()
+        let favourite_apps = { ...this.state.favourite_apps };
+        favourite_apps[id] = true;
+        this.initFavourite[id] = true;
+        const app = apps.find(a => a.id === id);
+        if (app) app.favourite = true;
+        const dock = this.state.dock.includes(id) ? [...this.state.dock] : [...this.state.dock, id];
+        safeLocalStorage?.setItem('pinnedApps', JSON.stringify(dock));
+        this.setState({ favourite_apps, dock }, () => { this.saveSession(); });
+        this.hideAllContextMenu();
     }
 
     unpinApp = (id) => {
-        let favourite_apps = { ...this.state.favourite_apps }
-        if (this.state.closed_windows[id]) favourite_apps[id] = false
-        this.initFavourite[id] = false
-        const app = apps.find(a => a.id === id)
-        if (app) app.favourite = false
-        let pinnedApps = [];
-        try { pinnedApps = JSON.parse(safeLocalStorage?.getItem('pinnedApps') || '[]'); } catch (e) { pinnedApps = []; }
-        pinnedApps = pinnedApps.filter(appId => appId !== id)
-        safeLocalStorage?.setItem('pinnedApps', JSON.stringify(pinnedApps))
-        this.setState({ favourite_apps }, () => { this.saveSession(); })
-        this.hideAllContextMenu()
+        let favourite_apps = { ...this.state.favourite_apps };
+        if (this.state.closed_windows[id]) favourite_apps[id] = false;
+        this.initFavourite[id] = false;
+        const app = apps.find(a => a.id === id);
+        if (app) app.favourite = false;
+        const dock = this.state.dock.filter(appId => appId !== id);
+        safeLocalStorage?.setItem('pinnedApps', JSON.stringify(dock));
+        this.setState({ favourite_apps, dock }, () => { this.saveSession(); });
+        this.hideAllContextMenu();
+    }
+
+    reorderDock = (dock) => {
+        safeLocalStorage?.setItem('pinnedApps', JSON.stringify(dock));
+        this.setState({ dock }, () => { this.saveSession(); });
     }
 
     focus = (objId) => {
-        // removes focus from all window and 
-        // gives focus to window with 'id = objId'
-        var focused_windows = this.state.focused_windows;
+        // removes focus from all windows and gives focus to window with 'id = objId'
+        const focused_windows = { ...this.state.focused_windows };
         focused_windows[objId] = true;
-        for (let key in focused_windows) {
-            if (focused_windows.hasOwnProperty(key)) {
-                if (key !== objId) {
-                    focused_windows[key] = false;
-                }
+        for (const key in focused_windows) {
+            if (key !== objId) {
+                focused_windows[key] = false;
             }
         }
-        this.setState({ focused_windows });
+        this.setState({ focused_windows }, () => {
+            this.windowRefs[objId]?.focusSelf?.();
+        });
+
+        const index = this.app_stack.indexOf(objId);
+        if (index !== -1) {
+            this.app_stack.splice(index, 1);
+        }
+        this.app_stack.push(objId);
     }
 
     addNewFolder = () => {
@@ -753,6 +969,10 @@ export class Desktop extends Component {
 
     openShortcutSelector = () => {
         this.setState({ showShortcutSelector: true });
+    }
+
+    openLauncherCreator = () => {
+        this.setState({ showLauncherCreator: true });
     }
 
     addShortcutToDesktop = (app_id) => {
@@ -787,6 +1007,53 @@ export class Desktop extends Component {
         }
     }
 
+    createLauncher = ({ name, comment, icon, command }) => {
+        const id = name.trim().replace(/\s+/g, '-').toLowerCase();
+        const finalIcon = icon || '/themes/Yaru/apps/bash.png';
+        apps.push({
+            id,
+            title: name,
+            icon: finalIcon,
+            comment,
+            command,
+            disabled: false,
+            favourite: false,
+            desktop_shortcut: true,
+            screen: () => { },
+        });
+        let launchers = [];
+        try { launchers = JSON.parse(safeLocalStorage?.getItem('custom_launchers') || '[]'); } catch (e) { launchers = []; }
+        launchers.push({ id, title: name, icon: finalIcon, comment, command });
+        safeLocalStorage?.setItem('custom_launchers', JSON.stringify(launchers));
+        this.setState({ showLauncherCreator: false }, this.updateAppsData);
+    }
+
+    checkForLaunchers = () => {
+        const stored = safeLocalStorage?.getItem('custom_launchers');
+        if (!stored) {
+            safeLocalStorage?.setItem('custom_launchers', JSON.stringify([]));
+            return;
+        }
+        try {
+            JSON.parse(stored).forEach(l => {
+                apps.push({
+                    id: l.id,
+                    title: l.title,
+                    icon: l.icon || '/themes/Yaru/apps/bash.png',
+                    comment: l.comment,
+                    command: l.command,
+                    disabled: false,
+                    favourite: false,
+                    desktop_shortcut: true,
+                    screen: () => { },
+                });
+            });
+            this.updateAppsData();
+        } catch (e) {
+            safeLocalStorage?.setItem('custom_launchers', JSON.stringify([]));
+        }
+    }
+
     updateTrashIcon = () => {
         let trash = [];
         try { trash = JSON.parse(safeLocalStorage?.getItem('window-trash') || '[]'); } catch (e) { trash = []; }
@@ -795,8 +1062,17 @@ export class Desktop extends Component {
             const icon = trash.length
                 ? '/themes/Yaru/status/user-trash-full-symbolic.svg'
                 : '/themes/Yaru/status/user-trash-symbolic.svg';
+            const count = trash.length;
+            let shouldUpdate = false;
             if (apps[appIndex].icon !== icon) {
                 apps[appIndex].icon = icon;
+                shouldUpdate = true;
+            }
+            if (apps[appIndex].tasks !== count) {
+                apps[appIndex].tasks = count;
+                shouldUpdate = true;
+            }
+            if (shouldUpdate) {
                 this.forceUpdate();
             }
         }
@@ -839,7 +1115,7 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} aria-label="Folder name" />
                 </div>
                 <div className="flex">
                     <button
@@ -882,6 +1158,7 @@ export class Desktop extends Component {
 
                 {/* Ubuntu Side Menu Bar */}
                 <SideBar apps={apps}
+                    dock={this.state.dock}
                     hide={this.state.hideSideBar}
                     hideSideBar={this.hideSideBar}
                     favourite_apps={this.state.favourite_apps}
@@ -890,7 +1167,9 @@ export class Desktop extends Component {
                     closed_windows={this.state.closed_windows}
                     focused_windows={this.state.focused_windows}
                     isMinimized={this.state.minimized_windows}
-                    openAppByAppId={this.openApp} />
+                    openAppByAppId={this.openApp}
+                    reorderDock={this.reorderDock}
+                />
 
                 {/* Taskbar */}
                 <Taskbar
@@ -898,6 +1177,7 @@ export class Desktop extends Component {
                     closed_windows={this.state.closed_windows}
                     minimized_windows={this.state.minimized_windows}
                     focused_windows={this.state.focused_windows}
+                    dock={this.state.dock}
                     openApp={this.openApp}
                     minimize={this.hasMinimised}
                 />
@@ -908,9 +1188,11 @@ export class Desktop extends Component {
                 {/* Context Menus */}
                 <DesktopMenu
                     active={this.state.context_menus.desktop}
+                    onClose={this.hideAllContextMenu}
                     openApp={this.openApp}
                     addNewFolder={this.addNewFolder}
                     openShortcutSelector={this.openShortcutSelector}
+                    openLauncherCreator={this.openLauncherCreator}
                     clearSession={() => { this.props.clearSession(); window.location.reload(); }}
                 />
                 <DefaultMenu active={this.state.context_menus.default} onClose={this.hideAllContextMenu} />
@@ -919,6 +1201,9 @@ export class Desktop extends Component {
                     pinned={this.initFavourite[this.state.context_app]}
                     pinApp={() => this.pinApp(this.state.context_app)}
                     unpinApp={() => this.unpinApp(this.state.context_app)}
+                    openMenuEditor={() => this.openApp('settings')}
+                    addToPanel={() => { const id = this.state.context_app; if (id) logger.info('Add to panel', id); }}
+                    addToDesktop={() => { const id = this.state.context_app; if (id) this.addShortcutToDesktop(id); }}
                     onClose={this.hideAllContextMenu}
                 />
                 <TaskbarMenu
@@ -940,6 +1225,17 @@ export class Desktop extends Component {
                     }}
                     onCloseMenu={this.hideAllContextMenu}
                 />
+                <WindowMenu
+                    active={this.state.context_menus.window}
+                    onMove={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.changeCursorToMove(); }}
+                    onResize={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.startResize(); }}
+                    onTop={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.toggleAlwaysOnTop(); }}
+                    onShade={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.toggleShade(); }}
+                    onStick={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.toggleStick(); }}
+                    onMaximize={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.maximizeWindow(); }}
+                    onClose={() => { const id = this.state.context_app; if (id) this.closeApp(id); }}
+                    onCloseMenu={this.hideAllContextMenu}
+                />
 
                 {/* Folder Input Name Bar */}
                 {
@@ -952,7 +1248,7 @@ export class Desktop extends Component {
                 { this.state.allAppsView ?
                     <AllApplications apps={apps}
                         games={games}
-                        recentApps={this.app_stack}
+                        recentApps={this.state.recentApps}
                         openApp={this.openApp} /> : null}
 
                 { this.state.showShortcutSelector ?
@@ -961,11 +1257,25 @@ export class Desktop extends Component {
                         onSelect={this.addShortcutToDesktop}
                         onClose={() => this.setState({ showShortcutSelector: false })} /> : null}
 
+                { this.state.showLauncherCreator ?
+                    <LauncherCreator
+                        onSave={this.createLauncher}
+                        onClose={() => this.setState({ showLauncherCreator: false })} /> : null}
+
                 { this.state.showWindowSwitcher ?
                     <WindowSwitcher
                         windows={this.state.switcherWindows}
                         onSelect={this.selectWindow}
                         onClose={this.closeWindowSwitcher} /> : null}
+
+                { this.state.showWorkspaceSwitcher ?
+                    <WorkspaceSwitcher
+                        workspaces={this.state.switcherWorkspaces}
+                        active={this.state.currentWorkspace}
+                        onSelect={this.selectWorkspace}
+                        onClose={this.closeWorkspaceSwitcher} /> : null}
+
+                <DesktopTour showAllApps={this.showAllApps} />
 
             </main>
         )

--- a/components/screen/launcher-creator.js
+++ b/components/screen/launcher-creator.js
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+
+function LauncherCreator({ onSave, onClose }) {
+    const [name, setName] = useState('');
+    const [comment, setComment] = useState('');
+    const [icon, setIcon] = useState('');
+    const [command, setCommand] = useState('');
+
+    const handleSubmit = () => {
+        if (!name || !command) return;
+        onSave({ name, comment, icon, command });
+    };
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-ub-grey bg-opacity-95">
+            <div className="bg-ub-cool-grey p-4 rounded w-80">
+                <h2 className="text-white mb-4">Create Launcher</h2>
+                <input
+                    className="w-full mb-2 px-2 py-1 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                    placeholder="Name"
+                    value={name}
+                    onChange={e => setName(e.target.value)}
+                />
+                <input
+                    className="w-full mb-2 px-2 py-1 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                    placeholder="Comment"
+                    value={comment}
+                    onChange={e => setComment(e.target.value)}
+                />
+                <input
+                    className="w-full mb-2 px-2 py-1 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                    placeholder="Icon URL"
+                    value={icon}
+                    onChange={e => setIcon(e.target.value)}
+                />
+                <input
+                    className="w-full mb-4 px-2 py-1 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                    placeholder="Command"
+                    value={command}
+                    onChange={e => setCommand(e.target.value)}
+                />
+                <div className="flex justify-end space-x-2">
+                    <button
+                        className="px-3 py-1 rounded bg-black bg-opacity-20 text-white"
+                        onClick={onClose}
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        className="px-3 py-1 rounded bg-black bg-opacity-20 text-white"
+                        onClick={handleSubmit}
+                    >
+                        Save
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default LauncherCreator;

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -1,37 +1,79 @@
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
 
-export default function LockScreen(props) {
+/**
+ * Authentication screen used for both login and lock flows.
+ * Shows the current time, a generic avatar and a password field.
+ */
+export default function AuthScreen({
+  isLocked = false,
+  mode = 'lock',
+  username = 'user',
+  onSubmit,
+}) {
+  const { wallpaper } = useSettings();
+  const [password, setPassword] = useState('');
+  const inputRef = useRef(null);
 
-    const { wallpaper } = useSettings();
+  const visible = mode === 'login' || isLocked;
 
-    if (props.isLocked) {
-        window.addEventListener('click', props.unLockScreen);
-        window.addEventListener('keypress', props.unLockScreen);
-    };
+  useEffect(() => {
+    if (visible) {
+      inputRef.current?.focus();
+    }
+  }, [visible]);
 
-    return (
-        <div
-            id="ubuntu-lock-screen"
-            style={{ zIndex: "100", contentVisibility: 'auto' }}
-            className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
-            <img
-                src={`/wallpapers/${wallpaper}.webp`}
-                alt=""
-                className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
-            />
-            <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
-                <div className=" text-7xl">
-                    <Clock onlyTime={true} />
-                </div>
-                <div className="mt-4 text-xl font-medium">
-                    <Clock onlyDay={true} />
-                </div>
-                <div className=" mt-16 text-base">
-                    Click or Press a key to unlock
-                </div>
-            </div>
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit?.(password);
+    setPassword('');
+  };
+
+  return (
+    <div
+      id="auth-screen"
+      style={{ zIndex: '100', contentVisibility: 'auto' }}
+      className={`${visible ? 'visible translate-y-0' : 'invisible -translate-y-full'} absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen`}
+    >
+      <img
+        src={`/wallpapers/${wallpaper}.webp`}
+        alt=""
+        className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${visible ? 'blur-md' : 'blur-none'}`}
+      />
+      <div className="w-full h-full z-50 relative flex flex-col items-center justify-center text-white">
+        <div className="absolute top-10 text-center">
+          <div className="text-7xl">
+            <Clock onlyTime={true} />
+          </div>
+          <div className="mt-2 text-xl font-medium">
+            <Clock onlyDay={true} />
+          </div>
         </div>
-    )
+        <form onSubmit={handleSubmit} className="bg-black bg-opacity-50 p-8 rounded flex flex-col items-center">
+          <div className="w-24 h-24 rounded-full mb-4 border-2 border-white bg-gray-600 flex items-center justify-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="w-16 h-16 text-white"
+            >
+              <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-3.866 0-7 3.134-7 7h14c0-3.866-3.134-7-7-7z" />
+            </svg>
+          </div>
+          <div className="text-2xl mb-4">{username}</div>
+          <input
+            ref={inputRef}
+            type="password"
+            className="px-4 py-2 rounded bg-gray-800 focus:outline-none"
+            placeholder="Password"
+            aria-label="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </form>
+      </div>
+    </div>
+  );
 }
+

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,47 +1,97 @@
 import React, { Component } from 'react';
 import Image from 'next/image';
-import Clock from '../util-components/clock';
+import Link from 'next/link';
+import PanelClock from '../util-components/PanelClock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import HelpMenu from '../menu/HelpMenu';
+import { getUndercover, setUndercover } from '../../utils/theme';
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+  constructor() {
+    super();
+    this.state = {
+      status_card: false,
+      undercover: getUndercover(),
+      showTip: false,
+    };
+  }
 
-	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
-                                </div>
-                                <WhiskerMenu />
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-                                        }
-                                >
-                                        <Clock />
-                                </div>
-                                <button
-                                        type="button"
-                                        id="status-bar"
-                                        aria-label="System status"
-                                        onClick={() => {
-                                                this.setState({ status_card: !this.state.status_card });
-                                        }}
-                                        className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-                                        }
-                                >
-                                        <Status />
-                                        <QuickSettings open={this.state.status_card} />
-                                </button>
-			</div>
-		);
-	}
+  componentDidMount() {
+    setUndercover(this.state.undercover);
+  }
+
+  render() {
+    const toggleUndercover = () => {
+      const next = !this.state.undercover;
+      setUndercover(next);
+      this.setState({ undercover: next });
+    };
+
+    return (
+      <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+        <div className="pl-3 pr-1">
+          <Image
+            src={
+              this.state.undercover
+                ? '/themes/Undercover/status/network.svg'
+                : '/themes/Yaru/status/network-wireless-signal-good-symbolic.svg'
+            }
+            alt="network icon"
+            width={16}
+            height={16}
+            className="w-4 h-4"
+          />
+        </div>
+        <WhiskerMenu />
+        <HelpMenu />
+        <button
+          type="button"
+          aria-label="Undercover mode"
+          onClick={toggleUndercover}
+          onMouseEnter={() => this.setState({ showTip: true })}
+          onMouseLeave={() => this.setState({ showTip: false })}
+          className="relative p-2"
+        >
+          <Image
+            src="/themes/Undercover/system/undercover.svg"
+            alt="undercover toggle"
+            width={16}
+            height={16}
+          />
+          {this.state.showTip && (
+            <div
+              role="tooltip"
+              className="absolute right-0 mt-1 w-48 p-2 text-xs text-white bg-black rounded shadow-lg"
+            >
+              Undercover mode – Windows-like theme.{' '}
+              <Link href="/undercover" className="underline text-blue-300">
+                Read disclaimer
+              </Link>
+            </div>
+          )}
+        </button>
+        <div className="pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1">
+          <PanelClock />
+        </div>
+        <button
+          type="button"
+          id="status-bar"
+          aria-label="System status"
+          onClick={() => {
+            this.setState({ status_card: !this.state.status_card });
+          }}
+          className="relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 "
+        >
+          <Status />
+          <QuickSettings
+            open={this.state.status_card}
+            lockScreen={this.props.lockScreen}
+            logOut={this.props.logOut}
+          />
+        </button>
+      </div>
+    );
+  }
 }

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -1,44 +1,102 @@
 import React, { useState } from 'react'
-import Image from 'next/image'
 import SideBarApp from '../base/side_bar_app';
-
-let renderApps = (props) => {
-    let sideBarAppsJsx = [];
-    props.apps.forEach((app, index) => {
-        if (props.favourite_apps[app.id] === false) return;
-        sideBarAppsJsx.push(
-            <SideBarApp key={app.id} id={app.id} title={app.title} icon={app.icon} isClose={props.closed_windows} isFocus={props.focused_windows} openApp={props.openAppByAppId} isMinimized={props.isMinimized} openFromMinimised={props.openFromMinimised} />
-        );
-    });
-    return sideBarAppsJsx;
-}
+import { Icon } from '../ui/Icon';
 
 export default function SideBar(props) {
 
-    function showSideBar() {
-        props.hideSideBar(null, false);
-    }
+    const [dragging, setDragging] = useState(null);
 
-    function hideSideBar() {
+    const showSideBar = () => {
+        props.hideSideBar(null, false);
+    };
+
+    const hideSideBar = () => {
         setTimeout(() => {
             props.hideSideBar(null, true);
         }, 2000);
-    }
+    };
+
+    const handleDragStart = (e, id) => {
+        setDragging(id);
+        e.dataTransfer.effectAllowed = 'move';
+    };
+
+    const handleDrop = (e, id) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (dragging === null || dragging === id) return;
+        const dock = [...props.dock];
+        const from = dock.indexOf(dragging);
+        const to = dock.indexOf(id);
+        if (from === -1 || to === -1) return;
+        dock.splice(from, 1);
+        dock.splice(to, 0, dragging);
+        props.reorderDock && props.reorderDock(dock);
+        setDragging(null);
+    };
+
+    const handleNavDrop = (e) => {
+        e.preventDefault();
+        if (dragging === null) return;
+        const dock = props.dock.filter(id => id !== dragging);
+        dock.push(dragging);
+        props.reorderDock && props.reorderDock(dock);
+        setDragging(null);
+    };
+
+    const handleDragOver = (e) => {
+        e.preventDefault();
+    };
+
+    const openUnpinned = props.apps
+        .filter(app => props.closed_windows[app.id] === false && !props.dock.includes(app.id))
+        .map(app => app.id);
+
+    const order = [...props.dock, ...openUnpinned];
 
     return (
         <>
             <nav
                 aria-label="Dock"
                 className={(props.hide ? " -translate-x-full " : "") +
-                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
+                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen flex flex-col justify-start items-center pt-7 border-black border-opacity-60"}
+                style={{
+                    width: 'var(--sidebar-width)',
+                    backgroundColor: 'var(--menu-bg)',
+                    opacity: 'var(--menu-opacity)',
+                    borderRadius: 'var(--menu-border-radius)'
+                }}
+                onDragOver={handleDragOver}
+                onDrop={handleNavDrop}
             >
-                {
-                    (
-                        Object.keys(props.closed_windows).length !== 0
-                            ? renderApps(props)
-                            : null
-                    )
-                }
+                {order.map(id => {
+                    const app = props.apps.find(a => a.id === id);
+                    if (!app) return null;
+                    const pinned = props.dock.includes(id);
+                    return (
+                        <div
+                            key={id}
+                            draggable={pinned}
+                            onDragStart={pinned ? (e) => handleDragStart(e, id) : undefined}
+                            onDragEnd={() => setDragging(null)}
+                            onDrop={pinned ? (e) => handleDrop(e, id) : undefined}
+                            onDragOver={pinned ? handleDragOver : undefined}
+                        >
+                            <SideBarApp
+                                id={app.id}
+                                title={app.title}
+                                icon={app.icon}
+                                isClose={props.closed_windows}
+                                isFocus={props.focused_windows}
+                                openApp={props.openAppByAppId}
+                                isMinimized={props.isMinimized}
+                                openFromMinimised={props.openFromMinimised}
+                                notifications={app.notifications}
+                                tasks={app.tasks}
+                            />
+                        </div>
+                    );
+                })}
                 <AllApps showApps={props.showAllApps} />
             </nav>
             <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className={"w-1 h-full absolute top-0 left-0 bg-transparent z-50"}></div>
@@ -51,7 +109,9 @@ export function AllApps(props) {
     const [title, setTitle] = useState(false);
 
     return (
-        <div
+        <button
+            type="button"
+            aria-label="Show Applications"
             className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
             style={{ marginTop: 'auto' }}
             onMouseEnter={() => {
@@ -63,14 +123,7 @@ export function AllApps(props) {
             onClick={props.showApps}
         >
             <div className="relative">
-                <Image
-                    width={28}
-                    height={28}
-                    className="w-7"
-                    src="/themes/Yaru/system/view-app-grid-symbolic.svg"
-                    alt="Ubuntu view app"
-                    sizes="28px"
-                />
+                <Icon name="grid" className="w-7 h-7" />
                 <div
                     className={
                         (title ? " visible " : " invisible ") +
@@ -80,6 +133,6 @@ export function AllApps(props) {
                     Show Applications
                 </div>
             </div>
-        </div>
+        </button>
     );
 }

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,12 +1,21 @@
-import React from 'react';
+"use client";
+
+import React, { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
+import usePersistentState from '../../hooks/usePersistentState';
 
 export default function Taskbar(props) {
-    const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const pinnedApps = props.apps.filter(app => (props.dock || []).includes(app.id));
+    const runningApps = props.apps.filter(
+        app => props.closed_windows[app.id] === false && !(props.dock || []).includes(app.id)
+    );
+    const [behavior] = usePersistentState('xfce.panel.autohideBehavior', 'never');
+    const [visible, setVisible] = useState(true);
+    const hideTimer = useRef(null);
 
     const handleClick = (app) => {
         const id = app.id;
-        if (props.minimized_windows[id]) {
+        if (props.closed_windows[id] || props.minimized_windows[id]) {
             props.openApp(id);
         } else if (props.focused_windows[id]) {
             props.minimize(id);
@@ -15,33 +24,89 @@ export default function Taskbar(props) {
         }
     };
 
-    return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => (
-                <button
-                    key={app.id}
-                    type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
-                    onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
+    const show = () => {
+        if (hideTimer.current) clearTimeout(hideTimer.current);
+        setVisible(true);
+    };
+
+    const scheduleHide = () => {
+        if (behavior === 'never') return;
+        const delay = behavior === 'intelligent' ? 800 : 0;
+        if (hideTimer.current) clearTimeout(hideTimer.current);
+        hideTimer.current = setTimeout(() => setVisible(false), delay);
+    };
+
+    useEffect(() => {
+        if (behavior === 'never') {
+            setVisible(true);
+            return;
+        }
+        scheduleHide();
+        const handleMove = (e) => {
+            if (window.innerHeight - e.clientY <= 5) {
+                show();
+            }
+        };
+        window.addEventListener('mousemove', handleMove);
+        return () => {
+            window.removeEventListener('mousemove', handleMove);
+            if (hideTimer.current) clearTimeout(hideTimer.current);
+        };
+    }, [behavior]);
+
+    const renderButton = (app) => {
+        const id = app.id;
+        const isFocused = props.focused_windows[id] && !props.minimized_windows[id];
+        const isRunning = props.closed_windows[id] === false;
+        return (
+            <button
+                key={id}
+                type="button"
+                aria-label={app.title}
+                data-context="taskbar"
+                data-app-id={id}
+                onClick={() => handleClick(app)}
+                className={
+                    (isFocused ? ' bg-white bg-opacity-20 ' : ' ') +
+                    'group relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10 active:bg-white active:bg-opacity-20 cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-white focus-visible:outline-offset-2 overflow-visible'
+                }
+            >
+                <Image
+                    width={24}
+                    height={24}
+                    className="w-5 h-5 transition-transform duration-200 ease-out group-hover:scale-110"
+                    src={app.icon.replace('./', '/')}
+                    alt={app.title}
+                    sizes="24px"
+                />
+                <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                {isRunning && (
+                    <span
+                        data-testid="running-indicator"
+                        className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded opacity-80 transition-opacity group-hover:opacity-100 group-active:opacity-100 group-focus-visible:opacity-100"
                     />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
-                </button>
-            ))}
+                )}
+            </button>
+        );
+    };
+
+    return (
+        <div
+            onMouseEnter={show}
+            onMouseLeave={scheduleHide}
+            style={{ transform: visible ? 'translateY(0)' : 'translateY(100%)', transition: 'transform 0.3s' }}
+            className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40"
+            role="toolbar"
+            aria-label="Taskbar"
+        >
+            {pinnedApps.map(renderButton)}
+            {pinnedApps.length > 0 && runningApps.length > 0 && (
+                <div
+                    data-testid="pinned-separator"
+                    className="w-px h-6 bg-white bg-opacity-20 mx-1"
+                />
+            )}
+            {runningApps.map(renderButton)}
         </div>
     );
 }

--- a/components/screen/ubuntu.tsx
+++ b/components/screen/ubuntu.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React, { useState, forwardRef, type ReactNode } from "react";
+import UbuntuCore from "../ubuntu";
+import usePersistentState from "../../hooks/usePersistentState";
+import { THEME_KEY, setTheme } from "../../utils/theme";
+
+// Simple Safe Mode screen presented when boot fails
+function SafeModeScreen({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="w-screen h-screen flex flex-col items-center justify-center bg-black text-white gap-4">
+      <h1 className="text-2xl font-bold">Safe Mode</h1>
+      <p className="max-w-md text-center">
+        An error occurred before the desktop could load. Custom themes and panel
+        profiles have been disabled.
+      </p>
+      <button onClick={onRetry} className="bg-ub-orange px-4 py-2 rounded">
+        Return to Desktop
+      </button>
+    </div>
+  );
+}
+
+class UbuntuErrorBoundary extends React.Component<
+  { children: ReactNode; onError: (e: Error) => void },
+  { hasError: boolean }
+> {
+  constructor(props: { children: ReactNode; onError: (e: Error) => void }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    this.props.onError(error);
+  }
+
+  render() {
+    if (this.state.hasError) return null;
+    return this.props.children;
+  }
+}
+
+export default forwardRef<any, any>(function UbuntuScreen(props, ref) {
+  const [safeMode, setSafeMode] = useState(false);
+  const [, , , clearTheme] = usePersistentState<string>(THEME_KEY, "default");
+  const [, , , clearProfiles] = usePersistentState<Record<string, unknown>>(
+    "panel:profiles",
+    {},
+  );
+
+  const handleError = (err: Error) => {
+    // Remove custom theme and panel profile
+    clearTheme();
+    clearProfiles();
+    try {
+      window.localStorage.removeItem("panelLayout");
+      window.localStorage.removeItem("pluginStates");
+      setTheme("default");
+    } catch {
+      /* ignore storage errors */
+    }
+    setSafeMode(true);
+    console.error("Boot error", err);
+  };
+
+  const retry = () => {
+    setSafeMode(false);
+    // Reload to attempt normal boot again
+    try {
+      window.location.reload();
+    } catch {
+      /* ignore reload issues */
+    }
+  };
+
+  if (safeMode) return <SafeModeScreen onRetry={retry} />;
+
+  return (
+    <UbuntuErrorBoundary onError={handleError}>
+      <UbuntuCore ref={ref} {...props} />
+    </UbuntuErrorBoundary>
+  );
+});

--- a/components/screen/workspace-switcher.tsx
+++ b/components/screen/workspace-switcher.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React, { useEffect } from "react";
+
+export interface WorkspaceInfo {
+  id: number;
+  name: string;
+}
+
+interface Props {
+  workspaces: WorkspaceInfo[];
+  active: number;
+  onSelect?: (id: number) => void;
+  onClose?: () => void;
+}
+
+export default function WorkspaceSwitcher({
+  workspaces,
+  active,
+  onSelect,
+  onClose,
+}: Props) {
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose?.();
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 text-white"
+      role="dialog"
+    >
+      <div
+        className="grid gap-4 w-11/12 max-w-3xl"
+        style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))' }}
+      >
+        {workspaces.map((ws) => (
+          <button
+            key={ws.id}
+            onClick={() => onSelect?.(ws.id)}
+            className={`p-4 rounded bg-ub-grey bg-opacity-60 hover:bg-ub-grey text-center focus:outline-none ${
+              active === ws.id ? "ring-2 ring-ub-orange" : ""
+            }`}
+          >
+            {ws.name}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/components/util-components/PanelClock.tsx
+++ b/components/util-components/PanelClock.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+
+const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+export default function PanelClock() {
+  const [now, setNow] = useState<Date | null>(null);
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const dayRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [focusedIdx, setFocusedIdx] = useState(-1);
+
+  useEffect(() => {
+    const tick = () => setNow(new Date());
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    const handle = (e: MouseEvent) => {
+      if (open && ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('click', handle);
+    return () => document.removeEventListener('click', handle);
+  }, [open]);
+
+  useEffect(() => {
+    if (open) {
+      const index = weeks
+        .flat()
+        .findIndex((d) => d === now?.getDate());
+      const firstValid = weeks.flat().findIndex((d) => d !== null);
+      const idx = index >= 0 ? index : firstValid;
+      setFocusedIdx(idx);
+      // focus will be applied in effect below
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (open && focusedIdx >= 0) {
+      dayRefs.current[focusedIdx]?.focus();
+    }
+  }, [open, focusedIdx]);
+
+  if (!now) return <span suppressHydrationWarning />;
+
+  const timeStr = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const tooltip = now.toLocaleString([], {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  const year = now.getFullYear();
+  const month = now.getMonth();
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const weeks: (number | null)[][] = [];
+  let day = 1 - firstDay;
+  for (let i = 0; i < 6; i++) {
+    const week: (number | null)[] = [];
+    for (let j = 0; j < 7; j++) {
+      if (day < 1 || day > daysInMonth) week.push(null);
+      else week.push(day);
+      day++;
+    }
+    weeks.push(week);
+  }
+
+  const total = 42;
+  const move = (delta: number) => {
+    let idx = focusedIdx;
+    do {
+      idx = (idx + delta + total) % total;
+    } while (!dayRefs.current[idx]);
+    setFocusedIdx(idx);
+  };
+
+  const handleKey = (e: React.KeyboardEvent) => {
+    if (!open) return;
+    switch (e.key) {
+      case 'ArrowRight':
+        e.preventDefault();
+        move(1);
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        move(-1);
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        move(7);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        move(-7);
+        break;
+      case 'Enter':
+        e.preventDefault();
+        dayRefs.current[focusedIdx]?.click();
+        break;
+      case 'Escape':
+        e.preventDefault();
+        setOpen(false);
+        buttonRef.current?.focus();
+        break;
+      case 'Tab':
+        e.preventDefault();
+        move(e.shiftKey ? -1 : 1);
+        break;
+    }
+  };
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        title={tooltip}
+        onClick={() => setOpen((o) => !o)}
+        className="outline-none"
+        ref={buttonRef}
+      >
+        {timeStr}
+      </button>
+      {open && (
+        <div
+          className="absolute right-0 mt-2 p-2 bg-ub-grey text-ubt-grey rounded shadow-lg"
+          onKeyDown={handleKey}
+        >
+          <div className="text-center mb-2">
+            {now.toLocaleString([], { month: 'long', year: 'numeric' })}
+          </div>
+          <table className="text-xs">
+            <thead>
+              <tr>
+                {dayNames.map((d) => (
+                  <th key={d} className="px-1">
+                    {d}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {weeks.map((week, idx) => (
+                <tr key={idx}>
+                  {week.map((d, i) => {
+                    const cellIndex = idx * 7 + i;
+                    const label = d
+                      ? new Date(year, month, d).toLocaleDateString('en-US', {
+                          weekday: 'long',
+                          month: 'long',
+                          day: 'numeric',
+                          year: 'numeric',
+                        })
+                      : undefined;
+                    if (!d) {
+                      dayRefs.current[cellIndex] = null;
+                      return (
+                        <td key={i} className="p-1 text-center">
+                          <span />
+                        </td>
+                      );
+                    }
+                    return (
+                      <td key={i} className="p-1 text-center">
+                        <button
+                          ref={(el) => (dayRefs.current[cellIndex] = el)}
+                          tabIndex={cellIndex === focusedIdx ? 0 : -1}
+                          aria-label={label}
+                          className={`w-6 h-6 rounded ${
+                            d === now.getDate()
+                              ? 'bg-ubt-blue text-ub-grey'
+                              : ''
+                          }`}
+                        >
+                          {d}
+                        </button>
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/components/util-components/calendar-popup.js
+++ b/components/util-components/calendar-popup.js
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react';
+import { listEvents } from '../../utils/orage';
+import usePersistentState from '../../hooks/usePersistentState';
+
+const MONTHS = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+const DAYS = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+
+export default function CalendarPopup() {
+  const today = new Date();
+  const [year, setYear] = useState(today.getFullYear());
+  const [month, setMonth] = useState(today.getMonth());
+  const [eventsMap, setEventsMap] = useState({});
+  const [selected, setSelected] = useState(null);
+  const [firstDayOfWeek, setFirstDayOfWeek] = usePersistentState('clock:first-day', 0);
+
+  useEffect(() => {
+    listEvents(year, month).then(evts => {
+      const map = {};
+      evts.forEach(e => {
+        const dt = new Date(e.date || e.start || e); // support multiple shapes
+        const key = dt.toISOString().slice(0,10);
+        if (!map[key]) map[key] = [];
+        map[key].push(e);
+      });
+      setEventsMap(map);
+    }).catch(() => setEventsMap({}));
+  }, [year, month]);
+
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const firstDay = new Date(year, month, 1).getDay();
+  const offset = (firstDay - firstDayOfWeek + 7) % 7;
+
+  useEffect(() => {
+    const onFirstDay = (e) => setFirstDayOfWeek(e.detail);
+    window.addEventListener('clock-first-day', onFirstDay);
+    return () => window.removeEventListener('clock-first-day', onFirstDay);
+  }, [setFirstDayOfWeek]);
+
+  const weeks = [];
+  let day = 1 - offset;
+  for (let w = 0; w < 6; w++) {
+    const wk = [];
+    for (let d = 0; d < 7; d++, day++) {
+      wk.push(day > 0 && day <= daysInMonth ? day : null);
+    }
+    weeks.push(wk);
+  }
+
+  const selectedKey = selected ? selected.toISOString().slice(0,10) : null;
+  const selectedEvents = selectedKey && eventsMap[selectedKey] ? eventsMap[selectedKey] : [];
+
+  return (
+    <div className="absolute right-0 mt-2 p-2 bg-neutral-900 text-white border border-neutral-700 rounded shadow-lg z-50 w-64">
+      <div className="flex justify-between items-center mb-2 text-sm">
+        <button onClick={() => setMonth(m => (m === 0 ? 11 : m - 1))}>◀</button>
+        <div>{MONTHS[month]} {year}</div>
+        <button onClick={() => setMonth(m => (m === 11 ? 0 : m + 1))}>▶</button>
+      </div>
+      <div className="grid grid-cols-7 gap-1 text-xs text-center">
+        {DAYS.slice(firstDayOfWeek).concat(DAYS.slice(0, firstDayOfWeek)).map(d => (
+          <div key={d} className="font-bold">{d}</div>
+        ))}
+        {weeks.map((wk,i) => wk.map((d,j) => {
+          const date = d ? new Date(year, month, d) : null;
+          const key = date ? date.toISOString().slice(0,10) : null;
+          const has = key && eventsMap[key];
+          const label = date
+            ? date.toLocaleDateString('en-US', {
+                weekday: 'long',
+                month: 'long',
+                day: 'numeric',
+                year: 'numeric',
+              })
+            : undefined;
+          return (
+            <button
+              key={`${i}-${j}`}
+              className={`w-8 h-8 relative rounded ${d ? 'hover:bg-neutral-700 focus:bg-neutral-700' : ''}`}
+              disabled={!d}
+              onClick={() => date && setSelected(date)}
+              aria-label={label}
+            >
+              {d || ''}
+              {has && <span className="absolute bottom-1 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-red-500"></span>}
+            </button>
+          );
+        }))}
+      </div>
+      <div className="mt-2 max-h-32 overflow-auto text-xs">
+        {selectedEvents.length ? selectedEvents.map((e,i) => (
+          <div key={i} className="border-t border-neutral-700 pt-1 mt-1">
+            <div className="font-semibold">{e.title || e.summary || 'Event'}</div>
+            {e.description && <div>{e.description}</div>}
+          </div>
+        )) : <div>No events</div>}
+      </div>
+      <div className="mt-2 text-xs">
+        <a
+          href="/apps/settings#datetime"
+          className="text-blue-400 hover:underline"
+        >
+          Time & Date Settings
+        </a>
+      </div>
+    </div>
+  );
+}
+

--- a/components/util-components/clock.js
+++ b/components/util-components/clock.js
@@ -1,61 +1,140 @@
-import { Component } from 'react'
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { useClickOutside } from '../../hooks/useClickOutside';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+import usePersistentState from '../../hooks/usePersistentState';
 
-export default class Clock extends Component {
-    constructor() {
-        super();
-        this.month_list = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-        this.day_list = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-        this.state = {
-            hour_12: true,
-            current_time: null
-        };
+const pad = (n) => n.toString().padStart(2, '0');
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+export default function Clock({ onlyTime, onlyDay }) {
+  const [now, setNow] = useState(new Date());
+  const [timezone, setTimezone] = usePersistentState(
+    'clock:timezone',
+    () => Intl.DateTimeFormat().resolvedOptions().timeZone,
+  );
+  const [twentyFourHour, setTwentyFourHour] = usePersistentState('clock:24h', true);
+  const [showSeconds, setShowSeconds] = usePersistentState('clock:seconds', false);
+  const menuRef = useRef(null);
+  const [open, setOpen] = useState(false);
+
+  useClickOutside(menuRef, () => setOpen(false));
+  useRovingTabIndex(menuRef, open, 'vertical');
+
+  // update time
+  useEffect(() => {
+    const update = () => setNow(new Date());
+    update();
+    const interval = setInterval(update, showSeconds ? 1000 : 10000);
+    return () => clearInterval(interval);
+  }, [showSeconds]);
+
+  // sync with settings page
+  useEffect(() => {
+    const onTz = (e) => setTimezone(e.detail);
+    const on24 = (e) => setTwentyFourHour(e.detail);
+    const onSec = (e) => setShowSeconds(e.detail);
+    window.addEventListener('clock-timezone', onTz);
+    window.addEventListener('clock-24h', on24);
+    window.addEventListener('clock-seconds', onSec);
+    return () => {
+      window.removeEventListener('clock-timezone', onTz);
+      window.removeEventListener('clock-24h', on24);
+      window.removeEventListener('clock-seconds', onSec);
+    };
+  }, [setTimezone, setTwentyFourHour, setShowSeconds]);
+
+  const tzNow = new Date(now.toLocaleString('en-US', { timeZone: timezone }));
+  let hour = tzNow.getHours();
+  let minute = tzNow.getMinutes();
+  let second = tzNow.getSeconds();
+  let meridiem = hour < 12 ? 'AM' : 'PM';
+  if (!twentyFourHour) {
+    hour = hour % 12 || 12;
+  }
+  const timeString =
+    (twentyFourHour ? pad(hour) : hour) +
+    ':' +
+    pad(minute) +
+    (showSeconds ? ':' + pad(second) : '') +
+    (twentyFourHour ? '' : ` ${meridiem}`);
+
+  const day = DAYS[tzNow.getDay()];
+  const month = MONTHS[tzNow.getMonth()];
+  const date = tzNow.getDate().toLocaleString();
+
+  const display = onlyTime
+    ? timeString
+    : onlyDay
+    ? `${day} ${month} ${date}`
+    : `${day} ${month} ${date} ${timeString}`;
+
+  const toggle24 = () => {
+    const val = !twentyFourHour;
+    setTwentyFourHour(val);
+    window.dispatchEvent(new CustomEvent('clock-24h', { detail: val }));
+  };
+  const toggleSeconds = () => {
+    const val = !showSeconds;
+    setShowSeconds(val);
+    window.dispatchEvent(new CustomEvent('clock-seconds', { detail: val }));
+  };
+
+  useEffect(() => {
+    if (open && menuRef.current) {
+      const first = menuRef.current.querySelector('[role="menuitem"], [role="menuitemcheckbox"]');
+      first && first.focus();
     }
+  }, [open]);
 
-    componentDidMount() {
-        const update = () => this.setState({ current_time: new Date() });
-        update();
-        if (typeof window !== 'undefined' && typeof Worker === 'function') {
-            this.worker = new Worker(new URL('../../workers/timer.worker.ts', import.meta.url));
-            this.worker.onmessage = update;
-            this.worker.postMessage({ action: 'start', interval: 10 * 1000 });
-        } else {
-            this.update_time = setInterval(update, 10 * 1000);
-        }
-    }
+  const handleKeyDown = (e) => {
+    if (e.key === 'Escape') setOpen(false);
+  };
 
-    componentWillUnmount() {
-        if (this.worker) {
-            this.worker.postMessage({ action: 'stop' });
-            this.worker.terminate();
-        }
-        if (this.update_time) clearInterval(this.update_time);
-    }
-
-    render() {
-        const { current_time } = this.state;
-        if (!current_time) return <span suppressHydrationWarning></span>;
-
-        let day = this.day_list[current_time.getDay()];
-        let hour = current_time.getHours();
-        let minute = current_time.getMinutes();
-        let month = this.month_list[current_time.getMonth()];
-        let date = current_time.getDate().toLocaleString();
-        let meridiem = (hour < 12 ? "AM" : "PM");
-
-        if (minute.toLocaleString().length === 1) {
-            minute = "0" + minute
-        }
-
-        if (this.state.hour_12 && hour > 12) hour -= 12;
-
-        let display_time;
-        if (this.props.onlyTime) {
-            display_time = hour + ":" + minute + " " + meridiem;
-        }
-        else if (this.props.onlyDay) {
-            display_time = day + " " + month + " " + date;
-        }
-        else display_time = day + " " + month + " " + date + " " + hour + ":" + minute + " " + meridiem;
-        return <span suppressHydrationWarning>{display_time}</span>;
-    }
+  return (
+    <div ref={menuRef} className="relative inline-block" onKeyDown={handleKeyDown}>
+      <span
+        data-testid="panel-clock"
+        suppressHydrationWarning
+        onClick={() => setOpen((o) => !o)}
+        className="cursor-pointer"
+      >
+        {display}
+      </span>
+      {open && (
+        <div
+          role="menu"
+          aria-label="Clock menu"
+          className="absolute right-0 mt-2 w-48 bg-neutral-900 text-white rounded shadow-lg z-50"
+        >
+          <button
+            role="menuitemcheckbox"
+            aria-checked={twentyFourHour}
+            onClick={toggle24}
+            className="flex justify-between w-full px-2 py-1 text-left hover:bg-neutral-700"
+          >
+            <span>24-hour</span>
+            {twentyFourHour && <span>✓</span>}
+          </button>
+          <button
+            role="menuitemcheckbox"
+            aria-checked={showSeconds}
+            onClick={toggleSeconds}
+            className="flex justify-between w-full px-2 py-1 text-left hover:bg-neutral-700"
+          >
+            <span>Show seconds</span>
+            {showSeconds && <span>✓</span>}
+          </button>
+          <Link
+            role="menuitem"
+            href="/apps/settings/date-time"
+            className="block px-2 py-1 hover:bg-neutral-700 text-left"
+          >
+            Date/Time settings
+          </Link>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -2,12 +2,20 @@ import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
-
-const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
+import { useTray } from '../../hooks/useTray';
 
 export default function Status() {
-  const { allowNetwork } = useSettings();
+  const { allowNetwork, theme, symbolicTrayIcons } = useSettings();
+  const { icons, register, unregister } = useTray();
   const [online, setOnline] = useState(true);
+  const [undercover, setUndercover] = useState(false);
+
+  useEffect(() => {
+    setUndercover(document.documentElement.dataset.undercover === 'true');
+    const handler = (e) => setUndercover(e.detail.value);
+    document.addEventListener('undercover-change', handler);
+    return () => document.removeEventListener('undercover-change', handler);
+  }, []);
 
   useEffect(() => {
     const pingServer = async () => {
@@ -38,46 +46,67 @@ export default function Status() {
     };
   }, []);
 
+  useEffect(() => {
+    const id = 'network';
+    const themeDir = undercover ? 'Undercover' : 'Yaru';
+    const connected = undercover
+      ? '/themes/Undercover/status/network.svg'
+      : `/themes/${themeDir}/status/network-wireless-signal-good-symbolic.svg`;
+    const disconnected = undercover
+      ? '/themes/Undercover/status/network.svg'
+      : `/themes/${themeDir}/status/network-wireless-signal-none-symbolic.svg`;
+    register({
+      id,
+      tooltip: online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline',
+      sni: online ? connected : disconnected,
+      legacy: online ? connected : disconnected,
+    });
+    return () => unregister(id);
+  }, [online, allowNetwork, register, unregister, undercover]);
+
+  useEffect(() => {
+    const id = 'volume';
+    const themeDir = theme === 'kali-light' ? 'Yaru' : 'Yaru';
+    const icon = `/themes/${themeDir}/status/audio-volume-medium-symbolic.svg`;
+    register({ id, tooltip: 'Volume', sni: icon, legacy: icon });
+    return () => unregister(id);
+  }, [register, unregister, theme]);
+
+  useEffect(() => {
+    const id = 'battery';
+    const themeDir = theme === 'kali-light' ? 'Yaru' : 'Yaru';
+    const icon = `/themes/${themeDir}/status/battery-good-symbolic.svg`;
+    register({ id, tooltip: 'Battery', sni: icon, legacy: icon });
+    return () => unregister(id);
+  }, [register, unregister, theme]);
+
   return (
-    <div className="flex justify-center items-center">
-      <span
-        className="mx-1.5 relative"
-        title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}
-      >
-        <Image
-          width={16}
-          height={16}
-          src={online ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"}
-          alt={online ? "online" : "offline"}
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
-        {!allowNetwork && (
-          <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
-        )}
-      </span>
-      <span className="mx-1.5">
-        <Image
-          width={16}
-          height={16}
-          src={VOLUME_ICON}
-          alt="volume"
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
-      </span>
-      <span className="mx-1.5">
-        <Image
-          width={16}
-          height={16}
-          src="/themes/Yaru/status/battery-good-symbolic.svg"
-          alt="ubuntu battry"
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
-      </span>
-      <span className="mx-1">
-        <SmallArrow angle="down" className=" status-symbol" />
+    <div className="flex items-center gap-2 md:gap-1 lg:gap-2" role="group" aria-label="System tray">
+      {icons.map((icon) => (
+        <span
+          key={icon.id}
+          className="relative flex items-center justify-center w-5 h-5 md:w-4 md:h-4 lg:w-5 lg:h-5"
+          title={icon.tooltip}
+        >
+          <Image
+            width={20}
+            height={20}
+            src={
+              symbolicTrayIcons
+                ? icon.sni || icon.legacy
+                : icon.legacy || icon.sni
+            }
+            alt={icon.tooltip || icon.id}
+            className="status-symbol w-5 h-5 md:w-4 md:h-4 lg:w-5 lg:h-5"
+            sizes="20px"
+          />
+          {icon.id === 'network' && !allowNetwork && (
+            <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
+          )}
+        </span>
+      ))}
+      <span className="flex items-center justify-center w-5 h-5 md:w-4 md:h-4 lg:w-5 lg:h-5">
+        <SmallArrow angle="down" className="status-symbol" />
       </span>
     </div>
   );

--- a/scripts/revert-ui.sh
+++ b/scripts/revert-ui.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+UI_BASE_SHA="${1:-}"
+if [ -z "$UI_BASE_SHA" ]; then
+  echo "Usage: $0 <ui-baseline-commit-or-merge-sha>"; exit 1
+fi
+
+git checkout main && git pull
+git checkout -b chore/restore-classic-ui-keep-apps
+
+git restore --source="$UI_BASE_SHA" -- \
+  components/ubuntu.tsx \
+  components/base \
+  components/screen \
+  components/context-menus \
+  components/util-components \
+  styles \
+  tailwind.config.js \
+  public/images
+
+# Keep apps and labels from main (includes About Alex via 311d8d1)
+grep -n "About Alex" apps.config.js || {
+  echo "About Alex missing in apps.config.js. Consider: git cherry-pick 311d8d107baaf556fba86ee1b9f1f14888dbae2c"
+}
+
+nvm use
+yarn install
+yarn lint || true
+yarn build

--- a/styles/colors-alt.css
+++ b/styles/colors-alt.css
@@ -1,0 +1,14 @@
+/* Alternative color palette */
+.alt-palette {
+    --color-bg: #fdf6e3;
+    --color-text: #073642;
+    --color-primary: #b58900;
+    --color-secondary: #eee8d5;
+    --color-accent: #268bd2;
+    --color-muted: #e0dbd1;
+    --color-surface: #eee8d5;
+    --color-inverse: #fdf6e3;
+    --color-border: #d3c6aa;
+    --color-terminal: #00ff00;
+    --color-dark: #002b36;
+}

--- a/styles/docs.css
+++ b/styles/docs.css
@@ -1,0 +1,38 @@
+/* Documentation specific overrides to match official docs */
+.docs-content {
+  font-family: var(--font-family-base, system-ui, sans-serif);
+}
+
+.docs-content ul,
+.docs-content ol {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+  padding-left: 1.25em;
+}
+
+.docs-content li + li {
+  margin-top: 0.25em;
+}
+
+.docs-content pre {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  padding: 0.75em 1em;
+  line-height: 1.4;
+  font-size: 0.9em;
+}
+
+.docs-content code {
+  font-family: var(--font-family-mono, monospace);
+}
+
+.docs-content blockquote {
+  margin: 1rem 0;
+  padding: 0.5rem 1rem;
+  border-left: 4px solid var(--color-primary);
+  background-color: var(--color-surface);
+}
+
+.docs-content blockquote > :last-child {
+  margin-bottom: 0;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,7 +19,25 @@
   --color-focus-ring: var(--color-accent);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
+  /* Toast bubble theme variables */
+  --toast-bg: var(--color-surface);
+  --toast-text: var(--color-text);
+  --toast-border: var(--color-border);
   accent-color: var(--color-control-accent);
+  /* Kali theme helpers */
+  --kali-bg: var(--color-bg);
+  --kali-panel: var(--color-surface);
+  --icon-spacing: var(--space-2);
+  --background-image: url(/wallpapers/wall-2.webp);
+  /* Code block tokens */
+  --code-token-comment: #6e7681;
+  --code-token-string: #a5d6ff;
+  --code-token-keyword: #ff7b72;
+  --code-token-function: #d2a8ff;
+  --code-token-number: #ffa657;
+  --code-gutter-bg: var(--color-secondary);
+  --code-gutter-border: var(--color-border);
+  --code-gutter-text: var(--color-muted);
 }
 
 /* Dark theme */
@@ -52,6 +70,85 @@ html[data-theme='neon'] {
   --color-dark: #000000;
 }
 
+/* Kali dark theme */
+html[data-theme='kali-dark'] {
+  --color-bg: var(--color-ub-grey);
+  --color-text: var(--color-ubt-grey);
+  --color-primary: var(--color-ub-orange);
+  --color-secondary: var(--color-ub-cool-grey);
+  --color-accent: var(--color-ub-orange);
+  --color-muted: var(--color-ub-dark-grey);
+  --color-surface: var(--color-ub-lite-abrgn);
+  --color-inverse: var(--color-ubt-grey);
+  --color-border: var(--color-ub-dark-grey);
+  --color-terminal: #00ff00;
+  --color-dark: var(--color-ub-window-title);
+}
+
+/* Kali light theme */
+html[data-theme='kali-light'] {
+  --color-bg: var(--color-ubt-grey);
+  --color-text: var(--color-ub-grey);
+  --color-primary: var(--color-ubt-blue);
+  --color-secondary: var(--color-ubt-cool-grey);
+  --color-accent: var(--color-ubt-blue);
+  --color-muted: var(--color-ubt-warm-grey);
+  --color-surface: var(--color-ubt-grey);
+  --color-inverse: var(--color-ub-grey);
+  --color-border: var(--color-ubt-cool-grey);
+  --color-terminal: #00ff00;
+  --color-dark: var(--color-ubt-gedit-dark);
+  /* Code block tokens */
+  --code-token-comment: #6a737d;
+  --code-token-string: #22863a;
+  --code-token-keyword: #d73a49;
+  --code-token-function: #6f42c1;
+  --code-token-number: #005cc5;
+  --code-gutter-bg: var(--color-muted);
+  --code-gutter-border: var(--color-border);
+  --code-gutter-text: var(--color-ubt-cool-grey);
+}
+
+/* Undercover mode */
+html[data-undercover='true'] {
+  --color-bg: #f0f0f0;
+  --color-text: #000000;
+  --color-primary: #0078d7;
+  --color-secondary: #e5e5e5;
+  --color-accent: #0078d7;
+  --color-muted: #d0d0d0;
+  --color-surface: #ffffff;
+  --color-inverse: #ffffff;
+  --color-border: #c0c0c0;
+  --color-terminal: #00ff00;
+  --color-dark: #0078d7;
+  --color-ub-grey: #dcdcdc;
+  --color-ubt-grey: #f7f7f7;
+  --color-ub-cool-grey: #e5e5e5;
+  --color-ub-orange: #0078d7;
+  --color-ub-window-title: #0078d7;
+  /* Code block tokens */
+  --code-token-comment: #6a737d;
+  --code-token-string: #22863a;
+  --code-token-keyword: #d73a49;
+  --code-token-function: #6f42c1;
+  --code-token-number: #005cc5;
+  --code-gutter-bg: var(--color-muted);
+  --code-gutter-border: var(--color-border);
+  --code-gutter-text: #666666;
+}
+
+html[data-undercover='true'] .main-navbar-vp {
+  background: #e5e5e5;
+  color: #000;
+}
+
+html[data-undercover='true'] .window-titlebar {
+  background: #ffffff;
+  color: #000;
+  border-bottom: 1px solid #c0c0c0;
+}
+
 /* Matrix theme */
 html[data-theme='matrix'] {
   --color-bg: #000000;
@@ -74,6 +171,93 @@ html[data-theme='matrix'] {
 }
 
 *:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
-  outline-offset: 2px;
+  outline: var(--focus-outline-width) var(--focus-outline-style) var(--focus-outline-color);
+  outline-offset: var(--focus-outline-offset);
+}
+
+.focus-outline:focus-visible {
+  outline: var(--focus-outline-width) var(--focus-outline-style) var(--focus-outline-color);
+  outline-offset: var(--focus-outline-offset);
+  transition: outline-offset var(--motion-fast);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .focus-outline:focus-visible {
+    transition: none;
+  }
+}
+
+.notification-center {
+  position: fixed;
+  z-index: 1000;
+  max-width: 20rem;
+  padding: 0.5rem;
+}
+.notification-center.top-left { top: 1rem; left: 1rem; }
+.notification-center.top-right { top: 1rem; right: 1rem; }
+.notification-center.bottom-left { bottom: 1rem; left: 1rem; }
+.notification-center.bottom-right { bottom: 1rem; right: 1rem; }
+
+.notification-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.notification-tabs button.active {
+  font-weight: bold;
+}
+.notification-group header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.notification-actions {
+  display: flex;
+  gap: 0.25rem;
+}
+.timestamp-separator {
+  font-size: 0.75rem;
+  opacity: 0.7;
+  margin-top: 0.5rem;
+}
+.notification-group ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.notification-group li.fade {
+  animation: fadeOut 0.5s forwards;
+}
+@keyframes fadeOut {
+  to { opacity: 0; }
+}
+
+/* Global table styling */
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 0.25rem 0.5rem;
+}
+
+tbody tr:nth-child(even) {
+  background-color: color-mix(in srgb, var(--color-muted), transparent 80%);
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--color-surface);
+}
+
+@media (max-width: 600px) {
+  table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,14 +1,115 @@
 @import './globals.css';
+@import './whisker.css';
+@import './colors-alt.css';
+@import './rtl.css';
+
+:root {
+    --color-bg: #0f1317;
+    --color-text: #f5f5f5;
+    --color-primary: #1793d1;
+    --color-secondary: #1a1f26;
+    --color-accent: #1793d1;
+    --color-muted: #2a2e36;
+    --color-surface: #1a1f26;
+    --color-inverse: #000000;
+    --color-border: #2a2e36;
+    --color-terminal: #00ff00;
+    --color-dark: #0c0f12;
+
+    --kali-info: #3b82f6;
+    --kali-success: #10b981;
+    --kali-warning: #f59e0b;
+    --kali-danger: #ef4444;
+}
 
 html {
-    font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
+    font-size: calc(14px * var(--font-multiplier));
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-border) transparent;
+}
+
+@media (min-width: 640px) {
+    html {
+        font-size: calc(16px * var(--font-multiplier));
+    }
+}
+
+@media (min-width: 768px) {
+    html {
+        font-size: calc(18px * var(--font-multiplier));
+    }
+}
+
+@media (min-width: 1024px) {
+    html {
+        font-size: calc(20px * var(--font-multiplier));
+    }
+}
+
+@media (min-width: 1280px) {
+    html {
+        font-size: calc(22px * var(--font-multiplier));
+    }
+}
+
+@media (min-width: 1536px) {
+    html {
+        font-size: calc(24px * var(--font-multiplier));
+    }
 }
 
 body{
     font-family: var(--font-family-base);
     font-display: swap;
     background-color: var(--color-bg);
+    background-image: var(--background-image);
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center center;
     color: var(--color-text);
+    line-height: 1.5;
+}
+
+/* Global scrollbar styling */
+::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+    background-color: var(--color-border);
+    border-radius: 4px;
+}
+
+@media (max-width: 600px) {
+    html {
+        scrollbar-width: none;
+    }
+
+    ::-webkit-scrollbar {
+        display: none;
+    }
+}
+
+/* Heading scale for vertical rhythm */
+h1, h2, h3, h4, h5, h6 {
+    line-height: 1.2;
+}
+
+h1 {
+    font-size: clamp(1.875rem, 1.5rem + 1vw, 2.25rem);
+}
+
+h2 {
+    font-size: clamp(1.5rem, 1.25rem + 0.5vw, 1.875rem);
+}
+
+h3 {
+    font-size: clamp(1.25rem, 1rem + 0.5vw, 1.5rem);
 }
 
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
@@ -16,26 +117,69 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
     min-height: var(--hit-area);
 }
 
+/* Reusable button styles */
+.btn {
+    --btn-bg: var(--color-muted);
+    --btn-text: var(--color-text);
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+    background-color: var(--btn-bg);
+    color: var(--btn-text);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color var(--motion-fast), transform var(--motion-fast);
+}
+
+.btn:hover {
+    background-color: color-mix(in srgb, var(--btn-bg), var(--color-inverse) 10%);
+}
+
+.btn:active {
+    background-color: color-mix(in srgb, var(--btn-bg), var(--color-inverse) 20%);
+    transform: scale(0.98);
+}
+
 a:focus-visible,
-button:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
-    outline-offset: 2px;
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+[role="button"]:focus-visible,
+[tabindex]:not([tabindex="-1"]):focus-visible {
+    outline: var(--focus-outline-width) var(--focus-outline-style) var(--focus-outline-color) !important;
+    outline-offset: var(--focus-outline-offset);
 }
 
 @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after {
-        animation-duration: 0.01ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important;
+        animation: none !important;
+        transition: none !important;
         scroll-behavior: auto !important;
     }
 }
 
 .reduced-motion *, .reduced-motion *::before, .reduced-motion *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
+    animation: none !important;
+    transition: none !important;
     scroll-behavior: auto !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .all-apps-anim,
+    .app-icon-launch,
+    .scalable-app-icon.scale {
+        animation: none !important;
+    }
+}
+
+.reduced-motion .all-apps-anim,
+.reduced-motion .app-icon-launch,
+.reduced-motion .scalable-app-icon.scale {
+    animation: none !important;
 }
 
 /* Top NavBar styling */
@@ -44,6 +188,22 @@ button:focus-visible {
     border-inline-start: 5px solid transparent;
     border-inline-end: 5px solid transparent;
     border-block-end: 5px solid var(--color-muted);
+}
+
+@keyframes window-shake {
+    0% { transform: translateX(0); }
+    25% { transform: translateX(-5px); }
+    50% { transform: translateX(5px); }
+    75% { transform: translateX(-5px); }
+    100% { transform: translateX(0); }
+}
+
+.window-shake {
+    animation: window-shake 0.5s;
+}
+
+.window-dimmed {
+    filter: blur(2px) brightness(0.7);
 }
 
 
@@ -367,7 +527,9 @@ dialog {
 /* Context Menu & Panels */
 .context-menu-bg,
 .windowMainScreen {
-    background-color: color-mix(in srgb, var(--color-bg), transparent 15%); /* Fallback for unsupported browsers */
+    background-color: var(--menu-bg);
+    border-radius: var(--menu-border-radius);
+    opacity: var(--menu-opacity);
 }
 
 @supports ((-webkit-backdrop-filter: blur(0)) or (backdrop-filter: blur(0))) {
@@ -375,7 +537,7 @@ dialog {
     .windowMainScreen {
         -webkit-backdrop-filter: blur(10px);
         backdrop-filter: blur(10px);
-        background-color: color-mix(in srgb, var(--color-bg), transparent 60%);
+        background-color: var(--menu-bg);
     }
 }
 
@@ -503,16 +665,58 @@ dialog {
 }
 
 /* Ensure monospace layout for app outputs */
-textarea,
-pre {
-    font-family: monospace;
+textarea {
+    font-family: var(--font-family-mono, monospace);
     line-height: 1.2;
+}
+
+/* Monospaced elements */
+code,
+kbd,
+pre {
+    font-family: var(--font-family-mono, monospace);
+    line-height: 1.2;
+    padding: var(--space-2);
+    overflow-x: auto;
+    position: relative;
+    background: var(--color-surface);
+    border-radius: var(--radius-md);
+}
+
+pre code {
+    display: block;
+    counter-reset: line;
+}
+
+pre code .token.comment { color: var(--code-token-comment); }
+pre code .token.string { color: var(--code-token-string); }
+pre code .token.keyword { color: var(--code-token-keyword); }
+pre code .token.function { color: var(--code-token-function); }
+pre code .token.number { color: var(--code-token-number); }
+
+pre code .line {
+    display: block;
+    padding-left: calc(var(--space-4) + 2.5rem);
+    position: relative;
+}
+
+pre code .line::before {
+    counter-increment: line;
+    content: counter(line);
+    position: absolute;
+    left: 0;
+    width: 2.5rem;
+    padding-right: var(--space-2);
+    text-align: right;
+    color: var(--code-gutter-text);
+    background: var(--code-gutter-bg);
+    border-right: 1px solid var(--code-gutter-border);
 }
 
 /* Visible focus rings for copy buttons and text areas */
 button:focus-visible,
 textarea:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline: var(--focus-outline-width) var(--focus-outline-style) var(--focus-outline-color);
     outline-offset: 2px;
 }
 
@@ -529,4 +733,55 @@ textarea:focus-visible {
 .high-contrast .bg-ub-orange {
     color: #000 !important;
 }
+
+
+.tour-highlight {
+    position: relative;
+    z-index: 60 !important;
+    box-shadow: 0 0 0 4px rgba(251,191,36,0.9);
+    border-radius: 4px;
+}
+
+/* Density utility classes */
+.ui-cozy {
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 1.5rem;
+    --space-6: 2rem;
+}
+
+.ui-dense {
+    --space-1: 0.125rem;
+    --space-2: 0.25rem;
+    --space-3: 0.5rem;
+    --space-4: 0.75rem;
+    --space-5: 1rem;
+    --space-6: 1.5rem;
+}
+
+.ui-cozy .p-4 { padding: var(--space-4); }
+.ui-dense .p-4 { padding: var(--space-2); }
+
+.ui-cozy .mt-4 { margin-top: var(--space-4); }
+.ui-dense .mt-4 { margin-top: var(--space-2); }
+
+.ui-cozy .gap-4 { gap: var(--space-4); }
+.ui-dense .gap-4 { gap: var(--space-2); }
+
+.ui-cozy .px-2 { padding-left: var(--space-2); padding-right: var(--space-2); }
+.ui-dense .px-2 { padding-left: var(--space-1); padding-right: var(--space-1); }
+
+.ui-cozy table th,
+.ui-cozy table td { padding: var(--space-4); }
+
+.ui-dense table th,
+.ui-dense table td { padding: var(--space-2); }
+
+.ui-cozy .tools-grid { gap: var(--space-4); }
+.ui-dense .tools-grid { gap: var(--space-2); }
+
+.ui-cozy .tools-card { padding: var(--space-4); }
+.ui-dense .tools-card { padding: var(--space-2); }
 

--- a/styles/print.css
+++ b/styles/print.css
@@ -6,6 +6,31 @@
     background: white;
     color: black;
   }
+  a[href]:not(.no-print)::after {
+    content: " (" attr(href) ")";
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  th,
+  td {
+    border: 1px solid #000;
+    padding: 0.25rem;
+  }
+  pre,
+  code {
+    background: #f5f5f5;
+    color: black;
+    font-family: monospace;
+  }
+  pre {
+    white-space: pre-wrap;
+    word-break: break-word;
+    border: 1px solid #ddd;
+    padding: 0.5rem;
+    page-break-inside: avoid;
+  }
   .no-print {
     display: none !important;
   }

--- a/styles/rtl.css
+++ b/styles/rtl.css
@@ -1,0 +1,8 @@
+/* RTL-specific utility classes */
+html[dir="rtl"] .rtl\:flex-row-reverse { flex-direction: row-reverse; }
+html[dir="rtl"] .rtl\:space-x-reverse > :not([hidden]) ~ :not([hidden]) { --tw-space-x-reverse: 1; }
+html[dir="rtl"] .rtl\:text-right { text-align: right; }
+html[dir="rtl"] .rtl\:left-auto { left: auto; }
+html[dir="rtl"] .rtl\:right-0 { right: 0; }
+html[dir="rtl"] .rtl\:ml-1 { margin-left: 0.25rem; }
+html[dir="rtl"] .rtl\:mr-0 { margin-right: 0; }

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -17,3 +17,20 @@
   }
 }
 
+@layer components {
+  .sparkline-led {
+    @apply fill-none stroke-green-400;
+    stroke-width: 2;
+    stroke-dasharray: 2 2;
+  }
+  .sparkline-gradient {
+    fill: none;
+    stroke-width: 2;
+    stroke: url(#sparkline-gradient);
+  }
+  .sparkline-fire {
+    fill: none;
+    stroke-width: 2;
+    stroke: url(#sparkline-fire);
+  }
+}

--- a/styles/themes/kali.ts
+++ b/styles/themes/kali.ts
@@ -3,6 +3,11 @@ export const kaliTheme = {
   text: 'var(--color-text)',
   accent: 'var(--color-primary)',
   sidebar: 'var(--color-secondary)',
+  bubble: {
+    background: 'var(--toast-bg)',
+    text: 'var(--toast-text)',
+    border: 'var(--toast-border)',
+  },
 };
 
 export type KaliTheme = typeof kaliTheme;

--- a/styles/themes/purple.css
+++ b/styles/themes/purple.css
@@ -1,0 +1,14 @@
+/* Purple theme design tokens */
+html[data-theme='purple'] {
+  --color-bg: #1b1039;
+  --color-text: #f5f5f5;
+  --color-primary: #805ad5;
+  --color-secondary: #120b26;
+  --color-accent: #805ad5;
+  --color-muted: #261b4d;
+  --color-surface: #1b1039;
+  --color-inverse: #ffffff;
+  --color-border: #433160;
+  --color-terminal: #00ff00;
+  --color-dark: #0d071a;
+}

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -3,7 +3,7 @@
 :root {
   /* Theme colors */
   --color-ub-grey: #0f1317;
-  --color-ub-warm-grey: #7d7f83;
+  --color-ub-warm-grey: #4d4d4d;
   --color-ub-cool-grey: #1a1f26;
   --color-ub-orange: #1793d1;
   --color-ub-lite-abrgn: #22262c;
@@ -14,8 +14,8 @@
   --color-ub-gedit-light: #003B70;
   --color-ub-gedit-darker: #010D1A;
   --color-ubt-grey: #F6F6F5;
-  --color-ubt-warm-grey: #AEA79F;
-  --color-ubt-cool-grey: #333333;
+  --color-ubt-warm-grey: #F6F6F5;
+  --color-ubt-cool-grey: #b3b3b3;
   --color-ubt-blue: #62A0EA;
   --color-ubt-green: #73D216;
   --color-ubt-gedit-orange: #F39A21;
@@ -25,6 +25,10 @@
   --color-ub-dark-grey: #2a2e36;
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
+  --color-primary: #1793d1;
+  --color-secondary: #1a1f26;
+  --color-tertiary: #374151;
+  --color-ghost: transparent;
 
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
@@ -51,20 +55,42 @@
   --motion-medium: 300ms;
   --motion-slow: 500ms;
 
+  /* Blur */
+  --blur-sm: 4px;
+  --blur-md: 8px;
+  --blur-lg: 16px;
+
+  /* Shadows */
+  --shadow-color: color-mix(in srgb, var(--color-inverse), transparent 80%);
+  --shadow-sm: 0 1px 2px var(--shadow-color);
+  --shadow-md: 0 4px 6px var(--shadow-color);
+  --shadow-lg: 0 8px 12px var(--shadow-color);
+
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;
   /* Focus outline */
-  --focus-outline-color: var(--color-ubt-blue);
+  --focus-outline-color: var(--color-accent);
   --focus-outline-width: 2px;
+  --focus-outline-style: solid;
+  --focus-outline-offset: 4px;
 }
 
 /* High contrast theme */
 .high-contrast {
   --color-bg: #000000;
   --color-text: #ffffff;
+  --color-primary: #ffff00;
+  --color-secondary: #000000;
+  --color-accent: #ffff00;
+  --color-muted: #000000;
+  --color-surface: #000000;
+  --color-inverse: #000000;
+  --color-border: #ffff00;
+  --color-info: #00ffff;
+  --color-success: #00ff00;
   --color-ub-grey: #000000;
   --color-ub-cool-grey: #000000;
   --color-ubt-grey: #ffffff;
@@ -72,10 +98,16 @@
   --color-ub-orange: #ffff00;
   --color-ub-lite-abrgn: #00ffff;
   --color-ub-border-orange: #ffff00;
+  --focus-outline-color: #ffff00;
+  --focus-outline-width: 3px;
+  --focus-outline-style: solid;
+  --focus-outline-offset: 5px;
   --game-color-secondary: #ffff00;
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --color-tertiary: #ffffff;
+  --color-ghost: transparent;
 }
 
 /* Dyslexia-friendly fonts */
@@ -115,5 +147,7 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+    --color-tertiary: #ffffff;
+    --color-ghost: transparent;
   }
 }

--- a/styles/whisker.css
+++ b/styles/whisker.css
@@ -1,0 +1,11 @@
+/* Theme variables for Whisker-style menu and sidebar */
+:root {
+  /* Background color for menus and sidebar */
+  --menu-bg: var(--color-bg);
+  /* Width of the sidebar/dock */
+  --sidebar-width: 4rem;
+  /* Rounded corners for menus and sidebar */
+  --menu-border-radius: 0.5rem;
+  /* Overall menu opacity (0 - 1) */
+  --menu-opacity: 0.9;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,11 +14,26 @@ module.exports = {
       screens: {
         '3xl': '1920px',
       },
-      colors: {
-        'ub-grey': 'var(--color-ub-grey)',
-        'ub-warm-grey': 'var(--color-ub-warm-grey)',
-        'ub-cool-grey': 'var(--color-ub-cool-grey)',
-        'ub-orange': 'var(--color-ub-orange)',
+        colors: {
+          bg: 'var(--color-bg)',
+          text: 'var(--color-text)',
+          primary: 'var(--color-primary)',
+          secondary: 'var(--color-secondary)',
+          accent: 'var(--color-accent)',
+          muted: 'var(--color-muted)',
+          surface: 'var(--color-surface)',
+          inverse: 'var(--color-inverse)',
+          border: 'var(--color-border)',
+          terminal: 'var(--color-terminal)',
+          dark: 'var(--color-dark)',
+          info: 'var(--kali-info)',
+          success: 'var(--kali-success)',
+          warning: 'var(--kali-warning)',
+          danger: 'var(--kali-danger)',
+          'ub-grey': 'var(--color-ub-grey)',
+          'ub-warm-grey': 'var(--color-ub-warm-grey)',
+          'ub-cool-grey': 'var(--color-ub-cool-grey)',
+          'ub-orange': 'var(--color-ub-orange)',
         'ub-lite-abrgn': 'var(--color-ub-lite-abrgn)',
         'ub-med-abrgn': 'var(--color-ub-med-abrgn)',
         'ub-drk-abrgn': 'var(--color-ub-drk-abrgn)',
@@ -37,8 +52,25 @@ module.exports = {
         'ub-border-orange': 'var(--color-ub-border-orange)',
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
       },
-      fontFamily: {
-        ubuntu: ['Ubuntu', 'sans-serif'],
+        fontFamily: {
+          ubuntu: ['Ubuntu', 'sans-serif'],
+        },
+        fontSize: {
+          base: ['1rem', { lineHeight: '1.5' }],
+          h1: ['clamp(1.875rem, 1.5rem + 1vw, 2.25rem)', { lineHeight: '1.2' }],
+          h2: ['clamp(1.5rem, 1.25rem + 0.5vw, 1.875rem)', { lineHeight: '1.3' }],
+          h3: ['clamp(1.25rem, 1rem + 0.5vw, 1.5rem)', { lineHeight: '1.4' }],
+        },
+      spacing: {
+        'space-0': '0px',
+        'space-1': '8px',
+        'space-2': '16px',
+        'space-3': '24px',
+        'space-4': '32px',
+        'space-5': '40px',
+        'space-6': '48px',
+        'space-7': '56px',
+        'space-8': '64px',
       },
       minWidth: {
         '0': '0',
@@ -69,6 +101,16 @@ module.exports = {
         'tray-icon': '16px',
         'tray-icon-lg': '32px',
       },
+      boxShadow: {
+        // eslint-disable-next-line no-top-level-window/no-top-level-window-or-document
+        window: '0 4px 8px rgba(0,0,0,0.3)',
+        card: '0 2px 4px rgba(0,0,0,0.2)',
+      },
+      borderColor: {
+        // eslint-disable-next-line no-top-level-window/no-top-level-window-or-document
+        window: 'var(--color-border)',
+        card: 'var(--color-border)',
+      },
       keyframes: {
         glow: {
           '0%, 100%': { boxShadow: '0 0 0px theme("colors.amber.400")' },
@@ -87,16 +129,29 @@ module.exports = {
           },
           '100%': { transform: 'translate(0,0) scale(1)', backgroundColor: 'theme("colors.red.500")' },
         },
+        'scale-in': {
+          '0%': { transform: 'scale(0)' },
+          '100%': { transform: 'scale(1)' },
+        },
+        'merge-pulse': {
+          '0%, 100%': { transform: 'scale(1)' },
+          '50%': { transform: 'scale(1.1)' },
+        },
       },
       animation: {
         glow: 'glow 1s ease-in-out infinite',
         flourish: 'flourish 0.6s ease-out',
         mine: 'mine 0.4s ease-in-out',
+        'scale-in': 'scale-in 0.15s ease-out',
+        'merge-pulse': 'merge-pulse 0.3s ease-out',
       },
     },
   },
   plugins: [
-    plugin(function ({ addUtilities }) {
+    require('@tailwindcss/typography'),
+    plugin(function ({ addUtilities, addVariant }) {
+      addVariant('hc', '.high-contrast &');
+      addVariant('rm', '.reduced-motion &');
       const cols = {};
       for (let i = 1; i <= 12; i++) {
         const width = `${(i / 12) * 100}%`;


### PR DESCRIPTION
## Summary
- restore classic shell components, styles, and images from baseline while keeping existing app registry and About Alex label
- add scripts/revert-ui.sh helper to reapply the shell snapshot
- restore PWA service worker files

## Testing
- `nvm use`
- `yarn install`
- `yarn lint` *(fails: Unexpected global 'document' and other lint errors)*
- `yarn build` *(fails: Cannot find module '@tailwindcss/typography')*
- `yarn test` *(fails: TypeError: (0 , _env.isBrowser) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c597d2a5f0832898709d2e092d5f6d