### PR TITLE
[settings] add persistent storage toggle

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import PersistenceToggle from "./storage/PersistenceToggle";
 
 export default function Settings() {
   const {
@@ -286,6 +287,7 @@ export default function Settings() {
               Import Settings
             </button>
           </div>
+          <PersistenceToggle />
         </>
       )}
         <input

--- a/apps/settings/storage/PersistenceToggle.tsx
+++ b/apps/settings/storage/PersistenceToggle.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type PersistenceState = "loading" | "unsupported" | "prompt" | "granted";
+
+const getStorageManager = (): StorageManager | null => {
+  if (typeof navigator === "undefined") return null;
+
+  return navigator.storage ?? null;
+};
+
+const hasPersistenceAPIs = (storage: StorageManager | null): storage is StorageManager & {
+  persisted: StorageManager["persisted"];
+  persist: StorageManager["persist"];
+} => Boolean(storage?.persisted && storage.persist);
+
+export default function PersistenceToggle() {
+  const [state, setState] = useState<PersistenceState>("loading");
+  const [requesting, setRequesting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const storage = getStorageManager();
+
+    if (!hasPersistenceAPIs(storage)) {
+      if (!cancelled) setState("unsupported");
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    storage
+      .persisted()
+      .then((persisted) => {
+        if (!cancelled) setState(persisted ? "granted" : "prompt");
+      })
+      .catch(() => {
+        if (!cancelled) setState("prompt");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleRequest = async () => {
+    const storage = getStorageManager();
+    if (!hasPersistenceAPIs(storage) || state !== "prompt" || requesting) return;
+
+    setRequesting(true);
+    setError(null);
+
+    try {
+      const granted = await storage.persist();
+      setState(granted ? "granted" : "prompt");
+      if (!granted) setError("Browser denied persistent storage.");
+    } catch (err) {
+      setError("Unable to request persistent storage.");
+    } finally {
+      setRequesting(false);
+    }
+  };
+
+  const buttonLabel = useMemo(() => {
+    if (state === "loading") return "Checking persistent storage...";
+    if (state === "granted") return "Persistent storage enabled";
+    if (requesting) return "Requesting persistent storage...";
+
+    return "Enable persistent storage";
+  }, [state, requesting]);
+
+  if (state === "unsupported") {
+    return (
+      <div className="px-4 mt-4 text-sm text-ubt-grey">
+        Persistent storage isn&apos;t supported in this browser.
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 mt-4">
+      <button
+        type="button"
+        onClick={handleRequest}
+        disabled={state !== "prompt" || requesting}
+        className="px-4 py-2 rounded bg-ub-orange text-white disabled:opacity-60 disabled:cursor-not-allowed"
+      >
+        {buttonLabel}
+      </button>
+      {error && <p className="mt-2 text-xs text-red-400" role="alert">{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a PersistenceToggle component that checks navigator.storage persist APIs and updates the button state after success
- surface the toggle in the Settings privacy tab so users can request persistent storage from the desktop UI

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label and no-top-level-window issues across legacy files)*
- yarn test *(fails: existing suites such as __tests__/nmapNse.test.tsx and __tests__/aboutAccessibility.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c902cc920083289b27362d8ac6aaa2