### PR TITLE
desktop: add taskbar previews

### DIFF
--- a/components/desktop/TaskbarPreview.tsx
+++ b/components/desktop/TaskbarPreview.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import Image from 'next/image';
+import React, {
+    ForwardedRef,
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+} from 'react';
+
+const CAPTURE_INTERVAL = 1000;
+let htmlToImagePromise: Promise<typeof import('html-to-image')> | null = null;
+
+const loadHtmlToImage = async () => {
+    if (!htmlToImagePromise) {
+        htmlToImagePromise = import('html-to-image');
+    }
+    return htmlToImagePromise;
+};
+
+export interface TaskbarPreviewProps {
+    appId: string;
+    title: string;
+    iconSrc?: string;
+    anchorRect: DOMRect | null;
+    minimized?: boolean;
+    onCloseApp: () => void;
+    onDismiss: () => void;
+    onPointerStateChange?: (inside: boolean) => void;
+    onFocusWithinChange?: (focusWithin: boolean) => void;
+}
+
+const TaskbarPreview = React.forwardRef(function TaskbarPreview(
+    {
+        appId,
+        title,
+        iconSrc,
+        anchorRect,
+        minimized = false,
+        onCloseApp,
+        onDismiss,
+        onPointerStateChange,
+        onFocusWithinChange,
+    }: TaskbarPreviewProps,
+    ref: ForwardedRef<HTMLDivElement>
+) {
+    const rootRef = useRef<HTMLDivElement | null>(null);
+    const [thumbnail, setThumbnail] = useState<string | null>(null);
+
+    const capturePreview = useCallback(async () => {
+        const node = document.getElementById(appId);
+        if (!node) return;
+
+        try {
+            const htmlToImage = await loadHtmlToImage();
+            const dataUrl = await htmlToImage.toPng(node, {
+                cacheBust: true,
+                pixelRatio: Math.min(window.devicePixelRatio || 1, 2),
+            });
+            setThumbnail(dataUrl);
+        } catch (error) {
+            // ignore capture failures; keep last known thumbnail
+        }
+    }, [appId]);
+
+    useEffect(() => {
+        if (!anchorRect) return;
+
+        let cancelled = false;
+        let intervalId: number | null = null;
+
+        const startCapture = async () => {
+            await capturePreview();
+            if (cancelled) return;
+            intervalId = window.setInterval(() => {
+                capturePreview();
+            }, CAPTURE_INTERVAL);
+        };
+
+        startCapture();
+
+        return () => {
+            cancelled = true;
+            if (intervalId) {
+                window.clearInterval(intervalId);
+            }
+        };
+    }, [anchorRect, capturePreview]);
+
+    useEffect(() => {
+        if (!anchorRect) return;
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                onDismiss();
+            }
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [anchorRect, onDismiss]);
+
+    useEffect(() => {
+        return () => {
+            onPointerStateChange?.(false);
+            onFocusWithinChange?.(false);
+        };
+    }, [onPointerStateChange, onFocusWithinChange]);
+
+    const handlePointerEnter = useCallback(() => {
+        onPointerStateChange?.(true);
+    }, [onPointerStateChange]);
+
+    const handlePointerLeave = useCallback(() => {
+        onPointerStateChange?.(false);
+    }, [onPointerStateChange]);
+
+    const handleFocusCapture = useCallback(() => {
+        onFocusWithinChange?.(true);
+    }, [onFocusWithinChange]);
+
+    const handleBlurCapture = useCallback((event: React.FocusEvent<HTMLDivElement>) => {
+        const nextTarget = event.relatedTarget as Node | null;
+        if (event.currentTarget.contains(nextTarget)) {
+            return;
+        }
+        onFocusWithinChange?.(false);
+    }, [onFocusWithinChange]);
+
+    if (!anchorRect) {
+        return null;
+    }
+
+    const positionStyle: React.CSSProperties = {
+        position: 'fixed',
+        top: Math.max(anchorRect.top - 8, 16),
+        left: anchorRect.left + anchorRect.width / 2,
+        transform: 'translate(-50%, -100%)',
+        zIndex: 1000,
+        pointerEvents: 'auto',
+    };
+
+    const resolvedIcon = iconSrc ? iconSrc.replace('./', '/') : null;
+
+    return (
+        <div
+            id={`${appId}-taskbar-preview`}
+            ref={node => {
+                rootRef.current = node;
+                if (typeof ref === 'function') {
+                    ref(node);
+                } else if (ref && typeof ref === 'object') {
+                    (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+                }
+            }}
+            role="dialog"
+            aria-modal="false"
+            aria-labelledby={`${appId}-preview-title`}
+            className="w-72 max-w-[min(18rem,90vw)] rounded-md border border-white/20 bg-zinc-900/95 px-3 py-2 text-white shadow-lg backdrop-blur"
+            style={positionStyle}
+            tabIndex={-1}
+            onMouseEnter={handlePointerEnter}
+            onMouseLeave={handlePointerLeave}
+            onFocusCapture={handleFocusCapture}
+            onBlurCapture={handleBlurCapture}
+        >
+            <div className="mb-2 flex items-start justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-2">
+                    {resolvedIcon ? (
+                        <Image
+                            src={resolvedIcon}
+                            alt=""
+                            width={20}
+                            height={20}
+                            className="h-5 w-5 flex-none"
+                        />
+                    ) : null}
+                    <p
+                        id={`${appId}-preview-title`}
+                        className="truncate text-sm font-medium"
+                    >
+                        {title}
+                    </p>
+                </div>
+                <button
+                    type="button"
+                    onClick={() => {
+                        onCloseApp();
+                        onDismiss();
+                    }}
+                    className="flex-none rounded bg-white/10 px-2 py-1 text-xs font-medium text-white transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                    aria-label={`Close ${title}`}
+                >
+                    Close
+                </button>
+            </div>
+            <div className="relative aspect-video w-full overflow-hidden rounded bg-black/60">
+                {thumbnail ? (
+                    <img
+                        src={thumbnail}
+                        alt={`Live preview of ${title}`}
+                        className="h-full w-full object-cover"
+                    />
+                ) : (
+                    <div className="flex h-full items-center justify-center px-4 text-center text-xs text-zinc-300">
+                        Preview will appear shortly
+                    </div>
+                )}
+                {minimized ? (
+                    <span className="absolute bottom-1 right-1 rounded bg-black/70 px-1 text-[10px] uppercase tracking-wide text-zinc-200">
+                        Minimized
+                    </span>
+                ) : null}
+            </div>
+        </div>
+    );
+});
+
+export default TaskbarPreview;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -900,6 +900,7 @@ export class Desktop extends Component {
                     focused_windows={this.state.focused_windows}
                     openApp={this.openApp}
                     minimize={this.hasMinimised}
+                    closeApp={this.closeApp}
                 />
 
                 {/* Desktop Apps */}

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,47 +1,230 @@
-import React from 'react';
+'use client';
+
+import React, {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import Image from 'next/image';
+import TaskbarPreview from '../desktop/TaskbarPreview';
 
 export default function Taskbar(props) {
-    const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const {
+        apps,
+        closed_windows,
+        minimized_windows,
+        focused_windows,
+        openApp,
+        minimize,
+        closeApp,
+    } = props;
 
-    const handleClick = (app) => {
-        const id = app.id;
-        if (props.minimized_windows[id]) {
-            props.openApp(id);
-        } else if (props.focused_windows[id]) {
-            props.minimize(id);
-        } else {
-            props.openApp(id);
+    const runningApps = useMemo(
+        () => apps.filter(app => closed_windows[app.id] === false),
+        [apps, closed_windows]
+    );
+
+    const [activePreview, setActivePreview] = useState(null);
+    const [anchorRect, setAnchorRect] = useState(null);
+    const buttonRefs = useRef({});
+    const closeTimeoutRef = useRef(null);
+    const previewNodeRef = useRef(null);
+    const pointerInsidePreviewRef = useRef(false);
+    const focusInsidePreviewRef = useRef(false);
+    const triggerRef = useRef(null);
+    const lastActiveRef = useRef(null);
+
+    const clearCloseTimeout = useCallback(() => {
+        if (closeTimeoutRef.current) {
+            window.clearTimeout(closeTimeoutRef.current);
+            closeTimeoutRef.current = null;
         }
-    };
+    }, []);
+
+    const measureAnchor = useCallback((id) => {
+        if (!id) return null;
+        const button = buttonRefs.current[id];
+        if (!button) return null;
+        return button.getBoundingClientRect();
+    }, []);
+
+    const updateAnchorForActive = useCallback(() => {
+        if (!activePreview) return;
+        const rect = measureAnchor(activePreview);
+        if (rect) {
+            setAnchorRect(rect);
+        }
+    }, [activePreview, measureAnchor]);
+
+    useEffect(() => {
+        if (!activePreview) return undefined;
+        updateAnchorForActive();
+        window.addEventListener('resize', updateAnchorForActive);
+        window.addEventListener('scroll', updateAnchorForActive, true);
+        return () => {
+            window.removeEventListener('resize', updateAnchorForActive);
+            window.removeEventListener('scroll', updateAnchorForActive, true);
+        };
+    }, [activePreview, updateAnchorForActive]);
+
+    const scheduleDismiss = useCallback((delay = 150) => {
+        clearCloseTimeout();
+        closeTimeoutRef.current = window.setTimeout(() => {
+            if (pointerInsidePreviewRef.current || focusInsidePreviewRef.current) {
+                return;
+            }
+            setActivePreview(null);
+            setAnchorRect(null);
+        }, delay);
+    }, [clearCloseTimeout]);
+
+    const handleDismiss = useCallback(() => {
+        clearCloseTimeout();
+        pointerInsidePreviewRef.current = false;
+        focusInsidePreviewRef.current = false;
+        setActivePreview(null);
+        setAnchorRect(null);
+    }, [clearCloseTimeout]);
+
+    useEffect(() => clearCloseTimeout, [clearCloseTimeout]);
+
+    useEffect(() => {
+        if (activePreview) {
+            lastActiveRef.current = activePreview;
+            return;
+        }
+        const lastId = lastActiveRef.current;
+        if (lastId && triggerRef.current === 'keyboard') {
+            const button = buttonRefs.current[lastId];
+            if (button && typeof button.focus === 'function') {
+                button.focus();
+            }
+        }
+        triggerRef.current = null;
+        lastActiveRef.current = null;
+    }, [activePreview]);
+
+    const openPreview = useCallback((id, trigger) => {
+        if (!id) return;
+        triggerRef.current = trigger;
+        pointerInsidePreviewRef.current = false;
+        focusInsidePreviewRef.current = false;
+        setActivePreview(id);
+        const rect = measureAnchor(id);
+        if (rect) {
+            setAnchorRect(rect);
+        }
+        clearCloseTimeout();
+    }, [measureAnchor, clearCloseTimeout]);
+
+    const handleButtonClick = useCallback((app) => {
+        const id = app.id;
+        if (minimized_windows[id]) {
+            openApp(id);
+        } else if (focused_windows[id]) {
+            minimize(id);
+        } else {
+            openApp(id);
+        }
+        handleDismiss();
+    }, [focused_windows, minimized_windows, minimize, openApp, handleDismiss]);
+
+    const handleButtonMouseLeave = useCallback(() => {
+        scheduleDismiss();
+    }, [scheduleDismiss]);
+
+    const handleButtonBlur = useCallback((event) => {
+        const next = event.relatedTarget;
+        const node = previewNodeRef.current;
+        if (node && next && node.contains(next)) {
+            return;
+        }
+        scheduleDismiss();
+    }, [scheduleDismiss]);
+
+    const handlePreviewPointerChange = useCallback((inside) => {
+        pointerInsidePreviewRef.current = inside;
+        if (inside) {
+            clearCloseTimeout();
+        } else {
+            scheduleDismiss();
+        }
+    }, [clearCloseTimeout, scheduleDismiss]);
+
+    const handlePreviewFocusChange = useCallback((inside) => {
+        focusInsidePreviewRef.current = inside;
+        if (inside) {
+            clearCloseTimeout();
+        } else {
+            scheduleDismiss();
+        }
+    }, [clearCloseTimeout, scheduleDismiss]);
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => (
-                <button
-                    key={app.id}
-                    type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
-                    onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
-                    />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
-                </button>
-            ))}
+        <div className="absolute bottom-0 left-0 flex h-10 w-full items-center bg-black bg-opacity-50 z-40" role="toolbar">
+            {runningApps.map(app => {
+                const id = app.id;
+                const isFocused = focused_windows[id] && !minimized_windows[id];
+                const isMinimized = !!minimized_windows[id];
+                const isPreviewOpen = activePreview === id;
+
+                return (
+                    <div key={id} className="relative">
+                        <button
+                            ref={node => {
+                                if (node) {
+                                    buttonRefs.current[id] = node;
+                                } else {
+                                    delete buttonRefs.current[id];
+                                }
+                            }}
+                            type="button"
+                            aria-label={app.title}
+                            aria-haspopup="dialog"
+                            aria-expanded={isPreviewOpen}
+                            aria-controls={isPreviewOpen ? `${id}-taskbar-preview` : undefined}
+                            data-context="taskbar"
+                            data-app-id={id}
+                            onClick={() => handleButtonClick(app)}
+                            onMouseEnter={() => openPreview(id, 'pointer')}
+                            onFocus={() => openPreview(id, 'keyboard')}
+                            onMouseLeave={handleButtonMouseLeave}
+                            onBlur={handleButtonBlur}
+                            className={(isFocused ? ' bg-white bg-opacity-20 ' : ' ') +
+                                'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white'}
+                        >
+                            <Image
+                                width={24}
+                                height={24}
+                                className="h-5 w-5"
+                                src={app.icon.replace('./', '/')}
+                                alt=""
+                                sizes="24px"
+                            />
+                            <span className="ml-1 whitespace-nowrap text-sm text-white">{app.title}</span>
+                            {!isFocused && !isMinimized && (
+                                <span className="absolute bottom-0 left-1/2 h-0.5 w-2 -translate-x-1/2 rounded bg-white" />
+                            )}
+                        </button>
+                        {isPreviewOpen ? (
+                            <TaskbarPreview
+                                ref={previewNodeRef}
+                                appId={id}
+                                title={app.title}
+                                iconSrc={app.icon}
+                                anchorRect={anchorRect}
+                                minimized={isMinimized}
+                                onCloseApp={() => closeApp(id)}
+                                onDismiss={handleDismiss}
+                                onPointerStateChange={handlePreviewPointerChange}
+                                onFocusWithinChange={handlePreviewFocusChange}
+                            />
+                        ) : null}
+                    </div>
+                );
+            })}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add a dedicated TaskbarPreview component that renders live window thumbnails with accessible controls
- wire the Taskbar to show previews on hover/focus, manage focus transitions, and support closing apps from the preview
- pass the close handler from Desktop so previews can dismiss windows directly

## Testing
- `yarn lint` *(fails: existing repo lint violations unrelated to this change)*
- `yarn test` *(fails: existing repo test failures; command left watch mode after verifying failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c984b9d3a88328bb0e81528fabfb70