### PR TITLE
[terminal] add upload command

### DIFF
--- a/apps/terminal/commands/index.ts
+++ b/apps/terminal/commands/index.ts
@@ -1,4 +1,5 @@
 import type { CommandHandler, CommandContext } from './types';
+import cmdUpload from './upload';
 
 async function man(args: string, ctx: CommandContext) {
   const name = args.trim();
@@ -41,6 +42,7 @@ const registry: Record<string, CommandHandler> = {
   man,
   history,
   alias,
+  upload: cmdUpload,
   cat: (args, ctx) => ctx.runWorker(`cat ${args}`),
   grep: (args, ctx) => ctx.runWorker(`grep ${args}`),
   jq: (args, ctx) => ctx.runWorker(`jq ${args}`),

--- a/apps/terminal/commands/upload.ts
+++ b/apps/terminal/commands/upload.ts
@@ -1,0 +1,85 @@
+import type { CommandContext } from './types';
+
+type SaveData = Blob | ArrayBuffer | ArrayBufferView | string;
+
+type ShowOpenFilePicker = (
+  options?: OpenFilePickerOptions,
+) => Promise<FileSystemFileHandle[]>;
+
+interface FilePickerWindow extends Window {
+  showOpenFilePicker?: ShowOpenFilePicker;
+}
+
+export async function saveToOPFS(path: string, data: SaveData): Promise<void> {
+  if (
+    typeof navigator === 'undefined' ||
+    !navigator.storage ||
+    typeof navigator.storage.getDirectory !== 'function'
+  ) {
+    throw new Error('OPFS not supported');
+  }
+
+  const segments = path
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  if (!segments.length) {
+    throw new Error('Invalid path');
+  }
+
+  const fileName = segments.pop();
+  if (!fileName) throw new Error('Invalid path');
+
+  const root = await navigator.storage.getDirectory();
+  let dir: FileSystemDirectoryHandle = root;
+
+  for (const segment of segments) {
+    dir = await dir.getDirectoryHandle(segment, { create: true });
+  }
+
+  const handle = await dir.getFileHandle(fileName, { create: true });
+  const writable = await handle.createWritable();
+
+  await writable.write(data);
+  await writable.close();
+}
+
+export async function cmdUpload(
+  _args: string,
+  ctx: CommandContext,
+): Promise<void> {
+  if (typeof window === 'undefined') {
+    ctx.writeLine('Upload is only available in the browser.');
+    return;
+  }
+
+  const picker = (window as FilePickerWindow).showOpenFilePicker;
+  if (!picker) {
+    ctx.writeLine('File picker not supported in this browser.');
+    return;
+  }
+
+  try {
+    const [fileHandle] = await picker({ multiple: false });
+    if (!fileHandle) {
+      ctx.writeLine('No file selected.');
+      return;
+    }
+
+    const file = await fileHandle.getFile();
+    await saveToOPFS(`Downloads/${file.name}`, file);
+
+    ctx.writeLine(`Saved ${file.name} to Downloads/${file.name}`);
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      ctx.writeLine('Upload cancelled.');
+      return;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    ctx.writeLine(`Upload failed: ${message}`);
+  }
+}
+
+export default cmdUpload;


### PR DESCRIPTION
## Summary
- add an `upload` terminal command that opens the browser file picker
- save the selected file into OPFS under Downloads via a helper and report the result
- register the new command in the terminal command registry

## Testing
- `yarn lint` *(fails: repository has numerous pre-existing accessibility and lint errors unrelated to this change)*
- `yarn test --watch=false` *(fails: existing test suites fail with act warnings, localStorage access in jsdom, and other pre-existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c902fd03088328a2a7530878da2ea2