### PR TITLE
[windows] Add client chart page

### DIFF
--- a/app/(windows)/charts/ClientChart.tsx
+++ b/app/(windows)/charts/ClientChart.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+const chartData = [
+  { label: 'Recon', value: 75 },
+  { label: 'Exploit', value: 55 },
+  { label: 'Post', value: 35 },
+  { label: 'Report', value: 90 },
+];
+
+export default function ClientChart() {
+  return (
+    <section className="flex h-full w-full flex-col justify-center gap-4 p-6">
+      <header className="space-y-1">
+        <h1 className="text-lg font-semibold text-slate-100">Engagement coverage</h1>
+        <p className="text-sm text-slate-400">
+          Simulated coverage percentages across the offensive security kill chain.
+        </p>
+      </header>
+      <div className="flex flex-col gap-3">
+        {chartData.map(({ label, value }) => (
+          <div key={label} className="flex items-center gap-3">
+            <span className="w-32 text-sm font-medium text-slate-300">{label}</span>
+            <div className="flex-1 rounded bg-slate-800" aria-hidden="true">
+              <div
+                className="h-3 rounded bg-cyan-500 transition-[width]"
+                style={{ width: `${value}%` }}
+              />
+            </div>
+            <span className="w-12 text-right text-xs tabular-nums text-slate-400">{value}%</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/(windows)/charts/page.tsx
+++ b/app/(windows)/charts/page.tsx
@@ -1,0 +1,14 @@
+import dynamic from 'next/dynamic';
+
+const ClientChart = dynamic(() => import('./ClientChart'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-full w-full items-center justify-center text-sm text-slate-400">
+      Loading chart...
+    </div>
+  ),
+});
+
+export default function ChartsPage() {
+  return <ClientChart />;
+}


### PR DESCRIPTION
## Summary
- add a client-rendered chart component for the windowed charts route
- dynamically load the chart on the charts page with a loading fallback

## Testing
- [ ] yarn lint *(fails: pre-existing accessibility violations throughout legacy apps)*
- [ ] yarn test *(fails: existing suites such as Modal and Ubuntu rely on browser-only APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68c852eb7fa08328832945304cc959ed