### PR TITLE
feat: enhance install prompt handling

### DIFF
--- a/__tests__/installButton.test.tsx
+++ b/__tests__/installButton.test.tsx
@@ -1,56 +1,112 @@
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import InstallButton from '../components/InstallButton';
-import { initA2HS } from '@/src/pwa/a2hs';
 
-describe('InstallButton', () => {
-  test('shows install prompt when beforeinstallprompt fires', async () => {
-    render(<InstallButton />);
-    initA2HS();
-    expect(screen.queryByText(/install/i)).toBeNull();
+const STORAGE_KEY = 'kali-linux-portfolio.installPrompt';
 
-    let resolveChoice: (value: any) => void = () => {};
-    const userChoice = new Promise((resolve) => {
+type ResolveChoice = (value: { outcome: 'accepted' | 'dismissed'; platform: string }) => void;
+
+type PromptEvent = Event & {
+  prompt: jest.Mock;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+  preventDefault: jest.Mock;
+};
+
+describe('InstallPrompt', () => {
+  const createPromptEvent = () => {
+    let resolveChoice: ResolveChoice = () => {};
+    const userChoice = new Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>((resolve) => {
       resolveChoice = resolve;
     });
 
-    const prompt = jest.fn().mockResolvedValue(undefined);
-    const event: any = new Event('beforeinstallprompt');
+    const event = new Event('beforeinstallprompt') as PromptEvent;
     event.preventDefault = jest.fn();
-    event.prompt = prompt;
+    event.prompt = jest.fn().mockResolvedValue(undefined);
     event.userChoice = userChoice;
+
+    return { event, resolveChoice, userChoice };
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  test('shows CTA after beforeinstallprompt and resolves acceptance', async () => {
+    const now = 1700000000000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    render(<InstallButton />);
+
+    expect(screen.queryByRole('button', { name: /install/i })).toBeNull();
+
+    const { event, resolveChoice, userChoice } = createPromptEvent();
 
     await act(async () => {
       window.dispatchEvent(event);
     });
 
-    // The install prompt shouldn't trigger automatically.
-    expect(prompt).not.toHaveBeenCalled();
-
-    const button = await screen.findByText(/install/i);
+    const button = await screen.findByRole('button', { name: /install/i });
     await userEvent.click(button);
-    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(event.prompt).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       resolveChoice({ outcome: 'accepted', platform: 'test' });
       await userChoice;
     });
 
-    await waitFor(() => expect(screen.queryByText(/install/i)).toBeNull());
+    await waitFor(() => expect(screen.queryByRole('button', { name: /install/i })).toBeNull());
+    expect(localStorage.getItem(STORAGE_KEY)).toContain('"accepted"');
+    expect(screen.getByText(/app installed/i)).toBeInTheDocument();
   });
 
-  test('can be focused via keyboard', async () => {
+  test('hides CTA after dismissal and stores state', async () => {
+    const now = 1800000000000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
     render(<InstallButton />);
-    initA2HS();
-    const event: any = new Event('beforeinstallprompt');
-    event.preventDefault = jest.fn();
-    event.prompt = jest.fn();
-    event.userChoice = Promise.resolve({ outcome: 'dismissed' });
+
+    const { event, resolveChoice, userChoice } = createPromptEvent();
+
     await act(async () => {
       window.dispatchEvent(event);
     });
+
     const button = await screen.findByRole('button', { name: /install/i });
-    await userEvent.tab();
-    expect(button).toHaveFocus();
+    await userEvent.click(button);
+
+    await act(async () => {
+      resolveChoice({ outcome: 'dismissed', platform: 'test' });
+      await userChoice;
+    });
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: /install/i })).toBeNull());
+    expect(localStorage.getItem(STORAGE_KEY)).toContain('"dismissed"');
+    expect(screen.getByText(/install dismissed/i)).toBeInTheDocument();
+  });
+
+  test('suppresses CTA when dismissal is still within cooldown', async () => {
+    const now = 1900000000000;
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ outcome: 'dismissed', timestamp: now }),
+    );
+    jest.spyOn(Date, 'now').mockReturnValue(now + 1000);
+
+    render(<InstallButton />);
+
+    const { event } = createPromptEvent();
+
+    await act(async () => {
+      window.dispatchEvent(event);
+    });
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: /install/i })).toBeNull());
+    expect(screen.queryByText(/install dismissed/i)).toBeNull();
+  });
+
+  test('shows fallback messaging when install prompt is unsupported', async () => {
+    render(<InstallButton />);
+
+    const fallback = await screen.findByText(/add this app to your home screen/i);
+    expect(fallback).toBeInTheDocument();
   });
 });

--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -1,36 +1,3 @@
 "use client";
 
-import { useEffect, useState } from 'react';
-import { trackEvent } from '@/lib/analytics-client';
-import { showA2HS } from '@/src/pwa/a2hs';
-
-const InstallButton: React.FC = () => {
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    const handler = () => setVisible(true);
-    (window as any).addEventListener('a2hs:available', handler);
-    return () => (window as any).removeEventListener('a2hs:available', handler);
-  }, []);
-
-  const handleInstall = async () => {
-    const shown = await showA2HS();
-    if (shown) {
-      trackEvent('cta_click', { location: 'install_button' });
-      setVisible(false);
-    }
-  };
-
-  if (!visible) return null;
-
-  return (
-    <button
-      onClick={handleInstall}
-      className="fixed bottom-4 right-4 bg-ubt-blue text-white px-3 py-1 rounded"
-    >
-      Install
-    </button>
-  );
-};
-
-export default InstallButton;
+export { default } from './system/InstallPrompt';

--- a/components/system/InstallPrompt.tsx
+++ b/components/system/InstallPrompt.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { trackEvent } from '@/lib/analytics-client';
+
+type PromptOutcome = 'accepted' | 'dismissed';
+
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{ outcome: PromptOutcome; platform: string }>;
+  prompt(): Promise<void>;
+}
+
+type StoredOutcome = {
+  outcome: PromptOutcome;
+  timestamp: number;
+};
+
+const STORAGE_KEY = 'kali-linux-portfolio.installPrompt';
+const DISMISS_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000; // one week
+
+const supportsBeforeInstallPrompt = () =>
+  typeof window !== 'undefined' &&
+  ('BeforeInstallPromptEvent' in window || 'onbeforeinstallprompt' in window);
+
+const readStoredOutcome = (): StoredOutcome | null => {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as Partial<StoredOutcome>;
+    if (
+      (parsed.outcome === 'accepted' || parsed.outcome === 'dismissed') &&
+      typeof parsed.timestamp === 'number'
+    ) {
+      return parsed as StoredOutcome;
+    }
+  } catch {
+    // ignore malformed storage
+  }
+
+  return null;
+};
+
+const persistOutcome = (outcome: PromptOutcome) => {
+  if (typeof window === 'undefined') return;
+
+  try {
+    const record: StoredOutcome = { outcome, timestamp: Date.now() };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(record));
+  } catch {
+    // ignore storage errors
+  }
+};
+
+const clearStoredOutcome = () => {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore storage errors
+  }
+};
+
+const shouldSnoozePrompt = (record: StoredOutcome | null) => {
+  if (!record) return false;
+  if (record.outcome === 'accepted') return true;
+
+  if (Date.now() - record.timestamp < DISMISS_COOLDOWN_MS) {
+    return true;
+  }
+
+  clearStoredOutcome();
+  return false;
+};
+
+const isStandaloneMode = () => {
+  if (typeof window === 'undefined') return false;
+
+  if (typeof window.matchMedia === 'function') {
+    try {
+      if (window.matchMedia('(display-mode: standalone)').matches) {
+        return true;
+      }
+    } catch {
+      // ignore matchMedia errors
+    }
+  }
+
+  return (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
+};
+
+const InstallPrompt = () => {
+  const [ctaVisible, setCtaVisible] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [supportStatus, setSupportStatus] = useState<'unknown' | 'supported' | 'unsupported'>(
+    'unknown',
+  );
+  const [isPrompting, setIsPrompting] = useState(false);
+  const promptEventRef = useRef<BeforeInstallPromptEvent | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const stored = readStoredOutcome();
+    if (stored?.outcome === 'accepted') {
+      setSupportStatus('supported');
+      return;
+    }
+
+    if (isStandaloneMode()) {
+      persistOutcome('accepted');
+      setSupportStatus('supported');
+      return;
+    }
+
+    if (!supportsBeforeInstallPrompt()) {
+      setSupportStatus((prev) => (prev === 'unknown' ? 'unsupported' : prev));
+    }
+
+    const handleBeforeInstallPrompt = (event: Event) => {
+      const promptEvent = event as BeforeInstallPromptEvent;
+      promptEvent.preventDefault();
+      setSupportStatus('supported');
+
+      const record = readStoredOutcome();
+      if (shouldSnoozePrompt(record)) {
+        promptEventRef.current = null;
+        return;
+      }
+
+      promptEventRef.current = promptEvent;
+      setStatusMessage(null);
+      setCtaVisible(true);
+    };
+
+    const handleAppInstalled = () => {
+      persistOutcome('accepted');
+      promptEventRef.current = null;
+      setCtaVisible(false);
+      setStatusMessage('App installed! Find it in your browser\'s app list.');
+      setSupportStatus('supported');
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    window.addEventListener('appinstalled', handleAppInstalled);
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+      window.removeEventListener('appinstalled', handleAppInstalled);
+    };
+  }, []);
+
+  const handleInstall = useCallback(async () => {
+    const promptEvent = promptEventRef.current;
+    if (!promptEvent) return;
+
+    setIsPrompting(true);
+    try {
+      await promptEvent.prompt();
+      const choice = await promptEvent.userChoice;
+      persistOutcome(choice.outcome);
+      trackEvent('cta_click', { location: 'install_prompt', outcome: choice.outcome });
+
+      setStatusMessage(
+        choice.outcome === 'accepted'
+          ? 'App installed! Find it in your browser\'s app list.'
+          : 'Install dismissed. You can use your browser menu to install later.',
+      );
+    } catch (error) {
+      console.error('Install prompt failed', error);
+      setStatusMessage('Unable to open the install prompt. Please try again later.');
+    } finally {
+      promptEventRef.current = null;
+      setCtaVisible(false);
+      setIsPrompting(false);
+    }
+  }, []);
+
+  const shouldRender = ctaVisible || statusMessage || supportStatus === 'unsupported';
+
+  if (!shouldRender) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 max-w-xs text-white" aria-live="polite">
+      <div className="rounded-lg border border-white/10 bg-black/70 p-4 shadow-lg backdrop-blur">
+        {ctaVisible ? (
+          <>
+            <p className="mb-3 text-sm font-medium">Install Kali Linux Portfolio</p>
+            <p className="mb-4 text-xs text-white/80">
+              Add this desktop experience to your home screen for quicker access.
+            </p>
+            <button
+              type="button"
+              onClick={handleInstall}
+              className="w-full rounded bg-ubt-blue px-3 py-2 text-sm font-semibold text-white hover:bg-ubt-blue/90 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-black disabled:cursor-not-allowed disabled:opacity-70"
+              disabled={isPrompting}
+            >
+              {isPrompting ? 'Opening browser prompt…' : 'Install'}
+            </button>
+          </>
+        ) : statusMessage ? (
+          <p className="text-sm" role="status">
+            {statusMessage}
+          </p>
+        ) : (
+          <p className="text-sm" role="status">
+            Install prompts aren\'t supported here. Use your browser menu to add this app to your
+            home screen.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default InstallPrompt;


### PR DESCRIPTION
## Summary
- add a dedicated system InstallPrompt component that listens for `beforeinstallprompt`, persists the dismissal/install outcome, and shows fallback messaging when unsupported
- reuse the new prompt UI from the existing InstallButton entry point
- expand install prompt unit tests to cover acceptance, dismissal persistence, cooldown behaviour, and unsupported fallback text

## Testing
- yarn test __tests__/installButton.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c9d57398fc8328b57a7b02b8d3005a