### PR TITLE
[a11y] expand pa11y coverage and fix muted contrast

### DIFF
--- a/apps/x/index.tsx
+++ b/apps/x/index.tsx
@@ -465,14 +465,14 @@ export default function XTimeline() {
                   >
                     <div className="relative">
                       <div className="w-12 h-12 rounded-full bg-[var(--color-muted)] animate-pulse" />
-                      <IconBadge className="w-3 h-3 absolute bottom-0 right-0 text-[var(--color-muted)]" />
+                      <IconBadge className="w-3 h-3 absolute bottom-0 right-0 text-[var(--color-text-muted)]" />
                     </div>
                     <div className="flex-1 space-y-1.5">
                       <div className="h-3 bg-[var(--color-muted)] rounded animate-pulse w-3/4" />
                       <div className="h-3 bg-[var(--color-muted)] rounded animate-pulse w-1/2" />
                       <div className="h-3 bg-[var(--color-muted)] rounded animate-pulse w-full" />
                     </div>
-                    <IconShare className="w-5 h-5 text-[var(--color-muted)]" />
+                    <IconShare className="w-5 h-5 text-[var(--color-text-muted)]" />
                   </li>
                 ))}
               </ul>
@@ -496,7 +496,7 @@ export default function XTimeline() {
               </div>
             )}
             {!loading && !timelineLoaded && !scriptError && (
-              <div className="text-center text-[var(--color-muted)]">Nothing to see</div>
+              <div className="text-center text-[var(--color-text-muted)]">Nothing to see</div>
             )}
           </>
         )}

--- a/pa11yci.json
+++ b/pa11yci.json
@@ -16,10 +16,63 @@
     "http://localhost:3000/apps"
   ],
   "scenarios": [
-    {},
+    {
+      "label": "default"
+    },
     {
       "label": "high-contrast",
-      "beforeScript": "scripts/a11y-high-contrast.js"
+      "beforeScript": "scripts/a11y-apply-settings.js",
+      "settings": {
+        "localStorage": {
+          "high-contrast": "true"
+        },
+        "classes": ["high-contrast"]
+      }
+    },
+    {
+      "label": "large-text",
+      "beforeScript": "scripts/a11y-apply-settings.js",
+      "settings": {
+        "localStorage": {
+          "font-scale": "1.3"
+        },
+        "style": {
+          "--font-multiplier": "1.3"
+        }
+      }
+    },
+    {
+      "label": "reduced-motion",
+      "beforeScript": "scripts/a11y-apply-settings.js",
+      "settings": {
+        "localStorage": {
+          "reduced-motion": "true"
+        },
+        "classes": ["reduced-motion"]
+      }
+    },
+    {
+      "label": "large-hit-areas",
+      "beforeScript": "scripts/a11y-apply-settings.js",
+      "settings": {
+        "localStorage": {
+          "large-hit-areas": "true"
+        },
+        "classes": ["large-hit-area"]
+      }
+    },
+    {
+      "label": "matrix-theme",
+      "beforeScript": "scripts/a11y-apply-settings.js",
+      "settings": {
+        "localStorage": {
+          "app:theme": "matrix"
+        },
+        "dataset": {
+          "theme": "matrix"
+        },
+        "classes": ["dark"]
+      }
     }
   ]
 }

--- a/scripts/a11y-apply-settings.js
+++ b/scripts/a11y-apply-settings.js
@@ -1,0 +1,47 @@
+module.exports = async (page, context = {}) => {
+  const scenarioSettings = context?.settings ?? context?.scenario?.settings ?? {};
+  const classes = scenarioSettings.classes ?? scenarioSettings.classList ?? [];
+
+  const config = {
+    localStorage: scenarioSettings.localStorage ?? {},
+    dataset: scenarioSettings.dataset ?? {},
+    classes: Array.isArray(classes)
+      ? classes.filter(Boolean)
+      : classes
+        ? [classes]
+        : [],
+    style: scenarioSettings.style ?? {},
+  };
+
+  await page.evaluateOnNewDocument(({ localStorage: storage, dataset, classes: classList, style }) => {
+    const root = document.documentElement;
+
+    if (storage && typeof storage === 'object') {
+      for (const [key, value] of Object.entries(storage)) {
+        try {
+          localStorage.setItem(key, String(value));
+        } catch (error) {
+          console.warn('Failed to persist accessibility preference', key, error);
+        }
+      }
+    }
+
+    if (Array.isArray(classList)) {
+      for (const className of classList) {
+        root.classList.add(className);
+      }
+    }
+
+    if (dataset && typeof dataset === 'object') {
+      for (const [dataKey, dataValue] of Object.entries(dataset)) {
+        root.dataset[dataKey] = dataValue;
+      }
+    }
+
+    if (style && typeof style === 'object') {
+      for (const [property, value] of Object.entries(style)) {
+        root.style.setProperty(property, value);
+      }
+    }
+  }, config);
+};

--- a/scripts/a11y-high-contrast.js
+++ b/scripts/a11y-high-contrast.js
@@ -1,6 +1,0 @@
-module.exports = async page => {
-  await page.evaluateOnNewDocument(() => {
-    localStorage.setItem('high-contrast', 'true');
-  });
-};
-

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -1,26 +1,74 @@
 import fs from 'fs';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
 import pa11y from 'pa11y';
+import puppeteer from 'puppeteer';
 
-const configPath = new URL('../pa11yci.json', import.meta.url);
+const configUrl = new URL('../pa11yci.json', import.meta.url);
+const configPath = fileURLToPath(configUrl);
+const configDir = path.dirname(configPath);
 const { defaults = {}, urls = [], scenarios = [{}] } = JSON.parse(
-  fs.readFileSync(configPath),
+  fs.readFileSync(configPath, 'utf8'),
 );
+
+const resolveScript = async scriptPath => {
+  const absolutePath = path.isAbsolute(scriptPath)
+    ? scriptPath
+    : path.join(configDir, scriptPath);
+  const scriptModule = await import(pathToFileURL(absolutePath));
+  return scriptModule.default || scriptModule;
+};
 
 (async () => {
   let hasErrors = false;
   for (const url of urls) {
     for (const scenario of scenarios) {
-      const options = { ...defaults, ...scenario };
-      const label = scenario.label ? ` (${scenario.label})` : '';
-      console.log(`Testing ${url}${label}`);
-      const results = await pa11y(url, options);
-      if (results.issues.length > 0) {
-        hasErrors = true;
-        for (const issue of results.issues) {
-          console.log(`  [${issue.code}] ${issue.message} (${issue.selector})`);
+      const { label, beforeScript, settings, ...scenarioOptions } = scenario;
+      const options = { ...defaults, ...scenarioOptions };
+      const labelSuffix = label ? ` (${label})` : '';
+      const launchConfig = options.chromeLaunchConfig ?? {};
+      console.log(`Testing ${url}${labelSuffix}`);
+      let browser;
+      let page;
+      try {
+        browser = await puppeteer.launch(launchConfig);
+        page = await browser.newPage();
+
+        if (beforeScript) {
+          const applyScenario = await resolveScript(beforeScript);
+          await applyScenario(page, { url, options, scenario, settings });
         }
-      } else {
-        console.log('  No issues found');
+
+        options.browser = browser;
+        options.page = page;
+
+        const results = await pa11y(url, options);
+        if (results.issues.length > 0) {
+          hasErrors = true;
+          for (const issue of results.issues) {
+            console.log(`  [${issue.code}] ${issue.message} (${issue.selector})`);
+          }
+        } else {
+          console.log('  No issues found');
+        }
+      } catch (error) {
+        hasErrors = true;
+        console.error(`  Failed to execute Pa11y: ${error.message}`);
+      } finally {
+        if (page) {
+          try {
+            await page.close();
+          } catch (closeError) {
+            console.warn('  Unable to close page cleanly', closeError.message);
+          }
+        }
+        if (browser) {
+          try {
+            await browser.close();
+          } catch (closeError) {
+            console.warn('  Unable to close browser cleanly', closeError.message);
+          }
+        }
       }
     }
   }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,6 +5,7 @@
   /* Base colors */
   --color-bg: #0f1317; /* kali background */
   --color-text: #f5f5f5; /* text on dark backgrounds */
+  --color-text-muted: #9ca3af; /* subdued text that still meets contrast */
   /* Brand accents */
   --color-primary: #1793d1; /* kali blue accent */
   --color-secondary: #1a1f26; /* complementary dark */
@@ -26,6 +27,7 @@
 html[data-theme='dark'] {
   --color-bg: #000000;
   --color-text: #e5e5e5;
+  --color-text-muted: #a3a3a3;
   --color-primary: #1e88e5;
   --color-secondary: #121212;
   --color-accent: #bb86fc;
@@ -41,6 +43,7 @@ html[data-theme='dark'] {
 html[data-theme='neon'] {
   --color-bg: #000000;
   --color-text: #ffffff;
+  --color-text-muted: #f0abfc;
   --color-primary: #39ff14;
   --color-secondary: #1a1a1a;
   --color-accent: #ff00ff;
@@ -56,6 +59,7 @@ html[data-theme='neon'] {
 html[data-theme='matrix'] {
   --color-bg: #000000;
   --color-text: #00ff00;
+  --color-text-muted: #66ff66;
   --color-primary: #00ff00;
   --color-secondary: #001100;
   --color-accent: #00ff00;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -25,6 +25,7 @@
   --color-ub-dark-grey: #2a2e36;
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
+  --color-text-muted: #9ca3af;
   --kali-bg: rgba(15, 19, 23, 0.85);
 
   /* Game palette tokens */
@@ -77,6 +78,7 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --color-text-muted: #ffffff;
 }
 
 /* Dyslexia-friendly fonts */
@@ -116,5 +118,6 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+    --color-text-muted: #ffffff;
   }
 }


### PR DESCRIPTION
## Summary
- introduce a reusable accessibility settings script and update `scripts/a11y.mjs` so Pa11y scenarios can preload stored preferences
- extend `pa11yci.json` with scenarios for high contrast, large text, reduced motion, large hit areas, and the matrix theme
- add a contrast-safe muted text token and apply it to the X timeline placeholder state

## Testing
- [ ] yarn lint *(fails: repository already has numerous jsx-a11y/control-has-associated-label violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c9671142208328b654f25a58486e85