### PR TITLE
[notes] handle share target routing

### DIFF
--- a/__tests__/shareTargetRoute.test.ts
+++ b/__tests__/shareTargetRoute.test.ts
@@ -1,0 +1,113 @@
+import { Readable } from 'stream';
+import type { IncomingMessage } from 'http';
+
+import {
+  buildRedirectDestination,
+  createNoteContent,
+  extractShareValuesFromBody,
+  extractShareValuesFromQuery,
+  mergeShareSources,
+} from '../pages/share-target';
+
+function createRequestStream(
+  body: string,
+  contentType = 'application/x-www-form-urlencoded',
+): IncomingMessage {
+  const stream = new Readable({
+    read() {
+      this.push(body);
+      this.push(null);
+    },
+  }) as unknown as IncomingMessage & { headers: Record<string, string>; method: string; complete: boolean };
+
+  stream.headers = { 'content-type': contentType };
+  stream.method = 'POST';
+  stream.complete = false;
+
+  return stream;
+}
+
+describe('share target utilities', () => {
+  it('extracts share values from the query string', () => {
+    const result = extractShareValuesFromQuery({
+      title: '  Shared Title  ',
+      text: ['Primary note', ''],
+      url: 'https://example.com  ',
+      ignored: 'value',
+    });
+
+    expect(result).toEqual({
+      title: ['Shared Title'],
+      text: ['Primary note'],
+      url: ['https://example.com'],
+    });
+  });
+
+  it('merges query and body values while keeping order', () => {
+    const queryValues = {
+      title: ['Shared Title'],
+      text: ['First line'],
+    };
+
+    const bodyValues = {
+      text: ['Second line'],
+      url: ['https://example.com'],
+    };
+
+    const merged = mergeShareSources(queryValues, bodyValues);
+
+    expect(merged).toEqual({
+      title: ['Shared Title'],
+      text: ['First line', 'Second line'],
+      url: ['https://example.com'],
+    });
+  });
+
+  it('creates note content in the expected order', () => {
+    const content = createNoteContent({
+      title: ['Shared Title'],
+      text: ['Message body'],
+      url: ['https://example.com/post'],
+    });
+
+    expect(content).toBe('Shared Title\n\nMessage body\n\nhttps://example.com/post');
+  });
+
+  it('encodes redirect destination with source tag', () => {
+    const destination = buildRedirectDestination('Shared Title\n\nMessage body');
+    const url = new URL(destination, 'https://example.com');
+
+    expect(url.pathname).toBe('/apps/sticky_notes');
+    expect(url.searchParams.get('text')).toBe('Shared Title\n\nMessage body');
+    expect(url.searchParams.get('source')).toBe('share-target');
+  });
+
+  it('includes only the source tag when there is no shared content', () => {
+    const destination = buildRedirectDestination('');
+    const url = new URL(destination, 'https://example.com');
+
+    expect(url.pathname).toBe('/apps/sticky_notes');
+    expect(url.searchParams.get('source')).toBe('share-target');
+    expect(url.searchParams.has('text')).toBe(false);
+  });
+
+  it('parses urlencoded body payloads', async () => {
+    const req = createRequestStream(
+      'title=Shared+Title&text=Message+body&url=https%3A%2F%2Fexample.com%2Fpost',
+    );
+    const values = await extractShareValuesFromBody(req);
+
+    expect(values).toEqual({
+      title: ['Shared Title'],
+      text: ['Message body'],
+      url: ['https://example.com/post'],
+    });
+  });
+
+  it('ignores bodies with unsupported content types', async () => {
+    const req = createRequestStream('text=hello', 'text/plain');
+    const values = await extractShareValuesFromBody(req);
+    expect(values).toBeUndefined();
+  });
+});
+

--- a/pages/share-target.ts
+++ b/pages/share-target.ts
@@ -1,0 +1,179 @@
+import type { GetServerSideProps, GetServerSidePropsContext } from 'next';
+import type { IncomingMessage } from 'http';
+import type { ParsedUrlQuery } from 'querystring';
+
+const SHARE_KEYS = ['title', 'text', 'url'] as const;
+
+type ShareTargetKey = (typeof SHARE_KEYS)[number];
+
+export type ShareTargetValueMap = Partial<Record<ShareTargetKey, string[]>>;
+
+function isFormUrlEncoded(contentType: string | string[] | undefined): boolean {
+  if (!contentType) return false;
+  if (Array.isArray(contentType)) {
+    return contentType.some((value) =>
+      value?.toLowerCase().includes('application/x-www-form-urlencoded'),
+    );
+  }
+  return contentType.toLowerCase().includes('application/x-www-form-urlencoded');
+}
+
+export function toArray(value: string | string[] | undefined): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string');
+  }
+  if (typeof value === 'string') {
+    return [value];
+  }
+  return [];
+}
+
+export function extractShareValuesFromQuery(query: ParsedUrlQuery): ShareTargetValueMap {
+  const result: ShareTargetValueMap = {};
+  for (const key of SHARE_KEYS) {
+    const rawValue = query[key as string];
+    const values = toArray(rawValue as string | string[] | undefined)
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+    if (values.length > 0) {
+      result[key] = values;
+    }
+  }
+  return result;
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  if (req.readableEnded || req.complete) {
+    return '';
+  }
+
+  return await new Promise<string>((resolve, reject) => {
+    let data = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => {
+      data += chunk;
+    });
+    req.on('end', () => {
+      resolve(data);
+    });
+    req.on('error', (err) => {
+      reject(err);
+    });
+  });
+}
+
+export async function extractShareValuesFromBody(
+  req: IncomingMessage,
+): Promise<ShareTargetValueMap | undefined> {
+  if (!isFormUrlEncoded(req.headers['content-type'])) {
+    return undefined;
+  }
+
+  const rawBody = await readRequestBody(req);
+  if (!rawBody) {
+    return undefined;
+  }
+
+  const params = new URLSearchParams(rawBody);
+  const result: ShareTargetValueMap = {};
+
+  for (const key of SHARE_KEYS) {
+    const values = params
+      .getAll(key)
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+    if (values.length > 0) {
+      result[key] = values;
+    }
+  }
+
+  return result;
+}
+
+export function mergeShareSources(
+  ...sources: Array<ShareTargetValueMap | undefined>
+): ShareTargetValueMap {
+  const result: ShareTargetValueMap = {};
+
+  for (const key of SHARE_KEYS) {
+    const collected: string[] = [];
+    for (const source of sources) {
+      if (!source?.[key]) continue;
+      for (const value of source[key] as string[]) {
+        const trimmed = value.trim();
+        if (trimmed.length > 0) {
+          collected.push(trimmed);
+        }
+      }
+    }
+    if (collected.length > 0) {
+      result[key] = collected;
+    }
+  }
+
+  return result;
+}
+
+export function createNoteContent(values: ShareTargetValueMap): string {
+  const parts: string[] = [];
+
+  for (const key of SHARE_KEYS) {
+    const entries = values[key];
+    if (!entries) continue;
+    for (const entry of entries) {
+      const trimmed = entry.trim();
+      if (trimmed.length > 0) {
+        parts.push(trimmed);
+      }
+    }
+  }
+
+  return parts.join('\n\n');
+}
+
+export function buildRedirectDestination(
+  noteContent: string,
+  basePath = '/apps/sticky_notes',
+  source = 'share-target',
+): string {
+  const params = new URLSearchParams();
+  if (noteContent.length > 0) {
+    params.set('text', noteContent);
+  }
+  if (source) {
+    params.set('source', source);
+  }
+
+  const query = params.toString();
+  return query ? `${basePath}?${query}` : basePath;
+}
+
+export const getServerSideProps: GetServerSideProps = async (
+  context: GetServerSidePropsContext,
+) => {
+  let bodyValues: ShareTargetValueMap | undefined;
+
+  if (context.req.method === 'POST') {
+    try {
+      bodyValues = await extractShareValuesFromBody(context.req);
+    } catch (error) {
+      console.error('Failed to parse shared data', error);
+    }
+  }
+
+  const queryValues = extractShareValuesFromQuery(context.query);
+  const merged = mergeShareSources(queryValues, bodyValues);
+  const noteContent = createNoteContent(merged);
+
+  return {
+    redirect: {
+      destination: buildRedirectDestination(noteContent),
+      permanent: false,
+    },
+  };
+};
+
+export default function ShareTargetPage() {
+  return null;
+}
+

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -21,17 +21,11 @@
   "share_target": {
     "action": "/share-target",
     "method": "POST",
-    "enctype": "multipart/form-data",
+    "enctype": "application/x-www-form-urlencoded",
     "params": {
       "title": "title",
       "text": "text",
-      "url": "url",
-      "files": [
-        {
-          "name": "files",
-          "accept": ["*/*"]
-        }
-      ]
+      "url": "url"
     }
   },
   "shortcuts": [


### PR DESCRIPTION
## Summary
- update the PWA manifest to expect urlencoded share payloads for the sticky notes share target
- add a share-target Next.js page that parses text, title, and URL data before redirecting into the notes app
- cover the share-target helpers with unit tests to ensure redirect behavior and payload parsing

## Testing
- yarn lint *(fails: repository has pre-existing accessibility errors across many apps)*
- npx eslint pages/share-target.ts __tests__/shareTargetRoute.test.ts
- yarn test shareTargetRoute.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c9673787d883288f20e7d2776b4916