### PR TITLE
[app] add share target route

### DIFF
--- a/app/share/route.ts
+++ b/app/share/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'edge';
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData();
+
+  const text = formData.get('text');
+  const url = formData.get('url');
+  const files = formData.getAll('files');
+
+  if (typeof text === 'string') {
+    console.log('Shared text:', text);
+  }
+
+  if (typeof url === 'string') {
+    console.log('Shared URL:', url);
+  }
+
+  files.forEach((file) => {
+    if (file instanceof File) {
+      console.log('Shared file:', file.name, file.type, file.size);
+    } else {
+      console.log('Shared file value:', file);
+    }
+  });
+
+  return NextResponse.redirect(new URL('/inbox', req.url), 303);
+}


### PR DESCRIPTION
## Summary
- handle web share posts at /share with edge runtime

## Testing
- `yarn lint` (fails: Unexpected global 'document', missing display name)
- `yarn test` (fails: window.test.tsx, nmapNse.test.tsx)
- `curl -i -X POST -F "text=hello" -F "url=https://example.com" -F "files=@/tmp/sample.txt" http://localhost:3000/share`


------
https://chatgpt.com/codex/tasks/task_e_68c6937da598832898a0643dca47e836