### PR TITLE
[components] add command drawer

### DIFF
--- a/__tests__/commandDrawer.test.tsx
+++ b/__tests__/commandDrawer.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import CommandDrawer from '../components/CommandDrawer';
+
+describe('CommandDrawer', () => {
+  test('shows os, prerequisites, command and output', () => {
+    render(
+      <CommandDrawer
+        open
+        onClose={() => {}}
+        command="echo hello"
+        expectedOutput="hello"
+        prerequisites={['bash']}
+        os={{ name: 'Ubuntu', version: '22.04' }}
+      />
+    );
+    expect(screen.getByText(/Ubuntu 22.04/)).toBeInTheDocument();
+    expect(screen.getByText('bash')).toBeInTheDocument();
+    expect(screen.getByLabelText('command')).toHaveTextContent('echo hello');
+    expect(screen.getByLabelText('expected output')).toHaveTextContent('hello');
+  });
+});
+

--- a/components/CommandDrawer.tsx
+++ b/components/CommandDrawer.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import React from 'react';
+import TerminalOutput from './TerminalOutput';
+
+interface CommandDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  command: string;
+  expectedOutput: string;
+  prerequisites: string[];
+  os: {
+    name: string;
+    version: string;
+  };
+}
+
+export default function CommandDrawer({
+  open,
+  onClose,
+  command,
+  expectedOutput,
+  prerequisites,
+  os,
+}: CommandDrawerProps) {
+  return (
+    <div
+      className={`fixed inset-0 bg-black/50 transition-opacity ${open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+      onClick={onClose}
+    >
+      <div
+        className={`absolute right-0 top-0 h-full w-80 bg-gray-900 p-4 overflow-y-auto transform transition-transform ${open ? 'translate-x-0' : 'translate-x-full'}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-lg mb-4">Setup</h3>
+        <div className="mb-4">
+          <h4 className="font-semibold">OS Requirements</h4>
+          <p>{os.name} {os.version}</p>
+        </div>
+        <div className="mb-4">
+          <h4 className="font-semibold">Prerequisites</h4>
+          <ul className="list-disc list-inside">
+            {prerequisites.map((p) => (
+              <li key={p}>{p}</li>
+            ))}
+          </ul>
+        </div>
+        <div className="mb-4">
+          <h4 className="font-semibold">Command</h4>
+          <TerminalOutput text={command} ariaLabel="command" />
+        </div>
+        <div className="mb-4">
+          <h4 className="font-semibold">Expected Output</h4>
+          <TerminalOutput text={expectedOutput} ariaLabel="expected output" />
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,6 +7,11 @@ This project is built with [Next.js](https://nextjs.org/).
 - Node.js 20
 - yarn or npm
 
+## OS Requirements
+
+- Ubuntu 22.04 LTS or
+- Kali Linux 2024.1
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary
- add CommandDrawer component to show prerequisites, command and expected output
- document supported OS versions in getting started guide

## Testing
- `npx eslint components/CommandDrawer.tsx __tests__/commandDrawer.test.tsx docs/getting-started.md`
- `yarn test __tests__/commandDrawer.test.tsx`
- `yarn lint` *(fails: Numerous "control-has-associated-label" errors in unrelated files)*
- `yarn test` *(fails: window and nmapNse test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c698413c648328b4a3abe0a7f1da77