### PR TITLE
[apps] add Kasm launch API and Kali desktop app

### DIFF
--- a/__tests__/api/kasm-launch.test.ts
+++ b/__tests__/api/kasm-launch.test.ts
@@ -1,0 +1,47 @@
+import handler from '../../pages/api/kasm/launch';
+import { createMocks } from 'node-mocks-http';
+
+describe('kasm launch api', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+    delete (global as any).fetch;
+    delete process.env.KASM_URL;
+    delete process.env.KASM_USERNAME;
+    delete process.env.KASM_PASSWORD;
+    delete process.env.KASM_IMAGE_ID;
+  });
+
+  test('returns session url', async () => {
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ token: 'abc' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ url: 'https://kasm/session' }),
+      });
+
+    process.env.KASM_URL = 'https://kasm.test';
+    process.env.KASM_USERNAME = 'user';
+    process.env.KASM_PASSWORD = 'pass';
+    process.env.KASM_IMAGE_ID = '123';
+
+    const { req, res } = createMocks({ method: 'POST' });
+    await handler(req as any, res as any);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ url: 'https://kasm/session' });
+    expect((global as any).fetch).toHaveBeenNthCalledWith(
+      1,
+      'https://kasm.test/api/login',
+      expect.any(Object),
+    );
+    expect((global as any).fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://kasm.test/api/create-session',
+      expect.any(Object),
+    );
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -113,6 +113,14 @@ const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
 const HtmlRewriteApp = createDynamicApp('html-rewriter', 'HTML Rewriter');
 const ContactApp = createDynamicApp('contact', 'Contact');
 
+const KaliDesktopApp = () => (
+  <iframe
+    src="/apps/kali-desktop"
+    title="Kali Desktop"
+    className="h-full w-full"
+  />
+);
+
 
 
 const displayTerminal = createDisplay(TerminalApp);
@@ -176,6 +184,7 @@ const displayBleSensor = createDisplay(BleSensorApp);
 const displayBeef = createDisplay(BeefApp);
 const displayMetasploit = createDisplay(MetasploitApp);
 const displayDsniff = createDisplay(DsniffApp);
+const displayKaliDesktop = createDisplay(KaliDesktopApp);
 const displayGomoku = createDisplay(GomokuApp);
 const displayPinball = createDisplay(PinballApp);
 const displayVolatility = createDisplay(VolatilityApp);
@@ -1050,6 +1059,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displaySecurityTools,
+  },
+  {
+    id: 'kali-desktop',
+    title: 'Kali Desktop',
+    icon: '/themes/Yaru/status/icons8-kali-linux.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayKaliDesktop,
   },
   // Utilities are grouped separately
   ...utilities,

--- a/pages/api/kasm/launch.ts
+++ b/pages/api/kasm/launch.ts
@@ -1,0 +1,57 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface LaunchResponse {
+  url: string;
+}
+
+interface ErrorResponse {
+  error: string;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<LaunchResponse | ErrorResponse>,
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { KASM_URL, KASM_USERNAME, KASM_PASSWORD, KASM_IMAGE_ID } = process.env;
+  if (!KASM_URL || !KASM_USERNAME || !KASM_PASSWORD || !KASM_IMAGE_ID) {
+    return res.status(500).json({ error: 'Kasm is not configured' });
+  }
+
+  try {
+    const loginRes = await fetch(`${KASM_URL}/api/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: KASM_USERNAME, password: KASM_PASSWORD }),
+    });
+    if (!loginRes.ok) {
+      throw new Error('login failed');
+    }
+    const { token } = await loginRes.json();
+
+    const sessionRes = await fetch(`${KASM_URL}/api/create-session`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ image_id: KASM_IMAGE_ID }),
+    });
+    if (!sessionRes.ok) {
+      throw new Error('session failed');
+    }
+    const data = await sessionRes.json();
+    const url = data.session_url || data.url;
+    if (!url) {
+      throw new Error('no url');
+    }
+
+    return res.status(200).json({ url });
+  } catch (err) {
+    return res.status(500).json({ error: 'Failed to launch Kasm session' });
+  }
+}

--- a/pages/apps/kali-desktop.tsx
+++ b/pages/apps/kali-desktop.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+const KaliDesktopPage = () => {
+  useEffect(() => {
+    let active = true;
+    fetch('/api/kasm/launch', { method: 'POST' })
+      .then((res) => res.json())
+      .then((data) => {
+        if (active && data?.url) {
+          window.location.href = data.url;
+        }
+      })
+      .catch(() => {
+        // ignore errors
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <div className="flex h-screen w-screen items-center justify-center bg-black text-white">
+      Launching Kali Desktop...
+    </div>
+  );
+};
+
+export default KaliDesktopPage;


### PR DESCRIPTION
## Summary
- add Kasm launch API that authenticates and starts a session
- add Kali Desktop app page that redirects to Kasm session
- register Kali Desktop app in app config and add API tests

## Testing
- `yarn lint` (fails: Unexpected global 'document' in public/apps/tetris/main.js)
- `yarn test` (fails: window.test.tsx, nmapNse.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68c6939a4c908328848466d192104d37