### PR TITLE
[ui] add calendar dropdown to top bar

### DIFF
--- a/__tests__/calendar.test.tsx
+++ b/__tests__/calendar.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Calendar from '../components/ui/Calendar';
+
+describe('Calendar dropdown', () => {
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-09-13T13:33:00'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('shows current month and year', () => {
+    render(<Calendar open={true} />);
+    expect(screen.getByText('September 2025')).toBeInTheDocument();
+  });
+});

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -4,13 +4,15 @@ import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import Calendar from '../ui/Calendar';
 
 export default class Navbar extends Component {
 	constructor() {
 		super();
-		this.state = {
-			status_card: false
-		};
+                this.state = {
+                        status_card: false,
+                        calendar: false
+                };
 	}
 
 	render() {
@@ -20,13 +22,16 @@ export default class Navbar extends Component {
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
                                 <WhiskerMenu />
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                <button
+                                        type="button"
+                                        onClick={() =>
+                                                this.setState({ calendar: !this.state.calendar })
                                         }
+                                        className="relative pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
                                 >
                                         <Clock />
-                                </div>
+                                        <Calendar open={this.state.calendar} />
+                                </button>
                                 <button
                                         type="button"
                                         id="status-bar"

--- a/components/ui/Calendar.tsx
+++ b/components/ui/Calendar.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from 'react';
+
+interface Props {
+  open: boolean;
+}
+
+const monthNames = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+const daysOfWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+const Calendar = ({ open }: Props) => {
+  const today = new Date();
+  const [current, setCurrent] = useState(
+    new Date(today.getFullYear(), today.getMonth(), 1)
+  );
+
+  const year = current.getFullYear();
+  const month = current.getMonth();
+
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  const weeks: (number | null)[][] = [];
+  let day = 1 - firstDay;
+  for (let i = 0; i < 6; i++) {
+    const week: (number | null)[] = [];
+    for (let j = 0; j < 7; j++, day++) {
+      if (day > 0 && day <= daysInMonth) {
+        week.push(day);
+      } else {
+        week.push(null);
+      }
+    }
+    weeks.push(week);
+  }
+
+  const prevMonth = () => setCurrent(new Date(year, month - 1, 1));
+  const nextMonth = () => setCurrent(new Date(year, month + 1, 1));
+
+  return (
+    <div
+      className={`absolute bg-ub-cool-grey rounded-md top-9 right-1 shadow border border-black border-opacity-20 text-xs w-64 ${
+        open ? '' : 'hidden'
+      }`}
+    >
+      <div className="flex justify-between items-center px-4 py-2">
+        <button onClick={prevMonth} aria-label="Previous month" className="px-2">
+          &lt;
+        </button>
+        <div>
+          {monthNames[month]} {year}
+        </div>
+        <button onClick={nextMonth} aria-label="Next month" className="px-2">
+          &gt;
+        </button>
+      </div>
+      <div className="grid grid-cols-7 text-center px-2 pb-2">
+        {daysOfWeek.map((d) => (
+          <div key={d} className="py-1">
+            {d}
+          </div>
+        ))}
+        {weeks.map((week, i) =>
+          week.map((d, j) => {
+            const isToday =
+              d === today.getDate() &&
+              month === today.getMonth() &&
+              year === today.getFullYear();
+            return (
+              <div
+                key={`${i}-${j}`}
+                className={`py-1 ${
+                  d ? '' : 'text-ubt-grey'
+                } ${isToday ? 'bg-ubt-grey text-black rounded' : ''}`}
+              >
+                {d || ''}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Calendar;
+


### PR DESCRIPTION
## Summary
- add dropdown calendar widget
- toggle calendar from top-bar clock
- cover calendar with unit test

## Testing
- `npx eslint components/screen/navbar.js components/ui/Calendar.tsx __tests__/calendar.test.tsx`
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx, calendar.test.tsx)*
- `yarn test __tests__/calendar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5ab037af88328b51a83ec8fe22328