### PR TITLE
[edge] set locale and mirror cookies

### DIFF
--- a/__tests__/geoCookies.test.ts
+++ b/__tests__/geoCookies.test.ts
@@ -1,0 +1,11 @@
+import { deriveCookies } from '../utils/geoCookies';
+
+describe('deriveCookies', () => {
+  it('returns locale and mirror from country', () => {
+    expect(deriveCookies('DE')).toEqual({ preferredMirror: 'de', locale: 'en-DE' });
+  });
+
+  it('falls back when country missing', () => {
+    expect(deriveCookies()).toEqual({ preferredMirror: 'global', locale: 'en-US' });
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server';
+import { deriveCookies } from './utils/geoCookies';
 
 function nonce() {
   const arr = new Uint8Array(16);
@@ -22,8 +23,19 @@ export function middleware(req: NextRequest) {
     "form-action 'self'"
   ].join('; ');
 
+  const { country } = req.geo ?? {};
+  const { preferredMirror, locale } = deriveCookies(country);
+
   const res = NextResponse.next();
   res.headers.set('x-csp-nonce', n);
   res.headers.set('Content-Security-Policy', csp);
+
+  if (!req.cookies.get('preferredMirror')) {
+    res.cookies.set('preferredMirror', preferredMirror, { path: '/' });
+  }
+  if (!req.cookies.get('locale')) {
+    res.cookies.set('locale', locale, { path: '/' });
+  }
+
   return res;
 }

--- a/utils/geoCookies.ts
+++ b/utils/geoCookies.ts
@@ -1,0 +1,5 @@
+export function deriveCookies(country?: string) {
+  const preferredMirror = country ? country.toLowerCase() : 'global';
+  const locale = country ? `en-${country}` : 'en-US';
+  return { preferredMirror, locale };
+}


### PR DESCRIPTION
## Summary
- populate `preferredMirror` and `locale` cookies from Vercel `request.geo`
- add utility and tests for geographic cookie derivation

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: Window snapping finalize test, NmapNSEApp test)*
- `yarn test __tests__/geoCookies.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c69861a4ac8328a6e845bbf77ba064