### PR TITLE
[core] centralize OPFS download helper

### DIFF
--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import useOPFS from '../../hooks/useOPFS';
 import { getDb } from '../../utils/safeIDB';
 import Breadcrumbs from '../ui/Breadcrumbs';
+import { downloadBlob } from '../../lib/download';
 
 export async function openFileDialog(options = {}) {
   if (typeof window !== 'undefined' && window.showOpenFilePicker) {
@@ -46,12 +47,7 @@ export async function saveFileDialog(options = {}) {
       return {
         async write(data) {
           const blob = data instanceof Blob ? data : new Blob([data]);
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement('a');
-          a.href = url;
-          a.download = options?.suggestedName || 'download';
-          a.click();
-          URL.revokeObjectURL(url);
+          downloadBlob(options?.suggestedName || 'download', blob);
         },
         async close() {},
       };

--- a/lib/download.ts
+++ b/lib/download.ts
@@ -1,0 +1,18 @@
+export function downloadBlob(name: string, blob: Blob): void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = name;
+
+  try {
+    document.body.appendChild(link);
+    link.click();
+  } finally {
+    link.remove();
+    URL.revokeObjectURL(url);
+  }
+}


### PR DESCRIPTION
## Summary
- add a `downloadBlob` utility for blob downloads that revokes the object URL
- update the file explorer OPFS fallback writer to reuse the shared helper

## Testing
- `yarn lint` *(fails: repository currently has many existing accessibility lint violations)*
- `yarn test` *(fails: several pre-existing unit tests already failing in the main branch)*

------
https://chatgpt.com/codex/tasks/task_e_68c902fd963c832889efb5560122ec2e