### PR TITLE
[api] Add edge ping health check route

### DIFF
--- a/app/api/ping/route.ts
+++ b/app/api/ping/route.ts
@@ -1,0 +1,5 @@
+export const runtime = 'edge';
+
+export async function GET() {
+  return Response.json({ ok: true, ts: Date.now() });
+}


### PR DESCRIPTION
## Summary
- add an edge runtime `/api/ping` route that reports `{ ok: true, ts }` for service health checks

## Testing
- [x] yarn lint *(fails: long-standing jsx-a11y and no-top-level-window violations in existing apps)*
- [x] yarn test *(fails: existing suites like window shortcuts, Nmap NSE app, and Modal due to legacy assumptions)*

- Flags toggled: none

------
https://chatgpt.com/codex/tasks/task_e_68c8eb74d16483288c2c75ce99c1638d