### PR TITLE
[api] add revalidate route

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { path } = await req.json();
+
+    if (typeof path !== 'string' || path.trim().length === 0) {
+      return NextResponse.json(
+        { ok: false, error: 'Invalid path provided.' },
+        { status: 400 }
+      );
+    }
+
+    revalidatePath(path);
+
+    return NextResponse.json({ ok: true, revalidatedPath: path });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: 'Invalid request body.' },
+      { status: 400 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add an app router API endpoint at `/api/revalidate` that reads a `path` from the request body
- call `revalidatePath` for the provided path and return JSON success or error responses

## Testing
- yarn lint *(fails: existing accessibility and lint issues throughout apps/ and public/ as in repo baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68c853018478832882de69c6a54e9d18