### PR TITLE
[feeds] add rss and json feeds

### DIFF
--- a/app/feed.json/route.ts
+++ b/app/feed.json/route.ts
@@ -1,0 +1,28 @@
+import { FEED_DESCRIPTION, FEED_TITLE, SITE_URL, getFeedItems } from '@/lib/feed';
+
+export async function GET() {
+  const items = getFeedItems().map((item) => ({
+    id: item.id,
+    url: item.url,
+    title: item.title,
+    content_text: item.summary,
+    date_published: item.date.toISOString(),
+    ...(item.tags.length ? { tags: item.tags } : {}),
+  }));
+
+  const feed = {
+    version: 'https://jsonfeed.org/version/1.1',
+    title: FEED_TITLE,
+    description: FEED_DESCRIPTION,
+    home_page_url: SITE_URL,
+    feed_url: `${SITE_URL}/feed.json`,
+    language: 'en-CA',
+    items,
+  };
+
+  return Response.json(feed, {
+    headers: {
+      'Cache-Control': 'public, max-age=0, s-maxage=1800',
+    },
+  });
+}

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,0 +1,35 @@
+import { FEED_DESCRIPTION, FEED_TITLE, SITE_URL, getFeedItems } from '@/lib/feed';
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export async function GET() {
+  const items = getFeedItems();
+  const lastBuildDate = items[0]?.date ?? new Date();
+
+  const feedItems = items
+    .map((item) => {
+      const categories = item.tags
+        .map((tag) => `      <category>${escapeXml(tag)}</category>`)
+        .join('\n');
+      const categoriesBlock = categories ? `\n${categories}` : '';
+
+      return `    <item>\n      <title>${escapeXml(item.title)}</title>\n      <link>${escapeXml(item.url)}</link>\n      <guid>${escapeXml(item.id)}</guid>\n      <description>${escapeXml(item.summary)}</description>\n      <pubDate>${item.date.toUTCString()}</pubDate>${categoriesBlock}\n    </item>`;
+    })
+    .join('\n');
+
+  const rss = `<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0">\n  <channel>\n    <title>${escapeXml(FEED_TITLE)}</title>\n    <link>${escapeXml(SITE_URL)}</link>\n    <description>${escapeXml(FEED_DESCRIPTION)}</description>\n    <language>en-CA</language>\n    <lastBuildDate>${lastBuildDate.toUTCString()}</lastBuildDate>\n${feedItems}\n  </channel>\n</rss>`;
+
+  return new Response(rss, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=0, s-maxage=1800',
+    },
+  });
+}

--- a/lib/feed.ts
+++ b/lib/feed.ts
@@ -1,0 +1,119 @@
+import aboutData from '@/components/apps/alex/data.json';
+
+const MONTH_MAP: Record<string, number> = {
+  jan: 0,
+  january: 0,
+  feb: 1,
+  february: 1,
+  mar: 2,
+  march: 2,
+  apr: 3,
+  april: 3,
+  may: 4,
+  jun: 5,
+  june: 5,
+  jul: 6,
+  july: 6,
+  aug: 7,
+  august: 7,
+  sep: 8,
+  sept: 8,
+  september: 8,
+  oct: 9,
+  october: 9,
+  nov: 10,
+  november: 10,
+  dec: 11,
+  december: 11,
+};
+
+export const SITE_URL = 'https://unnippillil.com';
+export const FEED_TITLE = 'Alex Unnippillil — Portfolio Projects';
+export const FEED_DESCRIPTION =
+  'Recently highlighted projects and experiments from the Kali Linux portfolio desktop experience.';
+
+interface RawProject {
+  name: string;
+  date: string;
+  link?: string;
+  description?: string[];
+  domains?: string[];
+}
+
+interface AboutData {
+  projects?: RawProject[];
+}
+
+export interface FeedItem {
+  id: string;
+  url: string;
+  title: string;
+  summary: string;
+  date: Date;
+  tags: string[];
+}
+
+const data = aboutData as AboutData;
+
+function parseProjectDate(value: string | undefined): Date {
+  if (!value) {
+    return new Date();
+  }
+  const normalized = value.trim();
+  const parts = normalized.toLowerCase().split(/\s+/).filter(Boolean);
+  if (parts.length === 2) {
+    const [maybeMonth, maybeYear] = parts;
+    const monthIndex = MONTH_MAP[maybeMonth];
+    const yearNumber = Number(maybeYear);
+    if (typeof monthIndex === 'number' && !Number.isNaN(yearNumber)) {
+      return new Date(Date.UTC(yearNumber, monthIndex, 1));
+    }
+  }
+
+  const parsed = new Date(normalized);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed;
+  }
+  return new Date();
+}
+
+function buildSummary(project: RawProject): string {
+  const joinedDescription = project.description?.join(' ');
+  const description = joinedDescription ? joinedDescription.trim() : '';
+  const domainSummary = project.domains && project.domains.length > 0
+    ? `Domains: ${project.domains.join(', ')}`
+    : '';
+  return [description, domainSummary].filter(Boolean).join(' ');
+}
+
+function deriveId(project: RawProject, fallbackUrl: string): string {
+  const trimmedLink = project.link?.trim();
+  if (trimmedLink) {
+    return trimmedLink;
+  }
+  const slug = project.name
+    ? project.name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+    : 'project';
+  return `${fallbackUrl}#${slug}`;
+}
+
+export function getFeedItems(): FeedItem[] {
+  const projects = data.projects ?? [];
+  const normalized = projects.map((project) => {
+    const date = parseProjectDate(project.date);
+    const url = project.link?.trim() || SITE_URL;
+    return {
+      id: deriveId(project, SITE_URL),
+      url,
+      title: project.name,
+      summary: buildSummary(project),
+      date,
+      tags: project.domains ?? [],
+    } satisfies FeedItem;
+  });
+
+  return normalized.sort((a, b) => b.date.getTime() - a.date.getTime());
+}


### PR DESCRIPTION
## Summary
- add a shared feed helper that normalizes project data for syndication
- expose /feed.xml with an RSS 2.0 response using the normalized projects
- add /feed.json that serves a JSON Feed representation with Response.json

## Testing
- yarn lint *(fails: repo already has numerous jsx-a11y label errors and public JS globals)*
- yarn test *(fails: existing suites such as ubuntu, modal, nmap-nse are already red under jest)*

------
https://chatgpt.com/codex/tasks/task_e_68c852e8406c8328a9c97dc58cdf5237