### PR TITLE
perf: inline critical css for desktop shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Serverful deployments run the built Next.js server so all API routes are availab
 ```bash
 yarn build && yarn start
 ```
+The build pipeline now generates route-specific critical CSS once `next build` finishes. The
+`scripts/build-critical-css.mjs` postbuild step snapshots the desktop shell and home route class
+usage, renders a trimmed Tailwind bundle, and writes `.next/cache/critical-css/{home,desktop}.css`.
+`pages/_document.jsx` inlines those styles during SSR and converts the remaining global stylesheets
+into async `rel="preload"` + `media="print"` pairs to avoid flashes of unstyled content during
+hydration.
 The service worker is automatically generated during `next build` via [`@ducanh2912/next-pwa`](https://github.com/DuCanhGH/next-pwa).
 After the server starts, exercise an API route to confirm server-side functionality:
 ```bash

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:gamepad": "tsc -p tsconfig.gamepad.json",
     "prebuild": "tsc -p tsconfig.gamepad.json",
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && node scripts/build-critical-css.mjs",
     "postbuild": "node scripts/safe-copy.mjs",
     "start": "next start",
     "export": "NEXT_PUBLIC_STATIC_EXPORT=true next build",

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,4 +1,31 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { Children, cloneElement, isValidElement } from 'react';
+
+const CRITICAL_ROUTE_KEYS = {
+  '/': 'home',
+  '/apps': 'desktop',
+};
+
+const criticalCssDir = path.join(process.cwd(), '.next', 'cache', 'critical-css');
+const criticalCssCache = new Map();
+
+function readCriticalCss(key) {
+  if (!key) return '';
+  if (criticalCssCache.has(key)) {
+    return criticalCssCache.get(key);
+  }
+  const filePath = path.join(criticalCssDir, `${key}.css`);
+  try {
+    const css = fs.readFileSync(filePath, 'utf8');
+    criticalCssCache.set(key, css);
+    return css;
+  } catch {
+    criticalCssCache.set(key, '');
+    return '';
+  }
+}
 
 class MyDocument extends Document {
   /**
@@ -7,17 +34,116 @@ class MyDocument extends Document {
   static async getInitialProps(ctx) {
     const initial = await Document.getInitialProps(ctx);
     const nonce = ctx?.res?.getHeader?.('x-csp-nonce');
-    return { ...initial, nonce };
+    const route = ctx?.pathname || ctx?.asPath || ctx?.req?.url?.split('?')[0] || '';
+    const routeKey = CRITICAL_ROUTE_KEYS[route];
+    const shouldOptimize =
+      Boolean(routeKey) && (!process.env.NODE_ENV || process.env.NODE_ENV === 'production');
+
+    let inlineCriticalCss = '';
+    let asyncStyleLinks = [];
+    let styles = initial.styles;
+
+    if (shouldOptimize) {
+      inlineCriticalCss = readCriticalCss(routeKey);
+      const styleNodes = Children.toArray(initial.styles);
+      const inline = [];
+      const links = [];
+
+      styleNodes.forEach((node) => {
+        if (isValidElement(node) && node.type === 'link' && node.props?.rel === 'stylesheet') {
+          links.push(node);
+        } else {
+          inline.push(node);
+        }
+      });
+
+      asyncStyleLinks = links;
+      styles = inline;
+    }
+
+    return {
+      ...initial,
+      styles,
+      nonce,
+      inlineCriticalCss,
+      asyncStyleLinks,
+      shouldOptimize,
+    };
   }
 
   render() {
-    const { nonce } = this.props;
+    const { nonce, inlineCriticalCss, asyncStyleLinks, shouldOptimize } = this.props;
+    const hasAsyncStyles = shouldOptimize && asyncStyleLinks && asyncStyleLinks.length > 0;
+    const preloadLinks = hasAsyncStyles
+      ? asyncStyleLinks.map((link, index) =>
+          cloneElement(link, {
+            key: `critical-preload-${index}`,
+            rel: 'preload',
+            as: 'style',
+            media: undefined,
+            onLoad: undefined,
+          })
+        )
+      : null;
+
+    const asyncStylesheets = hasAsyncStyles
+      ? asyncStyleLinks.map((link, index) =>
+          cloneElement(link, {
+            key: `critical-async-${index}`,
+            rel: 'stylesheet',
+            media: 'print',
+            'data-critical-async': true,
+          })
+        )
+      : null;
+
+    const noscriptStyles = hasAsyncStyles
+      ? asyncStyleLinks.map((link, index) =>
+          cloneElement(link, {
+            key: `critical-noscript-${index}`,
+            rel: 'stylesheet',
+            media: undefined,
+          })
+        )
+      : null;
+
+    const asyncLoaderScript = hasAsyncStyles
+      ? {
+          __html: `
+            (function(){
+              try {
+                var links = document.querySelectorAll('link[data-critical-async]');
+                links.forEach(function(link){
+                  if (!link || link.media === 'all') return;
+                  var enable = function(){ link.media = 'all'; };
+                  link.addEventListener('load', enable, { once: true });
+                  setTimeout(enable, 2000);
+                });
+              } catch (err) {
+                console.error('critical-css loader failed', err);
+              }
+            })();
+          `,
+        }
+      : null;
+
     return (
       <Html lang="en" data-csp-nonce={nonce}>
         <Head>
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
+          {inlineCriticalCss ? (
+            <style
+              nonce={nonce}
+              data-critical-css
+              dangerouslySetInnerHTML={{ __html: inlineCriticalCss }}
+            />
+          ) : null}
+          {preloadLinks}
+          {asyncStylesheets}
+          {noscriptStyles && <noscript>{noscriptStyles}</noscript>}
+          {asyncLoaderScript && <script nonce={nonce} dangerouslySetInnerHTML={asyncLoaderScript} />}
           <script nonce={nonce} src="/theme.js" />
         </Head>
         <body>

--- a/scripts/build-critical-css.mjs
+++ b/scripts/build-critical-css.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+import fg from 'fast-glob';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.join(__dirname, '..');
+
+const criticalOutputDir = path.join(projectRoot, '.next', 'cache', 'critical-css');
+
+const COMMON_GLOBS = [
+  'components/ubuntu.{js,jsx,ts,tsx}',
+  'components/screen/**/*.{js,jsx,ts,tsx}',
+  'components/base/**/*.{js,jsx,ts,tsx}',
+  'components/context-menus/**/*.{js,jsx,ts,tsx}',
+  'components/menu/**/*.{js,jsx,ts,tsx}',
+  'components/common/**/*.{js,jsx,ts,tsx}',
+];
+
+const ROUTES = [
+  {
+    key: 'home',
+    include: [
+      ...COMMON_GLOBS,
+      'pages/index.jsx',
+      'components/BetaBadge.{js,jsx,ts,tsx}',
+      'components/InstallButton.{js,jsx,ts,tsx}',
+    ],
+  },
+  {
+    key: 'desktop',
+    include: [
+      ...COMMON_GLOBS,
+      'pages/apps/index.jsx',
+    ],
+  },
+];
+
+const CLASSNAME_REGEX = /className\s*=\s*("[^"]*"|'[^']*'|`[^`]*`|{[^}]*})/g;
+const STRING_REGEX = /"([^"]+)"|'([^']+)'|`([^`]+)`/g;
+
+async function collectClasses(patterns) {
+  const files = await fg(patterns, { cwd: projectRoot, onlyFiles: true, dot: false, unique: true });
+  const classNames = new Set();
+
+  for (const file of files) {
+    const absolute = path.join(projectRoot, file);
+    const content = await fs.readFile(absolute, 'utf8');
+    let match;
+    while ((match = CLASSNAME_REGEX.exec(content))) {
+      const candidate = match[1];
+      if (!candidate) continue;
+      let stringMatch;
+      while ((stringMatch = STRING_REGEX.exec(candidate))) {
+        const value = stringMatch[1] || stringMatch[2] || stringMatch[3] || '';
+        value
+          .split(/\s+/)
+          .map((token) => token.trim())
+          .filter((token) => token && !token.includes('${') && !token.startsWith('{'))
+          .forEach((token) => classNames.add(token));
+      }
+    }
+  }
+
+  return classNames;
+}
+
+function createTempFile(name, content) {
+  const filePath = path.join(os.tmpdir(), `critical-css-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`);
+  return fs.writeFile(filePath, content, 'utf8').then(() => filePath);
+}
+
+async function runTailwind(inputPath, contentPath, outputPath) {
+  const tailwindBin = path.join(projectRoot, 'node_modules', '.bin', process.platform === 'win32' ? 'tailwindcss.cmd' : 'tailwindcss');
+  await new Promise((resolve, reject) => {
+    const child = spawn(tailwindBin, ['-i', inputPath, '-o', outputPath, '--content', contentPath, '--config', path.join(projectRoot, 'tailwind.config.js'), '--minify'], {
+      cwd: projectRoot,
+      stdio: 'inherit',
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`tailwindcss exited with code ${code}`));
+    });
+  });
+}
+
+async function buildCriticalCss() {
+  if (process.env.NODE_ENV && process.env.NODE_ENV !== 'production') {
+    console.log('[critical-css] Skipping critical CSS build outside production mode.');
+    return;
+  }
+
+  await fs.mkdir(criticalOutputDir, { recursive: true });
+
+  const tokensCss = await fs.readFile(path.join(projectRoot, 'styles', 'tokens.css'), 'utf8');
+  const globalsCss = await fs
+    .readFile(path.join(projectRoot, 'styles', 'globals.css'), 'utf8')
+    .then((css) => css.replace(/@import\s+['\"]\.\/tokens\.css['\"];?/, '').trim());
+  const indexCss = await fs
+    .readFile(path.join(projectRoot, 'styles', 'index.css'), 'utf8')
+    .then((css) => css.replace(/@import\s+['\"]\.\/globals\.css['\"];?/, '').trim());
+
+  const baseCss = [tokensCss.trim(), globalsCss, indexCss].filter(Boolean).join('\n\n');
+
+  for (const route of ROUTES) {
+    const classNames = await collectClasses(route.include);
+    if (classNames.size === 0) {
+      console.warn(`[critical-css] No class names found for route "${route.key}". Skipping.`);
+      continue;
+    }
+
+    const tempHtml = Array.from(classNames)
+      .map((cls) => `<div class="${cls.replace(/"/g, '&quot;').replace(/'/g, '&#39;')}"></div>`)
+      .join('\n');
+    const tempCssInput = '@tailwind base;\n@tailwind components;\n@tailwind utilities;';
+
+    const contentPath = await createTempFile(`${route.key}-content.html`, tempHtml);
+    const inputPath = await createTempFile(`${route.key}-input.css`, tempCssInput);
+    const outputPath = path.join(os.tmpdir(), `critical-css-${route.key}-${Date.now()}.css`);
+
+    try {
+      await runTailwind(inputPath, contentPath, outputPath);
+      const tailwindCss = await fs.readFile(outputPath, 'utf8');
+      const finalCss = [baseCss, tailwindCss.trim()].filter(Boolean).join('\n\n');
+      const destination = path.join(criticalOutputDir, `${route.key}.css`);
+      await fs.writeFile(destination, finalCss, 'utf8');
+      console.log(`[critical-css] Wrote ${route.key} critical CSS to ${destination}`);
+    } finally {
+      await Promise.allSettled([
+        fs.unlink(contentPath).catch(() => {}),
+        fs.unlink(inputPath).catch(() => {}),
+        fs.unlink(outputPath).catch(() => {}),
+      ]);
+    }
+  }
+}
+
+buildCriticalCss().catch((error) => {
+  console.error('[critical-css] Failed to build critical CSS');
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a build step that compiles route-specific critical CSS for the home and desktop experiences
- inline the generated critical styles in _document.jsx and async-load the remaining global stylesheets with a loader shim
- document the new pipeline and critical CSS generation workflow in the README

## Testing
- yarn lint *(fails: existing repo accessibility violations)*
- yarn test *(fails: existing repo unit/integration regressions)*
- CI=1 yarn build

------
https://chatgpt.com/codex/tasks/task_e_68c9d48aa92483289212a0949e2dbc50