### PR TITLE
[ui] add fullscreen toggle helper

### DIFF
--- a/src/ui/fullscreen.ts
+++ b/src/ui/fullscreen.ts
@@ -1,0 +1,53 @@
+interface FullscreenDocument extends Document {
+  webkitExitFullscreen?: () => Promise<void> | void;
+  mozCancelFullScreen?: () => Promise<void> | void;
+  msExitFullscreen?: () => Promise<void> | void;
+  webkitFullscreenElement?: Element | null;
+  mozFullScreenElement?: Element | null;
+  msFullscreenElement?: Element | null;
+}
+
+interface FullscreenElement extends Element {
+  webkitRequestFullscreen?: () => Promise<void> | void;
+  mozRequestFullScreen?: () => Promise<void> | void;
+  msRequestFullscreen?: () => Promise<void> | void;
+}
+
+export function toggleFullscreen(target?: Element | null) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const doc = document as FullscreenDocument;
+
+  const fullscreenElement =
+    doc.fullscreenElement ??
+    doc.webkitFullscreenElement ??
+    doc.mozFullScreenElement ??
+    doc.msFullscreenElement;
+
+  if (fullscreenElement) {
+    const exitFullscreen =
+      doc.exitFullscreen ??
+      doc.webkitExitFullscreen ??
+      doc.mozCancelFullScreen ??
+      doc.msExitFullscreen;
+
+    exitFullscreen?.call(doc);
+    return;
+  }
+
+  const element = (target ?? doc.documentElement) as FullscreenElement | null;
+
+  if (!element) {
+    return;
+  }
+
+  const requestFullscreen =
+    element.requestFullscreen ??
+    element.webkitRequestFullscreen ??
+    element.mozRequestFullScreen ??
+    element.msRequestFullscreen;
+
+  requestFullscreen?.call(element);
+}


### PR DESCRIPTION
## Summary
- add a `toggleFullscreen` utility that switches the current document between fullscreen and windowed modes
- include vendor-prefixed fallbacks and environment guards so unsupported browsers safely no-op

## Testing
- [x] yarn lint *(fails: repository has pre-existing accessibility and no-top-level-window violations)*
- [x] yarn test *(fails: repository has pre-existing failing suites and jest watch mode was exited after collecting failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb5b2c688328be3a7df21f38afea