### PR TITLE
[seo] Add sitemap for core routes

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next';
+
+const baseUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000').replace(/\/$/, '');
+
+const coreRoutes = ['', 'terminal', 'files', 'settings'];
+
+const buildUrl = (path: string) => (path ? `${baseUrl}/${path}` : baseUrl);
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return coreRoutes.map((path) => ({
+    url: buildUrl(path),
+    changeFrequency: 'daily',
+  }));
+}


### PR DESCRIPTION
## Summary
- add a sitemap route under the Next.js app directory for the core desktop pages
- build sitemap URLs from NEXT_PUBLIC_SITE_URL and mark the entries with a daily change frequency

## Testing
- yarn run eslint . --max-warnings=0 *(fails: repository contains numerous existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c852e6da3c83288f1e391cba36ebf0