### PR TITLE
[app] Add wallpaper image component

### DIFF
--- a/app/components/WallpaperImage.tsx
+++ b/app/components/WallpaperImage.tsx
@@ -1,0 +1,22 @@
+import Image, { type StaticImageData } from "next/image";
+
+export type WallpaperImageProps = {
+  src: StaticImageData | string;
+  alt?: string;
+  priority?: boolean;
+};
+
+const WallpaperImage = ({ src, alt = "Wallpaper", priority = false }: WallpaperImageProps) => (
+  <div className="relative h-screen w-full">
+    <Image
+      alt={alt}
+      className="object-cover"
+      fill
+      priority={priority}
+      sizes="100vw"
+      src={src}
+    />
+  </div>
+);
+
+export default WallpaperImage;


### PR DESCRIPTION
## Summary
- add a reusable WallpaperImage component that renders a full-viewport Next.js Image with fill positioning

## Testing
- [ ] yarn lint *(fails due to existing issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c852fe9f548328ad345da5538a3e09