### PR TITLE
[apps] highlight offline ready tiles

### DIFF
--- a/__tests__/AppTile.test.tsx
+++ b/__tests__/AppTile.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import AppTile from '../components/apps/AppTile';
+
+jest.mock('next/image', () => {
+  const MockedImage = (props: any) => <img {...props} alt={props.alt || ''} />;
+  MockedImage.displayName = 'MockedImage';
+  return MockedImage;
+});
+
+describe('AppTile', () => {
+  it('renders an offline badge for offline-capable grid tiles', () => {
+    render(
+      <AppTile
+        id="calculator"
+        title="Calculator"
+        icon="/themes/Yaru/apps/calc.png"
+        href="/apps/calculator"
+        offlineCapable
+      />
+    );
+
+    expect(screen.getByText(/offline ready/i)).toBeInTheDocument();
+  });
+
+  it('omits the offline badge when the app is online-only', () => {
+    render(
+      <AppTile
+        id="spotify"
+        title="Spotify"
+        icon="/themes/Yaru/apps/spotify.svg"
+        href="/apps/spotify"
+      />
+    );
+
+    expect(screen.queryByText(/offline ready/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the offline badge in detail view and renders descriptions', () => {
+    render(
+      <AppTile
+        id="quote"
+        title="Quote"
+        icon="/themes/Yaru/apps/quote.svg"
+        offlineCapable
+        variant="detail"
+        description="Browse motivational quotes without a network connection."
+      >
+        <p>Includes share and save options.</p>
+      </AppTile>
+    );
+
+    expect(screen.getByText(/offline ready/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/browse motivational quotes without a network connection/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/includes share and save options/i)).toBeInTheDocument();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -200,6 +200,27 @@ const displayContact = createDisplay(ContactApp);
 
 const displayHashcat = createDisplay(HashcatApp);
 
+const offlineAppIds = new Set([
+  'calculator',
+  'terminal',
+  'converter',
+  'sticky_notes',
+  'trash',
+  'serial-terminal',
+  'mimikatz/offline',
+  'ssh',
+  'http',
+  'html-rewriter',
+]);
+
+const applyOfflineFlag = (defaultOffline = false) => (app) => ({
+  ...app,
+  offlineCapable:
+    typeof app.offlineCapable === 'boolean'
+      ? app.offlineCapable
+      : defaultOffline || offlineAppIds.has(app.id),
+});
+
 const displayKismet = createDisplay(KismetApp);
 
 // Utilities list used for the "Utilities" folder on the desktop
@@ -267,7 +288,7 @@ const utilityList = [
     desktop_shortcut: false,
     screen: displayInputLab,
   },
-];
+].map(applyOfflineFlag(true));
 
 export const utilities = utilityList;
 
@@ -590,7 +611,7 @@ const gameList = [
     desktop_shortcut: false,
     screen: displayPinball,
   },
-];
+].map(applyOfflineFlag(true));
 
 export const games = gameList.map((game) => ({ ...gameDefaults, ...game }));
 
@@ -1055,6 +1076,6 @@ const apps = [
   ...utilities,
   // Games are included so they appear alongside apps
   ...games,
-];
+].map(applyOfflineFlag());
 
 export default apps;

--- a/components/apps/AppTile.tsx
+++ b/components/apps/AppTile.tsx
@@ -1,0 +1,141 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import clsx from 'clsx';
+import type { FC, ReactNode } from 'react';
+
+export type AppTileVariant = 'grid' | 'detail';
+
+export interface AppTileProps {
+  id: string;
+  title: string;
+  icon?: string | null;
+  href?: string;
+  description?: string;
+  offlineCapable?: boolean;
+  variant?: AppTileVariant;
+  className?: string;
+  children?: ReactNode;
+}
+
+const OfflineBadge: FC<{ variant: AppTileVariant }> = ({ variant }) => (
+  <span
+    className={clsx(
+      'inline-flex items-center rounded-full bg-emerald-500/90 px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-white shadow-sm ring-1 ring-emerald-400/60 backdrop-blur',
+      variant === 'grid' ? 'absolute right-2 top-2' : 'mb-3 self-start'
+    )}
+  >
+    Offline Ready
+  </span>
+);
+
+const renderIcon = (title: string, icon?: string | null, size = 64) => {
+  if (!icon) {
+    return (
+      <span className="flex h-16 w-16 items-center justify-center rounded-md bg-slate-200 text-lg font-semibold text-slate-700">
+        {title.charAt(0).toUpperCase()}
+      </span>
+    );
+  }
+
+  return (
+    <Image
+      src={icon}
+      alt=""
+      width={size}
+      height={size}
+      sizes={`${size}px`}
+      className="h-16 w-16"
+    />
+  );
+};
+
+const GridTile: FC<AppTileProps> = ({
+  id,
+  title,
+  icon,
+  href,
+  offlineCapable,
+  className,
+}) => {
+  const content = (
+    <>
+      {offlineCapable ? <OfflineBadge variant="grid" /> : null}
+      {renderIcon(title, icon)}
+      <span className="mt-2 text-sm font-medium text-slate-900 dark:text-slate-100">{title}</span>
+    </>
+  );
+
+  const baseClass = clsx(
+    'group relative flex flex-col items-center rounded-lg border border-slate-200/60 bg-white/80 p-4 text-center text-sm shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-ubt-blue focus-visible:ring-offset-2 focus-visible:ring-offset-transparent dark:border-white/20 dark:bg-slate-900/40',
+    className
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className={baseClass} aria-label={title} id={`app-tile-${id}`}>
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <div className={baseClass} role="link" tabIndex={0} aria-label={title} id={`app-tile-${id}`}>
+      {content}
+    </div>
+  );
+};
+
+const DetailTile: FC<AppTileProps> = ({
+  id,
+  title,
+  icon,
+  href,
+  description,
+  offlineCapable,
+  className,
+  children,
+}) => {
+  return (
+    <section
+      aria-labelledby={`${id}-detail-title`}
+      className={clsx(
+        'relative flex flex-col gap-4 rounded-xl border border-slate-200/70 bg-white/90 p-6 text-left shadow-sm dark:border-white/15 dark:bg-slate-900/60',
+        className
+      )}
+    >
+      {offlineCapable ? <OfflineBadge variant="detail" /> : null}
+      <div className="flex items-center gap-4">
+        <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-lg bg-slate-100 dark:bg-slate-800">
+          {renderIcon(title, icon, 72)}
+        </div>
+        <div className="flex flex-col">
+          <h3 id={`${id}-detail-title`} className="text-xl font-semibold text-slate-900 dark:text-white">
+            {title}
+          </h3>
+          {href ? (
+            <Link
+              href={href}
+              className="mt-2 inline-flex w-fit items-center rounded border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ubt-blue focus-visible:ring-offset-2 dark:border-white/20 dark:text-white dark:hover:bg-white/10"
+            >
+              Launch App
+            </Link>
+          ) : null}
+        </div>
+      </div>
+      {description ? (
+        <p className="text-sm leading-6 text-slate-600 dark:text-slate-200">{description}</p>
+      ) : null}
+      {children}
+    </section>
+  );
+};
+
+const AppTile: FC<AppTileProps> = (props) => {
+  const { variant = 'grid' } = props;
+  if (variant === 'detail') {
+    return <DetailTile {...props} />;
+  }
+  return <GridTile {...props} />;
+};
+
+export default AppTile;

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -10,6 +10,7 @@ type AppMeta = {
   icon: string;
   disabled?: boolean;
   favourite?: boolean;
+  offlineCapable?: boolean;
 };
 
 const CATEGORIES = [

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -1,6 +1,5 @@
-import Image from 'next/image';
 import { useEffect, useState } from 'react';
-import Link from 'next/link';
+import AppTile from '../../components/apps/AppTile';
 
 const AppsPage = () => {
   const [apps, setApps] = useState([]);
@@ -41,24 +40,14 @@ const AppsPage = () => {
         className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
       >
         {filteredApps.map((app) => (
-          <Link
+          <AppTile
             key={app.id}
+            id={app.id}
+            title={app.title}
+            icon={app.icon}
             href={`/apps/${app.id}`}
-            className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
-            aria-label={app.title}
-          >
-            {app.icon && (
-              <Image
-                src={app.icon}
-                alt=""
-                width={64}
-                height={64}
-                sizes="64px"
-                className="h-16 w-16"
-              />
-            )}
-            <span className="mt-2">{app.title}</span>
-          </Link>
+            offlineCapable={Boolean(app.offlineCapable)}
+          />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- introduce an `AppTile` component that surfaces an "Offline Ready" badge in both grid and detail variants
- annotate `apps.config.js` with an `offlineCapable` flag (including utilities and games) and update the apps catalog page to consume it
- add targeted tests to document offline versus online rendering behaviour

## Testing
- yarn test __tests__/AppTile.test.tsx
- yarn lint *(fails: repository already contains many jsx-a11y/no-top-level-window errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d57866e88328ba7a7a1244234930