### PR TITLE
[workers] add worker pool for heavy client tasks

### DIFF
--- a/src/workers/image.ts
+++ b/src/workers/image.ts
@@ -1,0 +1,46 @@
+import QRCode from 'qrcode';
+import type { QRCodeToStringOptions } from 'qrcode';
+
+import { WorkerPool, type WorkerPoolTask } from './workerPool';
+
+export interface QrEncodeMessage {
+  text: string;
+  opts: QRCodeToStringOptions;
+}
+
+export interface QrEncodeResult {
+  png: string;
+  svg: string;
+}
+
+const createQrWorker = () =>
+  new Worker(new URL('../../workers/qrEncode.worker.ts', import.meta.url));
+
+const qrPool = new WorkerPool<QrEncodeMessage, QrEncodeResult>({
+  size: 2,
+  createWorker: createQrWorker,
+});
+
+const isQrResult = (data: unknown): data is QrEncodeResult =>
+  typeof data === 'object' &&
+  data !== null &&
+  typeof (data as { png?: unknown }).png === 'string' &&
+  typeof (data as { svg?: unknown }).svg === 'string';
+
+export const queueQrEncode = (
+  text: string,
+  opts: QRCodeToStringOptions,
+): WorkerPoolTask<QrEncodeResult> =>
+  qrPool.runTask(
+    { text, opts },
+    {
+      resolve: (data) => (isQrResult(data) ? data : undefined),
+      fallback: async () => {
+        const value = text || ' ';
+        const png = await QRCode.toDataURL(value, opts);
+        const svg = await QRCode.toString(value, { ...(opts as any), type: 'svg' });
+        return { png, svg };
+      },
+    },
+  );
+

--- a/src/workers/parsing.ts
+++ b/src/workers/parsing.ts
@@ -1,0 +1,171 @@
+import { WorkerPool, type WorkerPoolTask, TASK_CANCELLED } from './workerPool';
+import type {
+  SimulatorParserRequest,
+  SimulatorParserResponse,
+  ParsedLine,
+} from '../../workers/simulatorParser.worker';
+
+type FixturesParseMessage =
+  | { type: 'parse'; text: string }
+  | { type: 'cancel' };
+
+type FixturesWorkerResponse =
+  | { type: 'progress'; payload: number }
+  | { type: 'result'; payload: any[] }
+  | { type: 'cancelled' };
+
+interface SimulatorProgressPayload {
+  progress: number;
+  eta: number;
+}
+
+export interface FixtureParseOptions {
+  onProgress?: (progress: number) => void;
+}
+
+export interface SimulatorParseOptions {
+  onProgress?: (payload: SimulatorProgressPayload) => void;
+}
+
+const createFixturesWorker = () =>
+  new Worker(new URL('../../workers/fixturesParser.ts', import.meta.url));
+
+const createSimulatorWorker = () =>
+  new Worker(new URL('../../workers/simulatorParser.worker.ts', import.meta.url));
+
+const fixturesPool = new WorkerPool<FixturesParseMessage, any[]>({
+  size: 2,
+  createWorker: createFixturesWorker,
+});
+
+const simulatorPool = new WorkerPool<SimulatorParserRequest, ParsedLine[]>({
+  size: 2,
+  createWorker: createSimulatorWorker,
+});
+
+const isFixturesProgress = (data: unknown): data is { type: 'progress'; payload: number } =>
+  typeof data === 'object' && data !== null && (data as FixturesWorkerResponse).type === 'progress';
+
+const isFixturesResult = (data: unknown): data is { type: 'result'; payload: any[] } =>
+  typeof data === 'object' && data !== null && (data as FixturesWorkerResponse).type === 'result';
+
+const isFixturesCancelled = (data: unknown): data is { type: 'cancelled' } =>
+  typeof data === 'object' && data !== null && (data as FixturesWorkerResponse).type === 'cancelled';
+
+const parseFixturesFallback = (
+  text: string,
+  onProgress?: (progress: number) => void,
+) => {
+  const lines = text.split(/\n/);
+  const total = lines.length || 1;
+  const result: any[] = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    try {
+      result.push(JSON.parse(line));
+    } catch {
+      result.push({ line });
+    }
+    if (i % 100 === 0) {
+      onProgress?.(Math.round(((i + 1) / total) * 100));
+    }
+  }
+  onProgress?.(100);
+  return result;
+};
+
+const parseSimulatorFallback = (
+  text: string,
+  onProgress?: (payload: SimulatorProgressPayload) => void,
+): ParsedLine[] => {
+  const lines = text.split(/\r?\n/);
+  const total = lines.length || 1;
+  const start = Date.now();
+  const parsed: ParsedLine[] = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const [key, ...rest] = line.split(':');
+    parsed.push({
+      line: i + 1,
+      key: key.trim(),
+      value: rest.join(':').trim(),
+      raw: line,
+    });
+    if (i % 100 === 0) {
+      const progress = (i + 1) / total;
+      const elapsed = Date.now() - start;
+      const eta = progress > 0 ? (elapsed * (1 - progress)) / progress : 0;
+      onProgress?.({ progress, eta });
+    }
+  }
+  onProgress?.({ progress: 1, eta: 0 });
+  return parsed;
+};
+
+export const parseFixtures = (
+  text: string,
+  options: FixtureParseOptions = {},
+): WorkerPoolTask<any[]> =>
+  fixturesPool.runTask(
+    { type: 'parse', text },
+    {
+      onMessage: (data) => {
+        if (isFixturesProgress(data)) {
+          options.onProgress?.(data.payload);
+        }
+      },
+      resolve: (data) => {
+        if (isFixturesResult(data)) return data.payload;
+        if (isFixturesCancelled(data)) return TASK_CANCELLED;
+        return undefined;
+      },
+      onCancel: (worker) => {
+        try {
+          worker.postMessage({ type: 'cancel' });
+        } catch {
+          /* ignore */
+        }
+      },
+      fallback: () => parseFixturesFallback(text, options.onProgress),
+    },
+  );
+
+const isSimulatorProgress = (
+  data: SimulatorParserResponse,
+): data is Extract<SimulatorParserResponse, { type: 'progress' }> =>
+  data?.type === 'progress';
+
+export const parseSimulator = (
+  text: string,
+  options: SimulatorParseOptions = {},
+): WorkerPoolTask<ParsedLine[]> =>
+  simulatorPool.runTask(
+    { action: 'parse', text },
+    {
+      onMessage: (data) => {
+        const response = data as SimulatorParserResponse;
+        if (isSimulatorProgress(response)) {
+          options.onProgress?.({
+            progress: response.progress,
+            eta: response.eta,
+          });
+        }
+      },
+      resolve: (data) => {
+        const response = data as SimulatorParserResponse;
+        if (response?.type === 'done') return response.parsed;
+        if (response?.type === 'cancelled') return TASK_CANCELLED;
+        return undefined;
+      },
+      onCancel: (worker) => {
+        try {
+          worker.postMessage({ action: 'cancel' } satisfies SimulatorParserRequest);
+        } catch {
+          /* ignore */
+        }
+      },
+      fallback: () => parseSimulatorFallback(text, options.onProgress),
+    },
+  );
+

--- a/src/workers/workerPool.ts
+++ b/src/workers/workerPool.ts
@@ -1,0 +1,280 @@
+const CANCEL_ERROR_NAME = 'AbortError';
+
+export const TASK_CANCELLED = Symbol('worker-task-cancelled');
+
+export class TaskCancelledError extends Error {
+  constructor(message = 'Task cancelled') {
+    super(message);
+    this.name = CANCEL_ERROR_NAME;
+  }
+}
+
+const createCancelError = () => new TaskCancelledError();
+
+export const isTaskCancelledError = (err: unknown): err is TaskCancelledError =>
+  err instanceof Error && err.name === CANCEL_ERROR_NAME;
+
+const getDefaultConcurrency = () => {
+  if (typeof navigator !== 'undefined' && navigator.hardwareConcurrency) {
+    const cores = navigator.hardwareConcurrency;
+    if (Number.isFinite(cores) && cores > 0) {
+      return Math.min(4, Math.max(1, Math.floor(cores / 2)));
+    }
+  }
+  return 2;
+};
+
+type ResolveResult<TResult> = TResult | typeof TASK_CANCELLED | undefined;
+
+type ResolveFn<TResult> = (data: unknown) => ResolveResult<TResult>;
+
+type WorkerFactory = () => Worker;
+
+export interface WorkerTaskOptions<TResult> {
+  onMessage?: (data: unknown) => void;
+  resolve?: ResolveFn<TResult>;
+  transfer?: Transferable[];
+  onCancel?: (worker: Worker) => void;
+  fallback?: () => TResult | Promise<TResult>;
+}
+
+interface WorkerTask<TMessage, TResult> {
+  message: TMessage;
+  transfer?: Transferable[];
+  onMessage?: (data: unknown) => void;
+  resolveExtractor: ResolveFn<TResult>;
+  onCancel?: (worker: Worker) => void;
+  resolve: (value: TResult) => void;
+  reject: (reason?: unknown) => void;
+  cancelled: boolean;
+}
+
+export interface WorkerPoolTask<TResult> {
+  promise: Promise<TResult>;
+  cancel: () => void;
+}
+
+export interface WorkerPoolOptions<TMessage, TResult> {
+  size?: number;
+  createWorker: WorkerFactory;
+}
+
+export class WorkerPool<TMessage, TResult> {
+  private readonly size: number;
+
+  private readonly createWorker: WorkerFactory;
+
+  private readonly queue: WorkerTask<TMessage, TResult>[] = [];
+
+  private readonly idleWorkers: Worker[] = [];
+
+  private readonly activeTasks = new Map<Worker, WorkerTask<TMessage, TResult>>();
+
+  private readonly workers = new Set<Worker>();
+
+  private readonly supported: boolean;
+
+  constructor({ size, createWorker }: WorkerPoolOptions<TMessage, TResult>) {
+    this.size = Math.max(1, size ?? getDefaultConcurrency());
+    this.createWorker = createWorker;
+    this.supported = typeof window !== 'undefined' && typeof Worker !== 'undefined';
+  }
+
+  runTask(message: TMessage, options: WorkerTaskOptions<TResult> = {}): WorkerPoolTask<TResult> {
+    if (!this.supported) {
+      const fallbackPromise = options.fallback
+        ? Promise.resolve().then(options.fallback)
+        : Promise.reject(new Error('Web Workers are not supported'));
+      return {
+        promise: fallbackPromise,
+        cancel: () => {
+          /* no-op */
+        },
+      };
+    }
+
+    const resolveExtractor: ResolveFn<TResult> =
+      options.resolve ?? ((data) => data as TResult);
+
+    let task: WorkerTask<TMessage, TResult>;
+
+    const promise = new Promise<TResult>((resolve, reject) => {
+      task = {
+        message,
+        transfer: options.transfer,
+        onMessage: options.onMessage,
+        resolveExtractor,
+        onCancel: options.onCancel,
+        resolve,
+        reject,
+        cancelled: false,
+      };
+      this.queue.push(task);
+      this.processQueue();
+    });
+
+    return {
+      promise,
+      cancel: () => this.cancelTask(task!),
+    };
+  }
+
+  destroy() {
+    for (const worker of Array.from(this.workers)) {
+      this.disposeWorker(worker);
+    }
+    this.queue.length = 0;
+    this.activeTasks.clear();
+    this.idleWorkers.length = 0;
+    this.workers.clear();
+  }
+
+  private cancelTask(task: WorkerTask<TMessage, TResult>) {
+    if (task.cancelled) return;
+    task.cancelled = true;
+    const queueIndex = this.queue.indexOf(task);
+    if (queueIndex >= 0) {
+      this.queue.splice(queueIndex, 1);
+      task.reject(createCancelError());
+      return;
+    }
+    for (const [worker, activeTask] of this.activeTasks.entries()) {
+      if (activeTask !== task) continue;
+      try {
+        activeTask.onCancel?.(worker);
+      } catch (err) {
+        console.warn('Worker cancel handler failed', err);
+      }
+      this.activeTasks.delete(worker);
+      task.reject(createCancelError());
+      this.disposeWorker(worker);
+      this.processQueue();
+      break;
+    }
+  }
+
+  private processQueue() {
+    if (!this.queue.length) return;
+    let worker = this.getIdleWorker();
+    while (worker && this.queue.length) {
+      const task = this.queue.shift();
+      if (!task) break;
+      if (task.cancelled) {
+        task.reject(createCancelError());
+        worker = this.getIdleWorker();
+        continue;
+      }
+      this.activeTasks.set(worker, task);
+      try {
+        if (task.transfer && task.transfer.length > 0) {
+          worker.postMessage(task.message, task.transfer);
+        } else {
+          worker.postMessage(task.message as any);
+        }
+      } catch (err) {
+        this.activeTasks.delete(worker);
+        task.reject(err);
+        this.disposeWorker(worker);
+        worker = this.getIdleWorker();
+        continue;
+      }
+      worker = this.getIdleWorker();
+    }
+  }
+
+  private getIdleWorker(): Worker | undefined {
+    if (this.idleWorkers.length > 0) {
+      return this.idleWorkers.pop();
+    }
+    if (!this.supported) return undefined;
+    if (this.workers.size >= this.size) return undefined;
+    try {
+      const worker = this.createWorker();
+      this.attachWorker(worker);
+      this.workers.add(worker);
+      return worker;
+    } catch (err) {
+      console.warn('Failed to create worker', err);
+      return undefined;
+    }
+  }
+
+  private attachWorker(worker: Worker) {
+    worker.onmessage = (event: MessageEvent) => {
+      this.handleMessage(worker, event);
+    };
+    worker.onerror = (error) => {
+      this.handleError(worker, error);
+    };
+    worker.onmessageerror = (error) => {
+      this.handleError(worker, error);
+    };
+  }
+
+  private handleMessage(worker: Worker, event: MessageEvent) {
+    const task = this.activeTasks.get(worker);
+    if (!task) return;
+
+    try {
+      task.onMessage?.(event.data);
+    } catch (err) {
+      console.warn('Worker message handler error', err);
+    }
+
+    let result: ResolveResult<TResult>;
+    try {
+      result = task.resolveExtractor(event.data);
+    } catch (err) {
+      this.activeTasks.delete(worker);
+      task.reject(err);
+      this.disposeWorker(worker);
+      this.processQueue();
+      return;
+    }
+
+    if (result === undefined) {
+      return;
+    }
+
+    this.activeTasks.delete(worker);
+    if (result === TASK_CANCELLED) {
+      task.reject(createCancelError());
+    } else {
+      task.resolve(result);
+    }
+    this.releaseWorker(worker);
+  }
+
+  private handleError(worker: Worker, error: unknown) {
+    const task = this.activeTasks.get(worker);
+    if (task) {
+      this.activeTasks.delete(worker);
+      task.reject(error);
+    }
+    this.disposeWorker(worker);
+    this.processQueue();
+  }
+
+  private releaseWorker(worker: Worker) {
+    if (!this.workers.has(worker)) return;
+    this.idleWorkers.push(worker);
+    this.processQueue();
+  }
+
+  private disposeWorker(worker: Worker) {
+    worker.onmessage = null;
+    worker.onerror = null;
+    worker.onmessageerror = null;
+    try {
+      worker.terminate();
+    } catch (err) {
+      console.warn('Failed to terminate worker', err);
+    }
+    const idleIndex = this.idleWorkers.indexOf(worker);
+    if (idleIndex >= 0) {
+      this.idleWorkers.splice(idleIndex, 1);
+    }
+    this.workers.delete(worker);
+  }
+}
+

--- a/workers/fixturesParser.ts
+++ b/workers/fixturesParser.ts
@@ -1,18 +1,42 @@
+interface ParseMessage {
+  type: 'parse';
+  text: string;
+}
+
+interface CancelMessage {
+  type: 'cancel';
+}
+
+type IncomingMessage = ParseMessage | CancelMessage;
+
+type ProgressMessage = { type: 'progress'; payload: number };
+type ResultMessage = { type: 'result'; payload: any[] };
+type CancelledMessage = { type: 'cancelled' };
+
+type OutgoingMessage = ProgressMessage | ResultMessage | CancelledMessage;
+
+const postMessage = (message: OutgoingMessage) =>
+  (self as DedicatedWorkerGlobalScope).postMessage(message);
+
 let cancelled = false;
 
-self.onmessage = (e: MessageEvent) => {
-  const { type, text } = e.data as { type: string; text?: string };
+self.onmessage = (e: MessageEvent<IncomingMessage>) => {
+  const { type } = e.data;
   if (type === 'cancel') {
     cancelled = true;
+    postMessage({ type: 'cancelled' });
     return;
   }
-  if (type === 'parse' && text) {
+  if (type === 'parse') {
+    const { text } = e.data;
     cancelled = false;
     const lines = text.split(/\n/);
-    const total = lines.length;
+    const total = lines.length || 1;
     const result: any[] = [];
-    for (let i = 0; i < lines.length; i++) {
-      if (cancelled) return;
+    for (let i = 0; i < lines.length; i += 1) {
+      if (cancelled) {
+        return;
+      }
       const line = lines[i].trim();
       if (!line) continue;
       try {
@@ -21,11 +45,11 @@ self.onmessage = (e: MessageEvent) => {
         result.push({ line });
       }
       if (i % 100 === 0) {
-        (self as any).postMessage({ type: 'progress', payload: Math.round((i / total) * 100) });
+        postMessage({ type: 'progress', payload: Math.round(((i + 1) / total) * 100) });
       }
     }
-    (self as any).postMessage({ type: 'progress', payload: 100 });
-    (self as any).postMessage({ type: 'result', payload: result });
+    postMessage({ type: 'progress', payload: 100 });
+    postMessage({ type: 'result', payload: result });
   }
 };
 


### PR DESCRIPTION
## Summary
- add a reusable worker pool utility with cancellation and fallback helpers
- route fixtures and simulator parsers through the pool and reuse it for QR encoding
- expose typed helpers in src/workers to offload text parsing and QR generation work

## Testing
- yarn lint *(fails: repo has numerous pre-existing accessibility and lint violations)*
- yarn test *(fails: existing suites such as window, modal, qr tool currently red)*

------
https://chatgpt.com/codex/tasks/task_e_68c984fb3d7c8328a26dedf18992cbaa