### PR TITLE
[desktop] add protected sign-out page

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -7,6 +7,10 @@ function nonce() {
 }
 
 export function middleware(req: NextRequest) {
+  if (req.nextUrl.pathname.startsWith('/desktop') && !req.cookies.get('session')) {
+    return NextResponse.redirect(new URL('/', req.url));
+  }
+
   const n = nonce();
   const csp = [
     "default-src 'self'",

--- a/src/app/desktop/page.tsx
+++ b/src/app/desktop/page.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+export default function DesktopPage() {
+  const handleSignOut = async () => {
+    await fetch('/api/session', { method: 'DELETE' });
+    window.location.href = '/';
+  };
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    await handleSignOut();
+  };
+
+  return (
+    <main className="flex flex-col items-center gap-4 p-4">
+      <h1 className="text-xl font-semibold">Welcome to the desktop</h1>
+      <form onSubmit={onSubmit} className="flex flex-col items-center gap-2">
+        <button
+          type="submit"
+          className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
+        >
+          Sign out
+        </button>
+      </form>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add desktop page with sign-out form
- protect `/desktop` via middleware redirect when no session cookie

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn typecheck`
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c6873c6c708328998fe949ab7add77