### PR TITLE
[test] stabilize jest DOM polyfills

### DIFF
--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -82,7 +82,7 @@ describe('NmapNSEApp', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Sample output')
     );
-    expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
+    expect(await screen.findByRole('status')).toHaveTextContent(/copied/i);
 
     mockFetch.mockRestore();
   });

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -199,7 +199,12 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({
+        key: 'ArrowDown',
+        altKey: true,
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+      } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();


### PR DESCRIPTION
## Summary
- mock alert, clipboard and documentPictureInPicture in test setup
- harden localStorage mock and update tests for new behavior

## Testing
- `yarn lint jest.setup.ts` *(fails: lints entire repo)*
- `npx eslint jest.setup.ts`
- `yarn test`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68c5abbfef708328912c0e7ab5c7525f