### PR TITLE
[files] Add blob download helper

### DIFF
--- a/src/apps/files/Download.tsx
+++ b/src/apps/files/Download.tsx
@@ -1,0 +1,20 @@
+export function downloadBlob(blob: Blob, filename: string): void {
+  if (typeof window === "undefined" || typeof document === "undefined" || !document.body) {
+    return;
+  }
+
+  const objectUrl = window.URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+
+  anchor.href = objectUrl;
+  anchor.download = filename;
+  anchor.style.display = "none";
+
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+
+  window.setTimeout(() => {
+    window.URL.revokeObjectURL(objectUrl);
+  }, 100);
+}


### PR DESCRIPTION
## Summary
- add a `downloadBlob` helper for the files app to trigger blob downloads and clean up object URLs

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window violations in unrelated files)*
- yarn test *(fails: existing window and nmap NSE tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb7a05bc832886c8e5bb0bbc3e16