### PR TITLE
[api] add revalidate route

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,22 @@
+import { revalidateTag } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const body = await req
+    .json()
+    .catch(() => null) as { tag?: unknown } | null;
+
+  const tag = typeof body?.tag === 'string' ? body.tag.trim() : '';
+
+  if (!tag) {
+    return NextResponse.json({ revalidated: false });
+  }
+
+  try {
+    await revalidateTag(tag);
+    return NextResponse.json({ revalidated: true });
+  } catch (error) {
+    console.error('Failed to revalidate tag:', error);
+    return NextResponse.json({ revalidated: false });
+  }
+}


### PR DESCRIPTION
## Summary
- add an API route under `app/api/revalidate` that reads a JSON body for a tag
- trigger `revalidateTag` when a tag is present and respond with a `{ revalidated: boolean }` payload

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label violations across many files)*
- yarn test *(fails: existing failing suites such as window, nmapNse, and modal tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb8b71fc83289cf1aeb497633d65