### PR TITLE
[motion] define presets and unify transitions

### DIFF
--- a/components/ToggleSwitch.tsx
+++ b/components/ToggleSwitch.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import { buildTransition } from "@/src/motion/presets";
 
 interface ToggleSwitchProps {
   checked: boolean;
@@ -14,6 +15,9 @@ export default function ToggleSwitch({
   className = "",
   ariaLabel,
 }: ToggleSwitchProps) {
+  const trackTransition = buildTransition("toggle", ["background-color"]);
+  const thumbTransition = buildTransition("toggle", ["transform", "background-color"]);
+
   return (
     <button
       role="switch"
@@ -23,11 +27,13 @@ export default function ToggleSwitch({
       className={`relative inline-flex w-10 h-5 rounded-full transition-colors focus:outline-none ${
         checked ? "bg-ub-orange" : "bg-ubt-cool-grey"
       } ${className}`.trim()}
+      style={{ transition: trackTransition }}
     >
       <span
-        className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-ub-cool-grey transition-transform duration-200 ${
+        className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-ub-cool-grey transition-transform ${
           checked ? "translate-x-5" : "translate-x-0"
         }`}
+        style={{ transition: thumbTransition }}
       />
     </button>
   );

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -65,7 +65,7 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
             (this.state.active_screen === section.id
               ? ' bg-ub-gedit-light bg-opacity-100 hover:bg-opacity-95'
               : ' hover:bg-gray-50 hover:bg-opacity-5 ') +
-            ' w-28 md:w-full md:rounded-none rounded-sm cursor-default outline-none py-1.5 focus:outline-none duration-100 my-0.5 flex justify-start items-center pl-2 md:pl-2.5'
+            ' w-28 md:w-full md:rounded-none rounded-sm cursor-default outline-none py-1.5 focus:outline-none transition-hover transition-active my-0.5 flex justify-start items-center pl-2 md:pl-2.5'
           }
         >
           <Image

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -67,7 +67,7 @@ export class AboutAlex extends Component {
                         id={section.id}
                         tabIndex="0"
                         onFocus={this.changeScreen}
-                        className={(this.state.active_screen === section.id ? " bg-ub-gedit-light bg-opacity-100 hover:bg-opacity-95" : " hover:bg-gray-50 hover:bg-opacity-5 ") + " w-28 md:w-full md:rounded-none rounded-sm cursor-default outline-none py-1.5 focus:outline-none duration-100 my-0.5 flex justify-start items-center pl-2 md:pl-2.5"}
+                        className={(this.state.active_screen === section.id ? " bg-ub-gedit-light bg-opacity-100 hover:bg-opacity-95" : " hover:bg-gray-50 hover:bg-opacity-5 ") + " w-28 md:w-full md:rounded-none rounded-sm cursor-default outline-none py-1.5 focus:outline-none transition-hover transition-active my-0.5 flex justify-start items-center pl-2 md:pl-2.5"}
                     >
                         <Image
                             className=" w-3 md:w-4"

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -120,7 +120,7 @@ const WhiskerMenu: React.FC = () => {
         ref={buttonRef}
         type="button"
         onClick={() => setOpen(o => !o)}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        className="pl-3 pr-3 outline-none transition-hover transition-active border-b-2 border-transparent py-1"
       >
         <Image
           src="/themes/Yaru/status/decompiler-symbolic.svg"

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -22,7 +22,7 @@ export default class Navbar extends Component {
                                 <WhiskerMenu />
                                 <div
                                         className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition-hover transition-active border-b-2 border-transparent py-1'
                                         }
                                 >
                                         <Clock />
@@ -35,7 +35,7 @@ export default class Navbar extends Component {
                                                 this.setState({ status_card: !this.state.status_card });
                                         }}
                                         className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
+                                                'relative pr-3 pl-3 outline-none transition-hover transition-active border-b-2 border-transparent focus:border-ubb-orange py-1 '
                                         }
                                 >
                                         <Status />

--- a/docs/motion-guidelines.md
+++ b/docs/motion-guidelines.md
@@ -1,0 +1,57 @@
+# Motion guidelines
+
+This project now exposes a small motion library so interactions across the desktop feel consistent.
+It has two parts: CSS design tokens in `styles/tokens.css` and a TypeScript helper in
+`src/motion/presets.ts`.
+
+## Interaction tokens
+
+The CSS tokens provide named durations and easing curves for the most common interactions:
+
+- `--motion-duration-tap` — quick responses for press/tap feedback (100 ms)
+- `--motion-duration-hover` — hover and focus states (150 ms)
+- `--motion-duration-toggle` — longer transitions for toggle switches (200 ms)
+- `--motion-ease-standard` — the default curve (`cubic-bezier(0.16, 1, 0.3, 1)`)
+- `--motion-ease-emphasized` — a snappier curve for press feedback (`cubic-bezier(0.33, 1, 0.68, 1)`)
+
+Utility classes in `styles/tailwind.css` apply these tokens:
+
+- `transition-hover` configures hover/focus transitions with the standard easing
+- `transition-active` uses the tap duration and emphasized easing for snappy feedback
+
+Buttons automatically pick up the hover preset and fall back to the tap preset while pressed.
+When reduced-motion is enabled the durations collapse to zero so that transitions disappear.
+
+## TypeScript presets
+
+Import helpers from `src/motion/presets.ts` when you need to author transitions or springs in
+JavaScript/TypeScript components.
+
+```ts
+import { buildTransition, getSpringPreset } from "@/src/motion/presets";
+
+const toggleTransition = buildTransition("toggle", ["transform"]);
+const hoverSpring = getSpringPreset("hover");
+```
+
+- `buildTransition()` accepts an interaction name (`tap`, `hover`, or `toggle`) and an optional
+  list of CSS properties. It returns a comma-delimited transition string that uses the shared
+  duration and easing curve. Use it for inline `style.transition` values when Tailwind utilities
+  are not enough. The helper references the CSS custom properties so reduced-motion preferences
+  still collapse the durations to zero.
+- `getSpringPreset()` returns a Framer Motion–compatible spring configuration tuned for the same
+  interactions. Pass the preset directly to `animate`/`whileHover`/`whileTap` props. The presets
+  share the same duration envelope so switches, hover cards, and tap feedback animate at similar
+  speeds.
+
+Both helpers use the `interactionMotion` tokens exported from the same module. If you extend the
+system with a new interaction, update the CSS tokens and the TypeScript module in tandem.
+
+## Usage checklist
+
+1. Use `transition-hover` and `transition-active` utilities for hoverable or pressable UI.
+2. Prefer `buildTransition()` for inline transitions instead of hard-coded durations.
+3. Reach for `getSpringPreset()` whenever you configure a spring (Framer Motion, Motion One, etc.).
+4. Never bypass the tokens for app-specific values unless animation timing is part of the feature
+   (e.g., minigames). Otherwise transitions across the desktop drift apart over time.
+5. Verify animations still respect reduced-motion by testing with the OS/browser flag.

--- a/src/motion/presets.ts
+++ b/src/motion/presets.ts
@@ -1,0 +1,86 @@
+export type InteractionName = 'tap' | 'hover' | 'toggle';
+
+export type SpringPreset = {
+  type: 'spring';
+  stiffness: number;
+  damping: number;
+  mass: number;
+  restSpeed: number;
+  restDelta: number;
+};
+
+export const motionDurations = {
+  tap: 100,
+  hover: 150,
+  toggle: 200,
+} as const satisfies Record<InteractionName, number>;
+
+export const motionEasings = {
+  standard: 'cubic-bezier(0.16, 1, 0.3, 1)',
+  emphasized: 'cubic-bezier(0.33, 1, 0.68, 1)',
+} as const;
+
+const durationVariables = {
+  tap: '--motion-duration-tap',
+  hover: '--motion-duration-hover',
+  toggle: '--motion-duration-toggle',
+} as const satisfies Record<InteractionName, `--${string}`>;
+
+export const interactionMotion = {
+  tap: {
+    duration: motionDurations.tap,
+    easing: motionEasings.emphasized,
+    cssVar: durationVariables.tap,
+  },
+  hover: {
+    duration: motionDurations.hover,
+    easing: motionEasings.standard,
+    cssVar: durationVariables.hover,
+  },
+  toggle: {
+    duration: motionDurations.toggle,
+    easing: motionEasings.standard,
+    cssVar: durationVariables.toggle,
+  },
+} as const satisfies Record<InteractionName, { duration: number; easing: string; cssVar: string }>;
+
+const baseSpring: Omit<SpringPreset, 'stiffness' | 'damping' | 'mass'> = {
+  type: 'spring',
+  restSpeed: 0.01,
+  restDelta: 0.001,
+};
+
+export const springPresets: Record<InteractionName, SpringPreset> = {
+  tap: {
+    ...baseSpring,
+    stiffness: 420,
+    damping: 35,
+    mass: 0.9,
+  },
+  hover: {
+    ...baseSpring,
+    stiffness: 260,
+    damping: 30,
+    mass: 1,
+  },
+  toggle: {
+    ...baseSpring,
+    stiffness: 320,
+    damping: 28,
+    mass: 1,
+  },
+} as const;
+
+export function getSpringPreset(name: InteractionName): SpringPreset {
+  return springPresets[name];
+}
+
+export function buildTransition(
+  name: InteractionName,
+  properties: string[] = ['all'],
+): string {
+  const { duration, easing, cssVar } = interactionMotion[name];
+  const durationToken = `var(${cssVar}, ${duration}ms)`;
+  const list = properties.length > 0 ? properties : ['all'];
+  return list.map((property) => `${property} ${durationToken} ${easing}`).join(', ');
+}

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -4,16 +4,26 @@
 
 @layer utilities {
   .transition-hover {
-    @apply transition ease-out duration-150;
+    transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform;
+    transition-duration: var(--motion-duration-hover, 150ms);
+    transition-timing-function: var(--motion-ease-standard, cubic-bezier(0.16, 1, 0.3, 1));
   }
   .transition-active {
-    @apply transition ease-out duration-100;
+    transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform;
+    transition-duration: var(--motion-duration-tap, 100ms);
+    transition-timing-function: var(--motion-ease-emphasized, cubic-bezier(0.33, 1, 0.68, 1));
   }
 }
 
 @layer base {
   button {
-    @apply transition-hover transition-active;
+    transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform;
+    transition-duration: var(--motion-duration-hover, 150ms);
+    transition-timing-function: var(--motion-ease-standard, cubic-bezier(0.16, 1, 0.3, 1));
+  }
+  button:active {
+    transition-duration: var(--motion-duration-tap, 100ms);
+    transition-timing-function: var(--motion-ease-emphasized, cubic-bezier(0.33, 1, 0.68, 1));
   }
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -51,6 +51,11 @@
   --motion-fast: 150ms;
   --motion-medium: 300ms;
   --motion-slow: 500ms;
+  --motion-duration-tap: 100ms;
+  --motion-duration-hover: 150ms;
+  --motion-duration-toggle: 200ms;
+  --motion-ease-standard: cubic-bezier(0.16, 1, 0.3, 1);
+  --motion-ease-emphasized: cubic-bezier(0.33, 1, 0.68, 1);
 
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
@@ -94,6 +99,9 @@
   --motion-fast: 0ms;
   --motion-medium: 0ms;
   --motion-slow: 0ms;
+  --motion-duration-tap: 0ms;
+  --motion-duration-hover: 0ms;
+  --motion-duration-toggle: 0ms;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -101,6 +109,9 @@
     --motion-fast: 0ms;
     --motion-medium: 0ms;
     --motion-slow: 0ms;
+    --motion-duration-tap: 0ms;
+    --motion-duration-hover: 0ms;
+    --motion-duration-toggle: 0ms;
   }
 }
 


### PR DESCRIPTION
## Summary
- add shared motion tokens and spring presets for tap, hover, and toggle interactions
- update common UI elements to use the shared motion timings and easing curves
- document how to apply the motion helpers in components and CSS utilities

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations in unrelated apps)*
- yarn test *(fails: pre-existing suite failures and hangs due to legacy tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c984ae37548328957ca9e876fff383