### PR TITLE
[app] add modal intercepting route for files

### DIFF
--- a/app/@modal/(.)apps/files/preview/[id]/ModalShell.tsx
+++ b/app/@modal/(.)apps/files/preview/[id]/ModalShell.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useRef } from 'react';
+import type { ReactNode } from 'react';
+
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'area[href]',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'button:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable="true"]',
+].join(',');
+
+interface ModalShellProps {
+  children: ReactNode;
+  labelledBy?: string;
+}
+
+export default function ModalShell({ children, labelledBy }: ModalShellProps) {
+  const router = useRouter();
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => {
+    if (typeof window !== 'undefined' && window.history.length <= 1) {
+      router.push('/apps');
+      return;
+    }
+
+    router.back();
+  }, [router]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [close]);
+
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    dialogRef.current?.focus();
+    return () => {
+      previouslyFocused?.focus();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, []);
+
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Tab') return;
+
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const elements = dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+    if (!elements.length) {
+      event.preventDefault();
+      dialog.focus();
+      return;
+    }
+
+    const first = elements[0];
+    const last = elements[elements.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+
+    if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    } else if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    }
+  }, []);
+
+  return (
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 p-4 backdrop-blur"
+      onClick={close}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={labelledBy}
+        tabIndex={-1}
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={handleKeyDown}
+        className="relative w-full max-w-3xl overflow-hidden rounded-2xl border border-white/10 bg-[#0b1220] text-white shadow-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+      >
+        <button
+          type="button"
+          onClick={close}
+          className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring focus-visible:ring-cyan-300"
+          aria-label="Close preview"
+        >
+          <svg
+            className="h-4 w-4"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+          </svg>
+        </button>
+        <div className="max-h-[80vh] overflow-y-auto px-6 py-8" data-testid="modal-content">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/@modal/(.)apps/files/preview/[id]/page.tsx
+++ b/app/@modal/(.)apps/files/preview/[id]/page.tsx
@@ -1,0 +1,33 @@
+import { notFound } from 'next/navigation';
+import FilePreviewArticle from '@/app/apps/files/preview/_components/FilePreviewArticle';
+import {
+  filePreviewRecords,
+  getFilePreviewById,
+} from '@/data/files/previews';
+import ModalShell from './ModalShell';
+
+interface PageProps {
+  params: { id: string };
+}
+
+export function generateStaticParams() {
+  return filePreviewRecords.map((record) => ({ id: record.id }));
+}
+
+export default function FilePreviewModal({ params }: PageProps) {
+  const preview = getFilePreviewById(params.id);
+
+  if (!preview) {
+    notFound();
+  }
+
+  return (
+    <ModalShell labelledBy="file-preview-modal-heading">
+      <FilePreviewArticle
+        item={preview}
+        headingId="file-preview-modal-heading"
+        variant="modal"
+      />
+    </ModalShell>
+  );
+}

--- a/app/@modal/default.tsx
+++ b/app/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function ModalDefault() {
+  return null;
+}

--- a/app/apps/files/preview/[id]/page.tsx
+++ b/app/apps/files/preview/[id]/page.tsx
@@ -1,0 +1,73 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import FilePreviewArticle from '../_components/FilePreviewArticle';
+import {
+  filePreviewRecords,
+  getFilePreviewById,
+} from '@/data/files/previews';
+
+interface PageProps {
+  params: { id: string };
+}
+
+export function generateStaticParams() {
+  return filePreviewRecords.map((record) => ({ id: record.id }));
+}
+
+export function generateMetadata({ params }: PageProps): Metadata {
+  const preview = getFilePreviewById(params.id);
+  if (!preview) {
+    return {
+      title: 'File preview',
+    };
+  }
+
+  return {
+    title: `${preview.title} • Files preview`,
+    description: preview.summary,
+  };
+}
+
+export default function FilePreviewPage({ params }: PageProps) {
+  const preview = getFilePreviewById(params.id);
+
+  if (!preview) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-[#010409] via-[#020b1a] to-[#020617]">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-10 sm:px-6 lg:px-8">
+        <nav aria-label="Breadcrumb" className="flex items-center justify-between text-sm">
+          <Link
+            href="/apps"
+            className="inline-flex items-center gap-2 text-cyan-200 transition hover:text-cyan-100"
+          >
+            <svg
+              className="h-4 w-4"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+            </svg>
+            Back to desktop
+          </Link>
+          <span className="text-xs uppercase tracking-wide text-cyan-300">
+            Direct file preview
+          </span>
+        </nav>
+        <FilePreviewArticle item={preview} headingId="file-preview-title" />
+        <p className="text-xs text-gray-400">
+          Share this URL with collaborators to let them review the artifact without
+          opening the Files app. Press the browser back button to return to your
+          previous workspace.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/apps/files/preview/_components/FilePreviewArticle.tsx
+++ b/app/apps/files/preview/_components/FilePreviewArticle.tsx
@@ -1,0 +1,196 @@
+import Link from 'next/link';
+import type {
+  FilePreviewRecord,
+  PreviewBlock,
+} from '@/data/files/previews';
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+  timeZone: 'UTC',
+  timeZoneName: 'short',
+});
+
+function formatDate(iso: string) {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return dateFormatter.format(date);
+}
+
+function renderMarkdown(content: string, index: number) {
+  const lines = content.split('\n').filter(Boolean);
+  if (lines.length === 0) {
+    return null;
+  }
+
+  const headingLine = lines[0];
+  const title = headingLine.replace(/^\*\*/u, '').replace(/\*\*$/u, '');
+  const bulletLines = lines.slice(1).map((line) => line.replace(/^[-*]\s*/u, '').trim());
+
+  return (
+    <section key={`markdown-${index}`} aria-label={title} className="space-y-3">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-cyan-300">
+        {title}
+      </h3>
+      <ul className="space-y-2 text-sm text-gray-100">
+        {bulletLines.map((item, idx) => (
+          <li key={`md-${index}-${idx}`} className="flex items-start gap-3">
+            <span
+              aria-hidden
+              className="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-cyan-400"
+            />
+            <span className="flex-1 leading-relaxed">{item}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function renderBlock(block: PreviewBlock, index: number) {
+  switch (block.kind) {
+    case 'text':
+      return (
+        <p
+          key={`text-${index}`}
+          className="text-sm leading-relaxed text-gray-100 whitespace-pre-wrap"
+        >
+          {block.content}
+        </p>
+      );
+    case 'code':
+      if (block.language === 'markdown') {
+        return renderMarkdown(block.content, index);
+      }
+      return (
+        <pre
+          key={`code-${index}`}
+          className="overflow-auto rounded-xl border border-white/10 bg-black/40 p-4 text-xs text-gray-100 shadow-inner"
+        >
+          <code>{block.content}</code>
+        </pre>
+      );
+    case 'image':
+      return (
+        <figure
+          key={`image-${index}`}
+          className="overflow-hidden rounded-xl border border-white/10 bg-black/30 shadow-lg"
+        >
+          <img
+            src={block.src}
+            alt={block.alt}
+            className="w-full object-cover"
+            loading="lazy"
+          />
+          {block.caption ? (
+            <figcaption className="px-4 py-3 text-xs text-gray-300">
+              {block.caption}
+            </figcaption>
+          ) : null}
+        </figure>
+      );
+    default:
+      return null;
+  }
+}
+
+function MetadataGrid({
+  item,
+}: {
+  item: FilePreviewRecord;
+}) {
+  const metadataEntries: Array<[string, string]> = [
+    ['Collected', formatDate(item.createdAt)],
+    ['File size', item.size],
+    ...Object.entries(item.metadata),
+  ];
+
+  return (
+    <dl className="grid gap-4 border-b border-white/10 px-6 py-5 text-sm text-gray-100 sm:grid-cols-2">
+      {metadataEntries.map(([label, value]) => (
+        <div key={label} className="flex flex-col gap-1">
+          <dt className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+            {label}
+          </dt>
+          <dd className="font-medium text-white break-words">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function TagPills({ tags }: { tags: string[] }) {
+  if (!tags.length) return null;
+  return (
+    <ul className="mt-3 flex flex-wrap gap-2" aria-label="File tags">
+      {tags.map((tag) => (
+        <li key={tag}>
+          <span className="inline-flex items-center rounded-full border border-cyan-500/60 bg-cyan-500/10 px-3 py-1 text-xs font-medium uppercase tracking-wide text-cyan-200">
+            {tag}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+interface FilePreviewArticleProps {
+  item: FilePreviewRecord;
+  headingId?: string;
+  variant?: 'page' | 'modal';
+}
+
+export default function FilePreviewArticle({
+  item,
+  headingId,
+  variant = 'page',
+}: FilePreviewArticleProps) {
+  const heading = headingId ?? 'file-preview-heading';
+  const containerStyles =
+    variant === 'modal'
+      ? 'rounded-2xl border border-white/10 bg-[#0f172a] shadow-2xl'
+      : 'rounded-3xl border border-white/10 bg-[#0f172a] shadow-2xl backdrop-blur';
+
+  return (
+    <article className={`${containerStyles} overflow-hidden`}> 
+      <header className="border-b border-white/10 bg-white/5 px-6 pb-5 pt-6">
+        <div className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-300">
+          Evidence preview
+        </div>
+        <h1 id={heading} className="mt-2 text-2xl font-semibold text-white">
+          {item.title}
+        </h1>
+        <p className="mt-3 text-sm leading-relaxed text-gray-200">{item.summary}</p>
+        <TagPills tags={item.tags} />
+      </header>
+      <MetadataGrid item={item} />
+      <div className="space-y-6 px-6 py-6">{item.blocks.map(renderBlock)}</div>
+      {item.downloadUrl ? (
+        <footer className="border-t border-white/10 bg-white/5 px-6 py-4">
+          <Link
+            href={item.downloadUrl}
+            download
+            className="inline-flex items-center gap-2 rounded-lg bg-cyan-500 px-4 py-2 text-sm font-semibold text-black transition hover:bg-cyan-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-200"
+          >
+            <svg
+              className="h-4 w-4"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M7.5 12 12 16.5m0 0 4.5-4.5M12 16.5V3"
+              />
+            </svg>
+            Download raw artifact
+          </Link>
+        </footer>
+      ) : null}
+    </article>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+import { Ubuntu } from 'next/font/google';
+import '../styles/tailwind.css';
+import '../styles/globals.css';
+import '../styles/index.css';
+import '../styles/resume-print.css';
+import '../styles/print.css';
+import '@xterm/xterm/css/xterm.css';
+import 'leaflet/dist/leaflet.css';
+import type { ReactNode } from 'react';
+
+const ubuntu = Ubuntu({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '700'],
+});
+
+export const metadata: Metadata = {
+  title: 'Kali Linux Portfolio',
+  description:
+    'A desktop-style security lab and portfolio experience built with Next.js',
+};
+
+type RootLayoutProps = {
+  children: ReactNode;
+  modal: ReactNode;
+};
+
+export default function RootLayout({ children, modal }: RootLayoutProps) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${ubuntu.className} bg-[#020617] text-white`}>
+        {children}
+        {modal}
+      </body>
+    </html>
+  );
+}

--- a/data/files/previews.ts
+++ b/data/files/previews.ts
@@ -1,0 +1,134 @@
+export type PreviewBlock =
+  | { kind: 'text'; content: string }
+  | { kind: 'code'; content: string; language?: string }
+  | { kind: 'image'; src: string; alt: string; caption?: string };
+
+export interface FilePreviewRecord {
+  id: string;
+  title: string;
+  summary: string;
+  createdAt: string;
+  size: string;
+  tags: string[];
+  metadata: Record<string, string>;
+  blocks: PreviewBlock[];
+  downloadUrl?: string;
+}
+
+export const filePreviewRecords: FilePreviewRecord[] = [
+  {
+    id: 'chain-of-custody-log',
+    title: 'Chain of Custody Log – WKS-14',
+    summary:
+      'Immutable audit entries captured during the onsite collection of workstation WKS-14. Each acquisition was hashed twice and sealed before transport to the forensic lab.',
+    createdAt: '2025-02-19T17:22:00Z',
+    size: '2.7 KB',
+    tags: ['forensics', 'audit', 'chain-of-custody'],
+    metadata: {
+      'Collected by': 'Analyst R. Singh',
+      Location: 'Field Site: Portland Lab',
+      'Checksum (SHA-256)': '9d7c3a6f2fb1f3c7c8a01b6d115be6f0f5a0ee5c22cda3f249d2a589b942ed3b',
+      Sensitivity: 'Confidential',
+    },
+    blocks: [
+      {
+        kind: 'text',
+        content:
+          'Entries are written immediately after the evidence seal is applied. Any modification to the log regenerates the hash value and invalidates the signature, so downstream tooling should treat mismatches as tamper indicators.',
+      },
+      {
+        kind: 'code',
+        language: 'text',
+        content: `2025-02-19T17:22Z | Capture start | Device=WKS-14-SSD | Hash=9d7c3a6f2fb1...
+2025-02-19T17:46Z | Capture sealed | Seal-ID=23-0411A | Courier=F. Morales
+2025-02-20T03:12Z | Intake verified | Vault=PF-Locker-07 | Intact=true
+2025-02-20T11:08Z | Analysis checkout | Analyst=R. Singh | Purpose=Timeline build
+2025-02-20T18:42Z | Return to vault | Chain hash verified | Notes=No anomalies`,
+      },
+    ],
+    downloadUrl: '/demo-data/files/chain-of-custody-log.txt',
+  },
+  {
+    id: 'endpoint-memory-report',
+    title: 'Endpoint Memory Survey – Suspicious Processes',
+    summary:
+      'Triaged processes pulled from a live memory acquisition. Enrichment aggregates prevalence data from the internal threat feed.',
+    createdAt: '2025-03-04T09:18:00Z',
+    size: '4.1 KB',
+    tags: ['incident-response', 'memory', 'analysis'],
+    metadata: {
+      Hostname: 'ENG-LAP-552',
+      'Collection tool': 'Volatility 3 (profile: Win10x64_19044)',
+      'Sweep operator': 'Analyst L. Njoroge',
+      'SHA-256 archive': '3b1f0aa9745b7b9f5d4d8c6bd8510a4c8f4a6e2013f4f915b87a0fd8a38e9021',
+    },
+    blocks: [
+      {
+        kind: 'text',
+        content:
+          'Only processes lacking a baseline match or signed binary were escalated. Analysts should compare the prevalence score with the internal allow list before triggering containment.',
+      },
+      {
+        kind: 'code',
+        language: 'text',
+        content: `PID   NAME                SIGNED  PREVALENCE  NOTES
+4048  rundll32.exe        false   02/50       Spawned from Teams updater cache
+5320  msedge.exe          false   00/50       Injected thread present, see dump
+6124  powershell.exe      false   01/50       Encoded command launches cURL beacon
+7332  svchost.exe         true    48/50       Hosting PrintWorkflow (expected)
+9004  diagtrackrunner.exe false   00/50       File absent on gold image`,
+      },
+      {
+        kind: 'text',
+        content:
+          'Recommendation: capture a full disk image if the unsigned rundll32 persistence survives reboot. Memory strings point to a sideloaded DLL within the Teams cache directory.',
+      },
+    ],
+    downloadUrl: '/demo-data/files/endpoint-memory-report.txt',
+  },
+  {
+    id: 'phishing-lure-email',
+    title: 'Phishing Lure – Invoice Reconciliation Thread',
+    summary:
+      'Headers and message body extracted from the quarantined phishing attempt impersonating the finance department. Links resolve to a credential-harvesting clone.',
+    createdAt: '2025-03-12T14:06:00Z',
+    size: '3.4 KB',
+    tags: ['phishing', 'email', 'intel'],
+    metadata: {
+      Sender: '"Accounts Payable" <accounts@contoso-internal.com>',
+      Recipient: 'finance-notifications@unnippillil.com',
+      'Attachment hash': '5a9bba8bdc1ec0d5577ed2514d1b149e2d61b179355fea6b10d5f88ebbd4bb11',
+      Verdict: 'Malicious – credential harvest',
+    },
+    blocks: [
+      {
+        kind: 'code',
+        language: 'text',
+        content: `Received: from gateway02 by mail.unnippillil.com with ESMTPS id 84ad3
+DKIM-Signature: v=1; a=rsa-sha256; d=contoso-internal.com; s=mail;
+Subject: Re: Q1 invoice reconciliation outstanding
+From: "Accounts Payable" <accounts@contoso-internal.com>
+To: finance-notifications@unnippillil.com
+Date: Tue, 12 Mar 2025 14:05:33 +0000`,
+      },
+      {
+        kind: 'text',
+        content:
+          'The visible link text matches the finance SharePoint instance while the href resolves to hxxps://invoice-check[.]support. The web kit mirrors the corporate Okta login and sends credentials to an Azure Functions collector.',
+      },
+      {
+        kind: 'code',
+        language: 'markdown',
+        content: `**Analyst notes**
+- Attachment is a HTML smuggling payload with an embedded VBScript downloader.
+- Reported by user within 11 minutes – reward eligible.
+- Block list entry pushed to secure email gateway at 14:19 UTC.`,
+      },
+    ],
+    downloadUrl: '/demo-data/files/phishing-lure-email.txt',
+  },
+];
+
+export function getFilePreviewById(id: string): FilePreviewRecord | undefined {
+  return filePreviewRecords.find((record) => record.id === id);
+}

--- a/public/demo-data/files/chain-of-custody-log.txt
+++ b/public/demo-data/files/chain-of-custody-log.txt
@@ -1,0 +1,7 @@
+# Chain of Custody Log – WKS-14
+
+2025-02-19T17:22Z | Capture start | Device=WKS-14-SSD | Hash=9d7c3a6f2fb1f3c7c8a01b6d115be6f0f5a0ee5c22cda3f249d2a589b942ed3b
+2025-02-19T17:46Z | Capture sealed | Seal-ID=23-0411A | Courier=F. Morales
+2025-02-20T03:12Z | Intake verified | Vault=PF-Locker-07 | Intact=true
+2025-02-20T11:08Z | Analysis checkout | Analyst=R. Singh | Purpose=Timeline build
+2025-02-20T18:42Z | Return to vault | Chain hash verified | Notes=No anomalies

--- a/public/demo-data/files/endpoint-memory-report.txt
+++ b/public/demo-data/files/endpoint-memory-report.txt
@@ -1,0 +1,8 @@
+# Endpoint Memory Survey – Suspicious Processes
+
+PID   NAME                SIGNED  PREVALENCE  NOTES
+4048  rundll32.exe        false   02/50       Spawned from Teams updater cache
+5320  msedge.exe          false   00/50       Injected thread present, see dump
+6124  powershell.exe      false   01/50       Encoded command launches cURL beacon
+7332  svchost.exe         true    48/50       Hosting PrintWorkflow (expected)
+9004  diagtrackrunner.exe false   00/50       File absent on gold image

--- a/public/demo-data/files/phishing-lure-email.txt
+++ b/public/demo-data/files/phishing-lure-email.txt
@@ -1,0 +1,11 @@
+# Phishing Lure – Invoice Reconciliation Thread
+
+Received: from gateway02 by mail.unnippillil.com with ESMTPS id 84ad3
+DKIM-Signature: v=1; a=rsa-sha256; d=contoso-internal.com; s=mail;
+Subject: Re: Q1 invoice reconciliation outstanding
+From: "Accounts Payable" <accounts@contoso-internal.com>
+To: finance-notifications@unnippillil.com
+Date: Tue, 12 Mar 2025 14:05:33 +0000
+
+Visible link: https://sharepoint.contoso-internal.com/finance
+Actual link:  hxxps://invoice-check.support/login


### PR DESCRIPTION
## Summary
- add an app router root layout with a @modal slot to host intercepting routes
- build a reusable file preview article backed by new forensic sample data
- serve previews from both the standalone page and the modal intercepting route with accessible controls

## Testing
- yarn lint *(fails: repository has existing jsx-a11y and no-top-level-window violations)*
- yarn test --watch=false *(fails: existing suites such as window, nmapNse, reconng depend on browser APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68c9030e366c8328bf04ce8951bc3eec