### PR TITLE
[theme] Dynamically sync theme-color meta tag

### DIFF
--- a/__tests__/documentMetadata.test.ts
+++ b/__tests__/documentMetadata.test.ts
@@ -1,0 +1,42 @@
+import {
+  FALLBACK_THEME_COLOR,
+  getThemeColor,
+  getThemeColorMetaContent,
+  setThemeColorMeta,
+} from '../utils/metadata';
+import { readAccentColorFromStyles } from '../utils/metadata.server';
+
+describe('document metadata utilities', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    document.documentElement.removeAttribute('style');
+  });
+
+  it('creates the theme-color meta tag when missing', () => {
+    expect(document.querySelector('meta[name="theme-color"]')).toBeNull();
+    setThemeColorMeta();
+    const meta = document.querySelector('meta[name="theme-color"]');
+    expect(meta).not.toBeNull();
+    expect(meta?.getAttribute('content')).toBe(FALLBACK_THEME_COLOR);
+  });
+
+  it('reads the runtime accent color for updates', () => {
+    document.documentElement.style.setProperty('--color-accent', '#123456');
+    setThemeColorMeta();
+    expect(getThemeColorMetaContent()).toBe('#123456');
+  });
+
+  it('accepts an explicit color override', () => {
+    setThemeColorMeta('#654321');
+    expect(getThemeColorMetaContent()).toBe('#654321');
+  });
+
+  it('falls back to default when accent variable is missing', () => {
+    document.documentElement.style.removeProperty('--color-accent');
+    expect(getThemeColor()).toBe(FALLBACK_THEME_COLOR);
+  });
+
+  it('reads the accent color from CSS files on the server', () => {
+    expect(readAccentColorFromStyles()).toBe('#1793d1');
+  });
+});

--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -20,8 +20,6 @@ export default function Meta() {
             <meta name="language" content="English" />
             <meta name="category" content="16" />
             <meta name="viewport" content="width=device-width, initial-scale=1" />
-            <meta name="theme-color" content="#0f1317" />
-
             {/* Search Engine */}
             <meta name="image" content="images/logos/fevicon.png" />
             {/* Schema.org for Google */}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -23,6 +23,7 @@ import {
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+import { setThemeColorMeta } from '../utils/metadata';
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
@@ -151,6 +152,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     });
     saveAccent(accent);
   }, [accent]);
+
+  useEffect(() => {
+    setThemeColorMeta();
+  }, [accent, theme]);
 
   useEffect(() => {
     saveWallpaper(wallpaper);

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,4 +1,5 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { readAccentColorFromStyles } from '../utils/metadata.server';
 
 class MyDocument extends Document {
   /**
@@ -12,12 +13,13 @@ class MyDocument extends Document {
 
   render() {
     const { nonce } = this.props;
+    const themeColor = readAccentColorFromStyles();
     return (
       <Html lang="en" data-csp-nonce={nonce}>
         <Head>
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
-          <meta name="theme-color" content="#0f1317" />
+          <meta name="theme-color" content={themeColor} />
           <script nonce={nonce} src="/theme.js" />
         </Head>
         <body>

--- a/public/theme.js
+++ b/public/theme.js
@@ -1,6 +1,25 @@
 (function () {
   var THEME_KEY = 'app:theme';
   try {
+    var updateThemeColorMeta = function () {
+      try {
+        var head = document.head || document.getElementsByTagName('head')[0];
+        if (!head) return;
+        var meta = head.querySelector('meta[name="theme-color"]');
+        if (!meta) {
+          meta = document.createElement('meta');
+          meta.setAttribute('name', 'theme-color');
+          head.appendChild(meta);
+        }
+        var computed = window
+          .getComputedStyle(document.documentElement)
+          .getPropertyValue('--color-accent')
+          .trim();
+        meta.setAttribute('content', computed || '#1793d1');
+      } catch (metaError) {
+        console.error('Failed to update theme-color meta tag', metaError);
+      }
+    };
     var stored = null;
     if (typeof window !== 'undefined' && typeof window.localStorage !== 'undefined') {
       stored = window.localStorage.getItem(THEME_KEY);
@@ -15,9 +34,16 @@
     document.documentElement.dataset.theme = theme;
     var darkThemes = ['dark', 'neon', 'matrix'];
     document.documentElement.classList.toggle('dark', darkThemes.includes(theme));
+    updateThemeColorMeta();
   } catch (e) {
     console.error('Failed to apply theme', e);
     document.documentElement.dataset.theme = 'default';
     document.documentElement.classList.remove('dark');
+    try {
+      var fallbackMeta = document.querySelector('meta[name="theme-color"]');
+      if (fallbackMeta) fallbackMeta.setAttribute('content', '#1793d1');
+    } catch (metaError) {
+      console.error('Failed to set fallback theme-color meta tag', metaError);
+    }
   }
 })();

--- a/utils/metadata.server.ts
+++ b/utils/metadata.server.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  ACCENT_COLOR_VARIABLE,
+  FALLBACK_THEME_COLOR,
+} from './metadata';
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const createCssVariableRegex = (variable: string): RegExp =>
+  new RegExp(`${escapeRegExp(variable)}\\s*:\\s*([^;]+);`);
+
+const CSS_SOURCES = [
+  join(process.cwd(), 'styles', 'globals.css'),
+  join(process.cwd(), 'styles', 'tokens.css'),
+];
+
+const ACCENT_REGEX = createCssVariableRegex(ACCENT_COLOR_VARIABLE);
+
+export const readAccentColorFromStyles = (): string => {
+  for (const file of CSS_SOURCES) {
+    try {
+      const css = readFileSync(file, 'utf8');
+      const match = css.match(ACCENT_REGEX);
+      if (match?.[1]) return match[1].trim();
+    } catch {
+      /* ignore missing styles */
+    }
+  }
+  return FALLBACK_THEME_COLOR;
+};
+
+export default readAccentColorFromStyles;

--- a/utils/metadata.ts
+++ b/utils/metadata.ts
@@ -1,0 +1,67 @@
+export const THEME_COLOR_META_NAME = 'theme-color';
+export const ACCENT_COLOR_VARIABLE = '--color-accent';
+export const FALLBACK_THEME_COLOR = '#1793d1';
+
+const sanitizeColor = (value?: string | null): string | null => {
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const readRuntimeCssVariable = (variable: string): string | null => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return null;
+  }
+  try {
+    const computed = window
+      .getComputedStyle(document.documentElement)
+      .getPropertyValue(variable);
+    return sanitizeColor(computed);
+  } catch {
+    return null;
+  }
+};
+
+const ensureMetaElement = (name: string): HTMLMetaElement | null => {
+  if (typeof document === 'undefined') return null;
+  const head = document.head || document.getElementsByTagName('head')[0];
+  if (!head) return null;
+
+  const selector = `meta[name="${name}"]`;
+  const existing = head.querySelector<HTMLMetaElement>(selector);
+  if (existing) return existing;
+
+  const meta = document.createElement('meta');
+  meta.setAttribute('name', name);
+  head.appendChild(meta);
+  return meta;
+};
+
+export const getThemeColor = (): string =>
+  readRuntimeCssVariable(ACCENT_COLOR_VARIABLE) ?? FALLBACK_THEME_COLOR;
+
+export const setThemeColorMeta = (color?: string | null): void => {
+  const meta = ensureMetaElement(THEME_COLOR_META_NAME);
+  if (!meta) return;
+  const resolved = sanitizeColor(color) ?? getThemeColor();
+  meta.setAttribute('content', resolved);
+};
+
+export const getThemeColorMetaContent = (): string | null => {
+  if (typeof document === 'undefined') return null;
+  const meta = document.querySelector<HTMLMetaElement>(
+    `meta[name="${THEME_COLOR_META_NAME}"]`,
+  );
+  return meta?.getAttribute('content') ?? null;
+};
+
+export const metadata = {
+  THEME_COLOR_META_NAME,
+  ACCENT_COLOR_VARIABLE,
+  FALLBACK_THEME_COLOR,
+  getThemeColor,
+  setThemeColorMeta,
+  getThemeColorMetaContent,
+};
+
+export default metadata;

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -1,3 +1,5 @@
+import { setThemeColorMeta } from './metadata';
+
 export const THEME_KEY = 'app:theme';
 
 // Score required to unlock each theme
@@ -33,6 +35,7 @@ export const setTheme = (theme: string): void => {
     window.localStorage.setItem(THEME_KEY, theme);
     document.documentElement.dataset.theme = theme;
     document.documentElement.classList.toggle('dark', isDarkTheme(theme));
+    setThemeColorMeta();
   } catch {
     /* ignore storage errors */
   }


### PR DESCRIPTION
## Summary
- add metadata helpers to read the accent CSS variable and manage the `theme-color` meta tag
- resolve the initial server render and runtime updates to use the computed accent color across document, settings, and preload script
- cover the new helpers with focused unit tests

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window rule violations across legacy files)*
- yarn test --runTestsByPath __tests__/documentMetadata.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c9671d15a8832888485347c6f2a006