### PR TITLE
[ui] add blur placeholders for gallery and icons

### DIFF
--- a/apps/project-gallery/pages/index.tsx
+++ b/apps/project-gallery/pages/index.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useEffect, useMemo, useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 import FilterChip from '../components/FilterChip';
+import { DEFAULT_BLUR_DATA_URL } from '@/utils/imagePlaceholder';
 
 const TagIcon = () => (
   <svg
@@ -289,8 +291,16 @@ export default function ProjectGalleryPage() {
                 className="group relative h-72 flex flex-col border rounded overflow-hidden transition-transform transition-opacity duration-300 hover:scale-105 hover:opacity-90 focus:scale-105 focus:opacity-90 focus:outline-none"
                 aria-label={`${p.title}: ${p.description}`}
               >
-                <div className="w-full aspect-video overflow-hidden">
-                  <img src={p.thumbnail} alt={p.title} className="w-full h-full object-cover" />
+                <div className="relative w-full aspect-video overflow-hidden">
+                  <Image
+                    src={p.thumbnail}
+                    alt={p.title}
+                    fill
+                    className="object-cover"
+                    sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+                    placeholder="blur"
+                    blurDataURL={DEFAULT_BLUR_DATA_URL}
+                  />
                 </div>
                 <div className="p-2 flex-1">
                   <h3 className="font-semibold text-base line-clamp-2">{p.title}</h3>

--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { DEFAULT_BLUR_DATA_URL } from '@/utils/imagePlaceholder';
 import { ModuleMetadata } from '../modules/metadata';
 
 interface ModuleCardProps {
@@ -47,12 +48,16 @@ export default function ModuleCard({
           alt="Details"
           width={24}
           height={24}
+          placeholder="blur"
+          blurDataURL={DEFAULT_BLUR_DATA_URL}
         />
         <Image
           src="/themes/Yaru/status/download.svg"
           alt="Run"
           width={24}
           height={24}
+          placeholder="blur"
+          blurDataURL={DEFAULT_BLUR_DATA_URL}
         />
       </div>
     </button>

--- a/components/ToolbarIcons.tsx
+++ b/components/ToolbarIcons.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { DEFAULT_BLUR_DATA_URL } from '@/utils/imagePlaceholder';
 
 export function CloseIcon() {
   return (
@@ -7,6 +8,8 @@ export function CloseIcon() {
       alt="Close"
       width={16}
       height={16}
+      placeholder="blur"
+      blurDataURL={DEFAULT_BLUR_DATA_URL}
     />
   );
 }
@@ -18,6 +21,8 @@ export function MinimizeIcon() {
       alt="Minimize"
       width={16}
       height={16}
+      placeholder="blur"
+      blurDataURL={DEFAULT_BLUR_DATA_URL}
     />
   );
 }
@@ -29,6 +34,8 @@ export function MaximizeIcon() {
       alt="Maximize"
       width={16}
       height={16}
+      placeholder="blur"
+      blurDataURL={DEFAULT_BLUR_DATA_URL}
     />
   );
 }
@@ -40,6 +47,8 @@ export function RestoreIcon() {
       alt="Restore"
       width={16}
       height={16}
+      placeholder="blur"
+      blurDataURL={DEFAULT_BLUR_DATA_URL}
     />
   );
 }
@@ -51,6 +60,8 @@ export function PinIcon() {
       alt="Pin"
       width={16}
       height={16}
+      placeholder="blur"
+      blurDataURL={DEFAULT_BLUR_DATA_URL}
     />
   );
 }

--- a/components/apps/project-gallery.tsx
+++ b/components/apps/project-gallery.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
+import Image from 'next/image';
+import { DEFAULT_BLUR_DATA_URL } from '@/utils/imagePlaceholder';
 import projectsData from '../../data/projects.json';
 
 interface Project {
@@ -260,12 +262,17 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
             className="mb-4 break-inside-avoid bg-gray-800 rounded shadow overflow-hidden"
           >
             <div className="flex flex-col md:flex-row h-48">
-              <img
-                src={project.thumbnail}
-                alt={project.title}
-                className="w-full md:w-1/2 h-48 object-cover"
-                loading="lazy"
-              />
+              <div className="relative w-full md:w-1/2 h-48">
+                <Image
+                  src={project.thumbnail}
+                  alt={project.title}
+                  fill
+                  className="object-cover"
+                  sizes="(min-width: 768px) 50vw, 100vw"
+                  placeholder="blur"
+                  blurDataURL={DEFAULT_BLUR_DATA_URL}
+                />
+              </div>
               <div className="w-full md:w-1/2 h-48">
                 <Editor
                   height="100%"

--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import Image from 'next/image';
+import { DEFAULT_BLUR_DATA_URL } from '@/utils/imagePlaceholder';
 import { toCanvas } from 'html-to-image';
 
 export class SideBarApp extends Component {
@@ -111,6 +112,8 @@ export class SideBarApp extends Component {
                     src={this.props.icon.replace('./', '/')}
                     alt="Ubuntu App Icon"
                     sizes="28px"
+                    placeholder="blur"
+                    blurDataURL={DEFAULT_BLUR_DATA_URL}
                 />
                 <Image
                     width={28}
@@ -119,6 +122,8 @@ export class SideBarApp extends Component {
                     src={this.props.icon.replace('./', '/')}
                     alt=""
                     sizes="28px"
+                    placeholder="blur"
+                    blurDataURL={DEFAULT_BLUR_DATA_URL}
                 />
                 {
                     (
@@ -142,6 +147,8 @@ export class SideBarApp extends Component {
                             alt={`Preview of ${this.props.title}`}
                             className="w-32 h-20 object-cover"
                             sizes="128px"
+                            placeholder="blur"
+                            blurDataURL={DEFAULT_BLUR_DATA_URL}
                         />
                     </div>
                 )}

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import Image from 'next/image'
+import { DEFAULT_BLUR_DATA_URL } from '@/utils/imagePlaceholder'
 
 export class UbuntuApp extends Component {
     constructor() {
@@ -57,6 +58,8 @@ export class UbuntuApp extends Component {
                     src={this.props.icon.replace('./', '/')}
                     alt={"Kali " + this.props.name}
                     sizes="40px"
+                    placeholder="blur"
+                    blurDataURL={DEFAULT_BLUR_DATA_URL}
                 />
                 {this.props.displayName || this.props.name}
 

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import Image from 'next/image';
+import { DEFAULT_BLUR_DATA_URL } from '@/utils/imagePlaceholder';
 import UbuntuApp from '../base/ubuntu_app';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
@@ -128,6 +129,8 @@ const WhiskerMenu: React.FC = () => {
           width={16}
           height={16}
           className="inline mr-1"
+          placeholder="blur"
+          blurDataURL={DEFAULT_BLUR_DATA_URL}
         />
         Applications
       </button>

--- a/pages/video-gallery.tsx
+++ b/pages/video-gallery.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import React, { useEffect, useState } from 'react';
+import { DEFAULT_BLUR_DATA_URL } from '@/utils/imagePlaceholder';
 
 interface Video {
   id: string;
@@ -67,14 +68,16 @@ const VideoGallery: React.FC = () => {
             className="text-left rounded outline outline-2 outline-offset-2 outline-transparent hover:outline-blue-500 focus-visible:outline-blue-500"
             onClick={() => setPlaying(video.id)}
           >
-            <Image
-              src={`https://i.ytimg.com/vi/${video.id}/hqdefault.jpg`}
-              alt={video.title}
-              width={480}
-              height={360}
-              sizes="(max-width: 768px) 100vw, 480px"
-              className="w-full"
-            />
+          <Image
+            src={`https://i.ytimg.com/vi/${video.id}/hqdefault.jpg`}
+            alt={video.title}
+            width={480}
+            height={360}
+            sizes="(max-width: 768px) 100vw, 480px"
+            className="w-full"
+            placeholder="blur"
+            blurDataURL={DEFAULT_BLUR_DATA_URL}
+          />
             <p className="mt-2 text-sm" style={{ maxInlineSize: '60ch' }}>{video.title}</p>
           </button>
         ))}

--- a/utils/imagePlaceholder.ts
+++ b/utils/imagePlaceholder.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_BLUR_DATA_URL =
+  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';


### PR DESCRIPTION
## Summary
- add a shared blur placeholder constant for Next.js images
- convert gallery cards to Next Image with blur placeholders and preserved aspect ratios
- apply blur placeholders to icon components to avoid layout shift when assets load

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations in unrelated files)*
- yarn test *(fails: pre-existing test failures and jsdom localStorage issues; command exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68c96716d4a083289b4be840c204cb23