### PR TITLE
[app] Add print stylesheet for cleaner print view

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+
+export default function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <head>
+        <link rel="stylesheet" href="/print.css" media="print" />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/print.css
+++ b/app/print.css
@@ -1,0 +1,14 @@
+@media print {
+  body {
+    background: #ffffff !important;
+    color: #000000 !important;
+  }
+
+  .dock,
+  .titlebar,
+  dialog,
+  dialog::backdrop,
+  .switcher {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated print-only stylesheet that hides desktop chrome and enforces a white-on-black color scheme for printouts
- add an app router root layout so the new stylesheet is linked in the document head during print

## Testing
- yarn lint *(fails: numerous existing `jsx-a11y/control-has-associated-label` and `no-top-level-window/no-top-level-window-or-document` errors in unrelated files)*
- yarn test *(fails: existing `__tests__/nmapNse.test.tsx` alert expectation and jsdom `localStorage` null origin error)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb4feb2c832881e9cee67f06ac16