### PR TITLE
[settings] auto accent from wallpaper

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -17,6 +17,8 @@ export default function Settings() {
   const {
     accent,
     setAccent,
+    accentLocked,
+    setAccentLocked,
     wallpaper,
     setWallpaper,
     density,
@@ -72,6 +74,7 @@ export default function Settings() {
     try {
       const parsed = JSON.parse(text);
       if (parsed.accent !== undefined) setAccent(parsed.accent);
+      if (parsed.accentLocked !== undefined) setAccentLocked(parsed.accentLocked);
       if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
       if (parsed.density !== undefined) setDensity(parsed.density);
       if (parsed.reducedMotion !== undefined)
@@ -95,6 +98,7 @@ export default function Settings() {
     await resetSettings();
     window.localStorage.clear();
     setAccent(defaults.accent);
+    setAccentLocked(defaults.accentLocked);
     setWallpaper(defaults.wallpaper);
     setDensity(defaults.density as any);
     setReducedMotion(defaults.reducedMotion);
@@ -149,6 +153,21 @@ export default function Settings() {
                 />
               ))}
             </div>
+          </div>
+          <div className="flex flex-col items-center my-2 text-ubt-grey">
+            <div className="flex items-center gap-2">
+              <span>Lock accent color</span>
+              <ToggleSwitch
+                checked={accentLocked}
+                onChange={setAccentLocked}
+                ariaLabel="Lock accent color"
+              />
+            </div>
+            <p className="text-xs mt-2 text-center max-w-xs">
+              {accentLocked
+                ? 'Accent stays fixed even when wallpapers change.'
+                : 'Accent updates automatically to match the current wallpaper.'}
+            </p>
           </div>
           <div className="flex justify-center my-4">
             <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -9,7 +9,7 @@ interface Props {
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const unlocked = getUnlockedThemes(highScore);
-  const { accent, setAccent, theme, setTheme } = useSettings();
+  const { accent, setAccent, accentLocked, setAccentLocked, theme, setTheme } = useSettings();
 
   return (
     <div>
@@ -51,6 +51,14 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
                 />
               ))}
             </div>
+          </label>
+          <label className="flex items-center gap-2 mt-3">
+            <input
+              type="checkbox"
+              checked={accentLocked}
+              onChange={(e) => setAccentLocked(e.target.checked)}
+            />
+            Lock accent color
           </label>
         </div>
       )}

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,7 @@ import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, accentLocked, setAccentLocked, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -87,6 +87,22 @@ export function Settings() {
                         />
                     ))}
                 </div>
+            </div>
+            <div className="flex flex-col items-center text-ubt-grey my-2">
+                <label className="flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={accentLocked}
+                        onChange={(e) => setAccentLocked(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Lock accent color
+                </label>
+                <p className="text-xs mt-2 text-center max-w-xs">
+                    {accentLocked
+                        ? 'Accent stays fixed when wallpapers change.'
+                        : 'Accent adjusts automatically to match your wallpaper.'}
+                </p>
             </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Density:</label>
@@ -245,6 +261,7 @@ export function Settings() {
                     onClick={async () => {
                         await resetSettings();
                         setAccent(defaults.accent);
+                        setAccentLocked(defaults.accentLocked);
                         setWallpaper(defaults.wallpaper);
                         setDensity(defaults.density);
                         setReducedMotion(defaults.reducedMotion);
@@ -270,6 +287,7 @@ export function Settings() {
                     try {
                         const parsed = JSON.parse(text);
                         if (parsed.accent !== undefined) setAccent(parsed.accent);
+                        if (parsed.accentLocked !== undefined) setAccentLocked(parsed.accentLocked);
                         if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
                         if (parsed.density !== undefined) setDensity(parsed.density);
                         if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);

--- a/src/theming/accentFromImage.ts
+++ b/src/theming/accentFromImage.ts
@@ -1,0 +1,225 @@
+const DEFAULT_MAX_DIMENSION = 128;
+const DEFAULT_SAMPLE_COUNT = 6000;
+
+const accentCache = new Map<string, string>();
+
+export interface AccentSampleOptions {
+  fallback?: string | null;
+  maxDimension?: number;
+  sampleCount?: number;
+}
+
+interface RGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
+interface HSL {
+  h: number;
+  s: number;
+  l: number;
+}
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
+const toHex = (value: number) => value.toString(16).padStart(2, '0');
+
+const rgbToHex = ({ r, g, b }: RGB) => `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+
+const rgbToHsl = (r: number, g: number, b: number): HSL => {
+  const rNorm = r / 255;
+  const gNorm = g / 255;
+  const bNorm = b / 255;
+  const max = Math.max(rNorm, gNorm, bNorm);
+  const min = Math.min(rNorm, gNorm, bNorm);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case rNorm:
+        h = (gNorm - bNorm) / d + (gNorm < bNorm ? 6 : 0);
+        break;
+      case gNorm:
+        h = (bNorm - rNorm) / d + 2;
+        break;
+      default:
+        h = (rNorm - gNorm) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+
+  return { h, s, l };
+};
+
+const hslToRgb = (h: number, s: number, l: number): RGB => {
+  if (s === 0) {
+    const value = Math.round(l * 255);
+    return { r: value, g: value, b: value };
+  }
+
+  const hueToRgb = (p: number, q: number, t: number) => {
+    let temp = t;
+    if (temp < 0) temp += 1;
+    if (temp > 1) temp -= 1;
+    if (temp < 1 / 6) return p + (q - p) * 6 * temp;
+    if (temp < 1 / 2) return q;
+    if (temp < 2 / 3) return p + (q - p) * (2 / 3 - temp) * 6;
+    return p;
+  };
+
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+
+  const r = hueToRgb(p, q, h + 1 / 3);
+  const g = hueToRgb(p, q, h);
+  const b = hueToRgb(p, q, h - 1 / 3);
+
+  return {
+    r: Math.round(r * 255),
+    g: Math.round(g * 255),
+    b: Math.round(b * 255),
+  };
+};
+
+const loadImage = (src: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.decoding = 'async';
+    image.onload = () => resolve(image);
+    image.onerror = (err) => reject(err);
+    image.src = src;
+  });
+
+const chooseDominantColor = (data: Uint8ClampedArray, sampleStep: number) => {
+  const buckets = new Map<number, { weight: number; r: number; g: number; b: number }>();
+  const fallback = { weight: 0, r: 0, g: 0, b: 0 };
+
+  for (let i = 0; i < data.length; i += 4 * sampleStep) {
+    const alpha = data[i + 3];
+    if (alpha < 200) continue;
+
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+
+    const { h, s, l } = rgbToHsl(r, g, b);
+
+    if (!Number.isFinite(s) || s < 0.18) {
+      fallback.weight += 1;
+      fallback.r += r;
+      fallback.g += g;
+      fallback.b += b;
+      continue;
+    }
+
+    if (l < 0.12 || l > 0.85) continue;
+
+    const bucket = Math.floor(((h % 1) + 1) % 1 * 12);
+    const weight = s * (1 - Math.abs(l - 0.5) * 1.8);
+    if (weight <= 0) continue;
+
+    const current =
+      buckets.get(bucket) ?? { weight: 0, r: 0, g: 0, b: 0 };
+    current.weight += weight;
+    current.r += r * weight;
+    current.g += g * weight;
+    current.b += b * weight;
+    buckets.set(bucket, current);
+  }
+
+  let best: RGB | null = null;
+  let bestWeight = 0;
+
+  buckets.forEach((entry) => {
+    if (entry.weight > bestWeight && entry.weight > 0) {
+      bestWeight = entry.weight;
+      best = {
+        r: Math.round(entry.r / entry.weight),
+        g: Math.round(entry.g / entry.weight),
+        b: Math.round(entry.b / entry.weight),
+      };
+    }
+  });
+
+  if (!best && fallback.weight > 0) {
+    best = {
+      r: Math.round(fallback.r / fallback.weight),
+      g: Math.round(fallback.g / fallback.weight),
+      b: Math.round(fallback.b / fallback.weight),
+    };
+  }
+
+  return best;
+};
+
+const enhanceColor = (rgb: RGB): RGB => {
+  const { h, s, l } = rgbToHsl(rgb.r, rgb.g, rgb.b);
+  const boostedS = clamp(s + 0.2, 0.35, 0.9);
+  const balancedL = clamp(l, 0.3, 0.6);
+  return hslToRgb(h, boostedS, balancedL);
+};
+
+export async function accentFromImage(
+  src: string,
+  options: AccentSampleOptions = {},
+): Promise<string | null> {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return options.fallback ?? null;
+  }
+
+  if (accentCache.has(src)) {
+    return accentCache.get(src)!;
+  }
+
+  const {
+    fallback = null,
+    maxDimension = DEFAULT_MAX_DIMENSION,
+    sampleCount = DEFAULT_SAMPLE_COUNT,
+  } = options;
+
+  let image: HTMLImageElement;
+  try {
+    image = await loadImage(src);
+  } catch {
+    return fallback;
+  }
+
+  const largestSide = Math.max(image.naturalWidth, image.naturalHeight);
+  const scale = largestSide > maxDimension ? maxDimension / largestSide : 1;
+  const width = Math.max(1, Math.round(image.naturalWidth * scale));
+  const height = Math.max(1, Math.round(image.naturalHeight * scale));
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext('2d');
+  if (!context) return fallback;
+
+  context.drawImage(image, 0, 0, width, height);
+
+  let imageData: ImageData;
+  try {
+    imageData = context.getImageData(0, 0, width, height);
+  } catch {
+    return fallback;
+  }
+
+  const totalPixels = imageData.data.length / 4;
+  const sampleStep = Math.max(1, Math.floor(totalPixels / sampleCount));
+  const dominant = chooseDominantColor(imageData.data, sampleStep);
+
+  if (!dominant) return fallback;
+
+  const enhanced = enhanceColor(dominant);
+  const hex = rgbToHex(enhanced);
+  accentCache.set(src, hex);
+  return hex;
+}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  accentLocked: false,
 };
 
 export async function getAccent() {
@@ -24,6 +25,17 @@ export async function getAccent() {
 export async function setAccent(accent) {
   if (typeof window === 'undefined') return;
   await set('accent', accent);
+}
+
+export async function getAccentLock() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.accentLocked;
+  const stored = await get('accent-locked');
+  return stored === undefined ? DEFAULT_SETTINGS.accentLocked : Boolean(stored);
+}
+
+export async function setAccentLock(locked) {
+  if (typeof window === 'undefined') return;
+  await set('accent-locked', locked);
 }
 
 export async function getWallpaper() {
@@ -128,6 +140,7 @@ export async function resetSettings() {
   await Promise.all([
     del('accent'),
     del('bg-image'),
+    del('accent-locked'),
   ]);
   window.localStorage.removeItem('density');
   window.localStorage.removeItem('reduced-motion');
@@ -142,6 +155,7 @@ export async function resetSettings() {
 export async function exportSettings() {
   const [
     accent,
+    accentLocked,
     wallpaper,
     density,
     reducedMotion,
@@ -153,6 +167,7 @@ export async function exportSettings() {
     haptics,
   ] = await Promise.all([
     getAccent(),
+    getAccentLock(),
     getWallpaper(),
     getDensity(),
     getReducedMotion(),
@@ -166,6 +181,7 @@ export async function exportSettings() {
   const theme = getTheme();
   return JSON.stringify({
     accent,
+    accentLocked,
     wallpaper,
     density,
     reducedMotion,
@@ -190,6 +206,7 @@ export async function importSettings(json) {
   }
   const {
     accent,
+    accentLocked,
     wallpaper,
     density,
     reducedMotion,
@@ -202,6 +219,7 @@ export async function importSettings(json) {
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
+  if (accentLocked !== undefined) await setAccentLock(accentLocked);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
   if (density !== undefined) await setDensity(density);
   if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);


### PR DESCRIPTION
## Summary
- add image sampling utility to derive an accent color from wallpapers and cache results
- automatically sync wallpaper changes to the accent color when unlocked and persist the new lock preference
- surface the accent lock toggle in both settings UIs and include it in import/export flows

## Testing
- yarn lint *(fails: repository has numerous existing jsx-a11y and no-top-level-window violations)*
- yarn test *(fails: suite already contains failures related to jsdom localStorage and alert queries)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c2ff7cc83288e9e6fd1430bfe6c