### PR TITLE
[apps] add environment comparison

### DIFF
--- a/__tests__/EnvironmentComparison.test.tsx
+++ b/__tests__/EnvironmentComparison.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import EnvironmentComparison from '../components/apps/environment-comparison';
+
+describe('EnvironmentComparison', () => {
+  it('renders environment headers', () => {
+    render(<EnvironmentComparison />);
+    expect(screen.getByText('Bare Metal')).toBeInTheDocument();
+    expect(screen.getByText('VM')).toBeInTheDocument();
+    expect(screen.getByText('WSL')).toBeInTheDocument();
+    expect(screen.getByText('Cloud')).toBeInTheDocument();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -73,6 +73,10 @@ const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery')
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
+const EnvironmentComparisonApp = createDynamicApp(
+  'environment-comparison',
+  'Environment Comparison'
+);
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
 const TrashApp = createDynamicApp('trash', 'Trash');
@@ -167,6 +171,7 @@ const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
 
 const displayGhidra = createDisplay(GhidraApp);
+const displayEnvironmentComparison = createDisplay(EnvironmentComparisonApp);
 
 const displayAutopsy = createDisplay(AutopsyApp);
 const displayPluginManager = createDisplay(PluginManagerApp);
@@ -257,6 +262,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayProjectGallery,
+  },
+  {
+    id: 'environment-comparison',
+    title: 'Environment Comparison',
+    icon: '/themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayEnvironmentComparison,
   },
   {
     id: 'input-lab',

--- a/components/apps/environment-comparison.tsx
+++ b/components/apps/environment-comparison.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+interface Props {
+  addFolder?: (name: string) => void;
+  openApp?: (id: string) => void;
+}
+
+const rows = [
+  {
+    feature: 'Setup',
+    bareMetal: 'Requires dedicated hardware and manual OS installation.',
+    vm: 'Needs hypervisor and VM configuration.',
+    wsl: 'Install from Microsoft Store; integrates with Windows.',
+    cloud: 'Provision instance and connect over the network.',
+  },
+  {
+    feature: 'Performance',
+    bareMetal: 'Full performance with direct hardware access.',
+    vm: 'Small overhead; depends on host resources.',
+    wsl: 'Near-native CPU performance but limited GPU access.',
+    cloud: 'Varies by provider and instance size; network latency applies.',
+  },
+  {
+    feature: 'Isolation',
+    bareMetal: 'No isolation from host; affects system directly.',
+    vm: 'Strong isolation between host and guest.',
+    wsl: 'Shares Windows kernel; moderate isolation.',
+    cloud: 'Isolated from local machine; provider manages host.',
+  },
+  {
+    feature: 'Hardware access',
+    bareMetal: 'Full access to all devices.',
+    vm: 'Virtualized access; USB/GPU require passthrough.',
+    wsl: 'Limited USB and peripheral support.',
+    cloud: 'Minimal local device access.',
+  },
+  {
+    feature: 'Use cases',
+    bareMetal: 'Best for dedicated lab hardware.',
+    vm: 'Great for snapshots and disposable environments.',
+    wsl: 'Convenient for Windows development workflows.',
+    cloud: 'Accessible anywhere with pay-as-you-go pricing.',
+  },
+];
+
+const EnvironmentComparison: React.FC<Props> = () => (
+  <div className="p-4 overflow-auto text-white bg-ub-cool-grey h-full">
+    <table className="w-full text-sm border-collapse">
+      <thead>
+        <tr className="bg-gray-800">
+          <th className="p-2 text-left">Feature</th>
+          <th className="p-2 text-left">Bare Metal</th>
+          <th className="p-2 text-left">VM</th>
+          <th className="p-2 text-left">WSL</th>
+          <th className="p-2 text-left">Cloud</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.feature} className="border-t border-gray-700 align-top">
+            <th className="p-2 text-left font-medium">{row.feature}</th>
+            <td className="p-2">{row.bareMetal}</td>
+            <td className="p-2">{row.vm}</td>
+            <td className="p-2">{row.wsl}</td>
+            <td className="p-2">{row.cloud}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default EnvironmentComparison;


### PR DESCRIPTION
## Summary
- add Environment Comparison app to compare bare metal, VM, WSL, and cloud setups
- register new app in apps config and add unit test for headers

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window.test.tsx TypeError and nmapNse.test.tsx missing alert)*

------
https://chatgpt.com/codex/tasks/task_e_68c69865e5048328bed215bfa1e8a02d