### PR TITLE
[pwa] add badge controls

### DIFF
--- a/__tests__/BadgeControls.test.tsx
+++ b/__tests__/BadgeControls.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BadgeControls from '@/src/pwa/BadgeControls';
+
+describe('BadgeControls', () => {
+  test('falls back to document title when app badge unsupported', async () => {
+    delete (navigator as any).setAppBadge;
+    delete (navigator as any).clearAppBadge;
+    document.title = 'Orig';
+
+    render(<BadgeControls />);
+
+    const dotBtn = screen.getByRole('button', { name: /set app badge to dot/i });
+    await userEvent.click(dotBtn);
+    expect(document.title).toBe('• Orig');
+
+    const numBtn = screen.getByRole('button', { name: /set app badge to number/i });
+    await userEvent.click(numBtn);
+    expect(document.title).toBe('(5) Orig');
+
+    const clearBtn = screen.getByRole('button', { name: /clear app badge/i });
+    await userEvent.click(clearBtn);
+    expect(document.title).toBe('Orig');
+  });
+
+  test('uses native app badge API and keyboard handlers', () => {
+    const setAppBadge = jest.fn().mockResolvedValue(undefined);
+    const clearAppBadge = jest.fn().mockResolvedValue(undefined);
+    (navigator as any).setAppBadge = setAppBadge;
+    (navigator as any).clearAppBadge = clearAppBadge;
+
+    render(<BadgeControls />);
+
+    const numBtn = screen.getByRole('button', { name: /set app badge to number/i });
+    fireEvent.keyDown(numBtn, { key: 'Enter' });
+    expect(setAppBadge).toHaveBeenCalledWith(5);
+
+    const clearBtn = screen.getByRole('button', { name: /clear app badge/i });
+    fireEvent.keyDown(clearBtn, { key: ' ' });
+    expect(clearAppBadge).toHaveBeenCalled();
+  });
+});
+

--- a/src/pwa/BadgeControls.tsx
+++ b/src/pwa/BadgeControls.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useRef } from 'react';
+
+export default function BadgeControls() {
+  const originalTitle = useRef<string | null>(null);
+
+  const setTitleBadge = (val: string) => {
+    if (typeof document === 'undefined') return;
+    if (!originalTitle.current) originalTitle.current = document.title;
+    document.title = `${val} ${originalTitle.current}`;
+  };
+
+  const clearTitleBadge = () => {
+    if (typeof document === 'undefined') return;
+    if (originalTitle.current !== null) {
+      document.title = originalTitle.current;
+      originalTitle.current = null;
+    }
+  };
+
+  const setDot = () => {
+    const nav: any = typeof navigator !== 'undefined' ? navigator : null;
+    if (nav?.setAppBadge) {
+      nav.setAppBadge().catch(() => {});
+    } else {
+      setTitleBadge('•');
+    }
+  };
+
+  const setNumber = (n = 5) => {
+    const nav: any = typeof navigator !== 'undefined' ? navigator : null;
+    if (nav?.setAppBadge) {
+      nav.setAppBadge(n).catch(() => {});
+    } else {
+      setTitleBadge(`(${n})`);
+    }
+  };
+
+  const clear = () => {
+    const nav: any = typeof navigator !== 'undefined' ? navigator : null;
+    if (nav?.clearAppBadge) {
+      nav.clearAppBadge().catch(() => {});
+    } else {
+      clearTitleBadge();
+    }
+  };
+
+  const handleKey = (fn: () => void) => (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      fn();
+    }
+  };
+
+  return (
+    <div className="flex gap-2">
+      <button
+        type="button"
+        onClick={setDot}
+        onKeyDown={handleKey(setDot)}
+        aria-label="Set app badge to dot"
+        className="border px-2 py-1 rounded"
+      >
+        Set dot
+      </button>
+      <button
+        type="button"
+        onClick={() => setNumber(5)}
+        onKeyDown={handleKey(() => setNumber(5))}
+        aria-label="Set app badge to number"
+        className="border px-2 py-1 rounded"
+      >
+        Set N
+      </button>
+      <button
+        type="button"
+        onClick={clear}
+        onKeyDown={handleKey(clear)}
+        aria-label="Clear app badge"
+        className="border px-2 py-1 rounded"
+      >
+        Clear
+      </button>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add BadgeControls with app-badge API and document title fallback
- cover BadgeControls behaviors with tests

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in unrelated files)*
- `yarn test` *(fails: e.preventDefault is not a function in window snapping, others)*
- `yarn test __tests__/BadgeControls.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c6937647088328a6781633599cdbed