### PR TITLE
[ui] add responsive keyboard table

### DIFF
--- a/pages/keyboard-reference.tsx
+++ b/pages/keyboard-reference.tsx
@@ -1,37 +1,37 @@
 import React from 'react';
 
+const shortcuts = [
+  { key: 'Ctrl + C', action: 'Copy selected text' },
+  { key: 'Ctrl + V', action: 'Paste from clipboard' },
+  { key: 'Ctrl + X', action: 'Cut selected text' },
+  { key: 'Alt + Tab', action: 'Switch between apps' },
+  { key: 'Alt + F4', action: 'Close current window' },
+];
+
 const KeyboardReference = () => (
   <main className="min-h-screen bg-ub-cool-grey text-white p-4 space-y-4">
     <h1 className="text-2xl font-bold">Keyboard Mapping Reference</h1>
     <p className="mb-4">Common shortcuts for navigating and interacting with the desktop.</p>
-    <table className="w-full border-collapse">
-      <thead>
+    <table className="w-full border-collapse text-sm">
+      <thead className="sr-only sticky top-0 bg-ub-cool-grey sm:not-sr-only">
         <tr>
-          <th className="p-2 text-left border border-ubt-grey">Key</th>
-          <th className="p-2 text-left border border-ubt-grey">Action</th>
+          <th className="p-2 text-left border border-ubt-grey" scope="col">Key</th>
+          <th className="p-2 text-left border border-ubt-grey" scope="col">Action</th>
         </tr>
       </thead>
-      <tbody>
-        <tr>
-          <td className="p-2 border border-ubt-grey">Ctrl + C</td>
-          <td className="p-2 border border-ubt-grey">Copy selected text</td>
-        </tr>
-        <tr>
-          <td className="p-2 border border-ubt-grey">Ctrl + V</td>
-          <td className="p-2 border border-ubt-grey">Paste from clipboard</td>
-        </tr>
-        <tr>
-          <td className="p-2 border border-ubt-grey">Ctrl + X</td>
-          <td className="p-2 border border-ubt-grey">Cut selected text</td>
-        </tr>
-        <tr>
-          <td className="p-2 border border-ubt-grey">Alt + Tab</td>
-          <td className="p-2 border border-ubt-grey">Switch between apps</td>
-        </tr>
-        <tr>
-          <td className="p-2 border border-ubt-grey">Alt + F4</td>
-          <td className="p-2 border border-ubt-grey">Close current window</td>
-        </tr>
+      <tbody className="block sm:table-row-group">
+        {shortcuts.map(({ key, action }) => (
+          <tr key={key} className="block border border-ubt-grey mb-2 sm:table-row sm:border-0 sm:mb-0">
+            <td className="p-2 border-b border-ubt-grey sm:border sm:border-ubt-grey sm:table-cell block" data-label="Key">
+              <span className="font-semibold sm:hidden" aria-hidden="true">Key: </span>
+              {key}
+            </td>
+            <td className="p-2 sm:border sm:border-ubt-grey sm:table-cell block" data-label="Action">
+              <span className="font-semibold sm:hidden" aria-hidden="true">Action: </span>
+              {action}
+            </td>
+          </tr>
+        ))}
       </tbody>
     </table>
   </main>


### PR DESCRIPTION
## Summary
- implement sticky header for keyboard reference table
- stack key/action pairs on small screens with screen-reader labels

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: e.preventDefault is not a function in __tests__/window.test.tsx; Unable to find role="alert" in __tests__/nmapNse.test.tsx; TypeError: Cannot read properties of null (reading '_origin'))*


------
https://chatgpt.com/codex/tasks/task_e_68c6985f2ad483288b92a07aafe01de1