### PR TITLE
[screen] allow skipping boot screen

### DIFF
--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -1,7 +1,22 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import Image from 'next/image'
 
 function BootingScreen(props) {
+    useEffect(() => {
+        if (!props.visible || props.isShutDown) return;
+
+        const handleSkip = () => {
+            if (props.onSkip) props.onSkip();
+        };
+
+        window.addEventListener('keydown', handleSkip);
+        window.addEventListener('click', handleSkip);
+
+        return () => {
+            window.removeEventListener('keydown', handleSkip);
+            window.removeEventListener('click', handleSkip);
+        };
+    }, [props.visible, props.isShutDown, props.onSkip]);
 
     return (
         <div

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -23,11 +23,15 @@ export default class Ubuntu extends Component {
 		this.getLocalData();
 	}
 
-	setTimeOutBootScreen = () => {
-		setTimeout(() => {
-			this.setState({ booting_screen: false });
-		}, 2000);
-	};
+        setTimeOutBootScreen = () => {
+                setTimeout(() => {
+                        this.setState({ booting_screen: false });
+                }, 2000);
+        };
+
+        skipBootScreen = () => {
+                this.setState({ booting_screen: false });
+        };
 
 	getLocalData = () => {
 		// Get Previously selected Background Image
@@ -121,11 +125,12 @@ export default class Ubuntu extends Component {
 					bgImgName={this.state.bg_image_name}
 					unLockScreen={this.unLockScreen}
 				/>
-				<BootingScreen
-					visible={this.state.booting_screen}
-					isShutDown={this.state.shutDownScreen}
-					turnOn={this.turnOn}
-				/>
+                                <BootingScreen
+                                        visible={this.state.booting_screen}
+                                        isShutDown={this.state.shutDownScreen}
+                                        turnOn={this.turnOn}
+                                        onSkip={this.skipBootScreen}
+                                />
 				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
 				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
 			</div>


### PR DESCRIPTION
## Summary
- allow BootingScreen to skip when user presses a key or clicks
- provide onSkip handler from Ubuntu component

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: TypeError e.preventDefault is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c6886054f48328a2cfcef1215b05f3