### PR TITLE
[ui] Improve dock tooltip accessibility

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -52,12 +52,21 @@ export class SideBarApp extends Component {
         this.setState({ scaleImage: true });
     }
 
+    showTooltip = () => {
+        this.captureThumbnail();
+        this.setState({ showTitle: true });
+    }
+
+    hideTooltip = () => {
+        this.setState({ showTitle: false, thumbnail: null });
+    }
+
     openApp = () => {
         if (!this.props.isMinimized[this.id] && this.props.isClose[this.id]) {
             this.scaleImage();
         }
         this.props.openApp(this.id);
-        this.setState({ showTitle: false, thumbnail: null });
+        this.hideTooltip();
     };
 
     captureThumbnail = async () => {
@@ -86,19 +95,24 @@ export class SideBarApp extends Component {
     };
 
     render() {
+        const tooltipId = `sidebar-tooltip-${this.props.id}`;
         return (
             <button
                 type="button"
                 aria-label={this.props.title}
+                aria-describedby={this.state.showTitle ? tooltipId : undefined}
                 data-context="app"
                 data-app-id={this.props.id}
                 onClick={this.openApp}
-                onMouseEnter={() => {
-                    this.captureThumbnail();
-                    this.setState({ showTitle: true });
-                }}
-                onMouseLeave={() => {
-                    this.setState({ showTitle: false, thumbnail: null });
+                onMouseEnter={this.showTooltip}
+                onMouseLeave={this.hideTooltip}
+                onFocus={this.showTooltip}
+                onBlur={this.hideTooltip}
+                onKeyDown={(event) => {
+                    if ((event.key === 'Escape' || event.key === 'Esc') && this.state.showTitle) {
+                        event.stopPropagation();
+                        this.hideTooltip();
+                    }
                 }}
                 className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
                     " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
@@ -134,6 +148,7 @@ export class SideBarApp extends Component {
                             " pointer-events-none absolute bottom-full mb-2 left-1/2 transform -translate-x-1/2" +
                             " rounded border border-gray-400 border-opacity-40 shadow-lg overflow-hidden bg-black bg-opacity-50"
                         }
+                        aria-hidden={!this.state.showTitle}
                     >
                         <Image
                             width={128}
@@ -146,6 +161,9 @@ export class SideBarApp extends Component {
                     </div>
                 )}
                 <div
+                    id={tooltipId}
+                    role="tooltip"
+                    aria-hidden={!this.state.showTitle}
                     className={
                         (this.state.showTitle ? " visible " : " invisible ") +
                         " w-max py-0.5 px-1.5 absolute top-1.5 left-full ml-3 m-1 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useId } from 'react'
 import Image from 'next/image'
 import SideBarApp from '../base/side_bar_app';
 
@@ -48,17 +48,28 @@ export default function SideBar(props) {
 
 export function AllApps(props) {
 
-    const [title, setTitle] = useState(false);
+    const [tooltipVisible, setTooltipVisible] = useState(false);
+    const tooltipId = useId();
+
+    const showTooltip = () => setTooltipVisible(true);
+    const hideTooltip = () => setTooltipVisible(false);
 
     return (
-        <div
-            className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
+        <button
+            type="button"
+            aria-label="Show applications"
+            aria-describedby={tooltipVisible ? tooltipId : undefined}
+            className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-50 bg-transparent`}
             style={{ marginTop: 'auto' }}
-            onMouseEnter={() => {
-                setTitle(true);
-            }}
-            onMouseLeave={() => {
-                setTitle(false);
+            onMouseEnter={showTooltip}
+            onMouseLeave={hideTooltip}
+            onFocus={showTooltip}
+            onBlur={hideTooltip}
+            onKeyDown={(event) => {
+                if ((event.key === 'Escape' || event.key === 'Esc') && tooltipVisible) {
+                    event.stopPropagation();
+                    hideTooltip();
+                }
             }}
             onClick={props.showApps}
         >
@@ -72,14 +83,17 @@ export function AllApps(props) {
                     sizes="28px"
                 />
                 <div
+                    id={tooltipId}
+                    role="tooltip"
+                    aria-hidden={!tooltipVisible}
                     className={
-                        (title ? " visible " : " invisible ") +
+                        (tooltipVisible ? " visible " : " invisible ") +
                         " w-max py-0.5 px-1.5 absolute top-1 left-full ml-5 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
                     }
                 >
                     Show Applications
                 </div>
             </div>
-        </div>
+        </button>
     );
 }


### PR DESCRIPTION
## Summary
- announce the dock "Show Applications" tooltip for both hover and keyboard focus
- allow dismissing dock tooltips with the Escape key and expose tooltip content via aria-describedby
- extend the same accessible tooltip behavior to pinned dock application icons

## Testing
- yarn lint *(fails: pre-existing a11y label errors across repo)*
- yarn test *(fails: existing test suites unrelated to changes)*

------
https://chatgpt.com/codex/tasks/task_e_68c966a0d8e48328b80d9bf43822f457