### PR TITLE
[docs] add release timeline and RSS feed

### DIFF
--- a/__tests__/releaseTimeline.test.tsx
+++ b/__tests__/releaseTimeline.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import ReleaseTimeline from '../components/ReleaseTimeline';
+
+describe('ReleaseTimeline', () => {
+  it('renders anchors and tags', () => {
+    const releases = [
+      { version: '2.1.0', date: '2025-09-03', tags: ['Added', 'Fixed'] },
+    ];
+    render(<ReleaseTimeline releases={releases} />);
+    const link = screen.getByRole('link', { name: '2.1.0' });
+    expect(link).toHaveAttribute('href', '#v2.1.0');
+    expect(screen.getByText('#Added')).toBeInTheDocument();
+  });
+});

--- a/__tests__/releases.test.ts
+++ b/__tests__/releases.test.ts
@@ -1,0 +1,9 @@
+import { parseReleases } from '../lib/releases';
+
+describe('parseReleases', () => {
+  it('parses version and tags from changelog', () => {
+    const releases = parseReleases();
+    expect(releases[0].version).toBe('2.1.0');
+    expect(releases[0].tags).toContain('Added');
+  });
+});

--- a/components/ReleaseTimeline.tsx
+++ b/components/ReleaseTimeline.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+interface Release {
+  version: string;
+  date: string;
+  tags: string[];
+}
+
+interface Props {
+  releases: Release[];
+}
+
+const ReleaseTimeline: React.FC<Props> = ({ releases }) => (
+  <ol className="space-y-6">
+    {releases.map((r) => {
+      const anchor = `v${r.version}`;
+      return (
+        <li key={r.version} id={anchor} className="bg-gray-800 p-4 rounded-lg">
+          <h2 className="text-xl font-bold">
+            <a href={`#${anchor}`} className="text-ubt-blue underline">
+              {r.version}
+            </a>
+            <span className="ml-2 text-sm text-gray-400">{r.date}</span>
+          </h2>
+          <ul className="flex flex-wrap gap-1 mt-2 text-xs md:text-sm text-gray-400">
+            {r.tags.map((tag) => (
+              <li key={tag}>#{tag}</li>
+            ))}
+          </ul>
+        </li>
+      );
+    })}
+  </ol>
+);
+
+export default ReleaseTimeline;

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Parse CHANGELOG.md into an array of release objects.
+ * Each release includes version, date, and tags (section headings).
+ */
+function parseReleases() {
+  const changelogPath = path.join(process.cwd(), 'CHANGELOG.md');
+  const content = fs.readFileSync(changelogPath, 'utf8');
+  const releaseRegex = /^##\s+\[(.+?)\]\s+-\s+(\d{4}-\d{2}-\d{2})/gm;
+  const matches = [...content.matchAll(releaseRegex)];
+  return matches.map((match, index) => {
+    const version = match[1];
+    const date = match[2];
+    const start = match.index + match[0].length;
+    const end = index + 1 < matches.length ? matches[index + 1].index : content.length;
+    const body = content.slice(start, end);
+    const tagMatches = [...body.matchAll(/^###\s+([^\n]+)/gm)];
+    const tags = tagMatches.map((m) => m[1].trim());
+    return { version, date, tags };
+  });
+}
+
+module.exports = { parseReleases };

--- a/pages/releases.tsx
+++ b/pages/releases.tsx
@@ -1,0 +1,42 @@
+import fs from 'fs';
+import path from 'path';
+import ReleaseTimeline from '../components/ReleaseTimeline';
+import { parseReleases } from '../lib/releases';
+
+interface Release {
+  version: string;
+  date: string;
+  tags: string[];
+}
+
+interface Props {
+  releases: Release[];
+}
+
+export async function getStaticProps() {
+  const releases = parseReleases();
+  const items = releases
+    .map(
+      (r) => `\n      <item>\n        <title>${r.version}</title>\n        <link>https://unnippillil.com/releases#v${r.version}</link>\n        <pubDate>${new Date(r.date).toUTCString()}</pubDate>\n        <description>${r.tags.join(', ')}</description>\n      </item>`,
+    )
+    .join('');
+  const rss = `<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0">\n<channel>\n<title>Kali Linux Portfolio Releases</title>\n<link>https://unnippillil.com/releases</link>\n<description>Release timeline for Kali Linux Portfolio</description>${items}\n</channel>\n</rss>`;
+  fs.writeFileSync(path.join(process.cwd(), 'public', 'releases.xml'), rss);
+  return { props: { releases } };
+}
+
+const ReleasesPage: React.FC<Props> = ({ releases }) => (
+  <main className="max-w-3xl mx-auto p-4">
+    <h1 className="text-2xl font-bold mb-4">Releases</h1>
+    <p className="mb-6 text-sm">
+      Subscribe to updates via{' '}
+      <a href="/releases.xml" className="text-ubt-blue underline">
+        RSS
+      </a>
+      .
+    </p>
+    <ReleaseTimeline releases={releases} />
+  </main>
+);
+
+export default ReleasesPage;

--- a/public/releases.xml
+++ b/public/releases.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+<channel>
+<title>Kali Linux Portfolio Releases</title>
+<link>https://unnippillil.com/releases</link>
+<description>Release timeline for Kali Linux Portfolio</description>
+  <item>
+    <title>2.1.0</title>
+    <link>https://unnippillil.com/releases#v2.1.0</link>
+    <pubDate>Wed, 03 Sep 2025 00:00:00 GMT</pubDate>
+    <description>Added, Fixed, Upgrading</description>
+  </item>
+</channel>
+</rss>

--- a/scripts/generate-release-rss.mjs
+++ b/scripts/generate-release-rss.mjs
@@ -1,0 +1,12 @@
+import fs from 'fs';
+import path from 'path';
+import { parseReleases } from '../lib/releases.js';
+
+const releases = parseReleases();
+const items = releases
+  .map(
+    (r) => `\n  <item>\n    <title>${r.version}</title>\n    <link>https://unnippillil.com/releases#v${r.version}</link>\n    <pubDate>${new Date(r.date).toUTCString()}</pubDate>\n    <description>${r.tags.join(', ')}</description>\n  </item>`,
+  )
+  .join('');
+const rss = `<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0">\n<channel>\n<title>Kali Linux Portfolio Releases</title>\n<link>https://unnippillil.com/releases</link>\n<description>Release timeline for Kali Linux Portfolio</description>${items}\n</channel>\n</rss>`;
+fs.writeFileSync(path.join(process.cwd(), 'public', 'releases.xml'), rss);


### PR DESCRIPTION
## Summary
- add ReleaseTimeline component with anchors and tags for each version
- build releases page and generate RSS feed from CHANGELOG
- include subscription call to action

## Testing
- `yarn lint` *(fails: jsx-a11y/control-has-associated-label, react/display-name)*
- `yarn test` *(fails: window snapping finalize and release, NmapNSEApp clipboard test)*

------
https://chatgpt.com/codex/tasks/task_e_68c69858a64c8328944b92733230fcf5