### PR TITLE
[feat] add window controls overlay titlebar

### DIFF
--- a/app/components/Titlebar.tsx
+++ b/app/components/Titlebar.tsx
@@ -1,0 +1,13 @@
+import type { FC } from 'react';
+
+const Titlebar: FC = () => (
+  <div
+    className="h-8 w-full"
+    style={{
+      WebkitAppRegion: 'drag',
+      paddingLeft: 'env(titlebar-area-x)'
+    }}
+  />
+);
+
+export default Titlebar;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useState, type ReactNode } from 'react';
+import Titlebar from './components/Titlebar';
+import '../styles/globals.css';
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function RootLayout({ children }: Props) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const overlay = (navigator as any).windowControlsOverlay;
+    const update = () => setVisible(Boolean(overlay?.visible));
+    update();
+    overlay?.addEventListener('geometrychange', update);
+    return () => overlay?.removeEventListener('geometrychange', update);
+  }, []);
+
+  return (
+    <html lang="en">
+      <body>
+        {visible && <Titlebar />}
+        {children}
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
- add drag-enabled Titlebar component for window controls overlay
- show Titlebar in layout when windowControlsOverlay is visible

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c6937fe97c83288ed286cb86360de5