### PR TITLE
[pwa] add install prompt component

### DIFF
--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+  prompt(): Promise<void>;
+}
+
+const InstallPrompt: React.FC = () => {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+
+  useEffect(() => {
+    const handleBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault();
+      setDeferredPrompt(event as BeforeInstallPromptEvent);
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    };
+  }, []);
+
+  const handleClick = async () => {
+    if (!deferredPrompt) return;
+
+    const promptEvent = deferredPrompt;
+    setDeferredPrompt(null);
+    try {
+      await promptEvent.prompt();
+      await promptEvent.userChoice;
+    } catch (error) {
+      // Ignore prompt errors; user dismissed or prompt is unsupported.
+    }
+  };
+
+  if (!deferredPrompt) {
+    return null;
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      className="fixed bottom-4 right-4 bg-ubt-blue text-white px-3 py-1 rounded shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ubt-blue"
+    >
+      Install
+    </button>
+  );
+};
+
+export default InstallPrompt;

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -13,10 +13,10 @@ const Ubuntu = dynamic(
     loading: () => <p>Loading Ubuntu...</p>,
   }
 );
-const InstallButton = dynamic(
+const InstallPrompt = dynamic(
   () =>
-    import('../components/InstallButton').catch((err) => {
-      console.error('Failed to load InstallButton component', err);
+    import('../components/InstallPrompt').catch((err) => {
+      console.error('Failed to load InstallPrompt component', err);
       throw err;
     }),
   {
@@ -36,7 +36,7 @@ const App = () => (
     <Meta />
     <Ubuntu />
     <BetaBadge />
-    <InstallButton />
+    <InstallPrompt />
   </>
 );
 


### PR DESCRIPTION
## Summary
- add a client-side InstallPrompt component that caches the `beforeinstallprompt` event and drives the install prompt on demand
- switch the home page dynamic import to use the new install prompt component

## Testing
- yarn lint *(fails: existing repository lint errors unrelated to this change)*
- yarn test *(fails: existing repository test failures unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c902d363988328927866d285e6c341