### PR TITLE
[style] centralize theme color tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ See Vercel's [Speed Insights Quickstart](https://vercel.com/docs/speed-insights/
 - Client-side only **simulations** of security tools (no real exploitation)
 - A large set of games rendered in-browser (Canvas/DOM), with a shared `GameLayout`
 
+## Theming & Design Tokens
+
+- Base tokens (background, surface, borders, text, primary/accent) live in [`styles/tokens.css`](./styles/tokens.css) under `--color-base-*` names. They centralize the Kali palette and any derived values such as `--color-bg`, `--color-text`, or `--color-border`.
+- State tokens (`--color-state-info`, `--color-state-success`, `--color-state-warning`, `--color-state-danger`, `--color-state-terminal`, `--color-state-focus`, `--color-state-selection`) capture semantic feedback colors so components can stay consistent with focus rings and status badges.
+- High contrast toggles and theme variants (`dark`, `neon`, `matrix`) only swap the base tokens in [`styles/globals.css`](./styles/globals.css), so UI code should always reference the base/state variables instead of hard-coded hex values.
+- The global `accent-color` property is driven by `--color-control-accent`, ensuring native form controls adopt the active accent automatically.
+
 ### Gamepad Input & Remapping
 
 Games can listen for normalized gamepad events via `utils/gamepad.ts`. The manager polls

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,70 +2,52 @@
 
 /* Accessible theme color palette meeting WCAG AA contrast ratios */
 :root {
-  /* Base colors */
-  --color-bg: #0f1317; /* kali background */
-  --color-text: #f5f5f5; /* text on dark backgrounds */
-  /* Brand accents */
-  --color-primary: #1793d1; /* kali blue accent */
-  --color-secondary: #1a1f26; /* complementary dark */
-  --color-accent: #1793d1; /* accent matches primary */
-  /* Utility colors */
-  --color-muted: #2a2e36; /* muted surfaces */
-  --color-surface: #1a1f26; /* panel surfaces */
-  --color-inverse: #000000; /* inverse of text */
-  --color-border: #2a2e36; /* subtle borders */
-  --color-terminal: #00ff00; /* terminal green */
-  --color-dark: #0c0f12; /* card back */
-  --color-focus-ring: var(--color-accent);
-  --color-selection: var(--color-accent);
-  --color-control-accent: var(--color-accent);
   accent-color: var(--color-control-accent);
 }
 
 /* Dark theme */
 html[data-theme='dark'] {
-  --color-bg: #000000;
-  --color-text: #e5e5e5;
-  --color-primary: #1e88e5;
-  --color-secondary: #121212;
-  --color-accent: #bb86fc;
-  --color-muted: #1f1f1f;
-  --color-surface: #121212;
-  --color-inverse: #ffffff;
-  --color-border: #333333;
-  --color-terminal: #00ff00;
-  --color-dark: #0a0a0a;
+  --color-base-background: #000000;
+  --color-base-text: #e5e5e5;
+  --color-base-primary: #1e88e5;
+  --color-base-accent: #bb86fc;
+  --color-base-secondary: #121212;
+  --color-base-surface: #121212;
+  --color-base-muted: #1f1f1f;
+  --color-base-border: #333333;
+  --color-base-inverse: #ffffff;
+  --color-base-dark: #0a0a0a;
+  --color-state-terminal: #00ff00;
 }
 
 /* Neon theme */
 html[data-theme='neon'] {
-  --color-bg: #000000;
-  --color-text: #ffffff;
-  --color-primary: #39ff14;
-  --color-secondary: #1a1a1a;
-  --color-accent: #ff00ff;
-  --color-muted: #222222;
-  --color-surface: #111111;
-  --color-inverse: #ffffff;
-  --color-border: #333333;
-  --color-terminal: #39ff14;
-  --color-dark: #000000;
+  --color-base-background: #000000;
+  --color-base-text: #ffffff;
+  --color-base-primary: #39ff14;
+  --color-base-accent: #ff00ff;
+  --color-base-secondary: #1a1a1a;
+  --color-base-surface: #111111;
+  --color-base-muted: #222222;
+  --color-base-border: #333333;
+  --color-base-inverse: #ffffff;
+  --color-base-dark: #000000;
+  --color-state-terminal: #39ff14;
 }
 
 /* Matrix theme */
 html[data-theme='matrix'] {
-  --color-bg: #000000;
-  --color-text: #00ff00;
-  --color-primary: #00ff00;
-  --color-secondary: #001100;
-  --color-accent: #00ff00;
-  --color-muted: #003300;
-  --color-surface: #001100;
-  --color-inverse: #ffffff;
-  --color-border: #003300;
-  --color-terminal: #00ff00;
-  --color-dark: #000000;
-
+  --color-base-background: #000000;
+  --color-base-text: #00ff00;
+  --color-base-primary: #00ff00;
+  --color-base-accent: #00ff00;
+  --color-base-secondary: #001100;
+  --color-base-surface: #001100;
+  --color-base-muted: #003300;
+  --color-base-border: #003300;
+  --color-base-inverse: #ffffff;
+  --color-base-dark: #000000;
+  --color-state-terminal: #00ff00;
 }
 
 ::selection {
@@ -74,6 +56,6 @@ html[data-theme='matrix'] {
 }
 
 *:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
+  outline: var(--focus-outline-width) solid var(--color-focus-ring);
   outline-offset: 2px;
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -527,6 +527,6 @@ textarea:focus-visible {
 
 /* High contrast overrides */
 .high-contrast .bg-ub-orange {
-    color: #000 !important;
+    color: var(--color-inverse) !important;
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -23,15 +23,51 @@
   --color-ubt-gedit-dark: #003B70;
   --color-ub-border-orange: #1793d1;
   --color-ub-dark-grey: #2a2e36;
-  --color-bg: #0f1317;
-  --color-text: #F5F5F5;
+
+  /* Base color tokens */
+  --color-base-background: #0f1317;
+  --color-base-surface: #1a1f26;
+  --color-base-secondary: #1a1f26;
+  --color-base-muted: #2a2e36;
+  --color-base-border: #2a2e36;
+  --color-base-dark: #0c0f12;
+  --color-base-text: #f5f5f5;
+  --color-base-inverse: #000000;
+  --color-base-primary: #1793d1;
+  --color-base-accent: #1793d1;
+
+  /* State color tokens */
+  --color-state-info: var(--color-base-primary);
+  --color-state-success: #15803d;
+  --color-state-warning: #d97706;
+  --color-state-danger: #b91c1c;
+  --color-state-terminal: #00ff00;
+  --color-state-focus: var(--color-base-accent);
+  --color-state-selection: var(--color-base-accent);
+
+  /* Derived color variables */
+  --color-bg: var(--color-base-background);
+  --color-text: var(--color-base-text);
+  --color-primary: var(--color-base-primary);
+  --color-secondary: var(--color-base-secondary);
+  --color-accent: var(--color-base-accent);
+  --color-muted: var(--color-base-muted);
+  --color-surface: var(--color-base-surface);
+  --color-inverse: var(--color-base-inverse);
+  --color-border: var(--color-base-border);
+  --color-terminal: var(--color-state-terminal);
+  --color-dark: var(--color-base-dark);
+  --color-focus-ring: var(--color-state-focus);
+  --color-selection: var(--color-state-selection);
+  --color-control-accent: var(--color-base-accent);
+
   --kali-bg: rgba(15, 19, 23, 0.85);
 
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
-  --game-color-success: #15803d;
-  --game-color-warning: #d97706;
-  --game-color-danger: #b91c1c;
+  --game-color-success: var(--color-state-success);
+  --game-color-warning: var(--color-state-warning);
+  --game-color-danger: var(--color-state-danger);
 
   /* Spacing scale */
   --space-1: 0.25rem;
@@ -58,14 +94,31 @@
   /* Minimum interactive target size */
   --hit-area: 32px;
   /* Focus outline */
-  --focus-outline-color: var(--color-ubt-blue);
+  --focus-outline-color: var(--color-state-focus);
   --focus-outline-width: 2px;
 }
 
 /* High contrast theme */
 .high-contrast {
-  --color-bg: #000000;
-  --color-text: #ffffff;
+  --color-base-background: #000000;
+  --color-base-surface: #000000;
+  --color-base-secondary: #000000;
+  --color-base-muted: #000000;
+  --color-base-border: #ffff00;
+  --color-base-dark: #000000;
+  --color-base-text: #ffffff;
+  --color-base-inverse: #000000;
+  --color-base-primary: #ffff00;
+  --color-base-accent: #ffff00;
+
+  --color-state-info: var(--color-base-primary);
+  --color-state-success: #00ffff;
+  --color-state-warning: #ff00ff;
+  --color-state-danger: #ff0000;
+  --color-state-terminal: #39ff14;
+  --color-state-focus: var(--color-base-accent);
+  --color-state-selection: var(--color-base-accent);
+
   --color-ub-grey: #000000;
   --color-ub-cool-grey: #000000;
   --color-ubt-grey: #ffffff;
@@ -73,6 +126,7 @@
   --color-ub-orange: #ffff00;
   --color-ub-lite-abrgn: #00ffff;
   --color-ub-border-orange: #ffff00;
+
   --game-color-secondary: #ffff00;
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
@@ -107,8 +161,25 @@
 /* Optional high contrast via media query */
 @media (prefers-contrast: more) {
   :root {
-    --color-bg: #000000;
-    --color-text: #ffffff;
+    --color-base-background: #000000;
+    --color-base-surface: #000000;
+    --color-base-secondary: #000000;
+    --color-base-muted: #000000;
+    --color-base-border: #ffff00;
+    --color-base-dark: #000000;
+    --color-base-text: #ffffff;
+    --color-base-inverse: #000000;
+    --color-base-primary: #ffff00;
+    --color-base-accent: #ffff00;
+
+    --color-state-info: var(--color-base-primary);
+    --color-state-success: #00ffff;
+    --color-state-warning: #ff00ff;
+    --color-state-danger: #ff0000;
+    --color-state-terminal: #39ff14;
+    --color-state-focus: var(--color-base-accent);
+    --color-state-selection: var(--color-base-accent);
+
     --color-ub-grey: #000000;
     --color-ub-cool-grey: #000000;
     --color-ubt-grey: #ffffff;
@@ -116,5 +187,10 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+
+    --game-color-secondary: #ffff00;
+    --game-color-success: #00ffff;
+    --game-color-warning: #ff00ff;
+    --game-color-danger: #ff0000;
   }
 }


### PR DESCRIPTION
## Summary
- define reusable base and state color tokens in `styles/tokens.css` and align high-contrast overrides
- map theme data attributes to the new tokens and derive focus rings from the shared focus width
- swap the remaining hard-coded high-contrast color for the shared inverse token and document the theming workflow in the README

## Testing
- `yarn lint` *(fails: repository has longstanding a11y lint failures)*
- `yarn test` *(fails: existing jest suites for nmap NSE clipboard flow and jsdom localStorage access)*

------
https://chatgpt.com/codex/tasks/task_e_68c9671c0a2083289729994b2dd412be