### PR TITLE
[a11y] Refresh high contrast palette and icons

### DIFF
--- a/docs/high-contrast-palette.md
+++ b/docs/high-contrast-palette.md
@@ -1,0 +1,51 @@
+# High contrast palette reference
+
+This document records the contrast ratios for the colors that power the high-contrast theme and icon set. The values were measured with the WCAG 2.1 relative luminance formula so future assets can keep the same accessibility bar.
+
+## Theme tokens
+
+| Token | Hex | Contrast vs `#000` (background) | Contrast vs `#fff` (text) | Notes |
+| --- | --- | --- | --- | --- |
+| `--color-ub-orange`, `--game-color-secondary`, `--color-ubt-blue` | `#1A73E8` | 4.66 | 4.51 | Primary accent and link tone. Works with either white or near-black text. |
+| `--color-ub-border-orange` | `#8AB4F8` | 9.96 | 2.11 | Border highlight; pair with dark surfaces for outlines. |
+| `--color-ub-lite-abrgn`, `--color-ub-dark-grey` | `#1F2937` | 1.43 | 14.68 | Default window surface against the pure-black desktop. |
+| `--game-color-success` | `#2DDC4B` | 11.45 | 1.83 | Success state, use with dark text when it becomes a fill. |
+| `--game-color-warning` | `#FFB400` | 11.78 | 1.78 | Warning tone, reserve for icon fills or pair with black text. |
+| `--game-color-danger` | `#FF375F` | 5.96 | 3.52 | Error/danger color. Meets the 3:1 AA requirement for UI indicators. |
+| `--focus-outline-color` | `#FFD60A` | 14.88 | 1.41 | High-visibility focus ring; 3px thickness in the theme. |
+
+All neutral tokens (`--color-ub-grey`, `--color-ub-cool-grey`, and `--color-bg`) sit at or near pure black so white text keeps a 21:1 contrast ratio. The shared surface tone at `#1F2937` ensures window content stays readable while still lifting off the desktop.
+
+## Icon palette
+
+The refreshed SVG icons in `public/icons/*/high-contrast.svg` use the same colors so the brand lockup passes WCAG checks on the black tile background:
+
+- Border `#1A73E8` vs background `#000000`: 4.66:1
+- Inner bar `#FFFFFF` vs background `#000000`: 21.00:1
+- Accent wedge `#FFD60A` vs background `#000000`: 14.88:1
+- Accent wedge `#2DDC4B` vs background `#000000`: 11.45:1
+
+When creating future icons, stick to combinations that stay above 4.5:1 for small UI details and 3:1 for large fills, and keep the background pure black so the contrast ratios hold. Reuse the Python helper in `/docs` if you need to check new swatches:
+
+```python
+from math import pow
+
+def srgb_to_linear(value: int) -> float:
+    value /= 255
+    if value <= 0.03928:
+        return value / 12.92
+    return pow((value + 0.055) / 1.055, 2.4)
+
+def contrast(a: str, b: str) -> float:
+    def luminance(color: str) -> float:
+        color = color.lstrip('#')
+        r = int(color[0:2], 16)
+        g = int(color[2:4], 16)
+        b = int(color[4:6], 16)
+        return 0.2126 * srgb_to_linear(r) + 0.7152 * srgb_to_linear(g) + 0.0722 * srgb_to_linear(b)
+    l1, l2 = luminance(a), luminance(b)
+    lighter, darker = max(l1, l2), min(l1, l2)
+    return (lighter + 0.05) / (darker + 0.05)
+```
+
+Using these baseline numbers keeps interactive focus states and iconography legible in both manual high-contrast mode and the `prefers-contrast` media query.

--- a/public/icons/128/high-contrast.svg
+++ b/public/icons/128/high-contrast.svg
@@ -1,0 +1,7 @@
+<svg width="128" height="128" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="256" height="256" rx="48" fill="#000000"/>
+  <rect x="8" y="8" width="240" height="240" rx="40" fill="none" stroke="#1A73E8" stroke-width="16" stroke-linejoin="round"/>
+  <rect x="72" y="60" width="48" height="136" fill="#FFFFFF"/>
+  <path d="M120 60H176L224 116H180L120 84Z" fill="#FFD60A"/>
+  <path d="M120 196H176L224 140H180L120 172Z" fill="#2DDC4B"/>
+</svg>

--- a/public/icons/256/high-contrast.svg
+++ b/public/icons/256/high-contrast.svg
@@ -1,0 +1,7 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="256" height="256" rx="48" fill="#000000"/>
+  <rect x="8" y="8" width="240" height="240" rx="40" fill="none" stroke="#1A73E8" stroke-width="16" stroke-linejoin="round"/>
+  <rect x="72" y="60" width="48" height="136" fill="#FFFFFF"/>
+  <path d="M120 60H176L224 116H180L120 84Z" fill="#FFD60A"/>
+  <path d="M120 196H176L224 140H180L120 172Z" fill="#2DDC4B"/>
+</svg>

--- a/public/icons/48/high-contrast.svg
+++ b/public/icons/48/high-contrast.svg
@@ -1,0 +1,7 @@
+<svg width="48" height="48" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="256" height="256" rx="48" fill="#000000"/>
+  <rect x="8" y="8" width="240" height="240" rx="40" fill="none" stroke="#1A73E8" stroke-width="16" stroke-linejoin="round"/>
+  <rect x="72" y="60" width="48" height="136" fill="#FFFFFF"/>
+  <path d="M120 60H176L224 116H180L120 84Z" fill="#FFD60A"/>
+  <path d="M120 196H176L224 140H180L120 172Z" fill="#2DDC4B"/>
+</svg>

--- a/public/icons/64/high-contrast.svg
+++ b/public/icons/64/high-contrast.svg
@@ -1,0 +1,7 @@
+<svg width="64" height="64" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="256" height="256" rx="48" fill="#000000"/>
+  <rect x="8" y="8" width="240" height="240" rx="40" fill="none" stroke="#1A73E8" stroke-width="16" stroke-linejoin="round"/>
+  <rect x="72" y="60" width="48" height="136" fill="#FFFFFF"/>
+  <path d="M120 60H176L224 116H180L120 84Z" fill="#FFD60A"/>
+  <path d="M120 196H176L224 140H180L120 172Z" fill="#2DDC4B"/>
+</svg>

--- a/styles/index.css
+++ b/styles/index.css
@@ -527,6 +527,6 @@ textarea:focus-visible {
 
 /* High contrast overrides */
 .high-contrast .bg-ub-orange {
-    color: #000 !important;
+    color: #fff !important;
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -66,17 +66,26 @@
 .high-contrast {
   --color-bg: #000000;
   --color-text: #ffffff;
-  --color-ub-grey: #000000;
-  --color-ub-cool-grey: #000000;
-  --color-ubt-grey: #ffffff;
-  --color-ubt-cool-grey: #ffffff;
-  --color-ub-orange: #ffff00;
-  --color-ub-lite-abrgn: #00ffff;
-  --color-ub-border-orange: #ffff00;
-  --game-color-secondary: #ffff00;
-  --game-color-success: #00ffff;
-  --game-color-warning: #ff00ff;
-  --game-color-danger: #ff0000;
+  --color-ub-grey: #050505;
+  --color-ub-cool-grey: #111827;
+  --color-ub-dark-grey: #1f2937;
+  --color-ubt-grey: #f9fafb;
+  --color-ubt-warm-grey: #e5e7eb;
+  --color-ubt-cool-grey: #e5e7eb;
+  --color-ub-orange: #1a73e8;
+  --color-ub-lite-abrgn: #1f2937;
+  --color-ub-border-orange: #8ab4f8;
+  --color-ubt-blue: #1a73e8;
+  --color-ubt-green: #2ddc4b;
+  --color-ubt-gedit-orange: #ffb400;
+  --color-ubt-gedit-blue: #64d2ff;
+  --color-ubt-gedit-dark: #0b1727;
+  --game-color-secondary: #1a73e8;
+  --game-color-success: #2ddc4b;
+  --game-color-warning: #ffb400;
+  --game-color-danger: #ff375f;
+  --focus-outline-color: #ffd60a;
+  --focus-outline-width: 3px;
 }
 
 /* Dyslexia-friendly fonts */
@@ -109,12 +118,25 @@
   :root {
     --color-bg: #000000;
     --color-text: #ffffff;
-    --color-ub-grey: #000000;
-    --color-ub-cool-grey: #000000;
-    --color-ubt-grey: #ffffff;
-    --color-ubt-cool-grey: #ffffff;
-    --color-ub-orange: #ffff00;
-    --color-ub-lite-abrgn: #00ffff;
-    --color-ub-border-orange: #ffff00;
+    --color-ub-grey: #050505;
+    --color-ub-cool-grey: #111827;
+    --color-ub-dark-grey: #1f2937;
+    --color-ubt-grey: #f9fafb;
+    --color-ubt-warm-grey: #e5e7eb;
+    --color-ubt-cool-grey: #e5e7eb;
+    --color-ub-orange: #1a73e8;
+    --color-ub-lite-abrgn: #1f2937;
+    --color-ub-border-orange: #8ab4f8;
+    --color-ubt-blue: #1a73e8;
+    --color-ubt-green: #2ddc4b;
+    --color-ubt-gedit-orange: #ffb400;
+    --color-ubt-gedit-blue: #64d2ff;
+    --color-ubt-gedit-dark: #0b1727;
+    --game-color-secondary: #1a73e8;
+    --game-color-success: #2ddc4b;
+    --game-color-warning: #ffb400;
+    --game-color-danger: #ff375f;
+    --focus-outline-color: #ffd60a;
+    --focus-outline-width: 3px;
   }
 }


### PR DESCRIPTION
## Summary
- replace the high-contrast CSS tokens with an AA-compliant palette and brighter focus outline
- update the high-contrast background text color override and add refreshed SVG icons at 48/64/128/256
- document the measured contrast ratios for theme tokens and icon colors for future work

## Testing
- yarn lint *(fails: pre-existing jsx-a11y label violations and legacy public game scripts)*
- yarn test *(fails: known jsdom localStorage limitations in settings store tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c984dba4d4832883f4a9fe9acf01bf