### PR TITLE
[a11y] improve form live announcements

### DIFF
--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -252,10 +252,19 @@ const ContactApp: React.FC = () => {
         <button
           type="submit"
           disabled={submitting}
+          aria-busy={submitting}
           className="flex h-12 w-full items-center justify-center rounded bg-blue-600 px-4 sm:w-auto disabled:opacity-50"
         >
           {submitting ? (
-            <div className="h-5 w-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+            <>
+              <div
+                className="h-5 w-5 border-2 border-white border-t-transparent rounded-full animate-spin"
+                aria-hidden="true"
+              />
+              <span className="sr-only" aria-live="polite">
+                Sending message…
+              </span>
+            </>
           ) : (
             "Send"
           )}

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -265,6 +265,8 @@ const ContactApp: React.FC = () => {
       <h1 className="mb-6 text-2xl">Contact</h1>
       {banner && (
         <div
+          role="status"
+          aria-live="polite"
           className={`mb-6 rounded p-3 text-sm ${
             banner.type === 'success' ? 'bg-green-600' : 'bg-red-600'
           }`}
@@ -386,10 +388,19 @@ const ContactApp: React.FC = () => {
         <button
           type="submit"
           disabled={submitting}
+          aria-busy={submitting}
           className="flex items-center justify-center rounded bg-blue-600 px-4 py-2 disabled:opacity-50"
         >
           {submitting ? (
-            <div className="h-5 w-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+            <>
+              <div
+                className="h-5 w-5 border-2 border-white border-t-transparent rounded-full animate-spin"
+                aria-hidden="true"
+              />
+              <span className="sr-only" aria-live="polite">
+                Sending message…
+              </span>
+            </>
           ) : (
             'Send'
           )}

--- a/pages/dummy-form.tsx
+++ b/pages/dummy-form.tsx
@@ -89,9 +89,17 @@ const DummyForm: React.FC = () => {
     <div className="flex min-h-screen items-center justify-center bg-gray-100">
       <form onSubmit={handleSubmit} className="w-full max-w-md rounded bg-white p-6 shadow-md">
         <h1 className="mb-4 text-xl font-bold">Contact Us</h1>
-        {recovered && <p className="mb-4 text-sm text-blue-600">Recovered draft</p>}
+        {recovered && (
+          <p className="mb-4 text-sm text-blue-600" role="status" aria-live="polite">
+            Recovered draft
+          </p>
+        )}
         {error && <FormError className="mb-4 mt-0">{error}</FormError>}
-        {success && <p className="mb-4 text-sm text-green-600">Form submitted successfully!</p>}
+        {success && (
+          <p className="mb-4 text-sm text-green-600" role="status" aria-live="polite">
+            Form submitted successfully!
+          </p>
+        )}
         <label className="mb-2 block text-sm font-medium" htmlFor="name">Name</label>
         <input
           id="name"


### PR DESCRIPTION
## Summary
- ensure contact form banners and dummy form statuses announce via polite live regions
- provide polite live text and aria-busy state for contact submit buttons during loading

## Testing
- yarn lint *(fails: pre-existing repo lint violations)*
- yarn test *(fails: pre-existing repo test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c9671209c88328b583a3d2389412ab