### PR TITLE
[docs] add installation stepper guides

### DIFF
--- a/__tests__/installStepper.test.tsx
+++ b/__tests__/installStepper.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import InstallStepper, { InstallStep } from '../components/InstallStepper';
+
+describe('InstallStepper', () => {
+  beforeEach(() => {
+    // @ts-ignore
+    navigator.clipboard = { writeText: jest.fn() };
+  });
+
+  it('copies command for current step', () => {
+    const steps: InstallStep[] = [
+      {
+        id: 's1',
+        title: 'Step 1',
+        description: 'First',
+        command: 'echo first',
+      },
+    ];
+    render(<InstallStepper steps={steps} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('echo first');
+  });
+});

--- a/components/InstallStepper.tsx
+++ b/components/InstallStepper.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+
+export interface InstallStep {
+  id: string;
+  title: string;
+  description: string;
+  command: string;
+}
+
+interface Props {
+  steps: InstallStep[];
+}
+
+const InstallStepper: React.FC<Props> = ({ steps }) => {
+  const [current, setCurrent] = useState(0);
+  const step = steps[current];
+
+  const copy = () => {
+    navigator.clipboard.writeText(step.command);
+  };
+
+  return (
+    <div className="p-4 bg-ub-cool-grey text-white">
+      <h3 id={step.id} className="text-xl font-bold mb-2">
+        <a href={`#${step.id}`} className="mr-2 text-ubt-blue" aria-label="Anchor">
+          #
+        </a>
+        {step.title}
+      </h3>
+      <p className="mb-2">{step.description}</p>
+      <div className="relative mb-4">
+        <pre className="bg-black text-green-400 p-2 overflow-x-auto" aria-label="code">
+{step.command}
+        </pre>
+        <button
+          onClick={copy}
+          className="absolute top-0 right-0 m-1 px-2 py-1 text-sm bg-gray-700 rounded"
+          aria-label="Copy"
+        >
+          Copy
+        </button>
+      </div>
+      <div className="flex justify-between">
+        <button
+          onClick={() => setCurrent((c) => Math.max(c - 1, 0))}
+          disabled={current === 0}
+          className="px-4 py-2 bg-gray-700 rounded disabled:opacity-50"
+        >
+          Previous
+        </button>
+        <button
+          onClick={() => setCurrent((c) => Math.min(c + 1, steps.length - 1))}
+          disabled={current === steps.length - 1}
+          className="px-4 py-2 bg-ub-green text-black rounded disabled:opacity-50"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default InstallStepper;

--- a/pages/install-guides.tsx
+++ b/pages/install-guides.tsx
@@ -1,0 +1,157 @@
+import React, { useState } from 'react';
+import InstallStepper, { InstallStep } from '../components/InstallStepper';
+import Tabs from '../components/Tabs';
+
+const calamaresSteps: InstallStep[] = [
+  {
+    id: 'calamares-launch',
+    title: 'Launch Calamares',
+    description: 'Start the Calamares installer from the live session.',
+    command: 'calamares',
+  },
+  {
+    id: 'calamares-partition',
+    title: 'List Disks',
+    description: 'Inspect disks before partitioning.',
+    command: 'sudo fdisk -l',
+  },
+  {
+    id: 'calamares-user',
+    title: 'Create User',
+    description: 'Add a user in the installer.',
+    command: 'sudo useradd -m <username>',
+  },
+  {
+    id: 'calamares-install',
+    title: 'Reboot',
+    description: 'Finish installation and reboot.',
+    command: 'sudo reboot',
+  },
+];
+
+const lvmSteps: InstallStep[] = [
+  {
+    id: 'lvm-format',
+    title: 'Format LUKS',
+    description: 'Encrypt the target disk.',
+    command: 'sudo cryptsetup luksFormat /dev/sdX',
+  },
+  {
+    id: 'lvm-open',
+    title: 'Open LUKS Container',
+    description: 'Map the encrypted disk for use.',
+    command: 'sudo cryptsetup open /dev/sdX cryptroot',
+  },
+  {
+    id: 'lvm-vg',
+    title: 'Create Volume Group',
+    description: 'Initialize LVM on the encrypted container.',
+    command: 'sudo vgcreate vg0 /dev/mapper/cryptroot',
+  },
+  {
+    id: 'lvm-lv',
+    title: 'Create Logical Volume',
+    description: 'Allocate space for the root filesystem.',
+    command: 'sudo lvcreate -L 20G -n root vg0',
+  },
+];
+
+const bootSteps: Record<string, InstallStep[]> = {
+  windows: [
+    {
+      id: 'win-download',
+      title: 'Download ISO',
+      description: 'Fetch the Kali image with PowerShell.',
+      command:
+        'Invoke-WebRequest -Uri https://cdimage.kali.org/kali.iso -OutFile kali.iso',
+    },
+    {
+      id: 'win-verify',
+      title: 'Verify Checksum',
+      description: 'Validate the downloaded image.',
+      command: 'Get-FileHash kali.iso -Algorithm SHA256',
+    },
+    {
+      id: 'win-write',
+      title: 'Write to USB',
+      description: 'Use WSL dd to create the boot media.',
+      command:
+        'wsl sudo dd if=kali.iso of=/dev/sdX bs=4M status=progress oflag=sync',
+    },
+  ],
+  mac: [
+    {
+      id: 'mac-download',
+      title: 'Download ISO',
+      description: 'Fetch the Kali image with curl.',
+      command: 'curl -LO https://cdimage.kali.org/kali.iso',
+    },
+    {
+      id: 'mac-verify',
+      title: 'Verify Checksum',
+      description: 'Verify the downloaded image.',
+      command: 'shasum -a 256 kali.iso',
+    },
+    {
+      id: 'mac-write',
+      title: 'Write to USB',
+      description: 'Use dd to create the boot media.',
+      command: 'sudo dd if=kali.iso of=/dev/rdisk2 bs=4m && sync',
+    },
+  ],
+  linux: [
+    {
+      id: 'linux-download',
+      title: 'Download ISO',
+      description: 'Fetch the Kali image with wget.',
+      command: 'wget https://cdimage.kali.org/kali.iso',
+    },
+    {
+      id: 'linux-verify',
+      title: 'Verify Checksum',
+      description: 'Verify the downloaded image.',
+      command: 'sha256sum kali.iso',
+    },
+    {
+      id: 'linux-write',
+      title: 'Write to USB',
+      description: 'Use dd to create the boot media.',
+      command:
+        'sudo dd if=kali.iso of=/dev/sdX bs=4M status=progress oflag=sync',
+    },
+  ],
+};
+
+const InstallGuides = () => {
+  const [os, setOs] = useState<'windows' | 'mac' | 'linux'>('windows');
+
+  return (
+    <main className="min-h-screen bg-ub-cool-grey text-white p-4 space-y-12">
+      <section>
+        <h1 className="text-2xl font-bold mb-4">Calamares Installer</h1>
+        <InstallStepper steps={calamaresSteps} />
+      </section>
+      <section>
+        <h1 className="text-2xl font-bold mb-4">Encrypted LVM Setup</h1>
+        <InstallStepper steps={lvmSteps} />
+      </section>
+      <section>
+        <h1 className="text-2xl font-bold mb-4">Boot Media Creation</h1>
+        <Tabs
+          tabs={[
+            { id: 'windows', label: 'Windows' },
+            { id: 'mac', label: 'macOS' },
+            { id: 'linux', label: 'Linux' },
+          ]}
+          active={os}
+          onChange={(id) => setOs(id as 'windows' | 'mac' | 'linux')}
+          className="mb-4"
+        />
+        <InstallStepper steps={bootSteps[os]} />
+      </section>
+    </main>
+  );
+};
+
+export default InstallGuides;
+


### PR DESCRIPTION
## Summary
- add reusable InstallStepper with anchors and copy buttons
- document Calamares, encrypted LVM, and boot media creation with OS-specific tabs
- test copy functionality of InstallStepper

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test __tests__/installStepper.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c6985021e083288ce6f5753569e395