### PR TITLE
[manifest] add file handlers for common documents

### DIFF
--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,127 @@
+import type { MetadataRoute } from 'next';
+
+type FileHandlerIcon = {
+  src: string;
+  sizes?: string;
+  type?: string;
+  purpose?: 'any' | 'maskable' | 'monochrome';
+};
+
+type FileHandler = {
+  action: string;
+  name: string;
+  accept: Record<string, string[]>;
+  icons: FileHandlerIcon[];
+};
+
+type ExtendedManifest = MetadataRoute.Manifest & {
+  offline_page?: string;
+  file_handlers?: FileHandler[];
+};
+
+const FILE_HANDLER_ACTION = '/apps/files/handle';
+
+const fileHandlers: FileHandler[] = [
+  {
+    action: FILE_HANDLER_ACTION,
+    name: 'Text Document',
+    accept: {
+      'text/plain': ['.txt'],
+    },
+    icons: [
+      {
+        src: '/icons/file-handlers/text-file.svg',
+        type: 'image/svg+xml',
+        sizes: '96x96',
+      },
+    ],
+  },
+  {
+    action: FILE_HANDLER_ACTION,
+    name: 'Log File',
+    accept: {
+      'text/plain': ['.log'],
+    },
+    icons: [
+      {
+        src: '/icons/file-handlers/log-file.svg',
+        type: 'image/svg+xml',
+        sizes: '96x96',
+      },
+    ],
+  },
+  {
+    action: FILE_HANDLER_ACTION,
+    name: 'Packet Capture',
+    accept: {
+      'application/vnd.tcpdump.pcap': ['.pcap'],
+    },
+    icons: [
+      {
+        src: '/icons/file-handlers/pcap-file.svg',
+        type: 'image/svg+xml',
+        sizes: '96x96',
+      },
+    ],
+  },
+];
+
+export default function manifest(): MetadataRoute.Manifest {
+  const manifestData: ExtendedManifest = {
+    name: 'Kali Linux Portfolio',
+    short_name: 'KaliPortfolio',
+    start_url: '/',
+    offline_page: '/offline.html',
+    display: 'standalone',
+    background_color: '#0f1317',
+    theme_color: '#0f1317',
+    icons: [
+      {
+        src: '/images/logos/fevicon.png',
+        sizes: '192x192',
+        type: 'image/png',
+      },
+      {
+        src: '/images/logos/logo_1024.png',
+        sizes: '512x512',
+        type: 'image/png',
+      },
+    ],
+    share_target: {
+      action: '/share-target',
+      method: 'POST',
+      enctype: 'multipart/form-data',
+      params: {
+        title: 'title',
+        text: 'text',
+        url: 'url',
+        files: [
+          {
+            name: 'files',
+            accept: ['*/*'],
+          },
+        ],
+      },
+    },
+    shortcuts: [
+      {
+        name: 'Open Terminal',
+        short_name: 'Terminal',
+        url: '/?open=terminal',
+      },
+      {
+        name: 'New Note',
+        short_name: 'Note',
+        url: '/apps/sticky_notes/',
+      },
+      {
+        name: 'Open 2048 Daily',
+        short_name: '2048',
+        url: '/?open=2048&daily=true',
+      },
+    ],
+    file_handlers: fileHandlers,
+  };
+
+  return manifestData as MetadataRoute.Manifest;
+}

--- a/public/icons/file-handlers/log-file.svg
+++ b/public/icons/file-handlers/log-file.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <rect width="96" height="96" rx="16" fill="#0f1317"/>
+  <path fill="#1f2937" d="M28 14c-3.3 0-6 2.7-6 6v56c0 3.3 2.7 6 6 6h40c3.3 0 6-2.7 6-6V32L54 14H28z"/>
+  <path fill="#111827" d="M54 14v18c0 2.2 1.8 4 4 4h16L54 14z"/>
+  <g fill="#f97316">
+    <rect x="32" y="44" width="30" height="4" rx="2" opacity="0.85"/>
+    <rect x="32" y="54" width="26" height="4" rx="2" opacity="0.7"/>
+    <rect x="32" y="64" width="22" height="4" rx="2" opacity="0.55"/>
+  </g>
+  <text x="48" y="34" fill="#f97316" font-family="'Fira Code', 'Courier New', monospace" font-size="14" font-weight="700" text-anchor="middle">LOG</text>
+</svg>

--- a/public/icons/file-handlers/pcap-file.svg
+++ b/public/icons/file-handlers/pcap-file.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <rect width="96" height="96" rx="16" fill="#0f1317"/>
+  <path fill="#1f2937" d="M28 14c-3.3 0-6 2.7-6 6v56c0 3.3 2.7 6 6 6h40c3.3 0 6-2.7 6-6V32L54 14H28z"/>
+  <path fill="#111827" d="M54 14v18c0 2.2 1.8 4 4 4h16L54 14z"/>
+  <g fill="none" stroke="#c084fc" stroke-width="2.5" stroke-linecap="round">
+    <circle cx="40" cy="52" r="6"/>
+    <circle cx="58" cy="62" r="5"/>
+    <circle cx="54" cy="42" r="4"/>
+    <line x1="45" y1="56" x2="53" y2="46"/>
+    <line x1="46" y1="58" x2="54" y2="64"/>
+  </g>
+  <text x="48" y="74" fill="#c084fc" font-family="'Fira Code', 'Courier New', monospace" font-size="16" font-weight="700" text-anchor="middle">PCAP</text>
+</svg>

--- a/public/icons/file-handlers/text-file.svg
+++ b/public/icons/file-handlers/text-file.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <rect width="96" height="96" rx="16" fill="#0f1317"/>
+  <path fill="#1f2937" d="M28 14c-3.3 0-6 2.7-6 6v56c0 3.3 2.7 6 6 6h40c3.3 0 6-2.7 6-6V32L54 14H28z"/>
+  <path fill="#111827" d="M54 14v18c0 2.2 1.8 4 4 4h16L54 14z"/>
+  <rect x="32" y="44" width="32" height="3" rx="1.5" fill="#1f2937" stroke="#38bdf8" stroke-width="1.5"/>
+  <rect x="32" y="52" width="28" height="3" rx="1.5" fill="#1f2937" stroke="#38bdf8" stroke-width="1.5"/>
+  <text x="48" y="72" fill="#38bdf8" font-family="'Fira Code', 'Courier New', monospace" font-size="18" font-weight="700" text-anchor="middle">TXT</text>
+</svg>


### PR DESCRIPTION
## Summary
- declare a manifest metadata route that keeps the existing app details and adds file handlers for .txt, .log, and .pcap files
- add SVG icons for each file type used by the new file handlers

## Testing
- yarn lint *(fails: pre-existing accessibility and lint errors across multiple apps)*
- yarn test *(fails: pre-existing failing suites such as reconng and window handling)*

------
https://chatgpt.com/codex/tasks/task_e_68c902c1211c83289753fd032e565675