### PR TITLE
Adjust module workspace layout for 1366px

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -8,12 +8,32 @@ function nonce() {
 
 export function middleware(req: NextRequest) {
   const n = nonce();
+  const isDev = process.env.NODE_ENV !== 'production';
+  const scriptSrc = [
+    "'self'",
+    "'unsafe-inline'",
+    `'nonce-${n}'`,
+    'https://vercel.live',
+    'https://platform.twitter.com',
+    'https://syndication.twitter.com',
+    'https://cdn.syndication.twimg.com',
+    'https://www.youtube.com',
+    'https://www.google.com',
+    'https://www.gstatic.com',
+    'https://cdn.jsdelivr.net',
+    'https://cdnjs.cloudflare.com',
+  ];
+
+  if (isDev) {
+    scriptSrc.push("'unsafe-eval'");
+  }
+
   const csp = [
     "default-src 'self'",
     "img-src 'self' https: data:",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
-    `script-src 'self' 'unsafe-inline' 'nonce-${n}' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com`,
+    `script-src ${scriptSrc.join(' ')}`,
     "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://stackblitz.com",
     "frame-src 'self' https://vercel.live https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
     "frame-ancestors 'self'",

--- a/pages/module-workspace.tsx
+++ b/pages/module-workspace.tsx
@@ -102,61 +102,67 @@ const ModuleWorkspace: React.FC = () => {
   }, [selected, optionValues]);
 
   return (
-    <div className="p-4 space-y-4 bg-ub-cool-grey text-white min-h-screen">
-      <section className="space-y-2">
-        <h1 className="text-xl font-semibold">Workspaces</h1>
-        <div className="flex gap-2">
-          <input
-            value={newWorkspace}
-            onChange={(e) => setNewWorkspace(e.target.value)}
-            placeholder="New workspace"
-            className="p-1 rounded text-black"
-          />
-          <button
-            onClick={addWorkspace}
-            className="px-2 py-1 bg-ub-orange rounded text-black"
-          >
-            Create
-          </button>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          {workspaces.map((ws) => (
+    <div className="min-h-screen bg-ub-cool-grey p-4 text-white md:p-6">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+        <section className="space-y-2">
+          <h1 className="text-xl font-semibold">Workspaces</h1>
+          <div className="flex gap-2">
+            <label htmlFor="workspace-name" className="sr-only">
+              Workspace name
+            </label>
+            <input
+              id="workspace-name"
+              value={newWorkspace}
+              onChange={(e) => setNewWorkspace(e.target.value)}
+              placeholder="New workspace"
+              className="p-1 rounded text-black"
+              aria-label="New workspace name"
+            />
             <button
-              key={ws}
-              onClick={() => setCurrentWorkspace(ws)}
-              className={`px-2 py-1 rounded ${
-                currentWorkspace === ws ? 'bg-blue-600' : 'bg-gray-700'
-              }`}
+              onClick={addWorkspace}
+              className="px-2 py-1 bg-ub-orange rounded text-black"
             >
-              {ws}
+              Create
             </button>
-          ))}
-        </div>
-      </section>
-      {currentWorkspace && (
-        <>
+          </div>
           <div className="flex flex-wrap gap-2">
-            <button
-              onClick={() => setFilter('')}
-              className={`px-2 py-1 text-sm rounded ${
-                filter === '' ? 'bg-blue-600' : 'bg-gray-700'
-              }`}
-            >
-              All
-            </button>
-            {tags.map((t) => (
+            {workspaces.map((ws) => (
               <button
-                key={t}
-                onClick={() => setFilter(t)}
-                className={`px-2 py-1 text-sm rounded ${
-                  filter === t ? 'bg-blue-600' : 'bg-gray-700'
+                key={ws}
+                onClick={() => setCurrentWorkspace(ws)}
+                className={`px-2 py-1 rounded ${
+                  currentWorkspace === ws ? 'bg-blue-600' : 'bg-gray-700'
                 }`}
               >
-                {t}
+                {ws}
               </button>
             ))}
           </div>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        </section>
+        {currentWorkspace && (
+          <>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => setFilter('')}
+                className={`px-2 py-1 text-sm rounded ${
+                  filter === '' ? 'bg-blue-600' : 'bg-gray-700'
+                }`}
+              >
+                All
+              </button>
+              {tags.map((t) => (
+                <button
+                  key={t}
+                  onClick={() => setFilter(t)}
+                  className={`px-2 py-1 text-sm rounded ${
+                    filter === t ? 'bg-blue-600' : 'bg-gray-700'
+                  }`}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
             {filteredModules.map((m) => (
               <button
                 key={m.id}
@@ -171,11 +177,17 @@ const ModuleWorkspace: React.FC = () => {
           {selected && (
             <div className="space-y-2">
               <h2 className="font-semibold">Command Composer</h2>
-              {selected.options.map((opt) => (
-                <div key={opt.name}>
-                  <label className="block text-sm">
-                    {opt.name} {opt.required ? '*' : ''}
+              {selected.options.map((opt) => {
+                const optionId = `module-option-${opt.name
+                  .toLowerCase()
+                  .replace(/\s+/g, '-')}`;
+                return (
+                  <div key={opt.name}>
+                    <label className="block text-sm" htmlFor={optionId}>
+                      {opt.name} {opt.required ? '*' : ''}
+                    </label>
                     <input
+                      id={optionId}
                       value={optionValues[opt.name]}
                       onChange={(e) =>
                         setOptionValues({
@@ -184,10 +196,11 @@ const ModuleWorkspace: React.FC = () => {
                         })
                       }
                       className="mt-1 w-full p-1 rounded text-black"
+                      aria-label={`${opt.name}${opt.required ? ' (required)' : ''}`}
                     />
-                  </label>
-                </div>
-              ))}
+                  </div>
+                );
+              })}
               <button
                 onClick={runCommand}
                 className="px-2 py-1 bg-green-600 rounded text-black"
@@ -195,9 +208,9 @@ const ModuleWorkspace: React.FC = () => {
                 Run
               </button>
               {result && (
-                <div className="flex items-start gap-2">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start">
                   <pre
-                    className="flex-1 bg-black text-green-400 p-2 overflow-auto font-mono"
+                    className="flex-1 min-w-0 overflow-auto bg-black p-2 font-mono text-green-400"
                     role="log"
                   >
                     {result}
@@ -206,7 +219,7 @@ const ModuleWorkspace: React.FC = () => {
                     onClick={() =>
                       navigator.clipboard?.writeText(result)
                     }
-                    className="px-2 py-1 text-sm rounded bg-gray-700"
+                    className="self-start rounded bg-gray-700 px-2 py-1 text-sm sm:self-auto"
                   >
                     Copy
                   </button>
@@ -228,6 +241,7 @@ const ModuleWorkspace: React.FC = () => {
           )}
         </>
       )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- limit development CSP to include `'unsafe-eval'` so the dev server can render during responsive checks
- reflow the module workspace layout with centered max width, responsive button grid, and ARIA labeling to avoid overflow at 1366px
- let the command result log shrink within flex layouts so the editor stays usable at desktop widths

## Testing
- `yarn lint` *(fails: existing accessibility and window globals errors across unrelated files)*
- `yarn test` *(fails: existing suites such as nmapNse and reconng due to pre-existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c9672561188328b378fdd97afb7ba2