### PR TITLE
feat(pwa): handle file openings

### DIFF
--- a/__tests__/fileHandlerListener.test.tsx
+++ b/__tests__/fileHandlerListener.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, act } from '@testing-library/react';
+import FileHandlerListener from '../components/file/FileHandlerListener';
+
+describe('FileHandlerListener', () => {
+  test('displays content from opened file', async () => {
+    const mockSetConsumer = jest.fn();
+    (window as any).launchQueue = { setConsumer: mockSetConsumer };
+
+    render(<FileHandlerListener />);
+
+    const consumer = mockSetConsumer.mock.calls[0][0];
+    const file = { text: async () => 'hello world', name: 'test.txt', type: 'text/plain' } as any;
+
+    await act(async () => {
+      await consumer({
+        files: [
+          {
+            getFile: async () => file,
+          },
+        ],
+      });
+    });
+
+    expect(await screen.findByTestId('file-content')).toHaveTextContent('hello world');
+  });
+});

--- a/components/file/FileHandlerListener.tsx
+++ b/components/file/FileHandlerListener.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState, type FC } from 'react';
+
+/**
+ * Listens for files opened via the PWA file handler and displays their contents.
+ */
+const FileHandlerListener: FC = () => {
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    if ('launchQueue' in window) {
+      (window as any).launchQueue.setConsumer(async (launchParams: any) => {
+        if (!launchParams.files || launchParams.files.length === 0) return;
+        const texts = await Promise.all(
+          launchParams.files.map(async (fileHandle: any) => {
+            const file = await fileHandle.getFile();
+            return await file.text();
+          })
+        );
+        setContent(texts.join('\n'));
+      });
+    }
+  }, []);
+
+  if (!content) return null;
+
+  return <pre data-testid="file-content">{content}</pre>;
+};
+
+export default FileHandlerListener;
+

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -24,6 +24,17 @@ const InstallButton = dynamic(
     loading: () => <p>Loading install options...</p>,
   }
 );
+const FileHandlerListener = dynamic(
+  () =>
+    import('../components/file/FileHandlerListener').catch((err) => {
+      console.error('Failed to load FileHandlerListener component', err);
+      throw err;
+    }),
+  {
+    ssr: false,
+    loading: () => null,
+  }
+);
 
 /**
  * @returns {JSX.Element}
@@ -37,6 +48,7 @@ const App = () => (
     <Ubuntu />
     <BetaBadge />
     <InstallButton />
+    <FileHandlerListener />
   </>
 );
 


### PR DESCRIPTION
## Summary
- register `launchQueue.setConsumer` and render opened file contents
- mount listener on home page so PWA can show files
- test `FileHandlerListener` behavior

## Testing
- `yarn lint` *(fails: Unexpected global 'document' etc.)*
- `yarn test` *(fails: window.snap finalize, nmapNSE, etc.)*
- `yarn test __tests__/fileHandlerListener.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c68877f5c88328aa0e675213147032