### PR TITLE
[tests] add desktop UI unit tests

### DIFF
--- a/__tests__/StatusCluster.test.tsx
+++ b/__tests__/StatusCluster.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import QuickSettings from '../components/ui/QuickSettings';
+
+describe('StatusCluster', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('toggles volume setting', async () => {
+    const user = userEvent.setup();
+    render(<QuickSettings open={true} />);
+    const [soundToggle] = screen.getAllByRole('checkbox');
+    expect(soundToggle).toBeChecked();
+    await user.click(soundToggle);
+    expect(soundToggle).not.toBeChecked();
+    expect(JSON.parse(window.localStorage.getItem('qs-sound') || 'true')).toBe(false);
+
+    render(<QuickSettings open={true} />);
+    const [persisted] = screen.getAllByRole('checkbox');
+    expect(persisted).not.toBeChecked();
+  });
+});

--- a/__tests__/TopPanel.test.tsx
+++ b/__tests__/TopPanel.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Navbar from '../components/screen/navbar';
+
+describe('TopPanel', () => {
+  test('renders clock', () => {
+    render(<Navbar />);
+    // Clock renders current time like "Mon Jan 1 12:34 AM"
+    expect(screen.getByText(/\d{1,2}:\d{2}/)).toBeInTheDocument();
+  });
+
+  test('toggles quick settings menu', async () => {
+    const user = userEvent.setup();
+    render(<Navbar />);
+    const toggle = screen.getByRole('button', { name: /system status/i });
+    const menu = screen.getByText('Theme').closest('div.absolute') as HTMLElement;
+
+    expect(menu.classList.contains('hidden')).toBe(true);
+
+    await user.click(toggle);
+    expect(menu.classList.contains('hidden')).toBe(false);
+
+    await user.click(toggle);
+    expect(menu.classList.contains('hidden')).toBe(true);
+  });
+});

--- a/__tests__/WhiskerMenu.test.tsx
+++ b/__tests__/WhiskerMenu.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import WhiskerMenu from '../components/menu/WhiskerMenu';
+
+describe('WhiskerMenu', () => {
+  test('keyboard navigation and launching', async () => {
+    const user = userEvent.setup();
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+    render(<WhiskerMenu />);
+
+    await user.click(screen.getByRole('button', { name: /applications/i }));
+    await screen.findByPlaceholderText(/search/i);
+
+    const appButtons = screen
+      .getAllByRole('button')
+      .filter((b) => b.dataset.appId);
+    const secondId = appButtons[1].dataset.appId!;
+
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{Enter}');
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'open-app', detail: secondId })
+    );
+  });
+});

--- a/__tests__/WorkspaceSwitcher.test.tsx
+++ b/__tests__/WorkspaceSwitcher.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ModuleWorkspace from '../pages/module-workspace';
+
+describe('WorkspaceSwitcher', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('activates workspaces and persists list', async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<ModuleWorkspace />);
+
+    const input = screen.getByPlaceholderText('New workspace');
+    const create = screen.getByRole('button', { name: /create/i });
+
+    await user.type(input, 'Alpha');
+    await user.click(create);
+    await user.type(input, 'Beta');
+    await user.click(create);
+
+    const alpha = screen.getByRole('button', { name: 'Alpha' });
+    const beta = screen.getByRole('button', { name: 'Beta' });
+
+    // Latest created workspace is active
+    expect(beta.className).toContain('bg-blue-600');
+
+    await user.click(alpha);
+    expect(alpha.className).toContain('bg-blue-600');
+
+    unmount();
+    render(<ModuleWorkspace />);
+    expect(screen.getByRole('button', { name: 'Alpha' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Beta' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add TopPanel quick settings and clock tests
- verify workspace switcher activation & persistence
- cover status cluster volume toggle and whisker menu keyboard launching

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window, nmapNse, Modal tests)*
- `yarn test __tests__/TopPanel.test.tsx __tests__/WorkspaceSwitcher.test.tsx __tests__/StatusCluster.test.tsx __tests__/WhiskerMenu.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5bca19e488328994cc71e67aa26f5