### PR TITLE
[app] add root layout metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  metadataBase: new URL('https://unnippillil.com'),
+  title: {
+    default: 'Kali Linux Portfolio',
+    template: '%s | Kali Linux Portfolio',
+  },
+  description:
+    'A desktop-style portfolio that emulates a Kali and Ubuntu experience with simulated security tools, utilities, and retro games.',
+};
+
+interface RootLayoutProps {
+  children: ReactNode;
+}
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/viewport.ts
+++ b/app/viewport.ts
@@ -1,0 +1,10 @@
+import type { Viewport } from 'next';
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  themeColor: [
+    { media: '(prefers-color-scheme: dark)', color: '#0f1317' },
+    { media: '(prefers-color-scheme: light)', color: '#f5f7fa' },
+  ],
+};


### PR DESCRIPTION
## Summary
- add an App Router root layout that exports shared metadata and wraps the document markup
- define viewport defaults for device sizing and theme colors for future App Router routes

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label and no-top-level-window errors throughout legacy apps)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb6d2adc83288560d6cef360a529