### PR TITLE
[a11y] Add skip link to main content

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,39 @@
+@import '../styles/globals.css';
+
+.skip {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  z-index: 10000;
+  display: inline-block;
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.75rem;
+  background: var(--color-text, #f5f5f5);
+  color: var(--color-bg, #0f1317);
+  font-weight: 600;
+  text-decoration: none;
+  line-height: 1.25;
+  white-space: nowrap;
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.35);
+  transform: translateY(-200%);
+  opacity: 0;
+  transition: transform 0.2s ease, opacity 0.2s ease, box-shadow 0.2s ease;
+}
+
+.skip:focus,
+.skip:focus-visible {
+  transform: translateY(0);
+  opacity: 1;
+  box-shadow: 0 0 0 3px var(--color-focus-ring, #1793d1), 0 4px 16px rgba(0, 0, 0, 0.35);
+}
+
+.skip:focus:not(:focus-visible) {
+  transform: translateY(-200%);
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skip {
+    transition: none;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+import './globals.css';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <a href="#main" className="skip">
+          Skip to content
+        </a>
+        <main id="main" tabIndex={-1}>
+          {children}
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import '../styles/tailwind.css';
-import '../styles/globals.css';
+import '../app/globals.css';
 import '../styles/index.css';
 import '../styles/resume-print.css';
 import '../styles/print.css';
@@ -150,16 +150,15 @@ function MyApp(props) {
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
-        <a
-          href="#app-grid"
-          className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
-        >
-          Skip to app grid
+        <a href="#main" className="skip">
+          Skip to content
         </a>
         <SettingsProvider>
           <PipPortalProvider>
             <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
+            <div id="main" tabIndex={-1}>
+              <Component {...pageProps} />
+            </div>
             <ShortcutOverlay />
             <Analytics
               beforeSend={(e) => {


### PR DESCRIPTION
## Summary
- add a root skip link and main landmark wrapper in the app router layout
- update the pages router shell to share the same skip link and main landmark
- style the reusable `.skip` helper so the link stays hidden until focused

## Testing
- [ ] yarn lint *(fails: existing unlabeled control warnings across legacy apps)*
- [ ] yarn test *(fails: existing suites such as Window and Nmap NSE; aborted after repeated time updates)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ec4795ec8328915dff848beaf02e