### PR TITLE
[config] Redirect legacy project slugs

### DIFF
--- a/apps/kismet/components/DeauthWalkthrough.tsx
+++ b/apps/kismet/components/DeauthWalkthrough.tsx
@@ -54,7 +54,7 @@ const DeauthWalkthrough: React.FC = () => {
       <p className="mt-2">
         For defensive guidance, review the{' '}
         <a
-          href="/docs/deauth-mitigation.md"
+          href="/docs/deauth-mitigation"
           className="text-blue-400 underline"
         >
           mitigation notes

--- a/next.config.js
+++ b/next.config.js
@@ -61,6 +61,24 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
 
+const legacyProjectRedirects = {
+  'pip-portal': 'pip-portal',
+  'internal-layouts': 'internal-layouts',
+  'deauth-mitigation': 'deauth-mitigation',
+  'nmap-nse-walkthrough': 'nmap-nse-walkthrough',
+  reconng: 'reconng',
+  'phaser-listeners': 'phaser-listeners',
+  'bare-fs-dependency': 'bare-fs-dependency',
+  'template-glossary': 'template-glossary',
+  'tasks-ui-polish': 'tasks-ui-polish',
+  'tasks_ui_polish': 'tasks-ui-polish',
+  'keyboard-only-test-plan': 'keyboard-only-test-plan',
+  tasks: 'tasks',
+  'new-app-checklist': 'new-app-checklist',
+  'getting-started': 'getting-started',
+  architecture: 'architecture',
+};
+
 const withPWA = require('@ducanh2912/next-pwa').default({
   dest: 'public',
   sw: 'sw.js',
@@ -124,6 +142,13 @@ module.exports = withBundleAnalyzer(
   withPWA({
     ...(isStaticExport && { output: 'export' }),
     webpack: configureWebpack,
+    async redirects() {
+      return Object.entries(legacyProjectRedirects).map(([legacySlug, newSlug]) => ({
+        source: `/projects/${legacySlug}`,
+        destination: `/docs/${newSlug}`,
+        statusCode: 301,
+      }));
+    },
 
     // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI
     eslint: {


### PR DESCRIPTION
## Summary
- add a legacy-to-new project slug redirect table in `next.config.js` so `/projects/*` URLs issue 301s to the MDX doc routes
- update the Kismet deauth walkthrough link to target the new mitigation doc slug

## Testing
- yarn lint *(fails: repository already has numerous `jsx-a11y/control-has-associated-label` and `no-top-level-window` violations)*
- yarn test *(fails: existing recon-ng/localStorage setup errors and related suite failures; run interrupted after failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d5833b1883289e0bd9b795a9223c