### PR TITLE
[lib] add badge helpers

### DIFF
--- a/lib/badge.ts
+++ b/lib/badge.ts
@@ -1,0 +1,44 @@
+export type BadgeNavigator = Navigator & {
+  setAppBadge?: (contents?: number) => Promise<void>;
+  clearAppBadge?: () => Promise<void>;
+};
+
+const getBadgeNavigator = (): BadgeNavigator | undefined => {
+  if (typeof navigator === "undefined") {
+    return undefined;
+  }
+
+  return navigator as BadgeNavigator;
+};
+
+export const setBadge = async (count: number): Promise<void> => {
+  const badgeNavigator = getBadgeNavigator();
+
+  if (!badgeNavigator?.setAppBadge) {
+    return;
+  }
+
+  try {
+    await badgeNavigator.setAppBadge(count);
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("Failed to set app badge", error);
+    }
+  }
+};
+
+export const clearBadge = async (): Promise<void> => {
+  const badgeNavigator = getBadgeNavigator();
+
+  if (!badgeNavigator?.clearAppBadge) {
+    return;
+  }
+
+  try {
+    await badgeNavigator.clearAppBadge();
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("Failed to clear app badge", error);
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add a badge utility that safely wraps the Navigator setAppBadge and clearAppBadge APIs
- ensure the calls are guarded for non-browser environments and unsupported platforms

## Testing
- yarn lint *(fails: existing accessibility and lint violations across multiple app files)*
- yarn test *(fails: existing suites such as Modal, window, and nmap-nse due to longstanding issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c902c4f1208328a7a7598aab4ea35a