### PR TITLE
[panel] Add ticking PanelClock component

### DIFF
--- a/__tests__/panelClock.test.tsx
+++ b/__tests__/panelClock.test.tsx
@@ -1,0 +1,48 @@
+import { render, act } from '@testing-library/react';
+import PanelClock from '../components/PanelClock';
+
+describe('PanelClock', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-01T08:09:10Z'));
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('formats the current time using Intl with overrides', () => {
+    const { container } = render(
+      <PanelClock locale="en-GB" timeZone="UTC" />
+    );
+
+    const timeElement = container.querySelector('time');
+    expect(timeElement).not.toBeNull();
+    expect(timeElement).toHaveTextContent('08:09:10');
+    expect(timeElement?.getAttribute('datetime')).toBe(
+      new Date('2024-01-01T08:09:10.000Z').toISOString()
+    );
+  });
+
+  it('updates the displayed time every second', () => {
+    const { container } = render(
+      <PanelClock locale="en-GB" timeZone="UTC" />
+    );
+
+    const timeElement = container.querySelector('time') as HTMLElement;
+    expect(timeElement).toHaveTextContent('08:09:10');
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(timeElement).toHaveTextContent('08:09:11');
+    expect(timeElement.getAttribute('datetime')).toBe(
+      new Date('2024-01-01T08:09:11.000Z').toISOString()
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(timeElement).toHaveTextContent('08:09:13');
+  });
+});

--- a/components/PanelClock.tsx
+++ b/components/PanelClock.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+type PanelClockProps = {
+  className?: string;
+  locale?: Intl.LocalesArgument;
+  options?: Intl.DateTimeFormatOptions;
+  timeZone?: string;
+};
+
+const DEFAULT_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+};
+
+export default function PanelClock({
+  className,
+  locale,
+  options,
+  timeZone,
+}: PanelClockProps) {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const tick = () => setNow(new Date());
+    const intervalId = window.setInterval(tick, 1000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, []);
+
+  const formatOptions = useMemo(() => {
+    const merged: Intl.DateTimeFormatOptions = {
+      ...DEFAULT_FORMAT_OPTIONS,
+      ...options,
+    };
+
+    if (timeZone) {
+      merged.timeZone = timeZone;
+    }
+
+    return merged;
+  }, [options, timeZone]);
+
+  const formatter = useMemo(
+    () => new Intl.DateTimeFormat(locale, formatOptions),
+    [locale, formatOptions]
+  );
+
+  return (
+    <time dateTime={now.toISOString()} className={className}>
+      {formatter.format(now)}
+    </time>
+  );
+}


### PR DESCRIPTION
## Summary
- add a PanelClock component that renders the current time with Intl.DateTimeFormat and supports time zone overrides
- ensure the component updates once per second without external dependencies and expose a datetime attribute for accessibility
- cover the new behavior with Jest tests for formatting and ticking updates

## Testing
- yarn lint *(fails: existing jsx-a11y control-has-associated-label errors in unrelated files)*
- yarn test panelClock

------
https://chatgpt.com/codex/tasks/task_e_68c902b5f0188328a0ff650c8a435765