### PR TITLE
settings: enhance appearance customization

### DIFF
--- a/apps/settings/appearance/AppearanceTab.tsx
+++ b/apps/settings/appearance/AppearanceTab.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
+import BackgroundSlideshow from "../components/BackgroundSlideshow";
+import { ACCENT_OPTIONS, useSettings } from "../../../hooks/useSettings";
+import usePersistentState from "../../../hooks/usePersistentState";
+import {
+  getWallpaperUrl,
+  isCustomWallpaper,
+  isSameWallpaper,
+} from "../../../utils/wallpaper";
+import {
+  BUILTIN_WALLPAPERS,
+  WallpaperOption,
+} from "./wallpapers";
+import { areColorsSimilar, useAccentPalette } from "./useAccentPalette";
+
+const ACCEPTED_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/webp",
+  "image/avif",
+];
+
+const MAX_UPLOAD_SIZE = 6 * 1024 * 1024; // 6MB
+const MAX_CUSTOM_WALLPAPERS = 6;
+const CUSTOM_WALLPAPERS_KEY = "custom-wallpapers";
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === "string");
+
+interface AccentSwatchProps {
+  color: string;
+  label: string;
+  onSelect: (color: string) => void;
+  selected: boolean;
+  variant?: "preset" | "suggested";
+}
+
+function AccentSwatch({
+  color,
+  label,
+  onSelect,
+  selected,
+  variant = "preset",
+}: AccentSwatchProps) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      aria-label={label}
+      title={label}
+      onClick={() => onSelect(color)}
+      className={`relative h-9 w-9 rounded-full border-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-black ${
+        selected
+          ? "border-white shadow-lg"
+          : "border-transparent hover:scale-105 hover:border-white/40"
+      } ${variant === "suggested" ? "ring-1 ring-white/30" : ""}`}
+      style={{ backgroundColor: color }}
+    >
+      <span className="sr-only">{label}</span>
+    </button>
+  );
+}
+
+interface WallpaperGridProps {
+  options: WallpaperOption[];
+  selected: string;
+  active: string;
+  onSelect: (value: string) => void;
+  onPreview: (value: string | null) => void;
+}
+
+function WallpaperGrid({
+  options,
+  selected,
+  active,
+  onSelect,
+  onPreview,
+}: WallpaperGridProps) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-sm font-medium uppercase tracking-wide text-ubt-cool-grey">
+          Wallpapers
+        </h3>
+        <span className="text-xs text-ubt-cool-grey/70">Hover to preview</span>
+      </div>
+      <div
+        role="radiogroup"
+        aria-label="Desktop wallpapers"
+        className="grid grid-cols-2 gap-3 md:grid-cols-4"
+      >
+        {options.map((option) => {
+          const isSelected = isSameWallpaper(option.value, selected);
+          const isActive = isSameWallpaper(option.value, active);
+          return (
+            <button
+              key={`${option.type}-${option.id}`}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              onClick={() => onSelect(option.value)}
+              onMouseEnter={() => onPreview(option.value)}
+              onFocus={() => onPreview(option.value)}
+              onMouseLeave={() => onPreview(null)}
+              onBlur={() => onPreview(null)}
+              className={`relative aspect-video overflow-hidden rounded-lg border-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-black ${
+                isSelected
+                  ? "border-white shadow-lg ring-2 ring-ub-orange/80"
+                  : isActive
+                    ? "border-white/60 shadow"
+                    : "border-transparent hover:border-white/40 hover:shadow"
+              }`}
+            >
+              <span className="sr-only">Select {option.label}</span>
+              <span
+                aria-hidden="true"
+                className="absolute inset-0 bg-cover bg-center"
+                style={{ backgroundImage: `url(${option.src})` }}
+              />
+              <span className="pointer-events-none absolute bottom-0 left-0 right-0 bg-black/50 px-2 py-1 text-xs font-medium text-white">
+                {option.label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+interface WallpaperPreviewProps {
+  src: string;
+  accent: string;
+  label: string;
+}
+
+function WallpaperPreview({ src, accent, label }: WallpaperPreviewProps) {
+  return (
+    <section className="space-y-2">
+      <h2 className="text-sm font-medium uppercase tracking-wide text-ubt-cool-grey">
+        Desktop preview
+      </h2>
+      <div className="mx-auto w-full max-w-3xl overflow-hidden rounded-xl border border-gray-900 bg-black/50 shadow-xl">
+        <div className="relative aspect-video">
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 bg-cover bg-center"
+            style={{ backgroundImage: `url(${src})` }}
+          />
+          <div className="absolute inset-0 bg-gradient-to-b from-black/15 via-black/20 to-black/45" />
+          <div className="absolute bottom-4 left-4 right-4 rounded-lg border border-white/10 bg-black/60 p-4 text-white backdrop-blur-sm">
+            <div className="flex items-center justify-between text-xs font-medium uppercase tracking-wide">
+              <span className="flex items-center gap-2 normal-case">
+                <span
+                  aria-hidden="true"
+                  className="h-4 w-4 rounded-full border border-white/50"
+                  style={{ backgroundColor: accent }}
+                />
+                Accent preview
+              </span>
+              <span className="rounded-full border border-white/20 bg-white/10 px-2 py-0.5 text-[0.65rem] normal-case">
+                {label}
+              </span>
+            </div>
+            <div className="mt-3 flex gap-2">
+              <div
+                className="h-12 flex-1 rounded-md border border-white/20 bg-white/10"
+                aria-hidden="true"
+              >
+                <div
+                  className="h-full w-1/3 rounded-l-md"
+                  style={{
+                    backgroundColor: accent,
+                    opacity: 0.45,
+                  }}
+                />
+              </div>
+              <div className="flex h-12 w-24 flex-col justify-between text-[0.6rem] uppercase tracking-wide text-white/70">
+                <span>Window</span>
+                <span className="text-right">Controls</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function AppearanceTab() {
+  const { accent, setAccent, wallpaper, setWallpaper } = useSettings();
+  const [customWallpapers, setCustomWallpapers] = usePersistentState<string[]>(
+    CUSTOM_WALLPAPERS_KEY,
+    [],
+    isStringArray,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [hoveredWallpaper, setHoveredWallpaper] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (
+      isCustomWallpaper(wallpaper) &&
+      !customWallpapers.includes(wallpaper)
+    ) {
+      setCustomWallpapers((prev) => {
+        const filtered = prev.filter((entry) => entry !== wallpaper);
+        return [wallpaper, ...filtered].slice(0, MAX_CUSTOM_WALLPAPERS);
+      });
+    }
+  }, [wallpaper, customWallpapers, setCustomWallpapers]);
+
+  const activeWallpaper = hoveredWallpaper ?? wallpaper;
+  const previewSrc = getWallpaperUrl(activeWallpaper);
+  const palette = useAccentPalette(previewSrc, 6);
+
+  const suggestions = useMemo(() => {
+    const seen = new Set<string>();
+    const colors: string[] = [];
+    palette.forEach((color) => {
+      const normalized = color.toLowerCase();
+      if (seen.has(normalized)) return;
+      seen.add(normalized);
+      if (!ACCENT_OPTIONS.some((preset) => areColorsSimilar(preset, color))) {
+        colors.push(color);
+      }
+    });
+    return colors;
+  }, [palette]);
+
+  const wallpaperOptions = useMemo(() => {
+    const customEntries: WallpaperOption[] = customWallpapers.map((src, index) => ({
+      id: `custom-${index}`,
+      label: `Custom ${index + 1}`,
+      value: src,
+      src,
+      type: "custom" as const,
+    }));
+    const builtin = BUILTIN_WALLPAPERS;
+    const combined: WallpaperOption[] = [...customEntries, ...builtin];
+    if (
+      wallpaper &&
+      !combined.some((option) => isSameWallpaper(option.value, wallpaper))
+    ) {
+      combined.unshift({
+        id: "current",
+        label: "Current wallpaper",
+        value: wallpaper,
+        src: getWallpaperUrl(wallpaper),
+        type: isCustomWallpaper(wallpaper) ? "custom" : "current",
+      });
+    }
+    return combined;
+  }, [customWallpapers, wallpaper]);
+
+  const activeLabel = useMemo(() => {
+    const match = wallpaperOptions.find((option) =>
+      isSameWallpaper(option.value, activeWallpaper),
+    );
+    return match ? match.label : "Wallpaper";
+  }, [wallpaperOptions, activeWallpaper]);
+
+  const handleWallpaperSelect = (value: string) => {
+    setError(null);
+    setHoveredWallpaper(null);
+    setWallpaper(value);
+  };
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+
+    setError(null);
+
+    if (!file.type || !file.type.startsWith("image/")) {
+      setError("Please choose an image file.");
+      return;
+    }
+
+    if (file.size > MAX_UPLOAD_SIZE) {
+      setError("Image must be smaller than 6MB.");
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== "string" || !result.startsWith("data:image")) {
+        setError("Unsupported image format.");
+        return;
+      }
+      setCustomWallpapers((prev) => {
+        const filtered = prev.filter((entry) => entry !== result);
+        return [result, ...filtered].slice(0, MAX_CUSTOM_WALLPAPERS);
+      });
+      setHoveredWallpaper(null);
+      setWallpaper(result);
+    };
+    reader.onerror = () => setError("Failed to read the selected file.");
+    reader.readAsDataURL(file);
+  };
+
+  const openFilePicker = () => {
+    setError(null);
+    fileInputRef.current?.click();
+  };
+
+  return (
+    <div className="space-y-6 px-4 py-6 text-ubt-grey">
+      <WallpaperPreview src={previewSrc} accent={accent} label={activeLabel} />
+
+      <section className="space-y-3">
+        <h3 className="text-sm font-medium uppercase tracking-wide text-ubt-cool-grey">
+          Accent color
+        </h3>
+        <p className="text-xs text-ubt-cool-grey/80">
+          Pick a highlight color or try one sampled from your wallpaper.
+        </p>
+        <div
+          role="radiogroup"
+          aria-label="Accent colors"
+          className="flex flex-wrap gap-2"
+        >
+          {ACCENT_OPTIONS.map((color) => (
+            <AccentSwatch
+              key={`preset-${color}`}
+              color={color}
+              label={`Accent color ${color}`}
+              selected={accent === color}
+              onSelect={setAccent}
+            />
+          ))}
+          {suggestions.map((color) => (
+            <AccentSwatch
+              key={`suggested-${color}`}
+              color={color}
+              label={`Suggested accent color ${color}`}
+              selected={accent === color}
+              onSelect={setAccent}
+              variant="suggested"
+            />
+          ))}
+        </div>
+        {suggestions.length > 0 && (
+          <p className="text-xs text-ubt-cool-grey/70">
+            Suggestions refresh automatically when you preview different wallpapers.
+          </p>
+        )}
+      </section>
+
+      <WallpaperGrid
+        options={wallpaperOptions}
+        selected={wallpaper}
+        active={activeWallpaper}
+        onSelect={handleWallpaperSelect}
+        onPreview={setHoveredWallpaper}
+      />
+
+      <section className="overflow-hidden rounded-lg border border-gray-900 bg-black/20">
+        <div className="border-b border-gray-900 px-4 py-3">
+          <h3 className="text-sm font-medium uppercase tracking-wide text-ubt-cool-grey">
+            Custom wallpaper
+          </h3>
+          <p className="text-xs text-ubt-cool-grey/70">
+            Upload PNG, JPG, WebP, or AVIF up to 6MB.
+          </p>
+          {error && <p className="mt-2 text-xs text-red-400">{error}</p>}
+        </div>
+        <div className="flex flex-col items-start gap-3 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-xs text-ubt-cool-grey/80">
+            <p>Custom uploads are stored locally for this browser.</p>
+          </div>
+          <button
+            type="button"
+            onClick={openFilePicker}
+            className="rounded bg-ub-orange px-4 py-2 text-sm font-medium text-white shadow hover:bg-orange-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+          >
+            Upload image
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={ACCEPTED_TYPES.join(",")}
+            onChange={handleFileChange}
+            className="hidden"
+            aria-label="Upload custom wallpaper"
+          />
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-gray-900 bg-black/20">
+        <div className="border-b border-gray-900 px-4 py-3">
+          <h3 className="text-sm font-medium uppercase tracking-wide text-ubt-cool-grey">
+            Background slideshow
+          </h3>
+          <p className="text-xs text-ubt-cool-grey/70">
+            Rotate through multiple wallpapers automatically.
+          </p>
+        </div>
+        <BackgroundSlideshow />
+      </section>
+    </div>
+  );
+}

--- a/apps/settings/appearance/index.ts
+++ b/apps/settings/appearance/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AppearanceTab";

--- a/apps/settings/appearance/useAccentPalette.ts
+++ b/apps/settings/appearance/useAccentPalette.ts
@@ -1,0 +1,186 @@
+import { useEffect, useState } from 'react';
+
+const rgbToHex = (r: number, g: number, b: number): string =>
+  `#${[r, g, b]
+    .map((value) => {
+      const clamped = Math.max(0, Math.min(255, Math.round(value)));
+      return clamped.toString(16).padStart(2, '0');
+    })
+    .join('')}`;
+
+const hexToRgb = (hex: string): [number, number, number] => {
+  const normalized = hex.replace('#', '');
+  const value = normalized.length === 3
+    ? normalized
+        .split('')
+        .map((char) => char + char)
+        .join('')
+    : normalized;
+  const int = parseInt(value, 16);
+  const r = (int >> 16) & 0xff;
+  const g = (int >> 8) & 0xff;
+  const b = int & 0xff;
+  return [r, g, b];
+};
+
+const colorDistance = (a: string, b: string): number => {
+  const [ar, ag, ab] = hexToRgb(a);
+  const [br, bg, bb] = hexToRgb(b);
+  const dr = ar - br;
+  const dg = ag - bg;
+  const db = ab - bb;
+  return Math.sqrt(dr * dr + dg * dg + db * db);
+};
+
+const adjustColor = (hex: string, factor: number): string => {
+  const [r, g, b] = hexToRgb(hex);
+  const mix = (channel: number, target: number) =>
+    Math.round(channel + (target - channel) * factor);
+  if (factor >= 0) {
+    return rgbToHex(mix(r, 255), mix(g, 255), mix(b, 255));
+  }
+  return rgbToHex(mix(r, 0), mix(g, 0), mix(b, 0));
+};
+
+const ensureVariety = (palette: string[], desired: number): string[] => {
+  if (palette.length >= desired) return palette.slice(0, desired);
+  const results = [...palette];
+  for (const color of palette) {
+    if (results.length >= desired) break;
+    const lighter = adjustColor(color, 0.25);
+    if (!results.some((existing) => colorDistance(existing, lighter) < 16)) {
+      results.push(lighter);
+    }
+  }
+  for (const color of palette) {
+    if (results.length >= desired) break;
+    const darker = adjustColor(color, -0.25);
+    if (!results.some((existing) => colorDistance(existing, darker) < 16)) {
+      results.push(darker);
+    }
+  }
+  return results.slice(0, desired);
+};
+
+const buildPalette = (image: HTMLImageElement, desired: number): string[] => {
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('2d', { willReadFrequently: true });
+  if (!context) return [];
+
+  const maxDimension = 240;
+  const scale = Math.min(
+    maxDimension / image.width || 1,
+    maxDimension / image.height || 1,
+    1,
+  );
+  const width = Math.max(1, Math.floor(image.width * scale));
+  const height = Math.max(1, Math.floor(image.height * scale));
+
+  canvas.width = width;
+  canvas.height = height;
+  context.drawImage(image, 0, 0, width, height);
+
+  let imageData: ImageData;
+  try {
+    imageData = context.getImageData(0, 0, width, height);
+  } catch {
+    return [];
+  }
+
+  const { data } = imageData;
+  const stride = Math.max(1, Math.floor((width * height) / 5000));
+  const buckets = new Map<number, { r: number; g: number; b: number; count: number }>();
+
+  for (let i = 0; i < data.length; i += 4 * stride) {
+    const alpha = data[i + 3];
+    if (alpha < 200) continue;
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    if (max - min < 18) continue;
+    const key = ((r & 0xf0) << 8) | ((g & 0xf0) << 4) | (b & 0xf0);
+    const bucket = buckets.get(key);
+    if (bucket) {
+      bucket.r += r;
+      bucket.g += g;
+      bucket.b += b;
+      bucket.count += 1;
+    } else {
+      buckets.set(key, { r, g, b, count: 1 });
+    }
+  }
+
+  const sorted = Array.from(buckets.values())
+    .filter((entry) => entry.count > 0)
+    .map((entry) => ({
+      count: entry.count,
+      color: rgbToHex(
+        entry.r / entry.count,
+        entry.g / entry.count,
+        entry.b / entry.count,
+      ),
+    }))
+    .sort((a, b) => b.count - a.count)
+    .map((entry) => entry.color);
+
+  const unique: string[] = [];
+  for (const color of sorted) {
+    if (unique.every((existing) => colorDistance(existing, color) > 24)) {
+      unique.push(color);
+    }
+    if (unique.length >= desired) break;
+  }
+
+  if (unique.length === 0 && data.length >= 3) {
+    unique.push(rgbToHex(data[0], data[1], data[2]));
+  }
+
+  return ensureVariety(unique, desired);
+};
+
+export const useAccentPalette = (
+  src: string | null,
+  desired = 5,
+): string[] => {
+  const [palette, setPalette] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!src || typeof window === 'undefined') {
+      setPalette([]);
+      return;
+    }
+
+    let cancelled = false;
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.src = src;
+
+    const handleLoad = () => {
+      if (cancelled) return;
+      const colors = buildPalette(image, desired);
+      setPalette(colors);
+    };
+
+    const handleError = () => {
+      if (!cancelled) setPalette([]);
+    };
+
+    if (image.complete) {
+      handleLoad();
+    } else {
+      image.onload = handleLoad;
+      image.onerror = handleError;
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [src, desired]);
+
+  return palette;
+};
+
+export const areColorsSimilar = (a: string, b: string): boolean =>
+  colorDistance(a, b) < 12;

--- a/apps/settings/appearance/wallpapers.ts
+++ b/apps/settings/appearance/wallpapers.ts
@@ -1,0 +1,27 @@
+import { getWallpaperUrl } from '../../../utils/wallpaper';
+
+export type WallpaperOptionType = 'builtin' | 'custom' | 'current';
+
+export interface WallpaperOption {
+  id: string;
+  label: string;
+  value: string;
+  src: string;
+  type: WallpaperOptionType;
+}
+
+const BUILTIN_COUNT = 8;
+
+export const BUILTIN_WALLPAPERS: WallpaperOption[] = Array.from(
+  { length: BUILTIN_COUNT },
+  (_, index) => {
+    const id = `wall-${index + 1}`;
+    return {
+      id,
+      label: `Wallpaper ${index + 1}`,
+      value: id,
+      src: getWallpaperUrl(id),
+      type: 'builtin' as const,
+    };
+  },
+);

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState, useRef } from "react";
-import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
-import BackgroundSlideshow from "./components/BackgroundSlideshow";
+import { useSettings } from "../../hooks/useSettings";
+import AppearanceTab from "./appearance";
 import {
   resetSettings,
   defaults,
@@ -42,19 +42,6 @@ export default function Settings() {
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
 
-  const wallpapers = [
-    "wall-1",
-    "wall-2",
-    "wall-3",
-    "wall-4",
-    "wall-5",
-    "wall-6",
-    "wall-7",
-    "wall-8",
-  ];
-
-  const changeBackground = (name: string) => setWallpaper(name);
-
   const handleExport = async () => {
     const data = await exportSettingsData();
     const blob = new Blob([data], { type: "application/json" });
@@ -71,6 +58,7 @@ export default function Settings() {
     await importSettingsData(text);
     try {
       const parsed = JSON.parse(text);
+      if (parsed.theme !== undefined) setTheme(parsed.theme);
       if (parsed.accent !== undefined) setAccent(parsed.accent);
       if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
       if (parsed.density !== undefined) setDensity(parsed.density);
@@ -79,7 +67,6 @@ export default function Settings() {
       if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
-      if (parsed.theme !== undefined) setTheme(parsed.theme);
     } catch (err) {
       console.error("Invalid settings", err);
     }
@@ -94,13 +81,13 @@ export default function Settings() {
       return;
     await resetSettings();
     window.localStorage.clear();
+    setTheme("default");
     setAccent(defaults.accent);
     setWallpaper(defaults.wallpaper);
     setDensity(defaults.density as any);
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
-    setTheme("default");
   };
 
   const [showKeymap, setShowKeymap] = useState(false);
@@ -112,15 +99,6 @@ export default function Settings() {
       </div>
       {activeTab === "appearance" && (
         <>
-          <div
-            className="md:w-2/5 w-2/3 h-1/3 m-auto my-4"
-            style={{
-              backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
-              backgroundSize: "cover",
-              backgroundRepeat: "no-repeat",
-              backgroundPosition: "center center",
-            }}
-          ></div>
           <div className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Theme:</label>
             <select
@@ -134,71 +112,7 @@ export default function Settings() {
               <option value="matrix">Matrix</option>
             </select>
           </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Accent:</label>
-            <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
-              {ACCENT_OPTIONS.map((c) => (
-                <button
-                  key={c}
-                  aria-label={`select-accent-${c}`}
-                  role="radio"
-                  aria-checked={accent === c}
-                  onClick={() => setAccent(c)}
-                  className={`w-8 h-8 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
-                  style={{ backgroundColor: c }}
-                />
-              ))}
-            </div>
-          </div>
-          <div className="flex justify-center my-4">
-            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>
-            <input
-              id="wallpaper-slider"
-              type="range"
-              min="0"
-              max={wallpapers.length - 1}
-              step="1"
-              value={wallpapers.indexOf(wallpaper)}
-              onChange={(e) =>
-                changeBackground(wallpapers[parseInt(e.target.value, 10)])
-              }
-              className="ubuntu-slider"
-              aria-label="Wallpaper"
-            />
-          </div>
-          <div className="flex justify-center my-4">
-            <BackgroundSlideshow />
-          </div>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
-            {wallpapers.map((name) => (
-              <div
-                key={name}
-                role="button"
-                aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
-                aria-pressed={name === wallpaper}
-                tabIndex={0}
-                onClick={() => changeBackground(name)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    changeBackground(name);
-                  }
-                }}
-                className={
-                  (name === wallpaper
-                    ? " border-yellow-700 "
-                    : " border-transparent ") +
-                  " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"
-                }
-                style={{
-                  backgroundImage: `url(/wallpapers/${name}.webp)`,
-                  backgroundSize: "cover",
-                  backgroundRepeat: "no-repeat",
-                  backgroundPosition: "center center",
-                }}
-              ></div>
-            ))}
-          </div>
+          <AppearanceTab />
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
             <button
               onClick={handleReset}

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
+import { getWallpaperUrl } from '../../utils/wallpaper';
 
 export function Settings() {
     const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
@@ -57,7 +58,7 @@ export function Settings() {
 
     return (
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
-            <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
+            <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(${getWallpaperUrl(wallpaper)})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
             </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Theme:</label>
@@ -214,7 +215,7 @@ export function Settings() {
                             }}
                             data-path={name}
                             className={((name === wallpaper) ? " border-yellow-700 " : " border-transparent ") + " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"}
-                            style={{ backgroundImage: `url(/wallpapers/${name}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}
+                                style={{ backgroundImage: `url(${getWallpaperUrl(name)})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}
                         ></div>
                     ))
                 }

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
+import { getWallpaperUrl } from '../../utils/wallpaper';
 
 export default function LockScreen(props) {
 
@@ -17,7 +18,7 @@ export default function LockScreen(props) {
             style={{ zIndex: "100", contentVisibility: 'auto' }}
             className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
             <img
-                src={`/wallpapers/${wallpaper}.webp`}
+                src={getWallpaperUrl(wallpaper)}
                 alt=""
                 className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
             />

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -2,44 +2,53 @@
 
 import React, { useEffect, useState } from 'react'
 import { useSettings } from '../../hooks/useSettings';
+import { getWallpaperUrl } from '../../utils/wallpaper';
 
 export default function BackgroundImage() {
     const { wallpaper } = useSettings();
     const [needsOverlay, setNeedsOverlay] = useState(false);
 
     useEffect(() => {
+        const src = getWallpaperUrl(wallpaper);
         const img = new Image();
-        img.src = `/wallpapers/${wallpaper}.webp`;
+        img.crossOrigin = 'anonymous';
+        img.src = src;
         img.onload = () => {
-            const canvas = document.createElement('canvas');
-            canvas.width = img.width;
-            canvas.height = img.height;
-            const ctx = canvas.getContext('2d');
-            if (!ctx) return;
-            ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-            const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
-            let r = 0, g = 0, b = 0, count = 0;
-            for (let i = 0; i < data.length; i += 40) {
-                r += data[i];
-                g += data[i + 1];
-                b += data[i + 2];
-                count++;
+            try {
+                const canvas = document.createElement('canvas');
+                canvas.width = img.width;
+                canvas.height = img.height;
+                const ctx = canvas.getContext('2d');
+                if (!ctx) return;
+                ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+                const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+                let r = 0, g = 0, b = 0, count = 0;
+                for (let i = 0; i < data.length; i += 40) {
+                    r += data[i];
+                    g += data[i + 1];
+                    b += data[i + 2];
+                    count++;
+                }
+                const avgR = r / count, avgG = g / count, avgB = b / count;
+                const toLinear = (c) => {
+                    c /= 255;
+                    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+                };
+                const lum = 0.2126 * toLinear(avgR) + 0.7152 * toLinear(avgG) + 0.0722 * toLinear(avgB);
+                const contrast = (1.05) / (lum + 0.05);
+                setNeedsOverlay(contrast < 4.5);
+            } catch (error) {
+                console.error('Failed to analyze wallpaper contrast', error);
+                setNeedsOverlay(false);
             }
-            const avgR = r / count, avgG = g / count, avgB = b / count;
-            const toLinear = (c) => {
-                c /= 255;
-                return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
-            };
-            const lum = 0.2126 * toLinear(avgR) + 0.7152 * toLinear(avgG) + 0.0722 * toLinear(avgB);
-            const contrast = (1.05) / (lum + 0.05); // white text luminance is 1
-            setNeedsOverlay(contrast < 4.5);
         };
+        img.onerror = () => setNeedsOverlay(false);
     }, [wallpaper]);
 
     return (
         <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
             <img
-                src={`/wallpapers/${wallpaper}.webp`}
+                src={getWallpaperUrl(wallpaper)}
                 alt=""
                 className="w-full h-full object-cover"
             />

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -1,7 +1,17 @@
 export const THEME_KEY = 'app:theme';
+export const THEME_STATE_KEY = 'app:theme-state';
 
-// Score required to unlock each theme
-export const THEME_UNLOCKS: Record<string, number> = {
+export interface ThemePreferences {
+  accent?: string;
+  wallpaper?: string;
+}
+
+interface ThemeState {
+  active: string;
+  preferences: Record<string, ThemePreferences>;
+}
+
+const THEME_UNLOCKS: Record<string, number> = {
   default: 0,
   neon: 100,
   dark: 500,
@@ -9,6 +19,73 @@ export const THEME_UNLOCKS: Record<string, number> = {
 };
 
 const DARK_THEMES = ['dark', 'neon', 'matrix'] as const;
+
+const sanitizePreferences = (value: ThemePreferences): ThemePreferences => {
+  const sanitized: ThemePreferences = {};
+  if (typeof value.accent === 'string' && value.accent.trim()) {
+    sanitized.accent = value.accent;
+  }
+  if (typeof value.wallpaper === 'string' && value.wallpaper) {
+    sanitized.wallpaper = value.wallpaper;
+  }
+  return sanitized;
+};
+
+const sanitizePreferenceMap = (
+  map: Record<string, ThemePreferences>,
+): Record<string, ThemePreferences> => {
+  const result: Record<string, ThemePreferences> = {};
+  Object.entries(map || {}).forEach(([key, value]) => {
+    if (typeof key !== 'string') return;
+    if (typeof value !== 'object' || value === null) return;
+    const sanitized = sanitizePreferences(value);
+    if (Object.keys(sanitized).length > 0) {
+      result[key] = sanitized;
+    }
+  });
+  return result;
+};
+
+const readThemeState = (): ThemeState => {
+  if (typeof window === 'undefined') {
+    return { active: 'default', preferences: {} };
+  }
+  try {
+    const stored = window.localStorage.getItem(THEME_STATE_KEY);
+    if (!stored) {
+      return { active: getTheme(), preferences: {} };
+    }
+    const parsed = JSON.parse(stored);
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof parsed.active === 'string' &&
+      typeof parsed.preferences === 'object' &&
+      parsed.preferences !== null
+    ) {
+      return {
+        active: parsed.active,
+        preferences: sanitizePreferenceMap(parsed.preferences as Record<string, ThemePreferences>),
+      };
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return { active: getTheme(), preferences: {} };
+};
+
+const writeThemeState = (state: ThemeState): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    const sanitized: ThemeState = {
+      active: state.active,
+      preferences: sanitizePreferenceMap(state.preferences),
+    };
+    window.localStorage.setItem(THEME_STATE_KEY, JSON.stringify(sanitized));
+  } catch {
+    // ignore storage errors
+  }
+};
 
 export const isDarkTheme = (theme: string): boolean =>
   DARK_THEMES.includes(theme as (typeof DARK_THEMES)[number]);
@@ -18,24 +95,64 @@ export const getTheme = (): string => {
   try {
     const stored = window.localStorage.getItem(THEME_KEY);
     if (stored) return stored;
-    const prefersDark = window.matchMedia?.(
-      '(prefers-color-scheme: dark)'
-    ).matches;
+    const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
     return prefersDark ? 'dark' : 'default';
   } catch {
     return 'default';
   }
 };
 
-export const setTheme = (theme: string): void => {
+export const setTheme = (theme: string, preferences?: ThemePreferences): void => {
   if (typeof window === 'undefined') return;
   try {
     window.localStorage.setItem(THEME_KEY, theme);
-    document.documentElement.dataset.theme = theme;
-    document.documentElement.classList.toggle('dark', isDarkTheme(theme));
   } catch {
     /* ignore storage errors */
   }
+  const currentState = readThemeState();
+  const sanitized = preferences ? sanitizePreferences(preferences) : undefined;
+  const nextPreferences = sanitized && Object.keys(sanitized).length > 0
+    ? {
+        ...currentState.preferences,
+        [theme]: {
+          ...currentState.preferences[theme],
+          ...sanitized,
+        },
+      }
+    : currentState.preferences;
+  writeThemeState({ active: theme, preferences: nextPreferences });
+  try {
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.classList.toggle('dark', isDarkTheme(theme));
+  } catch {
+    /* ignore DOM errors */
+  }
+};
+
+export const getThemePreferences = (theme: string): ThemePreferences => {
+  const state = readThemeState();
+  return { ...(state.preferences[theme] ?? {}) };
+};
+
+export const setThemePreferences = (
+  theme: string,
+  updates: ThemePreferences,
+): void => {
+  if (typeof window === 'undefined') return;
+  const sanitized = sanitizePreferences(updates);
+  const currentState = readThemeState();
+  if (Object.keys(sanitized).length === 0) {
+    writeThemeState({ active: currentState.active || theme, preferences: currentState.preferences });
+    return;
+  }
+  const nextPreferences = {
+    ...currentState.preferences,
+    [theme]: {
+      ...currentState.preferences[theme],
+      ...sanitized,
+    },
+  };
+  writeThemeState({ active: currentState.active || theme, preferences: nextPreferences });
 };
 
 export const getUnlockedThemes = (highScore: number): string[] =>

--- a/utils/wallpaper.ts
+++ b/utils/wallpaper.ts
@@ -1,0 +1,56 @@
+const DATA_URL_PATTERN = /^data:image\//i;
+const BLOB_URL_PATTERN = /^blob:/i;
+const ABSOLUTE_PATTERN = /^(?:https?:|file:)/i;
+
+const trimLeadingSlash = (value: string): string => value.replace(/^\/+/, '');
+
+export const isCustomWallpaper = (value: string): boolean =>
+  DATA_URL_PATTERN.test(value) || BLOB_URL_PATTERN.test(value);
+
+export const getWallpaperUrl = (value: string): string => {
+  if (!value) {
+    return '/wallpapers/wall-2.webp';
+  }
+
+  if (isCustomWallpaper(value) || ABSOLUTE_PATTERN.test(value)) {
+    return value;
+  }
+
+  if (value.startsWith('/')) {
+    return value;
+  }
+
+  const normalized = trimLeadingSlash(value);
+
+  if (normalized.startsWith('wallpapers/')) {
+    return `/${normalized}`;
+  }
+
+  if (/\.(?:png|jpe?g|webp|avif|gif)$/i.test(normalized)) {
+    return `/wallpapers/${normalized}`;
+  }
+
+  return `/wallpapers/${normalized}.webp`;
+};
+
+export const normalizeWallpaperId = (value: string): string => {
+  if (!value) return value;
+  if (isCustomWallpaper(value) || ABSOLUTE_PATTERN.test(value)) {
+    return value;
+  }
+  const normalized = trimLeadingSlash(value);
+  if (normalized.startsWith('wallpapers/')) {
+    const withoutPrefix = normalized.replace(/^wallpapers\//, '');
+    return withoutPrefix.replace(/\.(?:png|jpe?g|webp|avif|gif)$/i, '');
+  }
+  return normalized.replace(/\.(?:png|jpe?g|webp|avif|gif)$/i, '');
+};
+
+export const isSameWallpaper = (a: string, b: string): boolean => {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (isCustomWallpaper(a) || isCustomWallpaper(b)) {
+    return a === b;
+  }
+  return normalizeWallpaperId(a) === normalizeWallpaperId(b);
+};


### PR DESCRIPTION
## Summary
- introduce a dedicated appearance panel with wallpaper preview, accent swatches, custom uploads, and slideshow controls
- add wallpaper utility helpers and persist theme-specific accent/wallpaper selections for reuse
- update shared components and tests to handle data URL wallpapers and verify theme preference persistence

## Testing
- yarn lint *(fails: existing repo accessibility violations)*
- npx jest --runInBand __tests__/themePersistence.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c99c653c2c83289ee06de20e4126ac