### PR TITLE
[styles] normalize typography spacing

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,76 @@ body{
     color: var(--color-text);
 }
 
+:where(main, section, article, .windowMainScreen) {
+    --content-measure: min(var(--measure-text), 100%);
+}
+
+:where(main, section, article, .windowMainScreen) :where(p, h1, h2, h3, h4, h5, h6) {
+    max-inline-size: var(--content-measure);
+}
+
+:where(main, section, article, .windowMainScreen) :where(p) {
+    margin: 0;
+    margin-block-end: var(--space-3);
+    line-height: 1.6;
+}
+
+@media (min-width: 768px) {
+    :where(main, section, article, .windowMainScreen) :where(p) {
+        margin-block-end: var(--space-4);
+    }
+}
+
+:where(main, section, article, .windowMainScreen) :where(p:last-child) {
+    margin-block-end: 0;
+}
+
+:where(main, section, article, .windowMainScreen) :where(h1, h2, h3, h4, h5, h6) {
+    margin: 0;
+    font-weight: 700;
+}
+
+:where(main, section, article, .windowMainScreen) :where(h1) {
+    margin-block-start: var(--space-5);
+    margin-block-end: var(--space-3);
+    line-height: 1.2;
+}
+
+@media (min-width: 768px) {
+    :where(main, section, article, .windowMainScreen) :where(h1) {
+        margin-block-start: var(--space-6);
+        margin-block-end: var(--space-4);
+    }
+}
+
+:where(main, section, article, .windowMainScreen) :where(h2) {
+    margin-block-start: var(--space-4);
+    margin-block-end: var(--space-3);
+    line-height: 1.3;
+}
+
+@media (min-width: 768px) {
+    :where(main, section, article, .windowMainScreen) :where(h2) {
+        margin-block-start: var(--space-5);
+    }
+}
+
+:where(main, section, article, .windowMainScreen) :where(h3, h4, h5, h6) {
+    margin-block-start: var(--space-3);
+    margin-block-end: var(--space-2);
+    line-height: 1.35;
+}
+
+@media (min-width: 768px) {
+    :where(main, section, article, .windowMainScreen) :where(h3, h4, h5, h6) {
+        margin-block-start: var(--space-4);
+    }
+}
+
+:where(main, section, article, .windowMainScreen) :where(h1, h2, h3, h4, h5, h6):first-child {
+    margin-block-start: 0;
+}
+
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
     min-width: var(--hit-area);
     min-height: var(--hit-area);

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -41,6 +41,9 @@
   --space-5: 1.5rem;
   --space-6: 2rem;
 
+  /* Text measure */
+  --measure-text: 65ch;
+
   /* Radius */
   --radius-sm: 2px;
   --radius-md: 4px;


### PR DESCRIPTION
## Summary
- apply token-driven spacing to paragraphs and headings across window and page content
- limit long-form text width with a reusable `--measure-text` variable so typography stays readable on wide screens

## Testing
- yarn lint *(fails: repository has existing jsx-a11y and browser global lint violations)*
- yarn test --watch=false *(fails: suite already contains failing integration tests; command was stopped after repeated failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c96724f02c8328bce879f38f6c805b