### PR TITLE
[pwa] add demo pwa components

### DIFF
--- a/app/components/ServiceWorkerProvider.tsx
+++ b/app/components/ServiceWorkerProvider.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { createContext, useEffect, useState, ReactNode } from 'react';
+
+export const ServiceWorkerContext = createContext<ServiceWorkerRegistration | null>(null);
+
+interface Props {
+  children: ReactNode;
+}
+
+const ServiceWorkerProvider = ({ children }: Props) => {
+  const [registration, setRegistration] = useState<ServiceWorkerRegistration | null>(null);
+
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.ready
+        .then((reg) => setRegistration(reg))
+        .catch((err) => {
+          console.error('Service worker ready wait failed', err);
+        });
+    }
+  }, []);
+
+  return (
+    <ServiceWorkerContext.Provider value={registration}>
+      {children}
+    </ServiceWorkerContext.Provider>
+  );
+};
+
+export default ServiceWorkerProvider;

--- a/app/components/badge/BadgeControls.tsx
+++ b/app/components/badge/BadgeControls.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useCallback } from 'react';
+
+const BadgeControls = () => {
+  const setBadge = useCallback(async () => {
+    try {
+      if ('setAppBadge' in navigator) {
+        await (navigator as any).setAppBadge(1);
+      }
+    } catch (err) {
+      console.error('Failed to set app badge', err);
+    }
+  }, []);
+
+  const clearBadge = useCallback(async () => {
+    try {
+      if ('clearAppBadge' in navigator) {
+        await (navigator as any).clearAppBadge();
+      }
+    } catch (err) {
+      console.error('Failed to clear app badge', err);
+    }
+  }, []);
+
+  if (typeof navigator === 'undefined' || !('setAppBadge' in navigator)) {
+    return null;
+  }
+
+  return (
+    <div className="flex gap-2">
+      <button type="button" onClick={setBadge} className="px-2 py-1 border rounded">
+        Set Badge
+      </button>
+      <button type="button" onClick={clearBadge} className="px-2 py-1 border rounded">
+        Clear Badge
+      </button>
+    </div>
+  );
+};
+
+export default BadgeControls;

--- a/app/components/file/FileHandlerListener.tsx
+++ b/app/components/file/FileHandlerListener.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const FileHandlerListener = () => {
+  useEffect(() => {
+    if ('launchQueue' in window) {
+      (window as any).launchQueue.setConsumer(async (launchParams: any) => {
+        for (const fileHandle of launchParams.files || []) {
+          try {
+            const file = await fileHandle.getFile();
+            console.log('Received file:', file.name);
+          } catch (err) {
+            console.error('Failed to read file', err);
+          }
+        }
+      });
+    }
+  }, []);
+
+  return null;
+};
+
+export default FileHandlerListener;

--- a/app/components/push/PushSubscribeButton.tsx
+++ b/app/components/push/PushSubscribeButton.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+const PushSubscribeButton = () => {
+  const [subscribed, setSubscribed] = useState(false);
+
+  const subscribe = useCallback(async () => {
+    if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+    try {
+      const permission = await Notification.requestPermission();
+      if (permission !== 'granted') return;
+      const registration = await navigator.serviceWorker.ready;
+      await registration.pushManager.subscribe({ userVisibleOnly: true });
+      setSubscribed(true);
+    } catch (err) {
+      console.error('Push subscription failed', err);
+    }
+  }, []);
+
+  if (typeof window === 'undefined' || !('Notification' in window)) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={subscribe}
+      disabled={subscribed}
+      className="px-2 py-1 border rounded"
+    >
+      {subscribed ? 'Subscribed' : 'Enable Push'}
+    </button>
+  );
+};
+
+export default PushSubscribeButton;

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -24,6 +24,22 @@ const InstallButton = dynamic(
     loading: () => <p>Loading install options...</p>,
   }
 );
+const ServiceWorkerProvider = dynamic(
+  () => import('../app/components/ServiceWorkerProvider'),
+  { ssr: false }
+);
+const BadgeControls = dynamic(
+  () => import('../app/components/badge/BadgeControls'),
+  { ssr: false }
+);
+const PushSubscribeButton = dynamic(
+  () => import('../app/components/push/PushSubscribeButton'),
+  { ssr: false }
+);
+const FileHandlerListener = dynamic(
+  () => import('../app/components/file/FileHandlerListener'),
+  { ssr: false }
+);
 
 /**
  * @returns {JSX.Element}
@@ -37,6 +53,11 @@ const App = () => (
     <Ubuntu />
     <BetaBadge />
     <InstallButton />
+    <ServiceWorkerProvider>
+      <BadgeControls />
+      <PushSubscribeButton />
+      <FileHandlerListener />
+    </ServiceWorkerProvider>
   </>
 );
 


### PR DESCRIPTION
## Summary
- add ServiceWorkerProvider and demo PWA helpers (badge, push, file handler)
- load PWA helpers on index page via dynamic imports

## Testing
- `yarn lint` *(fails: Unexpected global 'document' errors)*
- `yarn test` *(fails: Window snapping finalize and release > releases snap..., NmapNSEApp › copies example output to clipboard, modal closes when Escape pressed globally)*

------
https://chatgpt.com/codex/tasks/task_e_68c69374e4ac8328bc69b60d5b0d93c7