### PR TITLE
[components] adjust boot screen timeout

### DIFF
--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -23,11 +23,11 @@ export default class Ubuntu extends Component {
 		this.getLocalData();
 	}
 
-	setTimeOutBootScreen = () => {
-		setTimeout(() => {
-			this.setState({ booting_screen: false });
-		}, 2000);
-	};
+        setTimeOutBootScreen = () => {
+                setTimeout(() => {
+                        this.setState({ booting_screen: false });
+                }, 2100);
+        };
 
 	getLocalData = () => {
 		// Get Previously selected Background Image


### PR DESCRIPTION
## Summary
- increase Ubuntu boot screen timeout to 2100ms

## Testing
- `yarn lint` *(fails: many jsx-a11y errors)*
- `yarn test` *(fails: window.snap, nmapNse, ubuntu tests and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c6885f1cb88328999c31aa508de201