### PR TITLE
[icons] standardize svg icon library

### DIFF
--- a/components/ToolbarIcons.tsx
+++ b/components/ToolbarIcons.tsx
@@ -1,56 +1,28 @@
-import Image from 'next/image';
+import { forwardRef } from 'react';
+import type { ForwardRefExoticComponent, RefAttributes } from 'react';
+import type { IconProps, IconSize } from './icons';
+import {
+  CloseIcon as CloseGlyph,
+  MaximizeIcon as MaximizeGlyph,
+  MinimizeIcon as MinimizeGlyph,
+  PinIcon as PinGlyph,
+  RestoreIcon as RestoreGlyph,
+} from './icons';
 
-export function CloseIcon() {
-  return (
-    <Image
-      src="/themes/Yaru/window/window-close-symbolic.svg"
-      alt="Close"
-      width={16}
-      height={16}
-    />
-  );
-}
+const DEFAULT_SIZE: IconSize = 16;
 
-export function MinimizeIcon() {
-  return (
-    <Image
-      src="/themes/Yaru/window/window-minimize-symbolic.svg"
-      alt="Minimize"
-      width={16}
-      height={16}
-    />
-  );
-}
+type GlyphComponent = ForwardRefExoticComponent<IconProps & RefAttributes<SVGSVGElement>>;
 
-export function MaximizeIcon() {
-  return (
-    <Image
-      src="/themes/Yaru/window/window-maximize-symbolic.svg"
-      alt="Maximize"
-      width={16}
-      height={16}
-    />
-  );
-}
+const withDefaultSize = (Component: GlyphComponent, displayName: string) => {
+  const Wrapped = forwardRef<SVGSVGElement, IconProps>(({ size, ...rest }, ref) => (
+    <Component ref={ref} size={size ?? DEFAULT_SIZE} {...rest} />
+  ));
+  Wrapped.displayName = displayName;
+  return Wrapped;
+};
 
-export function RestoreIcon() {
-  return (
-    <Image
-      src="/themes/Yaru/window/window-restore-symbolic.svg"
-      alt="Restore"
-      width={16}
-      height={16}
-    />
-  );
-}
-
-export function PinIcon() {
-  return (
-    <Image
-      src="/themes/Yaru/window/window-pin-symbolic.svg"
-      alt="Pin"
-      width={16}
-      height={16}
-    />
-  );
-}
+export const CloseIcon = withDefaultSize(CloseGlyph, 'CloseIcon');
+export const MinimizeIcon = withDefaultSize(MinimizeGlyph, 'MinimizeIcon');
+export const MaximizeIcon = withDefaultSize(MaximizeGlyph, 'MaximizeIcon');
+export const RestoreIcon = withDefaultSize(RestoreGlyph, 'RestoreIcon');
+export const PinIcon = withDefaultSize(PinGlyph, 'PinIcon');

--- a/components/icons/IconBase.tsx
+++ b/components/icons/IconBase.tsx
@@ -1,0 +1,58 @@
+import { forwardRef } from 'react';
+import type { ReactNode, SVGProps } from 'react';
+
+const ICON_SIZE_VALUES = [16, 20, 24] as const;
+export type IconSize = (typeof ICON_SIZE_VALUES)[number];
+export const ICON_SIZES: readonly IconSize[] = ICON_SIZE_VALUES;
+
+const isIconSize = (value: number): value is IconSize =>
+  ICON_SIZE_VALUES.some((allowed) => allowed === value);
+
+const normalizeIconSize = (size?: IconSize | number): IconSize => {
+  if (typeof size === 'number' && isIconSize(size)) {
+    return size;
+  }
+
+  return 20;
+};
+
+export interface IconProps extends Omit<SVGProps<SVGSVGElement>, 'width' | 'height'> {
+  size?: IconSize;
+  title?: string;
+}
+
+export interface IconBaseProps extends IconProps {
+  children: ReactNode;
+}
+
+export const IconBase = forwardRef<SVGSVGElement, IconBaseProps>(
+  ({ size, title, children, className, role, ...rest }, ref) => {
+    const dimension = normalizeIconSize(size);
+    const computedRole = role ?? (title ? 'img' : 'presentation');
+
+    return (
+      <svg
+        ref={ref}
+        width={dimension}
+        height={dimension}
+        viewBox="0 0 24 24"
+        className={className}
+        aria-hidden={title ? undefined : true}
+        focusable="false"
+        role={computedRole}
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+        shapeRendering="geometricPrecision"
+        {...rest}
+      >
+        {title ? <title>{title}</title> : null}
+        {children}
+      </svg>
+    );
+  }
+);
+
+IconBase.displayName = 'IconBase';

--- a/components/icons/SystemStatus.tsx
+++ b/components/icons/SystemStatus.tsx
@@ -1,0 +1,46 @@
+import { forwardRef } from 'react';
+import { IconBase } from './IconBase';
+import type { IconProps } from './IconBase';
+
+const stroke = { vectorEffect: 'non-scaling-stroke' } as const;
+
+export const WifiIcon = forwardRef<SVGSVGElement, IconProps>((props, ref) => (
+  <IconBase ref={ref} {...props}>
+    <path d="M4.5 10.5a11 11 0 0 1 15 0" {...stroke} />
+    <path d="M7.5 13.5a6.5 6.5 0 0 1 9 0" {...stroke} />
+    <path d="M10.5 16.5a2.75 2.75 0 0 1 3 0" {...stroke} />
+    <circle cx="12" cy="19" r="1" fill="currentColor" stroke="none" />
+  </IconBase>
+));
+WifiIcon.displayName = 'WifiIcon';
+
+export const WifiOffIcon = forwardRef<SVGSVGElement, IconProps>((props, ref) => (
+  <IconBase ref={ref} {...props}>
+    <path d="M5.25 11.25a11 11 0 0 1 12-2.25" {...stroke} />
+    <path d="M8.25 14.25a6.5 6.5 0 0 1 7-1.5" {...stroke} />
+    <path d="M11.25 17.25a2.5 2.5 0 0 1 1.5.5" {...stroke} />
+    <circle cx="12" cy="19" r="1" fill="currentColor" stroke="none" />
+    <path d="M6 6L18 18" {...stroke} />
+  </IconBase>
+));
+WifiOffIcon.displayName = 'WifiOffIcon';
+
+export const VolumeIcon = forwardRef<SVGSVGElement, IconProps>((props, ref) => (
+  <IconBase ref={ref} {...props}>
+    <path d="M6.75 10.25H9l4-3.25v10l-4-3.25H6.75Z" {...stroke} />
+    <path d="M15.75 9.75a3 3 0 0 1 0 4.5" {...stroke} />
+    <path d="M17.5 8.25a5 5 0 0 1 0 7.5" {...stroke} />
+  </IconBase>
+));
+VolumeIcon.displayName = 'VolumeIcon';
+
+export const BatteryIcon = forwardRef<SVGSVGElement, IconProps>((props, ref) => (
+  <IconBase ref={ref} {...props}>
+    <rect x="5" y="9" width="11.5" height="6" rx="1.5" {...stroke} />
+    <path d="M16.5 11.5h2" {...stroke} />
+    <path d="M8 11.5v2" {...stroke} />
+    <path d="M10.75 11.5v2" {...stroke} />
+    <path d="M13.5 11.5v2" {...stroke} />
+  </IconBase>
+));
+BatteryIcon.displayName = 'BatteryIcon';

--- a/components/icons/WindowControls.tsx
+++ b/components/icons/WindowControls.tsx
@@ -1,0 +1,44 @@
+import { forwardRef } from 'react';
+import { IconBase } from './IconBase';
+import type { IconProps } from './IconBase';
+
+const stroke = { vectorEffect: 'non-scaling-stroke' } as const;
+
+export const CloseIcon = forwardRef<SVGSVGElement, IconProps>((props, ref) => (
+  <IconBase ref={ref} {...props}>
+    <path d="M7 7L17 17" {...stroke} />
+    <path d="M17 7L7 17" {...stroke} />
+  </IconBase>
+));
+CloseIcon.displayName = 'CloseIcon';
+
+export const MinimizeIcon = forwardRef<SVGSVGElement, IconProps>((props, ref) => (
+  <IconBase ref={ref} {...props}>
+    <path d="M6 15H18" {...stroke} />
+  </IconBase>
+));
+MinimizeIcon.displayName = 'MinimizeIcon';
+
+export const MaximizeIcon = forwardRef<SVGSVGElement, IconProps>((props, ref) => (
+  <IconBase ref={ref} {...props}>
+    <rect x="6.75" y="6.75" width="10.5" height="10.5" rx="1.5" {...stroke} />
+  </IconBase>
+));
+MaximizeIcon.displayName = 'MaximizeIcon';
+
+export const RestoreIcon = forwardRef<SVGSVGElement, IconProps>((props, ref) => (
+  <IconBase ref={ref} {...props}>
+    <rect x="8" y="9" width="9" height="9" rx="1.5" {...stroke} />
+    <path d="M7 13V8.5A1.5 1.5 0 0 1 8.5 7H13" {...stroke} />
+    <path d="M11 7H15.5A1.5 1.5 0 0 1 17 8.5V13" {...stroke} />
+  </IconBase>
+));
+RestoreIcon.displayName = 'RestoreIcon';
+
+export const PinIcon = forwardRef<SVGSVGElement, IconProps>((props, ref) => (
+  <IconBase ref={ref} {...props}>
+    <path d="M12 20.5Q7.5 15.5 7.5 12a4.5 4.5 0 1 1 9 0q0 3.5-4.5 8.5Z" {...stroke} />
+    <circle cx="12" cy="11.5" r="1.75" {...stroke} />
+  </IconBase>
+));
+PinIcon.displayName = 'PinIcon';

--- a/components/icons/index.ts
+++ b/components/icons/index.ts
@@ -1,0 +1,10 @@
+export { IconBase, ICON_SIZES } from './IconBase';
+export type { IconBaseProps, IconProps, IconSize } from './IconBase';
+export {
+  CloseIcon,
+  MaximizeIcon,
+  MinimizeIcon,
+  PinIcon,
+  RestoreIcon,
+} from './WindowControls';
+export { BatteryIcon, VolumeIcon, WifiIcon, WifiOffIcon } from './SystemStatus';

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
-import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import { WifiIcon } from '../icons';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -17,7 +17,7 @@ export default class Navbar extends Component {
 		return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
+                                        <WifiIcon size={16} className="w-4 h-4" title="Network status" />
                                 </div>
                                 <WhiskerMenu />
                                 <div

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,9 +1,7 @@
 import React, { useEffect, useState } from "react";
-import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
-
-const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
+import { BatteryIcon, VolumeIcon, WifiIcon, WifiOffIcon } from '../icons';
 
 export default function Status() {
   const { allowNetwork } = useSettings();
@@ -38,43 +36,30 @@ export default function Status() {
     };
   }, []);
 
+  const NetworkGlyph = online ? WifiIcon : WifiOffIcon;
+  const networkTitle = online
+    ? allowNetwork
+      ? 'Online'
+      : 'Online (requests blocked)'
+    : 'Offline';
+
   return (
     <div className="flex justify-center items-center">
-      <span
-        className="mx-1.5 relative"
-        title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}
-      >
-        <Image
-          width={16}
-          height={16}
-          src={online ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"}
-          alt={online ? "online" : "offline"}
+      <span className="mx-1.5 relative" title={networkTitle}>
+        <NetworkGlyph
+          size={16}
           className="inline status-symbol w-4 h-4"
-          sizes="16px"
+          title={networkTitle}
         />
         {!allowNetwork && (
           <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
         )}
       </span>
       <span className="mx-1.5">
-        <Image
-          width={16}
-          height={16}
-          src={VOLUME_ICON}
-          alt="volume"
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
+        <VolumeIcon size={16} className="inline status-symbol w-4 h-4" title="Volume" />
       </span>
       <span className="mx-1.5">
-        <Image
-          width={16}
-          height={16}
-          src="/themes/Yaru/status/battery-good-symbolic.svg"
-          alt="ubuntu battry"
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
+        <BatteryIcon size={16} className="inline status-symbol w-4 h-4" title="Battery" />
       </span>
       <span className="mx-1">
         <SmallArrow angle="down" className=" status-symbol" />

--- a/docs/icon-guidelines.md
+++ b/docs/icon-guidelines.md
@@ -1,0 +1,63 @@
+# Icon guidelines
+
+This project now centralizes reusable SVG glyphs under [`components/icons`](../components/icons).
+The goal is to keep small UI icons crisp on both standard and high-density displays while
+sharing a consistent stroke style.
+
+## Standard sizes
+
+All icons are authored on a 24×24 viewBox and exposed through React components that accept a
+`size` prop limited to **16**, **20**, or **24** pixels.
+
+- **16 px** — compact UI like window controls or status pills.
+- **20 px** — default size for buttons and navigation.
+- **24 px** — large touch targets or spotlight tiles.
+
+Requests outside of these values are normalized to the 24 px grid to avoid blurry scaling.
+The exported `ICON_SIZES` constant lists the supported dimensions for design and QA checklists.
+
+## Implementation details
+
+- Use the `IconBase` helper to inherit the 24×24 viewBox, stroke styles, and accessibility
+  defaults.
+- Keep strokes at `1.5` units and align path coordinates to the grid. Combine with
+  `vectorEffect="non-scaling-stroke"` so thickness stays predictable on 1× and 2× DPR displays.
+- Favor `strokeLinecap="round"` and `strokeLinejoin="round"` for a consistent look with the rest
+  of the UI.
+- Include a `title` attribute when the icon needs to be announced by assistive tech; otherwise it
+  renders as decorative art.
+
+Example component pattern:
+
+```tsx
+import { forwardRef } from 'react';
+import { IconBase } from '../components/icons';
+import type { IconProps } from '../components/icons';
+
+export const ExampleIcon = forwardRef<SVGSVGElement, IconProps>((props, ref) => (
+  <IconBase ref={ref} {...props}>
+    <path d="M6 12h12" vectorEffect="non-scaling-stroke" />
+    <path d="M12 6v12" vectorEffect="non-scaling-stroke" />
+  </IconBase>
+));
+```
+
+## Usage
+
+Icons can be imported from `components/icons` or from wrappers such as `components/ToolbarIcons`
+when a default size is needed:
+
+```tsx
+import { CloseIcon, ICON_SIZES } from '../components/icons';
+
+export function ToolbarButton() {
+  return (
+    <button type="button" aria-label="Close window">
+      <CloseIcon size={ICON_SIZES[0]} />
+    </button>
+  );
+}
+```
+
+Refer to `components/util-components/status.js` and `components/screen/navbar.js` for inline usage
+examples that swap icons based on runtime state.


### PR DESCRIPTION
## Summary
- add a shared IconBase plus window control and system status glyphs sized for 16/20/24 px usage
- swap toolbar, status panel, and navbar to consume the new React icons with accessibility titles
- document icon sizing expectations and usage examples for contributors

## Testing
- yarn lint *(fails: repository already has numerous jsx-a11y violations outside this change)*
- yarn test *(fails: existing suites require browser APIs/localStorage setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d5883bd08328bdb1c377fef3882d