### PR TITLE
desktop: improve dock accessibility

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -85,22 +85,33 @@ export class SideBarApp extends Component {
         }
     };
 
+    handlePointerEnter = () => {
+        this.captureThumbnail();
+        this.setState({ showTitle: true });
+    };
+
+    handlePointerLeave = () => {
+        this.setState({ showTitle: false, thumbnail: null });
+    };
+
     render() {
+        const id = this.id || this.props.id;
+        const isOpen = this.props.isClose && this.props.isClose[id] === false;
+        const isPinned = Boolean(this.props.isPinned);
+        const isPressed = isPinned || isOpen;
         return (
             <button
                 type="button"
                 aria-label={this.props.title}
+                aria-pressed={isPressed}
                 data-context="app"
                 data-app-id={this.props.id}
                 onClick={this.openApp}
-                onMouseEnter={() => {
-                    this.captureThumbnail();
-                    this.setState({ showTitle: true });
-                }}
-                onMouseLeave={() => {
-                    this.setState({ showTitle: false, thumbnail: null });
-                }}
-                className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
+                onMouseEnter={this.handlePointerEnter}
+                onMouseLeave={this.handlePointerLeave}
+                onFocus={this.handlePointerEnter}
+                onBlur={this.handlePointerLeave}
+                className={(this.props.isClose[id] === false && this.props.isFocus[id] ? "bg-white bg-opacity-10 " : "") +
                     " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
                 id={"sidebar-" + this.props.id}
             >
@@ -122,7 +133,7 @@ export class SideBarApp extends Component {
                 />
                 {
                     (
-                        this.props.isClose[this.id] === false
+                        this.props.isClose[id] === false
                             ? <div className=" w-2 h-1 absolute bottom-0 left-1/2 transform -translate-x-1/2 bg-white rounded-md"></div>
                             : null
                     )

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -885,6 +885,7 @@ export class Desktop extends Component {
                     hide={this.state.hideSideBar}
                     hideSideBar={this.hideSideBar}
                     favourite_apps={this.state.favourite_apps}
+                    pinnedApps={this.initFavourite}
                     showAllApps={this.showAllApps}
                     allAppsView={this.state.allAppsView}
                     closed_windows={this.state.closed_windows}

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -7,7 +7,18 @@ let renderApps = (props) => {
     props.apps.forEach((app, index) => {
         if (props.favourite_apps[app.id] === false) return;
         sideBarAppsJsx.push(
-            <SideBarApp key={app.id} id={app.id} title={app.title} icon={app.icon} isClose={props.closed_windows} isFocus={props.focused_windows} openApp={props.openAppByAppId} isMinimized={props.isMinimized} openFromMinimised={props.openFromMinimised} />
+            <SideBarApp
+                key={app.id}
+                id={app.id}
+                title={app.title}
+                icon={app.icon}
+                isClose={props.closed_windows}
+                isFocus={props.focused_windows}
+                openApp={props.openAppByAppId}
+                isMinimized={props.isMinimized}
+                openFromMinimised={props.openFromMinimised}
+                isPinned={props.pinnedApps ? props.pinnedApps[app.id] : false}
+            />
         );
     });
     return sideBarAppsJsx;
@@ -28,7 +39,9 @@ export default function SideBar(props) {
     return (
         <>
             <nav
+                role="toolbar"
                 aria-label="Dock"
+                aria-orientation="vertical"
                 className={(props.hide ? " -translate-x-full " : "") +
                     " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
             >
@@ -51,13 +64,21 @@ export function AllApps(props) {
     const [title, setTitle] = useState(false);
 
     return (
-        <div
-            className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
+        <button
+            type="button"
+            aria-label="Show Applications"
+            className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white flex items-center justify-center transition-hover transition-active`}
             style={{ marginTop: 'auto' }}
             onMouseEnter={() => {
                 setTitle(true);
             }}
             onMouseLeave={() => {
+                setTitle(false);
+            }}
+            onFocus={() => {
+                setTitle(true);
+            }}
+            onBlur={() => {
                 setTitle(false);
             }}
             onClick={props.showApps}
@@ -80,6 +101,6 @@ export function AllApps(props) {
                     Show Applications
                 </div>
             </div>
-        </div>
+        </button>
     );
 }


### PR DESCRIPTION
## Summary
- treat the dock container as a vertical toolbar with an explicit label
- surface pinned or active state through `aria-pressed` and better focus handling on dock buttons
- convert the applications trigger into a real button and pass pinned metadata through the desktop shell

## Testing
- yarn lint *(fails: repository currently reports numerous control-has-associated-label and top-level window lint errors)*
- yarn test *(fails: existing suites for nmap NSE and settings store fail along with jsdom localStorage access)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c39fb688328ac115b7ad79f5276