### PR TITLE
[window] add accessible snap zone tooltips

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -118,6 +118,58 @@ describe('Window snapping preview', () => {
   });
 });
 
+describe('Snap zone tooltips', () => {
+  it('shows tooltip on focus and hides after snapping', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 5,
+      top: 10,
+      right: 105,
+      bottom: 110,
+      width: 100,
+      height: 100,
+      x: 5,
+      y: 10,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+
+    const preview = screen.getByTestId('snap-preview');
+    expect(screen.queryByRole('tooltip')).toBeNull();
+
+    fireEvent.focus(preview);
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Snap Left');
+    expect(tooltip).toHaveTextContent('Alt + ArrowLeft');
+
+    act(() => {
+      ref.current!.handleStop();
+    });
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    expect(screen.queryByTestId('snap-preview')).toBeNull();
+  });
+});
+
 describe('Window snapping finalize and release', () => {
   it('snaps window on drag stop near left edge', () => {
     const ref = React.createRef<Window>();


### PR DESCRIPTION
## Summary
- add snap zone tooltip metadata so the preview can describe zone names and shortcuts
- expose tooltip overlays on the snap preview and reset tooltip state after snapping
- cover the new behavior with a regression test exercising focus and snap completion

## Testing
- yarn lint *(fails: existing repository accessibility issues in multiple apps)*
- yarn test --watch=false *(fails: existing nmapNse suite missing alert role)*

------
https://chatgpt.com/codex/tasks/task_e_68c9670975b88328b0d06cff3e2128ed