### PR TITLE
[wm] apply shift-aware drag resistance

### DIFF
--- a/__tests__/dragHelpers.test.ts
+++ b/__tests__/dragHelpers.test.ts
@@ -1,0 +1,25 @@
+import { EDGE_RESISTANCE_DISTANCE, EDGE_RESISTANCE_STRENGTH, getResistedPosition } from '@/src/wm/dragHelpers';
+
+describe('getResistedPosition', () => {
+  const bounds = { width: 200, height: 200 };
+
+  it('slows movement as the pointer nears the edges', () => {
+    const position = getResistedPosition({ x: EDGE_RESISTANCE_DISTANCE - 2, y: EDGE_RESISTANCE_DISTANCE - 2 }, bounds);
+    const expected = (EDGE_RESISTANCE_DISTANCE - 2) * EDGE_RESISTANCE_STRENGTH;
+    expect(position.x).toBeCloseTo(expected);
+    expect(position.y).toBeCloseTo(expected);
+  });
+
+  it('skips resistance when the shift key is pressed', () => {
+    const original = EDGE_RESISTANCE_DISTANCE - 2;
+    const position = getResistedPosition({ x: original, y: original }, bounds, { shiftKey: true } as any);
+    expect(position.x).toBeCloseTo(original);
+    expect(position.y).toBeCloseTo(original);
+  });
+
+  it('supports overriding the resistance distance', () => {
+    const position = getResistedPosition({ x: 5, y: 5 }, bounds, undefined, { distance: 0 });
+    expect(position.x).toBe(5);
+    expect(position.y).toBe(5);
+  });
+});

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -7,6 +7,7 @@ import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
 import styles from './window.module.css';
+import { getResistedPosition } from '@/src/wm/dragHelpers';
 
 export class Window extends Component {
     constructor(props) {
@@ -336,30 +337,16 @@ export class Window extends Component {
         }
     }
 
-    applyEdgeResistance = (node, data) => {
-        if (!node || !data) return;
-        const threshold = 30;
-        const resistance = 0.35; // how much to slow near edges
-        let { x, y } = data;
-        const maxX = this.state.parentSize.width;
-        const maxY = this.state.parentSize.height;
-
-        const resist = (pos, min, max) => {
-            if (pos < min) return min;
-            if (pos < min + threshold) return min + (pos - min) * resistance;
-            if (pos > max) return max;
-            if (pos > max - threshold) return max - (max - pos) * resistance;
-            return pos;
-        }
-
-        x = resist(x, 0, maxX);
-        y = resist(y, 0, maxY);
-        node.style.transform = `translate(${x}px, ${y}px)`;
+    applyEdgeResistance = (event, data) => {
+        if (!data || !data.node) return;
+        const bounds = this.state.parentSize;
+        const { x, y } = getResistedPosition(data, bounds, event);
+        data.node.style.transform = `translate(${x}px, ${y}px)`;
     }
 
     handleDrag = (e, data) => {
         if (data && data.node) {
-            this.applyEdgeResistance(data.node, data);
+            this.applyEdgeResistance(e, data);
         }
         this.checkOverlap();
         this.checkSnapPreview();

--- a/src/wm/dragHelpers.ts
+++ b/src/wm/dragHelpers.ts
@@ -1,0 +1,109 @@
+import type { DraggableData, DraggableEvent } from 'react-draggable';
+
+export interface DragBounds {
+  width: number;
+  height: number;
+}
+
+export interface EdgeResistanceOptions {
+  /**
+   * Number of pixels from the edge that should apply resistance.
+   */
+  distance?: number;
+  /**
+   * Multiplier applied to the drag delta when resistance is active.
+   * Smaller values increase the slowdown effect.
+   */
+  strength?: number;
+}
+
+export const EDGE_RESISTANCE_DISTANCE = 12;
+export const EDGE_RESISTANCE_STRENGTH = 0.35;
+
+interface ShiftKeyEventLike {
+  shiftKey?: boolean;
+  nativeEvent?: {
+    shiftKey?: boolean;
+  };
+}
+
+const clamp = (value: number, min: number, max: number) => {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+};
+
+const isShiftKeyPressed = (event?: DraggableEvent): boolean => {
+  if (!event) return false;
+  const candidate = event as ShiftKeyEventLike;
+  if (typeof candidate.shiftKey === 'boolean') {
+    return candidate.shiftKey;
+  }
+  if (candidate.nativeEvent && typeof candidate.nativeEvent.shiftKey === 'boolean') {
+    return candidate.nativeEvent.shiftKey;
+  }
+  return false;
+};
+
+const applyAxisResistance = (
+  value: number,
+  min: number,
+  max: number,
+  distance: number,
+  strength: number
+) => {
+  const clamped = clamp(value, min, max);
+  if (distance <= 0) {
+    return clamped;
+  }
+
+  const lowerEdge = min + distance;
+  const upperEdge = max - distance;
+
+  if (clamped <= lowerEdge) {
+    const delta = clamped - min;
+    return min + delta * strength;
+  }
+
+  if (clamped >= upperEdge) {
+    const delta = max - clamped;
+    return max - delta * strength;
+  }
+
+  return clamped;
+};
+
+export const getResistedPosition = (
+  data: Pick<DraggableData, 'x' | 'y'>,
+  bounds: DragBounds,
+  event?: DraggableEvent,
+  options: EdgeResistanceOptions = {}
+): { x: number; y: number } => {
+  const { distance = EDGE_RESISTANCE_DISTANCE, strength = EDGE_RESISTANCE_STRENGTH } = options;
+  const maxX = bounds.width;
+  const maxY = bounds.height;
+
+  if (isShiftKeyPressed(event)) {
+    return {
+      x: clamp(data.x, 0, maxX),
+      y: clamp(data.y, 0, maxY),
+    };
+  }
+
+  return {
+    x: applyAxisResistance(data.x, 0, maxX, distance, strength),
+    y: applyAxisResistance(data.y, 0, maxY, distance, strength),
+  };
+};
+
+export const applyEdgeResistanceToNode = (
+  node: HTMLElement,
+  data: DraggableData,
+  bounds: DragBounds,
+  event?: DraggableEvent,
+  options?: EdgeResistanceOptions
+) => {
+  const { x, y } = getResistedPosition(data, bounds, event, options);
+  node.style.transform = `translate(${x}px, ${y}px)`;
+  return { x, y };
+};


### PR DESCRIPTION
## Summary
- centralize window drag edge resistance logic behind a helper with configurable distance and strength values
- slow drags within 12px of the desktop edge while still allowing shift to bypass the slowdown
- cover the new helper with focused unit tests

## Testing
- yarn lint *(fails: pre-existing accessibility and global window/document lint errors)*
- yarn test *(fails: existing window keyboard handling and Nmap NSE clipboard tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c984b6972883288a356d3f77febb29