### PR TITLE
fix: add media sizing and preserve layout

### DIFF
--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -129,7 +129,12 @@ const ScrollableTimeline: React.FC = () => {
                       <img
                         src={first.image}
                         alt={first.title}
-                        className="w-full h-32 object-cover mb-2 rounded"
+                        width={150}
+                        height={150}
+                        loading="lazy"
+                        decoding="async"
+                        className="mb-2 w-full rounded object-cover"
+                        style={{ aspectRatio: '1 / 1' }}
                       />
                       <p className="text-sm md:text-base mb-2">{first.title}</p>
                       {renderTags(first.tags)}
@@ -158,7 +163,12 @@ const ScrollableTimeline: React.FC = () => {
                     <img
                       src={m.image}
                       alt={m.title}
-                      className="w-full h-32 object-cover mb-2 rounded"
+                      width={150}
+                      height={150}
+                      loading="lazy"
+                      decoding="async"
+                      className="mb-2 w-full rounded object-cover"
+                      style={{ aspectRatio: '1 / 1' }}
                     />
                     <p className="text-sm md:text-base">{m.title}</p>
                   </a>

--- a/components/YouTubePlayer.js
+++ b/components/YouTubePlayer.js
@@ -220,7 +220,10 @@ export default function YouTubePlayer({ videoId }) {
                 src={`https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`}
                 alt="YouTube video thumbnail"
                 loading="lazy"
-                className="absolute inset-0 w-full h-full object-cover"
+                decoding="async"
+                width="1280"
+                height="720"
+                className="absolute inset-0 h-full w-full object-cover"
               />
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/pages/qr/index.tsx
+++ b/pages/qr/index.tsx
@@ -351,7 +351,17 @@ const QRPage: React.FC = () => {
         )}
       </div>
       <div className="w-full max-w-md">
-        <video ref={videoRef} className="h-48 w-full rounded border" />
+        <div
+          className="w-full"
+          style={{ aspectRatio: '4 / 3' }}
+        >
+          <video
+            ref={videoRef}
+            className="h-full w-full rounded border bg-black object-cover"
+            width={640}
+            height={480}
+          />
+        </div>
         {scanResult && (
           <p className="mt-2 text-center text-sm">Decoded: {scanResult}</p>
         )}

--- a/pages/video-gallery.tsx
+++ b/pages/video-gallery.tsx
@@ -50,8 +50,11 @@ const VideoGallery: React.FC = () => {
         <div className="mb-4 w-full max-w-2xl aspect-video">
           <iframe
             title="Selected video"
-            className="w-full h-full"
+            className="h-full w-full rounded"
             src={`https://www.youtube-nocookie.com/embed/${playing}`}
+            width="1280"
+            height="720"
+            loading="lazy"
             sandbox="allow-scripts allow-popups"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             referrerPolicy="no-referrer"


### PR DESCRIPTION
## Summary
- provide explicit dimensions for timeline cards and the YouTube player thumbnail to avoid image-driven layout shifts
- reserve space for the QR scanner video with a fixed aspect ratio wrapper and intrinsic media dimensions
- add desktop iframe sizing in the video gallery so the selected player area stays stable during load

## Testing
- yarn lint *(fails: numerous existing jsx-a11y/control-has-associated-label issues and public assets using window/document)*
- yarn test --watch=false *(fails: known window snapping and other suites, command interrupted after repeated hangs)*
- node cls-playwright.js *(Playwright script measuring layout shift reports CLS total 0)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c513b2c8328a60f5bf59fc378f7