### PR TITLE
[app] Add server theme cookie helper

### DIFF
--- a/app/theme-server.tsx
+++ b/app/theme-server.tsx
@@ -1,0 +1,14 @@
+import { cookies } from 'next/headers';
+
+const THEME_COOKIE = 'kali-theme';
+
+export default async function ThemeServer() {
+  const cookieStore = await cookies();
+  const theme = cookieStore.get(THEME_COOKIE)?.value ?? 'dark';
+
+  return (
+    <span hidden suppressHydrationWarning>
+      {theme}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- add a server component that reads the `kali-theme` cookie with the async `cookies()` API
- render the theme value in a hidden span with `suppressHydrationWarning` so the client can hydrate without mismatch

## Testing
- `yarn lint` *(fails: existing accessibility and lint violations in unrelated files)*
- `yarn test` *(fails: existing unit test failures and jsdom/localStorage errors in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb74cfc08328bc11bf290ece8617