### PR TITLE
[ui] Add contact service info and tidy metadata

### DIFF
--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -1,67 +1,77 @@
-import React from 'react'
+import React from 'react';
 import Head from 'next/head';
 import { getCspNonce } from '../../utils/csp';
 
+const siteUrl = 'https://unnippillil.com';
+const title = "Alex Unnippillil's Portfolio";
+const description =
+  'Cybersecurity-focused portfolio showcasing simulated Kali Linux tooling, utilities, and retro games.';
+const author = 'Alex Unnippillil';
+const keywords =
+  'Alex Unnippillil, cybersecurity portfolio, Kali Linux portfolio, security tools, Next.js, computer engineering';
+const ogImage = `${siteUrl}/images/logos/logo_1200.png`;
+const twitterImage = `${siteUrl}/images/logos/logo_1024.png`;
+const favicon = '/images/logos/fevicon.svg';
+const appleIcon = '/images/logos/logo.png';
+
 export default function Meta() {
-    const nonce = getCspNonce();
-    return (
-        <Head>
-            {/* Primary Meta Tags */}
-             <title>Alex Unnippillil&apos;s Portfolio </title>
-            <meta charSet="utf-8" />
-            <meta name="title" content="Alex Patel Portfolio - Computer Engineering Student" />
-            <meta name="description"
-                content="Alex Unnippillil Personal Portfolio Website" />
-            <meta name="author" content="Alex Unnippillil" />
-            <meta name="keywords"
-                content="Alex Unnippillil, Unnippillil's portfolio, linux, kali portfolio, alex unnippillil portfolio, alex computer, alex unnippillil, alex linux, alex unnippillil kali portfolio" />
-            <meta name="robots" content="index, follow" />
-            <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
-            <meta name="language" content="English" />
-            <meta name="category" content="16" />
-            <meta name="viewport" content="width=device-width, initial-scale=1" />
-            <meta name="theme-color" content="#0f1317" />
+  const nonce = getCspNonce();
 
-            {/* Search Engine */}
-            <meta name="image" content="images/logos/fevicon.png" />
-            {/* Schema.org for Google */}
-            <meta itemProp="name" content="Alex Unnippillil Portfolio " />
-            <meta itemProp="description"
-                content="Alex Unnippillil Personal Portfolio Website" />
-            <meta itemProp="image" content="images/logos/fevicon.png" />
-            {/* Twitter */}
-            <meta name="twitter:card" content="summary" />
-            <meta name="twitter:title" content="Alex Unnippillil Personal Portfolio Website" />
-            <meta name="twitter:description"
-                content="Alex Unnippillil Personal Portfolio Website" />
-            <meta name="twitter:site" content="alexunnippillil" />
-            <meta name="twitter:creator" content="unnippillil" />
-            <meta name="twitter:image:src" content="images/logos/logo_1024.png" />
-            {/* Open Graph general (Facebook, Pinterest & Google+) */}
-            <meta name="og:title" content="Alex Unnippillil Personal Portfolio Website " />
-            <meta name="og:description"
-                content="Alex Unnippillil Personal Portfolio Website. ." />
-            <meta name="og:image" content="https://unnippillil.com/images/logos/logo_1200.png" />
-            <meta name="og:url" content="https://unnippillil.com/" />
-            <meta name="og:site_name" content="Alex Unnippillil Personal Portfolio" />
-            <meta name="og:locale" content="en_CA" />
-            <meta name="og:type" content="website" />
+  return (
+    <Head>
+      {/* Primary Meta Tags */}
+      <title>{title}</title>
+      <meta charSet="utf-8" />
+      <meta name="title" content={title} />
+      <meta name="description" content={description} />
+      <meta name="author" content={author} />
+      <meta name="keywords" content={keywords} />
+      <meta name="robots" content="index, follow" />
+      <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
+      <meta name="language" content="English" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta name="theme-color" content="#0f1317" />
 
-            <link rel="canonical" href="https://unnippillil.com/" />
-            <link rel="icon" href="images/logos/fevicon.svg" />
-            <link rel="apple-touch-icon" href="images/logos/logo.png" />
-            <script
-                type="application/ld+json"
-                nonce={nonce}
-                dangerouslySetInnerHTML={{
-                    __html: JSON.stringify({
-                        "@context": "https://schema.org",
-                        "@type": "Person",
-                        name: "Alex Unnippillil",
-                        url: "https://unnippillil.com/",
-                    }),
-                }}
-            />
-        </Head>
-    )
+      {/* Search Engine */}
+      <meta name="image" content={ogImage} />
+
+      {/* Schema.org for Google */}
+      <meta itemProp="name" content={title} />
+      <meta itemProp="description" content={description} />
+      <meta itemProp="image" content={ogImage} />
+
+      {/* Twitter */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={twitterImage} />
+
+      {/* Open Graph */}
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={ogImage} />
+      <meta property="og:url" content={siteUrl} />
+      <meta property="og:site_name" content={title} />
+      <meta property="og:locale" content="en_CA" />
+      <meta property="og:type" content="website" />
+
+      <link rel="canonical" href={siteUrl} />
+      <link rel="icon" href={favicon} />
+      <link rel="apple-touch-icon" href={appleIcon} />
+      <script
+        type="application/ld+json"
+        nonce={nonce}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'Person',
+            name: author,
+            url: siteUrl,
+            description,
+            image: ogImage,
+          }),
+        }}
+      />
+    </Head>
+  );
 }

--- a/components/YouTubePlayer.js
+++ b/components/YouTubePlayer.js
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useRef, useState, useEffect, useCallback } from 'react';
-import Head from 'next/head';
 import usePrefersReducedMotion from '../hooks/usePrefersReducedMotion';
 import useOPFS from '../hooks/useOPFS';
 
@@ -195,13 +194,6 @@ export default function YouTubePlayer({ videoId }) {
 
   return (
     <>
-      <Head>
-        <link
-          rel="preconnect"
-          href="https://www.youtube-nocookie.com"
-        />
-        <link rel="preconnect" href="https://i.ytimg.com" />
-      </Head>
       <div
         className="relative w-full"
         style={{ aspectRatio: '16 / 9' }}

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -263,6 +263,33 @@ const ContactApp: React.FC = () => {
   return (
     <div className="min-h-screen bg-gray-900 text-white p-6">
       <h1 className="mb-6 text-2xl">Contact</h1>
+      <section
+        className="mb-6 rounded border border-blue-500 bg-gray-800 p-4 text-sm"
+        aria-labelledby="contact-service-info-title"
+      >
+        <h2
+          id="contact-service-info-title"
+          className="text-base font-semibold text-blue-200"
+        >
+          Service information
+        </h2>
+        <p className="mt-2 text-gray-200">
+          This portfolio runs the contact form as a demo. When server credentials
+          are not configured, the backend stays read-only and surfaces the copy
+          and mailto fallbacks so you can still reach out manually.
+        </p>
+        <p className="mt-2 text-gray-200">
+          Requests to <code className="bg-gray-900 px-1">/api/contact</code> are
+          rate limited to <strong>5 submissions per minute</strong> to protect the
+          service. If you see a rate limit warning, wait about a minute before
+          trying again.
+        </p>
+        <p className="mt-2 text-gray-200">
+          Drafts stay on your device thanks to the browser file system API, so
+          your message is preserved even while the backend operates in
+          read-only mode.
+        </p>
+      </section>
       {banner && (
         <div
           className={`mb-6 rounded p-3 text-sm ${


### PR DESCRIPTION
## Summary
- add a contact service information panel that explains the read-only demo mode, draft storage, and API rate limits
- refresh the SEO metadata so titles, descriptions, and social tags accurately reflect Alex Unnippillil's portfolio
- remove unused YouTube preconnect tags that were no longer required

## Testing
- yarn lint *(fails: repo has existing accessibility lint violations across many legacy files)*
- yarn test *(fails: existing suites fail because of act() warnings and jsdom localStorage errors in unrelated areas)*

------
https://chatgpt.com/codex/tasks/task_e_68c967261a148328980cd936976186ec