### PR TITLE
[panel] add 24h clock with seconds toggle

### DIFF
--- a/__tests__/panelClock.test.tsx
+++ b/__tests__/panelClock.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import PanelClock from '../components/panel/PanelClock';
+
+describe('PanelClock', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2020-01-01T13:05:07'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('renders time in 24-hour format', () => {
+    render(<PanelClock showSeconds={false} />);
+    expect(screen.getByText('13:05')).toBeInTheDocument();
+  });
+
+  test('renders seconds when enabled', () => {
+    render(<PanelClock showSeconds={true} />);
+    expect(screen.getByText('13:05:07')).toBeInTheDocument();
+  });
+});

--- a/components/panel/PanelClock.tsx
+++ b/components/panel/PanelClock.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+
+interface Props {
+  showSeconds: boolean;
+}
+
+const PanelClock = ({ showSeconds }: Props) => {
+  const [time, setTime] = useState<Date | null>(null);
+
+  useEffect(() => {
+    const update = () => setTime(new Date());
+    update();
+
+    let worker: Worker | undefined;
+    let interval: NodeJS.Timeout | undefined;
+    const intervalMs = showSeconds ? 1000 : 10 * 1000;
+
+    if (typeof window !== 'undefined' && typeof Worker === 'function') {
+      worker = new Worker(new URL('../../workers/timer.worker.ts', import.meta.url));
+      worker.onmessage = update;
+      worker.postMessage({ action: 'start', interval: intervalMs });
+    } else {
+      interval = setInterval(update, intervalMs);
+    }
+
+    return () => {
+      if (worker) {
+        worker.postMessage({ action: 'stop' });
+        worker.terminate();
+      }
+      if (interval) clearInterval(interval);
+    };
+  }, [showSeconds]);
+
+  if (!time) return <span suppressHydrationWarning></span>;
+
+  const hour = time.getHours().toString().padStart(2, '0');
+  const minute = time.getMinutes().toString().padStart(2, '0');
+  const second = time.getSeconds().toString().padStart(2, '0');
+
+  const display = showSeconds ? `${hour}:${minute}:${second}` : `${hour}:${minute}`;
+
+  return <span suppressHydrationWarning>{display}</span>;
+};
+
+export default PanelClock;

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,47 +1,42 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import Image from 'next/image';
-import Clock from '../util-components/clock';
+import PanelClock from '../panel/PanelClock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import usePersistentState from '../../hooks/usePersistentState';
 
-export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+const Navbar = () => {
+  const [statusCard, setStatusCard] = useState(false);
+  const [showSeconds, setShowSeconds] = usePersistentState('qs-show-seconds', false);
 
-	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
-                                </div>
-                                <WhiskerMenu />
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-                                        }
-                                >
-                                        <Clock />
-                                </div>
-                                <button
-                                        type="button"
-                                        id="status-bar"
-                                        aria-label="System status"
-                                        onClick={() => {
-                                                this.setState({ status_card: !this.state.status_card });
-                                        }}
-                                        className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-                                        }
-                                >
-                                        <Status />
-                                        <QuickSettings open={this.state.status_card} />
-                                </button>
-			</div>
-		);
-	}
-}
+  return (
+    <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+      <div className="pl-3 pr-1">
+        <Image
+          src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg"
+          alt="network icon"
+          width={16}
+          height={16}
+          className="w-4 h-4"
+        />
+      </div>
+      <WhiskerMenu />
+      <div className="pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1">
+        <PanelClock showSeconds={showSeconds} />
+      </div>
+      <button
+        type="button"
+        id="status-bar"
+        aria-label="System status"
+        onClick={() => setStatusCard(!statusCard)}
+        className="relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 "
+      >
+        <Status />
+        <QuickSettings open={statusCard} showSeconds={showSeconds} setShowSeconds={setShowSeconds} />
+      </button>
+    </div>
+  );
+};
+
+export default Navbar;

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -5,9 +5,11 @@ import { useEffect } from 'react';
 
 interface Props {
   open: boolean;
+  showSeconds: boolean;
+  setShowSeconds: (value: boolean) => void;
 }
 
-const QuickSettings = ({ open }: Props) => {
+const QuickSettings = ({ open, showSeconds, setShowSeconds }: Props) => {
   const [theme, setTheme] = usePersistentState('qs-theme', 'light');
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
@@ -43,6 +45,14 @@ const QuickSettings = ({ open }: Props) => {
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
         <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+      </div>
+      <div className="px-4 pb-2 flex justify-between">
+        <span>Show seconds</span>
+        <input
+          type="checkbox"
+          checked={showSeconds}
+          onChange={() => setShowSeconds(!showSeconds)}
+        />
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>


### PR DESCRIPTION
## Summary
- Replace navbar clock with new PanelClock using 24-hour time and optional seconds
- Add "Show seconds" toggle to Quick Settings
- Test PanelClock formatting

## Testing
- `yarn lint` *(fails: Unexpected global 'document' and missing display name)*
- `yarn test __tests__/panelClock.test.tsx`
- `yarn test` *(fails: window.test.tsx and nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bc9be2e0832896ce9da27b34f98e