### PR TITLE
[desktop] open About Alex on launch

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -78,7 +78,7 @@ export class Desktop extends Component {
                     session.windows.forEach(({ id }) => this.openApp(id));
                 });
             } else {
-                this.openApp('about-alex');
+                this.openApp('about');
             }
         });
         this.setContextListeners();


### PR DESCRIPTION
## Summary
- open "About Alex" window when no session windows are restored

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: Window snapping finalize and release; NmapNSEApp copies example output to clipboard; localStorage origin error)*
- `yarn smoke` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a8e98018832889211bfd60523c3d