### PR TITLE
[auth] add redirect middleware

### DIFF
--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,0 +1,65 @@
+import type { NextRequest } from 'next/server';
+
+class MockNextResponse {
+  status = 200;
+  headers = new Map<string, string>();
+  static next() {
+    return new MockNextResponse();
+  }
+  static redirect(url: URL) {
+    const res = new MockNextResponse();
+    res.status = 307;
+    res.headers.set('location', url.toString());
+    return res;
+  }
+}
+
+jest.mock('next/server', () => ({
+  NextResponse: MockNextResponse,
+}));
+
+const { middleware } = require('../middleware');
+
+function makeRequest(path: string, cookie?: string): NextRequest {
+  const url = new URL(`http://example.com${path}`);
+  return {
+    nextUrl: {
+      pathname: url.pathname,
+      clone: () => new URL(url.toString()),
+    } as any,
+    cookies: {
+      get: (name: string) => {
+        if (!cookie) return undefined;
+        const [k, v] = cookie.split('=');
+        return k === name ? { value: v } : undefined;
+      },
+    },
+  } as unknown as NextRequest;
+}
+
+describe('middleware authentication redirects', () => {
+  it('redirects unauthenticated users to /login', () => {
+    const req = makeRequest('/dashboard');
+    const res = middleware(req);
+    expect(res.headers.get('location')).toBe('http://example.com/login');
+  });
+
+  it('redirects authenticated users away from /login', () => {
+    const req = makeRequest('/login', 'auth=1');
+    const res = middleware(req);
+    expect(res.headers.get('location')).toBe('http://example.com/');
+  });
+
+  it('allows unauthenticated users to access /login', () => {
+    const req = makeRequest('/login');
+    const res = middleware(req);
+    expect(res.headers.get('location')).toBeUndefined();
+  });
+
+  it('allows authenticated users to access other routes', () => {
+    const req = makeRequest('/dashboard', 'auth=1');
+    const res = middleware(req);
+    expect(res.headers.get('location')).toBeUndefined();
+  });
+});
+

--- a/middleware.ts
+++ b/middleware.ts
@@ -6,7 +6,7 @@ function nonce() {
   return Buffer.from(arr).toString('base64');
 }
 
-export function middleware(req: NextRequest) {
+function withSecurityHeaders(res: NextResponse) {
   const n = nonce();
   const csp = [
     "default-src 'self'",
@@ -19,11 +19,36 @@ export function middleware(req: NextRequest) {
     "frame-ancestors 'self'",
     "object-src 'none'",
     "base-uri 'self'",
-    "form-action 'self'"
+    "form-action 'self'",
   ].join('; ');
 
-  const res = NextResponse.next();
   res.headers.set('x-csp-nonce', n);
   res.headers.set('Content-Security-Policy', csp);
   return res;
 }
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  const isAuthed = Boolean(req.cookies.get('auth'));
+
+  if (!isAuthed && pathname !== '/login') {
+    const url = req.nextUrl.clone();
+    url.pathname = '/login';
+    return withSecurityHeaders(NextResponse.redirect(url));
+  }
+
+  if (isAuthed && pathname === '/login') {
+    const url = req.nextUrl.clone();
+    url.pathname = '/';
+    return withSecurityHeaders(NextResponse.redirect(url));
+  }
+
+  return withSecurityHeaders(NextResponse.next());
+}
+
+export const config = {
+  matcher: [
+    '/((?!api|_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|.*\\..*|health).*)',
+  ],
+};
+


### PR DESCRIPTION
## Summary
- add authentication-aware middleware redirecting users based on login state
- cover redirect scenarios with unit tests

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test __tests__/middleware.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c6873ae3848328846f21557083a873