### PR TITLE
[ui] add workspace switcher

### DIFF
--- a/__tests__/WorkspaceSwitcher.test.tsx
+++ b/__tests__/WorkspaceSwitcher.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import WorkspaceSwitcher from '../components/WorkspaceSwitcher';
+import { WorkspaceProvider } from '../hooks/useWorkspaceStore';
+
+jest.mock('../hooks/useSettings', () => ({
+  useSettings: () => ({ accent: '#ff0000' }),
+}));
+
+describe('WorkspaceSwitcher', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('toggles workspaces and sets aria-pressed', () => {
+    render(
+      <WorkspaceProvider>
+        <WorkspaceSwitcher />
+      </WorkspaceProvider>
+    );
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(4);
+    expect(buttons[0]).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(buttons[2]);
+    expect(buttons[2]).toHaveAttribute('aria-pressed', 'true');
+    expect(buttons[0]).toHaveAttribute('aria-pressed', 'false');
+    expect(window.localStorage.getItem('active-workspace')).toBe('2');
+  });
+});

--- a/components/WorkspaceSwitcher.tsx
+++ b/components/WorkspaceSwitcher.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useSettings } from '../hooks/useSettings';
+import { useWorkspaceStore } from '../hooks/useWorkspaceStore';
+
+export default function WorkspaceSwitcher() {
+  const { accent } = useSettings();
+  const { activeWorkspace, setActiveWorkspace } = useWorkspaceStore();
+
+  return (
+    <div className="flex gap-1">
+      {[0, 1, 2, 3].map((i) => {
+        const isActive = activeWorkspace === i;
+        return (
+          <button
+            key={i}
+            aria-pressed={isActive}
+            onClick={() => setActiveWorkspace(i)}
+            className="w-8 h-8 flex items-center justify-center border-b-2"
+            style={{ borderBottomColor: isActive ? accent : 'transparent' }}
+          >
+            {i + 1}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/hooks/useWorkspaceStore.tsx
+++ b/hooks/useWorkspaceStore.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, ReactNode } from 'react';
+import usePersistentState from './usePersistentState';
+
+interface WorkspaceContextValue {
+  activeWorkspace: number;
+  setActiveWorkspace: (index: number) => void;
+}
+
+const WorkspaceContext = createContext<WorkspaceContextValue>({
+  activeWorkspace: 0,
+  setActiveWorkspace: () => {},
+});
+
+export function WorkspaceProvider({ children }: { children: ReactNode }) {
+  const [activeWorkspace, setActiveWorkspace] = usePersistentState<number>(
+    'active-workspace',
+    0,
+    (v): v is number => typeof v === 'number',
+  );
+
+  return (
+    <WorkspaceContext.Provider value={{ activeWorkspace, setActiveWorkspace }}>
+      {children}
+    </WorkspaceContext.Provider>
+  );
+}
+
+export const useWorkspaceStore = () => useContext(WorkspaceContext);


### PR DESCRIPTION
## Summary
- introduce WorkspaceSwitcher with four numbered buttons and accent border
- add persistent workspace store via context
- test workspace switching behavior

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `npx eslint components/WorkspaceSwitcher.tsx hooks/useWorkspaceStore.tsx __tests__/WorkspaceSwitcher.test.tsx`
- `yarn test WorkspaceSwitcher.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5bc99c9f0832893a01c800511e585