### PR TITLE
[windows] load theme cookie asynchronously

### DIFF
--- a/app/(windows)/settings/theme.tsx
+++ b/app/(windows)/settings/theme.tsx
@@ -1,0 +1,8 @@
+import { cookies } from 'next/headers';
+
+export default async function Theme() {
+  const cookieStore = await cookies();
+  const theme = cookieStore.get('theme')?.value ?? 'default';
+
+  return <span suppressHydrationWarning>{theme}</span>;
+}


### PR DESCRIPTION
## Summary
- load the theme cookie in the Windows settings theme module using the async cookies API
- render the cookie value with suppressHydrationWarning to prevent hydration mismatch warnings

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label violations across legacy app pages)*

------
https://chatgpt.com/codex/tasks/task_e_68c85303fa648328a68ce6abb84b1307