### PR TITLE
[desktop] honor reduced motion preferences

### DIFF
--- a/app/desktop/animations.css
+++ b/app/desktop/animations.css
@@ -1,0 +1,15 @@
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001s !important;
+    animation-iteration-count: 1 !important;
+    animation-delay: 0s !important;
+    transition-duration: 0.001s !important;
+    transition-delay: 0s !important;
+  }
+
+  html {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- add a desktop-specific animations.css that honors prefers-reduced-motion by shortening transitions and animations
- ensure scrolling falls back to auto when users request reduced motion

## Testing
- yarn lint *(fails: repository currently has numerous pre-existing lint errors such as jsx-a11y/control-has-associated-label and no-top-level-window/no-top-level-window-or-document)*
- CI=1 yarn test --runInBand *(fails: repository currently has pre-existing failing suites including __tests__/window.test.tsx, __tests__/nmapNse.test.tsx, and __tests__/ubuntu.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c852e398f88328bde130c32c099ee1