### PR TITLE
[desktop] add fullscreen toggle button component

### DIFF
--- a/app/desktop/FullscreenButton.tsx
+++ b/app/desktop/FullscreenButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCallback } from "react";
+import type { PropsWithChildren } from "react";
+
+type FullscreenButtonProps = PropsWithChildren<{
+  targetId: string;
+  className?: string;
+}>;
+
+const FullscreenButton = ({
+  targetId,
+  className,
+  children,
+}: FullscreenButtonProps) => {
+  const handleToggle = useCallback(async () => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    const targetElement = document.getElementById(targetId);
+
+    if (!targetElement) {
+      return;
+    }
+
+    if (document.fullscreenElement === targetElement) {
+      await document.exitFullscreen();
+      return;
+    }
+
+    if (document.fullscreenElement && document.fullscreenElement !== targetElement) {
+      await document.exitFullscreen();
+    }
+
+    await targetElement.requestFullscreen();
+  }, [targetId]);
+
+  return (
+    <button type="button" onClick={handleToggle} className={className}>
+      {children ?? "Toggle fullscreen"}
+    </button>
+  );
+};
+
+export default FullscreenButton;


### PR DESCRIPTION
## Summary
- add a client-side FullscreenButton component that toggles fullscreen for a given element id
- exit fullscreen when the target is already active and guard against missing DOM access

## Testing
- [x] yarn lint *(fails: repository has 578 pre-existing lint violations across legacy apps)*
- [x] yarn test *(fails: existing suites such as Modal and Ubuntu, and Jest remained in watch mode; terminated after results)*

## Flags
- none

------
https://chatgpt.com/codex/tasks/task_e_68c852f1e5208328b9ed76d3008d9f9e