### PR TITLE
[app] add app router not found pages

### DIFF
--- a/__tests__/not-found-pages.test.tsx
+++ b/__tests__/not-found-pages.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+
+import AppsNotFound from '../app/apps/not-found';
+import RootNotFound from '../app/not-found';
+
+describe('App Router not-found pages', () => {
+  it('links back to the desktop from the root not found page', () => {
+    render(<RootNotFound />);
+    const link = screen.getByRole('link', { name: /return to desktop/i });
+
+    expect(link).toHaveAttribute('href', '/');
+  });
+
+  it('links to the app launcher from the apps not found page', () => {
+    render(<AppsNotFound />);
+    const link = screen.getByRole('link', { name: /browse apps/i });
+
+    expect(link).toHaveAttribute('href', '/apps');
+  });
+});

--- a/app/apps/not-found.tsx
+++ b/app/apps/not-found.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 p-6 text-center">
+      <h1 className="text-3xl font-semibold">App not found</h1>
+      <p className="max-w-xl text-base text-slate-600 dark:text-slate-300">
+        We couldn&apos;t open that workspace. Explore the launcher to find available tools, games, and utilities in the
+        portfolio.
+      </p>
+      <Link
+        href="/apps"
+        className="rounded bg-slate-100 px-4 py-2 text-sm font-medium text-slate-900 transition hover:bg-slate-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+      >
+        Browse apps
+      </Link>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import Script from 'next/script';
+import { Ubuntu } from 'next/font/google';
+
+import '../styles/tailwind.css';
+import '../styles/globals.css';
+import '../styles/index.css';
+import '../styles/resume-print.css';
+import '../styles/print.css';
+import '@xterm/xterm/css/xterm.css';
+import 'leaflet/dist/leaflet.css';
+
+const ubuntu = Ubuntu({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '700'],
+  display: 'swap',
+});
+
+export const metadata: Metadata = {
+  title: {
+    default: 'Kali Linux Portfolio',
+    template: '%s | Kali Linux Portfolio',
+  },
+  description: 'Desktop-style portfolio featuring security tool simulations, utilities, and retro games.',
+  manifest: '/manifest.webmanifest',
+  themeColor: '#0f1317',
+  icons: {
+    icon: '/favicon.ico',
+  },
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={ubuntu.className}>
+        <Script src="/theme.js" strategy="beforeInteractive" />
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 p-6 text-center">
+      <h1 className="text-3xl font-semibold">Page not found</h1>
+      <p className="max-w-xl text-base text-slate-600 dark:text-slate-300">
+        The window you are looking for has been closed or never existed. Return to the desktop to open another
+        experience.
+      </p>
+      <Link
+        href="/"
+        className="rounded bg-slate-100 px-4 py-2 text-sm font-medium text-slate-900 transition hover:bg-slate-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+      >
+        Return to desktop
+      </Link>
+    </div>
+  );
+}

--- a/pages/apps/[...slug].tsx
+++ b/pages/apps/[...slug].tsx
@@ -1,0 +1,15 @@
+import type { GetServerSideProps } from 'next';
+
+import AppsNotFound from '../../app/apps/not-found';
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  if (res) {
+    res.statusCode = 404;
+  }
+
+  return { props: {} };
+};
+
+export default function AppsCatchAllNotFound() {
+  return <AppsNotFound />;
+}


### PR DESCRIPTION
## Summary
- add a root-level App Router not-found page that links back to the desktop
- provide an apps area not-found view and reuse it for unmatched /apps routes
- supply an app/ layout that loads global styles, theme script, and metadata for the new routes

## Testing
- yarn test not-found-pages.test.tsx
- yarn lint *(fails: existing accessibility lint errors in legacy apps and static assets)*
- curl -sS http://localhost:3000/does-not-exist | grep -o 'Return to desktop'
- curl -sS http://localhost:3000/apps/does-not-exist | grep -o 'Browse apps'

------
https://chatgpt.com/codex/tasks/task_e_68c9030dc7d48328abf8cdd6454c43e2