### PR TITLE
[pwa] add titlebar for window controls overlay

### DIFF
--- a/components/Titlebar.tsx
+++ b/components/Titlebar.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+/**
+ * Minimal title bar used when the Window Controls Overlay is visible.
+ * Provides a draggable region for custom window buttons in supported browsers.
+ */
+const Titlebar: React.FC = () => {
+  return <div style={{ height: '32px', WebkitAppRegion: 'drag' }} />;
+};
+
+export default Titlebar;
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import '../styles/tailwind.css';
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import Titlebar from '../components/Titlebar';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -27,6 +28,8 @@ const ubuntu = Ubuntu({
 
 function MyApp(props) {
   const { Component, pageProps } = props;
+
+  const [showTitlebar, setShowTitlebar] = useState(false);
 
 
   useEffect(() => {
@@ -78,6 +81,16 @@ function MyApp(props) {
         console.error('Service worker setup failed', err);
       });
     }
+  }, []);
+
+  useEffect(() => {
+    const overlay = navigator?.windowControlsOverlay;
+    if (!overlay) return;
+
+    const handleChange = () => setShowTitlebar(overlay.visible);
+    handleChange();
+    overlay.addEventListener('geometrychange', handleChange);
+    return () => overlay.removeEventListener('geometrychange', handleChange);
   }, []);
 
   useEffect(() => {
@@ -156,6 +169,7 @@ function MyApp(props) {
         >
           Skip to app grid
         </a>
+        {showTitlebar && <Titlebar />}
         <SettingsProvider>
           <PipPortalProvider>
             <div aria-live="polite" id="live-region" />

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -4,6 +4,7 @@
   "start_url": "/",
   "offline_page": "/offline.html",
   "display": "standalone",
+  "display_override": ["window-controls-overlay"],
   "background_color": "#0f1317",
   "theme_color": "#0f1317",
   "icons": [


### PR DESCRIPTION
## Summary
- add draggable Titlebar component for window controls overlay
- show Titlebar when `navigator.windowControlsOverlay` is visible
- ensure PWA manifest opts into window-controls-overlay display override

## Testing
- `yarn lint` *(fails: Unexpected global 'document'; Component definition missing display name)*
- `yarn test` *(fails: window snapping release; copies example output; modal traps focus)*

------
https://chatgpt.com/codex/tasks/task_e_68c6887a213483288b724af77a3b70d3