### PR TITLE
[ui] Add route progress indicator

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -12,6 +12,7 @@ import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
+import RouteProgress from '../src/ui/RouteProgress';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
@@ -150,6 +151,7 @@ function MyApp(props) {
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
+        <RouteProgress />
         <a
           href="#app-grid"
           className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"

--- a/src/ui/RouteProgress.tsx
+++ b/src/ui/RouteProgress.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+
+const HIDE_DELAY_MS = 300;
+const BAR_CLASSNAMES =
+  'pointer-events-none fixed inset-x-0 top-0 z-[1000] h-[2px] bg-gradient-to-r from-cyan-400 via-sky-500 to-blue-600 transition-opacity duration-200';
+
+const RouteProgress = () => {
+  const pathname = usePathname();
+  const [loading, setLoading] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const hasMountedRef = useRef(false);
+
+  useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    setLoading(true);
+
+    timeoutRef.current = setTimeout(() => {
+      setLoading(false);
+      timeoutRef.current = null;
+    }, HIDE_DELAY_MS);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, [pathname]);
+
+  useEffect(() => () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  return (
+    <div
+      aria-hidden="true"
+      className={`${BAR_CLASSNAMES} ${loading ? 'opacity-100' : 'opacity-0'}`}
+    />
+  );
+};
+
+export default RouteProgress;


### PR DESCRIPTION
## Summary
- add a RouteProgress client component that watches usePathname and toggles a gradient loading bar
- render the progress indicator from the global app shell so it overlays every page

## Testing
- yarn lint *(fails: repository has pre-existing accessibility lint violations)*
- yarn test *(fails: repository has pre-existing unit test failures tied to legacy window/localStorage usage)*

## Screenshots
![Route progress bar](browser:/invocations/vebbdkbu/artifacts/artifacts/route-progress.png)


------
https://chatgpt.com/codex/tasks/task_e_68c8ebf82eec8328a515da000106af86