### PR TITLE
[motion] add reusable presets for interactions

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -1,5 +1,11 @@
 import React, { Component } from 'react'
 import Image from 'next/image'
+import { transitionStyles } from '@/src/motion/presets'
+
+const APP_TRANSITION = transitionStyles(
+    { properties: ['background-color', 'border-color', 'color', 'box-shadow'], preset: 'hover' },
+    { properties: 'transform', preset: 'tap' }
+)
 
 export class UbuntuApp extends Component {
     constructor() {
@@ -42,8 +48,9 @@ export class UbuntuApp extends Component {
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
                 className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white "}
                 id={"app-" + this.props.id}
+                style={APP_TRANSITION}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
                 tabIndex={this.props.disabled ? -1 : 0}

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import { transitionStyles } from '@/src/motion/presets';
 
 type AppMeta = {
   id: string;
@@ -19,6 +20,16 @@ const CATEGORIES = [
   { id: 'utilities', label: 'Utilities' },
   { id: 'games', label: 'Games' }
 ];
+
+const MENU_BUTTON_MOTION = transitionStyles(
+  { properties: ['background-color', 'border-color', 'color'], preset: 'hover' },
+  { properties: 'transform', preset: 'tap' },
+);
+
+const CATEGORY_BUTTON_MOTION = transitionStyles({
+  properties: ['background-color', 'color'],
+  preset: 'hover',
+});
 
 const WhiskerMenu: React.FC = () => {
   const [open, setOpen] = useState(false);
@@ -120,7 +131,8 @@ const WhiskerMenu: React.FC = () => {
         ref={buttonRef}
         type="button"
         onClick={() => setOpen(o => !o)}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        className="pl-3 pr-3 outline-none border-b-2 border-transparent py-1"
+        style={MENU_BUTTON_MOTION}
       >
         <Image
           src="/themes/Yaru/status/decompiler-symbolic.svg"
@@ -148,6 +160,7 @@ const WhiskerMenu: React.FC = () => {
                 key={cat.id}
                 className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
                 onClick={() => setCategory(cat.id)}
+                style={CATEGORY_BUTTON_MOTION}
               >
                 {cat.label}
               </button>

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -4,6 +4,17 @@ import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import { transitionStyles } from '@/src/motion/presets';
+
+const NAV_ITEM_MOTION = transitionStyles({
+        properties: ['border-color', 'background-color', 'color'],
+        preset: 'hover',
+});
+
+const NAV_BUTTON_MOTION = transitionStyles(
+        { properties: ['border-color', 'background-color', 'color'], preset: 'hover' },
+        { properties: 'transform', preset: 'tap' },
+);
 
 export default class Navbar extends Component {
 	constructor() {
@@ -22,8 +33,9 @@ export default class Navbar extends Component {
                                 <WhiskerMenu />
                                 <div
                                         className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                                'pl-2 pr-2 text-xs md:text-sm outline-none border-b-2 border-transparent py-1'
                                         }
+                                        style={NAV_ITEM_MOTION}
                                 >
                                         <Clock />
                                 </div>
@@ -35,8 +47,9 @@ export default class Navbar extends Component {
                                                 this.setState({ status_card: !this.state.status_card });
                                         }}
                                         className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
+                                                'relative pr-3 pl-3 outline-none border-b-2 border-transparent focus:border-ubb-orange py-1 '
                                         }
+                                        style={NAV_BUTTON_MOTION}
                                 >
                                         <Status />
                                         <QuickSettings open={this.state.status_card} />

--- a/components/ui/ProgressBar.tsx
+++ b/components/ui/ProgressBar.tsx
@@ -1,4 +1,10 @@
 import React from 'react';
+import { transitionStyles } from '@/src/motion/presets';
+
+const PROGRESS_MOTION = transitionStyles({
+  properties: 'width',
+  preset: 'toggle',
+});
 
 interface ProgressBarProps {
   progress: number;
@@ -16,8 +22,8 @@ export default function ProgressBar({ progress, className = '' }: ProgressBarPro
       aria-valuemax={100}
     >
       <div
-        className="h-full bg-blue-500 transition-all duration-200"
-        style={{ width: `${clamped}%` }}
+        className="h-full bg-blue-500"
+        style={{ width: `${clamped}%`, ...PROGRESS_MOTION }}
       />
     </div>
   );

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,4 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { transitionStyles } from '@/src/motion/presets';
+
+const TOAST_MOTION = transitionStyles({
+  properties: ['transform', 'opacity'],
+  preset: 'toggle',
+});
 
 interface ToastProps {
   message: string;
@@ -32,7 +38,8 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center ${visible ? 'translate-y-0 opacity-100' : '-translate-y-full opacity-0'}`}
+      style={TOAST_MOTION}
     >
       <span>{message}</span>
       {onAction && actionLabel && (

--- a/docs/MOTION_PRESETS.md
+++ b/docs/MOTION_PRESETS.md
@@ -1,0 +1,50 @@
+# Motion presets and interaction patterns
+
+To keep desktop interactions cohesive we centralise all motion tokens and helper utilities in `src/motion/presets.ts`. These presets mirror the CSS custom properties declared in `styles/tokens.css`, so the existing reduced-motion toggles and media queries continue to work without additional code inside each component.
+
+## Token overview
+
+| Token | CSS variable | Default | Notes |
+| --- | --- | --- | --- |
+| `motionTokens.durations.tap` | `--motion-duration-tap` | `120ms` | Quick press/tap feedback. |
+| `motionTokens.durations.hover` | `--motion-duration-hover` | `180ms` | Standard hover state transitions. |
+| `motionTokens.durations.toggle` | `--motion-duration-toggle` | `240ms` | Visibility or layout toggles (drawers, toast). |
+| `motionTokens.durations.focusRing` | `--motion-duration-focus` | `200ms` | Focus outlines and keyboard cues. |
+| `motionTokens.easings.standard` | `--motion-ease-standard` | `cubic-bezier(0.4, 0, 0.2, 1)` | Default ease for soft hover/focus. |
+| `motionTokens.easings.emphasized` | `--motion-ease-emphasized` | `cubic-bezier(0.2, 0, 0, 1)` | Snappier response for taps/toggles. |
+| `motionTokens.easings.exit` | `--motion-ease-exit` | `cubic-bezier(0.4, 0, 1, 1)` | Decelerated exit transitions. |
+
+Spring presets are exported for libraries such as Framer Motion or React Spring when we need physics-based interactions:
+
+| Preset | Config |
+| --- | --- |
+| `springPresets.tap` | `{ stiffness: 620, damping: 38, mass: 0.9, restSpeed: 0.01, restDelta: 0.01 }` |
+| `springPresets.hover` | `{ stiffness: 360, damping: 30, mass: 1, restSpeed: 0.02, restDelta: 0.02 }` |
+| `springPresets.toggle` | `{ stiffness: 420, damping: 32, mass: 1, restSpeed: 0.02, restDelta: 0.02 }` |
+| `springPresets.panel` | `{ stiffness: 320, damping: 34, mass: 1.1, restSpeed: 0.02, restDelta: 0.02 }` |
+
+## Helper utilities
+
+`transitionStyles` and `composeTransitions` convert presets into CSS-ready strings:
+
+```tsx
+import { transitionStyles } from '@/src/motion/presets';
+
+const buttonMotion = transitionStyles(
+  { properties: ['background-color', 'border-color', 'color'], preset: 'hover' },
+  { properties: 'transform', preset: 'tap' },
+);
+
+<button style={buttonMotion}>Launch</button>;
+```
+
+Use `buildTransition` when you need a raw transition string (for example to mix with inline `transition` values or Tailwind overrides).
+
+Because the presets reference CSS variables, reduced-motion preferences automatically collapse durations to `0ms`. Avoid adding manual `matchMedia('(prefers-reduced-motion)')` checks unless an animation requires deeper changes than a simple duration tweak.
+
+## Usage guidance
+
+* Prefer `transitionStyles` for hover, tap, or toggle interactions instead of hard-coded Tailwind duration/easing classes.
+* When you need the same motion across multiple components, create a shared constant near the top of the file (e.g. `const MENU_BUTTON_MOTION = transitionStyles(...)`).
+* Reach for `springPresets` when adding Framer Motion/React Spring powered effects so the feeling stays consistent with the rest of the desktop.
+* If you introduce a new interaction pattern, extend `presets.ts` rather than sprinkling bespoke values in components. Update this document with the rationale so future changes stay aligned.

--- a/src/motion/presets.ts
+++ b/src/motion/presets.ts
@@ -1,0 +1,150 @@
+/**
+ * Motion tokens and helpers used across the desktop experience.
+ *
+ * The values lean on CSS custom properties declared in `styles/tokens.css`
+ * so that global toggles (e.g. reduced motion) can zero out the transitions
+ * without every component needing to know about the preference.
+ */
+
+export type TransitionPresetName =
+  | 'tap'
+  | 'hover'
+  | 'toggle'
+  | 'toggleExit'
+  | 'focusRing';
+
+export interface TransitionPreset {
+  duration: string;
+  easing: string;
+  delay?: string;
+}
+
+const motionDurations = Object.freeze({
+  tap: 'var(--motion-duration-tap, 120ms)',
+  hover: 'var(--motion-duration-hover, 180ms)',
+  toggle: 'var(--motion-duration-toggle, 240ms)',
+  focusRing: 'var(--motion-duration-focus, 200ms)',
+});
+
+const motionEasings = Object.freeze({
+  standard: 'var(--motion-ease-standard, cubic-bezier(0.4, 0, 0.2, 1))',
+  emphasized: 'var(--motion-ease-emphasized, cubic-bezier(0.2, 0, 0, 1))',
+  exit: 'var(--motion-ease-exit, cubic-bezier(0.4, 0, 1, 1))',
+});
+
+export const transitionPresets: Record<TransitionPresetName, TransitionPreset> = Object.freeze({
+  tap: {
+    duration: motionDurations.tap,
+    easing: motionEasings.emphasized,
+  },
+  hover: {
+    duration: motionDurations.hover,
+    easing: motionEasings.standard,
+  },
+  toggle: {
+    duration: motionDurations.toggle,
+    easing: motionEasings.emphasized,
+  },
+  toggleExit: {
+    duration: motionDurations.toggle,
+    easing: motionEasings.exit,
+  },
+  focusRing: {
+    duration: motionDurations.focusRing,
+    easing: motionEasings.standard,
+  },
+});
+
+export type SpringPresetName = 'tap' | 'hover' | 'toggle' | 'panel';
+
+export interface SpringPreset {
+  stiffness: number;
+  damping: number;
+  mass?: number;
+  restSpeed?: number;
+  restDelta?: number;
+  clamp?: boolean;
+}
+
+export const springPresets: Record<SpringPresetName, SpringPreset> = Object.freeze({
+  tap: {
+    stiffness: 620,
+    damping: 38,
+    mass: 0.9,
+    restSpeed: 0.01,
+    restDelta: 0.01,
+  },
+  hover: {
+    stiffness: 360,
+    damping: 30,
+    mass: 1,
+    restSpeed: 0.02,
+    restDelta: 0.02,
+  },
+  toggle: {
+    stiffness: 420,
+    damping: 32,
+    mass: 1,
+    restSpeed: 0.02,
+    restDelta: 0.02,
+  },
+  panel: {
+    stiffness: 320,
+    damping: 34,
+    mass: 1.1,
+    restSpeed: 0.02,
+    restDelta: 0.02,
+  },
+});
+
+const DEFAULT_DELAY = '0ms';
+
+type TransitionConfig = {
+  properties: string | string[];
+  preset: TransitionPresetName | TransitionPreset;
+  delay?: string;
+};
+
+function resolvePreset(preset: TransitionPresetName | TransitionPreset): TransitionPreset {
+  return typeof preset === 'string' ? transitionPresets[preset] : preset;
+}
+
+export function buildTransition(
+  properties: string | string[],
+  preset: TransitionPresetName | TransitionPreset,
+  options: { delay?: string } = {},
+): string {
+  const resolved = resolvePreset(preset);
+  const props = Array.isArray(properties) ? properties : [properties];
+  const delay = options.delay ?? resolved.delay;
+  return props
+    .filter(Boolean)
+    .map((property) =>
+      [property, resolved.duration, resolved.easing, delay ?? DEFAULT_DELAY]
+        .filter(Boolean)
+        .join(' '),
+    )
+    .join(', ');
+}
+
+export function composeTransitions(...entries: TransitionConfig[]): string {
+  const values = entries
+    .map((entry) =>
+      buildTransition(entry.properties, entry.preset, { delay: entry.delay }),
+    )
+    .filter(Boolean);
+  return values.length > 0 ? values.join(', ') : 'none';
+}
+
+export function transitionStyles(
+  ...entries: TransitionConfig[]
+): { transition: string } {
+  return { transition: composeTransitions(...entries) };
+}
+
+export const motionTokens = Object.freeze({
+  durations: motionDurations,
+  easings: motionEasings,
+  transitions: transitionPresets,
+  springs: springPresets,
+});

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -4,10 +4,26 @@
 
 @layer utilities {
   .transition-hover {
-    @apply transition ease-out duration-150;
+    @apply transition;
+    transition-duration: var(
+      --motion-duration-hover,
+      var(--motion-medium)
+    );
+    transition-timing-function: var(
+      --motion-ease-standard,
+      cubic-bezier(0.4, 0, 0.2, 1)
+    );
   }
   .transition-active {
-    @apply transition ease-out duration-100;
+    @apply transition;
+    transition-duration: var(
+      --motion-duration-tap,
+      var(--motion-fast)
+    );
+    transition-timing-function: var(
+      --motion-ease-emphasized,
+      cubic-bezier(0.2, 0, 0, 1)
+    );
   }
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -51,6 +51,13 @@
   --motion-fast: 150ms;
   --motion-medium: 300ms;
   --motion-slow: 500ms;
+  --motion-duration-tap: 120ms;
+  --motion-duration-hover: 180ms;
+  --motion-duration-toggle: 240ms;
+  --motion-duration-focus: 200ms;
+  --motion-ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --motion-ease-emphasized: cubic-bezier(0.2, 0, 0, 1);
+  --motion-ease-exit: cubic-bezier(0.4, 0, 1, 1);
 
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
@@ -94,6 +101,10 @@
   --motion-fast: 0ms;
   --motion-medium: 0ms;
   --motion-slow: 0ms;
+  --motion-duration-tap: 0ms;
+  --motion-duration-hover: 0ms;
+  --motion-duration-toggle: 0ms;
+  --motion-duration-focus: 0ms;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -101,6 +112,10 @@
     --motion-fast: 0ms;
     --motion-medium: 0ms;
     --motion-slow: 0ms;
+    --motion-duration-tap: 0ms;
+    --motion-duration-hover: 0ms;
+    --motion-duration-toggle: 0ms;
+    --motion-duration-focus: 0ms;
   }
 }
 


### PR DESCRIPTION
## Summary
- introduce `src/motion/presets.ts` with shared transition and spring presets backed by CSS variables
- refactor key UI elements (app icons, launcher menu, navbar, toast, progress bar) to use the new motion helpers
- document motion token usage patterns for future contributors

## Testing
- yarn lint *(fails: repository already contains outstanding accessibility lint errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c2f39048328b4354e43491be9fa