### PR TITLE
[calculator] add interactive history tape

### DIFF
--- a/apps/calculator/components/Tape.tsx
+++ b/apps/calculator/components/Tape.tsx
@@ -4,9 +4,11 @@ import { useCallback, useEffect, useRef } from 'react';
 
 interface TapeProps {
   entries: { expr: string; result: string }[];
+  onSelect: (entry: { expr: string; result: string }) => void;
+  onClear: () => void;
 }
 
-export default function Tape({ entries }: TapeProps) {
+export default function Tape({ entries, onSelect, onClear }: TapeProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -14,10 +16,12 @@ export default function Tape({ entries }: TapeProps) {
     if (el) el.scrollTop = 0;
   }, [entries]);
 
-  const handleRecall = useCallback((result: string) => {
-    const display = document.getElementById('display') as HTMLInputElement | null;
-    if (display) display.value = result;
-  }, []);
+  const handleSelect = useCallback(
+    (entry: { expr: string; result: string }) => {
+      onSelect(entry);
+    },
+    [onSelect],
+  );
 
   const handleCopy = useCallback(async (text: string) => {
     try {
@@ -28,31 +32,59 @@ export default function Tape({ entries }: TapeProps) {
   }, []);
 
   return (
-    <div ref={containerRef} className="tape font-mono max-h-40 overflow-y-auto">
-      {entries.map(({ expr, result }, i) => (
-        <div
-          key={i}
-          className="p-1 odd:bg-black/20 even:bg-black/10 flex items-center gap-2"
+    <aside className="tape-panel flex w-full flex-col gap-2 md:w-60">
+      <div className="flex items-center justify-between text-xs uppercase tracking-wide text-white/60">
+        <span>History</span>
+        <button
+          type="button"
+          onClick={onClear}
+          disabled={!entries.length}
+          className="rounded border border-white/10 px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-wider text-white/80 transition hover:border-white/30 hover:text-white disabled:cursor-not-allowed disabled:border-white/5 disabled:text-white/30"
         >
-          <div className="flex-1">
-            {expr} = {result}
-          </div>
-          <button
-            className="text-xs px-1 py-0.5 bg-black/20 rounded"
-            onClick={() => handleRecall(result)}
-            aria-label="recall result"
-          >
-            Ans
-          </button>
-          <button
-            className="text-xs px-1 py-0.5 bg-black/20 rounded"
-            onClick={() => handleCopy(result)}
-            aria-label="copy result"
-          >
-            Copy
-          </button>
-        </div>
-      ))}
-    </div>
+          Clear
+        </button>
+      </div>
+      <div
+        ref={containerRef}
+        className="flex-1 overflow-y-auto rounded border border-white/5 bg-black/30"
+        aria-live="polite"
+      >
+        {entries.length ? (
+          <ul className="divide-y divide-white/5" role="list">
+            {entries.map((entry, i) => (
+              <li key={`${entry.expr}-${i}`} className="group">
+                <div className="flex items-center gap-2 px-3 py-2">
+                  <button
+                    type="button"
+                    onClick={() => handleSelect(entry)}
+                    className="flex-1 text-left transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                    aria-label={`Insert result ${entry.result}`}
+                  >
+                    <span className="block text-[0.65rem] uppercase tracking-wide text-white/50">
+                      {entry.expr}
+                    </span>
+                    <span className="block font-mono text-sm text-white">
+                      = {entry.result}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleCopy(entry.result)}
+                    className="rounded bg-white/10 px-2 py-1 text-[0.65rem] uppercase tracking-wide text-white/70 transition hover:bg-white/20 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                    aria-label={`Copy result ${entry.result}`}
+                  >
+                    Copy
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="px-3 py-6 text-center text-xs text-white/60">
+            Calculations you run will appear here.
+          </p>
+        )}
+      </div>
+    </aside>
   );
 }

--- a/apps/calculator/styles.css
+++ b/apps/calculator/styles.css
@@ -14,7 +14,7 @@ body {
   border-radius: 8px;
   box-shadow: 0 2px 10px color-mix(in srgb, var(--color-inverse), transparent 90%);
   width: 100%;
-  max-width: 240px;
+  max-width: 720px;
   container-type: inline-size;
 }
 


### PR DESCRIPTION
## Summary
- add a right-aligned tape panel that surfaces recent calculator results and a clear control
- allow history entries to paste their result into the active calculation and keep the layout responsive
- widen the calculator shell so the keypad and tape comfortably share space

## Testing
- [ ] yarn lint *(fails: repository already has hundreds of accessibility lint errors unrelated to this change)*
- [ ] yarn test *(fails: existing suites such as window interactions and Nmap NSE tests are red in main)*

------
https://chatgpt.com/codex/tasks/task_e_68c984fe401083289ab71dc0cdce0eb8