### PR TITLE
[components] adjust boot screen timeout

### DIFF
--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -23,11 +23,11 @@ export default class Ubuntu extends Component {
 		this.getLocalData();
 	}
 
-	setTimeOutBootScreen = () => {
-		setTimeout(() => {
-			this.setState({ booting_screen: false });
-		}, 2000);
-	};
+        setTimeOutBootScreen = () => {
+                setTimeout(() => {
+                        this.setState({ booting_screen: false });
+                }, 2100);
+        };
 
 	getLocalData = () => {
 		// Get Previously selected Background Image


### PR DESCRIPTION
## Summary
- tweak Ubuntu boot screen timeout to 2100ms

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `CI=true yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, ubuntu.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c8c458e48328ad5aefbfd6b6364f