### PR TITLE
[pwa] replace service worker

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -64,24 +64,9 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 const withPWA = require('@ducanh2912/next-pwa').default({
   dest: 'public',
   sw: 'sw.js',
+  swSrc: 'public/workers/service-worker.js',
   disable: process.env.NODE_ENV === 'development',
   buildExcludes: [/dynamic-css-manifest\.json$/],
-  workboxOptions: {
-    navigateFallback: '/offline.html',
-    additionalManifestEntries: [
-      { url: '/', revision: null },
-      { url: '/feeds', revision: null },
-      { url: '/about', revision: null },
-      { url: '/projects', revision: null },
-      { url: '/projects.json', revision: null },
-      { url: '/apps', revision: null },
-      { url: '/apps/weather', revision: null },
-      { url: '/apps/terminal', revision: null },
-      { url: '/apps/checkers', revision: null },
-      { url: '/offline.html', revision: null },
-      { url: '/manifest.webmanifest', revision: null },
-    ],
-  },
 });
 
 const isStaticExport = process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true';


### PR DESCRIPTION
## Summary
- replace service worker with offline-first navigation handling, push notifications, badge, and periodic sync
- configure next-pwa to bundle custom worker

## Testing
- `yarn lint` *(fails: A control must be associated with a text label, etc.)*
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size; NmapNSEApp › copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68c688726f048328a20c3909552ef18d