### PR TITLE
[pwa] add theme-specific manifest icons

### DIFF
--- a/public/icons/kali-portfolio-icon-dark.svg
+++ b/public/icons/kali-portfolio-icon-dark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Kali Linux Portfolio icon for dark theme">
+  <rect width="512" height="512" rx="112" fill="#0f1317" />
+  <rect x="88" y="104" width="336" height="304" rx="60" fill="#111827" />
+  <rect x="188" y="160" width="52" height="192" rx="26" fill="#e0f2fe" />
+  <path d="M246 256L350 160H412L308 256L412 352H350L246 256Z" fill="#0ea5e9" />
+  <path d="M302 256L380 188H360L284 256L360 324H380L302 256Z" fill="#38bdf8" />
+</svg>

--- a/public/icons/kali-portfolio-icon-light.svg
+++ b/public/icons/kali-portfolio-icon-light.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Kali Linux Portfolio icon for light theme">
+  <rect width="512" height="512" rx="112" fill="#f4f7fb" />
+  <rect x="88" y="104" width="336" height="304" rx="60" fill="#e2e8f0" />
+  <rect x="188" y="160" width="52" height="192" rx="26" fill="#0f172a" />
+  <path d="M246 256L350 160H412L308 256L412 352H350L246 256Z" fill="#0284c7" />
+  <path d="M302 256L380 188H360L284 256L360 324H380L302 256Z" fill="#38bdf8" />
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -16,7 +16,26 @@
       "src": "/images/logos/logo_1024.png",
       "sizes": "512x512",
       "type": "image/png"
+    },
+    {
+      "src": "/icons/kali-portfolio-icon-light.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable",
+      "media": "(prefers-color-scheme: light)"
+    },
+    {
+      "src": "/icons/kali-portfolio-icon-dark.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable",
+      "media": "(prefers-color-scheme: dark)"
     }
+  ],
+  "categories": [
+    "productivity",
+    "utilities",
+    "education"
   ],
   "share_target": {
     "action": "/share-target",


### PR DESCRIPTION
## Summary
- add light and dark themed SVG icons to the manifest so the install prompt adapts to color scheme
- declare manifest categories alongside existing share target metadata
- check the manifest structure via a quick node script to confirm required fields

## Testing
- [ ] yarn lint *(fails in current main due to pre-existing jsx-a11y and no-top-level-window rules)*
- [x] node -e '...manifest includes required fields...'


------
https://chatgpt.com/codex/tasks/task_e_68c9668be2cc8328a985a6fde78ff621