### PR TITLE
feat: add skeleton loaders for heavy apps

### DIFF
--- a/components/app-skeletons/index.tsx
+++ b/components/app-skeletons/index.tsx
@@ -1,0 +1,511 @@
+import React from 'react';
+
+type SkeletonRenderer = () => React.ReactElement;
+
+const SkeletonLine = ({ className = '' }: { className?: string }) => (
+  <div className={`rounded bg-white/15 ${className} animate-pulse`} aria-hidden="true" />
+);
+
+const SkeletonCircle = ({ className = '' }: { className?: string }) => (
+  <div className={`rounded-full bg-white/15 ${className} animate-pulse`} aria-hidden="true" />
+);
+
+const SkeletonCard = ({ className = '' }: { className?: string }) => (
+  <div className={`rounded-lg border border-white/10 bg-white/[0.05] ${className}`}>
+    <div className="h-full w-full rounded-lg bg-gradient-to-br from-white/[0.12] to-transparent animate-pulse" />
+  </div>
+);
+
+const skeletons: Record<string, SkeletonRenderer> = {};
+
+const registerSkeleton = (ids: string[], renderer: SkeletonRenderer) => {
+  ids.forEach((id) => {
+    skeletons[id] = renderer;
+  });
+};
+
+const normalizeAppId = (id: string) =>
+  id
+    .replace(/\\/g, '/')
+    .replace(/^\.\//, '')
+    .replace(/^apps\//, '')
+    .replace(/^components\/apps\//, '')
+    .replace(/\.jsx?$/, '')
+    .replace(/\/index$/, '')
+    .replace(/\/pages$/, '')
+    .toLowerCase();
+
+const DefaultSkeleton = (title?: string) => (
+  <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white" aria-busy="true">
+    <SkeletonCircle className="h-12 w-12 mb-4" />
+    <span className="text-sm text-white/70">
+      {title ? `Loading ${title}…` : 'Loading app…'}
+    </span>
+  </div>
+);
+const TerminalSkeleton: SkeletonRenderer = () => (
+  <div className="h-full w-full overflow-y-auto bg-black text-white" aria-busy="true">
+    <div className="p-4 space-y-3">
+      <SkeletonLine className="h-4 w-40" />
+      <SkeletonLine className="h-3 w-56" />
+    </div>
+    <div className="mx-4 mb-4 rounded-lg border border-white/10 bg-white/[0.08]">
+      <div className="h-[22rem] w-full rounded-lg bg-gradient-to-b from-white/[0.18] to-transparent animate-pulse" />
+    </div>
+  </div>
+);
+
+const MediaFrameSkeleton: SkeletonRenderer = () => (
+  <div className="h-full w-full flex flex-col bg-black text-white" aria-busy="true">
+    <div className="flex items-center justify-between px-4 py-3 border-b border-white/10">
+      <SkeletonLine className="h-6 w-48" />
+      <div className="flex gap-2">
+        <SkeletonCircle className="h-4 w-4" />
+        <SkeletonCircle className="h-4 w-4" />
+        <SkeletonCircle className="h-4 w-4" />
+      </div>
+    </div>
+    <div className="flex-1">
+      <div className="h-full w-full bg-gradient-to-br from-white/[0.15] to-transparent animate-pulse" />
+    </div>
+  </div>
+);
+
+const VsCodeSkeleton: SkeletonRenderer = () => (
+  <div className="flex h-full w-full max-w-full flex-col bg-[#1f1f1f] text-white min-[1366px]:flex-row" aria-busy="true">
+    <aside className="flex min-[1366px]:h-full min-[1366px]:flex-col items-center gap-3 bg-black/60 p-2">
+      <SkeletonCircle className="h-10 w-10" />
+      <SkeletonCircle className="h-10 w-10" />
+      <SkeletonCircle className="h-10 w-10" />
+    </aside>
+    <div className="flex-1 flex flex-col overflow-hidden border border-white/10 bg-black/50">
+      <div className="flex items-center justify-end gap-3 border-b border-white/10 px-3 py-2">
+        <SkeletonCircle className="h-3 w-3" />
+        <SkeletonCircle className="h-3 w-3" />
+        <SkeletonCircle className="h-3 w-3" />
+      </div>
+      <div className="relative flex-1 bg-black/60">
+        <div className="h-full w-full bg-gradient-to-br from-white/[0.12] to-transparent animate-pulse" />
+        <div className="absolute left-4 top-4 flex items-center gap-4 rounded bg-black/70 p-4">
+          <SkeletonCircle className="h-12 w-12" />
+          <SkeletonLine className="h-4 w-28" />
+        </div>
+      </div>
+      <div className="flex items-center gap-2 border-t border-white/10 px-3 py-2">
+        <SkeletonLine className="h-5 w-20" />
+        <SkeletonLine className="h-5 w-16" />
+      </div>
+    </div>
+  </div>
+);
+const SpotifySkeleton: SkeletonRenderer = () => (
+  <div className="flex h-full w-full flex-col gap-4 bg-black p-4 text-white" aria-busy="true">
+    <div className="flex items-center justify-between gap-4">
+      <div className="flex items-center gap-3">
+        <SkeletonCircle className="h-14 w-14" />
+        <div className="space-y-2">
+          <SkeletonLine className="h-5 w-40" />
+          <SkeletonLine className="h-3 w-24" />
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <SkeletonCircle className="h-10 w-10" />
+        <SkeletonCircle className="h-10 w-10" />
+        <SkeletonCircle className="h-10 w-10" />
+      </div>
+    </div>
+    <div className="flex flex-1 flex-col gap-4 lg:flex-row">
+      <SkeletonCard className="h-64 flex-1" />
+      <div className="flex h-64 flex-1 flex-col gap-3 rounded-lg border border-white/10 bg-white/[0.06] p-4">
+        <SkeletonLine className="h-4 w-3/5" />
+        <SkeletonLine className="h-4 w-4/5" />
+        <SkeletonLine className="h-4 w-2/5" />
+        <SkeletonLine className="h-4 w-1/2" />
+      </div>
+    </div>
+    <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, idx) => (
+        <SkeletonCard key={idx} className="h-24" />
+      ))}
+    </div>
+  </div>
+);
+
+const XTimelineSkeleton: SkeletonRenderer = () => (
+  <div className="flex h-full w-full flex-col gap-4 bg-[#0f1419] p-4 text-white" aria-busy="true">
+    <div className="flex flex-wrap items-center gap-2">
+      <SkeletonLine className="h-8 w-32" />
+      <SkeletonLine className="h-8 w-28" />
+      <SkeletonLine className="h-8 w-24" />
+    </div>
+    <SkeletonCard className="h-28" />
+    <div className="flex flex-1 gap-4">
+      <div className="flex-1 space-y-4">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <SkeletonCard key={idx} className="h-32" />
+        ))}
+      </div>
+      <div className="hidden w-64 flex-col gap-3 rounded-lg border border-white/10 bg-white/[0.05] p-4 lg:flex">
+        <SkeletonLine className="h-4 w-3/4" />
+        <SkeletonLine className="h-4 w-full" />
+        <SkeletonLine className="h-4 w-5/6" />
+      </div>
+    </div>
+  </div>
+);
+
+const BeefSkeleton: SkeletonRenderer = () => (
+  <div className="flex h-full w-full flex-col bg-ub-cool-grey text-white" aria-busy="true">
+    <div className="flex items-center justify-between px-4 py-3 border-b border-white/10">
+      <div className="flex items-center gap-3">
+        <SkeletonCircle className="h-12 w-12" />
+        <SkeletonLine className="h-5 w-32" />
+      </div>
+      <div className="flex gap-2">
+        <SkeletonCircle className="h-6 w-6" />
+        <SkeletonCircle className="h-6 w-6" />
+      </div>
+    </div>
+    <div className="flex-1 overflow-hidden p-4">
+      <SkeletonCard className="h-full" />
+    </div>
+    <div className="border-t border-white/10 p-3 space-y-2">
+      {Array.from({ length: 3 }).map((_, idx) => (
+        <div key={idx} className="flex items-center gap-3">
+          <SkeletonLine className="h-5 w-16" />
+          <SkeletonLine className="h-4 w-20" />
+          <SkeletonLine className="h-4 flex-1" />
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+const AnalyzerSkeleton: SkeletonRenderer = () => (
+  <div className="flex h-full w-full bg-ub-cool-grey text-white" aria-busy="true">
+    <div className="hidden w-64 flex-shrink-0 flex-col gap-3 border-r border-white/10 p-4 lg:flex">
+      <SkeletonLine className="h-6 w-full" />
+      <SkeletonLine className="h-4 w-5/6" />
+      <SkeletonLine className="h-4 w-2/3" />
+      <SkeletonLine className="h-4 w-3/4" />
+      <SkeletonLine className="h-4 w-full" />
+    </div>
+    <div className="flex flex-1 flex-col">
+      <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
+        <SkeletonLine className="h-6 w-40" />
+        <div className="flex gap-2">
+          <SkeletonLine className="h-6 w-16" />
+          <SkeletonLine className="h-6 w-16" />
+        </div>
+      </div>
+      <div className="flex flex-1 flex-col gap-4 overflow-hidden p-4">
+        <SkeletonCard className="h-1/2 min-h-[200px]" />
+        <SkeletonCard className="flex-1 min-h-[200px]" />
+      </div>
+    </div>
+  </div>
+);
+
+const AutopsySkeleton: SkeletonRenderer = () => (
+  <div className="h-full w-full space-y-4 bg-ub-cool-grey p-4 text-white" aria-busy="true">
+    <div className="flex gap-2">
+      <SkeletonLine className="h-9 w-28" />
+      <SkeletonLine className="h-9 w-36" />
+    </div>
+    <SkeletonCard className="h-72" />
+    <SkeletonCard className="h-72" />
+  </div>
+);
+
+const VolatilitySkeleton: SkeletonRenderer = () => (
+  <div className="h-full w-full space-y-4 bg-ub-cool-grey p-4 text-white" aria-busy="true">
+    <SkeletonCard className="h-80" />
+    <SkeletonCard className="h-40" />
+  </div>
+);
+
+const WiresharkSkeleton: SkeletonRenderer = () => (
+  <div className="flex h-full w-full flex-col bg-ub-cool-grey text-white" aria-busy="true">
+    <div className="px-4 pt-3">
+      <SkeletonLine className="h-8 w-32" />
+    </div>
+    <div className="flex-1 p-4">
+      <SkeletonCard className="h-full" />
+    </div>
+  </div>
+);
+
+const ProjectGallerySkeleton: SkeletonRenderer = () => (
+  <div className="h-full w-full space-y-4 bg-ub-cool-grey p-4 text-white" aria-busy="true">
+    <div className="flex flex-wrap gap-2">
+      <SkeletonLine className="h-8 w-32" />
+      <SkeletonLine className="h-8 w-28" />
+      <SkeletonLine className="h-8 w-24" />
+      <SkeletonLine className="h-8 w-20" />
+    </div>
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, idx) => (
+        <SkeletonCard key={idx} className="h-48" />
+      ))}
+    </div>
+  </div>
+);
+const GameSkeleton: SkeletonRenderer = () => (
+  <div className="flex h-full w-full flex-col gap-4 bg-ub-cool-grey p-4 text-white" aria-busy="true">
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <SkeletonLine className="h-8 w-32" />
+      <div className="flex gap-2">
+        <SkeletonLine className="h-6 w-16" />
+        <SkeletonLine className="h-6 w-16" />
+        <SkeletonLine className="h-6 w-16" />
+      </div>
+    </div>
+    <div className="flex flex-1 flex-col gap-4 md:flex-row">
+      <SkeletonCard className="flex-1 min-h-[260px]" />
+      <div className="flex w-full flex-col gap-3 md:w-64">
+        <SkeletonLine className="h-6 w-full" />
+        <SkeletonLine className="h-6 w-5/6" />
+        <SkeletonLine className="h-6 w-4/6" />
+        <SkeletonLine className="h-6 w-3/6" />
+      </div>
+    </div>
+    <SkeletonLine className="h-10 w-full" />
+  </div>
+);
+
+const WordSearchSkeleton: SkeletonRenderer = () => (
+  <div className="flex h-full w-full flex-col gap-4 bg-ub-cool-grey p-4 text-white" aria-busy="true">
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <SkeletonLine className="h-8 w-36" />
+      <SkeletonLine className="h-6 w-24" />
+    </div>
+    <div className="flex flex-1 flex-col gap-4 lg:flex-row">
+      <div className="grid aspect-square w-full max-w-xl grid-cols-12 gap-1">
+        {Array.from({ length: 36 }).map((_, idx) => (
+          <SkeletonLine key={idx} className="h-6 w-full" />
+        ))}
+      </div>
+      <div className="flex w-full flex-col gap-2 lg:w-64">
+        {Array.from({ length: 8 }).map((_, idx) => (
+          <SkeletonLine key={idx} className="h-6 w-full" />
+        ))}
+      </div>
+    </div>
+    <SkeletonLine className="h-10 w-full" />
+  </div>
+);
+
+const FormSkeleton: SkeletonRenderer = () => (
+  <div className="min-h-screen bg-gray-900 p-4 text-white space-y-4" aria-busy="true">
+    <SkeletonLine className="h-8 w-40" />
+    <SkeletonLine className="h-4 w-60" />
+    <div className="space-y-3">
+      {Array.from({ length: 4 }).map((_, idx) => (
+        <div key={idx} className="space-y-2">
+          <SkeletonLine className="h-4 w-32" />
+          <SkeletonLine className="h-10 w-full" />
+        </div>
+      ))}
+    </div>
+    <div className="flex gap-3">
+      <SkeletonLine className="h-10 w-32" />
+      <SkeletonLine className="h-10 w-32" />
+    </div>
+  </div>
+);
+
+const WeatherSkeleton: SkeletonRenderer = () => (
+  <div className="h-full w-full space-y-4 bg-ub-cool-grey p-4 text-white" aria-busy="true">
+    <div className="flex flex-wrap gap-2">
+      <SkeletonLine className="h-9 w-28" />
+      <SkeletonLine className="h-9 w-40" />
+      <SkeletonLine className="h-9 w-32" />
+      <SkeletonLine className="h-9 w-28" />
+    </div>
+    <div className="grid gap-4 lg:grid-cols-[2fr,3fr]">
+      <div className="space-y-3">
+        {Array.from({ length: 4 }).map((_, idx) => (
+          <SkeletonCard key={idx} className="h-24" />
+        ))}
+      </div>
+      <SkeletonCard className="min-h-[300px]" />
+    </div>
+  </div>
+);
+
+const WidgetSkeleton: SkeletonRenderer = () => (
+  <div className="h-full w-full space-y-4 bg-ub-cool-grey p-4 text-white" aria-busy="true">
+    <div className="flex gap-2">
+      <SkeletonLine className="h-8 w-24" />
+      <SkeletonLine className="h-8 w-24" />
+      <SkeletonLine className="h-8 w-24" />
+    </div>
+    <SkeletonCard className="h-56" />
+    <SkeletonLine className="h-10 w-40" />
+  </div>
+);
+
+const StickyNotesSkeleton: SkeletonRenderer = () => (
+  <div className="h-full w-full space-y-4 bg-ub-cool-grey p-4 text-white" aria-busy="true">
+    <div className="flex gap-2">
+      <SkeletonLine className="h-9 w-32" />
+      <SkeletonLine className="h-9 w-24" />
+    </div>
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, idx) => (
+        <SkeletonCard key={idx} className="h-32" />
+      ))}
+    </div>
+  </div>
+);
+
+const SettingsSkeleton: SkeletonRenderer = () => (
+  <div className="flex h-full w-full flex-col bg-ub-cool-grey text-white" aria-busy="true">
+    <div className="border-b border-white/10 px-4 py-3">
+      <div className="flex gap-3">
+        <SkeletonLine className="h-8 w-28" />
+        <SkeletonLine className="h-8 w-28" />
+        <SkeletonLine className="h-8 w-28" />
+      </div>
+    </div>
+    <div className="flex-1 space-y-4 overflow-y-auto p-4">
+      <SkeletonCard className="h-48" />
+      <div className="flex flex-wrap gap-3">
+        {Array.from({ length: 6 }).map((_, idx) => (
+          <SkeletonLine key={idx} className="h-10 w-10 rounded-full" />
+        ))}
+      </div>
+      <SkeletonLine className="h-6 w-48" />
+      <SkeletonCard className="h-40" />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 8 }).map((_, idx) => (
+          <SkeletonCard key={idx} className="h-36" />
+        ))}
+      </div>
+    </div>
+  </div>
+);
+registerSkeleton(['terminal'], TerminalSkeleton);
+registerSkeleton(['vscode'], VsCodeSkeleton);
+registerSkeleton(['spotify'], SpotifySkeleton);
+registerSkeleton(['youtube'], MediaFrameSkeleton);
+registerSkeleton(['x'], XTimelineSkeleton);
+registerSkeleton(['beef'], BeefSkeleton);
+
+registerSkeleton(
+  [
+    'metasploit',
+    'metasploit-post',
+    'msf-post',
+    'radare2',
+    'ghidra',
+    'file-explorer',
+    'plugin-manager',
+    'security-tools',
+    'dsniff',
+    'nmap-nse',
+    'john',
+    'kismet',
+    'mimikatz',
+    'mimikatz/offline',
+    'nessus',
+    'openvas',
+    'reconng',
+    'recon-ng',
+    'evidence-vault',
+    'ettercap',
+    'reaver',
+    'hydra',
+    'msf',
+  ],
+  AnalyzerSkeleton,
+);
+
+registerSkeleton(['autopsy'], AutopsySkeleton);
+registerSkeleton(['volatility'], VolatilitySkeleton);
+registerSkeleton(['wireshark'], WiresharkSkeleton);
+registerSkeleton(['project-gallery', 'alex'], ProjectGallerySkeleton);
+
+registerSkeleton(
+  [
+    '2048',
+    'blackjack',
+    'breakout',
+    'sokoban',
+    'checkers',
+    'chess',
+    'connect-four',
+    'connect_four',
+    'tictactoe',
+    'frogger',
+    'flappy-bird',
+    'snake',
+    'memory',
+    'minesweeper',
+    'pong',
+    'pacman',
+    'car-racer',
+    'lane-runner',
+    'platformer',
+    'battleship',
+    'reversi',
+    'simon',
+    'solitaire',
+    'solitaire/index',
+    'tower-defense',
+    'tower_defense',
+    'pinball',
+    'asteroids',
+    'sudoku',
+    'space-invaders',
+    'space_invaders',
+    'nonogram',
+    'tetris',
+    'candy-crush',
+    'candy_crush',
+    'gomoku',
+    'phaser_matter',
+    'phaser-matter',
+    'wordle',
+    'hangman',
+    'lane_runner',
+    'spaceinvaders',
+  ],
+  GameSkeleton,
+);
+
+registerSkeleton(['word-search', 'word_search'], WordSearchSkeleton);
+
+registerSkeleton(
+  [
+    'contact',
+    'converter',
+    'figlet',
+    'http',
+    'input-lab',
+    'password_generator',
+    'password-generator',
+    'qr',
+    'calculator',
+    'ascii_art',
+    'ascii-art',
+    'quote',
+    'ssh',
+    'html-rewriter',
+  ],
+  FormSkeleton,
+);
+
+registerSkeleton(['weather'], WeatherSkeleton);
+registerSkeleton(['weather_widget', 'weather-widget', 'timer_stopwatch', 'timer-stopwatch', 'ble-sensor', 'ble_sensor'], WidgetSkeleton);
+registerSkeleton(['sticky_notes', 'sticky-notes'], StickyNotesSkeleton);
+registerSkeleton(['settings'], SettingsSkeleton);
+
+export const getAppSkeleton = (id: string, title?: string) => {
+  const key = normalizeAppId(id);
+  const renderer = skeletons[key];
+  if (renderer) {
+    return renderer();
+  }
+  return DefaultSkeleton(title ?? key);
+};

--- a/components/apps/calculator.js
+++ b/components/apps/calculator.js
@@ -1,9 +1,10 @@
 import '../../utils/decimal';
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../app-skeletons';
 
 const Calculator = dynamic(() => import('../../apps/calculator'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('calculator', 'Calculator'),
 });
 
 export default Calculator;

--- a/components/apps/quote/index.tsx
+++ b/components/apps/quote/index.tsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../app-skeletons';
 
 const QuoteApp = dynamic(() => import('../../../apps/quote'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('quote', 'Quote'),
 });
 
 export default QuoteApp;

--- a/components/apps/sticky_notes/index.tsx
+++ b/components/apps/sticky_notes/index.tsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../app-skeletons';
 
 const StickyNotes = dynamic(() => import('../../../apps/sticky_notes'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('sticky_notes', 'Sticky Notes'),
 });
 
 export default StickyNotes;

--- a/components/apps/terminal.tsx
+++ b/components/apps/terminal.tsx
@@ -1,14 +1,11 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../app-skeletons';
 import HelpPanel from '../HelpPanel';
 
 // Lazily load the heavy terminal app with session tabs on the client only.
 const TerminalApp = dynamic(() => import('../../apps/terminal/tabs'), {
   ssr: false,
-  loading: () => (
-    <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
-      Loading Terminal...
-    </div>
-  ),
+  loading: () => getAppSkeleton('terminal', 'Terminal'),
 });
 
 /**

--- a/components/apps/weather.js
+++ b/components/apps/weather.js
@@ -1,10 +1,11 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../app-skeletons';
 
 // Dynamically load the full Weather application. This remains the default
 // export so existing imports continue to work.
 const WeatherApp = dynamic(() => import('../../apps/weather'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('weather', 'Weather'),
 });
 
 /**

--- a/components/apps/weather_widget.js
+++ b/components/apps/weather_widget.js
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../app-skeletons';
 
 const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('weather_widget', 'Weather Widget'),
 });
 
 export default WeatherWidget;

--- a/pages/apps/2048.jsx
+++ b/pages/apps/2048.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const Page2048 = dynamic(() => import('../../apps/2048'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('2048', '2048'),
 });
 
 export default Page2048;

--- a/pages/apps/ascii-art.jsx
+++ b/pages/apps/ascii-art.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const AsciiArt = dynamic(() => import('../../apps/ascii-art'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('ascii-art', 'ASCII Art'),
 });
 
 export default AsciiArt;

--- a/pages/apps/autopsy.jsx
+++ b/pages/apps/autopsy.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const Autopsy = dynamic(() => import('../../apps/autopsy'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('autopsy', 'Autopsy'),
 });
 
 export default function AutopsyPage() {

--- a/pages/apps/beef.jsx
+++ b/pages/apps/beef.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const Beef = dynamic(() => import('../../apps/beef'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('beef', 'BeEF'),
 });
 
 export default function BeefPage() {

--- a/pages/apps/blackjack.jsx
+++ b/pages/apps/blackjack.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const Blackjack = dynamic(() => import('../../apps/blackjack'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('blackjack', 'Blackjack'),
 });
 
 export default function BlackjackPage() {

--- a/pages/apps/calculator.jsx
+++ b/pages/apps/calculator.jsx
@@ -1,12 +1,12 @@
 import '../../utils/decimal';
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const Calculator = dynamic(() => import('../../apps/calculator'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('calculator', 'Calculator'),
 });
 
 export default function CalculatorPage() {
   return <Calculator />;
 }
-

--- a/pages/apps/checkers.jsx
+++ b/pages/apps/checkers.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const Checkers = dynamic(() => import('../../apps/checkers'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('checkers', 'Checkers'),
 });
 
 export default function CheckersPage() {

--- a/pages/apps/connect-four.jsx
+++ b/pages/apps/connect-four.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const ConnectFour = dynamic(() => import('../../apps/connect-four'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('connect-four', 'Connect Four'),
 });
 
 export default ConnectFour;

--- a/pages/apps/contact.jsx
+++ b/pages/apps/contact.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const ContactApp = dynamic(() => import('../../apps/contact'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('contact', 'Contact'),
 });
 
 export default function ContactPage() {

--- a/pages/apps/converter.jsx
+++ b/pages/apps/converter.jsx
@@ -1,8 +1,9 @@
 import dynamic from "next/dynamic";
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const Converter = dynamic(() => import("../../apps/converter"), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('converter', 'Converter'),
 });
 
 export default function ConverterPage() {

--- a/pages/apps/figlet.jsx
+++ b/pages/apps/figlet.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const FigletPage = dynamic(() => import('../../apps/figlet'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('figlet', 'Figlet'),
 });
 
 export default FigletPage;

--- a/pages/apps/http.jsx
+++ b/pages/apps/http.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const HTTPPreview = dynamic(() => import('../../apps/http'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('http', 'HTTP'),
 });
 
 export default function HTTPPage() {

--- a/pages/apps/input-lab.jsx
+++ b/pages/apps/input-lab.jsx
@@ -1,6 +1,10 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
-const InputLab = dynamic(() => import('../../apps/input-lab'), { ssr: false });
+const InputLab = dynamic(() => import('../../apps/input-lab'), {
+  ssr: false,
+  loading: () => getAppSkeleton('input-lab', 'Input Lab'),
+});
 
 export default function InputLabPage() {
   return <InputLab />;

--- a/pages/apps/john.jsx
+++ b/pages/apps/john.jsx
@@ -1,11 +1,11 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const John = dynamic(() => import('../../apps/john'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('john', 'John the Ripper'),
 });
 
 export default function JohnPage() {
   return <John />;
 }
-

--- a/pages/apps/kismet.jsx
+++ b/pages/apps/kismet.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const Kismet = dynamic(() => import('../../apps/kismet'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('kismet', 'Kismet'),
 });
 
 export default function KismetPage() {

--- a/pages/apps/metasploit-post.jsx
+++ b/pages/apps/metasploit-post.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const MetasploitPost = dynamic(() => import('../../apps/metasploit-post'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('metasploit-post', 'Metasploit Post'),
 });
 
 export default function MetasploitPostPage() {

--- a/pages/apps/metasploit.jsx
+++ b/pages/apps/metasploit.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const Metasploit = dynamic(() => import('../../apps/metasploit'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('metasploit', 'Metasploit'),
 });
 
 export default function MetasploitPage() {

--- a/pages/apps/mimikatz/offline.jsx
+++ b/pages/apps/mimikatz/offline.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../../components/app-skeletons';
 
 const MimikatzOffline = dynamic(() => import('../../../apps/mimikatz/offline'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('mimikatz/offline', 'Mimikatz Offline'),
 });
 
 export default function MimikatzOfflinePage() {

--- a/pages/apps/minesweeper.jsx
+++ b/pages/apps/minesweeper.jsx
@@ -1,11 +1,11 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const Minesweeper = dynamic(() => import('../../apps/minesweeper'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('minesweeper', 'Minesweeper'),
 });
 
 export default function MinesweeperPage() {
   return <Minesweeper />;
 }
-

--- a/pages/apps/nmap-nse.jsx
+++ b/pages/apps/nmap-nse.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const NmapNSE = dynamic(() => import('../../apps/nmap-nse'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('nmap-nse', 'Nmap NSE'),
 });
 
 export default function NmapNSEPage() {

--- a/pages/apps/password_generator.jsx
+++ b/pages/apps/password_generator.jsx
@@ -1,9 +1,10 @@
 import dynamic from 'next/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const PasswordGenerator = dynamic(() => import('../../apps/password_generator'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('password_generator', 'Password Generator'),
 });
 
 export default function PasswordGeneratorPage() {

--- a/pages/apps/phaser_matter.jsx
+++ b/pages/apps/phaser_matter.jsx
@@ -1,9 +1,10 @@
 import dynamic from 'next/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const PhaserMatter = dynamic(() => import('../../apps/phaser_matter'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('phaser_matter', 'Phaser Matter'),
 });
 
 export default function PhaserMatterPage() {

--- a/pages/apps/pinball.jsx
+++ b/pages/apps/pinball.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const Pinball = dynamic(() => import('../../apps/pinball'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('pinball', 'Pinball'),
 });
 
 export default Pinball;

--- a/pages/apps/project-gallery.jsx
+++ b/pages/apps/project-gallery.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const ProjectGalleryApp = dynamic(() => import('../../apps/project-gallery/pages'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('project-gallery', 'Project Gallery'),
 });
 
 export default ProjectGalleryApp;

--- a/pages/apps/qr.jsx
+++ b/pages/apps/qr.jsx
@@ -1,11 +1,11 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const QRApp = dynamic(() => import('../../apps/qr'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('qr', 'QR Tool'),
 });
 
 export default function QRPage() {
   return <QRApp />;
 }
-

--- a/pages/apps/settings.jsx
+++ b/pages/apps/settings.jsx
@@ -1,8 +1,11 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
-const SettingsApp = dynamic(() => import('../../apps/settings'), { ssr: false });
+const SettingsApp = dynamic(() => import('../../apps/settings'), {
+  ssr: false,
+  loading: () => getAppSkeleton('settings', 'Settings'),
+});
 
 export default function SettingsPage() {
   return <SettingsApp />;
 }
-

--- a/pages/apps/simon.jsx
+++ b/pages/apps/simon.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const Simon = dynamic(() => import('../../apps/simon'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('simon', 'Simon'),
 });
 
 export default function SimonPage() {

--- a/pages/apps/sokoban.jsx
+++ b/pages/apps/sokoban.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const Sokoban = dynamic(() => import('../../apps/sokoban'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('sokoban', 'Sokoban'),
 });
 
 const SokobanPage = () => (

--- a/pages/apps/solitaire.jsx
+++ b/pages/apps/solitaire.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const PageSolitaire = dynamic(() => import('../../apps/solitaire'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('solitaire', 'Solitaire'),
 });
 
 export default PageSolitaire;

--- a/pages/apps/spotify.jsx
+++ b/pages/apps/spotify.jsx
@@ -1,9 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const SpotifyApp = dynamic(() => import('../../apps/spotify'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('spotify', 'Spotify'),
 });
 
 export default SpotifyApp;
-

--- a/pages/apps/ssh.jsx
+++ b/pages/apps/ssh.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const SSHPreview = dynamic(() => import('../../apps/ssh'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('ssh', 'SSH'),
 });
 
 export default function SSHPage() {

--- a/pages/apps/sticky_notes.jsx
+++ b/pages/apps/sticky_notes.jsx
@@ -1,11 +1,11 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const StickyNotes = dynamic(() => import('../../apps/sticky_notes'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('sticky_notes', 'Sticky Notes'),
 });
 
 export default function StickyNotesPage() {
   return <StickyNotes />;
 }
-

--- a/pages/apps/timer_stopwatch.jsx
+++ b/pages/apps/timer_stopwatch.jsx
@@ -1,11 +1,11 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const TimerStopwatch = dynamic(() => import('../../apps/timer_stopwatch'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('timer_stopwatch', 'Timer & Stopwatch'),
 });
 
 export default function TimerStopwatchPage() {
   return <TimerStopwatch />;
 }
-

--- a/pages/apps/tower-defense.jsx
+++ b/pages/apps/tower-defense.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const TowerDefense = dynamic(() => import('../../apps/tower-defense'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('tower-defense', 'Tower Defense'),
 });
 
 export default TowerDefense;

--- a/pages/apps/volatility.jsx
+++ b/pages/apps/volatility.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const Volatility = dynamic(() => import('../../apps/volatility'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('volatility', 'Volatility'),
 });
 
 export default function VolatilityPage() {

--- a/pages/apps/vscode.jsx
+++ b/pages/apps/vscode.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const VSCode = dynamic(() => import('../../apps/vscode'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('vscode', 'VSCode'),
 });
 
 export default function VSCodePage() {

--- a/pages/apps/weather.jsx
+++ b/pages/apps/weather.jsx
@@ -1,4 +1,5 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const WeatherApp = dynamic(
   () =>
@@ -8,9 +9,8 @@ const WeatherApp = dynamic(
     }),
   {
     ssr: false,
-    loading: () => <p>Loading...</p>,
+    loading: () => getAppSkeleton('weather', 'Weather'),
   }
 );
 
 export default WeatherApp;
-

--- a/pages/apps/weather_widget.jsx
+++ b/pages/apps/weather_widget.jsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('weather_widget', 'Weather Widget'),
 });
 
 // Display stored unit preference and the browser's location consent status.
@@ -46,4 +47,3 @@ export default function WeatherWidgetPage() {
     </div>
   );
 }
-

--- a/pages/apps/wireshark.jsx
+++ b/pages/apps/wireshark.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const Wireshark = dynamic(() => import('../../apps/wireshark'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('wireshark', 'Wireshark'),
 });
 
 export default function WiresharkPage() {

--- a/pages/apps/word_search.jsx
+++ b/pages/apps/word_search.jsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const WordSearch = dynamic(
   () => import('../../apps/word_search'),
-  { ssr: false, loading: () => <p>Loading...</p> },
+  {
+    ssr: false,
+    loading: () => getAppSkeleton('word_search', 'Word Search'),
+  },
 );
 
 export default function WordSearchPage() {

--- a/pages/apps/x.jsx
+++ b/pages/apps/x.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const PageX = dynamic(() => import('../../apps/x'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('x', 'X Timeline'),
 });
 
 export default PageX;

--- a/pages/games/blackjack/index.tsx
+++ b/pages/games/blackjack/index.tsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const Blackjack = dynamic(() => import('../../../games/blackjack'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('blackjack', 'Blackjack'),
 });
 
 export default function BlackjackGamePage() {

--- a/pages/games/blackjack/trainer.tsx
+++ b/pages/games/blackjack/trainer.tsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../../components/app-skeletons';
 
 const BlackjackTrainer = dynamic(() => import('../../../games/blackjack/trainer'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('blackjack', 'Blackjack Trainer'),
 });
 
 export default function BlackjackTrainerPage() {

--- a/pages/games/breakout/editor.tsx
+++ b/pages/games/breakout/editor.tsx
@@ -1,8 +1,9 @@
 import dynamic from "next/dynamic";
+import { getAppSkeleton } from "../../components/app-skeletons";
 
 const BreakoutEditor = dynamic(() => import("../../../games/breakout/editor"), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => getAppSkeleton('breakout', 'Breakout Editor'),
 });
 
 export default function BreakoutEditorPage() {

--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
+import { getAppSkeleton } from '../components/app-skeletons';
 import { logEvent } from './analytics';
 
 export const createDynamicApp = (id, title) =>
@@ -22,11 +23,7 @@ export const createDynamicApp = (id, title) =>
     },
     {
       ssr: false,
-      loading: () => (
-        <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
-          {`Loading ${title}...`}
-        </div>
-      ),
+      loading: () => getAppSkeleton(id, title),
     }
   );
 


### PR DESCRIPTION
## Summary
- add a centralized set of app skeleton components to cover heavy shells and games
- update dynamic app loading across shared components, pages, and games to render skeletons while modules load
- replace legacy loading placeholders so each app uses the lightweight skeleton layout during import

## Testing
- yarn lint *(fails: existing accessibility issues across legacy apps)*
- yarn test *(fails: existing environment limitations such as missing localStorage/Supabase mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68c9670b0fe483289dbebe6554ffe882