### PR TITLE
[terminal] Add visual bell flash

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -77,3 +77,22 @@ html[data-theme='matrix'] {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
+
+.visual-bell {
+  animation: visual-bell-flash 150ms ease-in-out;
+}
+
+@keyframes visual-bell-flash {
+  0% {
+    box-shadow: 0 0 0 0 rgba(23, 147, 209, 0);
+  }
+
+  45% {
+    box-shadow: 0 0 0 4px rgba(23, 147, 209, 0.65),
+      0 0 12px rgba(23, 147, 209, 0.55);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(23, 147, 209, 0);
+  }
+}


### PR DESCRIPTION
## Summary
- add a visual bell timer and helper that toggles a CSS class on the terminal container when BEL is received
- hook the class toggle to xterm's bell event with a graceful fallback that inspects writes when the event is unavailable
- define a `.visual-bell` animation that produces a short border glow to surface BEL even with audio/haptics disabled

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations in unrelated apps)*
- yarn test *(fails: existing accessibility and jsdom localStorage issues in unrelated suites)*
- yarn test --runTestsByPath __tests__/terminal.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68c90306846c8328a54992638e0489d7