### PR TITLE
[desktop] prune unused CSS and add coverage tooling

### DIFF
--- a/docs/css-coverage-after.json
+++ b/docs/css-coverage-after.json
@@ -1,0 +1,26 @@
+{
+  "url": "http://localhost:3000",
+  "generatedAt": "2025-09-16T21:57:36.769Z",
+  "totalBytes": 2890,
+  "usedBytes": 2890,
+  "unusedBytes": 0,
+  "unusedPercent": 0,
+  "overall": {
+    "totalBytes": 6530,
+    "usedBytes": 6530,
+    "unusedBytes": 0,
+    "unusedPercent": 0
+  },
+  "customSelectors": 66,
+  "customKeyframes": 14,
+  "stylesheets": [
+    {
+      "styleSheetId": "style-sheet-12185-219",
+      "sourceURL": "http://localhost:3000/_next/static/css/d0c8f5c7eb8a0490.css",
+      "totalBytes": 99992,
+      "usedBytes": 6530,
+      "unusedBytes": 93462,
+      "unusedPercent": 93.47
+    }
+  ]
+}

--- a/docs/css-coverage-before.json
+++ b/docs/css-coverage-before.json
@@ -1,0 +1,26 @@
+{
+  "url": "http://localhost:3000",
+  "generatedAt": "2025-09-16T21:31:04.222Z",
+  "totalBytes": 98993,
+  "usedBytes": 12263,
+  "unusedBytes": 86730,
+  "unusedPercent": 87.61,
+  "stylesheets": [
+    {
+      "styleSheetId": "style-sheet-8683-1",
+      "sourceURL": "http://localhost:3000/_next/static/css/d3d1d9a9891fb7a3.css",
+      "totalBytes": 98676,
+      "usedBytes": 12102,
+      "unusedBytes": 86574,
+      "unusedPercent": 87.74
+    },
+    {
+      "styleSheetId": "style-sheet-8683-2",
+      "sourceURL": "http://localhost:3000/_next/static/css/329b4cb75444d988.css",
+      "totalBytes": 317,
+      "usedBytes": 161,
+      "unusedBytes": 156,
+      "unusedPercent": 49.21
+    }
+  ]
+}

--- a/scripts/css-coverage.mjs
+++ b/scripts/css-coverage.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+import { chromium } from 'playwright-core';
+import fs from 'fs/promises';
+import path from 'path';
+import postcss from 'postcss';
+
+const [,, urlArg, outArg] = process.argv;
+const targetUrl = urlArg ?? 'http://localhost:3000/';
+const outputPath = outArg ?? 'docs/css-coverage-report.json';
+
+const browser = await chromium.launch({ args: ['--disable-dev-shm-usage'] });
+const page = await browser.newPage();
+const client = await page.context().newCDPSession(page);
+
+const sheetHeaders = new Map();
+client.on('CSS.styleSheetAdded', ({ header }) => {
+  sheetHeaders.set(header.styleSheetId, header);
+});
+
+await client.send('DOM.enable');
+await client.send('CSS.enable');
+await client.send('CSS.startRuleUsageTracking');
+
+const routes = new Set(['/']);
+try {
+  const manifestPath = path.resolve('.next', 'server', 'pages-manifest.json');
+  const manifestRaw = await fs.readFile(manifestPath, 'utf8');
+  const manifest = JSON.parse(manifestRaw);
+  Object.keys(manifest || {}).forEach((route) => {
+    if (
+      !route ||
+      route.startsWith('/api') ||
+      route.startsWith('/_next') ||
+      route === '/_document' ||
+      route === '/_app' ||
+      route === '/_error'
+    ) {
+      return;
+    }
+    routes.add(route);
+  });
+} catch (error) {
+  console.warn('Unable to parse pages-manifest.json for routes', error);
+}
+
+const sortedRoutes = Array.from(routes).sort((a, b) => {
+  if (a === '/') return -1;
+  if (b === '/') return 1;
+  return a.localeCompare(b);
+});
+
+const baseUrl = new URL(targetUrl);
+for (const route of sortedRoutes) {
+    const visitUrl = new URL(route.replace(/^\/+/, ''), baseUrl);
+    try {
+      await page.goto(visitUrl.toString(), { waitUntil: 'networkidle' });
+      await page.waitForTimeout(500);
+    } catch (error) {
+      console.warn(`Failed to capture ${visitUrl.toString()}:`, error.message);
+    }
+}
+
+const { ruleUsage } = await client.send('CSS.stopRuleUsageTracking');
+
+const normalizeSelector = (selector) =>
+  selector
+    ?.replace(/\s+/g, '')
+    .replace(/"|'/g, '')
+    .replace(/\\/g, '\\');
+
+const customSelectors = new Set();
+const customKeyframes = new Set();
+try {
+  const customCssPath = path.resolve('styles', 'index.css');
+  const customCss = await fs.readFile(customCssPath, 'utf8');
+  const customAst = postcss.parse(customCss);
+  customAst.walkAtRules('keyframes', (atRule) => {
+    if (atRule.params) {
+      customKeyframes.add(atRule.params.trim());
+    }
+  });
+  customAst.walkRules((rule) => {
+    if (rule.parent?.type === 'atrule' && rule.parent.name === 'keyframes') {
+      return;
+    }
+    const selectors = rule.selectors ?? [rule.selector];
+    selectors.forEach((selector) => {
+      const normalized = normalizeSelector(selector);
+      if (normalized) {
+        customSelectors.add(normalized);
+      }
+    });
+  });
+} catch (error) {
+  console.warn('Unable to parse styles/index.css', error);
+}
+
+const coverageBySheet = new Map();
+for (const usage of ruleUsage) {
+  if (!coverageBySheet.has(usage.styleSheetId)) {
+    coverageBySheet.set(usage.styleSheetId, []);
+  }
+  coverageBySheet.get(usage.styleSheetId).push(usage);
+}
+
+const report = [];
+let overallTotalBytes = 0;
+let overallUsedBytes = 0;
+let customTotalBytes = 0;
+let customUsedBytes = 0;
+
+const stylesheetMeta = new Map();
+
+for (const [styleSheetId, usages] of coverageBySheet.entries()) {
+  const header = sheetHeaders.get(styleSheetId);
+  const { text } = await client.send('CSS.getStyleSheetText', { styleSheetId });
+  if (!text) continue;
+  const rulesMap = new Map();
+  try {
+    const ast = postcss.parse(text);
+    ast.walkAtRules('keyframes', (atRule) => {
+      const start = atRule.source?.start?.offset;
+      const end = atRule.source?.end?.offset;
+      if (start == null || end == null) return;
+      rulesMap.set(`${start}:${end}`, {
+        selectors: [],
+        keyframe: atRule.params?.trim() ?? null,
+      });
+    });
+    ast.walkRules((rule) => {
+      const start = rule.source?.start?.offset;
+      const end = rule.source?.end?.offset;
+      if (start == null || end == null) return;
+      if (rule.parent?.type === 'atrule' && rule.parent.name === 'keyframes') {
+        return;
+      }
+      const selectors = (rule.selectors ?? [rule.selector]).map((sel) => normalizeSelector(sel)).filter(Boolean);
+      rulesMap.set(`${start}:${end}`, { selectors, keyframe: null });
+    });
+  } catch (error) {
+    console.warn(`Failed to parse stylesheet ${header?.sourceURL ?? styleSheetId}`, error);
+  }
+  stylesheetMeta.set(styleSheetId, rulesMap);
+  const totalLength = text.length;
+  const usedRanges = usages.filter((usage) => usage.used).map((usage) => [usage.startOffset, usage.endOffset]);
+  usedRanges.sort((a, b) => a[0] - b[0]);
+
+  let merged = [];
+  for (const [start, end] of usedRanges) {
+    if (!merged.length) {
+      merged.push([start, end]);
+      continue;
+    }
+    const last = merged[merged.length - 1];
+    if (start <= last[1]) {
+      last[1] = Math.max(last[1], end);
+    } else {
+      merged.push([start, end]);
+    }
+  }
+
+  let sheetUsed = 0;
+  for (const [start, end] of merged) {
+    sheetUsed += Math.max(0, end - start);
+  }
+
+  const sheetUnused = Math.max(0, totalLength - sheetUsed);
+
+  report.push({
+    styleSheetId,
+    sourceURL: header?.sourceURL ?? header?.origin ?? 'inline',
+    totalBytes: totalLength,
+    usedBytes: sheetUsed,
+    unusedBytes: sheetUnused,
+    unusedPercent: totalLength ? +( (sheetUnused / totalLength) * 100).toFixed(2) : 0,
+  });
+
+  for (const usage of usages) {
+    const span = Math.max(0, usage.endOffset - usage.startOffset);
+    overallTotalBytes += span;
+    if (usage.used) {
+      overallUsedBytes += span;
+    }
+    const rulesMapForSheet = stylesheetMeta.get(styleSheetId);
+    const ruleInfo = rulesMapForSheet?.get(`${usage.startOffset}:${usage.endOffset}`);
+    if (!ruleInfo) continue;
+    let isCustom = false;
+    if (ruleInfo.keyframe) {
+      if (customKeyframes.has(ruleInfo.keyframe)) {
+        isCustom = true;
+      }
+    } else if (ruleInfo.selectors?.length) {
+      for (const selector of ruleInfo.selectors) {
+        if (customSelectors.has(selector)) {
+          isCustom = true;
+          break;
+        }
+      }
+    }
+    if (isCustom) {
+      customTotalBytes += span;
+      if (usage.used) {
+        customUsedBytes += span;
+      }
+    }
+  }
+}
+
+await browser.close();
+
+report.sort((a, b) => (b.totalBytes - a.totalBytes));
+
+const summary = {
+  url: targetUrl,
+  generatedAt: new Date().toISOString(),
+  totalBytes: customTotalBytes,
+  usedBytes: customUsedBytes,
+  unusedBytes: Math.max(0, customTotalBytes - customUsedBytes),
+  unusedPercent: customTotalBytes
+    ? +(((customTotalBytes - customUsedBytes) / customTotalBytes) * 100).toFixed(2)
+    : 0,
+  overall: {
+    totalBytes: overallTotalBytes,
+    usedBytes: overallUsedBytes,
+    unusedBytes: Math.max(0, overallTotalBytes - overallUsedBytes),
+    unusedPercent: overallTotalBytes
+      ? +(((overallTotalBytes - overallUsedBytes) / overallTotalBytes) * 100).toFixed(2)
+      : 0,
+  },
+  customSelectors: customSelectors.size,
+  customKeyframes: customKeyframes.size,
+  stylesheets: report,
+};
+
+const resolvedPath = path.resolve(outputPath);
+await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
+await fs.writeFile(resolvedPath, JSON.stringify(summary, null, 2));
+
+console.log(`CSS coverage written to ${resolvedPath}`);
+console.log(JSON.stringify(summary, null, 2));

--- a/styles/index.css
+++ b/styles/index.css
@@ -38,15 +38,6 @@ button:focus-visible {
     scroll-behavior: auto !important;
 }
 
-/* Top NavBar styling */
-
-.top-arrow-up {
-    border-inline-start: 5px solid transparent;
-    border-inline-end: 5px solid transparent;
-    border-block-end: 5px solid var(--color-muted);
-}
-
-
 .animateShow {
     animation: transformDownShow 200ms 1 forwards;
 }
@@ -403,35 +394,6 @@ dialog {
     list-style: "⇀";
 }
 
-@keyframes shake {
-    10%, 90% { transform: translateX(-1px); }
-    20%, 80% { transform: translateX(2px); }
-    30%, 50%, 70% { transform: translateX(-4px); }
-    40%, 60% { transform: translateX(4px); }
-}
-
-.shake {
-    animation: shake 0.5s;
-}
-
-@keyframes keypress {
-    0%, 100% { transform: scale(1); }
-    50% { transform: scale(0.95); }
-}
-
-.key-press {
-    animation: keypress 0.1s;
-}
-
-@keyframes reveal {
-    from { opacity: 0; transform: scale(0.8); }
-    to { opacity: 1; transform: scale(1); }
-}
-
-.reveal {
-    animation: reveal 0.3s ease-out;
-}
-
 @keyframes tile-pop {
     from { transform: scale(0); }
     to { transform: scale(1); }
@@ -465,18 +427,6 @@ dialog {
 .score-pop {
     display: inline-block;
     animation: score-pop 0.3s ease-out;
-}
-
-@keyframes hangman-draw {
-    from { stroke-dashoffset: 100; }
-    to { stroke-dashoffset: 0; }
-}
-
-.hangman-part {
-    stroke-dasharray: 100;
-    stroke-dashoffset: 100;
-    animation: hangman-draw 0.5s ease-out forwards;
-
 }
 
 @keyframes word-found-highlight {
@@ -514,15 +464,6 @@ button:focus-visible,
 textarea:focus-visible {
     outline: var(--focus-outline-width) solid var(--focus-outline-color);
     outline-offset: 2px;
-}
-
-/* Enable scroll snapping for gallery containers */
-.gallery-container {
-    scroll-snap-type: x mandatory;
-}
-
-.gallery-container > * {
-    scroll-snap-align: start;
 }
 
 /* High contrast overrides */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,11 +2,12 @@ const plugin = require('tailwindcss/plugin');
 
 module.exports = {
   darkMode: 'class',
-  mode: 'jit',
   content: [
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
     './apps/**/*.{js,ts,jsx,tsx}',
+    './games/**/*.{js,ts,jsx,tsx}',
     './hooks/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
@@ -95,17 +96,5 @@ module.exports = {
       },
     },
   },
-  plugins: [
-    plugin(function ({ addUtilities }) {
-      const cols = {};
-      for (let i = 1; i <= 12; i++) {
-        const width = `${(i / 12) * 100}%`;
-        cols[`.col-${i}`] = { flex: `0 0 ${width}`, maxWidth: width };
-        if (i < 12) {
-          cols[`.offset-${i}`] = { marginLeft: width };
-        }
-      }
-      addUtilities(cols, ['responsive']);
-    }),
-  ],
+  plugins: [],
 };


### PR DESCRIPTION
## Summary
- remove unused desktop selectors and keyframes from `styles/index.css`
- drop the unused Tailwind column plugin and include the app/games directories in purge paths
- add a Playwright-based CSS coverage script and capture before/after reports under `docs/`

## Testing
- yarn build
- yarn lint *(fails: existing public/apps/tetris/main.js globals flagged by no-top-level-window)*
- yarn test *(fails: existing window snapping, nmap NSE, and storage tests expect DOM APIs not available in jsdom)*
- node scripts/css-coverage.mjs http://localhost:3000 docs/css-coverage-after.json


------
https://chatgpt.com/codex/tasks/task_e_68c9d55481b483289d89d2c8e4a343bb