### PR TITLE
[security] Gate kiosk routes behind middleware guard

### DIFF
--- a/lib/kiosk.ts
+++ b/lib/kiosk.ts
@@ -1,0 +1,46 @@
+export const kioskSessionCookieName = 'kiosk-session';
+
+export const kioskAllowedRoutes = [
+  { path: '/', label: 'Return to desktop' },
+  { path: '/apps', label: 'Open app grid' },
+  { path: '/profile', label: 'View profile timeline' },
+  { path: '/daily-quote', label: 'Daily quote' },
+  { path: '/video-gallery', label: 'Video gallery' },
+  { path: '/kiosk-blocked', label: 'Kiosk notice' },
+] as const;
+
+export const kioskAllowedApps = [
+  { slug: 'project-gallery', title: 'Project Gallery' },
+  { slug: 'weather', title: 'Weather Center' },
+  { slug: 'weather_widget', title: 'Weather Widget' },
+  { slug: 'quote', title: 'Quote of the Day' },
+  { slug: 'contact', title: 'Contact' },
+] as const;
+
+const kioskRouteAllowSet = new Set(kioskAllowedRoutes.map((route) => route.path));
+const kioskAllowedAppSlugs = new Set(kioskAllowedApps.map((app) => app.slug));
+
+export function normalizePathname(pathname: string): string {
+  if (!pathname || pathname === '/') {
+    return '/';
+  }
+  const normalized = pathname.replace(/\/+$/, '');
+  return normalized === '' ? '/' : normalized;
+}
+
+export function isKioskRouteAllowed(pathname: string): boolean {
+  const normalized = normalizePathname(pathname);
+  if (kioskRouteAllowSet.has(normalized)) {
+    return true;
+  }
+  if (normalized.startsWith('/apps/')) {
+    const slug = normalized.slice('/apps/'.length);
+    return kioskAllowedAppSlugs.has(slug);
+  }
+  return false;
+}
+
+export function kioskAppLabel(slug: string): string | null {
+  const match = kioskAllowedApps.find((app) => app.slug === slug);
+  return match ? match.title : null;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,13 @@
 import { NextResponse, type NextRequest } from 'next/server';
+import { createLogger } from './lib/logger';
+import {
+  kioskAppLabel,
+  kioskSessionCookieName,
+  isKioskRouteAllowed,
+  normalizePathname,
+} from './lib/kiosk';
+
+const KIOSK_SESSION_HEADER = 'x-kiosk-session';
 
 function nonce() {
   const arr = new Uint8Array(16);
@@ -6,9 +15,8 @@ function nonce() {
   return Buffer.from(arr).toString('base64');
 }
 
-export function middleware(req: NextRequest) {
-  const n = nonce();
-  const csp = [
+function buildCsp(n: string) {
+  return [
     "default-src 'self'",
     "img-src 'self' https: data:",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
@@ -19,11 +27,108 @@ export function middleware(req: NextRequest) {
     "frame-ancestors 'self'",
     "object-src 'none'",
     "base-uri 'self'",
-    "form-action 'self'"
+    "form-action 'self'",
   ].join('; ');
+}
+
+function applySecurityHeaders(res: NextResponse, n: string) {
+  res.headers.set('x-csp-nonce', n);
+  res.headers.set('Content-Security-Policy', buildCsp(n));
+}
+
+function parseToggle(value: string | null | undefined): boolean | null {
+  if (!value) {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on', 'active', 'enabled'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'off', 'inactive', 'disabled'].includes(normalized)) {
+    return false;
+  }
+  return null;
+}
+
+function isHtmlNavigation(req: NextRequest): boolean {
+  const accept = req.headers.get('accept');
+  return typeof accept === 'string' && accept.includes('text/html');
+}
+
+function commitKioskCookie(res: NextResponse, isKiosk: boolean, req: NextRequest) {
+  if (isKiosk) {
+    res.cookies.set(kioskSessionCookieName, '1', {
+      path: '/',
+      sameSite: 'lax',
+      maxAge: 60 * 60 * 12,
+      secure: req.nextUrl.protocol === 'https:',
+    });
+  } else {
+    res.cookies.delete(kioskSessionCookieName);
+  }
+}
+
+function attemptedAppSlug(pathname: string): string | null {
+  const normalized = normalizePathname(pathname);
+  if (!normalized.startsWith('/apps/')) {
+    return null;
+  }
+  return normalized.slice('/apps/'.length);
+}
+
+export function middleware(req: NextRequest) {
+  const nonceValue = nonce();
+  const url = req.nextUrl.clone();
+
+  const queryToggle = parseToggle(url.searchParams.get('kiosk'));
+  if (queryToggle !== null) {
+    url.searchParams.delete('kiosk');
+    const redirect = NextResponse.redirect(url);
+    commitKioskCookie(redirect, queryToggle, req);
+    redirect.headers.set('x-kiosk-mode', queryToggle ? 'active' : 'inactive');
+    applySecurityHeaders(redirect, nonceValue);
+    return redirect;
+  }
+
+  const headerSignal = parseToggle(req.headers.get(KIOSK_SESSION_HEADER));
+  const cookieSignal = parseToggle(req.cookies.get(kioskSessionCookieName)?.value);
+  const isKioskSession = headerSignal ?? cookieSignal ?? false;
+
+  const normalizedPath = normalizePathname(req.nextUrl.pathname);
+  if (isKioskSession && isHtmlNavigation(req) && !isKioskRouteAllowed(normalizedPath)) {
+    const blockedUrl = req.nextUrl.clone();
+    blockedUrl.pathname = '/kiosk-blocked';
+    blockedUrl.search = '';
+    const originalPathWithQuery = `${req.nextUrl.pathname}${req.nextUrl.search}`;
+    if (originalPathWithQuery) {
+      blockedUrl.searchParams.set('from', originalPathWithQuery);
+    }
+    const appSlug = attemptedAppSlug(req.nextUrl.pathname);
+    if (appSlug) {
+      blockedUrl.searchParams.set('app', appSlug);
+    }
+
+    const response = NextResponse.rewrite(blockedUrl);
+    commitKioskCookie(response, true, req);
+    response.headers.set('x-kiosk-mode', 'active');
+    response.headers.set('Cache-Control', 'no-store');
+    applySecurityHeaders(response, nonceValue);
+
+    const logger = createLogger();
+    const label = appSlug ? kioskAppLabel(appSlug) ?? appSlug : normalizedPath;
+    logger.warn('Blocked kiosk navigation', {
+      attempted: label,
+      path: normalizedPath,
+      ip: req.ip ?? req.headers.get('x-forwarded-for') ?? 'unknown',
+      referer: req.headers.get('referer') ?? undefined,
+    });
+
+    return response;
+  }
 
   const res = NextResponse.next();
-  res.headers.set('x-csp-nonce', n);
-  res.headers.set('Content-Security-Policy', csp);
+  commitKioskCookie(res, isKioskSession, req);
+  res.headers.set('x-kiosk-mode', isKioskSession ? 'active' : 'inactive');
+  applySecurityHeaders(res, nonceValue);
   return res;
 }

--- a/pages/kiosk-blocked.tsx
+++ b/pages/kiosk-blocked.tsx
@@ -1,0 +1,108 @@
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { kioskAllowedApps, kioskAllowedRoutes, kioskAppLabel } from '../lib/kiosk';
+
+function humanizeSlug(slug: string): string {
+  return slug
+    .split('/')
+    .map((segment) =>
+      segment
+        .split('-')
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' '),
+    )
+    .join(' / ');
+}
+
+const kioskRoutesForDisplay = kioskAllowedRoutes.filter((route) => route.path !== '/kiosk-blocked');
+
+export default function KioskBlockedPage() {
+  const router = useRouter();
+  const attemptedPathParam = router.query.from;
+  const attemptedAppParam = router.query.app;
+
+  const attemptedPath =
+    router.isReady && typeof attemptedPathParam === 'string' ? attemptedPathParam : undefined;
+  const attemptedApp =
+    router.isReady && typeof attemptedAppParam === 'string' ? attemptedAppParam : undefined;
+  const attemptedAppName = attemptedApp
+    ? kioskAppLabel(attemptedApp) ?? humanizeSlug(attemptedApp)
+    : undefined;
+
+  return (
+    <>
+      <Head>
+        <title>Kiosk mode restriction</title>
+        <meta name="robots" content="noindex" />
+      </Head>
+      <main className="flex min-h-screen flex-col items-center justify-center bg-gray-900 px-4 py-12 text-white">
+        <div className="w-full max-w-3xl space-y-6 rounded-lg border border-gray-700 bg-black/50 p-8 shadow-xl">
+          <header className="space-y-2 text-center">
+            <p className="text-sm uppercase tracking-widest text-indigo-300">Kiosk mode active</p>
+            <h1 className="text-3xl font-semibold">This experience is locked</h1>
+            <p className="text-lg text-gray-300">
+              {attemptedAppName
+                ? `The ${attemptedAppName} app is not available in this kiosk session.`
+                : 'This kiosk session is limited to a curated list of apps.'}
+            </p>
+          </header>
+
+          {attemptedPath && (
+            <p className="rounded border border-gray-700 bg-gray-900/60 px-4 py-3 text-sm text-gray-300">
+              Requested URL:
+              <code className="ml-2 rounded bg-black/70 px-2 py-1 font-mono text-indigo-200">{attemptedPath}</code>
+            </p>
+          )}
+
+          <p className="text-gray-300">
+            To keep the kiosk focused, only a few destinations are available. Choose one of the options below to continue.
+          </p>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            {kioskRoutesForDisplay.map((route) => (
+              <Link
+                key={route.path}
+                href={route.path}
+                className="rounded bg-indigo-600 px-4 py-3 text-center font-medium shadow transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:ring-offset-2 focus:ring-offset-gray-900"
+              >
+                {route.label}
+              </Link>
+            ))}
+          </div>
+
+          <section aria-labelledby="available-apps" className="space-y-3">
+            <div className="space-y-1 text-center sm:text-left">
+              <h2 id="available-apps" className="text-2xl font-semibold">
+                Apps available in kiosk mode
+              </h2>
+              <p className="text-sm text-gray-400">
+                These links open the apps that remain accessible for this session.
+              </p>
+            </div>
+            <ul className="grid gap-3 sm:grid-cols-2">
+              {kioskAllowedApps.map((app) => (
+                <li
+                  key={app.slug}
+                  className="flex items-center justify-between rounded border border-gray-700 bg-gray-900/60 px-4 py-3"
+                >
+                  <span>{app.title}</span>
+                  <Link
+                    href={`/apps/${app.slug}`}
+                    className="text-sm text-indigo-300 underline transition hover:text-indigo-200 focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:ring-offset-2 focus:ring-offset-gray-900"
+                  >
+                    Open
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <footer className="text-center text-xs text-gray-500">
+            Need broader access? Contact the kiosk owner for help.
+          </footer>
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a kiosk configuration module that documents the route and app allow lists used in kiosk sessions
- extend the edge middleware to respect kiosk signals, enforce the allow list, log blocked access, and surface the kiosk cookie/header
- serve a kiosk-blocked page that explains why deep links are denied and links to the approved destinations

## Testing
- yarn lint *(fails: repository has hundreds of pre-existing accessibility lint errors)*
- yarn test *(fails: existing suites rely on jsdom localStorage and incomplete act wrappers)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d58e0228832897f988488c953a59