### PR TITLE
[ui] introduce shell spacing tokens

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -101,7 +101,7 @@ export class SideBarApp extends Component {
                     this.setState({ showTitle: false, thumbnail: null });
                 }}
                 className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
-                    " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
+                    " w-auto p-[var(--space-s)] outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
                 id={"sidebar-" + this.props.id}
             >
                 <Image
@@ -131,7 +131,7 @@ export class SideBarApp extends Component {
                     <div
                         className={
                             (this.state.showTitle ? " visible " : " invisible ") +
-                            " pointer-events-none absolute bottom-full mb-2 left-1/2 transform -translate-x-1/2" +
+                            " pointer-events-none absolute bottom-full mb-[var(--space-s)] left-1/2 transform -translate-x-1/2" +
                             " rounded border border-gray-400 border-opacity-40 shadow-lg overflow-hidden bg-black bg-opacity-50"
                         }
                     >
@@ -148,7 +148,7 @@ export class SideBarApp extends Component {
                 <div
                     className={
                         (this.state.showTitle ? " visible " : " invisible ") +
-                        " w-max py-0.5 px-1.5 absolute top-1.5 left-full ml-3 m-1 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
+                        " w-max py-0.5 px-1.5 absolute top-1.5 left-full ml-[var(--space-m)] m-1 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
                     }
                 >
                     {this.props.title}

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -677,7 +677,7 @@ export default Window
 export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
     return (
         <div
-            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
+            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-[var(--space-m)] text-white w-full select-none rounded-b-none flex items-center h-11"}
             tabIndex={0}
             role="button"
             aria-grabbed={grabbed}

--- a/docs/TASKS_UI_POLISH.md
+++ b/docs/TASKS_UI_POLISH.md
@@ -101,6 +101,7 @@ This document tracks UI polish tasks for the Kali/Ubuntu inspired desktop experi
 23. **Ubuntu/Kali theme tokens audit**
     - **Accept:** One source of truth for colors, radii, shadows, spacing scale; tokens documented.
     - **Where:** `tailwind.config.js`, `styles/index.css`.
+    - **Notes:** Shell spacing tokens `--space-s`, `--space-m`, and `--space-l` map to 8/12/16 px for consistent dock and window padding.
 
 24. **Shadow elevation scale**
     - **Accept:** 4 levels: dock, window inactive, active, modal; consistent blurs and offsets.

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -165,6 +165,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         '--space-4': '1rem',
         '--space-5': '1.5rem',
         '--space-6': '2rem',
+        '--space-s': '8px',
+        '--space-m': '12px',
+        '--space-l': '16px',
       },
       compact: {
         '--space-1': '0.125rem',
@@ -173,6 +176,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         '--space-4': '0.75rem',
         '--space-5': '1rem',
         '--space-6': '1.5rem',
+        '--space-s': '8px',
+        '--space-m': '12px',
+        '--space-l': '16px',
       },
     };
     const vars = spacing[density];

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -41,6 +41,11 @@
   --space-5: 1.5rem;
   --space-6: 2rem;
 
+  /* Shell spacing tokens */
+  --space-s: 8px;
+  --space-m: 12px;
+  --space-l: 16px;
+
   /* Radius */
   --radius-sm: 2px;
   --radius-md: 4px;


### PR DESCRIPTION
## Summary
- add `--space-s/-m/-l` spacing variables to the design token palette and surface them through the density settings hook
- refactor dock/sidebar and window title bar padding to rely on the new spacing tokens for consistent shell spacing
- document the new shell spacing tokens alongside the existing theming checklist

## Testing
- `yarn lint` *(fails: existing jsx-a11y and top-level window lint errors across unrelated apps)*
- `yarn test` *(fails: existing suites such as window interactions, Nmap NSE, ReconNG due to historic issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d4a5d1ec832881b3b2f1365f635c