### PR TITLE
[desktop] add window component

### DIFF
--- a/src/desktop/Window.tsx
+++ b/src/desktop/Window.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import type { CSSProperties, PointerEvent as ReactPointerEvent, ReactNode } from 'react';
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+
+import type { DesktopWindow } from './wm-store';
+import { getServerSnapshot, getSnapshot, subscribe, wm } from './wm-store';
+
+export interface WindowProps {
+  id: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+function getWindowStyle(win: DesktopWindow): CSSProperties | undefined {
+  const { bounds, zIndex } = win;
+
+  if (!bounds && typeof zIndex !== 'number') {
+    return undefined;
+  }
+
+  const style: CSSProperties = { position: 'absolute' };
+
+  if (bounds) {
+    style.top = bounds.y;
+    style.left = bounds.x;
+    style.width = bounds.width;
+    style.height = bounds.height;
+  }
+
+  if (typeof zIndex === 'number') {
+    style.zIndex = zIndex;
+  }
+
+  return style;
+}
+
+function stopPointerDown(event: ReactPointerEvent<HTMLElement>): void {
+  event.stopPropagation();
+}
+
+export default function Window({ id, className, children }: WindowProps) {
+  const state = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const win = state.windows[id];
+  const isActiveWorkspace =
+    win && state.activeWorkspaceId && win.workspaceId === state.activeWorkspaceId;
+
+  const shouldRender = Boolean(win && isActiveWorkspace && !win.minimized);
+  const style = useMemo(() => (win ? getWindowStyle(win) : undefined), [win]);
+  const titleId = `desktop-window-${id}-title`;
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      event.stopPropagation();
+      if (event.button !== 0) return;
+      wm.focus(id);
+    },
+    [id],
+  );
+
+  const handleMinimize = useCallback(() => {
+    wm.minimize(id);
+  }, [id]);
+
+  const handleClose = useCallback(() => {
+    wm.close(id);
+  }, [id]);
+
+  if (!shouldRender || !win) {
+    return null;
+  }
+
+  const title = win.title ?? 'Untitled';
+
+  const composedClassName = [
+    'absolute flex min-h-[12rem] min-w-[16rem] select-none flex-col overflow-hidden rounded-lg bg-ub-grey shadow-lg',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <section
+      role="dialog"
+      aria-labelledby={titleId}
+      data-window-id={id}
+      className={composedClassName}
+      style={style}
+      onPointerDown={handlePointerDown}
+    >
+      <header className="flex items-center justify-between gap-2 bg-black/30 px-3 py-2 text-sm font-semibold text-white">
+        <span id={titleId} className="truncate" title={title}>
+          {title}
+        </span>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            aria-label="Minimize window"
+            className="h-6 w-6 rounded-full bg-ub-grey text-xs text-white transition hover:bg-ub-warm-grey focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ub-orange"
+            onPointerDown={stopPointerDown}
+            onClick={handleMinimize}
+          >
+            _
+          </button>
+          <button
+            type="button"
+            aria-label="Close window"
+            className="h-6 w-6 rounded-full bg-red-600 text-xs text-white transition hover:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-400"
+            onPointerDown={stopPointerDown}
+            onClick={handleClose}
+          >
+            ×
+          </button>
+        </div>
+      </header>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-ub-cool-grey text-white">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/src/desktop/wm-store.ts
+++ b/src/desktop/wm-store.ts
@@ -1,0 +1,111 @@
+'use client';
+
+export type WorkspaceId = string;
+export type WindowId = string;
+
+export interface DesktopWindowBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface DesktopWindow {
+  id: WindowId;
+  title: string;
+  workspaceId: WorkspaceId;
+  minimized: boolean;
+  bounds?: DesktopWindowBounds;
+  zIndex?: number;
+}
+
+export interface WindowManagerSnapshot {
+  activeWorkspaceId: WorkspaceId | null;
+  windows: Record<WindowId, DesktopWindow>;
+}
+
+type Listener = () => void;
+
+let snapshot: WindowManagerSnapshot = {
+  activeWorkspaceId: null,
+  windows: {},
+};
+
+const listeners = new Set<Listener>();
+
+function emit(): void {
+  listeners.forEach((listener) => listener());
+}
+
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getSnapshot(): WindowManagerSnapshot {
+  return snapshot;
+}
+
+export function getServerSnapshot(): WindowManagerSnapshot {
+  return snapshot;
+}
+
+export function setSnapshot(nextSnapshot: WindowManagerSnapshot): void {
+  snapshot = nextSnapshot;
+  emit();
+}
+
+export const wm = {
+  focus(windowId: WindowId): void {
+    const win = snapshot.windows[windowId];
+    if (!win) return;
+
+    const shouldRestore = win.minimized;
+    const workspaceChanged = snapshot.activeWorkspaceId !== win.workspaceId;
+
+    if (!shouldRestore && !workspaceChanged) {
+      return;
+    }
+
+    const nextWin = shouldRestore ? { ...win, minimized: false } : win;
+    const windows = shouldRestore
+      ? { ...snapshot.windows, [windowId]: nextWin }
+      : snapshot.windows;
+
+    snapshot = {
+      ...snapshot,
+      activeWorkspaceId: win.workspaceId,
+      windows,
+    };
+    emit();
+  },
+
+  minimize(windowId: WindowId): void {
+    const win = snapshot.windows[windowId];
+    if (!win || win.minimized) return;
+
+    snapshot = {
+      ...snapshot,
+      windows: {
+        ...snapshot.windows,
+        [windowId]: { ...win, minimized: true },
+      },
+    };
+    emit();
+  },
+
+  close(windowId: WindowId): void {
+    if (!snapshot.windows[windowId]) return;
+
+    const { [windowId]: _removed, ...rest } = snapshot.windows;
+    snapshot = {
+      ...snapshot,
+      windows: rest,
+    };
+    emit();
+  },
+};
+
+export default wm;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,7 @@ module.exports = {
     './components/**/*.{js,ts,jsx,tsx}',
     './apps/**/*.{js,ts,jsx,tsx}',
     './hooks/**/*.{js,ts,jsx,tsx}',
+    './src/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- add a client Window component that reads wm-store with `useSyncExternalStore` and wires focus/minimize/close handlers
- introduce a window manager store stub that exposes subscribe/snapshot helpers for the desktop
- include the src tree in Tailwind content paths so new desktop styles are generated

## Testing
- yarn lint *(fails: numerous pre-existing accessibility issues across legacy apps)*
- yarn test *(fails: existing window and nmap suites unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb3cd27483289d14cea501e407c7