### PR TITLE
[middleware] Set device cookie from user agent

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,4 @@
-import { NextResponse, type NextRequest } from 'next/server';
+import { NextResponse, type NextRequest, userAgent } from 'next/server';
 
 function nonce() {
   const arr = new Uint8Array(16);
@@ -8,6 +8,9 @@ function nonce() {
 
 export function middleware(req: NextRequest) {
   const n = nonce();
+  const { device } = userAgent(req);
+  const deviceType = device?.type;
+  const isMobileDevice = deviceType === 'mobile' || deviceType === 'tablet';
   const csp = [
     "default-src 'self'",
     "img-src 'self' https: data:",
@@ -25,5 +28,6 @@ export function middleware(req: NextRequest) {
   const res = NextResponse.next();
   res.headers.set('x-csp-nonce', n);
   res.headers.set('Content-Security-Policy', csp);
+  res.cookies.set('device', isMobileDevice ? 'm' : 'd', { path: '/' });
   return res;
 }


### PR DESCRIPTION
## Summary
- extend the middleware to read the request user agent
- classify mobile vs desktop devices and set a device cookie on each response

## Testing
- [ ] yarn lint *(fails with pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c85302c328832891338dac9e3c63b3