### PR TITLE
[protocols] register ssh and terminal handlers

### DIFF
--- a/components/RegisterProtocolHandlersClient.tsx
+++ b/components/RegisterProtocolHandlersClient.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect } from 'react';
+
+type ProtocolHandlerConfig = {
+  scheme: string;
+  path: string;
+  title: string;
+};
+
+const PROTOCOL_HANDLERS: ProtocolHandlerConfig[] = [
+  {
+    scheme: 'web+ssh',
+    path: '/apps/ssh?target=%s',
+    title: 'SSH Command Builder',
+  },
+  {
+    scheme: 'web+term',
+    path: '/apps/terminal?target=%s',
+    title: 'Terminal',
+  },
+];
+
+const RegisterProtocolHandlersClient = () => {
+  useEffect(() => {
+    if (
+      typeof window === 'undefined' ||
+      typeof navigator === 'undefined' ||
+      typeof navigator.registerProtocolHandler !== 'function'
+    ) {
+      return;
+    }
+
+    PROTOCOL_HANDLERS.forEach(({ scheme, path, title }) => {
+      try {
+        const handlerUrl = path.startsWith('http')
+          ? path
+          : `${window.location.origin}${path}`;
+        navigator.registerProtocolHandler(scheme, handlerUrl, title);
+      } catch (error) {
+        console.error(`Failed to register protocol handler for ${scheme}`, error);
+      }
+    });
+  }, []);
+
+  return null;
+};
+
+export default RegisterProtocolHandlersClient;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -14,6 +14,7 @@ import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
+import RegisterProtocolHandlersClient from '../components/RegisterProtocolHandlersClient';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
@@ -159,6 +160,7 @@ function MyApp(props) {
         <SettingsProvider>
           <PipPortalProvider>
             <div aria-live="polite" id="live-region" />
+            <RegisterProtocolHandlersClient />
             <Component {...pageProps} />
             <ShortcutOverlay />
             <Analytics

--- a/pages/apps/terminal.tsx
+++ b/pages/apps/terminal.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const TerminalPreview = dynamic(() => import('../../apps/terminal/tabs'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function TerminalPage() {
+  return <TerminalPreview />;
+}


### PR DESCRIPTION
## Summary
- add a client component that registers the `web+ssh` and `web+term` custom protocol handlers
- render the protocol registration helper from the app shell so the browser prompt appears on load
- expose a `/apps/terminal` preview page that can act as the handler target for terminal links

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations across legacy files)*
- yarn test *(fails: pre-existing act/localStorage warnings and Supabase mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68c902c079ec83289023423c2ac4049a