### PR TITLE
[config] add instrumentation hook logging

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,19 @@
+const globalForInstrumentation = globalThis as typeof globalThis & {
+  __kaliInstrumentationRegistered?: boolean;
+};
+
+export async function register() {
+  if (globalForInstrumentation.__kaliInstrumentationRegistered) {
+    return;
+  }
+
+  globalForInstrumentation.__kaliInstrumentationRegistered = true;
+
+  const environment = process.env.NODE_ENV ?? 'development';
+  const runtime = process.env.NEXT_RUNTIME ?? 'unknown';
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `[instrumentation] Initializing global telemetry hooks for ${runtime} runtime in ${environment} mode.`
+  );
+}

--- a/next.config.js
+++ b/next.config.js
@@ -124,6 +124,9 @@ module.exports = withBundleAnalyzer(
   withPWA({
     ...(isStaticExport && { output: 'export' }),
     webpack: configureWebpack,
+    experimental: {
+      instrumentationHook: true,
+    },
 
     // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI
     eslint: {


### PR DESCRIPTION
## Summary
- add an `instrumentation.ts` entry point that logs when the runtime boots and avoids duplicate registration
- enable the `experimental.instrumentationHook` flag so Next.js executes the instrumentation hook

## Testing
- yarn lint *(fails: repo has pre-existing jsx-a11y and public asset lint violations)*
- yarn test *(fails: suite already has multiple failing specs and later hung, aborted after ~2 minutes)*
- yarn dev
- CI=1 yarn build
- yarn start

------
https://chatgpt.com/codex/tasks/task_e_68c9031558348328b494caa2cdfd3ab1