### PR TITLE
[system] Persist tour completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,17 @@ Dynamic app modules include a `webpackPrefetch` hint and expose a `prefetch()` h
 keyboard focus so bundles are warmed before launch. When adding a new app, export a default component and register it with
 `createDynamicApp` to opt into this behaviour.
 
+### Desktop tour persistence
+
+The onboarding tour that introduces the desktop chrome lives in
+`components/system/Tour.tsx`. It stores a `system-tour-complete`
+flag in `localStorage` and guards every read/write so repeated calls are
+idempotent and safe even when storage APIs throw. The paired
+`components/system/HelpOverlay.tsx` surfaces a **Reset tour** button that
+clears the stored flag and automatically disables itself when storage is
+unavailable (e.g., strict privacy modes). Additional UI can reuse the
+`createTourPersistence()` helper to inspect or reset the persisted state.
+
 ---
 
 ## Environment Variables

--- a/__tests__/system/TourPersistence.test.ts
+++ b/__tests__/system/TourPersistence.test.ts
@@ -1,0 +1,112 @@
+import {
+  clearTourCompletion,
+  createTourPersistence,
+  persistTourCompletion,
+  readTourCompletion,
+} from "../../components/system/Tour";
+
+describe("createTourPersistence", () => {
+  const createMockStorage = () => {
+    const store: Record<string, string> = {};
+
+    return {
+      getItem: jest.fn((key: string) => (key in store ? store[key] : null)),
+      setItem: jest.fn((key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: jest.fn((key: string) => {
+        delete store[key];
+      }),
+    };
+  };
+
+  it("reads as incomplete when no state has been stored", () => {
+    const storage = createMockStorage();
+    const persistence = createTourPersistence("test-tour", storage);
+
+    expect(persistence.available).toBe(true);
+    expect(persistence.read()).toBe(false);
+    expect(storage.getItem).toHaveBeenCalledWith("test-tour");
+  });
+
+  it("persists completion and avoids duplicate writes", () => {
+    const storage = createMockStorage();
+    const persistence = createTourPersistence("tour", storage);
+
+    persistence.write(true);
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+    expect(storage.setItem).toHaveBeenLastCalledWith("tour", "1");
+    expect(persistence.read()).toBe(true);
+
+    persistence.write(true);
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes the stored value when asked to clear", () => {
+    const storage = createMockStorage();
+    const persistence = createTourPersistence("tour", storage);
+
+    persistence.write(true);
+    persistence.clear();
+
+    expect(storage.removeItem).toHaveBeenCalledWith("tour");
+    expect(persistence.read()).toBe(false);
+  });
+
+  it("is safe to call when storage is unavailable", () => {
+    const persistence = createTourPersistence("tour", null);
+
+    expect(persistence.available).toBe(false);
+    expect(persistence.read()).toBe(false);
+    expect(() => persistence.write(true)).not.toThrow();
+    expect(() => persistence.write(false)).not.toThrow();
+    expect(() => persistence.clear()).not.toThrow();
+  });
+
+  it("handles underlying storage errors gracefully", () => {
+    const storage = {
+      getItem: jest.fn(() => {
+        throw new Error("blocked");
+      }),
+      setItem: jest.fn(() => {
+        throw new Error("blocked");
+      }),
+      removeItem: jest.fn(() => {
+        throw new Error("blocked");
+      }),
+    };
+
+    const persistence = createTourPersistence("tour", storage);
+
+    expect(persistence.read()).toBe(false);
+    expect(() => persistence.write(true)).not.toThrow();
+    expect(() => persistence.write(false)).not.toThrow();
+    expect(() => persistence.clear()).not.toThrow();
+  });
+});
+
+describe("default tour persistence helpers", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    clearTourCompletion();
+  });
+
+  it("integrates with the browser localStorage", () => {
+    expect(readTourCompletion()).toBe(false);
+    persistTourCompletion(true);
+    expect(readTourCompletion()).toBe(true);
+    clearTourCompletion();
+    expect(readTourCompletion()).toBe(false);
+  });
+
+  it("avoids duplicate writes to localStorage", () => {
+    const spy = jest.spyOn(Storage.prototype, "setItem");
+
+    persistTourCompletion(true);
+    persistTourCompletion(true);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    spy.mockRestore();
+  });
+});

--- a/components/system/HelpOverlay.tsx
+++ b/components/system/HelpOverlay.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import type { FC } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+
+import {
+  TOUR_STORAGE_KEY,
+  createTourPersistence,
+} from "./Tour";
+
+interface HelpOverlayProps {
+  onClose: () => void;
+  onResetTour?: () => void;
+  storageKey?: string;
+}
+
+const HelpOverlay: FC<HelpOverlayProps> = ({
+  onClose,
+  onResetTour,
+  storageKey = TOUR_STORAGE_KEY,
+}) => {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const persistence = useMemo(
+    () => createTourPersistence(storageKey),
+    [storageKey],
+  );
+
+  useEffect(() => {
+    const node = overlayRef.current;
+    if (!node) return;
+
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+
+    const selectors =
+      'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])';
+    const focusables = Array.from(
+      node.querySelectorAll<HTMLElement>(selectors),
+    );
+    focusables[0]?.focus();
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab" || focusables.length === 0) return;
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    node.addEventListener("keydown", handleKey);
+
+    return () => {
+      node.removeEventListener("keydown", handleKey);
+      previousFocusRef.current?.focus();
+    };
+  }, [onClose]);
+
+  const handleReset = useCallback(() => {
+    persistence.clear();
+    onResetTour?.();
+  }, [persistence, onResetTour]);
+
+  return (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 bg-black bg-opacity-70 text-white flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="system-help-title"
+    >
+      <div className="max-w-lg w-full mx-4 bg-gray-900 rounded-lg shadow-lg border border-gray-700 p-6">
+        <h2 className="text-2xl font-semibold mb-4" id="system-help-title">
+          Desktop Help
+        </h2>
+        <p className="mb-3 text-gray-200">
+          The desktop tour introduces the dock, global shortcuts, and window
+          controls. Once you finish the walkthrough it stays hidden so it never
+          blocks returning visitors.
+        </p>
+        <p className="mb-6 text-sm text-gray-400">
+          Completion is stored in your browser using localStorage. If you want
+          to see the guided experience again or clear a shared machine, use the
+          reset button below.
+        </p>
+        <div className="flex flex-wrap justify-end gap-3">
+          <button
+            type="button"
+            className="px-3 py-2 rounded bg-gray-800 hover:bg-gray-700 focus:outline-none focus:ring focus:ring-blue-500 focus:ring-opacity-50"
+            onClick={handleReset}
+            disabled={!persistence.available}
+          >
+            Reset tour
+          </button>
+          <button
+            type="button"
+            className="px-3 py-2 rounded bg-blue-600 hover:bg-blue-500 focus:outline-none focus:ring focus:ring-blue-500 focus:ring-opacity-50"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+        {!persistence.available && (
+          <p className="mt-4 text-xs text-red-200" role="status">
+            Reset is unavailable because localStorage could not be accessed in
+            this environment.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default HelpOverlay;

--- a/components/system/Tour.tsx
+++ b/components/system/Tour.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import TourComponent, { type TourProps as BaseTourProps } from "@rc-component/tour";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { FC } from "react";
+
+export const TOUR_STORAGE_KEY = "system-tour-complete";
+const COMPLETED_FLAG = "1";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+const getDefaultStorage = (): StorageLike | undefined => {
+  if (typeof window === "undefined") return undefined;
+  try {
+    return window.localStorage;
+  } catch {
+    return undefined;
+  }
+};
+
+export const createTourPersistence = (
+  key: string = TOUR_STORAGE_KEY,
+  storage: StorageLike | null | undefined = getDefaultStorage(),
+) => {
+  const safeStorage = storage ?? undefined;
+  const available = Boolean(safeStorage);
+
+  const read = (): boolean => {
+    if (!safeStorage) return false;
+    try {
+      return safeStorage.getItem(key) === COMPLETED_FLAG;
+    } catch {
+      return false;
+    }
+  };
+
+  const write = (completed: boolean): void => {
+    if (!safeStorage) return;
+    try {
+      if (completed) {
+        if (safeStorage.getItem(key) !== COMPLETED_FLAG) {
+          safeStorage.setItem(key, COMPLETED_FLAG);
+        }
+      } else if (safeStorage.getItem(key) !== null) {
+        safeStorage.removeItem(key);
+      }
+    } catch {
+      /* swallow storage errors */
+    }
+  };
+
+  const clear = (): void => {
+    if (!safeStorage) return;
+    try {
+      if (safeStorage.getItem(key) !== null) {
+        safeStorage.removeItem(key);
+      }
+    } catch {
+      /* swallow storage errors */
+    }
+  };
+
+  return { read, write, clear, available };
+};
+
+const defaultPersistence = createTourPersistence();
+
+export const readTourCompletion = (): boolean => defaultPersistence.read();
+export const persistTourCompletion = (completed: boolean): void => {
+  defaultPersistence.write(completed);
+};
+export const clearTourCompletion = (): void => {
+  defaultPersistence.clear();
+};
+export const isTourPersistenceAvailable = (): boolean =>
+  defaultPersistence.available;
+
+export interface SystemTourProps extends BaseTourProps {
+  storageKey?: string;
+  persistCompletion?: boolean;
+}
+
+const SystemTour: FC<SystemTourProps> = ({
+  storageKey = TOUR_STORAGE_KEY,
+  open,
+  onClose,
+  onFinish,
+  persistCompletion = true,
+  ...rest
+}) => {
+  const persistence = useMemo(
+    () => createTourPersistence(storageKey),
+    [storageKey],
+  );
+
+  const isControlled = typeof open === "boolean";
+  const [internalOpen, setInternalOpen] = useState<boolean>(() => {
+    if (isControlled) {
+      return open as boolean;
+    }
+    return !persistence.read();
+  });
+
+  useEffect(() => {
+    if (typeof open === "boolean") {
+      setInternalOpen(open);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (typeof open !== "boolean") {
+      setInternalOpen(!persistence.read());
+    }
+  }, [open, persistence]);
+
+  const markCompleted = useCallback(() => {
+    if (persistCompletion) {
+      persistence.write(true);
+    }
+  }, [persistCompletion, persistence]);
+
+  const handleFinish = useCallback(() => {
+    markCompleted();
+    setInternalOpen(false);
+    onFinish?.();
+  }, [markCompleted, onFinish]);
+
+  const handleClose = useCallback(
+    (current: number) => {
+      setInternalOpen(false);
+      onClose?.(current);
+    },
+    [onClose],
+  );
+
+  return (
+    <TourComponent
+      {...rest}
+      open={internalOpen}
+      onClose={handleClose}
+      onFinish={handleFinish}
+    />
+  );
+};
+
+export default SystemTour;


### PR DESCRIPTION
## Summary
- persist the desktop tour completion flag in localStorage with guarded read/write helpers
- add a reset control to the system help overlay that clears the stored flag and disables itself when storage is unavailable
- document the behaviour and add unit tests for the persistence helpers

## Testing
- yarn lint *(fails: repository has pre-existing accessibility and window globals lint errors)*
- yarn test --runTestsByPath __tests__/system/TourPersistence.test.ts
- yarn test *(fails: multiple legacy suites rely on browser-only behaviours and require additional wrapping)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d589520c83289fc9f9825bd808e8