### PR TITLE
[screen] overhaul booting screen

### DIFF
--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -1,44 +1,81 @@
-import React from 'react'
-import Image from 'next/image'
+import React, { useEffect } from 'react';
+import Image from 'next/image';
 
-function BootingScreen(props) {
+function BootingScreen({ visible, isShutDown, turnOn }) {
+    useEffect(() => {
+        if (!isShutDown) return;
+        const handleTurnOn = () => turnOn();
+        window.addEventListener('keydown', handleTurnOn);
+        window.addEventListener('click', handleTurnOn);
+        return () => {
+            window.removeEventListener('keydown', handleTurnOn);
+            window.removeEventListener('click', handleTurnOn);
+        };
+    }, [isShutDown, turnOn]);
 
     return (
         <div
             style={{
-                ...(props.visible || props.isShutDown ? { zIndex: "100" } : { zIndex: "-20" }),
+                ...(visible || isShutDown ? { zIndex: '100' } : { zIndex: '-20' }),
                 contentVisibility: 'auto',
             }}
-            className={(props.visible || props.isShutDown ? " visible opacity-100" : " invisible opacity-0 ") + " absolute duration-500 select-none flex flex-col justify-around items-center top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen bg-black"}>
+            className={(visible || isShutDown ? 'visible opacity-100' : 'invisible opacity-0') + ' absolute duration-500 select-none flex flex-col justify-around items-center top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen bg-black'}
+        >
             <Image
                 width={400}
                 height={400}
                 className="md:w-1/4 w-1/2"
-                src="/themes/Yaru/status/cof_orange_hex.svg"
-                alt="Ubuntu Logo"
+                src="/themes/Yaru/status/icons8-kali-linux.svg"
+                alt="Kali Dragon"
                 sizes="(max-width: 768px) 50vw, 25vw"
                 priority
             />
-            <div className="w-10 h-10 flex justify-center items-center rounded-full outline-none cursor-pointer" onClick={props.turnOn} >
-                {(props.isShutDown
-                    ? <div className="bg-white rounded-full flex justify-center items-center w-10 h-10 hover:bg-gray-300"><Image width={32} height={32} className="w-8" src="/themes/Yaru/status/power-button.svg" alt="Power Button" sizes="32px" priority/></div>
-                    : <Image width={40} height={40} className={" w-10 " + (props.visible ? " animate-spin " : "")} src="/themes/Yaru/status/process-working-symbolic.svg" alt="Ubuntu Process Symbol" sizes="40px" priority/>)}
+            <div className="w-10 h-10 flex justify-center items-center rounded-full outline-none cursor-pointer" onClick={turnOn}>
+                {isShutDown ? (
+                    <div className="bg-white rounded-full flex justify-center items-center w-10 h-10 hover:bg-gray-300">
+                        <Image
+                            width={32}
+                            height={32}
+                            className="w-8"
+                            src="/themes/Yaru/status/power-button.svg"
+                            alt="Power Button"
+                            sizes="32px"
+                            priority
+                        />
+                    </div>
+                ) : (
+                    <Image
+                        width={40}
+                        height={40}
+                        className={'w-10' + (visible ? ' animate-spin' : '')}
+                        src="/themes/Yaru/status/process-working-symbolic.svg"
+                        alt="Loading Spinner"
+                        sizes="40px"
+                        priority
+                    />
+                )}
             </div>
             <Image
                 width={200}
                 height={100}
                 className="md:w-1/5 w-1/2"
-                src="/themes/Yaru/status/ubuntu_white_hex.svg"
-                alt="Kali Linux Name"
+                src="/images/logos/logo_1200.png"
+                alt="Kali Linux Wordmark"
                 sizes="(max-width: 768px) 50vw, 20vw"
+                priority
             />
             <div className="text-white mb-4">
-                <a className="underline" href="https://www.linkedin.com/in/unnippillil/" rel="noopener noreferrer" target="_blank">linkedin</a>
+                <a className="underline" href="https://www.linkedin.com/in/unnippillil/" rel="noopener noreferrer" target="_blank">
+                    linkedin
+                </a>
                 <span className="font-bold mx-1">|</span>
-                <a href="https://github.com/Alex-Unnippillil" rel="noopener noreferrer" target="_blank" className="underline">github</a>
+                <a href="https://github.com/Alex-Unnippillil" rel="noopener noreferrer" target="_blank" className="underline">
+                    github
+                </a>
             </div>
         </div>
-    )
+    );
 }
 
-export default BootingScreen
+export default BootingScreen;
+


### PR DESCRIPTION
## Summary
- replace boot screen with Kali-themed splash
- attach keyboard/mouse listeners to restart when shut down

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js; Component definition missing display name in utils/createDynamicApp.js)*
- `yarn test` *(fails: Window snapping tests and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c8c3550883288ccb4c68158a2a18