### PR TITLE
[desktop] Improve taskbar accessibility semantics

### DIFF
--- a/__tests__/taskbar.test.tsx
+++ b/__tests__/taskbar.test.tsx
@@ -4,7 +4,11 @@ import Taskbar from '../components/screen/taskbar';
 
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
 
-const apps = [{ id: 'app1', title: 'App One', icon: '/icon.png' }];
+const singleApp = [{ id: 'app1', title: 'App One', icon: '/icon.png' }];
+const twoApps = [
+  singleApp[0],
+  { id: 'app2', title: 'App Two', icon: '/icon-2.png' },
+];
 
 describe('Taskbar', () => {
   it('minimizes focused window on click', () => {
@@ -12,7 +16,7 @@ describe('Taskbar', () => {
     const minimize = jest.fn();
     render(
       <Taskbar
-        apps={apps}
+        apps={singleApp}
         closed_windows={{ app1: false }}
         minimized_windows={{ app1: false }}
         focused_windows={{ app1: true }}
@@ -24,6 +28,11 @@ describe('Taskbar', () => {
     fireEvent.click(button);
     expect(minimize).toHaveBeenCalledWith('app1');
     expect(button).toHaveAttribute('data-context', 'taskbar');
+    expect(button).toHaveAttribute('aria-label', 'App One (active window)');
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+    expect(button).toHaveAttribute('aria-posinset', '1');
+    expect(button).toHaveAttribute('aria-setsize', '1');
+    expect(button).toHaveAttribute('data-state', 'active');
   });
 
   it('restores minimized window on click', () => {
@@ -31,7 +40,7 @@ describe('Taskbar', () => {
     const minimize = jest.fn();
     render(
       <Taskbar
-        apps={apps}
+        apps={singleApp}
         closed_windows={{ app1: false }}
         minimized_windows={{ app1: true }}
         focused_windows={{ app1: false }}
@@ -42,5 +51,54 @@ describe('Taskbar', () => {
     const button = screen.getByRole('button', { name: /app one/i });
     fireEvent.click(button);
     expect(openApp).toHaveBeenCalledWith('app1');
+    expect(button).toHaveAttribute('aria-label', 'App One (minimized)');
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+    expect(button).toHaveAttribute('data-state', 'minimized');
+  });
+
+  it('describes background state for non-focused windows', () => {
+    render(
+      <Taskbar
+        apps={singleApp}
+        closed_windows={{ app1: false }}
+        minimized_windows={{ app1: false }}
+        focused_windows={{ app1: false }}
+        openApp={jest.fn()}
+        minimize={jest.fn()}
+      />
+    );
+    const button = screen.getByRole('button', { name: /running in background/i });
+    expect(button).toHaveAttribute('aria-label', 'App One (running in background)');
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+    expect(button).toHaveAttribute('data-state', 'background');
+  });
+
+  it('allows arrow key navigation to follow visual order', () => {
+    render(
+      <Taskbar
+        apps={twoApps}
+        closed_windows={{ app1: false, app2: false }}
+        minimized_windows={{ app1: false, app2: false }}
+        focused_windows={{ app1: true, app2: false }}
+        openApp={jest.fn()}
+        minimize={jest.fn()}
+      />
+    );
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0]).toHaveAttribute('aria-posinset', '1');
+    expect(buttons[0]).toHaveAttribute('aria-setsize', '2');
+    expect(buttons[1]).toHaveAttribute('aria-posinset', '2');
+    expect(buttons[1]).toHaveAttribute('aria-setsize', '2');
+
+    buttons[0].focus();
+    expect(document.activeElement).toBe(buttons[0]);
+
+    fireEvent.keyDown(buttons[0], { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(buttons[1]);
+
+    fireEvent.keyDown(buttons[1], { key: 'ArrowLeft' });
+    expect(document.activeElement).toBe(buttons[0]);
   });
 });

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import Image from 'next/image';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const buttonRefs = useRef([]);
+    buttonRefs.current.length = runningApps.length;
 
     const handleClick = (app) => {
         const id = app.id;
@@ -15,33 +17,89 @@ export default function Taskbar(props) {
         }
     };
 
+    const handleKeyDown = (event, index) => {
+        if (!runningApps.length) {
+            return;
+        }
+
+        let targetIndex = index;
+        switch (event.key) {
+            case 'ArrowRight':
+            case 'ArrowDown':
+                event.preventDefault();
+                targetIndex = (index + 1) % runningApps.length;
+                break;
+            case 'ArrowLeft':
+            case 'ArrowUp':
+                event.preventDefault();
+                targetIndex = (index - 1 + runningApps.length) % runningApps.length;
+                break;
+            case 'Home':
+                event.preventDefault();
+                targetIndex = 0;
+                break;
+            case 'End':
+                event.preventDefault();
+                targetIndex = runningApps.length - 1;
+                break;
+            default:
+                return;
+        }
+
+        const nextButton = buttonRefs.current[targetIndex];
+        if (nextButton) {
+            nextButton.focus();
+        }
+    };
+
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => (
-                <button
-                    key={app.id}
-                    type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
-                    onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
-                    />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
-                </button>
-            ))}
+        <div
+            className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40"
+            role="toolbar"
+            aria-label="Running applications"
+            aria-orientation="horizontal"
+        >
+            {runningApps.map((app, index) => {
+                const id = app.id;
+                const isMinimized = !!props.minimized_windows[id];
+                const isFocused = !!props.focused_windows[id];
+                const isActive = isFocused && !isMinimized;
+                const stateLabel = isMinimized ? 'minimized' : isActive ? 'active window' : 'running in background';
+
+                return (
+                    <button
+                        key={id}
+                        type="button"
+                        ref={(element) => {
+                            buttonRefs.current[index] = element;
+                        }}
+                        onKeyDown={(event) => handleKeyDown(event, index)}
+                        aria-label={`${app.title} (${stateLabel})`}
+                        aria-posinset={index + 1}
+                        aria-setsize={runningApps.length}
+                        aria-pressed={isActive}
+                        data-state={isMinimized ? 'minimized' : isActive ? 'active' : 'background'}
+                        data-context="taskbar"
+                        data-app-id={id}
+                        onClick={() => handleClick(app)}
+                        className={(isActive ? ' bg-white bg-opacity-20 ' : ' ') +
+                            'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white'}
+                    >
+                        <Image
+                            width={24}
+                            height={24}
+                            className="w-5 h-5"
+                            src={app.icon.replace('./', '/')}
+                            alt=""
+                            sizes="24px"
+                        />
+                        <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                        {!isFocused && !isMinimized && (
+                            <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
+                        )}
+                    </button>
+                );
+            })}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add explicit state labelling and ordering hints to the taskbar buttons
- wire horizontal toolbar semantics with keyboard navigation helpers
- extend taskbar unit tests to cover new accessibility behaviours

## Testing
- yarn lint *(fails: existing unlabeled control lint errors across apps and public demos)*
- yarn test *(fails: pre-existing window, nmapNse, and reconng suites)*
- yarn test __tests__/taskbar.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68c99c45ecc083288333ec8db9510ed2