### PR TITLE
[styles] add grid layout for terminal cards

### DIFF
--- a/assets/css/kali-components.css
+++ b/assets/css/kali-components.css
@@ -1,0 +1,16 @@
+.kali-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
+  grid-auto-rows: 1fr;
+}
+
+.terminal {
+  display: grid;
+  grid-template-rows: auto 1fr;
+}
+
+.terminal .screen {
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+}


### PR DESCRIPTION
## Summary
- add `.kali-grid` grid layout for terminal cards
- update `.terminal` and `.terminal .screen` to align with grid gutters

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window, nmap NSE, and modal tests)*
- `yarn smoke` *(fails: missing Playwright browsers)*
- `npx playwright test` *(fails: smoke tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c506e5ee6c8328b87c957c71bcad29