### PR TITLE
[apps] add mirror map with noscript fallback

### DIFF
--- a/__tests__/mirrorsPage.test.tsx
+++ b/__tests__/mirrorsPage.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import MirrorsPage from '../pages/mirrors';
+import mirrorsData from '../data/mirrors.json';
+import type { Mirror } from '../components/MirrorMap';
+
+const mirrors = mirrorsData as Mirror[];
+
+describe('Mirrors page', () => {
+  it('renders a pin for each mirror', () => {
+    const { container } = render(<MirrorsPage />);
+    expect(container.querySelectorAll('svg circle')).toHaveLength(mirrors.length);
+  });
+
+  it('includes a noscript fallback table', () => {
+    const { container } = render(<MirrorsPage />);
+    expect(container.querySelector('noscript')).not.toBeNull();
+  });
+});

--- a/components/MirrorMap.tsx
+++ b/components/MirrorMap.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+export interface Mirror {
+  id: string;
+  name: string;
+  location: string;
+  url: string;
+  description: string;
+  x: number;
+  y: number;
+}
+
+interface Props {
+  mirrors: Mirror[];
+  selectedId?: string;
+  onSelect: (mirror: Mirror) => void;
+}
+
+const MirrorMap: React.FC<Props> = ({ mirrors, selectedId, onSelect }) => {
+  return (
+    <svg viewBox="0 0 800 400" className="w-full max-w-3xl mx-auto bg-sky-100">
+      <g fill="#d1d5db" stroke="#9ca3af" strokeWidth="2">
+        <rect x="50" y="60" width="150" height="100" />
+        <rect x="120" y="180" width="80" height="120" />
+        <rect x="300" y="80" width="160" height="140" />
+        <rect x="480" y="80" width="180" height="140" />
+        <rect x="620" y="240" width="100" height="80" />
+      </g>
+      {mirrors.map((m) => (
+        <circle
+          key={m.id}
+          cx={m.x}
+          cy={m.y}
+          r={8}
+          className={`fill-red-500 cursor-pointer ${selectedId === m.id ? 'stroke-black stroke-2' : ''}`}
+          onClick={() => onSelect(m)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') onSelect(m);
+          }}
+          role="button"
+          tabIndex={0}
+          aria-label={`Select ${m.name}`}
+        />
+      ))}
+    </svg>
+  );
+};
+
+export default MirrorMap;

--- a/data/mirrors.json
+++ b/data/mirrors.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "us",
+    "name": "US Mirror",
+    "location": "New York, USA",
+    "url": "https://us.example.com/kali",
+    "description": "Primary mirror in the United States.",
+    "x": 150,
+    "y": 120
+  },
+  {
+    "id": "de",
+    "name": "Germany Mirror",
+    "location": "Frankfurt, Germany",
+    "url": "https://de.example.com/kali",
+    "description": "European mirror serving Germany.",
+    "x": 400,
+    "y": 110
+  },
+  {
+    "id": "jp",
+    "name": "Japan Mirror",
+    "location": "Tokyo, Japan",
+    "url": "https://jp.example.com/kali",
+    "description": "Asia mirror located in Tokyo.",
+    "x": 620,
+    "y": 130
+  }
+]

--- a/pages/mirrors/index.tsx
+++ b/pages/mirrors/index.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from 'react';
+import mirrorsData from '../../data/mirrors.json';
+import MirrorMap, { Mirror } from '../../components/MirrorMap';
+
+const mirrors = mirrorsData as Mirror[];
+
+export default function MirrorsPage() {
+  const [selected, setSelected] = useState<Mirror | null>(null);
+
+  return (
+    <main className="p-4 text-center">
+      <h1 className="text-2xl font-bold mb-4">Kali Linux Mirrors</h1>
+      <p className="mb-4">Select a mirror from the map to learn more.</p>
+      <MirrorMap mirrors={mirrors} selectedId={selected?.id} onSelect={setSelected} />
+      {selected && (
+        <div className="mt-4 p-4 border rounded max-w-md mx-auto text-left">
+          <h2 className="font-semibold">{selected.name}</h2>
+          <p className="text-sm mb-2">{selected.location}</p>
+          <p className="mb-2">{selected.description}</p>
+          <a href={selected.url} className="text-blue-500 underline">
+            {selected.url}
+          </a>
+        </div>
+      )}
+      <noscript>
+        <table className="mt-4 mx-auto text-left border-collapse">
+          <thead>
+            <tr>
+              <th className="border px-2 py-1">Name</th>
+              <th className="border px-2 py-1">Location</th>
+              <th className="border px-2 py-1">URL</th>
+              <th className="border px-2 py-1">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {mirrors.map((m) => (
+              <tr key={m.id}>
+                <td className="border px-2 py-1">{m.name}</td>
+                <td className="border px-2 py-1">{m.location}</td>
+                <td className="border px-2 py-1">
+                  <a href={m.url}>{m.url}</a>
+                </td>
+                <td className="border px-2 py-1">{m.description}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </noscript>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- render SVG world map with clickable mirror pins
- show details for selected mirror
- include noscript table fallback for no-JS users
- add unit test for mirror map

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `npx eslint components/MirrorMap.tsx pages/mirrors/index.tsx __tests__/mirrorsPage.test.tsx`
- `yarn test` *(fails: window.test.tsx release snap and nmapNse.test.tsx alert)*
- `yarn test __tests__/mirrorsPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c698386e248328b82f4029ecf772a4