### PR TITLE
[accessibility] Improve modal background aria handling

### DIFF
--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -88,9 +88,26 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
 
     useEffect(() => {
         inertRootRef.current = getOverlayRoot();
+        const root = inertRootRef.current;
+
+        const applyBackgroundHiding = (value: boolean) => {
+            if (!root) return;
+            if (value) {
+                root.setAttribute('inert', '');
+                if (root !== document.body) {
+                    root.setAttribute('aria-hidden', 'true');
+                }
+            } else {
+                root.removeAttribute('inert');
+                if (root !== document.body) {
+                    root.removeAttribute('aria-hidden');
+                }
+            }
+        };
+
         if (isOpen) {
             triggerRef.current = document.activeElement as HTMLElement;
-            inertRootRef.current?.setAttribute('inert', '');
+            applyBackgroundHiding(true);
             const elements = modalRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
             if (elements && elements.length > 0) {
                 elements[0].focus();
@@ -98,12 +115,12 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
                 modalRef.current?.focus();
             }
         } else {
-            inertRootRef.current?.removeAttribute('inert');
+            applyBackgroundHiding(false);
             triggerRef.current?.focus();
             triggerRef.current = null;
         }
         return () => {
-            inertRootRef.current?.removeAttribute('inert');
+            applyBackgroundHiding(false);
         };
     }, [isOpen, getOverlayRoot]);
 


### PR DESCRIPTION
## Summary
- apply `aria-hidden` alongside `inert` to hide the background container while the modal is open
- retain the modal's focus trap, role, and `aria-modal` semantics to keep assistive tech support intact

## Testing
- yarn lint *(fails: existing accessibility lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c966a017e883289a32f72d5d148e83