### PR TITLE
[styles] improve MDX link accessibility

### DIFF
--- a/docs/content-author-guidelines.md
+++ b/docs/content-author-guidelines.md
@@ -1,0 +1,41 @@
+# Content authoring guidelines
+
+These guidelines keep MDX and Markdown surfaces consistent, legible, and accessible across the Kali Linux Portfolio experience.
+
+## Link styling reference
+
+Links rendered inside `.mdx-content`, `.prose`, `.docs-content`, or `#docs-root` automatically receive the accessible color system defined in `styles/content.css`.
+
+| State   | Dark / default theme | Light theme | Neon theme | Matrix theme | High contrast |
+| ------- | -------------------- | ----------- | ---------- | ------------ | ------------- |
+| Default | `#4DB8FF`            | `#0062B8`   | `#FF66FF`  | `#66FFBF`    | `#FFFF00`     |
+| Hover   | `#86D6FF`            | `#3389E5`   | `#FF85FF`  | `#7CFFD4`    | `#FFEF5C`     |
+| Active  | `#C2E9FF`            | `#0A7CD6`   | `#FF99FF`  | `#A5FFE8`    | `#FFD400`     |
+| Visited | `#B889FF`            | `#5B2AA7`   | `#D9A6FF`  | `#99FF8F`    | `#FFBF33`     |
+
+Each color combination delivers at least a 3:1 contrast ratio against its background so visited links remain legible without losing their affordance.
+
+## Writing accessible content
+
+- Use semantic Markdown/MDX. Prefer headings in order (`#`, `##`, `###`), descriptive link text, and bulleted lists to keep navigation friendly.
+- Avoid inline color overrides or `style` attributes. They can break the shared palette above and cause contrast failures.
+- Add `rel="noopener noreferrer"` on external links opened in a new tab: `[Label](https://example.com){:target="_blank" rel="noopener noreferrer"}` when using MDX.
+- Keep paragraph copy short (60–90 characters per line) and use `<strong>`/`**` sparingly to avoid overwhelming emphasis.
+- Supply alternative text for every image (`![Alt text](image.png "Optional caption")`).
+
+## Layout expectations
+
+- Wrap rich-text regions in a container with the `.mdx-content` class (or reuse the existing `.prose` utility) so the shared link styling applies automatically.
+- When embedding interactive components, ensure focus management returns to the main document after dismissing a modal or overlay.
+- For callout blocks, prefer existing components or Tailwind utilities that respect theme tokens instead of bespoke inline styles.
+
+## Editorial review checklist
+
+1. **Keyboard**: Tab through every link to confirm the new focus outline is visible and offset from surrounding text.
+2. **Theme coverage**: Toggle between default, dark, neon, matrix, and high-contrast themes. Confirm link states remain above a 3:1 contrast ratio.
+3. **Color scheme**: Switch the OS/browser to light and dark modes (`prefers-color-scheme`) to confirm fallbacks render correctly.
+4. **Responsive**: Preview the page at 320px, 768px, and 1280px widths (browser dev tools are sufficient) to make sure the underline and outline remain visible.
+5. **Touch devices**: Trigger link focus via long-press or external keyboard on a tablet/phone to confirm outlines render.
+6. **Reduced motion**: Enable reduced-motion settings to make sure hover/focus transitions become instant (they do via `styles/content.css`).
+
+Following this checklist keeps authored content accessible and consistent with the wider desktop simulation.

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -6,6 +6,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next';
 import '../styles/tailwind.css';
 import '../styles/globals.css';
 import '../styles/index.css';
+import '../styles/content.css';
 import '../styles/resume-print.css';
 import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';

--- a/styles/content.css
+++ b/styles/content.css
@@ -1,0 +1,124 @@
+/* Link styling for MDX and Markdown-rendered surfaces */
+:root {
+  --content-link-color: #4db8ff;
+  --content-link-hover-color: #86d6ff;
+  --content-link-active-color: #c2e9ff;
+  --content-link-visited-color: #b889ff;
+  --content-link-underline-color: color-mix(in srgb, var(--content-link-color) 70%, transparent);
+  --content-link-focus-shadow: color-mix(in srgb, var(--focus-outline-color) 35%, transparent);
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --content-link-color: #0062b8;
+    --content-link-hover-color: #3389e5;
+    --content-link-active-color: #0a7cd6;
+    --content-link-visited-color: #5b2aa7;
+    --content-link-underline-color: color-mix(in srgb, var(--content-link-color) 60%, transparent);
+  }
+}
+
+html[data-theme='light'] {
+  --content-link-color: #0062b8;
+  --content-link-hover-color: #3389e5;
+  --content-link-active-color: #0a7cd6;
+  --content-link-visited-color: #5b2aa7;
+  --content-link-underline-color: color-mix(in srgb, var(--content-link-color) 60%, transparent);
+}
+
+html[data-theme='dark'] {
+  --content-link-color: #82cfff;
+  --content-link-hover-color: #a8daff;
+  --content-link-active-color: #cbe6ff;
+  --content-link-visited-color: #d0b3ff;
+  --content-link-underline-color: color-mix(in srgb, var(--content-link-color) 65%, transparent);
+}
+
+html[data-theme='neon'] {
+  --content-link-color: #ff66ff;
+  --content-link-hover-color: #ff85ff;
+  --content-link-active-color: #ff99ff;
+  --content-link-visited-color: #d9a6ff;
+  --content-link-underline-color: color-mix(in srgb, var(--content-link-color) 65%, transparent);
+}
+
+html[data-theme='matrix'] {
+  --content-link-color: #66ffbf;
+  --content-link-hover-color: #7cffd4;
+  --content-link-active-color: #a5ffe8;
+  --content-link-visited-color: #99ff8f;
+  --content-link-underline-color: color-mix(in srgb, var(--content-link-color) 65%, transparent);
+}
+
+.high-contrast {
+  --content-link-color: #ffff00;
+  --content-link-hover-color: #ffef5c;
+  --content-link-active-color: #ffd400;
+  --content-link-visited-color: #ffbf33;
+  --content-link-underline-color: color-mix(in srgb, var(--content-link-color) 70%, transparent);
+}
+
+:where(.mdx-content, .prose, .docs-content, #docs-root) a {
+  color: var(--content-link-color);
+  text-decoration-color: var(--content-link-underline-color);
+  text-decoration-thickness: 0.1em;
+  text-underline-offset: 0.2em;
+  transition:
+    color var(--motion-fast, 150ms) ease,
+    text-decoration-color var(--motion-fast, 150ms) ease,
+    outline-color var(--motion-fast, 150ms) ease,
+    box-shadow var(--motion-fast, 150ms) ease;
+}
+
+:where(.mdx-content, .prose, .docs-content, #docs-root) a:hover {
+  color: var(--content-link-hover-color);
+  text-decoration-color: color-mix(in srgb, var(--content-link-hover-color) 70%, transparent);
+}
+
+:where(.mdx-content, .prose, .docs-content, #docs-root) a:visited {
+  color: var(--content-link-visited-color);
+  text-decoration-color: color-mix(in srgb, var(--content-link-visited-color) 70%, transparent);
+}
+
+:where(.mdx-content, .prose, .docs-content, #docs-root) a:active {
+  color: var(--content-link-active-color);
+  text-decoration-color: color-mix(in srgb, var(--content-link-active-color) 70%, transparent);
+}
+
+:where(.mdx-content, .prose, .docs-content, #docs-root) a:focus-visible {
+  color: var(--content-link-hover-color);
+  text-decoration-color: color-mix(in srgb, var(--content-link-hover-color) 70%, transparent);
+  outline: var(--focus-outline-width, 3px) solid var(--focus-outline-color);
+  outline-offset: 3px;
+  border-radius: 2px;
+  box-shadow: 0 0 0 3px var(--content-link-focus-shadow);
+}
+
+:where(.mdx-content, .prose, .docs-content, #docs-root) a:focus-visible:visited {
+  color: var(--content-link-visited-color);
+  text-decoration-color: color-mix(in srgb, var(--content-link-visited-color) 70%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :where(.mdx-content, .prose, .docs-content, #docs-root) a {
+    transition: none;
+  }
+}
+
+@media (forced-colors: active) {
+  :where(.mdx-content, .prose, .docs-content, #docs-root) a {
+    color: LinkText;
+    text-decoration-color: LinkText;
+  }
+
+  :where(.mdx-content, .prose, .docs-content, #docs-root) a:visited {
+    color: VisitedText;
+    text-decoration-color: VisitedText;
+  }
+
+  :where(.mdx-content, .prose, .docs-content, #docs-root) a:focus-visible {
+    box-shadow: none;
+    outline: 2px solid Highlight;
+    outline-offset: 3px;
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,7 +16,8 @@
   --color-border: #2a2e36; /* subtle borders */
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
-  --color-focus-ring: var(--color-accent);
+  --color-focus-ring: #4db8ff;
+  --focus-outline-color: var(--color-focus-ring);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   accent-color: var(--color-control-accent);
@@ -35,6 +36,13 @@ html[data-theme='dark'] {
   --color-border: #333333;
   --color-terminal: #00ff00;
   --color-dark: #0a0a0a;
+  --color-focus-ring: #82cfff;
+  --focus-outline-color: var(--color-focus-ring);
+}
+
+html[data-theme='light'] {
+  --color-focus-ring: #0a7cd6;
+  --focus-outline-color: var(--color-focus-ring);
 }
 
 /* Neon theme */
@@ -50,6 +58,8 @@ html[data-theme='neon'] {
   --color-border: #333333;
   --color-terminal: #39ff14;
   --color-dark: #000000;
+  --color-focus-ring: #ff66ff;
+  --focus-outline-color: var(--color-focus-ring);
 }
 
 /* Matrix theme */
@@ -65,7 +75,20 @@ html[data-theme='matrix'] {
   --color-border: #003300;
   --color-terminal: #00ff00;
   --color-dark: #000000;
+  --color-focus-ring: #66ffbf;
+  --focus-outline-color: var(--color-focus-ring);
+}
 
+@media (prefers-color-scheme: light) {
+  :root {
+    --color-focus-ring: #0a7cd6;
+    --focus-outline-color: var(--color-focus-ring);
+  }
+}
+
+.high-contrast {
+  --color-focus-ring: #ffff00;
+  --focus-outline-color: var(--color-focus-ring);
 }
 
 ::selection {
@@ -74,6 +97,6 @@ html[data-theme='matrix'] {
 }
 
 *:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
-  outline-offset: 2px;
+  outline: var(--focus-outline-width, 3px) solid var(--color-focus-ring);
+  outline-offset: 3px;
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -18,8 +18,8 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
 
 a:focus-visible,
 button:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
-    outline-offset: 2px;
+    outline: var(--focus-outline-width, 3px) solid var(--focus-outline-color) !important;
+    outline-offset: 3px;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -58,8 +58,8 @@
   /* Minimum interactive target size */
   --hit-area: 32px;
   /* Focus outline */
-  --focus-outline-color: var(--color-ubt-blue);
-  --focus-outline-width: 2px;
+  --focus-outline-color: var(--color-focus-ring, #4db8ff);
+  --focus-outline-width: 3px;
 }
 
 /* High contrast theme */


### PR DESCRIPTION
## Summary
- add a shared content stylesheet that defines accessible default, hover, visited, and focus link states across supported themes
- update global focus tokens and imports so keyboard outlines meet accessibility contrast and thickness guidance
- document MDX authoring guidance so content creators preserve the new styling and testing expectations

## Testing
- yarn lint *(fails: pre-existing jsx-a11y/control-has-associated-label and no-top-level-window errors in legacy apps)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d4959b188328bd38d367b857a7a1