### PR TITLE
[metasploit-post] add collapsible issue list

### DIFF
--- a/__tests__/IssueList.test.tsx
+++ b/__tests__/IssueList.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import IssueList from '../apps/metasploit-post/components/IssueList';
+import issues from '../apps/metasploit-post/issues.json';
+
+describe('IssueList', () => {
+  it('renders issues with ids and severity tags', () => {
+    const { container } = render(<IssueList />);
+    (issues as any[]).forEach((issue) => {
+      const el = container.querySelector(`#issue-${issue.id}`);
+      expect(el).toBeTruthy();
+      expect(el?.textContent).toContain(issue.severity);
+    });
+  });
+});
+

--- a/apps/metasploit-post/components/IssueList.tsx
+++ b/apps/metasploit-post/components/IssueList.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import issues from '../issues.json';
+
+interface Issue {
+  id: number;
+  issue: string;
+  remediation: string;
+  severity: string;
+}
+
+const severityClass = (sev: string) => {
+  switch (sev) {
+    case 'High':
+      return 'bg-red-600 text-white';
+    case 'Medium':
+      return 'bg-yellow-500 text-black';
+    case 'Low':
+      return 'bg-green-600 text-white';
+    default:
+      return 'bg-gray-500 text-white';
+  }
+};
+
+const IssueList: React.FC = () => {
+  useEffect(() => {
+    const hash = typeof window !== 'undefined' ? window.location.hash.slice(1) : '';
+    if (hash) {
+      const el = document.getElementById(hash) as HTMLDetailsElement | null;
+      if (el) {
+        el.open = true;
+        el.scrollIntoView();
+      }
+    }
+  }, []);
+
+  return (
+    <div className="mt-4">
+      <h3 className="font-semibold mb-2">Issues</h3>
+      <ul className="space-y-2">
+        {(issues as Issue[]).map((item) => (
+          <li key={item.id}>
+            <details id={`issue-${item.id}`} className="bg-gray-800 rounded">
+              <summary className="cursor-pointer px-3 py-2 flex items-center justify-between">
+                <span>{item.issue}</span>
+                <span className={`ml-2 px-2 py-0.5 rounded text-xs ${severityClass(item.severity)}`}>
+                  {item.severity}
+                </span>
+              </summary>
+              <div className="px-3 py-2 text-sm text-yellow-300">{item.remediation}</div>
+            </details>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default IssueList;
+

--- a/apps/metasploit-post/index.tsx
+++ b/apps/metasploit-post/index.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import modules from './modules.json';
 import privTree from './priv-esc.json';
 import RemediationTable from './components/RemediationTable';
+import IssueList from './components/IssueList';
 import ResultCard from './components/ResultCard';
 import usePersistentState from '../../hooks/usePersistentState';
 
@@ -383,6 +384,7 @@ const MetasploitPost: React.FC = () => {
             <h3 className="font-semibold mb-2">Privilege Escalation Tree</h3>
             <PrivTree node={privTree as PrivNode} />
           </div>
+          <IssueList />
           <RemediationTable />
           <EvidenceVault />
         </div>


### PR DESCRIPTION
## Summary
- add collapsible IssueList component with severity tags and deep-link IDs
- render IssueList in Metasploit post-exploitation app
- test IssueList rendering of ids and severity tags

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test __tests__/IssueList.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c69842ed5483289c6b23c6af19bdba