### PR TITLE
[app] add desktop context menu component

### DIFF
--- a/app/desktop/ContextMenu.tsx
+++ b/app/desktop/ContextMenu.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+type Coordinates = {
+  x: number;
+  y: number;
+};
+
+const MENU_WIDTH = 208;
+const MENU_HEIGHT = 200;
+const ACTIONS = ['New File', 'New Folder', 'Paste', 'Refresh', 'Display Settings'];
+
+const DesktopContextMenu = () => {
+  const [visible, setVisible] = useState(false);
+  const [position, setPosition] = useState<Coordinates>({ x: 0, y: 0 });
+
+  const closeMenu = useCallback(() => {
+    setVisible(false);
+  }, []);
+
+  useEffect(() => {
+    const handleContextMenu = (event: MouseEvent) => {
+      event.preventDefault();
+
+      const { clientX, clientY } = event;
+      const clampedX = Math.min(
+        clientX,
+        Math.max(0, window.innerWidth - MENU_WIDTH),
+      );
+      const clampedY = Math.min(
+        clientY,
+        Math.max(0, window.innerHeight - MENU_HEIGHT),
+      );
+
+      setPosition({ x: clampedX, y: clampedY });
+      setVisible(true);
+    };
+
+    const handleDocumentClick = () => {
+      closeMenu();
+    };
+
+    document.addEventListener('contextmenu', handleContextMenu);
+    document.addEventListener('click', handleDocumentClick);
+
+    return () => {
+      document.removeEventListener('contextmenu', handleContextMenu);
+      document.removeEventListener('click', handleDocumentClick);
+    };
+  }, [closeMenu]);
+
+  return (
+    <div
+      className={`fixed z-50 w-52 overflow-hidden rounded-md border border-slate-700 bg-slate-900/95 text-slate-50 shadow-lg transition-opacity ${
+        visible ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
+      }`}
+      style={{ left: position.x, top: position.y }}
+      role="menu"
+      aria-hidden={!visible}
+    >
+      <ul className="py-2">
+        {ACTIONS.map((action) => (
+          <li key={action}>
+            <button
+              type="button"
+              role="menuitem"
+              className="flex w-full cursor-default items-center gap-2 px-4 py-1.5 text-left text-sm hover:bg-slate-700 focus:bg-slate-700 focus:outline-none"
+              onClick={closeMenu}
+            >
+              {action}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default DesktopContextMenu;


### PR DESCRIPTION
## Summary
- add a desktop context menu component under app/desktop that listens for right click
- position the menu near the cursor, prevent the native context menu, and provide placeholder actions
- hide the context menu when clicking elsewhere on the page

## Testing
- yarn lint *(fails: existing accessibility and window/global errors in repository)*
- yarn test *(fails and long-running due to existing test failures in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c852f8da908328981b847f78c265a7