### PR TITLE
[terminal] add find overlay

### DIFF
--- a/__tests__/terminal-find-overlay.test.tsx
+++ b/__tests__/terminal-find-overlay.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import FindOverlay, { HIGHLIGHT_CLASS } from '../apps/terminal/FindOverlay';
+
+describe('Terminal find overlay', () => {
+  const setup = () =>
+    render(
+      <div>
+        <div className="term-line">alpha entry</div>
+        <div className="term-line">beta entry</div>
+        <FindOverlay />
+      </div>,
+    );
+
+  it('toggles the overlay with Ctrl+F', () => {
+    const { queryByPlaceholderText } = setup();
+
+    expect(queryByPlaceholderText('Find...')).toBeNull();
+
+    fireEvent.keyDown(window, { key: 'f', ctrlKey: true });
+    expect(queryByPlaceholderText('Find...')).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'f', ctrlKey: true });
+    expect(queryByPlaceholderText('Find...')).toBeNull();
+  });
+
+  it('clears highlights when the query is emptied', () => {
+    const { container, getByPlaceholderText } = setup();
+    const [firstLine, secondLine] = container.querySelectorAll('.term-line');
+
+    fireEvent.keyDown(window, { key: 'f', ctrlKey: true });
+    const input = getByPlaceholderText('Find...') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: 'alpha' } });
+    expect(firstLine?.classList.contains(HIGHLIGHT_CLASS)).toBe(true);
+    expect(secondLine?.classList.contains(HIGHLIGHT_CLASS)).toBe(false);
+
+    fireEvent.change(input, { target: { value: '' } });
+    expect(firstLine?.classList.contains(HIGHLIGHT_CLASS)).toBe(false);
+    expect(secondLine?.classList.contains(HIGHLIGHT_CLASS)).toBe(false);
+  });
+});

--- a/apps/terminal/FindOverlay.tsx
+++ b/apps/terminal/FindOverlay.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+export const HIGHLIGHT_CLASS = 'term-line-highlight';
+
+const highlightLines = (query: string) => {
+  const normalized = query.trim().toLowerCase();
+  const lines = Array.from(
+    document.querySelectorAll<HTMLElement>('.term-line'),
+  );
+  lines.forEach((line) => {
+    const content = line.textContent?.toLowerCase() ?? '';
+    const shouldHighlight = normalized.length > 0 && content.includes(normalized);
+    if (shouldHighlight) {
+      if (!line.classList.contains(HIGHLIGHT_CLASS)) {
+        line.classList.add(HIGHLIGHT_CLASS);
+      }
+      line.setAttribute('data-term-highlight', 'true');
+    } else {
+      line.classList.remove(HIGHLIGHT_CLASS);
+      line.removeAttribute('data-term-highlight');
+    }
+  });
+};
+
+const FindOverlay: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const closeOverlay = useCallback(() => {
+    setOpen(false);
+    setQuery('');
+    highlightLines('');
+  }, []);
+
+  useEffect(() => {
+    highlightLines(query);
+  }, [query]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.ctrlKey && event.key.toLowerCase() === 'f') {
+        event.preventDefault();
+        setOpen((prev) => {
+          const next = !prev;
+          if (next) {
+            window.setTimeout(() => {
+              inputRef.current?.focus();
+              inputRef.current?.select();
+            }, 0);
+          } else {
+            highlightLines('');
+            setQuery('');
+          }
+          return next;
+        });
+      } else if (event.key === 'Escape' && open) {
+        event.preventDefault();
+        closeOverlay();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [closeOverlay, open]);
+
+  useEffect(() => () => highlightLines(''), []);
+
+  return (
+    <>
+      {open && (
+        <div className="absolute right-2 top-2 z-20 flex items-center gap-2 rounded bg-gray-900/95 p-2 text-sm text-white shadow-lg">
+          <label className="flex items-center gap-2" htmlFor="terminal-find-input">
+            <span className="sr-only">Search terminal output</span>
+            <input
+              id="terminal-find-input"
+              ref={inputRef}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              className="w-48 rounded bg-gray-800 px-2 py-1 text-white outline-none"
+              placeholder="Find..."
+              aria-label="Find in terminal"
+            />
+          </label>
+          {query && (
+            <button
+              type="button"
+              className="rounded bg-gray-700 px-2 py-1 text-xs uppercase tracking-wide"
+              onClick={() => setQuery('')}
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      )}
+      <style jsx global>{`
+        .term-line.${HIGHLIGHT_CLASS} {
+          background-color: rgba(23, 147, 209, 0.35);
+        }
+      `}</style>
+    </>
+  );
+};
+
+export default FindOverlay;

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -11,6 +11,7 @@ import React, {
 import useOPFS from '../../hooks/useOPFS';
 import commandRegistry, { CommandContext } from './commands';
 import TerminalContainer from './components/Terminal';
+import FindOverlay from './FindOverlay';
 
 const CopyIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg
@@ -80,7 +81,6 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<any>(null);
   const fitRef = useRef<any>(null);
-  const searchRef = useRef<any>(null);
   const commandRef = useRef('');
   const contentRef = useRef('');
   const registryRef = useRef(commandRegistry);
@@ -296,10 +296,9 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
   useEffect(() => {
     let disposed = false;
     (async () => {
-      const [{ Terminal: XTerm }, { FitAddon }, { SearchAddon }] = await Promise.all([
+      const [{ Terminal: XTerm }, { FitAddon }] = await Promise.all([
         import('@xterm/xterm'),
         import('@xterm/addon-fit'),
-        import('@xterm/addon-search'),
       ]);
       await import('@xterm/xterm/css/xterm.css');
       if (disposed) return;
@@ -316,12 +315,9 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
         },
       });
       const fit = new FitAddon();
-      const search = new SearchAddon();
       termRef.current = term;
       fitRef.current = fit;
-      searchRef.current = search;
       term.loadAddon(fit);
-      term.loadAddon(search);
       term.open(containerRef.current!);
       fit.fit();
       term.focus();
@@ -348,10 +344,6 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
         if (domEvent.key === 'Tab') {
           domEvent.preventDefault();
           autocomplete();
-        } else if (domEvent.ctrlKey && domEvent.key === 'f') {
-          domEvent.preventDefault();
-          const q = window.prompt('Search');
-          if (q) searchRef.current?.findNext(q);
         } else if (domEvent.ctrlKey && domEvent.key === 'r') {
           domEvent.preventDefault();
           const q = window.prompt('Search history');
@@ -412,6 +404,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
 
   return (
     <div className="relative h-full w-full">
+      <FindOverlay />
       {paletteOpen && (
         <div className="absolute inset-0 bg-black bg-opacity-75 flex items-start justify-center z-10">
           <div className="mt-10 w-80 bg-gray-800 p-4 rounded">


### PR DESCRIPTION
## Summary
- add a terminal find overlay that highlights matching `.term-line` entries
- integrate the overlay into the terminal UI and remove the old prompt-based search
- cover the overlay behaviour with tests for toggling and clearing highlights

## Testing
- yarn test __tests__/terminal-find-overlay.test.tsx
- yarn test *(fails: existing nmap NSE alert expectation)*
- yarn lint *(fails: repository-wide accessibility lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c902f4e7988328ae01c24899e19221