### PR TITLE
Improve media sizing to reduce layout shifts

### DIFF
--- a/components/ExternalFrame.js
+++ b/components/ExternalFrame.js
@@ -16,7 +16,14 @@ const isAllowed = (src) => {
  * Iframe wrapper for allowed external sources.
  * Optionally prefetches the iframe source.
  */
-export default function ExternalFrame({ src, title, prefetch = false, onLoad: onLoadProp, ...props }) {
+export default function ExternalFrame({
+  src,
+  title,
+  prefetch = false,
+  onLoad: onLoadProp,
+  minHeight = 360,
+  ...props
+}) {
   const [cookiesBlocked, setCookiesBlocked] = useState(false);
   const [showDialog, setShowDialog] = useState(false);
   const [loaded, setLoaded] = useState(false);
@@ -51,7 +58,10 @@ export default function ExternalFrame({ src, title, prefetch = false, onLoad: on
             </button>
           </div>
         )}
-        <div className="relative flex-1">
+        <div
+          className="relative flex-1"
+          style={{ minHeight: typeof minHeight === 'number' ? `${minHeight}px` : minHeight }}
+        >
           <a
             href={src}
             target="_blank"
@@ -71,6 +81,8 @@ export default function ExternalFrame({ src, title, prefetch = false, onLoad: on
               onLoadProp?.(e);
             }}
             className={`w-full h-full ${loaded ? '' : 'invisible'}`}
+            width="100%"
+            height="100%"
             {...props}
           />
           {!loaded && (

--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -126,11 +126,20 @@ const ScrollableTimeline: React.FC = () => {
                       className="text-left w-full focus:outline-none"
                     >
                       <div className="text-ubt-blue font-bold text-lg mb-2">{year}</div>
-                      <img
-                        src={first.image}
-                        alt={first.title}
-                        className="w-full h-32 object-cover mb-2 rounded"
-                      />
+                      <div
+                        className="relative w-full mb-2 rounded overflow-hidden"
+                        style={{ aspectRatio: '4 / 3' }}
+                      >
+                        <img
+                          src={first.image}
+                          alt={first.title}
+                          width={800}
+                          height={600}
+                          className="absolute inset-0 h-full w-full object-cover"
+                          loading="lazy"
+                          decoding="async"
+                        />
+                      </div>
                       <p className="text-sm md:text-base mb-2">{first.title}</p>
                       {renderTags(first.tags)}
                     </button>
@@ -155,11 +164,20 @@ const ScrollableTimeline: React.FC = () => {
                     rel="noopener noreferrer"
                     className="block mb-2"
                   >
-                    <img
-                      src={m.image}
-                      alt={m.title}
-                      className="w-full h-32 object-cover mb-2 rounded"
-                    />
+                    <div
+                      className="relative w-full mb-2 rounded overflow-hidden"
+                      style={{ aspectRatio: '4 / 3' }}
+                    >
+                      <img
+                        src={m.image}
+                        alt={m.title}
+                        width={800}
+                        height={600}
+                        className="absolute inset-0 h-full w-full object-cover"
+                        loading="lazy"
+                        decoding="async"
+                      />
+                    </div>
                     <p className="text-sm md:text-base">{m.title}</p>
                   </a>
                   {renderTags(m.tags)}

--- a/components/YouTubePlayer.js
+++ b/components/YouTubePlayer.js
@@ -220,6 +220,9 @@ export default function YouTubePlayer({ videoId }) {
                 src={`https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`}
                 alt="YouTube video thumbnail"
                 loading="lazy"
+                decoding="async"
+                width={1280}
+                height={720}
                 className="absolute inset-0 w-full h-full object-cover"
               />
               <svg

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -11,33 +11,29 @@ import AboutSlides from './slides';
 import ScrollableTimeline from '../../ScrollableTimeline';
 
 class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_screen: string; navbar: boolean }> {
-  screens: Record<string, React.ReactNode> = {};
+  screens: Record<string, React.ReactNode> = {
+    about: <About />,
+    education: <Education />,
+    skills: <Skills skills={data.skills} />,
+    certs: <Certs />,
+    projects: <Projects projects={data.projects} />,
+    resume: <Resume />,
+  };
 
   constructor(props: unknown) {
     super(props);
     this.state = {
-      screen: <></>,
+      screen: <About />,
       active_screen: 'about',
       navbar: false,
     };
   }
 
   componentDidMount() {
-    this.screens = {
-      about: <About />,
-      education: <Education />,
-      skills: <Skills skills={data.skills} />,
-      certs: <Certs />,
-      projects: <Projects projects={data.projects} />,
-      resume: <Resume />,
-    };
-
-    let lastVisitedScreen = localStorage.getItem('about-section');
-    if (!lastVisitedScreen) {
-      lastVisitedScreen = 'about';
+    const lastVisitedScreen = localStorage.getItem('about-section') || 'about';
+    if (lastVisitedScreen !== 'about') {
+      this.changeScreen({ id: lastVisitedScreen } as unknown as EventTarget & { id: string });
     }
-
-    this.changeScreen({ id: lastVisitedScreen } as unknown as EventTarget & { id: string });
   }
 
   changeScreen = (e: any) => {
@@ -360,10 +356,14 @@ const SkillSection = ({ title, badges }: { title: string; badges: { src: string;
         {filteredBadges.map((badge) => (
           <img
             key={badge.alt}
-            className="m-1 cursor-pointer"
+            className="m-1 h-12 w-40 cursor-pointer object-contain"
             src={badge.src}
             alt={badge.alt}
             title={badge.description}
+            width={160}
+            height={48}
+            loading="lazy"
+            decoding="async"
             onClick={() => setSelected(badge)}
           />
         ))}

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -11,15 +11,6 @@ export class AboutAlex extends Component {
 
     constructor() {
         super();
-        this.screens = {};
-        this.state = {
-            screen: () => { },
-            active_screen: "about", // by default 'about' screen is active
-            navbar: false,
-        }
-    }
-
-    componentDidMount() {
         this.screens = {
             "about": <About />,
             "education": <Education />,
@@ -27,15 +18,28 @@ export class AboutAlex extends Component {
             "certs": <Certs />,
             "projects": <Projects projects={data.projects} />,
             "resume": <Resume data={resumeData} />,
+        };
+        this.state = {
+            screen: this.screens["about"],
+            active_screen: "about", // by default 'about' screen is active
+            navbar: false,
         }
+    }
 
+    componentDidMount() {
         let lastVisitedScreen = localStorage.getItem("about-section");
         if (lastVisitedScreen === null || lastVisitedScreen === undefined) {
             lastVisitedScreen = "about";
         }
 
-        // focus last visited screen
-        this.changeScreen(document.getElementById(lastVisitedScreen));
+        if (lastVisitedScreen !== "about") {
+            const target = document.getElementById(lastVisitedScreen);
+            if (target) {
+                this.changeScreen(target);
+            } else {
+                this.changeScreen({ id: lastVisitedScreen });
+            }
+        }
     }
 
     changeScreen = (e) => {
@@ -312,10 +316,14 @@ const SkillSection = ({ title, badges }) => {
         {filteredBadges.map(badge => (
           <img
             key={badge.alt}
-            className="m-1 cursor-pointer"
+            className="m-1 h-12 w-40 cursor-pointer object-contain"
             src={badge.src}
             alt={badge.alt}
             title={badge.description}
+            width={160}
+            height={48}
+            loading="lazy"
+            decoding="async"
             onClick={() => setSelected(badge)}
           />
         ))}
@@ -377,6 +385,10 @@ function Skills({ skills }) {
             src="https://ghchart.rshah.org/Alex-Unnippillil"
             alt="Alex Unnippillil's GitHub contribution graph"
             className="w-full rounded"
+            width={876}
+            height={128}
+            loading="lazy"
+            decoding="async"
           />
         </div>
       </div>

--- a/components/apps/qr/index.tsx
+++ b/components/apps/qr/index.tsx
@@ -116,7 +116,13 @@ const QRScanner: React.FC = () => {
   return (
     <div className="p-4 space-y-4 text-white bg-ub-cool-grey h-full flex flex-col items-center">
       <div className="relative w-full max-w-sm">
-        <video ref={videoRef} className="w-full rounded-md border-2 border-white bg-black" />
+        <video
+          ref={videoRef}
+          className="w-full rounded-md border-2 border-white bg-black"
+          width={640}
+          height={480}
+          playsInline
+        />
         <div className="absolute top-2 right-2 flex gap-2">
           <button
             type="button"
@@ -143,7 +149,11 @@ const QRScanner: React.FC = () => {
             <img
               src={preview}
               alt="QR preview"
-              className="w-32 h-32 rounded-md border"
+              className="w-32 h-32 rounded-md border object-contain"
+              width={128}
+              height={128}
+              loading="lazy"
+              decoding="async"
             />
           )}
           <div className="flex-1 min-w-0">

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -19,7 +19,11 @@ export default function LockScreen(props) {
             <img
                 src={`/wallpapers/${wallpaper}.webp`}
                 alt=""
+                width={3840}
+                height={2160}
                 className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+                loading="lazy"
+                decoding="async"
             />
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
                 <div className=" text-7xl">

--- a/components/ui/VideoPlayer.tsx
+++ b/components/ui/VideoPlayer.tsx
@@ -7,12 +7,14 @@ interface VideoPlayerProps {
   src: string;
   poster?: string;
   className?: string;
+  aspectRatio?: string;
 }
 
 const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
   src,
   poster,
   className = "",
+  aspectRatio = "16 / 9",
 }) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const { open, close } = usePipPortal();
@@ -128,8 +130,11 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
   };
 
   return (
-    <div className={`relative ${className}`.trim()}>
-      <video ref={videoRef} src={src} poster={poster} controls className="w-full h-auto" />
+    <div
+      className={`relative ${className}`.trim()}
+      style={aspectRatio ? { aspectRatio } : undefined}
+    >
+      <video ref={videoRef} src={src} poster={poster} controls className="h-full w-full" />
       {pipSupported && (
         <button
           type="button"

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -41,7 +41,11 @@ export default function BackgroundImage() {
             <img
                 src={`/wallpapers/${wallpaper}.webp`}
                 alt=""
+                width={3840}
+                height={2160}
                 className="w-full h-full object-cover"
+                loading="eager"
+                decoding="async"
             />
             {needsOverlay && (
                 <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>

--- a/pages/qr/index.tsx
+++ b/pages/qr/index.tsx
@@ -351,7 +351,13 @@ const QRPage: React.FC = () => {
         )}
       </div>
       <div className="w-full max-w-md">
-        <video ref={videoRef} className="h-48 w-full rounded border" />
+        <video
+          ref={videoRef}
+          className="h-48 w-full rounded border"
+          width={640}
+          height={480}
+          playsInline
+        />
         {scanResult && (
           <p className="mt-2 text-center text-sm">Decoded: {scanResult}</p>
         )}


### PR DESCRIPTION
## Summary
- add explicit dimensions to wallpaper overlays, timeline thumbnails, and YouTube previews so full-screen and hero imagery render without shifting
- render the About window’s initial content immediately and size skill badges/GitHub chart placeholders to keep the desktop layout stable
- normalize aspect ratios for videos and embeds, including shared VideoPlayer, ExternalFrame iframes, and QR scanner previews, to give each surface a predictable footprint

## Testing
- `npx @lhci/cli@0.13.0 autorun --collect.url=http://localhost:3000 --collect.numberOfRuns=1 --collect.settings.preset=desktop --collect.settings.chromeFlags="--headless --no-sandbox --disable-dev-shm-usage" --upload.target=filesystem --upload.outputDir=./lhci-desktop`
- `yarn lint` *(fails: pre-existing accessibility and window/document lint violations)*
- `yarn test` *(fails: pre-existing act/localStorage warnings in test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c984f756848328916c3e693420f142