### PR TITLE
[ui] add fade-in animation for app shells

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,8 +1,8 @@
-
 'use client';
 
 import { useEffect } from 'react';
 import { reportClientError } from '../lib/client-error-reporter';
+import FadeInOnMount from '../components/common/FadeInOnMount';
 
 export default function Error({ error, reset }: { error: Error; reset: () => void }) {
   useEffect(() => {
@@ -10,7 +10,7 @@ export default function Error({ error, reset }: { error: Error; reset: () => voi
   }, [error]);
 
   return (
-    <div className="flex flex-col items-center justify-center gap-4 p-4">
+    <FadeInOnMount className="flex flex-col items-center justify-center gap-4 p-4">
       <h2 className="text-xl font-semibold">Something went wrong!</h2>
       <button
         type="button"
@@ -19,6 +19,6 @@ export default function Error({ error, reset }: { error: Error; reset: () => voi
       >
         Try again
       </button>
-    </div>
+    </FadeInOnMount>
   );
 }

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import { reportClientError } from '../lib/client-error-reporter';
+import FadeInOnMount from '../components/common/FadeInOnMount';
 
 export default function GlobalError({
   error,
@@ -17,7 +18,7 @@ export default function GlobalError({
   return (
     <html>
       <body>
-        <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4">
+        <FadeInOnMount className="flex min-h-screen flex-col items-center justify-center gap-4 p-4">
           <h2 className="text-xl font-semibold">Something went wrong!</h2>
           <button
             type="button"
@@ -26,7 +27,7 @@ export default function GlobalError({
           >
             Try again
           </button>
-        </div>
+        </FadeInOnMount>
       </body>
     </html>
   );

--- a/components/common/FadeInOnMount.tsx
+++ b/components/common/FadeInOnMount.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { ComponentPropsWithoutRef, ReactNode, useEffect, useState } from 'react';
+import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
+
+type FadeInOnMountProps = {
+  className?: string;
+  children: ReactNode;
+} & Omit<ComponentPropsWithoutRef<'div'>, 'className' | 'children'>;
+
+export default function FadeInOnMount({
+  className = '',
+  children,
+  ...rest
+}: FadeInOnMountProps) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const [ready, setReady] = useState(() => prefersReducedMotion);
+
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      setReady(true);
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => {
+      setReady(true);
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  }, [prefersReducedMotion]);
+
+  const classes = ['app-shell'];
+  if (className) classes.push(className);
+  if (ready) classes.push('app-shell--ready');
+
+  return (
+    <div className={classes.join(' ')} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/components/games/GameShell.tsx
+++ b/components/games/GameShell.tsx
@@ -5,6 +5,7 @@ import useOrientationGuard from '../../hooks/useOrientationGuard';
 import useGameInput from '../../hooks/useGameInput';
 import usePersistentState from '../../hooks/usePersistentState';
 import { exportGameSettings, importGameSettings } from '../../utils/gameSettings';
+import FadeInOnMount from '../common/FadeInOnMount';
 
 interface GameShellProps {
   game: string;
@@ -74,9 +75,10 @@ export default function GameShell({
     importGameSettings(game, text);
   };
 
+  const shellClassName = `game-shell${paused ? ' paused' : ''}${muted ? ' muted' : ''}`;
+
   return (
-    <div className={`game-shell${paused ? ' paused' : ''}${muted ? ' muted' : ''}`}
-         data-speed={speed}>
+    <FadeInOnMount className={shellClassName} data-speed={speed}>
       <div className="game-content">{children}</div>
       {controls && <div className="game-controls">{controls}</div>}
       {showSettings && settings && (
@@ -125,6 +127,6 @@ export default function GameShell({
           if (e.target) e.target.value = '';
         }}
       />
-    </div>
+    </FadeInOnMount>
   );
 }

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -15,6 +15,7 @@ import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
+import FadeInOnMount from '../components/common/FadeInOnMount';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
 import { Ubuntu } from 'next/font/google';
@@ -149,7 +150,7 @@ function MyApp(props) {
   return (
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />
-      <div className={ubuntu.className}>
+      <FadeInOnMount className={ubuntu.className}>
         <a
           href="#app-grid"
           className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
@@ -173,7 +174,7 @@ function MyApp(props) {
             {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
           </PipPortalProvider>
         </SettingsProvider>
-      </div>
+      </FadeInOnMount>
     </ErrorBoundary>
 
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -38,6 +38,26 @@ button:focus-visible {
     scroll-behavior: auto !important;
 }
 
+.app-shell {
+    opacity: 0;
+    transform: translateY(0.75rem);
+    transition: opacity 320ms ease-out, transform 320ms ease-out;
+    will-change: opacity, transform;
+}
+
+.app-shell--ready {
+    opacity: 1;
+    transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .app-shell {
+        opacity: 1;
+        transform: none;
+        transition: none;
+    }
+}
+
 /* Top NavBar styling */
 
 .top-arrow-up {


### PR DESCRIPTION
## Summary
- add a reusable FadeInOnMount wrapper that skips motion when reduced-motion is preferred
- add global app-shell transition styles and apply to the Next.js app shell, game shell, and error views
- ensure error and game shells reuse the new animation so they fade in on mount

## Testing
- [ ] yarn lint *(fails: repo has existing accessibility and no-top-level-window issues)*
- [ ] yarn test *(fails: repo has existing suite failures)*

## Flags
- none

------
https://chatgpt.com/codex/tasks/task_e_68c966d7344c8328b50371e3bc83e0ea