### PR TITLE
[app] Add SmartLink for internal and external links

### DIFF
--- a/app/ui/SmartLink.tsx
+++ b/app/ui/SmartLink.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import type { AnchorHTMLAttributes, PropsWithChildren } from 'react';
+
+export type SmartLinkProps = PropsWithChildren<
+  AnchorHTMLAttributes<HTMLAnchorElement>
+> & {
+  href: string;
+};
+
+export default function SmartLink({ href, children, ...rest }: SmartLinkProps) {
+  if (href.startsWith('/')) {
+    return (
+      <Link href={href} {...rest}>
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <a href={href} {...rest} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary
- add a SmartLink component that automatically selects Next.js Link for internal URLs
- fall back to a new-window anchor for external destinations with noopener protection

## Testing
- [ ] yarn lint *(fails: existing jsx-a11y control-has-associated-label errors across apps and legacy public game scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68c853053ce48328995043921652ec04