### PR TITLE
[apps] add Kali Desktop Kasm launcher

### DIFF
--- a/__tests__/api/kasm-launch.test.ts
+++ b/__tests__/api/kasm-launch.test.ts
@@ -1,0 +1,40 @@
+import handler from '../../pages/api/kasm/launch';
+import { createMocks } from 'node-mocks-http';
+
+describe('kasm launch api', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+    delete (global as any).fetch;
+    delete process.env.KASM_URL;
+    delete process.env.KASM_USERNAME;
+    delete process.env.KASM_PASSWORD;
+    delete process.env.KASM_WORKSPACE_ID;
+  });
+
+  test('returns session url', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ token: 'tok' }),
+      })
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ url: 'https://session' }),
+      });
+    (global as any).fetch = fetchMock;
+
+    process.env.KASM_URL = 'https://kasm.local';
+    process.env.KASM_USERNAME = 'user';
+    process.env.KASM_PASSWORD = 'pass';
+    process.env.KASM_WORKSPACE_ID = 'work';
+
+    const { req, res } = createMocks({ method: 'GET' });
+    await handler(req as any, res as any);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe('https://kasm.local/api/v1/authenticate');
+    expect(fetchMock.mock.calls[1][0]).toBe('https://kasm.local/api/v1/containers/launch');
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ url: 'https://session' });
+  });
+});
+

--- a/apps.config.js
+++ b/apps.config.js
@@ -112,6 +112,7 @@ const SSHApp = createDynamicApp('ssh', 'SSH Command Builder');
 const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
 const HtmlRewriteApp = createDynamicApp('html-rewriter', 'HTML Rewriter');
 const ContactApp = createDynamicApp('contact', 'Contact');
+const KaliDesktopApp = createDynamicApp('kali-desktop', 'Kali Desktop');
 
 
 
@@ -198,6 +199,7 @@ const displayHTTP = createDisplay(HTTPApp);
 const displayHtmlRewrite = createDisplay(HtmlRewriteApp);
 const displayContact = createDisplay(ContactApp);
 
+const displayKaliDesktop = createDisplay(KaliDesktopApp);
 const displayHashcat = createDisplay(HashcatApp);
 
 const displayKismet = createDisplay(KismetApp);
@@ -978,6 +980,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayVolatility,
+  },
+  {
+    id: 'kali-desktop',
+    title: 'Kali Desktop',
+    icon: '/themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayKaliDesktop,
   },
   {
     id: 'hashcat',

--- a/components/apps/kali-desktop.tsx
+++ b/components/apps/kali-desktop.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const KaliDesktop: React.FC = () => {
+  useEffect(() => {
+    const launch = async () => {
+      try {
+        const res = await fetch('/api/kasm/launch');
+        const data = await res.json();
+        if (data?.url) {
+          window.location.href = data.url;
+        }
+      } catch {
+        // ignore errors
+      }
+    };
+    launch();
+  }, []);
+
+  return (
+    <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+      Launching Kali Desktop...
+    </div>
+  );
+};
+
+export default KaliDesktop;
+

--- a/pages/api/kasm/launch.ts
+++ b/pages/api/kasm/launch.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const baseUrl = process.env.KASM_URL;
+  const username = process.env.KASM_USERNAME;
+  const password = process.env.KASM_PASSWORD;
+  const profileId = process.env.KASM_WORKSPACE_ID;
+
+  if (!baseUrl || !username || !password || !profileId) {
+    res.status(500).json({ error: 'Kasm not configured' });
+    return;
+  }
+
+  try {
+    const authRes = await fetch(`${baseUrl}/api/v1/authenticate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    const { token } = await authRes.json();
+
+    const launchRes = await fetch(`${baseUrl}/api/v1/containers/launch`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ profile_id: profileId }),
+    });
+    const { url } = await launchRes.json();
+
+    res.status(200).json({ url });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to launch session' });
+  }
+}
+

--- a/pages/apps/kali-desktop.tsx
+++ b/pages/apps/kali-desktop.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const KaliDesktop = dynamic(() => import('../../components/apps/kali-desktop'), {
+  ssr: false,
+});
+
+export default KaliDesktop;
+


### PR DESCRIPTION
## Summary
- authenticate with Kasm and return session URL via `/api/kasm/launch`
- add Kali Desktop page that redirects to launched session and register app
- cover Kasm launch endpoint with unit test

## Testing
- `yarn lint` *(fails: Unexpected global 'document' etc.)*
- `CI=1 yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c690ae8c948328ad77155b5c7cf3d9