### PR TITLE
[styles] brighten dark theme surfaces

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -24,17 +24,17 @@
 
 /* Dark theme */
 html[data-theme='dark'] {
-  --color-bg: #000000;
-  --color-text: #e5e5e5;
-  --color-primary: #1e88e5;
-  --color-secondary: #121212;
-  --color-accent: #bb86fc;
-  --color-muted: #1f1f1f;
-  --color-surface: #121212;
+  --color-bg: #0c1116;
+  --color-text: #f3f4f6;
+  --color-primary: #45b0ff;
+  --color-secondary: #17202b;
+  --color-accent: #45b0ff;
+  --color-muted: #32495f;
+  --color-surface: #1a2530;
   --color-inverse: #ffffff;
-  --color-border: #333333;
+  --color-border: #3a5369;
   --color-terminal: #00ff00;
-  --color-dark: #0a0a0a;
+  --color-dark: #0a1016;
 }
 
 /* Neon theme */

--- a/styles/index.css
+++ b/styles/index.css
@@ -494,12 +494,14 @@ dialog {
     background-size: 0% 100%;
     animation: word-found-highlight 0.6s forwards;
     display: inline-block;
+    color: var(--color-bg);
 }
 
 /* Highlight currently selected cells in word search */
 .selection {
     /* amber tone for colorblind-safe contrast */
     background-color: var(--color-accent);
+    color: var(--color-bg);
 }
 
 /* Ensure monospace layout for app outputs */

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -25,7 +25,7 @@
   --color-ub-dark-grey: #2a2e36;
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
-  --kali-bg: rgba(15, 19, 23, 0.85);
+  --kali-bg: rgba(12, 17, 22, 0.88);
 
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;


### PR DESCRIPTION
## Summary
- lift dark theme surface tokens to slightly brighter blues for better layered contrast
- ensure word-search selections render readable text against accent backgrounds
- tune the semi-transparent Kali wallpaper surface token to match the brighter base

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations in unrelated apps)*
- yarn test *(fails: pre-existing modal and window test failures; interrupted after repeats)*

------
https://chatgpt.com/codex/tasks/task_e_68c96740448083288cd36a96e9b876f8