### PR TITLE
[ui] add worker-powered search box

### DIFF
--- a/app/ui/SearchBox.tsx
+++ b/app/ui/SearchBox.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+export interface SearchBoxProps {
+  files: string[];
+  placeholder?: string;
+  className?: string;
+  debounceMs?: number;
+  resultLimit?: number;
+}
+
+type WorkerDirectoryCount = { name: string; count: number };
+
+type SearchWorkerResultMessage = {
+  type: 'result';
+  requestId: number;
+  total: number;
+  matches: string[];
+  directories: WorkerDirectoryCount[];
+  extensions: WorkerDirectoryCount[];
+};
+
+type SearchWorkerErrorMessage = {
+  type: 'error';
+  requestId: number;
+  message: string;
+};
+
+type SearchWorkerResponse =
+  | SearchWorkerResultMessage
+  | SearchWorkerErrorMessage;
+
+type SearchWorkerRequest = {
+  type: 'count';
+  files: string[];
+  query?: string;
+  limit?: number;
+  requestId?: number;
+};
+
+const combineClassNames = (...values: Array<string | undefined>): string =>
+  values.filter(Boolean).join(' ');
+
+const formatSummary = (result: SearchWorkerResultMessage | null, query: string) => {
+  if (!result) {
+    return query
+      ? `Searching ${query}\u2026`
+      : 'Start typing to filter the project files.';
+  }
+
+  if (result.total === 0) {
+    return query
+      ? `No files found for “${query}”.`
+      : 'No files to display yet.';
+  }
+
+  if (query) {
+    return `Showing ${result.matches.length} of ${result.total} matching files for “${query}”.`;
+  }
+
+  return `Listing ${result.matches.length} of ${result.total} project files.`;
+};
+
+const SearchBox = ({
+  files,
+  placeholder = 'Search files…',
+  className,
+  debounceMs = 150,
+  resultLimit = 20,
+}: SearchBoxProps) => {
+  const [query, setQuery] = useState('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<SearchWorkerResultMessage | null>(null);
+  const workerRef = useRef<Worker | null>(null);
+  const [workerReady, setWorkerReady] = useState(false);
+  const requestCounterRef = useRef(0);
+  const activeRequestRef = useRef(0);
+  const inputId = useId();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    try {
+      const worker = new Worker(
+        new URL('../../public/workers/search.worker.ts', import.meta.url),
+        { type: 'module' },
+      );
+
+      workerRef.current = worker;
+      setWorkerReady(true);
+
+      worker.onmessage = (
+        event: MessageEvent<SearchWorkerResponse>,
+      ) => {
+        const data = event.data;
+
+        if (!data || typeof data !== 'object') return;
+        if (
+          'requestId' in data &&
+          typeof data.requestId === 'number' &&
+          data.requestId !== activeRequestRef.current
+        ) {
+          if (data.requestId < activeRequestRef.current) {
+            return;
+          }
+        }
+
+        if (data.type === 'result') {
+          setResult(data);
+          setStatus('ready');
+          setError(null);
+        } else if (data.type === 'error') {
+          setStatus('error');
+          setError(data.message);
+        }
+      };
+
+      worker.onerror = () => {
+        setStatus('error');
+        setError('Search worker encountered an error.');
+      };
+
+      return () => {
+        setWorkerReady(false);
+        workerRef.current = null;
+        worker.terminate();
+      };
+    } catch (err) {
+      console.error('Failed to start search worker', err);
+      setStatus('error');
+      setError('Search worker could not be started.');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!workerReady) return;
+    const worker = workerRef.current;
+    if (!worker) return;
+
+    setStatus('loading');
+    setError(null);
+
+    const handle = window.setTimeout(() => {
+      const requestId = requestCounterRef.current + 1;
+      requestCounterRef.current = requestId;
+      activeRequestRef.current = requestId;
+
+      const message: SearchWorkerRequest = {
+        type: 'count',
+        files,
+        query,
+        limit: resultLimit,
+        requestId,
+      };
+
+      try {
+        worker.postMessage(message);
+      } catch (err) {
+        console.error('Failed to post message to search worker', err);
+        setStatus('error');
+        setError('Unable to communicate with the search worker.');
+      }
+    }, debounceMs);
+
+    return () => {
+      window.clearTimeout(handle);
+    };
+  }, [files, query, debounceMs, resultLimit, workerReady]);
+
+  const summary = useMemo(
+    () => formatSummary(result, query),
+    [query, result],
+  );
+
+  const topDirectories = useMemo(
+    () => (result ? result.directories.slice(0, 6) : []),
+    [result],
+  );
+
+  const topExtensions = useMemo(
+    () => (result ? result.extensions.slice(0, 6) : []),
+    [result],
+  );
+
+  const visibleMatches = useMemo(
+    () => (result ? result.matches : []),
+    [result],
+  );
+
+  return (
+    <div
+      className={combineClassNames(
+        'space-y-4 rounded-lg border border-zinc-700/40 bg-zinc-950/70 p-4 shadow-xl shadow-black/30 backdrop-blur',
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-2">
+        <label
+          htmlFor={inputId}
+          className="text-sm font-semibold uppercase tracking-wide text-zinc-300"
+        >
+          Search files
+        </label>
+        <input
+          id={inputId}
+          type="search"
+          placeholder={placeholder}
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          className="w-full rounded-md border border-zinc-700/60 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-500/50"
+          aria-describedby={`${inputId}-summary`}
+        />
+      </div>
+
+      <div
+        id={`${inputId}-summary`}
+        className="text-xs text-zinc-400"
+        aria-live="polite"
+      >
+        {status === 'loading' && (
+          <p className="text-cyan-300">Scanning files…</p>
+        )}
+        {status === 'error' && error && (
+          <p className="text-rose-400">{error}</p>
+        )}
+        {status !== 'error' && summary && <p>{summary}</p>}
+      </div>
+
+      {status === 'ready' && result && result.total > 0 && (
+        <div className="grid gap-4 lg:grid-cols-2">
+          <section className="space-y-2">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
+              Top directories
+            </h3>
+            <ul className="space-y-1 text-sm text-zinc-200">
+              {topDirectories.length === 0 && (
+                <li className="rounded bg-zinc-900/50 px-3 py-2 text-zinc-500">
+                  No directories to show.
+                </li>
+              )}
+              {topDirectories.map((item) => (
+                <li
+                  key={`${item.name}-${item.count}`}
+                  className="flex items-center justify-between rounded bg-zinc-900/70 px-3 py-1.5"
+                >
+                  <span className="mr-2 truncate" title={item.name}>
+                    {item.name}
+                  </span>
+                  <span className="text-xs text-zinc-400">{item.count}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
+              Top extensions
+            </h3>
+            <ul className="space-y-1 text-sm text-zinc-200">
+              {topExtensions.length === 0 && (
+                <li className="rounded bg-zinc-900/50 px-3 py-2 text-zinc-500">
+                  No extensions to show.
+                </li>
+              )}
+              {topExtensions.map((item) => (
+                <li
+                  key={`${item.name}-${item.count}`}
+                  className="flex items-center justify-between rounded bg-zinc-900/70 px-3 py-1.5"
+                >
+                  <span className="mr-2 truncate" title={item.name}>
+                    {item.name}
+                  </span>
+                  <span className="text-xs text-zinc-400">{item.count}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
+      )}
+
+      {status === 'ready' && visibleMatches.length > 0 && (
+        <section className="space-y-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
+            Sample matches
+          </h3>
+          <ul className="space-y-1 text-sm text-zinc-100">
+            {visibleMatches.map((match) => (
+              <li
+                key={match}
+                className="truncate rounded bg-zinc-900/60 px-3 py-1.5"
+                title={match}
+              >
+                {match}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+};
+
+export default SearchBox;

--- a/public/workers/search.worker.ts
+++ b/public/workers/search.worker.ts
@@ -1,0 +1,146 @@
+const ctx: DedicatedWorkerGlobalScope = self as DedicatedWorkerGlobalScope;
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 200;
+const ROOT_LABEL = '(root)';
+
+export type SearchWorkerCountMessage = {
+  type: 'count';
+  files: string[];
+  query?: string;
+  limit?: number;
+  requestId?: number;
+};
+
+export type SearchWorkerCancelMessage = {
+  type: 'cancel';
+  requestId?: number;
+};
+
+export type SearchWorkerMessage =
+  | SearchWorkerCountMessage
+  | SearchWorkerCancelMessage;
+
+export type SearchWorkerResultMessage = {
+  type: 'result';
+  requestId: number;
+  total: number;
+  matches: string[];
+  directories: Array<{ name: string; count: number }>;
+  extensions: Array<{ name: string; count: number }>;
+};
+
+export type SearchWorkerErrorMessage = {
+  type: 'error';
+  requestId: number;
+  message: string;
+};
+
+const cancelledRequests = new Set<number>();
+
+const sanitizeFiles = (files: unknown): string[] => {
+  if (!Array.isArray(files)) return [];
+  return files.filter((file): file is string => typeof file === 'string');
+};
+
+const normalizeLimit = (value: unknown): number => {
+  if (typeof value !== 'number' || Number.isNaN(value)) return DEFAULT_LIMIT;
+  const limit = Math.floor(value);
+  if (limit < 0) return 0;
+  return Math.min(limit, MAX_LIMIT);
+};
+
+const toDirectory = (path: string): string => {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  if (parts.length <= 1) return ROOT_LABEL;
+  return parts[parts.length - 2] ?? ROOT_LABEL;
+};
+
+const toExtension = (path: string): string => {
+  const filename = path.split(/[\\/]/).pop() ?? path;
+  const dotIndex = filename.lastIndexOf('.');
+  if (dotIndex <= 0 || dotIndex === filename.length - 1) return '(no ext)';
+  return filename.slice(dotIndex + 1).toLowerCase();
+};
+
+const sortCounts = (
+  map: Map<string, number>,
+): Array<{ name: string; count: number }> =>
+  Array.from(map.entries())
+    .sort((a, b) => {
+      if (b[1] === a[1]) {
+        return a[0].localeCompare(b[0]);
+      }
+      return b[1] - a[1];
+    })
+    .map(([name, count]) => ({ name, count }));
+
+ctx.onmessage = (event: MessageEvent<SearchWorkerMessage>) => {
+  const message = event.data;
+
+  if (!message || typeof message !== 'object') {
+    ctx.postMessage({
+      type: 'error',
+      requestId: 0,
+      message: 'Invalid worker message received',
+    } satisfies SearchWorkerErrorMessage);
+    return;
+  }
+
+  if (message.type === 'cancel') {
+    if (typeof message.requestId === 'number') {
+      cancelledRequests.add(message.requestId);
+    }
+    return;
+  }
+
+  if (message.type !== 'count') {
+    ctx.postMessage({
+      type: 'error',
+      requestId: message.requestId ?? 0,
+      message: `Unsupported worker message: ${String(message.type)}`,
+    } satisfies SearchWorkerErrorMessage);
+    return;
+  }
+
+  const requestId = message.requestId ?? 0;
+  if (cancelledRequests.has(requestId)) {
+    cancelledRequests.delete(requestId);
+    return;
+  }
+
+  const files = sanitizeFiles(message.files);
+  const limit = normalizeLimit(message.limit);
+  const query = (message.query ?? '').trim().toLowerCase();
+
+  const matches =
+    query.length === 0
+      ? files.slice()
+      : files.filter((file) => file.toLowerCase().includes(query));
+
+  const total = matches.length;
+  const limitedMatches = limit > 0 ? matches.slice(0, limit) : [];
+
+  const directoryCounts = new Map<string, number>();
+  const extensionCounts = new Map<string, number>();
+
+  for (const file of matches) {
+    const directory = toDirectory(file);
+    const extension = toExtension(file);
+    directoryCounts.set(directory, (directoryCounts.get(directory) ?? 0) + 1);
+    extensionCounts.set(extension, (extensionCounts.get(extension) ?? 0) + 1);
+  }
+
+  const response: SearchWorkerResultMessage = {
+    type: 'result',
+    requestId,
+    total,
+    matches: limitedMatches,
+    directories: sortCounts(directoryCounts),
+    extensions: sortCounts(extensionCounts),
+  };
+
+  ctx.postMessage(response);
+};
+
+export {}; // ensure module scope


### PR DESCRIPTION
## Summary
- add a dedicated search worker that counts matches, directories, and extensions
- create a client SearchBox component that communicates with the worker and renders counts

## Testing
- yarn lint *(fails: existing accessibility and lint issues across unrelated apps)*
- yarn test *(fails: existing unit test failures in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c852ec7dbc832897628042a23ef035