### PR TITLE
[video] Remove manual preconnect tags from YouTube player

### DIFF
--- a/components/YouTubePlayer.js
+++ b/components/YouTubePlayer.js
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useRef, useState, useEffect, useCallback } from 'react';
-import Head from 'next/head';
 import usePrefersReducedMotion from '../hooks/usePrefersReducedMotion';
 import useOPFS from '../hooks/useOPFS';
 
@@ -195,13 +194,6 @@ export default function YouTubePlayer({ videoId }) {
 
   return (
     <>
-      <Head>
-        <link
-          rel="preconnect"
-          href="https://www.youtube-nocookie.com"
-        />
-        <link rel="preconnect" href="https://i.ytimg.com" />
-      </Head>
       <div
         className="relative w-full"
         style={{ aspectRatio: '16 / 9' }}


### PR DESCRIPTION
## Summary
- remove the manual YouTube preconnect links so the player renders without injecting extra resource hints
- confirm existing SEO metadata component continues to supply OG and Twitter tags

## Testing
- [ ] yarn lint *(fails: numerous pre-existing `jsx-a11y/control-has-associated-label` errors in various apps and legacy public game scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68c9668159288328b5b10038c9caf655