### PR TITLE
[api] add sse stream console

### DIFF
--- a/app/api/sse/route.ts
+++ b/app/api/sse/route.ts
@@ -1,0 +1,65 @@
+const encoder = new TextEncoder();
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export function GET(request: Request) {
+  let tickInterval: ReturnType<typeof setInterval> | undefined;
+  let keepAliveInterval: ReturnType<typeof setInterval> | undefined;
+  let abortListener: (() => void) | undefined;
+
+  const cleanup = () => {
+    if (tickInterval) {
+      clearInterval(tickInterval);
+      tickInterval = undefined;
+    }
+
+    if (keepAliveInterval) {
+      clearInterval(keepAliveInterval);
+      keepAliveInterval = undefined;
+    }
+
+    if (abortListener) {
+      request.signal.removeEventListener('abort', abortListener);
+      abortListener = undefined;
+    }
+  };
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let counter = 0;
+
+      const sendTick = () => {
+        counter += 1;
+        const payload = `data: tick ${counter}\n\n`;
+        controller.enqueue(encoder.encode(payload));
+      };
+
+      const sendKeepAlive = () => {
+        controller.enqueue(encoder.encode(': keep-alive\n\n'));
+      };
+
+      sendTick();
+      tickInterval = setInterval(sendTick, 1000);
+      keepAliveInterval = setInterval(sendKeepAlive, 15000);
+
+      abortListener = () => {
+        cleanup();
+        controller.close();
+      };
+
+      request.signal.addEventListener('abort', abortListener);
+    },
+    cancel() {
+      cleanup();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/src/ui/SSEConsole.tsx
+++ b/src/ui/SSEConsole.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+const SSEConsole = () => {
+  const [lines, setLines] = useState<string[]>([]);
+  const preRef = useRef<HTMLPreElement | null>(null);
+
+  useEffect(() => {
+    const source = new EventSource('/api/sse');
+
+    const handleMessage = (event: MessageEvent<string>) => {
+      setLines((prev) => [...prev, event.data]);
+    };
+
+    const handleError = () => {
+      source.close();
+    };
+
+    source.addEventListener('message', handleMessage);
+    source.addEventListener('error', handleError);
+
+    return () => {
+      source.removeEventListener('message', handleMessage);
+      source.removeEventListener('error', handleError);
+      source.close();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (preRef.current) {
+      preRef.current.scrollTop = preRef.current.scrollHeight;
+    }
+  }, [lines]);
+
+  const content = useMemo(() => {
+    if (lines.length === 0) {
+      return 'Waiting for server-sent events...';
+    }
+
+    return lines.join('\n');
+  }, [lines]);
+
+  return (
+    <div className="h-full w-full">
+      <pre
+        ref={preRef}
+        className="h-full max-h-64 overflow-auto rounded bg-black/80 p-4 text-sm text-lime-300"
+        aria-live="polite"
+      >
+        {content}
+      </pre>
+    </div>
+  );
+};
+
+export default SSEConsole;


### PR DESCRIPTION
## Summary
- add a server-sent events route that emits tick messages once per second
- provide a client-side SSE console component that appends streamed lines in a scrollable pre block

## Testing
- [x] yarn lint *(fails due to pre-existing lint violations in unrelated files)*
- [x] yarn test --watch=false *(fails due to pre-existing test failures in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb7523388328b57283afd067fb78