### PR TITLE
[seo] add metadata routes for robots and sitemap

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from 'next';
+
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, '') ?? 'https://unnippillil.com';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+      },
+    ],
+    host: siteUrl,
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next';
+
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, '') ?? 'https://unnippillil.com';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  return [
+    {
+      url: siteUrl,
+      lastModified: new Date(),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- add an app router robots metadata route that derives the host from NEXT_PUBLIC_SITE_URL or a default
- expose a sitemap metadata route that announces the root URL with a dynamic last modified timestamp

## Testing
- [ ] yarn lint *(fails: numerous pre-existing jsx-a11y and custom lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb749ab08328ac49df0f38836c54