### PR TITLE
[apps] add file explorer app

### DIFF
--- a/__tests__/files.api.test.ts
+++ b/__tests__/files.api.test.ts
@@ -1,0 +1,41 @@
+import handler from '../pages/api/files';
+
+type Req = {
+  method: string;
+  query: { [key: string]: any };
+};
+
+function createRes() {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn((data) => {
+    res.body = data;
+    return res;
+  });
+  res.end = jest.fn();
+  return res;
+}
+
+async function call(req: Req) {
+  const res = createRes();
+  await handler(req as any, res as any);
+  return res;
+}
+
+describe('files api', () => {
+  it('lists root directory', async () => {
+    const res = await call({ method: 'GET', query: {} });
+    expect(res.body.items).toBeTruthy();
+    expect(Array.isArray(res.body.items)).toBe(true);
+  });
+
+  it('prevents path traversal', async () => {
+    const res = await call({ method: 'GET', query: { path: '../../' } });
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns file content', async () => {
+    const res = await call({ method: 'GET', query: { path: 'README.md' } });
+    expect(res.body.content).toContain('Kali Linux Portfolio');
+  });
+});

--- a/apps/file-explorer/index.tsx
+++ b/apps/file-explorer/index.tsx
@@ -1,0 +1,74 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+interface Item {
+  name: string;
+  type: 'file' | 'dir';
+}
+
+export default function FileExplorer() {
+  const [path, setPath] = useState<string[]>([]);
+  const [items, setItems] = useState<Item[]>([]);
+  const [content, setContent] = useState<string | null>(null);
+
+  const currentPath = path.join('/');
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const res = await fetch(`/api/files?path=${encodeURIComponent(currentPath)}`);
+      const data = await res.json();
+      if ('content' in data) {
+        setContent(data.content);
+        setItems([]);
+      } else {
+        setItems(data.items || []);
+        setContent(null);
+      }
+    };
+    fetchData().catch(() => {
+      setItems([]);
+      setContent(null);
+    });
+  }, [currentPath]);
+
+  const openItem = (item: Item) => {
+    setPath((p) => [...p, item.name]);
+  };
+
+  const goUp = () => {
+    setPath((p) => p.slice(0, -1));
+  };
+
+  return (
+    <div className="p-2 text-sm text-white">
+      <div className="flex items-center gap-2 mb-2">
+        <button
+          className="px-2 py-1 bg-gray-700 rounded disabled:opacity-50"
+          onClick={goUp}
+          disabled={path.length === 0}
+        >
+          Up
+        </button>
+        <span>/{currentPath}</span>
+      </div>
+      {content !== null ? (
+        <pre className="whitespace-pre-wrap text-xs bg-gray-900 p-2 rounded overflow-auto">
+          {content}
+        </pre>
+      ) : (
+        <ul className="space-y-1">
+          {items.map((item) => (
+            <li key={item.name}>
+              <button
+                className="w-full text-left px-2 py-1 hover:bg-gray-700 rounded"
+                onClick={() => openItem(item)}
+              >
+                {item.type === 'dir' ? '📁' : '📄'} {item.name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/pages/api/files.ts
+++ b/pages/api/files.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs/promises';
+import path from 'path';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    res.status(405).end();
+    return;
+  }
+
+  const q = req.query.path ?? '';
+  const relativePath = Array.isArray(q) ? q.join('/') : q;
+  const base = process.cwd();
+  const target = path.resolve(base, relativePath);
+
+  if (!target.startsWith(base)) {
+    res.status(400).json({ error: 'Invalid path' });
+    return;
+  }
+
+  try {
+    const stat = await fs.stat(target);
+    if (stat.isDirectory()) {
+      const names = await fs.readdir(target);
+      const items = await Promise.all(
+        names.map(async (name) => {
+          const s = await fs.stat(path.join(target, name));
+          return { name, type: s.isDirectory() ? 'dir' : 'file' } as const;
+        })
+      );
+      res.status(200).json({ path: relativePath, items });
+    } else {
+      const content = await fs.readFile(target, 'utf8');
+      res.status(200).json({ path: relativePath, content });
+    }
+  } catch (err) {
+    res.status(404).json({ error: 'Not found' });
+  }
+}

--- a/pages/apps/file-explorer.jsx
+++ b/pages/apps/file-explorer.jsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const FileExplorer = dynamic(() => import('../../apps/file-explorer'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function FileExplorerPage() {
+  return <FileExplorer />;
+}


### PR DESCRIPTION
## Summary
- add Files app with simple browser to navigate repository
- expose `/api/files` for safe file listing and content viewing
- cover API with unit tests

## Testing
- `yarn lint` *(fails: Unexpected global 'document', Component definition is missing display name)*
- `npx eslint pages/api/files.ts apps/file-explorer/index.tsx pages/apps/file-explorer.jsx __tests__/files.api.test.ts` *(warn: File ignored because no matching configuration was supplied)*
- `yarn test` *(fails: Window snapping finalize and release; NmapNSEApp copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a9c5ea748328bea4b940ff357ea3