### PR TITLE
[seo] add person JSON-LD component for homepage

### DIFF
--- a/app/components/JsonLdPerson.tsx
+++ b/app/components/JsonLdPerson.tsx
@@ -1,0 +1,30 @@
+import Head from 'next/head';
+
+import { getCspNonce } from '../../utils/csp';
+
+type JsonLdPersonProps = {
+  name: string;
+  url: string;
+};
+
+const JsonLdPerson = ({ name, url }: JsonLdPersonProps) => {
+  const nonce = getCspNonce();
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name,
+    url,
+  };
+
+  return (
+    <Head>
+      <script
+        type="application/ld+json"
+        nonce={nonce}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </Head>
+  );
+};
+
+export default JsonLdPerson;

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
+import JsonLdPerson from '../app/components/JsonLdPerson';
 
 const Ubuntu = dynamic(
   () =>
@@ -34,6 +35,7 @@ const App = () => (
       Skip to content
     </a>
     <Meta />
+    <JsonLdPerson name="Alex Unnippillil" url="https://unnippillil.com/" />
     <Ubuntu />
     <BetaBadge />
     <InstallButton />


### PR DESCRIPTION
## Summary
- add a typed `JsonLdPerson` component that emits a schema.org Person JSON-LD script with the configured CSP nonce
- render the new structured data component on the homepage with Alex Unnippillil’s name and canonical URL

## Testing
- yarn lint *(fails: existing repository lint violations unrelated to this change)*
- yarn test *(fails: existing repository test failures and long-running suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c852fa1e908328b84775c4d962b0d9