### PR TITLE
[desktop] open About app on launch

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -78,7 +78,7 @@ export class Desktop extends Component {
                     session.windows.forEach(({ id }) => this.openApp(id));
                 });
             } else {
-                this.openApp('about-alex');
+                this.openApp('about');
             }
         });
         this.setContextListeners();


### PR DESCRIPTION
## Summary
- ensure the About window opens when no previous session exists

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: e.preventDefault is not a function in window.test.tsx; unable to find role="alert" in nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ad06a9b48328ab95a73447e0c0c5