### PR TITLE
[docs] add verify CLI and warning documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ See `.env.local.example` for the full list.
 - `yarn test` – run the test suite.
 - `yarn lint` – check code for linting issues.
 - `yarn export` – generate a static export in the `out/` directory.
+- `npx @kali/verify` – run lint, type-checks, build, and a smoke test.
+  *Warning:* installs dependencies and starts a local server.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,3 +22,11 @@ yarn dev
 See the [Architecture](./architecture.md) document for an overview of how the project is organized.
 
 For app contributions, see the [New App Checklist](./new-app-checklist.md).
+
+## Verification CLI
+
+```bash
+npx @kali/verify
+```
+
+> **Warning:** This command installs dependencies, lints, type-checks, builds, and briefly starts the project. Run it only in environments you trust.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import noTopLevelWindow from './eslint-plugin-no-top-level-window/index.js';
 const compat = new FlatCompat();
 
 const config = [
-  { ignores: ['components/apps/Chrome/index.tsx'] },
+  { ignores: ['components/apps/Chrome/index.tsx', 'public/**'] },
   {
     plugins: {
       'no-top-level-window': noTopLevelWindow,

--- a/pages/verify.tsx
+++ b/pages/verify.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { WindowMainScreen } from '../components/base/window';
+
+const VerifyCli = () => (
+  <WindowMainScreen
+    screen={() => (
+      <div className="p-4 space-y-4">
+        <div
+          className="bg-yellow-300 text-black p-4 rounded"
+          role="alert"
+        >
+          <p className="font-bold">Warning</p>
+          <p>
+            The verification CLI installs dependencies, runs tests, and starts
+            the project locally. Inspect the source and run it only in
+            environments you trust.
+          </p>
+        </div>
+        <p>Run all checks with:</p>
+        <pre className="bg-black text-green-400 p-2 rounded"><code>npx @kali/verify</code></pre>
+        <p>
+          This command verifies Node and yarn versions, lints, type-checks,
+          builds the project, and performs a basic smoke test against key
+          routes.
+        </p>
+      </div>
+    )}
+  />
+);
+
+export default VerifyCli;

--- a/verify-cli/index.mjs
+++ b/verify-cli/index.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import { execSync, spawn } from 'child_process';
+import { createRequire } from 'module';
+import net from 'net';
+import waitOn from 'wait-on';
+
+const require = createRequire(import.meta.url);
+
+const run = (cmd, args = [], opts = {}) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: 'inherit', ...opts });
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+      }
+    });
+  });
+
+const getPort = () =>
+  new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+    srv.on('error', reject);
+  });
+
+(async () => {
+  try {
+    const yarnVersion = execSync('yarn --version', { encoding: 'utf8' }).trim();
+    const nextVersion = require('next/package.json').version;
+    console.log(`node: ${process.version}`);
+    console.log(`yarn: ${yarnVersion}`);
+    console.log(`next: ${nextVersion}`);
+
+    await run('yarn', ['install', '--immutable']);
+    await run('yarn', ['lint']);
+    await run('yarn', ['tsc', '--noEmit']);
+    await run('yarn', ['build']);
+
+    const port = await getPort();
+    const server = spawn('yarn', ['start', '-p', String(port)], { stdio: 'inherit' });
+    process.on('exit', () => server.kill());
+    await waitOn({ resources: [`http://localhost:${port}`], timeout: 60000 });
+
+    const routes = ['/', '/dummy-form', '/video-gallery', '/profile'];
+    for (const route of routes) {
+      const res = await fetch(`http://localhost:${port}${route}`);
+      const header = res.headers.get('x-powered-by');
+      if (res.status !== 200 || header !== 'Next.js') {
+        throw new Error(`Route ${route} failed: status ${res.status}, header ${header}`);
+      }
+      console.log(`\u2713 ${route}`);
+    }
+
+    console.log('verify: PASS');
+    server.kill();
+  } catch (err) {
+    console.error('verify: FAIL');
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/verify-cli/package.json
+++ b/verify-cli/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@kali/verify",
+  "version": "1.0.0",
+  "type": "module",
+  "bin": "index.mjs",
+  "dependencies": {
+    "wait-on": "^8.0.4"
+  }
+}


### PR DESCRIPTION
## Summary
- publish `@kali/verify` Node CLI
- add site page and docs showing `npx @kali/verify` usage with warnings
- exclude `public/**` from linting

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: window and nmapNse tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c69854e864832889f2eff34ee1fc6c