### PR TITLE
[ci] enforce performance budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,23 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
+  performance:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn build && yarn export
+      - name: Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          configPath: ./lighthouserc.json
+          budgetPath: ./lighthouse/budgets.json
+
   vercel-preview:
     runs-on: ubuntu-latest
     needs: install

--- a/lighthouse/budgets.json
+++ b/lighthouse/budgets.json
@@ -1,0 +1,22 @@
+[
+  {
+    "path": "/",
+    "resourceSizes": [
+      { "resourceType": "script", "budget": 160 },
+      { "resourceType": "image", "budget": 300 }
+    ],
+    "timings": [
+      { "metric": "largest-contentful-paint", "threshold": 2200 }
+    ]
+  },
+  {
+    "path": "/apps",
+    "resourceSizes": [
+      { "resourceType": "script", "budget": 160 },
+      { "resourceType": "image", "budget": 300 }
+    ],
+    "timings": [
+      { "metric": "largest-contentful-paint", "threshold": 2200 }
+    ]
+  }
+]

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,24 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./out",
+      "url": ["/", "/apps"],
+      "numberOfRuns": 3,
+      "settings": {
+        "throttlingMethod": "simulate",
+        "throttling": {
+          "rttMs": 150,
+          "throughputKbps": 1600,
+          "cpuSlowdownMultiplier": 4
+        },
+        "formFactor": "mobile",
+        "screenEmulation": { "mobile": true }
+      }
+    },
+    "assert": {
+      "assertions": {
+        "largest-contentful-paint": ["error", { "maxNumericValue": 2200, "aggregationMethod": "p95" }]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Lighthouse CI config to watch key routes on Fast 3G
- reject bundles >160KB JS and oversize images via budgets
- run performance budget check in CI

## Testing
- `npx eslint lighthouserc.json lighthouse/budgets.json .github/workflows/ci.yml`
- `yarn test` *(fails: `window.test.tsx`, `nmapNse.test.tsx`, `Modal.test.tsx`)*


------
https://chatgpt.com/codex/tasks/task_e_68c6984a21c483288e178b045edafe34