### PR TITLE
[tests] add keyboard navigation e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,22 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn test --coverage
 
+  e2e:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: npx playwright install --with-deps
+      - run: |
+          yarn dev &
+          npx wait-on http://localhost:3000
+      - run: npx playwright test
+
   security:
     runs-on: ubuntu-latest
     needs: install

--- a/pages/test/keyboard.tsx
+++ b/pages/test/keyboard.tsx
@@ -1,0 +1,115 @@
+"use client";
+import { useState } from "react";
+
+export default function KeyboardDemo() {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [tab, setTab] = useState("one");
+  const colors = ["red", "green", "blue"] as const;
+  const [color, setColor] = useState<typeof colors[number]>("red");
+
+  return (
+    <main className="p-4 space-y-4">
+      <nav aria-label="Main panel" className="flex gap-2">
+        <button id="panel-btn">Panel Button</button>
+      </nav>
+
+      <button id="open-drawer" onClick={() => setDrawerOpen(true)}>
+        Open Drawer
+      </button>
+
+      {drawerOpen && (
+        <div
+          role="dialog"
+          aria-label="Drawer"
+          className="fixed inset-0 bg-black/50 flex"
+          onKeyDown={(e) => {
+            if (e.key === "Escape") setDrawerOpen(false);
+          }}
+        >
+          <div className="m-auto bg-white p-4 space-y-2">
+            <button id="close-drawer" onClick={() => setDrawerOpen(false)}>
+              Close Drawer
+            </button>
+            <div
+              role="radiogroup"
+              aria-label="Palette"
+              className="flex gap-2"
+              onKeyDown={(e) => {
+                const idx = colors.indexOf(color);
+                if (e.key === "ArrowRight") {
+                  setColor(colors[(idx + 1) % colors.length]);
+                } else if (e.key === "ArrowLeft") {
+                  setColor(colors[(idx + colors.length - 1) % colors.length]);
+                }
+              }}
+            >
+              {colors.map((c) => (
+                <button
+                  key={c}
+                  role="radio"
+                  aria-checked={color === c}
+                  onClick={() => setColor(c)}
+                  style={{ background: c }}
+                  className="w-6 h-6 rounded-full border-2 border-black"
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div
+        role="tablist"
+        aria-label="Tabs"
+        className="flex gap-2"
+        onKeyDown={(e) => {
+          const order = ["one", "two", "three"] as const;
+          const idx = order.indexOf(tab as any);
+          if (e.key === "ArrowRight") {
+            setTab(order[(idx + 1) % order.length]);
+          } else if (e.key === "ArrowLeft") {
+            setTab(order[(idx + order.length - 1) % order.length]);
+          }
+        }}
+      >
+        {(["one", "two", "three"] as const).map((id) => (
+          <button
+            key={id}
+            role="tab"
+            aria-selected={tab === id}
+            tabIndex={tab === id ? 0 : -1}
+            onClick={() => setTab(id)}
+            className="px-2 py-1 border"
+          >
+            {id}
+          </button>
+        ))}
+      </div>
+
+      <button id="open-modal" onClick={() => setModalOpen(true)}>
+        Open Modal
+      </button>
+
+      {modalOpen && (
+        <div
+          id="modal"
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 bg-black/50 flex"
+          onKeyDown={(e) => {
+            if (e.key === "Escape") setModalOpen(false);
+          }}
+        >
+          <div className="m-auto bg-white p-4 space-y-2">
+            <p>Modal Content</p>
+            <button id="close-modal" onClick={() => setModalOpen(false)}>
+              Close Modal
+            </button>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}
+

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
@@ -6,4 +6,9 @@ export default defineConfig({
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
 });

--- a/tests/keyboard-navigation.spec.ts
+++ b/tests/keyboard-navigation.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('keyboard navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/test/keyboard');
+  });
+
+  test('panel button is reachable via keyboard', async ({ page }) => {
+    await page.keyboard.press('Tab');
+    await expect(page.locator('#panel-btn')).toBeFocused();
+  });
+
+  test('drawer and palette are keyboard accessible', async ({ page }) => {
+    await page.keyboard.press('Tab'); // focus panel button
+    await page.keyboard.press('Tab'); // open drawer button
+    await expect(page.locator('#open-drawer')).toBeFocused();
+    await page.keyboard.press('Enter');
+    const drawer = page.locator('[aria-label="Drawer"]');
+    await expect(drawer).toBeVisible();
+    await page.keyboard.press('Tab'); // focus close button
+    await page.keyboard.press('Tab'); // focus first radio
+    const secondRadio = page.locator('[role=radio]').nth(1);
+    await page.keyboard.press('ArrowRight');
+    await expect(secondRadio).toHaveAttribute('aria-checked', 'true');
+    await page.keyboard.press('Escape');
+    await expect(drawer).toBeHidden();
+  });
+
+  test('tabs can be changed with arrow keys', async ({ page }) => {
+    const firstTab = page.getByRole('tab', { name: 'one' });
+    await firstTab.focus();
+    await page.keyboard.press('ArrowRight');
+    await expect(page.getByRole('tab', { name: 'two' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('modal opens and closes with keyboard', async ({ page }) => {
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab'); // focus open modal button
+    await expect(page.locator('#open-modal')).toBeFocused();
+    await page.keyboard.press('Enter');
+    const modal = page.locator('#modal');
+    await expect(modal).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(modal).toBeHidden();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add demo page showcasing panel, drawer, palette, tabs, and modal
- cover keyboard-only navigation with Playwright
- run Playwright in CI across Chromium, Firefox and WebKit

## Testing
- `npm run lint` *(fails: process interrupted)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx etc.)*
- `npx playwright test tests/keyboard-navigation.spec.ts` *(fails: net::ERR_ABORTED)*

------
https://chatgpt.com/codex/tasks/task_e_68c5070c167883289cf46523d6de90f1