### PR TITLE
[docs] add release index with LTS/EOL badges

### DIFF
--- a/__tests__/releases.test.ts
+++ b/__tests__/releases.test.ts
@@ -1,0 +1,11 @@
+import { getReleases } from '../lib/releases';
+
+describe('getReleases', () => {
+  it('parses LTS and EOL front matter', () => {
+    const releases = getReleases();
+    const current = releases.find((r) => r.version === '2024.1');
+    expect(current).toBeDefined();
+    expect(current?.lts).toBe(true);
+    expect(current?.eol).toBe('2026-01-01');
+  });
+});

--- a/data/releases/2023.4.mdx
+++ b/data/releases/2023.4.mdx
@@ -1,0 +1,7 @@
+---
+version: "2023.4"
+title: "Kali Linux 2023.4"
+eol: "2024-12-31"
+---
+
+Previous stable release.

--- a/data/releases/2024.1.mdx
+++ b/data/releases/2024.1.mdx
@@ -1,0 +1,8 @@
+---
+version: "2024.1"
+title: "Kali Linux 2024.1"
+lts: true
+eol: "2026-01-01"
+---
+
+Initial 2024 release.

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+
+export interface ReleaseMeta {
+  slug: string;
+  version: string;
+  title: string;
+  lts?: boolean;
+  eol?: string;
+}
+
+const releasesDir = path.join(process.cwd(), 'data', 'releases');
+
+export function getReleases(): ReleaseMeta[] {
+  return fs
+    .readdirSync(releasesDir)
+    .filter((file) => file.endsWith('.mdx'))
+    .map((file) => {
+      const slug = file.replace(/\.mdx$/, '');
+      const { data } = matter.read(path.join(releasesDir, file));
+      return { slug, ...data } as ReleaseMeta;
+    });
+}

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "dompurify": "^3.2.6",
     "fast-xml-parser": "^4.3.5",
     "figlet": "^1.8.2",
+    "gray-matter": "^4.0.3",
     "hash-wasm": "^4.12.0",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",

--- a/pages/releases/index.tsx
+++ b/pages/releases/index.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { GetStaticProps } from 'next';
+import { ReleaseMeta, getReleases } from '../../lib/releases';
+
+interface Props {
+  releases: ReleaseMeta[];
+}
+
+export default function ReleasesPage({ releases }: Props) {
+  const [filter, setFilter] = useState<'all' | 'lts' | 'eol'>('all');
+  const filtered = releases.filter((r) => {
+    if (filter === 'lts') return r.lts;
+    if (filter === 'eol') return Boolean(r.eol);
+    return true;
+  });
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Releases</h1>
+      <select
+        className="border p-1"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value as 'all' | 'lts' | 'eol')}
+      >
+        <option value="all">All</option>
+        <option value="lts">LTS</option>
+        <option value="eol">EOL</option>
+      </select>
+      <ul className="space-y-2">
+        {filtered.map((release) => (
+          <li key={release.slug} id={release.slug} className="scroll-mt-16">
+            <a href={`#${release.slug}`} className="font-medium">
+              {release.title}
+            </a>
+            {release.lts && (
+              <span className="ml-2 rounded bg-green-200 px-2 py-0.5 text-xs text-green-800">
+                LTS
+              </span>
+            )}
+            {release.eol && (
+              <span className="ml-1 rounded bg-red-200 px-2 py-0.5 text-xs text-red-800">
+                EOL {release.eol}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export const getStaticProps: GetStaticProps<Props> = async () => {
+  const releases = getReleases();
+  return { props: { releases } };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7210,6 +7210,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"extend-shallow@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "extend-shallow@npm:2.0.1"
+  dependencies:
+    is-extendable: "npm:^0.1.0"
+  checksum: 10c0/ee1cb0a18c9faddb42d791b2d64867bd6cfd0f3affb711782eb6e894dd193e2934a7f529426aac7c8ddb31ac5d38000a00aa2caf08aa3dfc3e1c8ff6ba340bd9
+  languageName: node
+  linkType: hard
+
 "extract-zip@npm:^2.0.1":
   version: 2.0.1
   resolution: "extract-zip@npm:2.0.1"
@@ -7879,6 +7888,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gray-matter@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "gray-matter@npm:4.0.3"
+  dependencies:
+    js-yaml: "npm:^3.13.1"
+    kind-of: "npm:^6.0.2"
+    section-matter: "npm:^1.0.0"
+    strip-bom-string: "npm:^1.0.0"
+  checksum: 10c0/e38489906dad4f162ca01e0dcbdbed96d1a53740cef446b9bf76d80bec66fa799af07776a18077aee642346c5e1365ed95e4c91854a12bf40ba0d4fb43a625a6
+  languageName: node
+  linkType: hard
+
 "gzip-size@npm:^6.0.0":
   version: 6.0.0
   resolution: "gzip-size@npm:6.0.0"
@@ -8302,6 +8323,13 @@ __metadata:
     call-bound: "npm:^1.0.2"
     has-tostringtag: "npm:^1.0.2"
   checksum: 10c0/1a4d199c8e9e9cac5128d32e6626fa7805175af9df015620ac0d5d45854ccf348ba494679d872d37301032e35a54fc7978fba1687e8721b2139aea7870cafa2f
+  languageName: node
+  linkType: hard
+
+"is-extendable@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "is-extendable@npm:0.1.1"
+  checksum: 10c0/dd5ca3994a28e1740d1e25192e66eed128e0b2ff161a7ea348e87ae4f616554b486854de423877a2a2c171d5f7cd6e8093b91f54533bc88a59ee1c9838c43879
   languageName: node
   linkType: hard
 
@@ -9448,6 +9476,13 @@ __metadata:
   dependencies:
     json-buffer: "npm:3.0.1"
   checksum: 10c0/aa52f3c5e18e16bb6324876bb8b59dd02acf782a4b789c7b2ae21107fab95fab3890ed448d4f8dba80ce05391eeac4bfabb4f02a20221342982f806fa2cf271e
+  languageName: node
+  linkType: hard
+
+"kind-of@npm:^6.0.0, kind-of@npm:^6.0.2":
+  version: 6.0.3
+  resolution: "kind-of@npm:6.0.3"
+  checksum: 10c0/61cdff9623dabf3568b6445e93e31376bee1cdb93f8ba7033d86022c2a9b1791a1d9510e026e6465ebd701a6dd2f7b0808483ad8838341ac52f003f512e0b4c4
   languageName: node
   linkType: hard
 
@@ -12407,6 +12442,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"section-matter@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "section-matter@npm:1.0.0"
+  dependencies:
+    extend-shallow: "npm:^2.0.1"
+    kind-of: "npm:^6.0.0"
+  checksum: 10c0/8007f91780adc5aaa781a848eaae50b0f680bbf4043b90cf8a96778195b8fab690c87fe7a989e02394ce69890e330811ec8dab22397d384673ce59f7d750641d
+  languageName: node
+  linkType: hard
+
 "seedrandom@npm:^3.0.5":
   version: 3.0.5
   resolution: "seedrandom@npm:3.0.5"
@@ -12993,6 +13038,13 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.0.1"
   checksum: 10c0/a198c3762e8832505328cbf9e8c8381de14a4fa50a4f9b2160138158ea88c0f5549fb50cb13c651c3088f47e63a108b34622ec18c0499b6c8c3a5ddf6b305ac4
+  languageName: node
+  linkType: hard
+
+"strip-bom-string@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "strip-bom-string@npm:1.0.0"
+  checksum: 10c0/5c5717e2643225aa6a6d659d34176ab2657037f1fe2423ac6fcdb488f135e14fef1022030e426d8b4d0989e09adbd5c3288d5d3b9c632abeefd2358dfc512bca
   languageName: node
   linkType: hard
 
@@ -13911,6 +13963,7 @@ __metadata:
     fast-glob: "npm:^3.3.3"
     fast-xml-parser: "npm:^4.3.5"
     figlet: "npm:^1.8.2"
+    gray-matter: "npm:^4.0.3"
     hash-wasm: "npm:^4.12.0"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"


### PR DESCRIPTION
## Summary
- parse MDX release front matter for version, LTS, and EOL metadata
- add filterable release index page with badges and deep-link anchors

## Testing
- `yarn lint` (fails: Unexpected global 'document' in public/apps/tetris/main.js)
- `yarn test` (fails: Window snapping finalize test; NmapNSEApp copy output test)

------
https://chatgpt.com/codex/tasks/task_e_68c6983700848328acee85b07b640209