### PR TITLE
[home] add rotating weekly cards

### DIFF
--- a/__tests__/weeklyCards.test.tsx
+++ b/__tests__/weeklyCards.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { act } from 'react';
+import WeeklyCards from '../components/WeeklyCards';
+
+describe('WeeklyCards', () => {
+  const cards = [
+    { title: 'Card 1', description: 'First' },
+    { title: 'Card 2', description: 'Second' },
+  ];
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('auto-rotates cards', () => {
+    render(<WeeklyCards cards={cards} />);
+    expect(screen.getByText('Card 1')).toBeInTheDocument();
+    act(() => {
+      jest.advanceTimersByTime(6000);
+    });
+    expect(screen.getByText('Card 2')).toBeInTheDocument();
+  });
+
+  test('pin stops rotation', async () => {
+    render(<WeeklyCards cards={cards} />);
+    fireEvent.click(screen.getByRole('button', { name: /pin/i }));
+    act(() => {
+      jest.advanceTimersByTime(6000);
+    });
+    expect(screen.getByText('Card 1')).toBeInTheDocument();
+  }, 10000);
+
+  test('focus pauses rotation', () => {
+    render(<WeeklyCards cards={cards} />);
+    const container = screen.getByTestId('weekly-card');
+    act(() => {
+      fireEvent.focus(container);
+    });
+    act(() => {
+      jest.advanceTimersByTime(6000);
+    });
+    expect(screen.getByText('Card 1')).toBeInTheDocument();
+  });
+});

--- a/components/WeeklyCards.tsx
+++ b/components/WeeklyCards.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import cardsData from '../data/weeklyCards.json';
+
+type Card = {
+  title: string;
+  description: string;
+};
+
+interface Props {
+  cards?: Card[];
+}
+
+const ROTATE_MS = 5000;
+
+export default function WeeklyCards({ cards = cardsData }: Props) {
+  const [index, setIndex] = useState(0);
+  const [pinnedIndex, setPinnedIndex] = useState<number | null>(null);
+  const [paused, setPaused] = useState(false);
+
+  const activeIndex = pinnedIndex ?? index;
+
+  useEffect(() => {
+    if (pinnedIndex !== null || paused) return;
+    const id = setInterval(() => {
+      setIndex((prev) => (prev + 1) % cards.length);
+    }, ROTATE_MS);
+    return () => clearInterval(id);
+  }, [cards.length, pinnedIndex, paused]);
+
+  const togglePin = () => {
+    setPinnedIndex(pinnedIndex === activeIndex ? null : activeIndex);
+  };
+
+  return (
+    <div
+      data-testid="weekly-card"
+      tabIndex={0}
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      onFocus={() => setPaused(true)}
+      onBlur={() => setPaused(false)}
+      className="mx-auto my-4 max-w-md rounded border bg-gray-800 p-4 text-white"
+    >
+      <h2 className="text-lg font-bold">{cards[activeIndex].title}</h2>
+      <p className="text-sm">{cards[activeIndex].description}</p>
+      <button
+        type="button"
+        onClick={togglePin}
+        className="mt-2 text-xs underline"
+      >
+        {pinnedIndex !== null ? 'Unpin' : 'Pin'}
+      </button>
+    </div>
+  );
+}

--- a/data/weeklyCards.json
+++ b/data/weeklyCards.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "Release 1.0",
+    "description": "Initial weekly highlights." 
+  },
+  {
+    "title": "Release 1.1",
+    "description": "Minor improvements and fixes." 
+  },
+  {
+    "title": "Major Release",
+    "description": "Big update with new features." 
+  }
+]

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
+import WeeklyCards from '../components/WeeklyCards';
 
 const Ubuntu = dynamic(
   () =>
@@ -34,6 +35,7 @@ const App = () => (
       Skip to content
     </a>
     <Meta />
+    <WeeklyCards />
     <Ubuntu />
     <BetaBadge />
     <InstallButton />


### PR DESCRIPTION
## Summary
- show weekly update cards at top of homepage
- cards auto-rotate, can be pinned, and pause rotation on hover or focus
- tests cover rotation, pinning, and pause behavior

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test __tests__/weeklyCards.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c6985bbb1483289355e2b94ec195fb