### PR TITLE
[ui] add kali-like login screen

### DIFF
--- a/__tests__/loginPage.test.tsx
+++ b/__tests__/loginPage.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoginPage from '../pages/login';
+
+const push = jest.fn();
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push }),
+}));
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    push.mockReset();
+  });
+
+  it('toggles password visibility and blocks invalid credentials', async () => {
+    const user = userEvent.setup();
+    render(<LoginPage />);
+    const pass = screen.getByLabelText(/^password$/i);
+    await user.type(screen.getByLabelText(/username/i), 'kali');
+    await user.type(pass, 'wrong');
+    await user.click(screen.getByLabelText(/show password/i));
+    expect(pass).toHaveAttribute('type', 'text');
+    await user.click(screen.getByRole('button', { name: /log in/i }));
+    expect(screen.getByText(/invalid credentials/i)).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('logs in with correct credentials', async () => {
+    const user = userEvent.setup();
+    render(<LoginPage />);
+    await user.type(screen.getByLabelText(/username/i), 'kali');
+    await user.type(screen.getByLabelText(/^password$/i), 'kali');
+    await user.click(screen.getByRole('button', { name: /log in/i }));
+    expect(push).toHaveBeenCalledWith('/');
+  });
+});
+

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (username === 'kali' && password === 'kali') {
+      router.push('/');
+    } else {
+      setError('Invalid credentials');
+    }
+  };
+
+  const handleCancel = () => {
+    setUsername('');
+    setPassword('');
+    setError('');
+  };
+
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center bg-cover bg-center"
+      style={{ backgroundImage: "url('/wallpapers/wall-6.webp')" }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white bg-opacity-90 rounded shadow-md p-8 w-80"
+      >
+        <div className="mb-4">
+          <label htmlFor="username" className="block text-sm font-medium mb-1">
+            Username
+          </label>
+          <input
+            id="username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div className="mb-4">
+          <label htmlFor="password" className="block text-sm font-medium mb-1">
+            Password
+          </label>
+          <div className="relative">
+            <input
+              id="password"
+              type={showPassword ? 'text' : 'password'}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full border border-gray-300 rounded px-3 py-2 pr-10 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((p) => !p)}
+              aria-label={showPassword ? 'Hide password' : 'Show password'}
+              className="absolute inset-y-0 right-0 px-2 text-sm text-gray-600"
+            >
+              {showPassword ? 'Hide' : 'Show'}
+            </button>
+          </div>
+        </div>
+        {error && <p className="text-red-600 text-sm mb-4">{error}</p>}
+        <div className="flex justify-between mt-6">
+          <button
+            type="button"
+            onClick={handleCancel}
+            className="px-4 py-2 rounded bg-gray-200 text-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="px-4 py-2 rounded bg-blue-600 text-white"
+          >
+            Log In
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add standalone login page with Kali-style wallpaper and basic credential check
- include show/hide password toggle and invalid credential messaging
- cover login behavior with unit tests

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in legacy files)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*
- `yarn test __tests__/loginPage.test.tsx`
- `yarn smoke` *(fails: connection refused to http://localhost:3000)*
- `npx playwright test` *(fails: connection refused to http://localhost:3000)*

------
https://chatgpt.com/codex/tasks/task_e_68c5abae822083288ad224ff4d01d20c