### PR TITLE
[app] Add modal-enabled projects gallery

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from 'next';
+import { Ubuntu } from 'next/font/google';
+import type { ReactNode } from 'react';
+
+import '../styles/tailwind.css';
+import '../styles/globals.css';
+import '../styles/index.css';
+import '../styles/resume-print.css';
+import '../styles/print.css';
+
+const ubuntu = Ubuntu({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '700'],
+  display: 'swap',
+});
+
+export const metadata: Metadata = {
+  title: 'Kali Linux Portfolio',
+  description: 'Desktop-inspired portfolio featuring security tooling simulations and project showcases.',
+};
+
+type RootLayoutProps = {
+  children: ReactNode;
+};
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="en" className="bg-slate-950">
+      <body className={`${ubuntu.className} bg-slate-950 text-slate-100 min-h-screen`}>{children}</body>
+    </html>
+  );
+}

--- a/app/projects/@modal/(.)[id]/page.tsx
+++ b/app/projects/@modal/(.)[id]/page.tsx
@@ -1,0 +1,24 @@
+import { notFound } from 'next/navigation';
+
+import ProjectModal from '@/app/projects/_components/ProjectModal';
+import { getProjectById, getProjectParams } from '@/app/projects/_lib/projects';
+
+type ModalPageProps = {
+  params: {
+    id: string;
+  };
+};
+
+export default function ProjectModalPage({ params }: ModalPageProps) {
+  const project = getProjectById(params.id);
+
+  if (!project) {
+    notFound();
+  }
+
+  return <ProjectModal project={project} />;
+}
+
+export function generateStaticParams() {
+  return getProjectParams();
+}

--- a/app/projects/@modal/default.tsx
+++ b/app/projects/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function DefaultModalSlot() {
+  return null;
+}

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import ProjectGrid from '../_components/ProjectGrid';
+import ProjectModal from '../_components/ProjectModal';
+import { getProjectById, getProjectParams, getProjects } from '../_lib/projects';
+
+type ProjectPageProps = {
+  params: {
+    id: string;
+  };
+};
+
+export async function generateMetadata({ params }: ProjectPageProps): Promise<Metadata> {
+  const project = getProjectById(params.id);
+
+  if (!project) {
+    return {
+      title: 'Project not found | Kali Linux Portfolio',
+    };
+  }
+
+  return {
+    title: `${project.title} | Kali Linux Portfolio`,
+    description: project.description,
+  };
+}
+
+export default function ProjectStandalonePage({ params }: ProjectPageProps) {
+  const project = getProjectById(params.id);
+  const projects = getProjects();
+
+  if (!project) {
+    notFound();
+  }
+
+  return (
+    <>
+      <ProjectGrid projects={projects} activeId={project.id} />
+      <ProjectModal project={project} isStandalone />
+    </>
+  );
+}
+
+export function generateStaticParams() {
+  return getProjectParams();
+}

--- a/app/projects/_components/ProjectGrid.tsx
+++ b/app/projects/_components/ProjectGrid.tsx
@@ -1,0 +1,82 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+import type { Project } from '../_lib/projects';
+
+type ProjectGridProps = {
+  projects: Project[];
+  activeId?: number;
+};
+
+export default function ProjectGrid({ projects, activeId }: ProjectGridProps) {
+  return (
+    <>
+      <header className="mb-10 space-y-3">
+        <p className="text-sm uppercase tracking-[0.2em] text-sky-400">Project gallery</p>
+        <h1 className="text-3xl font-semibold sm:text-4xl">Interactive security tooling portfolio</h1>
+        <p className="max-w-3xl text-base text-slate-300">
+          Explore recent simulations, utilities, and experiments. Select a project to view deep-dive notes,
+          technology stacks, and links without leaving the gallery. Modals keep the grid in place so you can
+          continue browsing after closing a detail view.
+        </p>
+      </header>
+
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {projects.map((project) => {
+          const isActive = project.id === activeId;
+          return (
+            <Link
+              key={project.id}
+              href={`/projects/${project.id}`}
+              className={`group relative flex h-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-slate-900/60 transition duration-200 hover:border-sky-400/60 hover:bg-slate-900/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
+                isActive ? 'ring-2 ring-sky-400 ring-offset-2 ring-offset-slate-950' : ''
+              }`}
+              aria-labelledby={`project-${project.id}-title`}
+            >
+              <div className="relative h-48 w-full overflow-hidden">
+                <Image
+                  src={project.thumbnail}
+                  alt={project.title}
+                  fill
+                  sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                  className="object-cover transition duration-200 group-hover:scale-105"
+                  priority={Boolean(isActive)}
+                />
+                <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-slate-950/80 to-transparent p-4 text-xs text-slate-200">
+                  <span className="font-semibold">{project.year}</span>
+                  <span className="ml-3 inline-flex items-center rounded-full bg-slate-950/70 px-2 py-0.5 text-[0.65rem] uppercase tracking-wide text-sky-300">
+                    {project.type}
+                  </span>
+                </div>
+              </div>
+
+              <article className="flex flex-1 flex-col gap-3 p-5" aria-describedby={`project-${project.id}-summary`}>
+                <h2 id={`project-${project.id}-title`} className="text-xl font-semibold text-slate-50">
+                  {project.title}
+                </h2>
+                <p id={`project-${project.id}-summary`} className="text-sm leading-relaxed text-slate-300">
+                  {project.description}
+                </p>
+                <div className="mt-auto flex flex-wrap gap-2 pt-2">
+                  {project.stack.slice(0, 4).map((tech) => (
+                    <span
+                      key={tech}
+                      className="rounded-full bg-slate-800/80 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-200"
+                    >
+                      {tech}
+                    </span>
+                  ))}
+                  {project.stack.length > 4 ? (
+                    <span className="rounded-full bg-slate-800/50 px-3 py-1 text-xs font-medium text-slate-300">
+                      +{project.stack.length - 4} more
+                    </span>
+                  ) : null}
+                </div>
+              </article>
+            </Link>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/app/projects/_components/ProjectModal.tsx
+++ b/app/projects/_components/ProjectModal.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect } from 'react';
+
+import type { Project } from '../_lib/projects';
+
+type ProjectModalProps = {
+  project: Project;
+  isStandalone?: boolean;
+};
+
+export default function ProjectModal({ project, isStandalone = false }: ProjectModalProps) {
+  const router = useRouter();
+
+  const closeModal = useCallback(() => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      router.back();
+    } else {
+      router.replace('/projects');
+    }
+  }, [router]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeModal();
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [closeModal]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 backdrop-blur-sm p-4"
+      onClick={closeModal}
+      role="presentation"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`project-${project.id}-modal-title`}
+        className="relative max-h-full w-full max-w-3xl overflow-y-auto rounded-2xl border border-white/10 bg-slate-900 shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={closeModal}
+          className="absolute right-4 top-4 inline-flex h-10 w-10 items-center justify-center rounded-full bg-slate-900/80 text-slate-200 transition hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+          aria-label="Close project details"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="h-5 w-5"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+          </svg>
+        </button>
+
+        <div className="relative aspect-video w-full overflow-hidden bg-slate-800">
+          <Image
+            src={project.thumbnail}
+            alt={project.title}
+            fill
+            className="object-cover"
+            sizes="(max-width: 768px) 100vw, 640px"
+            priority
+          />
+        </div>
+
+        <div className="space-y-6 p-6">
+          <header className="space-y-3">
+            <p className="text-sm uppercase tracking-[0.2em] text-sky-400">{project.type}</p>
+            <h2 id={`project-${project.id}-modal-title`} className="text-2xl font-semibold text-slate-50">
+              {project.title}
+            </h2>
+            <p className="text-sm text-slate-300">{project.description}</p>
+          </header>
+
+          <section className="space-y-3">
+            <h3 className="text-sm font-semibold uppercase tracking-widest text-slate-400">Stack</h3>
+            <div className="flex flex-wrap gap-2">
+              {project.stack.map((tech) => (
+                <span
+                  key={tech}
+                  className="rounded-full bg-slate-800/80 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-100"
+                >
+                  {tech}
+                </span>
+              ))}
+            </div>
+          </section>
+
+          {project.tags.length ? (
+            <section className="space-y-3">
+              <h3 className="text-sm font-semibold uppercase tracking-widest text-slate-400">Highlights</h3>
+              <div className="flex flex-wrap gap-2">
+                {project.tags.map((tag) => (
+                  <span key={tag} className="rounded-lg bg-slate-800/50 px-3 py-1 text-xs text-slate-200">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          {project.snippet ? (
+            <section className="space-y-3">
+              <h3 className="text-sm font-semibold uppercase tracking-widest text-slate-400">Sample snippet</h3>
+              <pre className="max-h-60 overflow-auto rounded-xl bg-slate-950/70 p-4 text-xs text-slate-100">
+                <code>{project.snippet}</code>
+              </pre>
+            </section>
+          ) : null}
+
+          <footer className="flex flex-wrap gap-3 text-sm">
+            {project.repo ? (
+              <Link
+                href={project.repo}
+                className="inline-flex items-center gap-2 rounded-full bg-slate-800 px-4 py-2 text-slate-100 transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                <span>View repository</span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                  className="h-4 w-4"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="m13.5 4.5 6 6m0 0-6 6m6-6H6"
+                  />
+                </svg>
+              </Link>
+            ) : null}
+            {project.demo ? (
+              <Link
+                href={project.demo}
+                className="inline-flex items-center gap-2 rounded-full border border-sky-500/60 px-4 py-2 text-sky-300 transition hover:border-sky-400 hover:text-sky-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                <span>Launch demo</span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                  className="h-4 w-4"
+                  aria-hidden="true"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.25h13.5v13.5M18.75 5.25 5.25 18.75" />
+                </svg>
+              </Link>
+            ) : null}
+          </footer>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/projects/_lib/projects.ts
+++ b/app/projects/_lib/projects.ts
@@ -1,0 +1,34 @@
+import projectsData from '@/data/projects.json';
+
+export type Project = {
+  id: number;
+  title: string;
+  description: string;
+  stack: string[];
+  tags: string[];
+  year: number;
+  type: string;
+  thumbnail: string;
+  repo?: string;
+  demo?: string;
+  snippet?: string;
+  language?: string;
+};
+
+const projects = projectsData as Project[];
+
+export function getProjects(): Project[] {
+  return projects;
+}
+
+export function getProjectById(id: string): Project | undefined {
+  const numericId = Number(id);
+  if (Number.isNaN(numericId)) {
+    return undefined;
+  }
+  return projects.find((project) => project.id === numericId);
+}
+
+export function getProjectParams() {
+  return projects.map((project) => ({ id: project.id.toString() }));
+}

--- a/app/projects/layout.tsx
+++ b/app/projects/layout.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+type ProjectsLayoutProps = {
+  children: ReactNode;
+  modal: ReactNode;
+};
+
+export default function ProjectsLayout({ children, modal }: ProjectsLayoutProps) {
+  return (
+    <div className="relative min-h-screen bg-slate-950 text-slate-100">
+      <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-4 py-12 sm:px-6 lg:px-8">
+        {children}
+      </div>
+      {modal}
+    </div>
+  );
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+
+import ProjectGrid from './_components/ProjectGrid';
+import { getProjects } from './_lib/projects';
+
+export const metadata: Metadata = {
+  title: 'Projects | Kali Linux Portfolio',
+  description: 'Browse recent security tooling simulations, utilities, and experiments built for the Kali Linux desktop portfolio.',
+};
+
+export default function ProjectsPage() {
+  const projects = getProjects();
+
+  return <ProjectGrid projects={projects} />;
+}


### PR DESCRIPTION
## Summary
- add an App Router root layout that loads existing global styles and font configuration
- create a `/projects` App Router page with a grid that links to project details
- surface project details in a modal via the `@modal` parallel route slot with a standalone fallback view

## Testing
- yarn lint *(fails: existing jsx-a11y label violations and `no-top-level-window` errors in legacy code)*
- yarn test *(fails: existing window manager and nmap NSE tests in the suite)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb8c13148328a4e2436790badfcc