### PR TITLE
[ui] add time-based theme fallback

### DIFF
--- a/assets/js/kali-ui.js
+++ b/assets/js/kali-ui.js
@@ -1,0 +1,52 @@
+(function () {
+  const THEME_KEY = 'app:theme';
+  const DARK_THEMES = ['dark', 'neon', 'matrix'];
+
+  const applyTheme = (theme) => {
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.classList.toggle('dark', DARK_THEMES.includes(theme));
+  };
+
+  const setStoredTheme = (theme) => {
+    try {
+      window.localStorage.setItem(THEME_KEY, theme);
+    } catch {
+      /* ignore storage errors */
+    }
+    applyTheme(theme);
+  };
+
+  const init = () => {
+    let theme = null;
+    try {
+      theme = window.localStorage.getItem(THEME_KEY);
+    } catch {
+      theme = null;
+    }
+
+    if (!theme) {
+      let prefersDark = false;
+      try {
+        prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      } catch {
+        prefersDark = false;
+      }
+
+      if (prefersDark) {
+        theme = 'dark';
+      } else {
+        const hour = new Date().getHours();
+        theme = hour >= 18 || hour < 7 ? 'dark' : 'default';
+      }
+    }
+
+    applyTheme(theme || 'default');
+  };
+
+  // expose setter for manual selection persistence
+  window.kaliTheme = {
+    set: setStoredTheme,
+  };
+
+  init();
+})();


### PR DESCRIPTION
## Summary
- initialize theme from local storage, system preference, or time of day
- expose `kaliTheme.set` helper to persist user-selected theme

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in existing files)*
- `yarn test` *(fails: Window snapping finalize and release releases snap with Alt+ArrowDown restoring size; NmapNSEApp copies example output to clipboard; modal traps focus, disables background, and restores opener focus)*

------
https://chatgpt.com/codex/tasks/task_e_68c506e8e37c83289e60b94d08c18d8b