### PR TITLE
chore: prioritize landing hero imagery

### DIFF
--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -125,6 +125,7 @@ function About() {
                     height={256}
                     sizes="(max-width: 768px) 50vw, 25vw"
                     priority
+                    fetchPriority="high"
                 />
             </div>
             <div className=" mt-4 md:mt-8 text-lg md:text-2xl text-center px-1">

--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -18,6 +18,7 @@ function BootingScreen(props) {
                 alt="Ubuntu Logo"
                 sizes="(max-width: 768px) 50vw, 25vw"
                 priority
+                fetchPriority="high"
             />
             <div className="w-10 h-10 flex justify-center items-center rounded-full outline-none cursor-pointer" onClick={props.turnOn} >
                 {(props.isShutDown
@@ -31,6 +32,8 @@ function BootingScreen(props) {
                 src="/themes/Yaru/status/ubuntu_white_hex.svg"
                 alt="Kali Linux Name"
                 sizes="(max-width: 768px) 50vw, 20vw"
+                priority
+                fetchPriority="high"
             />
             <div className="text-white mb-4">
                 <a className="underline" href="https://www.linkedin.com/in/unnippillil/" rel="noopener noreferrer" target="_blank">linkedin</a>


### PR DESCRIPTION
## Summary
- add high fetch priority to the boot screen hero artwork so it loads immediately
- ensure the About Alex hero portrait opts into high-priority loading as part of the landing page experience

## Testing
- yarn lint *(fails: pre-existing jsx-a11y and no-top-level-window warnings across multiple apps)*
- yarn test *(fails: existing suites such as window keyboard shortcuts and nmap NSE due to act/localStorage issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c9672ebed88328a8eac3ba2b499c4d