### PR TITLE
[calculator] add interactive tape history panel

### DIFF
--- a/__tests__/calculator.tape.test.tsx
+++ b/__tests__/calculator.tape.test.tsx
@@ -11,20 +11,29 @@ describe('Calculator Tape', () => {
 
   it('recalls result to display', () => {
     const { getByLabelText } = render(
-      <Tape entries={[{ expr: '1+1', result: '2' }]} />,
+      <Tape entries={[{ expr: '1+1', result: '2' }]} onClear={jest.fn()} />,
     );
-    fireEvent.click(getByLabelText('recall result'));
+    fireEvent.click(getByLabelText('Use result 2 from 1+1'));
     const display = document.getElementById('display') as HTMLInputElement;
     expect(display.value).toBe('2');
   });
 
   it('copies result to clipboard', async () => {
     const { getByLabelText } = render(
-      <Tape entries={[{ expr: '1+1', result: '2' }]} />,
+      <Tape entries={[{ expr: '1+1', result: '2' }]} onClear={jest.fn()} />,
     );
-    fireEvent.click(getByLabelText('copy result'));
+    fireEvent.click(getByLabelText('Copy result 2 to clipboard'));
     await waitFor(() =>
       expect((navigator.clipboard as any).writeText).toHaveBeenCalledWith('2'),
     );
+  });
+
+  it('clears the tape when requested', () => {
+    const handleClear = jest.fn();
+    const { getByText } = render(
+      <Tape entries={[{ expr: '2+2', result: '4' }]} onClear={handleClear} />,
+    );
+    fireEvent.click(getByText('Clear'));
+    expect(handleClear).toHaveBeenCalled();
   });
 });

--- a/apps/calculator/index.tsx
+++ b/apps/calculator/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
 import ModeSwitcher from './components/ModeSwitcher';
 import MemorySlots from './components/MemorySlots';
@@ -24,6 +24,10 @@ export default function Calculator() {
 
   const btnCls =
     'btn min-h-12 w-12 transition-transform duration-150 hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:ring-white';
+
+  const handleHistoryClear = useCallback(() => {
+    setHistory([]);
+  }, [setHistory]);
 
   useEffect(() => {
     let evaluate: any;
@@ -327,14 +331,7 @@ export default function Calculator() {
         <div id="paren-indicator" />
       </div>
       <FormulaEditor />
-      <div id="history" className="history hidden" aria-live="polite">
-        {history.map(({ expr, result }, i) => (
-          <div key={i} className="history-entry">
-            {expr} = {result}
-          </div>
-        ))}
-      </div>
-      <Tape entries={history} />
+      <Tape entries={history} onClear={handleHistoryClear} />
     </div>
   );
 }

--- a/apps/calculator/styles.css
+++ b/apps/calculator/styles.css
@@ -101,38 +101,127 @@ body {
   position: fixed;
   top: 0;
   right: 0;
-  width: 200px;
+  width: min(260px, 80vw);
   height: 100%;
-  overflow-y: auto;
   background: var(--color-surface);
   border-left: 1px solid var(--color-border);
-  padding: 0.5rem;
-  font-size: 0.9rem;
   box-shadow: -2px 0 5px color-mix(in srgb, var(--color-inverse), transparent 90%);
+  padding: 0.75rem;
+  font-size: 0.9rem;
   display: flex;
   flex-direction: column;
+  gap: 0.75rem;
   z-index: 1000;
 }
 
 .history-header {
   display: flex;
-  justify-content: flex-end;
-  margin-bottom: 0.5rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
 }
 
-#history-list {
-  overflow-y: auto;
+.history-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.history-clear {
+  border: none;
+  border-radius: 4px;
+  padding: 0.25rem 0.75rem;
+  background: color-mix(in srgb, var(--color-muted), transparent 20%);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: background 150ms ease, opacity 150ms ease;
+}
+
+.history-clear:hover:not(:disabled),
+.history-clear:focus-visible:not(:disabled) {
+  background: color-mix(in srgb, var(--color-muted), var(--color-text) 15%);
+  outline: none;
+}
+
+.history-clear:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.history-list {
   flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-right: 0.25rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
 }
 
 .history-entry {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.25rem;
+  gap: 0.5rem;
+  align-items: stretch;
 }
 
-.history-entry button {
-  margin-left: 0.5rem;
-  padding: 0.25rem 0.5rem;
+.history-entry-button {
+  flex: 1;
+  border: none;
+  border-radius: 6px;
+  padding: 0.5rem;
+  background: color-mix(in srgb, var(--color-muted), transparent 10%);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  transition: background 150ms ease, transform 150ms ease;
+}
+
+.history-entry-button:hover,
+.history-entry-button:focus-visible {
+  background: color-mix(in srgb, var(--color-muted), var(--color-text) 15%);
+  outline: 2px solid color-mix(in srgb, var(--color-text), transparent 40%);
+  outline-offset: 2px;
+  transform: translateY(-1px);
+}
+
+.history-entry-expr {
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+.history-entry-result {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.history-copy {
+  border: none;
+  border-radius: 6px;
+  padding: 0.35rem 0.6rem;
+  background: color-mix(in srgb, var(--color-muted), transparent 20%);
+  color: inherit;
+  font: inherit;
+  font-size: 0.75rem;
+  cursor: pointer;
+  align-self: center;
+  white-space: nowrap;
+  transition: background 150ms ease;
+}
+
+.history-copy:hover,
+.history-copy:focus-visible {
+  background: color-mix(in srgb, var(--color-muted), var(--color-text) 15%);
+  outline: none;
+}
+
+.history-empty {
+  margin: auto 0;
+  text-align: center;
+  color: color-mix(in srgb, var(--color-text), transparent 45%);
 }


### PR DESCRIPTION
## Summary
- add an always-available history tape panel with selectable, keyboard-accessible entries and copy controls
- allow clearing stored tape entries from the panel and focus the display when values are recalled
- refresh calculator tape styling and update its tests to cover selection, copy, and clearing behaviors

## Testing
- yarn lint *(fails: repo-wide accessibility and no-top-level-window lint violations in unrelated apps)*
- yarn test *(fails: existing suites such as window snapping, nmap NSE clipboard, and hydra API timeout)*
- yarn test __tests__/calculator.tape.test.tsx --runTestsByPath


------
https://chatgpt.com/codex/tasks/task_e_68c99c811b3c83289f21ab56c3c54cf2