### PR TITLE
[ui] Kali-style desktop context menu

### DIFF
--- a/__tests__/desktopMenu.test.tsx
+++ b/__tests__/desktopMenu.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import DesktopMenu from '../components/context-menus/desktop-menu';
+
+describe('Desktop menu', () => {
+  it('renders Kali style entries', () => {
+    const { getByRole } = render(
+      <DesktopMenu
+        active={true}
+        openApp={jest.fn()}
+        addNewFolder={jest.fn()}
+        openShortcutSelector={jest.fn()}
+        showAllApps={jest.fn()}
+      />
+    );
+    expect(getByRole('menuitem', { name: /Create Folder/i })).toBeInTheDocument();
+    expect(getByRole('menuitem', { name: /Applications/i })).toBeInTheDocument();
+  });
+});

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,17 +1,6 @@
-import React, { useState, useEffect } from 'react'
-import logger from '../../utils/logger'
+import React from 'react'
 
 function DesktopMenu(props) {
-
-    const [isFullScreen, setIsFullScreen] = useState(false)
-
-    useEffect(() => {
-        document.addEventListener('fullscreenchange', checkFullScreen);
-        return () => {
-            document.removeEventListener('fullscreenchange', checkFullScreen);
-        };
-    }, [])
-
 
     const openTerminal = () => {
         props.openApp("terminal");
@@ -21,28 +10,6 @@ function DesktopMenu(props) {
         props.openApp("settings");
     }
 
-    const checkFullScreen = () => {
-        if (document.fullscreenElement) {
-            setIsFullScreen(true)
-        } else {
-            setIsFullScreen(false)
-        }
-    }
-
-    const goFullScreen = () => {
-        // make website full screen
-        try {
-            if (document.fullscreenElement) {
-                document.exitFullscreen()
-            } else {
-                document.documentElement.requestFullscreen()
-            }
-        }
-        catch (e) {
-            logger.error(e)
-        }
-    }
-
     return (
         <div
             id="desktop-menu"
@@ -50,83 +17,72 @@ function DesktopMenu(props) {
             aria-label="Desktop context menu"
             className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
         >
-            <button
-                onClick={props.addNewFolder}
-                type="button"
-                role="menuitem"
-                aria-label="New Folder"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">New Folder</span>
-            </button>
+            <div role="menuitem" aria-label="Create Launcher" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+                <span className="ml-5">Create Launcher...</span>
+            </div>
             <button
                 onClick={props.openShortcutSelector}
                 type="button"
                 role="menuitem"
-                aria-label="Create Shortcut"
+                aria-label="Create URL Link"
                 className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
-                <span className="ml-5">Create Shortcut...</span>
+                <span className="ml-5">Create URL Link...</span>
             </button>
+            <button
+                onClick={props.addNewFolder}
+                type="button"
+                role="menuitem"
+                aria-label="Create Folder"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
+                <span className="ml-5">Create Folder...</span>
+            </button>
+            <div role="menuitem" aria-label="Create Document" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+                <span className="ml-5">Create Document</span>
+            </div>
             <Devider />
             <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
                 <span className="ml-5">Paste</span>
             </div>
             <Devider />
-            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Show Desktop in Files</span>
-            </div>
             <button
                 onClick={openTerminal}
                 type="button"
                 role="menuitem"
-                aria-label="Open in Terminal"
+                aria-label="Open Terminal Here"
                 className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
-                <span className="ml-5">Open in Terminal</span>
+                <span className="ml-5">Open Terminal Here</span>
             </button>
+            <div role="menuitem" aria-label="Open as Root" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+                <span className="ml-5">Open as Root</span>
+            </div>
+            <div role="menuitem" aria-label="Open in New Window" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+                <span className="ml-5">Open in New Window</span>
+            </div>
             <Devider />
-            <button
-                onClick={openSettings}
-                type="button"
-                role="menuitem"
-                aria-label="Change Background"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Change Background...</span>
-            </button>
-            <Devider />
-            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Display Settings</span>
+            <div role="menuitem" aria-label="Arrange Desktop Icons" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+                <span className="ml-5">Arrange Desktop Icons</span>
             </div>
             <button
                 onClick={openSettings}
                 type="button"
                 role="menuitem"
-                aria-label="Settings"
+                aria-label="Desktop Settings"
                 className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
-                <span className="ml-5">Settings</span>
+                <span className="ml-5">Desktop Settings</span>
             </button>
             <Devider />
             <button
-                onClick={goFullScreen}
+                onClick={props.showAllApps}
                 type="button"
                 role="menuitem"
-                aria-label={isFullScreen ? "Exit Full Screen" : "Enter Full Screen"}
+                aria-label="Applications"
                 className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
-                <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
-            </button>
-            <Devider />
-            <button
-                onClick={props.clearSession}
-                type="button"
-                role="menuitem"
-                aria-label="Clear Session"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Clear Session</span>
+                <span className="ml-5">Applications</span>
             </button>
         </div>
     )

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -838,8 +838,8 @@ export class Desktop extends Component {
         return (
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
-                    <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <label htmlFor="folder-name-input">New folder name</label>
+                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} aria-label="New folder name" />
                 </div>
                 <div className="flex">
                     <button
@@ -911,7 +911,7 @@ export class Desktop extends Component {
                     openApp={this.openApp}
                     addNewFolder={this.addNewFolder}
                     openShortcutSelector={this.openShortcutSelector}
-                    clearSession={() => { this.props.clearSession(); window.location.reload(); }}
+                    showAllApps={this.showAllApps}
                 />
                 <DefaultMenu active={this.state.context_menus.default} onClose={this.hideAllContextMenu} />
                 <AppMenu


### PR DESCRIPTION
## Summary
- redesign desktop context menu to resemble Kali's options
- wire Applications entry to toggle the all-apps view
- add unit test for desktop menu rendering

## Testing
- `npx eslint components/context-menus/desktop-menu.js components/screen/desktop.js __tests__/desktopMenu.test.tsx`
- `yarn test __tests__/desktopMenu.test.tsx`
- `yarn smoke` *(fails: Executable doesn't exist for Playwright browser)*
- `npx playwright test` *(fails: Playwright browser missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a8c0dca8832886c3f84c55722ea9