### PR TITLE
[pwa] add .foo file handler

### DIFF
--- a/components/FileHandlerListener.tsx
+++ b/components/FileHandlerListener.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface FilePreview {
+  name: string;
+  content: string;
+}
+
+export default function FileHandlerListener() {
+  const [files, setFiles] = useState<FilePreview[]>([]);
+
+  useEffect(() => {
+    if ("launchQueue" in window) {
+      (window as any).launchQueue.setConsumer(async (launchParams: any) => {
+        if (launchParams.files && launchParams.files.length) {
+          const previews = await Promise.all(
+            launchParams.files.map(async (fileHandle: any) => {
+              const file = await fileHandle.getFile();
+              const content = await file.text();
+              return {
+                name: file.name,
+                content: content.slice(0, 100),
+              };
+            })
+          );
+          setFiles(previews);
+        }
+      });
+    }
+  }, []);
+
+  if (!files.length) return null;
+
+  return (
+    <div>
+      {files.map((file) => (
+        <div key={file.name} className="mb-4">
+          <p className="font-bold">{file.name}</p>
+          <pre className="whitespace-pre-wrap">{file.content}</pre>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -34,6 +34,14 @@
       ]
     }
   },
+  "file_handlers": [
+    {
+      "action": "/",
+      "accept": {
+        "application/x-foobar": [".foo"]
+      }
+    }
+  ],
   "shortcuts": [
     {
       "name": "Open Terminal",


### PR DESCRIPTION
## Summary
- listen for launched files using `launchQueue` and render preview
- allow the PWA to open `.foo` files via `file_handlers`

## Testing
- `node_modules/.bin/eslint public/manifest.webmanifest`
- `yarn test __tests__/window.test.tsx` *(fails: releases snap with Alt+ArrowDown restoring size)*

------
https://chatgpt.com/codex/tasks/task_e_68c69377606c8328b83e43d71394ed5f