### PR TITLE
[docs] add sticky TOC with skip link

### DIFF
--- a/__tests__/toc.test.tsx
+++ b/__tests__/toc.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import TOC from '../components/TOC';
+
+describe('TOC', () => {
+  test('highlights active heading on intersection', () => {
+    document.body.innerHTML =
+      '<h2 id="sec1">Section 1</h2><h2 id="sec2">Section 2</h2>';
+
+    let callback: IntersectionObserverCallback = () => {};
+    (global as any).IntersectionObserver = class {
+      constructor(cb: IntersectionObserverCallback) {
+        callback = cb;
+      }
+      observe() {}
+      disconnect() {}
+    };
+
+    const { getByRole } = render(
+      <TOC headings={[{ id: 'sec1', text: 'Section 1' }, { id: 'sec2', text: 'Section 2' }]} />
+    );
+
+    act(() => {
+      callback(
+        [
+          {
+            target: document.getElementById('sec2') as Element,
+            isIntersecting: true,
+            intersectionRatio: 1,
+            time: 0,
+            boundingClientRect: {} as DOMRectReadOnly,
+            intersectionRect: {} as DOMRectReadOnly,
+            rootBounds: null,
+          } as IntersectionObserverEntry,
+        ],
+        {} as IntersectionObserver
+      );
+    });
+
+    expect(getByRole('link', { name: 'Section 2' }).className).toMatch(/font-bold/);
+  });
+});
+

--- a/components/TOC.tsx
+++ b/components/TOC.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+
+interface Heading {
+  id: string;
+  text: string;
+}
+
+interface TOCProps {
+  headings: Heading[];
+}
+
+const TOC: React.FC<TOCProps> = ({ headings }) => {
+  const [activeId, setActiveId] = useState<string>('');
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        });
+      },
+      { rootMargin: '0px 0px -80% 0px' }
+    );
+
+    headings.forEach(({ id }) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, [headings]);
+
+  return (
+    <nav aria-label="Table of contents" className="sticky top-0 p-4 max-h-screen overflow-auto">
+      <ul className="space-y-2">
+        {headings.map(({ id, text }) => (
+          <li key={id}>
+            <a href={`#${id}`} className={activeId === id ? 'font-bold text-blue-500' : ''}>
+              {text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+};
+
+export default TOC;
+

--- a/pages/docs/getting-started.tsx
+++ b/pages/docs/getting-started.tsx
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import path from 'path';
+import React from 'react';
+import { marked } from 'marked';
+import TOC from '../../components/TOC';
+
+interface Heading {
+  id: string;
+  text: string;
+}
+
+interface Props {
+  html: string;
+  headings: Heading[];
+}
+
+const GettingStarted = ({ html, headings }: Props) => (
+  <div className="flex gap-4">
+    <a
+      href="#main-content"
+      className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 bg-white text-black p-2 z-50"
+    >
+      Skip to main content
+    </a>
+    <TOC headings={headings} />
+    <main
+      id="main-content"
+      className="prose dark:prose-invert max-w-none flex-1 p-4"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  </div>
+);
+
+export async function getStaticProps() {
+  const filePath = path.join(process.cwd(), 'docs', 'getting-started.md');
+  const markdown = fs.readFileSync(filePath, 'utf-8');
+  const slugger = new marked.Slugger();
+  const tokens = marked.lexer(markdown);
+  const headings: Heading[] = tokens
+    .filter((t) => t.type === 'heading' && t.depth <= 3)
+    .map((t) => ({ id: slugger.slug(t.text), text: t.text }));
+
+  const renderer = new marked.Renderer();
+  renderer.heading = (text, level, raw) => {
+    const id = slugger.slug(raw);
+    return `<h${level} id="${id}">${text}</h${level}>`;
+  };
+
+  const html = marked(markdown, { renderer });
+
+  return { props: { html, headings } };
+}
+
+export default GettingStarted;
+


### PR DESCRIPTION
## Summary
- implement sticky table of contents using IntersectionObserver
- add skip link and markdown-powered docs page
- verify TOC highlighting behavior with unit test

## Testing
- `yarn lint` (fails: A control must be associated with a text label)
- `yarn test` (fails: window.test.tsx, nmapNse.test.tsx)
- `yarn test __tests__/toc.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c698302bf083289b0e9e4292aca1dc