### PR TITLE
[desktop] enable window chrome drag helpers

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,7 @@
+.drag {
+  -webkit-app-region: drag;
+}
+
+.no-drag {
+  -webkit-app-region: no-drag;
+}

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -677,7 +677,7 @@ export default Window
 export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
     return (
         <div
-            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
+            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11 drag"}
             tabIndex={0}
             role="button"
             aria-grabbed={grabbed}
@@ -739,7 +739,7 @@ export function WindowEditButtons(props) {
                 <button
                     type="button"
                     aria-label="Window pin"
-                    className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                    className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6 no-drag"
                     onClick={togglePin}
                 >
                     <NextImage
@@ -755,7 +755,7 @@ export function WindowEditButtons(props) {
             <button
                 type="button"
                 aria-label="Window minimize"
-                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6 no-drag"
                 onClick={props.minimize}
             >
                 <NextImage
@@ -773,7 +773,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window restore"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6 no-drag"
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -789,7 +789,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window maximize"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6 no-drag"
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -807,7 +807,7 @@ export function WindowEditButtons(props) {
                 type="button"
                 id={`close-${props.id}`}
                 aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
+                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6 no-drag"
                 onClick={props.close}
             >
                 <NextImage

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -5,6 +5,7 @@ import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import '../styles/tailwind.css';
 import '../styles/globals.css';
+import '../app/globals.css';
 import '../styles/index.css';
 import '../styles/resume-print.css';
 import '../styles/print.css';


### PR DESCRIPTION
## Summary
- add app-level drag/no-drag CSS helpers so PWAs can define draggable regions
- load the helpers in the app shell and apply them to the window title bar and controls so only the bar drags

## Testing
- [ ] yarn lint *(fails: repository has 571 existing eslint errors about missing control labels and top-level window/document usage)*


------
https://chatgpt.com/codex/tasks/task_e_68c902a891d88328b5d4e7d3c4f37e73