### PR TITLE
[desktop] Add rotating wallpaper component

### DIFF
--- a/app/desktop/Wallpaper.tsx
+++ b/app/desktop/Wallpaper.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const WALLPAPERS = [
+  '/wallpapers/wall-1.webp',
+  '/wallpapers/wall-2.webp',
+  '/wallpapers/wall-3.webp',
+  '/wallpapers/wall-4.webp',
+  '/wallpapers/wall-5.webp',
+  '/wallpapers/wall-6.webp',
+  '/wallpapers/wall-7.webp',
+  '/wallpapers/wall-8.webp',
+] as const;
+
+const ROTATION_INTERVAL_MS = 15_000;
+
+export default function Wallpaper() {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (WALLPAPERS.length <= 1) {
+      return undefined;
+    }
+
+    const timer = window.setInterval(() => {
+      setIndex((current) => (current + 1) % WALLPAPERS.length);
+    }, ROTATION_INTERVAL_MS);
+
+    return () => window.clearInterval(timer);
+  }, []);
+
+  const currentWallpaper = WALLPAPERS[index] ?? WALLPAPERS[0];
+
+  return (
+    <div
+      className="fixed inset-0 -z-10 bg-cover bg-center bg-no-repeat"
+      style={{ backgroundImage: `url(${currentWallpaper})` }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add a client wallpaper component for the desktop app directory
- rotate through the bundled wallpapers on a 15 second interval and expose the active image as a full-screen background

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window lint violations throughout legacy files)*
- yarn test *(fails: legacy suites such as window.test.tsx and contact.api.test.ts throw before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68c852f32acc83289da80c6f9d3fa586