### PR TITLE
[notes] Add notes app with labels and ordering

### DIFF
--- a/__tests__/notes.state.test.ts
+++ b/__tests__/notes.state.test.ts
@@ -1,0 +1,72 @@
+import { reorderNotesArray, sanitizeNotesState, type Note } from '../apps/notes/state';
+
+describe('sanitizeNotesState', () => {
+  it('adds default metadata when missing', () => {
+    const state = sanitizeNotesState({
+      notes: [{ id: 'note-1', title: 'Draft', content: 'Body text' }],
+    });
+
+    expect(state.notes).toHaveLength(1);
+    const note = state.notes[0];
+    expect(note.order).toBe(0);
+    expect(note.archived).toBe(false);
+    expect(note.labelIds).toEqual([]);
+    expect(typeof note.createdAt).toBe('string');
+    expect(state.labels.length).toBeGreaterThan(0);
+  });
+
+  it('filters invalid label references and preserves filter settings', () => {
+    const state = sanitizeNotesState({
+      labels: [
+        { id: 'work', name: 'Work', color: '#ff8800' },
+        { id: 'ideas', name: 'Ideas', color: '#38bdf8' },
+      ],
+      notes: [
+        {
+          id: 'note-2',
+          title: 'Research',
+          content: 'Investigate tooling',
+          archived: true,
+          labelIds: ['work', 'invalid', 'work'],
+        },
+      ],
+      filter: { labelIds: ['work', 'invalid'], showArchived: true },
+    });
+
+    expect(state.notes[0].labelIds).toEqual(['work']);
+    expect(state.filter.labelIds).toEqual(['work']);
+    expect(state.filter.showArchived).toBe(true);
+  });
+});
+
+describe('reorderNotesArray', () => {
+  const createNote = (id: string, order: number): Note => ({
+    id,
+    title: id.toUpperCase(),
+    content: `${id} content`,
+    labelIds: [],
+    archived: false,
+    order,
+    createdAt: '2023-01-01T00:00:00.000Z',
+    updatedAt: '2023-01-01T00:00:00.000Z',
+  });
+
+  it('moves a note before the target note and normalizes order', () => {
+    const original = [createNote('a', 0), createNote('b', 1), createNote('c', 2)];
+    const reordered = reorderNotesArray(original, 'c', 'a');
+
+    expect(reordered.map((note) => note.id)).toEqual(['c', 'a', 'b']);
+    expect(reordered[0].order).toBe(0);
+    expect(reordered[1].order).toBe(1);
+    expect(reordered[0].updatedAt).not.toEqual(original[2].updatedAt);
+  });
+
+  it('appends to the end when dropping without a target', () => {
+    const original = [createNote('a', 0), createNote('b', 1), createNote('c', 2)];
+    const reordered = reorderNotesArray(original, 'a', null);
+
+    expect(reordered.map((note) => note.id)).toEqual(['b', 'c', 'a']);
+    expect(reordered[2].order).toBe(2);
+  });
+});
+

--- a/apps.config.js
+++ b/apps.config.js
@@ -74,6 +74,7 @@ const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
+const NotesApp = createDynamicApp('notes', 'Notes');
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
 const TrashApp = createDynamicApp('trash', 'Trash');
 const SerialTerminalApp = createDynamicApp('serial-terminal', 'Serial Terminal');
@@ -161,6 +162,7 @@ const displayAsciiArt = createDisplay(AsciiArtApp);
 const displayQuote = createDisplay(QuoteApp);
 const displayProjectGallery = createDisplay(ProjectGalleryApp);
 const displayTrash = createDisplay(TrashApp);
+const displayNotes = createDisplay(NotesApp);
 const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
@@ -763,6 +765,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayTodoist,
+  },
+  {
+    id: 'notes',
+    title: 'Notes',
+    icon: '/themes/Yaru/apps/notes.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayNotes,
   },
   {
     id: 'sticky_notes',

--- a/apps/notes/index.tsx
+++ b/apps/notes/index.tsx
@@ -1,0 +1,448 @@
+"use client";
+
+import { useMemo, useState } from 'react';
+import type { DragEvent } from 'react';
+import { useNotesState, type Note, type NoteLabel } from './state';
+
+function cx(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+function parseHexColor(color: string) {
+  const trimmed = color.trim();
+  const match = /^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.exec(trimmed);
+  if (!match) return null;
+  let hex = match[1];
+  if (hex.length === 3) {
+    hex = hex
+      .split('')
+      .map((ch) => ch + ch)
+      .join('');
+  }
+  const value = Number.parseInt(hex, 16);
+  if (Number.isNaN(value)) return null;
+  return {
+    r: (value >> 16) & 255,
+    g: (value >> 8) & 255,
+    b: value & 255,
+  };
+}
+
+function withAlpha(color: string, alpha: number) {
+  const rgb = parseHexColor(color);
+  if (!rgb) return undefined;
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`;
+}
+
+function getReadableTextColor(color: string) {
+  const rgb = parseHexColor(color);
+  if (!rgb) return undefined;
+  const luminance = (0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b) / 255;
+  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
+}
+
+function formatUpdatedAt(timestamp: string) {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '';
+  try {
+    return date.toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return date.toISOString();
+  }
+}
+
+interface FilterChipProps {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  color?: string;
+  ariaLabel?: string;
+}
+
+function FilterChip({ label, active, onClick, color, ariaLabel }: FilterChipProps) {
+  const style = active && color
+    ? {
+        backgroundColor: withAlpha(color, 0.2) ?? color,
+        borderColor: withAlpha(color, 0.6) ?? color,
+        color: getReadableTextColor(color),
+      }
+    : color
+    ? { borderColor: withAlpha(color, 0.6) ?? color }
+    : undefined;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      aria-label={ariaLabel}
+      className={cx(
+        'flex items-center gap-2 rounded-full border px-3 py-1 text-sm transition focus:outline-none focus:ring focus:ring-sky-500/30 focus:ring-offset-2 focus:ring-offset-slate-900',
+        active ? 'bg-white/10 text-slate-100 shadow-sm' : 'border-slate-700/60 text-slate-300 hover:bg-slate-800/60',
+      )}
+      style={style}
+    >
+      {color ? (
+        <span
+          aria-hidden
+          className="h-2.5 w-2.5 rounded-full"
+          style={{ backgroundColor: color }}
+        />
+      ) : null}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+interface LabelToggleProps {
+  label: NoteLabel;
+  active: boolean;
+  onToggle: () => void;
+}
+
+function LabelToggle({ label, active, onToggle }: LabelToggleProps) {
+  const style = active
+    ? {
+        backgroundColor: withAlpha(label.color, 0.25) ?? label.color,
+        borderColor: withAlpha(label.color, 0.6) ?? label.color,
+        color: getReadableTextColor(label.color),
+      }
+    : { borderColor: withAlpha(label.color, 0.6) ?? label.color };
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={active}
+      className={cx(
+        'flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition focus:outline-none focus:ring focus:ring-sky-500/30 focus:ring-offset-2 focus:ring-offset-slate-900',
+        active ? 'shadow-sm' : 'text-slate-300 hover:bg-slate-800/60',
+      )}
+      style={style}
+    >
+      <span
+        aria-hidden
+        className="h-2 w-2 rounded-full"
+        style={{ backgroundColor: label.color }}
+      />
+      <span>{label.name}</span>
+    </button>
+  );
+}
+
+interface NoteCardProps {
+  note: Note;
+  labels: NoteLabel[];
+  isDragging: boolean;
+  isDragOver: boolean;
+  onDragStart: (event: DragEvent<HTMLButtonElement>) => void;
+  onDragEnd: () => void;
+  onDragEnter: () => void;
+  onDragLeave: () => void;
+  onDrop: () => void;
+  onTitleChange: (value: string) => void;
+  onContentChange: (value: string) => void;
+  onToggleLabel: (labelId: string) => void;
+  onArchive: () => void;
+  onDelete: () => void;
+}
+
+function NoteCard({
+  note,
+  labels,
+  isDragging,
+  isDragOver,
+  onDragStart,
+  onDragEnd,
+  onDragEnter,
+  onDragLeave,
+  onDrop,
+  onTitleChange,
+  onContentChange,
+  onToggleLabel,
+  onArchive,
+  onDelete,
+}: NoteCardProps) {
+  const assignedLabels = labels.filter((label) => note.labelIds.includes(label.id));
+  const primaryColor = assignedLabels[0]?.color;
+  const cardStyle = primaryColor
+    ? {
+        borderColor: withAlpha(primaryColor, 0.55) ?? primaryColor,
+        backgroundColor: withAlpha(primaryColor, 0.12) ?? undefined,
+      }
+    : undefined;
+
+  return (
+    <article
+      role="listitem"
+      aria-label={note.title || 'Untitled note'}
+      className={cx(
+        'group flex h-full flex-col rounded-xl border border-slate-700/60 bg-slate-900/70 p-3 shadow transition',
+        isDragOver ? 'ring-2 ring-sky-400/60 ring-offset-2 ring-offset-slate-900' : 'ring-0',
+        note.archived ? 'opacity-75' : 'opacity-100',
+      )}
+      style={cardStyle}
+      onDragEnter={(event) => {
+        event.preventDefault();
+        onDragEnter();
+      }}
+      onDragOver={(event) => {
+        event.preventDefault();
+      }}
+      onDrop={(event) => {
+        event.preventDefault();
+        onDrop();
+      }}
+      onDragLeave={(event) => {
+        if (event.currentTarget === event.target) {
+          onDragLeave();
+        }
+      }}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <input
+          type="text"
+          value={note.title}
+          onChange={(event) => onTitleChange(event.target.value)}
+          placeholder="Title"
+          aria-label="Note title"
+          className="w-full rounded-md border border-slate-700/60 bg-slate-900/60 px-2 py-1 text-sm font-semibold text-slate-100 shadow-sm focus:border-sky-400 focus:outline-none focus:ring focus:ring-sky-500/30"
+        />
+        <button
+          type="button"
+          className={cx(
+            'flex h-8 w-8 items-center justify-center rounded-md border border-slate-700/60 bg-slate-800/70 text-slate-300 transition focus:outline-none focus:ring focus:ring-sky-500/30 focus:ring-offset-2 focus:ring-offset-slate-900',
+            isDragging ? 'cursor-grabbing' : 'cursor-grab',
+          )}
+          aria-label="Drag note to reorder"
+          draggable
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
+        >
+          <span aria-hidden className="text-lg leading-none">☰</span>
+        </button>
+      </div>
+
+      <textarea
+        value={note.content}
+        onChange={(event) => onContentChange(event.target.value)}
+        placeholder="Write your note..."
+        rows={5}
+        aria-label="Note content"
+        className="mt-3 min-h-[120px] flex-1 rounded-md border border-slate-700/60 bg-slate-900/60 px-2 py-2 text-sm text-slate-100 shadow-sm focus:border-sky-400 focus:outline-none focus:ring focus:ring-sky-500/30"
+      />
+
+      <div className="mt-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Labels</p>
+        <div className="mt-1 flex flex-wrap gap-1">
+          {labels.map((label) => (
+            <LabelToggle
+              key={label.id}
+              label={label}
+              active={note.labelIds.includes(label.id)}
+              onToggle={() => onToggleLabel(label.id)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-2 text-xs text-slate-400">
+        <span>{formatUpdatedAt(note.updatedAt) || 'Just now'}</span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onArchive}
+            className="rounded-md border border-slate-700/60 px-2 py-1 text-xs font-medium text-slate-200 transition hover:bg-slate-800/70 focus:outline-none focus:ring focus:ring-sky-500/30 focus:ring-offset-2 focus:ring-offset-slate-900"
+          >
+            {note.archived ? 'Restore' : 'Archive'}
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            className="rounded-md border border-rose-500/50 px-2 py-1 text-xs font-medium text-rose-200 transition hover:bg-rose-500/20 focus:outline-none focus:ring focus:ring-rose-500/40 focus:ring-offset-2 focus:ring-offset-slate-900"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function EmptyState({ filterActive }: { filterActive: boolean }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center rounded-xl border border-slate-700/60 bg-slate-900/60 p-8 text-center text-slate-400">
+      <p className="text-sm">
+        {filterActive
+          ? 'No notes match the current filters yet. Try adjusting the chips above.'
+          : 'Create your first note to capture ideas, tasks, or research leads.'}
+      </p>
+    </div>
+  );
+}
+
+export default function NotesApp() {
+  const {
+    state: { notes, labels, filter },
+    actions: {
+      addNote,
+      updateNote,
+      deleteNote,
+      toggleArchive,
+      toggleNoteLabel,
+      moveNote,
+      setFilterLabel,
+      clearLabelFilters,
+      setShowArchived,
+    },
+  } = useNotesState();
+
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dragOverId, setDragOverId] = useState<string | null>(null);
+
+  const visibleNotes = useMemo(() => {
+    return notes.filter((note) => {
+      if (filter.showArchived) {
+        if (!note.archived) return false;
+      } else if (note.archived) {
+        return false;
+      }
+      if (filter.labelIds.length > 0) {
+        return filter.labelIds.some((id) => note.labelIds.includes(id));
+      }
+      return true;
+    });
+  }, [notes, filter]);
+
+  const sortedNotes = useMemo(
+    () => [...visibleNotes].sort((a, b) => a.order - b.order),
+    [visibleNotes],
+  );
+
+  const handleDragStart = (noteId: string) => (event: DragEvent<HTMLButtonElement>) => {
+    event.dataTransfer.setData('text/plain', noteId);
+    event.dataTransfer.effectAllowed = 'move';
+    setDraggingId(noteId);
+    setDragOverId(noteId);
+  };
+
+  const handleDragEnd = () => {
+    setDraggingId(null);
+    setDragOverId(null);
+  };
+
+  const handleDropOnNote = (targetId: string) => {
+    if (!draggingId) return;
+    if (draggingId === targetId) {
+      handleDragEnd();
+      return;
+    }
+    moveNote(draggingId, targetId);
+    handleDragEnd();
+  };
+
+  const handleDropAtEnd = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    if (!draggingId) return;
+    moveNote(draggingId, null);
+    handleDragEnd();
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-slate-950 text-slate-100">
+      <header className="border-b border-slate-800/70 px-4 py-4">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => addNote()}
+              className="rounded-md border border-sky-500/50 bg-sky-500/20 px-4 py-2 text-sm font-semibold text-sky-100 transition hover:bg-sky-500/30 focus:outline-none focus:ring focus:ring-sky-500/40 focus:ring-offset-2 focus:ring-offset-slate-900"
+            >
+              New note
+            </button>
+            <div className="flex flex-wrap items-center gap-2" role="group" aria-label="Archive filter">
+              <FilterChip
+                label="Active"
+                active={!filter.showArchived}
+                onClick={() => setShowArchived(false)}
+              />
+              <FilterChip
+                label="Archived"
+                active={filter.showArchived}
+                onClick={() => setShowArchived(true)}
+              />
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2" role="group" aria-label="Label filters">
+            <FilterChip
+              label="All labels"
+              active={filter.labelIds.length === 0}
+              onClick={clearLabelFilters}
+            />
+            {labels.map((label) => (
+              <FilterChip
+                key={label.id}
+                label={label.name}
+                color={label.color}
+                active={filter.labelIds.includes(label.id)}
+                onClick={() => setFilterLabel(label.id)}
+                ariaLabel={`Toggle filter for ${label.name}`}
+              />
+            ))}
+          </div>
+        </div>
+      </header>
+      <main className="flex-1 overflow-y-auto px-4 py-6">
+        {sortedNotes.length === 0 ? (
+          <EmptyState filterActive={filter.labelIds.length > 0 || filter.showArchived} />
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2 2xl:grid-cols-3" role="list">
+            {sortedNotes.map((note) => (
+              <NoteCard
+                key={note.id}
+                note={note}
+                labels={labels}
+                isDragging={draggingId === note.id}
+                isDragOver={dragOverId === note.id && draggingId !== note.id}
+                onDragStart={handleDragStart(note.id)}
+                onDragEnd={handleDragEnd}
+                onDragEnter={() => {
+                  if (!draggingId || draggingId === note.id) return;
+                  setDragOverId(note.id);
+                }}
+                onDragLeave={() => {
+                  if (dragOverId === note.id) {
+                    setDragOverId(null);
+                  }
+                }}
+                onDrop={() => handleDropOnNote(note.id)}
+                onTitleChange={(value) => updateNote(note.id, { title: value })}
+                onContentChange={(value) => updateNote(note.id, { content: value })}
+                onToggleLabel={(labelId) => toggleNoteLabel(note.id, labelId)}
+                onArchive={() => toggleArchive(note.id)}
+                onDelete={() => deleteNote(note.id)}
+              />
+            ))}
+          </div>
+        )}
+        <div
+          className={cx(
+            'mt-6 flex h-16 items-center justify-center rounded-xl border border-dashed border-slate-700/60 text-sm text-slate-400 transition',
+            draggingId ? 'opacity-100' : 'pointer-events-none opacity-0',
+          )}
+          onDragOver={(event) => event.preventDefault()}
+          onDragEnter={() => setDragOverId(null)}
+          onDrop={handleDropAtEnd}
+        >
+          Drop here to move to the end
+        </div>
+      </main>
+    </div>
+  );
+}
+

--- a/apps/notes/state.ts
+++ b/apps/notes/state.ts
@@ -1,0 +1,475 @@
+"use client";
+
+import { useCallback, useEffect, useMemo } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+
+export interface NoteLabel {
+  id: string;
+  name: string;
+  color: string;
+}
+
+export interface Note {
+  id: string;
+  title: string;
+  content: string;
+  labelIds: string[];
+  archived: boolean;
+  order: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface NotesFilter {
+  labelIds: string[];
+  /**
+   * When true, the UI should display archived notes instead of active ones.
+   */
+  showArchived: boolean;
+}
+
+export interface NotesState {
+  notes: Note[];
+  labels: NoteLabel[];
+  filter: NotesFilter;
+}
+
+type NotesStateStorage = {
+  notes?: Partial<Note>[];
+  labels?: Partial<NoteLabel>[];
+  filter?: Partial<NotesFilter>;
+};
+
+const STORAGE_KEY = 'notes-app-state-v1';
+
+const DEFAULT_LABELS: readonly NoteLabel[] = [
+  { id: 'inbox', name: 'Inbox', color: '#3B82F6' },
+  { id: 'work', name: 'Work', color: '#F97316' },
+  { id: 'research', name: 'Research', color: '#8B5CF6' },
+  { id: 'personal', name: 'Personal', color: '#10B981' },
+];
+
+function createDefaultLabels(): NoteLabel[] {
+  return DEFAULT_LABELS.map((label) => ({ ...label }));
+}
+
+function createDefaultState(): NotesState {
+  return {
+    notes: [],
+    labels: createDefaultLabels(),
+    filter: { labelIds: [], showArchived: false },
+  };
+}
+
+function isValidStorage(value: unknown): value is NotesStateStorage {
+  if (!value || typeof value !== 'object') return false;
+  const storage = value as NotesStateStorage;
+  if ('notes' in storage && !Array.isArray(storage.notes)) return false;
+  if ('labels' in storage && !Array.isArray(storage.labels)) return false;
+  if ('filter' in storage && typeof storage.filter !== 'object') return false;
+  return true;
+}
+
+function sanitizeLabel(partial: Partial<NoteLabel> | undefined, index: number): NoteLabel | null {
+  if (!partial || typeof partial !== 'object') return null;
+  const fallback = DEFAULT_LABELS[index % DEFAULT_LABELS.length];
+  const idCandidate =
+    typeof partial.id === 'string' && partial.id.trim()
+      ? partial.id.trim()
+      : fallback?.id ?? `label-${index + 1}`;
+  const name =
+    typeof partial.name === 'string' && partial.name.trim()
+      ? partial.name.trim()
+      : fallback?.name ?? `Label ${index + 1}`;
+  const color =
+    typeof partial.color === 'string' && partial.color.trim()
+      ? partial.color.trim()
+      : fallback?.color ?? '#3B82F6';
+  return { id: idCandidate, name, color };
+}
+
+function sanitizeLabels(raw: Partial<NoteLabel>[] | undefined): NoteLabel[] {
+  const seen = new Set<string>();
+  const source = Array.isArray(raw) && raw.length > 0 ? raw : createDefaultLabels();
+  const labels: NoteLabel[] = [];
+  source.forEach((partial, index) => {
+    const candidate = sanitizeLabel(partial, index);
+    if (!candidate) return;
+    let id = candidate.id;
+    let counter = 1;
+    while (seen.has(id)) {
+      id = `${candidate.id}-${counter++}`;
+    }
+    seen.add(id);
+    labels.push({ ...candidate, id });
+  });
+  return labels.length > 0 ? labels : createDefaultLabels();
+}
+
+function sanitizeNote(
+  partial: Partial<Note> | undefined,
+  index: number,
+  validLabelIds: Set<string>,
+): Note | null {
+  if (!partial || typeof partial !== 'object') return null;
+  const now = new Date().toISOString();
+  const id =
+    typeof partial.id === 'string' && partial.id.trim()
+      ? partial.id.trim()
+      : typeof partial.id === 'number'
+      ? `note-${partial.id}`
+      : `note-${index + 1}`;
+  const title = typeof partial.title === 'string' ? partial.title : '';
+  const content = typeof partial.content === 'string' ? partial.content : '';
+  const archived = typeof partial.archived === 'boolean' ? partial.archived : false;
+  const order =
+    typeof partial.order === 'number' && Number.isFinite(partial.order)
+      ? partial.order
+      : index;
+  const createdAt =
+    typeof partial.createdAt === 'string' && partial.createdAt
+      ? partial.createdAt
+      : now;
+  const updatedAt =
+    typeof partial.updatedAt === 'string' && partial.updatedAt
+      ? partial.updatedAt
+      : createdAt;
+  const labelIds = Array.isArray(partial.labelIds)
+    ? Array.from(
+        new Set(
+          partial.labelIds.filter(
+            (labelId): labelId is string =>
+              typeof labelId === 'string' && validLabelIds.has(labelId),
+          ),
+        ),
+      )
+    : [];
+
+  return {
+    id,
+    title,
+    content,
+    labelIds,
+    archived,
+    order,
+    createdAt,
+    updatedAt,
+  };
+}
+
+function sanitizeNotes(
+  raw: Partial<Note>[] | undefined,
+  validLabelIds: Set<string>,
+): Note[] {
+  if (!Array.isArray(raw)) return [];
+  const notes: Note[] = [];
+  const seen = new Set<string>();
+  raw.forEach((partial, index) => {
+    const note = sanitizeNote(partial, index, validLabelIds);
+    if (!note) return;
+    let id = note.id;
+    let counter = 1;
+    while (seen.has(id)) {
+      id = `${note.id}-${counter++}`;
+    }
+    seen.add(id);
+    notes.push({ ...note, id });
+  });
+  notes.sort((a, b) => {
+    if (a.order !== b.order) return a.order - b.order;
+    if (a.createdAt !== b.createdAt) return a.createdAt.localeCompare(b.createdAt);
+    return a.id.localeCompare(b.id);
+  });
+  return notes.map((note, index) =>
+    note.order === index ? note : { ...note, order: index },
+  );
+}
+
+function sanitizeFilter(
+  partial: Partial<NotesFilter> | undefined,
+  validLabelIds: Set<string>,
+): NotesFilter {
+  if (!partial || typeof partial !== 'object') {
+    return { labelIds: [], showArchived: false };
+  }
+  const labelIds = Array.isArray(partial.labelIds)
+    ? partial.labelIds.filter((id): id is string => typeof id === 'string' && validLabelIds.has(id))
+    : [];
+  const unique = Array.from(new Set(labelIds));
+  const showArchived = typeof partial.showArchived === 'boolean' ? partial.showArchived : false;
+  return { labelIds: unique, showArchived };
+}
+
+export function sanitizeNotesState(value: unknown): NotesState {
+  const storage: NotesStateStorage = isValidStorage(value) ? value : {};
+  const labels = sanitizeLabels(storage.labels);
+  const labelIdSet = new Set(labels.map((label) => label.id));
+  const notes = sanitizeNotes(storage.notes, labelIdSet);
+  const filter = sanitizeFilter(storage.filter, labelIdSet);
+
+  const normalizedNotes = notes.map((note) => ({
+    ...note,
+    labelIds: note.labelIds.filter((id) => labelIdSet.has(id)),
+  }));
+
+  return {
+    notes: normalizedNotes,
+    labels,
+    filter,
+  };
+}
+
+function statesEqual(a: unknown, b: unknown): boolean {
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
+function generateId() {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    try {
+      return crypto.randomUUID();
+    } catch {
+      // fall back if randomUUID is not available
+    }
+  }
+  return `note-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function reorderNotesArray(
+  notes: Note[],
+  noteId: string,
+  targetId: string | null,
+): Note[] {
+  const ordered = [...notes].sort((a, b) => a.order - b.order);
+  const sourceIndex = ordered.findIndex((note) => note.id === noteId);
+  if (sourceIndex === -1) return ordered;
+  const [moved] = ordered.splice(sourceIndex, 1);
+  let targetIndex = targetId ? ordered.findIndex((note) => note.id === targetId) : -1;
+  if (targetIndex < 0 || targetIndex > ordered.length) {
+    targetIndex = ordered.length;
+  }
+  ordered.splice(targetIndex, 0, moved);
+  const now = new Date().toISOString();
+  return ordered.map((note, index) => {
+    if (note.order === index) return note;
+    if (note.id === moved.id) {
+      return { ...note, order: index, updatedAt: now };
+    }
+    return { ...note, order: index };
+  });
+}
+
+export function useNotesState() {
+  const [storedState, setStoredState, resetStoredState] = usePersistentState<NotesStateStorage>(
+    STORAGE_KEY,
+    () => createDefaultState(),
+    isValidStorage,
+  );
+
+  const state = useMemo(() => sanitizeNotesState(storedState), [storedState]);
+
+  useEffect(() => {
+    if (!statesEqual(storedState, state)) {
+      setStoredState(state);
+    }
+  }, [state, storedState, setStoredState]);
+
+  const applyStateUpdate = useCallback(
+    (updater: (previous: NotesState) => NotesState) => {
+      setStoredState((prev) => {
+        const base = sanitizeNotesState(prev);
+        const next = sanitizeNotesState(updater(base));
+        return next;
+      });
+    },
+    [setStoredState],
+  );
+
+  const addNote = useCallback(
+    (defaults?: Partial<Pick<Note, 'title' | 'content' | 'labelIds'>>) => {
+      applyStateUpdate((prev) => {
+        const validLabelIds = new Set(prev.labels.map((label) => label.id));
+        let initialLabels: string[] = [];
+        if (Array.isArray(defaults?.labelIds)) {
+          initialLabels = defaults.labelIds.filter((id) => validLabelIds.has(id));
+        } else if (prev.filter.labelIds.length === 1) {
+          initialLabels = prev.filter.labelIds;
+        }
+        const now = new Date().toISOString();
+        const note: Note = {
+          id: generateId(),
+          title: typeof defaults?.title === 'string' ? defaults.title : '',
+          content: typeof defaults?.content === 'string' ? defaults.content : '',
+          labelIds: Array.from(new Set(initialLabels)),
+          archived: false,
+          order: prev.notes.length,
+          createdAt: now,
+          updatedAt: now,
+        };
+        return { ...prev, notes: [...prev.notes, note] };
+      });
+    },
+    [applyStateUpdate],
+  );
+
+  const updateNote = useCallback(
+    (noteId: string, changes: Partial<Pick<Note, 'title' | 'content' | 'labelIds'>>) => {
+      applyStateUpdate((prev) => {
+        const index = prev.notes.findIndex((note) => note.id === noteId);
+        if (index === -1) return prev;
+        const validLabelIds = new Set(prev.labels.map((label) => label.id));
+        const nextNotes = [...prev.notes];
+        const current = nextNotes[index];
+        let modified = false;
+        let nextNote = { ...current };
+        if (typeof changes.title === 'string' && changes.title !== current.title) {
+          nextNote = { ...nextNote, title: changes.title, updatedAt: new Date().toISOString() };
+          modified = true;
+        }
+        if (typeof changes.content === 'string' && changes.content !== current.content) {
+          nextNote = { ...nextNote, content: changes.content, updatedAt: new Date().toISOString() };
+          modified = true;
+        }
+        if (Array.isArray(changes.labelIds)) {
+          const sanitizedLabels = Array.from(
+            new Set(changes.labelIds.filter((id) => typeof id === 'string' && validLabelIds.has(id))),
+          );
+          if (JSON.stringify(sanitizedLabels) !== JSON.stringify(current.labelIds)) {
+            nextNote = {
+              ...nextNote,
+              labelIds: sanitizedLabels,
+              updatedAt: new Date().toISOString(),
+            };
+            modified = true;
+          }
+        }
+        if (!modified) return prev;
+        nextNotes[index] = nextNote;
+        return { ...prev, notes: nextNotes };
+      });
+    },
+    [applyStateUpdate],
+  );
+
+  const deleteNote = useCallback(
+    (noteId: string) => {
+      applyStateUpdate((prev) => {
+        if (!prev.notes.some((note) => note.id === noteId)) return prev;
+        const remaining = prev.notes
+          .filter((note) => note.id !== noteId)
+          .map((note, index) => (note.order === index ? note : { ...note, order: index }));
+        return { ...prev, notes: remaining };
+      });
+    },
+    [applyStateUpdate],
+  );
+
+  const toggleArchive = useCallback(
+    (noteId: string) => {
+      applyStateUpdate((prev) => {
+        const now = new Date().toISOString();
+        const notes = prev.notes.map((note) =>
+          note.id === noteId
+            ? { ...note, archived: !note.archived, updatedAt: now }
+            : note,
+        );
+        return { ...prev, notes };
+      });
+    },
+    [applyStateUpdate],
+  );
+
+  const toggleNoteLabel = useCallback(
+    (noteId: string, labelId: string) => {
+      applyStateUpdate((prev) => {
+        const valid = prev.labels.some((label) => label.id === labelId);
+        if (!valid) return prev;
+        const now = new Date().toISOString();
+        const notes = prev.notes.map((note) => {
+          if (note.id !== noteId) return note;
+          const hasLabel = note.labelIds.includes(labelId);
+          const nextLabels = hasLabel
+            ? note.labelIds.filter((id) => id !== labelId)
+            : [...note.labelIds, labelId];
+          return { ...note, labelIds: nextLabels, updatedAt: now };
+        });
+        return { ...prev, notes };
+      });
+    },
+    [applyStateUpdate],
+  );
+
+  const moveNote = useCallback(
+    (noteId: string, targetId: string | null) => {
+      applyStateUpdate((prev) => {
+        const reordered = reorderNotesArray(prev.notes, noteId, targetId);
+        if (statesEqual(reordered, prev.notes)) return prev;
+        return { ...prev, notes: reordered };
+      });
+    },
+    [applyStateUpdate],
+  );
+
+  const setFilterLabel = useCallback(
+    (labelId: string) => {
+      applyStateUpdate((prev) => {
+        if (!prev.labels.some((label) => label.id === labelId)) return prev;
+        const current = prev.filter.labelIds;
+        const set = new Set(current);
+        if (set.has(labelId)) {
+          set.delete(labelId);
+        } else {
+          set.add(labelId);
+        }
+        const orderMap = new Map(prev.labels.map((label, index) => [label.id, index] as const));
+        const nextLabels = Array.from(set).sort((a, b) =>
+          (orderMap.get(a) ?? 0) - (orderMap.get(b) ?? 0),
+        );
+        if (JSON.stringify(nextLabels) === JSON.stringify(current)) return prev;
+        return { ...prev, filter: { ...prev.filter, labelIds: nextLabels } };
+      });
+    },
+    [applyStateUpdate],
+  );
+
+  const clearLabelFilters = useCallback(() => {
+    applyStateUpdate((prev) => {
+      if (prev.filter.labelIds.length === 0) return prev;
+      return { ...prev, filter: { ...prev.filter, labelIds: [] } };
+    });
+  }, [applyStateUpdate]);
+
+  const setShowArchived = useCallback(
+    (show: boolean) => {
+      applyStateUpdate((prev) => {
+        if (prev.filter.showArchived === show) return prev;
+        return { ...prev, filter: { ...prev.filter, showArchived: show } };
+      });
+    },
+    [applyStateUpdate],
+  );
+
+  const reset = useCallback(() => {
+    resetStoredState();
+  }, [resetStoredState]);
+
+  return {
+    state,
+    actions: {
+      addNote,
+      updateNote,
+      deleteNote,
+      toggleArchive,
+      toggleNoteLabel,
+      moveNote,
+      setFilterLabel,
+      clearLabelFilters,
+      setShowArchived,
+    },
+    reset,
+  } as const;
+}
+

--- a/components/apps/notes/index.tsx
+++ b/components/apps/notes/index.tsx
@@ -1,0 +1,13 @@
+import dynamic from 'next/dynamic';
+
+const NotesApp = dynamic(() => import('../../../apps/notes'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-full items-center justify-center bg-ub-cool-grey text-white">
+      Loading Notes...
+    </div>
+  ),
+});
+
+export default NotesApp;
+

--- a/pages/apps/notes.jsx
+++ b/pages/apps/notes.jsx
@@ -1,0 +1,11 @@
+import dynamic from 'next/dynamic';
+
+const Notes = dynamic(() => import('../../apps/notes'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function NotesPage() {
+  return <Notes />;
+}
+

--- a/public/themes/Yaru/apps/notes.svg
+++ b/public/themes/Yaru/apps/notes.svg
@@ -1,0 +1,14 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="note-bg" x1="12" y1="6" x2="52" y2="58" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#38bdf8" />
+      <stop offset="1" stop-color="#6366f1" />
+    </linearGradient>
+  </defs>
+  <rect x="8" y="6" width="48" height="52" rx="8" fill="url(#note-bg)" />
+  <path d="M40 6H48C52.4183 6 56 9.58172 56 14V30L40 14V6Z" fill="rgba(15,23,42,0.2)" />
+  <rect x="16" y="20" width="24" height="4" rx="2" fill="#e2e8f0" opacity="0.9" />
+  <rect x="16" y="30" width="32" height="4" rx="2" fill="#e2e8f0" opacity="0.85" />
+  <rect x="16" y="40" width="28" height="4" rx="2" fill="#e2e8f0" opacity="0.8" />
+  <path d="M40 14L56 30V50C56 54.4183 52.4183 58 48 58H24C19.5817 58 16 54.4183 16 50V48H38C39.6569 48 41 46.6569 41 45V22L40 21.0016V14Z" fill="rgba(15,23,42,0.12)" />
+</svg>


### PR DESCRIPTION
## Summary
- add a dedicated Notes app with draggable cards, label filters, and archive support
- persist note state with label metadata, ordering fields, and archive toggles in IndexedDB-backed storage
- expose the app through the launcher with a new icon and regression tests for note state utilities

## Testing
- yarn lint *(fails: existing accessibility and window/document lint errors across legacy apps)*
- yarn test *(fails: existing suites such as nmapNse and window management; new notes tests pass)*
- npx eslint apps/notes/index.tsx
- npx eslint apps/notes/state.ts


------
https://chatgpt.com/codex/tasks/task_e_68c99c88663c8328996ca85c89c0fd8b