### PR TITLE
feat(games): add overlay controls legend and unified help

### DIFF
--- a/__tests__/HelpOverlay.test.tsx
+++ b/__tests__/HelpOverlay.test.tsx
@@ -1,19 +1,44 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import HelpOverlay from '../components/apps/HelpOverlay';
+import HelpOverlay, { GAME_INSTRUCTIONS } from '../components/apps/HelpOverlay';
+
+const baseProps = {
+  view: 'help' as const,
+  onClose: jest.fn(),
+  onViewChange: jest.fn(),
+  onResume: jest.fn(),
+  paused: false,
+  mapping: {},
+  setKey: jest.fn(),
+  overlayLegend: [{ label: 'Shift + /', description: 'Cycle overlay' }],
+} as const;
 
 describe('HelpOverlay', () => {
-  it('returns null when no instructions exist for the game', () => {
-    const { container } = render(<HelpOverlay gameId="unknown" onClose={() => {}} />);
-    expect(container.firstChild).toBeNull();
+  it('renders fallback copy when instructions are missing', () => {
+    render(<HelpOverlay {...baseProps} gameId="unknown" />);
+    expect(screen.getByText('Game menu')).toBeInTheDocument();
+    expect(
+      screen.getByText('Explore the controls below to get started.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Use on-screen prompts to interact.')
+    ).toBeInTheDocument();
   });
 
   it('renders instructions when available', () => {
-    render(<HelpOverlay gameId="2048" onClose={() => {}} />);
-    expect(screen.getByText('2048 Help')).toBeInTheDocument();
+    const mapping = GAME_INSTRUCTIONS['2048'].actions ?? {};
+    render(
+      <HelpOverlay
+        {...baseProps}
+        gameId="2048"
+        mapping={mapping}
+        overlayLegend={[]}
+      />,
+    );
+    expect(screen.getByText('Game menu')).toBeInTheDocument();
     expect(
       screen.getByText('Reach the 2048 tile by merging numbers.')
     ).toBeInTheDocument();
-    expect(screen.getByText(/up: ArrowUp/i)).toBeInTheDocument();
+    expect(screen.getByText(/up: Arrow Up/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- integrate a shared help/pause overlay with keyboard cycling, pause state management, and on-screen control legend for games
- refresh the help overlay UI with accessible tabs, focus management, and fallback messaging when instructions are missing
- align unit tests with the updated overlay contract and behaviors

## Testing
- yarn lint *(fails: existing accessibility and top-level window lint violations outside the change)*
- yarn test *(fails: legacy suites unrelated to this change, including window focus handling and settings store tests)*
- yarn test __tests__/HelpOverlay.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68c96736f9f08328b396a1128d71986d