### PR TITLE
[desktop] Add Show Desktop button

### DIFF
--- a/__tests__/show-desktop-button.test.tsx
+++ b/__tests__/show-desktop-button.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ShowDesktopButton from '../components/ShowDesktopButton';
+
+describe('ShowDesktopButton', () => {
+  it('sets data-minimized on all windows and hides them', () => {
+    render(
+      <div>
+        <div data-window id="window-1" />
+        <div data-window id="window-2" />
+        <ShowDesktopButton>Show Desktop</ShowDesktopButton>
+      </div>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /show desktop/i }));
+
+    const windows = Array.from(document.querySelectorAll<HTMLElement>('[data-window]'));
+    expect(windows).toHaveLength(2);
+    windows.forEach((windowEl) => {
+      expect(windowEl).toHaveAttribute('data-minimized', 'true');
+      expect(windowEl.style.pointerEvents).toBe('none');
+      expect(windowEl.style.opacity).toBe('0');
+      expect(windowEl.style.transform).toBe('scale(0.9) translateY(20px)');
+    });
+  });
+});

--- a/components/ShowDesktopButton.tsx
+++ b/components/ShowDesktopButton.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { ButtonHTMLAttributes, PropsWithChildren, useCallback } from 'react';
+
+type ShowDesktopButtonProps = PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>>;
+
+const minimizedStyles = `
+  [data-window][data-minimized="true"] {
+    pointer-events: none !important;
+    opacity: 0 !important;
+    transform: scale(0.9) translateY(20px) !important;
+    transition: transform 150ms ease, opacity 150ms ease;
+  }
+`;
+
+const ShowDesktopButton = ({ children, ...props }: ShowDesktopButtonProps) => {
+  const handleClick = useCallback(() => {
+    const windows = document.querySelectorAll<HTMLElement>('[data-window]');
+    windows.forEach((windowEl) => {
+      windowEl.setAttribute('data-minimized', 'true');
+      windowEl.style.pointerEvents = 'none';
+      windowEl.style.opacity = '0';
+      windowEl.style.transform = 'scale(0.9) translateY(20px)';
+      windowEl.style.transition = 'transform 150ms ease, opacity 150ms ease';
+    });
+  }, []);
+
+  return (
+    <>
+      <style>{minimizedStyles}</style>
+      <button type="button" onClick={handleClick} {...props}>
+        {children ?? 'Show Desktop'}
+      </button>
+    </>
+  );
+};
+
+export default ShowDesktopButton;

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -634,6 +634,7 @@ export class Window extends Component {
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
                 >
                     <div
+                        data-window={this.id}
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
                         className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}


### PR DESCRIPTION
## Summary
- add a client-side ShowDesktopButton that marks all `[data-window]` elements as minimized and hides them with inline styles
- tag window containers with a `data-window` attribute so they can be targeted by the new control
- cover the behaviour with a unit test that verifies all windows receive the minimized styles after a click

## Testing
- yarn test --watch=false show-desktop-button
- yarn lint *(fails: repository has pre-existing accessibility and lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c902aa068083288a891e12240eb35f