### PR TITLE
[ci] enforce CSS budget limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,17 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: npm run lint
 
+  css-budget:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Check CSS size budget
+        run: node scripts/check-css-size.mjs
+
   typecheck:
     runs-on: ubuntu-latest
     needs: install

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "module-report": "node scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
-    "verify:all": "node scripts/verify.mjs"
+    "verify:all": "node scripts/verify.mjs",
+    "check:css-budget": "node scripts/check-css-size.mjs"
   },
   "engines": {
     "node": "20.19.5"

--- a/scripts/check-css-size.mjs
+++ b/scripts/check-css-size.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const DEFAULT_LIMIT_KB = 120;
+const limitKb = parseLimitFromArgs(DEFAULT_LIMIT_KB);
+const limitBytes = Math.round(limitKb * 1024);
+
+const repoRoot = process.cwd();
+const cssFiles = [];
+const IGNORED_DIRECTORIES = new Set([
+  '.git',
+  'node_modules',
+  '.next',
+  'out',
+  'dist',
+  'build',
+  'coverage',
+  '.turbo',
+  '.vercel',
+  '.cache',
+  '.tmp',
+  'tmp',
+  'temp',
+  '.pnpm',
+  '.yarn',
+  'playwright-report',
+]);
+
+async function main() {
+  await walkDirectory(repoRoot);
+
+  const totalBytes = cssFiles.reduce((sum, file) => sum + file.bytes, 0);
+  const formattedTotal = formatBytes(totalBytes);
+  const formattedLimit = formatBytes(limitBytes);
+
+  console.log(`Found ${cssFiles.length} CSS file${cssFiles.length === 1 ? '' : 's'}. Total size: ${formattedTotal} (limit: ${formattedLimit}).`);
+
+  if (cssFiles.length) {
+    const topFiles = [...cssFiles]
+      .sort((a, b) => b.bytes - a.bytes)
+      .slice(0, 5)
+      .map((file) => `- ${file.path} — ${formatBytes(file.bytes)}`)
+      .join('\n');
+
+    console.log('Top CSS files by size:\n' + topFiles);
+  }
+
+  if (totalBytes > limitBytes) {
+    const overage = formatBytes(totalBytes - limitBytes);
+    const summary = `Total CSS size ${formattedTotal} exceeds limit ${formattedLimit} by ${overage}.`;
+    console.error(`::error title=CSS budget exceeded::${summary} Reduce CSS payload or adjust the budget if this growth is intentional.`);
+    process.exit(1);
+  }
+
+  console.log('CSS budget check passed ✅');
+}
+
+async function walkDirectory(directory) {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    console.warn(`Skipping directory ${directory}: ${error.message}`);
+    return;
+  }
+
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+
+    const fullPath = path.join(directory, entry.name);
+    const relativePath = path.relative(repoRoot, fullPath);
+
+    if (entry.isDirectory()) {
+      if (shouldIgnoreDirectory(relativePath)) {
+        continue;
+      }
+      await walkDirectory(fullPath);
+    } else if (entry.isFile() && entry.name.endsWith('.css')) {
+      const { size } = await stat(fullPath);
+      cssFiles.push({
+        path: relativePath.split(path.sep).join('/'),
+        bytes: size,
+      });
+    }
+  }
+}
+
+function shouldIgnoreDirectory(relativePath) {
+  if (!relativePath) {
+    return false;
+  }
+
+  const segments = relativePath.split(path.sep);
+  return segments.some((segment) => IGNORED_DIRECTORIES.has(segment));
+}
+
+function parseLimitFromArgs(defaultLimit) {
+  const limitArg = process.argv.slice(2).find((value) => value.startsWith('--limit='));
+  if (!limitArg) {
+    return defaultLimit;
+  }
+
+  const parsedValue = Number.parseFloat(limitArg.split('=')[1]);
+  if (Number.isNaN(parsedValue) || parsedValue <= 0) {
+    console.error('::error title=Invalid limit argument::Expected a positive number for --limit.');
+    process.exit(1);
+  }
+
+  return parsedValue;
+}
+
+function formatBytes(bytes) {
+  const kilobytes = bytes / 1024;
+  const precision = kilobytes >= 100 ? 1 : 2;
+  return `${kilobytes.toFixed(precision)} KB`;
+}
+
+main().catch((error) => {
+  console.error('::error title=CSS budget check failed unexpectedly::' + error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a css-budget job to the CI workflow to block builds when css exceeds 120 KB
- implement a node script that totals css sizes and reports top offenders with an actionable error
- expose the budget check via `yarn check:css-budget` for easy local execution

## Testing
- node scripts/check-css-size.mjs
- yarn check:css-budget

------
https://chatgpt.com/codex/tasks/task_e_68c9d48962f08328b65d5b7d30b99c81