### PR TITLE
[i18n] add Intl formatting helpers

### DIFF
--- a/__tests__/i18n.format.test.ts
+++ b/__tests__/i18n.format.test.ts
@@ -1,0 +1,127 @@
+import {
+  createLocaleFormatters,
+  formatDate,
+  formatNumber,
+  formatPlural,
+  PluralForms,
+} from '../src/i18n/format';
+
+describe('i18n format helpers', () => {
+  const sampleDate = new Date(Date.UTC(2023, 0, 15, 13, 45, 30));
+  const dateOptions: Intl.DateTimeFormatOptions = {
+    timeZone: 'UTC',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  };
+
+  const numberOptions: Intl.NumberFormatOptions = {
+    style: 'currency',
+    currencyDisplay: 'symbol',
+  };
+
+  const pluralForms: PluralForms = {
+    zero: 'no files',
+    one: 'one file',
+    other: 'many files',
+  };
+
+  it('formats dates across locales', () => {
+    expect({
+      'en-US': formatDate(sampleDate, 'en-US', dateOptions),
+      'fr-FR': formatDate(sampleDate, 'fr-FR', dateOptions),
+      'ja-JP': formatDate(sampleDate, 'ja-JP', dateOptions),
+    }).toMatchInlineSnapshot(`
+      {
+        "en-US": "01/15/2023",
+        "fr-FR": "15/01/2023",
+        "ja-JP": "2023/01/15",
+      }
+    `);
+  });
+
+  it('formats currency across locales', () => {
+    expect({
+      'en-US': formatNumber(1234.56, 'en-US', { ...numberOptions, currency: 'USD' }),
+      'fr-FR': formatNumber(1234.56, 'fr-FR', { ...numberOptions, currency: 'EUR' }),
+      'ja-JP': formatNumber(1234.56, 'ja-JP', { ...numberOptions, currency: 'JPY' }),
+    }).toMatchInlineSnapshot(`
+      {
+        "en-US": "$1,234.56",
+        "fr-FR": "1\u202f234,56\u00a0€",
+        "ja-JP": "\uffe51,235",
+      }
+    `);
+  });
+
+  it('selects plural forms for different locales', () => {
+    expect({
+      'en-US': {
+        0: formatPlural(0, 'en-US', pluralForms),
+        1: formatPlural(1, 'en-US', pluralForms),
+        2: formatPlural(2, 'en-US', pluralForms),
+      },
+      'fr-FR': {
+        0: formatPlural(0, 'fr-FR', pluralForms),
+        1: formatPlural(1, 'fr-FR', pluralForms),
+        2: formatPlural(2, 'fr-FR', pluralForms),
+      },
+      'ja-JP': {
+        0: formatPlural(0, 'ja-JP', pluralForms),
+        1: formatPlural(1, 'ja-JP', pluralForms),
+        2: formatPlural(2, 'ja-JP', pluralForms),
+      },
+    }).toMatchInlineSnapshot(`
+      {
+        "en-US": {
+          "0": "many files",
+          "1": "one file",
+          "2": "many files",
+        },
+        "fr-FR": {
+          "0": "one file",
+          "1": "one file",
+          "2": "many files",
+        },
+        "ja-JP": {
+          "0": "many files",
+          "1": "many files",
+          "2": "many files",
+        },
+      }
+    `);
+  });
+
+  it('supports locale factories with defaults', () => {
+    const frFormatter = createLocaleFormatters('fr-FR', {
+      date: dateOptions,
+      number: { ...numberOptions, currency: 'EUR' },
+    });
+
+    expect({
+      date: frFormatter.date(sampleDate),
+      number: frFormatter.number(1234.56),
+      plural: frFormatter.plural(0, pluralForms),
+    }).toMatchInlineSnapshot(`
+      {
+        "date": "15/01/2023",
+        "number": "1\u202f234,56\u00a0€",
+        "plural": "one file",
+      }
+    `);
+  });
+
+  it('falls back gracefully when Intl APIs are unavailable', () => {
+    const originalIntl = globalThis.Intl;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).Intl = undefined;
+
+    try {
+      expect(formatDate(sampleDate, 'en-US', dateOptions)).toBe('2023-01-15T13:45:30.000Z');
+      expect(formatNumber(1234.56, 'en-US', { style: 'decimal' })).toBe('1234.56');
+      expect(formatPlural(1, 'en-US', pluralForms)).toBe('one file');
+    } finally {
+      (globalThis as any).Intl = originalIntl;
+    }
+  });
+});

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,3 +22,17 @@ yarn dev
 See the [Architecture](./architecture.md) document for an overview of how the project is organized.
 
 For app contributions, see the [New App Checklist](./new-app-checklist.md).
+
+## Localization and locales
+
+Formatting helpers for dates, numbers, and plurals live in [`src/i18n/format.ts`](../src/i18n/format.ts). They wrap the browser `Intl` APIs and provide caching plus safe fallbacks when those APIs are unavailable.
+
+### Adding a new locale
+
+1. Pick the [BCP-47](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) locale tag you want to support (for example, `es-ES`).
+2. Instantiate helpers with `createLocaleFormatters('<locale>')` or call `formatDate`, `formatNumber`, and `formatPlural` directly with the new locale where you need formatted output.
+3. If the locale has preferred defaults (time zone, currency, ordinal rules), pass them as the second argument to `createLocaleFormatters` so the rest of the UI can rely on a single definition.
+4. Add or update tests in `__tests__/i18n.format.test.ts` to snapshot the expected output for the locale. This protects against regressions when Node or browser `Intl` data changes.
+5. Run `yarn lint` and `yarn test` before submitting your changes.
+
+The helpers fall back to ISO-style strings and simple plural selection when `Intl` is missing, so the UI stays readable even in constrained environments.

--- a/src/i18n/format.ts
+++ b/src/i18n/format.ts
@@ -1,0 +1,248 @@
+export type DateInput = Date | number | string;
+export type NumericInput = number | bigint;
+
+export type PluralForms = Partial<Record<Intl.LDMLPluralRule, string>> & {
+  other: string;
+};
+
+const dateTimeFormatCache = new Map<string, Intl.DateTimeFormat>();
+const numberFormatCache = new Map<string, Intl.NumberFormat>();
+const pluralRulesCache = new Map<string, Intl.PluralRules>();
+
+function createCacheKey(locale: string, options?: Record<string, unknown>) {
+  if (!options) {
+    return locale;
+  }
+
+  const sortedEntries = Object.entries(options)
+    .filter(([, value]) => value !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b));
+
+  return `${locale}:${JSON.stringify(sortedEntries)}`;
+}
+
+function hasDateTimeFormat(): boolean {
+  return typeof globalThis.Intl !== 'undefined' && typeof globalThis.Intl.DateTimeFormat === 'function';
+}
+
+function hasNumberFormat(): boolean {
+  return typeof globalThis.Intl !== 'undefined' && typeof globalThis.Intl.NumberFormat === 'function';
+}
+
+function hasPluralRules(): boolean {
+  return typeof globalThis.Intl !== 'undefined' && typeof globalThis.Intl.PluralRules === 'function';
+}
+
+function normalizeDate(value: DateInput): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : new Date(value.getTime());
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date;
+}
+
+function fallbackDate(date: Date): string {
+  if (Number.isNaN(date.getTime())) {
+    return 'Invalid Date';
+  }
+
+  return date.toISOString();
+}
+
+function fallbackNumber(value: NumericInput): string {
+  return value.toString();
+}
+
+function fallbackPlural(value: number, forms: PluralForms): string {
+  const absolute = Math.abs(value);
+
+  if (absolute === 0 && forms.zero) {
+    return forms.zero;
+  }
+
+  if (absolute === 1 && forms.one) {
+    return forms.one;
+  }
+
+  if (absolute === 2 && forms.two) {
+    return forms.two;
+  }
+
+  if (absolute >= 2 && absolute <= 4 && forms.few) {
+    return forms.few;
+  }
+
+  if (absolute >= 5 && forms.many) {
+    return forms.many;
+  }
+
+  return forms.other;
+}
+
+function getDateTimeFormatter(locale: string, options?: Intl.DateTimeFormatOptions) {
+  const cacheKey = createCacheKey(locale, options as Record<string, unknown> | undefined);
+  const cachedFormatter = dateTimeFormatCache.get(cacheKey);
+
+  if (cachedFormatter) {
+    return cachedFormatter;
+  }
+
+  const formatter = new globalThis.Intl.DateTimeFormat(locale, options);
+  dateTimeFormatCache.set(cacheKey, formatter);
+  return formatter;
+}
+
+function getNumberFormatter(locale: string, options?: Intl.NumberFormatOptions) {
+  const cacheKey = createCacheKey(locale, options as Record<string, unknown> | undefined);
+  const cachedFormatter = numberFormatCache.get(cacheKey);
+
+  if (cachedFormatter) {
+    return cachedFormatter;
+  }
+
+  const formatter = new globalThis.Intl.NumberFormat(locale, options);
+  numberFormatCache.set(cacheKey, formatter);
+  return formatter;
+}
+
+function getPluralRules(locale: string, options?: Intl.PluralRulesOptions) {
+  const cacheKey = createCacheKey(locale, options as Record<string, unknown> | undefined);
+  const cachedRules = pluralRulesCache.get(cacheKey);
+
+  if (cachedRules) {
+    return cachedRules;
+  }
+
+  const rules = new globalThis.Intl.PluralRules(locale, options);
+  pluralRulesCache.set(cacheKey, rules);
+  return rules;
+}
+
+function resolveLocale(locale?: string) {
+  if (locale) {
+    return locale;
+  }
+
+  if (typeof navigator !== 'undefined') {
+    if (Array.isArray((navigator as Navigator & { languages?: string[] }).languages)) {
+      const [primary] = (navigator as Navigator & { languages?: string[] }).languages;
+      if (primary) {
+        return primary;
+      }
+    }
+
+    if (navigator.language) {
+      return navigator.language;
+    }
+  }
+
+  return 'en-US';
+}
+
+export function formatDate(
+  value: DateInput,
+  locale?: string,
+  options?: Intl.DateTimeFormatOptions,
+): string {
+  const date = normalizeDate(value);
+
+  if (!date) {
+    return 'Invalid Date';
+  }
+
+  const resolvedLocale = resolveLocale(locale);
+
+  if (!hasDateTimeFormat()) {
+    return fallbackDate(date);
+  }
+
+  try {
+    return getDateTimeFormatter(resolvedLocale, options).format(date);
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('formatDate fallback triggered', error);
+    }
+    return fallbackDate(date);
+  }
+}
+
+export function formatNumber(
+  value: NumericInput,
+  locale?: string,
+  options?: Intl.NumberFormatOptions,
+): string {
+  const resolvedLocale = resolveLocale(locale);
+
+  if (!hasNumberFormat()) {
+    return fallbackNumber(value);
+  }
+
+  try {
+    return getNumberFormatter(resolvedLocale, options).format(value);
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('formatNumber fallback triggered', error);
+    }
+    return fallbackNumber(value);
+  }
+}
+
+export function formatPlural(
+  value: number,
+  locale?: string,
+  forms: PluralForms,
+  options?: Intl.PluralRulesOptions,
+): string {
+  const resolvedLocale = resolveLocale(locale);
+
+  if (!hasPluralRules()) {
+    return fallbackPlural(value, forms);
+  }
+
+  try {
+    const rule = getPluralRules(resolvedLocale, options).select(value);
+    return forms[rule] ?? forms.other;
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('formatPlural fallback triggered', error);
+    }
+    return fallbackPlural(value, forms);
+  }
+}
+
+export interface LocaleFormatterDefaults {
+  date?: Intl.DateTimeFormatOptions;
+  number?: Intl.NumberFormatOptions;
+  plural?: Intl.PluralRulesOptions;
+}
+
+function mergeOptions<T extends Record<string, unknown> | undefined>(
+  defaults?: T,
+  overrides?: T,
+): T | undefined {
+  if (defaults && overrides) {
+    return { ...defaults, ...overrides } as T;
+  }
+
+  return overrides ?? defaults;
+}
+
+export function createLocaleFormatters(locale: string, defaults: LocaleFormatterDefaults = {}) {
+  return {
+    date(value: DateInput, options?: Intl.DateTimeFormatOptions) {
+      return formatDate(value, locale, mergeOptions(defaults.date, options));
+    },
+    number(value: NumericInput, options?: Intl.NumberFormatOptions) {
+      return formatNumber(value, locale, mergeOptions(defaults.number, options));
+    },
+    plural(value: number, forms: PluralForms, options?: Intl.PluralRulesOptions) {
+      return formatPlural(value, locale, forms, mergeOptions(defaults.plural, options));
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add `src/i18n/format.ts` with cached Intl helpers for dates, numbers, and plurals plus graceful fallbacks
- cover en-US, fr-FR, and ja-JP formatting along with Intl-less behaviour in dedicated snapshot tests
- document the workflow for adding new locales in `docs/getting-started.md`

## Testing
- yarn lint *(fails: repository has hundreds of pre-existing accessibility lint violations in apps and public assets)*
- CI=1 yarn test __tests__/i18n.format.test.ts
- yarn test *(fails: existing suites such as window, reconng, and contact tests fail without new changes)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d4925b8c8328b807861bf1cad2ba