### PR TITLE
[windows] add share button component

### DIFF
--- a/app/(windows)/files/ShareButton.tsx
+++ b/app/(windows)/files/ShareButton.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+interface ShareButtonProps {
+  url: string;
+  title: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+const ShareButton = ({ url, title, className, children }: ShareButtonProps) => {
+  const handleShare = async () => {
+    const share = (navigator as Navigator & {
+      share?: (data?: ShareData) => Promise<void>;
+    }).share;
+
+    if (!share) {
+      window.alert('Sharing is unavailable on this device.');
+      return;
+    }
+
+    try {
+      await share({ title, url });
+    } catch (error) {
+      if ((error as DOMException)?.name === 'AbortError') return;
+      console.error('Failed to share the provided link.', error);
+    }
+  };
+
+  return (
+    <button type="button" onClick={handleShare} className={className}>
+      {children ?? 'Share'}
+    </button>
+  );
+};
+
+export default ShareButton;


### PR DESCRIPTION
## Summary
- add a ShareButton client component under the windows files route that triggers the Web Share API with the provided title and URL
- alert when sharing is unsupported and log unexpected share errors

## Testing
- yarn lint *(fails: existing accessibility and browser global lint violations in unrelated files)*
- yarn test *(fails: existing Ubuntu window, Modal, and Nmap NSE test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c852f607c083288ac606e5ca6be848