### PR TITLE
[ui] add notification hook

### DIFF
--- a/src/ui/useNotify.ts
+++ b/src/ui/useNotify.ts
@@ -1,0 +1,39 @@
+import { useCallback } from 'react';
+
+type NotifyFn = (title: string, body?: string) => Promise<void>;
+
+const isNotificationSupported = (): boolean =>
+  typeof window !== 'undefined' && 'Notification' in window;
+
+const showNotification = (title: string, body?: string) => {
+  if (body) {
+    new Notification(title, { body });
+  } else {
+    new Notification(title);
+  }
+};
+
+const useNotify = () => {
+  const notify = useCallback<NotifyFn>(async (title, body) => {
+    if (!isNotificationSupported()) {
+      return;
+    }
+
+    if (Notification.permission !== 'granted') {
+      try {
+        const permission = await Notification.requestPermission();
+        if (permission !== 'granted') {
+          return;
+        }
+      } catch {
+        return;
+      }
+    }
+
+    showNotification(title, body);
+  }, []);
+
+  return { notify };
+};
+
+export default useNotify;


### PR DESCRIPTION
## Summary
- add a reusable `useNotify` hook that manages Notification permission requests and display

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label errors across many apps)*
- yarn test *(fails: existing suites such as window and nmap nse already failing, jest run terminated after repeated failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb4a58848328b684c117e7982306