### PR TITLE
[desktop] add marquee selection

### DIFF
--- a/__tests__/desktopSelection.test.tsx
+++ b/__tests__/desktopSelection.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react';
+import DesktopSelection from '../components/DesktopSelection';
+
+type RectConfig = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+function mockBoundingClientRect(element: HTMLElement, config: RectConfig) {
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    value: () =>
+      ({
+        x: config.left,
+        y: config.top,
+        left: config.left,
+        top: config.top,
+        right: config.left + config.width,
+        bottom: config.top + config.height,
+        width: config.width,
+        height: config.height,
+        toJSON: () => ({}),
+      } as DOMRect),
+  });
+}
+
+describe('DesktopSelection marquee behavior', () => {
+  test('dragging selects multiple icons and clears on mouseup', async () => {
+    const { getByTestId } = render(
+      <main
+        id="desktop"
+        style={{ position: 'relative', width: '400px', height: '400px' }}
+      >
+        <div
+          data-testid="icon-a"
+          data-context="app"
+          style={{ position: 'absolute', left: '20px', top: '20px' }}
+        />
+        <div
+          data-testid="icon-b"
+          data-context="app"
+          style={{ position: 'absolute', left: '120px', top: '20px' }}
+        />
+        <div
+          data-testid="icon-c"
+          data-context="app"
+          style={{ position: 'absolute', left: '220px', top: '20px' }}
+        />
+        <DesktopSelection />
+      </main>
+    );
+
+    await act(async () => {});
+
+    const desktop = document.getElementById('desktop');
+    if (!desktop) {
+      throw new Error('Desktop root not found');
+    }
+
+    mockBoundingClientRect(desktop, {
+      left: 0,
+      top: 0,
+      width: 400,
+      height: 400,
+    });
+
+    const iconA = getByTestId('icon-a');
+    const iconB = getByTestId('icon-b');
+    const iconC = getByTestId('icon-c');
+
+    mockBoundingClientRect(iconA, {
+      left: 20,
+      top: 20,
+      width: 50,
+      height: 50,
+    });
+
+    mockBoundingClientRect(iconB, {
+      left: 120,
+      top: 20,
+      width: 50,
+      height: 50,
+    });
+
+    mockBoundingClientRect(iconC, {
+      left: 220,
+      top: 20,
+      width: 50,
+      height: 50,
+    });
+
+    fireEvent.mouseDown(desktop, { button: 0, clientX: 10, clientY: 10 });
+    fireEvent.mouseMove(document, { clientX: 190, clientY: 100 });
+
+    expect(iconA).toHaveAttribute('data-selected', '1');
+    expect(iconB).toHaveAttribute('data-selected', '1');
+    expect(iconC).not.toHaveAttribute('data-selected');
+
+    fireEvent.mouseUp(document);
+
+    expect(iconA).not.toHaveAttribute('data-selected');
+    expect(iconB).not.toHaveAttribute('data-selected');
+    expect(iconC).not.toHaveAttribute('data-selected');
+  });
+});

--- a/components/DesktopSelection.tsx
+++ b/components/DesktopSelection.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type Point = {
+  x: number;
+  y: number;
+};
+
+type SelectionRect = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+type SelectionBounds = {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+};
+
+function intersects(bounds: SelectionBounds, rect: DOMRect): boolean {
+  return (
+    rect.left <= bounds.right &&
+    rect.right >= bounds.left &&
+    rect.top <= bounds.bottom &&
+    rect.bottom >= bounds.top
+  );
+}
+
+export default function DesktopSelection() {
+  const [rect, setRect] = useState<SelectionRect | null>(null);
+  const startPoint = useRef<Point | null>(null);
+  const isSelecting = useRef(false);
+  const desktopRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const desktop = document.getElementById("desktop");
+    if (!desktop) return;
+
+    desktopRef.current = desktop;
+
+    const resetIcons = () => {
+      if (!desktopRef.current) return;
+      const icons = desktopRef.current.querySelectorAll<HTMLElement>('[data-context="app"]');
+      icons.forEach((icon) => {
+        icon.removeAttribute("data-selected");
+      });
+    };
+
+    const updateIconSelection = (bounds: SelectionBounds) => {
+      if (!desktopRef.current) return;
+      const icons = desktopRef.current.querySelectorAll<HTMLElement>('[data-context="app"]');
+      icons.forEach((icon) => {
+        const iconRect = icon.getBoundingClientRect();
+        if (intersects(bounds, iconRect)) {
+          icon.setAttribute("data-selected", "1");
+        } else {
+          icon.removeAttribute("data-selected");
+        }
+      });
+    };
+
+    const stopSelection = () => {
+      if (!isSelecting.current) return;
+      isSelecting.current = false;
+      startPoint.current = null;
+      setRect(null);
+      resetIcons();
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+
+    function handleMouseMove(event: MouseEvent) {
+      if (!isSelecting.current || !desktopRef.current || !startPoint.current) {
+        return;
+      }
+
+      const { x: startX, y: startY } = startPoint.current;
+      const currentX = event.clientX;
+      const currentY = event.clientY;
+
+      const left = Math.min(startX, currentX);
+      const top = Math.min(startY, currentY);
+      const width = Math.abs(currentX - startX);
+      const height = Math.abs(currentY - startY);
+
+      const desktopBounds = desktopRef.current.getBoundingClientRect();
+
+      setRect({
+        left: left - desktopBounds.left,
+        top: top - desktopBounds.top,
+        width,
+        height,
+      });
+
+      updateIconSelection({
+        left,
+        top,
+        right: left + width,
+        bottom: top + height,
+      });
+    }
+
+    function handleMouseUp() {
+      stopSelection();
+    }
+
+    function handleMouseDown(event: MouseEvent) {
+      if (event.button !== 0) return;
+      if (!(event.target instanceof Element)) return;
+      if (event.target.closest("#window-area")) return;
+      if (event.target.closest("nav[aria-label='Dock']")) return;
+      if (event.target.closest("[role='toolbar']")) return;
+      if (event.target.closest("[role='menu']")) return;
+
+      isSelecting.current = true;
+      startPoint.current = { x: event.clientX, y: event.clientY };
+      resetIcons();
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+
+      if (!event.target.closest('[data-context="app"]')) {
+        event.preventDefault();
+      }
+    }
+
+    desktop.addEventListener("mousedown", handleMouseDown);
+
+    return () => {
+      desktop.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, []);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute rounded-sm border border-blue-400 bg-blue-500 bg-opacity-20"
+      style={{
+        display: rect ? "block" : "none",
+        left: rect ? `${rect.left}px` : undefined,
+        top: rect ? `${rect.top}px` : undefined,
+        width: rect ? `${rect.width}px` : undefined,
+        height: rect ? `${rect.height}px` : undefined,
+        zIndex: 30,
+      }}
+    />
+  );
+}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -19,6 +19,7 @@ import DefaultMenu from '../context-menus/default';
 import AppMenu from '../context-menus/app-menu';
 import Taskbar from './taskbar';
 import TaskbarMenu from '../context-menus/taskbar-menu';
+import DesktopSelection from '../DesktopSelection';
 import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
@@ -904,6 +905,8 @@ export class Desktop extends Component {
 
                 {/* Desktop Apps */}
                 {this.renderDesktopApps()}
+
+                <DesktopSelection />
 
                 {/* Context Menus */}
                 <DesktopMenu


### PR DESCRIPTION
## Summary
- add a DesktopSelection component that renders the marquee rectangle and toggles icon selection
- mount the selection overlay in the desktop screen so icon drag selects intersecting tiles
- cover the selection behaviour with a focused unit test

## Testing
- yarn test desktopSelection

------
https://chatgpt.com/codex/tasks/task_e_68c902b4ff9483289ae2f95ef7b030d1