### PR TITLE
[a11y] add contrast tokens and CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,18 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn test --coverage
 
+  contrast:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn contrast
+
   security:
     runs-on: ubuntu-latest
     needs: install

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import noTopLevelWindow from './eslint-plugin-no-top-level-window/index.js';
 const compat = new FlatCompat();
 
 const config = [
-  { ignores: ['components/apps/Chrome/index.tsx'] },
+  { ignores: ['components/apps/Chrome/index.tsx', 'public/**'] },
   {
     plugins: {
       'no-top-level-window': noTopLevelWindow,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "module-report": "node scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
-    "verify:all": "node scripts/verify.mjs"
+    "verify:all": "node scripts/verify.mjs",
+    "contrast": "node scripts/contrast.mjs"
   },
   "engines": {
     "node": "20.19.5"

--- a/scripts/contrast.mjs
+++ b/scripts/contrast.mjs
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import tinycolor from 'tinycolor2';
+
+const css = fs.readFileSync('styles/globals.css', 'utf8');
+
+function extractVars(selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(`${escaped}\\s*{([\\s\\S]*?)}`, 'm');
+  const match = css.match(regex);
+  if (!match) {
+    throw new Error(`Selector ${selector} not found in styles/globals.css`);
+  }
+  const block = match[1];
+  const vars = {};
+  const varRegex = /--(color-[^:]+):\s*([^;]+)/g;
+  let m;
+  while ((m = varRegex.exec(block)) !== null) {
+    vars[m[1]] = m[2].trim();
+  }
+  return vars;
+}
+
+function checkContrast(bg, fg, label) {
+  const ratio = tinycolor.readability(bg, fg);
+  if (ratio < 4.5) {
+    console.error(`${label} contrast ratio ${ratio.toFixed(2)} < 4.5`);
+    process.exitCode = 1;
+  } else {
+    console.log(`${label} contrast ratio ${ratio.toFixed(2)}`);
+  }
+}
+
+const dark = extractVars(':root');
+const light = extractVars("html[data-theme='light']");
+
+checkContrast(dark['color-bg'], dark['color-text'], 'dark bg/text');
+checkContrast(dark['color-bg'], dark['color-primary'], 'dark bg/primary');
+checkContrast(light['color-bg'], light['color-text'], 'light bg/text');
+checkContrast(light['color-bg'], light['color-primary'], 'light bg/primary');
+
+if (process.exitCode) {
+  process.exit(1);
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -22,6 +22,21 @@
   accent-color: var(--color-control-accent);
 }
 
+/* Light theme */
+html[data-theme='light'] {
+  --color-bg: #ffffff;
+  --color-text: #1a1f26;
+  --color-primary: #0d47a1;
+  --color-secondary: #f5f5f5;
+  --color-accent: #0d47a1;
+  --color-muted: #e5e5e5;
+  --color-surface: #f5f5f5;
+  --color-inverse: #000000;
+  --color-border: #d1d5db;
+  --color-terminal: #006400;
+  --color-dark: #f5f5f5;
+}
+
 /* Dark theme */
 html[data-theme='dark'] {
   --color-bg: #000000;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -61,6 +61,17 @@
   --focus-outline-width: 2px;
 }
 
+/* Explicit light and dark theme overrides */
+html[data-theme='light'] {
+  --color-bg: #ffffff;
+  --color-text: #1a1f26;
+}
+
+html[data-theme='dark'] {
+  --color-bg: #0f1317;
+  --color-text: #F5F5F5;
+}
+
 /* High contrast theme */
 .high-contrast {
   --color-bg: #000000;

--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -13,11 +13,13 @@ export const createDynamicApp = (id, title) =>
         return mod.default;
       } catch (err) {
         console.error(`Failed to load ${title}`, err);
-        return () => (
+        const Fallback = () => (
           <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
             {`Unable to load ${title}`}
           </div>
         );
+        Fallback.displayName = 'DynamicAppFallback';
+        return Fallback;
       }
     },
     {


### PR DESCRIPTION
## Summary
- add explicit light/dark theme tokens with WCAG AA contrast
- wire contrast checker into CI

## Testing
- `node scripts/contrast.mjs`
- `npx eslint scripts/contrast.mjs eslint.config.mjs utils/createDynamicApp.js`
- `yarn lint` *(fails: missing labels across existing pages)*
- `yarn test` *(fails: window snapping test & Nmap NSE alert not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c69848b9c8832892dd16bd48ca3e54