### PR TITLE
[desktop] add view transition links

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -38,6 +38,7 @@ export class UbuntuApp extends Component {
                 aria-disabled={this.props.disabled}
                 data-context="app"
                 data-app-id={this.props.id}
+                style={{ viewTransitionName: `icon-${this.props.id}` }}
                 draggable
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -649,6 +649,7 @@ export class Window extends Component {
                             onKeyDown={this.handleTitleBarKeyDown}
                             onBlur={this.releaseGrab}
                             grabbed={this.state.grabbed}
+                            viewTransitionName={`icon-${this.props.id}`}
                         />
                         <WindowEditButtons
                             minimize={this.minimizeWindow}
@@ -674,7 +675,7 @@ export class Window extends Component {
 export default Window
 
 // Window's title bar
-export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
+export function WindowTopBar({ title, onKeyDown, onBlur, grabbed, viewTransitionName }) {
     return (
         <div
             className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
@@ -683,6 +684,7 @@ export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
             aria-grabbed={grabbed}
             onKeyDown={onKeyDown}
             onBlur={onBlur}
+            style={viewTransitionName ? { viewTransitionName } : undefined}
         >
             <div className="flex justify-center w-full text-sm font-bold">{title}</div>
         </div>


### PR DESCRIPTION
## Summary
- add a unique `viewTransitionName` style to each desktop icon so transitions can target specific windows
- propagate the same `viewTransitionName` to the window title bar so icon-to-window morphs are possible

## Testing
- yarn lint *(fails: repository currently has hundreds of pre-existing accessibility lint errors)*
- yarn test *(fails: multiple legacy suites fail under jsdom, e.g. window focus and mock network cases)*

------
https://chatgpt.com/codex/tasks/task_e_68c852e22d3c832882a12052f6dd030e