### PR TITLE
[app] Add dock clock SSE feed

### DIFF
--- a/app/api/clock/route.ts
+++ b/app/api/clock/route.ts
@@ -1,0 +1,43 @@
+export const runtime = 'edge';
+
+export function GET(request: Request) {
+  const encoder = new TextEncoder();
+  let intervalId: ReturnType<typeof setInterval> | undefined;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const sendTimestamp = () => {
+        const payload = `data: ${new Date().toISOString()}\n\n`;
+        controller.enqueue(encoder.encode(payload));
+      };
+
+      sendTimestamp();
+      intervalId = setInterval(sendTimestamp, 1000);
+    },
+    cancel() {
+      if (intervalId !== undefined) {
+        clearInterval(intervalId);
+      }
+    },
+  });
+
+  if (request.signal) {
+    request.signal.addEventListener(
+      'abort',
+      () => {
+        if (intervalId !== undefined) {
+          clearInterval(intervalId);
+        }
+      },
+      { once: true },
+    );
+  }
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/app/ui/DockClock.tsx
+++ b/app/ui/DockClock.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+interface DockClockProps {
+  className?: string;
+}
+
+const FALLBACK_DISPLAY = '--:--:--';
+
+function formatTime(isoTimestamp: string | null) {
+  if (!isoTimestamp) {
+    return FALLBACK_DISPLAY;
+  }
+
+  const date = new Date(isoTimestamp);
+
+  if (Number.isNaN(date.getTime())) {
+    return FALLBACK_DISPLAY;
+  }
+
+  return date.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}
+
+export default function DockClock({ className }: DockClockProps) {
+  const [isoTime, setIsoTime] = useState<string | null>(null);
+
+  useEffect(() => {
+    const eventSource = new EventSource('/api/clock');
+
+    eventSource.onmessage = (event) => {
+      if (event?.data) {
+        setIsoTime(event.data);
+      }
+    };
+
+    eventSource.onerror = (event) => {
+      console.error('Dock clock stream error:', event);
+    };
+
+    return () => {
+      eventSource.close();
+    };
+  }, []);
+
+  const displayTime = useMemo(() => formatTime(isoTime), [isoTime]);
+
+  return (
+    <time dateTime={isoTime ?? undefined} className={className}>
+      {displayTime}
+    </time>
+  );
+}


### PR DESCRIPTION
## Summary
- add an Edge runtime clock API route that streams ISO timestamps
- create a DockClock client component that subscribes to the clock stream with EventSource

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations in unrelated files)*
- yarn test *(fails: existing suites such as modal and ubuntu component tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c852ec06488328a3aba42d932c7842