### PR TITLE
[resource-monitor] add live range controls and accessible chart

### DIFF
--- a/apps/resource-monitor/components/NetworkInsights.tsx
+++ b/apps/resource-monitor/components/NetworkInsights.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 import {
   onFetchProxy,
@@ -8,28 +8,105 @@ import {
   FetchEntry,
 } from '../../../lib/fetchProxy';
 import { exportMetrics } from '../export';
-import RequestChart from './RequestChart';
+import { HistoryEntry, isHistoryEntryArray } from '../types';
+import RequestChart, { ChartPoint } from './RequestChart';
 
 const HISTORY_KEY = 'network-insights-history';
+
+const TIME_RANGE_OPTIONS = [
+  { id: '1m', label: '1 min', durationMs: 60_000, description: 'Last 1 minute' },
+  { id: '5m', label: '5 min', durationMs: 5 * 60_000, description: 'Last 5 minutes' },
+  { id: '15m', label: '15 min', durationMs: 15 * 60_000, description: 'Last 15 minutes' },
+] as const;
+
+type TimeRangeId = (typeof TIME_RANGE_OPTIONS)[number]['id'];
+
+const MAX_HISTORY_ITEMS = 500;
+const MAX_HISTORY_DURATION = TIME_RANGE_OPTIONS[TIME_RANGE_OPTIONS.length - 1].durationMs;
 
 const formatBytes = (bytes?: number) =>
   typeof bytes === 'number' ? `${(bytes / 1024).toFixed(1)} kB` : '—';
 
 export default function NetworkInsights() {
   const [active, setActive] = useState<FetchEntry[]>(getActiveFetches());
-  const [history, setHistory] = usePersistentState<FetchEntry[]>(HISTORY_KEY, []);
+  const [history, setHistory] = usePersistentState<HistoryEntry[]>(
+    HISTORY_KEY,
+    [],
+    isHistoryEntryArray,
+  );
+  const [timeRange, setTimeRange] = useState<TimeRangeId>('1m');
+  const [now, setNow] = useState(() => Date.now());
+  const [paused, setPaused] = useState(false);
+  const [pausedSnapshot, setPausedSnapshot] = useState<HistoryEntry[] | null>(null);
+  const [pausedAt, setPausedAt] = useState<number | null>(null);
 
   useEffect(() => {
     const unsubStart = onFetchProxy('start', () => setActive(getActiveFetches()));
     const unsubEnd = onFetchProxy('end', (e: CustomEvent<FetchEntry>) => {
       setActive(getActiveFetches());
-      setHistory((h) => [...h, e.detail]);
+      const recordedAt = Date.now();
+      const cutoff = recordedAt - MAX_HISTORY_DURATION;
+      setHistory((previous) => {
+        const trimmed = previous.filter((entry) => entry.recordedAt >= cutoff);
+        const next: HistoryEntry[] = [...trimmed, { ...e.detail, recordedAt }];
+        return next.length > MAX_HISTORY_ITEMS ? next.slice(-MAX_HISTORY_ITEMS) : next;
+      });
     });
     return () => {
       unsubStart();
       unsubEnd();
     };
   }, [setHistory]);
+
+  useEffect(() => {
+    const cutoff = Date.now() - MAX_HISTORY_DURATION;
+    setHistory((entries) => entries.filter((entry) => entry.recordedAt >= cutoff));
+  }, [setHistory]);
+
+  useEffect(() => {
+    if (paused) return;
+    const id = window.setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, [paused]);
+
+  useEffect(() => {
+    if (paused) {
+      setPausedSnapshot((snapshot) => snapshot ?? history);
+      setPausedAt((value) => value ?? Date.now());
+    } else {
+      setPausedSnapshot(null);
+      setPausedAt(null);
+      setNow(Date.now());
+    }
+  }, [paused, history]);
+
+  useEffect(() => {
+    setNow(Date.now());
+  }, [timeRange]);
+
+  const activeRange = TIME_RANGE_OPTIONS.find((option) => option.id === timeRange)!;
+  const effectiveNow = pausedAt ?? now;
+  const visibleHistory = paused && pausedSnapshot ? pausedSnapshot : history;
+
+  const filteredHistory = useMemo(
+    () =>
+      visibleHistory.filter(
+        (entry) => effectiveNow - entry.recordedAt <= activeRange.durationMs,
+      ),
+    [visibleHistory, effectiveNow, activeRange.durationMs],
+  );
+
+  const chartData: ChartPoint[] = useMemo(
+    () =>
+      filteredHistory.map((entry) => ({
+        value: entry.duration ?? 0,
+        timestamp: entry.recordedAt,
+        label: `${entry.method} ${entry.url}`,
+      })),
+    [filteredHistory],
+  );
 
   return (
     <div className="p-2 text-xs text-white bg-[var(--kali-bg)]">
@@ -47,11 +124,54 @@ export default function NetworkInsights() {
           </li>
         ))}
       </ul>
-      <div className="flex items-center mb-1">
-        <h2 className="font-bold">History</h2>
+      <div className="flex flex-wrap items-center gap-2 mb-1" role="group" aria-label="History controls">
+        <h2 className="font-bold mr-2">History</h2>
+        <fieldset className="flex flex-wrap gap-1" aria-label="Select time range">
+          <legend className="sr-only">Time range</legend>
+          {TIME_RANGE_OPTIONS.map((option) => (
+            <label
+              key={option.id}
+              className={`relative inline-flex cursor-pointer select-none items-center rounded border px-2 py-1 transition focus-within:outline focus-within:outline-2 focus-within:outline-offset-1 focus-within:outline-green-400 ${
+                timeRange === option.id
+                  ? 'border-green-400 bg-green-500 text-black'
+                  : 'border-gray-700 bg-[var(--kali-panel)] text-gray-200 hover:border-green-400'
+              }`}
+            >
+              <input
+                type="radio"
+                name="network-history-range"
+                value={option.id}
+                checked={timeRange === option.id}
+                onChange={() => setTimeRange(option.id)}
+                className="sr-only"
+                aria-label={option.description}
+              />
+              <span aria-hidden>{option.label}</span>
+            </label>
+          ))}
+        </fieldset>
+        <button
+          type="button"
+          onClick={() => setPaused((value) => !value)}
+          aria-pressed={paused}
+          className={`ml-auto inline-flex items-center rounded border px-2 py-1 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-400 ${
+            paused
+              ? 'border-yellow-500 bg-yellow-400/20 text-yellow-200'
+              : 'border-green-500 bg-green-500/20 text-green-200 hover:border-green-400'
+          }`}
+        >
+          {paused ? 'Resume updates' : 'Pause updates'}
+        </button>
+        <span
+          className="text-[11px] text-gray-300"
+          role="status"
+          aria-live="polite"
+        >
+          {paused ? 'Updates paused' : 'Live updates on'}
+        </span>
         <button
           onClick={() => exportMetrics(history)}
-          className="ml-auto px-2 py-1 rounded bg-[var(--kali-panel)]"
+          className="ml-2 inline-flex items-center rounded border border-gray-700 bg-[var(--kali-panel)] px-2 py-1 hover:border-green-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-400"
         >
           Export
         </button>
@@ -72,10 +192,12 @@ export default function NetworkInsights() {
           </li>
         ))}
       </ul>
-      <div className="mt-2 flex justify-center">
+      <div className="mt-3 flex justify-center">
         <RequestChart
-          data={history.map((h) => h.duration ?? 0)}
+          data={chartData}
           label="Request duration (ms)"
+          description={activeRange.description}
+          paused={paused}
         />
       </div>
     </div>

--- a/apps/resource-monitor/components/RequestChart.tsx
+++ b/apps/resource-monitor/components/RequestChart.tsx
@@ -1,65 +1,217 @@
 'use client';
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 
-interface RequestChartProps {
-  data: number[];
+export interface ChartPoint {
+  value: number;
+  timestamp: number;
   label: string;
 }
 
-export default function RequestChart({ data, label }: RequestChartProps) {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+interface RequestChartProps {
+  data: ChartPoint[];
+  label: string;
+  description?: string;
+  paused?: boolean;
+}
+
+const GRID_LINE_COUNT = 4;
+const VERTICAL_PADDING = 8;
+const MAX_HEIGHT = 100;
+const CHART_HEIGHT = MAX_HEIGHT - VERTICAL_PADDING * 2;
+
+const formatValue = (value: number) => `${Math.round(value)} ms`;
+
+const createTimeFormatter = () =>
+  new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+
+type PointWithCoordinates = ChartPoint & {
+  index: number;
+  x: number;
+  y: number;
+};
+
+export default function RequestChart({
+  data,
+  label,
+  description,
+  paused = false,
+}: RequestChartProps) {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const tooltipBaseId = useId();
+  const formatterRef = useRef(createTimeFormatter());
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
+    setActiveIndex(null);
+    buttonRefs.current = [];
+  }, [data]);
 
-    const width = canvas.width;
-    const height = canvas.height;
+  const maxValue = useMemo(() => {
+    if (data.length === 0) return 0;
+    return Math.max(...data.map((point) => point.value));
+  }, [data]);
 
-    ctx.clearRect(0, 0, width, height);
+  const points: PointWithCoordinates[] = useMemo(() => {
+    if (data.length === 0) return [];
+    const denominator = Math.max(data.length - 1, 1);
+    const effectiveMax = maxValue <= 0 ? 1 : maxValue;
+    return data.map((point, index) => {
+      const x = (index / denominator) * 100;
+      const relativeHeight = (point.value / effectiveMax) * CHART_HEIGHT;
+      const y = VERTICAL_PADDING + (CHART_HEIGHT - relativeHeight);
+      return {
+        ...point,
+        index,
+        x,
+        y,
+      };
+    });
+  }, [data, maxValue]);
 
-    // draw panel background
-    ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue('--kali-panel');
-    ctx.fillRect(0, 0, width, height);
+  const pathD = useMemo(() => {
+    if (points.length === 0) return '';
+    return points
+      .map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x.toFixed(2)} ${point.y.toFixed(2)}`)
+      .join(' ');
+  }, [points]);
 
-    // gridlines
-    ctx.strokeStyle = 'rgba(255,255,255,0.1)';
-    ctx.lineWidth = 1;
-    for (let i = 1; i < 5; i++) {
-      const y = (height / 5) * i;
-      ctx.beginPath();
-      ctx.moveTo(0, y);
-      ctx.lineTo(width, y);
-      ctx.stroke();
+  const areaD = useMemo(() => {
+    if (points.length === 0) return '';
+    const start = `M ${points[0].x.toFixed(2)} ${MAX_HEIGHT.toFixed(2)}`;
+    const middle = points
+      .map((point) => `L ${point.x.toFixed(2)} ${point.y.toFixed(2)}`)
+      .join(' ');
+    const end = `L ${points[points.length - 1].x.toFixed(2)} ${MAX_HEIGHT.toFixed(2)} Z`;
+    return `${start} ${middle} ${end}`;
+  }, [points]);
+
+  const tooltipPoint = activeIndex != null ? points[activeIndex] : null;
+  const tooltipId = tooltipPoint ? `${tooltipBaseId}-${tooltipPoint.index}` : undefined;
+
+  const chartLabel = [label, description, paused ? 'paused' : null]
+    .filter(Boolean)
+    .join(', ');
+
+  const handleKeyNavigation = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    if (points.length === 0) return;
+    if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+      event.preventDefault();
+      const delta = event.key === 'ArrowRight' ? 1 : -1;
+      const nextIndex = (index + delta + points.length) % points.length;
+      buttonRefs.current[nextIndex]?.focus();
+      setActiveIndex(nextIndex);
     }
-
-    if (data.length > 0) {
-      const maxVal = Math.max(...data);
-      ctx.strokeStyle = '#00ff00';
-      ctx.lineWidth = 2;
-      ctx.beginPath();
-      data.forEach((v, i) => {
-        const x = (i / (data.length - 1 || 1)) * width;
-        const y = height - (v / maxVal) * height;
-        if (i === 0) ctx.moveTo(x, y);
-        else ctx.lineTo(x, y);
-      });
-      ctx.stroke();
-    }
-
-    // legend
-    ctx.fillStyle = '#ffffff';
-    ctx.font = '10px sans-serif';
-    ctx.fillText(label, 4, 12);
-  }, [data, label]);
+  };
 
   return (
-    <div className="w-full max-w-[300px] h-[150px]" style={{ background: 'var(--kali-panel)' }}>
-      <canvas ref={canvasRef} width={300} height={150} className="w-full h-full" />
+    <div
+      className="relative w-full max-w-[320px] h-[180px] rounded border border-gray-700 bg-[var(--kali-panel)] p-2"
+      role="group"
+      aria-label={chartLabel}
+    >
+      <svg
+        viewBox={`0 0 100 ${MAX_HEIGHT}`}
+        preserveAspectRatio="none"
+        className="absolute inset-2 h-[calc(100%-1rem)] w-[calc(100%-1rem)]"
+        aria-hidden="true"
+      >
+        <rect
+          x={0}
+          y={0}
+          width={100}
+          height={MAX_HEIGHT}
+          fill="transparent"
+          stroke="rgba(255,255,255,0.08)"
+          strokeWidth={0.5}
+          rx={2}
+        />
+        {Array.from({ length: GRID_LINE_COUNT }).map((_, index) => {
+          const y =
+            VERTICAL_PADDING + ((index + 1) * CHART_HEIGHT) / (GRID_LINE_COUNT + 1);
+          return (
+            <line
+              key={`grid-${index}`}
+              x1={0}
+              x2={100}
+              y1={y}
+              y2={y}
+              stroke="rgba(255,255,255,0.12)"
+              strokeWidth={0.5}
+            />
+          );
+        })}
+        {areaD && (
+          <path d={areaD} fill="rgba(0,255,0,0.12)" stroke="none" />
+        )}
+        {pathD && (
+          <path d={pathD} fill="none" stroke="#00ff00" strokeWidth={1.2} />
+        )}
+      </svg>
+      <div className="relative z-10 h-full w-full">
+        {points.map((point) => (
+          <button
+            key={point.index}
+            ref={(element) => {
+              buttonRefs.current[point.index] = element;
+            }}
+            type="button"
+            className={`absolute -translate-x-1/2 -translate-y-1/2 rounded-full border focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-400 ${
+              activeIndex === point.index
+                ? 'h-4 w-4 border-green-300 bg-green-400/80'
+                : 'h-3 w-3 border-green-300 bg-green-400/60 hover:h-4 hover:w-4'
+            }`}
+            style={{
+              left: `${point.x}%`,
+              top: `${point.y}%`,
+            }}
+            aria-label={`${label} at ${formatterRef.current.format(
+              new Date(point.timestamp),
+            )} is ${formatValue(point.value)}`}
+            aria-describedby={
+              tooltipPoint && tooltipPoint.index === point.index ? tooltipId : undefined
+            }
+            onFocus={() => setActiveIndex(point.index)}
+            onBlur={() => setActiveIndex((current) => (current === point.index ? null : current))}
+            onMouseEnter={() => setActiveIndex(point.index)}
+            onMouseLeave={() =>
+              setActiveIndex((current) => (current === point.index ? null : current))
+            }
+            onKeyDown={(event) => handleKeyNavigation(event, point.index)}
+          >
+            <span className="sr-only">{formatValue(point.value)}</span>
+          </button>
+        ))}
+        {tooltipPoint && (
+          <div
+            role="tooltip"
+            id={tooltipId}
+            className="pointer-events-none absolute -translate-x-1/2 -translate-y-full rounded bg-black/80 px-2 py-1 text-[11px] text-white shadow-lg"
+            style={{
+              left: `${tooltipPoint.x}%`,
+              top: `${tooltipPoint.y}%`,
+              marginTop: -6,
+            }}
+          >
+            <div className="font-semibold">{formatValue(tooltipPoint.value)}</div>
+            <div className="text-[10px] text-gray-200">
+              {formatterRef.current.format(new Date(tooltipPoint.timestamp))}
+            </div>
+          </div>
+        )}
+        {points.length === 0 && (
+          <div className="flex h-full items-center justify-center text-center text-[11px] text-gray-400">
+            No data in this range yet
+          </div>
+        )}
+      </div>
     </div>
   );
 }
-

--- a/apps/resource-monitor/types.ts
+++ b/apps/resource-monitor/types.ts
@@ -1,0 +1,13 @@
+import { FetchEntry } from '../../lib/fetchProxy';
+
+export interface HistoryEntry extends FetchEntry {
+  recordedAt: number;
+}
+
+export const isHistoryEntryArray = (value: unknown): value is HistoryEntry[] =>
+  Array.isArray(value) &&
+  value.every((item) =>
+    item !== null &&
+    typeof item === 'object' &&
+    typeof (item as Partial<HistoryEntry>).recordedAt === 'number',
+  );


### PR DESCRIPTION
## Summary
- track request history timestamps so charts can filter 1/5/15-minute windows and persist clean data
- add pause/resume controls with live status messaging for the resource monitor timeline
- replace the canvas chart with an accessible SVG chart that exposes focusable points and tooltips

## Testing
- yarn lint *(fails: repo has pre-existing jsx-a11y and no-top-level-window violations across many apps)*
- yarn test *(fails: existing suites like __tests__/nmapNse.test.tsx expect role="alert" and other tests rely on browser APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c89a8b883289845ce2acba1912f