### PR TITLE
[seo] add canonical tags for multi-route pages

### DIFF
--- a/pages/apps/qr.jsx
+++ b/pages/apps/qr.jsx
@@ -1,4 +1,5 @@
 import dynamic from 'next/dynamic';
+import Head from 'next/head';
 
 const QRApp = dynamic(() => import('../../apps/qr'), {
   ssr: false,
@@ -6,6 +7,13 @@ const QRApp = dynamic(() => import('../../apps/qr'), {
 });
 
 export default function QRPage() {
-  return <QRApp />;
+  return (
+    <>
+      <Head>
+        <link rel="canonical" href="https://unnippillil.com/qr" />
+      </Head>
+      <QRApp />
+    </>
+  );
 }
 

--- a/pages/input-hub.tsx
+++ b/pages/input-hub.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import emailjs from '@emailjs/browser';
 import { useRouter } from 'next/router';
+import Head from 'next/head';
 
 const subjectTemplates = [
   'General Inquiry',
@@ -169,10 +170,14 @@ const InputHub = () => {
   };
 
   return (
-    <div className="p-4 text-black max-w-md mx-auto">
-      <div className="mb-4">
-        <span
-          className={`px-2 py-1 text-sm rounded ${
+    <>
+      <Head>
+        <link rel="canonical" href="https://unnippillil.com/input-hub" />
+      </Head>
+      <div className="p-4 text-black max-w-md mx-auto">
+        <div className="mb-4">
+          <span
+            className={`px-2 py-1 text-sm rounded ${
             emailjsReady ? 'bg-green-600 text-white' : 'bg-red-600 text-white'
           }`}
         >
@@ -230,7 +235,8 @@ const InputHub = () => {
           {status}
         </div>
       )}
-    </div>
+      </div>
+    </>
   );
 };
 

--- a/pages/qr/index.tsx
+++ b/pages/qr/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from 'next/image';
+import Head from 'next/head';
 import React, { useEffect, useRef, useState } from 'react';
 import QRCode from 'qrcode';
 import { BrowserQRCodeReader, NotFoundException } from '@zxing/library';
@@ -188,14 +189,18 @@ const QRPage: React.FC = () => {
   };
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-8 p-4">
-      <div className="w-full max-w-md">
-        <Tabs
-          tabs={tabs}
-          active={active}
-          onChange={setActive}
-          className="mb-4 justify-center"
-        />
+    <>
+      <Head>
+        <link rel="canonical" href="https://unnippillil.com/qr" />
+      </Head>
+      <div className="flex min-h-screen flex-col items-center justify-center gap-8 p-4">
+        <div className="w-full max-w-md">
+          <Tabs
+            tabs={tabs}
+            active={active}
+            onChange={setActive}
+            className="mb-4 justify-center"
+          />
         {active === 'text' && (
           <form onSubmit={generateQr} className="space-y-2">
             <label className="block text-sm" htmlFor="qr-text">
@@ -378,8 +383,9 @@ const QRPage: React.FC = () => {
             </div>
           </>
         )}
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/pages/share-target.tsx
+++ b/pages/share-target.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
+import Head from 'next/head';
 
 export default function ShareTarget() {
   const router = useRouter();
@@ -32,5 +33,12 @@ export default function ShareTarget() {
     }
   }, [router]);
 
-  return <p>Loading...</p>;
+  return (
+    <>
+      <Head>
+        <link rel="canonical" href="https://unnippillil.com/share-target" />
+      </Head>
+      <p>Loading...</p>
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- add canonical link to input hub to avoid query-param duplicates
- include canonical tag for share target redirect
- unify qr tool pages under /qr

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size; NmapNSEApp › copies example output to clipboard; modal closes when Escape pressed globally)*
- `curl -s http://localhost:3000/input-hub?title=test | head`
- `curl -s http://localhost:3000/share-target?title=a | head -n 5`
- `curl -s http://localhost:3000/apps/qr | head -n 5`
- `curl -s http://localhost:3000/qr | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68c506fc825083288fd907ecd5bfe379