### PR TITLE
pages: add About Alex route and redirect

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -675,7 +675,7 @@ const apps = [
     screen: displayBeef,
   },
   {
-    id: 'about',
+    id: 'about-alex',
     title: 'About Alex',
     icon: '/themes/Yaru/system/user-home.png',
     disabled: false,

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import Head from 'next/head';
 import ReactGA from 'react-ga4';
 import GitHubStars from '../../GitHubStars';
@@ -112,7 +113,7 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
     return (
       <main className="w-full h-full flex bg-ub-cool-grey text-white select-none relative">
         <Head>
-          <title>About</title>
+          <title>About Alex</title>
           <script
             type="application/ld+json"
             nonce={nonce}
@@ -147,6 +148,25 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
           </div>
         </div>
         <div className="flex flex-col w-3/4 md:w-4/5 justify-start items-center flex-grow bg-ub-grey overflow-y-auto windowMainScreen">
+          <nav
+            aria-label="Breadcrumb"
+            className="w-full max-w-3xl px-4 pt-4 mb-4 text-xs text-gray-300 md:px-8"
+          >
+            <ol className="flex flex-wrap items-center gap-1">
+              <li>
+                <Link
+                  href="/"
+                  className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ubt-blue rounded"
+                >
+                  Home
+                </Link>
+              </li>
+              <li aria-hidden="true">/</li>
+              <li aria-current="page" className="font-semibold text-white">
+                About Alex
+              </li>
+            </ol>
+          </nav>
           {this.state.screen}
         </div>
       </main>

--- a/components/apps/alex/data.json
+++ b/components/apps/alex/data.json
@@ -1,6 +1,6 @@
 {
   "sections": [
-    {"id": "about", "label": "About Me", "icon": "/themes/Yaru/status/about.svg", "alt": "about Unnippillil"},
+    {"id": "about", "label": "About Alex", "icon": "/themes/Yaru/status/about.svg", "alt": "About Alex Unnippillil"},
     {"id": "education", "label": "Education", "icon": "/themes/Yaru/status/education.svg", "alt": "Unnippillil' education"},
     {"id": "skills", "label": "Skills", "icon": "/themes/Yaru/status/skills.svg", "alt": "Unnippillil' skills"},
     {"id": "certs", "label": "Certs", "icon": "/themes/Yaru/status/experience.svg", "alt": "Unnippillil's certifications"},

--- a/next.config.js
+++ b/next.config.js
@@ -71,7 +71,7 @@ const withPWA = require('@ducanh2912/next-pwa').default({
     additionalManifestEntries: [
       { url: '/', revision: null },
       { url: '/feeds', revision: null },
-      { url: '/about', revision: null },
+      { url: '/about-alex', revision: null },
       { url: '/projects', revision: null },
       { url: '/projects.json', revision: null },
       { url: '/apps', revision: null },
@@ -128,6 +128,15 @@ module.exports = withBundleAnalyzer(
     // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI
     eslint: {
       ignoreDuringBuilds: true,
+    },
+    async redirects() {
+      return [
+        {
+          source: '/about',
+          destination: '/about-alex',
+          statusCode: 308,
+        },
+      ];
     },
     images: {
       unoptimized: true,

--- a/pages/about-alex.tsx
+++ b/pages/about-alex.tsx
@@ -1,0 +1,1 @@
+export { default } from '../apps/About';

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -4,4 +4,8 @@
     <loc>https://unnippillil.com/</loc>
     <lastmod>2025-08-19</lastmod>
   </url>
+  <url>
+    <loc>https://unnippillil.com/about-alex</loc>
+    <lastmod>2025-08-19</lastmod>
+  </url>
 </urlset>

--- a/public/workers/service-worker.js
+++ b/public/workers/service-worker.js
@@ -2,7 +2,7 @@ const CACHE_NAME = 'periodic-cache-v1';
 const ASSETS = [
   '/apps/weather.js',
   '/feeds',
-  '/about',
+  '/about-alex',
   '/projects',
   '/projects.json',
   '/apps',

--- a/workers/service-worker.js
+++ b/workers/service-worker.js
@@ -2,7 +2,7 @@ const CACHE_NAME = 'periodic-cache-v1';
 const ASSETS = [
   '/apps/weather.js',
   '/feeds',
-  '/about',
+  '/about-alex',
   '/projects',
   '/projects.json',
   '/apps',


### PR DESCRIPTION
## Summary
- add an `/about-alex` route and update the About experience with an "About Alex" title and breadcrumb
- rename the desktop About window id and section label to align with the new naming
- point the redirect, sitemap, and cached asset lists at `/about-alex`

## Testing
- yarn lint *(fails: repository already contains numerous jsx-a11y and no-top-level-window violations)*
- yarn test *(fails: existing suites such as aboutAccessibility and nmapNse still error in the baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d55b6cc483289b4312412284311b