### PR TITLE
Add layout persistence for desktop windows

### DIFF
--- a/app/desktop/windowing/layout-store.ts
+++ b/app/desktop/windowing/layout-store.ts
@@ -1,0 +1,71 @@
+import { safeLocalStorage } from '@/utils/safeStorage';
+
+export interface WindowLayoutSnapshot {
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+}
+
+export type LayoutState = Record<string, WindowLayoutSnapshot>;
+
+const STORAGE_KEY = 'kali:layout:v1';
+
+const isNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+export function loadLayout(): LayoutState {
+  if (!safeLocalStorage) {
+    return {};
+  }
+
+  try {
+    const raw = safeLocalStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== 'object') {
+      return {};
+    }
+
+    const layout: LayoutState = {};
+    for (const [id, value] of Object.entries(parsed)) {
+      if (!value || typeof value !== 'object') {
+        continue;
+      }
+      const maybeX = (value as Record<string, unknown>).x;
+      const maybeY = (value as Record<string, unknown>).y;
+      if (!isNumber(maybeX) || !isNumber(maybeY)) {
+        continue;
+      }
+      const snapshot: WindowLayoutSnapshot = { x: maybeX, y: maybeY };
+      const maybeWidth = (value as Record<string, unknown>).width;
+      const maybeHeight = (value as Record<string, unknown>).height;
+      if (isNumber(maybeWidth)) {
+        snapshot.width = maybeWidth;
+      }
+      if (isNumber(maybeHeight)) {
+        snapshot.height = maybeHeight;
+      }
+      layout[id] = snapshot;
+    }
+
+    return layout;
+  } catch (error) {
+    return {};
+  }
+}
+
+export function saveLayout(layout: LayoutState): void {
+  if (!safeLocalStorage) {
+    return;
+  }
+
+  try {
+    safeLocalStorage.setItem(STORAGE_KEY, JSON.stringify(layout));
+  } catch (error) {
+    // Ignore quota or serialization issues
+  }
+}


### PR DESCRIPTION
## Summary
- add a small layout storage helper keyed under `kali:layout:v1`
- update the desktop window component to read stored positions/sizes and persist them when the user moves or resizes a window
- guard the test environment so snapshot layout data does not leak across Jest runs

## Testing
- yarn test __tests__/window.test.tsx --watchAll=false
- yarn lint *(fails: repository already has numerous accessibility issues flagged by eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68c852efdf5c83289603188bc985c038