### PR TITLE
[a11y] add polite download announcements

### DIFF
--- a/__tests__/liveRegion.test.tsx
+++ b/__tests__/liveRegion.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import Toast from '../components/ui/Toast';
 import FormError from '../components/ui/FormError';
+import Toaster, { announcePolite } from '../components/system/Toaster';
 
 describe('live region components', () => {
   it('Toast uses polite live region', () => {
@@ -15,5 +16,63 @@ describe('live region components', () => {
     render(<FormError>Required field</FormError>);
     const region = screen.getByRole('status');
     expect(region).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('Toaster announces custom messages politely', () => {
+    jest.useFakeTimers();
+    try {
+      render(<Toaster />);
+      const region = screen.getByRole('status');
+
+      act(() => {
+        announcePolite('Saved successfully');
+        jest.advanceTimersByTime(80);
+      });
+
+      expect(region).toHaveTextContent('Saved successfully');
+
+      act(() => {
+        jest.advanceTimersByTime(2200);
+      });
+
+      expect(region).toHaveTextContent('');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('Toaster announces download start and completion', () => {
+    jest.useFakeTimers();
+    const link = document.createElement('a');
+    try {
+      render(<Toaster />);
+      const region = screen.getByRole('status');
+      link.download = 'report.csv';
+      document.body.appendChild(link);
+
+      act(() => {
+        link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+        jest.advanceTimersByTime(80);
+      });
+
+      expect(region).toHaveTextContent('Download started: report.csv');
+
+      act(() => {
+        jest.advanceTimersByTime(1500);
+      });
+
+      expect(region).toHaveTextContent('Download complete: report.csv');
+
+      act(() => {
+        jest.advanceTimersByTime(2200);
+      });
+
+      expect(region).toHaveTextContent('');
+    } finally {
+      if (link.isConnected) {
+        document.body.removeChild(link);
+      }
+      jest.useRealTimers();
+    }
   });
 });

--- a/components/system/Toaster.tsx
+++ b/components/system/Toaster.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useRef, useState } from 'react';
+
+type PolitenessSetting = 'polite' | 'assertive';
+
+export type ToasterEventDetail = {
+  message?: string;
+  politeness?: PolitenessSetting;
+};
+
+const ANNOUNCE_EVENT = 'system:announce';
+
+const ANNOUNCEMENT_DELAY = 60;
+const CLEAR_DELAY = 2000;
+const DOWNLOAD_COMPLETE_DELAY = 1500;
+
+export const announcePolite = (message: string) => {
+  if (typeof window === 'undefined' || !message) return;
+  const event = new CustomEvent<ToasterEventDetail>(ANNOUNCE_EVENT, {
+    detail: { message, politeness: 'polite' },
+  });
+  window.dispatchEvent(event);
+};
+
+const resolveFileName = (anchor: HTMLAnchorElement): string => {
+  const explicit = anchor.getAttribute('download');
+  if (explicit && explicit.trim().length > 0) {
+    return explicit.trim();
+  }
+
+  const href = anchor.getAttribute('href') ?? '';
+  if (!href) return 'download';
+
+  try {
+    const url = new URL(href, window.location.href);
+    const segments = url.pathname.split('/').filter(Boolean);
+    if (segments.length > 0) {
+      return segments[segments.length - 1];
+    }
+  } catch {
+    // ignore parsing issues
+  }
+
+  if (href.startsWith('blob:')) return 'file';
+
+  const fallback = href.split('/').filter(Boolean).pop();
+  return fallback ?? 'download';
+};
+
+const Toaster = () => {
+  const [message, setMessage] = useState('');
+  const [politeness, setPoliteness] = useState<PolitenessSetting>('polite');
+  const clearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const messageTimers = useRef<Array<ReturnType<typeof setTimeout>>>([]);
+  const downloadTimers = useRef<Array<ReturnType<typeof setTimeout>>>([]);
+
+  const registerMessageTimer = (timer: ReturnType<typeof setTimeout>) => {
+    messageTimers.current.push(timer);
+    return timer;
+  };
+
+  const cancelMessageTimers = () => {
+    messageTimers.current.forEach((timer) => clearTimeout(timer));
+    messageTimers.current = [];
+    clearTimer.current = null;
+  };
+
+  const registerDownloadTimer = (timer: ReturnType<typeof setTimeout>) => {
+    downloadTimers.current.push(timer);
+    return timer;
+  };
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const handleAnnounce = (event: Event) => {
+      const detail = (event as CustomEvent<ToasterEventDetail>).detail;
+      const nextMessage = detail?.message?.trim();
+      if (!nextMessage) return;
+
+      cancelMessageTimers();
+
+      setMessage('');
+      setPoliteness(detail.politeness ?? 'polite');
+
+      const showTimer = window.setTimeout(() => {
+        setMessage(nextMessage);
+        messageTimers.current = messageTimers.current.filter((timer) => timer !== showTimer);
+      }, ANNOUNCEMENT_DELAY);
+      registerMessageTimer(showTimer);
+
+      const hideTimer = window.setTimeout(() => {
+        setMessage('');
+        clearTimer.current = null;
+        messageTimers.current = messageTimers.current.filter((timer) => timer !== hideTimer);
+      }, CLEAR_DELAY + ANNOUNCEMENT_DELAY);
+      clearTimer.current = registerMessageTimer(hideTimer);
+    };
+
+    window.addEventListener(ANNOUNCE_EVENT, handleAnnounce as EventListener);
+
+    return () => {
+      window.removeEventListener(ANNOUNCE_EVENT, handleAnnounce as EventListener);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+
+    const handleDownload = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+
+      const anchor = target.closest('a[download]') as HTMLAnchorElement | null;
+      if (!anchor) return;
+
+      const fileName = resolveFileName(anchor);
+      announcePolite(`Download started: ${fileName}`);
+
+      const completionTimer = window.setTimeout(() => {
+        announcePolite(`Download complete: ${fileName}`);
+        downloadTimers.current = downloadTimers.current.filter((timer) => timer !== completionTimer);
+      }, DOWNLOAD_COMPLETE_DELAY);
+      registerDownloadTimer(completionTimer);
+    };
+
+    document.addEventListener('click', handleDownload, true);
+
+    return () => {
+      document.removeEventListener('click', handleDownload, true);
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      cancelMessageTimers();
+      downloadTimers.current.forEach((timer) => clearTimeout(timer));
+      downloadTimers.current = [];
+    };
+  }, []);
+
+  return (
+    <div
+      role="status"
+      aria-live={politeness}
+      aria-atomic="true"
+      className="sr-only"
+      data-testid="system-toaster"
+    >
+      {message}
+    </div>
+  );
+};
+
+export default Toaster;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import Toaster, { announcePolite } from '../components/system/Toaster';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -81,19 +82,9 @@ function MyApp(props) {
   }, []);
 
   useEffect(() => {
-    const liveRegion = document.getElementById('live-region');
-    if (!liveRegion) return;
-
-    const update = (message) => {
-      liveRegion.textContent = '';
-      setTimeout(() => {
-        liveRegion.textContent = message;
-      }, 100);
-    };
-
-    const handleCopy = () => update('Copied to clipboard');
-    const handleCut = () => update('Cut to clipboard');
-    const handlePaste = () => update('Pasted from clipboard');
+    const handleCopy = () => announcePolite('Copied to clipboard');
+    const handleCut = () => announcePolite('Cut to clipboard');
+    const handlePaste = () => announcePolite('Pasted from clipboard');
 
     window.addEventListener('copy', handleCopy);
     window.addEventListener('cut', handleCut);
@@ -104,14 +95,14 @@ function MyApp(props) {
     const originalRead = clipboard?.readText?.bind(clipboard);
     if (originalWrite) {
       clipboard.writeText = async (text) => {
-        update('Copied to clipboard');
+        announcePolite('Copied to clipboard');
         return originalWrite(text);
       };
     }
     if (originalRead) {
       clipboard.readText = async () => {
         const text = await originalRead();
-        update('Pasted from clipboard');
+        announcePolite('Pasted from clipboard');
         return text;
       };
     }
@@ -119,7 +110,7 @@ function MyApp(props) {
     const OriginalNotification = window.Notification;
     if (OriginalNotification) {
       const WrappedNotification = function (title, options) {
-        update(`${title}${options?.body ? ' ' + options.body : ''}`);
+        announcePolite(`${title}${options?.body ? ' ' + options.body : ''}`);
         return new OriginalNotification(title, options);
       };
       WrappedNotification.requestPermission = OriginalNotification.requestPermission.bind(
@@ -158,7 +149,7 @@ function MyApp(props) {
         </a>
         <SettingsProvider>
           <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
+            <Toaster />
             <Component {...pageProps} />
             <ShortcutOverlay />
             <Analytics


### PR DESCRIPTION
## Summary
- add a shared Toaster live region that accepts polite announcements and tracks download events
- route clipboard and notification announcements through the live region host
- cover the new announcer with unit tests, including download start and completion messaging

## Testing
- yarn lint *(fails: pre-existing accessibility violations across unrelated apps)*
- yarn test __tests__/liveRegion.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c984ce7f588328b057eb99d433141b