### PR TITLE
[api] handle share uploads

### DIFF
--- a/pages/api/share.js
+++ b/pages/api/share.js
@@ -1,14 +1,27 @@
-export default function handler(req, res) {
+export const config = {
+  runtime: 'edge',
+};
+
+export default async function handler(req) {
   if (req.method !== 'POST') {
-    res.status(405).end();
-    return;
+    return new Response(null, { status: 405 });
   }
 
-  const { text, url, title } = req.body || {};
-  const content = text || url || title || '';
-  const params = new URLSearchParams();
-  if (content) {
-    params.set('text', content);
-  }
-  res.redirect(307, `/apps/sticky_notes/?${params.toString()}`);
+  const formData = await req.formData();
+  const title = formData.get('title')?.toString() || '';
+  const text = formData.get('text')?.toString() || '';
+  const url = formData.get('url')?.toString() || '';
+  const files = formData.getAll('files');
+
+  console.log('Received share', {
+    title,
+    text,
+    url,
+    files: files.map((f) => (typeof f === 'object' && 'name' in f ? f.name : String(f))),
+  });
+
+  return new Response(null, {
+    status: 302,
+    headers: { Location: '/inbox' },
+  });
 }


### PR DESCRIPTION
## Summary
- refactor share endpoint to Edge runtime with formData parsing

## Testing
- `yarn lint` *(fails: A control must be associated with a text label, etc.)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c688769f508328adcc1719d06e5e57