### PR TITLE
[desktop] add quick launch dock shortcuts

### DIFF
--- a/__tests__/quickLaunch.test.tsx
+++ b/__tests__/quickLaunch.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import QuickLaunch, { AppShortcut } from '../components/desktop/QuickLaunch';
+
+describe('QuickLaunch', () => {
+  const sampleApps: AppShortcut[] = [
+    { id: 'terminal', title: 'Terminal', icon: '/icons/terminal.svg', favourite: true },
+    { id: 'files', title: 'Files', icon: '/icons/files.svg', favourite: true },
+    { id: 'browser', title: 'Browser', icon: '/icons/browser.svg', favourite: false },
+    { id: 'notes', title: 'Notes', icon: '/icons/notes.svg', favourite: true },
+  ];
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders favourite apps as pinned with numeric hints', () => {
+    render(<QuickLaunch apps={sampleApps} />);
+
+    const terminalButton = screen.getByRole('button', {
+      name: /Launch Terminal \(Alt\+1\)/i,
+    });
+    const filesButton = screen.getByRole('button', {
+      name: /Launch Files \(Alt\+2\)/i,
+    });
+
+    expect(terminalButton).toHaveAttribute('data-hotkey', '1');
+    expect(filesButton).toHaveAttribute('data-hotkey', '2');
+  });
+
+  it('launches the correct app when pressing Alt+1', () => {
+    const onLaunch = jest.fn();
+    render(<QuickLaunch apps={sampleApps} onLaunch={onLaunch} />);
+
+    fireEvent.keyDown(window, { altKey: true, key: '1' });
+
+    expect(onLaunch).toHaveBeenCalledWith('terminal');
+  });
+
+  it('ignores Alt shortcuts when focus is in an editable control', () => {
+    const onLaunch = jest.fn();
+    render(
+      <div>
+        <input data-testid="shortcut-input" />
+        <QuickLaunch apps={sampleApps} onLaunch={onLaunch} />
+      </div>
+    );
+
+    const input = screen.getByTestId('shortcut-input');
+    input.focus();
+    fireEvent.keyDown(input, { altKey: true, key: '1' });
+
+    expect(onLaunch).not.toHaveBeenCalled();
+  });
+
+  it('allows drag and drop reordering of pinned apps', () => {
+    render(<QuickLaunch apps={sampleApps} />);
+
+    const notesButton = screen.getByRole('button', {
+      name: /Launch Notes \(Alt\+3\)/i,
+    });
+    const terminalButton = screen.getByRole('button', {
+      name: /Launch Terminal \(Alt\+1\)/i,
+    });
+
+    const dataTransfer = {
+      data: {} as Record<string, string>,
+      setData(key: string, value: string) {
+        this.data[key] = value;
+      },
+      getData(key: string) {
+        return this.data[key];
+      },
+      dropEffect: 'move',
+      effectAllowed: 'move',
+    };
+
+    fireEvent.dragStart(notesButton, { dataTransfer });
+    fireEvent.dragOver(terminalButton, { dataTransfer });
+    fireEvent.drop(terminalButton, { dataTransfer });
+    fireEvent.dragEnd(notesButton, { dataTransfer });
+
+    const orderedButtons = screen.getAllByRole('button', { name: /Launch/ });
+    expect(orderedButtons[0]).toHaveAttribute('aria-label', expect.stringContaining('Notes'));
+
+    const stored = JSON.parse(window.localStorage.getItem('quick-launch-pins') || '[]');
+    expect(stored[0]).toBe('notes');
+  });
+
+  it('allows pinning additional apps via the selector', () => {
+    render(<QuickLaunch apps={sampleApps} />);
+
+    const select = screen.getByLabelText('Pin application');
+    fireEvent.change(select, { target: { value: 'browser' } });
+
+    expect(
+      screen.getByRole('button', {
+        name: /Launch Browser/,
+      })
+    ).toBeInTheDocument();
+
+    const stored = JSON.parse(window.localStorage.getItem('quick-launch-pins') || '[]');
+    expect(stored).toContain('browser');
+  });
+
+  it('removes apps when the unpin button is pressed', () => {
+    render(<QuickLaunch apps={sampleApps} />);
+
+    const removeButton = screen.getByRole('button', { name: 'Unpin Terminal' });
+    fireEvent.click(removeButton);
+
+    expect(
+      screen.queryByRole('button', {
+        name: /Launch Terminal/,
+      })
+    ).not.toBeInTheDocument();
+
+    const stored = JSON.parse(window.localStorage.getItem('quick-launch-pins') || '[]');
+    expect(stored).not.toContain('terminal');
+  });
+});

--- a/components/desktop/QuickLaunch.tsx
+++ b/components/desktop/QuickLaunch.tsx
@@ -1,0 +1,298 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import type { DragEvent } from 'react';
+import Image from 'next/image';
+import usePersistentState from '../../hooks/usePersistentState';
+import rawApps from '../../apps.config';
+
+export interface AppShortcut {
+  id: string;
+  title: string;
+  icon: string;
+  disabled?: boolean;
+  favourite?: boolean;
+}
+
+type QuickLaunchProps = {
+  apps?: AppShortcut[];
+  onLaunch?: (id: string) => void;
+};
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string');
+
+type RawApp = {
+  id: string;
+  title: string;
+  icon: string;
+  disabled?: boolean;
+  favourite?: boolean;
+};
+
+const DEFAULT_APPS: AppShortcut[] = (rawApps as RawApp[]).map(
+  ({ id, title, icon, disabled, favourite }) => ({
+    id,
+    title,
+    icon,
+    disabled,
+    favourite,
+  })
+);
+
+const normalizePins = (ids: string[], map: Map<string, AppShortcut>) => {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (const id of ids) {
+    if (!map.has(id) || seen.has(id)) continue;
+    normalized.push(id);
+    seen.add(id);
+  }
+  return normalized;
+};
+
+const isEditableElement = (element: Element | null) => {
+  if (!element) return false;
+  const tagName = element.tagName;
+  if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT') {
+    return true;
+  }
+  if (tagName === 'BUTTON') {
+    return true;
+  }
+  return (element as HTMLElement).isContentEditable;
+};
+
+const QuickLaunch = ({ apps: providedApps, onLaunch }: QuickLaunchProps) => {
+  const availableApps = useMemo(() => {
+    const source = providedApps ?? DEFAULT_APPS;
+    const seen = new Set<string>();
+    return source.filter((app) => {
+      if (!app.id || !app.title || !app.icon) return false;
+      if (app.disabled) return false;
+      if (seen.has(app.id)) return false;
+      seen.add(app.id);
+      return true;
+    });
+  }, [providedApps]);
+
+  const appMap = useMemo(() => {
+    const map = new Map<string, AppShortcut>();
+    for (const app of availableApps) {
+      map.set(app.id, app);
+    }
+    return map;
+  }, [availableApps]);
+
+  const defaultPinned = useMemo(
+    () => availableApps.filter((app) => app.favourite).map((app) => app.id),
+    [availableApps]
+  );
+
+  const [pinned, setPinned] = usePersistentState<string[]>(
+    'quick-launch-pins',
+    defaultPinned,
+    isStringArray
+  );
+
+  const normalizedPinned = useMemo(
+    () => normalizePins(pinned, appMap),
+    [pinned, appMap]
+  );
+
+  useEffect(() => {
+    const needsUpdate =
+      pinned.length !== normalizedPinned.length ||
+      pinned.some((id, index) => normalizedPinned[index] !== id);
+    if (needsUpdate) {
+      setPinned(normalizedPinned);
+    }
+  }, [normalizedPinned, pinned, setPinned]);
+
+  const availableForPin = useMemo(
+    () => availableApps.filter((app) => !normalizedPinned.includes(app.id)),
+    [availableApps, normalizedPinned]
+  );
+
+  const dragSourceId = useRef<string | null>(null);
+
+  const launch = useCallback(
+    (id: string) => {
+      if (!appMap.has(id)) return;
+      if (onLaunch) {
+        onLaunch(id);
+      } else {
+        window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
+      }
+    },
+    [appMap, onLaunch]
+  );
+
+  const handleDragStart = useCallback(
+    (event: DragEvent<HTMLButtonElement>, id: string) => {
+      dragSourceId.current = id;
+      if (event.dataTransfer) {
+        event.dataTransfer.effectAllowed = 'move';
+        try {
+          event.dataTransfer.setData('text/plain', id);
+        } catch {
+          // Ignore errors from unsupported browsers
+        }
+      }
+    },
+    []
+  );
+
+  const handleDragOver = useCallback((event: DragEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'move';
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (event: DragEvent<HTMLButtonElement>, targetId: string) => {
+      event.preventDefault();
+      const sourceId = event.dataTransfer?.getData('text/plain') || dragSourceId.current;
+      dragSourceId.current = null;
+      if (!sourceId || sourceId === targetId) return;
+
+      const sourceIndex = normalizedPinned.indexOf(sourceId);
+      const targetIndex = normalizedPinned.indexOf(targetId);
+      if (sourceIndex === -1 || targetIndex === -1) return;
+
+      const updated = [...normalizedPinned];
+      updated.splice(sourceIndex, 1);
+      updated.splice(targetIndex, 0, sourceId);
+      setPinned(updated);
+    },
+    [normalizedPinned, setPinned]
+  );
+
+  const handleDragEnd = useCallback(() => {
+    dragSourceId.current = null;
+  }, []);
+
+  const handleRemove = useCallback(
+    (id: string) => {
+      setPinned(normalizedPinned.filter((item) => item !== id));
+    },
+    [normalizedPinned, setPinned]
+  );
+
+  const handleAdd = useCallback(
+    (id: string) => {
+      if (!id || normalizedPinned.includes(id) || !appMap.has(id)) return;
+      setPinned([...normalizedPinned, id]);
+    },
+    [appMap, normalizedPinned, setPinned]
+  );
+
+  useEffect(() => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (!event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+        return;
+      }
+      if (!/^[1-9]$/.test(event.key)) {
+        return;
+      }
+      if (isEditableElement(document.activeElement)) {
+        return;
+      }
+
+      const index = Number(event.key) - 1;
+      const id = normalizedPinned[index];
+      if (!id) return;
+      event.preventDefault();
+      launch(id);
+    };
+
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
+  }, [normalizedPinned, launch]);
+
+  return (
+    <nav
+      aria-label="Quick launch"
+      className="flex items-center gap-3 rounded-md bg-black/40 px-3 py-2 text-white backdrop-blur"
+    >
+      <ul className="flex list-none items-center gap-2 p-0" role="list">
+        {normalizedPinned.map((id, index) => {
+          const app = appMap.get(id);
+          if (!app) return null;
+          const hotkeyNumber = index < 9 ? index + 1 : null;
+          const ariaLabel = `Launch ${app.title}${hotkeyNumber ? ` (Alt+${hotkeyNumber})` : ''}`;
+          return (
+            <li key={id} className="relative">
+              <button
+                type="button"
+                aria-label={ariaLabel}
+                title={`${app.title}${hotkeyNumber ? ` · Alt+${hotkeyNumber}` : ''}`}
+                className="relative flex h-12 w-12 items-center justify-center rounded-md bg-white/10 transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
+                onClick={() => launch(id)}
+                draggable
+                onDragStart={(event) => handleDragStart(event, id)}
+                onDragOver={handleDragOver}
+                onDrop={(event) => handleDrop(event, id)}
+                onDragEnd={handleDragEnd}
+                data-hotkey={hotkeyNumber ?? undefined}
+              >
+                <Image
+                  src={app.icon.replace('./', '/')}
+                  alt=""
+                  width={32}
+                  height={32}
+                  className="h-8 w-8"
+                />
+                {hotkeyNumber && (
+                  <span className="absolute -bottom-1 -right-1 flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-ubt-blue px-1 text-xs font-semibold text-black">
+                    {hotkeyNumber}
+                  </span>
+                )}
+              </button>
+              <button
+                type="button"
+                className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-black/70 text-xs text-white transition hover:bg-black"
+                aria-label={`Unpin ${app.title}`}
+                onClick={() => handleRemove(id)}
+              >
+                <span aria-hidden="true">×</span>
+              </button>
+            </li>
+          );
+        })}
+        {normalizedPinned.length === 0 && (
+          <li className="text-sm text-white/70">Pin apps for quick access</li>
+        )}
+      </ul>
+      {availableForPin.length > 0 && (
+        <div>
+          <label htmlFor="quick-launch-add" className="sr-only">
+            Pin application
+          </label>
+          <select
+            id="quick-launch-add"
+            defaultValue=""
+            className="rounded-md bg-black/30 px-2 py-1 text-sm text-white focus:outline-none focus:ring-2 focus:ring-ubt-blue"
+            onChange={(event) => {
+              const value = event.target.value;
+              handleAdd(value);
+              event.target.value = '';
+            }}
+          >
+            <option value="" disabled>
+              Pin application…
+            </option>
+            {availableForPin.map((app) => (
+              <option key={app.id} value={app.id}>
+                {app.title}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+    </nav>
+  );
+};
+
+export default QuickLaunch;


### PR DESCRIPTION
## Summary
- add a QuickLaunch dock component that persists pinned apps, exposes Alt+1-9 accelerators, and supports drag-and-drop reordering with screen-reader friendly labels
- add focused unit tests covering keyboard shortcuts, drag-and-drop, persistence, and pin management behaviours

## Testing
- yarn lint *(fails: pre-existing accessibility violations across numerous legacy components)*
- yarn test --runTestsByPath __tests__/quickLaunch.test.tsx
- yarn test *(fails: pre-existing suites such as window.test.tsx, nmapNse.test.tsx, reconNG app tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c7850cc8328b9089aaed96412cc