### PR TITLE
[settings] add export/import component

### DIFF
--- a/apps/settings/export.tsx
+++ b/apps/settings/export.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { ChangeEvent, useRef } from "react";
+import { useSettings } from "../../hooks/useSettings";
+import {
+  exportSettings as exportSettingsData,
+  importSettings as importSettingsData,
+} from "../../utils/settingsStore";
+
+type Density = "regular" | "compact";
+
+interface SettingsPayload {
+  accent?: unknown;
+  wallpaper?: unknown;
+  density?: unknown;
+  reducedMotion?: unknown;
+  fontScale?: unknown;
+  highContrast?: unknown;
+  largeHitAreas?: unknown;
+  pongSpin?: unknown;
+  allowNetwork?: unknown;
+  haptics?: unknown;
+  theme?: unknown;
+}
+
+const isDensity = (value: unknown): value is Density =>
+  value === "regular" || value === "compact";
+
+const download = (content: string, filename: string) => {
+  const blob = new Blob([content], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+export default function ExportSettings() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const {
+    setAccent,
+    setWallpaper,
+    setDensity,
+    setReducedMotion,
+    setFontScale,
+    setHighContrast,
+    setLargeHitAreas,
+    setPongSpin,
+    setAllowNetwork,
+    setHaptics,
+    setTheme,
+  } = useSettings();
+
+  const applySettings = (settings: SettingsPayload) => {
+    if (typeof settings.accent === "string") setAccent(settings.accent);
+    if (typeof settings.wallpaper === "string") setWallpaper(settings.wallpaper);
+    if (isDensity(settings.density)) setDensity(settings.density);
+    if (typeof settings.reducedMotion === "boolean")
+      setReducedMotion(settings.reducedMotion);
+    if (typeof settings.fontScale === "number" && Number.isFinite(settings.fontScale))
+      setFontScale(settings.fontScale);
+    if (typeof settings.highContrast === "boolean")
+      setHighContrast(settings.highContrast);
+    if (typeof settings.largeHitAreas === "boolean")
+      setLargeHitAreas(settings.largeHitAreas);
+    if (typeof settings.pongSpin === "boolean") setPongSpin(settings.pongSpin);
+    if (typeof settings.allowNetwork === "boolean")
+      setAllowNetwork(settings.allowNetwork);
+    if (typeof settings.haptics === "boolean") setHaptics(settings.haptics);
+    if (typeof settings.theme === "string") setTheme(settings.theme);
+  };
+
+  const handleExport = async () => {
+    const data = await exportSettingsData();
+    download(data, "kali-settings.json");
+  };
+
+  const handleImport = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      const parsed: SettingsPayload = JSON.parse(text);
+      await importSettingsData(parsed);
+      applySettings(parsed);
+    } catch (error) {
+      console.error("Failed to import settings", error);
+    } finally {
+      event.target.value = "";
+    }
+  };
+
+  return (
+    <>
+      <div className="flex justify-center my-4 space-x-4">
+        <button
+          onClick={handleExport}
+          className="px-4 py-2 rounded bg-ub-orange text-white"
+        >
+          Export Settings
+        </button>
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          className="px-4 py-2 rounded bg-ub-orange text-white"
+        >
+          Import Settings
+        </button>
+      </div>
+      <input
+        type="file"
+        accept="application/json"
+        ref={fileInputRef}
+        aria-label="Import settings file"
+        onChange={handleImport}
+        className="hidden"
+      />
+    </>
+  );
+}

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,17 +1,16 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
   resetSettings,
   defaults,
-  exportSettings as exportSettingsData,
-  importSettings as importSettingsData,
 } from "../../utils/settingsStore";
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import ExportSettings from "./export";
 
 export default function Settings() {
   const {
@@ -32,8 +31,6 @@ export default function Settings() {
     theme,
     setTheme,
   } = useSettings();
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
   const tabs = [
     { id: "appearance", label: "Appearance" },
     { id: "accessibility", label: "Accessibility" },
@@ -54,36 +51,6 @@ export default function Settings() {
   ];
 
   const changeBackground = (name: string) => setWallpaper(name);
-
-  const handleExport = async () => {
-    const data = await exportSettingsData();
-    const blob = new Blob([data], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "settings.json";
-    a.click();
-    URL.revokeObjectURL(url);
-  };
-
-  const handleImport = async (file: File) => {
-    const text = await file.text();
-    await importSettingsData(text);
-    try {
-      const parsed = JSON.parse(text);
-      if (parsed.accent !== undefined) setAccent(parsed.accent);
-      if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
-      if (parsed.density !== undefined) setDensity(parsed.density);
-      if (parsed.reducedMotion !== undefined)
-        setReducedMotion(parsed.reducedMotion);
-      if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
-      if (parsed.highContrast !== undefined)
-        setHighContrast(parsed.highContrast);
-      if (parsed.theme !== undefined) setTheme(parsed.theme);
-    } catch (err) {
-      console.error("Invalid settings", err);
-    }
-  };
 
   const handleReset = async () => {
     if (
@@ -270,36 +237,7 @@ export default function Settings() {
           </div>
         </>
       )}
-      {activeTab === "privacy" && (
-        <>
-          <div className="flex justify-center my-4 space-x-4">
-            <button
-              onClick={handleExport}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Export Settings
-            </button>
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Import Settings
-            </button>
-          </div>
-        </>
-      )}
-        <input
-          type="file"
-          accept="application/json"
-          ref={fileInputRef}
-          aria-label="Import settings file"
-          onChange={(e) => {
-            const file = e.target.files && e.target.files[0];
-            if (file) handleImport(file);
-            e.target.value = "";
-          }}
-          className="hidden"
-        />
+      {activeTab === "privacy" && <ExportSettings />}
       <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
     </div>
   );


### PR DESCRIPTION
## Summary
- add dedicated settings export component that downloads the kali-settings.json backup
- reuse the component in the settings privacy tab and apply imported values to the active session

## Testing
- yarn lint *(fails: existing accessibility and lint violations in unrelated files)*
- yarn test *(fails: existing jest failures in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c902e436208328b24010a58cfd1661