### PR TITLE
[desktop] Add keymap service for keyboard shortcuts

### DIFF
--- a/__tests__/desktopKeymap.test.ts
+++ b/__tests__/desktopKeymap.test.ts
@@ -1,0 +1,59 @@
+import { fireEvent } from '@testing-library/dom';
+import { attach, register, __testing } from '../src/desktop/keymap';
+
+describe('desktop keymap service', () => {
+  let detach: () => void;
+
+  beforeEach(() => {
+    detach = attach(window);
+  });
+
+  afterEach(() => {
+    detach();
+    __testing.registry.clear();
+    document.body.innerHTML = '';
+  });
+
+  it('invokes registered handler for matching combo and prevents default', () => {
+    const handler = jest.fn();
+    register('Alt+Enter', handler);
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    window.dispatchEvent(event);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('ignores input targets unless explicitly allowed', () => {
+    const handler = jest.fn();
+    register('Ctrl+K', handler);
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    fireEvent.keyDown(input, { key: 'k', ctrlKey: true });
+    expect(handler).not.toHaveBeenCalled();
+
+    const handlerAllowed = jest.fn();
+    register('Ctrl+K', handlerAllowed, { allowInInput: true });
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'k',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    input.dispatchEvent(event);
+
+    expect(handlerAllowed).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+});

--- a/apps/settings/components/KeymapOverlay.tsx
+++ b/apps/settings/components/KeymapOverlay.tsx
@@ -2,22 +2,12 @@
 
 import { useEffect, useState } from 'react';
 import useKeymap from '../keymapRegistry';
+import { eventToCombo } from '../../../src/desktop/keymap';
 
 interface KeymapOverlayProps {
   open: boolean;
   onClose: () => void;
 }
-
-const formatEvent = (e: KeyboardEvent) => {
-  const parts = [
-    e.ctrlKey ? 'Ctrl' : '',
-    e.altKey ? 'Alt' : '',
-    e.shiftKey ? 'Shift' : '',
-    e.metaKey ? 'Meta' : '',
-    e.key.length === 1 ? e.key.toUpperCase() : e.key,
-  ];
-  return parts.filter(Boolean).join('+');
-};
 
 export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
   const { shortcuts, updateShortcut } = useKeymap();
@@ -27,7 +17,7 @@ export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
     if (!rebinding) return;
     const handler = (e: KeyboardEvent) => {
       e.preventDefault();
-      const combo = formatEvent(e);
+      const combo = eventToCombo(e);
       updateShortcut(rebinding, combo);
       setRebinding(null);
     };

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -6,9 +6,14 @@ export interface Shortcut {
 }
 
 const DEFAULT_SHORTCUTS: Shortcut[] = [
-  { description: 'Show keyboard shortcuts', keys: '?' },
+  { description: 'Show keyboard shortcuts', keys: 'Shift+?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
 ];
+
+const sanitizeKeys = (keys: string) => {
+  if (keys === '?') return 'Shift+?';
+  return keys;
+};
 
 const validator = (value: unknown): value is Record<string, string> => {
   return (
@@ -36,13 +41,21 @@ export function useKeymap() {
     validator
   );
 
+  const normalizedMap = Object.entries(map).reduce<Record<string, string>>(
+    (acc, [description, keys]) => {
+      acc[description] = sanitizeKeys(keys);
+      return acc;
+    },
+    {}
+  );
+
   const shortcuts = DEFAULT_SHORTCUTS.map(({ description, keys }) => ({
     description,
-    keys: map[description] || keys,
+    keys: normalizedMap[description] || sanitizeKeys(keys),
   }));
 
   const updateShortcut = (description: string, keys: string) =>
-    setMap({ ...map, [description]: keys });
+    setMap({ ...normalizedMap, [description]: keys });
 
   return { shortcuts, updateShortcut };
 }

--- a/src/desktop/keymap.ts
+++ b/src/desktop/keymap.ts
@@ -1,0 +1,191 @@
+const MODIFIER_ORDER = [
+  { prop: 'altKey' as const, label: 'Alt', normalized: 'alt', aliases: ['alt', 'option'] },
+  { prop: 'ctrlKey' as const, label: 'Ctrl', normalized: 'ctrl', aliases: ['ctrl', 'control'] },
+  { prop: 'shiftKey' as const, label: 'Shift', normalized: 'shift', aliases: ['shift'] },
+  { prop: 'metaKey' as const, label: 'Meta', normalized: 'meta', aliases: ['meta', 'cmd', 'command', 'super', 'win'] },
+];
+
+export type KeyCombo = string;
+export type KeymapHandler = (event: KeyboardEvent) => void;
+
+export interface RegisterOptions {
+  /**
+   * When true, the shortcut will fire even if the focused element is an input, textarea,
+   * or content editable region. Defaults to false so typing in fields is unaffected.
+   */
+  allowInInput?: boolean;
+}
+
+interface RegisteredEntry {
+  handler: KeymapHandler;
+  allowInInput: boolean;
+}
+
+const registry = new Map<string, Set<RegisteredEntry>>();
+
+const DEFAULT_OPTIONS: Required<RegisterOptions> = {
+  allowInInput: false,
+};
+
+function normalizeKeyForMatch(key: string): string {
+  if (!key) return '';
+  if (key === ' ') return 'space';
+  if (key.length === 1) return key.toUpperCase();
+  return key.toLowerCase();
+}
+
+function normalizeCombo(combo: string): string {
+  if (!combo) return '';
+  const parts = combo
+    .split('+')
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  const modifiers = new Set<string>();
+  let key: string | null = null;
+
+  for (const part of parts) {
+    const lower = part.toLowerCase();
+    const modifier = MODIFIER_ORDER.find((m) => m.aliases.includes(lower));
+    if (modifier) {
+      modifiers.add(modifier.normalized);
+      continue;
+    }
+
+    if (key === null) {
+      key = part;
+    } else {
+      key += `+${part}`;
+    }
+  }
+
+  const normalizedKey = normalizeKeyForMatch(key ?? '');
+  const ordered: string[] = [];
+  for (const modifier of MODIFIER_ORDER) {
+    if (modifiers.has(modifier.normalized)) {
+      ordered.push(modifier.normalized);
+    }
+  }
+  if (normalizedKey) {
+    ordered.push(normalizedKey);
+  }
+  return ordered.join('+');
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!target) return false;
+  if (target instanceof HTMLElement) {
+    const tag = target.tagName;
+    return (
+      tag === 'INPUT' ||
+      tag === 'TEXTAREA' ||
+      target.isContentEditable
+    );
+  }
+  return false;
+}
+
+function eventToNormalized(event: KeyboardEvent): string {
+  const parts: string[] = [];
+  for (const modifier of MODIFIER_ORDER) {
+    if (event[modifier.prop]) {
+      parts.push(modifier.normalized);
+    }
+  }
+  const key = normalizeKeyForMatch(event.key);
+  if (key) parts.push(key);
+  return parts.join('+');
+}
+
+function normalizeKeyForDisplay(key: string): string {
+  if (!key) return '';
+  if (key === ' ') return 'Space';
+  if (key.length === 1) return key.toUpperCase();
+  return key;
+}
+
+export function eventToCombo(event: KeyboardEvent): string {
+  const parts: string[] = [];
+  for (const modifier of MODIFIER_ORDER) {
+    if (event[modifier.prop]) {
+      parts.push(modifier.label);
+    }
+  }
+  const key = normalizeKeyForDisplay(event.key);
+  if (key) parts.push(key);
+  return parts.join('+');
+}
+
+export function register(
+  combo: KeyCombo,
+  handler: KeymapHandler,
+  options: RegisterOptions = {}
+): () => void {
+  const normalized = normalizeCombo(combo);
+  if (!normalized || typeof handler !== 'function') {
+    return () => {};
+  }
+
+  const entry: RegisteredEntry = {
+    handler,
+    allowInInput: options.allowInInput ?? DEFAULT_OPTIONS.allowInInput,
+  };
+
+  const bucket = registry.get(normalized);
+  if (bucket) {
+    bucket.add(entry);
+  } else {
+    registry.set(normalized, new Set([entry]));
+  }
+
+  return () => {
+    const current = registry.get(normalized);
+    if (!current) return;
+    current.delete(entry);
+    if (current.size === 0) {
+      registry.delete(normalized);
+    }
+  };
+}
+
+export function attach(
+  target: EventTarget | null =
+    typeof window !== 'undefined' ? (window as unknown as EventTarget) : null
+): () => void {
+  if (!target || !target.addEventListener || !target.removeEventListener) {
+    return () => {};
+  }
+
+  const listener = (event: Event) => {
+    if (!(event instanceof KeyboardEvent)) return;
+    const normalized = eventToNormalized(event);
+    const entries = registry.get(normalized);
+    if (!entries || entries.size === 0) return;
+
+    const editable = isEditableTarget(event.target);
+    let handled = false;
+
+    for (const entry of entries) {
+      if (editable && !entry.allowInInput) {
+        continue;
+      }
+      if (!handled) {
+        event.preventDefault();
+        handled = true;
+      }
+      entry.handler(event);
+    }
+  };
+
+  target.addEventListener('keydown', listener as EventListener);
+
+  return () => {
+    target.removeEventListener('keydown', listener as EventListener);
+  };
+}
+
+export const __testing = {
+  normalizeCombo,
+  eventToNormalized,
+  registry,
+};


### PR DESCRIPTION
## Summary
- add a desktop keymap service that normalizes combos, registers handlers, and provides an attach helper
- wire ShortcutOverlay and the settings keymap editor to the service while sanitizing default shortcuts
- add unit coverage for the keymap handler to verify combo matching and input filtering

## Testing
- yarn lint *(fails with numerous pre-existing jsx-a11y and no-top-level-window violations across apps/public assets)*
- yarn test *(fails in existing suites such as Modal.test.tsx due to localStorage usage; new keymap tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb5616608328b66308d8e01183e9