### PR TITLE
[ui] load locale fonts on demand

### DIFF
--- a/__tests__/kali-ui.test.ts
+++ b/__tests__/kali-ui.test.ts
@@ -1,0 +1,22 @@
+import { loadLocaleFonts } from '../public/kali-ui';
+
+describe('loadLocaleFonts', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    document.documentElement.lang = '';
+  });
+
+  it('does not inject fonts for English locale', () => {
+    document.documentElement.lang = 'en';
+    loadLocaleFonts(document);
+    expect(document.head.querySelector('link[data-locale-font]')).toBeNull();
+  });
+
+  it('injects fonts for Japanese locale', () => {
+    document.documentElement.lang = 'ja';
+    loadLocaleFonts(document);
+    const link = document.head.querySelector('link[data-locale-font]');
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute('data-locale-font')).toBe('ja');
+  });
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import noTopLevelWindow from './eslint-plugin-no-top-level-window/index.js';
 const compat = new FlatCompat();
 
 const config = [
-  { ignores: ['components/apps/Chrome/index.tsx'] },
+  { ignores: ['components/apps/Chrome/index.tsx', 'public/apps/**'] },
   {
     plugins: {
       'no-top-level-window': noTopLevelWindow,

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -19,6 +19,7 @@ class MyDocument extends Document {
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
           <script nonce={nonce} src="/theme.js" />
+          <script nonce={nonce} src="/kali-ui.js" />
         </Head>
         <body>
           <Main />

--- a/public/kali-ui.js
+++ b/public/kali-ui.js
@@ -1,0 +1,36 @@
+(function () {
+  function loadLocaleFonts(doc) {
+    try {
+      if (!doc) return;
+      var lang = (doc.documentElement.lang || (typeof navigator !== 'undefined' && navigator.language) || 'en').toLowerCase();
+      var prefix = lang.split('-')[0];
+      var map = {
+        zh: 'https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;700&display=swap',
+        ja: 'https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap',
+        ko: 'https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=swap',
+        ar: 'https://fonts.googleapis.com/css2?family=Noto+Sans+Arabic:wght@400;700&display=swap',
+        hi: 'https://fonts.googleapis.com/css2?family=Noto+Sans+Devanagari:wght@400;700&display=swap',
+        bn: 'https://fonts.googleapis.com/css2?family=Noto+Sans+Bengali:wght@400;700&display=swap',
+        th: 'https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;700&display=swap'
+      };
+      var href = map[prefix];
+      if (href && !doc.querySelector('link[data-locale-font]')) {
+        var link = doc.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = href;
+        link.setAttribute('data-locale-font', prefix);
+        doc.head.appendChild(link);
+      }
+    } catch (e) {
+      console.error('Failed to load locale fonts', e);
+    }
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { loadLocaleFonts };
+  } else {
+    loadLocaleFonts(globalThis.document);
+    // expose for debugging
+    globalThis.loadLocaleFonts = loadLocaleFonts;
+  }
+})();

--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -13,20 +13,25 @@ export const createDynamicApp = (id, title) =>
         return mod.default;
       } catch (err) {
         console.error(`Failed to load ${title}`, err);
-        return () => (
-          <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
-            {`Unable to load ${title}`}
-          </div>
-        );
+        function LoadError() {
+          return (
+            <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+              {`Unable to load ${title}`}
+            </div>
+          );
+        }
+        return LoadError;
       }
     },
     {
       ssr: false,
-      loading: () => (
-        <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
-          {`Loading ${title}...`}
-        </div>
-      ),
+      loading: function Loading() {
+        return (
+          <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+            {`Loading ${title}...`}
+          </div>
+        );
+      },
     }
   );
 


### PR DESCRIPTION
## Summary
- detect page language and conditionally inject Noto fonts for CJK and complex scripts
- expose font loader function and test that Japanese triggers a load while English does not
- ignore bundled public apps in ESLint and name dynamic app fallbacks

## Testing
- `npx eslint public/kali-ui.js`
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c5070b4ce08328b8753d8b0715e9e2