### PR TITLE
[pwa] Add DisplayModeClient to manage installed class

### DIFF
--- a/__tests__/displayModeClient.test.tsx
+++ b/__tests__/displayModeClient.test.tsx
@@ -1,0 +1,137 @@
+import { render } from '@testing-library/react';
+import DisplayModeClient from '../components/DisplayModeClient';
+
+const DISPLAY_MODE_QUERY = '(display-mode: standalone)';
+
+type Listener = (event: MediaQueryListEvent) => void;
+
+type MatchMediaStubOptions = {
+  supportEventListener?: boolean;
+  supportListener?: boolean;
+};
+
+type MatchMediaStub = {
+  mediaQueryList: MediaQueryList & {
+    addEventListener?: jest.Mock;
+    removeEventListener?: jest.Mock;
+    addListener?: jest.Mock;
+    removeListener?: jest.Mock;
+  };
+  emit: (matches: boolean) => void;
+};
+
+const createMatchMediaStub = (
+  initialMatches: boolean,
+  options: MatchMediaStubOptions = {},
+): MatchMediaStub => {
+  const { supportEventListener = true, supportListener = true } = options;
+  const listeners = new Set<Listener>();
+
+  const addEventListenerMock = jest.fn((eventName: string, listener: EventListener) => {
+    if (eventName === 'change') {
+      listeners.add(listener as unknown as Listener);
+    }
+  });
+
+  const removeEventListenerMock = jest.fn((eventName: string, listener: EventListener) => {
+    if (eventName === 'change') {
+      listeners.delete(listener as unknown as Listener);
+    }
+  });
+
+  const addListenerMock = jest.fn((listener: MediaQueryListListener) => {
+    if (listener) {
+      listeners.add(listener as unknown as Listener);
+    }
+  });
+
+  const removeListenerMock = jest.fn((listener: MediaQueryListListener) => {
+    if (listener) {
+      listeners.delete(listener as unknown as Listener);
+    }
+  });
+
+  const mediaQueryList = {
+    matches: initialMatches,
+    media: DISPLAY_MODE_QUERY,
+    onchange: null,
+    addEventListener: supportEventListener ? addEventListenerMock : undefined,
+    removeEventListener: supportEventListener ? removeEventListenerMock : undefined,
+    addListener: supportListener ? addListenerMock : undefined,
+    removeListener: supportListener ? removeListenerMock : undefined,
+    dispatchEvent: jest.fn(),
+  } as unknown as MatchMediaStub['mediaQueryList'];
+
+  const emit = (matches: boolean) => {
+    mediaQueryList.matches = matches;
+    const event = { matches } as MediaQueryListEvent;
+    listeners.forEach((listener) => listener.call(mediaQueryList, event));
+  };
+
+  return {
+    mediaQueryList,
+    emit,
+  };
+};
+
+describe('DisplayModeClient', () => {
+  let originalMatchMedia: typeof window.matchMedia | undefined;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+    document.documentElement.className = '';
+  });
+
+  afterEach(() => {
+    if (originalMatchMedia) {
+      window.matchMedia = originalMatchMedia;
+    } else {
+      delete (window as any).matchMedia;
+    }
+  });
+
+  test('toggles the installed class based on display mode changes', () => {
+    const stub = createMatchMediaStub(true);
+    window.matchMedia = jest.fn().mockReturnValue(stub.mediaQueryList);
+
+    const { unmount } = render(<DisplayModeClient />);
+
+    expect(document.documentElement.classList.contains('installed')).toBe(true);
+
+    stub.emit(false);
+    expect(document.documentElement.classList.contains('installed')).toBe(false);
+
+    unmount();
+    expect(document.documentElement.classList.contains('installed')).toBe(false);
+  });
+
+  test('adds the installed class when standalone mode activates', () => {
+    const stub = createMatchMediaStub(false);
+    window.matchMedia = jest.fn().mockReturnValue(stub.mediaQueryList);
+
+    render(<DisplayModeClient />);
+
+    expect(document.documentElement.classList.contains('installed')).toBe(false);
+
+    stub.emit(true);
+    expect(document.documentElement.classList.contains('installed')).toBe(true);
+
+    stub.emit(false);
+    expect(document.documentElement.classList.contains('installed')).toBe(false);
+  });
+
+  test('supports the legacy addListener API', () => {
+    const stub = createMatchMediaStub(true, { supportEventListener: false, supportListener: true });
+    window.matchMedia = jest.fn().mockReturnValue(stub.mediaQueryList);
+
+    const { unmount } = render(<DisplayModeClient />);
+
+    expect(document.documentElement.classList.contains('installed')).toBe(true);
+
+    stub.emit(false);
+    expect(document.documentElement.classList.contains('installed')).toBe(false);
+
+    unmount();
+    expect(document.documentElement.classList.contains('installed')).toBe(false);
+  });
+});

--- a/components/DisplayModeClient.tsx
+++ b/components/DisplayModeClient.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect } from 'react';
+
+const DISPLAY_MODE_QUERY = '(display-mode: standalone)';
+
+const DisplayModeClient: React.FC = () => {
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const mediaQueryList = window.matchMedia(DISPLAY_MODE_QUERY);
+    const root = document.documentElement;
+
+    const applyMatches = (matches: boolean) => {
+      if (matches) {
+        root.classList.add('installed');
+      } else {
+        root.classList.remove('installed');
+      }
+    };
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      applyMatches(event.matches);
+    };
+
+    applyMatches(mediaQueryList.matches);
+
+    if (typeof mediaQueryList.addEventListener === 'function') {
+      mediaQueryList.addEventListener('change', handleChange);
+      return () => {
+        mediaQueryList.removeEventListener('change', handleChange);
+        root.classList.remove('installed');
+      };
+    }
+
+    if (typeof mediaQueryList.addListener === 'function') {
+      const legacyHandler: MediaQueryListListener = function (event) {
+        applyMatches(event.matches);
+      };
+      mediaQueryList.addListener(legacyHandler);
+      return () => {
+        mediaQueryList.removeListener(legacyHandler);
+        root.classList.remove('installed');
+      };
+    }
+
+    return () => {
+      root.classList.remove('installed');
+    };
+  }, []);
+
+  return null;
+};
+
+export default DisplayModeClient;


### PR DESCRIPTION
## Summary
- add a client component that watches the standalone display mode media query and toggles the `installed` class on `<html>`
- ensure cleanup removes the class when leaving standalone mode or unmounting
- cover the behaviour with tests, including the legacy `addListener` fallback

## Testing
- yarn lint *(fails: existing accessibility and top-level window lint errors across legacy apps)*
- yarn test displayModeClient

------
https://chatgpt.com/codex/tasks/task_e_68c902c648648328a4b84d2df6c1bb93