### PR TITLE
[app] add no-prefetch link helper for heavy lists

### DIFF
--- a/app/ui/NoPrefetchLink.tsx
+++ b/app/ui/NoPrefetchLink.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import Link from 'next/link';
+import type { ComponentPropsWithoutRef } from 'react';
+import { forwardRef } from 'react';
+
+type NoPrefetchLinkProps = Omit<ComponentPropsWithoutRef<typeof Link>, 'prefetch'>;
+
+const NoPrefetchLink = forwardRef<HTMLAnchorElement, NoPrefetchLinkProps>(
+  ({ children, ...props }, ref) => (
+    <Link ref={ref} {...props} prefetch={false}>
+      {children}
+    </Link>
+  ),
+);
+
+NoPrefetchLink.displayName = 'NoPrefetchLink';
+
+export default NoPrefetchLink;

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
-import Link from 'next/link';
+import NoPrefetchLink from '@/app/ui/NoPrefetchLink';
 
 const AppsPage = () => {
   const [apps, setApps] = useState([]);
@@ -41,7 +41,7 @@ const AppsPage = () => {
         className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
       >
         {filteredApps.map((app) => (
-          <Link
+          <NoPrefetchLink
             key={app.id}
             href={`/apps/${app.id}`}
             className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
@@ -58,7 +58,7 @@ const AppsPage = () => {
               />
             )}
             <span className="mt-2">{app.title}</span>
-          </Link>
+          </NoPrefetchLink>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a reusable `NoPrefetchLink` client component that wraps `next/link` with `prefetch={false}`
- switch the apps listing grid to use the no-prefetch link to avoid eager loading every app page

## Testing
- yarn lint *(fails: repository currently has 571 accessibility lint errors and 7 warnings unrelated to this change)*
- yarn test *(fails: existing suites such as Ubuntu, Nmap NSE, and PDF viewer tests already failing in main)*

------
https://chatgpt.com/codex/tasks/task_e_68c852e9dbac83289d41b59483a8ebbb