### PR TITLE
[components] add scroll-driven DeviceSequence

### DIFF
--- a/__tests__/deviceSequence.test.tsx
+++ b/__tests__/deviceSequence.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import DeviceSequence from '../components/DeviceSequence';
+
+// Simplify next/image for the test environment
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img {...props} />;
+  },
+}));
+
+describe('DeviceSequence', () => {
+  it('renders static frame when prefers-reduced-motion', () => {
+    // mock matchMedia to prefer reduced motion
+    // @ts-ignore
+    window.matchMedia = () => ({
+      matches: true,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+    });
+
+    render(<DeviceSequence frames={['/a.png', '/b.png']} alt="demo" />);
+    const img = screen.getByAltText('demo') as HTMLImageElement;
+    expect(img.getAttribute('src')).toContain('/a.png');
+  });
+});
+

--- a/components/DeviceSequence.tsx
+++ b/components/DeviceSequence.tsx
@@ -1,0 +1,105 @@
+import { useRef, useEffect } from 'react';
+import Image from 'next/image';
+import { motion, useScroll, useTransform, useMotionValue, useReducedMotion } from 'framer-motion';
+import PropTypes from 'prop-types';
+
+export interface DeviceSequenceProps {
+  /**
+   * Array of image frame URLs. In MDX, supply via front matter:
+   *
+   * ```mdx
+   * ---
+   * frames:
+   *   - /images/frame1.png
+   *   - /images/frame2.png
+   * ---
+   *
+   * <DeviceSequence frames={frontMatter.frames} alt="demo" />
+   * ```
+   */
+  frames: string[];
+  /** Alt text applied to each frame */
+  alt: string;
+  /** Optional className applied to wrapper */
+  className?: string;
+}
+
+/**
+ * Renders a scroll-driven image sequence using the native ScrollTimeline API
+ * when available, with a Framer Motion fallback. Users with
+ * `prefers-reduced-motion` receive the first frame only.
+ */
+const DeviceSequence: React.FC<DeviceSequenceProps> = ({ frames, alt, className }) => {
+  const prefersReduced = useReducedMotion();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { scrollYProgress } = useScroll({ target: containerRef });
+  const frameIndex = useTransform(scrollYProgress, [0, 1], [0, frames.length - 1]);
+  const currentFrame = useMotionValue(frames[0]);
+
+  useEffect(() => {
+    return frameIndex.on('change', (v) => {
+      const idx = Math.round(v);
+      currentFrame.set(frames[idx] || frames[0]);
+    });
+  }, [frameIndex, frames, currentFrame]);
+
+  const supportsScrollTimeline =
+    typeof window !== 'undefined' &&
+    typeof window.CSS !== 'undefined' &&
+    typeof window.CSS.supports === 'function' &&
+    window.CSS.supports('animation-timeline: scroll()');
+
+  if (prefersReduced || frames.length === 0) {
+    return (
+      <Image src={frames[0]} alt={alt} width={800} height={600} className={className} />
+    );
+  }
+
+  if (supportsScrollTimeline) {
+    return (
+      <div
+        className={className ? `relative ${className}` : 'relative'}
+        style={{ viewTimelineName: '--device-seq', viewTimelineAxis: 'block' }}
+      >
+        {frames.map((src, i) => (
+          <Image
+            key={i}
+            src={src}
+            alt={alt}
+            fill
+            sizes="100vw"
+            className="absolute inset-0 object-contain opacity-0"
+            style={{
+              animationName: 'ds-reveal',
+              animationTimingFunction: `steps(${frames.length})`,
+              animationDuration: '1s',
+              animationFillMode: 'both',
+              animationTimeline: '--device-seq',
+              animationDelay: `-${i / frames.length}s`,
+            }}
+          />
+        ))}
+        <style jsx>{`
+          @keyframes ds-reveal {
+            to { opacity: 1; }
+          }
+        `}</style>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className={className}>
+      <motion.img src={currentFrame.get()} alt={alt} className="w-full h-auto" />
+    </div>
+  );
+};
+
+DeviceSequence.propTypes = {
+  frames: PropTypes.arrayOf(PropTypes.string).isRequired,
+  alt: PropTypes.string.isRequired,
+  className: PropTypes.string,
+};
+
+export default DeviceSequence;
+

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "dompurify": "^3.2.6",
     "fast-xml-parser": "^4.3.5",
     "figlet": "^1.8.2",
+    "framer-motion": "^11.0.0",
     "hash-wasm": "^4.12.0",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7539,6 +7539,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"framer-motion@npm:^11.0.0":
+  version: 11.18.2
+  resolution: "framer-motion@npm:11.18.2"
+  dependencies:
+    motion-dom: "npm:^11.18.1"
+    motion-utils: "npm:^11.18.1"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    "@emotion/is-prop-valid": "*"
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/is-prop-valid":
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 10c0/41b1ef1b4e54ea13adaf01d61812a8783d2352f74641c91b50519775704bc6274db6b6863ff494a1f705fa6c6ed8f4df3497292327c906d53ea0129cef3ec361
+  languageName: node
+  linkType: hard
+
 "fresh@npm:^0.5.2":
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
@@ -10039,6 +10061,22 @@ __metadata:
   version: 0.52.2
   resolution: "monaco-editor@npm:0.52.2"
   checksum: 10c0/5a92da64f1e2ab375c0ce99364137f794d057c97bed10ecc65a08d6e6846804b8ecbd377eacf01e498f7dfbe1b21e8be64f728256681448f0484df90e767b435
+  languageName: node
+  linkType: hard
+
+"motion-dom@npm:^11.18.1":
+  version: 11.18.1
+  resolution: "motion-dom@npm:11.18.1"
+  dependencies:
+    motion-utils: "npm:^11.18.1"
+  checksum: 10c0/98378bdf9d77870829cdf3624c5eff02e48cfa820dfc74450364d7421884700048d60e277bfbf477df33270fbae4c1980e5914586f5b6dff28d4921fdca8ac47
+  languageName: node
+  linkType: hard
+
+"motion-utils@npm:^11.18.1":
+  version: 11.18.1
+  resolution: "motion-utils@npm:11.18.1"
+  checksum: 10c0/dac083bdeb6e433a277ac4362211b0fdce59ff09d6f7897f0f49d1e3561209c6481f676876daf99a33485054bc7e4b1d1b8d1de16f7b1e5c6f117fe76358ca00
   languageName: node
   linkType: hard
 
@@ -13911,6 +13949,7 @@ __metadata:
     fast-glob: "npm:^3.3.3"
     fast-xml-parser: "npm:^4.3.5"
     figlet: "npm:^1.8.2"
+    framer-motion: "npm:^11.0.0"
     hash-wasm: "npm:^4.12.0"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"


### PR DESCRIPTION
## Summary
- add DeviceSequence component driven by ScrollTimeline with framer-motion fallback
- consume frames from MDX front matter and respect prefers-reduced-motion
- cover reduced-motion behaviour with a unit test

## Testing
- ⚠️ `yarn lint` (fails: Unexpected global 'document')
- ✅ `yarn test __tests__/deviceSequence.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c693dcc5e4832894d7a5ba89b1bc17