### PR TITLE
[ui] improve toast accessibility and feedback

### DIFF
--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -52,6 +52,7 @@ describe('NmapNSEApp', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('nmap')
     );
+    expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
 
     mockFetch.mockRestore();
   });

--- a/components/apps/nmap-nse/index.js
+++ b/components/apps/nmap-nse/index.js
@@ -88,6 +88,11 @@ const NmapNSEApp = () => {
   const outputRef = useRef(null);
   const phases = ['prerule', 'hostrule', 'portrule'];
 
+  const showToast = (msg) => {
+    setToast('');
+    setTimeout(() => setToast(msg), 0);
+  };
+
   useEffect(() => {
     fetch('/demo/nmap-nse.json')
       .then((r) => r.json())
@@ -134,7 +139,7 @@ const NmapNSEApp = () => {
     if (typeof window !== 'undefined') {
       try {
         await navigator.clipboard.writeText(command);
-        setToast('Command copied');
+        showToast('Command copied');
       } catch (e) {
         // ignore
       }
@@ -148,7 +153,7 @@ const NmapNSEApp = () => {
     if (!text.trim()) return;
     try {
       await navigator.clipboard.writeText(text);
-      setToast('Output copied');
+      showToast('Output copied');
     } catch (e) {
       // ignore
     }
@@ -162,7 +167,7 @@ const NmapNSEApp = () => {
     const sel = window.getSelection();
     sel.removeAllRanges();
     sel.addRange(range);
-    setToast('Output selected');
+    showToast('Output selected');
   };
 
   const handleOutputKey = (e) => {

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -30,8 +30,8 @@ const Toast: React.FC<ToastProps> = ({
 
   return (
     <div
-      role="status"
-      aria-live="polite"
+      role="alert"
+      aria-live="assertive"
       className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
     >
       <span>{message}</span>


### PR DESCRIPTION
## Summary
- make toast use `role="alert"` and `aria-live="assertive"`
- ensure Nmap NSE copy actions show toast via helper
- test that copying the command triggers an alert toast

## Testing
- `yarn lint components/ui/Toast.tsx components/apps/nmap-nse/index.js __tests__/nmapNse.test.tsx` *(fails: A control must be associated with a text label, etc.)*
- `yarn test __tests__/nmapNse.test.tsx`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68c5abbf72e4832887024a59da7d6fd1