### PR TITLE
security: ensure CSP nonce propagation

### DIFF
--- a/__tests__/cspNonce.test.tsx
+++ b/__tests__/cspNonce.test.tsx
@@ -1,0 +1,187 @@
+import React from 'react';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import BaseDocument, { NextScript } from 'next/document';
+import { HeadManagerContext } from 'next/dist/shared/lib/head-manager-context.shared-runtime';
+import MyDocument from '../pages/_document.jsx';
+import Meta from '../components/SEO/Meta';
+import { AboutAlex } from '../components/apps/About';
+import { CspNonceProvider } from '../utils/csp';
+
+jest.mock('react-ga4', () => ({
+  send: jest.fn(),
+  event: jest.fn(),
+  initialize: jest.fn(),
+}));
+
+const ensureFetchPolyfill = () => {
+  if (typeof global.ReadableStream === 'undefined') {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const streamWeb = require('stream/web');
+    // @ts-ignore
+    global.ReadableStream = streamWeb.ReadableStream;
+  }
+  if (
+    typeof global.Request === 'undefined' ||
+    typeof global.Response === 'undefined' ||
+    typeof global.Headers === 'undefined' ||
+    typeof global.fetch === 'undefined'
+  ) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const edgeFetch = require('next/dist/compiled/@edge-runtime/primitives/fetch');
+    if (typeof global.Request === 'undefined') {
+      // @ts-ignore
+      global.Request = edgeFetch.Request;
+    }
+    if (typeof global.Response === 'undefined') {
+      // @ts-ignore
+      global.Response = edgeFetch.Response;
+    }
+    if (typeof global.Headers === 'undefined') {
+      // @ts-ignore
+      global.Headers = edgeFetch.Headers;
+    }
+    if (typeof global.fetch === 'undefined') {
+      // @ts-ignore
+      global.fetch = edgeFetch.fetch;
+    }
+  }
+};
+
+let middleware: typeof import('../middleware').middleware;
+
+beforeAll(async () => {
+  ensureFetchPolyfill();
+  ({ middleware } = await import('../middleware'));
+});
+
+afterEach(() => {
+  cleanup();
+  document.head.innerHTML = '';
+  document.title = '';
+  jest.restoreAllMocks();
+});
+
+describe('Content Security Policy nonce integration', () => {
+  test('middleware sets nonce header and CSP policy without unsafe-inline', () => {
+    const request = { headers: new Headers() } as any;
+    const response = middleware(request);
+    const nonce = response.headers.get('x-nonce');
+    const csp = response.headers.get('Content-Security-Policy') ?? '';
+    const scriptDirective = csp
+      .split(';')
+      .map((directive) => directive.trim())
+      .find((directive) => directive.startsWith('script-src'));
+
+    expect(typeof nonce).toBe('string');
+    expect(nonce).not.toBe('');
+    expect(csp).toContain(`'nonce-${nonce}'`);
+    expect(scriptDirective).toBeDefined();
+    expect(scriptDirective).not.toContain("'unsafe-inline'");
+  });
+
+  test('document renders nonce attributes on html and scripts', () => {
+    const props: any = {
+      __NEXT_DATA__: { props: {}, page: '/', query: {} },
+      buildManifest: {
+        polyfillFiles: [],
+        devFiles: [],
+        lowPriorityFiles: [],
+        rootMainFiles: [],
+        pages: {},
+      },
+      docComponentsRendered: { Head: false, Main: false, NextScript: false },
+      head: [],
+      html: '',
+      inAmpMode: false,
+      locale: undefined,
+      defaultLocale: undefined,
+      scriptLoader: [],
+      styles: [],
+      nonce: 'test-nonce',
+    };
+
+    const doc = new MyDocument(props);
+    doc.props = props;
+    const tree = doc.render();
+
+    expect(tree.props['data-csp-nonce']).toBe('test-nonce');
+
+    const [headEl, bodyEl] = React.Children.toArray(tree.props.children) as any[];
+    const headChildren = React.Children.toArray(headEl.props.children);
+    const inlineScript = headChildren.find((child: any) => child?.type === 'script');
+    expect(inlineScript?.props?.nonce).toBe('test-nonce');
+
+    const bodyChildren = React.Children.toArray(bodyEl.props.children);
+    const nextScriptEl = bodyChildren.find((child: any) => child?.type === NextScript);
+    expect(nextScriptEl?.props?.nonce).toBe('test-nonce');
+  });
+
+  test('document getInitialProps forwards nonce to the App component', async () => {
+    const nonce = 'ctx-nonce';
+
+    const renderPage = jest.fn((options: any = {}) => {
+      const App = jest.fn(() => null);
+      const EnhancedApp = options.enhanceApp ? options.enhanceApp(App) : App;
+      const element = EnhancedApp({ Component: () => null, pageProps: {} });
+      expect(element?.props?.cspNonce).toBe(nonce);
+      return { html: '', head: [], styles: [] };
+    });
+
+    const ctx: any = {
+      req: { headers: { 'x-nonce': nonce } },
+      res: { getHeader: jest.fn() },
+      renderPage,
+    };
+
+    jest.spyOn(BaseDocument, 'getInitialProps').mockImplementation(async (context: any) => {
+      context.renderPage?.();
+      return {
+        html: '',
+        head: [],
+        styles: [],
+      } as any;
+    });
+
+    const initial = await MyDocument.getInitialProps(ctx);
+
+    expect(initial.nonce).toBe(nonce);
+    expect(renderPage).toHaveBeenCalled();
+  });
+
+  test('inline scripts receive the nonce from context', async () => {
+    const headElements: React.ReactElement[] = [];
+    const headManager = {
+      mountedInstances: new Set<unknown>(),
+      updateHead: (elements: React.ReactElement[]) => {
+        headElements.splice(0, headElements.length, ...elements);
+      },
+      updateScripts: () => {},
+      updateLink: () => {},
+      updateStyle: () => {},
+    };
+
+    await act(async () => {
+      render(
+        <HeadManagerContext.Provider value={headManager as any}>
+          <CspNonceProvider nonce="inline-nonce">
+            <>
+              <Meta />
+              <AboutAlex nonce="inline-nonce" />
+            </>
+          </CspNonceProvider>
+        </HeadManagerContext.Provider>,
+      );
+    });
+
+    await waitFor(() => {
+      const scriptNonces = headElements
+        .filter((element) => element.type === 'script')
+        .map((element) => element.props?.nonce)
+        .filter(Boolean);
+      expect(scriptNonces.length).toBeGreaterThan(0);
+      scriptNonces.forEach((nonce) => {
+        expect(nonce).toBe('inline-nonce');
+      });
+    });
+  });
+});

--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import Head from 'next/head';
-import { getCspNonce } from '../../utils/csp';
+import { useCspNonce } from '../../utils/csp';
 
 export default function Meta() {
-    const nonce = getCspNonce();
+    const nonce = useCspNonce();
     return (
         <Head>
             {/* Primary Meta Tags */}

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -6,14 +6,18 @@ import GitHubStars from '../../GitHubStars';
 import Certs from '../certs';
 import data from '../alex/data.json';
 import SafetyNote from './SafetyNote';
-import { getCspNonce } from '../../../utils/csp';
+import { useCspNonce } from '../../../utils/csp';
 import AboutSlides from './slides';
 import ScrollableTimeline from '../../ScrollableTimeline';
 
-class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_screen: string; navbar: boolean }> {
+type AboutAlexProps = {
+  nonce?: string;
+};
+
+class AboutAlex extends Component<AboutAlexProps, { screen: React.ReactNode; active_screen: string; navbar: boolean }> {
   screens: Record<string, React.ReactNode> = {};
 
-  constructor(props: unknown) {
+  constructor(props: AboutAlexProps) {
     super(props);
     this.state = {
       screen: <></>,
@@ -107,7 +111,7 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
       name: 'Alex Unnippillil',
       url: 'https://unnippillil.com',
     };
-    const nonce = getCspNonce();
+    const { nonce } = this.props;
 
     return (
       <main className="w-full h-full flex bg-ub-cool-grey text-white select-none relative">
@@ -155,13 +159,16 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
 }
 
 export default function AboutApp() {
+  const nonce = useCspNonce();
   return (
     <>
-      <AboutAlex />
+      <AboutAlex nonce={nonce} />
       <AboutSlides />
     </>
   );
 }
+
+export { AboutAlex };
 
 export { default as SafetyNote } from './SafetyNote';
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -8,6 +8,28 @@ if (typeof global.structuredClone !== 'function') {
 require('fake-indexeddb/auto');
 import '@testing-library/jest-dom';
 
+try {
+  const edgeFetch = require('next/dist/compiled/@edge-runtime/primitives/fetch');
+  if (typeof global.Request === 'undefined') {
+    // @ts-ignore
+    global.Request = edgeFetch.Request;
+  }
+  if (typeof global.Response === 'undefined') {
+    // @ts-ignore
+    global.Response = edgeFetch.Response;
+  }
+  if (typeof global.Headers === 'undefined') {
+    // @ts-ignore
+    global.Headers = edgeFetch.Headers;
+  }
+  if (typeof global.fetch === 'undefined') {
+    // @ts-ignore
+    global.fetch = edgeFetch.fetch;
+  }
+} catch {
+  // ignore if primitives are unavailable in the test environment
+}
+
 // Provide TextEncoder/TextDecoder for libraries that expect them in the test environment
 // @ts-ignore
 global.TextEncoder = TextEncoder;

--- a/middleware.ts
+++ b/middleware.ts
@@ -13,7 +13,7 @@ export function middleware(req: NextRequest) {
     "img-src 'self' https: data:",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
-    `script-src 'self' 'unsafe-inline' 'nonce-${n}' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com`,
+    `script-src 'self' 'nonce-${n}' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com`,
     "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://stackblitz.com",
     "frame-src 'self' https://vercel.live https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
     "frame-ancestors 'self'",
@@ -22,8 +22,15 @@ export function middleware(req: NextRequest) {
     "form-action 'self'"
   ].join('; ');
 
-  const res = NextResponse.next();
-  res.headers.set('x-csp-nonce', n);
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set('x-nonce', n);
+
+  const res = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+  res.headers.set('x-nonce', n);
   res.headers.set('Content-Security-Policy', csp);
   return res;
 }

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { CspNonceProvider, useCspNonce } from '../utils/csp';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -25,9 +26,8 @@ const ubuntu = Ubuntu({
 });
 
 
-function MyApp(props) {
-  const { Component, pageProps } = props;
-
+function AppContent({ Component, pageProps }) {
+  const nonce = useCspNonce();
 
   useEffect(() => {
     if (typeof window !== 'undefined' && typeof window.initA2HS === 'function') {
@@ -148,7 +148,7 @@ function MyApp(props) {
 
   return (
     <ErrorBoundary>
-      <Script src="/a2hs.js" strategy="beforeInteractive" />
+      <Script nonce={nonce} src="/a2hs.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
         <a
           href="#app-grid"
@@ -175,8 +175,16 @@ function MyApp(props) {
         </SettingsProvider>
       </div>
     </ErrorBoundary>
+  );
+}
 
+function MyApp(props) {
+  const { Component, pageProps, cspNonce } = props;
 
+  return (
+    <CspNonceProvider nonce={cspNonce}>
+      <AppContent Component={Component} pageProps={pageProps} />
+    </CspNonceProvider>
   );
 }
 

--- a/utils/csp.ts
+++ b/utils/csp.ts
@@ -1,6 +1,26 @@
-export function getCspNonce(): string | undefined {
+import { createContext, createElement, useContext } from 'react';
+import type { ReactNode } from 'react';
+
+const CspNonceContext = createContext<string | undefined>(undefined);
+
+type ProviderProps = {
+  children: ReactNode;
+  nonce?: string;
+};
+
+export function CspNonceProvider({ children, nonce }: ProviderProps) {
+  return createElement(CspNonceContext.Provider, { value: nonce }, children);
+}
+
+export function useCspNonce(): string | undefined {
+  const contextNonce = useContext(CspNonceContext);
+  if (contextNonce) {
+    return contextNonce;
+  }
+
   if (typeof document !== 'undefined') {
     return document.documentElement.dataset.cspNonce;
   }
+
   return undefined;
 }


### PR DESCRIPTION
## Summary
- update middleware to emit an x-nonce header and nonce-backed script CSP
- flow the nonce through _document and a new CspNonceProvider so inline scripts receive it
- extend jest setup and add coverage that exercises middleware and inline nonce usage

## Testing
- yarn test __tests__/cspNonce.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68c90314400c8328ab6ce59452bec5d4