### PR TITLE
[opfs] add helper for saving data

### DIFF
--- a/__tests__/opfs.test.ts
+++ b/__tests__/opfs.test.ts
@@ -1,0 +1,198 @@
+import { saveToOPFS, readFromOPFS } from '../lib/opfs';
+
+type DirectoryNode = {
+  kind: 'directory';
+  entries: Map<string, DirectoryNode | FileNode>;
+};
+
+type FileNode = {
+  kind: 'file';
+  data: string;
+};
+
+type OPFSStorageMock = {
+  root: DirectoryNode;
+  storageManager: StorageManager & {
+    getDirectory: () => Promise<FileSystemDirectoryHandle>;
+  };
+};
+
+function createDirectoryNode(): DirectoryNode {
+  return { kind: 'directory', entries: new Map() };
+}
+
+function createFileNode(initialData = ''): FileNode {
+  return { kind: 'file', data: initialData };
+}
+
+function createWritableStream(node: FileNode): FileSystemWritableFileStream {
+  return {
+    async write(chunk: unknown) {
+      if (typeof chunk === 'string') {
+        node.data = chunk;
+      } else if (chunk instanceof Blob) {
+        node.data = await chunk.text();
+      } else if (chunk instanceof ArrayBuffer) {
+        node.data = new TextDecoder().decode(chunk);
+      } else if (ArrayBuffer.isView(chunk)) {
+        const view = chunk as ArrayBufferView;
+        const buffer = view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength);
+        node.data = new TextDecoder().decode(buffer);
+      } else if (chunk) {
+        node.data = String(chunk);
+      } else {
+        node.data = '';
+      }
+    },
+    async close() {
+      return;
+    },
+  } as FileSystemWritableFileStream;
+}
+
+function createFileHandle(node: FileNode): FileSystemFileHandle {
+  return {
+    kind: 'file',
+    async getFile() {
+      return {
+        async text() {
+          return node.data;
+        },
+      } as File;
+    },
+    async createWritable() {
+      return createWritableStream(node);
+    },
+  } as FileSystemFileHandle;
+}
+
+function createDirectoryHandle(node: DirectoryNode): FileSystemDirectoryHandle {
+  return {
+    kind: 'directory',
+    async getDirectoryHandle(name: string, options: any = {}) {
+      const { create = false } = options;
+      const existing = node.entries.get(name);
+      if (existing) {
+        if (existing.kind !== 'directory') {
+          throw new TypeError(`Entry "${name}" is not a directory.`);
+        }
+        return createDirectoryHandle(existing);
+      }
+      if (!create) {
+        throw new Error(`Directory "${name}" does not exist.`);
+      }
+      const child = createDirectoryNode();
+      node.entries.set(name, child);
+      return createDirectoryHandle(child);
+    },
+    async getFileHandle(name: string, options: any = {}) {
+      const { create = false } = options;
+      const existing = node.entries.get(name);
+      if (existing) {
+        if (existing.kind !== 'file') {
+          throw new TypeError(`Entry "${name}" is not a file.`);
+        }
+        return createFileHandle(existing);
+      }
+      if (!create) {
+        throw new Error(`File "${name}" does not exist.`);
+      }
+      const fileNode = createFileNode();
+      node.entries.set(name, fileNode);
+      return createFileHandle(fileNode);
+    },
+    async removeEntry(name: string) {
+      node.entries.delete(name);
+    },
+    async *values() {
+      for (const entry of node.entries.values()) {
+        if (entry.kind === 'file') {
+          yield createFileHandle(entry);
+        }
+      }
+    },
+  } as FileSystemDirectoryHandle;
+}
+
+function createOPFSStorage(existingRoot?: DirectoryNode): OPFSStorageMock {
+  const root = existingRoot ?? createDirectoryNode();
+  const baseStorage = ((navigator as any).storage ?? {}) as Record<string, unknown>;
+  return {
+    root,
+    storageManager: {
+      ...baseStorage,
+      async getDirectory() {
+        return createDirectoryHandle(root);
+      },
+    } as StorageManager & {
+      getDirectory: () => Promise<FileSystemDirectoryHandle>;
+    },
+  };
+}
+
+function setNavigatorStorage(storage: OPFSStorageMock) {
+  Object.defineProperty(navigator, 'storage', {
+    configurable: true,
+    value: storage.storageManager,
+  });
+}
+
+async function readFileFromNavigator(path: string): Promise<string> {
+  const root = await (navigator.storage as any).getDirectory();
+  const segments = path
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  const fileName = segments.pop();
+  if (!fileName) {
+    throw new Error('Invalid file path');
+  }
+
+  let currentDir = root as FileSystemDirectoryHandle;
+  for (const segment of segments) {
+    currentDir = await currentDir.getDirectoryHandle(segment, { create: false });
+  }
+  const fileHandle = await currentDir.getFileHandle(fileName, { create: false });
+  const file = await fileHandle.getFile();
+  return file.text();
+}
+
+describe('saveToOPFS', () => {
+  let root: DirectoryNode;
+  let originalStorage: StorageManager | undefined;
+  let hadStorage: boolean;
+
+  beforeEach(() => {
+    hadStorage = 'storage' in navigator;
+    originalStorage = (navigator as any).storage;
+    const storage = createOPFSStorage();
+    root = storage.root;
+    setNavigatorStorage(storage);
+  });
+
+  afterEach(() => {
+    if (hadStorage) {
+      Object.defineProperty(navigator, 'storage', {
+        configurable: true,
+        value: originalStorage,
+      });
+    } else {
+      delete (navigator as any).storage;
+    }
+  });
+
+  it('saves text and retrieves it across reloads', async () => {
+    await saveToOPFS('documents/notes/persist.txt', 'OPFS survives reloads');
+
+    const reloadedStorage = createOPFSStorage(root);
+    setNavigatorStorage(reloadedStorage);
+
+    await expect(readFileFromNavigator('documents/notes/persist.txt')).resolves.toBe(
+      'OPFS survives reloads',
+    );
+
+    await expect(readFromOPFS('documents/notes/persist.txt')).resolves.toBe(
+      'OPFS survives reloads',
+    );
+  });
+});

--- a/lib/opfs.ts
+++ b/lib/opfs.ts
@@ -1,0 +1,126 @@
+const PATH_SEPARATOR = '/';
+
+export type OPFSWriteData = string | Blob | ArrayBuffer | ArrayBufferView;
+
+type NavigatorWithOPFS = Navigator & {
+  storage?: StorageManager & {
+    getDirectory?: () => Promise<FileSystemDirectoryHandle>;
+  };
+};
+
+function getNavigatorWithOPFS(): NavigatorWithOPFS | null {
+  if (typeof navigator === 'undefined') {
+    return null;
+  }
+  return navigator as NavigatorWithOPFS;
+}
+
+function sanitizePath(path: string): string[] {
+  return path
+    .split(PATH_SEPARATOR)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0 && segment !== '.')
+    .map((segment) => {
+      if (segment === '..') {
+        throw new Error('Parent directory segments are not allowed in OPFS paths.');
+      }
+      return segment;
+    });
+}
+
+async function getOPFSRoot(): Promise<FileSystemDirectoryHandle> {
+  const nav = getNavigatorWithOPFS();
+  const storageManager = nav?.storage;
+
+  if (!storageManager?.getDirectory) {
+    throw new Error('OPFS is not supported in this environment.');
+  }
+
+  const root = await storageManager.getDirectory();
+  return root as FileSystemDirectoryHandle;
+}
+
+export async function saveToOPFS(
+  path: string,
+  data: OPFSWriteData,
+): Promise<FileSystemFileHandle> {
+  if (!path || typeof path !== 'string') {
+    throw new Error('A valid file path is required to save to OPFS.');
+  }
+
+  const parts = sanitizePath(path);
+  if (parts.length === 0) {
+    throw new Error('The provided path does not include a file name.');
+  }
+
+  const fileName = parts.pop() as string;
+  const root = await getOPFSRoot();
+
+  let currentDir = root;
+  for (const segment of parts) {
+    currentDir = await currentDir.getDirectoryHandle(segment, { create: true });
+  }
+
+  const fileHandle = await currentDir.getFileHandle(fileName, { create: true });
+  const writable = await fileHandle.createWritable();
+
+  let writeError: unknown = null;
+  try {
+    await writable.write(data as any);
+  } catch (error) {
+    writeError = error;
+  }
+
+  try {
+    await writable.close();
+  } catch (closeError) {
+    if (!writeError) {
+      throw closeError;
+    }
+  }
+
+  if (writeError) {
+    throw writeError;
+  }
+
+  return fileHandle;
+}
+
+export async function readFromOPFS(path: string): Promise<string | null> {
+  if (!path || typeof path !== 'string') {
+    throw new Error('A valid file path is required to read from OPFS.');
+  }
+
+  const parts = sanitizePath(path);
+  if (parts.length === 0) {
+    throw new Error('The provided path does not include a file name.');
+  }
+
+  const fileName = parts.pop() as string;
+  const root = await getOPFSRoot();
+
+  let currentDir = root;
+  for (const segment of parts) {
+    currentDir = await currentDir.getDirectoryHandle(segment, { create: false });
+  }
+
+  try {
+    const fileHandle = await currentDir.getFileHandle(fileName, { create: false });
+    const file = await fileHandle.getFile();
+    return await file.text();
+  } catch {
+    return null;
+  }
+}
+
+export async function ensureDirectory(
+  path: string,
+): Promise<FileSystemDirectoryHandle> {
+  const parts = sanitizePath(path);
+  const root = await getOPFSRoot();
+  let currentDir = root;
+  for (const segment of parts) {
+    currentDir = await currentDir.getDirectoryHandle(segment, { create: true });
+  }
+  return currentDir;
+}


### PR DESCRIPTION
## Summary
- add an OPFS utility that sanitizes paths, creates directories, and saves data via writable handles
- expose helpers to read files and ensure directories for callers needing OPFS access
- add a Jest test that mocks the OPFS API and verifies text persists across a simulated reload

## Testing
- yarn test opfs


------
https://chatgpt.com/codex/tasks/task_e_68c902cd1de08328b8f50eaedd69c8d3