### PR TITLE
[a11y] add skip link and roving tabindex

### DIFF
--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -83,6 +83,7 @@ export default function AppGrid({ openApp }) {
           name={app.title}
           displayName={<>{app.nodes}</>}
           openApp={() => openApp && openApp(app.id)}
+          tabIndex={index === data.focusedIndex ? 0 : -1}
         />
       </div>
     );
@@ -91,7 +92,7 @@ export default function AppGrid({ openApp }) {
   return (
     <div className="flex flex-col items-center h-full">
       <input
-        className="mb-6 mt-4 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+        className="mb-6 mt-4 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white"
         placeholder="Search"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
@@ -113,7 +114,9 @@ export default function AppGrid({ openApp }) {
                 width={width}
                 className="scroll-smooth"
               >
-                {(props) => <Cell {...props} data={{ items: filtered, columnCount }} />}
+                {(props) => (
+                  <Cell {...props} data={{ items: filtered, columnCount, focusedIndex }} />
+                )}
               </Grid>
             );
           }}

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -46,7 +46,7 @@ export class UbuntuApp extends Component {
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
-                tabIndex={this.props.disabled ? -1 : 0}
+                tabIndex={this.props.disabled ? -1 : (this.props.tabIndex ?? 0)}
                 onMouseEnter={this.handlePrefetch}
                 onFocus={this.handlePrefetch}
             >

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -865,12 +865,11 @@ export class Desktop extends Component {
 
     render() {
         return (
-            <main id="desktop" role="main" className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
+            <main id="main-content" role="main" className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
 
                 {/* Window Area */}
                 <div
-                    id="window-area"
-                    role="main"
+                    role="presentation"
                     className="absolute h-full w-full bg-transparent"
                     data-context="desktop-area"
                 >

--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -17,7 +17,7 @@ const Breadcrumbs: React.FC<Props> = ({ path, onNavigate }) => {
           <button
             type="button"
             onClick={() => onNavigate(idx)}
-            className="hover:underline focus:outline-none"
+            className="hover:underline"
           >
             {seg.name || '/'}
           </button>

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -38,7 +38,7 @@ const Toast: React.FC<ToastProps> = ({
       {onAction && actionLabel && (
         <button
           onClick={onAction}
-          className="ml-4 underline focus:outline-none"
+          className="ml-4 underline"
         >
           {actionLabel}
         </button>

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -151,10 +151,10 @@ function MyApp(props) {
       <Script src="/a2hs.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
         <a
-          href="#app-grid"
+          href="#main-content"
           className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
         >
-          Skip to app grid
+          Skip to main content
         </a>
         <SettingsProvider>
           <PipPortalProvider>

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -23,7 +23,7 @@ const AppsPage = () => {
   );
 
   return (
-    <div className="p-4">
+    <main id="main-content" className="p-4">
       <label htmlFor="app-search" className="sr-only">
         Search apps
       </label>
@@ -61,7 +61,7 @@ const AppsPage = () => {
           </Link>
         ))}
       </div>
-    </div>
+    </main>
   );
 };
 

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -30,9 +30,6 @@ const InstallButton = dynamic(
  */
 const App = () => (
   <>
-    <a href="#window-area" className="sr-only focus:not-sr-only">
-      Skip to content
-    </a>
     <Meta />
     <Ubuntu />
     <BetaBadge />


### PR DESCRIPTION
## Summary
- add global skip link to main content
- enable roving tabindex for app grid items
- restore visible focus outlines on buttons and search inputs

## Testing
- `yarn lint` (fails: Unexpected global 'document' in public/apps/tetris/main.js)
- `yarn test` (fails: e.preventDefault is not a function in window.test.tsx)
- `npx playwright test playwright/a11y.spec.ts` (fails: No tests found)


------
https://chatgpt.com/codex/tasks/task_e_68c69847be4c832891c897fb54f650d8