### PR TITLE
[dev] add husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn lint && yarn format

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "module-report": "node scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
-    "verify:all": "node scripts/verify.mjs"
+    "verify:all": "node scripts/verify.mjs",
+    "prepare": "husky install",
+    "format": "prettier --write ."
   },
   "engines": {
     "node": "20.19.5"
@@ -132,6 +134,7 @@
     "eslint-config-next": "15.5.2",
     "fake-indexeddb": "^6.1.0",
     "fast-glob": "^3.3.3",
+    "husky": "^8.0.0",
     "jest": "30.0.5",
     "jest-environment-jsdom": "30.0.5",
     "magic-string": "0.30.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8051,6 +8051,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"husky@npm:^9.1.7":
+  version: 9.1.7
+  resolution: "husky@npm:9.1.7"
+  bin:
+    husky: bin.js
+  checksum: 10c0/35bb110a71086c48906aa7cd3ed4913fb913823715359d65e32e0b964cb1e255593b0ae8014a5005c66a68e6fa66c38dcfa8056dbbdfb8b0187c0ffe7ee3a58f
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -13915,6 +13924,7 @@ __metadata:
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"
     html2canvas: "npm:^1.4.1"
+    husky: "npm:^9.1.7"
     idb: "npm:7.1.1"
     idb-keyval: "npm:^6.2.1"
     jest: "npm:30.0.5"


### PR DESCRIPTION
## Summary
- install Husky and add pre-commit hook that runs lint and format scripts
- expose `format` script and Husky prepare step in package.json

## Testing
- `yarn lint` *(fails: numerous jsx-a11y and no-top-level-window errors)*
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c506fcf0f08328822b5e492fcbfcbf