### PR TITLE
[styles] Add locale-aware monospace fallback

### DIFF
--- a/styles/fonts.css
+++ b/styles/fonts.css
@@ -1,0 +1,60 @@
+/* Monospace fallbacks tuned for consistent glyph widths across locales.
+ * - Modern developer fonts lead the stack for crisp Latin/Cyrillic rendering.
+ * - Platform defaults follow to match macOS, Windows, and Linux expectations.
+ * - Courier New and script-specific faces cover RTL use cases without width jitter.
+ * - Noto Sans Mono CJK variants round out East Asian support before the generic fallback.
+ */
+:root {
+  --font-family-monospace:
+    /* Contemporary IDE-friendly monospace faces */
+    'JetBrains Mono',
+    'Fira Code',
+    'Fira Mono',
+    'Ubuntu Mono',
+    'Cascadia Code',
+    'Source Code Pro',
+    'IBM Plex Mono',
+    /* Platform defaults to preserve native rendering */
+    'SFMono-Regular',
+    'Menlo',
+    'Consolas',
+    'DejaVu Sans Mono',
+    'Liberation Mono',
+    /* Wide-script fallbacks with reliable advance widths */
+    'Courier New',
+    'Noto Sans Mono',
+    'Noto Sans Mono CJK JP',
+    'Noto Sans Mono CJK KR',
+    'Noto Sans Mono CJK SC',
+    'Noto Sans Mono CJK TC',
+    ui-monospace,
+    monospace;
+}
+
+/* Prefer fonts with proven Arabic and Hebrew coverage when the page runs RTL. */
+:root[dir='rtl'],
+[dir='rtl'] {
+  --font-family-monospace:
+    'Simplified Arabic Fixed',
+    'Miriam Fixed',
+    'Courier New',
+    'Noto Sans Mono',
+    'Noto Sans Mono CJK JP',
+    'Noto Sans Mono CJK KR',
+    'Noto Sans Mono CJK SC',
+    'Noto Sans Mono CJK TC',
+    'JetBrains Mono',
+    'Fira Code',
+    'Fira Mono',
+    'Ubuntu Mono',
+    'Cascadia Code',
+    'Source Code Pro',
+    'IBM Plex Mono',
+    'SFMono-Regular',
+    'Menlo',
+    'Consolas',
+    'DejaVu Sans Mono',
+    'Liberation Mono',
+    ui-monospace,
+    monospace;
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,3 +1,4 @@
+@import './fonts.css';
 @import './globals.css';
 
 html {
@@ -505,7 +506,7 @@ dialog {
 /* Ensure monospace layout for app outputs */
 textarea,
 pre {
-    font-family: monospace;
+    font-family: var(--font-family-monospace);
     line-height: 1.2;
 }
 


### PR DESCRIPTION
## Summary
- add a documented monospace font stack that favors even glyph widths across locales
- import the stack into the global stylesheet and apply it to textarea/pre elements

## Testing
- yarn lint *(fails: existing accessibility and browser globals lint violations in unrelated files)*
- yarn test *(fails: existing unit test failures in unrelated areas)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d49c9aa083289021b6d7807a3fa9