### PR TITLE
[accessibility] add focus outlines and aria attributes

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -119,8 +119,12 @@ const WhiskerMenu: React.FC = () => {
       <button
         ref={buttonRef}
         type="button"
+        aria-label="Applications menu"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-pressed={open}
         onClick={() => setOpen(o => !o)}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        className="pl-3 pr-3 transition duration-100 ease-in-out border-b-2 border-transparent py-1"
       >
         <Image
           src="/themes/Yaru/status/decompiler-symbolic.svg"
@@ -136,6 +140,7 @@ const WhiskerMenu: React.FC = () => {
           ref={menuRef}
           className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
           tabIndex={-1}
+          role="dialog"
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node)) {
               setOpen(false);
@@ -146,6 +151,7 @@ const WhiskerMenu: React.FC = () => {
             {CATEGORIES.map(cat => (
               <button
                 key={cat.id}
+                aria-pressed={category === cat.id}
                 className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
                 onClick={() => setCategory(cat.id)}
               >
@@ -155,7 +161,7 @@ const WhiskerMenu: React.FC = () => {
           </div>
           <div className="p-3">
             <input
-              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20"
               placeholder="Search"
               value={query}
               onChange={e => setQuery(e.target.value)}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -4,13 +4,15 @@ import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import CalendarPopover from '../ui/CalendarPopover';
 
 export default class Navbar extends Component {
 	constructor() {
 		super();
-		this.state = {
-			status_card: false
-		};
+                this.state = {
+                        status_card: false,
+                        calendar_card: false
+                };
 	}
 
 	render() {
@@ -20,23 +22,31 @@ export default class Navbar extends Component {
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
                                 <WhiskerMenu />
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-                                        }
+                                <button
+                                        type="button"
+                                        aria-label="Show calendar"
+                                        aria-haspopup="dialog"
+                                        aria-expanded={this.state.calendar_card}
+                                        aria-pressed={this.state.calendar_card}
+                                        onClick={() => {
+                                                this.setState({ calendar_card: !this.state.calendar_card });
+                                        }}
+                                        className="relative pl-2 pr-2 text-xs md:text-sm transition duration-100 ease-in-out border-b-2 border-transparent py-1"
                                 >
                                         <Clock />
-                                </div>
+                                        <CalendarPopover open={this.state.calendar_card} />
+                                </button>
                                 <button
                                         type="button"
                                         id="status-bar"
                                         aria-label="System status"
+                                        aria-haspopup="dialog"
+                                        aria-expanded={this.state.status_card}
+                                        aria-pressed={this.state.status_card}
                                         onClick={() => {
                                                 this.setState({ status_card: !this.state.status_card });
                                         }}
-                                        className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-                                        }
+                                        className="relative pr-3 pl-3 transition duration-100 ease-in-out border-b-2 border-transparent py-1"
                                 >
                                         <Status />
                                         <QuickSettings open={this.state.status_card} />

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -39,7 +39,7 @@ export default function SideBar(props) {
                             : null
                     )
                 }
-                <AllApps showApps={props.showAllApps} />
+                <AllApps showApps={props.showAllApps} open={props.allAppsView} />
             </nav>
             <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className={"w-1 h-full absolute top-0 left-0 bg-transparent z-50"}></div>
         </>
@@ -51,7 +51,12 @@ export function AllApps(props) {
     const [title, setTitle] = useState(false);
 
     return (
-        <div
+        <button
+            type="button"
+            aria-label="Show applications"
+            aria-haspopup="dialog"
+            aria-expanded={props.open}
+            aria-pressed={props.open}
             className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
             style={{ marginTop: 'auto' }}
             onMouseEnter={() => {
@@ -80,6 +85,6 @@ export function AllApps(props) {
                     Show Applications
                 </div>
             </div>
-        </div>
+        </button>
     );
 }

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -22,6 +22,7 @@ export default function Taskbar(props) {
                     key={app.id}
                     type="button"
                     aria-label={app.title}
+                    aria-pressed={!props.minimized_windows[app.id] && props.focused_windows[app.id]}
                     data-context="taskbar"
                     data-app-id={app.id}
                     onClick={() => handleClick(app)}

--- a/components/ui/CalendarPopover.tsx
+++ b/components/ui/CalendarPopover.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface Props {
+  open: boolean;
+}
+
+const CalendarPopover = ({ open }: Props) => {
+  const now = new Date();
+  const date = now.toLocaleDateString(undefined, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+  return (
+    <div
+      role="dialog"
+      className={`absolute top-9 left-1/2 -translate-x-1/2 bg-ub-cool-grey text-white p-4 rounded shadow border border-black border-opacity-20 ${open ? '' : 'hidden'}`}
+    >
+      <time dateTime={now.toISOString()}>{date}</time>
+    </div>
+  );
+};
+
+export default CalendarPopover;

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -23,6 +23,7 @@ const QuickSettings = ({ open }: Props) => {
 
   return (
     <div
+      role="dialog"
       className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
         open ? '' : 'hidden'
       }`}

--- a/pages/module-workspace.tsx
+++ b/pages/module-workspace.tsx
@@ -123,6 +123,7 @@ const ModuleWorkspace: React.FC = () => {
           {workspaces.map((ws) => (
             <button
               key={ws}
+              aria-pressed={currentWorkspace === ws}
               onClick={() => setCurrentWorkspace(ws)}
               className={`px-2 py-1 rounded ${
                 currentWorkspace === ws ? 'bg-blue-600' : 'bg-gray-700'
@@ -138,6 +139,7 @@ const ModuleWorkspace: React.FC = () => {
           <div className="flex flex-wrap gap-2">
             <button
               onClick={() => setFilter('')}
+              aria-pressed={filter === ''}
               className={`px-2 py-1 text-sm rounded ${
                 filter === '' ? 'bg-blue-600' : 'bg-gray-700'
               }`}
@@ -147,6 +149,7 @@ const ModuleWorkspace: React.FC = () => {
             {tags.map((t) => (
               <button
                 key={t}
+                aria-pressed={filter === t}
                 onClick={() => setFilter(t)}
                 className={`px-2 py-1 text-sm rounded ${
                   filter === t ? 'bg-blue-600' : 'bg-gray-700'

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -74,6 +74,6 @@ html[data-theme='matrix'] {
 }
 
 *:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
+  outline: var(--kali-focus-ring);
   outline-offset: 2px;
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -59,6 +59,7 @@
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;
+  --kali-focus-ring: var(--focus-outline-width) solid var(--focus-outline-color);
 }
 
 /* High contrast theme */


### PR DESCRIPTION
## Summary
- add `--kali-focus-ring` token and global focus outline
- expose calendar popover and update navbar/tray aria attributes
- apply aria-pressed/expanded to menu, workspace, and dock buttons

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: TypeError e.preventDefault is not a function; Unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68c5bca06dc08328a4b1851eb5b55f4c