### PR TITLE
[seo] add structured data for person and projects

### DIFF
--- a/__tests__/structuredData.test.ts
+++ b/__tests__/structuredData.test.ts
@@ -1,0 +1,102 @@
+import {
+  generatePersonSchema,
+  generateProjectItemList,
+  generatePortfolioJsonLd,
+} from '@/utils/structuredData';
+
+const getItemListElements = (result: Record<string, unknown>): Array<Record<string, unknown>> =>
+  (result.itemListElement as Array<Record<string, unknown>>) ?? [];
+
+describe('structured data generator', () => {
+  it('builds a Person schema with core metadata', () => {
+    const schema = generatePersonSchema();
+    const sameAs = (schema.sameAs as string[]) ?? [];
+    const knowsAbout = (schema.knowsAbout as string[]) ?? [];
+
+    expect(schema).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'Person',
+      name: 'Alex Unnippillil',
+      url: 'https://unnippillil.com',
+      jobTitle: 'Cybersecurity Specialist',
+    });
+    expect(sameAs).toEqual(
+      expect.arrayContaining([
+        'https://github.com/Alex-Unnippillil',
+        'https://www.linkedin.com/in/unnippillil/',
+      ]),
+    );
+    expect(knowsAbout).toContain('Cybersecurity');
+  });
+
+  it('creates an ItemList for projects with descriptions and keywords', () => {
+    const result = generateProjectItemList(
+      [
+        {
+          name: 'Encryption Toolkit',
+          link: 'https://example.com/encryption',
+          description: ['AES cipher demo', 'CLI utilities'],
+          domains: ['Python', 'Security'],
+        },
+        {
+          name: 'Network Visualizer',
+          link: 'https://example.com/network',
+          description: 'Graphs a network topology',
+        },
+      ],
+      { listName: 'Test Projects', listUrl: 'https://example.com/projects' },
+    );
+
+    expect(result).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      name: 'Test Projects',
+      url: 'https://example.com/projects',
+      numberOfItems: 2,
+    });
+
+    const items = getItemListElements(result);
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({
+      '@type': 'ListItem',
+      position: 1,
+      url: 'https://example.com/encryption',
+      item: {
+        '@type': 'SoftwareSourceCode',
+        name: 'Encryption Toolkit',
+        url: 'https://example.com/encryption',
+        description: 'AES cipher demo CLI utilities',
+        keywords: 'Python, Security',
+      },
+    });
+  });
+
+  it('deduplicates projects by link and respects limit', () => {
+    const result = generateProjectItemList(
+      [
+        { name: 'One', link: 'https://example.com/project' },
+        { name: 'Duplicate', link: 'https://example.com/project' },
+        { name: 'Two', link: 'https://example.com/second' },
+      ],
+      { limit: 1 },
+    );
+
+    const items = getItemListElements(result);
+    expect(result.numberOfItems).toBe(1);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      position: 1,
+      url: 'https://example.com/project',
+    });
+  });
+
+  it('packages person and project data when generating the portfolio bundle', () => {
+    const bundle = generatePortfolioJsonLd([
+      { name: 'One', link: 'https://example.com/one' },
+    ]);
+
+    expect(bundle).toHaveLength(2);
+    expect(bundle[0]).toMatchObject({ '@type': 'Person' });
+    expect(bundle[1]).toMatchObject({ '@type': 'ItemList' });
+  });
+});

--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -1,9 +1,14 @@
 import React from 'react'
 import Head from 'next/head';
 import { getCspNonce } from '../../utils/csp';
+import { generatePersonSchema, generateProjectItemList } from '@/utils/structuredData';
+import portfolioData from '@/components/apps/alex/data.json';
 
 export default function Meta() {
     const nonce = getCspNonce();
+    const { projects = [] } = portfolioData;
+    const personSchema = generatePersonSchema();
+    const projectListSchema = generateProjectItemList(projects, { limit: 12 });
     return (
         <Head>
             {/* Primary Meta Tags */}
@@ -54,12 +59,14 @@ export default function Meta() {
                 type="application/ld+json"
                 nonce={nonce}
                 dangerouslySetInnerHTML={{
-                    __html: JSON.stringify({
-                        "@context": "https://schema.org",
-                        "@type": "Person",
-                        name: "Alex Unnippillil",
-                        url: "https://unnippillil.com/",
-                    }),
+                    __html: JSON.stringify(personSchema),
+                }}
+            />
+            <script
+                type="application/ld+json"
+                nonce={nonce}
+                dangerouslySetInnerHTML={{
+                    __html: JSON.stringify(projectListSchema),
                 }}
             />
         </Head>

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -9,6 +9,7 @@ import SafetyNote from './SafetyNote';
 import { getCspNonce } from '../../../utils/csp';
 import AboutSlides from './slides';
 import ScrollableTimeline from '../../ScrollableTimeline';
+import { generatePersonSchema, generateProjectItemList } from '@/utils/structuredData';
 
 class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_screen: string; navbar: boolean }> {
   screens: Record<string, React.ReactNode> = {};
@@ -101,12 +102,9 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
   };
 
   render() {
-    const structured = {
-      '@context': 'https://schema.org',
-      '@type': 'Person',
-      name: 'Alex Unnippillil',
-      url: 'https://unnippillil.com',
-    };
+    const projects = Array.isArray(data.projects) ? data.projects : [];
+    const personSchema = generatePersonSchema();
+    const projectListSchema = generateProjectItemList(projects);
     const nonce = getCspNonce();
 
     return (
@@ -116,7 +114,12 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
           <script
             type="application/ld+json"
             nonce={nonce}
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(structured) }}
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(personSchema) }}
+          />
+          <script
+            type="application/ld+json"
+            nonce={nonce}
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(projectListSchema) }}
           />
         </Head>
         <div

--- a/utils/structuredData.ts
+++ b/utils/structuredData.ts
@@ -1,0 +1,158 @@
+const SITE_URL = 'https://unnippillil.com';
+
+type JsonLd = Record<string, unknown>;
+
+export interface ProjectForSchema {
+  name?: string;
+  link?: string;
+  description?: string[] | string;
+  domains?: string[];
+}
+
+export interface ProjectListOptions {
+  /**
+   * Optional limit on how many projects should be included in the ItemList. Any value less than 1
+   * results in an empty list.
+   */
+  limit?: number;
+  /**
+   * Optional override for the ItemList name. Defaults to "Alex Unnippillil Projects".
+   */
+  listName?: string;
+  /**
+   * Optional override for the canonical URL of the ItemList.
+   */
+  listUrl?: string;
+}
+
+const PERSON_SOCIAL_LINKS = [
+  'https://github.com/Alex-Unnippillil',
+  'https://www.linkedin.com/in/unnippillil/',
+];
+
+const PERSON_KNOWS_ABOUT = [
+  'Cybersecurity',
+  'Penetration Testing',
+  'Network Security',
+  'Cloud Security',
+  'Software Development',
+];
+
+export const generatePersonSchema = (): JsonLd => ({
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: 'Alex Unnippillil',
+  url: SITE_URL,
+  image: `${SITE_URL}/images/logos/bitmoji.png`,
+  jobTitle: 'Cybersecurity Specialist',
+  sameAs: PERSON_SOCIAL_LINKS,
+  knowsAbout: PERSON_KNOWS_ABOUT,
+  alumniOf: [
+    {
+      '@type': 'CollegeOrUniversity',
+      name: 'Ontario Tech University',
+      sameAs: 'https://ontariotechu.ca/',
+    },
+  ],
+});
+
+const normalizeDescription = (description?: string[] | string): string | undefined => {
+  if (!description) return undefined;
+  if (Array.isArray(description)) {
+    const merged = description.map((line) => line.trim()).filter(Boolean).join(' ');
+    return merged || undefined;
+  }
+  const trimmed = description.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+const normalizeKeywords = (domains?: string[]): string | undefined => {
+  if (!domains?.length) return undefined;
+  const filtered = domains.map((domain) => domain.trim()).filter(Boolean);
+  return filtered.length ? filtered.join(', ') : undefined;
+};
+
+type NormalizedProject = Required<Pick<ProjectForSchema, 'name' | 'link'>> &
+  Pick<ProjectForSchema, 'description' | 'domains'>;
+
+const sanitizeProjects = (
+  projects: ProjectForSchema[],
+  limit?: number,
+): NormalizedProject[] => {
+  const finiteLimit =
+    typeof limit === 'number' && Number.isFinite(limit) ? Math.max(0, Math.floor(limit)) : undefined;
+  const uniqueByLink = new Map<string, NormalizedProject>();
+
+  projects.forEach((project) => {
+    if (!project?.name || !project?.link) return;
+    const link = String(project.link).trim();
+    const name = String(project.name).trim();
+    if (!link || !name) return;
+    if (!uniqueByLink.has(link)) {
+      uniqueByLink.set(link, {
+        ...project,
+        name,
+        link,
+      });
+    }
+  });
+
+  const values = Array.from(uniqueByLink.values());
+  if (finiteLimit === undefined) {
+    return values;
+  }
+  return values.slice(0, finiteLimit);
+};
+
+export const generateProjectItemList = (
+  projects: ProjectForSchema[],
+  { limit, listName, listUrl }: ProjectListOptions = {},
+): JsonLd => {
+  const sanitizedProjects = sanitizeProjects(projects, limit);
+  const itemListElement = sanitizedProjects.map((project, index) => {
+    const description = normalizeDescription(project.description);
+    const keywords = normalizeKeywords(project.domains);
+
+    const item: Record<string, unknown> = {
+      '@type': 'SoftwareSourceCode',
+      name: project.name,
+      url: project.link,
+      creator: {
+        '@type': 'Person',
+        name: 'Alex Unnippillil',
+        url: SITE_URL,
+      },
+    };
+
+    if (description) {
+      item.description = description;
+    }
+    if (keywords) {
+      item.keywords = keywords;
+    }
+
+    return {
+      '@type': 'ListItem',
+      position: index + 1,
+      url: project.link,
+      item,
+    };
+  });
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: listName ?? 'Alex Unnippillil Projects',
+    url: listUrl ?? `${SITE_URL}/apps/about#projects`,
+    itemListOrder: 'https://schema.org/ItemListOrderAscending',
+    numberOfItems: itemListElement.length,
+    itemListElement,
+  };
+};
+
+export const generatePortfolioJsonLd = (
+  projects: ProjectForSchema[],
+  options?: ProjectListOptions,
+): JsonLd[] => [generatePersonSchema(), generateProjectItemList(projects, options)];
+
+export { SITE_URL };


### PR DESCRIPTION
## Summary
- add a structured data helper that builds Person and project ItemList JSON-LD payloads
- wire Meta and the About window to emit the generated schemas
- cover the generator with unit tests

## Testing
- yarn lint *(fails: pre-existing accessibility and no-top-level-window lint errors in unrelated apps)*
- yarn test *(fails: pre-existing window focus and nmap NSE test assertions)*
- npx structured-data-testing-tool --file /tmp/portfolio-schema.json


------
https://chatgpt.com/codex/tasks/task_e_68c966825a548328bb918923a8690ca1