### PR TITLE
[tooling] add magnet URI generator

### DIFF
--- a/__tests__/magnet.test.ts
+++ b/__tests__/magnet.test.ts
@@ -1,0 +1,23 @@
+/** @jest-environment node */
+import fs from 'fs'
+import path from 'path'
+import { createHash, createVerify, generateKeyPairSync } from 'crypto'
+import { generateSignedMagnet } from '../utils/magnet.js'
+
+test('generateSignedMagnet produces valid hash and signature', async () => {
+  const tmpFile = path.join(__dirname, 'tmp.txt')
+  fs.writeFileSync(tmpFile, 'test')
+  const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+  const privPath = path.join(__dirname, 'tmp.key')
+  fs.writeFileSync(privPath, privateKey.export({ type: 'pkcs1', format: 'pem' }))
+  const { sha256, magnet, signature } = await generateSignedMagnet(tmpFile, privPath)
+  const expectedHash = createHash('sha256').update('test').digest('hex')
+  expect(sha256).toBe(expectedHash)
+  const verifier = createVerify('sha256')
+  verifier.update(magnet)
+  verifier.end()
+  const valid = verifier.verify(publicKey.export({ type: 'pkcs1', format: 'pem' }), Buffer.from(signature, 'base64'))
+  expect(valid).toBe(true)
+  fs.unlinkSync(tmpFile)
+  fs.unlinkSync(privPath)
+})

--- a/docs/magnet-uris.md
+++ b/docs/magnet-uris.md
@@ -1,0 +1,36 @@
+# Release Magnet URIs and Verification
+
+Use `scripts/generate-signed-magnet.mjs` to publish magnet links for release files.
+The script prints the file's SHA-256, a magnet URI embedding that hash, and a
+signature produced with your private key.
+
+```bash
+node scripts/generate-signed-magnet.mjs <file> <privateKey> [httpMirror]
+```
+
+- `file` – path to the release artifact.
+- `privateKey` – PEM file used to sign the magnet URI.
+- `httpMirror` – optional HTTP(S) URL to check parity against.
+
+When a mirror URL is supplied the script downloads the file and confirms the
+SHA-256 matches the local copy.
+
+## Verifying downloads
+
+1. **Check the hash**
+   ```bash
+   sha256sum <downloaded-file>
+   # compare with the SHA-256 displayed next to the magnet URI
+   ```
+2. **Validate the signature**
+   ```bash
+   echo -n 'magnet:?dn=...' > magnet.txt
+   base64 -d <<<"<signature>" > magnet.sig
+   openssl dgst -sha256 -verify public.pem -signature magnet.sig magnet.txt
+   ```
+3. **Mirror parity**
+   If the script reported a mismatch, fetch another mirror and repeat the hash
+   check.
+
+Distribute the magnet URI, SHA-256, and signature together so users can confirm
+integrity before installing a release.

--- a/scripts/generate-signed-magnet.mjs
+++ b/scripts/generate-signed-magnet.mjs
@@ -1,0 +1,22 @@
+import { generateSignedMagnet } from '../utils/magnet.js'
+
+const [,, file, key, mirror] = process.argv
+
+if (!file || !key) {
+  console.error('Usage: node scripts/generate-signed-magnet.mjs <file> <privateKey> [mirrorUrl]')
+  process.exit(1)
+}
+
+try {
+  const { sha256, magnet, signature, mirrorMatch } = await generateSignedMagnet(file, key, mirror)
+  console.log('SHA-256:', sha256)
+  console.log('Magnet URI:', magnet)
+  console.log('Signature (base64):', signature)
+  if (mirror) {
+    console.log(`HTTP mirror hash ${mirrorMatch ? 'matches' : 'does not match'} local hash`)
+    if (!mirrorMatch) process.exit(1)
+  }
+} catch (err) {
+  console.error(err)
+  process.exit(1)
+}

--- a/utils/magnet.js
+++ b/utils/magnet.js
@@ -1,0 +1,64 @@
+const fs = require('fs')
+const path = require('path')
+const crypto = require('crypto')
+const http = require('http')
+const https = require('https')
+const { URL } = require('url')
+
+const sha256File = (filePath) =>
+  new Promise((resolve, reject) => {
+    const hash = crypto.createHash('sha256')
+    const stream = fs.createReadStream(filePath)
+    stream.on('data', (data) => hash.update(data))
+    stream.on('end', () => resolve(hash.digest('hex')))
+    stream.on('error', reject)
+  })
+
+const magnetURI = (filePath, sha256) => {
+  const name = path.basename(filePath)
+  return `magnet:?dn=${encodeURIComponent(name)}&xt=urn:sha256:${sha256}`
+}
+
+const signMagnet = (magnet, privateKey) => {
+  const signer = crypto.createSign('sha256')
+  signer.update(magnet)
+  signer.end()
+  return signer.sign(privateKey).toString('base64')
+}
+
+const fetchSha256 = (url) =>
+  new Promise((resolve, reject) => {
+    const hash = crypto.createHash('sha256')
+    const parsed = new URL(url)
+    const getter = parsed.protocol === 'https:' ? https.get : http.get
+    getter(url, (res) => {
+      if (res.statusCode !== 200) {
+        reject(new Error(`HTTP ${res.statusCode}`))
+        return
+      }
+      res.on('data', (d) => hash.update(d))
+      res.on('end', () => resolve(hash.digest('hex')))
+      res.on('error', reject)
+    }).on('error', reject)
+  })
+
+const generateSignedMagnet = async (filePath, keyPath, mirrorUrl) => {
+  const sha256 = await sha256File(filePath)
+  const magnet = magnetURI(filePath, sha256)
+  const privateKey = fs.readFileSync(keyPath, 'utf8')
+  const signature = signMagnet(magnet, privateKey)
+  let mirrorMatch
+  if (mirrorUrl) {
+    const mirrorHash = await fetchSha256(mirrorUrl)
+    mirrorMatch = mirrorHash === sha256
+  }
+  return { sha256, magnet, signature, mirrorMatch }
+}
+
+module.exports = {
+  sha256File,
+  magnetURI,
+  signMagnet,
+  fetchSha256,
+  generateSignedMagnet,
+}


### PR DESCRIPTION
## Summary
- add utility to hash files, build magnet URIs, sign them, and verify HTTP mirror parity
- expose CLI script for generating signed magnet links per release
- document magnet URI generation and verification steps
- add unit test covering magnet generation and signature

## Testing
- `yarn lint` *(fails: Unexpected global 'document' errors in existing files)*
- `npx eslint utils/magnet.js scripts/generate-signed-magnet.mjs __tests__/magnet.test.ts docs/magnet-uris.md`
- `yarn test` *(fails: Window snapping and NmapNSE tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c6983c58d88328ae4e5ea24d4bf2a7