### PR TITLE
[analytics] add RUM endpoint and web vitals hook

### DIFF
--- a/app/api/rum/route.ts
+++ b/app/api/rum/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const body = await req.text();
+
+  console.log('RUM metric:', body);
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/ui/WebVitals.tsx
+++ b/src/ui/WebVitals.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useReportWebVitals, type WebVitalsMetric } from 'next/web-vitals';
+
+const RUM_ENDPOINT = '/api/rum';
+
+const roundMetricValue = (metric: WebVitalsMetric) => {
+  const precision = metric.name === 'CLS' ? 1000 : 100;
+  return Math.round(metric.value * precision) / precision;
+};
+
+const sendMetric = (metric: WebVitalsMetric) => {
+  if (typeof navigator === 'undefined' || !('sendBeacon' in navigator)) {
+    return;
+  }
+
+  navigator.sendBeacon(RUM_ENDPOINT, JSON.stringify(metric));
+};
+
+export function WebVitals() {
+  useReportWebVitals((metric) => {
+    const roundedValue = roundMetricValue(metric);
+
+    console.log(`[WebVitals] ${metric.name}`, roundedValue);
+    sendMetric(metric);
+  });
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a WebVitals client component that logs metrics and beacons them to the RUM endpoint
- add a /api/rum handler that logs received payloads and returns a 204 response

## Testing
- yarn lint *(fails: repository currently has extensive pre-existing accessibility lint violations)*
- yarn test *(fails: existing suites outside this change abort with act/localStorage errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ebb05df083288af56e232b689bc7