### PR TITLE
[pwa] surface install prompt controls

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,8 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import useInstallPrompt from "@/hooks/useInstallPrompt";
+import { trackEvent } from "@/lib/analytics-client";
 
 export default function Settings() {
   const {
@@ -33,6 +35,7 @@ export default function Settings() {
     setTheme,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { available: canInstall, requestInstall } = useInstallPrompt();
 
   const tabs = [
     { id: "appearance", label: "Appearance" },
@@ -104,6 +107,13 @@ export default function Settings() {
   };
 
   const [showKeymap, setShowKeymap] = useState(false);
+
+  const handleInstall = async () => {
+    const shown = await requestInstall();
+    if (shown) {
+      trackEvent("cta_click", { location: "settings_install" });
+    }
+  };
 
   return (
     <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
@@ -272,6 +282,19 @@ export default function Settings() {
       )}
       {activeTab === "privacy" && (
         <>
+          {canInstall && (
+            <div className="flex flex-col items-center text-center my-4 space-y-2">
+              <p className="text-ubt-grey">
+                Install this desktop for quick launch support.
+              </p>
+              <button
+                onClick={handleInstall}
+                className="px-4 py-2 rounded bg-ubt-blue text-white"
+              >
+                Install App
+              </button>
+            </div>
+          )}
           <div className="flex justify-center my-4 space-x-4">
             <button
               onClick={handleExport}

--- a/components/HelpPanel.tsx
+++ b/components/HelpPanel.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react';
 import DOMPurify from 'dompurify';
 import { marked } from 'marked';
+import useInstallPrompt from '@/hooks/useInstallPrompt';
+import { trackEvent } from '@/lib/analytics-client';
 
 interface HelpPanelProps {
   appId: string;
@@ -12,6 +14,7 @@ interface HelpPanelProps {
 export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
   const [open, setOpen] = useState(false);
   const [html, setHtml] = useState("<p>Loading...</p>");
+  const { available, requestInstall } = useInstallPrompt();
 
   useEffect(() => {
     if (!open) return;
@@ -48,6 +51,13 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
 
   const toggle = () => setOpen((o) => !o);
 
+  const handleInstall = async () => {
+    const shown = await requestInstall();
+    if (shown) {
+      trackEvent('cta_click', { location: 'help_panel_install' });
+    }
+  };
+
   return (
     <>
       <button
@@ -69,6 +79,20 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
             onClick={(e) => e.stopPropagation()}
           >
             <div dangerouslySetInnerHTML={{ __html: html }} />
+            {available && (
+              <div className="mt-4 border-t border-gray-200 pt-4">
+                <p className="text-sm text-gray-600 mb-2">
+                  Install this desktop for quicker access.
+                </p>
+                <button
+                  type="button"
+                  onClick={handleInstall}
+                  className="px-3 py-1 bg-ubt-blue text-white rounded focus:outline-none focus:ring"
+                >
+                  Install App
+                </button>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -1,27 +1,19 @@
 "use client";
 
-import { useEffect, useState } from 'react';
 import { trackEvent } from '@/lib/analytics-client';
-import { showA2HS } from '@/src/pwa/a2hs';
+import useInstallPrompt from '@/hooks/useInstallPrompt';
 
 const InstallButton: React.FC = () => {
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    const handler = () => setVisible(true);
-    (window as any).addEventListener('a2hs:available', handler);
-    return () => (window as any).removeEventListener('a2hs:available', handler);
-  }, []);
+  const { available, requestInstall } = useInstallPrompt();
 
   const handleInstall = async () => {
-    const shown = await showA2HS();
+    const shown = await requestInstall();
     if (shown) {
       trackEvent('cta_click', { location: 'install_button' });
-      setVisible(false);
     }
   };
 
-  if (!visible) return null;
+  if (!available) return null;
 
   return (
     <button

--- a/hooks/useInstallPrompt.ts
+++ b/hooks/useInstallPrompt.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useCallback, useEffect, useState } from 'react';
+import { initA2HS, showA2HS } from '@/src/pwa/a2hs';
+
+const STANDALONE_MEDIA = '(display-mode: standalone)';
+
+const isStandalone = () => {
+  if (typeof window === 'undefined') return false;
+  try {
+    if (typeof window.matchMedia === 'function') {
+      const media = window.matchMedia(STANDALONE_MEDIA);
+      if (media?.matches) return true;
+    }
+  } catch {
+    // ignore – matchMedia may throw in unsupported environments
+  }
+
+  return Boolean((window.navigator as any)?.standalone);
+};
+
+export default function useInstallPrompt() {
+  const [available, setAvailable] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    initA2HS();
+
+    if (!isStandalone() && window.__a2hsAvailable) {
+      setAvailable(true);
+    }
+
+    const handleAvailable = () => {
+      if (!isStandalone()) setAvailable(true);
+    };
+    const handleConsumed = () => setAvailable(false);
+
+    window.addEventListener('a2hs:available', handleAvailable);
+    window.addEventListener('a2hs:consumed', handleConsumed);
+    window.addEventListener('a2hs:installed', handleConsumed);
+    window.addEventListener('appinstalled', handleConsumed);
+
+    return () => {
+      window.removeEventListener('a2hs:available', handleAvailable);
+      window.removeEventListener('a2hs:consumed', handleConsumed);
+      window.removeEventListener('a2hs:installed', handleConsumed);
+      window.removeEventListener('appinstalled', handleConsumed);
+    };
+  }, []);
+
+  const requestInstall = useCallback(async () => {
+    const shown = await showA2HS();
+    if (!shown) setAvailable(false);
+    return shown;
+  }, []);
+
+  return { available, requestInstall } as const;
+}
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -14,8 +14,8 @@ import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
-import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { initA2HS } from '@/src/pwa/a2hs';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -25,14 +25,16 @@ const ubuntu = Ubuntu({
 });
 
 
+if (typeof window !== 'undefined') {
+  initA2HS();
+}
+
 function MyApp(props) {
   const { Component, pageProps } = props;
 
 
   useEffect(() => {
-    if (typeof window !== 'undefined' && typeof window.initA2HS === 'function') {
-      window.initA2HS();
-    }
+    initA2HS();
     const initAnalytics = async () => {
       const trackingId = process.env.NEXT_PUBLIC_TRACKING_ID;
       if (trackingId) {
@@ -148,7 +150,6 @@ function MyApp(props) {
 
   return (
     <ErrorBoundary>
-      <Script src="/a2hs.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
         <a
           href="#app-grid"

--- a/src/pwa/a2hs.ts
+++ b/src/pwa/a2hs.ts
@@ -4,15 +4,48 @@ interface BeforeInstallPromptEvent extends Event {
   prompt(): Promise<void>;
 }
 
+declare global {
+  interface Window {
+    __a2hsAvailable?: boolean;
+  }
+}
+
+const AVAILABLE_EVENT = 'a2hs:available';
+const CONSUMED_EVENT = 'a2hs:consumed';
+const INSTALLED_EVENT = 'a2hs:installed';
+
 let deferredPrompt: BeforeInstallPromptEvent | null = null;
+let initialized = false;
+
+const dispatchAvailable = () => {
+  if (typeof window === 'undefined') return;
+  window.__a2hsAvailable = true;
+  window.dispatchEvent(new Event(AVAILABLE_EVENT));
+};
+
+const dispatchConsumed = () => {
+  if (typeof window === 'undefined') return;
+  window.__a2hsAvailable = false;
+  window.dispatchEvent(new Event(CONSUMED_EVENT));
+};
 
 export function initA2HS() {
-  if (typeof window === 'undefined') return;
+  if (typeof window === 'undefined' || initialized) return;
+  initialized = true;
+
+  window.__a2hsAvailable ||= false;
+
   window.addEventListener('beforeinstallprompt', (e: Event) => {
     const event = e as BeforeInstallPromptEvent;
     event.preventDefault();
     deferredPrompt = event;
-    window.dispatchEvent(new Event('a2hs:available'));
+    dispatchAvailable();
+  });
+
+  window.addEventListener('appinstalled', () => {
+    deferredPrompt = null;
+    dispatchConsumed();
+    window.dispatchEvent(new Event(INSTALLED_EVENT));
   });
 }
 
@@ -20,7 +53,12 @@ export async function showA2HS() {
   if (!deferredPrompt) return false;
   const promptEvent = deferredPrompt;
   deferredPrompt = null;
-  await promptEvent.prompt();
-  await promptEvent.userChoice;
-  return true;
+
+  try {
+    await promptEvent.prompt();
+    await promptEvent.userChoice;
+    return true;
+  } finally {
+    dispatchConsumed();
+  }
 }


### PR DESCRIPTION
## Summary
- upgrade the PWA install utility to cache the deferred prompt, dispatch availability events, and clean up when installed
- add a shared `useInstallPrompt` hook and wire it into the floating install button, Settings privacy tab, and help overlay
- initialize add-to-home-screen detection during app boot so install affordances only appear when supported

## Testing
- yarn lint *(fails: existing repo-wide accessibility and no-top-level-window lint errors)*
- CI=1 yarn test *(fails: known suites such as window snapping, nmap NSE, and settings store relying on localStorage)*

------
https://chatgpt.com/codex/tasks/task_e_68c96694fb208328b1cec5dbb58f4408