### PR TITLE
[app] add view transition link wrapper

### DIFF
--- a/app/ui/VTLink.tsx
+++ b/app/ui/VTLink.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import Link from 'next/link';
+import { forwardRef, type ComponentProps, type MouseEvent } from 'react';
+
+import { withViewTransition } from './withViewTransition';
+
+export type VTLinkProps = ComponentProps<typeof Link>;
+
+const isModifiedEvent = (event: MouseEvent<HTMLAnchorElement>): boolean => {
+  const target = event.currentTarget.getAttribute('target');
+
+  return (
+    event.button !== 0 ||
+    event.metaKey ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    (target !== null && target !== '_self') ||
+    event.currentTarget.hasAttribute('download')
+  );
+};
+
+const VTLink = forwardRef<HTMLAnchorElement, VTLinkProps>(
+  ({ onClick, ...props }, ref) => {
+    const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+      onClick?.(event);
+
+      if (event.defaultPrevented || isModifiedEvent(event)) {
+        return;
+      }
+
+      void withViewTransition();
+    };
+
+    return <Link ref={ref} {...props} onClick={handleClick} />;
+  }
+);
+
+VTLink.displayName = 'VTLink';
+
+export default VTLink;

--- a/app/ui/withViewTransition.ts
+++ b/app/ui/withViewTransition.ts
@@ -1,0 +1,46 @@
+'use client';
+
+const waitForNextFrame = () =>
+  new Promise<void>((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(resolve);
+    });
+  });
+
+/**
+ * Runs the provided callback inside a View Transition when supported.
+ * Falls back to calling the callback immediately when the API is unavailable or errors.
+ */
+export const withViewTransition = async (
+  callback?: () => void | Promise<void>
+): Promise<void> => {
+  if (typeof document === 'undefined') {
+    await callback?.();
+    return;
+  }
+
+  const { startViewTransition } = document;
+
+  if (typeof startViewTransition !== 'function') {
+    await callback?.();
+    return;
+  }
+
+  let invoked = false;
+
+  try {
+    const transition = startViewTransition(async () => {
+      invoked = true;
+      await callback?.();
+      await waitForNextFrame();
+    });
+
+    await transition.finished;
+  } catch {
+    if (!invoked) {
+      await callback?.();
+    }
+  }
+};
+
+export default withViewTransition;


### PR DESCRIPTION
## Summary
- add a VTLink component in app/ui that wraps next/link for view transition support
- provide a withViewTransition helper to safely invoke document.startViewTransition

## Testing
- yarn lint *(fails: existing accessibility and lint violations in unrelated files)*
- yarn test *(fails/hangs: multiple pre-existing test failures and timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68c852e189d48328a508bfb4bcf1cd49