### PR TITLE
[ui] replace navbar with TopPanel

### DIFF
--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -5,8 +5,8 @@ import Ubuntu from '../components/ubuntu';
 jest.mock('../components/screen/desktop', () => function DesktopMock() {
   return <div data-testid="desktop" />;
 });
-jest.mock('../components/screen/navbar', () => function NavbarMock() {
-  return <div data-testid="navbar" />;
+jest.mock('../components/kali/TopPanel', () => function TopPanelMock() {
+  return <div data-testid="top-panel" />;
 });
 jest.mock('../components/screen/lock_screen', () => function LockScreenMock() {
   return <div data-testid="lock-screen" />;

--- a/components/kali/TopPanel.tsx
+++ b/components/kali/TopPanel.tsx
@@ -1,0 +1,44 @@
+import Image from 'next/image';
+import { useState } from 'react';
+import Clock from '../util-components/clock';
+import Status from '../util-components/status';
+import QuickSettings from '../ui/QuickSettings';
+import WhiskerMenu from '../menu/WhiskerMenu';
+
+export interface TopPanelProps {
+  lockScreen?: () => void;
+  shutDown?: () => void;
+}
+
+export default function TopPanel(_props: TopPanelProps) {
+  const [statusCard, setStatusCard] = useState(false);
+
+  return (
+    <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+      <div className="pl-3 pr-1">
+        <Image
+          src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg"
+          alt="network icon"
+          width={16}
+          height={16}
+          className="w-4 h-4"
+        />
+      </div>
+      <WhiskerMenu />
+      <div className="pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1">
+        <Clock />
+      </div>
+      <button
+        type="button"
+        id="status-bar"
+        aria-label="System status"
+        onClick={() => setStatusCard(!statusCard)}
+        className="relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 "
+      >
+        <Status />
+        <QuickSettings open={statusCard} />
+      </button>
+    </div>
+  );
+}
+

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import BootingScreen from './screen/booting_screen';
 import Desktop from './screen/desktop';
 import LockScreen from './screen/lock_screen';
-import Navbar from './screen/navbar';
+import TopPanel from './kali/TopPanel';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
 
@@ -126,7 +126,7 @@ export default class Ubuntu extends Component {
 					isShutDown={this.state.shutDownScreen}
 					turnOn={this.turnOn}
 				/>
-				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
+                                <TopPanel lockScreen={this.lockScreen} shutDown={this.shutDown} />
 				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
 			</div>
 		);


### PR DESCRIPTION
## Summary
- add Kali TopPanel component and move Ubuntu shell to use it
- update Ubuntu tests to mock new TopPanel

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: e.preventDefault is not a function)*
- `yarn smoke` *(fails: Playwright browser missing)*
- `npx playwright test` *(fails: browserType.launch executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bc9e4128832888a6cbb7ff2c3162