### PR TITLE
[ui] refine snap preview and overlay

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -199,7 +199,12 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({
+        key: 'ArrowDown',
+        altKey: true,
+        preventDefault: () => {},
+        stopPropagation: () => {}
+      } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();
@@ -252,6 +257,61 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBeNull();
     expect(ref.current!.state.width).toBe(60);
     expect(ref.current!.state.height).toBe(85);
+  });
+
+  it('clears snap when dragged away before release', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    // Start near edge
+    winEl.getBoundingClientRect = () => ({
+      left: 5,
+      top: 10,
+      right: 105,
+      bottom: 110,
+      width: 100,
+      height: 100,
+      x: 5,
+      y: 10,
+      toJSON: () => {}
+    });
+    act(() => {
+      ref.current!.handleDrag();
+    });
+    // Move away
+    winEl.getBoundingClientRect = () => ({
+      left: 200,
+      top: 200,
+      right: 300,
+      bottom: 300,
+      width: 100,
+      height: 100,
+      x: 200,
+      y: 200,
+      toJSON: () => {}
+    });
+    act(() => {
+      ref.current!.handleDrag();
+    });
+    act(() => {
+      ref.current!.handleStop();
+    });
+
+    expect(ref.current!.state.snapped).toBeNull();
+    expect(ref.current!.state.snapPreview).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure overlay root inert attribute toggles on open/close
- tighten snap preview logic and clean up when window moves away
- test window snap clearing and overlay focus return

## Testing
- `yarn lint components/base/window.js __tests__/window.test.tsx` *(fails: A control must be associated with a text label)*
- `yarn eslint components/base/window.js __tests__/window.test.tsx`
- `yarn test __tests__/window.test.tsx`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68c5abbef96c83288697321c07cff2a1