### PR TITLE
feat(ui): add elevation tokens for desktop surfaces

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -519,46 +519,46 @@ export class Window extends Component {
     }
 
     handleKeyDown = (e) => {
+        const preventInteraction = () => {
+            if (typeof e.preventDefault === 'function') {
+                e.preventDefault();
+            }
+            if (typeof e.stopPropagation === 'function') {
+                e.stopPropagation();
+            }
+        };
         if (e.key === 'Escape') {
             this.closeWindow();
         } else if (e.key === 'Tab') {
             this.focusWindow();
         } else if (e.altKey) {
             if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                preventInteraction();
                 this.unsnapWindow();
             } else if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                preventInteraction();
                 this.snapWindow('left');
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                preventInteraction();
                 this.snapWindow('right');
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                preventInteraction();
                 this.snapWindow('top');
             }
             this.focusWindow();
         } else if (e.shiftKey) {
             const step = 1;
             if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                preventInteraction();
                 this.setState(prev => ({ width: Math.max(prev.width - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                preventInteraction();
                 this.setState(prev => ({ width: Math.min(prev.width + step, 100) }), this.resizeBoundries);
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                preventInteraction();
                 this.setState(prev => ({ height: Math.max(prev.height - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                preventInteraction();
                 this.setState(prev => ({ height: Math.min(prev.height + step, 100) }), this.resizeBoundries);
             }
             this.focusWindow();
@@ -635,7 +635,7 @@ export class Window extends Component {
                 >
                     <div
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 window-shadow-active " : " z-20 notFocused ") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow surface-border-strong border-t-0 flex flex-col"}
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -99,7 +99,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
       aria-hidden={!open}
       style={{ left: pos.x, top: pos.y }}
       className={(open ? 'block ' : 'hidden ') +
-        'cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+        'cursor-default w-52 context-menu-bg text-left rounded text-white py-4 absolute z-50 text-sm'}
     >
       {items.map((item, i) => (
         <button

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -28,7 +28,7 @@ function AppMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
-            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg text-left rounded text-white py-4 absolute z-50 text-sm'}
         >
             <button
                 type="button"

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -20,7 +20,7 @@ function DefaultMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
-            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg text-left rounded text-white py-4 absolute z-50 text-sm"}
         >
 
             <Devider />

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -48,7 +48,7 @@ function DesktopMenu(props) {
             id="desktop-menu"
             role="menu"
             aria-label="Desktop context menu"
-            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg text-left font-light rounded text-white py-4 absolute z-50 text-sm"}
         >
             <button
                 onClick={props.addNewFolder}

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -30,7 +30,7 @@ function TaskbarMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
-            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-40 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm'}
+            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-40 context-menu-bg text-left rounded text-white py-2 absolute z-50 text-sm'}
         >
             <button
                 type="button"

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -134,7 +134,7 @@ const WhiskerMenu: React.FC = () => {
       {open && (
         <div
           ref={menuRef}
-          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
+          className="absolute left-0 mt-1 z-50 flex surface-popover text-white"
           tabIndex={-1}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node)) {

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -15,7 +15,7 @@ export default class Navbar extends Component {
 
 	render() {
 		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                        <div className="main-navbar-vp absolute top-0 right-0 w-screen surface-panel flex flex-nowrap justify-between items-center text-ubt-grey text-sm select-none z-50">
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -30,7 +30,7 @@ export default function SideBar(props) {
             <nav
                 aria-label="Dock"
                 className={(props.hide ? " -translate-x-full " : "") +
-                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
+                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 surface-dock"}
             >
                 {
                     (

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -16,7 +16,7 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div className="absolute bottom-0 left-0 w-full h-10 surface-dock flex items-center z-40" role="toolbar">
             {runningApps.map(app => (
                 <button
                     key={app.id}

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -23,7 +23,7 @@ const QuickSettings = ({ open }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      className={`absolute surface-popover rounded-md py-4 top-9 right-3 ${
         open ? '' : 'hidden'
       }`}
     >

--- a/styles/elevation.css
+++ b/styles/elevation.css
@@ -1,0 +1,75 @@
+/* Elevation and surface tokens */
+
+:root {
+  /* Shadow-driven elevation scale for lighter themes */
+  --elevation-level-0: none;
+  --elevation-level-1: 0 2px 4px rgba(15, 19, 23, 0.18), 0 1px 0 rgba(15, 19, 23, 0.12);
+  --elevation-level-2: 0 8px 16px rgba(15, 19, 23, 0.22), 0 2px 6px rgba(15, 19, 23, 0.18);
+  --elevation-level-3: 0 16px 28px rgba(15, 19, 23, 0.28), 0 6px 12px rgba(15, 19, 23, 0.2);
+  --elevation-level-4: 0 28px 48px rgba(15, 19, 23, 0.35), 0 12px 20px rgba(15, 19, 23, 0.24);
+
+  --elevation-dock: var(--elevation-level-1);
+  --elevation-panel: var(--elevation-level-1);
+  --elevation-popover: var(--elevation-level-2);
+  --elevation-window: var(--elevation-level-2);
+  --elevation-window-active: var(--elevation-level-3);
+  --elevation-modal: var(--elevation-level-4);
+
+  --surface-dock: color-mix(in srgb, var(--color-surface) 88%, #ffffff 12%);
+  --surface-panel: color-mix(in srgb, var(--color-surface) 92%, #ffffff 8%);
+  --surface-popover: color-mix(in srgb, var(--color-surface) 84%, #ffffff 16%);
+  --surface-modal: color-mix(in srgb, var(--color-surface) 80%, #ffffff 20%);
+  --surface-window: color-mix(in srgb, var(--color-surface) 88%, #ffffff 12%);
+  --surface-scrim: rgba(15, 19, 23, 0.6);
+
+  --surface-border-subtle: color-mix(in srgb, var(--color-inverse) 16%, transparent);
+  --surface-border-strong: color-mix(in srgb, var(--color-inverse) 24%, transparent);
+}
+
+html.dark {
+  /* Overlay-driven elevation scale for dark themes */
+  --elevation-level-1: 0 0 0 1px rgba(255, 255, 255, 0.08), 0 10px 24px rgba(0, 0, 0, 0.5);
+  --elevation-level-2: 0 0 0 1px rgba(255, 255, 255, 0.1), 0 18px 36px rgba(0, 0, 0, 0.55);
+  --elevation-level-3: 0 0 0 1px rgba(255, 255, 255, 0.12), 0 26px 44px rgba(0, 0, 0, 0.6);
+  --elevation-level-4: 0 0 0 1px rgba(255, 255, 255, 0.16), 0 36px 60px rgba(0, 0, 0, 0.65);
+
+  --surface-dock: color-mix(in srgb, var(--color-surface) 72%, #ffffff 28%);
+  --surface-panel: color-mix(in srgb, var(--color-surface) 76%, #ffffff 24%);
+  --surface-popover: color-mix(in srgb, var(--color-surface) 68%, #ffffff 32%);
+  --surface-modal: color-mix(in srgb, var(--color-surface) 62%, #ffffff 38%);
+  --surface-window: color-mix(in srgb, var(--color-surface) 70%, #ffffff 30%);
+  --surface-scrim: rgba(3, 6, 10, 0.72);
+
+  --surface-border-subtle: color-mix(in srgb, #ffffff 18%, transparent);
+  --surface-border-strong: color-mix(in srgb, #ffffff 28%, transparent);
+}
+
+.surface-dock {
+  background-color: var(--surface-dock, var(--color-surface));
+  box-shadow: var(--elevation-dock);
+}
+
+.surface-panel {
+  background-color: var(--surface-panel, var(--color-surface));
+  box-shadow: var(--elevation-panel);
+}
+
+.surface-popover {
+  background-color: var(--surface-popover, var(--color-surface));
+  box-shadow: var(--elevation-popover);
+  border: 1px solid var(--surface-border-subtle);
+}
+
+.surface-modal {
+  background-color: var(--surface-modal, var(--color-surface));
+  box-shadow: var(--elevation-modal);
+  border: 1px solid var(--surface-border-strong);
+}
+
+.surface-border {
+  border: 1px solid var(--surface-border-subtle);
+}
+
+.surface-border-strong {
+  border: 1px solid var(--surface-border-strong);
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,4 +1,5 @@
 @import './globals.css';
+@import './elevation.css';
 
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
@@ -105,9 +106,15 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .window-shadow {
-    box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -webkit-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -moz-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+    box-shadow: var(--elevation-window);
+    -webkit-box-shadow: var(--elevation-window);
+    -moz-box-shadow: var(--elevation-window);
+}
+
+.window-shadow-active {
+    box-shadow: var(--elevation-window-active);
+    -webkit-box-shadow: var(--elevation-window-active);
+    -moz-box-shadow: var(--elevation-window-active);
 }
 
 .closed-window {
@@ -365,17 +372,25 @@ dialog {
 }
 
 /* Context Menu & Panels */
-.context-menu-bg,
 .windowMainScreen {
-    background-color: color-mix(in srgb, var(--color-bg), transparent 15%); /* Fallback for unsupported browsers */
+    background-color: var(--surface-window, var(--color-surface));
+}
+
+.context-menu-bg {
+    background-color: var(--surface-popover, var(--color-surface));
+    box-shadow: var(--elevation-popover);
+    border: 1px solid var(--surface-border-subtle);
 }
 
 @supports ((-webkit-backdrop-filter: blur(0)) or (backdrop-filter: blur(0))) {
-    .context-menu-bg,
+    .context-menu-bg {
+        -webkit-backdrop-filter: blur(14px);
+        backdrop-filter: blur(14px);
+    }
+
     .windowMainScreen {
-        -webkit-backdrop-filter: blur(10px);
-        backdrop-filter: blur(10px);
-        background-color: color-mix(in srgb, var(--color-bg), transparent 60%);
+        -webkit-backdrop-filter: blur(8px);
+        backdrop-filter: blur(8px);
     }
 }
 


### PR DESCRIPTION
## Summary
- add shared elevation tokens and surface helpers to cover both shadow and overlay themes
- update desktop chrome (navbar, dock, taskbar, quick settings, whisker menu, context menus) to consume the new tokens
- align window borders and shadows with the token scale while hardening keyboard handling

## Testing
- yarn lint *(fails: repo has existing accessibility/no-top-level-window lint violations)*
- CI=1 yarn test --watch=false *(fails: suite has pre-existing accessibility and environment dependent test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c2f8c48832885c654b18d49537a