### PR TITLE
[ui] Normalize dock icon sizing

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -101,24 +101,24 @@ export class SideBarApp extends Component {
                     this.setState({ showTitle: false, thumbnail: null });
                 }}
                 className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
-                    " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
+                    " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-2 transition-hover transition-active"}
                 id={"sidebar-" + this.props.id}
             >
                 <Image
-                    width={28}
-                    height={28}
-                    className="w-7"
+                    width={24}
+                    height={24}
+                    className="h-6 w-6"
                     src={this.props.icon.replace('./', '/')}
                     alt="Ubuntu App Icon"
-                    sizes="28px"
+                    sizes="24px"
                 />
                 <Image
-                    width={28}
-                    height={28}
-                    className={(this.state.scaleImage ? " scale " : "") + " scalable-app-icon w-7 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"}
+                    width={24}
+                    height={24}
+                    className={(this.state.scaleImage ? " scale " : "") + " scalable-app-icon h-6 w-6 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"}
                     src={this.props.icon.replace('./', '/')}
                     alt=""
-                    sizes="28px"
+                    sizes="24px"
                 />
                 {
                     (

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -52,7 +52,7 @@ export function AllApps(props) {
 
     return (
         <div
-            className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
+            className={`w-10 h-10 rounded m-2 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
             style={{ marginTop: 'auto' }}
             onMouseEnter={() => {
                 setTitle(true);
@@ -64,12 +64,12 @@ export function AllApps(props) {
         >
             <div className="relative">
                 <Image
-                    width={28}
-                    height={28}
-                    className="w-7"
+                    width={24}
+                    height={24}
+                    className="h-6 w-6"
                     src="/themes/Yaru/system/view-app-grid-symbolic.svg"
                     alt="Ubuntu view app"
-                    sizes="28px"
+                    sizes="24px"
                 />
                 <div
                     className={


### PR DESCRIPTION
## Summary
- resize dock app and application grid icons to 24px so they align to the 8px baseline grid
- update dock spacing utilities to keep icon buttons aligned to the new grid

## Testing
- yarn lint *(fails: pre-existing accessibility and no-top-level-window lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c9671d0c30832891ecbc7e0a142487