### PR TITLE
[i18n] persist locale selection

### DIFF
--- a/__tests__/i18nPersist.test.ts
+++ b/__tests__/i18nPersist.test.ts
@@ -1,0 +1,68 @@
+import {
+  LOCALE_PERSISTENCE_KEY,
+  __resetLocalePersistenceForTests,
+  clearPersistedLocale,
+  getPersistedLocale,
+  persistLocale,
+  subscribeToLocaleChanges,
+} from '@/src/i18n/persist';
+
+const dispatchStorageEvent = (value: string | null) => {
+  const event = new StorageEvent('storage', {
+    key: LOCALE_PERSISTENCE_KEY,
+    newValue: value,
+    storageArea: window.localStorage,
+  });
+  window.dispatchEvent(event);
+};
+
+describe('locale persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    __resetLocalePersistenceForTests();
+  });
+
+  test('returns fallback locale when nothing stored', () => {
+    expect(getPersistedLocale('en-US')).toBe('en-US');
+    expect(window.localStorage.getItem(LOCALE_PERSISTENCE_KEY)).toBeNull();
+  });
+
+  test('persists and restores the last selected locale', () => {
+    persistLocale('fr-CA');
+    expect(window.localStorage.getItem(LOCALE_PERSISTENCE_KEY)).toBe('fr-CA');
+
+    // Reset cache to simulate a fresh load
+    __resetLocalePersistenceForTests();
+    expect(getPersistedLocale('en-US')).toBe('fr-CA');
+  });
+
+  test('notifies subscribers when locale changes locally and remotely', () => {
+    const updates: string[] = [];
+    const unsubscribe = subscribeToLocaleChanges((locale) => {
+      updates.push(locale);
+    });
+
+    persistLocale('de-DE');
+    expect(updates).toEqual(['de-DE']);
+
+    dispatchStorageEvent('it-IT');
+    expect(updates).toEqual(['de-DE', 'it-IT']);
+
+    unsubscribe();
+  });
+
+  test('falls back to default locale when storage entry is cleared', () => {
+    getPersistedLocale('en-US');
+    const updates: string[] = [];
+    const unsubscribe = subscribeToLocaleChanges((locale) => {
+      updates.push(locale);
+    });
+
+    dispatchStorageEvent(null);
+    expect(updates).toEqual(['en-US']);
+
+    unsubscribe();
+    clearPersistedLocale();
+    expect(getPersistedLocale('en-US')).toBe('en-US');
+  });
+});

--- a/src/i18n/persist.ts
+++ b/src/i18n/persist.ts
@@ -1,0 +1,171 @@
+const LOCALE_STORAGE_KEY = 'app:locale';
+const LOCALE_CHANNEL_NAME = 'app:locale';
+
+type LocaleListener = (locale: string) => void;
+
+type LocaleMessage = {
+  locale?: unknown;
+};
+
+const listeners = new Set<LocaleListener>();
+let cachedLocale: string | null = null;
+let defaultLocale = 'en';
+let detachStorageListener: (() => void) | null = null;
+let detachChannel: (() => void) | null = null;
+let channel: BroadcastChannel | null = null;
+
+const isLocale = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+const notify = (locale: string) => {
+  listeners.forEach((listener) => {
+    try {
+      listener(locale);
+    } catch {
+      // Swallow listener errors to keep other subscribers responsive
+    }
+  });
+};
+
+const resolveLocale = (value: unknown): string => {
+  if (isLocale(value)) {
+    return value;
+  }
+  return defaultLocale;
+};
+
+const handleIncomingLocale = (value: unknown) => {
+  const next = resolveLocale(value);
+  cachedLocale = next;
+  notify(next);
+};
+
+const readStoredLocale = (): string | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(LOCALE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+const ensureBindings = () => {
+  if (typeof window === 'undefined') return;
+
+  if (!detachStorageListener) {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === LOCALE_STORAGE_KEY) {
+        handleIncomingLocale(event.newValue);
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    detachStorageListener = () => {
+      window.removeEventListener('storage', handleStorage);
+      detachStorageListener = null;
+    };
+  }
+
+  if (!channel && typeof BroadcastChannel !== 'undefined') {
+    const nextChannel = new BroadcastChannel(LOCALE_CHANNEL_NAME);
+    const handleMessage = (event: MessageEvent<LocaleMessage>) => {
+      if (event?.data && 'locale' in event.data) {
+        handleIncomingLocale(event.data.locale);
+      }
+    };
+    nextChannel.addEventListener('message', handleMessage);
+    channel = nextChannel;
+    detachChannel = () => {
+      nextChannel.removeEventListener('message', handleMessage);
+      nextChannel.close();
+      channel = null;
+      detachChannel = null;
+    };
+  }
+};
+
+export const getPersistedLocale = (fallback: string = defaultLocale): string => {
+  defaultLocale = fallback;
+  ensureBindings();
+
+  if (isLocale(cachedLocale)) {
+    return cachedLocale;
+  }
+
+  const stored = readStoredLocale();
+  if (isLocale(stored)) {
+    cachedLocale = stored;
+    return stored;
+  }
+
+  cachedLocale = defaultLocale;
+  return defaultLocale;
+};
+
+export const persistLocale = (locale: string): void => {
+  const next = resolveLocale(locale);
+  cachedLocale = next;
+  ensureBindings();
+
+  if (typeof window !== 'undefined') {
+    try {
+      if (isLocale(locale)) {
+        window.localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+      } else {
+        window.localStorage.removeItem(LOCALE_STORAGE_KEY);
+      }
+    } catch {
+      // Ignore storage errors
+    }
+  }
+
+  try {
+    channel?.postMessage({ locale: next });
+  } catch {
+    // Ignore broadcast errors
+  }
+
+  notify(next);
+};
+
+export const subscribeToLocaleChanges = (
+  listener: LocaleListener,
+): (() => void) => {
+  listeners.add(listener);
+  ensureBindings();
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const clearPersistedLocale = (): void => {
+  cachedLocale = null;
+  ensureBindings();
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.removeItem(LOCALE_STORAGE_KEY);
+    } catch {
+      // Ignore storage errors
+    }
+  }
+  try {
+    channel?.postMessage({ locale: defaultLocale });
+  } catch {
+    // Ignore broadcast errors
+  }
+  notify(defaultLocale);
+};
+
+export const __resetLocalePersistenceForTests = (): void => {
+  listeners.clear();
+  cachedLocale = null;
+  defaultLocale = 'en';
+  if (detachStorageListener) {
+    detachStorageListener();
+  }
+  if (detachChannel) {
+    detachChannel();
+  }
+};
+
+export const LOCALE_PERSISTENCE_KEY = LOCALE_STORAGE_KEY;
+export const LOCALE_CHANNEL = LOCALE_CHANNEL_NAME;


### PR DESCRIPTION
## Summary
- add a locale persistence utility that caches the last selection, stores it in localStorage, and listens for storage/broadcast updates to keep tabs in sync
- expose helpers to read the stored locale with a graceful default, subscribe to changes, clear the cache, and reset state for tests
- cover locale persistence and cross-tab synchronization with dedicated unit tests

## Testing
- yarn lint *(fails: repository contains pre-existing accessibility/window usage violations)*
- yarn test *(fails: repository contains multiple legacy failing suites while new locale tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d48d5b6883288f1d5e801babb563