### PR TITLE
[app] add streaming desktop shell skeletons

### DIFF
--- a/__tests__/skeletons.test.tsx
+++ b/__tests__/skeletons.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import BetaBadgeSkeleton from '../components/shells/BetaBadgeSkeleton';
+import DesktopShellSkeleton from '../components/shells/DesktopShellSkeleton';
+import InstallButtonSkeleton from '../components/shells/InstallButtonSkeleton';
+
+describe('streaming skeleton shells', () => {
+  test('desktop skeleton preserves window-area anchor for skip links', () => {
+    const { container } = render(<DesktopShellSkeleton />);
+    expect(container.querySelector('#window-area')).not.toBeNull();
+  });
+
+  test('beta badge skeleton renders a muted badge', () => {
+    render(<BetaBadgeSkeleton />);
+    const badge = screen.getByText(/beta/i);
+    expect(badge).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('install button skeleton reserves call-to-action space', () => {
+    render(<InstallButtonSkeleton />);
+    const install = screen.getByText(/install/i);
+    expect(install).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/app/head.tsx
+++ b/app/head.tsx
@@ -1,0 +1,62 @@
+import { getCspNonce } from '../utils/csp';
+
+export default function Head() {
+  const nonce = getCspNonce();
+
+  return (
+    <>
+      <title>Alex Unnippillil&apos;s Portfolio </title>
+      <meta charSet="utf-8" />
+      <meta name="title" content="Alex Patel Portfolio - Computer Engineering Student" />
+      <meta name="description" content="Alex Unnippillil Personal Portfolio Website" />
+      <meta name="author" content="Alex Unnippillil" />
+      <meta
+        name="keywords"
+        content="Alex Unnippillil, Unnippillil's portfolio, linux, kali portfolio, alex unnippillil portfolio, alex computer, alex unnippillil, alex linux, alex unnippillil kali portfolio"
+      />
+      <meta name="robots" content="index, follow" />
+      <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
+      <meta name="language" content="English" />
+      <meta name="category" content="16" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta name="theme-color" content="#0f1317" />
+
+      <meta name="image" content="images/logos/fevicon.png" />
+
+      <meta itemProp="name" content="Alex Unnippillil Portfolio " />
+      <meta itemProp="description" content="Alex Unnippillil Personal Portfolio Website" />
+      <meta itemProp="image" content="images/logos/fevicon.png" />
+
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:title" content="Alex Unnippillil Personal Portfolio Website" />
+      <meta name="twitter:description" content="Alex Unnippillil Personal Portfolio Website" />
+      <meta name="twitter:site" content="alexunnippillil" />
+      <meta name="twitter:creator" content="unnippillil" />
+      <meta name="twitter:image:src" content="images/logos/logo_1024.png" />
+
+      <meta name="og:title" content="Alex Unnippillil Personal Portfolio Website " />
+      <meta name="og:description" content="Alex Unnippillil Personal Portfolio Website. ." />
+      <meta name="og:image" content="https://unnippillil.com/images/logos/logo_1200.png" />
+      <meta name="og:url" content="https://unnippillil.com/" />
+      <meta name="og:site_name" content="Alex Unnippillil Personal Portfolio" />
+      <meta name="og:locale" content="en_CA" />
+      <meta name="og:type" content="website" />
+
+      <link rel="canonical" href="https://unnippillil.com/" />
+      <link rel="icon" href="images/logos/fevicon.svg" />
+      <link rel="apple-touch-icon" href="images/logos/logo.png" />
+      <script
+        type="application/ld+json"
+        nonce={nonce}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'Person',
+            name: 'Alex Unnippillil',
+            url: 'https://unnippillil.com/',
+          }),
+        }}
+      />
+    </>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+import { Ubuntu } from 'next/font/google';
+import DesktopProviders from '@/components/app/DesktopProviders';
+import ErrorBoundary from '@/components/core/ErrorBoundary';
+import '@/styles/tailwind.css';
+import '@/styles/globals.css';
+import '@/styles/index.css';
+import '@/styles/resume-print.css';
+import '@/styles/print.css';
+import '@xterm/xterm/css/xterm.css';
+import 'leaflet/dist/leaflet.css';
+
+const ubuntu = Ubuntu({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '700'],
+});
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={ubuntu.className}>
+        <a
+          href="#app-grid"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
+        >
+          Skip to app grid
+        </a>
+        <ErrorBoundary>
+          <DesktopProviders>{children}</DesktopProviders>
+        </ErrorBoundary>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,26 @@
+import { Suspense } from 'react';
+import BetaBadge from '@/components/BetaBadge';
+import InstallButton from '@/components/InstallButton';
+import Ubuntu from '@/components/ubuntu';
+import BetaBadgeSkeleton from '@/components/shells/BetaBadgeSkeleton';
+import DesktopShellSkeleton from '@/components/shells/DesktopShellSkeleton';
+import InstallButtonSkeleton from '@/components/shells/InstallButtonSkeleton';
+
+export default function HomePage() {
+  return (
+    <>
+      <a href="#window-area" className="sr-only focus:not-sr-only">
+        Skip to content
+      </a>
+      <Suspense fallback={<DesktopShellSkeleton />}>
+        <Ubuntu />
+      </Suspense>
+      <Suspense fallback={<BetaBadgeSkeleton />}>
+        <BetaBadge />
+      </Suspense>
+      <Suspense fallback={<InstallButtonSkeleton />}>
+        <InstallButton />
+      </Suspense>
+    </>
+  );
+}

--- a/components/BetaBadge.jsx
+++ b/components/BetaBadge.jsx
@@ -1,3 +1,5 @@
+"use client";
+
 export default function BetaBadge() {
   if (process.env.NEXT_PUBLIC_SHOW_BETA !== '1') return null;
   return (

--- a/components/app/DesktopProviders.tsx
+++ b/components/app/DesktopProviders.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { Analytics } from '@vercel/analytics/next';
+import { SpeedInsights } from '@vercel/speed-insights/next';
+import Script from 'next/script';
+import { ReactNode, useEffect } from 'react';
+import { SettingsProvider } from '../../hooks/useSettings';
+import PipPortalProvider from '../common/PipPortal';
+import ShortcutOverlay from '../common/ShortcutOverlay';
+
+type ExtendedWindow = Window & typeof globalThis & {
+  initA2HS?: () => void;
+  manualRefresh?: () => void;
+};
+
+type PeriodicRegistration = ServiceWorkerRegistration & {
+  periodicSync?: {
+    register: (tag: string, options: { minInterval: number }) => Promise<void>;
+  };
+};
+
+interface DesktopProvidersProps {
+  children: ReactNode;
+}
+
+export default function DesktopProviders({ children }: DesktopProvidersProps) {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const extendedWindow = window as ExtendedWindow;
+
+    if (typeof extendedWindow.initA2HS === 'function') {
+      extendedWindow.initA2HS();
+    }
+
+    const initAnalytics = async () => {
+      const trackingId = process.env.NEXT_PUBLIC_TRACKING_ID;
+      if (!trackingId) return;
+
+      try {
+        const { default: ReactGA } = await import('react-ga4');
+        ReactGA.initialize(trackingId);
+      } catch (err) {
+        console.error('Analytics initialization failed', err);
+      }
+    };
+
+    initAnalytics().catch((err) => {
+      console.error('Analytics setup threw', err);
+    });
+
+    if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+      const register = async () => {
+        try {
+          const registration = (await navigator.serviceWorker.register('/sw.js')) as PeriodicRegistration;
+
+          extendedWindow.manualRefresh = () => registration.update();
+
+          if (registration.periodicSync) {
+            try {
+              const permissions = navigator.permissions as unknown as {
+                query: (descriptor: { name: string }) => Promise<PermissionStatus>;
+              };
+
+              const status = await permissions.query({ name: 'periodic-background-sync' });
+
+              if (status.state === 'granted') {
+                await registration.periodicSync.register('content-sync', {
+                  minInterval: 24 * 60 * 60 * 1000,
+                });
+              } else {
+                registration.update();
+              }
+            } catch (error) {
+              console.error('Periodic background sync setup failed', error);
+              registration.update();
+            }
+          } else {
+            registration.update();
+          }
+        } catch (error) {
+          console.error('Service worker registration failed', error);
+        }
+      };
+
+      register().catch((err) => {
+        console.error('Service worker setup failed', err);
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const liveRegion = document.getElementById('live-region');
+    if (!liveRegion) return;
+
+    const update = (message: string) => {
+      liveRegion.textContent = '';
+      setTimeout(() => {
+        liveRegion.textContent = message;
+      }, 100);
+    };
+
+    const handleCopy = () => update('Copied to clipboard');
+    const handleCut = () => update('Cut to clipboard');
+    const handlePaste = () => update('Pasted from clipboard');
+
+    window.addEventListener('copy', handleCopy);
+    window.addEventListener('cut', handleCut);
+    window.addEventListener('paste', handlePaste);
+
+    const { clipboard } = navigator;
+    const originalWrite = clipboard?.writeText?.bind(clipboard);
+    const originalRead = clipboard?.readText?.bind(clipboard);
+
+    if (originalWrite) {
+      clipboard.writeText = async (text: string) => {
+        update('Copied to clipboard');
+        return originalWrite(text);
+      };
+    }
+
+    if (originalRead) {
+      clipboard.readText = async () => {
+        const text = await originalRead();
+        update('Pasted from clipboard');
+        return text;
+      };
+    }
+
+    const OriginalNotification = window.Notification;
+    if (OriginalNotification) {
+      const WrappedNotification = function (title: string, options?: NotificationOptions) {
+        update(`${title}${options?.body ? ` ${options.body}` : ''}`);
+        return new OriginalNotification(title, options);
+      } as typeof Notification;
+
+      WrappedNotification.requestPermission = OriginalNotification.requestPermission.bind(
+        OriginalNotification,
+      );
+
+      Object.defineProperty(WrappedNotification, 'permission', {
+        get: () => OriginalNotification.permission,
+      });
+
+      WrappedNotification.prototype = OriginalNotification.prototype;
+      window.Notification = WrappedNotification;
+    }
+
+    return () => {
+      window.removeEventListener('copy', handleCopy);
+      window.removeEventListener('cut', handleCut);
+      window.removeEventListener('paste', handlePaste);
+
+      if (clipboard) {
+        if (originalWrite) clipboard.writeText = originalWrite;
+        if (originalRead) clipboard.readText = originalRead;
+      }
+
+      if (OriginalNotification) {
+        window.Notification = OriginalNotification;
+      }
+    };
+  }, []);
+
+  return (
+    <SettingsProvider>
+      <PipPortalProvider>
+        <Script src="/a2hs.js" strategy="beforeInteractive" />
+        <div aria-live="polite" id="live-region" />
+        {children}
+        <ShortcutOverlay />
+        <Analytics
+          beforeSend={(event) => {
+            if (event.url.includes('/admin') || event.url.includes('/private')) {
+              return null;
+            }
+
+            const evt = event;
+            if (evt.metadata?.email) {
+              delete evt.metadata.email;
+            }
+
+            return evt;
+          }}
+        />
+        {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+      </PipPortalProvider>
+    </SettingsProvider>
+  );
+}

--- a/components/core/ErrorBoundary.tsx
+++ b/components/core/ErrorBoundary.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { createLogger } from '../../lib/logger';
 

--- a/components/shells/BetaBadgeSkeleton.tsx
+++ b/components/shells/BetaBadgeSkeleton.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function BetaBadgeSkeleton() {
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed bottom-4 right-4 flex h-7 items-center justify-center rounded bg-yellow-500/40 px-3 text-xs font-semibold uppercase tracking-wide text-yellow-100/80 shadow-lg backdrop-blur-sm animate-pulse"
+    >
+      Beta
+    </div>
+  );
+}

--- a/components/shells/DesktopShellSkeleton.tsx
+++ b/components/shells/DesktopShellSkeleton.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+const gridPlaceholders = ['one', 'two', 'three', 'four', 'five', 'six'] as const;
+const dockPlaceholders = ['dock-a', 'dock-b', 'dock-c', 'dock-d', 'dock-e'] as const;
+
+export default function DesktopShellSkeleton() {
+  return (
+    <div className="relative flex min-h-screen flex-col overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-300">
+      <div className="h-11 w-full animate-pulse bg-slate-900/80 backdrop-blur-sm" />
+      <div id="window-area" className="flex flex-1 items-center justify-center p-6">
+        <div className="grid w-full max-w-4xl grid-cols-2 gap-6 lg:grid-cols-3">
+          {gridPlaceholders.map((placeholder) => (
+            <div
+              key={placeholder}
+              className="flex aspect-square flex-col items-center justify-center rounded-lg bg-slate-800/60 p-4 text-center shadow-inner animate-pulse"
+            >
+              <div className="mb-3 h-10 w-10 rounded-full bg-slate-700/80" />
+              <div className="h-2 w-16 rounded-full bg-slate-700/60" />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="flex h-16 w-full items-center justify-center gap-4 bg-slate-950/80 px-6 pb-4 pt-3 backdrop-blur-md">
+        {dockPlaceholders.map((placeholder) => (
+          <div key={placeholder} className="h-4 w-12 rounded-full bg-slate-800/70 animate-pulse" />
+        ))}
+        <div className="ml-auto flex items-center gap-2">
+          <div className="h-5 w-5 rounded-full bg-red-500/50 animate-pulse" />
+          <div className="h-5 w-5 rounded-full bg-yellow-400/50 animate-pulse" />
+          <div className="h-5 w-5 rounded-full bg-green-500/50 animate-pulse" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/shells/InstallButtonSkeleton.tsx
+++ b/components/shells/InstallButtonSkeleton.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function InstallButtonSkeleton() {
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed bottom-4 right-4 flex h-10 w-28 items-center justify-center rounded-md bg-ubt-blue/50 text-sm font-medium uppercase tracking-wide text-white/70 shadow-lg backdrop-blur-sm animate-pulse"
+    >
+      Install
+    </div>
+  );
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { useEffect } from 'react';
-import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from '@vercel/speed-insights/next';
 import '../styles/tailwind.css';
 import '../styles/globals.css';
 import '../styles/index.css';
@@ -10,145 +7,19 @@ import '../styles/resume-print.css';
 import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
-import { SettingsProvider } from '../hooks/useSettings';
-import ShortcutOverlay from '../components/common/ShortcutOverlay';
-import PipPortalProvider from '../components/common/PipPortal';
-import ErrorBoundary from '../components/core/ErrorBoundary';
-import Script from 'next/script';
-import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
-
 import { Ubuntu } from 'next/font/google';
+import DesktopProviders from '../components/app/DesktopProviders';
+import ErrorBoundary from '../components/core/ErrorBoundary';
+import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
 const ubuntu = Ubuntu({
   subsets: ['latin'],
   weight: ['300', '400', '500', '700'],
 });
 
-
-function MyApp(props) {
-  const { Component, pageProps } = props;
-
-
-  useEffect(() => {
-    if (typeof window !== 'undefined' && typeof window.initA2HS === 'function') {
-      window.initA2HS();
-    }
-    const initAnalytics = async () => {
-      const trackingId = process.env.NEXT_PUBLIC_TRACKING_ID;
-      if (trackingId) {
-        const { default: ReactGA } = await import('react-ga4');
-        ReactGA.initialize(trackingId);
-      }
-    };
-    initAnalytics().catch((err) => {
-      console.error('Analytics initialization failed', err);
-    });
-
-    if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
-      // Register PWA service worker generated via @ducanh2912/next-pwa
-      const register = async () => {
-        try {
-          const registration = await navigator.serviceWorker.register('/sw.js');
-
-          window.manualRefresh = () => registration.update();
-
-          if ('periodicSync' in registration) {
-            try {
-              const status = await navigator.permissions.query({
-                name: 'periodic-background-sync',
-              });
-              if (status.state === 'granted') {
-                await registration.periodicSync.register('content-sync', {
-                  minInterval: 24 * 60 * 60 * 1000,
-                });
-              } else {
-                registration.update();
-              }
-            } catch {
-              registration.update();
-            }
-          } else {
-            registration.update();
-          }
-        } catch (err) {
-          console.error('Service worker registration failed', err);
-        }
-      };
-      register().catch((err) => {
-        console.error('Service worker setup failed', err);
-      });
-    }
-  }, []);
-
-  useEffect(() => {
-    const liveRegion = document.getElementById('live-region');
-    if (!liveRegion) return;
-
-    const update = (message) => {
-      liveRegion.textContent = '';
-      setTimeout(() => {
-        liveRegion.textContent = message;
-      }, 100);
-    };
-
-    const handleCopy = () => update('Copied to clipboard');
-    const handleCut = () => update('Cut to clipboard');
-    const handlePaste = () => update('Pasted from clipboard');
-
-    window.addEventListener('copy', handleCopy);
-    window.addEventListener('cut', handleCut);
-    window.addEventListener('paste', handlePaste);
-
-    const { clipboard } = navigator;
-    const originalWrite = clipboard?.writeText?.bind(clipboard);
-    const originalRead = clipboard?.readText?.bind(clipboard);
-    if (originalWrite) {
-      clipboard.writeText = async (text) => {
-        update('Copied to clipboard');
-        return originalWrite(text);
-      };
-    }
-    if (originalRead) {
-      clipboard.readText = async () => {
-        const text = await originalRead();
-        update('Pasted from clipboard');
-        return text;
-      };
-    }
-
-    const OriginalNotification = window.Notification;
-    if (OriginalNotification) {
-      const WrappedNotification = function (title, options) {
-        update(`${title}${options?.body ? ' ' + options.body : ''}`);
-        return new OriginalNotification(title, options);
-      };
-      WrappedNotification.requestPermission = OriginalNotification.requestPermission.bind(
-        OriginalNotification,
-      );
-      Object.defineProperty(WrappedNotification, 'permission', {
-        get: () => OriginalNotification.permission,
-      });
-      WrappedNotification.prototype = OriginalNotification.prototype;
-      window.Notification = WrappedNotification;
-    }
-
-    return () => {
-      window.removeEventListener('copy', handleCopy);
-      window.removeEventListener('cut', handleCut);
-      window.removeEventListener('paste', handlePaste);
-      if (clipboard) {
-        if (originalWrite) clipboard.writeText = originalWrite;
-        if (originalRead) clipboard.readText = originalRead;
-      }
-      if (OriginalNotification) {
-        window.Notification = OriginalNotification;
-      }
-    };
-  }, []);
-
+function MyApp({ Component, pageProps }) {
   return (
     <ErrorBoundary>
-      <Script src="/a2hs.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
         <a
           href="#app-grid"
@@ -156,27 +27,11 @@ function MyApp(props) {
         >
           Skip to app grid
         </a>
-        <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
-
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
-        </SettingsProvider>
+        <DesktopProviders>
+          <Component {...pageProps} />
+        </DesktopProviders>
       </div>
     </ErrorBoundary>
-
-
   );
 }
 


### PR DESCRIPTION
## Summary
- add app router layout, head, and page that stream the desktop experience behind Suspense fallbacks
- extract a reusable DesktopProviders client wrapper so both routers share analytics, settings, and live-region wiring
- create shell skeleton components and a regression test to ensure streaming placeholders expose expected structure

## Testing
- yarn lint *(fails: repo-wide jsx-a11y and public app lint violations pre-existing)*
- npx eslint app/layout.tsx app/page.tsx app/head.tsx components/app/DesktopProviders.tsx components/shells/DesktopShellSkeleton.tsx components/shells/BetaBadgeSkeleton.tsx components/shells/InstallButtonSkeleton.tsx components/BetaBadge.jsx __tests__/skeletons.test.tsx
- yarn test *(fails: existing suites for window controls and recon-ng rely on DOM APIs like localStorage and emit act warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c648a4083289f5be1a23ff80da8