### PR TITLE
[apps] add Kali container runner

### DIFF
--- a/__tests__/api/kali-container-start.test.ts
+++ b/__tests__/api/kali-container-start.test.ts
@@ -1,0 +1,57 @@
+import handler from '../../pages/api/kali-container/start';
+import { createMocks } from 'node-mocks-http';
+
+jest.mock('child_process', () => ({
+  execFile: jest.fn((cmd: string, args: string[], options: any, cb: any) => {
+    if (typeof options === 'function') {
+      cb = options;
+    }
+    cb(null, 'started', '');
+  }),
+}));
+
+const execFileMock = require('child_process').execFile as jest.Mock;
+
+describe('kali-container api', () => {
+  beforeEach(() => {
+    process.env.FEATURE_TOOL_APIS = 'enabled';
+    process.env.FEATURE_KALI_CONTAINER = 'enabled';
+  });
+
+  afterEach(() => {
+    execFileMock.mockClear();
+    delete process.env.FEATURE_TOOL_APIS;
+    delete process.env.FEATURE_KALI_CONTAINER;
+  });
+
+  it('runs docker with provided tag and flags', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: { tag: 'latest', flags: ['--rm'] },
+    });
+
+    await handler(req as any, res as any);
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      'docker',
+      ['run', '--rm', 'kalilinux/kali-rolling:latest'],
+      { timeout: 60000 },
+      expect.any(Function)
+    );
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ stdout: 'started' });
+  });
+
+  it('rejects invalid tags', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: { tag: 'bad;tag' },
+    });
+
+    await handler(req as any, res as any);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+});
+

--- a/apps.config.js
+++ b/apps.config.js
@@ -102,6 +102,7 @@ const MimikatzOfflineApp = createDynamicApp('mimikatz/offline', 'Mimikatz Offlin
 const EttercapApp = createDynamicApp('ettercap', 'Ettercap');
 const ReaverApp = createDynamicApp('reaver', 'Reaver');
 const HydraApp = createDynamicApp('hydra', 'Hydra');
+const KaliContainerApp = createDynamicApp('kali-container', 'Kali Container');
 const JohnApp = createDynamicApp('john', 'John the Ripper');
 const NessusApp = createDynamicApp('nessus', 'Nessus');
 const NmapNSEApp = createDynamicApp('nmap-nse', 'Nmap NSE');
@@ -187,6 +188,7 @@ const displayMimikatzOffline = createDisplay(MimikatzOfflineApp);
 const displayEttercap = createDisplay(EttercapApp);
 const displayReaver = createDisplay(ReaverApp);
 const displayHydra = createDisplay(HydraApp);
+const displayKaliContainer = createDisplay(KaliContainerApp);
 const displayJohn = createDisplay(JohnApp);
 const displayNessus = createDisplay(NessusApp);
 const displayNmapNSE = createDisplay(NmapNSEApp);
@@ -1023,6 +1025,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayJohn,
+  },
+  {
+    id: 'kali-container',
+    title: 'Kali Container',
+    icon: '/themes/Yaru/apps/bash.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayKaliContainer,
   },
   {
     id: 'openvas',

--- a/pages/api/kali-container/start.ts
+++ b/pages/api/kali-container/start.ts
@@ -1,0 +1,44 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { execFile } from 'child_process';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (
+    process.env.FEATURE_TOOL_APIS !== 'enabled' ||
+    process.env.FEATURE_KALI_CONTAINER !== 'enabled'
+  ) {
+    res.status(501).json({ error: 'Not implemented' });
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { tag = 'latest', flags = [] } = req.body || {};
+  const tagPattern = /^[\w.-]+$/;
+  const flagPattern = /^[-\w=/:]+$/;
+
+  const flagArray: string[] = Array.isArray(flags)
+    ? flags
+    : typeof flags === 'string'
+    ? flags.split(/\s+/).filter(Boolean)
+    : [];
+
+  if (!tagPattern.test(tag) || flagArray.some((f) => !flagPattern.test(f))) {
+    res.status(400).json({ error: 'Invalid tag or flags' });
+    return;
+  }
+
+  const args = ['run', ...flagArray, `kalilinux/kali-rolling:${tag}`];
+
+  execFile('docker', args, { timeout: 1000 * 60 }, (error, stdout, stderr) => {
+    if (error) {
+      res.status(500).json({ error: stderr?.toString() || error.message });
+      return;
+    }
+    res.status(200).json({ stdout: stdout.toString() });
+  });
+}
+

--- a/pages/apps/kali-container.tsx
+++ b/pages/apps/kali-container.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+
+export default function KaliContainer() {
+  const [tag, setTag] = useState('latest');
+  const [flags, setFlags] = useState('');
+  const [output, setOutput] = useState('');
+  const [error, setError] = useState('');
+
+  const runContainer = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setOutput('');
+    setError('');
+    try {
+      const res = await fetch('/api/kali-container/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tag, flags: flags.trim().split(/\s+/).filter(Boolean) }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Failed to start container');
+      } else {
+        setOutput(data.stdout || 'Container started');
+      }
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4 text-white bg-black h-full w-full overflow-auto">
+      <form onSubmit={runContainer} className="space-y-4">
+        <label className="block">
+          <span className="text-sm">Tag</span>
+          <select
+            value={tag}
+            onChange={(e) => setTag(e.target.value)}
+            className="w-full bg-black border border-gray-600 p-1 mt-1"
+          >
+            <option value="latest">latest</option>
+            <option value="2024.1">2024.1</option>
+            <option value="2023.4">2023.4</option>
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-sm">Runtime Flags</span>
+          <input
+            value={flags}
+            onChange={(e) => setFlags(e.target.value)}
+            placeholder="--rm -it"
+            className="w-full bg-black border border-gray-600 p-1 mt-1"
+          />
+        </label>
+        <button
+          type="submit"
+          className="px-4 py-2 bg-ub-orange text-black rounded"
+        >
+          Start
+        </button>
+      </form>
+      {error && <pre className="text-red-500 whitespace-pre-wrap">{error}</pre>}
+      {output && <pre className="whitespace-pre-wrap">{output}</pre>}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Kali Container app with tag selection and runtime flag inputs
- implement API route to start official kalilinux/kali-rolling containers via Docker
- register Kali Container in app registry and cover API with tests

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: Window snapping finalize and release releases snap with Alt+ArrowDown restoring size, NmapNSEApp copies example output to clipboard, ReconNG app stores API keys in localStorage, PdfViewer update not wrapped in act)*
- `yarn test __tests__/api/kali-container-start.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c690affbf48328a2ccaea9d4a5c3ab