### PR TITLE
[a11y] Improve keyboard flows for menus and drawers

### DIFF
--- a/__tests__/filtersDrawer.accessibility.test.tsx
+++ b/__tests__/filtersDrawer.accessibility.test.tsx
@@ -1,0 +1,65 @@
+import React, { useRef, useState } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FiltersDrawer from '../apps/nessus/components/FiltersDrawer';
+
+const severityFilters = {
+  Critical: true,
+  High: true,
+  Medium: true,
+  Low: true,
+  Info: true,
+};
+
+const tags = ['web', 'db'];
+
+describe('FiltersDrawer accessibility', () => {
+  it('traps focus and returns it to the trigger on close', async () => {
+    const user = userEvent.setup();
+    const onCloseSpy = jest.fn();
+
+    const Wrapper = () => {
+      const [open, setOpen] = useState(true);
+      const triggerRef = useRef<HTMLButtonElement>(null);
+
+      const handleClose = () => {
+        setOpen(false);
+        onCloseSpy();
+      };
+
+      return (
+        <div>
+          <button ref={triggerRef} type="button">
+            Filters
+          </button>
+          <FiltersDrawer
+            id="test-filters-drawer"
+            open={open}
+            onClose={handleClose}
+            severityFilters={severityFilters}
+            toggleSeverity={jest.fn()}
+            tags={tags}
+            tagFilters={[]}
+            toggleTag={jest.fn()}
+            returnFocusRef={triggerRef}
+          />
+        </div>
+      );
+    };
+
+    render(<Wrapper />);
+
+    const firstCheckbox = await screen.findByRole('checkbox', { name: /critical/i });
+    await waitFor(() => expect(firstCheckbox).toHaveFocus());
+
+    await user.keyboard('{Shift>}{Tab}{/Shift}');
+    expect(screen.getByRole('button', { name: /db/i })).toHaveFocus();
+
+    await user.keyboard('{Tab}');
+    await waitFor(() => expect(firstCheckbox).toHaveFocus());
+
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(onCloseSpy).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByRole('button', { name: /filters/i })).toHaveFocus());
+  });
+});

--- a/__tests__/navbarAccessibility.test.tsx
+++ b/__tests__/navbarAccessibility.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Navbar from '../components/screen/navbar';
+
+jest.mock('next/image', () => {
+  const MockedImage = ({ src = '', alt = '', ...rest }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <img src={typeof src === 'string' ? src : ''} alt={alt ?? ''} {...rest} />
+  );
+  MockedImage.displayName = 'MockedImage';
+  return MockedImage;
+});
+
+describe('Navbar accessibility', () => {
+  it('allows keyboard navigation through the quick settings dialog', async () => {
+    const user = userEvent.setup();
+    render(<Navbar />);
+
+    const statusButton = screen.getByRole('button', { name: /system status/i });
+    statusButton.focus();
+    expect(statusButton).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+
+    const dialog = await screen.findByRole('dialog', { name: /quick settings/i });
+    const themeButton = within(dialog).getByRole('button', { name: /theme/i });
+    await waitFor(() => expect(themeButton).toHaveFocus());
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => expect(statusButton).toHaveFocus());
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: /quick settings/i })).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/apps/nessus/components/FiltersDrawer.tsx
+++ b/apps/nessus/components/FiltersDrawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import React, { RefObject, useId, useRef } from 'react';
+import useFocusTrap from '../../../hooks/useFocusTrap';
 import { Severity, severities } from '../types';
 
 interface Props {
@@ -11,6 +12,8 @@ interface Props {
   tags: string[];
   tagFilters: string[];
   toggleTag: (tag: string) => void;
+  id?: string;
+  returnFocusRef?: RefObject<HTMLElement>;
 }
 
 export default function FiltersDrawer({
@@ -21,22 +24,48 @@ export default function FiltersDrawer({
   tags,
   tagFilters,
   toggleTag,
+  id,
+  returnFocusRef,
 }: Props) {
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const firstCheckboxRef = useRef<HTMLInputElement>(null);
+  const reactId = useId();
+  const drawerId = id ?? `${reactId}-filters-drawer`;
+  const headingId = `${drawerId}-heading`;
+
+  useFocusTrap({
+    active: open,
+    containerRef: drawerRef,
+    initialFocusRef: firstCheckboxRef,
+    onEscape: onClose,
+    returnFocusRef,
+  });
+
   return (
     <div
       className={`fixed inset-0 bg-black/50 transition-opacity ${open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
       onClick={onClose}
+      aria-hidden={!open}
     >
       <div
+        id={drawerId}
+        ref={drawerRef}
         className={`absolute right-0 top-0 h-full w-64 bg-gray-900 p-4 overflow-y-auto transform transition-transform ${open ? 'translate-x-0' : 'translate-x-full'}`}
         onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        tabIndex={-1}
       >
-        <h3 className="text-lg mb-4">Filters</h3>
+        <h3 id={headingId} className="text-lg mb-4">
+          Filters
+        </h3>
         <div className="mb-6">
           <h4 className="font-semibold mb-2">Severity</h4>
           {severities.map((sev) => (
             <label key={sev} className="flex items-center gap-2 mb-1">
               <input
+                ref={sev === severities[0] ? firstCheckboxRef : undefined}
                 type="checkbox"
                 checked={severityFilters[sev]}
                 onChange={() => toggleSeverity(sev)}

--- a/apps/nessus/index.tsx
+++ b/apps/nessus/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef, useState, useMemo } from 'react';
+import React, { useEffect, useRef, useState, useMemo, useId } from 'react';
 import { toPng } from 'html-to-image';
 import TrendChart from './components/TrendChart';
 import SummaryDashboard from './components/SummaryDashboard';
@@ -35,6 +35,8 @@ const Nessus: React.FC = () => {
   const [trend, setTrend] = useState<number[]>([]);
   const chartRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
+  const filtersButtonRef = useRef<HTMLButtonElement>(null);
+  const filtersDrawerId = `${useId()}-filters-drawer`;
   const PAGE_SIZE = 50;
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
@@ -171,9 +173,13 @@ const Nessus: React.FC = () => {
       <section>
         <h2 className="text-xl mb-2">Plugin Feed</h2>
         <button
+          ref={filtersButtonRef}
           type="button"
           onClick={() => setDrawerOpen(true)}
           className="mb-4 px-3 py-1 bg-gray-700 rounded"
+          aria-haspopup="dialog"
+          aria-expanded={drawerOpen}
+          aria-controls={filtersDrawerId}
         >
           Filters
         </button>
@@ -230,6 +236,7 @@ const Nessus: React.FC = () => {
         <TrendChart />
       </section>
       <FiltersDrawer
+        id={filtersDrawerId}
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
         severityFilters={severityFilters}
@@ -237,6 +244,7 @@ const Nessus: React.FC = () => {
         tags={tags}
         tagFilters={tagFilters}
         toggleTag={toggleTag}
+        returnFocusRef={filtersButtonRef}
       />
     </div>
   );

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,6 +1,9 @@
-import { useState } from 'react';
+"use client";
+
+import { useEffect, useId, useRef, useState } from 'react';
 import { getUnlockedThemes } from '../utils/theme';
 import { useSettings, ACCENT_OPTIONS } from '../hooks/useSettings';
+import useFocusTrap from '../hooks/useFocusTrap';
 
 interface Props {
   highScore?: number;
@@ -10,20 +13,71 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const unlocked = getUnlockedThemes(highScore);
   const { accent, setAccent, theme, setTheme } = useSettings();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const selectRef = useRef<HTMLSelectElement>(null);
+  const idBase = useId();
+  const drawerId = `${idBase}-settings-drawer`;
+  const headingId = `${idBase}-settings-heading`;
+
+  useFocusTrap({
+    active: open,
+    containerRef: drawerRef,
+    initialFocusRef: selectRef,
+    onEscape: () => setOpen(false),
+    returnFocusRef: triggerRef,
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node;
+      if (drawerRef.current?.contains(target)) return;
+      if (triggerRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('touchstart', handlePointerDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('touchstart', handlePointerDown);
+    };
+  }, [open, triggerRef]);
 
   return (
     <div>
-      <button aria-label="settings" onClick={() => setOpen(!open)}>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label="settings"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={drawerId}
+        onClick={() => setOpen((prev) => !prev)}
+      >
         Settings
       </button>
       {open && (
-        <div role="dialog">
-          <label>
-            Theme
+        <div
+          id={drawerId}
+          ref={drawerRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={headingId}
+          className="mt-2 rounded-md border border-white/10 bg-ub-cool-grey p-4 shadow-lg"
+        >
+          <h2 id={headingId} className="sr-only">
+            Settings
+          </h2>
+          <label className="flex flex-col gap-2">
+            <span>Theme</span>
             <select
+              ref={selectRef}
               aria-label="theme-select"
               value={theme}
               onChange={(e) => setTheme(e.target.value)}
+              className="rounded bg-black/40 px-2 py-1"
             >
               {unlocked.map((t) => (
                 <option key={t} value={t}>
@@ -32,21 +86,24 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
               ))}
             </select>
           </label>
-          <label>
-            Accent
+          <label className="mt-4 flex flex-col gap-2">
+            <span>Accent</span>
             <div
               aria-label="accent-color-picker"
               role="radiogroup"
-              className="flex gap-2 mt-1"
+              className="flex gap-2"
             >
               {ACCENT_OPTIONS.map((c) => (
                 <button
                   key={c}
+                  type="button"
                   aria-label={`select-accent-${c}`}
                   role="radio"
                   aria-checked={accent === c}
                   onClick={() => setAccent(c)}
-                  className={`w-6 h-6 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
+                  className={`h-6 w-6 rounded-full border-2 transition-shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubb-orange ${
+                    accent === c ? 'border-white shadow' : 'border-transparent'
+                  }`}
                   style={{ backgroundColor: c }}
                 />
               ))}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, createRef } from 'react';
 import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
@@ -6,15 +6,16 @@ import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+        constructor() {
+                super();
+                this.state = {
+                        status_card: false
+                };
+                this.statusButtonRef = createRef();
+        }
 
-	render() {
-		return (
+        render() {
+                return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
@@ -27,21 +28,31 @@ export default class Navbar extends Component {
                                 >
                                         <Clock />
                                 </div>
-                                <button
-                                        type="button"
-                                        id="status-bar"
-                                        aria-label="System status"
-                                        onClick={() => {
-                                                this.setState({ status_card: !this.state.status_card });
-                                        }}
-                                        className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-                                        }
-                                >
-                                        <Status />
-                                        <QuickSettings open={this.state.status_card} />
-                                </button>
-			</div>
-		);
-	}
+                                <div className="relative">
+                                        <button
+                                                ref={this.statusButtonRef}
+                                                type="button"
+                                                id="status-bar"
+                                                aria-label="System status"
+                                                aria-haspopup="dialog"
+                                                aria-expanded={this.state.status_card}
+                                                aria-controls="quick-settings-dialog"
+                                                onClick={() => {
+                                                        this.setState({ status_card: !this.state.status_card });
+                                                }}
+                                                className={
+                                                        'pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
+                                                }
+                                        >
+                                                <Status />
+                                        </button>
+                                        <QuickSettings
+                                                open={this.state.status_card}
+                                                onClose={() => this.setState({ status_card: false })}
+                                                anchorRef={this.statusButtonRef}
+                                        />
+                                </div>
+                        </div>
+                );
+        }
 }

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,17 +1,36 @@
 "use client";
 
+import { RefObject, useEffect, useId, useRef } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
 
 interface Props {
   open: boolean;
+  onClose: () => void;
+  anchorRef?: RefObject<HTMLElement>;
 }
 
-const QuickSettings = ({ open }: Props) => {
+const QuickSettings = ({ open, onClose, anchorRef }: Props) => {
   const [theme, setTheme] = usePersistentState('qs-theme', 'light');
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const themeButtonRef = useRef<HTMLButtonElement>(null);
+  const idBase = useId();
+  const headingId = `${idBase}-heading`;
+  const soundId = `${idBase}-sound`;
+  const networkId = `${idBase}-network`;
+  const motionId = `${idBase}-motion`;
+
+  useFocusTrap({
+    active: open,
+    containerRef,
+    initialFocusRef: themeButtonRef,
+    onEscape: onClose,
+    returnFocusRef: anchorRef,
+  });
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -21,37 +40,86 @@ const QuickSettings = ({ open }: Props) => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
 
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node;
+      if (containerRef.current?.contains(target)) return;
+      if (anchorRef?.current?.contains(target)) return;
+      onClose();
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('touchstart', handlePointerDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('touchstart', handlePointerDown);
+    };
+  }, [open, onClose, anchorRef]);
+
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      id="quick-settings-dialog"
+      ref={containerRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={headingId}
+      aria-hidden={!open}
+      tabIndex={-1}
+      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 focus:outline-none ${
         open ? '' : 'hidden'
       }`}
     >
+      <h2 id={headingId} className="sr-only">
+        Quick settings
+      </h2>
       <div className="px-4 pb-2">
         <button
-          className="w-full flex justify-between"
+          ref={themeButtonRef}
+          type="button"
+          className="w-full flex items-center justify-between gap-4 px-2 py-1 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubb-orange"
           onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
         >
           <span>Theme</span>
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
+      <label
+        htmlFor={soundId}
+        className="px-4 pb-2 flex items-center justify-between gap-4 text-left"
+      >
         <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
+        <input
+          id={soundId}
+          type="checkbox"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+        />
+      </label>
+      <label
+        htmlFor={networkId}
+        className="px-4 pb-2 flex items-center justify-between gap-4 text-left"
+      >
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
+        <input
+          id={networkId}
+          type="checkbox"
+          checked={online}
+          onChange={() => setOnline(!online)}
+        />
+      </label>
+      <label
+        htmlFor={motionId}
+        className="px-4 flex items-center justify-between gap-4 text-left"
+      >
         <span>Reduced motion</span>
         <input
+          id={motionId}
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
         />
-      </div>
+      </label>
     </div>
   );
 };

--- a/docs/keyboard-only-test-plan.md
+++ b/docs/keyboard-only-test-plan.md
@@ -21,3 +21,16 @@
 1. After resizing or snapping, press **Tab** to move focus inside the window.
 2. Continue pressing **Tab** to confirm focus can leave the window and is not trapped.
 3. Shift+Tab moves focus backward as expected.
+
+## Menus and drawers
+1. From the desktop, focus the **System status** button and press **Enter**.
+   - The Quick Settings dialog should open with the Theme toggle focused.
+   - Use **Tab** and **Shift+Tab** to cycle through all controls; focus should remain inside the dialog.
+   - Press **Escape** to close the dialog and confirm focus returns to the System status button.
+2. Focus the **Applications** button and press **Enter** or **Space** to open the Whisker menu.
+   - Type to filter results and use the arrow keys to move the highlighted app tile.
+   - Press **Escape** to close the menu and confirm focus returns to the Applications button.
+3. Open the Nessus demo and focus the **Filters** button.
+   - Press **Enter** to open the filter drawer; the first severity checkbox should receive focus.
+   - Use **Shift+Tab** to verify focus loops to the last tag pill, then **Tab** to return to the first checkbox.
+   - Press **Escape** to close the drawer and verify focus returns to the Filters button.


### PR DESCRIPTION
## Summary
- refactor the quick settings popover to trap focus, close on escape/click-away, and expose dialog semantics so the status button fully supports keyboard use
- tighten the Nessus filters drawer and settings drawer with the shared focus-trap helper, updated aria attributes, and documentation covering the new keyboard checks
- add dedicated tests that exercise opening, navigating, and closing the quick settings and filters drawer from the keyboard

## Testing
- yarn test __tests__/navbarAccessibility.test.tsx
- yarn test __tests__/filtersDrawer.accessibility.test.tsx
- yarn lint *(fails: existing repository accessibility and no-top-level-window warnings outside the change scope)*

------
https://chatgpt.com/codex/tasks/task_e_68c966a1caa08328825b7a8209e63810