### PR TITLE
[pwa] add protocol handler

### DIFF
--- a/components/common/ServiceWorkerProvider.tsx
+++ b/components/common/ServiceWorkerProvider.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { ReactNode, useEffect } from 'react';
+
+interface ServiceWorkerProviderProps {
+  children: ReactNode;
+}
+
+export default function ServiceWorkerProvider({ children }: ServiceWorkerProviderProps) {
+  useEffect(() => {
+    if (typeof navigator !== 'undefined' && navigator.registerProtocolHandler) {
+      try {
+        navigator.registerProtocolHandler('web+foo', '/protocol?url=%s');
+      } catch (err) {
+        console.error('Protocol handler registration failed', err);
+      }
+    }
+  }, []);
+
+  return <>{children}</>;
+}
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import ServiceWorkerProvider from '../components/common/ServiceWorkerProvider';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -148,32 +149,34 @@ function MyApp(props) {
 
   return (
     <ErrorBoundary>
-      <Script src="/a2hs.js" strategy="beforeInteractive" />
-      <div className={ubuntu.className}>
-        <a
-          href="#app-grid"
-          className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
-        >
-          Skip to app grid
-        </a>
-        <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+      <ServiceWorkerProvider>
+        <Script src="/a2hs.js" strategy="beforeInteractive" />
+        <div className={ubuntu.className}>
+          <a
+            href="#app-grid"
+            className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
+          >
+            Skip to app grid
+          </a>
+          <SettingsProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
-        </SettingsProvider>
-      </div>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </SettingsProvider>
+        </div>
+      </ServiceWorkerProvider>
     </ErrorBoundary>
 
 

--- a/pages/protocol.tsx
+++ b/pages/protocol.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+export default function ProtocolHandler() {
+  const router = useRouter();
+  const { url } = router.query;
+  const [decoded, setDecoded] = useState<string>('');
+
+  useEffect(() => {
+    if (typeof url !== 'string') return;
+    const decodedUrl = decodeURIComponent(url);
+    setDecoded(decodedUrl);
+    if (decodedUrl.startsWith('/')) {
+      router.replace(decodedUrl);
+    }
+  }, [url, router]);
+
+  if (!decoded) return null;
+
+  if (decoded.startsWith('/')) {
+    return null;
+  }
+
+  return (
+    <div className="p-4">
+      <p>
+        <a href={decoded}>{decoded}</a>
+      </p>
+    </div>
+  );
+}
+

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -50,5 +50,11 @@
       "short_name": "2048",
       "url": "/?open=2048&daily=true"
     }
+  ],
+  "protocol_handlers": [
+    {
+      "protocol": "web+foo",
+      "url": "/protocol?url=%s"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- add `web+foo` custom protocol handler to web manifest
- register protocol handler at runtime
- handle `web+foo:` deep links via new `/protocol` page

## Testing
- `yarn lint` (fails: Unexpected global 'document' in public/apps/tetris/main.js)
- `yarn test` (fails: `window.test.tsx`, `nmapNse.test.tsx`, `Modal.test.tsx`)


------
https://chatgpt.com/codex/tasks/task_e_68c68878ea048328956ce186286bf40a