### PR TITLE
[accessibility] improve high-contrast tokens and assets

### DIFF
--- a/__tests__/tokens-contrast.test.ts
+++ b/__tests__/tokens-contrast.test.ts
@@ -1,0 +1,84 @@
+import fs from 'fs';
+import path from 'path';
+import { contrastRatio } from '../components/apps/Games/common/theme';
+
+type TokenMap = Record<string, string>;
+
+const loadHighContrastTokens = (): TokenMap => {
+  const file = path.join(__dirname, '..', 'styles', 'tokens.css');
+  const source = fs.readFileSync(file, 'utf8');
+  const match = source.match(/\.high-contrast\s*\{([\s\S]*?)\n\}/);
+  if (!match) throw new Error('Unable to locate .high-contrast token block');
+  const body = match[1];
+  const tokens: TokenMap = {};
+  body
+    .split('\n')
+    .map((line) => line.trim())
+    .forEach((line) => {
+      const tokenMatch = line.match(/^(--[a-z0-9-]+):\s*([^;]+);/i);
+      if (tokenMatch) {
+        const [, name, value] = tokenMatch;
+        tokens[name] = value.trim();
+      }
+    });
+  return tokens;
+};
+
+describe('high contrast tokens', () => {
+  const tokens = loadHighContrastTokens();
+  const resolve = (value: string): string => {
+    if (value.startsWith('--')) {
+      const resolved = tokens[value];
+      if (!resolved) throw new Error(`Missing token ${value}`);
+      return resolved;
+    }
+    return value;
+  };
+
+  const combos: Array<{ fg: string; bg: string; min: number; label: string }> = [
+    { fg: '--color-text', bg: '--color-bg', min: 7, label: 'text on base background' },
+    { fg: '--color-text', bg: '--color-ub-grey', min: 7, label: 'text on primary surface' },
+    { fg: '--color-text', bg: '--color-ub-cool-grey', min: 7, label: 'text on cool grey surface' },
+    { fg: '--color-text', bg: '--color-ub-dark-grey', min: 7, label: 'text on dark grey surface' },
+    { fg: '--color-text', bg: '--color-ub-gedit-dark', min: 7, label: 'text on gedit workspace' },
+    { fg: '#ffffff', bg: '--color-ub-orange', min: 4.5, label: 'white on accent orange' },
+    { fg: '#000000', bg: '--color-ub-orange', min: 4.5, label: 'black on accent orange' },
+    { fg: '#ffffff', bg: '--color-ubt-blue', min: 4.5, label: 'white on utility blue' },
+    { fg: '#000000', bg: '--color-ubt-blue', min: 4.5, label: 'black on utility blue' },
+    { fg: '#ffffff', bg: '--color-ubt-green', min: 4.5, label: 'white on utility green' },
+    { fg: '#000000', bg: '--color-ubt-green', min: 4.5, label: 'black on utility green' },
+    { fg: '#ffffff', bg: '--color-ubt-gedit-orange', min: 4.5, label: 'white on gedit orange' },
+    { fg: '#000000', bg: '--color-ubt-gedit-orange', min: 4.5, label: 'black on gedit orange' },
+    { fg: '#ffffff', bg: '--color-ubt-gedit-blue', min: 4.5, label: 'white on gedit blue' },
+    { fg: '#000000', bg: '--color-ubt-gedit-blue', min: 4.5, label: 'black on gedit blue' },
+    { fg: '--color-ubt-gedit-blue', bg: '--color-ub-gedit-dark', min: 4.5, label: 'gedit blue labels' },
+    { fg: '--color-ubt-gedit-orange', bg: '--color-ub-gedit-dark', min: 4.5, label: 'gedit orange labels' },
+    { fg: '#ffffff', bg: '--color-ubt-cool-grey', min: 4.5, label: 'white on utility cool grey' },
+    { fg: '#000000', bg: '--color-ubt-cool-grey', min: 4.5, label: 'black on utility cool grey' },
+    { fg: '#ffffff', bg: '--game-color-secondary', min: 4.5, label: 'white on game secondary' },
+    { fg: '#000000', bg: '--game-color-secondary', min: 4.5, label: 'black on game secondary' },
+    { fg: '#ffffff', bg: '--game-color-success', min: 4.5, label: 'white on game success' },
+    { fg: '#000000', bg: '--game-color-success', min: 4.5, label: 'black on game success' },
+    { fg: '#ffffff', bg: '--game-color-warning', min: 4.5, label: 'white on game warning' },
+    { fg: '#000000', bg: '--game-color-warning', min: 4.5, label: 'black on game warning' },
+    { fg: '#ffffff', bg: '--game-color-danger', min: 4.5, label: 'white on game danger' },
+    { fg: '#000000', bg: '--game-color-danger', min: 4.5, label: 'black on game danger' },
+    { fg: '--focus-outline-color', bg: '--color-bg', min: 4.5, label: 'focus outline against background' },
+  ];
+
+  test('meet contrast requirements', () => {
+    combos.forEach(({ fg, bg, min, label }) => {
+      const fgColor = resolve(fg);
+      const bgColor = resolve(bg);
+      expect(fgColor).toBeDefined();
+      expect(bgColor).toBeDefined();
+      const ratio = contrastRatio(fgColor, bgColor);
+      if (ratio < min) {
+        throw new Error(
+          `Contrast for ${label} (${fgColor} on ${bgColor}) was ${ratio.toFixed(2)}, expected ≥ ${min}`,
+        );
+      }
+      expect(ratio).toBeGreaterThanOrEqual(min);
+    });
+  });
+});

--- a/public/icons/128/kali-high-contrast.svg
+++ b/public/icons/128/kali-high-contrast.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 256 256" role="img" aria-labelledby="title">
+  <title>Kali high contrast icon 128px</title>
+  <rect width="256" height="256" rx="48" fill="#000000" />
+  <rect x="16" y="16" width="224" height="224" rx="40" fill="none" stroke="#0B6BFF" stroke-width="16" />
+  <path d="M84 72h52v112H84z" fill="#00883A" />
+  <path d="M152 72h40l-68 56 68 56h-40l-68-56z" fill="#C05600" />
+  <circle cx="188" cy="92" r="28" fill="#FFFFFF" />
+  <circle cx="188" cy="92" r="18" fill="#0B6BFF" />
+</svg>

--- a/public/icons/256/kali-high-contrast.svg
+++ b/public/icons/256/kali-high-contrast.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256" role="img" aria-labelledby="title">
+  <title>Kali high contrast icon 256px</title>
+  <rect width="256" height="256" rx="48" fill="#000000" />
+  <rect x="16" y="16" width="224" height="224" rx="40" fill="none" stroke="#0B6BFF" stroke-width="16" />
+  <path d="M84 72h52v112H84z" fill="#00883A" />
+  <path d="M152 72h40l-68 56 68 56h-40l-68-56z" fill="#C05600" />
+  <circle cx="188" cy="92" r="28" fill="#FFFFFF" />
+  <circle cx="188" cy="92" r="18" fill="#0B6BFF" />
+</svg>

--- a/public/icons/48/kali-high-contrast.svg
+++ b/public/icons/48/kali-high-contrast.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 256 256" role="img" aria-labelledby="title">
+  <title>Kali high contrast icon 48px</title>
+  <rect width="256" height="256" rx="48" fill="#000000" />
+  <rect x="16" y="16" width="224" height="224" rx="40" fill="none" stroke="#0B6BFF" stroke-width="16" />
+  <path d="M84 72h52v112H84z" fill="#00883A" />
+  <path d="M152 72h40l-68 56 68 56h-40l-68-56z" fill="#C05600" />
+  <circle cx="188" cy="92" r="28" fill="#FFFFFF" />
+  <circle cx="188" cy="92" r="18" fill="#0B6BFF" />
+</svg>

--- a/public/icons/64/kali-high-contrast.svg
+++ b/public/icons/64/kali-high-contrast.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 256 256" role="img" aria-labelledby="title">
+  <title>Kali high contrast icon 64px</title>
+  <rect width="256" height="256" rx="48" fill="#000000" />
+  <rect x="16" y="16" width="224" height="224" rx="40" fill="none" stroke="#0B6BFF" stroke-width="16" />
+  <path d="M84 72h52v112H84z" fill="#00883A" />
+  <path d="M152 72h40l-68 56 68 56h-40l-68-56z" fill="#C05600" />
+  <circle cx="188" cy="92" r="28" fill="#FFFFFF" />
+  <circle cx="188" cy="92" r="18" fill="#0B6BFF" />
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -68,12 +68,30 @@ html[data-theme='matrix'] {
 
 }
 
+html.high-contrast {
+  --color-bg: #000000;
+  --color-text: #ffffff;
+  --color-primary: #0b6bff;
+  --color-secondary: #000000;
+  --color-accent: #a06a00;
+  --color-muted: #101010;
+  --color-surface: #000000;
+  --color-inverse: #000000;
+  --color-border: #757575;
+  --color-terminal: #00ff00;
+  --color-dark: #000000;
+  --color-focus-ring: #0b6bff;
+  --color-selection: #0b6bff;
+  --color-control-accent: #0b6bff;
+  accent-color: #0b6bff;
+}
+
 ::selection {
   background: var(--color-selection);
   color: var(--color-inverse);
 }
 
 *:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, var(--color-focus-ring));
   outline-offset: 2px;
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -67,16 +67,32 @@
   --color-bg: #000000;
   --color-text: #ffffff;
   --color-ub-grey: #000000;
+  --color-ub-warm-grey: #1f1f1f;
   --color-ub-cool-grey: #000000;
-  --color-ubt-grey: #ffffff;
-  --color-ubt-cool-grey: #ffffff;
-  --color-ub-orange: #ffff00;
-  --color-ub-lite-abrgn: #00ffff;
-  --color-ub-border-orange: #ffff00;
-  --game-color-secondary: #ffff00;
-  --game-color-success: #00ffff;
-  --game-color-warning: #ff00ff;
-  --game-color-danger: #ff0000;
+  --color-ub-lite-abrgn: #000a14;
+  --color-ub-med-abrgn: #000610;
+  --color-ub-drk-abrgn: #000000;
+  --color-ub-window-title: #000000;
+  --color-ub-gedit-dark: #000000;
+  --color-ub-gedit-light: #00324d;
+  --color-ub-gedit-darker: #00060f;
+  --color-ubt-grey: #f5f5f5;
+  --color-ubt-warm-grey: #e6e0d6;
+  --color-ubt-cool-grey: #757575;
+  --color-ubt-blue: #0b6bff;
+  --color-ubt-green: #00883a;
+  --color-ubt-gedit-orange: #c05600;
+  --color-ubt-gedit-blue: #0074e0;
+  --color-ubt-gedit-dark: #0b6bff;
+  --color-ub-orange: #a06a00;
+  --color-ub-border-orange: #a06a00;
+  --color-ub-dark-grey: #000000;
+  --focus-outline-color: #0b6bff;
+  --kali-bg: rgba(0, 0, 0, 0.9);
+  --game-color-secondary: #0b6bff;
+  --game-color-success: #00883a;
+  --game-color-warning: #c05600;
+  --game-color-danger: #c0504f;
 }
 
 /* Dyslexia-friendly fonts */
@@ -110,11 +126,31 @@
     --color-bg: #000000;
     --color-text: #ffffff;
     --color-ub-grey: #000000;
+    --color-ub-warm-grey: #1f1f1f;
     --color-ub-cool-grey: #000000;
-    --color-ubt-grey: #ffffff;
-    --color-ubt-cool-grey: #ffffff;
-    --color-ub-orange: #ffff00;
-    --color-ub-lite-abrgn: #00ffff;
-    --color-ub-border-orange: #ffff00;
+    --color-ub-lite-abrgn: #000a14;
+    --color-ub-med-abrgn: #000610;
+    --color-ub-drk-abrgn: #000000;
+    --color-ub-window-title: #000000;
+    --color-ub-gedit-dark: #000000;
+    --color-ub-gedit-light: #00324d;
+    --color-ub-gedit-darker: #00060f;
+    --color-ubt-grey: #f5f5f5;
+    --color-ubt-warm-grey: #e6e0d6;
+    --color-ubt-cool-grey: #757575;
+    --color-ubt-blue: #0b6bff;
+    --color-ubt-green: #00883a;
+    --color-ubt-gedit-orange: #c05600;
+    --color-ubt-gedit-blue: #0074e0;
+    --color-ubt-gedit-dark: #0b6bff;
+    --color-ub-orange: #a06a00;
+    --color-ub-border-orange: #a06a00;
+    --color-ub-dark-grey: #000000;
+    --focus-outline-color: #0b6bff;
+    --kali-bg: rgba(0, 0, 0, 0.9);
+    --game-color-secondary: #0b6bff;
+    --game-color-success: #00883a;
+    --game-color-warning: #c05600;
+    --game-color-danger: #c0504f;
   }
 }


### PR DESCRIPTION
## Summary
- refresh the high-contrast token palette to use WCAG-compliant color pairs and ensure focus outlines stay visible
- add high-contrast icon variants in `public/icons` for key sizes
- add a regression test that verifies the updated token combinations exceed the required contrast ratios

## Testing
- yarn lint *(fails: repository has pre-existing jsx-a11y/no-top-level-window violations outside this change)*
- yarn test __tests__/tokens-contrast.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c99c3f9cfc8328b4765896c07ffd0d