### PR TITLE
[whats-new] add tabbed what's new page

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,13 @@
+
+import React from 'react';
+import '../styles/tailwind.css';
+import '../styles/globals.css';
+import '../styles/index.css';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/whats-new/page.tsx
+++ b/app/whats-new/page.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+
+interface Category {
+  label: string;
+  src: string;
+}
+
+const categories: Category[] = [
+  {
+    label: 'Security',
+    src: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+  },
+  {
+    label: 'Images',
+    src: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+  },
+  {
+    label: 'WSL',
+    src: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+  },
+  {
+    label: 'NetHunter',
+    src: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+  },
+];
+
+function LazyVideo({ src, label }: { src: string; label: string }) {
+  const ref = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            if (!el.src) {
+              el.src = src;
+              el.load();
+            }
+            el.play().catch(() => {});
+          } else {
+            el.pause();
+          }
+        });
+      },
+      { threshold: 0.25 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [src]);
+
+  return (
+    <video
+      ref={ref}
+      width={640}
+      height={360}
+      className="w-full max-w-2xl bg-black"
+      muted
+      loop
+      playsInline
+      preload="none"
+      aria-label={label}
+    />
+  );
+}
+
+export default function WhatsNewPage() {
+  const [active, setActive] = useState<string>(categories[0].label);
+  const activeCategory = categories.find((c) => c.label === active) ?? categories[0];
+
+  return (
+    <div className="p-4">
+      <div role="tablist" aria-label="Categories" className="mb-4 flex gap-2 border-b">
+        {categories.map((cat) => (
+          <button
+            key={cat.label}
+            role="tab"
+            aria-selected={active === cat.label}
+            type="button"
+            onClick={() => setActive(cat.label)}
+            className={`px-4 py-2 text-sm focus:outline-none ${active === cat.label ? 'border-b-2 border-blue-500 font-medium' : 'text-gray-500'}`}
+          >
+            {cat.label}
+          </button>
+        ))}
+      </div>
+      <div role="tabpanel" className="flex justify-center">
+        <LazyVideo key={activeCategory.label} src={activeCategory.src} label={activeCategory.label} />
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add root app layout for new routes
- introduce `/whats-new` page with category tabs and lazy-loaded looping videos

## Testing
- `npx eslint app/layout.tsx app/whats-new/page.tsx`
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: e.preventDefault is not a function in window.test.tsx; Unable to find role="alert" in nmapNse.test.tsx; modal closes when Escape pressed globally)*

------
https://chatgpt.com/codex/tasks/task_e_68c6982ffe6883289fffa1fdb1af750d