### PR TITLE
[pwa] sync manifest colors with accent

### DIFF
--- a/__tests__/manifest.test.ts
+++ b/__tests__/manifest.test.ts
@@ -32,4 +32,13 @@ describe('web manifest', () => {
       expect(shortcut.url).toBeDefined();
     }
   });
+
+  test('uses accent for theme and background color', () => {
+    const cssPath = path.join(process.cwd(), 'styles', 'globals.css');
+    const css = fs.readFileSync(cssPath, 'utf8');
+    const match = css.match(/:root\s*{[^}]*--color-accent:\s*(#[0-9a-fA-F]{6})/);
+    const accent = match ? match[1] : undefined;
+    expect(manifest.theme_color).toBe(accent);
+    expect(manifest.background_color).toBe(accent);
+  });
 });

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -23,6 +23,7 @@ import {
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+import { updateManifestColor } from '../utils/manifest';
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
@@ -149,6 +150,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     Object.entries(vars).forEach(([key, value]) => {
       document.documentElement.style.setProperty(key, value);
     });
+    updateManifestColor(accent);
     saveAccent(accent);
   }, [accent]);
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://unnippillil.com/",
   "scripts": {
     "build:gamepad": "tsc -p tsconfig.gamepad.json",
-    "prebuild": "tsc -p tsconfig.gamepad.json",
+    "prebuild": "node scripts/update-manifest-accent.mjs && tsc -p tsconfig.gamepad.json",
     "dev": "next dev",
     "build": "next build",
     "postbuild": "node scripts/safe-copy.mjs",

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -17,7 +17,7 @@ class MyDocument extends Document {
         <Head>
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
-          <meta name="theme-color" content="#0f1317" />
+          <meta name="theme-color" content="#1793d1" />
           <script nonce={nonce} src="/theme.js" />
         </Head>
         <body>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -4,8 +4,8 @@
   "start_url": "/",
   "offline_page": "/offline.html",
   "display": "standalone",
-  "background_color": "#0f1317",
-  "theme_color": "#0f1317",
+  "background_color": "#1793d1",
+  "theme_color": "#1793d1",
   "icons": [
     {
       "src": "/images/logos/fevicon.png",
@@ -29,7 +29,9 @@
       "files": [
         {
           "name": "files",
-          "accept": ["*/*"]
+          "accept": [
+            "*/*"
+          ]
         }
       ]
     }

--- a/scripts/update-manifest-accent.mjs
+++ b/scripts/update-manifest-accent.mjs
@@ -1,0 +1,24 @@
+import { readFile, writeFile } from 'fs/promises';
+import path from 'path';
+
+async function run() {
+  const manifestPath = path.join(process.cwd(), 'public', 'manifest.webmanifest');
+  const cssPath = path.join(process.cwd(), 'styles', 'globals.css');
+  let accent = '#1793d1';
+  try {
+    const css = await readFile(cssPath, 'utf8');
+    const match = css.match(/:root\s*{[^}]*--color-accent:\s*(#[0-9a-fA-F]{6})/);
+    if (match) accent = match[1];
+  } catch {}
+
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  manifest.theme_color = accent;
+  manifest.background_color = accent;
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+  console.log(`Updated manifest colors to ${accent}`);
+}
+
+run().catch(err => {
+  console.error('Failed to update manifest', err);
+  process.exit(1);
+});

--- a/utils/manifest.ts
+++ b/utils/manifest.ts
@@ -1,0 +1,30 @@
+"use client";
+
+let manifestUrl: string | null = null;
+
+export function updateManifestColor(accent: string): void {
+  if (typeof document === 'undefined') return;
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (meta) {
+    meta.setAttribute('content', accent);
+  }
+  const link = document.querySelector('link[rel="manifest"]');
+  if (!link) return;
+  fetch('/manifest.webmanifest')
+    .then((res) => res.json())
+    .then((manifest) => {
+      manifest.theme_color = accent;
+      manifest.background_color = accent;
+      const blob = new Blob([JSON.stringify(manifest)], {
+        type: 'application/manifest+json',
+      });
+      if (manifestUrl) {
+        URL.revokeObjectURL(manifestUrl);
+      }
+      manifestUrl = URL.createObjectURL(blob);
+      link.setAttribute('href', manifestUrl);
+    })
+    .catch(() => {
+      /* ignore errors */
+    });
+}


### PR DESCRIPTION
## Summary
- derive manifest theme/background colors from active accent on build and runtime
- update settings flow to rewrite manifest and theme-color meta when accent changes
- include test covering manifest colors

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window.test.tsx; nmapNse.test.tsx; settingsStore localStorage error)*

------
https://chatgpt.com/codex/tasks/task_e_68c5070728908328b7920b305777d3e9