### PR TITLE
[ui] Align title bar with browser titlebar area

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,27 @@
+/* Global styles for the desktop shell title bar */
+:root {
+  --app-titlebar-default-height: 3rem;
+  --app-titlebar-x: env(titlebar-area-x, 0px);
+  --app-titlebar-y: env(titlebar-area-y, 0px);
+  --app-titlebar-width: env(titlebar-area-width, 100vw);
+  --app-titlebar-height: env(titlebar-area-height, var(--app-titlebar-default-height));
+}
+
+.app-titlebar {
+  position: fixed;
+  inset-inline-start: max(var(--app-titlebar-x), 0px);
+  inset-block-start: max(var(--app-titlebar-y), 0px);
+  width: min(var(--app-titlebar-width), 100vw);
+  height: max(var(--app-titlebar-height), 2.5rem);
+  max-width: 100vw;
+  background-color: var(--color-ub-grey, #0f1317);
+  color: var(--color-ubt-grey, #f6f6f5);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-ubt-grey, #f6f6f5), transparent 85%);
+  box-shadow: 0 1px 12px color-mix(in srgb, var(--color-inverse, #000000), transparent 85%);
+  z-index: 60;
+}
+
+/* Keep the desktop workspace below the draggable title bar */
+#desktop {
+  padding-top: max(var(--app-titlebar-height), 2.5rem);
+}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -15,7 +15,7 @@ export default class Navbar extends Component {
 
 	render() {
 		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                        <div className="app-titlebar main-navbar-vp shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -8,6 +8,7 @@ import '../styles/globals.css';
 import '../styles/index.css';
 import '../styles/resume-print.css';
 import '../styles/print.css';
+import '../app/globals.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';


### PR DESCRIPTION
## Summary
- add a dedicated `app/globals.css` to expose title bar sizing variables backed by `env(titlebar-area-*)`
- update the desktop navbar to use the new `.app-titlebar` class so it stays fixed and matches the Kali chrome palette
- pad the desktop workspace with the computed title bar height and wire the stylesheet into `_app`

## Testing
- yarn lint *(fails: pre-existing accessibility and no-top-level-window lint violations across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68c902a822a88328b17487b9a070cdec