### PR TITLE
[settings] add search filter and focus improvements

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useState, useRef } from "react";
+import {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+} from "react";
+import type { ReactNode } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
@@ -12,6 +18,27 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+
+const WALLPAPERS = [
+  "wall-1",
+  "wall-2",
+  "wall-3",
+  "wall-4",
+  "wall-5",
+  "wall-6",
+  "wall-7",
+  "wall-8",
+] as const;
+
+type FocusableRefCallback = (element: HTMLElement | null) => void;
+
+type SectionConfig = {
+  id: string;
+  searchText: string;
+  className?: string;
+  useContainerForFocus?: boolean;
+  render: (registerFocusable: FocusableRefCallback) => ReactNode;
+};
 
 export default function Settings() {
   const {
@@ -41,21 +68,15 @@ export default function Settings() {
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [showKeymap, setShowKeymap] = useState(false);
 
-  const wallpapers = [
-    "wall-1",
-    "wall-2",
-    "wall-3",
-    "wall-4",
-    "wall-5",
-    "wall-6",
-    "wall-7",
-    "wall-8",
-  ];
+  const changeBackground = useCallback(
+    (name: string) => setWallpaper(name),
+    [setWallpaper]
+  );
 
-  const changeBackground = (name: string) => setWallpaper(name);
-
-  const handleExport = async () => {
+  const handleExport = useCallback(async () => {
     const data = await exportSettingsData();
     const blob = new Blob([data], { type: "application/json" });
     const url = URL.createObjectURL(blob);
@@ -64,34 +85,46 @@ export default function Settings() {
     a.download = "settings.json";
     a.click();
     URL.revokeObjectURL(url);
-  };
+  }, []);
 
-  const handleImport = async (file: File) => {
-    const text = await file.text();
-    await importSettingsData(text);
-    try {
-      const parsed = JSON.parse(text);
-      if (parsed.accent !== undefined) setAccent(parsed.accent);
-      if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
-      if (parsed.density !== undefined) setDensity(parsed.density);
-      if (parsed.reducedMotion !== undefined)
-        setReducedMotion(parsed.reducedMotion);
-      if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
-      if (parsed.highContrast !== undefined)
-        setHighContrast(parsed.highContrast);
-      if (parsed.theme !== undefined) setTheme(parsed.theme);
-    } catch (err) {
-      console.error("Invalid settings", err);
-    }
-  };
+  const handleImport = useCallback(
+    async (file: File) => {
+      const text = await file.text();
+      await importSettingsData(text);
+      try {
+        const parsed = JSON.parse(text);
+        if (parsed.accent !== undefined) setAccent(parsed.accent);
+        if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
+        if (parsed.density !== undefined) setDensity(parsed.density);
+        if (parsed.reducedMotion !== undefined)
+          setReducedMotion(parsed.reducedMotion);
+        if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
+        if (parsed.highContrast !== undefined)
+          setHighContrast(parsed.highContrast);
+        if (parsed.theme !== undefined) setTheme(parsed.theme);
+      } catch (err) {
+        console.error("Invalid settings", err);
+      }
+    },
+    [
+      setAccent,
+      setWallpaper,
+      setDensity,
+      setReducedMotion,
+      setFontScale,
+      setHighContrast,
+      setTheme,
+    ]
+  );
 
-  const handleReset = async () => {
+  const handleReset = useCallback(async () => {
     if (
       !window.confirm(
         "Reset desktop to default settings? This will clear all saved data."
       )
-    )
+    ) {
       return;
+    }
     await resetSettings();
     window.localStorage.clear();
     setAccent(defaults.accent);
@@ -101,29 +134,62 @@ export default function Settings() {
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
     setTheme("default");
-  };
+  }, [
+    setAccent,
+    setWallpaper,
+    setDensity,
+    setReducedMotion,
+    setFontScale,
+    setHighContrast,
+    setTheme,
+  ]);
 
-  const [showKeymap, setShowKeymap] = useState(false);
+  const focusRefs = useRef<Record<string, HTMLElement | null>>({});
+  const containerRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
-  return (
-    <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
-      <div className="flex justify-center border-b border-gray-900">
-        <Tabs tabs={tabs} active={activeTab} onChange={setActiveTab} />
-      </div>
-      {activeTab === "appearance" && (
-        <>
-          <div
-            className="md:w-2/5 w-2/3 h-1/3 m-auto my-4"
-            style={{
-              backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
-              backgroundSize: "cover",
-              backgroundRepeat: "no-repeat",
-              backgroundPosition: "center center",
-            }}
-          ></div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Theme:</label>
+  const registerFocusable = useCallback(
+    (sectionId: string) => (element: HTMLElement | null) => {
+      if (element) {
+        focusRefs.current[sectionId] = element;
+      } else {
+        delete focusRefs.current[sectionId];
+      }
+    },
+    []
+  );
+
+  const registerContainer = useCallback(
+    (sectionId: string) => (element: HTMLDivElement | null) => {
+      if (element) {
+        containerRefs.current[sectionId] = element;
+      } else {
+        delete containerRefs.current[sectionId];
+      }
+    },
+    []
+  );
+
+  const normalizedSearch = searchTerm.trim().toLowerCase();
+  const searchTokens = normalizedSearch
+    ? normalizedSearch.split(/\s+/).filter(Boolean)
+    : [];
+
+  const wallpaperIndex = Math.max(0, WALLPAPERS.indexOf(wallpaper));
+
+  const sectionsByTab: Record<TabId, SectionConfig[]> = {
+    appearance: [
+      {
+        id: "theme",
+        searchText: "theme appearance mode default dark neon matrix color",
+        className: "flex justify-center my-4",
+        render: (register) => (
+          <>
+            <label htmlFor="settings-theme" className="mr-2 text-ubt-grey">
+              Theme:
+            </label>
             <select
+              id="settings-theme"
+              ref={register}
               value={theme}
               onChange={(e) => setTheme(e.target.value)}
               className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
@@ -133,88 +199,140 @@ export default function Settings() {
               <option value="neon">Neon</option>
               <option value="matrix">Matrix</option>
             </select>
-          </div>
-          <div className="flex justify-center my-4">
+          </>
+        ),
+      },
+      {
+        id: "accent",
+        searchText: "accent color highlight blue red orange green purple pink",
+        className: "flex justify-center my-4",
+        render: (register) => (
+          <>
             <label className="mr-2 text-ubt-grey">Accent:</label>
-            <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
-              {ACCENT_OPTIONS.map((c) => (
+            <div
+              aria-label="Accent color picker"
+              role="radiogroup"
+              className="flex gap-2"
+            >
+              {ACCENT_OPTIONS.map((color, index) => (
                 <button
-                  key={c}
-                  aria-label={`select-accent-${c}`}
+                  key={color}
+                  ref={index === 0 ? register : undefined}
+                  aria-label={`select-accent-${color}`}
                   role="radio"
-                  aria-checked={accent === c}
-                  onClick={() => setAccent(c)}
-                  className={`w-8 h-8 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
-                  style={{ backgroundColor: c }}
+                  aria-checked={accent === color}
+                  onClick={() => setAccent(color)}
+                  className={`w-8 h-8 rounded-full border-2 ${
+                    accent === color ? "border-white" : "border-transparent"
+                  }`}
+                  style={{ backgroundColor: color }}
                 />
               ))}
             </div>
-          </div>
-          <div className="flex justify-center my-4">
-            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>
-            <input
-              id="wallpaper-slider"
-              type="range"
-              min="0"
-              max={wallpapers.length - 1}
-              step="1"
-              value={wallpapers.indexOf(wallpaper)}
-              onChange={(e) =>
-                changeBackground(wallpapers[parseInt(e.target.value, 10)])
-              }
-              className="ubuntu-slider"
-              aria-label="Wallpaper"
+          </>
+        ),
+      },
+      {
+        id: "wallpaper",
+        searchText:
+          "wallpaper background image slideshow rotate preview gallery",
+        render: (register) => (
+          <>
+            <div
+              className="md:w-2/5 w-2/3 h-1/3 m-auto my-4"
+              style={{
+                backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
+                backgroundSize: "cover",
+                backgroundRepeat: "no-repeat",
+                backgroundPosition: "center center",
+              }}
+              aria-hidden="true"
             />
-          </div>
-          <div className="flex justify-center my-4">
-            <BackgroundSlideshow />
-          </div>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
-            {wallpapers.map((name) => (
-              <div
-                key={name}
-                role="button"
-                aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
-                aria-pressed={name === wallpaper}
-                tabIndex={0}
-                onClick={() => changeBackground(name)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    changeBackground(name);
-                  }
-                }}
-                className={
-                  (name === wallpaper
-                    ? " border-yellow-700 "
-                    : " border-transparent ") +
-                  " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"
+            <div className="flex justify-center my-4">
+              <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">
+                Wallpaper:
+              </label>
+              <input
+                id="wallpaper-slider"
+                ref={register}
+                type="range"
+                min="0"
+                max={WALLPAPERS.length - 1}
+                step="1"
+                value={wallpaperIndex}
+                onChange={(e) =>
+                  changeBackground(
+                    WALLPAPERS[parseInt(e.target.value, 10)] ?? WALLPAPERS[0]
+                  )
                 }
-                style={{
-                  backgroundImage: `url(/wallpapers/${name}.webp)`,
-                  backgroundSize: "cover",
-                  backgroundRepeat: "no-repeat",
-                  backgroundPosition: "center center",
-                }}
-              ></div>
-            ))}
-          </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
-            <button
-              onClick={handleReset}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Reset Desktop
-            </button>
-          </div>
-        </>
-      )}
-      {activeTab === "accessibility" && (
-        <>
-          <div className="flex justify-center my-4">
-            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">Icon Size:</label>
+                className="ubuntu-slider"
+                aria-label="Wallpaper"
+              />
+            </div>
+            <div className="flex justify-center my-4">
+              <BackgroundSlideshow />
+            </div>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
+              {WALLPAPERS.map((name) => (
+                <div
+                  key={name}
+                  role="button"
+                  aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
+                  aria-pressed={name === wallpaper}
+                  tabIndex={0}
+                  onClick={() => changeBackground(name)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      changeBackground(name);
+                    }
+                  }}
+                  className={
+                    (name === wallpaper
+                      ? " border-yellow-700 "
+                      : " border-transparent ") +
+                    " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"
+                  }
+                  style={{
+                    backgroundImage: `url(/wallpapers/${name}.webp)`,
+                    backgroundSize: "cover",
+                    backgroundRepeat: "no-repeat",
+                    backgroundPosition: "center center",
+                  }}
+                />
+              ))}
+            </div>
+          </>
+        ),
+      },
+      {
+        id: "reset",
+        searchText: "reset defaults clear data restore desktop settings",
+        className: "border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center",
+        render: (register) => (
+          <button
+            ref={register}
+            onClick={handleReset}
+            className="px-4 py-2 rounded bg-ub-orange text-white"
+          >
+            Reset Desktop
+          </button>
+        ),
+      },
+    ],
+    accessibility: [
+      {
+        id: "icon-size",
+        searchText: "icon size scale font accessibility",
+        className: "flex justify-center my-4",
+        render: (register) => (
+          <>
+            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">
+              Icon Size:
+            </label>
             <input
               id="font-scale"
+              ref={register}
               type="range"
               min="0.75"
               max="1.5"
@@ -224,56 +342,104 @@ export default function Settings() {
               className="ubuntu-slider"
               aria-label="Icon size"
             />
-          </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Density:</label>
+          </>
+        ),
+      },
+      {
+        id: "density",
+        searchText: "density spacing compact regular layout",
+        className: "flex justify-center my-4",
+        render: (register) => (
+          <>
+            <label htmlFor="density-select" className="mr-2 text-ubt-grey">
+              Density:
+            </label>
             <select
+              id="density-select"
+              ref={register}
               value={density}
-              onChange={(e) => setDensity(e.target.value as any)}
+              onChange={(e) => setDensity(e.target.value as typeof density)}
               className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
             >
               <option value="regular">Regular</option>
               <option value="compact">Compact</option>
             </select>
-          </div>
-          <div className="flex justify-center my-4 items-center">
+          </>
+        ),
+      },
+      {
+        id: "reduced-motion",
+        searchText: "reduced motion animation accessibility",
+        className: "flex justify-center my-4 items-center",
+        render: (register) => (
+          <>
             <span className="mr-2 text-ubt-grey">Reduced Motion:</span>
             <ToggleSwitch
+              ref={register}
               checked={reducedMotion}
               onChange={setReducedMotion}
               ariaLabel="Reduced Motion"
             />
-          </div>
-          <div className="flex justify-center my-4 items-center">
+          </>
+        ),
+      },
+      {
+        id: "high-contrast",
+        searchText: "high contrast visibility accessibility",
+        className: "flex justify-center my-4 items-center",
+        render: (register) => (
+          <>
             <span className="mr-2 text-ubt-grey">High Contrast:</span>
             <ToggleSwitch
+              ref={register}
               checked={highContrast}
               onChange={setHighContrast}
               ariaLabel="High Contrast"
             />
-          </div>
-          <div className="flex justify-center my-4 items-center">
+          </>
+        ),
+      },
+      {
+        id: "haptics",
+        searchText: "haptics vibration feedback accessibility",
+        className: "flex justify-center my-4 items-center",
+        render: (register) => (
+          <>
             <span className="mr-2 text-ubt-grey">Haptics:</span>
             <ToggleSwitch
+              ref={register}
               checked={haptics}
               onChange={setHaptics}
               ariaLabel="Haptics"
             />
-          </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
+          </>
+        ),
+      },
+      {
+        id: "shortcuts",
+        searchText: "shortcuts keymap keyboard hotkeys",
+        className: "border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center",
+        render: (register) => (
+          <button
+            ref={register}
+            onClick={() => setShowKeymap(true)}
+            className="px-4 py-2 rounded bg-ub-orange text-white"
+          >
+            Edit Shortcuts
+          </button>
+        ),
+      },
+    ],
+    privacy: [
+      {
+        id: "export-import",
+        searchText:
+          "privacy export import backup restore settings data upload download",
+        className: "flex justify-center my-4 space-x-4",
+        render: (register) => (
+          <>
             <button
-              onClick={() => setShowKeymap(true)}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Edit Shortcuts
-            </button>
-          </div>
-        </>
-      )}
-      {activeTab === "privacy" && (
-        <>
-          <div className="flex justify-center my-4 space-x-4">
-            <button
+              ref={register}
               onClick={handleExport}
               className="px-4 py-2 rounded bg-ub-orange text-white"
             >
@@ -285,21 +451,123 @@ export default function Settings() {
             >
               Import Settings
             </button>
-          </div>
-        </>
-      )}
-        <input
-          type="file"
-          accept="application/json"
-          ref={fileInputRef}
-          aria-label="Import settings file"
-          onChange={(e) => {
-            const file = e.target.files && e.target.files[0];
-            if (file) handleImport(file);
-            e.target.value = "";
-          }}
-          className="hidden"
+          </>
+        ),
+      },
+    ],
+  };
+
+  const activeSections = sectionsByTab[activeTab];
+  const visibleSections =
+    searchTokens.length === 0
+      ? activeSections
+      : activeSections.filter((section) =>
+          searchTokens.every((token) => section.searchText.includes(token))
+        );
+  const visibleSectionIds = visibleSections.map((section) => section.id);
+
+  const previousMatchesRef = useRef<string[]>([]);
+
+  useEffect(() => {
+    if (!normalizedSearch) {
+      previousMatchesRef.current = visibleSectionIds;
+      return;
+    }
+
+    if (visibleSectionIds.length === 0) {
+      previousMatchesRef.current = visibleSectionIds;
+      return;
+    }
+
+    const previous = previousMatchesRef.current;
+    const hasNarrowed =
+      previous.length === 0 ||
+      visibleSectionIds.length < previous.length ||
+      visibleSectionIds.some((id, index) => id !== previous[index]);
+
+    if (hasNarrowed) {
+      for (const id of visibleSectionIds) {
+        const section = activeSections.find((item) => item.id === id);
+        if (!section) continue;
+        const focusTarget =
+          focusRefs.current[id] ??
+          (section.useContainerForFocus ? containerRefs.current[id] ?? null : null);
+        if (focusTarget) {
+          focusTarget.focus();
+          break;
+        }
+      }
+    }
+
+    previousMatchesRef.current = visibleSectionIds;
+  }, [activeSections, normalizedSearch, visibleSectionIds]);
+
+  useEffect(() => {
+    previousMatchesRef.current = [];
+  }, [activeTab]);
+
+  const renderSection = (section: SectionConfig) => {
+    const register = registerFocusable(section.id);
+    const setContainerRef = registerContainer(section.id);
+    return (
+      <div
+        key={section.id}
+        data-settings-section={section.id}
+        className={section.className}
+        ref={(element) => {
+          setContainerRef(element);
+          if (section.useContainerForFocus) {
+            register(element);
+          }
+        }}
+        tabIndex={section.useContainerForFocus ? -1 : undefined}
+      >
+        {section.render(register)}
+      </div>
+    );
+  };
+
+  return (
+    <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
+      <div className="border-b border-gray-900 px-4 py-3 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <Tabs
+          tabs={tabs}
+          active={activeTab}
+          onChange={setActiveTab}
+          className="justify-center md:justify-start"
         />
+        <div className="flex justify-center md:justify-end">
+          <label htmlFor="settings-search" className="w-full md:w-64">
+            <span className="sr-only">Search settings</span>
+            <input
+              id="settings-search"
+              type="search"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              placeholder="Search settings"
+              className="w-full px-3 py-2 rounded bg-ub-cool-grey text-ubt-grey border border-ubt-cool-grey focus:outline-none focus:border-ub-orange"
+            />
+          </label>
+        </div>
+      </div>
+      {visibleSections.map(renderSection)}
+      {normalizedSearch && visibleSections.length === 0 && (
+        <p className="px-4 py-8 text-center text-ubt-grey" role="status">
+          No settings match "{searchTerm}". Try a different search term.
+        </p>
+      )}
+      <input
+        type="file"
+        accept="application/json"
+        ref={fileInputRef}
+        aria-label="Import settings file"
+        onChange={(e) => {
+          const file = e.target.files && e.target.files[0];
+          if (file) handleImport(file);
+          e.target.value = "";
+        }}
+        className="hidden"
+      />
       <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
     </div>
   );

--- a/components/ToggleSwitch.tsx
+++ b/components/ToggleSwitch.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { forwardRef } from "react";
 
 interface ToggleSwitchProps {
   checked: boolean;
@@ -8,27 +8,32 @@ interface ToggleSwitchProps {
   ariaLabel: string;
 }
 
-export default function ToggleSwitch({
-  checked,
-  onChange,
-  className = "",
-  ariaLabel,
-}: ToggleSwitchProps) {
-  return (
-    <button
-      role="switch"
-      aria-checked={checked}
-      aria-label={ariaLabel}
-      onClick={() => onChange(!checked)}
-      className={`relative inline-flex w-10 h-5 rounded-full transition-colors focus:outline-none ${
-        checked ? "bg-ub-orange" : "bg-ubt-cool-grey"
-      } ${className}`.trim()}
-    >
-      <span
-        className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-ub-cool-grey transition-transform duration-200 ${
-          checked ? "translate-x-5" : "translate-x-0"
-        }`}
-      />
-    </button>
-  );
-}
+const ToggleSwitch = forwardRef<HTMLButtonElement, ToggleSwitchProps>(
+  function ToggleSwitch({
+    checked,
+    onChange,
+    className = "",
+    ariaLabel,
+  }, ref) {
+    return (
+      <button
+        ref={ref}
+        role="switch"
+        aria-checked={checked}
+        aria-label={ariaLabel}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex w-10 h-5 rounded-full transition-colors focus:outline-none ${
+          checked ? "bg-ub-orange" : "bg-ubt-cool-grey"
+        } ${className}`.trim()}
+      >
+        <span
+          className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-ub-cool-grey transition-transform duration-200 ${
+            checked ? "translate-x-5" : "translate-x-0"
+          }`}
+        />
+      </button>
+    );
+  }
+);
+
+export default ToggleSwitch;


### PR DESCRIPTION
## Summary
- add a settings search field that filters sections per tab as you type
- automatically focus the first matching control and show a message when no settings match
- forward refs through the toggle switch so filtered focus targets remain keyboard accessible

## Testing
- yarn lint *(fails: repository has pre-existing accessibility lint violations across many apps)*
- yarn test *(fails: repository has existing failing suites such as nmapNse.test.tsx and contact API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c7b86c48328bef0854cd03b9979