### PR TITLE
[wm] Persist window geometry per app

### DIFF
--- a/__tests__/wmPersistence.test.ts
+++ b/__tests__/wmPersistence.test.ts
@@ -1,0 +1,77 @@
+import { saveWindowGeometry, restoreWindowGeometry, removeWindowGeometry, clearAllWindowGeometry } from '@/src/wm/persistence';
+
+const viewport = { width: 1200, height: 800 } as const;
+
+describe('window geometry persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('stores and restores geometry per application', () => {
+    saveWindowGeometry(
+      'app-1',
+      { x: 160, y: 120, widthPct: 60, heightPct: 70 },
+      viewport,
+    );
+
+    const restored = restoreWindowGeometry('app-1', viewport);
+    expect(restored.widthPct).toBeCloseTo(60);
+    expect(restored.heightPct).toBeCloseTo(70);
+    expect(restored.x).toBeCloseTo(160);
+    expect(restored.y).toBeCloseTo(120);
+  });
+
+  it('falls back to defaults when no stored entry exists', () => {
+    const defaults = { x: 24, y: 48, widthPct: 55, heightPct: 65 };
+    const restored = restoreWindowGeometry('missing-app', viewport, defaults);
+    expect(restored).toEqual(defaults);
+  });
+
+  it('clamps restored geometry to remain on-screen for smaller viewports', () => {
+    saveWindowGeometry(
+      'app-2',
+      { x: 800, y: 500, widthPct: 70, heightPct: 70 },
+      { width: 1920, height: 1080 },
+    );
+
+    const smallerViewport = { width: 1280, height: 720 };
+    const restored = restoreWindowGeometry('app-2', smallerViewport);
+    expect(restored.widthPct).toBeCloseTo(70);
+    expect(restored.heightPct).toBeCloseTo(70);
+    const widthPx = (restored.widthPct! / 100) * smallerViewport.width;
+    const heightPx = (restored.heightPct! / 100) * smallerViewport.height;
+    expect(restored.x).toBeGreaterThanOrEqual(0);
+    expect(restored.y).toBeGreaterThanOrEqual(0);
+    expect(restored.x!).toBeLessThanOrEqual(smallerViewport.width - widthPx + 0.1);
+    expect(restored.y!).toBeLessThanOrEqual(smallerViewport.height - heightPx + 0.1);
+  });
+
+  it('removes stored geometry entries for specific apps', () => {
+    saveWindowGeometry(
+      'app-3',
+      { x: 200, y: 150, widthPct: 65, heightPct: 75 },
+      viewport,
+    );
+
+    removeWindowGeometry('app-3');
+    const restored = restoreWindowGeometry('app-3', viewport, { widthPct: 50, heightPct: 60 });
+    expect(restored.widthPct).toBeCloseTo(50);
+    expect(restored.heightPct).toBeCloseTo(60);
+    expect(restored.x).toBeUndefined();
+    expect(restored.y).toBeUndefined();
+  });
+
+  it('clears all stored geometry entries', () => {
+    saveWindowGeometry(
+      'app-4',
+      { x: 120, y: 80, widthPct: 55, heightPct: 65 },
+      viewport,
+    );
+    clearAllWindowGeometry();
+    const restored = restoreWindowGeometry('app-4', viewport, { widthPct: 40, heightPct: 50 });
+    expect(restored.widthPct).toBeCloseTo(40);
+    expect(restored.heightPct).toBeCloseTo(50);
+    expect(restored.x).toBeUndefined();
+    expect(restored.y).toBeUndefined();
+  });
+});

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -5,6 +5,8 @@ export interface SessionWindow {
   id: string;
   x: number;
   y: number;
+  width?: number;
+  height?: number;
 }
 
 export interface DesktopSession {
@@ -22,11 +24,20 @@ const initialSession: DesktopSession = {
 function isSession(value: unknown): value is DesktopSession {
   if (!value || typeof value !== 'object') return false;
   const s = value as DesktopSession;
-  return (
-    Array.isArray(s.windows) &&
-    typeof s.wallpaper === 'string' &&
-    Array.isArray(s.dock)
-  );
+  if (!Array.isArray(s.windows) || typeof s.wallpaper !== 'string' || !Array.isArray(s.dock)) {
+    return false;
+  }
+  return s.windows.every((win) => {
+    if (!win || typeof win !== 'object') return false;
+    const candidate = win as SessionWindow;
+    return (
+      typeof candidate.id === 'string' &&
+      typeof candidate.x === 'number' &&
+      typeof candidate.y === 'number' &&
+      (candidate.width === undefined || typeof candidate.width === 'number') &&
+      (candidate.height === undefined || typeof candidate.height === 'number')
+    );
+  });
 }
 
 export default function useSession() {

--- a/src/wm/persistence.ts
+++ b/src/wm/persistence.ts
@@ -1,0 +1,224 @@
+import { safeLocalStorage } from '@/utils/safeStorage';
+
+const STORAGE_KEY = 'wm:geometry';
+const MIN_WINDOW_PERCENT = 20;
+const MAX_WINDOW_PERCENT = 100;
+const DEFAULT_WIDTH = 60;
+const DEFAULT_HEIGHT = 85;
+
+type StoredGeometryMap = Record<string, StoredGeometry>;
+
+interface StoredGeometry {
+  widthPct: number;
+  heightPct: number;
+  xRatio: number;
+  yRatio: number;
+}
+
+export interface WindowGeometry {
+  x: number;
+  y: number;
+  widthPct: number;
+  heightPct: number;
+}
+
+export interface ViewportSize {
+  width: number;
+  height: number;
+}
+
+export interface GeometrySnapshot {
+  x?: number;
+  y?: number;
+  widthPct?: number;
+  heightPct?: number;
+}
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const sanitizePercent = (value: unknown, fallback: number) => {
+  const base = isFiniteNumber(value) ? value : fallback;
+  return clamp(base, MIN_WINDOW_PERCENT, MAX_WINDOW_PERCENT);
+};
+
+const sanitizeRatio = (value: unknown) =>
+  clamp(isFiniteNumber(value) ? value : 0, 0, 1);
+
+const inferViewport = (): ViewportSize | undefined => {
+  if (typeof window === 'undefined') return undefined;
+  if (!window.innerWidth || !window.innerHeight) return undefined;
+  return { width: window.innerWidth, height: window.innerHeight };
+};
+
+const readStore = (): StoredGeometryMap => {
+  if (!safeLocalStorage) return {};
+  try {
+    const raw = safeLocalStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return {};
+
+    const result: StoredGeometryMap = {};
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!value || typeof value !== 'object') continue;
+      const entry = value as Partial<StoredGeometry>;
+      if (
+        isFiniteNumber(entry.widthPct) &&
+        isFiniteNumber(entry.heightPct) &&
+        isFiniteNumber(entry.xRatio) &&
+        isFiniteNumber(entry.yRatio)
+      ) {
+        result[key] = {
+          widthPct: entry.widthPct,
+          heightPct: entry.heightPct,
+          xRatio: entry.xRatio,
+          yRatio: entry.yRatio,
+        };
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+};
+
+const writeStore = (data: StoredGeometryMap) => {
+  if (!safeLocalStorage) return;
+  try {
+    const keys = Object.keys(data);
+    if (!keys.length) {
+      safeLocalStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    safeLocalStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch {
+    // ignore write errors
+  }
+};
+
+const measureBounds = (viewport: ViewportSize, geometry: GeometrySnapshot) => {
+  const widthPct = sanitizePercent(
+    geometry.widthPct,
+    geometry.widthPct ?? DEFAULT_WIDTH,
+  );
+  const heightPct = sanitizePercent(
+    geometry.heightPct,
+    geometry.heightPct ?? DEFAULT_HEIGHT,
+  );
+  const widthPx = (widthPct / 100) * viewport.width;
+  const heightPx = (heightPct / 100) * viewport.height;
+  const maxX = Math.max(viewport.width - widthPx, 0);
+  const maxY = Math.max(viewport.height - heightPx, 0);
+  return { widthPct, heightPct, widthPx, heightPx, maxX, maxY };
+};
+
+export const restoreWindowGeometry = (
+  appId: string,
+  viewport?: ViewportSize,
+  defaults: GeometrySnapshot = {},
+): GeometrySnapshot => {
+  const store = readStore();
+  const stored = store[appId];
+  const result: GeometrySnapshot = { ...defaults };
+
+  if (!stored) {
+    return result;
+  }
+
+  const baseViewport = viewport ?? inferViewport();
+  const widthPct = sanitizePercent(
+    stored.widthPct,
+    defaults.widthPct ?? DEFAULT_WIDTH,
+  );
+  const heightPct = sanitizePercent(
+    stored.heightPct,
+    defaults.heightPct ?? DEFAULT_HEIGHT,
+  );
+
+  result.widthPct = widthPct;
+  result.heightPct = heightPct;
+
+  if (!baseViewport || baseViewport.width <= 0 || baseViewport.height <= 0) {
+    return result;
+  }
+
+  const { maxX, maxY } = measureBounds(baseViewport, {
+    widthPct,
+    heightPct,
+  });
+  const ratioX = sanitizeRatio(stored.xRatio);
+  const ratioY = sanitizeRatio(stored.yRatio);
+  const x = clamp(ratioX * maxX, 0, maxX);
+  const y = clamp(ratioY * maxY, 0, maxY);
+
+  result.x = x;
+  result.y = y;
+  return result;
+};
+
+export const saveWindowGeometry = (
+  appId: string,
+  geometry: WindowGeometry,
+  viewport?: ViewportSize,
+): void => {
+  if (!appId || !safeLocalStorage) return;
+  if (
+    !isFiniteNumber(geometry.x) ||
+    !isFiniteNumber(geometry.y) ||
+    !isFiniteNumber(geometry.widthPct) ||
+    !isFiniteNumber(geometry.heightPct)
+  ) {
+    return;
+  }
+
+  const baseViewport = viewport ?? inferViewport();
+  const store = readStore();
+  const widthPct = sanitizePercent(geometry.widthPct, DEFAULT_WIDTH);
+  const heightPct = sanitizePercent(geometry.heightPct, DEFAULT_HEIGHT);
+
+  if (!baseViewport || baseViewport.width <= 0 || baseViewport.height <= 0) {
+    store[appId] = {
+      widthPct,
+      heightPct,
+      xRatio: 0,
+      yRatio: 0,
+    };
+    writeStore(store);
+    return;
+  }
+
+  const { maxX, maxY } = measureBounds(baseViewport, { widthPct, heightPct });
+  const clampedX = clamp(geometry.x, 0, maxX);
+  const clampedY = clamp(geometry.y, 0, maxY);
+  const xRatio = maxX === 0 ? 0 : clampedX / maxX;
+  const yRatio = maxY === 0 ? 0 : clampedY / maxY;
+
+  store[appId] = {
+    widthPct,
+    heightPct,
+    xRatio,
+    yRatio,
+  };
+  writeStore(store);
+};
+
+export const removeWindowGeometry = (appId: string) => {
+  if (!appId) return;
+  const store = readStore();
+  if (!(appId in store)) return;
+  delete store[appId];
+  writeStore(store);
+};
+
+export const clearAllWindowGeometry = () => {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore remove errors
+  }
+};


### PR DESCRIPTION
## Summary
- add a window manager persistence module that stores window bounds per app in localStorage with viewport-aware clamping
- teach the desktop shell to restore and save per-app positions and sizes, update stored session metadata, and clear persisted bounds when resetting
- extend the session hook to keep optional width/height metadata and cover the new persistence helper with unit tests

## Testing
- yarn lint *(fails: repository has pre-existing accessibility and no-top-level-window lint errors outside the modified files)*
- yarn test *(fails: existing suites unrelated to this change continue to fail; new persistence tests pass locally)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c75372c83288425e804e99640ec