### PR TITLE
[ui] Pause animations when tab hidden

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,7 @@
+[data-paused="true"] *,
+[data-paused="true"] *::before,
+[data-paused="true"] *::after {
+  animation: none !important;
+  animation-play-state: paused !important;
+  transition: none !important;
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
+import '../app/globals.css';
 import '../styles/tailwind.css';
 import '../styles/globals.css';
 import '../styles/index.css';
@@ -15,6 +16,7 @@ import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
+import VisibilityPause from '../src/ui/VisibilityPause';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
 import { Ubuntu } from 'next/font/google';
@@ -149,6 +151,7 @@ function MyApp(props) {
   return (
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />
+      <VisibilityPause />
       <div className={ubuntu.className}>
         <a
           href="#app-grid"

--- a/src/ui/VisibilityPause.tsx
+++ b/src/ui/VisibilityPause.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+const setPausedState = (paused: boolean) => {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  if (!root) return;
+  root.setAttribute('data-paused', paused ? 'true' : 'false');
+};
+
+const VisibilityPause = (): null => {
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+
+    const handleChange = () => {
+      setPausedState(document.visibilityState === 'hidden');
+    };
+
+    handleChange();
+    document.addEventListener('visibilitychange', handleChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleChange);
+      setPausedState(false);
+    };
+  }, []);
+
+  return null;
+};
+
+export default VisibilityPause;


### PR DESCRIPTION
## Summary
- add a VisibilityPause component that listens for visibility changes and sets the html `data-paused` flag
- disable global animations/transitions while `data-paused="true"` and import the helper in the app shell

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations across apps)*
- CI=1 yarn test *(fails: pre-existing window snapping, Nmap NSE, and modal/localStorage tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb4b3ccc832891f375d8215d4aa4