### PR TITLE
[mirrors] add SWR mirror list with retries and cache

### DIFF
--- a/__tests__/mirrors.test.tsx
+++ b/__tests__/mirrors.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import MirrorsPage from '../pages/mirrors';
+import { useMirrors } from '../hooks/useMirrors';
+
+jest.mock('../hooks/useMirrors');
+
+const mockedUseMirrors = useMirrors as jest.MockedFunction<typeof useMirrors>;
+
+describe('MirrorsPage', () => {
+  it('shows skeleton while loading', () => {
+    mockedUseMirrors.mockReturnValue({ mirrors: null, isLoading: true, error: undefined } as any);
+    render(<MirrorsPage />);
+    expect(screen.getByTestId('mirrors-skeleton')).toBeInTheDocument();
+  });
+
+  it('shows error state', () => {
+    mockedUseMirrors.mockReturnValue({ mirrors: null, isLoading: false, error: new Error('fail') } as any);
+    render(<MirrorsPage />);
+    expect(screen.getByRole('alert')).toHaveTextContent(/failed to load mirrors/i);
+  });
+});

--- a/hooks/useMirrors.ts
+++ b/hooks/useMirrors.ts
@@ -1,0 +1,47 @@
+import useSWR from 'swr';
+import { useEffect } from 'react';
+
+const MIRROR_CACHE_KEY = 'mirrors-cache';
+
+async function fetcher(url: string) {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error('Failed to fetch mirrors');
+  }
+  return res.json();
+}
+
+export function useMirrors() {
+  const { data, error, isValidating, mutate } = useSWR('/api/mirrors', fetcher, {
+    revalidateOnFocus: false,
+    fallbackData: typeof window !== 'undefined'
+      ? JSON.parse(localStorage.getItem(MIRROR_CACHE_KEY) || 'null')
+      : null,
+    onErrorRetry: (err, key, config, revalidate, { retryCount }) => {
+      if (!navigator.onLine) return;
+      if (retryCount >= 5) return;
+      const timeout = Math.min(30000, 1000 * 2 ** retryCount);
+      setTimeout(() => revalidate({ retryCount }), timeout);
+    },
+  });
+
+  useEffect(() => {
+    if (data) {
+      try {
+        localStorage.setItem(MIRROR_CACHE_KEY, JSON.stringify(data));
+      } catch {
+        // ignore
+      }
+    }
+  }, [data]);
+
+  return {
+    mirrors: data as any,
+    isLoading: !data && !error,
+    error,
+    mutate,
+    isValidating,
+  };
+}
+
+export default useMirrors;

--- a/pages/api/mirrors.ts
+++ b/pages/api/mirrors.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    const response = await fetch('https://mirror-status.kali.org/mirrors.json');
+    if (!response.ok) {
+      res.status(response.status).json({ error: 'Failed to fetch mirrors' });
+      return;
+    }
+    const data = await response.json();
+    res.setHeader('Cache-Control', 's-maxage=3600, stale-while-revalidate=86400');
+    res.status(200).json(data);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch mirrors' });
+  }
+}

--- a/pages/mirrors.tsx
+++ b/pages/mirrors.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import useMirrors from '../hooks/useMirrors';
+
+export default function MirrorsPage() {
+  const { mirrors, isLoading, error } = useMirrors();
+
+  if (isLoading) {
+    return <div data-testid="mirrors-skeleton" className="p-4">Loading mirrors...</div>;
+  }
+
+  if (error) {
+    return (
+      <div role="alert" className="p-4 text-red-600">
+        Failed to load mirrors.
+      </div>
+    );
+  }
+
+  return (
+    <ul className="p-4 list-disc list-inside">
+      {Array.isArray(mirrors) && mirrors.length > 0 ? (
+        mirrors.map((m: any, idx: number) => (
+          <li key={idx}>{m.url || m.href || JSON.stringify(m)}</li>
+        ))
+      ) : (
+        <li>No mirrors available.</li>
+      )}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- fetch Kali mirror status via SWR with exponential backoff and offline cache
- expose `/api/mirrors` endpoint proxying mirror-status
- add mirrors page with skeleton loading and error states

## Testing
- `npx eslint hooks/useMirrors.ts pages/mirrors.tsx pages/api/mirrors.ts __tests__/mirrors.test.tsx && echo LINT OK`
- `yarn test __tests__/mirrors.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c6985fa7748328bd00094ec1388c97