### PR TITLE
[downloads] show checksum data with copy buttons

### DIFF
--- a/lib/checksums.ts
+++ b/lib/checksums.ts
@@ -1,0 +1,39 @@
+import crypto from 'crypto';
+import fs from 'fs/promises';
+import path from 'path';
+
+export interface ChecksumResult {
+  checksums: Record<string, string>;
+  signature: string | null;
+}
+
+/**
+ * Fetch checksum JSON and sign it with HMAC-SHA256.
+ * Falls back to reading a local checksums.json if CHECKSUM_URL is unset.
+ */
+export async function fetchAndSignChecksums(): Promise<ChecksumResult> {
+  let checksums: Record<string, string>;
+  const url = process.env.CHECKSUM_URL;
+
+  if (url) {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch checksum json: ${res.statusText}`);
+    }
+    checksums = await res.json();
+  } else {
+    const filePath = path.join(process.cwd(), 'public', 'checksums.json');
+    const file = await fs.readFile(filePath, 'utf8');
+    checksums = JSON.parse(file);
+  }
+
+  const secret = process.env.CHECKSUM_SECRET;
+  const json = JSON.stringify(checksums);
+  const signature = secret
+    ? crypto.createHmac('sha256', secret).update(json).digest('hex')
+    : null;
+
+  return { checksums, signature };
+}
+
+export default fetchAndSignChecksums;

--- a/pages/api/checksums.ts
+++ b/pages/api/checksums.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { fetchAndSignChecksums } from '../../lib/checksums';
+
+export default async function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  try {
+    const { checksums, signature } = await fetchAndSignChecksums();
+    res.status(200).json({ checksums, signature });
+  } catch (err) {
+    console.error('checksum API error', err);
+    res.status(500).json({ error: 'Unable to load checksums' });
+  }
+}

--- a/pages/downloads.tsx
+++ b/pages/downloads.tsx
@@ -1,0 +1,59 @@
+import { GetServerSideProps } from 'next';
+import { fetchAndSignChecksums } from '../lib/checksums';
+
+interface DownloadItem {
+  name: string;
+  url: string;
+  checksum: string;
+}
+
+interface DownloadsPageProps {
+  items: DownloadItem[];
+}
+
+const DOWNLOADS: Omit<DownloadItem, 'checksum'>[] = [
+  { name: 'Resume PDF', url: '/resume.pdf' },
+  { name: 'vCard', url: '/assets/alex-unnippillil.vcf' },
+];
+
+export default function DownloadsPage({ items }: DownloadsPageProps) {
+  const copy = (text: string) => {
+    if (navigator?.clipboard) {
+      navigator.clipboard.writeText(text);
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-4">Downloads</h1>
+      <ul className="space-y-4">
+        {items.map(({ name, url, checksum }) => (
+          <li key={url} className="flex flex-col sm:flex-row sm:items-center">
+            <a href={url} className="text-ubt-blue underline mr-2">{name}</a>
+            <div className="flex items-center mt-2 sm:mt-0">
+              <code className="bg-gray-800 text-gray-100 px-2 py-1 text-xs rounded w-[20ch]">
+                {checksum}
+              </code>
+              <button
+                type="button"
+                className="ml-2 px-2 py-1 text-xs bg-ub-gedit-light rounded"
+                onClick={() => copy(checksum)}
+              >
+                Copy
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<DownloadsPageProps> = async () => {
+  const { checksums } = await fetchAndSignChecksums();
+  const items: DownloadItem[] = DOWNLOADS.map((d) => ({
+    ...d,
+    checksum: checksums[d.url] || '',
+  }));
+  return { props: { items } };
+};

--- a/public/checksums.json
+++ b/public/checksums.json
@@ -1,0 +1,4 @@
+{
+  "/resume.pdf": "b9d140fca33fd7d15073be92c209d5f1eba12a29ce24e61250c376552da51d17",
+  "/assets/alex-unnippillil.vcf": "7ad85d825767e3f47a695e530e8f8e687f9dd4fee2e68a5799b7893485c81eff"
+}


### PR DESCRIPTION
## Summary
- fetch and sign checksum data on the server
- expose checksums via `/api/checksums`
- render checksums with copy controls on downloads page

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: releases snap with Alt+ArrowDown restoring size; copies example output to clipboard; modal closes when Escape pressed globally)*

------
https://chatgpt.com/codex/tasks/task_e_68c698396c248328a84b9a524f85d51c