### PR TITLE
[pages] add download scenario cards

### DIFF
--- a/__tests__/downloadCard.test.tsx
+++ b/__tests__/downloadCard.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DownloadCard from '../components/DownloadCard';
+
+describe('DownloadCard', () => {
+  it('copies command when copy button is clicked', () => {
+    const steps = [{ text: 'Step one', command: 'echo test' }];
+    render(<DownloadCard title="Test" steps={steps} />);
+    fireEvent.click(screen.getByText('Test'));
+    (navigator as any).clipboard = { writeText: jest.fn() };
+    fireEvent.click(screen.getByRole('button', { name: /Copy command/i }));
+    expect((navigator as any).clipboard.writeText).toHaveBeenCalledWith('echo test');
+  });
+});
+

--- a/components/DownloadCard.tsx
+++ b/components/DownloadCard.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import copyToClipboard from '../utils/clipboard';
+
+export interface Step {
+  text: string;
+  command: string;
+}
+
+interface Props {
+  title: string;
+  steps: Step[];
+}
+
+export default function DownloadCard({ title, steps }: Props) {
+  const handleCopy = (cmd: string) => {
+    copyToClipboard(cmd);
+  };
+
+  return (
+    <details className="bg-black/30 rounded">
+      <summary className="cursor-pointer p-4 font-bold list-none">{title}</summary>
+      <ol className="p-4 space-y-4">
+        {steps.map((step, idx) => (
+          <li key={idx} className="space-y-2">
+            <p>{step.text}</p>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 bg-black/50 p-2 rounded break-all">{step.command}</code>
+              <button
+                className="px-2 py-1 bg-blue-600 text-white rounded"
+                onClick={() => handleCopy(step.command)}
+                aria-label="Copy command"
+              >
+                Copy
+              </button>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </details>
+  );
+}
+

--- a/pages/download.tsx
+++ b/pages/download.tsx
@@ -1,0 +1,104 @@
+import DownloadCard from '../components/DownloadCard';
+
+const scenarios = [
+  {
+    title: 'ISO',
+    steps: [
+      {
+        text: 'Download the ISO',
+        command: 'curl -O https://cdimage.kali.org/current/kali.iso',
+      },
+      {
+        text: 'Verify the download',
+        command: 'sha256sum kali.iso',
+      },
+      {
+        text: 'Write to USB drive',
+        command: 'sudo dd if=kali.iso of=/dev/sdX bs=4M status=progress && sync',
+      },
+    ],
+  },
+  {
+    title: 'VM',
+    steps: [
+      {
+        text: 'Download the VM image',
+        command: 'curl -O https://cdimage.kali.org/current/kali-vm.7z',
+      },
+      {
+        text: 'Extract the image',
+        command: '7z x kali-vm.7z',
+      },
+      {
+        text: 'Open in your hypervisor',
+        command: 'vmplayer kali-linux.vmx',
+      },
+    ],
+  },
+  {
+    title: 'Cloud',
+    steps: [
+      {
+        text: 'Fetch the cloud image',
+        command: 'curl -O https://cloud-images.kali.org/kali-cloud.qcow2',
+      },
+      {
+        text: 'Boot with QEMU',
+        command: 'qemu-system-x86_64 -m 2048 -hda kali-cloud.qcow2',
+      },
+    ],
+  },
+  {
+    title: 'WSL',
+    steps: [
+      {
+        text: 'Install from the store',
+        command: 'wsl --install -d kali-linux',
+      },
+      {
+        text: 'Launch the distro',
+        command: 'wsl -d kali-linux',
+      },
+    ],
+  },
+  {
+    title: 'Containers',
+    steps: [
+      {
+        text: 'Pull the latest image',
+        command: 'docker pull kalilinux/kali-rolling',
+      },
+      {
+        text: 'Start a container',
+        command: 'docker run -it kalilinux/kali-rolling bash',
+      },
+    ],
+  },
+  {
+    title: 'NetHunter',
+    steps: [
+      {
+        text: 'Download the APK',
+        command: 'curl -O https://images.kali.org/nethunter/nethunter.apk',
+      },
+      {
+        text: 'Install on device',
+        command: 'adb install nethunter.apk',
+      },
+    ],
+  },
+];
+
+export default function DownloadPage() {
+  return (
+    <div className="min-h-screen bg-ub-cool-grey text-white p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Download Options</h1>
+      <div className="grid md:grid-cols-2 gap-4">
+        {scenarios.map((s) => (
+          <DownloadCard key={s.title} title={s.title} steps={s.steps} />
+        ))}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a `/download` page with scenario cards for ISO, VM, Cloud, WSL, Containers, and NetHunter
- introduce `DownloadCard` component that expands to show steps with copy buttons
- add a unit test covering the copy interaction

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `npx eslint components/DownloadCard.tsx pages/download.tsx __tests__/downloadCard.test.tsx`
- `yarn test __tests__/downloadCard.test.tsx`
- `yarn test` *(fails: window snapping, nmapNse, reconng tests)*
- `yarn smoke` *(fails: Playwright missing system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c69837cffc8328b379a0c28035f41d