### PR TITLE
[youtube] add privacy toggle and loading skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,9 @@ Browse all apps, games, and security tool demos at `/apps`, which presents a sea
 
 > The VS Code app now embeds a StackBlitz IDE via iframe instead of the local Monaco editor.
 
+The YouTube app defaults to privacy-enhanced embeds (`youtube-nocookie.com`) and surfaces a toggle with context so visitors can
+switch to the standard player if they prefer the regular YouTube domain.
+
 The Spotify app lets you customize a mood-to-playlist mapping. Use the in-app form to
 add, reorder, or delete moods; selections persist in the browser's Origin Private File
 System so your choices restore on load. The last mood played is remembered, and

--- a/__tests__/youtube.test.tsx
+++ b/__tests__/youtube.test.tsx
@@ -29,8 +29,34 @@ describe('YouTube search app', () => {
     const user = userEvent.setup();
     render(<YouTubeApp initialResults={mockVideos} />);
     await user.click(screen.getByAltText('Video A'));
+    expect(
+      screen.getByLabelText('Loading video player'),
+    ).toBeInTheDocument();
     const iframe = screen.getByTitle('YouTube video player');
-    expect(iframe).toHaveAttribute('src', expect.stringContaining('a'));
+    expect(iframe).toHaveAttribute(
+      'src',
+      expect.stringContaining('youtube-nocookie.com/embed/a'),
+    );
+  });
+
+  it('allows toggling privacy-enhanced mode', async () => {
+    const user = userEvent.setup();
+    render(<YouTubeApp initialResults={mockVideos} />);
+    await user.click(screen.getByAltText('Video A'));
+    const toggle = screen.getByLabelText(/Privacy-enhanced mode/i);
+    expect(toggle).toBeChecked();
+    await user.click(toggle);
+    expect(toggle).not.toBeChecked();
+    const iframe = screen.getByTitle('YouTube video player');
+    expect(iframe).toHaveAttribute(
+      'src',
+      expect.stringContaining('youtube.com/embed/a'),
+    );
+    await waitFor(() =>
+      expect(window.localStorage.getItem('youtube:privacy-enhanced')).toBe(
+        'false',
+      ),
+    );
   });
 
   it('adds to queue and watch later lists', async () => {


### PR DESCRIPTION
## Summary
- add a persisted privacy-enhanced mode toggle for the YouTube app and switch the iframe API host accordingly
- render an accessible loading skeleton over the player until the iframe API is ready
- document the toggle and cover the new behavior with unit tests

## Testing
- yarn lint *(fails: repository currently has hundreds of pre-existing lint violations unrelated to this change)*
- yarn test *(fails: repository has numerous failing suites prior to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c967271c90832886090ff88e6e0f68