### PR TITLE
[components] Fix persistent state hydration mismatches

### DIFF
--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import Tabs from "../Tabs";
 import ToggleSwitch from "../ToggleSwitch";
 
@@ -17,48 +17,70 @@ export default function Preferences() {
   ];
 
   const [active, setActive] = useState<TabId>("display");
-
-  const [size, setSize] = useState(() => {
-    if (typeof window === "undefined") return 24;
-    const stored = localStorage.getItem(`${PANEL_PREFIX}size`);
-    return stored ? parseInt(stored, 10) : 24;
-  });
-  const [length, setLength] = useState(() => {
-    if (typeof window === "undefined") return 100;
-    const stored = localStorage.getItem(`${PANEL_PREFIX}length`);
-    return stored ? parseInt(stored, 10) : 100;
-  });
-  const [orientation, setOrientation] = useState<"horizontal" | "vertical">(() => {
-    if (typeof window === "undefined") return "horizontal";
-    return (localStorage.getItem(`${PANEL_PREFIX}orientation`) as
-      | "horizontal"
-      | "vertical"
-      | null) || "horizontal";
-  });
-  const [autohide, setAutohide] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return localStorage.getItem(`${PANEL_PREFIX}autohide`) === "true";
-  });
+  const [size, setSize] = useState(24);
+  const [length, setLength] = useState(100);
+  const [orientation, setOrientation] = useState<"horizontal" | "vertical">(
+    "horizontal",
+  );
+  const [autohide, setAutohide] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    localStorage.setItem(`${PANEL_PREFIX}size`, String(size));
-  }, [size]);
+    try {
+      const storedSize = window.localStorage.getItem(`${PANEL_PREFIX}size`);
+      if (storedSize) {
+        const parsed = Number.parseInt(storedSize, 10);
+        if (!Number.isNaN(parsed)) {
+          setSize((prev) => (prev === parsed ? prev : parsed));
+        }
+      }
+
+      const storedLength = window.localStorage.getItem(`${PANEL_PREFIX}length`);
+      if (storedLength) {
+        const parsed = Number.parseInt(storedLength, 10);
+        if (!Number.isNaN(parsed)) {
+          setLength((prev) => (prev === parsed ? prev : parsed));
+        }
+      }
+
+      const storedOrientation = window.localStorage.getItem(
+        `${PANEL_PREFIX}orientation`,
+      );
+      if (storedOrientation === "horizontal" || storedOrientation === "vertical") {
+        setOrientation((prev) =>
+          prev === storedOrientation ? prev : storedOrientation,
+        );
+      }
+
+      const storedAutohide = window.localStorage.getItem(
+        `${PANEL_PREFIX}autohide`,
+      );
+      if (storedAutohide !== null) {
+        const next = storedAutohide === "true";
+        setAutohide((prev) => (prev === next ? prev : next));
+      }
+    } catch {
+      // ignore read errors and fall back to defaults
+    }
+
+    setHydrated(true);
+  }, []);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    localStorage.setItem(`${PANEL_PREFIX}length`, String(length));
-  }, [length]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    localStorage.setItem(`${PANEL_PREFIX}orientation`, orientation);
-  }, [orientation]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    localStorage.setItem(`${PANEL_PREFIX}autohide`, autohide ? "true" : "false");
-  }, [autohide]);
+    if (!hydrated || typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(`${PANEL_PREFIX}size`, String(size));
+      window.localStorage.setItem(`${PANEL_PREFIX}length`, String(length));
+      window.localStorage.setItem(`${PANEL_PREFIX}orientation`, orientation);
+      window.localStorage.setItem(
+        `${PANEL_PREFIX}autohide`,
+        autohide ? "true" : "false",
+      );
+    } catch {
+      // ignore write errors
+    }
+  }, [autohide, hydrated, length, orientation, size]);
 
   return (
     <div>

--- a/hooks/usePersistentState.js
+++ b/hooks/usePersistentState.js
@@ -1,44 +1,65 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 // Persist state in localStorage with validation and helpers.
 export default function usePersistentState(key, initial, validator) {
-  const getInitial = () => (typeof initial === "function" ? initial() : initial);
+  const initialRef = useRef(initial);
+  useEffect(() => {
+    initialRef.current = initial;
+  }, [initial]);
 
-  const [state, setState] = useState(() => {
-    if (typeof window === "undefined") return getInitial();
+  const getInitial = useCallback(() => {
+    const value = initialRef.current;
+    return typeof value === "function" ? value() : value;
+  }, []);
+
+  const [state, setState] = useState(() => getInitial());
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    let nextValue = getInitial();
     try {
       const stored = window.localStorage.getItem(key);
       if (stored !== null) {
         const parsed = JSON.parse(stored);
         if (!validator || validator(parsed)) {
-          return parsed;
+          nextValue = parsed;
         }
       }
     } catch {
-      // ignore parsing errors and fall back
+      // ignore parsing errors and fall back to the initial value
     }
-    return getInitial();
-  });
+
+    setState((prev) => (Object.is(prev, nextValue) ? prev : nextValue));
+    setReady(true);
+  }, [getInitial, key, validator]);
 
   useEffect(() => {
+    if (!ready || typeof window === "undefined") return;
     try {
       window.localStorage.setItem(key, JSON.stringify(state));
     } catch {
       // ignore write errors
     }
-  }, [key, state]);
+  }, [key, ready, state]);
 
-  const reset = () => setState(getInitial());
-  const clear = () => {
-    try {
-      window.localStorage.removeItem(key);
-    } catch {
-      // ignore remove errors
+  const reset = useCallback(() => {
+    setState(getInitial());
+  }, [getInitial]);
+
+  const clear = useCallback(() => {
+    if (typeof window !== "undefined") {
+      try {
+        window.localStorage.removeItem(key);
+      } catch {
+        // ignore remove errors
+      }
     }
     reset();
-  };
+  }, [key, reset]);
 
   return [state, setState, reset, clear];
 }


### PR DESCRIPTION
## Summary
- update the persistent state hook to hydrate from localStorage after mount so SSR and CSR render the same default markup
- defer writing back to storage until after hydration and reuse defaults when stored data is invalid
- initialize panel preferences with static defaults and only read/write saved settings once the client has mounted

## Testing
- yarn lint *(fails: existing repo accessibility violations and public asset lint errors)*
- yarn test *(fails: existing reconng localStorage error and other legacy jest failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c984f7a1f4832890afbf2afb3f7751