### PR TITLE
[ui] add dialog demo component

### DIFF
--- a/app/ui/Dialog.tsx
+++ b/app/ui/Dialog.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { SyntheticEvent, useCallback, useRef } from "react";
+
+export function DialogDemo() {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const openDialog = useCallback(() => {
+    if (!dialogRef.current) return;
+
+    if (typeof dialogRef.current.showModal === "function") {
+      dialogRef.current.showModal();
+    } else {
+      dialogRef.current.setAttribute("open", "");
+    }
+  }, []);
+
+  const closeDialog = useCallback(() => {
+    dialogRef.current?.close();
+  }, []);
+
+  const handleCancel = useCallback(
+    (event: SyntheticEvent<HTMLDialogElement, Event>) => {
+      event.preventDefault();
+      closeDialog();
+    },
+    [closeDialog]
+  );
+
+  const handleClose = useCallback(() => {
+    window.requestAnimationFrame(() => {
+      triggerRef.current?.focus();
+    });
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <button
+        type="button"
+        ref={triggerRef}
+        onClick={openDialog}
+        className="rounded bg-slate-800 px-4 py-2 text-white shadow"
+      >
+        Open dialog
+      </button>
+
+      <dialog
+        ref={dialogRef}
+        aria-modal="true"
+        className="rounded-lg border border-slate-700 bg-slate-900 p-6 text-left text-slate-100 shadow-xl"
+        onCancel={handleCancel}
+        onClose={handleClose}
+      >
+        <p className="mb-4">This is a native dialog element rendered as a modal.</p>
+        <button
+          type="button"
+          onClick={closeDialog}
+          className="rounded bg-slate-700 px-3 py-2 text-sm text-white"
+        >
+          Close
+        </button>
+      </dialog>
+    </div>
+  );
+}
+
+export default DialogDemo;


### PR DESCRIPTION
## Summary
- add a client-side DialogDemo component that opens a native dialog via showModal
- wire the dialog to restore focus to the trigger on close and handle Escape via cancel events

## Testing
- yarn lint *(fails: pre-existing jsx-a11y/control-has-associated-label issues across multiple apps and lint errors in public game scripts)*
- yarn test --runInBand *(fails: existing window, nmap NSE, settings store, and other suites currently red)*

------
https://chatgpt.com/codex/tasks/task_e_68c852f727488328bdb12a20b17bda00