### PR TITLE
[a11y] Improve window labels and taskbar state

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -612,6 +612,10 @@ export class Window extends Component {
     }
 
     render() {
+        const windowLabel =
+            typeof this.props.title === 'string' && this.props.title.trim().length > 0
+                ? this.props.title
+                : this.props.id;
         return (
             <>
                 {this.state.snapPreview && (
@@ -638,7 +642,7 @@ export class Window extends Component {
                         className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
                         role="dialog"
-                        aria-label={this.props.title}
+                        aria-label={windowLabel}
                         tabIndex={0}
                         onKeyDown={this.handleKeyDown}
                     >

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -17,31 +17,38 @@ export default function Taskbar(props) {
 
     return (
         <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => (
-                <button
-                    key={app.id}
-                    type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
-                    onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
-                    />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
-                </button>
-            ))}
+            {runningApps.map(app => {
+                const isMinimized = props.minimized_windows[app.id];
+                const isFocused = props.focused_windows[app.id];
+                const isActive = isFocused && !isMinimized;
+
+                return (
+                    <button
+                        key={app.id}
+                        type="button"
+                        aria-label={app.title}
+                        aria-pressed={isActive}
+                        data-context="taskbar"
+                        data-app-id={app.id}
+                        onClick={() => handleClick(app)}
+                        className={(isActive ? ' bg-white bg-opacity-20 ' : ' ') +
+                            'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                    >
+                        <Image
+                            width={24}
+                            height={24}
+                            className="w-5 h-5"
+                            src={app.icon.replace('./', '/')}
+                            alt=""
+                            sizes="24px"
+                        />
+                        <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                        {!isFocused && !isMinimized && (
+                            <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
+                        )}
+                    </button>
+                );
+            })}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- ensure each window dialog computes a stable aria-label from the app title (falling back to the id when titles are missing)
- add aria-pressed to taskbar buttons so screen readers know which window is active

## Testing
- yarn lint *(fails: repository currently has widespread accessibility lint errors unrelated to this change)*
- yarn test --watch=false *(fails: repository has pre-existing failing suites; see logs for details)*

------
https://chatgpt.com/codex/tasks/task_e_68c966a15ea88328bb2aaad4a5240b0c