### PR TITLE
[app] add clipboard helper

### DIFF
--- a/app/lib/clipboard.ts
+++ b/app/lib/clipboard.ts
@@ -1,0 +1,18 @@
+export async function copy(text: string): Promise<void> {
+  if (typeof navigator === 'undefined') {
+    return;
+  }
+
+  const { clipboard } = navigator;
+  if (!clipboard || typeof clipboard.writeText !== 'function') {
+    return;
+  }
+
+  try {
+    await clipboard.writeText(text);
+  } catch {
+    // Swallow clipboard errors to avoid crashing callers when the API is unavailable.
+  }
+}
+
+export default copy;


### PR DESCRIPTION
## Summary
- add an app router clipboard helper that safely attempts to write text via the Clipboard API

## Testing
- yarn lint *(fails: pre-existing accessibility and no-top-level-window errors throughout repo)*

------
https://chatgpt.com/codex/tasks/task_e_68c852f7cbec8328bc2917aca589b35f