### PR TITLE
[screen] Add navbar drawer context menu

### DIFF
--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -43,7 +43,8 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.shiftKey && e.key === 'F10') {
+      const isContextKey = e.key === 'ContextMenu' || e.key === 'Apps';
+      if ((e.shiftKey && e.key === 'F10') || isContextKey) {
         e.preventDefault();
         const rect = node.getBoundingClientRect();
         setPos({ x: rect.left, y: rect.bottom });

--- a/components/screen/navbar/drawer/DrawerAppItem.tsx
+++ b/components/screen/navbar/drawer/DrawerAppItem.tsx
@@ -1,0 +1,70 @@
+import React, { useMemo, useRef } from 'react';
+import UbuntuApp from '../../../base/ubuntu_app';
+import ContextMenu, { MenuItem } from '../../../common/ContextMenu';
+import type { DrawerAppMeta } from './types';
+
+interface DrawerAppItemProps {
+  app: DrawerAppMeta;
+  className?: string;
+  onOpen: (id: string) => void;
+  onPin: (id: string) => void;
+  onUnpin: (id: string) => void;
+  onAddQuickLaunch: (id: string) => void;
+  onRemoveQuickLaunch: (id: string) => void;
+  isPinned: boolean;
+  isQuickLaunch: boolean;
+}
+
+const DrawerAppItem: React.FC<DrawerAppItemProps> = ({
+  app,
+  className = '',
+  onOpen,
+  onPin,
+  onUnpin,
+  onAddQuickLaunch,
+  onRemoveQuickLaunch,
+  isPinned,
+  isQuickLaunch,
+}) => {
+  const targetRef = useRef<HTMLDivElement>(null);
+
+  const items: MenuItem[] = useMemo(() => {
+    const menuItems: MenuItem[] = [];
+
+    if (isPinned) {
+      menuItems.push({
+        label: 'Unpin from Favorites',
+        onSelect: () => onUnpin(app.id),
+      });
+    } else {
+      menuItems.push({
+        label: 'Pin to Favorites',
+        onSelect: () => onPin(app.id),
+      });
+    }
+
+    menuItems.push({
+      label: isQuickLaunch ? 'Remove from Quick Launch' : 'Add to Quick Launch',
+      onSelect: () => (isQuickLaunch ? onRemoveQuickLaunch(app.id) : onAddQuickLaunch(app.id)),
+    });
+
+    return menuItems;
+  }, [app.id, isPinned, isQuickLaunch, onAddQuickLaunch, onPin, onRemoveQuickLaunch, onUnpin]);
+
+  return (
+    <div ref={targetRef} className={`relative ${className}`}>
+      <UbuntuApp
+        id={app.id}
+        icon={app.icon}
+        name={app.title}
+        displayName={app.displayName}
+        openApp={() => onOpen(app.id)}
+        disabled={app.disabled}
+        prefetch={app.screen?.prefetch}
+      />
+      <ContextMenu targetRef={targetRef} items={items} />
+    </div>
+  );
+};
+
+export default DrawerAppItem;

--- a/components/screen/navbar/drawer/QuickLaunchSection.tsx
+++ b/components/screen/navbar/drawer/QuickLaunchSection.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import DrawerAppItem from './DrawerAppItem';
+import type { DrawerAppMeta } from './types';
+
+interface QuickLaunchSectionProps {
+  apps: DrawerAppMeta[];
+  onOpen: (id: string) => void;
+  onPin: (id: string) => void;
+  onUnpin: (id: string) => void;
+  onAddQuickLaunch: (id: string) => void;
+  onRemoveQuickLaunch: (id: string) => void;
+  pinnedSet: Set<string>;
+  quickLaunchSet: Set<string>;
+}
+
+const QuickLaunchSection: React.FC<QuickLaunchSectionProps> = ({
+  apps,
+  onOpen,
+  onPin,
+  onUnpin,
+  onAddQuickLaunch,
+  onRemoveQuickLaunch,
+  pinnedSet,
+  quickLaunchSet,
+}) => {
+  if (apps.length === 0) return null;
+
+  return (
+    <section aria-label="Quick Launch" className="mb-4">
+      <h2 className="text-xs uppercase tracking-wide text-ubt-grey mb-2">Quick Launch</h2>
+      <div className="grid grid-cols-3 gap-2">
+        {apps.map((app) => (
+          <DrawerAppItem
+            key={`quick-${app.id}`}
+            app={app}
+            onOpen={onOpen}
+            onPin={onPin}
+            onUnpin={onUnpin}
+            onAddQuickLaunch={onAddQuickLaunch}
+            onRemoveQuickLaunch={onRemoveQuickLaunch}
+            isPinned={pinnedSet.has(app.id)}
+            isQuickLaunch={quickLaunchSet.has(app.id)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default QuickLaunchSection;

--- a/components/screen/navbar/drawer/types.ts
+++ b/components/screen/navbar/drawer/types.ts
@@ -1,0 +1,11 @@
+export type DrawerAppMeta = {
+  id: string;
+  title: string;
+  icon: string;
+  disabled?: boolean;
+  favourite?: boolean;
+  displayName?: string;
+  screen?: {
+    prefetch?: () => void;
+  };
+};


### PR DESCRIPTION
## Summary
- add drawer-specific app item component that wires accessible context menus for pinning and quick launch actions
- update whisker menu to surface quick launch items, sync pinned state from storage, and dispatch global events for desktop integration
- extend desktop and shared context menu logic to react to new events and keyboard context menu key presses

## Testing
- yarn lint *(fails: existing repository lint violations unrelated to these changes)*
- yarn test *(fails: existing Jest suites related to window context and accessibility expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d49cf1708328808b85b106579a63