### PR TITLE
[app] Implement appearance API and settings page data fetching

### DIFF
--- a/app/(windows)/settings/page.tsx
+++ b/app/(windows)/settings/page.tsx
@@ -1,0 +1,112 @@
+import { headers } from 'next/headers';
+
+import type { AppearancePayload } from '@/lib/appearance-store';
+
+function resolveBaseUrl(): string {
+  const headerList = headers();
+  const forwardedHost = headerList.get('x-forwarded-host');
+  const host = forwardedHost ?? headerList.get('host');
+
+  if (host) {
+    const protocol =
+      headerList.get('x-forwarded-proto') ??
+      (host.includes('localhost') || host.startsWith('127.') ? 'http' : 'https');
+    return `${protocol}://${host}`;
+  }
+
+  const envUrl =
+    process.env.NEXT_PUBLIC_SITE_URL ??
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null);
+
+  if (envUrl) {
+    return envUrl.replace(/\/+$, '');
+  }
+
+  return 'http://localhost:3000';
+}
+
+async function fetchAppearance(): Promise<AppearancePayload> {
+  const baseUrl = resolveBaseUrl();
+  const url = new URL('/api/appearance', baseUrl);
+  const response = await fetch(url.toString(), {
+    next: { tags: ['appearance'] },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load appearance data (${response.status})`);
+  }
+
+  return response.json() as Promise<AppearancePayload>;
+}
+
+const formatBoolean = (value: boolean) => (value ? 'Enabled' : 'Disabled');
+
+export default async function SettingsPage() {
+  const { settings, options } = await fetchAppearance();
+
+  const currentSettings = [
+    { label: 'Theme', value: settings.theme },
+    { label: 'Accent color', value: settings.accent },
+    { label: 'Wallpaper', value: settings.wallpaper },
+    { label: 'Density', value: settings.density },
+    { label: 'Font scale', value: settings.fontScale.toString() },
+    { label: 'Reduced motion', value: formatBoolean(settings.reducedMotion) },
+    { label: 'High contrast', value: formatBoolean(settings.highContrast) },
+    { label: 'Large hit areas', value: formatBoolean(settings.largeHitAreas) },
+    { label: 'Pong spin', value: formatBoolean(settings.pongSpin) },
+    { label: 'Network access', value: formatBoolean(settings.allowNetwork) },
+    { label: 'Haptics', value: formatBoolean(settings.haptics) },
+  ];
+
+  const optionSections = [
+    { title: 'Available themes', items: options.themes },
+    { title: 'Accent palette', items: options.accents },
+    { title: 'Wallpapers', items: options.wallpapers },
+    { title: 'Density presets', items: options.densities },
+  ];
+
+  return (
+    <section className="flex h-full flex-col gap-6 overflow-y-auto bg-slate-950/70 p-6 text-sm text-slate-200">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-white">Appearance</h1>
+        <p className="max-w-2xl text-slate-300">
+          Review the current desktop theme configuration and the presets that can be applied across the Kali Linux desktop
+          simulation.
+        </p>
+      </header>
+
+      <article className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 shadow">
+        <h2 className="mb-3 text-lg font-medium text-white">Current settings</h2>
+        <dl className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          {currentSettings.map(({ label, value }) => (
+            <div key={label} className="flex flex-col rounded border border-slate-800/50 bg-slate-900/40 p-3">
+              <dt className="text-xs uppercase tracking-wide text-slate-400">{label}</dt>
+              <dd className="mt-1 text-base text-white">{value}</dd>
+            </div>
+          ))}
+        </dl>
+      </article>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {optionSections.map((section) => (
+          <article
+            key={section.title}
+            className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 shadow"
+          >
+            <h3 className="mb-3 text-base font-medium text-white">{section.title}</h3>
+            <ul className="flex flex-wrap gap-2">
+              {section.items.map((item) => (
+                <li
+                  key={item}
+                  className="rounded-full border border-slate-700/60 bg-slate-800/80 px-3 py-1 text-xs uppercase tracking-wide text-slate-200"
+                >
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/api/appearance/route.ts
+++ b/app/api/appearance/route.ts
@@ -1,0 +1,35 @@
+import { revalidateTag } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server';
+
+import {
+  getAppearancePayload,
+  parseAppearanceUpdate,
+  writeAppearanceSettings,
+} from '@/lib/appearance-store';
+
+export async function GET() {
+  const payload = getAppearancePayload();
+  return NextResponse.json(payload);
+}
+
+export async function POST(request: NextRequest) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+  }
+
+  const update = parseAppearanceUpdate(body);
+
+  if (!update || Object.keys(update).length === 0) {
+    return NextResponse.json({ error: 'No valid settings provided' }, { status: 400 });
+  }
+
+  writeAppearanceSettings(update);
+  revalidateTag('appearance');
+
+  const payload = getAppearancePayload();
+
+  return NextResponse.json(payload);
+}

--- a/lib/appearance-store.ts
+++ b/lib/appearance-store.ts
@@ -1,0 +1,155 @@
+export type DensitySetting = 'regular' | 'compact';
+
+export interface AppearanceSettings {
+  theme: string;
+  accent: string;
+  wallpaper: string;
+  density: DensitySetting;
+  reducedMotion: boolean;
+  fontScale: number;
+  highContrast: boolean;
+  largeHitAreas: boolean;
+  pongSpin: boolean;
+  allowNetwork: boolean;
+  haptics: boolean;
+}
+
+export interface AppearanceOptions {
+  themes: string[];
+  accents: string[];
+  wallpapers: string[];
+  densities: DensitySetting[];
+}
+
+export interface AppearancePayload {
+  settings: AppearanceSettings;
+  options: AppearanceOptions;
+}
+
+export const DEFAULT_APPEARANCE: AppearanceSettings = {
+  theme: 'default',
+  accent: '#1793d1',
+  wallpaper: 'wall-2',
+  density: 'regular',
+  reducedMotion: false,
+  fontScale: 1,
+  highContrast: false,
+  largeHitAreas: false,
+  pongSpin: true,
+  allowNetwork: false,
+  haptics: true,
+};
+
+export const APPEARANCE_OPTIONS: AppearanceOptions = {
+  themes: ['default', 'dark', 'neon', 'matrix'],
+  accents: ['#1793d1', '#e53e3e', '#d97706', '#38a169', '#805ad5', '#ed64a6'],
+  wallpapers: [
+    'wall-1',
+    'wall-2',
+    'wall-3',
+    'wall-4',
+    'wall-5',
+    'wall-6',
+    'wall-7',
+    'wall-8',
+  ],
+  densities: ['regular', 'compact'],
+};
+
+const STORE_SYMBOL = Symbol.for('kali-linux-portfolio.appearance');
+
+interface AppearanceStore {
+  settings: AppearanceSettings;
+}
+
+function ensureStore(): AppearanceStore {
+  const globalSymbols = Object.getOwnPropertySymbols(globalThis);
+  if (!globalSymbols.includes(STORE_SYMBOL)) {
+    (globalThis as any)[STORE_SYMBOL] = {
+      settings: { ...DEFAULT_APPEARANCE },
+    } satisfies AppearanceStore;
+  }
+  return (globalThis as any)[STORE_SYMBOL] as AppearanceStore;
+}
+
+export function readAppearanceSettings(): AppearanceSettings {
+  const store = ensureStore();
+  return { ...store.settings };
+}
+
+export function writeAppearanceSettings(update: Partial<AppearanceSettings>): AppearanceSettings {
+  const store = ensureStore();
+  store.settings = { ...store.settings, ...update };
+  return { ...store.settings };
+}
+
+const BOOLEAN_KEYS: (keyof AppearanceSettings)[] = [
+  'reducedMotion',
+  'highContrast',
+  'largeHitAreas',
+  'pongSpin',
+  'allowNetwork',
+  'haptics',
+];
+
+export function parseAppearanceUpdate(input: unknown): Partial<AppearanceSettings> | null {
+  if (!input || typeof input !== 'object') return null;
+
+  const base =
+    'settings' in (input as Record<string, unknown>) &&
+    (input as Record<string, unknown>).settings &&
+    typeof (input as Record<string, unknown>).settings === 'object' &&
+    !Array.isArray((input as Record<string, unknown>).settings)
+      ? (input as Record<string, unknown>).settings
+      : input;
+
+  if (!base || typeof base !== 'object' || Array.isArray(base)) return null;
+
+  const record = base as Record<string, unknown>;
+  const next: Partial<AppearanceSettings> = {};
+
+  if (typeof record.theme === 'string') {
+    next.theme = record.theme;
+  }
+
+  if (typeof record.accent === 'string') {
+    next.accent = record.accent;
+  }
+
+  if (typeof record.wallpaper === 'string') {
+    next.wallpaper = record.wallpaper;
+  }
+
+  if (
+    typeof record.density === 'string' &&
+    (record.density === 'regular' || record.density === 'compact')
+  ) {
+    next.density = record.density;
+  }
+
+  if (typeof record.fontScale === 'number' && Number.isFinite(record.fontScale)) {
+    next.fontScale = record.fontScale;
+  }
+
+  for (const key of BOOLEAN_KEYS) {
+    const value = record[key];
+    if (typeof value === 'boolean') {
+      next[key] = value;
+    }
+  }
+
+  return next;
+}
+
+export function getAppearancePayload(): AppearancePayload {
+  const settings = readAppearanceSettings();
+  return {
+    settings,
+    options: {
+      themes: [...APPEARANCE_OPTIONS.themes],
+      accents: [...APPEARANCE_OPTIONS.accents],
+      wallpapers: [...APPEARANCE_OPTIONS.wallpapers],
+      densities: [...APPEARANCE_OPTIONS.densities],
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared appearance store with defaults and parsing helpers
- expose the data through a new /api/appearance route with revalidation on POST
- fetch the appearance payload from the settings window using the appearance tag

## Testing
- yarn lint *(fails: repository has existing accessibility violations in multiple apps)*
- yarn test *(fails: existing suites such as Modal and Ubuntu fail under jsdom due to legacy issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c853011f9083288b92fd380f2508a0