### PR TITLE
[chore] restore legacy desktop UI

### DIFF
--- a/components/context-menus/window-menu.js
+++ b/components/context-menus/window-menu.js
@@ -1,0 +1,42 @@
+import React, { useRef } from 'react';
+import useFocusTrap from '@/hooks/useFocusTrap';
+import useRovingTabIndex from '@/hooks/useRovingTabIndex';
+
+function WindowMenu(props) {
+    const menuRef = useRef(null);
+    useFocusTrap(menuRef, props.active);
+    useRovingTabIndex(menuRef, props.active, 'vertical');
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            props.onCloseMenu && props.onCloseMenu();
+        }
+    };
+
+    const wrap = (fn) => () => {
+        fn && fn();
+        props.onCloseMenu && props.onCloseMenu();
+    };
+
+    return (
+        <div
+            id="window-menu"
+            role="menu"
+            aria-label="Window context menu"
+            aria-hidden={!props.active}
+            ref={menuRef}
+            onKeyDown={handleKeyDown}
+            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-48 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm'}
+        >
+            <button type="button" aria-label="Move" onClick={wrap(props.onMove)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Move</span></button>
+            <button type="button" aria-label="Resize" onClick={wrap(props.onResize)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Resize</span></button>
+            <button type="button" aria-label="Always on top" onClick={wrap(props.onTop)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Always on top</span></button>
+            <button type="button" aria-label="Shade" onClick={wrap(props.onShade)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Shade</span></button>
+            <button type="button" aria-label="Stick" onClick={wrap(props.onStick)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Stick</span></button>
+            <button type="button" aria-label="Maximize" onClick={wrap(props.onMaximize)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Maximize</span></button>
+            <button type="button" aria-label="Close" onClick={wrap(props.onClose)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700"><span className="ml-5">Close</span></button>
+        </div>
+    );
+}
+
+export default WindowMenu;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -88,14 +88,12 @@ export class Desktop extends Component {
         this.updateTrashIcon();
         window.addEventListener('trash-change', this.updateTrashIcon);
         document.addEventListener('keydown', this.handleGlobalShortcut);
-        window.addEventListener('open-app', this.handleOpenAppEvent);
     }
 
     componentWillUnmount() {
         this.removeContextListeners();
         document.removeEventListener('keydown', this.handleGlobalShortcut);
         window.removeEventListener('trash-change', this.updateTrashIcon);
-        window.removeEventListener('open-app', this.handleOpenAppEvent);
     }
 
     checkForNewFolders = () => {
@@ -576,13 +574,6 @@ export class Desktop extends Component {
         return result;
     }
 
-    handleOpenAppEvent = (e) => {
-        const id = e.detail;
-        if (id) {
-            this.openApp(id);
-        }
-    }
-
     openApp = (objId) => {
 
         // google analytics
@@ -636,13 +627,6 @@ export class Desktop extends Component {
             });
 
             safeLocalStorage?.setItem('frequentApps', JSON.stringify(frequentApps));
-
-            let recentApps = [];
-            try { recentApps = JSON.parse(safeLocalStorage?.getItem('recentApps') || '[]'); } catch (e) { recentApps = []; }
-            recentApps = recentApps.filter(id => id !== objId);
-            recentApps.unshift(objId);
-            recentApps = recentApps.slice(0, 10);
-            safeLocalStorage?.setItem('recentApps', JSON.stringify(recentApps));
 
             setTimeout(() => {
                 favourite_apps[objId] = true; // adds opened app to sideBar

--- a/components/screen/launcher-creator.js
+++ b/components/screen/launcher-creator.js
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+
+function LauncherCreator({ onSave, onClose }) {
+    const [name, setName] = useState('');
+    const [comment, setComment] = useState('');
+    const [icon, setIcon] = useState('');
+    const [command, setCommand] = useState('');
+
+    const handleSubmit = () => {
+        if (!name || !command) return;
+        onSave({ name, comment, icon, command });
+    };
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-ub-grey bg-opacity-95">
+            <div className="bg-ub-cool-grey p-4 rounded w-80">
+                <h2 className="text-white mb-4">Create Launcher</h2>
+                <input
+                    className="w-full mb-2 px-2 py-1 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                    placeholder="Name"
+                    value={name}
+                    onChange={e => setName(e.target.value)}
+                />
+                <input
+                    className="w-full mb-2 px-2 py-1 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                    placeholder="Comment"
+                    value={comment}
+                    onChange={e => setComment(e.target.value)}
+                />
+                <input
+                    className="w-full mb-2 px-2 py-1 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                    placeholder="Icon URL"
+                    value={icon}
+                    onChange={e => setIcon(e.target.value)}
+                />
+                <input
+                    className="w-full mb-4 px-2 py-1 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                    placeholder="Command"
+                    value={command}
+                    onChange={e => setCommand(e.target.value)}
+                />
+                <div className="flex justify-end space-x-2">
+                    <button
+                        className="px-3 py-1 rounded bg-black bg-opacity-20 text-white"
+                        onClick={onClose}
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        className="px-3 py-1 rounded bg-black bg-opacity-20 text-white"
+                        onClick={handleSubmit}
+                    >
+                        Save
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default LauncherCreator;

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,7 +3,6 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
-import WhiskerMenu from '../menu/WhiskerMenu';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -19,7 +18,18 @@ export default class Navbar extends Component {
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
-                                <WhiskerMenu />
+                                <div
+                                        className={'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 '}
+                                >
+                                        <Image
+                                                src="/themes/Yaru/status/decompiler-symbolic.svg"
+                                                alt="Decompiler"
+                                                width={16}
+                                                height={16}
+                                                className="inline mr-1"
+                                        />
+                                        Activities
+                                </div>
                                 <div
                                         className={
                                                 'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'

--- a/components/screen/ubuntu.tsx
+++ b/components/screen/ubuntu.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React, { useState, forwardRef, type ReactNode } from "react";
+import UbuntuCore from "../ubuntu";
+import usePersistentState from "../../hooks/usePersistentState";
+import { THEME_KEY, setTheme } from "../../utils/theme";
+
+// Simple Safe Mode screen presented when boot fails
+function SafeModeScreen({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="w-screen h-screen flex flex-col items-center justify-center bg-black text-white gap-4">
+      <h1 className="text-2xl font-bold">Safe Mode</h1>
+      <p className="max-w-md text-center">
+        An error occurred before the desktop could load. Custom themes and panel
+        profiles have been disabled.
+      </p>
+      <button onClick={onRetry} className="bg-ub-orange px-4 py-2 rounded">
+        Return to Desktop
+      </button>
+    </div>
+  );
+}
+
+class UbuntuErrorBoundary extends React.Component<
+  { children: ReactNode; onError: (e: Error) => void },
+  { hasError: boolean }
+> {
+  constructor(props: { children: ReactNode; onError: (e: Error) => void }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    this.props.onError(error);
+  }
+
+  render() {
+    if (this.state.hasError) return null;
+    return this.props.children;
+  }
+}
+
+export default forwardRef<any, any>(function UbuntuScreen(props, ref) {
+  const [safeMode, setSafeMode] = useState(false);
+  const [, , , clearTheme] = usePersistentState<string>(THEME_KEY, "default");
+  const [, , , clearProfiles] = usePersistentState<Record<string, unknown>>(
+    "panel:profiles",
+    {},
+  );
+
+  const handleError = (err: Error) => {
+    // Remove custom theme and panel profile
+    clearTheme();
+    clearProfiles();
+    try {
+      window.localStorage.removeItem("panelLayout");
+      window.localStorage.removeItem("pluginStates");
+      setTheme("default");
+    } catch {
+      /* ignore storage errors */
+    }
+    setSafeMode(true);
+    console.error("Boot error", err);
+  };
+
+  const retry = () => {
+    setSafeMode(false);
+    // Reload to attempt normal boot again
+    try {
+      window.location.reload();
+    } catch {
+      /* ignore reload issues */
+    }
+  };
+
+  if (safeMode) return <SafeModeScreen onRetry={retry} />;
+
+  return (
+    <UbuntuErrorBoundary onError={handleError}>
+      <UbuntuCore ref={ref} {...props} />
+    </UbuntuErrorBoundary>
+  );
+});

--- a/components/screen/workspace-switcher.tsx
+++ b/components/screen/workspace-switcher.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React, { useEffect } from "react";
+
+export interface WorkspaceInfo {
+  id: number;
+  name: string;
+}
+
+interface Props {
+  workspaces: WorkspaceInfo[];
+  active: number;
+  onSelect?: (id: number) => void;
+  onClose?: () => void;
+}
+
+export default function WorkspaceSwitcher({
+  workspaces,
+  active,
+  onSelect,
+  onClose,
+}: Props) {
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose?.();
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 text-white"
+      role="dialog"
+    >
+      <div
+        className="grid gap-4 w-11/12 max-w-3xl"
+        style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))' }}
+      >
+        {workspaces.map((ws) => (
+          <button
+            key={ws.id}
+            onClick={() => onSelect?.(ws.id)}
+            className={`p-4 rounded bg-ub-grey bg-opacity-60 hover:bg-ub-grey text-center focus:outline-none ${
+              active === ws.id ? "ring-2 ring-ub-orange" : ""
+            }`}
+          >
+            {ws.name}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/components/util-components/PanelClock.tsx
+++ b/components/util-components/PanelClock.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+
+const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+export default function PanelClock() {
+  const [now, setNow] = useState<Date | null>(null);
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const dayRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [focusedIdx, setFocusedIdx] = useState(-1);
+
+  useEffect(() => {
+    const tick = () => setNow(new Date());
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    const handle = (e: MouseEvent) => {
+      if (open && ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('click', handle);
+    return () => document.removeEventListener('click', handle);
+  }, [open]);
+
+  useEffect(() => {
+    if (open) {
+      const index = weeks
+        .flat()
+        .findIndex((d) => d === now?.getDate());
+      const firstValid = weeks.flat().findIndex((d) => d !== null);
+      const idx = index >= 0 ? index : firstValid;
+      setFocusedIdx(idx);
+      // focus will be applied in effect below
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (open && focusedIdx >= 0) {
+      dayRefs.current[focusedIdx]?.focus();
+    }
+  }, [open, focusedIdx]);
+
+  if (!now) return <span suppressHydrationWarning />;
+
+  const timeStr = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const tooltip = now.toLocaleString([], {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  const year = now.getFullYear();
+  const month = now.getMonth();
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const weeks: (number | null)[][] = [];
+  let day = 1 - firstDay;
+  for (let i = 0; i < 6; i++) {
+    const week: (number | null)[] = [];
+    for (let j = 0; j < 7; j++) {
+      if (day < 1 || day > daysInMonth) week.push(null);
+      else week.push(day);
+      day++;
+    }
+    weeks.push(week);
+  }
+
+  const total = 42;
+  const move = (delta: number) => {
+    let idx = focusedIdx;
+    do {
+      idx = (idx + delta + total) % total;
+    } while (!dayRefs.current[idx]);
+    setFocusedIdx(idx);
+  };
+
+  const handleKey = (e: React.KeyboardEvent) => {
+    if (!open) return;
+    switch (e.key) {
+      case 'ArrowRight':
+        e.preventDefault();
+        move(1);
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        move(-1);
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        move(7);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        move(-7);
+        break;
+      case 'Enter':
+        e.preventDefault();
+        dayRefs.current[focusedIdx]?.click();
+        break;
+      case 'Escape':
+        e.preventDefault();
+        setOpen(false);
+        buttonRef.current?.focus();
+        break;
+      case 'Tab':
+        e.preventDefault();
+        move(e.shiftKey ? -1 : 1);
+        break;
+    }
+  };
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        title={tooltip}
+        onClick={() => setOpen((o) => !o)}
+        className="outline-none"
+        ref={buttonRef}
+      >
+        {timeStr}
+      </button>
+      {open && (
+        <div
+          className="absolute right-0 mt-2 p-2 bg-ub-grey text-ubt-grey rounded shadow-lg"
+          onKeyDown={handleKey}
+        >
+          <div className="text-center mb-2">
+            {now.toLocaleString([], { month: 'long', year: 'numeric' })}
+          </div>
+          <table className="text-xs">
+            <thead>
+              <tr>
+                {dayNames.map((d) => (
+                  <th key={d} className="px-1">
+                    {d}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {weeks.map((week, idx) => (
+                <tr key={idx}>
+                  {week.map((d, i) => {
+                    const cellIndex = idx * 7 + i;
+                    const label = d
+                      ? new Date(year, month, d).toLocaleDateString('en-US', {
+                          weekday: 'long',
+                          month: 'long',
+                          day: 'numeric',
+                          year: 'numeric',
+                        })
+                      : undefined;
+                    if (!d) {
+                      dayRefs.current[cellIndex] = null;
+                      return (
+                        <td key={i} className="p-1 text-center">
+                          <span />
+                        </td>
+                      );
+                    }
+                    return (
+                      <td key={i} className="p-1 text-center">
+                        <button
+                          ref={(el) => (dayRefs.current[cellIndex] = el)}
+                          tabIndex={cellIndex === focusedIdx ? 0 : -1}
+                          aria-label={label}
+                          className={`w-6 h-6 rounded ${
+                            d === now.getDate()
+                              ? 'bg-ubt-blue text-ub-grey'
+                              : ''
+                          }`}
+                        >
+                          {d}
+                        </button>
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/components/util-components/calendar-popup.js
+++ b/components/util-components/calendar-popup.js
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react';
+import { listEvents } from '../../utils/orage';
+import usePersistentState from '../../hooks/usePersistentState';
+
+const MONTHS = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+const DAYS = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+
+export default function CalendarPopup() {
+  const today = new Date();
+  const [year, setYear] = useState(today.getFullYear());
+  const [month, setMonth] = useState(today.getMonth());
+  const [eventsMap, setEventsMap] = useState({});
+  const [selected, setSelected] = useState(null);
+  const [firstDayOfWeek, setFirstDayOfWeek] = usePersistentState('clock:first-day', 0);
+
+  useEffect(() => {
+    listEvents(year, month).then(evts => {
+      const map = {};
+      evts.forEach(e => {
+        const dt = new Date(e.date || e.start || e); // support multiple shapes
+        const key = dt.toISOString().slice(0,10);
+        if (!map[key]) map[key] = [];
+        map[key].push(e);
+      });
+      setEventsMap(map);
+    }).catch(() => setEventsMap({}));
+  }, [year, month]);
+
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const firstDay = new Date(year, month, 1).getDay();
+  const offset = (firstDay - firstDayOfWeek + 7) % 7;
+
+  useEffect(() => {
+    const onFirstDay = (e) => setFirstDayOfWeek(e.detail);
+    window.addEventListener('clock-first-day', onFirstDay);
+    return () => window.removeEventListener('clock-first-day', onFirstDay);
+  }, [setFirstDayOfWeek]);
+
+  const weeks = [];
+  let day = 1 - offset;
+  for (let w = 0; w < 6; w++) {
+    const wk = [];
+    for (let d = 0; d < 7; d++, day++) {
+      wk.push(day > 0 && day <= daysInMonth ? day : null);
+    }
+    weeks.push(wk);
+  }
+
+  const selectedKey = selected ? selected.toISOString().slice(0,10) : null;
+  const selectedEvents = selectedKey && eventsMap[selectedKey] ? eventsMap[selectedKey] : [];
+
+  return (
+    <div className="absolute right-0 mt-2 p-2 bg-neutral-900 text-white border border-neutral-700 rounded shadow-lg z-50 w-64">
+      <div className="flex justify-between items-center mb-2 text-sm">
+        <button onClick={() => setMonth(m => (m === 0 ? 11 : m - 1))}>◀</button>
+        <div>{MONTHS[month]} {year}</div>
+        <button onClick={() => setMonth(m => (m === 11 ? 0 : m + 1))}>▶</button>
+      </div>
+      <div className="grid grid-cols-7 gap-1 text-xs text-center">
+        {DAYS.slice(firstDayOfWeek).concat(DAYS.slice(0, firstDayOfWeek)).map(d => (
+          <div key={d} className="font-bold">{d}</div>
+        ))}
+        {weeks.map((wk,i) => wk.map((d,j) => {
+          const date = d ? new Date(year, month, d) : null;
+          const key = date ? date.toISOString().slice(0,10) : null;
+          const has = key && eventsMap[key];
+          const label = date
+            ? date.toLocaleDateString('en-US', {
+                weekday: 'long',
+                month: 'long',
+                day: 'numeric',
+                year: 'numeric',
+              })
+            : undefined;
+          return (
+            <button
+              key={`${i}-${j}`}
+              className={`w-8 h-8 relative rounded ${d ? 'hover:bg-neutral-700 focus:bg-neutral-700' : ''}`}
+              disabled={!d}
+              onClick={() => date && setSelected(date)}
+              aria-label={label}
+            >
+              {d || ''}
+              {has && <span className="absolute bottom-1 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-red-500"></span>}
+            </button>
+          );
+        }))}
+      </div>
+      <div className="mt-2 max-h-32 overflow-auto text-xs">
+        {selectedEvents.length ? selectedEvents.map((e,i) => (
+          <div key={i} className="border-t border-neutral-700 pt-1 mt-1">
+            <div className="font-semibold">{e.title || e.summary || 'Event'}</div>
+            {e.description && <div>{e.description}</div>}
+          </div>
+        )) : <div>No events</div>}
+      </div>
+      <div className="mt-2 text-xs">
+        <a
+          href="/apps/settings#datetime"
+          className="text-blue-400 hover:underline"
+        >
+          Time & Date Settings
+        </a>
+      </div>
+    </div>
+  );
+}
+

--- a/styles/colors-alt.css
+++ b/styles/colors-alt.css
@@ -1,0 +1,14 @@
+/* Alternative color palette */
+.alt-palette {
+    --color-bg: #fdf6e3;
+    --color-text: #073642;
+    --color-primary: #b58900;
+    --color-secondary: #eee8d5;
+    --color-accent: #268bd2;
+    --color-muted: #e0dbd1;
+    --color-surface: #eee8d5;
+    --color-inverse: #fdf6e3;
+    --color-border: #d3c6aa;
+    --color-terminal: #00ff00;
+    --color-dark: #002b36;
+}

--- a/styles/docs.css
+++ b/styles/docs.css
@@ -1,0 +1,38 @@
+/* Documentation specific overrides to match official docs */
+.docs-content {
+  font-family: var(--font-family-base, system-ui, sans-serif);
+}
+
+.docs-content ul,
+.docs-content ol {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+  padding-left: 1.25em;
+}
+
+.docs-content li + li {
+  margin-top: 0.25em;
+}
+
+.docs-content pre {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  padding: 0.75em 1em;
+  line-height: 1.4;
+  font-size: 0.9em;
+}
+
+.docs-content code {
+  font-family: var(--font-family-mono, monospace);
+}
+
+.docs-content blockquote {
+  margin: 1rem 0;
+  padding: 0.5rem 1rem;
+  border-left: 4px solid var(--color-primary);
+  background-color: var(--color-surface);
+}
+
+.docs-content blockquote > :last-child {
+  margin-bottom: 0;
+}

--- a/styles/rtl.css
+++ b/styles/rtl.css
@@ -1,0 +1,8 @@
+/* RTL-specific utility classes */
+html[dir="rtl"] .rtl\:flex-row-reverse { flex-direction: row-reverse; }
+html[dir="rtl"] .rtl\:space-x-reverse > :not([hidden]) ~ :not([hidden]) { --tw-space-x-reverse: 1; }
+html[dir="rtl"] .rtl\:text-right { text-align: right; }
+html[dir="rtl"] .rtl\:left-auto { left: auto; }
+html[dir="rtl"] .rtl\:right-0 { right: 0; }
+html[dir="rtl"] .rtl\:ml-1 { margin-left: 0.25rem; }
+html[dir="rtl"] .rtl\:mr-0 { margin-right: 0; }

--- a/styles/themes/purple.css
+++ b/styles/themes/purple.css
@@ -1,0 +1,14 @@
+/* Purple theme design tokens */
+html[data-theme='purple'] {
+  --color-bg: #1b1039;
+  --color-text: #f5f5f5;
+  --color-primary: #805ad5;
+  --color-secondary: #120b26;
+  --color-accent: #805ad5;
+  --color-muted: #261b4d;
+  --color-surface: #1b1039;
+  --color-inverse: #ffffff;
+  --color-border: #433160;
+  --color-terminal: #00ff00;
+  --color-dark: #0d071a;
+}

--- a/styles/whisker.css
+++ b/styles/whisker.css
@@ -1,0 +1,11 @@
+/* Theme variables for Whisker-style menu and sidebar */
+:root {
+  /* Background color for menus and sidebar */
+  --menu-bg: var(--color-bg);
+  /* Width of the sidebar/dock */
+  --sidebar-width: 4rem;
+  /* Rounded corners for menus and sidebar */
+  --menu-border-radius: 0.5rem;
+  /* Overall menu opacity (0 - 1) */
+  --menu-opacity: 0.9;
+}


### PR DESCRIPTION
## Summary
- restore desktop shell and supporting components from baseline commit 88a69db while keeping latest app files
- add panel clock/calendar utilities and legacy style sheets

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn build` *(fails: Type error: Type '(el: HTMLButtonElement | null) => HTMLButtonElement | null' is not assignable to type 'Ref<HTMLButtonElement | undefined')*
- `yarn test` *(fails: e.preventDefault is not a function; Unable to find role="alert"; Cannot read properties of null (reading '_origin'))*
- `npx pa11y http://localhost:3000/` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npx pa11y http://localhost:3000/apps/2048` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npx pa11y http://localhost:3000/apps/connect-four` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c579a9b234832891fd87617302ffb2