### PR TITLE
[theme] add elevation shadow tokens

### DIFF
--- a/apps/calculator/styles.css
+++ b/apps/calculator/styles.css
@@ -12,7 +12,7 @@ body {
   background: var(--color-surface);
   padding: 1rem;
   border-radius: 8px;
-  box-shadow: 0 2px 10px color-mix(in srgb, var(--color-inverse), transparent 90%);
+  box-shadow: var(--shadow-elevation-3);
   width: 100%;
   max-width: 240px;
   container-type: inline-size;
@@ -108,7 +108,7 @@ body {
   border-left: 1px solid var(--color-border);
   padding: 0.5rem;
   font-size: 0.9rem;
-  box-shadow: -2px 0 5px color-mix(in srgb, var(--color-inverse), transparent 90%);
+  box-shadow: var(--shadow-elevation-2), -2px 0 5px color-mix(in srgb, var(--color-inverse), transparent 90%);
   display: flex;
   flex-direction: column;
   z-index: 1000;

--- a/apps/color_picker/index.css
+++ b/apps/color_picker/index.css
@@ -12,11 +12,12 @@ h1 {
   border: none;
   border-radius: 4px;
   cursor: pointer;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  transition: transform 0.2s ease;
+  box-shadow: var(--shadow-elevation-1);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 #color-input:hover {
   transform: scale(1.05);
+  box-shadow: var(--shadow-elevation-2);
 }
 #swatches {
   margin-top: 1.5rem;
@@ -34,5 +35,5 @@ h1 {
 }
 .swatch:hover {
   transform: scale(1.1);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-elevation-2);
 }

--- a/apps/mimikatz/index.tsx
+++ b/apps/mimikatz/index.tsx
@@ -12,7 +12,7 @@ const MimikatzPage: React.FC = () => {
   if (!confirmed) {
     return (
       <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-80 text-white z-50">
-        <div className="max-w-md p-6 bg-ub-dark rounded shadow text-center space-y-4">
+        <div className="max-w-md p-6 bg-ub-dark rounded elevation-3 text-center space-y-4">
           <h2 className="text-xl font-bold">High-Risk Command Warning</h2>
           <p>
             Mimikatz can execute high-risk commands that may compromise system

--- a/apps/nikto/index.tsx
+++ b/apps/nikto/index.tsx
@@ -158,7 +158,7 @@ const NiktoPage: React.FC = () => {
         <h2 className="text-lg mb-2">Command Preview</h2>
         <pre className="bg-black text-green-400 p-2 rounded overflow-auto">{command}</pre>
       </div>
-      <div className="relative bg-gray-800 p-4 rounded shadow space-y-4">
+      <div className="relative bg-gray-800 p-4 rounded elevation-2 space-y-4">
         <div className="absolute top-2 right-2 bg-gray-700 text-xs px-2 py-1 rounded-full">
           Phase 3 • {findings.length} results
         </div>

--- a/apps/recon-ng/components/DataModelExplorer.tsx
+++ b/apps/recon-ng/components/DataModelExplorer.tsx
@@ -83,7 +83,7 @@ const DataModelExplorer: React.FC = () => {
       />
       {menu && (
         <div
-          className="fixed z-10 bg-gray-800 text-white text-xs rounded shadow"
+          className="fixed z-10 bg-gray-800 text-white text-xs rounded elevation-1"
           style={{ top: menu.y, left: menu.x }}
         >
           <button
@@ -104,7 +104,7 @@ const DataModelExplorer: React.FC = () => {
         </div>
       )}
       {selected && (
-        <div className="absolute top-0 right-0 m-2 max-w-xs rounded bg-gray-800 p-2 text-xs text-white shadow">
+        <div className="absolute top-0 right-0 m-2 max-w-xs rounded bg-gray-800 p-2 text-xs text-white elevation-1">
           <div className="mb-1 font-bold">{selected.label}</div>
           <pre className="whitespace-pre-wrap">
             {JSON.stringify(selected.data, null, 2)}

--- a/apps/sokoban/index.tsx
+++ b/apps/sokoban/index.tsx
@@ -29,7 +29,7 @@ const LevelThumb: React.FC<{ level: string[] }> = ({ level }) => {
   const tileStyle = { width: LEVEL_THUMB_CELL, height: LEVEL_THUMB_CELL } as React.CSSProperties;
   return (
     <div
-      className="relative bg-gray-700 shadow-md"
+      className="relative bg-gray-700 elevation-2"
       style={{ width: width * LEVEL_THUMB_CELL, height: height * LEVEL_THUMB_CELL }}
     >
       {level.map((row, y) =>
@@ -484,7 +484,7 @@ const Sokoban: React.FC<SokobanProps> = ({ getDailySeed }) => {
         {status && <div className="ml-4 text-red-500">{status}</div>}
       </div>
       <div
-        className="relative bg-gray-700 shadow-lg"
+        className="relative bg-gray-700 elevation-3"
         style={{ width: state.width * CELL, height: state.height * CELL }}
         onMouseLeave={() => setGhost(new Set())}
       >
@@ -535,7 +535,7 @@ const Sokoban: React.FC<SokobanProps> = ({ getDailySeed }) => {
               key={b}
               className={`absolute transition-transform duration-100 ${
                 dead ? 'bg-red-500' : 'bg-orange-400'
-              } shadow-md`}
+              } elevation-2`}
               style={{
                 ...cellStyle,
                 transform: `translate(${x * CELL}px, ${y * CELL}px) scale(${b === lastPush ? 1.1 : 1})`,
@@ -562,21 +562,21 @@ const Sokoban: React.FC<SokobanProps> = ({ getDailySeed }) => {
         <button
           type="button"
           onClick={handleUndo}
-          className="px-3 py-1 bg-gray-300 rounded shadow"
+          className="px-3 py-1 bg-gray-300 rounded elevation-1"
         >
           Undo
         </button>
         <button
           type="button"
           onClick={handleRedo}
-          className="px-3 py-1 bg-gray-300 rounded shadow"
+          className="px-3 py-1 bg-gray-300 rounded elevation-1"
         >
           Redo
         </button>
         <button
           type="button"
           onClick={handleReset}
-          className="px-3 py-1 bg-gray-300 rounded shadow"
+          className="px-3 py-1 bg-gray-300 rounded elevation-1"
         >
           Reset
         </button>

--- a/apps/spotify/index.tsx
+++ b/apps/spotify/index.tsx
@@ -224,7 +224,7 @@ const SpotifyApp = () => {
       )}
       {currentTrack && (
         <div className="mt-2">
-          <div className="relative w-32 aspect-square mb-2 shadow-lg overflow-hidden">
+          <div className="relative w-32 aspect-square mb-2 elevation-3 overflow-hidden">
             {currentTrack.cover ? (
               <img
                 src={currentTrack.cover}

--- a/apps/sticky_notes/styles.css
+++ b/apps/sticky_notes/styles.css
@@ -28,8 +28,7 @@ body {
   padding: 10px;
   resize: both;
   overflow: auto;
-  box-shadow: 0 4px 6px color-mix(in srgb, var(--color-inverse), transparent 90%),
-    0 1px 3px color-mix(in srgb, var(--color-inverse), transparent 92%);
+  box-shadow: var(--shadow-elevation-2);
   border-radius: 4px;
 }
 

--- a/apps/weather_widget/styles.css
+++ b/apps/weather_widget/styles.css
@@ -11,7 +11,7 @@ body {
 .widget-container {
   background: var(--color-surface);
   border-radius: 8px;
-  box-shadow: 0 4px 10px color-mix(in srgb, var(--color-inverse), transparent 90%);
+  box-shadow: var(--shadow-elevation-3);
   padding: 20px;
   display: flex;
   flex-direction: column;

--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -90,7 +90,7 @@ const BadgeList = ({ badges, className = '' }) => {
         >
           <div
             ref={modalRef}
-            className="bg-white text-black p-4 rounded shadow max-w-sm"
+            className="bg-white text-black p-4 rounded elevation-3 max-w-sm"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="font-bold mb-2">{selected.label}</div>

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -137,7 +137,7 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
           <div
             className={
               (this.state.navbar ? ' visible animateShow z-30 ' : ' invisible ') +
-              ' md:hidden text-xs absolute bg-ub-cool-grey py-0.5 px-1 rounded-sm top-full mt-1 left-0 shadow border-black border border-opacity-20'
+              ' md:hidden text-xs absolute bg-ub-cool-grey py-0.5 px-1 rounded-sm top-full mt-1 left-0 elevation-1 border-black border border-opacity-20'
             }
             role="tablist"
             aria-orientation="vertical"

--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -216,7 +216,7 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
       role="dialog"
       aria-modal="true"
     >
-      <div className="max-w-md p-4 bg-gray-800 rounded shadow-lg">
+      <div className="max-w-md p-4 bg-gray-800 rounded elevation-3">
         <h2 className="text-xl font-bold mb-2">{gameId} Help</h2>
         <p className="mb-2">
           <strong>Objective:</strong> {info.objective}

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -94,7 +94,7 @@ export class AboutAlex extends Component {
                     <div className=" w-3.5 border-t border-white"></div>
                     <div className=" w-3.5 border-t border-white" style={{ marginTop: "2pt", marginBottom: "2pt" }}></div>
                     <div className=" w-3.5 border-t border-white"></div>
-                    <div className={(this.state.navbar ? " visible animateShow z-30 " : " invisible ") + " md:hidden text-xs absolute bg-ub-cool-grey py-0.5 px-1 rounded-sm top-full mt-1 left-0 shadow border-black border border-opacity-20"}>
+                    <div className={(this.state.navbar ? " visible animateShow z-30 " : " invisible ") + " md:hidden text-xs absolute bg-ub-cool-grey py-0.5 px-1 rounded-sm top-full mt-1 left-0 elevation-1 border-black border border-opacity-20"}>
                         {this.renderNavLinks()}
                     </div>
                 </div>
@@ -372,7 +372,7 @@ function Skills({ skills }) {
       </div>
       <div className="w-full md:w-10/12 flex flex-col items-center mt-8">
         <div className="font-bold text-sm md:text-base mb-2 text-center">GitHub Contributions</div>
-        <div className="bg-ub-gedit-light bg-opacity-20 p-1 md:p-2 rounded-md shadow-md">
+        <div className="bg-ub-gedit-light bg-opacity-20 p-1 md:p-2 rounded-md elevation-2">
           <img
             src="https://ghchart.rshah.org/Alex-Unnippillil"
             alt="Alex Unnippillil's GitHub contribution graph"

--- a/components/apps/beef/GuideOverlay.js
+++ b/components/apps/beef/GuideOverlay.js
@@ -51,7 +51,7 @@ export default function GuideOverlay({ onClose }) {
       tabIndex={-1}
       onKeyDown={onKeyDown}
     >
-      <div className="max-w-md p-4 bg-gray-800 rounded shadow-lg">
+      <div className="max-w-md p-4 bg-gray-800 rounded elevation-3">
         <div className="mb-2 text-center font-bold">
           Demo data, no live scanning
         </div>

--- a/components/apps/beef/HookGraph.js
+++ b/components/apps/beef/HookGraph.js
@@ -20,7 +20,7 @@ export default function HookGraph({ hooks, steps }) {
             href={mod.link}
             target="_blank"
             rel="noopener noreferrer"
-            className="bg-ub-gray-50 text-black p-3 rounded shadow transition-transform duration-300 transform hover:scale-105 fade-in"
+            className="bg-ub-gray-50 text-black p-3 rounded elevation-2 transition-transform duration-300 transform hover:scale-105 fade-in"
           >
             <h3 className="font-bold text-sm mb-1">{mod.name}</h3>
             <p className="text-xs mb-2">{mod.description}</p>

--- a/components/apps/chrome/AddressBar.tsx
+++ b/components/apps/chrome/AddressBar.tsx
@@ -240,7 +240,7 @@ const AddressBar: React.FC<AddressBarProps> = ({
         />
       </div>
       {suggestions.length > 0 && (
-        <ul className="absolute left-0 right-0 bg-white text-black mt-0.5 max-h-48 overflow-auto z-10 shadow">
+        <ul className="absolute left-0 right-0 bg-white text-black mt-0.5 max-h-48 overflow-auto z-10 elevation-1">
           {suggestions.map((s, i) => {
             const fav = favorites.find((f) => f.url === s);
             return (
@@ -261,7 +261,7 @@ const AddressBar: React.FC<AddressBarProps> = ({
       )}
       {menu && (
         <ul
-          className="absolute bg-white text-black shadow border z-20"
+          className="absolute bg-white text-black elevation-1 border z-20"
           style={{ left: menu.x, top: menu.y }}
         >
           <li

--- a/components/apps/hangman.js
+++ b/components/apps/hangman.js
@@ -500,7 +500,7 @@ const Hangman = () => {
         <button
           onClick={handleHint}
           disabled={hintCoins <= 0 || paused}
-          className="px-2 py-0.5 bg-ub-orange text-black rounded-full text-xs shadow" 
+          className="px-2 py-0.5 bg-ub-orange text-black rounded-full text-xs elevation-1"
         >
           Hint ({hintCoins})
         </button>

--- a/components/apps/nessus/index.js
+++ b/components/apps/nessus/index.js
@@ -397,7 +397,7 @@ const Nessus = () => {
         ))}
       </ul>
       {selected && (
-        <div className="fixed top-0 right-0 w-80 h-full bg-gray-800 p-4 overflow-auto shadow-lg">
+        <div className="fixed top-0 right-0 w-80 h-full bg-gray-800 p-4 overflow-auto elevation-3">
           <button
             type="button"
             onClick={() => setSelected(null)}

--- a/components/apps/nikto/index.js
+++ b/components/apps/nikto/index.js
@@ -245,7 +245,7 @@ const NiktoApp = () => {
         </table>
       </div>
       {selected && (
-        <div className="fixed top-0 right-0 w-80 h-full bg-gray-800 p-4 overflow-auto shadow-lg">
+        <div className="fixed top-0 right-0 w-80 h-full bg-gray-800 p-4 overflow-auto elevation-3">
           <button
             type="button"
             onClick={() => setSelected(null)}

--- a/components/apps/project-gallery.tsx
+++ b/components/apps/project-gallery.tsx
@@ -257,7 +257,7 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
         {filtered.map((project) => (
           <div
             key={project.id}
-            className="mb-4 break-inside-avoid bg-gray-800 rounded shadow overflow-hidden"
+            className="mb-4 break-inside-avoid bg-gray-800 rounded elevation-2 overflow-hidden"
           >
             <div className="flex flex-col md:flex-row h-48">
               <img

--- a/components/apps/radare2/GuideOverlay.js
+++ b/components/apps/radare2/GuideOverlay.js
@@ -48,7 +48,7 @@ export default function GuideOverlay({ onClose }) {
       role="dialog"
       aria-modal="true"
     >
-      <div className="max-w-md p-4 bg-gray-800 rounded shadow-lg">
+      <div className="max-w-md p-4 bg-gray-800 rounded elevation-3">
         <h2 className="text-xl font-bold mb-2">Radare2 Tutorial</h2>
         <p className="mb-4">{STEPS[step]}</p>
         <div className="flex justify-between mb-4">

--- a/components/apps/reversi.js
+++ b/components/apps/reversi.js
@@ -393,13 +393,13 @@ const Reversi = () => {
         />
         <div className="absolute top-1 left-1 flex items-center space-x-1 text-sm">
           <div
-            className={`w-4 h-4 rounded-full ${diskTheme === 'dark' ? 'bg-black' : 'bg-gray-700'} shadow`}
+            className={`w-4 h-4 rounded-full ${diskTheme === 'dark' ? 'bg-black' : 'bg-gray-700'} elevation-1`}
           />
           <span>{score.black}</span>
         </div>
         <div className="absolute top-1 right-1 flex items-center space-x-1 text-sm">
           <div
-            className={`w-4 h-4 rounded-full ${diskTheme === 'dark' ? 'bg-white' : 'bg-gray-200'} shadow`}
+            className={`w-4 h-4 rounded-full ${diskTheme === 'dark' ? 'bg-white' : 'bg-gray-200'} elevation-1`}
           />
           <span>{score.white}</span>
         </div>

--- a/components/apps/solitaire/index.tsx
+++ b/components/apps/solitaire/index.tsx
@@ -357,7 +357,7 @@ const Solitaire = () => {
     ghost.style.top = '-1000px';
     ghost.style.left = '-1000px';
     ghost.style.pointerEvents = 'none';
-    ghost.style.boxShadow = '0 8px 16px rgba(0,0,0,0.3)';
+    ghost.style.boxShadow = 'var(--shadow-elevation-3)';
     document.body.appendChild(ghost);
     e.dataTransfer.setDragImage(ghost, 32, 48);
     dragImageRef.current = ghost;
@@ -694,7 +694,7 @@ const Solitaire = () => {
             className="absolute transition-transform duration-1000 ease-[cubic-bezier(0.22,1,0.36,1)]"
             style={{
               transform: `translate(${c.x}px, ${c.y}px) rotate(${c.angle}deg)`,
-              boxShadow: '0 8px 16px rgba(0,0,0,0.3)',
+              boxShadow: 'var(--shadow-elevation-3)',
             }}
           >
             {renderCard(c)}

--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -587,7 +587,7 @@ export default function Todoist() {
           draggable
           onDragStart={handleDragStart(group, task)}
           onKeyDown={handleKeyDown(group, task)}
-          className="rounded shadow bg-white text-black flex items-center px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="rounded elevation-2 bg-white text-black flex items-center px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
           role="listitem"
         >
           <label className="mr-2 inline-flex items-center">

--- a/components/apps/vscode.jsx
+++ b/components/apps/vscode.jsx
@@ -64,7 +64,7 @@ export default function VsCodeWrapper({ openApp }) {
       <VsCode />
       {visible && (
         <div className="absolute inset-0 flex items-start justify-center pt-24 bg-black/50">
-          <div className="bg-gray-800 text-white w-11/12 max-w-md rounded shadow-lg p-2">
+          <div className="bg-gray-800 text-white w-11/12 max-w-md rounded elevation-3 p-2">
             <input
               autoFocus
               className="w-full p-2 mb-2 bg-gray-700 rounded outline-none"

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -79,7 +79,7 @@ function ChannelHovercard({ id, name }: { id: string; name: string }) {
     <span className="relative" onMouseEnter={handleEnter} onMouseLeave={handleLeave}>
       {name}
       {show && info && (
-        <div className="absolute z-10 mt-1 w-48 rounded bg-ub-cool-grey p-2 text-xs text-ubt-cool-grey shadow">
+        <div className="absolute z-10 mt-1 w-48 rounded bg-ub-cool-grey p-2 text-xs text-ubt-cool-grey elevation-1">
           <div className="font-bold">{info.name}</div>
           {info.subscriberCount && <div>{info.subscriberCount} subs</div>}
         </div>

--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -132,7 +132,7 @@ export class SideBarApp extends Component {
                         className={
                             (this.state.showTitle ? " visible " : " invisible ") +
                             " pointer-events-none absolute bottom-full mb-2 left-1/2 transform -translate-x-1/2" +
-                            " rounded border border-gray-400 border-opacity-40 shadow-lg overflow-hidden bg-black bg-opacity-50"
+                            " rounded border border-gray-400 border-opacity-40 elevation-3 overflow-hidden bg-black bg-opacity-50"
                         }
                     >
                         <Image

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -134,7 +134,7 @@ const WhiskerMenu: React.FC = () => {
       {open && (
         <div
           ref={menuRef}
-          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
+          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white elevation-3"
           tabIndex={-1}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node)) {

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -15,7 +15,7 @@ export default class Navbar extends Component {
 
 	render() {
 		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                        <div className="main-navbar-vp absolute top-0 right-0 w-screen elevation-2 flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -23,7 +23,7 @@ const QuickSettings = ({ open }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 elevation-2 border-black border border-opacity-20 ${
         open ? '' : 'hidden'
       }`}
     >

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -32,7 +32,7 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md elevation-2 flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
     >
       <span>{message}</span>
       {onAction && actionLabel && (

--- a/docs/theme-guide.md
+++ b/docs/theme-guide.md
@@ -1,0 +1,39 @@
+# Theme guide
+
+The desktop shell relies on design tokens defined in `styles/tokens.css`. These CSS custom properties keep the Ubuntu/Kali skin consistent across apps and surfaces.
+
+## Shadow elevation tokens
+
+Use the `--shadow-elevation-*` tokens to express depth. They adapt to the active theme palette and automatically switch to high-contrast outlines when the accessibility mode is enabled.
+
+| Token | Typical use | Notes |
+| --- | --- | --- |
+| `--shadow-elevation-1` | Small chips, hover previews, menus | Subtle lift for low emphasis UI. |
+| `--shadow-elevation-2` | Sticky notes, dropdowns, toast notifications | Two-layer shadow for floating surfaces. |
+| `--shadow-elevation-3` | Dialogs, feature cards, draggable elements | Deeper lift used for primary overlays. |
+| `--shadow-elevation-4` | Desktop windows, modals with chrome | Heaviest elevation. Includes a spread for window chrome. |
+
+### Applying shadows in CSS
+
+```css
+.card {
+  box-shadow: var(--shadow-elevation-2);
+}
+```
+
+To keep usage consistent in JSX/TSX, prefer the global helper classes declared in `styles/index.css`:
+
+- `.elevation-1`
+- `.elevation-2`
+- `.elevation-3`
+- `.elevation-4`
+
+```jsx
+<div className="rounded-md elevation-3">…</div>
+```
+
+The helper classes read from the same tokens, so custom themes or high-contrast overrides only need to change the token values.
+
+### Accessibility behaviour
+
+The high-contrast theme and the `prefers-contrast: more` media query swap the soft shadows for solid outlines. Components keep their elevation semantics without relying on blurred shadows, improving focus and legibility for assistive setups.

--- a/pages/dummy-form.tsx
+++ b/pages/dummy-form.tsx
@@ -87,7 +87,7 @@ const DummyForm: React.FC = () => {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100">
-      <form onSubmit={handleSubmit} className="w-full max-w-md rounded bg-white p-6 shadow-md">
+      <form onSubmit={handleSubmit} className="w-full max-w-md rounded bg-white p-6 elevation-2">
         <h1 className="mb-4 text-xl font-bold">Contact Us</h1>
         {recovered && <p className="mb-4 text-sm text-blue-600">Recovered draft</p>}
         {error && <FormError className="mb-4 mt-0">{error}</FormError>}

--- a/pages/hydra-preview.tsx
+++ b/pages/hydra-preview.tsx
@@ -36,7 +36,7 @@ const HydraPreview: React.FC = () => {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100">
-      <div className="w-full max-w-md rounded bg-white p-6 shadow-md">
+      <div className="w-full max-w-md rounded bg-white p-6 elevation-2">
         {error && <FormError className="mb-4 mt-0">{error}</FormError>}
         {step === 0 && (
           <div>

--- a/pages/nessus-report.tsx
+++ b/pages/nessus-report.tsx
@@ -281,7 +281,7 @@ const NessusReport: React.FC = () => {
       {selected && (
         <div
           role="dialog"
-          className="fixed top-0 right-0 h-full w-80 bg-gray-800 p-4 overflow-auto shadow-lg"
+          className="fixed top-0 right-0 h-full w-80 bg-gray-800 p-4 overflow-auto elevation-3"
         >
           <button
             type="button"

--- a/pages/spoofing.tsx
+++ b/pages/spoofing.tsx
@@ -12,7 +12,7 @@ const ToolTile = ({ title, link, children }: TileProps) => (
     href={link}
     target="_blank"
     rel="noopener noreferrer"
-    className="block p-4 bg-ub-grey text-white rounded shadow hover:bg-black focus:outline-none focus:ring"
+    className="block p-4 bg-ub-grey text-white rounded elevation-2 hover:bg-black focus:outline-none focus:ring"
   >
     <h2 className="text-xl mb-2">{title}</h2>
     {children}

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -23,7 +23,7 @@ function Toggle({
       }`}
     >
       <span
-        className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform duration-200 ${
+        className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full elevation-1 transition-transform duration-200 ${
           checked ? 'translate-x-6' : ''
         }`}
       ></span>

--- a/styles/index.css
+++ b/styles/index.css
@@ -105,9 +105,25 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .window-shadow {
-    box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -webkit-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -moz-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+    box-shadow: var(--shadow-elevation-4);
+    -webkit-box-shadow: var(--shadow-elevation-4);
+    -moz-box-shadow: var(--shadow-elevation-4);
+}
+
+.elevation-1 {
+    box-shadow: var(--shadow-elevation-1);
+}
+
+.elevation-2 {
+    box-shadow: var(--shadow-elevation-2);
+}
+
+.elevation-3 {
+    box-shadow: var(--shadow-elevation-3);
+}
+
+.elevation-4 {
+    box-shadow: var(--shadow-elevation-4);
 }
 
 .closed-window {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -47,6 +47,15 @@
   --radius-lg: 8px;
   --radius-round: 9999px;
 
+  /* Elevation shadows */
+  --shadow-elevation-1: 0 1px 2px color-mix(in srgb, var(--color-inverse), transparent 88%);
+  --shadow-elevation-2: 0 4px 6px color-mix(in srgb, var(--color-inverse), transparent 85%),
+    0 1px 3px color-mix(in srgb, var(--color-inverse), transparent 92%);
+  --shadow-elevation-3: 0 8px 16px color-mix(in srgb, var(--color-inverse), transparent 78%),
+    0 3px 6px color-mix(in srgb, var(--color-inverse), transparent 88%);
+  --shadow-elevation-4: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%),
+    0 6px 18px color-mix(in srgb, var(--color-inverse), transparent 85%);
+
   /* Motion durations */
   --motion-fast: 150ms;
   --motion-medium: 300ms;
@@ -77,6 +86,10 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --shadow-elevation-1: 0 0 0 1px var(--color-text);
+  --shadow-elevation-2: 0 0 0 2px var(--color-text);
+  --shadow-elevation-3: 0 0 0 2px var(--color-text);
+  --shadow-elevation-4: 0 0 0 3px var(--color-text);
 }
 
 /* Dyslexia-friendly fonts */
@@ -116,5 +129,9 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+    --shadow-elevation-1: 0 0 0 1px var(--color-text);
+    --shadow-elevation-2: 0 0 0 2px var(--color-text);
+    --shadow-elevation-3: 0 0 0 2px var(--color-text);
+    --shadow-elevation-4: 0 0 0 3px var(--color-text);
   }
 }


### PR DESCRIPTION
## Summary
- add `--shadow-elevation-*` design tokens with high-contrast overrides
- add global `.elevation-*` helpers and replace ad-hoc shadows across menus, overlays, and utility cards
- document elevation usage in the theme guide for future contributors

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label and no-top-level-window warnings)*
- yarn test *(fails: existing window, nmap NSE, modal tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c9671dd14083289e4895d6712d3f1c