### PR TITLE
[components] Handle window controls overlay visibility

### DIFF
--- a/components/WindowControlsOverlayClient.tsx
+++ b/components/WindowControlsOverlayClient.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect } from 'react';
+
+type WindowControlsOverlayGeometryChangeEvent = Event & {
+  visible: boolean;
+};
+
+type WindowControlsOverlay = {
+  visible?: boolean;
+  addEventListener: (
+    type: 'geometrychange',
+    listener: (event: WindowControlsOverlayGeometryChangeEvent) => void,
+    options?: boolean | AddEventListenerOptions,
+  ) => void;
+  removeEventListener: (
+    type: 'geometrychange',
+    listener: (event: WindowControlsOverlayGeometryChangeEvent) => void,
+    options?: boolean | EventListenerOptions,
+  ) => void;
+};
+
+type NavigatorWithWindowControlsOverlay = Navigator & {
+  windowControlsOverlay?: WindowControlsOverlay;
+};
+
+const WindowControlsOverlayClient = () => {
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || typeof document === 'undefined') {
+      return undefined;
+    }
+
+    const htmlElement = document.documentElement;
+    const overlay = (navigator as NavigatorWithWindowControlsOverlay).windowControlsOverlay;
+
+    if (!overlay) {
+      htmlElement.classList.remove('wco-visible');
+      return undefined;
+    }
+
+    const updateVisibility = (isVisible: boolean) => {
+      if (isVisible) {
+        htmlElement.classList.add('wco-visible');
+      } else {
+        htmlElement.classList.remove('wco-visible');
+      }
+    };
+
+    const handleGeometryChange = (event: WindowControlsOverlayGeometryChangeEvent) => {
+      updateVisibility(Boolean(event.visible));
+    };
+
+    updateVisibility(Boolean(overlay.visible));
+
+    overlay.addEventListener('geometrychange', handleGeometryChange);
+
+    return () => {
+      overlay.removeEventListener('geometrychange', handleGeometryChange);
+      htmlElement.classList.remove('wco-visible');
+    };
+  }, []);
+
+  return null;
+};
+
+export default WindowControlsOverlayClient;


### PR DESCRIPTION
## Summary
- add a client component that subscribes to the `navigator.windowControlsOverlay.geometrychange` event
- toggle a `wco-visible` class on the document root when the overlay is visible

## Testing
- yarn lint *(fails: existing accessibility violations across apps and public assets)*
- yarn test *(fails: existing suite issues such as window keyboard handling and jsdom localStorage access)*

------
https://chatgpt.com/codex/tasks/task_e_68c902a7a7a88328b54fb2da456e3c2a