### PR TITLE
system: add install prompt guidance

### DIFF
--- a/__tests__/installButton.test.tsx
+++ b/__tests__/installButton.test.tsx
@@ -27,8 +27,12 @@ describe('InstallButton', () => {
     // The install prompt shouldn't trigger automatically.
     expect(prompt).not.toHaveBeenCalled();
 
-    const button = await screen.findByText(/install/i);
-    await userEvent.click(button);
+    const dialog = await screen.findByRole('dialog', {
+      name: /install kali linux portfolio/i,
+    });
+    expect(dialog).toBeInTheDocument();
+    const installCta = await screen.findByRole('button', { name: /^install$/i });
+    await userEvent.click(installCta);
     expect(prompt).toHaveBeenCalledTimes(1);
 
     await act(async () => {
@@ -36,7 +40,8 @@ describe('InstallButton', () => {
       await userChoice;
     });
 
-    await waitFor(() => expect(screen.queryByText(/install/i)).toBeNull());
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    expect(screen.queryByRole('button', { name: /install app/i })).toBeNull();
   });
 
   test('can be focused via keyboard', async () => {
@@ -49,8 +54,10 @@ describe('InstallButton', () => {
     await act(async () => {
       window.dispatchEvent(event);
     });
-    const button = await screen.findByRole('button', { name: /install/i });
+    const notNow = await screen.findByRole('button', { name: /not now/i });
+    await userEvent.click(notNow);
+    const opener = await screen.findByRole('button', { name: /install app/i });
     await userEvent.tab();
-    expect(button).toHaveFocus();
+    expect(opener).toHaveFocus();
   });
 });

--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -1,35 +1,61 @@
 "use client";
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { trackEvent } from '@/lib/analytics-client';
 import { showA2HS } from '@/src/pwa/a2hs';
+import InstallPrompt from './system/InstallPrompt';
 
 const InstallButton: React.FC = () => {
-  const [visible, setVisible] = useState(false);
+  const [available, setAvailable] = useState(false);
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
-    const handler = () => setVisible(true);
+    const handler = () => {
+      setAvailable(true);
+      setOpen(true);
+    };
     (window as any).addEventListener('a2hs:available', handler);
     return () => (window as any).removeEventListener('a2hs:available', handler);
   }, []);
 
-  const handleInstall = async () => {
+  const handleInstall = useCallback(async () => {
     const shown = await showA2HS();
     if (shown) {
-      trackEvent('cta_click', { location: 'install_button' });
-      setVisible(false);
+      trackEvent('cta_click', { location: 'install_prompt_install' });
+      setOpen(false);
+      setAvailable(false);
     }
-  };
+  }, []);
 
-  if (!visible) return null;
+  const handleClose = useCallback(() => {
+    trackEvent('cta_dismiss', { location: 'install_prompt' });
+    setOpen(false);
+  }, []);
+
+  const handleOpen = useCallback(() => {
+    setOpen(true);
+    trackEvent('cta_open', { location: 'install_prompt' });
+  }, []);
+
+  if (!available && !open) return null;
 
   return (
-    <button
-      onClick={handleInstall}
-      className="fixed bottom-4 right-4 bg-ubt-blue text-white px-3 py-1 rounded"
-    >
-      Install
-    </button>
+    <>
+      {available && (
+        <button
+          type="button"
+          onClick={handleOpen}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          ref={buttonRef}
+          className="fixed bottom-6 right-6 z-[60] rounded-full bg-ubt-blue px-4 py-2 text-sm font-semibold text-ubt-grey shadow-lg transition hover:bg-ubt-green hover:text-black focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
+        >
+          Install app
+        </button>
+      )}
+      <InstallPrompt open={open} onClose={handleClose} onInstall={handleInstall} />
+    </>
   );
 };
 

--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -11,6 +11,9 @@ interface ModalProps {
      * Defaults to the Next.js root (`__next`).
      */
     overlayRoot?: string | HTMLElement;
+    className?: string;
+    labelledBy?: string;
+    describedBy?: string;
 }
 
 const FOCUSABLE_SELECTORS = [
@@ -27,7 +30,15 @@ const FOCUSABLE_SELECTORS = [
     '[contenteditable]'
 ].join(',');
 
-const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot }) => {
+const Modal: React.FC<ModalProps> = ({
+    isOpen,
+    onClose,
+    children,
+    overlayRoot,
+    className,
+    labelledBy,
+    describedBy,
+}) => {
     const modalRef = useRef<HTMLDivElement>(null);
     const triggerRef = useRef<HTMLElement | null>(null);
     const portalRef = useRef<HTMLDivElement | null>(null);
@@ -116,6 +127,9 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
             ref={modalRef}
             onKeyDown={handleKeyDown}
             tabIndex={-1}
+            className={className}
+            aria-labelledby={labelledBy}
+            aria-describedby={describedBy}
         >
             {children}
         </div>,

--- a/components/system/InstallPrompt.tsx
+++ b/components/system/InstallPrompt.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useId } from 'react';
+import Modal from '../base/Modal';
+
+interface InstallPromptProps {
+  open: boolean;
+  onClose: () => void;
+  onInstall: () => void;
+}
+
+const steps = [
+  {
+    title: 'Start the install flow',
+    description: 'Select Install to ask your browser for the Add to Home Screen prompt.',
+  },
+  {
+    title: 'Confirm in the browser prompt',
+    description: 'Approve the Add or Install action when your browser displays its confirmation.',
+  },
+  {
+    title: 'Launch from your device',
+    description: 'Find Kali Linux Portfolio in your app list or home screen once the install completes.',
+  },
+];
+
+const InstallPrompt: React.FC<InstallPromptProps> = ({ open, onClose, onInstall }) => {
+  const titleId = useId();
+  const descriptionId = useId();
+
+  return (
+    <Modal
+      isOpen={open}
+      onClose={onClose}
+      className="fixed inset-0 z-[1200] flex items-end justify-center px-4 py-6 sm:items-center focus:outline-none"
+      labelledBy={titleId}
+      describedBy={descriptionId}
+    >
+      <div
+        className="absolute inset-0 bg-black/60"
+        aria-hidden="true"
+        onClick={onClose}
+        role="presentation"
+      />
+      <section
+        role="document"
+        className="relative z-10 w-full max-w-md rounded-lg border border-ubt-blue bg-ub-lite-abrgn p-5 text-ubt-grey shadow-2xl backdrop-blur-sm"
+      >
+        <header className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <p id={descriptionId} className="text-xs uppercase tracking-wide text-ubt-warm-grey">
+              Install the desktop for quick access on any device.
+            </p>
+            <h2 id={titleId} className="text-lg font-semibold text-white">
+              Install Kali Linux Portfolio
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-transparent text-ubt-warm-grey transition hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
+            aria-label="Close install guide"
+          >
+            <span aria-hidden="true">×</span>
+          </button>
+        </header>
+        <ol className="mt-4 space-y-3 text-sm list-none" aria-label="Installation steps">
+          {steps.map((step, index) => (
+            <li key={step.title} className="flex items-start gap-3">
+              <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-ubt-blue text-xs font-semibold text-ubt-grey">
+                {index + 1}
+              </span>
+              <div className="space-y-1">
+                <p className="font-medium text-white">{step.title}</p>
+                <p className="text-xs text-ubt-warm-grey">{step.description}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <footer className="mt-6 flex flex-wrap items-center justify-between gap-3 text-sm">
+          <a
+            href="https://unnippillil.com/docs/getting-started"
+            target="_blank"
+            rel="noreferrer"
+            className="font-medium text-ubt-blue underline-offset-4 transition hover:text-white hover:underline focus-visible:text-white focus-visible:underline"
+          >
+            Learn more
+          </a>
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-transparent px-4 py-2 font-medium text-ubt-warm-grey transition hover:text-ubt-grey focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
+            >
+              Not now
+            </button>
+            <button
+              type="button"
+              onClick={onInstall}
+              className="rounded-md bg-ubt-blue px-4 py-2 font-semibold text-ubt-grey shadow-md transition hover:bg-ubt-green hover:text-black focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
+            >
+              Install
+            </button>
+          </div>
+        </footer>
+      </section>
+    </Modal>
+  );
+};
+
+export default InstallPrompt;


### PR DESCRIPTION
## Summary
- add a reusable InstallPrompt sheet with descriptive steps and a learn more link
- wire the InstallButton to open the sheet, track interactions, and call the A2HS prompt
- extend the shared Modal with styling and labelling hooks and update tests for the new flow

## Testing
- ⚠️ `yarn lint` *(fails with existing accessibility violations in unrelated apps)*
- ⚠️ `yarn test` *(many pre-existing suite failures; targeted suite run below)*
- ✅ `yarn test __tests__/installButton.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c9d5740b7c832889fcdb47ce7e39b4