### PR TITLE
[api] add session route

### DIFF
--- a/__tests__/session.route.test.ts
+++ b/__tests__/session.route.test.ts
@@ -1,0 +1,51 @@
+const { POST, DELETE } = require('@/src/app/api/session/route');
+
+class MockResponse {
+  status: number;
+  headersMap: Map<string, string>;
+  headers: { get: (name: string) => string | null };
+
+  constructor(_body?: any, init: any = {}) {
+    this.status = init.status ?? 200;
+    this.headersMap = new Map<string, string>();
+    if (init.headers) {
+      for (const [k, v] of Object.entries(init.headers)) {
+        this.headersMap.set(k.toLowerCase(), String(v));
+      }
+    }
+    this.headers = {
+      get: (name: string) => this.headersMap.get(name.toLowerCase()) || null,
+    };
+  }
+}
+
+(global as any).Response = MockResponse as any;
+
+describe('session route', () => {
+  test('rejects empty username or password', async () => {
+    const req = { json: () => Promise.resolve({ username: '', password: '' }) } as any;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  test('sets cookie when credentials provided', async () => {
+    const req = { json: () => Promise.resolve({ username: 'user', password: 'pass' }) } as any;
+    const res = await POST(req);
+    const cookie = res.headers.get('set-cookie') || '';
+
+    expect(res.status).toBe(200);
+    expect(cookie).toContain('portfolio_session=1');
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toContain('Secure');
+    expect(cookie).toContain('Max-Age=28800');
+  });
+
+  test('clears cookie on DELETE', async () => {
+    const res = await DELETE();
+    const cookie = res.headers.get('set-cookie') || '';
+
+    expect(res.status).toBe(200);
+    expect(cookie).toContain('portfolio_session=');
+    expect(cookie).toContain('Max-Age=0');
+  });
+});

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -1,0 +1,37 @@
+const COOKIE_NAME = 'portfolio_session';
+const MAX_AGE_SECONDS = 60 * 60 * 8; // 8 hours
+
+const createCookie = (value: string, maxAge: number) =>
+  `${COOKIE_NAME}=${value}; HttpOnly; Secure; Path=/; Max-Age=${maxAge}`;
+
+export async function POST(request: Request) {
+  const { username, password } = await request.json();
+
+  if (!username || !password) {
+    return new Response(
+      JSON.stringify({ error: 'Username and password required' }),
+      {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  }
+
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Set-Cookie': createCookie('1', MAX_AGE_SECONDS),
+    },
+  });
+}
+
+export async function DELETE() {
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Set-Cookie': createCookie('', 0),
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add API handlers to set and clear `portfolio_session` cookie
- cover session API with basic tests

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: existing window/nmap tests)*
- `yarn test __tests__/session.route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c68739ba0c8328bbbd814e778f65fb