### PR TITLE
[apps] add kali builder form

### DIFF
--- a/__tests__/apps/kali-builder.test.tsx
+++ b/__tests__/apps/kali-builder.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import KaliBuilder from '../../components/apps/kali-builder';
+
+describe('Kali Builder form', () => {
+  test('requires base image', () => {
+    render(<KaliBuilder />);
+    fireEvent.click(screen.getByText(/build/i));
+    expect(screen.getByText(/base image is required/i)).toBeInTheDocument();
+  });
+
+  test('requires at least one metapackage', () => {
+    render(<KaliBuilder />);
+    fireEvent.change(screen.getByLabelText(/base image/i), {
+      target: { value: 'kali-rolling' },
+    });
+    fireEvent.click(screen.getByText(/build/i));
+    expect(
+      screen.getByText(/select at least one metapackage/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -112,6 +112,7 @@ const SSHApp = createDynamicApp('ssh', 'SSH Command Builder');
 const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
 const HtmlRewriteApp = createDynamicApp('html-rewriter', 'HTML Rewriter');
 const ContactApp = createDynamicApp('contact', 'Contact');
+const KaliBuilderApp = createDynamicApp('kali-builder', 'Kali Builder');
 
 
 
@@ -197,6 +198,7 @@ const displaySSH = createDisplay(SSHApp);
 const displayHTTP = createDisplay(HTTPApp);
 const displayHtmlRewrite = createDisplay(HtmlRewriteApp);
 const displayContact = createDisplay(ContactApp);
+const displayKaliBuilder = createDisplay(KaliBuilderApp);
 
 const displayHashcat = createDisplay(HashcatApp);
 
@@ -915,6 +917,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayContact,
+  },
+  {
+    id: 'kali-builder',
+    title: 'Kali Builder',
+    icon: '/themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayKaliBuilder,
   },
   {
     id: 'hydra',

--- a/apps/kali-builder/index.tsx
+++ b/apps/kali-builder/index.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+import KaliBuilder from '../../components/apps/kali-builder';
+
+export default KaliBuilder;

--- a/components/apps/kali-builder.tsx
+++ b/components/apps/kali-builder.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import React, { useState } from 'react';
+import presets from '../../data/kali-presets.json';
+
+interface Preset {
+  name: string;
+  baseImage: string;
+  metapackages: string[];
+  kernel?: boolean;
+  persistence?: boolean;
+}
+
+const METAPACKAGES = ['default', 'top10', 'forensic', 'wireless'];
+
+const KaliBuilder: React.FC = () => {
+  const [baseImage, setBaseImage] = useState('');
+  const [packages, setPackages] = useState<string[]>([]);
+  const [kernel, setKernel] = useState(false);
+  const [persistence, setPersistence] = useState(false);
+  const [errors, setErrors] = useState<{ baseImage?: string; packages?: string }>({});
+
+  const applyPreset = (presetName: string) => {
+    const preset = (presets as Preset[]).find((p) => p.name === presetName);
+    if (preset) {
+      setBaseImage(preset.baseImage);
+      setPackages(preset.metapackages);
+      setKernel(!!preset.kernel);
+      setPersistence(!!preset.persistence);
+    }
+  };
+
+  const togglePackage = (pkg: string) => {
+    setPackages((prev) =>
+      prev.includes(pkg) ? prev.filter((p) => p !== pkg) : [...prev, pkg]
+    );
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const newErrors: { baseImage?: string; packages?: string } = {};
+    if (!baseImage) newErrors.baseImage = 'Base image is required';
+    if (packages.length === 0)
+      newErrors.packages = 'Select at least one metapackage';
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length === 0) {
+      // Placeholder build action
+      console.log({ baseImage, packages, kernel, persistence });
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 space-y-4 text-black">
+      <div>
+        <label className="block" htmlFor="preset-select">
+          Preset
+        </label>
+        <select
+          id="preset-select"
+          className="w-full border p-1"
+          defaultValue=""
+          onChange={(e) => applyPreset(e.target.value)}
+        >
+          <option value="">Custom</option>
+          {(presets as Preset[]).map((p) => (
+            <option key={p.name} value={p.name}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="block" htmlFor="base-image">
+          Base Image
+        </label>
+        <select
+          id="base-image"
+          value={baseImage}
+          onChange={(e) => setBaseImage(e.target.value)}
+          className="w-full border p-1"
+        >
+          <option value="">Select</option>
+          <option value="kali-rolling">kali-rolling</option>
+          <option value="kali-last-snapshot">kali-last-snapshot</option>
+        </select>
+        {errors.baseImage && (
+          <p role="alert" className="text-red-600">
+            {errors.baseImage}
+          </p>
+        )}
+      </div>
+      <fieldset>
+        <legend className="font-medium">Metapackages</legend>
+        {METAPACKAGES.map((pkg) => (
+          <label key={pkg} className="block">
+            <input
+              type="checkbox"
+              aria-label={pkg}
+              checked={packages.includes(pkg)}
+              onChange={() => togglePackage(pkg)}
+            />{' '}
+            {pkg}
+          </label>
+        ))}
+        {errors.packages && (
+          <p role="alert" className="text-red-600">
+            {errors.packages}
+          </p>
+        )}
+      </fieldset>
+      <label className="block">
+        <input
+          type="checkbox"
+          aria-label="Custom kernel"
+          checked={kernel}
+          onChange={(e) => setKernel(e.target.checked)}
+        />{' '}
+        Custom kernel
+      </label>
+      <label className="block">
+        <input
+          type="checkbox"
+          aria-label="Enable persistence"
+          checked={persistence}
+          onChange={(e) => setPersistence(e.target.checked)}
+        />{' '}
+        Enable persistence
+      </label>
+      <button
+        type="submit"
+        className="bg-blue-600 text-white px-3 py-1 rounded"
+      >
+        Build
+      </button>
+    </form>
+  );
+};
+
+export default KaliBuilder;

--- a/data/kali-presets.json
+++ b/data/kali-presets.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "Default",
+    "baseImage": "kali-rolling",
+    "metapackages": ["default"],
+    "kernel": false,
+    "persistence": false
+  },
+  {
+    "name": "Forensics",
+    "baseImage": "kali-rolling",
+    "metapackages": ["top10", "forensic"],
+    "kernel": true,
+    "persistence": false
+  },
+  {
+    "name": "Persistent",
+    "baseImage": "kali-last-snapshot",
+    "metapackages": ["default"],
+    "kernel": false,
+    "persistence": true
+  }
+]

--- a/pages/apps/kali-builder.tsx
+++ b/pages/apps/kali-builder.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const KaliBuilder = dynamic(() => import('../../apps/kali-builder'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function KaliBuilderPage() {
+  return <KaliBuilder />;
+}


### PR DESCRIPTION
## Summary
- add Kali Builder app with presets and kernel/persistence flags
- load canonical presets from data file
- cover form validation with tests

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `npx eslint components/apps/kali-builder.tsx pages/apps/kali-builder.tsx apps/kali-builder/index.tsx apps.config.js __tests__/apps/kali-builder.test.tsx`
- `yarn test __tests__/apps/kali-builder.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c69393ec4483289523a0c393ea3787