### PR TITLE
[terminal] add selectable color schemes

### DIFF
--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -9,9 +9,11 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
     <div
       ref={ref}
       data-testid="xterm-container"
-      className={`text-white ${className}`}
+      className={`terminal ${className}`}
       style={{
-        background: 'var(--kali-bg)',
+        background: 'var(--term-bg)',
+        color: 'var(--term-fg)',
+        caretColor: 'var(--term-accent)',
         fontFamily: 'monospace',
         fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
         lineHeight: 1.4,

--- a/assets/data/term-schemes.json
+++ b/assets/data/term-schemes.json
@@ -1,0 +1,22 @@
+{
+  "Solarized": {
+    "--term-bg": "#002b36",
+    "--term-fg": "#839496",
+    "--term-accent": "#268bd2"
+  },
+  "Dracula": {
+    "--term-bg": "#282a36",
+    "--term-fg": "#f8f8f2",
+    "--term-accent": "#bd93f9"
+  },
+  "One Dark": {
+    "--term-bg": "#282c34",
+    "--term-fg": "#abb2bf",
+    "--term-accent": "#61afef"
+  },
+  "Kali": {
+    "--term-bg": "#0f1317",
+    "--term-fg": "#f5f5f5",
+    "--term-accent": "#1793d1"
+  }
+}

--- a/assets/js/kali-ui.js
+++ b/assets/js/kali-ui.js
@@ -1,0 +1,79 @@
+(function () {
+  async function loadSchemes() {
+    try {
+      const response = await globalThis.fetch('/assets/data/term-schemes.json');
+      if (!response.ok) return;
+      const schemes = await response.json();
+      buildDrawer(schemes);
+    } catch (err) {
+      console.error('Failed to load terminal schemes', err);
+    }
+  }
+
+  function buildDrawer(schemes) {
+    const doc = globalThis.document;
+    if (!doc) return;
+
+    const drawer = doc.createElement('aside');
+    drawer.id = 'term-scheme-drawer';
+    drawer.style.position = 'fixed';
+    drawer.style.bottom = '1rem';
+    drawer.style.right = '-180px';
+    drawer.style.width = '180px';
+    drawer.style.background = '#111';
+    drawer.style.color = '#fff';
+    drawer.style.padding = '0.5rem';
+    drawer.style.borderRadius = '4px 0 0 4px';
+    drawer.style.transition = 'right 0.3s ease';
+    drawer.style.zIndex = '1000';
+
+    const toggle = doc.createElement('button');
+    toggle.textContent = 'Themes';
+    toggle.style.position = 'absolute';
+    toggle.style.left = '-60px';
+    toggle.style.top = '0';
+    toggle.style.height = '100%';
+    toggle.style.writingMode = 'vertical-rl';
+    toggle.style.transform = 'rotate(180deg)';
+    toggle.style.background = '#111';
+    toggle.style.color = '#fff';
+    toggle.style.border = 'none';
+    toggle.style.cursor = 'pointer';
+
+    const select = doc.createElement('select');
+    select.style.width = '100%';
+    Object.keys(schemes).forEach((name) => {
+      const option = doc.createElement('option');
+      option.value = name;
+      option.textContent = name;
+      select.appendChild(option);
+    });
+
+    drawer.appendChild(toggle);
+    drawer.appendChild(select);
+    doc.body.appendChild(drawer);
+
+    toggle.addEventListener('click', () => {
+      const open = drawer.style.right === '0px';
+      drawer.style.right = open ? '-180px' : '0px';
+    });
+
+    select.addEventListener('change', () => applyScheme(schemes[select.value]));
+    applyScheme(schemes[select.value] || schemes[Object.keys(schemes)[0]]);
+  }
+
+  function applyScheme(scheme) {
+    const doc = globalThis.document;
+    if (!doc) return;
+    const terminals = doc.querySelectorAll('.terminal, .xterm');
+    terminals.forEach((el) => {
+      Object.entries(scheme).forEach(([key, value]) => {
+        el.style.setProperty(key, value);
+      });
+    });
+  }
+
+  if (globalThis.addEventListener) {
+    globalThis.addEventListener('DOMContentLoaded', loadSchemes);
+  }
+})();


### PR DESCRIPTION
## Summary
- add terminal color scheme presets
- load schemes via drawer UI and apply to terminal elements only
- wire terminal component to use new color vars

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `npx eslint assets/js/kali-ui.js apps/terminal/components/Terminal.tsx`
- `yarn test` *(fails: window, nmapNse, reconng tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c506ea74dc83289b22111feeae0898