### PR TITLE
[seo] use next/script for structured data

### DIFF
--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -1,11 +1,13 @@
 import React from 'react'
 import Head from 'next/head';
+import Script from 'next/script';
 import { getCspNonce } from '../../utils/csp';
 
 export default function Meta() {
     const nonce = getCspNonce();
     return (
-        <Head>
+        <>
+            <Head>
             {/* Primary Meta Tags */}
              <title>Alex Unnippillil&apos;s Portfolio </title>
             <meta charSet="utf-8" />
@@ -50,9 +52,12 @@ export default function Meta() {
             <link rel="canonical" href="https://unnippillil.com/" />
             <link rel="icon" href="images/logos/fevicon.svg" />
             <link rel="apple-touch-icon" href="images/logos/logo.png" />
-            <script
+            </Head>
+            <Script
+                id="meta-structured-data"
                 type="application/ld+json"
                 nonce={nonce}
+                strategy="beforeInteractive"
                 dangerouslySetInnerHTML={{
                     __html: JSON.stringify({
                         "@context": "https://schema.org",
@@ -62,6 +67,6 @@ export default function Meta() {
                     }),
                 }}
             />
-        </Head>
+        </>
     )
 }

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import Image from 'next/image';
 import Head from 'next/head';
+import Script from 'next/script';
 import ReactGA from 'react-ga4';
 import GitHubStars from '../../GitHubStars';
 import Certs from '../certs';
@@ -113,12 +114,14 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
       <main className="w-full h-full flex bg-ub-cool-grey text-white select-none relative">
         <Head>
           <title>About</title>
-          <script
-            type="application/ld+json"
-            nonce={nonce}
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(structured) }}
-          />
         </Head>
+        <Script
+          id="about-structured-data"
+          type="application/ld+json"
+          nonce={nonce}
+          strategy="beforeInteractive"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structured) }}
+        />
         <div
           className="md:flex hidden flex-col w-1/4 md:w-1/5 text-sm overflow-y-auto windowMainScreen border-r border-black"
           role="tablist"


### PR DESCRIPTION
## Summary
- replace inline structured data script tags in the global Meta component with Next.js Script using a beforeInteractive strategy
- update the About app to load its JSON-LD data through next/script for CSP compatibility

## Testing
- yarn lint *(fails: numerous pre-existing jsx-a11y/control-has-associated-label violations across apps and legacy public assets)*
- yarn test *(fails: known suites such as nmapNse, Modal, and aboutAccessibility due to existing act/localStorage expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68c9850d69288328a7c3f860a85ef177