### PR TITLE
[security-tools] Add tutorial overlay system

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ See Vercel's [Speed Insights Quickstart](https://vercel.com/docs/speed-insights/
 - **Vercel Analytics** (`@vercel/analytics`)
 - **EmailJS** for the contact (“Gedit”) app
 - Simple in-memory rate limiter for the contact API (not distributed across instances)
-- Client-side only **simulations** of security tools (no real exploitation)
+- Client-side only **simulations** of security tools (no real exploitation) with guided tutorials persisted in `localStorage` (keys `tutorial:<appId>`) and a replay action in each app menu
 - A large set of games rendered in-browser (Canvas/DOM), with a shared `GameLayout`
 
 ### Gamepad Input & Remapping

--- a/components/HelpOverlay.tsx
+++ b/components/HelpOverlay.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+
+export interface TutorialStep {
+  title: string;
+  body: ReactNode;
+  selector?: string;
+  tip?: ReactNode;
+}
+
+interface HelpOverlayProps {
+  open: boolean;
+  title: string;
+  steps: TutorialStep[];
+  onClose: () => void;
+  finishLabel?: string;
+}
+
+const FOCUSABLE_SELECTORS =
+  'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+const HelpOverlay: React.FC<HelpOverlayProps> = ({
+  open,
+  title,
+  steps,
+  onClose,
+  finishLabel = 'Finish',
+}) => {
+  const [index, setIndex] = useState(0);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+  const highlightRef = useRef<HTMLElement | null>(null);
+  const titleId = useId();
+
+  const close = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  const handlePrev = useCallback(() => {
+    setIndex((value) => Math.max(0, value - 1));
+  }, []);
+
+  const handleNext = useCallback(() => {
+    setIndex((value) => {
+      if (value >= steps.length - 1) {
+        close();
+        return value;
+      }
+      return value + 1;
+    });
+  }, [close, steps.length]);
+
+  useEffect(() => {
+    if (!open) {
+      setIndex(0);
+      if (highlightRef.current) {
+        highlightRef.current.removeAttribute('data-help-highlight');
+        highlightRef.current = null;
+      }
+      return;
+    }
+
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+
+    const node = cardRef.current;
+    if (!node) return;
+
+    const focusables = Array.from(
+      node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)
+    ).filter((el) => !el.hasAttribute('disabled'));
+
+    focusables[0]?.focus({ preventScroll: true });
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!open) return;
+      if (event.key === 'Tab' && focusables.length > 0) {
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        if (event.shiftKey) {
+          if (document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          }
+        } else if (document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        handleNext();
+      } else if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        handlePrev();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previouslyFocused.current?.focus?.();
+    };
+  }, [open, close, handleNext, handlePrev]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    if (highlightRef.current) {
+      highlightRef.current.removeAttribute('data-help-highlight');
+      highlightRef.current = null;
+    }
+
+    const current = steps[index];
+    if (!current?.selector) return;
+
+    const target = document.querySelector<HTMLElement>(current.selector);
+    if (!target) return;
+
+    target.setAttribute('data-help-highlight', 'true');
+    highlightRef.current = target;
+    target.scrollIntoView({ block: 'center', inline: 'center', behavior: 'smooth' });
+
+    return () => {
+      if (highlightRef.current === target) {
+        highlightRef.current.removeAttribute('data-help-highlight');
+        highlightRef.current = null;
+      } else {
+        target.removeAttribute('data-help-highlight');
+      }
+    };
+  }, [open, index, steps]);
+
+  if (!open || steps.length === 0) {
+    return null;
+  }
+
+  const step = steps[index];
+  const isLastStep = index === steps.length - 1;
+
+  return (
+    <>
+      <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black bg-opacity-80 px-4 py-6">
+        <div
+          ref={cardRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          className="w-full max-w-lg rounded-lg bg-gray-900 text-white shadow-2xl focus:outline-none"
+        >
+          <header className="flex items-start justify-between border-b border-white/10 px-4 py-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wider text-ub-yellow">
+                Guided tour
+              </p>
+              <h2 id={titleId} className="text-lg font-bold">
+                {title}
+              </h2>
+            </div>
+            <button
+              type="button"
+              onClick={close}
+              className="ml-2 rounded px-2 py-1 text-sm transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-ub-yellow"
+              aria-label="Close tutorial"
+            >
+              ×
+            </button>
+          </header>
+          <div className="px-4 py-3 space-y-3">
+            <div className="text-sm font-semibold text-ub-yellow">{step.title}</div>
+            <div className="text-sm leading-relaxed text-gray-100">{step.body}</div>
+            {step.tip && (
+              <p className="rounded border-l-4 border-ub-yellow bg-white/5 px-3 py-2 text-xs text-gray-200">
+                {step.tip}
+              </p>
+            )}
+          </div>
+          <footer className="flex items-center justify-between border-t border-white/10 px-4 py-3 text-xs text-gray-300">
+            <span>
+              Step {index + 1} of {steps.length}
+            </span>
+            <div className="flex space-x-2">
+              <button
+                type="button"
+                onClick={handlePrev}
+                disabled={index === 0}
+                className="rounded px-3 py-1 text-sm transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-ub-yellow disabled:opacity-50 disabled:hover:bg-transparent"
+              >
+                Previous
+              </button>
+              <button
+                type="button"
+                onClick={isLastStep ? close : handleNext}
+                className="rounded bg-ub-yellow px-3 py-1 text-sm font-semibold text-black transition hover:bg-yellow-300 focus:outline-none focus:ring-2 focus:ring-ub-yellow"
+              >
+                {isLastStep ? finishLabel : 'Next'}
+              </button>
+            </div>
+          </footer>
+        </div>
+      </div>
+      <style jsx global>{`
+        [data-help-highlight='true'] {
+          position: relative !important;
+          z-index: 70 !important;
+          box-shadow: 0 0 0 3px rgba(250, 204, 21, 0.95), 0 0 0 6px rgba(17, 24, 39, 0.6);
+          border-radius: 0.5rem;
+        }
+      `}</style>
+    </>
+  );
+};
+
+export default HelpOverlay;

--- a/components/apps/security-tools/index.js
+++ b/components/apps/security-tools/index.js
@@ -1,9 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import LabMode from '../../LabMode';
 import CommandBuilder from '../../CommandBuilder';
 import FixturesLoader from '../../FixturesLoader';
 import ResultViewer from '../../ResultViewer';
 import ExplainerPane from '../../ExplainerPane';
+import HelpOverlay from '../../HelpOverlay';
+import tutorials from './tutorial';
 
 const tabs = [
   { id: 'repeater', label: 'Repeater' },
@@ -20,6 +22,11 @@ export default function SecurityTools() {
   const [query, setQuery] = useState('');
   const [authorized, setAuthorized] = useState(false);
   const [fixtureData, setFixtureData] = useState([]);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [tutorialApp, setTutorialApp] = useState(null);
+  const [tutorialOpen, setTutorialOpen] = useState(false);
+  const menuContainerRef = useRef(null);
+  const menuButtonRef = useRef(null);
 
   // Logs, rules and fixtures
   const [suricata, setSuricata] = useState([]);
@@ -62,6 +69,77 @@ export default function SecurityTools() {
     setAuthorized(true);
   };
 
+  const openTutorial = useCallback(
+    (appId, force = false) => {
+      const config = tutorials[appId];
+      if (!config || !config.steps || config.steps.length === 0) {
+        return;
+      }
+      if (!force) {
+        try {
+          if (typeof window !== 'undefined') {
+            const stored = localStorage.getItem(`tutorial:${appId}`);
+            if (stored === 'done') {
+              return;
+            }
+          }
+        } catch {
+          // ignore storage errors
+        }
+      }
+      setTutorialApp(appId);
+      setTutorialOpen(true);
+    },
+    []
+  );
+
+  const closeTutorial = useCallback(() => {
+    if (tutorialApp && typeof window !== 'undefined') {
+      try {
+        localStorage.setItem(`tutorial:${tutorialApp}`, 'done');
+      } catch {
+        // ignore storage errors
+      }
+    }
+    setTutorialOpen(false);
+    setTutorialApp(null);
+  }, [tutorialApp]);
+
+  useEffect(() => {
+    if (!authorized) return;
+    openTutorial(active);
+  }, [authorized, active, openTutorial]);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handlePointer = (event) => {
+      const container = menuContainerRef.current;
+      if (container && container.contains(event.target)) {
+        return;
+      }
+      setMenuOpen(false);
+    };
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        setMenuOpen(false);
+        menuButtonRef.current?.focus?.();
+      }
+    };
+    document.addEventListener('mousedown', handlePointer);
+    document.addEventListener('touchstart', handlePointer);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointer);
+      document.removeEventListener('touchstart', handlePointer);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [menuOpen]);
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [active]);
+
+
   // Global search results
   const lower = query.toLowerCase();
   const suricataResults = lower ? suricata.filter(log => JSON.stringify(log).toLowerCase().includes(lower)) : [];
@@ -91,6 +169,13 @@ export default function SecurityTools() {
       {t.label}
     </button>
   );
+
+  const activeTutorialConfig = tutorialApp ? tutorials[tutorialApp] : null;
+  const overlayVisible = Boolean(tutorialOpen && activeTutorialConfig);
+  const handleReplay = useCallback(() => {
+    setMenuOpen(false);
+    openTutorial(active, true);
+  }, [active, openTutorial]);
 
   if (!authorized) {
     return (
@@ -128,14 +213,54 @@ export default function SecurityTools() {
 
   return (
     <LabMode>
-      <div className="w-full h-full bg-ub-dark text-white p-2 overflow-auto flex">
+      <div className="relative flex h-full w-full overflow-auto bg-ub-dark p-2 text-white">
+        <HelpOverlay
+          open={overlayVisible}
+          title={activeTutorialConfig?.title || ''}
+          steps={activeTutorialConfig?.steps || []}
+          onClose={closeTutorial}
+          finishLabel="Close"
+        />
         <div className="flex-1 pr-2">
-          <input
-            value={query}
-            onChange={e => setQuery(e.target.value)}
-            placeholder="Search all tools"
-            className="w-full mb-2 p-1 text-black text-xs"
-          />
+          <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <input
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder="Search all tools"
+              className="w-full p-1 text-xs text-black sm:flex-1"
+              data-tutorial="global-search"
+              aria-label="Search across security tool data"
+            />
+            <div className="relative self-start sm:self-auto" ref={menuContainerRef}>
+              <button
+                type="button"
+                ref={menuButtonRef}
+                onClick={() => setMenuOpen(open => !open)}
+                className="rounded bg-ub-cool-grey px-3 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-ub-yellow"
+                aria-haspopup="true"
+                aria-expanded={menuOpen}
+                aria-controls="security-tools-menu"
+              >
+                Menu
+              </button>
+              {menuOpen && (
+                <div
+                  id="security-tools-menu"
+                  role="menu"
+                  className="absolute right-0 z-50 mt-2 w-48 rounded-md border border-white/10 bg-gray-900 shadow-lg"
+                >
+                  <button
+                    type="button"
+                    onClick={handleReplay}
+                    className="block w-full px-3 py-2 text-left text-sm hover:bg-white/10 focus:bg-white/10 focus:outline-none"
+                    role="menuitem"
+                  >
+                    Replay tutorial
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
           {query ? (
             <div className="text-xs">
           {suricataResults.length > 0 && (
@@ -194,10 +319,10 @@ export default function SecurityTools() {
         ) : (
           <>
             <p className="text-xs mb-2">All tools are static demos using local fixtures. No external network activity occurs.</p>
-            <div className="mb-2 flex flex-wrap">{tabs.map(tabButton)}</div>
+            <div className="mb-2 flex flex-wrap" data-tutorial="tabs">{tabs.map(tabButton)}</div>
 
             {active === 'repeater' && (
-              <div>
+              <div data-tutorial="tab-repeater">
                 <CommandBuilder
                   doc="Build a curl command. Output is copy-only and not executed."
                   build={({ target = '', opts = '' }) => `curl ${opts} ${target}`.trim()}
@@ -206,7 +331,7 @@ export default function SecurityTools() {
             )}
 
             {active === 'suricata' && (
-            <div>
+            <div data-tutorial="tab-suricata">
               <p className="text-xs mb-2">Sample Suricata alerts from local JSON fixture.</p>
               {suricata.map((log, i) => (
                 <pre key={i} className="text-xs bg-black p-1 mb-1 overflow-auto">{JSON.stringify(log, null, 2)}</pre>
@@ -215,7 +340,7 @@ export default function SecurityTools() {
           )}
 
             {active === 'zeek' && (
-            <div>
+            <div data-tutorial="tab-zeek">
               <p className="text-xs mb-2">Sample Zeek logs from local JSON fixture.</p>
               {zeek.map((log, i) => (
                 <pre key={i} className="text-xs bg-black p-1 mb-1 overflow-auto">{JSON.stringify(log, null, 2)}</pre>
@@ -224,7 +349,7 @@ export default function SecurityTools() {
           )}
 
             {active === 'sigma' && (
-            <div>
+            <div data-tutorial="tab-sigma">
               <p className="text-xs mb-2">Static Sigma rules loaded from fixture.</p>
               {sigma.map((rule) => (
                 <div key={rule.id} className="mb-2">
@@ -236,18 +361,30 @@ export default function SecurityTools() {
           )}
 
             {active === 'yara' && (
-            <div>
+            <div data-tutorial="tab-yara">
               <p className="text-xs mb-2">Simplified YARA tester using sample text. Pattern matching is simulated.</p>
-              <textarea value={yaraRule} onChange={e=>setYaraRule(e.target.value)} className="w-full h-24 text-black p-1" />
+              <textarea
+                value={yaraRule}
+                onChange={e=>setYaraRule(e.target.value)}
+                className="w-full h-24 text-black p-1"
+                data-tutorial="yara-editor"
+                aria-label="YARA rule editor"
+              />
               <div className="text-xs mt-2 mb-1">Sample file:</div>
-              <textarea value={sampleText} readOnly className="w-full h-24 text-black p-1" />
+              <textarea
+                value={sampleText}
+                readOnly
+                className="w-full h-24 text-black p-1"
+                data-tutorial="yara-sample"
+                aria-label="Sample file contents"
+              />
               <button onClick={runYara} className="mt-2 px-2 py-1 bg-ub-green text-black text-xs">Scan</button>
               {yaraResult && <div className="mt-2 text-xs">{yaraResult}</div>}
             </div>
           )}
 
             {active === 'mitre' && (
-            <div>
+            <div data-tutorial="tab-mitre">
               <p className="text-xs mb-2">Mini MITRE ATT&CK navigator from static data.</p>
               {mitre.tactics.map((tac) => (
                 <div key={tac.id} className="mb-2">
@@ -264,10 +401,10 @@ export default function SecurityTools() {
 
             {active === 'fixtures' && (
               <div className="flex">
-                <div className="w-1/2 pr-2">
+                <div className="w-1/2 pr-2" data-tutorial="fixtures-loader">
                   <FixturesLoader onData={setFixtureData} />
                 </div>
-                <div className="w-1/2">
+                <div className="w-1/2" data-tutorial="fixtures-result">
                   <ResultViewer data={fixtureData} />
                 </div>
               </div>
@@ -275,13 +412,15 @@ export default function SecurityTools() {
           </>
         )}
         </div>
-        <ExplainerPane
-          lines={["Use this lab to explore static security data."]}
-          resources={[
-            { label: 'NIST SP 800-115', url: 'https://csrc.nist.gov/publications/detail/sp/800-115/final' },
-            { label: 'OWASP Testing Guide', url: 'https://owasp.org/www-project-web-security-testing-guide/' },
-          ]}
-        />
+        <div data-tutorial="explainer">
+          <ExplainerPane
+            lines={["Use this lab to explore static security data."]}
+            resources={[
+              { label: 'NIST SP 800-115', url: 'https://csrc.nist.gov/publications/detail/sp/800-115/final' },
+              { label: 'OWASP Testing Guide', url: 'https://owasp.org/www-project-web-security-testing-guide/' },
+            ]}
+          />
+        </div>
       </div>
     </LabMode>
   );

--- a/components/apps/security-tools/tutorial.ts
+++ b/components/apps/security-tools/tutorial.ts
@@ -1,0 +1,155 @@
+import type { TutorialStep } from '../../HelpOverlay';
+
+type TutorialDefinition = {
+  title: string;
+  steps: TutorialStep[];
+};
+
+const tutorials: Record<string, TutorialDefinition> = {
+  repeater: {
+    title: 'HTTP Repeater tutorial',
+    steps: [
+      {
+        title: 'Search the simulated data lake',
+        body: 'Use the global search to filter Suricata, Zeek, Sigma, YARA, and MITRE fixtures without leaving the browser. Every result is loaded from local JSON so no outbound traffic is ever generated.',
+        selector: '[data-tutorial="global-search"]',
+      },
+      {
+        title: 'Assemble copy-only commands',
+        body: 'The repeater form mirrors a curl builder. Populate target and options to generate a command you can copy for later lab work. The portfolio never executes requests on your behalf.',
+        selector: '[data-tutorial="tab-repeater"]',
+        tip: 'Paste the rendered command into your own isolated environment when you are ready to run a real scan.',
+      },
+      {
+        title: 'Keep lab context close',
+        body: 'Use the resources panel for links to official methodology guides. They reinforce that everything here is a learning aid, not a live exploit surface.',
+        selector: '[data-tutorial="explainer"]',
+      },
+    ],
+  },
+  suricata: {
+    title: 'Suricata log review',
+    steps: [
+      {
+        title: 'Filter before you dig in',
+        body: 'Start with the global search to narrow results to an IP, signature, or technique. Because the data is static, queries are instant and safe for demos.',
+        selector: '[data-tutorial="global-search"]',
+      },
+      {
+        title: 'Inspect canned alerts',
+        body: 'Scroll through the Suricata pane to see alert JSON loaded from fixtures/suricata.json. These samples explain how detections are structured without touching live sensors.',
+        selector: '[data-tutorial="tab-suricata"]',
+      },
+      {
+        title: 'Reference best practices',
+        body: 'The resource column links out to NIST SP 800-115 and the OWASP Testing Guide so you always validate actions against authorized procedures.',
+        selector: '[data-tutorial="explainer"]',
+      },
+    ],
+  },
+  zeek: {
+    title: 'Zeek telemetry walk-through',
+    steps: [
+      {
+        title: 'Find interesting records fast',
+        body: 'Use the search bar to slice the Zeek dataset by host, URI, or protocol. It operates entirely on your local copy of fixtures/zeek.json.',
+        selector: '[data-tutorial="global-search"]',
+      },
+      {
+        title: 'Review session metadata',
+        body: 'Each entry in the Zeek pane is a static log so you can teach parsing and triage techniques without connecting to a network sensor.',
+        selector: '[data-tutorial="tab-zeek"]',
+      },
+      {
+        title: 'Stay grounded in lab-only use',
+        body: 'Keep the methodology links nearby when explaining how these flows fit into a full investigation.',
+        selector: '[data-tutorial="explainer"]',
+      },
+    ],
+  },
+  sigma: {
+    title: 'Sigma explorer',
+    steps: [
+      {
+        title: 'Search signatures instantly',
+        body: 'Enter keywords or tactics in the search bar to filter the local Sigma ruleset. Nothing leaves your browser while you explore detections.',
+        selector: '[data-tutorial="global-search"]',
+      },
+      {
+        title: 'Read translated rules',
+        body: 'The Sigma pane shows static YAML content so analysts can learn field mappings and severity levels without uploading to a SIEM.',
+        selector: '[data-tutorial="tab-sigma"]',
+        tip: 'Encourage students to copy snippets into their own rule repositories for further experimentation.',
+      },
+      {
+        title: 'Reinforce ethical usage',
+        body: 'Point back to the resource links to reiterate that these exercises are for sanctioned environments only.',
+        selector: '[data-tutorial="explainer"]',
+      },
+    ],
+  },
+  yara: {
+    title: 'YARA pattern lab',
+    steps: [
+      {
+        title: 'Tune patterns safely',
+        body: 'Adjust the rule editor to experiment with matches against a bundled sample file. Scans run entirely in-memory so no files are touched.',
+        selector: '[data-tutorial="yara-editor"]',
+      },
+      {
+        title: 'Review the sample corpus',
+        body: 'The read-only sample text demonstrates how case-sensitive matches behave. Use it to explain rule testing before deploying to production.',
+        selector: '[data-tutorial="yara-sample"]',
+      },
+      {
+        title: 'Remember: demo only',
+        body: 'Once again, the resources column keeps the simulation grounded in approved lab work.',
+        selector: '[data-tutorial="explainer"]',
+      },
+    ],
+  },
+  mitre: {
+    title: 'MITRE ATT&CK navigator',
+    steps: [
+      {
+        title: 'Search tactics and techniques',
+        body: 'Combine the search box with the MITRE list to highlight tactics and technique IDs. All data comes from fixtures/mitre.json bundled with the app.',
+        selector: '[data-tutorial="global-search"]',
+      },
+      {
+        title: 'Discuss coverage gaps',
+        body: 'Use the static matrix to talk through detection and response plans without exposing production dashboards.',
+        selector: '[data-tutorial="tab-mitre"]',
+      },
+      {
+        title: 'Cross-check methodology',
+        body: 'Wrap up by directing learners to the methodology links so they plan authorized tests before running anything real.',
+        selector: '[data-tutorial="explainer"]',
+      },
+    ],
+  },
+  fixtures: {
+    title: 'Fixture loader sandbox',
+    steps: [
+      {
+        title: 'Drop artifacts into the loader',
+        body: 'The loader accepts JSON, CSV, and text files and parses them client-side to demonstrate pipeline concepts without transmitting data elsewhere.',
+        selector: '[data-tutorial="fixtures-loader"]',
+      },
+      {
+        title: 'Inspect structured output',
+        body: 'Results render next to the loader with a JSON viewer so you can walk through how enrichment might look in a real system.',
+        selector: '[data-tutorial="fixtures-result"]',
+      },
+      {
+        title: 'Lean on the methodology links',
+        body: 'Use the reference column to reiterate that this sandbox is meant for rehearsing workflows before touching production.',
+        selector: '[data-tutorial="explainer"]',
+      },
+    ],
+  },
+};
+
+export type TutorialId = keyof typeof tutorials;
+
+export default tutorials;

--- a/docs/security-tools.md
+++ b/docs/security-tools.md
@@ -1,0 +1,14 @@
+# Security tools simulation notes
+
+All security-oriented apps in this portfolio run entirely in the browser and read from local fixtures so no network activity or exploitation occurs. The `Security Tools` hub stitches these demos together under a shared [lab gate](../components/LabMode.tsx) and now ships with a guided tutorial system so visitors understand the guard rails before exploring.
+
+## Guided tutorials
+
+- `components/HelpOverlay.tsx` renders an accessible overlay that traps focus, supports keyboard navigation (Arrow keys, Tab, Escape), and can optionally highlight UI regions using `data-help-highlight` attributes. The final step closes the overlay and records completion.
+- Each tab in `components/apps/security-tools/` declares its steps in [`tutorial.ts`](../components/apps/security-tools/tutorial.ts). Steps point at elements annotated with `data-tutorial="*"` in the main component so highlights remain stable.
+- When a tutorial is dismissed the app sets `localStorage` keys in the form `tutorial:<appId>` (for example `tutorial:repeater`). The default behaviour is to auto-open the overlay the first time a tab is visited unless that key is already set.
+- Every app menu includes a **Replay tutorial** option which forces the overlay to reopen without touching the stored completion flag. Clearing browser storage removes the keys if you want to verify the first-run behaviour.
+
+## Simulation reminders
+
+The overlay copy reiterates the project’s hard boundary: these views are static teaching aids only. The fixtures live in `/fixtures/` and nothing ever calls out to a target. Update both the tutorial content and the readme bullet in tandem whenever you add a new simulation so the documentation continues to make the educational intent obvious.


### PR DESCRIPTION
## Summary
- add a reusable HelpOverlay component with focus management and optional element highlights
- wire the security tools hub to open tutorials on first visit, persist completion state in localStorage, and provide a menu action to replay them
- define tab-specific tutorial copy and update documentation to emphasize the simulation-first workflow

## Testing
- yarn lint *(fails: existing repo-wide accessibility checks and window usage errors)*
- yarn test *(fails: existing act() warnings and missing elements in legacy suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c8549ebbbc8328b23b4519f3ace299