### PR TITLE
[pwa] Add service worker update prompt

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import SWUpdate from '../src/pwa/SWUpdate';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -160,6 +161,7 @@ function MyApp(props) {
           <PipPortalProvider>
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />
+            <SWUpdate />
             <ShortcutOverlay />
             <Analytics
               beforeSend={(e) => {

--- a/src/pwa/SWUpdate.tsx
+++ b/src/pwa/SWUpdate.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const SWUpdate = () => {
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+  const initialController = useRef<ServiceWorker | null | undefined>();
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('serviceWorker' in navigator)) {
+      return;
+    }
+
+    initialController.current = navigator.serviceWorker.controller;
+
+    const handleControllerChange = () => {
+      const newController = navigator.serviceWorker.controller ?? null;
+
+      if (!initialController.current) {
+        initialController.current = newController;
+        return;
+      }
+
+      if (newController === initialController.current) {
+        return;
+      }
+
+      setUpdateAvailable(true);
+    };
+
+    navigator.serviceWorker.addEventListener('controllerchange', handleControllerChange);
+
+    navigator.serviceWorker.ready
+      .then((registration) => {
+        if (registration.waiting) {
+          setUpdateAvailable(true);
+        }
+      })
+      .catch(() => {
+        // No-op: readiness might reject if SW is disabled.
+      });
+
+    return () => {
+      navigator.serviceWorker.removeEventListener('controllerchange', handleControllerChange);
+    };
+  }, []);
+
+  if (!updateAvailable) {
+    return null;
+  }
+
+  const handleReload = () => {
+    if (typeof window !== 'undefined') {
+      window.location.reload();
+    }
+  };
+
+  return (
+    <div
+      className="pointer-events-none fixed bottom-4 right-4 z-[1000] flex max-w-sm justify-end"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="pointer-events-auto flex items-center gap-3 rounded-md border border-slate-600/60 bg-slate-900/95 px-4 py-3 text-sm text-white shadow-lg backdrop-blur">
+        <span className="font-medium">Update ready</span>
+        <button
+          type="button"
+          onClick={handleReload}
+          className="rounded-md bg-sky-500 px-3 py-1 text-xs font-semibold text-slate-900 transition hover:bg-sky-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+        >
+          Reload
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SWUpdate;


### PR DESCRIPTION
## Summary
- add a client component that listens for service worker controller changes and surfaces a reload CTA
- render the update toast alongside the service worker registration logic in the app shell

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window issues in unrelated files)*
- yarn test *(fails: existing recon, window accessibility, and API related tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ec51174c83289d23e37f644669de