### PR TITLE
[ui] add document title badge fallback

### DIFF
--- a/__tests__/notification_center.badge.test.tsx
+++ b/__tests__/notification_center.badge.test.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect } from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import NotificationCenter from '../components/common/NotificationCenter';
+import useNotifications from '../hooks/useNotifications';
+
+describe('NotificationCenter badge fallback', () => {
+  const originalTitle = document.title;
+  const nav: any = navigator;
+  const originalSet = nav.setAppBadge;
+  const originalClear = nav.clearAppBadge;
+
+  beforeEach(() => {
+    document.title = 'Test';
+    delete nav.setAppBadge;
+    delete nav.clearAppBadge;
+  });
+
+  afterEach(() => {
+    document.title = originalTitle;
+    if (originalSet !== undefined) nav.setAppBadge = originalSet;
+    if (originalClear !== undefined) nav.clearAppBadge = originalClear;
+  });
+
+  it('updates document.title when badge API is unavailable', async () => {
+    const TestComponent: React.FC = () => {
+      const { pushNotification, clearNotifications } = useNotifications();
+      useEffect(() => {
+        pushNotification('app', 'hi');
+      }, [pushNotification]);
+      return <button onClick={() => clearNotifications()}>clear</button>;
+    };
+
+    const { getByText } = render(
+      <NotificationCenter>
+        <TestComponent />
+      </NotificationCenter>
+    );
+
+    await waitFor(() => expect(document.title).toBe('(1) Test'));
+    fireEvent.click(getByText('clear'));
+    await waitFor(() => expect(document.title).toBe('Test'));
+  });
+});

--- a/__tests__/side_bar_app.badge.test.js
+++ b/__tests__/side_bar_app.badge.test.js
@@ -1,0 +1,30 @@
+import SideBarApp from '../components/base/side_bar_app';
+
+describe('SideBarApp updateBadge fallback', () => {
+  const originalTitle = document.title;
+  const nav = navigator;
+  const originalSet = nav.setAppBadge;
+  const originalClear = nav.clearAppBadge;
+
+  beforeEach(() => {
+    document.title = 'Test';
+    delete nav.setAppBadge;
+    delete nav.clearAppBadge;
+  });
+
+  afterEach(() => {
+    document.title = originalTitle;
+    if (originalSet !== undefined) nav.setAppBadge = originalSet;
+    if (originalClear !== undefined) nav.clearAppBadge = originalClear;
+  });
+
+  it('prefixes and removes document.title when badge API unavailable', () => {
+    const app = new SideBarApp();
+    app.props = { notifications: [1], tasks: 2 };
+    app.updateBadge();
+    expect(document.title).toBe('(3) Test');
+    app.props = { notifications: [], tasks: [] };
+    app.updateBadge();
+    expect(document.title).toBe('Test');
+  });
+});

--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -28,7 +28,6 @@ export class SideBarApp extends Component {
         if (typeof navigator === 'undefined') return;
         const hasSet = 'setAppBadge' in navigator;
         const hasClear = 'clearAppBadge' in navigator;
-        if (!hasSet && !hasClear) return;
 
         const notifications = Array.isArray(this.props.notifications)
             ? this.props.notifications.length
@@ -38,10 +37,24 @@ export class SideBarApp extends Component {
             : (typeof this.props.tasks === 'number' ? this.props.tasks : 0);
         const count = notifications + tasks;
 
-        if (count > 0 && hasSet) {
-            navigator.setAppBadge(count).catch(() => {});
-        } else if (hasClear) {
-            navigator.clearAppBadge().catch(() => {});
+        const cleanTitle = () => {
+            if (typeof document !== 'undefined') {
+                document.title = document.title.replace(/^\(\d+\)\s*/, '');
+            }
+        };
+
+        if (hasSet || hasClear) {
+            if (count > 0 && hasSet) {
+                navigator.setAppBadge(count).catch(() => {});
+            } else if (hasClear) {
+                navigator.clearAppBadge().catch(() => {});
+            }
+            cleanTitle();
+        } else {
+            cleanTitle();
+            if (count > 0 && typeof document !== 'undefined') {
+                document.title = `(${count}) ${document.title}`;
+            }
         }
     };
 

--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -50,10 +50,25 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
   );
 
   useEffect(() => {
-    const nav: any = navigator;
-    if (nav && nav.setAppBadge) {
-      if (totalCount > 0) nav.setAppBadge(totalCount).catch(() => {});
-      else nav.clearAppBadge?.().catch(() => {});
+    const nav: any = typeof navigator === 'undefined' ? null : navigator;
+    const hasSet = !!nav?.setAppBadge;
+    const hasClear = !!nav?.clearAppBadge;
+
+    const cleanTitle = () => {
+      if (typeof document !== 'undefined') {
+        document.title = document.title.replace(/^\(\d+\)\s*/, '');
+      }
+    };
+
+    if (hasSet || hasClear) {
+      if (totalCount > 0 && hasSet) nav.setAppBadge(totalCount).catch(() => {});
+      else if (hasClear) nav.clearAppBadge().catch(() => {});
+      cleanTitle();
+    } else if (typeof document !== 'undefined') {
+      cleanTitle();
+      if (totalCount > 0) {
+        document.title = `(${totalCount}) ${document.title}`;
+      }
     }
   }, [totalCount]);
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import noTopLevelWindow from './eslint-plugin-no-top-level-window/index.js';
 const compat = new FlatCompat();
 
 const config = [
-  { ignores: ['components/apps/Chrome/index.tsx'] },
+  { ignores: ['components/apps/Chrome/index.tsx', 'public/apps/**'] },
   {
     plugins: {
       'no-top-level-window': noTopLevelWindow,

--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -13,20 +13,25 @@ export const createDynamicApp = (id, title) =>
         return mod.default;
       } catch (err) {
         console.error(`Failed to load ${title}`, err);
-        return () => (
-          <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
-            {`Unable to load ${title}`}
-          </div>
-        );
+        function FallbackComponent() {
+          return (
+            <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+              {`Unable to load ${title}`}
+            </div>
+          );
+        }
+        return FallbackComponent;
       }
     },
     {
       ssr: false,
-      loading: () => (
-        <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
-          {`Loading ${title}...`}
-        </div>
-      ),
+      loading: function LoadingComponent() {
+        return (
+          <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+            {`Loading ${title}...`}
+          </div>
+        );
+      },
     }
   );
 


### PR DESCRIPTION
## Summary
- fallback to document title when app badge APIs are missing
- support same fallback in notification center
- add tests for badge fallbacks and tweak lint setup

## Testing
- `yarn lint` *(fails: A control must be associated with a text label in multiple pages)*
- `yarn test` *(fails: e.preventDefault is not a function, Unable to find role="alert", Cannot read properties of null)*
- `yarn test __tests__/notification_center.badge.test.tsx __tests__/side_bar_app.badge.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6887512e88328a0e4a7a3de0233e8