### PR TITLE
[navbar] Enable touch long-press context menu

### DIFF
--- a/__tests__/drawerLongPress.test.tsx
+++ b/__tests__/drawerLongPress.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import DrawerAppTile from '../components/screen/navbar/drawer/DrawerAppTile';
+import { useDrawerLongPress, type DrawerLongPressHandlers } from '../components/screen/navbar/drawer/useDrawerLongPress';
+
+type TriggerFn = Parameters<typeof useDrawerLongPress>[0];
+
+type LongPressDetails = Parameters<TriggerFn>[0];
+
+const withVibrationMock = (fn: () => void) => {
+  const originalVibrate = navigator.vibrate;
+  const vibrateMock = jest.fn();
+  Object.defineProperty(window.navigator, 'vibrate', {
+    configurable: true,
+    writable: true,
+    value: vibrateMock,
+  });
+  fn();
+  Object.defineProperty(window.navigator, 'vibrate', {
+    configurable: true,
+    writable: true,
+    value: originalVibrate,
+  });
+  return vibrateMock;
+};
+
+const createPointerEventMock = (
+  currentTarget: HTMLElement,
+  target: HTMLElement,
+  overrides: Partial<PointerEventInit> = {},
+) => ({
+  currentTarget,
+  target,
+  pointerId: 1,
+  pointerType: 'touch',
+  isPrimary: true,
+  clientX: 100,
+  clientY: 120,
+  pageX: 100,
+  pageY: 120,
+  preventDefault: jest.fn(),
+  stopPropagation: jest.fn(),
+  ...overrides,
+});
+
+describe('useDrawerLongPress hook', () => {
+  const TestHarness: React.FC<{ onTrigger: TriggerFn; capture: (handlers: DrawerLongPressHandlers<HTMLDivElement>) => void }>
+    = ({ onTrigger, capture }) => {
+      const handlers = useDrawerLongPress<HTMLDivElement>(onTrigger);
+      React.useEffect(() => {
+        capture(handlers);
+      }, [handlers, capture]);
+      return (
+        <div data-testid="wrapper" {...handlers}>
+          <div data-context="app" data-app-id="terminal" tabIndex={0}>
+            Terminal
+          </div>
+        </div>
+      );
+    };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('fires after a 450ms touch hold and vibrates when supported', () => {
+    const onTrigger = jest.fn();
+    let vibrateCalls = 0;
+
+    withVibrationMock(() => {
+      const vibrateSpy = navigator.vibrate as jest.Mock;
+      let handlers: DrawerLongPressHandlers<HTMLDivElement> | null = null;
+      const { getByTestId } = render(<TestHarness onTrigger={onTrigger} capture={(h) => { handlers = h; }} />);
+      const wrapper = getByTestId('wrapper');
+      const context = wrapper.querySelector('[data-context]') as HTMLElement;
+
+      act(() => {
+        handlers?.onPointerDown?.(createPointerEventMock(wrapper, context) as any);
+        jest.advanceTimersByTime(460);
+      });
+
+      expect(onTrigger).toHaveBeenCalledTimes(1);
+      vibrateCalls = vibrateSpy.mock.calls.length;
+
+      act(() => {
+        handlers?.onPointerUp?.(createPointerEventMock(wrapper, context) as any);
+      });
+    });
+
+    expect(vibrateCalls).toBeGreaterThan(0);
+  });
+
+  test('cancels when the finger moves beyond the scroll threshold', () => {
+    const onTrigger = jest.fn();
+    let handlers: DrawerLongPressHandlers<HTMLDivElement> | null = null;
+    const { getByTestId } = render(<TestHarness onTrigger={onTrigger} capture={(h) => { handlers = h; }} />);
+    const wrapper = getByTestId('wrapper');
+    const context = wrapper.querySelector('[data-context]') as HTMLElement;
+
+    act(() => {
+      handlers?.onPointerDown?.(createPointerEventMock(wrapper, context) as any);
+      handlers?.onPointerMove?.(
+        createPointerEventMock(wrapper, context, { clientX: 150, clientY: 180, pageX: 150, pageY: 180 }) as any,
+      );
+      jest.advanceTimersByTime(600);
+    });
+
+    expect(onTrigger).not.toHaveBeenCalled();
+  });
+});
+
+jest.mock('../components/screen/navbar/drawer/useDrawerLongPress', () => {
+  const actual = jest.requireActual('../components/screen/navbar/drawer/useDrawerLongPress');
+  const hookedCalls: TriggerFn[] = [];
+  const wrappedUseDrawerLongPress = (callback: TriggerFn, options?: any) => {
+    hookedCalls.push(callback);
+    return actual.useDrawerLongPress(callback, options);
+  };
+  return {
+    __esModule: true,
+    ...actual,
+    useDrawerLongPress: wrappedUseDrawerLongPress,
+    __hookedCalls: hookedCalls,
+  };
+});
+
+describe('DrawerAppTile', () => {
+  const { __hookedCalls } = jest.requireMock('../components/screen/navbar/drawer/useDrawerLongPress') as {
+    __hookedCalls: TriggerFn[];
+  };
+
+  beforeEach(() => {
+    __hookedCalls.length = 0;
+  });
+
+  test('dispatches a contextmenu event when the long press callback fires', () => {
+    const { getByRole } = render(
+      <DrawerAppTile id="terminal" title="Terminal" icon="/icons/terminal.svg" onOpen={() => {}} />,
+    );
+    const button = getByRole('button', { name: 'Terminal' });
+    const contextSpy = jest.fn();
+    button.addEventListener('contextmenu', contextSpy);
+
+    const trigger = __hookedCalls[0];
+    const details: LongPressDetails = {
+      target: button,
+      clientX: 100,
+      clientY: 140,
+      pageX: 100,
+      pageY: 140,
+    };
+
+    act(() => {
+      trigger(details);
+    });
+
+    expect(contextSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import Image from 'next/image';
-import UbuntuApp from '../base/ubuntu_app';
+import DrawerAppTile from '../screen/navbar/drawer/DrawerAppTile';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
 
@@ -163,15 +163,15 @@ const WhiskerMenu: React.FC = () => {
             />
             <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
               {currentApps.map((app, idx) => (
-                <div key={app.id} className={idx === highlight ? 'ring-2 ring-ubb-orange' : ''}>
-                  <UbuntuApp
-                    id={app.id}
-                    icon={app.icon}
-                    name={app.title}
-                    openApp={() => openSelectedApp(app.id)}
-                    disabled={app.disabled}
-                  />
-                </div>
+                <DrawerAppTile
+                  key={app.id}
+                  id={app.id}
+                  title={app.title}
+                  icon={app.icon}
+                  disabled={app.disabled}
+                  onOpen={openSelectedApp}
+                  className={idx === highlight ? 'ring-2 ring-ubb-orange' : ''}
+                />
               ))}
             </div>
           </div>

--- a/components/screen/navbar/drawer/DrawerAppTile.tsx
+++ b/components/screen/navbar/drawer/DrawerAppTile.tsx
@@ -1,0 +1,46 @@
+import React, { useCallback } from 'react';
+import UbuntuApp from '../../../base/ubuntu_app';
+import { useDrawerLongPress } from './useDrawerLongPress';
+import type { DrawerLongPressEvent } from './useDrawerLongPress';
+
+type DrawerAppTileProps = {
+  id: string;
+  title: string;
+  icon: string;
+  disabled?: boolean;
+  onOpen: (id: string) => void;
+  className?: string;
+};
+
+const DrawerAppTile: React.FC<DrawerAppTileProps> = ({ id, title, icon, disabled, onOpen, className }) => {
+  const handleOpen = useCallback(() => {
+    onOpen(id);
+  }, [id, onOpen]);
+
+  const handleLongPress = useCallback((event: DrawerLongPressEvent) => {
+    const contextTarget = event.target;
+    const contextMenuEvent = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+      button: 2,
+      buttons: 2,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      screenX: window.screenX + event.clientX,
+      screenY: window.screenY + event.clientY,
+    });
+
+    contextTarget.dispatchEvent(contextMenuEvent);
+  }, []);
+
+  const longPressHandlers = useDrawerLongPress<HTMLDivElement>(handleLongPress);
+
+  return (
+    <div className={className} {...longPressHandlers}>
+      <UbuntuApp id={id} icon={icon} name={title} displayName={title} disabled={disabled} openApp={handleOpen} />
+    </div>
+  );
+};
+
+export default DrawerAppTile;

--- a/components/screen/navbar/drawer/useDrawerLongPress.ts
+++ b/components/screen/navbar/drawer/useDrawerLongPress.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef } from 'react';
+import type { PointerEventHandler } from 'react';
+
+const LONG_PRESS_DELAY_MS = 450;
+const MOVE_THRESHOLD_PX = 12;
+
+export type DrawerLongPressEvent = {
+  target: HTMLElement;
+  clientX: number;
+  clientY: number;
+  pageX: number;
+  pageY: number;
+};
+
+export type DrawerLongPressHandlers<T extends HTMLElement = HTMLElement> = {
+  onPointerDown: PointerEventHandler<T>;
+  onPointerMove: PointerEventHandler<T>;
+  onPointerUp: PointerEventHandler<T>;
+  onPointerCancel: PointerEventHandler<T>;
+  onPointerLeave: PointerEventHandler<T>;
+};
+
+const vibrateOnce = () => {
+  if (typeof navigator === 'undefined') return;
+  const vibrate = navigator.vibrate;
+  if (typeof vibrate === 'function') {
+    try {
+      vibrate.call(navigator, 10);
+    } catch {
+      // ignore vibration errors (e.g. unsupported platforms)
+    }
+  }
+};
+
+export const useDrawerLongPress = <T extends HTMLElement = HTMLElement>(
+  onTrigger: (event: DrawerLongPressEvent) => void,
+  options?: {
+    delay?: number;
+    moveThreshold?: number;
+  },
+): DrawerLongPressHandlers<T> => {
+  const delay = options?.delay ?? LONG_PRESS_DELAY_MS;
+  const moveThreshold = options?.moveThreshold ?? MOVE_THRESHOLD_PX;
+
+  const timerRef = useRef<number | null>(null);
+  const pointerIdRef = useRef<number | null>(null);
+  const startRef = useRef<{ clientX: number; clientY: number; pageX: number; pageY: number } | null>(null);
+  const targetRef = useRef<HTMLElement | null>(null);
+  const triggeredRef = useRef(false);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    clearTimer();
+    pointerIdRef.current = null;
+    startRef.current = null;
+    targetRef.current = null;
+    triggeredRef.current = false;
+  }, [clearTimer]);
+
+  const fire = useCallback(() => {
+    if (!targetRef.current || !startRef.current) return;
+    triggeredRef.current = true;
+    clearTimer();
+    vibrateOnce();
+    onTrigger({
+      target: targetRef.current,
+      clientX: startRef.current.clientX,
+      clientY: startRef.current.clientY,
+      pageX: startRef.current.pageX,
+      pageY: startRef.current.pageY,
+    });
+  }, [clearTimer, onTrigger]);
+
+  const onPointerDown = useCallback<PointerEventHandler<T>>(
+    (event) => {
+      if (event.pointerType !== 'touch' || !event.isPrimary) return;
+      const host = event.currentTarget as HTMLElement | null;
+      const eventTarget = event.target as HTMLElement | null;
+      const contextElement =
+        eventTarget?.closest('[data-context]') ?? host?.querySelector('[data-context]');
+      if (!contextElement) return;
+      pointerIdRef.current = event.pointerId;
+      startRef.current = {
+        clientX: event.clientX,
+        clientY: event.clientY,
+        pageX: event.pageX,
+        pageY: event.pageY,
+      };
+      targetRef.current = contextElement as HTMLElement;
+      triggeredRef.current = false;
+      clearTimer();
+      timerRef.current = window.setTimeout(fire, delay);
+    },
+    [clearTimer, delay, fire],
+  );
+
+  const onPointerMove = useCallback<PointerEventHandler<T>>(
+    (event) => {
+      if (pointerIdRef.current !== event.pointerId || event.pointerType !== 'touch') return;
+      if (!startRef.current || triggeredRef.current) return;
+      const dx = event.clientX - startRef.current.clientX;
+      const dy = event.clientY - startRef.current.clientY;
+      if (Math.hypot(dx, dy) > moveThreshold) {
+        reset();
+      }
+    },
+    [moveThreshold, reset],
+  );
+
+  const onPointerUp = useCallback<PointerEventHandler<T>>(
+    (event) => {
+      if (pointerIdRef.current !== event.pointerId) return;
+      if (triggeredRef.current) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+      reset();
+    },
+    [reset],
+  );
+
+  const onPointerCancel = useCallback<PointerEventHandler<T>>(
+    (event) => {
+      if (pointerIdRef.current !== event.pointerId) return;
+      reset();
+    },
+    [reset],
+  );
+
+  const onPointerLeave = useCallback<PointerEventHandler<T>>(
+    (event) => {
+      if (pointerIdRef.current !== event.pointerId) return;
+      if (triggeredRef.current) {
+        reset();
+        return;
+      }
+      reset();
+    },
+    [reset],
+  );
+
+  useEffect(() => reset, [reset]);
+
+  return {
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+    onPointerLeave,
+  };
+};


### PR DESCRIPTION
## Summary
- add a reusable DrawerAppTile component that dispatches the context menu on touch long-press with vibration feedback
- introduce a useDrawerLongPress hook that waits 450ms, cancels on scroll-like movement, and keeps the Web Vibration API optional
- swap WhiskerMenu to the new tile component and cover the touch behaviour with a dedicated Jest test suite

## Testing
- yarn lint *(fails: repo has pre-existing accessibility and window globals violations)*
- yarn test drawerLongPress


------
https://chatgpt.com/codex/tasks/task_e_68c9d5687cb48328b0173b93e2fb129a