### PR TITLE
[docs] add N-1 release comparison table

### DIFF
--- a/__tests__/releaseComparison.test.tsx
+++ b/__tests__/releaseComparison.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ReleaseComparison from '../pages/release-comparison';
+
+describe('ReleaseComparison', () => {
+  it('filters table rows by component', async () => {
+    const user = userEvent.setup();
+    render(<ReleaseComparison />);
+
+    // header + 3 rows
+    expect(screen.getAllByRole('row')).toHaveLength(4);
+
+    await user.type(screen.getByPlaceholderText(/filter components/i), 'kernel');
+
+    // header + 1 filtered row
+    expect(screen.getAllByRole('row')).toHaveLength(2);
+    expect(screen.getByText('Kernel')).toBeInTheDocument();
+    expect(screen.queryByText('Image')).not.toBeInTheDocument();
+  });
+});

--- a/pages/release-comparison.tsx
+++ b/pages/release-comparison.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from 'react';
+
+interface ReleaseInfo {
+  component: string;
+  previous: string;
+  current: string;
+}
+
+const data: ReleaseInfo[] = [
+  { component: 'Image', previous: '2023.4', current: '2024.1' },
+  { component: 'Kernel', previous: '6.5', current: '6.7' },
+  { component: 'Desktop', previous: 'KDE Plasma 5.27', current: 'KDE Plasma 5.28' },
+];
+
+const ReleaseComparison = () => {
+  const [query, setQuery] = useState('');
+
+  const filtered = data.filter((item) =>
+    item.component.toLowerCase().includes(query.toLowerCase())
+  );
+
+  return (
+    <div className="p-4 print:p-0">
+      <input
+        id="comparison-filter"
+        type="search"
+        aria-label="Filter components"
+        placeholder="Filter components"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        className="mb-4 w-full rounded border p-2 print:border-black"
+      />
+      <table className="w-full border-collapse print:border print:border-black">
+        <thead>
+          <tr>
+            <th className="border p-2 print:border-black">Component</th>
+            <th className="border p-2 print:border-black">N-1</th>
+            <th className="border p-2 print:border-black">Current</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((item) => (
+            <tr key={item.component}>
+              <td className="border p-2 print:border-black">{item.component}</td>
+              <td className="border p-2 print:border-black">{item.previous}</td>
+              <td className="border p-2 print:border-black">{item.current}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default ReleaseComparison;
+


### PR DESCRIPTION
## Summary
- add release comparison page with N-1 vs current image/kernel/desktop
- filter field with print-friendly styling

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window and nmapNse tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c69859d5508328a915dcd7686a3394