### PR TITLE
[a11y] add global landmarks and skip link

### DIFF
--- a/apps/nmap-nse/index.tsx
+++ b/apps/nmap-nse/index.tsx
@@ -168,7 +168,7 @@ const NmapNSE: React.FC = () => {
         </aside>
 
         {/* details */}
-        <main className="flex-1 p-4 overflow-y-auto">
+        <section className="flex-1 p-4 overflow-y-auto" aria-live="polite">
           {selected ? (
             <div>
               <h1 className="text-2xl mb-2 font-mono">{selected.name}</h1>
@@ -208,7 +208,7 @@ const NmapNSE: React.FC = () => {
           ) : (
             <p>Select a script to view details.</p>
           )}
-        </main>
+        </section>
       </div>
     </div>
   );

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -110,7 +110,10 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
     const nonce = getCspNonce();
 
     return (
-      <main className="w-full h-full flex bg-ub-cool-grey text-white select-none relative">
+      <section
+        aria-label="About workspace"
+        className="w-full h-full flex bg-ub-cool-grey text-white select-none relative"
+      >
         <Head>
           <title>About</title>
           <script
@@ -149,7 +152,7 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
         <div className="flex flex-col w-3/4 md:w-4/5 justify-start items-center flex-grow bg-ub-grey overflow-y-auto windowMainScreen">
           {this.state.screen}
         </div>
-      </main>
+      </section>
     );
   }
 }

--- a/components/apps/chrome/index.tsx
+++ b/components/apps/chrome/index.tsx
@@ -774,7 +774,8 @@ const Chrome: React.FC = () => {
           {activeTab.url === HOME_URL ? (
             homeGrid
           ) : articles[activeId] ? (
-            <main
+            <article
+              aria-label="Article content"
               style={{ maxInlineSize: '60ch', margin: 'auto' }}
               dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(articles[activeId] ?? '') }}
             />

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -865,12 +865,16 @@ export class Desktop extends Component {
 
     render() {
         return (
-            <main id="desktop" role="main" className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
+            <div
+                id="desktop"
+                role="region"
+                aria-label="Desktop workspace"
+                className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}
+            >
 
                 {/* Window Area */}
                 <div
                     id="window-area"
-                    role="main"
                     className="absolute h-full w-full bg-transparent"
                     data-context="desktop-area"
                 >
@@ -967,7 +971,7 @@ export class Desktop extends Component {
                         onSelect={this.selectWindow}
                         onClose={this.closeWindowSwitcher} /> : null}
 
-            </main>
+            </div>
         )
     }
 }

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -14,8 +14,8 @@ export default class Navbar extends Component {
 	}
 
 	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+        return (
+                        <header className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
@@ -41,7 +41,7 @@ export default class Navbar extends Component {
                                         <Status />
                                         <QuickSettings open={this.state.status_card} />
                                 </button>
-			</div>
-		);
-	}
+                        </header>
+                );
+        }
 }

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -16,7 +16,7 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <footer className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
             {runningApps.map(app => (
                 <button
                     key={app.id}
@@ -42,6 +42,6 @@ export default function Taskbar(props) {
                     )}
                 </button>
             ))}
-        </div>
+        </footer>
     );
 }

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -10,6 +10,7 @@ import '../styles/resume-print.css';
 import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
+import Link from 'next/link';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
@@ -23,6 +24,13 @@ const ubuntu = Ubuntu({
   subsets: ['latin'],
   weight: ['300', '400', '500', '700'],
 });
+
+const NAV_LINKS = [
+  { href: '/', label: 'Desktop' },
+  { href: '/apps', label: 'App catalog' },
+  { href: '/daily-quote', label: 'Daily quote' },
+  { href: '/profile', label: 'Timeline' },
+];
 
 
 function MyApp(props) {
@@ -151,15 +159,48 @@ function MyApp(props) {
       <Script src="/a2hs.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
         <a
-          href="#app-grid"
+          href="#main-content"
           className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
         >
-          Skip to app grid
+          Skip to main content
         </a>
         <SettingsProvider>
           <PipPortalProvider>
             <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
+            <div className="flex min-h-screen flex-col">
+              <header className="sr-only focus-within:not-sr-only focus-within:absolute focus-within:left-0 focus-within:top-0 focus-within:z-50 focus-within:bg-white focus-within:text-black focus-within:p-4 focus-within:shadow-lg">
+                <h1 className="text-lg font-semibold">
+                  <Link href="/" className="focus:outline-none focus-visible:ring">
+                    Kali Linux Portfolio
+                  </Link>
+                </h1>
+              </header>
+              <nav
+                aria-label="Primary"
+                className="sr-only focus-within:not-sr-only focus-within:absolute focus-within:left-0 focus-within:top-16 focus-within:z-50 focus-within:bg-white focus-within:text-black focus-within:p-4 focus-within:shadow-lg"
+              >
+                <ul className="flex flex-col gap-2">
+                  {NAV_LINKS.map((link) => (
+                    <li key={link.href}>
+                      <Link
+                        href={link.href}
+                        className="underline focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
+                      >
+                        {link.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </nav>
+              <main id="main-content" tabIndex={-1} className="flex-1 focus:outline-none">
+                <Component {...pageProps} />
+              </main>
+              <footer className="sr-only focus-within:not-sr-only focus-within:absolute focus-within:bottom-0 focus-within:left-0 focus-within:z-50 focus-within:bg-white focus-within:text-black focus-within:p-4 focus-within:shadow-lg">
+                <p>
+                  © {new Date().getFullYear()} Alex Unnippillil. Educational simulations only.
+                </p>
+              </footer>
+            </div>
             <ShortcutOverlay />
             <Analytics
               beforeSend={(e) => {

--- a/pages/hook-flow.tsx
+++ b/pages/hook-flow.tsx
@@ -8,8 +8,14 @@ const HookFlow: React.FC = () => {
 
   if (!consented) {
     return (
-      <main className="p-4 text-center">
-        <p className="mb-4 font-bold">
+      <section
+        aria-labelledby="hook-flow-consent-heading"
+        className="p-4 text-center"
+      >
+        <h1 id="hook-flow-consent-heading" className="mb-4 font-bold">
+          View React hook flow diagram
+        </h1>
+        <p className="mb-4">
           This page contains diagrams and links to external documentation.
         </p>
         <button
@@ -18,12 +24,18 @@ const HookFlow: React.FC = () => {
         >
           Continue
         </button>
-      </main>
+      </section>
     );
   }
 
   return (
-    <main className="p-4 space-y-4">
+    <section
+      aria-labelledby="hook-flow-heading"
+      className="p-4 space-y-4"
+    >
+      <h1 id="hook-flow-heading" className="text-2xl font-semibold">
+        React hook flow reference
+      </h1>
       <Image
         src="/hook-flow.svg"
         alt="React hook flow diagram"
@@ -38,7 +50,7 @@ const HookFlow: React.FC = () => {
         sandbox="allow-scripts allow-same-origin"
         className="w-full h-96 border"
       />
-    </main>
+    </section>
   );
 };
 

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -30,9 +30,6 @@ const InstallButton = dynamic(
  */
 const App = () => (
   <>
-    <a href="#window-area" className="sr-only focus:not-sr-only">
-      Skip to content
-    </a>
     <Meta />
     <Ubuntu />
     <BetaBadge />

--- a/pages/keyboard-reference.tsx
+++ b/pages/keyboard-reference.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 
 const KeyboardReference = () => (
-  <main className="min-h-screen bg-ub-cool-grey text-white p-4 space-y-4">
-    <h1 className="text-2xl font-bold">Keyboard Mapping Reference</h1>
+  <section
+    aria-labelledby="keyboard-reference-heading"
+    className="min-h-screen bg-ub-cool-grey text-white p-4 space-y-4"
+  >
+    <h1 id="keyboard-reference-heading" className="text-2xl font-bold">
+      Keyboard Mapping Reference
+    </h1>
     <p className="mb-4">Common shortcuts for navigating and interacting with the desktop.</p>
     <table className="w-full border-collapse">
       <thead>
@@ -34,7 +39,7 @@ const KeyboardReference = () => (
         </tr>
       </tbody>
     </table>
-  </main>
+  </section>
 );
 
 export default KeyboardReference;

--- a/pages/network-topology.tsx
+++ b/pages/network-topology.tsx
@@ -7,7 +7,13 @@ const NetworkTopology: React.FC = () => {
   return (
     <>
       <Meta />
-      <main className="bg-ub-cool-grey text-white min-h-screen p-4 space-y-4">
+      <section
+        aria-labelledby="network-topology-heading"
+        className="bg-ub-cool-grey text-white min-h-screen p-4 space-y-4"
+      >
+        <h1 id="network-topology-heading" className="text-2xl font-semibold">
+          Network topology mitigation demo
+        </h1>
         <button
           onClick={() => setMitigated((m) => !m)}
           className="px-4 py-2 bg-blue-600 rounded focus:outline-none focus:ring-2 focus:ring-blue-400"
@@ -116,7 +122,7 @@ const NetworkTopology: React.FC = () => {
             </>
           )}
         </svg>
-      </main>
+      </section>
     </>
   );
 };

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -35,9 +35,12 @@ export default function PostExploitation() {
   return (
     <>
       <Meta />
-      <main className="mx-auto grid gap-4 p-4 md:grid-cols-2">
+      <section
+        aria-labelledby="post-exploitation-heading"
+        className="mx-auto grid gap-4 p-4 md:grid-cols-2"
+      >
         <section className="prose">
-          <h1>Metasploit Post-Exploitation Modules</h1>
+          <h1 id="post-exploitation-heading">Metasploit Post-Exploitation Modules</h1>
           <p>
             Post-exploitation refers to any actions taken after a session is opened. Rapid7&apos;s{' '}
             <a
@@ -125,7 +128,7 @@ export default function PostExploitation() {
             </button>
           </div>
         </aside>
-      </main>
+      </section>
     </>
   );
 }

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,10 +1,15 @@
 import ScrollableTimeline from '../components/ScrollableTimeline';
 
 const ProfilePage = () => (
-  <main className="min-h-screen p-4 bg-gray-900 text-white">
-    <h1 className="mb-4 text-2xl">Timeline</h1>
+  <section
+    aria-labelledby="timeline-heading"
+    className="min-h-screen p-4 bg-gray-900 text-white"
+  >
+    <h1 id="timeline-heading" className="mb-4 text-2xl">
+      Timeline
+    </h1>
     <ScrollableTimeline />
-  </main>
+  </section>
 );
 
 export default ProfilePage;

--- a/pages/sekurlsa_logonpasswords.tsx
+++ b/pages/sekurlsa_logonpasswords.tsx
@@ -75,7 +75,13 @@ const SekurlsaLogonpasswords = () => {
       <div style={{ backgroundColor: '#fcd34d', padding: '1rem', textAlign: 'center', fontWeight: 'bold' }}>
         Sanitized credential data for educational use only.
       </div>
-      <main className="grid gap-4 p-4 md:grid-cols-2">
+      <section
+        aria-labelledby="sekurlsa-heading"
+        className="grid gap-4 p-4 md:grid-cols-2"
+      >
+        <h1 id="sekurlsa-heading" className="md:col-span-2 text-2xl font-semibold">
+          Parsed sekurlsa::logonpasswords output
+        </h1>
         {sessions.map((s) => (
           <div key={s.authId} className="p-4 bg-ub-dark text-white rounded border border-ub-dark-grey">
             <h2 className="text-lg mb-2">Authentication Id: {s.authId}</h2>
@@ -86,7 +92,7 @@ const SekurlsaLogonpasswords = () => {
             <p><strong>SID:</strong> {s.sid}</p>
           </div>
         ))}
-      </main>
+      </section>
     </>
   );
 };

--- a/pages/spoofing.tsx
+++ b/pages/spoofing.tsx
@@ -61,14 +61,23 @@ const DnsDiagram = () => (
 const SpoofingOverview = () => (
   <>
     <Meta />
-    <main className="p-4 grid gap-4 md:grid-cols-2 bg-ub-cool-grey min-h-screen">
+    <section
+      aria-labelledby="spoofing-heading"
+      className="p-4 grid gap-4 md:grid-cols-2 bg-ub-cool-grey min-h-screen"
+    >
+      <h1 id="spoofing-heading" className="md:col-span-2 text-2xl font-semibold text-white">
+        Spoofing simulations
+      </h1>
+      <p className="md:col-span-2 text-white/80">
+        Visual explainers for ARP and DNS spoofing are paired with links to upstream documentation.
+      </p>
       <ToolTile title="arpspoof" link="https://manpages.debian.org/unstable/dsniff/arpspoof.8.en.html">
         <ArpDiagram />
       </ToolTile>
       <ToolTile title="dnsspoof" link="https://manpages.debian.org/unstable/dsniff/dnsspoof.8.en.html">
         <DnsDiagram />
       </ToolTile>
-    </main>
+    </section>
   </>
 );
 

--- a/pages/video-gallery.tsx
+++ b/pages/video-gallery.tsx
@@ -38,7 +38,13 @@ const VideoGallery: React.FC = () => {
   );
 
   return (
-    <main className="p-4">
+    <section
+      aria-labelledby="video-gallery-heading"
+      className="p-4"
+    >
+      <h1 id="video-gallery-heading" className="mb-4 text-2xl font-semibold">
+        Kali Linux video gallery
+      </h1>
       <input
         type="text"
         placeholder="Search videos..."
@@ -79,7 +85,7 @@ const VideoGallery: React.FC = () => {
           </button>
         ))}
       </div>
-    </main>
+    </section>
   );
 };
 

--- a/pages/wps-attack.tsx
+++ b/pages/wps-attack.tsx
@@ -44,8 +44,13 @@ const WpsAttack = () => {
   return (
     <>
       <Meta />
-      <main className="bg-ub-cool-grey text-white min-h-screen p-4">
-        <h1 className="text-2xl mb-4">WPS Attack Walkthrough</h1>
+      <section
+        aria-labelledby="wps-attack-heading"
+        className="bg-ub-cool-grey text-white min-h-screen p-4"
+      >
+        <h1 id="wps-attack-heading" className="text-2xl mb-4">
+          WPS Attack Walkthrough
+        </h1>
         <ol className="space-y-4">
           {steps.map((s, idx) => (
             <li
@@ -83,7 +88,7 @@ ${s.output}`}
         <p className="text-xs text-red-400 mt-6">
           Warning: This walkthrough is for educational purposes only. Unauthorized network access is illegal and unethical. Always obtain permission before testing security.
         </p>
-      </main>
+      </section>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- add a skip link and semantic header/nav/main/footer container to the app shell
- promote the desktop navbar and taskbar to header/footer landmarks for the OS simulation
- replace nested `<main>` elements in app windows and learning pages with labelled sections and headings

## Testing
- yarn lint *(fails: repository has pre-existing jsx-a11y label violations and top-level window/document usage in legacy apps)*

------
https://chatgpt.com/codex/tasks/task_e_68c966decb808328985163d1903a5352