### PR TITLE
[apps] add Kali container launcher

### DIFF
--- a/__tests__/api/kali-container-start.test.ts
+++ b/__tests__/api/kali-container-start.test.ts
@@ -1,0 +1,49 @@
+// @jest-environment node
+import util from 'util';
+
+describe('kali-container start API', () => {
+  beforeEach(() => {
+    process.env.FEATURE_TOOL_APIS = 'enabled';
+  });
+  afterEach(() => {
+    jest.resetModules();
+    jest.dontMock('child_process');
+    delete process.env.FEATURE_TOOL_APIS;
+  });
+
+  it('runs docker with provided tag and flags', async () => {
+    const execFileMock = jest.fn((cmd: string, args: string[], cb: any) => {
+      cb(null, '123456', '');
+    });
+    execFileMock[util.promisify.custom] = (...args: any[]) => {
+      return new Promise((resolve, reject) => {
+        execFileMock(...(args as any), (err: any, stdout: string, stderr: string) => {
+          if (err) reject(err);
+          else resolve({ stdout, stderr });
+        });
+      });
+    };
+    jest.doMock('child_process', () => ({ execFile: execFileMock }));
+
+    const handler = (await import('../../pages/api/kali-container/start')).default;
+    const req: any = { method: 'POST', body: { tag: 'latest', flags: '--rm -d' } };
+    const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await handler(req, res);
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      'docker',
+      ['run', '--rm', '-d', 'kalilinux/kali-rolling:latest'],
+      expect.any(Function),
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('rejects invalid tags', async () => {
+    const handler = (await import('../../pages/api/kali-container/start')).default;
+    const req: any = { method: 'POST', body: { tag: 'bad tag', flags: '' } };
+    const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -112,6 +112,10 @@ const SSHApp = createDynamicApp('ssh', 'SSH Command Builder');
 const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
 const HtmlRewriteApp = createDynamicApp('html-rewriter', 'HTML Rewriter');
 const ContactApp = createDynamicApp('contact', 'Contact');
+const KaliContainerApp = createDynamicApp(
+  'kali-container',
+  'Kali Container',
+);
 
 
 
@@ -197,6 +201,8 @@ const displaySSH = createDisplay(SSHApp);
 const displayHTTP = createDisplay(HTTPApp);
 const displayHtmlRewrite = createDisplay(HtmlRewriteApp);
 const displayContact = createDisplay(ContactApp);
+
+const displayKaliContainer = createDisplay(KaliContainerApp);
 
 const displayHashcat = createDisplay(HashcatApp);
 
@@ -1041,6 +1047,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayReconNG,
+  },
+  {
+    id: 'kali-container',
+    title: 'Kali Container',
+    icon: '/themes/Yaru/apps/bash.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayKaliContainer,
   },
   {
     id: 'security-tools',

--- a/pages/api/kali-container/start.ts
+++ b/pages/api/kali-container/start.ts
@@ -1,0 +1,51 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+const tagRegex = /^[a-zA-Z0-9._-]+$/;
+const flagRegex = /^-{1,2}[a-zA-Z0-9][a-zA-Z0-9-]*(=.*)?$/;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
+    res.status(501).json({ error: 'Not implemented' });
+    return;
+  }
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { tag = 'latest', flags = '' } = req.body || {};
+  if (typeof tag !== 'string' || !tagRegex.test(tag)) {
+    res.status(400).json({ error: 'Invalid tag' });
+    return;
+  }
+
+  const parsedFlags =
+    typeof flags === 'string'
+      ? flags
+          .trim()
+          .split(/\s+/)
+          .filter(Boolean)
+      : [];
+  for (const f of parsedFlags) {
+    if (!flagRegex.test(f)) {
+      res.status(400).json({ error: 'Invalid flag' });
+      return;
+    }
+  }
+
+  const args = ['run', ...parsedFlags, `kalilinux/kali-rolling:${tag}`];
+  try {
+    const { stdout } = await execFileAsync('docker', args);
+    res.status(200).json({ id: stdout.toString().trim() });
+  } catch (error: any) {
+    const msg = error.stderr?.toString() || error.message;
+    res.status(500).json({ error: msg });
+  }
+}

--- a/pages/apps/kali-container.tsx
+++ b/pages/apps/kali-container.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+
+const TAGS = ['latest', 'rolling', 'weekly'];
+
+export default function KaliContainerPage() {
+  const [tag, setTag] = useState<string>('latest');
+  const [flags, setFlags] = useState<string>('');
+  const [result, setResult] = useState<string>('');
+
+  const startContainer = async () => {
+    setResult('');
+    try {
+      const res = await fetch('/api/kali-container/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tag, flags }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setResult(data.id || 'started');
+      } else {
+        setResult(data.error || 'error');
+      }
+    } catch (err: any) {
+      setResult(err.message);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div>
+        <label htmlFor="kali-tag" className="block text-sm font-medium mb-1">
+          Tag
+        </label>
+        <select
+          id="kali-tag"
+          value={tag}
+          onChange={(e) => setTag(e.target.value)}
+          className="border rounded px-2 py-1 w-full"
+        >
+          {TAGS.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label
+          htmlFor="kali-flags"
+          className="block text-sm font-medium mb-1"
+        >
+          Runtime Flags
+        </label>
+        <input
+          id="kali-flags"
+          type="text"
+          value={flags}
+          onChange={(e) => setFlags(e.target.value)}
+          placeholder="--rm -it"
+          aria-label="Runtime Flags"
+          className="border rounded px-2 py-1 w-full"
+        />
+      </div>
+      <button
+        onClick={startContainer}
+        className="bg-blue-600 text-white px-4 py-2 rounded"
+      >
+        Start
+      </button>
+      {result && (
+        <pre className="mt-4 bg-gray-100 p-2 rounded text-xs whitespace-pre-wrap">
+          {result}
+        </pre>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Kali container page with tag selection and runtime flags
- start kalilinux/kali-rolling containers through new API route
- register Kali Container app and tests

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: TypeError: e.preventDefault is not a function)*
- `yarn test __tests__/api/kali-container-start.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c69399529483289bbb64d98c6d3337