### PR TITLE
[pwa] prompt update toast

### DIFF
--- a/__tests__/liveRegion.test.tsx
+++ b/__tests__/liveRegion.test.tsx
@@ -11,6 +11,20 @@ describe('live region components', () => {
     unmount();
   });
 
+  it('Toast remains visible when duration is null', () => {
+    jest.useFakeTimers();
+    const onClose = jest.fn();
+    const { unmount } = render(<Toast message="Stay" duration={null} onClose={onClose} />);
+
+    try {
+      jest.advanceTimersByTime(10_000);
+      expect(onClose).not.toHaveBeenCalled();
+    } finally {
+      unmount();
+      jest.useRealTimers();
+    }
+  });
+
   it('FormError announces politely', () => {
     render(<FormError>Required field</FormError>);
     const region = screen.getByRole('status');

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -5,7 +5,7 @@ interface ToastProps {
   actionLabel?: string;
   onAction?: () => void;
   onClose?: () => void;
-  duration?: number;
+  duration?: number | null;
 }
 
 const Toast: React.FC<ToastProps> = ({
@@ -20,9 +20,11 @@ const Toast: React.FC<ToastProps> = ({
 
   useEffect(() => {
     setVisible(true);
-    timeoutRef.current = setTimeout(() => {
-      onClose && onClose();
-    }, duration);
+    if (typeof duration === 'number' && Number.isFinite(duration)) {
+      timeoutRef.current = setTimeout(() => {
+        onClose && onClose();
+      }, duration);
+    }
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };


### PR DESCRIPTION
## Summary
- surface service worker updates with a toast and an "Update and reload" action
- skip the toast auto-dismiss timer when duration is null to support persistent prompts
- cover the new toast behavior with a unit test

## Testing
- [x] yarn lint *(fails due to existing accessibility violations across legacy app fixtures)*
- [x] yarn test *(fails due to pre-existing act/localStorage issues in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c9669438c483289e106fedc85cea1f