### PR TITLE
[app] add container queries for desktop window controls

### DIFF
--- a/app/desktop/window.css
+++ b/app/desktop/window.css
@@ -1,0 +1,17 @@
+.window {
+  container-type: inline-size;
+}
+
+.window .icon-only {
+  display: none;
+}
+
+@container (max-width: 420px) {
+  .window .text-label {
+    display: none;
+  }
+
+  .window .icon-only {
+    display: inline-flex;
+  }
+}


### PR DESCRIPTION
## Summary
- add `container-type: inline-size` to the desktop window scope so child elements can respond to the window width
- hide the text label and show the icon-only element below a 420px container width with a CSS container query

## Testing
- yarn lint *(fails: existing jsx-a11y/no-top-level-window errors in unrelated files)*
- CI=1 yarn test *(fails: existing jsdom localStorage errors and long-running suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c852f08b048328b4787c3f6f2ddf18