### PR TITLE
[ui] add accessible callout, figure, and download card components

### DIFF
--- a/__tests__/Callout.test.tsx
+++ b/__tests__/Callout.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import Callout from '../components/ui/Callout';
+
+describe('Callout', () => {
+  test('renders with appropriate role and label', () => {
+    render(<Callout title="Info">Hello</Callout>);
+    const callout = screen.getByRole('status', { name: /info/i });
+    expect(callout).toBeInTheDocument();
+    expect(callout).toHaveTextContent('Hello');
+  });
+});

--- a/__tests__/DownloadCard.test.tsx
+++ b/__tests__/DownloadCard.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import DownloadCard from '../components/ui/DownloadCard';
+
+describe('DownloadCard', () => {
+  test('renders download link with label', () => {
+    render(
+      <DownloadCard title="File" description="Desc" href="/file.txt" />
+    );
+    const link = screen.getByRole('link', { name: /download file/i });
+    expect(link).toHaveAttribute('href', '/file.txt');
+    expect(link).toHaveAttribute('download');
+  });
+});

--- a/__tests__/Figure.test.tsx
+++ b/__tests__/Figure.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import Figure from '../components/ui/Figure';
+
+describe('Figure', () => {
+  test('renders image with caption', () => {
+    render(<Figure src="/test.png" alt="Test image" caption="Caption" />);
+    expect(screen.getByRole('img', { name: /test image/i })).toBeInTheDocument();
+    expect(screen.getByText('Caption')).toBeInTheDocument();
+  });
+});

--- a/components/ui/Callout.tsx
+++ b/components/ui/Callout.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+interface CalloutProps {
+  /** Optional title displayed at the top of the callout */
+  title?: string;
+  /** Callout contents */
+  children: React.ReactNode;
+  /** Visual style of the callout */
+  type?: 'info' | 'success' | 'warning' | 'error';
+}
+
+const styles: Record<NonNullable<CalloutProps['type']>, { bg: string; text: string; border: string; role: 'status' | 'alert' }> = {
+  info: { bg: 'bg-blue-100', text: 'text-blue-900', border: 'border-blue-300', role: 'status' },
+  success: { bg: 'bg-green-100', text: 'text-green-900', border: 'border-green-300', role: 'status' },
+  warning: { bg: 'bg-amber-100', text: 'text-amber-900', border: 'border-amber-300', role: 'alert' },
+  error: { bg: 'bg-red-100', text: 'text-red-900', border: 'border-red-300', role: 'alert' },
+};
+
+export default function Callout({ title, children, type = 'info' }: CalloutProps) {
+  const { bg, text, border, role } = styles[type];
+  const titleId = title ? `${title.replace(/\s+/g, '-')}-callout-title` : undefined;
+
+  return (
+    <div
+      role={role}
+      aria-labelledby={title ? titleId : undefined}
+      className={`p-4 border-l-4 ${bg} ${text} ${border}`.trim()}
+    >
+      {title && (
+        <p id={titleId} className="font-semibold mb-2">
+          {title}
+        </p>
+      )}
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/components/ui/DownloadCard.tsx
+++ b/components/ui/DownloadCard.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface DownloadCardProps {
+  /** Title of the downloadable item */
+  title: string;
+  /** Short description */
+  description?: string;
+  /** URL to download */
+  href: string;
+  /** Optional className for custom styling */
+  className?: string;
+}
+
+export default function DownloadCard({ title, description, href, className = '' }: DownloadCardProps) {
+  const label = `Download ${title}`;
+  return (
+    <article
+      className={`border rounded p-4 ${className}`.trim()}
+      aria-label={label}
+    >
+      <h3 className="text-lg font-semibold mb-2">{title}</h3>
+      {description && <p className="text-sm mb-4">{description}</p>}
+      <a href={href} download aria-label={label} className="text-blue-600 underline">
+        Download
+      </a>
+    </article>
+  );
+}

--- a/components/ui/Figure.tsx
+++ b/components/ui/Figure.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface FigureProps {
+  /** Image source */
+  src: string;
+  /** Alternative text for the image */
+  alt: string;
+  /** Optional caption displayed below the image */
+  caption?: React.ReactNode;
+  /** Optional className for custom styling */
+  className?: string;
+}
+
+export default function Figure({ src, alt, caption, className = '' }: FigureProps) {
+  return (
+    <figure className={className}>
+      <img src={src} alt={alt} className="max-w-full" />
+      {caption && <figcaption className="text-center text-sm mt-2">{caption}</figcaption>}
+    </figure>
+  );
+}


### PR DESCRIPTION
## Summary
- add Callout component with role-based styling
- add Figure wrapper for images with optional caption
- add DownloadCard linking to downloadable resources

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `npx eslint components/ui/Callout.tsx components/ui/Figure.tsx components/ui/DownloadCard.tsx __tests__/Callout.test.tsx __tests__/Figure.test.tsx __tests__/DownloadCard.test.tsx --max-warnings=0`
- `yarn test` *(fails: TypeError in window.test.tsx and missing alert in nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c6985d5bfc832888a151d396b080b5