### PR TITLE
[monitor] Add accessible multi-range request chart

### DIFF
--- a/apps/resource-monitor/components/NetworkInsights.tsx
+++ b/apps/resource-monitor/components/NetworkInsights.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 import {
   onFetchProxy,
@@ -8,22 +8,48 @@ import {
   FetchEntry,
 } from '../../../lib/fetchProxy';
 import { exportMetrics } from '../export';
-import RequestChart from './RequestChart';
+import RequestChart, {
+  type RequestChartPoint,
+} from './RequestChart';
+
+interface HistoryEntry extends FetchEntry {
+  recordedAt: number;
+}
 
 const HISTORY_KEY = 'network-insights-history';
+const MINUTE_IN_MS = 60_000;
+const RANGE_OPTIONS = [
+  { label: '1 min', minutes: 1 },
+  { label: '5 min', minutes: 5 },
+  { label: '15 min', minutes: 15 },
+];
+
+const getWallNow = () => Date.now();
 
 const formatBytes = (bytes?: number) =>
   typeof bytes === 'number' ? `${(bytes / 1024).toFixed(1)} kB` : '—';
 
 export default function NetworkInsights() {
+  const bootTimeRef = useRef(getWallNow());
   const [active, setActive] = useState<FetchEntry[]>(getActiveFetches());
-  const [history, setHistory] = usePersistentState<FetchEntry[]>(HISTORY_KEY, []);
+  const [history, setHistory] = usePersistentState<HistoryEntry[]>(HISTORY_KEY, []);
+  const [rangeMinutes, setRangeMinutes] = useState<number>(5);
+  const [isPaused, setIsPaused] = useState(false);
+  const [pausedAt, setPausedAt] = useState<number | null>(null);
+  const [snapshot, setSnapshot] = useState<HistoryEntry[]>([]);
+  const [nowMarker, setNowMarker] = useState(getWallNow());
 
   useEffect(() => {
-    const unsubStart = onFetchProxy('start', () => setActive(getActiveFetches()));
+    const unsubStart = onFetchProxy('start', () =>
+      setActive(getActiveFetches()),
+    );
     const unsubEnd = onFetchProxy('end', (e: CustomEvent<FetchEntry>) => {
       setActive(getActiveFetches());
-      setHistory((h) => [...h, e.detail]);
+      const record: HistoryEntry = {
+        ...e.detail,
+        recordedAt: getWallNow(),
+      };
+      setHistory((h) => [...h, record]);
     });
     return () => {
       unsubStart();
@@ -31,10 +57,85 @@ export default function NetworkInsights() {
     };
   }, [setHistory]);
 
+  useEffect(() => {
+    if (history.length === 0) return;
+    let updated = false;
+    const upgraded = history.map((entry) => {
+      if (Number.isFinite(entry.recordedAt)) return entry;
+      updated = true;
+      return { ...entry, recordedAt: getWallNow() };
+    });
+    if (updated) {
+      setHistory(upgraded);
+    }
+  }, [history, setHistory]);
+
+  useEffect(() => {
+    if (isPaused) return;
+    const tick = () => setNowMarker(getWallNow());
+    tick();
+    const id = window.setInterval(tick, 1000);
+    return () => window.clearInterval(id);
+  }, [isPaused]);
+
+  const currentTime = isPaused && pausedAt != null ? pausedAt : nowMarker;
+  const effectiveHistory = isPaused ? snapshot : history;
+  const chartRangeMs = rangeMinutes * MINUTE_IN_MS;
+  const rangeLabel =
+    rangeMinutes === 1 ? 'last minute' : `last ${rangeMinutes} minutes`;
+  const fallbackRecordedAt = bootTimeRef.current;
+
+  const filteredHistory = useMemo(() => {
+    const cutoff = currentTime - chartRangeMs;
+    return effectiveHistory.filter((entry) => {
+      const time = Number.isFinite(entry.recordedAt)
+        ? entry.recordedAt
+        : fallbackRecordedAt;
+      return time >= cutoff;
+    });
+  }, [chartRangeMs, currentTime, effectiveHistory, fallbackRecordedAt]);
+
+  const chartData = useMemo<RequestChartPoint[]>(() => {
+    return filteredHistory
+      .filter((entry) => typeof entry.duration === 'number')
+      .map((entry) => ({
+        time: Number.isFinite(entry.recordedAt)
+          ? entry.recordedAt
+          : fallbackRecordedAt,
+        value: entry.duration ?? 0,
+      }));
+  }, [filteredHistory, fallbackRecordedAt]);
+
+  const togglePause = () => {
+    if (isPaused) {
+      setIsPaused(false);
+      setPausedAt(null);
+      setSnapshot([]);
+      setNowMarker(getWallNow());
+      return;
+    }
+    const now = getWallNow();
+    setSnapshot(
+      history.map((entry) =>
+        Number.isFinite(entry.recordedAt)
+          ? entry
+          : { ...entry, recordedAt: now },
+      ),
+    );
+    setPausedAt(now);
+    setNowMarker(now);
+    setIsPaused(true);
+  };
+
+  const pausedTimeLabel =
+    isPaused && pausedAt != null
+      ? new Date(pausedAt).toLocaleTimeString()
+      : null;
+
   return (
-    <div className="p-2 text-xs text-white bg-[var(--kali-bg)]">
-      <h2 className="font-bold mb-1">Active Fetches</h2>
-      <ul className="mb-2 divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
+    <div className="bg-[var(--kali-bg)] p-2 text-xs text-white">
+      <h2 className="mb-1 font-bold">Active Fetches</h2>
+      <ul className="mb-2 divide-y divide-gray-700 rounded border border-gray-700 bg-[var(--kali-panel)]">
         {active.length === 0 && <li className="p-1 text-gray-400">None</li>}
         {active.map((f) => (
           <li key={f.id} className="p-1">
@@ -42,21 +143,27 @@ export default function NetworkInsights() {
               {f.method} {f.url}
             </div>
             <div className="text-gray-400">
-              {((typeof performance !== 'undefined' ? performance.now() : Date.now()) - f.startTime).toFixed(0)}ms elapsed
+              {(
+                (typeof performance !== 'undefined'
+                  ? performance.now()
+                  : Date.now()) - f.startTime
+              ).toFixed(0)}
+              ms elapsed
             </div>
           </li>
         ))}
       </ul>
-      <div className="flex items-center mb-1">
+      <div className="mb-1 flex items-center">
         <h2 className="font-bold">History</h2>
         <button
+          type="button"
           onClick={() => exportMetrics(history)}
-          className="ml-auto px-2 py-1 rounded bg-[var(--kali-panel)]"
+          className="ml-auto rounded bg-[var(--kali-panel)] px-2 py-1"
         >
           Export
         </button>
       </div>
-      <ul className="divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
+      <ul className="divide-y divide-gray-700 rounded border border-gray-700 bg-[var(--kali-panel)]">
         {history.length === 0 && <li className="p-1 text-gray-400">No requests</li>}
         {history.map((f) => (
           <li key={f.id} className="p-1">
@@ -67,18 +174,61 @@ export default function NetworkInsights() {
               )}
             </div>
             <div className="text-gray-400">
-              {f.duration ? `${f.duration.toFixed(0)}ms` : ''} · req {formatBytes(f.requestSize)} · res {formatBytes(f.responseSize)}
+              {f.duration ? `${f.duration.toFixed(0)}ms` : ''} · req{' '}
+              {formatBytes(f.requestSize)} · res {formatBytes(f.responseSize)}
             </div>
           </li>
         ))}
       </ul>
-      <div className="mt-2 flex justify-center">
+      <div className="mt-3 space-y-2">
+        <div
+          className="flex flex-wrap items-center gap-2"
+          role="group"
+          aria-label="Chart controls"
+        >
+          <span className="text-gray-300">Range:</span>
+          {RANGE_OPTIONS.map((option) => (
+            <button
+              key={option.minutes}
+              type="button"
+              onClick={() => setRangeMinutes(option.minutes)}
+              aria-pressed={rangeMinutes === option.minutes}
+              className={`rounded border px-2 py-1 text-[0.7rem] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#00ff00] ${
+                rangeMinutes === option.minutes
+                  ? 'border-[#00ff00] bg-[#00ff00]/20 text-[#00ff00]'
+                  : 'border-gray-700 bg-[var(--kali-panel)] text-gray-200 hover:border-[#00ff00]/40'
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={togglePause}
+            aria-pressed={isPaused}
+            className={`ml-auto rounded border px-2 py-1 text-[0.7rem] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#00ff00] ${
+              isPaused
+                ? 'border-yellow-400 bg-yellow-500/20 text-yellow-300'
+                : 'border-gray-700 bg-[var(--kali-panel)] text-gray-200 hover:border-[#00ff00]/40'
+            }`}
+          >
+            {isPaused ? 'Resume' : 'Pause'}
+          </button>
+        </div>
         <RequestChart
-          data={history.map((h) => h.duration ?? 0)}
+          data={chartData}
           label="Request duration (ms)"
+          rangeLabel={rangeLabel}
+          rangeMs={chartRangeMs}
+          currentTime={currentTime}
+          unit="ms"
         />
+        {isPaused && pausedTimeLabel && (
+          <p className="text-[0.65rem] text-yellow-300">
+            Chart paused at {pausedTimeLabel}
+          </p>
+        )}
       </div>
     </div>
   );
 }
-

--- a/apps/resource-monitor/components/RequestChart.tsx
+++ b/apps/resource-monitor/components/RequestChart.tsx
@@ -1,65 +1,320 @@
 'use client';
 
-import React, { useEffect, useRef } from 'react';
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react';
 
-interface RequestChartProps {
-  data: number[];
-  label: string;
+export interface RequestChartPoint {
+  time: number;
+  value: number;
 }
 
-export default function RequestChart({ data, label }: RequestChartProps) {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+interface RequestChartProps {
+  data: RequestChartPoint[];
+  label: string;
+  rangeLabel: string;
+  rangeMs: number;
+  currentTime: number;
+  unit?: string;
+}
+
+const CHART_WIDTH = 320;
+const CHART_HEIGHT = 160;
+const CHART_PADDING = 16;
+const GRID_LINE_COUNT = 4;
+
+const relativeTimeFormatter = new Intl.RelativeTimeFormat('en', {
+  numeric: 'auto',
+});
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const formatRelativeTime = (diffMs: number) => {
+  if (!Number.isFinite(diffMs) || diffMs <= 0) return 'just now';
+  if (diffMs < 60_000) {
+    const seconds = Math.max(1, Math.round(diffMs / 1000));
+    return relativeTimeFormatter.format(-seconds, 'second');
+  }
+  if (diffMs < 3_600_000) {
+    const minutes = Math.max(1, Math.round(diffMs / 60_000));
+    return relativeTimeFormatter.format(-minutes, 'minute');
+  }
+  const hours = Math.max(1, Math.round(diffMs / 3_600_000));
+  return relativeTimeFormatter.format(-hours, 'hour');
+};
+
+export default function RequestChart({
+  data,
+  label,
+  rangeLabel,
+  rangeMs,
+  currentTime,
+  unit = 'ms',
+}: RequestChartProps) {
+  const figureTitleId = useId();
+  const svgTitleId = useId();
+  const svgDescId = useId();
+  const summaryId = useId();
+
+  const sanitizedData = useMemo(
+    () =>
+      data
+        .filter((point) => Number.isFinite(point.value))
+        .sort((a, b) => a.time - b.time),
+    [data],
+  );
+
+  const domainStart = currentTime - rangeMs;
+  const domainSpan = Math.max(rangeMs, 1);
+
+  const values = sanitizedData.map((point) => point.value);
+  const maxValue = values.length > 0 ? Math.max(...values) : 1;
+  const minValue = values.length > 0 ? Math.min(...values) : 0;
+
+  const normalizedPoints = useMemo(
+    () =>
+      sanitizedData.map((point) => {
+        const xRatio = clamp((point.time - domainStart) / domainSpan, 0, 1);
+        const svgX =
+          CHART_PADDING + xRatio * (CHART_WIDTH - CHART_PADDING * 2);
+
+        const yRatio =
+          maxValue === minValue
+            ? 0.5
+            : clamp((point.value - minValue) / (maxValue - minValue), 0, 1);
+        const svgY =
+          CHART_PADDING +
+          (1 - yRatio) * (CHART_HEIGHT - CHART_PADDING * 2);
+
+        return {
+          ...point,
+          svgX,
+          svgY,
+          xPercent: (svgX / CHART_WIDTH) * 100,
+          yPercent: (svgY / CHART_HEIGHT) * 100,
+        };
+      }),
+    [sanitizedData, domainSpan, domainStart, maxValue, minValue],
+  );
+
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+  const [focusIndex, setFocusIndex] = useState<number | null>(null);
+  const pointRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
+    pointRefs.current = pointRefs.current.slice(0, normalizedPoints.length);
+  }, [normalizedPoints.length]);
 
-    const width = canvas.width;
-    const height = canvas.height;
+  useEffect(() => {
+    setHoverIndex((prev) =>
+      prev != null && prev >= normalizedPoints.length ? null : prev,
+    );
+    setFocusIndex((prev) =>
+      prev != null && prev >= normalizedPoints.length ? null : prev,
+    );
+  }, [normalizedPoints.length]);
 
-    ctx.clearRect(0, 0, width, height);
+  const activeIndex = hoverIndex ?? focusIndex ?? null;
+  const activePoint =
+    activeIndex != null ? normalizedPoints[activeIndex] : null;
 
-    // draw panel background
-    ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue('--kali-panel');
-    ctx.fillRect(0, 0, width, height);
-
-    // gridlines
-    ctx.strokeStyle = 'rgba(255,255,255,0.1)';
-    ctx.lineWidth = 1;
-    for (let i = 1; i < 5; i++) {
-      const y = (height / 5) * i;
-      ctx.beginPath();
-      ctx.moveTo(0, y);
-      ctx.lineTo(width, y);
-      ctx.stroke();
+  const summary = useMemo(() => {
+    if (values.length === 0) {
+      return `No request data captured in the ${rangeLabel}.`;
     }
+    const total = values.reduce((sum, value) => sum + value, 0);
+    const average = total / values.length;
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    return `${values.length} requests in the ${rangeLabel}. Minimum ${min.toFixed(
+      0,
+    )} ${unit}, maximum ${max.toFixed(0)} ${unit}, average ${average.toFixed(
+      0,
+    )} ${unit}.`;
+  }, [rangeLabel, unit, values]);
 
-    if (data.length > 0) {
-      const maxVal = Math.max(...data);
-      ctx.strokeStyle = '#00ff00';
-      ctx.lineWidth = 2;
-      ctx.beginPath();
-      data.forEach((v, i) => {
-        const x = (i / (data.length - 1 || 1)) * width;
-        const y = height - (v / maxVal) * height;
-        if (i === 0) ctx.moveTo(x, y);
-        else ctx.lineTo(x, y);
-      });
-      ctx.stroke();
+  const pathData = useMemo(() => {
+    if (normalizedPoints.length === 0) return '';
+    return normalizedPoints
+      .map((point, index) =>
+        `${index === 0 ? 'M' : 'L'} ${point.svgX} ${point.svgY}`,
+      )
+      .join(' ');
+  }, [normalizedPoints]);
+
+  const gridLines = useMemo(() => {
+    return Array.from({ length: GRID_LINE_COUNT }, (_, index) => {
+      const ratio = (index + 1) / (GRID_LINE_COUNT + 1);
+      const y =
+        CHART_PADDING + (1 - ratio) * (CHART_HEIGHT - CHART_PADDING * 2);
+      return (
+        <line
+          key={`grid-${index}`}
+          x1={CHART_PADDING}
+          x2={CHART_WIDTH - CHART_PADDING}
+          y1={y}
+          y2={y}
+          stroke="rgba(255,255,255,0.12)"
+          strokeWidth={1}
+        />
+      );
+    });
+  }, []);
+
+  const handleKeyNavigation = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    if (normalizedPoints.length === 0) return;
+
+    const moveFocus = (targetIndex: number) => {
+      const nextIndex = clamp(targetIndex, 0, normalizedPoints.length - 1);
+      pointRefs.current[nextIndex]?.focus();
+    };
+
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        event.preventDefault();
+        moveFocus(index + 1);
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        event.preventDefault();
+        moveFocus(index - 1);
+        break;
+      case 'Home':
+        event.preventDefault();
+        moveFocus(0);
+        break;
+      case 'End':
+        event.preventDefault();
+        moveFocus(normalizedPoints.length - 1);
+        break;
+      default:
+        break;
     }
-
-    // legend
-    ctx.fillStyle = '#ffffff';
-    ctx.font = '10px sans-serif';
-    ctx.fillText(label, 4, 12);
-  }, [data, label]);
+  };
 
   return (
-    <div className="w-full max-w-[300px] h-[150px]" style={{ background: 'var(--kali-panel)' }}>
-      <canvas ref={canvasRef} width={300} height={150} className="w-full h-full" />
-    </div>
+    <figure
+      className="w-full max-w-[360px] text-white"
+      role="group"
+      aria-labelledby={figureTitleId}
+      aria-describedby={summaryId}
+    >
+      <figcaption id={figureTitleId} className="mb-2 text-sm font-semibold">
+        {label}
+      </figcaption>
+      <div className="relative w-full min-h-[190px] rounded border border-gray-700 bg-[var(--kali-panel)]">
+        <svg
+          className="h-full w-full"
+          viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+          role="img"
+          aria-labelledby={`${svgTitleId} ${svgDescId}`}
+          preserveAspectRatio="none"
+        >
+          <title id={svgTitleId}>{label}</title>
+          <desc id={svgDescId}>{summary}</desc>
+          <rect
+            x={0}
+            y={0}
+            width={CHART_WIDTH}
+            height={CHART_HEIGHT}
+            fill="transparent"
+          />
+          {gridLines}
+          {pathData && (
+            <path d={pathData} fill="none" stroke="#00ff00" strokeWidth={2} />
+          )}
+          {normalizedPoints.map((point, index) => (
+            <circle
+              key={`marker-${point.time}-${index}`}
+              cx={point.svgX}
+              cy={point.svgY}
+              r={3}
+              fill="#00ff00"
+              opacity={0.35}
+            />
+          ))}
+        </svg>
+        {normalizedPoints.length > 0 && (
+          <div className="absolute inset-0">
+            {normalizedPoints.map((point, index) => {
+              const relativeDiff = Math.max(0, currentTime - point.time);
+              const valueLabel = `${point.value.toFixed(0)} ${unit}`;
+              const timeLabel = formatRelativeTime(relativeDiff);
+              return (
+                <button
+                  key={`point-${point.time}-${index}`}
+                  type="button"
+                  aria-label={`Request ${index + 1}, ${valueLabel}, ${timeLabel}.`}
+                  title={`${valueLabel} • ${timeLabel}`}
+                  className={`absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/60 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#00ff00] ${
+                    activeIndex === index
+                      ? 'bg-[#00ff00]'
+                      : 'bg-[#00ff00]/70'
+                  }`}
+                  style={{
+                    left: `${point.xPercent}%`,
+                    top: `${point.yPercent}%`,
+                    width: '12px',
+                    height: '12px',
+                  }}
+                  onFocus={() => setFocusIndex(index)}
+                  onBlur={() =>
+                    setFocusIndex((prev) => (prev === index ? null : prev))
+                  }
+                  onMouseEnter={() => setHoverIndex(index)}
+                  onMouseLeave={() =>
+                    setHoverIndex((prev) => (prev === index ? null : prev))
+                  }
+                  onKeyDown={(event) => handleKeyNavigation(event, index)}
+                  ref={(el) => {
+                    pointRefs.current[index] = el;
+                  }}
+                />
+              );
+            })}
+          </div>
+        )}
+        {activePoint && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded bg-black/80 px-2 py-1 text-[0.65rem] text-white shadow-lg"
+            style={{
+              left: `${activePoint.xPercent}%`,
+              top: `${activePoint.yPercent}%`,
+            }}
+          >
+            <div className="font-semibold">
+              {`${activePoint.value.toFixed(0)} ${unit}`}
+            </div>
+            <div className="text-[0.6rem] opacity-80">
+              {formatRelativeTime(Math.max(0, currentTime - activePoint.time))}
+            </div>
+          </div>
+        )}
+        {normalizedPoints.length === 0 && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-xs text-gray-400">
+            No data available in this range
+          </div>
+        )}
+      </div>
+      <p
+        id={summaryId}
+        className="mt-2 text-[0.7rem] leading-snug text-gray-300"
+      >
+        {summary}
+      </p>
+    </figure>
   );
 }
 
+export { formatRelativeTime };


### PR DESCRIPTION
## Summary
- add persistent timestamps and controls to the resource monitor history view
- support live/pause toggling and 1/5/15 minute chart ranges with accessible controls
- replace the canvas chart with an accessible SVG chart that includes tooltips and keyboard focus

## Testing
- yarn lint (fails: repo has pre-existing accessibility and window global lint errors)
- yarn test --watch=false (fails: suite has existing act/localStorage errors; run cancelled after repeated failures)


------
https://chatgpt.com/codex/tasks/task_e_68c98500af148328b0361656a0e6073a