### PR TITLE
[docs] add vercel import instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,12 @@ Workflow: `.github/workflows/gh-deploy.yml`:
   - `NEXT_PUBLIC_GHIDRA_WASM`
   - `NEXT_PUBLIC_UI_EXPERIMENTS`
 
+### Quick Vercel mock session
+1. Commit and push this repository to your own Git provider (e.g., GitHub).
+2. In the Vercel dashboard, choose **Add New Project** → **Import Git Repository** and select your fork.
+3. Accept the defaults; no environment variables are required for this mock deployment.
+4. After the build completes, visit `/login`, sign in, and ensure you are redirected to `/desktop`.
+
 ### Vercel deployment
 - Create a Vercel project and connect this repo.
 - Required env variables (Project Settings):


### PR DESCRIPTION
## Summary
- document quick Vercel mock session with push/import steps and login verification

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: e.preventDefault is not a function in Window snapping test; Unable to find role="alert" in NmapNSEApp)*

------
https://chatgpt.com/codex/tasks/task_e_68c6873d78fc83289b26100ef9456a96