### PR TITLE
[desktop] bring windows to front on focus

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -9,6 +9,52 @@ jest.mock('react-draggable', () => ({
 }));
 jest.mock('../components/apps/terminal', () => ({ displayTerminal: jest.fn() }));
 
+describe('Window focus management', () => {
+  it('calls focus callback on mouse down', () => {
+    const focus = jest.fn();
+
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={focus}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+      />
+    );
+
+    const winEl = screen.getByRole('dialog', { name: /test/i });
+    fireEvent.mouseDown(winEl);
+
+    expect(focus).toHaveBeenCalledWith('test-window');
+  });
+
+  it('calls focus callback on focus events', () => {
+    const focus = jest.fn();
+
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={focus}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+      />
+    );
+
+    const winEl = screen.getByRole('dialog', { name: /test/i });
+    fireEvent.focus(winEl);
+
+    expect(focus).toHaveBeenCalledWith('test-window');
+  });
+});
+
 describe('Window lifecycle', () => {
   it('invokes callbacks on close', () => {
     jest.useFakeTimers();
@@ -198,8 +244,15 @@ describe('Window snapping finalize and release', () => {
 
     expect(ref.current!.state.snapped).toBe('left');
 
+    const altEvent = {
+      key: 'ArrowDown',
+      altKey: true,
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+    } as any;
+
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown(altEvent);
     });
 
     expect(ref.current!.state.snapped).toBeNull();

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -379,6 +379,10 @@ export class Window extends Component {
         this.props.focus(this.id);
     }
 
+    handleActivation = () => {
+        this.focusWindow();
+    }
+
     minimizeWindow = () => {
         let posx = -310;
         if (this.state.maximized) {
@@ -612,6 +616,26 @@ export class Window extends Component {
     }
 
     render() {
+        const windowClasses = [
+            this.state.cursorType,
+            this.state.closed ? 'closed-window' : '',
+            this.state.maximized ? 'duration-300 rounded-none' : 'rounded-lg rounded-b-none',
+            this.props.minimized ? 'opacity-0 invisible duration-200' : '',
+            this.state.grabbed ? 'opacity-70' : '',
+            this.state.snapPreview ? 'ring-2 ring-blue-400' : '',
+            this.props.isFocused ? '' : 'notFocused',
+            'opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col',
+        ].filter(Boolean).join(' ');
+
+        const windowStyle = {
+            width: `${this.state.width}%`,
+            height: `${this.state.height}%`,
+        };
+
+        if (this.props.zIndex !== undefined) {
+            windowStyle.zIndex = this.props.zIndex;
+        }
+
         return (
             <>
                 {this.state.snapPreview && (
@@ -634,13 +658,16 @@ export class Window extends Component {
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
                 >
                     <div
-                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        style={windowStyle}
+                        className={windowClasses}
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}
                         tabIndex={0}
                         onKeyDown={this.handleKeyDown}
+                        onFocusCapture={this.handleActivation}
+                        onMouseDown={this.handleActivation}
+                        onTouchStart={this.handleActivation}
                     >
                         {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} />}
                         {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}


### PR DESCRIPTION
## Summary
- add global z-index tracking so the desktop manager promotes focused windows
- update the window component to request focus on pointer and focus events
- add regression tests covering focus activation and keyboard snap release

## Testing
- yarn lint *(fails: repository has numerous pre-existing accessibility and no-top-level-window lint errors)*
- CI=1 yarn test __tests__/window.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68c96673906c8328885ea7a30df4dde9