### PR TITLE
[ui] normalize icon set

### DIFF
--- a/components/PopularModules.tsx
+++ b/components/PopularModules.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import modulesData from '../data/module-index.json';
 import versionInfo from '../data/module-version.json';
+import { CheckCircleIcon, InfoCircleIcon, WarningTriangleIcon, XCircleIcon } from './icons';
+import type { IconProps } from './icons';
 
 interface Module {
   id: string;
@@ -93,91 +95,14 @@ const PopularModules: React.FC = () => {
     }
   };
 
-  const levelClass: Record<string, string> = {
-    info: 'text-blue-300',
-    success: 'text-green-400',
-    error: 'text-red-400',
-    warning: 'text-yellow-300',
+  const levelStyles: Record<string, { color: string; Icon: React.ComponentType<IconProps> }> = {
+    info: { color: 'text-blue-300', Icon: InfoCircleIcon },
+    success: { color: 'text-green-400', Icon: CheckCircleIcon },
+    warning: { color: 'text-yellow-300', Icon: WarningTriangleIcon },
+    error: { color: 'text-red-400', Icon: XCircleIcon },
   };
 
-  const levelIcon: Record<string, React.ReactElement> = {
-    info: (
-      <svg
-        className="w-6 h-6 text-blue-300"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-        aria-hidden="true"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z"
-        />
-      </svg>
-    ),
-    success: (
-      <svg
-        className="w-6 h-6 text-green-400"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-        aria-hidden="true"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M5 13l4 4L19 7"
-        />
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"
-        />
-      </svg>
-    ),
-    warning: (
-      <svg
-        className="w-6 h-6 text-yellow-300"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-        aria-hidden="true"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M12 8v4m0 4h.01M4.93 19h14.14c1.2 0 1.94-1.3 1.34-2.33L13.34 4.67c-.6-1.04-2.08-1.04-2.68 0L3.59 16.67c-.6 1.03-.15 2.33 1.34 2.33z"
-        />
-      </svg>
-    ),
-    error: (
-      <svg
-        className="w-6 h-6 text-red-400"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-        aria-hidden="true"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M12 2a10 10 0 100 20 10 10 0 000-20z"
-        />
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M15 9l-6 6m0-6l6 6"
-        />
-      </svg>
-    ),
-  };
+  const defaultLevelStyle = levelStyles.info;
 
   return (
     <div className="p-4 space-y-4 bg-ub-cool-grey text-white min-h-screen">
@@ -300,18 +225,21 @@ const PopularModules: React.FC = () => {
               Copy Logs
             </button>
             <ol className="border-l-2 border-gray-700 pl-4 space-y-2" role="log">
-              {filteredLog.map((line, idx) => (
-                <li key={idx} className="flex items-center gap-2">
-                  {levelIcon[line.level] || levelIcon.info}
-                  <span
-                    className={`px-2 py-1 rounded-full bg-gray-700 text-sm font-mono ${
-                      levelClass[line.level] || levelClass.info
-                    }`}
-                  >
-                    {line.message}
-                  </span>
-                </li>
-              ))}
+              {filteredLog.map((line, idx) => {
+                const { Icon: LevelIcon, color } =
+                  levelStyles[line.level] || defaultLevelStyle;
+
+                return (
+                  <li key={idx} className="flex items-center gap-2">
+                    <LevelIcon className={`w-6 h-6 ${color}`} aria-hidden="true" />
+                    <span
+                      className={`px-2 py-1 rounded-full bg-gray-700 text-sm font-mono ${color}`}
+                    >
+                      {line.message}
+                    </span>
+                  </li>
+                );
+              })}
             </ol>
           </div>
           <table className="min-w-full text-sm">

--- a/components/apps/qr/index.tsx
+++ b/components/apps/qr/index.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import QRCode from 'qrcode';
+import { CopyIcon, FlashIcon, SwitchCameraIcon } from '../../icons';
 
 const QRScanner: React.FC = () => {
   const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -162,52 +163,6 @@ const QRScanner: React.FC = () => {
     </div>
   );
 };
-
-const FlashIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    {...props}
-  >
-    <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
-  </svg>
-);
-
-const SwitchCameraIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    {...props}
-  >
-    <path d="M23 4v6h-6" />
-    <path d="M1 20v-6h6" />
-    <path d="M3.51 9a9 9 0 0 1 14.13-3.36L23 10" />
-    <path d="M20.49 15a9 9 0 0 1-14.13 3.36L1 14" />
-  </svg>
-);
-
-const CopyIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    {...props}
-  >
-    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-  </svg>
-);
 
 export default QRScanner;
 

--- a/components/icons/CheckCircleIcon.tsx
+++ b/components/icons/CheckCircleIcon.tsx
@@ -1,0 +1,10 @@
+import { IconBase, type IconProps } from './IconBase';
+
+export function CheckCircleIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <circle cx={12} cy={12} r={8.25} />
+      <path d="M8.25 12.5 11 15.25 15.75 9.5" />
+    </IconBase>
+  );
+}

--- a/components/icons/CopyIcon.tsx
+++ b/components/icons/CopyIcon.tsx
@@ -1,0 +1,10 @@
+import { IconBase, type IconProps } from './IconBase';
+
+export function CopyIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <rect x="3.75" y="3.75" width="10.5" height="10.5" rx="2.25" />
+      <rect x="8.75" y="8.75" width="10.5" height="10.5" rx="2.25" />
+    </IconBase>
+  );
+}

--- a/components/icons/FlashIcon.tsx
+++ b/components/icons/FlashIcon.tsx
@@ -1,0 +1,9 @@
+import { IconBase, type IconProps } from './IconBase';
+
+export function FlashIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M12.75 3 3.75 14.25H12L11.25 21.75 20.25 10.5H12L12.75 3Z" />
+    </IconBase>
+  );
+}

--- a/components/icons/IconBase.tsx
+++ b/components/icons/IconBase.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode, SVGProps } from 'react';
+
+export type IconProps = SVGProps<SVGSVGElement>;
+
+interface IconBaseProps extends IconProps {
+  children: ReactNode;
+}
+
+export function IconBase({
+  children,
+  strokeWidth = 1.5,
+  role = 'img',
+  focusable,
+  'aria-label': ariaLabel,
+  'aria-hidden': ariaHidden,
+  ...rest
+}: IconBaseProps) {
+  const computedAriaHidden = ariaLabel ? ariaHidden ?? undefined : ariaHidden ?? true;
+  const computedFocusable = ariaLabel ? focusable : focusable ?? false;
+
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={strokeWidth}
+      role={role}
+      focusable={computedFocusable}
+      aria-label={ariaLabel}
+      aria-hidden={computedAriaHidden}
+      {...rest}
+    >
+      {children}
+    </svg>
+  );
+}

--- a/components/icons/InfoCircleIcon.tsx
+++ b/components/icons/InfoCircleIcon.tsx
@@ -1,0 +1,11 @@
+import { IconBase, type IconProps } from './IconBase';
+
+export function InfoCircleIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <circle cx={12} cy={12} r={8.25} />
+      <path d="M12 10.75v4.5" />
+      <path d="M12 7.25h.01" />
+    </IconBase>
+  );
+}

--- a/components/icons/SwitchCameraIcon.tsx
+++ b/components/icons/SwitchCameraIcon.tsx
@@ -1,0 +1,12 @@
+import { IconBase, type IconProps } from './IconBase';
+
+export function SwitchCameraIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M22.75 4.25v5.5h-5.5" />
+      <path d="M1.25 19.75v-5.5h5.5" />
+      <path d="M3.75 9.25a8.75 8.75 0 0 1 13.34-3.08L22.75 10.25" />
+      <path d="M20.25 14.75a8.75 8.75 0 0 1-13.34 3.08L1.25 13.75" />
+    </IconBase>
+  );
+}

--- a/components/icons/WarningTriangleIcon.tsx
+++ b/components/icons/WarningTriangleIcon.tsx
@@ -1,0 +1,11 @@
+import { IconBase, type IconProps } from './IconBase';
+
+export function WarningTriangleIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M12 4.25 4.5 19.25h15Z" />
+      <path d="M12 10.5v3.75" />
+      <path d="M12 16.25h.01" />
+    </IconBase>
+  );
+}

--- a/components/icons/XCircleIcon.tsx
+++ b/components/icons/XCircleIcon.tsx
@@ -1,0 +1,11 @@
+import { IconBase, type IconProps } from './IconBase';
+
+export function XCircleIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <circle cx={12} cy={12} r={8.25} />
+      <path d="m9.25 9.25 5.5 5.5" />
+      <path d="m14.75 9.25-5.5 5.5" />
+    </IconBase>
+  );
+}

--- a/components/icons/index.ts
+++ b/components/icons/index.ts
@@ -1,0 +1,9 @@
+export { IconBase } from './IconBase';
+export type { IconProps } from './IconBase';
+export { CopyIcon } from './CopyIcon';
+export { FlashIcon } from './FlashIcon';
+export { SwitchCameraIcon } from './SwitchCameraIcon';
+export { InfoCircleIcon } from './InfoCircleIcon';
+export { CheckCircleIcon } from './CheckCircleIcon';
+export { WarningTriangleIcon } from './WarningTriangleIcon';
+export { XCircleIcon } from './XCircleIcon';

--- a/docs/TASKS_UI_POLISH.md
+++ b/docs/TASKS_UI_POLISH.md
@@ -115,8 +115,9 @@ This document tracks UI polish tasks for the Kali/Ubuntu inspired desktop experi
     - **Where:** desktop and lock components.
 
 27. **Iconography pass**
-    - **Accept:** SVG icons normalized to common grid (e.g., 24 or 32), consistent stroke widths.
-    - **Where:** `public/images/*`.
+    - **Accept:** SVG icons normalized to a 24 px grid with a consistent 1.5 px stroke; shapes land on the pixel grid to avoid blur.
+    - **How:** Use the shared helpers in `components/icons/IconBase.tsx` and keep decorative glyphs `aria-hidden`.
+    - **Where:** `components/icons/*`, `public/images/*`.
 
 28. **Hover and pressed states**
     - **Accept:** Dock tiles, app grid, buttons have clear hover and pressed; 100–150 ms ease out.


### PR DESCRIPTION
## Summary
- add a shared IconBase helper and redraw the icons used by the QR scanner and module log severities on a consistent 24px grid
- update QR scanner and module list components to consume the shared icons and apply the new severity styling helper
- document the iconography guidelines and point to the new components/icons directory

## Testing
- yarn lint *(fails: repo contains existing jsx-a11y and no-top-level-window issues)*
- yarn test *(fails: pre-existing act warnings and jsdom localStorage error in suite)*

------
https://chatgpt.com/codex/tasks/task_e_68c984aeb66883289b525140ccd6ff20