### PR TITLE
[ui] Sync theme and DND toggles via BroadcastChannel

### DIFF
--- a/src/lib/bc.ts
+++ b/src/lib/bc.ts
@@ -1,0 +1,45 @@
+export type BroadcastPayload = unknown;
+
+export interface BroadcastMessage<T = BroadcastPayload> {
+  type: string;
+  payload: T;
+}
+
+export const BC_EVENTS = {
+  theme: 'theme:change',
+  dnd: 'dnd:change',
+} as const;
+
+const hasBroadcastChannel =
+  typeof globalThis !== 'undefined' &&
+  'BroadcastChannel' in globalThis &&
+  typeof globalThis.BroadcastChannel === 'function';
+
+const channel = hasBroadcastChannel
+  ? new globalThis.BroadcastChannel('kali')
+  : null;
+
+export type Unsubscribe = () => void;
+
+export function publish<T = BroadcastPayload>(type: string, payload: T): void {
+  channel?.postMessage({ type, payload } as BroadcastMessage<T>);
+}
+
+export function subscribe<T = BroadcastPayload>(
+  type: string,
+  callback: (payload: T) => void,
+): Unsubscribe {
+  if (!channel) return () => {};
+
+  const handler = (event: MessageEvent<BroadcastMessage<T>>) => {
+    const message = event.data;
+    if (!message || typeof message !== 'object') return;
+    if (message.type !== type) return;
+    callback(message.payload as T);
+  };
+
+  channel.addEventListener('message', handler as EventListener);
+  return () => channel.removeEventListener('message', handler as EventListener);
+}
+
+export { channel };

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -1,4 +1,7 @@
+import { BC_EVENTS, publish } from '@/src/lib/bc';
+
 export const THEME_KEY = 'app:theme';
+export const THEME_EVENT = BC_EVENTS.theme;
 
 // Score required to unlock each theme
 export const THEME_UNLOCKS: Record<string, number> = {
@@ -27,12 +30,20 @@ export const getTheme = (): string => {
   }
 };
 
-export const setTheme = (theme: string): void => {
+interface SetThemeOptions {
+  broadcast?: boolean;
+}
+
+export const setTheme = (
+  theme: string,
+  { broadcast = true }: SetThemeOptions = {},
+): void => {
   if (typeof window === 'undefined') return;
   try {
     window.localStorage.setItem(THEME_KEY, theme);
     document.documentElement.dataset.theme = theme;
     document.documentElement.classList.toggle('dark', isDarkTheme(theme));
+    if (broadcast) publish<string>(THEME_EVENT, theme);
   } catch {
     /* ignore storage errors */
   }


### PR DESCRIPTION
## Summary
- add src/lib/bc.ts with a shared BroadcastChannel helper and named events
- broadcast theme updates from utils/theme and subscribe in useTheme/useSettings to keep state in sync
- hook QuickSettings into the shared theme/DND signals so toggles reflect changes across windows

## Testing
- yarn lint *(fails: large set of pre-existing accessibility and window usage warnings across legacy apps)*
- yarn test *(fails: existing window sizing and jsdom localStorage issues in legacy test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb6a39108328bb0cfc132debb98a