### PR TITLE
[desktop] add drag-to-create workspace support

### DIFF
--- a/__tests__/DesktopSwitcher.test.tsx
+++ b/__tests__/DesktopSwitcher.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react';
+import DesktopSwitcher, {
+  WINDOW_DRAG_JSON,
+  WINDOW_DRAG_TYPE,
+} from '../components/desktop/DesktopSwitcher';
+
+type DataMap = Record<string, string>;
+
+function createDataTransfer(initial: DataMap = {}): DataTransfer {
+  const store = new Map<string, string>();
+  const types: string[] = [];
+
+  const dataTransfer: Partial<DataTransfer> = {
+    dropEffect: 'none',
+    effectAllowed: 'all',
+    files: [] as unknown as FileList,
+    items: [] as unknown as DataTransferItemList,
+    types,
+    setData(type: string, value: string) {
+      store.set(type, value);
+      if (!types.includes(type)) {
+        types.push(type);
+      }
+    },
+    getData(type: string) {
+      return store.get(type) ?? '';
+    },
+    clearData(type?: string) {
+      if (typeof type === 'string') {
+        store.delete(type);
+        const index = types.indexOf(type);
+        if (index !== -1) {
+          types.splice(index, 1);
+        }
+      } else {
+        store.clear();
+        types.splice(0, types.length);
+      }
+    },
+  };
+
+  Object.entries(initial).forEach(([type, value]) => {
+    dataTransfer.setData?.(type, value);
+  });
+
+  return dataTransfer as DataTransfer;
+}
+
+describe('DesktopSwitcher', () => {
+  it('highlights the create-desktop drop zone when a window thumbnail is dragged over', () => {
+    const { getByTestId } = render(
+      <DesktopSwitcher
+        desktops={[]}
+        onCreateDesktop={() => 'desktop-1'}
+      />,
+    );
+
+    const dropZone = getByTestId('desktop-switcher-create');
+    const dataTransfer = createDataTransfer({ [WINDOW_DRAG_TYPE]: 'window-1' });
+
+    fireEvent.dragEnter(dropZone, { dataTransfer });
+    expect(dropZone).toHaveAttribute('data-highlighted', 'true');
+
+    fireEvent.dragLeave(dropZone, { dataTransfer, relatedTarget: null });
+    expect(dropZone).toHaveAttribute('data-highlighted', 'false');
+  });
+
+  it('creates a desktop, moves the window, and switches focus on drop', async () => {
+    const createDesktop = jest.fn().mockResolvedValue({ id: 'desktop-2' });
+    const moveWindow = jest.fn().mockResolvedValue(undefined);
+    const selectDesktop = jest.fn().mockResolvedValue(undefined);
+
+    const { getByTestId } = render(
+      <DesktopSwitcher
+        desktops={[{ id: 'desktop-1', name: 'Main', windows: [] }]}
+        activeDesktopId="desktop-1"
+        onCreateDesktop={createDesktop}
+        onMoveWindow={moveWindow}
+        onSelectDesktop={selectDesktop}
+      />,
+    );
+
+    const dropZone = getByTestId('desktop-switcher-create');
+    const dataTransfer = createDataTransfer({ [WINDOW_DRAG_TYPE]: 'window-42' });
+
+    await act(async () => {
+      fireEvent.drop(dropZone, { dataTransfer });
+      await Promise.resolve();
+    });
+
+    expect(createDesktop).toHaveBeenCalledWith({ windowId: 'window-42' });
+    expect(moveWindow).toHaveBeenCalledWith('window-42', 'desktop-2');
+    expect(selectDesktop).toHaveBeenCalledWith('desktop-2');
+    expect(dropZone).toHaveAttribute('data-highlighted', 'false');
+  });
+
+  it('supports JSON payloads when extracting the dragged window id', async () => {
+    const createDesktop = jest.fn().mockResolvedValue('desktop-3');
+    const moveWindow = jest.fn().mockResolvedValue(undefined);
+    const selectDesktop = jest.fn().mockResolvedValue(undefined);
+
+    const { getByTestId } = render(
+      <DesktopSwitcher
+        desktops={[{ id: 'desktop-1', name: 'Main', windows: [] }]}
+        onCreateDesktop={createDesktop}
+        onMoveWindow={moveWindow}
+        onSelectDesktop={selectDesktop}
+      />,
+    );
+
+    const payload = JSON.stringify({ windowId: 'window-5' });
+    const dataTransfer = createDataTransfer({ [WINDOW_DRAG_JSON]: payload });
+
+    await act(async () => {
+      fireEvent.drop(getByTestId('desktop-switcher-create'), { dataTransfer });
+      await Promise.resolve();
+    });
+
+    expect(createDesktop).toHaveBeenCalledWith({ windowId: 'window-5' });
+    expect(moveWindow).toHaveBeenCalledWith('window-5', 'desktop-3');
+    expect(selectDesktop).toHaveBeenCalledWith('desktop-3');
+  });
+
+  it('ignores drops that do not contain window data', async () => {
+    const createDesktop = jest.fn().mockResolvedValue(null);
+    const moveWindow = jest.fn();
+    const selectDesktop = jest.fn();
+
+    const { getByTestId } = render(
+      <DesktopSwitcher
+        desktops={[{ id: 'desktop-1', name: 'Main', windows: [] }]}
+        onCreateDesktop={createDesktop}
+        onMoveWindow={moveWindow}
+        onSelectDesktop={selectDesktop}
+      />,
+    );
+
+    const dataTransfer = createDataTransfer({ 'text/plain': 'not-a-window' });
+
+    await act(async () => {
+      fireEvent.drop(getByTestId('desktop-switcher-create'), { dataTransfer });
+      await Promise.resolve();
+    });
+
+    expect(createDesktop).not.toHaveBeenCalled();
+    expect(moveWindow).not.toHaveBeenCalled();
+    expect(selectDesktop).not.toHaveBeenCalled();
+  });
+});

--- a/components/desktop/DesktopSwitcher.tsx
+++ b/components/desktop/DesktopSwitcher.tsx
@@ -1,0 +1,369 @@
+'use client';
+
+import React, {
+  CSSProperties,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+export const WINDOW_DRAG_TYPE = 'application/x-kali-desktop-window';
+export const WINDOW_DRAG_JSON = 'application/x-kali-desktop-window+json';
+export const WINDOW_DRAG_PLAIN_PREFIX = 'desktop-window:';
+
+type CreateDesktopResult = { id: string } | string | null | undefined;
+
+export interface WindowThumbnail {
+  id: string;
+  title: string;
+  preview?: string | null;
+  appId?: string;
+}
+
+export interface DesktopSummary {
+  id: string;
+  name: string;
+  windows: WindowThumbnail[];
+}
+
+export interface DesktopSwitcherProps {
+  desktops: DesktopSummary[];
+  activeDesktopId?: string;
+  onSelectDesktop?: (desktopId: string) => void | Promise<void>;
+  onMoveWindow?: (windowId: string, targetDesktopId: string) => void | Promise<void>;
+  onCreateDesktop?: (options: { windowId?: string }) =>
+    | CreateDesktopResult
+    | Promise<CreateDesktopResult>;
+  className?: string;
+  emptyLabel?: string;
+}
+
+type DataTransferTypes = DOMStringList | string[] | undefined;
+
+function listHasType(list: DataTransferTypes, value: string): boolean {
+  if (!list) return false;
+  if (Array.isArray(list)) {
+    return list.includes(value);
+  }
+  if (typeof list.contains === 'function') {
+    return list.contains(value);
+  }
+  for (let i = 0; i < list.length; i += 1) {
+    if (list.item(i) === value) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function resolveDesktopId(result: CreateDesktopResult): string | null {
+  if (!result) return null;
+  if (typeof result === 'string') return result;
+  if (typeof result === 'object' && 'id' in result && typeof result.id === 'string') {
+    return result.id;
+  }
+  return null;
+}
+
+export function getWindowIdFromDataTransfer(dataTransfer: DataTransfer | null): string | null {
+  if (!dataTransfer) return null;
+  if (listHasType(dataTransfer.types, WINDOW_DRAG_TYPE)) {
+    const raw = dataTransfer.getData(WINDOW_DRAG_TYPE);
+    return raw || null;
+  }
+  if (listHasType(dataTransfer.types, WINDOW_DRAG_JSON)) {
+    try {
+      const payload = JSON.parse(dataTransfer.getData(WINDOW_DRAG_JSON));
+      if (payload && typeof payload.windowId === 'string') {
+        return payload.windowId;
+      }
+      if (payload && typeof payload.id === 'string') {
+        return payload.id;
+      }
+    } catch (error) {
+      console.error('Failed to parse desktop drag payload', error);
+    }
+  }
+  if (listHasType(dataTransfer.types, 'text/plain')) {
+    try {
+      const plain = dataTransfer.getData('text/plain');
+      if (plain.startsWith(WINDOW_DRAG_PLAIN_PREFIX)) {
+        return plain.slice(WINDOW_DRAG_PLAIN_PREFIX.length);
+      }
+    } catch (error) {
+      // Some browsers restrict reading arbitrary formats during drag.
+    }
+  }
+  return null;
+}
+
+export function isWindowThumbnailTransfer(dataTransfer: DataTransfer | null): boolean {
+  if (!dataTransfer) return false;
+  if (listHasType(dataTransfer.types, WINDOW_DRAG_TYPE)) return true;
+  if (listHasType(dataTransfer.types, WINDOW_DRAG_JSON)) return true;
+  if (listHasType(dataTransfer.types, 'text/plain')) {
+    try {
+      const plain = dataTransfer.getData('text/plain');
+      return plain.startsWith(WINDOW_DRAG_PLAIN_PREFIX);
+    } catch (error) {
+      return false;
+    }
+  }
+  return false;
+}
+
+const MAX_WINDOW_THUMBNAILS = 6;
+
+const DesktopSwitcher: React.FC<DesktopSwitcherProps> = ({
+  desktops,
+  activeDesktopId,
+  onSelectDesktop,
+  onMoveWindow,
+  onCreateDesktop,
+  className = '',
+  emptyLabel = 'No desktops yet',
+}) => {
+  const [hoveredDesktop, setHoveredDesktop] = useState<string | null>(null);
+  const [newDesktopPreview, setNewDesktopPreview] = useState(false);
+  const newDesktopDragDepth = useRef(0);
+
+  const resetDragState = useCallback(() => {
+    newDesktopDragDepth.current = 0;
+    setNewDesktopPreview(false);
+    setHoveredDesktop(null);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const handleDragEnd = () => resetDragState();
+    window.addEventListener('dragend', handleDragEnd);
+    window.addEventListener('drop', handleDragEnd);
+    return () => {
+      window.removeEventListener('dragend', handleDragEnd);
+      window.removeEventListener('drop', handleDragEnd);
+    };
+  }, [resetDragState]);
+
+  const handleSelectDesktop = useCallback(
+    async (desktopId: string) => {
+      if (!onSelectDesktop) return;
+      await onSelectDesktop(desktopId);
+    },
+    [onSelectDesktop],
+  );
+
+  const handleDesktopDragEnter = useCallback(
+    (desktopId: string) => (event: React.DragEvent<HTMLButtonElement>) => {
+      if (!isWindowThumbnailTransfer(event.dataTransfer)) return;
+      event.preventDefault();
+      setHoveredDesktop(desktopId);
+    },
+    [],
+  );
+
+  const handleDesktopDragOver = useCallback(
+    (desktopId: string) => (event: React.DragEvent<HTMLButtonElement>) => {
+      if (!isWindowThumbnailTransfer(event.dataTransfer)) return;
+      event.preventDefault();
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = 'move';
+      }
+      if (hoveredDesktop !== desktopId) {
+        setHoveredDesktop(desktopId);
+      }
+    },
+    [hoveredDesktop],
+  );
+
+  const handleDesktopDragLeave = useCallback(
+    (desktopId: string) => (event: React.DragEvent<HTMLButtonElement>) => {
+      if (!isWindowThumbnailTransfer(event.dataTransfer)) return;
+      const nextTarget = event.relatedTarget as Node | null;
+      if (!nextTarget || !event.currentTarget.contains(nextTarget)) {
+        setHoveredDesktop((prev) => (prev === desktopId ? null : prev));
+      }
+    },
+    [],
+  );
+
+  const handleDesktopDrop = useCallback(
+    (desktopId: string) => async (event: React.DragEvent<HTMLButtonElement>) => {
+      if (!isWindowThumbnailTransfer(event.dataTransfer)) return;
+      event.preventDefault();
+      setHoveredDesktop(null);
+      const windowId = getWindowIdFromDataTransfer(event.dataTransfer);
+      if (!windowId) return;
+      if (onMoveWindow) {
+        await onMoveWindow(windowId, desktopId);
+      }
+      if (onSelectDesktop) {
+        await onSelectDesktop(desktopId);
+      }
+    },
+    [onMoveWindow, onSelectDesktop],
+  );
+
+  const handleNewDesktopDragEnter = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (!onCreateDesktop) return;
+      if (!isWindowThumbnailTransfer(event.dataTransfer)) return;
+      event.preventDefault();
+      newDesktopDragDepth.current += 1;
+      setNewDesktopPreview(true);
+    },
+    [onCreateDesktop],
+  );
+
+  const handleNewDesktopDragOver = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (!onCreateDesktop) return;
+      if (!isWindowThumbnailTransfer(event.dataTransfer)) return;
+      event.preventDefault();
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = 'copy';
+      }
+      if (!newDesktopPreview) {
+        setNewDesktopPreview(true);
+      }
+    },
+    [newDesktopPreview, onCreateDesktop],
+  );
+
+  const handleNewDesktopDragLeave = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (!onCreateDesktop) return;
+      if (!isWindowThumbnailTransfer(event.dataTransfer)) return;
+      const nextTarget = event.relatedTarget as Node | null;
+      if (nextTarget && event.currentTarget.contains(nextTarget)) {
+        return;
+      }
+      newDesktopDragDepth.current = Math.max(0, newDesktopDragDepth.current - 1);
+      if (newDesktopDragDepth.current === 0) {
+        setNewDesktopPreview(false);
+      }
+    },
+    [onCreateDesktop],
+  );
+
+  const handleNewDesktopDrop = useCallback(
+    async (event: React.DragEvent<HTMLDivElement>) => {
+      if (!onCreateDesktop) return;
+      if (!isWindowThumbnailTransfer(event.dataTransfer)) return;
+      event.preventDefault();
+      newDesktopDragDepth.current = 0;
+      setNewDesktopPreview(false);
+      const windowId = getWindowIdFromDataTransfer(event.dataTransfer);
+      if (!windowId) return;
+      const created = await onCreateDesktop({ windowId });
+      const newDesktopId = resolveDesktopId(created);
+      if (!newDesktopId) return;
+      if (onMoveWindow) {
+        await onMoveWindow(windowId, newDesktopId);
+      }
+      if (onSelectDesktop) {
+        await onSelectDesktop(newDesktopId);
+      }
+    },
+    [onCreateDesktop, onMoveWindow, onSelectDesktop],
+  );
+
+  return (
+    <div className={`desktop-switcher flex flex-wrap gap-3 p-4 text-ubt-grey ${className}`.trim()}>
+      {desktops.length === 0 && (
+        <div className="flex h-32 w-48 flex-col items-center justify-center rounded-md border border-white/10 bg-black/30 text-center text-sm">
+          {emptyLabel}
+        </div>
+      )}
+      {desktops.map((desktop) => {
+        const isActive = desktop.id === activeDesktopId;
+        const isHovered = hoveredDesktop === desktop.id;
+        const style: CSSProperties = {};
+        if (isActive) {
+          style.borderColor = 'var(--color-accent)';
+        }
+        if (isHovered) {
+          style.boxShadow = '0 0 0 2px var(--color-accent)';
+        }
+        const windows = desktop.windows.slice(0, MAX_WINDOW_THUMBNAILS);
+        return (
+          <button
+            key={desktop.id}
+            type="button"
+            className="group relative flex h-32 w-48 flex-col justify-between rounded-md border border-white/20 bg-black/40 p-3 text-left text-xs transition-all duration-150 hover:border-white/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+            style={style}
+            onClick={() => handleSelectDesktop(desktop.id)}
+            onDragEnter={handleDesktopDragEnter(desktop.id)}
+            onDragOver={handleDesktopDragOver(desktop.id)}
+            onDragLeave={handleDesktopDragLeave(desktop.id)}
+            onDrop={handleDesktopDrop(desktop.id)}
+            data-testid={`desktop-switcher-${desktop.id}`}
+          >
+            <div className="flex items-center justify-between text-ubt-grey text-opacity-90">
+              <span className="truncate text-sm font-medium" title={desktop.name}>
+                {desktop.name}
+              </span>
+              {isActive && <span className="text-[10px] uppercase">Active</span>}
+            </div>
+            <div className="mt-2 grid flex-1 grid-cols-3 gap-1">
+              {windows.map((win) => (
+                <div
+                  key={win.id}
+                  className="flex h-10 items-center justify-center overflow-hidden rounded bg-black/40 px-1 text-[10px] text-ubt-grey text-opacity-80"
+                  title={win.title}
+                >
+                  {win.preview ? (
+                    <img
+                      src={win.preview}
+                      alt={win.title}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <span className="truncate leading-tight">{win.title}</span>
+                  )}
+                </div>
+              ))}
+              {windows.length === 0 && (
+                <div className="col-span-3 flex h-full items-center justify-center rounded border border-dashed border-white/20 text-[11px] text-ubt-grey text-opacity-70">
+                  No windows
+                </div>
+              )}
+            </div>
+            <div className="mt-2 flex items-center justify-between text-[11px] text-ubt-grey text-opacity-75">
+              <span>{desktop.windows.length} window{desktop.windows.length === 1 ? '' : 's'}</span>
+              <span>#{desktop.id}</span>
+            </div>
+          </button>
+        );
+      })}
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label="Create a new desktop"
+        data-testid="desktop-switcher-create"
+        data-highlighted={newDesktopPreview ? 'true' : 'false'}
+        className="flex h-32 w-48 flex-col items-center justify-center rounded-md border border-dashed border-white/25 bg-black/20 text-center text-xs transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+        style={
+          newDesktopPreview
+            ? {
+                borderColor: 'var(--color-accent)',
+                boxShadow: '0 0 0 2px var(--color-accent)',
+              }
+            : undefined
+        }
+        onDragEnter={handleNewDesktopDragEnter}
+        onDragOver={handleNewDesktopDragOver}
+        onDragLeave={handleNewDesktopDragLeave}
+        onDrop={handleNewDesktopDrop}
+      >
+        <span className="text-xl font-semibold text-ubt-grey">+</span>
+        <span className="mt-1 text-sm font-medium text-ubt-grey">New Desktop</span>
+        <span className="mt-2 max-w-[150px] text-[11px] text-ubt-grey text-opacity-80">
+          Drag a window thumbnail here to create another workspace.
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default DesktopSwitcher;


### PR DESCRIPTION
## Summary
- create a desktop switcher component that allows dropping a window thumbnail to create and activate a new workspace
- add regression tests covering drag preview, new desktop creation, and JSON payload support for window transfers

## Testing
- yarn lint *(fails: repository has many pre-existing accessibility lint violations)*
- yarn test *(fails: repository has pre-existing failing suites that rely on DOM APIs/localStorage)*

------
https://chatgpt.com/codex/tasks/task_e_68c984b536488328bbc9d2aa994d33be