### PR TITLE
[theme] persist theme cookies for SSR

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,0 +1,22 @@
+'use server';
+
+import { cookies } from 'next/headers';
+
+const COOKIE_OPTIONS = {
+  path: '/',
+  maxAge: 31536000,
+  sameSite: 'lax' as const,
+};
+
+const THEME_OPTIONS = new Set(['default', 'dark', 'neon', 'matrix']);
+const ACCENT_PATTERN = /^#[0-9a-fA-F]{6}$/;
+const DEFAULT_THEME = 'default';
+const DEFAULT_ACCENT = '#1793d1';
+
+export async function setThemeCookie(theme: string, accent: string): Promise<void> {
+  const store = await cookies();
+  const nextTheme = THEME_OPTIONS.has(theme) ? theme : DEFAULT_THEME;
+  const nextAccent = ACCENT_PATTERN.test(accent) ? accent : DEFAULT_ACCENT;
+  store.set('kali-theme', nextTheme, COOKIE_OPTIONS);
+  store.set('kali-accent', nextAccent, COOKIE_OPTIONS);
+}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -22,6 +22,7 @@ import {
   setHaptics as saveHaptics,
   defaults,
 } from '../utils/settingsStore';
+import { setThemeCookie } from '../app/actions';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
 type Density = 'regular' | 'compact';
 
@@ -134,6 +135,21 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     saveTheme(theme);
   }, [theme]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true') return;
+
+    const persist = async () => {
+      try {
+        await setThemeCookie(theme, accent);
+      } catch (error) {
+        console.error('Failed to persist theme preferences', error);
+      }
+    };
+
+    void persist();
+  }, [theme, accent]);
 
   useEffect(() => {
     const border = shadeColor(accent, -0.2);

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,5 +1,66 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 
+const DEFAULT_THEME = 'default';
+const DEFAULT_ACCENT = '#1793d1';
+const THEME_OPTIONS = new Set(['default', 'dark', 'neon', 'matrix']);
+const DARK_THEMES = new Set(['dark', 'neon', 'matrix']);
+
+const parseCookies = (cookieHeader) => {
+  if (!cookieHeader) return {};
+  return cookieHeader.split(';').reduce((acc, part) => {
+    const [rawName, ...rawValue] = part.split('=');
+    if (!rawName) return acc;
+    const trimmedName = rawName.trim();
+    if (!trimmedName) return acc;
+    let name = trimmedName;
+    try {
+      name = decodeURIComponent(trimmedName);
+    } catch {
+      /* ignore malformed encodings */
+    }
+    const raw = rawValue.join('=').trim();
+    let value = raw;
+    try {
+      value = decodeURIComponent(raw);
+    } catch {
+      /* ignore malformed encodings */
+    }
+    if (name) acc[name] = value;
+    return acc;
+  }, {});
+};
+
+const isValidAccent = (accent) => /^#[0-9a-fA-F]{6}$/.test(accent);
+
+const shadeColor = (color, percent) => {
+  const value = parseInt(color.slice(1), 16);
+  const target = percent < 0 ? 0 : 255;
+  const p = Math.abs(percent);
+  const r = value >> 16;
+  const g = (value >> 8) & 0x00ff;
+  const b = value & 0x0000ff;
+  const newR = Math.round((target - r) * p) + r;
+  const newG = Math.round((target - g) * p) + g;
+  const newB = Math.round((target - b) * p) + b;
+  return `#${(0x1000000 + newR * 0x10000 + newG * 0x100 + newB)
+    .toString(16)
+    .slice(1)}`;
+};
+
+const buildAccentStyles = (accent) => {
+  const border = shadeColor(accent, -0.2);
+  return {
+    '--color-ub-orange': accent,
+    '--color-ub-border-orange': border,
+    '--color-primary': accent,
+    '--color-accent': accent,
+    '--color-focus-ring': accent,
+    '--color-selection': accent,
+    '--color-control-accent': accent,
+    accentColor: accent,
+  };
+};
+
 class MyDocument extends Document {
   /**
    * @param {import('next/document').DocumentContext} ctx
@@ -7,13 +68,27 @@ class MyDocument extends Document {
   static async getInitialProps(ctx) {
     const initial = await Document.getInitialProps(ctx);
     const nonce = ctx?.res?.getHeader?.('x-csp-nonce');
-    return { ...initial, nonce };
+    const cookies = parseCookies(ctx?.req?.headers?.cookie ?? '');
+    const themeCookie = cookies['kali-theme'];
+    const accentCookie = cookies['kali-accent'];
+    const theme = THEME_OPTIONS.has(themeCookie) ? themeCookie : DEFAULT_THEME;
+    const accent = isValidAccent(accentCookie) ? accentCookie : DEFAULT_ACCENT;
+    return { ...initial, nonce, theme, accent };
   }
 
   render() {
-    const { nonce } = this.props;
+    const { nonce, theme: initialTheme, accent: initialAccent } = this.props;
+    const theme = THEME_OPTIONS.has(initialTheme) ? initialTheme : DEFAULT_THEME;
+    const accent = isValidAccent(initialAccent) ? initialAccent : DEFAULT_ACCENT;
+    const accentStyles = buildAccentStyles(accent);
     return (
-      <Html lang="en" data-csp-nonce={nonce}>
+      <Html
+        lang="en"
+        data-csp-nonce={nonce}
+        data-theme={theme}
+        className={DARK_THEMES.has(theme) ? 'dark' : undefined}
+        style={accentStyles}
+      >
         <Head>
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />


### PR DESCRIPTION
## Summary
- add a server action to persist kali-theme and kali-accent cookies with long-lived options
- sync the settings provider with the new cookies and hydrate SSR with the stored theme/accent

## Testing
- yarn lint *(fails: numerous existing jsx-a11y/control-has-associated-label and no-top-level-window violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ebc9ed0c8328a5b1bbfb386f926b