### PR TITLE
[terminal] mimic kali look

### DIFF
--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -12,6 +12,8 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
       className={`text-white ${className}`}
       style={{
         background: 'var(--kali-bg)',
+        backdropFilter: 'blur(4px)',
+        border: '1px solid var(--color-border)',
         fontFamily: 'monospace',
         fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
         lineHeight: 1.4,

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -146,7 +146,11 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
   contextRef.current.writeLine = writeLine;
 
   const prompt = useCallback(() => {
-    if (termRef.current) termRef.current.write('$ ');
+    if (!termRef.current) return;
+    termRef.current.writeln(
+      '\x1b[1;34m┌──(\x1b[0m\x1b[1;36mkali\x1b[0m\x1b[1;34m㉿\x1b[0m\x1b[1;36mkali\x1b[0m\x1b[1;34m)-[\x1b[0m\x1b[1;32m~\x1b[0m\x1b[1;34m]\x1b[0m',
+    );
+    termRef.current.write('\x1b[1;34m└─\x1b[0m$ ');
   }, []);
 
   const handleCopy = () => {
@@ -304,6 +308,12 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
         scrollback: 1000,
         cols: 80,
         rows: 24,
+        fontFamily: '"Fira Code", monospace',
+        theme: {
+          background: '#0f1317',
+          foreground: '#f5f5f5',
+          cursor: '#1793d1',
+        },
       });
       const fit = new FitAddon();
       const search = new SearchAddon();

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -25,6 +25,7 @@
   --color-ub-dark-grey: #2a2e36;
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
+  --kali-bg: rgba(15, 19, 23, 0.85);
 
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;


### PR DESCRIPTION
## Summary
- add kali-style prompt and theme to terminal
- blur terminal background and add semi-transparent var

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: TypeError e.preventDefault is not a function, Unable to find role="alert"))*

------
https://chatgpt.com/codex/tasks/task_e_68c5a9a7d00483289d5fe58c12e38300