### PR TITLE
[build] enforce image asset policy

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -e
+
+node scripts/check-images.mjs --staged

--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ See `.env.local.example` for the full list.
 
 - Run `yarn lint` and `yarn test` before committing changes.
 - For manual smoke tests, start `yarn dev` and in another terminal run `yarn smoke` to visit every `/apps/*` route.
+- Large raster assets (`.png`, `.jpg`, `.jpeg`, `.webp`, `.avif`) must be ≤ 2000px wide unless the filename includes `-large`.
+
+### Image Asset Policy
+
+- Use the `-large` suffix (for example, `hero-wallpaper-large.png`) for intentional high-resolution exports that exceed 2000 pixels
+  in width.
+- The pre-commit hook runs `node scripts/check-images.mjs --staged` to block commits containing oversize images without the
+  suffix.
+- Run `node scripts/check-images.mjs --all` locally if you need to audit the full repository (useful before adding new art
+  packs or when updating wallpapers).
+- Resize or recompress images where possible to avoid unnecessary bundle weight; the suffix is intended for rare cases such as
+  hero backgrounds or marketing captures that require higher fidelity.
 
 ---
 

--- a/scripts/check-images.mjs
+++ b/scripts/check-images.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+import { access } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import sharp from 'sharp';
+
+const MAX_WIDTH = 2000;
+const LARGE_TOKEN = '-large';
+const SUPPORTED_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.avif']);
+
+const runGitCommand = (command) => {
+  try {
+    return execSync(command, { encoding: 'utf8' });
+  } catch (error) {
+    if (process.env.CI) {
+      throw error;
+    }
+
+    console.warn(`Failed to run "${command}".`, error.message);
+    return '';
+  }
+};
+
+const parseGitOutput = (output) =>
+  output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+const getFilesFromArgs = () => {
+  const args = process.argv.slice(2);
+  const optionArgs = new Set();
+  const positional = [];
+
+  for (const arg of args) {
+    if (arg === '--help' || arg === '-h') {
+      console.log(`Usage: node scripts/check-images.mjs [options] [files...]\n\nOptions:\n  --staged   Check staged files (default when no files passed)\n  --all      Check all tracked image files\n  -h, --help Show this help message\n`);
+      process.exit(0);
+    }
+
+    if (arg.startsWith('--')) {
+      optionArgs.add(arg);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  if (optionArgs.has('--all')) {
+    return parseGitOutput(runGitCommand('git ls-files --full-name'));
+  }
+
+  if (positional.length > 0) {
+    return positional;
+  }
+
+  // Default to staged files when no explicit list was provided.
+  if (optionArgs.has('--staged') || positional.length === 0) {
+    return parseGitOutput(runGitCommand('git diff --cached --name-only --diff-filter=ACMR'));
+  }
+
+  return positional;
+};
+
+const isSupportedImage = (filePath) => {
+  const ext = path.extname(filePath).toLowerCase();
+  return SUPPORTED_EXTENSIONS.has(ext);
+};
+
+const hasLargeToken = (filePath) => {
+  const baseName = path.basename(filePath, path.extname(filePath)).toLowerCase();
+  return baseName.includes(LARGE_TOKEN);
+};
+
+const fileExists = async (filePath) => {
+  try {
+    await access(filePath, constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const getOffendingImages = async (files) => {
+  const offenders = [];
+
+  for (const file of files) {
+    if (!isSupportedImage(file)) {
+      continue;
+    }
+
+    // Skip files that are no longer present (e.g., deleted in the same commit).
+    if (!(await fileExists(file))) {
+      continue;
+    }
+
+    try {
+      const metadata = await sharp(file).metadata();
+      const width = metadata?.width;
+
+      if (typeof width !== 'number') {
+        continue;
+      }
+
+      if (width > MAX_WIDTH && !hasLargeToken(file)) {
+        offenders.push({ file, width });
+      }
+    } catch (error) {
+      console.warn(`Unable to read ${file}: ${error.message}`);
+    }
+  }
+
+  return offenders;
+};
+
+const main = async () => {
+  const files = [...new Set(getFilesFromArgs())];
+
+  if (files.length === 0) {
+    process.exit(0);
+  }
+
+  const offenders = await getOffendingImages(files);
+
+  if (offenders.length === 0) {
+    process.exit(0);
+  }
+
+  console.error('\nImage policy violation: some assets are wider than 2000px without the "-large" suffix.');
+  for (const { file, width } of offenders) {
+    console.error(` - ${file} (${width}px wide)`);
+  }
+
+  console.error('\nResize the images to 2000px or less, or rename them to include "-large" before the extension.');
+  process.exit(1);
+};
+
+main().catch((error) => {
+  console.error('Unexpected failure while checking images.');
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a `scripts/check-images.mjs` helper that flags raster assets wider than 2000px unless they use the `-large` suffix
- run the checker from a Husky pre-commit hook so oversized files block commits
- document the image policy and how to run the script in the README for contributors

## Testing
- yarn lint *(fails: existing jsx-a11y and custom lint errors in unrelated legacy files)*
- node scripts/check-images.mjs --staged

------
https://chatgpt.com/codex/tasks/task_e_68c9d484be2c83288107e1c79c1ca456