### PR TITLE
[fonts] Harden fallback stacks and layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+import type { Metadata } from 'next';
+import { Ubuntu } from 'next/font/google';
+import '../styles/tailwind.css';
+import '../styles/globals.css';
+import '../styles/index.css';
+import '../styles/print.css';
+import '../styles/resume-print.css';
+import '@xterm/xterm/css/xterm.css';
+import 'leaflet/dist/leaflet.css';
+
+const ubuntu = Ubuntu({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '700'],
+  display: 'swap',
+  fallback: ['Segoe UI', 'Noto Sans', 'Helvetica Neue', 'Arial', 'Liberation Sans', 'sans-serif'],
+  preload: true,
+});
+
+export const metadata: Metadata = {
+  title: 'Kali Linux Portfolio',
+  description: 'A Kali/Ubuntu-inspired desktop portfolio experience built with Next.js.',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+      </head>
+      <body className={ubuntu.className}>{children}</body>
+    </html>
+  );
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -22,6 +22,9 @@ import { Ubuntu } from 'next/font/google';
 const ubuntu = Ubuntu({
   subsets: ['latin'],
   weight: ['300', '400', '500', '700'],
+  display: 'swap',
+  fallback: ['Segoe UI', 'Noto Sans', 'Helvetica Neue', 'Arial', 'Liberation Sans', 'sans-serif'],
+  preload: true,
 });
 
 

--- a/styles/fonts.css
+++ b/styles/fonts.css
@@ -1,0 +1,69 @@
+/*
+  Font-family fallbacks and optional font-face declarations.
+  The base UI font is still provided by Next.js' `Ubuntu` font loader,
+  but we ensure every stack has resilient system fallbacks so first paint
+  never hides text if a web font is late to load.
+*/
+
+:root {
+  /* Resilient sans-serif stack approximating Ubuntu metrics */
+  --font-stack-sans: 'Segoe UI', 'Noto Sans', 'Helvetica Neue', Arial, 'Liberation Sans', system-ui, sans-serif;
+  /* Monospace stack used by terminal-style apps */
+  --font-stack-mono: 'Ubuntu Mono', 'SFMono-Regular', 'SF Mono', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  /* Dyslexia-friendly stack that falls back to broadly available faces */
+  --font-stack-dyslexic: 'OpenDyslexic', 'Atkinson Hyperlegible', 'Comic Sans MS', 'Segoe UI', 'Noto Sans', Arial, sans-serif;
+
+  /* Default base font combines the primary web font with the system stack */
+  --font-family-base: 'Ubuntu', var(--font-stack-sans);
+}
+
+/* Adjust for systems with variable fonts available */
+@supports (font-variation-settings: normal) {
+  :root {
+    --font-stack-sans: 'Segoe UI Variable Text', 'Segoe UI Variable Display', 'Segoe UI', 'Noto Sans', 'Helvetica Neue', Arial,
+      'Liberation Sans', system-ui, sans-serif;
+  }
+}
+
+/* When dyslexia mode is enabled we favour the accessible stack */
+.dyslexia {
+  --font-family-base: 'OpenDyslexic', var(--font-stack-dyslexic);
+}
+
+/* Optional font-face declarations rely on locally installed fonts.
+   We mark them optional so they never block render on slow connections. */
+@font-face {
+  font-family: 'OpenDyslexic';
+  font-style: normal;
+  font-weight: 400;
+  font-display: optional;
+  src: local('OpenDyslexic'), local('OpenDyslexic-Regular');
+  unicode-range: U+0000-00FF;
+}
+
+@font-face {
+  font-family: 'OpenDyslexic';
+  font-style: normal;
+  font-weight: 700;
+  font-display: optional;
+  src: local('OpenDyslexic Bold'), local('OpenDyslexic-Bold');
+  unicode-range: U+0000-00FF;
+}
+
+@font-face {
+  font-family: 'Ubuntu Mono';
+  font-style: normal;
+  font-weight: 400;
+  font-display: optional;
+  src: local('Ubuntu Mono'), local('UbuntuMono-Regular');
+  unicode-range: U+0000-00FF;
+}
+
+@font-face {
+  font-family: 'Ubuntu Mono';
+  font-style: normal;
+  font-weight: 700;
+  font-display: optional;
+  src: local('Ubuntu Mono Bold'), local('UbuntuMono-Bold');
+  unicode-range: U+0000-00FF;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,5 @@
 @import './tokens.css';
+@import './fonts.css';
 
 /* Accessible theme color palette meeting WCAG AA contrast ratios */
 :root {


### PR DESCRIPTION
## Summary
- add a dedicated fonts.css with resilient system stacks and optional font-face declarations for non-critical families
- import the new stacks globally and align the Next.js Google font configuration with explicit fallbacks
- add an App Router root layout that preconnects font origins and applies the shared Ubuntu font class

## Testing
- yarn lint *(fails: repository has existing jsx-a11y control-has-associated-label and no-top-level-window errors across legacy apps)*
- yarn test *(fails: repository has existing Jest failures such as window key handling, nmapNse alert lookup, install button localStorage access; run interrupted after repeated failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c584a6083289dd2c35340e3e9ff