### PR TITLE
[apps] Virtualize module & project listings

### DIFF
--- a/components/apps/project-gallery.tsx
+++ b/components/apps/project-gallery.tsx
@@ -1,6 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
+import List, { type ListRef } from 'rc-virtual-list';
 import projectsData from '../../data/projects.json';
+import { useVirtualGrid } from '../../hooks/useVirtualGrid';
 
 interface Project {
   id: number;
@@ -26,15 +28,48 @@ const Editor = dynamic(() => import('@monaco-editor/react'), { ssr: false });
 const STORAGE_KEY = 'project-gallery-filters';
 const STORAGE_FILE = 'project-gallery-filters.json';
 
+const getStoredFilters = () => {
+  if (typeof window === 'undefined') {
+    return { search: '', stack: '', year: '', type: '', tags: [] as string[] };
+  }
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return { search: '', stack: '', year: '', type: '', tags: [] };
+    }
+    const parsed = JSON.parse(raw);
+    return {
+      search: typeof parsed.search === 'string' ? parsed.search : '',
+      stack: typeof parsed.stack === 'string' ? parsed.stack : '',
+      year: typeof parsed.year === 'string' ? parsed.year : '',
+      type: typeof parsed.type === 'string' ? parsed.type : '',
+      tags: Array.isArray(parsed.tags)
+        ? parsed.tags.filter((tag: unknown): tag is string => typeof tag === 'string')
+        : [],
+    };
+  } catch {
+    return { search: '', stack: '', year: '', type: '', tags: [] };
+  }
+};
+
 const ProjectGallery: React.FC<Props> = ({ openApp }) => {
   const projects: Project[] = projectsData as Project[];
-  const [search, setSearch] = useState('');
-  const [stack, setStack] = useState('');
-  const [year, setYear] = useState('');
-  const [type, setType] = useState('');
-  const [tags, setTags] = useState<string[]>([]);
+  const storedFiltersRef = useRef(getStoredFilters());
+  const [search, setSearch] = useState(storedFiltersRef.current.search);
+  const [stack, setStack] = useState(storedFiltersRef.current.stack);
+  const [year, setYear] = useState(storedFiltersRef.current.year);
+  const [type, setType] = useState(storedFiltersRef.current.type);
+  const [tags, setTags] = useState<string[]>(storedFiltersRef.current.tags);
   const [ariaMessage, setAriaMessage] = useState('');
   const [selected, setSelected] = useState<Project[]>([]);
+
+  const {
+    containerRef: projectsContainerRef,
+    height: projectsHeight,
+    columns: projectColumns,
+    recalculate: recalcProjects,
+  } = useVirtualGrid({ minHeight: 320, viewportOffset: 40 });
+  const listRef = useRef<ListRef | null>(null);
 
   const readFilters = async () => {
     try {
@@ -133,6 +168,30 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
       `Showing ${filtered.length} project${filtered.length === 1 ? '' : 's'}${stack ? ` filtered by ${stack}` : ''}${tags.length ? ` with tags ${tags.join(', ')}` : ''}${year ? ` in ${year}` : ''}${type ? ` of type ${type}` : ''}${search ? ` matching "${search}"` : ''}`
     );
   }, [filtered.length, stack, year, type, tags, search]);
+
+  const projectRows = useMemo(() => {
+    if (!filtered.length) return [] as Project[][];
+    const size = Math.max(projectColumns, 1);
+    const rows: Project[][] = [];
+    for (let i = 0; i < filtered.length; i += size) {
+      rows.push(filtered.slice(i, i + size));
+    }
+    return rows;
+  }, [filtered, projectColumns]);
+
+  const estimatedProjectRowHeight = useMemo(() => {
+    if (projectColumns >= 3) return 420;
+    if (projectColumns === 2) return 460;
+    return 520;
+  }, [projectColumns]);
+
+  useEffect(() => {
+    listRef.current?.scrollTo(0);
+  }, [projectRows]);
+
+  useEffect(() => {
+    recalcProjects();
+  }, [stack, year, type, tags, search, selected.length, filtered.length, recalcProjects]);
 
   const openInChrome = (url: string) => {
     try {
@@ -253,101 +312,144 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
           </table>
         </div>
       )}
-      <div className="columns-1 sm:columns-2 md:columns-3 gap-4">
-        {filtered.map((project) => (
-          <div
-            key={project.id}
-            className="mb-4 break-inside-avoid bg-gray-800 rounded shadow overflow-hidden"
+      {projectRows.length === 0 ? (
+        <p className="text-sm text-gray-300">
+          No projects match your filters.
+        </p>
+      ) : (
+        <div ref={projectsContainerRef} className="mt-4">
+          <List
+            ref={listRef}
+            data={projectRows}
+            height={projectsHeight}
+            itemHeight={estimatedProjectRowHeight}
+            itemKey={(row, rowIndex) =>
+              row.map((item) => item.id).join('|') || `row-${rowIndex}`
+            }
+            fullHeight={false}
+            style={{ width: '100%' }}
           >
-            <div className="flex flex-col md:flex-row h-48">
-              <img
-                src={project.thumbnail}
-                alt={project.title}
-                className="w-full md:w-1/2 h-48 object-cover"
-                loading="lazy"
-              />
-              <div className="w-full md:w-1/2 h-48">
-                <Editor
-                  height="100%"
-                  theme="vs-dark"
-                  language={project.language}
-                  value={project.snippet}
-                  options={{ readOnly: true, minimap: { enabled: false } }}
-                />
-              </div>
-            </div>
-            <div className="p-4 space-y-2">
-              <h3 className="text-lg font-semibold">{project.title}</h3>
-              <p className="text-sm">{project.description}</p>
-              <button
-                onClick={() => toggleSelect(project)}
-                aria-label={`Select ${project.title} for comparison`}
-                className="bg-gray-700 text-xs px-2 py-1 rounded-full"
+            {(row, rowIndex, { style }) => (
+              <div
+                style={{
+                  ...style,
+                  width: '100%',
+                  paddingBottom:
+                    rowIndex === projectRows.length - 1 ? 0 : 16,
+                }}
+                className="box-border"
               >
-                {selected.some((p) => p.id === project.id)
-                  ? 'Deselect'
-                  : 'Compare'}
-              </button>
-              <div className="flex flex-wrap gap-1">
-                {project.stack.map((s) => (
-                  <button
-                    key={s}
-                    onClick={() => setStack(s)}
-                    className="bg-gray-700 text-xs px-2 py-1 rounded-full"
-                  >
-                    {s}
-                  </button>
-                ))}
-              </div>
-              <div className="flex flex-wrap gap-1">
-                {project.tags.map((t) => (
-                  <button
-                    key={t}
-                    onClick={() =>
-                      setTags((prev) =>
-                        prev.includes(t)
-                          ? prev.filter((tag) => tag !== t)
-                          : [...prev, t]
-                      )
-                    }
-                    className="bg-gray-700 text-xs px-2 py-1 rounded-full"
-                  >
-                    {t}
-                  </button>
-                ))}
-              </div>
-              <div className="flex flex-wrap gap-3 text-sm pt-2">
-                <a
-                  href={project.repo}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-400 hover:underline"
+                <div
+                  className="grid gap-4"
+                  style={{
+                    gridTemplateColumns: `repeat(${Math.min(
+                      projectColumns,
+                      row.length
+                    )}, minmax(0, 1fr))`,
+                  }}
                 >
-                  Repo
-                </a>
-                {project.demo && (
-                  <>
-                    <a
-                      href={project.demo}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-400 hover:underline"
+                  {row.map((project) => (
+                    <div
+                      key={project.id}
+                      className="break-inside-avoid bg-gray-800 rounded shadow overflow-hidden"
                     >
-                      Live Demo
-                    </a>
-                    <button
-                      onClick={() => openInChrome(project.demo)}
-                      className="text-blue-400 hover:underline"
-                    >
-                      Open in Chrome
-                    </button>
-                  </>
-                )}
+                      <div className="flex flex-col md:flex-row h-48">
+                        <img
+                          src={project.thumbnail}
+                          alt={project.title}
+                          className="w-full md:w-1/2 h-48 object-cover"
+                          loading="lazy"
+                        />
+                        <div className="w-full md:w-1/2 h-48">
+                          <Editor
+                            height="100%"
+                            theme="vs-dark"
+                            language={project.language}
+                            value={project.snippet}
+                            options={{
+                              readOnly: true,
+                              minimap: { enabled: false },
+                            }}
+                          />
+                        </div>
+                      </div>
+                      <div className="p-4 space-y-2">
+                        <h3 className="text-lg font-semibold">{project.title}</h3>
+                        <p className="text-sm">{project.description}</p>
+                        <button
+                          onClick={() => toggleSelect(project)}
+                          aria-label={`Select ${project.title} for comparison`}
+                          className="bg-gray-700 text-xs px-2 py-1 rounded-full"
+                        >
+                          {selected.some((p) => p.id === project.id)
+                            ? 'Deselect'
+                            : 'Compare'}
+                        </button>
+                        <div className="flex flex-wrap gap-1">
+                          {project.stack.map((s) => (
+                            <button
+                              key={s}
+                              onClick={() => setStack(s)}
+                              className="bg-gray-700 text-xs px-2 py-1 rounded-full"
+                            >
+                              {s}
+                            </button>
+                          ))}
+                        </div>
+                        <div className="flex flex-wrap gap-1">
+                          {project.tags.map((t) => (
+                            <button
+                              key={t}
+                              onClick={() =>
+                                setTags((prev) =>
+                                  prev.includes(t)
+                                    ? prev.filter((tag) => tag !== t)
+                                    : [...prev, t]
+                                )
+                              }
+                              className="bg-gray-700 text-xs px-2 py-1 rounded-full"
+                            >
+                              {t}
+                            </button>
+                          ))}
+                        </div>
+                        <div className="flex flex-wrap gap-3 text-sm pt-2">
+                          <a
+                            href={project.repo}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-400 hover:underline"
+                          >
+                            Repo
+                          </a>
+                          {project.demo && (
+                            <>
+                              <a
+                                href={project.demo}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-blue-400 hover:underline"
+                              >
+                                Live Demo
+                              </a>
+                              <button
+                                onClick={() => openInChrome(project.demo)}
+                                className="text-blue-400 hover:underline"
+                              >
+                                Open in Chrome
+                              </button>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
               </div>
-            </div>
-          </div>
-        ))}
-      </div>
+            )}
+          </List>
+        </div>
+      )}
       <div aria-live="polite" className="sr-only">
         {ariaMessage}
       </div>

--- a/hooks/useVirtualGrid.ts
+++ b/hooks/useVirtualGrid.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+interface Options {
+  /**
+   * Minimum height applied to the virtual list container. This prevents the
+   * viewport from collapsing while metrics are calculated.
+   */
+  minHeight?: number;
+  /**
+   * Pixels to subtract from the available viewport height. This leaves space
+   * for padding or content rendered beneath the list.
+   */
+  viewportOffset?: number;
+}
+
+interface VirtualGridMetrics {
+  containerRef: (node: HTMLDivElement | null) => void;
+  height: number;
+  columns: number;
+  recalculate: () => void;
+}
+
+/**
+ * Computes layout metrics for virtualised grid lists. The hook measures the
+ * container element and derives a responsive column count that mirrors the
+ * Tailwind breakpoints used throughout the desktop shell.
+ */
+export function useVirtualGrid(options?: Options): VirtualGridMetrics {
+  const { minHeight = 320, viewportOffset = 24 } = options ?? {};
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const [height, setHeight] = useState<number>(minHeight);
+  const [columns, setColumns] = useState<number>(1);
+
+  const computeColumns = useCallback((width: number) => {
+    if (width >= 1024) return 3;
+    if (width >= 640) return 2;
+    return 1;
+  }, []);
+
+  const updateMetrics = useCallback(() => {
+    if (typeof window === 'undefined' || !container) return;
+
+    const width = container.clientWidth;
+    const nextColumns = computeColumns(width);
+    setColumns((prev) => (prev === nextColumns ? prev : nextColumns));
+
+    const rect = container.getBoundingClientRect();
+    const viewport = window.innerHeight || 0;
+    const nextHeight = Math.max(minHeight, viewport - rect.top - viewportOffset);
+
+    setHeight((prev) => (Math.abs(prev - nextHeight) < 1 ? prev : nextHeight));
+  }, [computeColumns, container, minHeight, viewportOffset]);
+
+  useEffect(() => {
+    if (!container || typeof window === 'undefined') return;
+
+    let frame = requestAnimationFrame(updateMetrics);
+
+    const handleResize = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(updateMetrics);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    let resizeObserver: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(() => handleResize());
+      resizeObserver.observe(container);
+    }
+
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener('resize', handleResize);
+      resizeObserver?.disconnect();
+    };
+  }, [container, updateMetrics]);
+
+  const containerRef = useCallback((node: HTMLDivElement | null) => {
+    setContainer(node);
+  }, []);
+
+  const recalculate = useCallback(() => {
+    updateMetrics();
+  }, [updateMetrics]);
+
+  return useMemo(
+    () => ({
+      containerRef,
+      height,
+      columns,
+      recalculate,
+    }),
+    [columns, containerRef, height, recalculate]
+  );
+}
+
+export default useVirtualGrid;


### PR DESCRIPTION
## Summary
- add a reusable `useVirtualGrid` hook to compute responsive heights and columns for virtualized grids
- update the Popular Modules view to render module cards with `rc-virtual-list`, memoized filters, and viewport-aware scrolling
- virtualize the Project Gallery cards, load persisted filters on first render, and keep grid layout responsive to container width

## Testing
- yarn lint *(fails: existing accessibility and top-level window lint errors in unrelated files)*
- yarn test *(aborted after encountering pre-existing suite failures and long runtime)*
- yarn test __tests__/projectGallery.test.tsx --runTestsByPath
- yarn test __tests__/popularModules.test.tsx --runTestsByPath

------
https://chatgpt.com/codex/tasks/task_e_68c966d60e608328a63f0baf1c9cf9c7