### PR TITLE
[apps] Add container query fallback for launcher grid

### DIFF
--- a/__tests__/Grid.test.tsx
+++ b/__tests__/Grid.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import Grid, {
+  resetContainerQuerySupportCache,
+  supportsContainerQueries,
+} from '../components/apps/Grid';
+
+const originalCSS = global.CSS;
+const originalContainerRule = (global as any).CSSContainerRule;
+
+describe('App grid container query detection', () => {
+  afterEach(() => {
+    resetContainerQuerySupportCache();
+    global.CSS = originalCSS;
+    (global as any).CSSContainerRule = originalContainerRule;
+  });
+
+  it('reports support when CSS container queries are available', async () => {
+    global.CSS = {
+      supports: jest.fn(() => true),
+    } as any;
+
+    const { getByTestId } = render(
+      <Grid data-testid="grid">
+        <div />
+      </Grid>,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('grid').dataset.containerQueries).toBe('supported');
+    });
+
+    expect(getByTestId('grid').className.split(' ')).not.toContain('fallback');
+    expect(supportsContainerQueries()).toBe(true);
+    expect((global.CSS as any).supports).toHaveBeenCalled();
+  });
+
+  it('falls back when CSS.supports reports no container query support', async () => {
+    global.CSS = {
+      supports: jest.fn(() => false),
+    } as any;
+
+    const { getByTestId } = render(
+      <Grid data-testid="grid">
+        <div />
+      </Grid>,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('grid').dataset.containerQueries).toBe('fallback');
+    });
+
+    expect(getByTestId('grid').className.split(' ')).toContain('fallback');
+    expect(supportsContainerQueries()).toBe(false);
+  });
+
+  it('can be forced into fallback mode even when support exists', async () => {
+    global.CSS = {
+      supports: jest.fn(() => true),
+    } as any;
+
+    const { getByTestId } = render(
+      <Grid data-testid="grid" disableContainerQueries>
+        <div />
+      </Grid>,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('grid').dataset.containerQueries).toBe('forced-fallback');
+    });
+
+    const classList = getByTestId('grid').className.split(' ');
+    expect(classList).toContain('fallback');
+  });
+});

--- a/components/apps/Grid.module.css
+++ b/components/apps/Grid.module.css
@@ -1,0 +1,94 @@
+.grid {
+  --app-grid-gap: clamp(1rem, 1.8vw, 1.75rem);
+  --app-grid-min: clamp(160px, 18vw, 208px);
+  display: grid;
+  gap: var(--app-grid-gap);
+  grid-template-columns: repeat(auto-fit, minmax(var(--app-grid-min), 1fr));
+  container-type: inline-size;
+}
+
+@container (max-width: 1200px) {
+  .grid {
+    --app-grid-min: clamp(148px, 22vw, 192px);
+  }
+}
+
+@container (max-width: 960px) {
+  .grid {
+    --app-grid-min: clamp(136px, 28vw, 184px);
+  }
+}
+
+@container (max-width: 760px) {
+  .grid {
+    --app-grid-min: clamp(124px, 36vw, 176px);
+  }
+}
+
+@container (max-width: 560px) {
+  .grid {
+    --app-grid-min: min(100%, 168px);
+  }
+}
+
+.fallback {
+  container-type: normal;
+  display: grid;
+  gap: var(--app-grid-gap);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (min-width: 480px) {
+  .fallback {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 640px) {
+  .fallback {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 768px) {
+  .fallback {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .fallback {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+}
+
+@supports not (container-type: inline-size) {
+  .grid {
+    container-type: normal;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (min-width: 480px) {
+    .grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  @media (min-width: 640px) {
+    .grid {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+
+  @media (min-width: 768px) {
+    .grid {
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .grid {
+      grid-template-columns: repeat(6, minmax(0, 1fr));
+    }
+  }
+}

--- a/components/apps/Grid.tsx
+++ b/components/apps/Grid.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { forwardRef, useEffect, useState } from "react";
+import type { HTMLAttributes } from "react";
+import styles from "./Grid.module.css";
+
+export interface GridProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Forces the grid into the breakpoint-based fallback regardless of browser
+   * support. Useful for tests and debugging.
+   */
+  disableContainerQueries?: boolean;
+}
+
+let cachedSupport: boolean | null = null;
+
+/**
+ * Feature-detects CSS Container Query support. The result is cached for the
+ * lifetime of the module to avoid recomputing DOM work on every render.
+ */
+export const supportsContainerQueries = (): boolean => {
+  if (cachedSupport !== null) {
+    return cachedSupport;
+  }
+
+  if (typeof window === "undefined") {
+    return true;
+  }
+
+  const css = window.CSS;
+  if (css && typeof css.supports === "function") {
+    if (css.supports("container-type: inline-size") || css.supports("container: inline-size")) {
+      cachedSupport = true;
+      return true;
+    }
+  }
+
+  if (typeof window.CSSContainerRule !== "undefined") {
+    cachedSupport = true;
+    return true;
+  }
+
+  cachedSupport = false;
+  return false;
+};
+
+/**
+ * Resets the cached detection value. Intended for tests only.
+ */
+export const resetContainerQuerySupportCache = () => {
+  cachedSupport = null;
+};
+
+const Grid = forwardRef<HTMLDivElement, GridProps>(function Grid(
+  { disableContainerQueries = false, className, children, ...rest },
+  ref,
+) {
+  const [hasSupport, setHasSupport] = useState<boolean | null>(() =>
+    disableContainerQueries ? false : null,
+  );
+
+  useEffect(() => {
+    if (disableContainerQueries) {
+      setHasSupport(false);
+      return;
+    }
+
+    const next = supportsContainerQueries();
+    setHasSupport((prev) => (prev === next ? prev : next));
+  }, [disableContainerQueries]);
+
+  const fallbackActive = disableContainerQueries || hasSupport === false;
+  const status = disableContainerQueries
+    ? "forced-fallback"
+    : hasSupport === null
+    ? "unknown"
+    : hasSupport
+    ? "supported"
+    : "fallback";
+
+  const mergedClassName = [
+    styles.grid,
+    fallbackActive ? styles.fallback : null,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      ref={ref}
+      className={mergedClassName}
+      data-container-queries={status}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+});
+
+Grid.displayName = "AppGrid";
+
+export default Grid;

--- a/docs/internal-layouts.md
+++ b/docs/internal-layouts.md
@@ -20,3 +20,34 @@ Offsets are also available through `offset-*` classes.
   <div class="col-4 offset-4">Centered</div>
 </div>
 ```
+
+## App grid container query fallback
+
+The desktop launcher grid (`components/apps/Grid.tsx`) now relies on CSS container
+queries so each window can size its tiles relative to its own width. We detect
+support in two places:
+
+- CSS uses `@supports (container-type: inline-size)` to keep the container-based
+  layout when available and swap to breakpoint-driven rules when the feature is
+  missing.
+- JavaScript calls `CSS.supports('container-type: inline-size')` (with a few
+  additional heuristics) and annotates the DOM with
+  `data-container-queries="supported|fallback"`. That flag lets tests and debug
+  tooling confirm which path is active and exposes a `disableContainerQueries`
+  escape hatch for forcing the fallback.
+
+When queries are unavailable (older Safari/WebKit builds, Chromium before v105),
+we fall back to the viewport breakpoints defined alongside the primary styles in
+`Grid.module.css`. This preserves the previous behavior while keeping all layout
+rules colocated with the component.
+
+### Limitations
+
+- The fallback grid is viewport-based, so it will not respond to arbitrarily
+  narrow window resizes until the next breakpoint is crossed.
+- JavaScript detection runs after hydration. Browsers without JS still benefit
+  from the CSS `@supports` path, but there can be a brief flash of the container
+  layout before the fallback rules apply.
+- Very old engines without `CSS.supports` skip the JS hint and rely entirely on
+  the CSS branch, which mirrors Safari 15 and earlier behavior that we test via
+  mocks.


### PR DESCRIPTION
## Summary
- add an App Grid wrapper that detects CSS container query support and exposes a runtime fallback flag
- co-locate container-query and breakpoint rules in Grid.module.css for the fallback path
- document the detection strategy/limitations and cover it with new Jest tests

## Testing
- yarn lint *(fails: repository already has numerous accessibility lint violations unrelated to this change)*
- yarn test --runTestsByPath __tests__/Grid.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68c9d57f61a483289c2d6d147e9c3b9b