### PR TITLE
seo: add Person JSON-LD to home page

### DIFF
--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -59,6 +59,11 @@ export default function Meta() {
                         "@type": "Person",
                         name: "Alex Unnippillil",
                         url: "https://unnippillil.com/",
+                        sameAs: [
+                            "https://github.com/unnippillil",
+                            "https://www.linkedin.com/in/alex-unnippillil",
+                        ],
+                        jobTitle: "Computer Engineering Student",
                     }),
                 }}
             />


### PR DESCRIPTION
## Summary
- extend Person JSON-LD on home page with `sameAs` and `jobTitle`

## Testing
- `npx eslint components/SEO/Meta.js --max-warnings=0`
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, reconng.test.tsx)*
- `curl https://search.google.com/test/rich-results?code=…` *(400 Bad Request)*

------
https://chatgpt.com/codex/tasks/task_e_68c506f9c0a08328a1e4f8eb23f79c81