### PR TITLE
[pwa] improve offline fallback screen

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -79,6 +79,8 @@ const withPWA = require('@ducanh2912/next-pwa').default({
       { url: '/apps/terminal', revision: null },
       { url: '/apps/checkers', revision: null },
       { url: '/offline.html', revision: null },
+      { url: '/offline.css', revision: null },
+      { url: '/offline.js', revision: null },
       { url: '/manifest.webmanifest', revision: null },
     ],
   },

--- a/public/offline.css
+++ b/public/offline.css
@@ -1,2 +1,154 @@
-body { font-family: sans-serif; padding: 2rem; text-align: center; }
-ul { list-style: none; padding: 0; }
+:root {
+  color-scheme: dark;
+  font-family: 'Ubuntu', 'Segoe UI', Roboto, system-ui, -apple-system, sans-serif;
+  background-color: #020617;
+  color: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background: radial-gradient(circle at 20% 20%, #0f172a, #020617 70%);
+}
+
+.offline {
+  width: min(48rem, 100%);
+  display: grid;
+  gap: 2rem;
+  background: rgba(15, 23, 42, 0.85);
+  border-radius: 1.5rem;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  box-shadow:
+    0 25px 50px -12px rgba(15, 23, 42, 0.6),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.offline__card h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
+}
+
+.offline__card p {
+  margin: 0 0 1.25rem;
+  line-height: 1.6;
+  color: #cbd5f5;
+}
+
+.offline__retry {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.75rem;
+  border: none;
+  border-radius: 9999px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: #0b1120;
+  background: linear-gradient(135deg, #38bdf8, #22d3ee);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.offline__retry:hover,
+.offline__retry:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px rgba(34, 211, 238, 0.35);
+  outline: none;
+}
+
+.offline__retry:active {
+  transform: translateY(0);
+}
+
+.offline__retry:disabled {
+  cursor: wait;
+  opacity: 0.7;
+  box-shadow: none;
+}
+
+.offline__apps {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 1.25rem;
+  padding: clamp(1.25rem, 4vw, 2rem);
+}
+
+.offline__apps-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.offline__apps-header h2 {
+  margin: 0;
+  font-size: clamp(1.25rem, 4vw, 1.75rem);
+}
+
+.offline__apps-header p {
+  margin: 0;
+  color: #94a3b8;
+  min-height: 1.25rem;
+}
+
+@media (min-width: 600px) {
+  .offline__apps-header {
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: space-between;
+  }
+}
+
+.offline__apps-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.offline__apps-item {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: 0.9rem;
+  background: rgba(148, 163, 184, 0.12);
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+
+.offline__apps-item a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
+  display: block;
+}
+
+.offline__apps-item:focus-within,
+.offline__apps-item:hover {
+  transform: translateY(-1px);
+  background: rgba(148, 163, 184, 0.24);
+}
+
+.offline__apps-empty {
+  color: #cbd5f5;
+  font-style: italic;
+  background: none;
+  padding: 0;
+}
+
+@media (max-width: 500px) {
+  body {
+    padding: 1.5rem;
+  }
+
+  .offline {
+    border-radius: 1.25rem;
+  }
+}

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,21 +1,29 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Offline</title>
-  <link rel="stylesheet" href="/offline.css">
-</head>
-<body>
-  <main>
-    <h1>Offline</h1>
-    <p>You appear to be offline. Please check your connection.</p>
-    <button id="retry">Retry</button>
-    <section>
-      <h2>Cached Apps</h2>
-      <ul id="apps"></ul>
-    </section>
-  </main>
-  <script src="/offline.js" defer></script>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Offline | Kali Linux Portfolio</title>
+    <link rel="stylesheet" href="/offline.css" />
+  </head>
+  <body>
+    <main class="offline" role="main">
+      <section class="offline__card" aria-labelledby="offline-heading">
+        <h1 id="offline-heading">You&apos;re offline</h1>
+        <p>
+          The desktop can still open any apps you&apos;ve cached locally. Reconnect to
+          restore live data or retry the connection below.
+        </p>
+        <button id="retry" type="button" class="offline__retry">Retry connection</button>
+      </section>
+      <section class="offline__apps" aria-labelledby="apps-heading">
+        <div class="offline__apps-header">
+          <h2 id="apps-heading">Cached apps</h2>
+          <p id="apps-status" role="status" aria-live="polite"></p>
+        </div>
+        <ul id="apps" class="offline__apps-list"></ul>
+      </section>
+    </main>
+    <script src="/offline.js" defer></script>
+  </body>
 </html>

--- a/public/offline.js
+++ b/public/offline.js
@@ -1,36 +1,135 @@
 /* eslint-disable no-top-level-window/no-top-level-window-or-document */
-document.getElementById('retry').addEventListener('click', () => {
-  window.location.reload();
-});
+const retryButton = document.getElementById('retry');
+const appsList = document.getElementById('apps');
+const statusElement = document.getElementById('apps-status');
 
-(async () => {
-  const list = document.getElementById('apps');
+if (retryButton) {
+  retryButton.addEventListener('click', () => {
+    retryButton.disabled = true;
+    retryButton.textContent = 'Retrying…';
+    window.location.reload();
+  });
+}
+
+const setStatus = (message) => {
+  if (statusElement) {
+    statusElement.textContent = message;
+  }
+};
+
+const createMessageItem = (text) => {
+  const item = document.createElement('li');
+  item.className = 'offline__apps-empty';
+  item.textContent = text;
+  return item;
+};
+
+const formatAppName = (path) => {
+  const slug = path.replace('/apps/', '').replace(/\/index$/, '');
+  return slug
+    .split(/[-_/]/)
+    .filter(Boolean)
+    .map((segment) => segment.replace(/_/g, ' ').trim())
+    .filter(Boolean)
+    .map((segment) => {
+      if (segment.length <= 3 && /^[a-zA-Z]+$/.test(segment)) {
+        return segment.toUpperCase();
+      }
+      return segment.charAt(0).toUpperCase() + segment.slice(1);
+    })
+    .join(' ');
+};
+
+const populateCachedApps = async () => {
+  if (!appsList) {
+    return;
+  }
+
+  if (!('caches' in window)) {
+    setStatus('Caching is unavailable in this browser.');
+    appsList.innerHTML = '';
+    appsList.appendChild(createMessageItem('Your browser does not support offline caches.'));
+    return;
+  }
+
+  setStatus('Scanning cached apps…');
+
   try {
-    const names = await caches.keys();
-    const urls = new Set();
-    for (const name of names) {
+    const cacheNames = await caches.keys();
+    const appEntries = new Map();
+
+    for (const name of cacheNames) {
       const cache = await caches.open(name);
-      const keys = await cache.keys();
-      for (const request of keys) {
+      const requests = await cache.keys();
+
+      for (const request of requests) {
         const url = new URL(request.url);
-        if (url.pathname.startsWith('/apps/') && !url.pathname.endsWith('.js')) {
-          urls.add(url.pathname);
+        if (url.origin !== window.location.origin) {
+          continue;
         }
+        if (!url.pathname.startsWith('/apps/') || url.pathname.endsWith('.js')) {
+          continue;
+        }
+
+        const normalizedPath = url.pathname.replace(/\/index$/, '');
+        if (appEntries.has(normalizedPath)) {
+          continue;
+        }
+
+        let title = formatAppName(normalizedPath);
+        try {
+          const response = await cache.match(request);
+          if (
+            response &&
+            response.ok &&
+            response.headers.get('content-type') &&
+            response.headers.get('content-type').includes('text/html')
+          ) {
+            const text = await response.clone().text();
+            const match = text.match(/<title>([^<]*)<\/title>/i);
+            if (match && match[1]) {
+              title = match[1].split('|')[0].trim();
+            }
+          }
+        } catch (err) {
+          // Ignore errors when inspecting cached responses.
+        }
+
+        appEntries.set(normalizedPath, title);
       }
     }
-    if (urls.size === 0) {
-      list.innerHTML = '<li>No apps available offline.</li>';
-    } else {
-      urls.forEach((path) => {
-        const li = document.createElement('li');
-        const a = document.createElement('a');
-        a.href = path;
-        a.textContent = path.replace('/apps/', '');
-        li.appendChild(a);
-        list.appendChild(li);
-      });
+
+    appsList.innerHTML = '';
+
+    if (appEntries.size === 0) {
+      setStatus('No cached apps yet.');
+      appsList.appendChild(
+        createMessageItem('Launch an app while you are online to make it available offline.'),
+      );
+      return;
     }
-  } catch (err) {
-    list.innerHTML = '<li>Unable to access cached apps.</li>';
+
+    setStatus('Available offline');
+
+    const fragment = document.createDocumentFragment();
+    Array.from(appEntries.entries())
+      .sort((a, b) => a[1].localeCompare(b[1]))
+      .forEach(([path, title]) => {
+        const item = document.createElement('li');
+        item.className = 'offline__apps-item';
+        const link = document.createElement('a');
+        link.href = path;
+        link.textContent = title;
+        item.appendChild(link);
+        fragment.appendChild(item);
+      });
+
+    appsList.appendChild(fragment);
+  } catch (error) {
+    setStatus('Unable to access caches.');
+    appsList.innerHTML = '';
+    appsList.appendChild(createMessageItem('Cached app data is unavailable right now.'));
   }
-})();
+};
+
+populateCachedApps();

--- a/public/workers/service-worker.js
+++ b/public/workers/service-worker.js
@@ -10,6 +10,8 @@ const ASSETS = [
   '/apps/terminal',
   '/apps/checkers',
   '/offline.html',
+  '/offline.css',
+  '/offline.js',
   '/manifest.webmanifest',
 ];
 

--- a/workers/service-worker.js
+++ b/workers/service-worker.js
@@ -10,6 +10,8 @@ const ASSETS = [
   '/apps/terminal',
   '/apps/checkers',
   '/offline.html',
+  '/offline.css',
+  '/offline.js',
   '/manifest.webmanifest',
 ];
 


### PR DESCRIPTION
## Summary
- redesign the offline fallback HTML to present a styled offline card, cached app list, and retry control
- enhance the offline script to surface cached Next.js app routes with friendly titles pulled from the precache
- precache the offline shell assets in the PWA and periodic worker so the fallback loads without network access

## Testing
- [ ] yarn lint (fails: repository contains pre-existing jsx-a11y label violations)
- [ ] yarn test (fails: existing unit tests such as window and nmap NSE suites)


------
https://chatgpt.com/codex/tasks/task_e_68c966958bb4832897795a94936fb3a7