### PR TITLE
[pwa] add protocol handler route

### DIFF
--- a/app/protocol/page.tsx
+++ b/app/protocol/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+export default function ProtocolPage() {
+  const router = useRouter();
+  const search = useSearchParams();
+  const [target, setTarget] = useState<string | null>(null);
+
+  useEffect(() => {
+    const param = search.get('url');
+    if (!param) return;
+
+    try {
+      const decoded = decodeURIComponent(param);
+      setTarget(decoded);
+      if (decoded.startsWith('/')) {
+        router.replace(decoded);
+      }
+    } catch {
+      setTarget(param);
+    }
+  }, [router, search]);
+
+  if (target && target.startsWith('/')) {
+    return null;
+  }
+
+  return (
+    <div className="p-4">
+      {target ? (
+        <a href={target} className="underline text-blue-500">
+          {target}
+        </a>
+      ) : (
+        <p>No URL provided</p>
+      )}
+    </div>
+  );
+}
+

--- a/components/common/ServiceWorkerProvider.tsx
+++ b/components/common/ServiceWorkerProvider.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { ReactNode, useEffect } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function ServiceWorkerProvider({ children }: Props) {
+  useEffect(() => {
+    if (typeof navigator !== 'undefined' && 'registerProtocolHandler' in navigator) {
+      try {
+        navigator.registerProtocolHandler('web+kali', '/protocol?url=%s');
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('Protocol handler registration failed', err);
+      }
+    }
+  }, []);
+
+  return <>{children}</>;
+}
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -13,6 +13,7 @@ import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
+import ServiceWorkerProvider from '../components/common/ServiceWorkerProvider';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
@@ -157,21 +158,23 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+          <ServiceWorkerProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </ServiceWorkerProvider>
         </SettingsProvider>
       </div>
     </ErrorBoundary>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -34,6 +34,12 @@
       ]
     }
   },
+  "protocol_handlers": [
+    {
+      "protocol": "web+kali",
+      "url": "/protocol?url=%s"
+    }
+  ],
   "shortcuts": [
     {
       "name": "Open Terminal",


### PR DESCRIPTION
## Summary
- add `/protocol` page to redirect or show incoming URLs
- register custom `web+kali` protocol handler in ServiceWorkerProvider
- expose matching protocol handler in manifest and wrap app with provider

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: releases snap with Alt+ArrowDown restoring size; copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68c6937edd988328bc484aabe92ad9ef