### PR TITLE
[pwa] tighten caching config

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ To send text or links directly into the Sticky Notes app:
 ### Service Worker (SW)
 
 - Generated via [`@ducanh2912/next-pwa`](https://github.com/DuCanhGH/next-pwa); output is `public/sw.js`.
-- Only assets under `public/` are precached.
-- Dynamic routes or API responses are not cached.
+- Precaches only the offline shell (`offline.html`, `offline.css`, `offline.js`), the web app manifest, and install icons/favicons referenced by the manifest.
+- Runtime caching covers embed providers (YouTube, X/Twitter, Spotify, StackBlitz) with a `StaleWhileRevalidate` strategy capped at 32 responses and 24 hours, preventing unbounded cache growth while keeping recent embeds available.
+- Dynamic routes or API responses remain network-only beyond those embed responses.
 - Future work may use `injectManifest` for finer control.
 
 ---

--- a/next.config.js
+++ b/next.config.js
@@ -61,6 +61,56 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
 
+const embedCacheOptions = {
+  cacheName: 'embeds-runtime',
+  expiration: {
+    maxEntries: 32,
+    maxAgeSeconds: 60 * 60 * 24,
+  },
+  cacheableResponse: {
+    statuses: [0, 200],
+  },
+};
+
+const createEmbedCacheOptions = () => ({
+  ...embedCacheOptions,
+  expiration: { ...embedCacheOptions.expiration },
+  cacheableResponse: { ...embedCacheOptions.cacheableResponse },
+});
+
+const runtimeCaching = [
+  {
+    urlPattern: /^https:\/\/(?:platform|syndication)\.twitter\.com\/.*$/i,
+    handler: 'StaleWhileRevalidate',
+    options: createEmbedCacheOptions(),
+  },
+  {
+    urlPattern: /^https:\/\/cdn\.syndication\.twimg\.com\/.*$/i,
+    handler: 'StaleWhileRevalidate',
+    options: createEmbedCacheOptions(),
+  },
+  {
+    urlPattern: /^https:\/\/i\.ytimg\.com\/.*$/i,
+    handler: 'StaleWhileRevalidate',
+    options: createEmbedCacheOptions(),
+  },
+  {
+    urlPattern: /^https:\/\/(?:www\.)?youtube(?:-nocookie)?\.com\/.*$/i,
+    handler: 'StaleWhileRevalidate',
+    options: createEmbedCacheOptions(),
+  },
+  {
+    urlPattern: /^https:\/\/open\.spotify\.com\/.*$/i,
+    handler: 'StaleWhileRevalidate',
+    options: createEmbedCacheOptions(),
+  },
+  {
+    urlPattern: /^https:\/\/(?:embed\.)?stackblitz\.com\/.*$/i,
+    handler: 'StaleWhileRevalidate',
+    options: createEmbedCacheOptions(),
+  },
+];
+
 const withPWA = require('@ducanh2912/next-pwa').default({
   dest: 'public',
   sw: 'sw.js',
@@ -69,18 +119,16 @@ const withPWA = require('@ducanh2912/next-pwa').default({
   workboxOptions: {
     navigateFallback: '/offline.html',
     additionalManifestEntries: [
-      { url: '/', revision: null },
-      { url: '/feeds', revision: null },
-      { url: '/about', revision: null },
-      { url: '/projects', revision: null },
-      { url: '/projects.json', revision: null },
-      { url: '/apps', revision: null },
-      { url: '/apps/weather', revision: null },
-      { url: '/apps/terminal', revision: null },
-      { url: '/apps/checkers', revision: null },
       { url: '/offline.html', revision: null },
+      { url: '/offline.css', revision: null },
+      { url: '/offline.js', revision: null },
       { url: '/manifest.webmanifest', revision: null },
+      { url: '/favicon.ico', revision: null },
+      { url: '/favicon.svg', revision: null },
+      { url: '/images/logos/fevicon.png', revision: null },
+      { url: '/images/logos/logo_1024.png', revision: null },
     ],
+    runtimeCaching,
   },
 });
 


### PR DESCRIPTION
## Summary
- limit the Workbox precache manifest to the offline shell, manifest, and install icons
- add runtime caching for embed providers with capped size and max age to keep recent embeds available without unbounded growth
- document the revised service worker strategy in the README

## Testing
- yarn lint *(fails: repository has numerous existing accessibility lint violations unrelated to this change)*
- yarn test *(fails: upstream Jest suite already red with window/Nmap NSE-related failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c9668c66848328aeac082e7ad926ce