### PR TITLE
perf: preconnect font hosts

### DIFF
--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -15,6 +15,14 @@ class MyDocument extends Document {
     return (
       <Html lang="en" data-csp-nonce={nonce}>
         <Head>
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link
+            rel="preconnect"
+            href="https://fonts.gstatic.com"
+            crossOrigin="anonymous"
+          />
+          <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
+          <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />


### PR DESCRIPTION
## Summary
- preconnect and prefetch Google font hosts

## Testing
- `yarn lint` *(fails: Unexpected global 'document', Component definition is missing display name)*
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/niktoPage.test.tsx` *(fails: window.snap Alt+ArrowDown, NmapNSEApp copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68c50707c0b883288fe43bbfc82f497c