### PR TITLE
[apps] add Kali Builder form

### DIFF
--- a/__tests__/apps/kali-builder.test.tsx
+++ b/__tests__/apps/kali-builder.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import KaliBuilder from '../../pages/apps/kali-builder';
+
+describe('Kali Builder form', () => {
+  it('validates required fields', () => {
+    render(<KaliBuilder />);
+
+    fireEvent.click(screen.getByText('Build'));
+    expect(screen.getByRole('alert')).toHaveTextContent('Base image is required');
+
+    fireEvent.change(screen.getByTestId('base-image'), { target: { value: 'kali-rolling' } });
+    fireEvent.click(screen.getByText('Build'));
+    expect(screen.getByRole('alert')).toHaveTextContent('Select at least one metapackage');
+
+    fireEvent.click(screen.getByTestId('meta-core'));
+    fireEvent.click(screen.getByText('Build'));
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -112,6 +112,7 @@ const SSHApp = createDynamicApp('ssh', 'SSH Command Builder');
 const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
 const HtmlRewriteApp = createDynamicApp('html-rewriter', 'HTML Rewriter');
 const ContactApp = createDynamicApp('contact', 'Contact');
+const KaliBuilderApp = createDynamicApp('kali-builder', 'Kali Builder');
 
 
 
@@ -197,6 +198,7 @@ const displaySSH = createDisplay(SSHApp);
 const displayHTTP = createDisplay(HTTPApp);
 const displayHtmlRewrite = createDisplay(HtmlRewriteApp);
 const displayContact = createDisplay(ContactApp);
+const displayKaliBuilder = createDisplay(KaliBuilderApp);
 
 const displayHashcat = createDisplay(HashcatApp);
 
@@ -257,6 +259,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayProjectGallery,
+  },
+  {
+    id: 'kali-builder',
+    title: 'Kali Builder',
+    icon: '/themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayKaliBuilder,
   },
   {
     id: 'input-lab',

--- a/data/kali-presets.json
+++ b/data/kali-presets.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "Default",
+    "baseImage": "kali-rolling",
+    "metapackages": ["core"],
+    "customKernel": false,
+    "persistence": false
+  },
+  {
+    "name": "Pen Testing",
+    "baseImage": "kali-rolling",
+    "metapackages": ["top10", "wireless"],
+    "customKernel": false,
+    "persistence": true
+  }
+]

--- a/pages/apps/kali-builder.tsx
+++ b/pages/apps/kali-builder.tsx
@@ -1,0 +1,160 @@
+import React, { useState } from 'react';
+import presetsData from '../../data/kali-presets.json';
+
+interface Preset {
+  name: string;
+  baseImage: string;
+  metapackages: string[];
+  customKernel?: boolean;
+  persistence?: boolean;
+}
+
+const baseImages = ['kali-rolling', 'kali-last-snapshot'];
+const metapackageOptions = [
+  { id: 'core', label: 'Core' },
+  { id: 'top10', label: 'Top 10' },
+  { id: 'wireless', label: 'Wireless' },
+  { id: 'forensics', label: 'Forensics' },
+];
+
+const KaliBuilder: React.FC = () => {
+  const presets = presetsData as Preset[];
+
+  const [baseImage, setBaseImage] = useState('');
+  const [metapackages, setMetapackages] = useState<string[]>([]);
+  const [customKernel, setCustomKernel] = useState(false);
+  const [persistence, setPersistence] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const applyPreset = (name: string) => {
+    const preset = presets.find((p) => p.name === name);
+    if (preset) {
+      setBaseImage(preset.baseImage);
+      setMetapackages(preset.metapackages);
+      setCustomKernel(!!preset.customKernel);
+      setPersistence(!!preset.persistence);
+    }
+  };
+
+  const toggleMetapackage = (pkg: string) => {
+    setMetapackages((prev) =>
+      prev.includes(pkg) ? prev.filter((p) => p !== pkg) : [...prev, pkg]
+    );
+  };
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!baseImage) {
+      setError('Base image is required');
+      return;
+    }
+    if (metapackages.length === 0) {
+      setError('Select at least one metapackage');
+      return;
+    }
+    setError(null);
+    // Simulation: Normally build process would start here
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-4">Kali Builder</h1>
+      <form onSubmit={onSubmit}>
+        <label className="block mb-2">
+          Preset
+          <select
+            data-testid="preset-select"
+            defaultValue=""
+            onChange={(e) => applyPreset(e.target.value)}
+            className="ml-2 border"
+          >
+            <option value="" disabled>
+              Select preset
+            </option>
+            {presets.map((p) => (
+              <option key={p.name} value={p.name}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="block mb-2">
+          Base Image
+          <select
+            data-testid="base-image"
+            className="ml-2 border"
+            value={baseImage}
+            onChange={(e) => setBaseImage(e.target.value)}
+          >
+            <option value="">Select</option>
+            {baseImages.map((img) => (
+              <option key={img} value={img}>
+                {img}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <fieldset className="mb-2">
+          <legend>Metapackages</legend>
+          {metapackageOptions.map((pkg) => (
+            <div key={pkg.id} className="block">
+              <input
+                id={`meta-${pkg.id}`}
+                type="checkbox"
+                data-testid={`meta-${pkg.id}`}
+                checked={metapackages.includes(pkg.id)}
+                onChange={() => toggleMetapackage(pkg.id)}
+                aria-label={pkg.label}
+              />
+              <label htmlFor={`meta-${pkg.id}`} className="ml-1">
+                {pkg.label}
+              </label>
+            </div>
+          ))}
+        </fieldset>
+
+        <div className="block">
+          <input
+            id="custom-kernel"
+            type="checkbox"
+            data-testid="custom-kernel"
+            checked={customKernel}
+            onChange={(e) => setCustomKernel(e.target.checked)}
+            aria-label="Include Custom Kernel"
+          />
+          <label htmlFor="custom-kernel" className="ml-1">
+            Include Custom Kernel
+          </label>
+        </div>
+
+        <div className="block mb-2">
+          <input
+            id="persistence"
+            type="checkbox"
+            data-testid="persistence"
+            checked={persistence}
+            onChange={(e) => setPersistence(e.target.checked)}
+            aria-label="Enable Persistence"
+          />
+          <label htmlFor="persistence" className="ml-1">
+            Enable Persistence
+          </label>
+        </div>
+
+        {error && (
+          <p data-testid="error" role="alert" className="text-red-500">
+            {error}
+          </p>
+        )}
+
+        <button type="submit" className="mt-2 px-2 py-1 border">
+          Build
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default KaliBuilder;


### PR DESCRIPTION
## Summary
- add Kali Builder page with selectable presets and build options
- surface presets list from `kali-presets.json`
- register Kali Builder in launcher and cover validation with tests

## Testing
- `yarn lint` *(fails: A control must be associated with a text label across unrelated files)*
- `npx eslint pages/apps/kali-builder.tsx __tests__/apps/kali-builder.test.tsx apps.config.js`
- `yarn test __tests__/apps/kali-builder.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c690ab972c8328b46ed488faa90a22