### PR TITLE
fix: stabilize panel settings hydration

### DIFF
--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -17,28 +17,45 @@ export default function Preferences() {
   ];
 
   const [active, setActive] = useState<TabId>("display");
+  const [size, setSize] = useState(24);
+  const [length, setLength] = useState(100);
+  const [orientation, setOrientation] = useState<"horizontal" | "vertical">(
+    "horizontal",
+  );
+  const [autohide, setAutohide] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
 
-  const [size, setSize] = useState(() => {
-    if (typeof window === "undefined") return 24;
-    const stored = localStorage.getItem(`${PANEL_PREFIX}size`);
-    return stored ? parseInt(stored, 10) : 24;
-  });
-  const [length, setLength] = useState(() => {
-    if (typeof window === "undefined") return 100;
-    const stored = localStorage.getItem(`${PANEL_PREFIX}length`);
-    return stored ? parseInt(stored, 10) : 100;
-  });
-  const [orientation, setOrientation] = useState<"horizontal" | "vertical">(() => {
-    if (typeof window === "undefined") return "horizontal";
-    return (localStorage.getItem(`${PANEL_PREFIX}orientation`) as
-      | "horizontal"
-      | "vertical"
-      | null) || "horizontal";
-  });
-  const [autohide, setAutohide] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return localStorage.getItem(`${PANEL_PREFIX}autohide`) === "true";
-  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const storedSize = window.localStorage.getItem(`${PANEL_PREFIX}size`);
+    if (storedSize) {
+      const parsed = parseInt(storedSize, 10);
+      if (!Number.isNaN(parsed)) setSize(parsed);
+    }
+
+    const storedLength = window.localStorage.getItem(`${PANEL_PREFIX}length`);
+    if (storedLength) {
+      const parsed = parseInt(storedLength, 10);
+      if (!Number.isNaN(parsed)) setLength(parsed);
+    }
+
+    const storedOrientation = window.localStorage.getItem(
+      `${PANEL_PREFIX}orientation`,
+    );
+    if (storedOrientation === "horizontal" || storedOrientation === "vertical") {
+      setOrientation(storedOrientation);
+    }
+
+    const storedAutohide = window.localStorage.getItem(
+      `${PANEL_PREFIX}autohide`,
+    );
+    if (storedAutohide !== null) {
+      setAutohide(storedAutohide === "true");
+    }
+
+    setHydrated(true);
+  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -63,77 +80,91 @@ export default function Preferences() {
   return (
     <div>
       <Tabs tabs={TABS} active={active} onChange={setActive} />
-      <div className="p-4">
-        {active === "display" && (
-          <div className="space-y-4">
-            <div className="flex items-center justify-between">
-              <label htmlFor="orientation" className="text-ubt-grey">
-                Orientation
-              </label>
-              <select
-                id="orientation"
-                value={orientation}
-                onChange={(e) =>
-                  setOrientation(e.target.value as "horizontal" | "vertical")
-                }
-                className="bg-ub-cool-grey text-white px-2 py-1 rounded"
-              >
-                <option value="horizontal">Horizontal</option>
-                <option value="vertical">Vertical</option>
-              </select>
-            </div>
-            <div className="flex items-center justify-between">
-              <span className="text-ubt-grey">Autohide</span>
-              <ToggleSwitch
-                checked={autohide}
-                onChange={setAutohide}
-                ariaLabel="Autohide panel"
-              />
-            </div>
+      <div className="p-4" aria-busy={!hydrated}>
+        {!hydrated ? (
+          <div role="status" className="space-y-4 animate-pulse">
+            <span className="sr-only">Loading saved panel preferences…</span>
+            <div className="h-4 w-32 rounded bg-white/10" />
+            <div className="h-10 w-full rounded bg-white/5" />
+            <div className="h-10 w-full rounded bg-white/5" />
+            <div className="h-10 w-full rounded bg-white/5" />
           </div>
-        )}
-        {active === "measurements" && (
-          <div className="space-y-4">
-            <div className="flex items-center justify-between">
-              <label htmlFor="panel-size" className="text-ubt-grey">
-                Size: {size}px
-              </label>
-              <input
-                id="panel-size"
-                type="range"
-                min="16"
-                max="128"
-                value={size}
-                onChange={(e) => setSize(parseInt(e.target.value, 10))}
-                className="ubuntu-slider"
-                aria-label="Panel size"
-              />
-            </div>
-            <div className="flex items-center justify-between">
-              <label htmlFor="panel-length" className="text-ubt-grey">
-                Length: {length}%
-              </label>
-              <input
-                id="panel-length"
-                type="range"
-                min="10"
-                max="100"
-                value={length}
-                onChange={(e) => setLength(parseInt(e.target.value, 10))}
-                className="ubuntu-slider"
-                aria-label="Panel length"
-              />
-            </div>
-          </div>
-        )}
-        {active === "appearance" && (
-          <p className="text-ubt-grey">Appearance settings are not available yet.</p>
-        )}
-        {active === "opacity" && (
-          <p className="text-ubt-grey">Opacity settings are not available yet.</p>
-        )}
-        {active === "items" && (
-          <p className="text-ubt-grey">Item settings are not available yet.</p>
+        ) : (
+          <>
+            {active === "display" && (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <label htmlFor="orientation" className="text-ubt-grey">
+                    Orientation
+                  </label>
+                  <select
+                    id="orientation"
+                    value={orientation}
+                    onChange={(e) =>
+                      setOrientation(e.target.value as "horizontal" | "vertical")
+                    }
+                    className="bg-ub-cool-grey text-white px-2 py-1 rounded"
+                  >
+                    <option value="horizontal">Horizontal</option>
+                    <option value="vertical">Vertical</option>
+                  </select>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-ubt-grey">Autohide</span>
+                  <ToggleSwitch
+                    checked={autohide}
+                    onChange={setAutohide}
+                    ariaLabel="Autohide panel"
+                  />
+                </div>
+              </div>
+            )}
+            {active === "measurements" && (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <label htmlFor="panel-size" className="text-ubt-grey">
+                    Size: {size}px
+                  </label>
+                  <input
+                    id="panel-size"
+                    type="range"
+                    min="16"
+                    max="128"
+                    value={size}
+                    onChange={(e) => setSize(parseInt(e.target.value, 10))}
+                    className="ubuntu-slider"
+                    aria-label="Panel size"
+                  />
+                </div>
+                <div className="flex items-center justify-between">
+                  <label htmlFor="panel-length" className="text-ubt-grey">
+                    Length: {length}%
+                  </label>
+                  <input
+                    id="panel-length"
+                    type="range"
+                    min="10"
+                    max="100"
+                    value={length}
+                    onChange={(e) => setLength(parseInt(e.target.value, 10))}
+                    className="ubuntu-slider"
+                    aria-label="Panel length"
+                  />
+                </div>
+              </div>
+            )}
+            {active === "appearance" && (
+              <p className="text-ubt-grey">
+                Appearance settings are not available yet.
+              </p>
+            )}
+            {active === "opacity" && (
+              <p className="text-ubt-grey">Opacity settings are not available yet.</p>
+            )}
+            {active === "items" && (
+              <p className="text-ubt-grey">Item settings are not available yet.</p>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -112,7 +112,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
-  const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [theme, setTheme] = useState<string>('default');
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- hydrate panel preference sliders from localStorage after mount and show a skeleton placeholder until values load
- default the shared settings provider to the neutral theme so the saved selection is applied client-side without SSR mismatches

## Testing
- yarn lint *(fails: repository has existing accessibility and window globals errors)*
- yarn test *(fails: existing suites such as ReconNG and contact API rely on unavailable browser APIs in jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c578f2483288f58e4125c13119f