### PR TITLE
[apps] Add calendar views with keyboard navigation

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -71,6 +71,7 @@ const AsciiArtApp = createDynamicApp('ascii_art', 'ASCII Art');
 const QuoteApp = createDynamicApp('quote', 'Quote');
 const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery');
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
+const CalendarApp = createDynamicApp('calendar', 'Calendar');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
@@ -165,6 +166,7 @@ const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
+const displayCalendar = createDisplay(CalendarApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 
@@ -754,6 +756,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayWireshark,
+  },
+  {
+    id: 'calendar',
+    title: 'Calendar',
+    icon: '/themes/Yaru/apps/calendar.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayCalendar,
   },
   {
     id: 'todoist',

--- a/apps/calendar/components/AgendaList.tsx
+++ b/apps/calendar/components/AgendaList.tsx
@@ -1,0 +1,87 @@
+import { useMemo } from 'react';
+import {
+  compareDates,
+  dateKey,
+  formatDate,
+  startOfDay,
+} from '../date-utils';
+import { CalendarEvent } from '../types';
+
+interface AgendaListProps {
+  events: CalendarEvent[];
+  onSelectDate: (date: Date) => void;
+  selectedDate: Date;
+}
+
+const locale = typeof navigator !== 'undefined' ? navigator.language : 'en-US';
+
+export default function AgendaList({
+  events,
+  onSelectDate,
+  selectedDate,
+}: AgendaListProps) {
+  const grouped = useMemo(() => {
+    const sorted = events
+      .slice()
+      .sort((a, b) => compareDates(a.start, b.start) || a.start.getTime() - b.start.getTime());
+    const map = new Map<string, { date: Date; items: CalendarEvent[] }>();
+    sorted.forEach((event) => {
+      const key = dateKey(event.start);
+      if (!map.has(key)) {
+        map.set(key, { date: startOfDay(event.start), items: [event] });
+      } else {
+        map.get(key)?.items.push(event);
+      }
+    });
+    return Array.from(map.values());
+  }, [events]);
+
+  if (grouped.length === 0) {
+    return <p className="mt-6 text-slate-300">No upcoming events scheduled.</p>;
+  }
+
+  return (
+    <div className="mt-4 space-y-6 text-white">
+      {grouped.map((group) => {
+        const isSelected = startOfDay(group.date).getTime() === startOfDay(selectedDate).getTime();
+        return (
+          <section key={dateKey(group.date)}>
+            <button
+              type="button"
+              onClick={() => onSelectDate(group.date)}
+              className={`flex items-baseline gap-3 text-left focus:outline-none focus:ring ${
+                isSelected ? 'text-blue-400' : 'text-slate-200'
+              }`}
+            >
+              <span className="text-lg font-semibold">
+                {formatDate(group.date, { month: 'long', day: 'numeric' }, locale)}
+              </span>
+              <span className="text-sm uppercase tracking-wide text-slate-400">
+                {formatDate(group.date, { weekday: 'short' }, locale)}
+              </span>
+            </button>
+            <ul className="mt-2 space-y-2">
+              {group.items.map((event) => (
+                <li key={event.id} className="rounded border border-slate-700 bg-slate-900 p-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="font-medium">{event.title}</div>
+                    <div className="text-xs text-slate-300">
+                      {formatDate(event.start, { hour: 'numeric', minute: '2-digit' }, locale)} –
+                      {` ${formatDate(event.end, { hour: 'numeric', minute: '2-digit' }, locale)}`}
+                    </div>
+                  </div>
+                  {event.location && (
+                    <div className="mt-1 text-xs text-slate-400">{event.location}</div>
+                  )}
+                  {event.description && (
+                    <p className="mt-2 text-sm text-slate-300">{event.description}</p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/calendar/components/MonthGrid.tsx
+++ b/apps/calendar/components/MonthGrid.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { KeyboardEvent } from 'react';
+import {
+  addDays,
+  dateKey,
+  formatDate,
+  getMonthMatrix,
+  isSameDay,
+  isSameMonth,
+  parseDateKey,
+  startOfDay,
+} from '../date-utils';
+import { CalendarEvent } from '../types';
+
+interface MonthGridProps {
+  referenceDate: Date;
+  selectedDate: Date;
+  onSelectDate: (date: Date) => void;
+  eventsByDate: Record<string, CalendarEvent[]>;
+}
+
+const locale = typeof navigator !== 'undefined' ? navigator.language : 'en-US';
+
+export default function MonthGrid({
+  referenceDate,
+  selectedDate,
+  onSelectDate,
+  eventsByDate,
+}: MonthGridProps) {
+  const gridRef = useRef<HTMLDivElement>(null);
+  const today = useMemo(() => startOfDay(new Date()), []);
+
+  const weeks = useMemo(() => getMonthMatrix(referenceDate), [referenceDate]);
+  const headerDates = useMemo(() => {
+    const firstWeek = weeks[0] ?? [];
+    return firstWeek.map((day) =>
+      formatDate(day, { weekday: 'short' }, locale).toUpperCase(),
+    );
+  }, [weeks]);
+
+  useEffect(() => {
+    const key = dateKey(selectedDate);
+    const button = gridRef.current?.querySelector<HTMLButtonElement>(
+      `[data-date="${key}"]`,
+    );
+    if (button && document.activeElement !== button) {
+      button.focus();
+    }
+  }, [selectedDate]);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    const dataset = event.currentTarget.dataset.date;
+    const currentDate = dataset ? parseDateKey(dataset) : selectedDate;
+    let nextDate: Date | null = null;
+
+    switch (event.key) {
+      case 'ArrowLeft':
+        nextDate = addDays(currentDate, -1);
+        break;
+      case 'ArrowRight':
+        nextDate = addDays(currentDate, 1);
+        break;
+      case 'ArrowUp':
+        nextDate = addDays(currentDate, -7);
+        break;
+      case 'ArrowDown':
+        nextDate = addDays(currentDate, 7);
+        break;
+      case 'Home':
+        nextDate = addDays(currentDate, -currentDate.getDay());
+        break;
+      case 'End':
+        nextDate = addDays(currentDate, 6 - currentDate.getDay());
+        break;
+      default:
+        break;
+    }
+
+    if (nextDate) {
+      event.preventDefault();
+      onSelectDate(startOfDay(nextDate));
+    }
+  };
+
+  return (
+    <div
+      className="mt-4 overflow-hidden rounded border border-slate-700 text-white"
+      role="grid"
+      aria-label="Monthly calendar"
+      ref={gridRef}
+    >
+      <div className="grid grid-cols-7 bg-slate-800 text-center text-xs uppercase tracking-wide text-slate-200">
+        {headerDates.map((label) => (
+          <div key={label} role="columnheader" className="px-2 py-2">
+            {label}
+          </div>
+        ))}
+      </div>
+      <div className="grid grid-cols-7 gap-px bg-slate-800">
+        {weeks.map((week, rowIndex) => (
+          <div key={`week-${rowIndex}`} role="row" className="contents">
+            {week.map((day) => {
+              const key = dateKey(day);
+              const events = eventsByDate[key] ?? [];
+              const inMonth = isSameMonth(day, referenceDate);
+              const isSelected = isSameDay(day, selectedDate);
+              const isToday = isSameDay(day, today);
+              return (
+                <div
+                  key={key}
+                  role="gridcell"
+                  aria-selected={isSelected}
+                  className={`min-h-[5.5rem] bg-slate-900 p-2 text-sm transition ${
+                    inMonth ? 'text-white' : 'text-slate-500'
+                  } ${isSelected ? 'ring-2 ring-blue-500 ring-offset-2 ring-offset-slate-800' : ''}`}
+                >
+                  <button
+                    type="button"
+                    data-date={key}
+                    tabIndex={isSelected ? 0 : -1}
+                    className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold focus:outline-none focus:ring ${
+                      isToday
+                        ? 'bg-blue-600 text-white'
+                        : isSelected
+                        ? 'bg-slate-700'
+                        : 'hover:bg-slate-700'
+                    }`}
+                    aria-label={`${formatDate(day, { weekday: 'long' }, locale)} ${formatDate(
+                      day,
+                      { month: 'long', day: 'numeric' },
+                      locale,
+                    )}`}
+                    onClick={() => onSelectDate(startOfDay(day))}
+                    onKeyDown={handleKeyDown}
+                  >
+                    {day.getDate()}
+                  </button>
+                  <ul className="mt-2 space-y-1">
+                    {events.slice(0, 2).map((event) => (
+                      <li
+                        key={event.id}
+                        className="truncate rounded bg-slate-700/60 px-2 py-1 text-xs"
+                        title={`${event.title} (${formatDate(event.start, { hour: 'numeric', minute: '2-digit' }, locale)})`}
+                      >
+                        <span className="mr-1 inline-block h-2 w-2 rounded-full bg-blue-400 align-middle" aria-hidden="true" />
+                        {event.title}
+                      </li>
+                    ))}
+                    {events.length > 2 && (
+                      <li className="text-xs text-slate-300">+{events.length - 2} more</li>
+                    )}
+                  </ul>
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/calendar/components/ViewToolbar.tsx
+++ b/apps/calendar/components/ViewToolbar.tsx
@@ -1,0 +1,76 @@
+import { CalendarView } from '../types';
+
+interface ViewToolbarProps {
+  label: string;
+  onPrev: () => void;
+  onNext: () => void;
+  onToday: () => void;
+  view: CalendarView;
+  onViewChange: (view: CalendarView) => void;
+}
+
+const VIEW_OPTIONS: { id: CalendarView; label: string }[] = [
+  { id: 'month', label: 'Month' },
+  { id: 'week', label: 'Week' },
+  { id: 'agenda', label: 'Agenda' },
+];
+
+export default function ViewToolbar({
+  label,
+  onPrev,
+  onNext,
+  onToday,
+  view,
+  onViewChange,
+}: ViewToolbarProps) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onPrev}
+          className="rounded border border-slate-500 px-3 py-1 text-sm font-medium text-white transition hover:bg-slate-600 focus:outline-none focus:ring"
+          aria-label="Previous"
+        >
+          ‹
+        </button>
+        <button
+          type="button"
+          onClick={onToday}
+          className="rounded border border-slate-500 px-3 py-1 text-sm font-medium text-white transition hover:bg-slate-600 focus:outline-none focus:ring"
+        >
+          Today
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          className="rounded border border-slate-500 px-3 py-1 text-sm font-medium text-white transition hover:bg-slate-600 focus:outline-none focus:ring"
+          aria-label="Next"
+        >
+          ›
+        </button>
+        <span className="ml-2 text-lg font-semibold text-white" aria-live="polite">
+          {label}
+        </span>
+      </div>
+      <div className="flex items-center gap-1" role="tablist" aria-label="Calendar views">
+        {VIEW_OPTIONS.map((option) => (
+          <button
+            key={option.id}
+            type="button"
+            role="tab"
+            aria-selected={view === option.id}
+            className={`rounded px-3 py-1 text-sm font-medium focus:outline-none focus:ring ${
+              view === option.id
+                ? 'bg-blue-600 text-white'
+                : 'border border-slate-500 text-white hover:bg-slate-600'
+            }`}
+            onClick={() => onViewChange(option.id)}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/calendar/components/WeekAgenda.tsx
+++ b/apps/calendar/components/WeekAgenda.tsx
@@ -1,0 +1,78 @@
+import { useMemo } from 'react';
+import {
+  addDays,
+  dateKey,
+  formatDate,
+  startOfDay,
+  startOfWeek,
+} from '../date-utils';
+import { CalendarEvent } from '../types';
+
+interface WeekAgendaProps {
+  referenceDate: Date;
+  eventsByDate: Record<string, CalendarEvent[]>;
+  selectedDate: Date;
+  onSelectDate: (date: Date) => void;
+}
+
+const locale = typeof navigator !== 'undefined' ? navigator.language : 'en-US';
+
+export default function WeekAgenda({
+  referenceDate,
+  eventsByDate,
+  selectedDate,
+  onSelectDate,
+}: WeekAgendaProps) {
+  const weekStart = useMemo(() => startOfWeek(referenceDate), [referenceDate]);
+  const days = useMemo(
+    () => Array.from({ length: 7 }, (_, index) => addDays(weekStart, index)),
+    [weekStart],
+  );
+
+  return (
+    <div className="mt-4 grid gap-4 text-white md:grid-cols-7">
+      {days.map((day) => {
+        const key = dateKey(day);
+        const events = (eventsByDate[key] ?? []).slice().sort((a, b) => a.start.getTime() - b.start.getTime());
+        const formattedDate = formatDate(day, { month: 'short', day: 'numeric' }, locale);
+        const isSelected = startOfDay(day).getTime() === startOfDay(selectedDate).getTime();
+        return (
+          <section
+            key={key}
+            className={`rounded border border-slate-700 bg-slate-900 p-3 ${
+              isSelected ? 'ring-2 ring-blue-500 ring-offset-2 ring-offset-slate-900' : ''
+            }`}
+          >
+            <button
+              type="button"
+              onClick={() => onSelectDate(startOfDay(day))}
+              className="flex w-full flex-col items-start gap-1 focus:outline-none focus:ring"
+            >
+              <span className="text-xs uppercase tracking-wide text-slate-300">
+                {formatDate(day, { weekday: 'short' }, locale)}
+              </span>
+              <span className="text-lg font-semibold">{formattedDate}</span>
+            </button>
+            <ul className="mt-3 space-y-2 text-sm">
+              {events.length === 0 && (
+                <li className="text-slate-400">No events</li>
+              )}
+              {events.map((event) => (
+                <li key={event.id} className="rounded bg-slate-700/60 p-2">
+                  <div className="font-medium">{event.title}</div>
+                  <div className="text-xs text-slate-300">
+                    {formatDate(event.start, { hour: 'numeric', minute: '2-digit' }, locale)} –
+                    {` ${formatDate(event.end, { hour: 'numeric', minute: '2-digit' }, locale)}`}
+                  </div>
+                  {event.location && (
+                    <div className="text-xs text-slate-400">{event.location}</div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/calendar/date-utils.ts
+++ b/apps/calendar/date-utils.ts
@@ -1,0 +1,130 @@
+export const DAYS_IN_WEEK = 7;
+
+export function startOfDay(date: Date): Date {
+  const result = new Date(date);
+  result.setHours(0, 0, 0, 0);
+  return result;
+}
+
+export function startOfMonth(date: Date): Date {
+  return startOfDay(new Date(date.getFullYear(), date.getMonth(), 1));
+}
+
+export function endOfMonth(date: Date): Date {
+  return startOfDay(new Date(date.getFullYear(), date.getMonth() + 1, 0));
+}
+
+export function startOfWeek(date: Date, weekStartsOn = 0): Date {
+  const result = startOfDay(date);
+  const day = result.getDay();
+  const diff = (day - weekStartsOn + DAYS_IN_WEEK) % DAYS_IN_WEEK;
+  result.setDate(result.getDate() - diff);
+  return result;
+}
+
+export function endOfWeek(date: Date, weekStartsOn = 0): Date {
+  const result = startOfWeek(date, weekStartsOn);
+  result.setDate(result.getDate() + (DAYS_IN_WEEK - 1));
+  return result;
+}
+
+export function addDays(date: Date, amount: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + amount);
+  return result;
+}
+
+export function addWeeks(date: Date, amount: number): Date {
+  return addDays(date, amount * DAYS_IN_WEEK);
+}
+
+export function addMonths(date: Date, amount: number): Date {
+  const result = new Date(date);
+  const dayOfMonth = result.getDate();
+  result.setDate(1);
+  result.setMonth(result.getMonth() + amount);
+  const monthLength = new Date(
+    result.getFullYear(),
+    result.getMonth() + 1,
+    0,
+  ).getDate();
+  result.setDate(Math.min(dayOfMonth, monthLength));
+  return startOfDay(result);
+}
+
+export function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+export function isSameMonth(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
+}
+
+export function dateKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+export function parseDateKey(key: string): Date {
+  const [yearStr, monthStr, dayStr] = key.split('-');
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+  if ([year, month, day].some((value) => Number.isNaN(value))) {
+    return startOfDay(new Date(key));
+  }
+  return startOfDay(new Date(year, month - 1, day));
+}
+
+export function formatDate(
+  date: Date,
+  options: Intl.DateTimeFormatOptions,
+  locale = 'en-US',
+): string {
+  return new Intl.DateTimeFormat(locale, options).format(date);
+}
+
+export function compareDates(a: Date, b: Date): number {
+  return startOfDay(a).getTime() - startOfDay(b).getTime();
+}
+
+export function getMonthMatrix(
+  reference: Date,
+  weekStartsOn = 0,
+): Date[][] {
+  const firstDay = startOfWeek(startOfMonth(reference), weekStartsOn);
+  const lastDay = endOfWeek(endOfMonth(reference), weekStartsOn);
+  const matrix: Date[][] = [];
+  let current = firstDay;
+  while (current <= lastDay) {
+    const week: Date[] = [];
+    for (let i = 0; i < DAYS_IN_WEEK; i += 1) {
+      week.push(current);
+      current = addDays(current, 1);
+    }
+    matrix.push(week);
+  }
+  return matrix;
+}
+
+export function isBefore(a: Date, b: Date): boolean {
+  return startOfDay(a).getTime() < startOfDay(b).getTime();
+}
+
+export function isAfter(a: Date, b: Date): boolean {
+  return startOfDay(a).getTime() > startOfDay(b).getTime();
+}
+
+export function daysBetween(start: Date, end: Date): number {
+  const startDay = startOfDay(start).getTime();
+  const endDay = startOfDay(end).getTime();
+  const diff = endDay - startDay;
+  return Math.round(diff / (1000 * 60 * 60 * 24));
+}
+

--- a/apps/calendar/index.tsx
+++ b/apps/calendar/index.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import AgendaList from './components/AgendaList';
+import MonthGrid from './components/MonthGrid';
+import ViewToolbar from './components/ViewToolbar';
+import WeekAgenda from './components/WeekAgenda';
+import {
+  addDays,
+  addMonths,
+  addWeeks,
+  dateKey,
+  daysBetween,
+  formatDate,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+} from './date-utils';
+import { mockEvents } from './mock-data';
+import { CalendarEvent, CalendarView } from './types';
+
+const locale = typeof navigator !== 'undefined' ? navigator.language : 'en-US';
+
+function normalizeForView(date: Date, view: CalendarView): Date {
+  if (view === 'month') {
+    return startOfMonth(date);
+  }
+  if (view === 'week') {
+    return startOfWeek(date);
+  }
+  return startOfDay(date);
+}
+
+export default function CalendarApp() {
+  const today = useMemo(() => startOfDay(new Date()), []);
+  const [view, setView] = useState<CalendarView>('month');
+  const [selectedDate, setSelectedDate] = useState<Date>(today);
+  const [referenceDate, setReferenceDate] = useState<Date>(normalizeForView(today, 'month'));
+
+  const eventsByDate = useMemo(() => {
+    const map: Record<string, CalendarEvent[]> = {};
+    mockEvents.forEach((event) => {
+      const days = daysBetween(event.start, event.end);
+      for (let offset = 0; offset <= Math.max(0, days); offset += 1) {
+        const day = addDays(startOfDay(event.start), offset);
+        const key = dateKey(day);
+        if (!map[key]) {
+          map[key] = [];
+        }
+        map[key].push(event);
+      }
+    });
+    return map;
+  }, []);
+
+  const handleSelectDate = (date: Date) => {
+    const normalized = startOfDay(date);
+    setSelectedDate(normalized);
+    setReferenceDate(normalizeForView(normalized, view));
+  };
+
+  const handleViewChange = (nextView: CalendarView) => {
+    setView(nextView);
+    setReferenceDate(normalizeForView(selectedDate, nextView));
+  };
+
+  const moveView = (direction: number) => {
+    setSelectedDate((current) => {
+      let next: Date;
+      if (view === 'month') {
+        next = addMonths(current, direction);
+      } else if (view === 'week') {
+        next = addWeeks(current, direction);
+      } else {
+        next = addDays(current, direction * 7);
+      }
+      setReferenceDate(normalizeForView(next, view));
+      return next;
+    });
+  };
+
+  const goToToday = () => {
+    setSelectedDate(today);
+    setReferenceDate(normalizeForView(today, view));
+  };
+
+  const viewLabel = useMemo(() => {
+    if (view === 'month') {
+      return formatDate(referenceDate, { month: 'long', year: 'numeric' }, locale);
+    }
+    if (view === 'week') {
+      const start = startOfWeek(referenceDate);
+      const end = addDays(start, 6);
+      const startLabel = formatDate(start, { month: 'short', day: 'numeric' }, locale);
+      const endLabel = formatDate(end, { month: 'short', day: 'numeric' }, locale);
+      const yearLabel = formatDate(end, { year: 'numeric' }, locale);
+      return `${startLabel} – ${endLabel} ${yearLabel}`;
+    }
+    return `Agenda • ${formatDate(referenceDate, { month: 'long', year: 'numeric' }, locale)}`;
+  }, [referenceDate, view]);
+
+  const selectedEvents = eventsByDate[dateKey(selectedDate)] ?? [];
+
+  return (
+    <div className="h-full w-full overflow-y-auto bg-slate-950 p-4 text-white">
+      <ViewToolbar
+        label={viewLabel}
+        onPrev={() => moveView(-1)}
+        onNext={() => moveView(1)}
+        onToday={goToToday}
+        view={view}
+        onViewChange={handleViewChange}
+      />
+      {view === 'month' && (
+        <MonthGrid
+          referenceDate={referenceDate}
+          selectedDate={selectedDate}
+          onSelectDate={handleSelectDate}
+          eventsByDate={eventsByDate}
+        />
+      )}
+      {view === 'week' && (
+        <WeekAgenda
+          referenceDate={referenceDate}
+          selectedDate={selectedDate}
+          onSelectDate={handleSelectDate}
+          eventsByDate={eventsByDate}
+        />
+      )}
+      {view === 'agenda' && (
+        <AgendaList
+          events={mockEvents}
+          onSelectDate={handleSelectDate}
+          selectedDate={selectedDate}
+        />
+      )}
+      <section className="mt-6 rounded border border-slate-700 bg-slate-900 p-4">
+        <h2 className="text-lg font-semibold">
+          {formatDate(selectedDate, { weekday: 'long', month: 'long', day: 'numeric' }, locale)}
+        </h2>
+        {selectedEvents.length === 0 ? (
+          <p className="mt-2 text-slate-300">No events planned for this day.</p>
+        ) : (
+          <ul className="mt-3 space-y-3 text-sm">
+            {selectedEvents
+              .slice()
+              .sort((a, b) => a.start.getTime() - b.start.getTime())
+              .map((event) => (
+                <li key={event.id} className="rounded bg-slate-800 p-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="font-medium">{event.title}</span>
+                    <span className="text-xs text-slate-300">
+                      {formatDate(event.start, { hour: 'numeric', minute: '2-digit' }, locale)} –
+                      {` ${formatDate(event.end, { hour: 'numeric', minute: '2-digit' }, locale)}`}
+                    </span>
+                  </div>
+                  {event.location && (
+                    <div className="mt-1 text-xs text-slate-400">{event.location}</div>
+                  )}
+                  {event.description && (
+                    <p className="mt-2 text-slate-200">{event.description}</p>
+                  )}
+                </li>
+              ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/calendar/mock-data.ts
+++ b/apps/calendar/mock-data.ts
@@ -1,0 +1,101 @@
+import { addDays, startOfDay } from './date-utils';
+import { CalendarEvent } from './types';
+
+function setTime(base: Date, hours: number, minutes = 0): Date {
+  const date = new Date(base);
+  date.setHours(hours, minutes, 0, 0);
+  return date;
+}
+
+const today = startOfDay(new Date());
+
+function createEvent(
+  id: string,
+  offset: number,
+  startHour: number,
+  durationHours: number,
+  details: Omit<CalendarEvent, 'id' | 'start' | 'end'>,
+  startMinutes = 0,
+): CalendarEvent {
+  const startDate = setTime(addDays(today, offset), startHour, startMinutes);
+  const endDate = new Date(startDate);
+  endDate.setHours(startDate.getHours() + durationHours);
+  return {
+    id,
+    start: startDate,
+    end: endDate,
+    ...details,
+  };
+}
+
+export const mockEvents: CalendarEvent[] = [
+  createEvent('team-sync', 0, 9, 1, {
+    title: 'Daily Stand-up',
+    location: 'Ops Briefing Room',
+    description: 'Short sync to review red team findings and blue team responses.',
+    category: 'work',
+  }, 30),
+  createEvent('intel-brief', 1, 10, 2, {
+    title: 'Threat Intel Briefing',
+    location: 'Situation Room',
+    description:
+      'Review latest advisories, share intel about emerging vulnerabilities, and assign action items.',
+    category: 'work',
+  }),
+  createEvent('training-lab', 2, 14, 1, {
+    title: 'Purple Team Lab',
+    location: 'Lab 3',
+    description: 'Hands-on lab simulating lateral movement with mitigations.',
+    category: 'work',
+  }, 30),
+  createEvent('fitness', -2, 7, 1, {
+    title: 'Morning Run',
+    location: 'Waterfront Trail',
+    description: '3 mile tempo run to reset before the incident response rotation.',
+    category: 'personal',
+  }),
+  createEvent('capture-flag', 5, 18, 3, {
+    title: 'CTF League Night',
+    location: 'Hackerspace',
+    description: 'Friendly capture the flag exercises focusing on web exploits.',
+    category: 'personal',
+  }),
+  {
+    id: 'conference',
+    title: 'Blue Team Summit',
+    start: setTime(addDays(today, 7), 9),
+    end: setTime(addDays(today, 9), 16),
+    location: 'Baltimore Convention Center',
+    description:
+      'Multi-day summit covering detection engineering, incident command, and post-incident recovery.',
+    category: 'work',
+  },
+  {
+    id: 'travel',
+    title: 'Travel to Summit',
+    start: setTime(addDays(today, 6), 13, 30),
+    end: setTime(addDays(today, 6), 18, 30),
+    location: 'BWI Airport',
+    description: 'Flight and transit time ahead of the Blue Team Summit.',
+    category: 'travel',
+  },
+  createEvent('retro', -7, 11, 1, {
+    title: 'Incident Retro',
+    location: 'Ops Briefing Room',
+    description: 'Lessons learned from last week’s simulated ransomware drill.',
+    category: 'work',
+  }, 30),
+  createEvent('mentor', 3, 16, 1, {
+    title: 'Mentorship 1:1',
+    location: 'Video Call',
+    description: 'Coaching session with new analysts on alert triage techniques.',
+    category: 'work',
+  }),
+  createEvent('dinner', 4, 19, 2, {
+    title: 'Team Dinner',
+    location: 'Signal Station Bistro',
+    description: 'Celebrating milestone for the portfolio launch.',
+    category: 'personal',
+  }),
+];
+

--- a/apps/calendar/types.ts
+++ b/apps/calendar/types.ts
@@ -1,0 +1,18 @@
+export type CalendarView = 'month' | 'week' | 'agenda';
+
+export type CalendarCategory = 'work' | 'personal' | 'reminder' | 'travel';
+
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+  location?: string;
+  description?: string;
+  category?: CalendarCategory;
+}
+
+export interface GroupedEvents {
+  date: Date;
+  events: CalendarEvent[];
+}

--- a/pages/apps/calendar.jsx
+++ b/pages/apps/calendar.jsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const CalendarApp = dynamic(() => import('../../apps/calendar'), {
+  ssr: false,
+  loading: () => <p>Loading calendar...</p>,
+});
+
+export default function CalendarPage() {
+  return <CalendarApp />;
+}

--- a/public/themes/Yaru/apps/calendar.svg
+++ b/public/themes/Yaru/apps/calendar.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <rect x="4" y="6" width="40" height="36" rx="4" ry="4" fill="#354155"/>
+  <rect x="4" y="6" width="40" height="10" rx="4" ry="4" fill="#4F5D75"/>
+  <path d="M14 6v-2a2 2 0 114 0v2h12v-2a2 2 0 114 0v2" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round"/>
+  <g fill="#E0E7FF">
+    <rect x="12" y="20" width="8" height="6" rx="1"/>
+    <rect x="24" y="20" width="8" height="6" rx="1"/>
+    <rect x="12" y="30" width="8" height="6" rx="1"/>
+    <rect x="24" y="30" width="8" height="6" rx="1"/>
+  </g>
+  <rect x="18" y="24" width="8" height="6" rx="1" fill="#7A9E9F"/>
+</svg>


### PR DESCRIPTION
## Summary
- add a desktop calendar app with month, week, and agenda views plus a selected-day detail panel
- implement keyboard-friendly month navigation, supporting arrow keys and a Today shortcut, backed by new date utilities
- seed the calendar with mock events and register the app with a dedicated launcher icon

## Testing
- yarn lint *(fails: existing accessibility lint errors across legacy apps)*
- yarn test *(fails: pre-existing suite failures unrelated to the new calendar app)*

------
https://chatgpt.com/codex/tasks/task_e_68c984fed8688328922f7ebd21acd045