### PR TITLE
[desktop] add reduced transparency mode

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -31,6 +31,8 @@ export default function Settings() {
     setHaptics,
     theme,
     setTheme,
+    reducedTransparency,
+    setReducedTransparency,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -80,6 +82,8 @@ export default function Settings() {
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
       if (parsed.theme !== undefined) setTheme(parsed.theme);
+      if (parsed.reducedTransparency !== undefined)
+        setReducedTransparency(parsed.reducedTransparency);
     } catch (err) {
       console.error("Invalid settings", err);
     }
@@ -100,6 +104,7 @@ export default function Settings() {
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
+    setReducedTransparency(defaults.reducedTransparency);
     setTheme("default");
   };
 
@@ -242,6 +247,14 @@ export default function Settings() {
               checked={reducedMotion}
               onChange={setReducedMotion}
               ariaLabel="Reduced Motion"
+            />
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Reduced Transparency:</span>
+            <ToggleSwitch
+              checked={reducedTransparency}
+              onChange={setReducedTransparency}
+              ariaLabel="Reduced Transparency"
             />
           </div>
           <div className="flex justify-center my-4 items-center">

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -634,8 +634,15 @@ export class Window extends Component {
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
                 >
                     <div
-                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        style={{
+                            width: `${this.state.width}%`,
+                            height: `${this.state.height}%`,
+                            backgroundColor: 'var(--surface-window-muted)',
+                            borderColor: 'var(--border-window)',
+                            backdropFilter: 'var(--window-backdrop-filter)',
+                            WebkitBackdropFilter: 'var(--window-backdrop-filter)',
+                        }}
+                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border border-t-0 flex flex-col"}
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}
@@ -838,7 +845,10 @@ export class WindowMainScreen extends Component {
     }
     render() {
         return (
-            <div className={"w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen" + (this.state.setDarkBg ? " bg-ub-drk-abrgn " : " bg-ub-cool-grey")}>
+            <div
+                className={"w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen"}
+                data-surface={this.state.setDarkBg ? 'main' : 'muted'}
+            >
                 {this.props.screen(this.props.addFolder, this.props.openApp)}
             </div>
         )

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getReducedTransparency as loadReducedTransparency,
+  setReducedTransparency as saveReducedTransparency,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -63,6 +65,7 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  reducedTransparency: boolean;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +77,7 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setReducedTransparency: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +92,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  reducedTransparency: defaults.reducedTransparency,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +104,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setReducedTransparency: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -113,6 +119,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [reducedTransparency, setReducedTransparency] = useState<boolean>(
+    defaults.reducedTransparency,
+  );
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -128,6 +137,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
       setTheme(loadTheme());
+      setReducedTransparency(await loadReducedTransparency());
     })();
   }, []);
 
@@ -236,6 +246,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    document.documentElement.classList.toggle('solid-surfaces', reducedTransparency);
+    saveReducedTransparency(reducedTransparency);
+  }, [reducedTransparency]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -250,6 +265,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        reducedTransparency,
         setAccent,
         setWallpaper,
         setDensity,
@@ -261,6 +277,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setReducedTransparency,
       }}
     >
       {children}

--- a/styles/index.css
+++ b/styles/index.css
@@ -105,9 +105,17 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .window-shadow {
-    box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -webkit-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -moz-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+    box-shadow: var(--shadow-window);
+    -webkit-box-shadow: var(--shadow-window);
+    -moz-box-shadow: var(--shadow-window);
+}
+
+.opened-window {
+    background-color: var(--surface-window-muted);
+    border-color: var(--border-window);
+    backdrop-filter: var(--window-backdrop-filter);
+    -webkit-backdrop-filter: var(--window-backdrop-filter);
+    transition: box-shadow var(--motion-medium) ease, background-color var(--motion-medium) ease, border-color var(--motion-medium) ease;
 }
 
 .closed-window {
@@ -130,6 +138,14 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 .windowMainScreen {
     container-type: inline-size;
+}
+
+.windowMainScreen[data-surface='muted'] {
+    background-color: var(--surface-window-muted);
+}
+
+.windowMainScreen[data-surface='main'] {
+    background-color: var(--surface-window);
 }
 
 .windowMainScreen::-webkit-scrollbar-track {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -27,6 +27,25 @@
   --color-text: #F5F5F5;
   --kali-bg: rgba(15, 19, 23, 0.85);
 
+  /* Window surface treatments */
+  --surface-window-glass: color-mix(in srgb, var(--color-ub-drk-abrgn), transparent 35%);
+  --surface-window-muted-glass: color-mix(in srgb, var(--color-ub-cool-grey), transparent 45%);
+  --surface-window-solid: var(--color-ub-drk-abrgn);
+  --surface-window-muted-solid: var(--color-ub-cool-grey);
+  --shadow-window-glass: 0 24px 52px -28px color-mix(in srgb, var(--color-inverse), transparent 70%);
+  --shadow-window-solid: 0 26px 60px -24px color-mix(in srgb, var(--color-inverse), transparent 35%);
+  --border-window-glass: color-mix(in srgb, var(--color-inverse), transparent 65%);
+  --border-window-solid: color-mix(in srgb, var(--color-inverse), transparent 25%);
+  --window-backdrop-filter-glass: blur(18px);
+  --window-backdrop-filter-solid: none;
+
+  /* Active window tokens */
+  --surface-window: var(--surface-window-glass);
+  --surface-window-muted: var(--surface-window-muted-glass);
+  --shadow-window: var(--shadow-window-glass);
+  --border-window: var(--border-window-glass);
+  --window-backdrop-filter: var(--window-backdrop-filter-glass);
+
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
   --game-color-success: #15803d;
@@ -73,6 +92,11 @@
   --color-ub-orange: #ffff00;
   --color-ub-lite-abrgn: #00ffff;
   --color-ub-border-orange: #ffff00;
+  --surface-window: #000000;
+  --surface-window-muted: #000000;
+  --shadow-window: 0 0 0 2px #ffffff;
+  --border-window: #ffffff;
+  --window-backdrop-filter: none;
   --game-color-secondary: #ffff00;
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
@@ -96,6 +120,15 @@
   --motion-slow: 0ms;
 }
 
+/* Reduced transparency / solid surfaces */
+.solid-surfaces {
+  --surface-window: var(--surface-window-solid);
+  --surface-window-muted: var(--surface-window-muted-solid);
+  --shadow-window: var(--shadow-window-solid);
+  --border-window: var(--border-window-solid);
+  --window-backdrop-filter: var(--window-backdrop-filter-solid);
+}
+
 @media (prefers-reduced-motion: reduce) {
   :root {
     --motion-fast: 0ms;
@@ -116,5 +149,10 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+    --surface-window: #000000;
+    --surface-window-muted: #000000;
+    --shadow-window: 0 0 0 2px #ffffff;
+    --border-window: #ffffff;
+    --window-backdrop-filter: none;
   }
 }

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  reducedTransparency: false,
 };
 
 export async function getAccent() {
@@ -102,6 +103,16 @@ export async function setHaptics(value) {
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+export async function getReducedTransparency() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedTransparency;
+  return window.localStorage.getItem('reduced-transparency') === 'true';
+}
+
+export async function setReducedTransparency(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('reduced-transparency', value ? 'true' : 'false');
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -137,6 +148,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('reduced-transparency');
 }
 
 export async function exportSettings() {
@@ -151,6 +163,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    reducedTransparency,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +175,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getReducedTransparency(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +189,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    reducedTransparency,
     theme,
   });
 }
@@ -199,6 +214,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    reducedTransparency,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +227,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (reducedTransparency !== undefined) await setReducedTransparency(reducedTransparency);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add solid surface tokens and CSS variables to back a reduced transparency theme state
- update window chrome to consume the new tokens for backgrounds, borders, and shadows
- surface a reduced transparency toggle in settings and persist the preference across sessions

## Testing
- yarn lint *(fails: existing repository violations such as jsx-a11y/control-has-associated-label in multiple apps)*
- yarn test *(fails: existing suites like __tests__/nmapNse.test.tsx due to jsdom/localStorage limitations and missing alerts)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c3b4b7883288064c7a6cf9f1ce9