### PR TITLE
[screen] allow skipping boot sequence

### DIFF
--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -1,7 +1,20 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import Image from 'next/image'
 
 function BootingScreen(props) {
+    useEffect(() => {
+        if (props.visible && !props.isShutDown && props.onSkip) {
+            const handleSkip = () => {
+                props.onSkip()
+            }
+            window.addEventListener('keydown', handleSkip)
+            window.addEventListener('click', handleSkip)
+            return () => {
+                window.removeEventListener('keydown', handleSkip)
+                window.removeEventListener('click', handleSkip)
+            }
+        }
+    }, [props.visible, props.isShutDown, props.onSkip])
 
     return (
         <div

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -9,25 +9,29 @@ import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
 
 export default class Ubuntu extends Component {
-	constructor() {
-		super();
-		this.state = {
-			screen_locked: false,
-			bg_image_name: 'wall-2',
-			booting_screen: true,
-			shutDownScreen: false
-		};
-	}
+        constructor() {
+                super();
+                this.state = {
+                        screen_locked: false,
+                        bg_image_name: 'wall-2',
+                        booting_screen: true,
+                        shutDownScreen: false
+                };
+        }
 
 	componentDidMount() {
 		this.getLocalData();
 	}
 
-	setTimeOutBootScreen = () => {
-		setTimeout(() => {
-			this.setState({ booting_screen: false });
-		}, 2000);
-	};
+        setTimeOutBootScreen = () => {
+                setTimeout(() => {
+                        this.setState({ booting_screen: false });
+                }, 2000);
+        };
+
+        skipBootScreen = () => {
+                this.setState({ booting_screen: false });
+        };
 
 	getLocalData = () => {
 		// Get Previously selected Background Image
@@ -121,11 +125,12 @@ export default class Ubuntu extends Component {
 					bgImgName={this.state.bg_image_name}
 					unLockScreen={this.unLockScreen}
 				/>
-				<BootingScreen
-					visible={this.state.booting_screen}
-					isShutDown={this.state.shutDownScreen}
-					turnOn={this.turnOn}
-				/>
+                                <BootingScreen
+                                        visible={this.state.booting_screen}
+                                        isShutDown={this.state.shutDownScreen}
+                                        turnOn={this.turnOn}
+                                        onSkip={this.skipBootScreen}
+                                />
 				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
 				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
 			</div>


### PR DESCRIPTION
## Summary
- allow BootingScreen to take an `onSkip` callback and fire it on any key or click while visible
- wire Ubuntu shell to hide booting screen when skipped

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c8c486f0832889495b2490d2af2f