### PR TITLE
desktop: add workspace hotkeys and filtering

### DIFF
--- a/__tests__/taskbar.test.tsx
+++ b/__tests__/taskbar.test.tsx
@@ -16,6 +16,8 @@ describe('Taskbar', () => {
         closed_windows={{ app1: false }}
         minimized_windows={{ app1: false }}
         focused_windows={{ app1: true }}
+        window_workspaces={{ app1: 'ws_1' }}
+        activeWorkspace="ws_1"
         openApp={openApp}
         minimize={minimize}
       />
@@ -35,6 +37,8 @@ describe('Taskbar', () => {
         closed_windows={{ app1: false }}
         minimized_windows={{ app1: true }}
         focused_windows={{ app1: false }}
+        window_workspaces={{ app1: 'ws_1' }}
+        activeWorkspace="ws_1"
         openApp={openApp}
         minimize={minimize}
       />

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -2,7 +2,12 @@ import React from 'react';
 import Image from 'next/image';
 
 export default function Taskbar(props) {
-    const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const { window_workspaces = {}, activeWorkspace } = props;
+    const runningApps = props.apps.filter(
+        app =>
+            props.closed_windows[app.id] === false &&
+            window_workspaces[app.id] === activeWorkspace
+    );
 
     const handleClick = (app) => {
         const id = app.id;

--- a/src/desktop/WorkspaceHotkeys.tsx
+++ b/src/desktop/WorkspaceHotkeys.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+
+import wm, { WORKSPACES } from './wm';
+
+const WorkspaceHotkeys = () => {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (!event.ctrlKey || !event.altKey || event.metaKey) return;
+      if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+
+      event.preventDefault();
+
+      const { ws } = wm.getState();
+      const currentIndex = WORKSPACES.indexOf(ws);
+      if (currentIndex === -1) return;
+
+      const direction = event.key === 'ArrowLeft' ? -1 : 1;
+      const nextIndex = (currentIndex + direction + WORKSPACES.length) % WORKSPACES.length;
+      const nextWorkspace = WORKSPACES[nextIndex];
+
+      wm.setWs(nextWorkspace);
+    };
+
+    window.addEventListener('keydown', handleKeydown);
+    return () => {
+      window.removeEventListener('keydown', handleKeydown);
+    };
+  }, []);
+
+  return null;
+};
+
+export default WorkspaceHotkeys;

--- a/src/desktop/wm.ts
+++ b/src/desktop/wm.ts
@@ -1,0 +1,43 @@
+export type WorkspaceId = 'ws_1' | 'ws_2' | 'ws_3' | 'ws_4';
+
+export const WORKSPACES: WorkspaceId[] = ['ws_1', 'ws_2', 'ws_3', 'ws_4'];
+export const DEFAULT_WORKSPACE: WorkspaceId = WORKSPACES[0];
+
+export interface WorkspaceState {
+  ws: WorkspaceId;
+}
+
+type Listener = (state: WorkspaceState) => void;
+
+class WorkspaceManager {
+  private state: WorkspaceState = { ws: DEFAULT_WORKSPACE };
+  private listeners: Set<Listener> = new Set();
+
+  getState(): WorkspaceState {
+    return this.state;
+  }
+
+  setWs(ws: WorkspaceId) {
+    if (this.state.ws === ws) return;
+    this.state = { ...this.state, ws };
+    this.listeners.forEach((listener) => listener(this.state));
+
+    if (typeof window !== 'undefined') {
+      const event = new CustomEvent<WorkspaceId>('desktop:workspace-change', {
+        detail: ws,
+      });
+      window.dispatchEvent(event);
+    }
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+}
+
+const wm = new WorkspaceManager();
+
+export default wm;


### PR DESCRIPTION
## Summary
- add a workspace hotkey listener and window manager helpers for cycling Ctrl+Alt+Arrow shortcuts
- extend the desktop window logic to track active workspace assignments, filter rendered windows, and keep focus in sync
- update the taskbar and its unit tests to reflect workspace-aware running apps

## Testing
- yarn lint (fails: pre-existing accessibility violations across apps)
- yarn test (fails: existing jest suites such as nmapNse and modal tests)


------
https://chatgpt.com/codex/tasks/task_e_68c8eb41bd808328a3f33d3c5d9f807d