### PR TITLE
[resume] improve print layout for resume export

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,24 @@ See `.env.local.example` for the full list.
 
 ---
 
+## Resume Printing
+
+The About Alex app exposes the interactive resume. To print a snapshot:
+
+1. Open **About Alex → Resume** and load the resume content.
+2. Choose **Download PDF** (which triggers `window.print()`) or use the browser print shortcut.
+3. In the print dialog pick either **A4** or **Letter** and keep margins at **12&nbsp;mm** (the layout already sets this value).
+4. Enable background graphics so the Kali theme colors and charts are preserved.
+5. Confirm the page range before printing—long resumes will span multiple sheets.
+
+**Known limitations / tips**
+
+- The resume honors the last active experience filter. Because the print view hides the filter buttons, switch back to **All** before opening the print dialog.
+- Some older browsers ignore `break-inside` on flex containers, which can allow a column to split across pages. Reflowing the content (resize the window once) usually fixes the breakpoints before printing.
+- Browser previews may override the 12&nbsp;mm margin when "Fit to page" or similar scaling is enabled. Set scaling to 100&nbsp;% for predictable spacing.
+
+---
+
 ## Speed Insights
 
 - Enable Speed Insights in the Vercel project dashboard.

--- a/styles/resume-print.css
+++ b/styles/resume-print.css
@@ -1,20 +1,77 @@
 @media print {
   @page {
-    margin: 1in;
+    margin: 12mm;
+    size: auto;
   }
+
+  :root {
+    --resume-print-width: calc(210mm - 24mm);
+  }
+
   body {
     background: var(--color-surface);
     color: var(--color-inverse);
     -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
   }
+
+  html,
+  body {
+    width: 100%;
+    min-height: auto;
+  }
+
   .no-print {
     display: none !important;
   }
+
   .windowMainScreen {
     background: var(--color-surface) !important;
   }
+
   #resume-content {
-    max-height: 520mm;
-    overflow: hidden;
+    box-sizing: border-box;
+    max-width: var(--resume-print-width);
+    margin: 0 auto;
+    max-height: none;
+    overflow: visible;
+    page-break-inside: avoid;
+  }
+
+  #resume-content > * {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  #resume-content .timeline-item,
+  #resume-content .exp-item,
+  #resume-content li,
+  #resume-content .react-activity-calendar,
+  #resume-content .flex,
+  #resume-content .grid {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  #resume-content .exp-item {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  #resume-content .flex.flex-wrap.my-2 {
+    display: none !important;
+  }
+
+  #resume-content button,
+  #resume-content [role='button'],
+  #resume-content input,
+  #resume-content select {
+    display: none !important;
+  }
+}
+
+@media print and (size: 8.5in 11in) {
+  :root {
+    --resume-print-width: calc(8.5in - 24mm);
   }
 }


### PR DESCRIPTION
## Summary
- adjust the resume print stylesheet to enforce 12 mm margins, keep sections together on page breaks, and hide interactive controls during printing
- add documentation covering print steps, recommended browser settings, and known limitations for exporting the resume

## Testing
- yarn lint *(fails: repository currently contains numerous pre-existing accessibility lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d56c8e5883289c4a374675c11960