### PR TITLE
[screen] boot sequence lines display

### DIFF
--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -1,7 +1,32 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import Image from 'next/image'
 
+const bootLines = [
+    'Initializing Kali Linux...',
+    'Loading kernel modules...',
+    'Starting services...',
+    'System boot complete.'
+]
+
 function BootingScreen(props) {
+    const [visibleCount, setVisibleCount] = useState(0)
+
+    useEffect(() => {
+        if (!props.visible) {
+            setVisibleCount(0)
+            return
+        }
+        const interval = setInterval(() => {
+            setVisibleCount(count => {
+                if (count >= bootLines.length) {
+                    clearInterval(interval)
+                    return count
+                }
+                return count + 1
+            })
+        }, 400)
+        return () => clearInterval(interval)
+    }, [props.visible])
 
     return (
         <div
@@ -9,7 +34,8 @@ function BootingScreen(props) {
                 ...(props.visible || props.isShutDown ? { zIndex: "100" } : { zIndex: "-20" }),
                 contentVisibility: 'auto',
             }}
-            className={(props.visible || props.isShutDown ? " visible opacity-100" : " invisible opacity-0 ") + " absolute duration-500 select-none flex flex-col justify-around items-center top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen bg-black"}>
+            className={(props.visible || props.isShutDown ? " visible opacity-100" : " invisible opacity-0 ") + " absolute duration-500 select-none flex flex-col justify-around items-center top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen bg-black"}
+>
             <Image
                 width={400}
                 height={400}
@@ -37,6 +63,13 @@ function BootingScreen(props) {
                 <span className="font-bold mx-1">|</span>
                 <a href="https://github.com/Alex-Unnippillil" rel="noopener noreferrer" target="_blank" className="underline">github</a>
             </div>
+            {props.visible && (
+                <div className="absolute bottom-4 left-4 text-green-400 font-mono text-xs space-y-1 text-left">
+                    {bootLines.slice(0, visibleCount).map((line, index) => (
+                        <div key={index}>{line}</div>
+                    ))}
+                </div>
+            )}
         </div>
     )
 }


### PR DESCRIPTION
## Summary
- show simulated boot process lines while splash screen is visible

## Testing
- `yarn lint` *(fails: Unexpected global 'document' errors in public/apps/tetris/main.js)*
- `yarn test` *(fails: window snapping and NmapNSE clipboard tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c68861f2848328acb8bf56efdf559c