### PR TITLE
[download] hint image type from user agent

### DIFF
--- a/__tests__/download.test.ts
+++ b/__tests__/download.test.ts
@@ -1,0 +1,18 @@
+import { getSuggestedImage } from '../pages/download';
+
+describe('getSuggestedImage', () => {
+  it('suggests WSL for Windows user agents', () => {
+    const ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)';
+    expect(getSuggestedImage(ua)).toBe('wsl');
+  });
+
+  it('suggests VM for macOS user agents', () => {
+    const ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)';
+    expect(getSuggestedImage(ua)).toBe('vm');
+  });
+
+  it('defaults to ISO for other user agents', () => {
+    const ua = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64)';
+    expect(getSuggestedImage(ua)).toBe('iso');
+  });
+});

--- a/pages/download.tsx
+++ b/pages/download.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+
+export type ImageType = 'vm' | 'iso' | 'wsl';
+
+export function getSuggestedImage(ua: string): ImageType {
+  const lower = ua.toLowerCase();
+  if (lower.includes('windows')) return 'wsl';
+  if (lower.includes('mac os') || lower.includes('macintosh')) return 'vm';
+  return 'iso';
+}
+
+export default function DownloadPage() {
+  const [suggested, setSuggested] = useState<ImageType>('iso');
+  const [showAll, setShowAll] = useState(false);
+
+  useEffect(() => {
+    const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+    setSuggested(getSuggestedImage(ua));
+  }, []);
+
+  const images: ImageType[] = ['vm', 'iso', 'wsl'];
+  const display = showAll ? images : [suggested];
+
+  const labelMap: Record<ImageType, string> = {
+    vm: 'Virtual Machine',
+    iso: 'ISO',
+    wsl: 'WSL',
+  };
+
+  return (
+    <div className="p-8 space-y-4">
+      <h1 className="text-2xl font-bold">Download</h1>
+      {!showAll && (
+        <p>
+          We think the <strong>{labelMap[suggested]}</strong> image is best for you.
+        </p>
+      )}
+      <div className="grid gap-4 md:grid-cols-3">
+        {display.map((type) => (
+          <a
+            key={type}
+            href={`#${type}`}
+            className="border rounded p-4 hover:bg-ub-grey"
+          >
+            {labelMap[type]}
+          </a>
+        ))}
+      </div>
+      {!showAll && (
+        <button
+          className="underline"
+          onClick={() => setShowAll(true)}
+        >
+          Show all options
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add /download page that recommends VM, ISO, or WSL image based on user agent
- keep a "Show all options" toggle to reveal every image type
- test UA detection helper

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `npx eslint pages/download.tsx __tests__/download.test.ts`
- `yarn test __tests__/download.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c698556d408328801d10443f395cb6