### PR TITLE
[lib] add secure clipboard helper

### DIFF
--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,61 @@
+const SECURE_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+type GlobalClipboardContext = typeof globalThis & {
+  location?: Location;
+  isSecureContext?: boolean;
+};
+
+const getGlobalContext = (): GlobalClipboardContext | undefined => {
+  if (typeof globalThis !== 'undefined') {
+    return globalThis as GlobalClipboardContext;
+  }
+
+  if (typeof window !== 'undefined') {
+    return window as unknown as GlobalClipboardContext;
+  }
+
+  return undefined;
+};
+
+const isSecureEnvironment = (): boolean => {
+  const globalContext = getGlobalContext();
+  if (!globalContext) {
+    return false;
+  }
+
+  if (typeof globalContext.isSecureContext === 'boolean') {
+    return globalContext.isSecureContext;
+  }
+
+  const { location } = globalContext;
+  if (!location) {
+    return false;
+  }
+
+  const { protocol, hostname } = location;
+  return protocol === 'https:' || SECURE_HOSTS.has(hostname);
+};
+
+/**
+ * Copy arbitrary text to the clipboard using the asynchronous Clipboard API.
+ * The API requires a secure context (HTTPS or localhost) which aligns with
+ * Terminal and Files quick-copy workflows in the desktop simulation.
+ */
+export async function copy(text: string): Promise<boolean> {
+  if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+    return false;
+  }
+
+  if (!isSecureEnvironment()) {
+    return false;
+  }
+
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export default copy;


### PR DESCRIPTION
## Summary
- add a clipboard helper that wraps navigator.clipboard.writeText in an async copy API
- guard clipboard usage so it only runs in secure contexts such as HTTPS or localhost

## Testing
- yarn lint *(fails: repository already has 500+ pre-existing accessibility lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb6688b4832894cfd3b0ba9dbac4