### PR TITLE
[config] add headers for PWA files

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -174,6 +174,25 @@ module.exports = withBundleAnalyzer(
                   },
                 ],
               },
+              {
+                source: '/sw.js',
+                headers: [
+                  {
+                    key: 'Cache-Control',
+                    value: 'public, max-age=0, must-revalidate',
+                  },
+                ],
+              },
+              {
+                source: '/manifest.webmanifest',
+                headers: [
+                  {
+                    key: 'Content-Type',
+                    value:
+                      'application/manifest+json; charset=utf-8',
+                  },
+                ],
+              },
             ];
           },
         }),


### PR DESCRIPTION
## Summary
- add cache-control header for service worker
- set manifest content-type

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: Window snapping finalize and release releases snap with Alt+ArrowDown restoring size; NmapNSEApp copies example output to clipboard)*
- `yarn build`
- `curl -I http://localhost:3000/sw.js` *(fails: Internal Server Error)*
- `curl -I http://localhost:3000/manifest.webmanifest` *(fails: Internal Server Error)*

------
https://chatgpt.com/codex/tasks/task_e_68c69370310083289f3f89268747c34d