### PR TITLE
[ui] Add quick high-contrast toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,9 @@
+:root {
+  --panel-border: rgba(255, 255, 255, 0.2);
+  --text: var(--color-text, #f5f5f5);
+}
+
+[data-contrast='high'] {
+  --panel-border: #f8f003;
+  --text: #ffffff;
+}

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,7 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import HighContrastToggle from '../../src/ui/HighContrastToggle';
 
 interface Props {
   open: boolean;
@@ -12,6 +13,8 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const borderColor = 'var(--panel-border, rgba(255, 255, 255, 0.2))';
+  const textColor = 'var(--text, var(--color-text))';
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -23,11 +26,15 @@ const QuickSettings = ({ open }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border transition-colors ${
         open ? '' : 'hidden'
       }`}
+      style={{ borderColor, color: textColor }}
     >
-      <div className="px-4 pb-2">
+      <div className="px-4 pb-3 border-b" style={{ borderColor }}>
+        <HighContrastToggle />
+      </div>
+      <div className="px-4 pt-3 pb-2">
         <button
           className="w-full flex justify-between"
           onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -193,7 +193,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [fontScale]);
 
   useEffect(() => {
-    document.documentElement.classList.toggle('high-contrast', highContrast);
+    const root = document.documentElement;
+    root.classList.toggle('high-contrast', highContrast);
+    if (highContrast) {
+      root.setAttribute('data-contrast', 'high');
+    } else {
+      root.removeAttribute('data-contrast');
+    }
     saveHighContrast(highContrast);
   }, [highContrast]);
 

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -8,6 +8,7 @@ import '../styles/globals.css';
 import '../styles/index.css';
 import '../styles/resume-print.css';
 import '../styles/print.css';
+import '../app/globals.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';

--- a/src/ui/HighContrastToggle.tsx
+++ b/src/ui/HighContrastToggle.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSettings } from '../../hooks/useSettings';
+
+const HighContrastToggle = () => {
+  const { highContrast, setHighContrast } = useSettings();
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (highContrast) {
+      root.setAttribute('data-contrast', 'high');
+    } else {
+      root.removeAttribute('data-contrast');
+    }
+  }, [highContrast]);
+
+  return (
+    <button
+      type="button"
+      onClick={() => setHighContrast(!highContrast)}
+      className="flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm font-medium transition-colors hover:bg-ub-dark-grey focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ubt-blue"
+      aria-pressed={highContrast}
+      style={{ color: 'var(--text, var(--color-text))' }}
+    >
+      <span>High contrast</span>
+      <span
+        className="ml-3 inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs font-semibold uppercase tracking-wide"
+        style={{
+          borderColor: 'var(--panel-border, rgba(255, 255, 255, 0.2))',
+          backgroundColor: highContrast
+            ? 'var(--panel-border, rgba(255, 255, 255, 0.35))'
+            : 'transparent',
+          color: highContrast ? '#000000' : 'var(--text, var(--color-text))',
+        }}
+      >
+        {highContrast ? 'On' : 'Off'}
+      </span>
+    </button>
+  );
+};
+
+export default HighContrastToggle;


### PR DESCRIPTION
## Summary
- add a dedicated HighContrastToggle component that updates the html data-contrast flag and a pill indicator
- wire the toggle into the quick settings panel and style the panel via reusable CSS variables
- define app-level high-contrast overrides and import them in the Next.js app shell

## Testing
- yarn lint *(fails: existing repo lint violations)*
- yarn test *(fails: existing jest failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ebf9a284832883380ba5b8a52d00