### PR TITLE
[apps] Add shortcut filtering to help overlay

### DIFF
--- a/__tests__/HelpOverlay.test.tsx
+++ b/__tests__/HelpOverlay.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import HelpOverlay from '../components/apps/HelpOverlay';
 
 describe('HelpOverlay', () => {
@@ -14,6 +15,43 @@ describe('HelpOverlay', () => {
     expect(
       screen.getByText('Reach the 2048 tile by merging numbers.')
     ).toBeInTheDocument();
-    expect(screen.getByText(/up: ArrowUp/i)).toBeInTheDocument();
+    const filterInput = screen.getByLabelText(/filter shortcuts/i);
+    expect(filterInput).toBeInTheDocument();
+
+    const list = screen.getByRole('list');
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(4);
+    expect(items[0]).toHaveTextContent(/up/i);
+    expect(items[0]).toHaveTextContent(/ArrowUp/i);
+  });
+
+  it('filters shortcuts by text and highlights matches', async () => {
+    const user = userEvent.setup();
+    render(<HelpOverlay gameId="2048" onClose={() => {}} />);
+
+    const filterInput = screen.getByLabelText(/filter shortcuts/i);
+    await user.clear(filterInput);
+    await user.type(filterInput, 'left');
+
+    const list = screen.getByRole('list');
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveTextContent(/left/i);
+    expect(items[0]).toHaveTextContent(/ArrowLeft/i);
+    expect(items[0].querySelectorAll('mark')).toHaveLength(2);
+
+    const remapButtons = screen.getAllByRole('button', { name: /change key for/i });
+    expect(remapButtons).toHaveLength(1);
+    expect(remapButtons[0]).toHaveTextContent(/ArrowLeft/i);
+
+    expect(screen.getByRole('status')).toHaveTextContent('1 of 4 shortcuts shown');
+
+    await user.clear(filterInput);
+    await user.type(filterInput, 'zzz');
+    expect(screen.getByText(/No shortcuts match/i)).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('0 of 4 shortcuts shown');
+    expect(
+      screen.queryAllByRole('button', { name: /change key for/i })
+    ).toHaveLength(0);
   });
 });

--- a/components/apps/Games/common/input-remap/InputRemap.tsx
+++ b/components/apps/Games/common/input-remap/InputRemap.tsx
@@ -4,9 +4,15 @@ interface Props {
   mapping: Record<string, string>;
   setKey: (action: string, key: string) => string | null;
   actions: Record<string, string>;
+  highlightQuery?: string;
 }
 
-const InputRemap: React.FC<Props> = ({ mapping, setKey, actions }) => {
+const InputRemap: React.FC<Props> = ({
+  mapping,
+  setKey,
+  actions,
+  highlightQuery,
+}) => {
   const [waiting, setWaiting] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
 
@@ -24,17 +30,46 @@ const InputRemap: React.FC<Props> = ({ mapping, setKey, actions }) => {
     window.addEventListener('keydown', handler);
   };
 
+  const highlightMatches = (text: string, keyPrefix: string) => {
+    const trimmed = highlightQuery?.trim();
+    if (!trimmed) return text;
+    const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`(${escaped})`, 'ig');
+    const parts = text.split(regex);
+    if (parts.length === 1) return text;
+    return parts.map((part, index) =>
+      index % 2 === 1 ? (
+        <mark
+          key={`${keyPrefix}-${index}`}
+          className="rounded-sm bg-yellow-300 px-0.5 text-black"
+        >
+          {part}
+        </mark>
+      ) : (
+        <React.Fragment key={`${keyPrefix}-${index}`}>{part}</React.Fragment>
+      ),
+    );
+  };
+
   return (
     <div className="space-y-2">
       {Object.keys(actions).map((action) => (
         <div key={action} className="flex items-center justify-between">
-          <span className="mr-2 capitalize">{action}</span>
+          <span className="mr-2 capitalize">
+            {highlightMatches(action, `${action}-action`)}
+          </span>
           <button
             type="button"
             onClick={() => capture(action)}
             className="px-2 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+            aria-label={`Change key for ${action}`}
           >
-            {waiting === action ? 'Press key...' : mapping[action]}
+            {waiting === action
+              ? 'Press key...'
+              : highlightMatches(
+                  mapping[action] ?? actions[action] ?? '',
+                  `${action}-key`,
+                )}
           </button>
         </div>
       ))}


### PR DESCRIPTION
## Summary
- add an accessible search filter and improved focus management to the game help overlay so shortcuts can be searched and highlighted
- update the input remap controls to highlight matches and expose clearer screen reader labels
- expand HelpOverlay tests to cover the new filtering behaviour and empty states

## Testing
- yarn lint *(fails: repository has many existing jsx-a11y and no-top-level-window violations across other apps)*
- yarn test *(fails: existing suites such as window.test.tsx and NmapNSEApp tests already fail; command stopped after the repeated failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d5619b7c832896b8c8f0d0ddd5cb