### PR TITLE
[ui] add low power mode toggle

### DIFF
--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -12,6 +12,7 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const [lowPowerMode, setLowPowerMode] = usePersistentState('qs-low-power', false);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -20,6 +21,13 @@ const QuickSettings = ({ open }: Props) => {
   useEffect(() => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('low-power', lowPowerMode);
+    return () => {
+      document.documentElement.classList.remove('low-power');
+    };
+  }, [lowPowerMode]);
 
   return (
     <div
@@ -44,12 +52,20 @@ const QuickSettings = ({ open }: Props) => {
         <span>Network</span>
         <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
       </div>
-      <div className="px-4 flex justify-between">
+      <div className="px-4 pb-2 flex justify-between">
         <span>Reduced motion</span>
         <input
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
+        />
+      </div>
+      <div className="px-4 flex justify-between">
+        <span>Low power mode</span>
+        <input
+          type="checkbox"
+          checked={lowPowerMode}
+          onChange={() => setLowPowerMode(!lowPowerMode)}
         />
       </div>
     </div>

--- a/styles/index.css
+++ b/styles/index.css
@@ -31,6 +31,7 @@ button:focus-visible {
     }
 }
 
+.low-power *, .low-power *::before, .low-power *::after,
 .reduced-motion *, .reduced-motion *::before, .reduced-motion *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
@@ -377,6 +378,13 @@ dialog {
         backdrop-filter: blur(10px);
         background-color: color-mix(in srgb, var(--color-bg), transparent 60%);
     }
+}
+
+.low-power .context-menu-bg,
+.low-power .windowMainScreen {
+    -webkit-backdrop-filter: none !important;
+    backdrop-filter: none !important;
+    background-color: color-mix(in srgb, var(--color-bg), transparent 15%);
 }
 
 .emoji-list>li {


### PR DESCRIPTION
## Summary
- add a low power mode toggle to the quick settings menu and persist the preference
- apply the `.low-power` class to reduce expensive CSS animations when the toggle is active
- remove blur effects from panels when low power mode is on

## Testing
- yarn lint *(fails due to pre-existing repo warnings about unlabeled controls and CSP-restricted public game scripts)*
- yarn test *(fails because of pre-existing act warnings and jsdom localStorage access issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c9031a5d80832890e6eebba8cf8edf