### PR TITLE
[tests] cover kali-ui theme and accent persistence

### DIFF
--- a/__tests__/kali-ui.test.ts
+++ b/__tests__/kali-ui.test.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('kali-ui theme and accent bootstrap', () => {
+  const scriptPath = path.join(__dirname, '..', 'public', 'kali-ui.js');
+  const script = fs.readFileSync(scriptPath, 'utf8');
+
+  const runScript = () => {
+    // @ts-ignore evaluating external script
+    eval(script);
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.dataset.theme = '';
+    document.documentElement.className = '';
+    document.documentElement.style.cssText = '';
+  });
+
+  test.each([
+    ['default', false],
+    ['dark', true],
+  ])('applies %s theme from storage', (theme, isDark) => {
+    localStorage.setItem('app:theme', theme);
+    runScript();
+    expect(document.documentElement.dataset.theme).toBe(theme);
+    expect(document.documentElement.classList.contains('dark')).toBe(isDark);
+  });
+
+  test.each([
+    '#e53e3e',
+    '#38a169',
+  ])('applies %s accent from storage', (accent) => {
+    localStorage.setItem('accent', accent);
+    runScript();
+    expect(
+      document.documentElement.style.getPropertyValue('--color-primary')
+    ).toBe(accent);
+  });
+});

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -18,7 +18,8 @@ class MyDocument extends Document {
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
-          <script nonce={nonce} src="/theme.js" />
+          {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+          <script nonce={nonce} src="/kali-ui.js" />
         </Head>
         <body>
           <Main />

--- a/public/kali-ui.js
+++ b/public/kali-ui.js
@@ -1,9 +1,15 @@
 (function () {
   var THEME_KEY = 'app:theme';
+  var ACCENT_KEY = 'accent';
   try {
-    var stored = null;
-    if (typeof window !== 'undefined' && typeof window.localStorage !== 'undefined') {
-      stored = window.localStorage.getItem(THEME_KEY);
+    var storedTheme = null;
+    var storedAccent = null;
+    if (
+      typeof window !== 'undefined' &&
+      typeof window.localStorage !== 'undefined'
+    ) {
+      storedTheme = window.localStorage.getItem(THEME_KEY);
+      storedAccent = window.localStorage.getItem(ACCENT_KEY);
     }
 
     var prefersDark = false;
@@ -11,12 +17,16 @@
       prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
 
-    var theme = stored || (prefersDark ? 'dark' : 'default');
+    var theme = storedTheme || (prefersDark ? 'dark' : 'default');
     document.documentElement.dataset.theme = theme;
     var darkThemes = ['dark', 'neon', 'matrix'];
     document.documentElement.classList.toggle('dark', darkThemes.includes(theme));
+
+    if (storedAccent) {
+      document.documentElement.style.setProperty('--color-primary', storedAccent);
+    }
   } catch (e) {
-    console.error('Failed to apply theme', e);
+    console.error('Failed to apply theme/accent', e);
     document.documentElement.dataset.theme = 'default';
     document.documentElement.classList.remove('dark');
   }


### PR DESCRIPTION
## Summary
- replace theme bootstrap with `kali-ui.js` and apply stored accent color
- load new script in `_document` to initialize theme and accent from localStorage
- add unit tests confirming theme and accent survive reload

## Testing
- `npx eslint --ext .js,.jsx public/kali-ui.js pages/_document.jsx __tests__/kali-ui.test.ts`
- `yarn test __tests__/kali-ui.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5070dc5a88328937305d623ba373d