### PR TITLE
[config] add headers for PWA assets

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -174,6 +174,24 @@ module.exports = withBundleAnalyzer(
                   },
                 ],
               },
+              {
+                source: '/sw.js',
+                headers: [
+                  {
+                    key: 'Cache-Control',
+                    value: 'public, max-age=0, must-revalidate',
+                  },
+                ],
+              },
+              {
+                source: '/manifest.webmanifest',
+                headers: [
+                  {
+                    key: 'Content-Type',
+                    value: 'application/manifest+json; charset=utf-8',
+                  },
+                ],
+              },
             ];
           },
         }),


### PR DESCRIPTION
## Summary
- add cache-control header for service worker
- declare manifest content-type header

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `CI=true yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c68870f1f48328bc57d30a30594804