### PR TITLE
[ui] adopt Kali-style window controls

### DIFF
--- a/apps/beef/index.tsx
+++ b/apps/beef/index.tsx
@@ -39,12 +39,12 @@ const BeefPage: React.FC = () => {
         </div>
         <div className="flex gap-2">
           <img
-            src="/themes/Yaru/window/window-minimize-symbolic.svg"
+            src="/themes/Kali/window/window-minimize-symbolic.svg"
             alt="minimize"
             className="w-6 h-6"
           />
           <img
-            src="/themes/Yaru/window/window-close-symbolic.svg"
+            src="/themes/Kali/window/window-close-symbolic.svg"
             alt="close"
             className="w-6 h-6"
           />

--- a/components/ToolbarIcons.tsx
+++ b/components/ToolbarIcons.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 export function CloseIcon() {
   return (
     <Image
-      src="/themes/Yaru/window/window-close-symbolic.svg"
+      src="/themes/Kali/window/window-close-symbolic.svg"
       alt="Close"
       width={16}
       height={16}
@@ -14,7 +14,7 @@ export function CloseIcon() {
 export function MinimizeIcon() {
   return (
     <Image
-      src="/themes/Yaru/window/window-minimize-symbolic.svg"
+      src="/themes/Kali/window/window-minimize-symbolic.svg"
       alt="Minimize"
       width={16}
       height={16}
@@ -25,7 +25,7 @@ export function MinimizeIcon() {
 export function MaximizeIcon() {
   return (
     <Image
-      src="/themes/Yaru/window/window-maximize-symbolic.svg"
+      src="/themes/Kali/window/window-maximize-symbolic.svg"
       alt="Maximize"
       width={16}
       height={16}
@@ -36,7 +36,7 @@ export function MaximizeIcon() {
 export function RestoreIcon() {
   return (
     <Image
-      src="/themes/Yaru/window/window-restore-symbolic.svg"
+      src="/themes/Kali/window/window-restore-symbolic.svg"
       alt="Restore"
       width={16}
       height={16}
@@ -47,7 +47,7 @@ export function RestoreIcon() {
 export function PinIcon() {
   return (
     <Image
-      src="/themes/Yaru/window/window-pin-symbolic.svg"
+      src="/themes/Kali/window/window-pin-symbolic.svg"
       alt="Pin"
       width={16}
       height={16}

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -743,7 +743,7 @@ export function WindowEditButtons(props) {
                     onClick={togglePin}
                 >
                     <NextImage
-                        src="/themes/Yaru/window/window-pin-symbolic.svg"
+                        src="/themes/Kali/window/window-pin-symbolic.svg"
                         alt="Kali window pin"
                         className="h-4 w-4 inline"
                         width={16}
@@ -759,7 +759,7 @@ export function WindowEditButtons(props) {
                 onClick={props.minimize}
             >
                 <NextImage
-                    src="/themes/Yaru/window/window-minimize-symbolic.svg"
+                    src="/themes/Kali/window/window-minimize-symbolic.svg"
                     alt="Kali window minimize"
                     className="h-4 w-4 inline"
                     width={16}
@@ -777,7 +777,7 @@ export function WindowEditButtons(props) {
                             onClick={props.maximize}
                         >
                             <NextImage
-                                src="/themes/Yaru/window/window-restore-symbolic.svg"
+                                src="/themes/Kali/window/window-restore-symbolic.svg"
                                 alt="Kali window restore"
                                 className="h-4 w-4 inline"
                                 width={16}
@@ -793,7 +793,7 @@ export function WindowEditButtons(props) {
                             onClick={props.maximize}
                         >
                             <NextImage
-                                src="/themes/Yaru/window/window-maximize-symbolic.svg"
+                                src="/themes/Kali/window/window-maximize-symbolic.svg"
                                 alt="Kali window maximize"
                                 className="h-4 w-4 inline"
                                 width={16}
@@ -811,7 +811,7 @@ export function WindowEditButtons(props) {
                 onClick={props.close}
             >
                 <NextImage
-                    src="/themes/Yaru/window/window-close-symbolic.svg"
+                    src="/themes/Kali/window/window-close-symbolic.svg"
                     alt="Kali window close"
                     className="h-4 w-4 inline"
                     width={16}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import noTopLevelWindow from './eslint-plugin-no-top-level-window/index.js';
 const compat = new FlatCompat();
 
 const config = [
-  { ignores: ['components/apps/Chrome/index.tsx'] },
+  { ignores: ['components/apps/Chrome/index.tsx', 'public/apps/**/*'] },
   {
     plugins: {
       'no-top-level-window': noTopLevelWindow,

--- a/public/themes/Kali/window/window-close-symbolic.svg
+++ b/public/themes/Kali/window/window-close-symbolic.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" stroke="white" stroke-width="2" stroke-linecap="round">
+  <line x1="4" y1="4" x2="12" y2="12"/>
+  <line x1="12" y1="4" x2="4" y2="12"/>
+</svg>

--- a/public/themes/Kali/window/window-maximize-symbolic.svg
+++ b/public/themes/Kali/window/window-maximize-symbolic.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" stroke="white" stroke-width="2" fill="none">
+  <rect x="3" y="3" width="10" height="10"/>
+</svg>

--- a/public/themes/Kali/window/window-minimize-symbolic.svg
+++ b/public/themes/Kali/window/window-minimize-symbolic.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" stroke="white" stroke-width="2" stroke-linecap="round">
+  <line x1="3" y1="8" x2="13" y2="8"/>
+</svg>

--- a/public/themes/Kali/window/window-pin-symbolic.svg
+++ b/public/themes/Kali/window/window-pin-symbolic.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="white">
+  <path d="M6 1l3 3-1.5 1.5 4 4-1 1-4-4L5 9 2 6l3-3L6 1z"/>
+</svg>

--- a/public/themes/Kali/window/window-restore-symbolic.svg
+++ b/public/themes/Kali/window/window-restore-symbolic.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" stroke="white" stroke-width="2" fill="none">
+  <rect x="4" y="6" width="8" height="8"/>
+  <path d="M6 4h6v6" />
+</svg>

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -9,10 +9,12 @@
   --color-ub-lite-abrgn: #22262c;
   --color-ub-med-abrgn: #1b1f24;
   --color-ub-drk-abrgn: #13171b;
-  --color-ub-window-title: #0c0f12;
+  --color-ub-window-title: #1a1f26;
   --color-ub-gedit-dark: #021B33;
   --color-ub-gedit-light: #003B70;
   --color-ub-gedit-darker: #010D1A;
+  --kali-bg: #0f1317;
+  --kali-panel: #1a1f26;
   --color-ubt-grey: #F6F6F5;
   --color-ubt-warm-grey: #AEA79F;
   --color-ubt-cool-grey: #333333;

--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -13,11 +13,13 @@ export const createDynamicApp = (id, title) =>
         return mod.default;
       } catch (err) {
         console.error(`Failed to load ${title}`, err);
-        return () => (
+        const Fallback = () => (
           <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
             {`Unable to load ${title}`}
           </div>
         );
+        Fallback.displayName = 'DynamicAppFallback';
+        return Fallback;
       }
     },
     {
@@ -37,6 +39,7 @@ export const createDisplay = (Component) => {
   const Display = (addFolder, openApp) => (
     <DynamicComponent addFolder={addFolder} openApp={openApp} />
   );
+  Display.displayName = 'DynamicDisplay';
 
   Display.prefetch = () => {
     if (typeof Component.preload === 'function') {


### PR DESCRIPTION
## Summary
- replace Yaru window buttons with Kali-themed icons
- switch window chrome variables to Kali colors and add theme tokens
- add display names for dynamic app fallback and ignore public apps in ESLint

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: window snapping finalize error; missing alert in Nmap NSE test)*
- `yarn smoke` *(fails: Playwright browser not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a7116d7083289d095e7b5dfdfcce