### PR TITLE
[screen] add boot splash log output

### DIFF
--- a/__tests__/bootingScreen.test.tsx
+++ b/__tests__/bootingScreen.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { render, screen, act } from '@testing-library/react'
+import BootingScreen, { bootLines } from '../components/screen/booting_screen'
+
+describe('BootingScreen', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('reveals boot lines over time when visible', () => {
+    render(<BootingScreen visible={true} isShutDown={false} turnOn={() => {}} />)
+
+    const container = screen.getByTestId('boot-lines')
+    expect(container.textContent).toBe('')
+
+    act(() => {
+      jest.advanceTimersByTime(250)
+    })
+    expect(container.textContent).toBe(bootLines[0])
+
+    act(() => {
+      jest.advanceTimersByTime(250)
+    })
+    expect(container.textContent).toBe(bootLines.slice(0, 2).join('\n'))
+  })
+})
+

--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -1,15 +1,43 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import Image from 'next/image'
 
+export const bootLines = [
+    'Boot sequence initiated…',
+    'Loading kernel modules…',
+    'Mounting file systems…',
+    'Starting services…',
+    'Launching desktop environment…'
+]
+
 function BootingScreen(props) {
+    const [visibleCount, setVisibleCount] = useState(0)
+
+    useEffect(() => {
+        if (props.visible && !props.isShutDown) {
+            setVisibleCount(0)
+            const id = setInterval(() => {
+                setVisibleCount((c) => {
+                    if (c >= bootLines.length) {
+                        clearInterval(id)
+                        return c
+                    }
+                    return c + 1
+                })
+            }, 200)
+            return () => clearInterval(id)
+        }
+        setVisibleCount(0)
+        return () => {}
+    }, [props.visible, props.isShutDown])
 
     return (
         <div
             style={{
-                ...(props.visible || props.isShutDown ? { zIndex: "100" } : { zIndex: "-20" }),
+                ...(props.visible || props.isShutDown ? { zIndex: '100' } : { zIndex: '-20' }),
                 contentVisibility: 'auto',
             }}
-            className={(props.visible || props.isShutDown ? " visible opacity-100" : " invisible opacity-0 ") + " absolute duration-500 select-none flex flex-col justify-around items-center top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen bg-black"}>
+            className={(props.visible || props.isShutDown ? ' visible opacity-100' : ' invisible opacity-0') + ' absolute duration-500 select-none flex flex-col justify-around items-center top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen bg-black'}
+        >
             <Image
                 width={400}
                 height={400}
@@ -20,9 +48,11 @@ function BootingScreen(props) {
                 priority
             />
             <div className="w-10 h-10 flex justify-center items-center rounded-full outline-none cursor-pointer" onClick={props.turnOn} >
-                {(props.isShutDown
-                    ? <div className="bg-white rounded-full flex justify-center items-center w-10 h-10 hover:bg-gray-300"><Image width={32} height={32} className="w-8" src="/themes/Yaru/status/power-button.svg" alt="Power Button" sizes="32px" priority/></div>
-                    : <Image width={40} height={40} className={" w-10 " + (props.visible ? " animate-spin " : "")} src="/themes/Yaru/status/process-working-symbolic.svg" alt="Ubuntu Process Symbol" sizes="40px" priority/>)}
+                {(
+                    props.isShutDown
+                        ? <div className="bg-white rounded-full flex justify-center items-center w-10 h-10 hover:bg-gray-300"><Image width={32} height={32} className="w-8" src="/themes/Yaru/status/power-button.svg" alt="Power Button" sizes="32px" priority/></div>
+                        : <Image width={40} height={40} className={' w-10 ' + (props.visible ? ' animate-spin ' : '')} src="/themes/Yaru/status/process-working-symbolic.svg" alt="Ubuntu Process Symbol" sizes="40px" priority/>
+                )}
             </div>
             <Image
                 width={200}
@@ -37,8 +67,15 @@ function BootingScreen(props) {
                 <span className="font-bold mx-1">|</span>
                 <a href="https://github.com/Alex-Unnippillil" rel="noopener noreferrer" target="_blank" className="underline">github</a>
             </div>
+            <div
+                data-testid="boot-lines"
+                className="absolute bottom-0 left-0 m-4 font-mono text-green-400 text-xs whitespace-pre"
+            >
+                {bootLines.slice(0, visibleCount).join('\n')}
+            </div>
         </div>
     )
 }
 
 export default BootingScreen
+


### PR DESCRIPTION
## Summary
- show boot sequence lines during splash screen
- test progressive boot log rendering

## Testing
- `yarn lint` *(fails: public/apps/tetris/main.js no-top-level-window, utils/createDynamicApp.js display name)*
- `npx eslint components/screen/booting_screen.js __tests__/bootingScreen.test.tsx`
- `yarn test` *(fails: nmapNse.test.tsx, Modal.test.tsx)*
- `yarn test __tests__/bootingScreen.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5c8c53e8c8328bcda73cd54804953