### PR TITLE
[desktop] Improve window switcher search UX

### DIFF
--- a/__tests__/windowSwitcher.test.tsx
+++ b/__tests__/windowSwitcher.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import WindowSwitcher from '../components/screen/window-switcher';
+
+describe('WindowSwitcher', () => {
+  const windows = [
+    { id: 'wireshark', title: 'Wireshark' },
+    { id: 'calculator', title: 'Calculator' },
+    { id: 'hashcat', title: 'Hashcat' },
+  ];
+
+  it('filters windows by tag metadata and highlights matches', () => {
+    render(<WindowSwitcher windows={windows} onSelect={jest.fn()} onClose={jest.fn()} />);
+
+    const input = screen.getByPlaceholderText('Search windows');
+    fireEvent.change(input, { target: { value: 'network' } });
+
+    expect(screen.getByText('Wireshark')).toBeInTheDocument();
+    expect(screen.queryByText('Calculator')).not.toBeInTheDocument();
+    expect(screen.getByText('network', { selector: 'mark' })).toBeInTheDocument();
+  });
+
+  it('captures typing even when the search field is unfocused', () => {
+    render(<WindowSwitcher windows={windows} onSelect={jest.fn()} onClose={jest.fn()} />);
+
+    const input = screen.getByPlaceholderText('Search windows');
+    input.blur();
+
+    fireEvent.keyDown(window, { key: 'p' });
+
+    expect(input).toHaveValue('p');
+  });
+
+  it('resets the query when closed', () => {
+    const onClose = jest.fn();
+    render(<WindowSwitcher windows={windows} onSelect={jest.fn()} onClose={onClose} />);
+
+    const input = screen.getByPlaceholderText('Search windows');
+    fireEvent.change(input, { target: { value: 'hash' } });
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalled();
+    expect(input).toHaveValue('');
+  });
+});

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -1,17 +1,77 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { getAppMetadata } from '../../data/appMetadata';
+
+const SPECIAL_KEYS = new Set(['Tab', 'ArrowDown', 'ArrowUp']);
+
+const escapeRegExp = (str = '') => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const highlightMatches = (text, tokens) => {
+  if (!tokens.length || !text) return text;
+  const escaped = tokens.map(escapeRegExp).join('|');
+  if (!escaped) return text;
+  const regex = new RegExp(`(${escaped})`, 'gi');
+  const parts = text.split(regex);
+  const tokenSet = new Set(tokens.map((token) => token.toLowerCase()));
+
+  return parts
+    .filter((part) => part !== '')
+    .map((part, index) => {
+      const key = `${part}-${index}`;
+      if (tokenSet.has(part.toLowerCase())) {
+        return (
+          <mark key={key} className="rounded bg-ub-orange px-1 text-black">
+            {part}
+          </mark>
+        );
+      }
+      return (
+        <React.Fragment key={key}>{part}</React.Fragment>
+      );
+    });
+};
 
 export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState(0);
   const inputRef = useRef(null);
 
-  const filtered = windows.filter((w) =>
-    w.title.toLowerCase().includes(query.toLowerCase())
+  const tokens = useMemo(
+    () =>
+      query
+        .trim()
+        .toLowerCase()
+        .split(/\s+/)
+        .filter(Boolean),
+    [query]
   );
+
+  const enrichedWindows = useMemo(
+    () =>
+      windows.map((w) => {
+        const meta = getAppMetadata(w.id);
+        const tags = Array.isArray(meta?.tags) ? meta.tags : [];
+        return { ...w, tags };
+      }),
+    [windows]
+  );
+
+  const filtered = useMemo(() => {
+    if (!tokens.length) return enrichedWindows;
+    return enrichedWindows.filter((w) => {
+      const haystack = `${w.title} ${w.tags.join(' ')}`.toLowerCase();
+      return tokens.every((token) => haystack.includes(token));
+    });
+  }, [enrichedWindows, tokens]);
 
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
+
+  const handleClose = useCallback(() => {
+    setQuery('');
+    setSelected(0);
+    if (typeof onClose === 'function') onClose();
+  }, [onClose]);
 
   useEffect(() => {
     const handleKeyUp = (e) => {
@@ -19,14 +79,58 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
         const win = filtered[selected];
         if (win && typeof onSelect === 'function') {
           onSelect(win.id);
-        } else if (typeof onClose === 'function') {
-          onClose();
+        } else {
+          handleClose();
         }
       }
     };
     window.addEventListener('keyup', handleKeyUp);
     return () => window.removeEventListener('keyup', handleKeyUp);
-  }, [filtered, selected, onSelect, onClose]);
+  }, [filtered, selected, onSelect, handleClose]);
+
+  useEffect(() => {
+    const handleGlobalKey = (e) => {
+      if (!inputRef.current) return;
+      if (SPECIAL_KEYS.has(e.key)) return;
+      if (document.activeElement === inputRef.current) return;
+
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleClose();
+        return;
+      }
+
+      if (e.key === 'Backspace') {
+        e.preventDefault();
+        setQuery((prev) => {
+          const next = prev.slice(0, -1);
+          if (next !== prev) setSelected(0);
+          return next;
+        });
+        inputRef.current.focus();
+        return;
+      }
+
+      if (e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault();
+        setQuery((prev) => {
+          const next = `${prev}${e.key}`;
+          setSelected(0);
+          return next;
+        });
+        inputRef.current.focus();
+      }
+    };
+
+    window.addEventListener('keydown', handleGlobalKey);
+    return () => window.removeEventListener('keydown', handleGlobalKey);
+  }, [handleClose]);
+
+  useEffect(() => {
+    if (selected >= filtered.length) {
+      setSelected(filtered.length ? Math.min(selected, filtered.length - 1) : 0);
+    }
+  }, [filtered.length, selected]);
 
   const handleKeyDown = (e) => {
     if (e.key === 'Tab') {
@@ -45,9 +149,15 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
       const len = filtered.length;
       if (!len) return;
       setSelected((selected - 1 + len) % len);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const win = filtered[selected];
+      if (win && typeof onSelect === 'function') {
+        onSelect(win.id);
+      }
     } else if (e.key === 'Escape') {
       e.preventDefault();
-      if (typeof onClose === 'function') onClose();
+      handleClose();
     }
   };
 
@@ -65,15 +175,34 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
           onChange={handleChange}
           onKeyDown={handleKeyDown}
           className="w-full mb-4 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+          aria-label="Search open windows"
           placeholder="Search windows"
         />
         <ul>
           {filtered.map((w, i) => (
             <li
               key={w.id}
-              className={`px-2 py-1 rounded ${i === selected ? 'bg-ub-orange text-black' : ''}`}
+              className={`px-2 py-2 rounded transition-colors ${
+                i === selected ? 'bg-ub-orange text-black' : 'hover:bg-white hover:bg-opacity-10'
+              }`}
             >
-              {w.title}
+              <div className="text-sm font-medium">
+                {highlightMatches(w.title, tokens)}
+              </div>
+              {w.tags.length > 0 && (
+                <div className="mt-1 flex flex-wrap gap-1 text-xs text-gray-200">
+                  {w.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className={`rounded bg-white bg-opacity-10 px-2 py-0.5 ${
+                        i === selected ? 'text-black' : ''
+                      }`}
+                    >
+                      {highlightMatches(tag, tokens)}
+                    </span>
+                  ))}
+                </div>
+              )}
             </li>
           ))}
         </ul>

--- a/data/appMetadata.ts
+++ b/data/appMetadata.ts
@@ -1,0 +1,134 @@
+export interface AppMetadata {
+  tags: string[];
+}
+
+const baseTagConfig: Record<string, string[]> = {
+  chrome: ['browser', 'web', 'internet', 'utility'],
+  calculator: ['math', 'calculator', 'utility'],
+  terminal: ['terminal', 'shell', 'cli', 'system'],
+  vscode: ['editor', 'code', 'development', 'productivity'],
+  x: ['social', 'media', 'feed'],
+  spotify: ['music', 'media', 'streaming'],
+  youtube: ['video', 'media', 'streaming'],
+  beef: ['security', 'web', 'exploitation', 'browser'],
+  about: ['about', 'profile', 'portfolio'],
+  settings: ['settings', 'preferences', 'system'],
+  files: ['files', 'explorer', 'system', 'storage'],
+  'resource-monitor': ['system', 'performance', 'monitoring', 'utility'],
+  'screen-recorder': ['screen', 'recording', 'media', 'utility'],
+  ettercap: ['security', 'network', 'sniffer', 'mitm'],
+  'ble-sensor': ['security', 'bluetooth', 'wireless', 'monitoring'],
+  metasploit: ['security', 'framework', 'exploitation'],
+  wireshark: ['security', 'network', 'analysis', 'sniffer'],
+  todoist: ['productivity', 'tasks', 'todo'],
+  sticky_notes: ['productivity', 'notes', 'reminders'],
+  trash: ['system', 'cleanup', 'storage'],
+  gedit: ['contact', 'email', 'communication'],
+  converter: ['utility', 'math', 'conversion'],
+  kismet: ['security', 'wifi', 'monitoring', 'network'],
+  nikto: ['security', 'scanner', 'web'],
+  autopsy: ['security', 'forensics', 'analysis'],
+  'plugin-manager': ['system', 'plugins', 'management'],
+  reaver: ['security', 'wifi', 'bruteforce'],
+  nessus: ['security', 'scanner', 'vulnerability'],
+  ghidra: ['security', 'reverse-engineering', 'analysis'],
+  mimikatz: ['security', 'credentials', 'exfiltration'],
+  'mimikatz/offline': ['security', 'credentials', 'offline'],
+  ssh: ['network', 'ssh', 'builder', 'utility'],
+  http: ['network', 'http', 'builder', 'utility'],
+  'html-rewriter': ['web', 'html', 'utility'],
+  contact: ['contact', 'communication', 'form'],
+  hydra: ['security', 'password', 'bruteforce'],
+  'nmap-nse': ['security', 'network', 'scanner'],
+  weather: ['weather', 'forecast', 'utility'],
+  'weather-widget': ['weather', 'widget', 'dashboard'],
+  'serial-terminal': ['hardware', 'serial', 'debugging', 'utility'],
+  radare2: ['security', 'reverse-engineering', 'analysis'],
+  volatility: ['security', 'memory', 'forensics'],
+  hashcat: ['security', 'password', 'cracking'],
+  'msf-post': ['security', 'metasploit', 'post-exploitation'],
+  'evidence-vault': ['security', 'forensics', 'notes'],
+  dsniff: ['security', 'network', 'sniffer'],
+  john: ['security', 'password', 'cracking'],
+  openvas: ['security', 'scanner', 'vulnerability'],
+  'recon-ng': ['security', 'osint', 'reconnaissance'],
+  'security-tools': ['security', 'dashboard', 'collection'],
+};
+
+const utilityTagConfig: Record<string, string[]> = {
+  qr: ['utility', 'generator', 'qr'],
+  'ascii-art': ['utility', 'art', 'text'],
+  'clipboard-manager': ['utility', 'clipboard', 'productivity'],
+  figlet: ['utility', 'ascii', 'text'],
+  quote: ['utility', 'quotes', 'reading'],
+  'project-gallery': ['portfolio', 'projects', 'showcase'],
+  'input-lab': ['utility', 'testing', 'forms', 'accessibility'],
+};
+
+const gameTagConfig: Record<string, string[]> = {
+  '2048': ['game', 'puzzle', 'numbers'],
+  asteroids: ['game', 'arcade', 'space'],
+  battleship: ['game', 'strategy', 'board'],
+  blackjack: ['game', 'card', 'casino'],
+  breakout: ['game', 'arcade', 'retro'],
+  'car-racer': ['game', 'racing', 'arcade'],
+  'lane-runner': ['game', 'endless', 'runner'],
+  checkers: ['game', 'board', 'strategy'],
+  chess: ['game', 'board', 'strategy'],
+  'connect-four': ['game', 'board', 'puzzle'],
+  frogger: ['game', 'arcade', 'retro'],
+  hangman: ['game', 'word', 'puzzle'],
+  memory: ['game', 'puzzle', 'memory'],
+  minesweeper: ['game', 'puzzle', 'logic'],
+  pacman: ['game', 'arcade', 'retro'],
+  platformer: ['game', 'platformer', 'retro'],
+  pong: ['game', 'arcade', 'retro'],
+  reversi: ['game', 'board', 'strategy'],
+  simon: ['game', 'memory', 'rhythm'],
+  snake: ['game', 'arcade', 'retro'],
+  sokoban: ['game', 'puzzle', 'logic'],
+  solitaire: ['game', 'card', 'patience'],
+  tictactoe: ['game', 'board', 'puzzle'],
+  tetris: ['game', 'puzzle', 'retro'],
+  'tower-defense': ['game', 'strategy', 'defense'],
+  'word-search': ['game', 'word', 'puzzle'],
+  wordle: ['game', 'word', 'puzzle'],
+  nonogram: ['game', 'puzzle', 'logic'],
+  'space-invaders': ['game', 'arcade', 'space'],
+  sudoku: ['game', 'puzzle', 'numbers'],
+  'flappy-bird': ['game', 'arcade', 'endless'],
+  'candy-crush': ['game', 'puzzle', 'match-three'],
+  gomoku: ['game', 'board', 'strategy'],
+  pinball: ['game', 'arcade', 'retro'],
+};
+
+const buildMetadata = () => {
+  const map = new Map<string, Set<string>>();
+
+  const addTags = (id: string, tags: string[]) => {
+    if (!map.has(id)) {
+      map.set(id, new Set());
+    }
+    const tagSet = map.get(id)!;
+    tags.forEach((tag) => {
+      const normalized = tag.trim().toLowerCase();
+      if (normalized) tagSet.add(normalized);
+    });
+  };
+
+  [baseTagConfig, utilityTagConfig, gameTagConfig].forEach((config) => {
+    Object.entries(config).forEach(([id, tags]) => addTags(id, tags));
+  });
+
+  const metadata: Record<string, AppMetadata> = {};
+  map.forEach((tags, id) => {
+    metadata[id] = { tags: Array.from(tags).sort() };
+  });
+  return metadata;
+};
+
+const APP_METADATA = buildMetadata();
+
+export const getAppMetadata = (id: string): AppMetadata => APP_METADATA[id] || { tags: [] };
+
+export default APP_METADATA;


### PR DESCRIPTION
## Summary
- focus the window switcher input on launch, capture global typing, and highlight matched text while filtering by tags
- introduce `data/appMetadata.ts` to supply tag metadata for apps shown in the switcher
- add tests that cover tag filtering, global typing capture, and clearing the query when the overlay closes

## Testing
- yarn test windowSwitcher.test.tsx
- npx eslint components/screen/window-switcher.js data/appMetadata.ts __tests__/windowSwitcher.test.tsx --max-warnings=0
- yarn lint *(fails: repository currently trips existing jsx-a11y/control-has-associated-label violations across many legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9670a38208328ba1dab9b8f7900e7