### PR TITLE
[desktop] enhance window focus styling

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -93,7 +93,11 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     position: relative;
 }
 
-.notFocused {
+.window-unfocused {
+    outline: none;
+}
+
+.window-unfocused .window-titlebar {
     filter: brightness(90%);
 }
 
@@ -108,6 +112,17 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
     -webkit-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
     -moz-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+}
+
+.window-shadow.window-focused {
+    outline: 2px solid var(--color-focus-ring);
+    outline-offset: 0;
+    box-shadow: 0 18px 48px -12px color-mix(in srgb, var(--color-inverse), transparent 55%),
+        0 12px 28px -16px color-mix(in srgb, var(--color-focus-ring), transparent 70%);
+    -webkit-box-shadow: 0 18px 48px -12px color-mix(in srgb, var(--color-inverse), transparent 55%),
+        0 12px 28px -16px color-mix(in srgb, var(--color-focus-ring), transparent 70%);
+    -moz-box-shadow: 0 18px 48px -12px color-mix(in srgb, var(--color-inverse), transparent 55%),
+        0 12px 28px -16px color-mix(in srgb, var(--color-focus-ring), transparent 70%);
 }
 
 .closed-window {


### PR DESCRIPTION
## Summary
- add internal focus tracking to Window so focus/blur events trigger desktop z-order updates and styling
- style active windows with an outline and elevated shadow while dimming inactive titlebars via shared CSS
- cover the focus transitions with unit tests and adjust snapping test to provide full keyboard event mocks

## Testing
- yarn test __tests__/window.test.tsx
- yarn lint *(fails: pre-existing accessibility violations across apps)*

------
https://chatgpt.com/codex/tasks/task_e_68c9666f482c83288cfd2429065ff5e0