### PR TITLE
[chrome] document sandbox permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ These external domains are whitelisted in the default CSP. Update this list when
 | `*.twitter.com` | Additional Twitter content |
 | `*.x.com` | X (Twitter) domain equivalents |
 | `*.google.com` | Google services and Chrome app favicons |
+| `duckduckgo.com` | Chrome app suggestion API |
 | `example.com` | Chrome app demo origin |
 | `developer.mozilla.org` | Chrome app demo origin |
 | `en.wikipedia.org` | Chrome app demo origin |
@@ -378,6 +379,17 @@ Browse all apps, games, and security tool demos at `/apps`, which presents a sea
 | Quote | /apps/quote | Utility / Media |
 
 > The VS Code app now embeds a StackBlitz IDE via iframe instead of the local Monaco editor.
+
+#### Chrome app limitations
+
+The in-window Chrome app is a sandboxed demo. It only loads curated origins (`example.com`,
+`developer.mozilla.org`, `en.wikipedia.org`) and opens other URLs externally. Tabs run inside an
+iframe with `sandbox="allow-scripts allow-forms allow-popups"` and the inline CSP
+`default-src 'self'; script-src 'none'; connect-src 'none';`, so network calls, service workers, and
+authentication flows frequently fail. A global Permissions Policy (`camera=(), microphone=()`) keeps
+camera and microphone requests blocked even though the iframe asks for them. Downloads and
+persistent storage are unreliable—use the ↗ toolbar button to continue in a real browser tab when you
+need full functionality.
 
 The Spotify app lets you customize a mood-to-playlist mapping. Use the in-app form to
 add, reorder, or delete moods; selections persist in the browser's Origin Private File

--- a/next.config.js
+++ b/next.config.js
@@ -23,7 +23,7 @@ const ContentSecurityPolicy = [
   // External scripts required for embedded timelines
   "script-src 'self' 'unsafe-inline' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
   // Allow outbound connections for embeds and the in-browser Chrome app
-  "connect-src 'self' https://example.com https://developer.mozilla.org https://en.wikipedia.org https://www.google.com https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
+  "connect-src 'self' https://example.com https://developer.mozilla.org https://en.wikipedia.org https://www.google.com https://duckduckgo.com https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
   // Allow iframes from specific providers so the Chrome and StackBlitz apps can load allowed content
   "frame-src 'self' https://vercel.live https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com https://example.com https://developer.mozilla.org https://en.wikipedia.org",
 
@@ -139,6 +139,7 @@ module.exports = withBundleAnalyzer(
         'yt3.ggpht.com',
         'i.scdn.co',
         'www.google.com',
+        'duckduckgo.com',
         'example.com',
         'developer.mozilla.org',
         'en.wikipedia.org',


### PR DESCRIPTION
## Summary
- add a sandbox & permissions callout to the Chrome app home grid and expand the in-app overlay with allowed origins and iframe capabilities
- derive iframe permission constants, reuse them for the allow attribute, and add aria-labels for tile controls/search inputs
- whitelist duckduckgo.com for Chrome suggestions and document the Chrome app limitations & CSP table updates in the README

## Testing
- yarn lint *(fails: repository has numerous existing accessibility lint violations outside this change)*
- yarn test *(fails: existing suites such as window, nmap NSE, and modal tests already red)*

------
https://chatgpt.com/codex/tasks/task_e_68c96738d628832892de63afb08ded97