### PR TITLE
[components] add segment aware top tabs

### DIFF
--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import Link from 'next/link';
+import { useSelectedLayoutSegment } from 'next/navigation';
+import type { ReactNode } from 'react';
+
+export type TopTab = {
+  /**
+   * Route segment that activates this tab. Use `null` for the default segment.
+   */
+  id: string | null;
+  /**
+   * Link destination for the tab.
+   */
+  href: string;
+  /**
+   * Visible label or content rendered inside the tab link.
+   */
+  label: ReactNode;
+  /**
+   * Optional additional classes scoped to this tab.
+   */
+  className?: string;
+};
+
+export interface TopTabsProps {
+  /**
+   * Collection of tabs to render across the top navigation.
+   */
+  tabs: readonly TopTab[];
+  /**
+   * Optional class names applied to the tabs container.
+   */
+  className?: string;
+  /**
+   * Classes shared by every tab instance.
+   */
+  tabClassName?: string;
+}
+
+export default function TopTabs({
+  tabs,
+  className = '',
+  tabClassName = '',
+}: TopTabsProps) {
+  const selectedSegment = useSelectedLayoutSegment();
+
+  return (
+    <nav className={className || undefined} aria-label="Top tabs">
+      {tabs.map((tab) => {
+        const isActive = selectedSegment === tab.id;
+        const key = tab.id ?? tab.href;
+        const combinedClassName = [
+          tabClassName,
+          tab.className,
+          isActive ? 'active' : '',
+        ]
+          .filter(Boolean)
+          .join(' ')
+          .trim();
+
+        return (
+          <Link
+            key={key}
+            href={tab.href}
+            className={combinedClassName || undefined}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce a reusable `TopTabs` component that maps navigation tabs to `next/link`
- track the selected layout segment to automatically apply an `active` class to the matching tab
- allow callers to supply shared and per-tab classes while keeping the current tab highlighted after navigation

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9030ee12883289e993c59fe8be4bf