### PR TITLE
[settings] Add storage usage panel

### DIFF
--- a/__tests__/StoragePanel.test.tsx
+++ b/__tests__/StoragePanel.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import StoragePanel from '../apps/settings/storage/StoragePanel';
+
+const mebibyte = 1024 * 1024;
+const originalStorage = (navigator as any).storage;
+
+describe('StoragePanel', () => {
+  afterEach(() => {
+    if (originalStorage === undefined) {
+      delete (navigator as any).storage;
+    } else {
+      Object.defineProperty(navigator, 'storage', {
+        configurable: true,
+        value: originalStorage,
+      });
+    }
+    jest.clearAllMocks();
+  });
+
+  it('renders fallback when the Storage API is unavailable', () => {
+    delete (navigator as any).storage;
+    render(<StoragePanel />);
+    expect(
+      screen.getByText(/Storage information is not available/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows usage and quota in MiB', async () => {
+    const estimate = jest.fn().mockResolvedValue({
+      usage: 2 * mebibyte,
+      quota: 10 * mebibyte,
+    });
+    Object.defineProperty(navigator, 'storage', {
+      configurable: true,
+      value: { estimate },
+    });
+
+    render(<StoragePanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('storage-usage')).toHaveTextContent('2.00 MiB');
+      expect(screen.getByTestId('storage-quota')).toHaveTextContent('10.00 MiB');
+    });
+
+    expect(estimate).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates when a storage event is dispatched', async () => {
+    const estimate = jest
+      .fn()
+      .mockResolvedValueOnce({ usage: 1 * mebibyte, quota: 4 * mebibyte })
+      .mockResolvedValueOnce({ usage: 3 * mebibyte, quota: 5 * mebibyte });
+
+    Object.defineProperty(navigator, 'storage', {
+      configurable: true,
+      value: { estimate },
+    });
+
+    render(<StoragePanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('storage-usage')).toHaveTextContent('1.00 MiB');
+    });
+
+    window.dispatchEvent(new StorageEvent('storage'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('storage-usage')).toHaveTextContent(
+        '3.00 MiB'
+      );
+      expect(screen.getByTestId('storage-quota')).toHaveTextContent(
+        '5.00 MiB'
+      );
+    });
+
+    expect(estimate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import StoragePanel from "./storage/StoragePanel";
 
 export default function Settings() {
   const {
@@ -285,6 +286,9 @@ export default function Settings() {
             >
               Import Settings
             </button>
+          </div>
+          <div className="px-4 pb-4">
+            <StoragePanel />
           </div>
         </>
       )}

--- a/apps/settings/storage/StoragePanel.tsx
+++ b/apps/settings/storage/StoragePanel.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const BYTES_PER_MEBIBYTE = 1024 * 1024;
+
+const formatMebibytes = (formatter: Intl.NumberFormat, bytes: number) =>
+  `${formatter.format(bytes / BYTES_PER_MEBIBYTE)} MiB`;
+
+const hasStorageEstimate = () =>
+  typeof navigator !== "undefined" &&
+  Boolean(navigator.storage && navigator.storage.estimate);
+
+export default function StoragePanel() {
+  const [usage, setUsage] = useState(0);
+  const [quota, setQuota] = useState(0);
+  const [supported, setSupported] = useState(hasStorageEstimate);
+  const mounted = useRef(false);
+
+  const updateEstimate = useCallback(async () => {
+    if (typeof navigator === "undefined" || !navigator.storage?.estimate) {
+      if (mounted.current) {
+        setSupported(false);
+        setUsage(0);
+        setQuota(0);
+      }
+      return;
+    }
+
+    try {
+      const { usage: nextUsage = 0, quota: nextQuota = 0 } =
+        (await navigator.storage.estimate()) ?? {};
+
+      if (!mounted.current) return;
+
+      setSupported(true);
+      setUsage(nextUsage);
+      setQuota(nextQuota);
+    } catch {
+      if (!mounted.current) return;
+
+      setSupported(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    mounted.current = true;
+
+    void updateEstimate();
+
+    if (typeof window === "undefined") {
+      return () => {
+        mounted.current = false;
+      };
+    }
+
+    const handleStorageChange = () => {
+      void updateEstimate();
+    };
+
+    window.addEventListener("storage", handleStorageChange);
+
+    return () => {
+      mounted.current = false;
+      window.removeEventListener("storage", handleStorageChange);
+    };
+  }, [updateEstimate]);
+
+  const formatter = useMemo(
+    () =>
+      new Intl.NumberFormat(undefined, {
+        maximumFractionDigits: 2,
+        minimumFractionDigits: 2,
+      }),
+    []
+  );
+
+  if (!supported) {
+    return (
+      <section
+        aria-live="polite"
+        className="rounded border border-gray-900 bg-ub-cool-grey p-4 text-ubt-grey"
+      >
+        <h2 className="text-lg font-semibold text-white">Storage Usage</h2>
+        <p className="mt-2">
+          Storage information is not available in this environment.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-live="polite"
+      className="rounded border border-gray-900 bg-ub-cool-grey p-4 text-ubt-grey"
+    >
+      <h2 className="text-lg font-semibold text-white">Storage Usage</h2>
+      <dl className="mt-3 space-y-2 text-sm">
+        <div className="flex items-center justify-between">
+          <dt>Usage</dt>
+          <dd data-testid="storage-usage" className="font-mono text-white">
+            {formatMebibytes(formatter, usage)}
+          </dd>
+        </div>
+        <div className="flex items-center justify-between">
+          <dt>Quota</dt>
+          <dd data-testid="storage-quota" className="font-mono text-white">
+            {formatMebibytes(formatter, quota)}
+          </dd>
+        </div>
+      </dl>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a storage panel to the Settings privacy tab
- surface navigator.storage.estimate() usage/quota values in MiB and react to storage events
- cover the new behaviour with a StoragePanel test suite

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label and no-top-level-window errors in unrelated files)*
- yarn test StoragePanel.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c902d4253c83288c9a4dcecf0d1e25