### PR TITLE
[desktop] Add overview hot corner trigger

### DIFF
--- a/components/HotCorners.tsx
+++ b/components/HotCorners.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from 'react';
+
+const CORNER_SIZE = 32;
+
+const HotCorners = () => {
+  const hotCornerActiveRef = useRef(false);
+
+  const handleMouseEnter = useCallback(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const root = document.documentElement;
+    const alreadyActive = root.classList.contains('show-overview');
+    root.classList.add('show-overview');
+    hotCornerActiveRef.current = !alreadyActive;
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    if (typeof document === 'undefined') {
+      hotCornerActiveRef.current = false;
+      return;
+    }
+
+    const root = document.documentElement;
+    if (hotCornerActiveRef.current) {
+      root.classList.remove('show-overview');
+    }
+    hotCornerActiveRef.current = false;
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (typeof document === 'undefined') {
+        return;
+      }
+
+      if (hotCornerActiveRef.current) {
+        document.documentElement.classList.remove('show-overview');
+      }
+    };
+  }, []);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="fixed left-0 top-0 z-50 opacity-0"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      style={{ height: CORNER_SIZE, width: CORNER_SIZE }}
+    />
+  );
+};
+
+export default HotCorners;


### PR DESCRIPTION
## Summary
- add a reusable HotCorners component that toggles the global show-overview class when the top-left corner is hovered
- sync the desktop overview state with the root element class and render the hot corner target on the desktop

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window lint violations in unrelated areas)*
- yarn test *(fails: pre-existing window resizing and nmap NSE tests as well as jsdom localStorage errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c902b5762c83289e2039f8f82fe33a