### PR TITLE
[rtl] add locale-aware direction handling

### DIFF
--- a/components/apps/reaver/index.js
+++ b/components/apps/reaver/index.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import data from './data/handshakes.json';
-import SmallArrow from '../../util-components/small_arrow';
+import LogicalArrow from '../../shared/LogicalArrow';
 
 const ReaverStepper = () => {
   const { handshakes, risks, defenses } = data;
@@ -33,7 +33,9 @@ const ReaverStepper = () => {
               direction === 'right' ? 'arrow-right' : 'arrow-left'
             }`}
           >
-            <SmallArrow angle={direction} />
+            <LogicalArrow
+              direction={direction === 'right' ? 'end' : 'start'}
+            />
           </div>
           <span className="absolute left-0 -top-6 text-xs">
             {messages[current].from}

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import DirectionalIcon from '../shared/DirectionalIcon';
+import { useDirection } from '../shared/DirectionProvider';
 
 type AppMeta = {
   id: string;
@@ -27,6 +28,7 @@ const WhiskerMenu: React.FC = () => {
   const [highlight, setHighlight] = useState(0);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const { isRTL } = useDirection();
 
   const allApps: AppMeta[] = apps as any;
   const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
@@ -122,19 +124,20 @@ const WhiskerMenu: React.FC = () => {
         onClick={() => setOpen(o => !o)}
         className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
       >
-        <Image
+        <DirectionalIcon
           src="/themes/Yaru/status/decompiler-symbolic.svg"
           alt="Menu"
           width={16}
           height={16}
-          className="inline mr-1"
+          className={`inline ${isRTL ? 'ml-1' : 'mr-1'}`}
+          sizes="16px"
         />
         Applications
       </button>
       {open && (
         <div
           ref={menuRef}
-          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
+          className={`absolute ${isRTL ? 'right-0' : 'left-0'} mt-1 z-50 flex ${isRTL ? 'flex-row-reverse' : ''} bg-ub-grey text-white shadow-lg`}
           tabIndex={-1}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node)) {
@@ -142,11 +145,11 @@ const WhiskerMenu: React.FC = () => {
             }
           }}
         >
-          <div className="flex flex-col bg-gray-800 p-2">
+          <div className={`flex flex-col bg-gray-800 p-2 ${isRTL ? 'items-end text-right' : ''}`}>
             {CATEGORIES.map(cat => (
               <button
                 key={cat.id}
-                className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
+                className={`px-2 py-1 rounded mb-1 ${isRTL ? 'text-right' : 'text-left'} ${category === cat.id ? 'bg-gray-700' : ''}`}
                 onClick={() => setCategory(cat.id)}
               >
                 {cat.label}
@@ -155,7 +158,7 @@ const WhiskerMenu: React.FC = () => {
           </div>
           <div className="p-3">
             <input
-              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+              className={`mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none ${isRTL ? 'text-right' : ''}`}
               placeholder="Search"
               value={query}
               onChange={e => setQuery(e.target.value)}

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import Image from 'next/image'
 import SideBarApp from '../base/side_bar_app';
+import { useDirection } from '../shared/DirectionProvider';
 
 let renderApps = (props) => {
     let sideBarAppsJsx = [];
@@ -14,6 +15,8 @@ let renderApps = (props) => {
 }
 
 export default function SideBar(props) {
+
+    const { isRTL } = useDirection();
 
     function showSideBar() {
         props.hideSideBar(null, false);
@@ -29,8 +32,7 @@ export default function SideBar(props) {
         <>
             <nav
                 aria-label="Dock"
-                className={(props.hide ? " -translate-x-full " : "") +
-                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
+                className={`absolute transform duration-300 select-none z-40 ${isRTL ? 'right-0' : 'left-0'} top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50 ${props.hide ? (isRTL ? 'translate-x-full' : '-translate-x-full') : ''}`}
             >
                 {
                     (
@@ -41,7 +43,7 @@ export default function SideBar(props) {
                 }
                 <AllApps showApps={props.showAllApps} />
             </nav>
-            <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className={"w-1 h-full absolute top-0 left-0 bg-transparent z-50"}></div>
+            <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className={`w-1 h-full absolute top-0 ${isRTL ? 'right-0' : 'left-0'} bg-transparent z-50`}></div>
         </>
     )
 }
@@ -49,6 +51,7 @@ export default function SideBar(props) {
 export function AllApps(props) {
 
     const [title, setTitle] = useState(false);
+    const { isRTL } = useDirection();
 
     return (
         <div
@@ -72,10 +75,7 @@ export function AllApps(props) {
                     sizes="28px"
                 />
                 <div
-                    className={
-                        (title ? " visible " : " invisible ") +
-                        " w-max py-0.5 px-1.5 absolute top-1 left-full ml-5 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
-                    }
+                    className={`${title ? 'visible' : 'invisible'} w-max py-0.5 px-1.5 absolute top-1 ${isRTL ? 'right-full mr-5 text-right' : 'left-full ml-5'} text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md`}
                 >
                     Show Applications
                 </div>

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,8 +1,10 @@
 import React from 'react';
-import Image from 'next/image';
+import DirectionalIcon from '../shared/DirectionalIcon';
+import { useDirection } from '../shared/DirectionProvider';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const { isRTL } = useDirection();
 
     const handleClick = (app) => {
         const id = app.id;
@@ -16,7 +18,11 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div
+            className={`taskbar-root absolute bottom-0 w-full h-10 bg-black bg-opacity-50 flex ${isRTL ? 'flex-row-reverse' : ''} items-center z-40`}
+            role="toolbar"
+            style={{ left: isRTL ? 'auto' : 0, right: isRTL ? 0 : 'auto' }}
+        >
             {runningApps.map(app => (
                 <button
                     key={app.id}
@@ -25,10 +31,9 @@ export default function Taskbar(props) {
                     data-context="taskbar"
                     data-app-id={app.id}
                     onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                    className={`${props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' '}relative flex items-center ${isRTL ? 'flex-row-reverse' : ''} mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10`}
                 >
-                    <Image
+                    <DirectionalIcon
                         width={24}
                         height={24}
                         className="w-5 h-5"
@@ -36,7 +41,7 @@ export default function Taskbar(props) {
                         alt=""
                         sizes="24px"
                     />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                    <span className={`${isRTL ? 'mr-1 text-right' : 'ml-1'} text-sm text-white whitespace-nowrap`}>{app.title}</span>
                     {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
                         <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
                     )}

--- a/components/shared/DirectionProvider.tsx
+++ b/components/shared/DirectionProvider.tsx
@@ -1,0 +1,74 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { useRouter } from 'next/router';
+import { getDirectionFromLocale, TextDirection } from '../../lib/direction';
+
+interface DirectionContextValue {
+  dir: TextDirection;
+  isRTL: boolean;
+  locale?: string;
+}
+
+const DirectionContext = createContext<DirectionContextValue>({
+  dir: 'ltr',
+  isRTL: false,
+  locale: undefined,
+});
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export const DirectionProvider: React.FC<Props> = ({ children }) => {
+  const { locale, defaultLocale } = useRouter();
+  const documentLocale =
+    typeof document !== 'undefined' ? document.documentElement.lang : undefined;
+  const navigatorLocale =
+    typeof navigator !== 'undefined'
+      ? navigator.language || navigator.languages?.[0]
+      : undefined;
+  const effectiveLocale = locale ?? documentLocale ?? defaultLocale ?? navigatorLocale;
+
+  const [dir, setDir] = useState<TextDirection>(() =>
+    getDirectionFromLocale(effectiveLocale, 'ltr'),
+  );
+
+  useEffect(() => {
+    const docLocale =
+      typeof document !== 'undefined' ? document.documentElement.lang : undefined;
+    const navLocale =
+      typeof navigator !== 'undefined'
+        ? navigator.language || navigator.languages?.[0]
+        : undefined;
+    const nextLocale = locale ?? docLocale ?? defaultLocale ?? navLocale;
+    setDir((prev) => {
+      const nextDir = getDirectionFromLocale(nextLocale, prev);
+      return nextDir;
+    });
+  }, [locale, defaultLocale]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    root.setAttribute('dir', dir);
+    if (effectiveLocale) {
+      root.setAttribute('lang', effectiveLocale);
+    }
+  }, [dir, effectiveLocale]);
+
+  const value = useMemo(
+    () => ({ dir, isRTL: dir === 'rtl', locale: effectiveLocale }),
+    [dir, effectiveLocale],
+  );
+
+  return (
+    <DirectionContext.Provider value={value}>{children}</DirectionContext.Provider>
+  );
+};
+
+export const useDirection = (): DirectionContextValue => useContext(DirectionContext);

--- a/components/shared/DirectionalIcon.tsx
+++ b/components/shared/DirectionalIcon.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Image, { ImageProps } from 'next/image';
+import { useDirection } from './DirectionProvider';
+
+type Props = ImageProps & {
+  flipForRtl?: boolean;
+};
+
+const DirectionalIcon: React.FC<Props> = ({ flipForRtl = false, className, ...props }) => {
+  const { isRTL } = useDirection();
+  const classes = [className, flipForRtl && isRTL ? 'rtl-flip' : '']
+    .filter(Boolean)
+    .join(' ')
+    .trim();
+
+  return <Image {...props} className={classes || undefined} />;
+};
+
+export default DirectionalIcon;

--- a/components/shared/LogicalArrow.tsx
+++ b/components/shared/LogicalArrow.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import SmallArrow from '../util-components/small_arrow';
+import { useDirection } from './DirectionProvider';
+
+type LogicalDirection = 'up' | 'down' | 'left' | 'right' | 'start' | 'end';
+
+interface Props {
+  direction: LogicalDirection;
+  className?: string;
+}
+
+const LogicalArrow: React.FC<Props> = ({ direction, className }) => {
+  const { isRTL } = useDirection();
+
+  const resolved = React.useMemo(() => {
+    if (direction === 'start') {
+      return isRTL ? 'right' : 'left';
+    }
+    if (direction === 'end') {
+      return isRTL ? 'left' : 'right';
+    }
+    if (direction === 'left') {
+      return isRTL ? 'right' : 'left';
+    }
+    if (direction === 'right') {
+      return isRTL ? 'left' : 'right';
+    }
+    return direction;
+  }, [direction, isRTL]);
+
+  return <SmallArrow angle={resolved} className={className} />;
+};
+
+export default LogicalArrow;

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,7 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import { useDirection } from '../shared/DirectionProvider';
 
 interface Props {
   open: boolean;
@@ -12,6 +13,7 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const { isRTL } = useDirection();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -23,7 +25,7 @@ const QuickSettings = ({ open }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 ${isRTL ? 'left-3' : 'right-3'} shadow border-black border border-opacity-20 ${
         open ? '' : 'hidden'
       }`}
     >

--- a/components/util-components/small_arrow.js
+++ b/components/util-components/small_arrow.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './small_arrow.module.css';
 
-export default function SmallArrow({ angle = 'up' }) {
+export default function SmallArrow({ angle = 'up', className = '' }) {
     const rotations = {
         up: '',
         down: 'rotate-180',
@@ -9,5 +9,10 @@ export default function SmallArrow({ angle = 'up' }) {
         right: 'rotate-90',
     };
 
-    return <div className={`${styles.arrow} ${rotations[angle] ?? ''}`}></div>;
+    const classes = [styles.arrow, rotations[angle] ?? '', className]
+        .filter(Boolean)
+        .join(' ')
+        .trim();
+
+    return <div className={classes}></div>;
 }

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import Image from 'next/image';
-import SmallArrow from "./small_arrow";
+import LogicalArrow from "../shared/LogicalArrow";
 import { useSettings } from '../../hooks/useSettings';
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
@@ -77,7 +77,7 @@ export default function Status() {
         />
       </span>
       <span className="mx-1">
-        <SmallArrow angle="down" className=" status-symbol" />
+        <LogicalArrow direction="down" className="status-symbol" />
       </span>
     </div>
   );

--- a/lib/direction.ts
+++ b/lib/direction.ts
@@ -1,0 +1,60 @@
+export type TextDirection = 'ltr' | 'rtl';
+
+const RTL_LOCALES = new Set([
+  'ar',
+  'arc',
+  'ckb',
+  'dv',
+  'fa',
+  'he',
+  'ku',
+  'ps',
+  'sd',
+  'ug',
+  'ur',
+  'yi',
+]);
+
+const normalizeLocale = (locale?: string | null): string | undefined => {
+  if (!locale) return undefined;
+  return locale.toLowerCase();
+};
+
+export const isRtlLocale = (locale?: string | null): boolean => {
+  const normalized = normalizeLocale(locale);
+  if (!normalized) return false;
+  if (RTL_LOCALES.has(normalized)) return true;
+  const base = normalized.split('-')[0];
+  return RTL_LOCALES.has(base);
+};
+
+export const getDirectionFromLocale = (
+  locale?: string | null,
+  fallback: TextDirection = 'ltr',
+): TextDirection => {
+  if (locale) {
+    return isRtlLocale(locale) ? 'rtl' : 'ltr';
+  }
+
+  if (typeof document !== 'undefined') {
+    const explicitDir = document.documentElement.getAttribute('dir');
+    if (explicitDir === 'rtl' || explicitDir === 'ltr') {
+      return explicitDir;
+    }
+    const langAttr = document.documentElement.getAttribute('lang');
+    if (langAttr && isRtlLocale(langAttr)) {
+      return 'rtl';
+    }
+  }
+
+  if (typeof navigator !== 'undefined') {
+    const navLang = navigator.language || navigator.languages?.[0];
+    if (navLang && isRtlLocale(navLang)) {
+      return 'rtl';
+    }
+  }
+
+  return fallback;
+};
+
+export { RTL_LOCALES };

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { DirectionProvider } from '../components/shared/DirectionProvider';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -150,29 +151,31 @@ function MyApp(props) {
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
-        <a
-          href="#app-grid"
-          className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
-        >
-          Skip to app grid
-        </a>
-        <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+        <DirectionProvider>
+          <a
+            href="#app-grid"
+            className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
+          >
+            Skip to app grid
+          </a>
+          <SettingsProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
-        </SettingsProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </SettingsProvider>
+        </DirectionProvider>
       </div>
     </ErrorBoundary>
 

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,4 +1,5 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { getDirectionFromLocale } from '../lib/direction';
 
 class MyDocument extends Document {
   /**
@@ -11,9 +12,11 @@ class MyDocument extends Document {
   }
 
   render() {
-    const { nonce } = this.props;
+    const { nonce, locale } = this.props;
+    const lang = locale || 'en';
+    const dir = getDirectionFromLocale(lang, 'ltr');
     return (
-      <Html lang="en" data-csp-nonce={nonce}>
+      <Html lang={lang} dir={dir} data-csp-nonce={nonce}>
         <Head>
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,4 +1,5 @@
 @import './globals.css';
+@import './rtl.css';
 
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);

--- a/styles/rtl.css
+++ b/styles/rtl.css
@@ -1,0 +1,24 @@
+html[dir='rtl'] body {
+  direction: rtl;
+}
+
+html[dir='rtl'] #monitor-screen {
+  direction: rtl;
+}
+
+html[dir='rtl'] .main-navbar-vp {
+  flex-direction: row-reverse;
+}
+
+html[dir='rtl'] .main-navbar-vp > * {
+  direction: rtl;
+}
+
+html[dir='rtl'] nav[aria-label='Dock'] {
+  direction: rtl;
+}
+
+html[dir='rtl'] .rtl-flip {
+  display: inline-block;
+  transform: scaleX(-1);
+}


### PR DESCRIPTION
## Summary
- add locale-aware direction helpers and provider to propagate `dir` and locale metadata across the app shell【F:lib/direction.ts†L1-L58】【F:components/shared/DirectionProvider.tsx†L1-L74】
- introduce RTL-specific stylesheet and update dock, taskbar, menu, and quick settings UI to mirror layout when `isRTL`【F:styles/rtl.css†L1-L24】【F:components/screen/side_bar.js†L1-L84】【F:components/screen/taskbar.js†L1-L52】【F:components/menu/WhiskerMenu.tsx†L1-L187】【F:components/ui/QuickSettings.tsx†L1-L61】
- provide shared direction-aware icon and arrow helpers and apply them to status indicators and Reaver stepper visuals【F:components/shared/DirectionalIcon.tsx†L1-L16】【F:components/shared/LogicalArrow.tsx†L1-L24】【F:components/util-components/status.js†L1-L84】【F:components/apps/reaver/index.js†L1-L76】

## Testing
- yarn lint *(fails: existing accessibility rule violations across legacy apps)*【029712†L1-L121】
- yarn test *(fails: multiple pre-existing Jest suites such as window and reconNG tests)*【6266ff†L1-L139】

------
https://chatgpt.com/codex/tasks/task_e_68c984f3994483289b0b3982cfdf888a