### PR TITLE
[rtl] Improve desktop shell mirroring

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import useLocaleDirection from '../../hooks/useLocaleDirection';
 
 type AppMeta = {
   id: string;
@@ -27,6 +28,8 @@ const WhiskerMenu: React.FC = () => {
   const [highlight, setHighlight] = useState(0);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const direction = useLocaleDirection();
+  const isRTL = direction === 'rtl';
 
   const allApps: AppMeta[] = apps as any;
   const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
@@ -127,14 +130,14 @@ const WhiskerMenu: React.FC = () => {
           alt="Menu"
           width={16}
           height={16}
-          className="inline mr-1"
+          className={`inline ${isRTL ? 'ml-1' : 'mr-1'}`}
         />
         Applications
       </button>
       {open && (
         <div
           ref={menuRef}
-          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
+          className={`absolute ${isRTL ? 'right-0' : 'left-0'} mt-1 z-50 flex bg-ub-grey text-white shadow-lg ${isRTL ? 'flex-row-reverse' : ''}`}
           tabIndex={-1}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node)) {
@@ -142,11 +145,11 @@ const WhiskerMenu: React.FC = () => {
             }
           }}
         >
-          <div className="flex flex-col bg-gray-800 p-2">
+          <div className={`flex flex-col bg-gray-800 p-2 ${isRTL ? 'items-end text-right' : ''}`}>
             {CATEGORIES.map(cat => (
               <button
                 key={cat.id}
-                className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
+                className={`${isRTL ? 'text-right' : 'text-left'} px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
                 onClick={() => setCategory(cat.id)}
               >
                 {cat.label}
@@ -159,9 +162,13 @@ const WhiskerMenu: React.FC = () => {
               placeholder="Search"
               value={query}
               onChange={e => setQuery(e.target.value)}
+              style={{ textAlign: isRTL ? 'right' : 'left' }}
               autoFocus
             />
-            <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
+            <div
+              className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto"
+              style={{ direction: isRTL ? 'rtl' : 'ltr' }}
+            >
               {currentApps.map((app, idx) => (
                 <div key={app.id} className={idx === highlight ? 'ring-2 ring-ubb-orange' : ''}>
                   <UbuntuApp

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,47 +1,38 @@
-import React, { Component } from 'react';
+import { useState } from 'react';
 import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import useLocaleDirection from '../../hooks/useLocaleDirection';
 
-export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+export default function Navbar() {
+        const [statusOpen, setStatusOpen] = useState(false);
+        const isRTL = useLocaleDirection() === 'rtl';
 
-	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
-                                </div>
-                                <WhiskerMenu />
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-                                        }
-                                >
-                                        <Clock />
-                                </div>
-                                <button
-                                        type="button"
-                                        id="status-bar"
-                                        aria-label="System status"
-                                        onClick={() => {
-                                                this.setState({ status_card: !this.state.status_card });
-                                        }}
-                                        className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-                                        }
-                                >
-                                        <Status />
-                                        <QuickSettings open={this.state.status_card} />
-                                </button>
-			</div>
-		);
-	}
+        const barLayout = isRTL ? 'flex-row-reverse' : '';
+        const networkPadding = isRTL ? 'pr-3 pl-1' : 'pl-3 pr-1';
+
+        return (
+                <div className={`main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50 ${barLayout}`}>
+                        <div className={networkPadding}>
+                                <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
+                        </div>
+                        <WhiskerMenu />
+                        <div className="pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1">
+                                <Clock />
+                        </div>
+                        <button
+                                type="button"
+                                id="status-bar"
+                                aria-label="System status"
+                                onClick={() => setStatusOpen((open) => !open)}
+                                className="relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1"
+                                aria-expanded={statusOpen}
+                        >
+                                <Status />
+                                <QuickSettings open={statusOpen} />
+                        </button>
+                </div>
+        );
 }

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import Image from 'next/image'
 import SideBarApp from '../base/side_bar_app';
+import useLocaleDirection from '../../hooks/useLocaleDirection';
 
 let renderApps = (props) => {
     let sideBarAppsJsx = [];
@@ -14,6 +15,8 @@ let renderApps = (props) => {
 }
 
 export default function SideBar(props) {
+
+    const isRTL = useLocaleDirection() === 'rtl';
 
     function showSideBar() {
         props.hideSideBar(null, false);
@@ -29,8 +32,7 @@ export default function SideBar(props) {
         <>
             <nav
                 aria-label="Dock"
-                className={(props.hide ? " -translate-x-full " : "") +
-                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
+                className={`${props.hide ? (isRTL ? 'translate-x-full' : '-translate-x-full') : ''} absolute transform duration-300 select-none z-40 ${isRTL ? 'right-0' : 'left-0'} top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50`}
             >
                 {
                     (
@@ -41,7 +43,7 @@ export default function SideBar(props) {
                 }
                 <AllApps showApps={props.showAllApps} />
             </nav>
-            <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className={"w-1 h-full absolute top-0 left-0 bg-transparent z-50"}></div>
+            <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className={`w-1 h-full absolute top-0 ${isRTL ? 'right-0' : 'left-0'} bg-transparent z-50`}></div>
         </>
     )
 }
@@ -49,6 +51,7 @@ export default function SideBar(props) {
 export function AllApps(props) {
 
     const [title, setTitle] = useState(false);
+    const isRTL = useLocaleDirection() === 'rtl';
 
     return (
         <div
@@ -74,7 +77,7 @@ export function AllApps(props) {
                 <div
                     className={
                         (title ? " visible " : " invisible ") +
-                        " w-max py-0.5 px-1.5 absolute top-1 left-full ml-5 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
+                        ` w-max py-0.5 px-1.5 absolute top-1 ${isRTL ? 'right-full mr-5 text-right' : 'left-full ml-5'} text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md`
                     }
                 >
                     Show Applications

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import Image from 'next/image';
+import useLocaleDirection from '../../hooks/useLocaleDirection';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const isRTL = useLocaleDirection() === 'rtl';
 
     const handleClick = (app) => {
         const id = app.id;
@@ -16,7 +18,7 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div className={`absolute bottom-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40 ${isRTL ? 'right-0 flex-row-reverse' : 'left-0'}`} role="toolbar">
             {runningApps.map(app => (
                 <button
                     key={app.id}
@@ -26,7 +28,7 @@ export default function Taskbar(props) {
                     data-app-id={app.id}
                     onClick={() => handleClick(app)}
                     className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                        `relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10 ${isRTL ? 'flex-row-reverse' : ''}`}
                 >
                     <Image
                         width={24}
@@ -36,7 +38,7 @@ export default function Taskbar(props) {
                         alt=""
                         sizes="24px"
                     />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                    <span className={`${isRTL ? 'mr-1 ml-0' : 'ml-1 mr-0'} text-sm text-white whitespace-nowrap`}>{app.title}</span>
                     {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
                         <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
                     )}

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,7 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import useLocaleDirection from '../../hooks/useLocaleDirection';
 
 interface Props {
   open: boolean;
@@ -12,6 +13,7 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const isRTL = useLocaleDirection() === 'rtl';
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -23,9 +25,9 @@ const QuickSettings = ({ open }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 shadow border-black border border-opacity-20 ${
         open ? '' : 'hidden'
-      }`}
+      } ${isRTL ? 'left-3 right-auto' : 'right-3 left-auto'}`}
     >
       <div className="px-4 pb-2">
         <button

--- a/components/util-components/small_arrow.js
+++ b/components/util-components/small_arrow.js
@@ -1,7 +1,16 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import useLocaleDirection from '../../hooks/useLocaleDirection';
 import styles from './small_arrow.module.css';
 
 export default function SmallArrow({ angle = 'up' }) {
+    const direction = useLocaleDirection();
+    const resolvedAngle = useMemo(() => {
+        if (direction !== 'rtl') return angle;
+        if (angle === 'left') return 'right';
+        if (angle === 'right') return 'left';
+        return angle;
+    }, [angle, direction]);
+
     const rotations = {
         up: '',
         down: 'rotate-180',
@@ -9,5 +18,5 @@ export default function SmallArrow({ angle = 'up' }) {
         right: 'rotate-90',
     };
 
-    return <div className={`${styles.arrow} ${rotations[angle] ?? ''}`}></div>;
+    return <div className={`${styles.arrow} ${rotations[resolvedAngle] ?? ''}`}></div>;
 }

--- a/hooks/useLocaleDirection.ts
+++ b/hooks/useLocaleDirection.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+export type LocaleDirection = 'ltr' | 'rtl';
+
+export const getDocumentDirection = (): LocaleDirection => {
+  if (typeof document === 'undefined') return 'ltr';
+  const dir = document.documentElement.getAttribute('dir');
+  return dir === 'rtl' ? 'rtl' : 'ltr';
+};
+
+const useLocaleDirection = (): LocaleDirection => {
+  const [direction, setDirection] = useState<LocaleDirection>(() => getDocumentDirection());
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+
+    const update = () => setDirection(getDocumentDirection());
+
+    update();
+
+    const observer = new MutationObserver(update);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['dir'] });
+
+    window.addEventListener('languagechange', update);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('languagechange', update);
+    };
+  }, []);
+
+  return direction;
+};
+
+export default useLocaleDirection;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -6,6 +6,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next';
 import '../styles/tailwind.css';
 import '../styles/globals.css';
 import '../styles/index.css';
+import '../styles/rtl.css';
 import '../styles/resume-print.css';
 import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';

--- a/styles/rtl.css
+++ b/styles/rtl.css
@@ -1,0 +1,26 @@
+/* RTL support utilities */
+
+html[dir='rtl'] body {
+  direction: rtl;
+}
+
+html[dir='rtl'] body * {
+  direction: inherit;
+}
+
+html[dir='rtl'] .text-left {
+  text-align: right;
+}
+
+html[dir='rtl'] .text-right {
+  text-align: left;
+}
+
+html[dir='rtl'] .space-x-1 > :not([hidden]) ~ :not([hidden]),
+html[dir='rtl'] .space-x-2 > :not([hidden]) ~ :not([hidden]),
+html[dir='rtl'] .space-x-3 > :not([hidden]) ~ :not([hidden]),
+html[dir='rtl'] .space-x-4 > :not([hidden]) ~ :not([hidden]),
+html[dir='rtl'] .space-x-6 > :not([hidden]) ~ :not([hidden]),
+html[dir='rtl'] .space-x-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 1;
+}


### PR DESCRIPTION
## Summary
- add a standalone rtl stylesheet to flip directional spacing and alignment
- create a reusable locale-direction hook and apply it across desktop chrome components
- mirror shared arrow affordances so icons reflect the current locale

## Testing
- yarn lint *(fails: repository contains pre-existing accessibility lint errors)*
- yarn test *(fails: existing suites for nmap NSE and About rely on alerts/act handling)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c46b85883288531666285ecaf70