### PR TITLE
[app] add development web vitals logger

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+import WebVitals from './ui/WebVitals';
+
+const isDevelopment = process.env.NODE_ENV === 'development';
+
+export default function RootLayout({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <html lang="en">
+      <body>
+        {children}
+        {isDevelopment ? <WebVitals /> : null}
+      </body>
+    </html>
+  );
+}

--- a/app/ui/WebVitals.tsx
+++ b/app/ui/WebVitals.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useReportWebVitals } from 'next/web-vitals';
+
+const formatMetricLabel = (label: string) => (label === 'web-vital' ? 'Web Vitals' : 'Next.js metric');
+
+export default function WebVitals(): null {
+  const reportMetric = useCallback<Parameters<typeof useReportWebVitals>[0]>((metric) => {
+    if (typeof console === 'undefined') return;
+
+    const { id, name, label, value, delta } = metric;
+    const origin = formatMetricLabel(label);
+
+    console.log(`[${origin}] ${name}`, {
+      id,
+      value: Number.isFinite(value) ? Number(value.toFixed(2)) : value,
+      delta: Number.isFinite(delta) ? Number(delta.toFixed(2)) : delta,
+      label,
+    });
+  }, []);
+
+  useReportWebVitals(reportMetric);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add an app router WebVitals client component that logs metrics with useReportWebVitals
- register a minimal app/layout.tsx that mounts the logger during development

## Testing
- yarn lint *(fails: repository has numerous existing accessibility violations)*
- CI=1 yarn test *(fails: suite has pre-existing failures and ran for an extended period)*

------
https://chatgpt.com/codex/tasks/task_e_68c853006e6c8328b22a1fecfd23749f