### PR TITLE
[pwa] support share target import

### DIFF
--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,60 @@
+import type { MetadataRoute } from 'next';
+
+const shareTarget = {
+  action: '/share-target',
+  method: 'POST',
+  enctype: 'multipart/form-data',
+  params: {
+    title: 'title',
+    text: 'text',
+    url: 'url',
+    files: [
+      {
+        name: 'files',
+        accept: ['*/*'],
+      },
+    ],
+  },
+} as const;
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Kali Linux Portfolio',
+    short_name: 'KaliPortfolio',
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#0f1317',
+    theme_color: '#0f1317',
+    icons: [
+      {
+        src: '/images/logos/fevicon.png',
+        sizes: '192x192',
+        type: 'image/png',
+      },
+      {
+        src: '/images/logos/logo_1024.png',
+        sizes: '512x512',
+        type: 'image/png',
+      },
+    ],
+    shortcuts: [
+      {
+        name: 'Open Terminal',
+        short_name: 'Terminal',
+        url: '/?open=terminal',
+      },
+      {
+        name: 'New Note',
+        short_name: 'Note',
+        url: '/apps/sticky_notes/',
+      },
+      {
+        name: 'Open 2048 Daily',
+        short_name: '2048',
+        url: '/?open=2048&daily=true',
+      },
+    ],
+    offline_page: '/offline.html',
+    share_target: shareTarget,
+  } as MetadataRoute.Manifest;
+}

--- a/app/share-target/route.ts
+++ b/app/share-target/route.ts
@@ -1,0 +1,95 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const MAX_FIELD_LENGTH = 2000;
+const MAX_FILES = 8;
+
+type ShareMetadataFile = {
+  name: string;
+  type: string;
+  size: number;
+  lastModified: number;
+};
+
+type ShareMetadata = {
+  title?: string;
+  text?: string;
+  url?: string;
+  files?: ShareMetadataFile[];
+};
+
+function sanitizeEntry(value: FormDataEntryValue | null): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > MAX_FIELD_LENGTH
+    ? `${trimmed.slice(0, Math.max(0, MAX_FIELD_LENGTH - 1))}…`
+    : trimmed;
+}
+
+function buildMetadata(formData: FormData): ShareMetadata {
+  const metadata: ShareMetadata = {};
+
+  const title = sanitizeEntry(formData.get('title'));
+  if (title) metadata.title = title;
+
+  const text = sanitizeEntry(formData.get('text'));
+  if (text) metadata.text = text;
+
+  const url = sanitizeEntry(formData.get('url'));
+  if (url) metadata.url = url;
+
+  const entries = formData.getAll('files').filter((item): item is File => item instanceof File);
+  if (entries.length) {
+    metadata.files = entries.slice(0, MAX_FILES).map((file) => ({
+      name: file.name,
+      type: file.type || 'application/octet-stream',
+      size: file.size,
+      lastModified: file.lastModified,
+    }));
+  }
+
+  return metadata;
+}
+
+function metadataToSearchParams(metadata: ShareMetadata, existing: URLSearchParams): URLSearchParams {
+  const params = new URLSearchParams(existing);
+
+  if (metadata.title) params.set('title', metadata.title);
+  if (metadata.text) params.set('text', metadata.text);
+  if (metadata.url) params.set('url', metadata.url);
+
+  if (metadata.files?.length) {
+    try {
+      params.set('files', JSON.stringify(metadata.files));
+    } catch {
+      // Ignore serialization failures
+    }
+  }
+
+  if (!params.has('source')) {
+    params.set('source', 'share-target');
+  }
+
+  return params;
+}
+
+export async function POST(request: NextRequest) {
+  const redirectUrl = new URL('/apps/files/import', request.url);
+  let params = new URLSearchParams(request.nextUrl.searchParams);
+
+  try {
+    const formData = await request.formData();
+    const metadata = buildMetadata(formData);
+    params = metadataToSearchParams(metadata, params);
+  } catch {
+    // Ignore parsing errors and fall back to original query parameters
+  }
+
+  const search = params.toString();
+  if (search) {
+    redirectUrl.search = search;
+  }
+
+  return NextResponse.redirect(redirectUrl, { status: 303 });
+}


### PR DESCRIPTION
## Summary
- add an `app/manifest.ts` implementation so the PWA manifest exposes the share target
- accept POST submissions at `/share-target`, extract key metadata, and redirect into the Files import flow

## Testing
- yarn lint *(fails: repo has pre-existing accessibility and browser globals violations across many apps)*
- yarn test *(fails: existing suite failures such as `nmapNse` alert lookup and jsdom localStorage access)*

------
https://chatgpt.com/codex/tasks/task_e_68c902b6c2688328b00141e1b89df762