### PR TITLE
[theming] add BroadcastChannel fallback

### DIFF
--- a/__tests__/themeChannel.test.ts
+++ b/__tests__/themeChannel.test.ts
@@ -1,0 +1,107 @@
+import type { ThemeChannel } from '@/src/theming/channel';
+
+describe('theme channel', () => {
+  const originalBroadcastChannel = (global as typeof globalThis & {
+    BroadcastChannel?: typeof BroadcastChannel;
+  }).BroadcastChannel;
+
+  afterEach(() => {
+    jest.resetModules();
+    if (originalBroadcastChannel) {
+      (global as typeof globalThis & { BroadcastChannel?: typeof BroadcastChannel }).BroadcastChannel =
+        originalBroadcastChannel;
+    } else {
+      delete (global as typeof globalThis & { BroadcastChannel?: typeof BroadcastChannel }).BroadcastChannel;
+    }
+    window.localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it('uses BroadcastChannel when available', () => {
+    const postMessageMock = jest.fn();
+    const addEventListenerMock = jest.fn();
+    const removeEventListenerMock = jest.fn();
+    const closeMock = jest.fn();
+    let onmessageHandler: ((event: MessageEvent) => void) | null = null;
+
+    class MockBroadcastChannel {
+      constructor(public name: string) {}
+
+      postMessage = postMessageMock;
+
+      addEventListener = addEventListenerMock;
+
+      removeEventListener = removeEventListenerMock;
+
+      close = closeMock;
+
+      set onmessage(handler: ((event: MessageEvent) => void) | null) {
+        onmessageHandler = handler;
+      }
+
+      get onmessage() {
+        return onmessageHandler;
+      }
+    }
+
+    (global as typeof globalThis & { BroadcastChannel: typeof BroadcastChannel }).BroadcastChannel =
+      MockBroadcastChannel as unknown as typeof BroadcastChannel;
+
+    jest.isolateModules(() => {
+      const { createThemeChannel } = require('../src/theming/channel') as {
+        createThemeChannel: (name?: string) => ThemeChannel;
+      };
+      const channel = createThemeChannel('test');
+      expect(channel.mode).toBe('broadcast');
+
+      const handler = jest.fn();
+      channel.addEventListener('message', handler);
+      expect(addEventListenerMock).toHaveBeenCalledWith('message', handler, undefined);
+
+      channel.postMessage('dark');
+      expect(postMessageMock).toHaveBeenCalledWith('dark');
+
+      const onmessage = jest.fn();
+      channel.onmessage = onmessage;
+      expect(onmessageHandler).toBe(onmessage);
+
+      channel.close();
+      expect(closeMock).toHaveBeenCalled();
+    });
+  });
+
+  it('falls back to storage events when BroadcastChannel is unavailable', () => {
+    delete (global as typeof globalThis & { BroadcastChannel?: typeof BroadcastChannel }).BroadcastChannel;
+    window.localStorage.clear();
+
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+
+    jest.isolateModules(() => {
+      const { createThemeChannel } = require('../src/theming/channel') as {
+        createThemeChannel: (name?: string) => ThemeChannel;
+      };
+      const channel = createThemeChannel('test');
+      expect(channel.mode).toBe('storage');
+      expect(channel.storageKey).toBeDefined();
+
+      const handler = jest.fn();
+      channel.addEventListener('message', handler);
+      channel.postMessage('neon');
+      expect(handler).toHaveBeenCalledWith(expect.objectContaining({ data: 'neon' }));
+
+      expect(addSpy).toHaveBeenCalledWith('storage', expect.any(Function));
+
+      const storageKey = channel.storageKey!;
+      const payload = JSON.stringify({ data: 'matrix', timestamp: Date.now() });
+      window.dispatchEvent(new StorageEvent('storage', { key: storageKey, newValue: payload }));
+      expect(handler).toHaveBeenCalledWith(expect.objectContaining({ data: 'matrix' }));
+
+      channel.close();
+      expect(removeSpy).toHaveBeenCalledWith('storage', expect.any(Function));
+    });
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,26 +1,37 @@
 import { useEffect, useState } from 'react';
-import { THEME_KEY, getTheme, setTheme as applyTheme } from '../utils/theme';
+import { getTheme, setTheme as applyTheme } from '../utils/theme';
+import themeChannel from '@/src/theming/channel';
 
 export const useTheme = () => {
   const [theme, setThemeState] = useState<string>(() => getTheme());
 
   useEffect(() => {
-    const handleStorage = (e: StorageEvent) => {
-      if (e.key === THEME_KEY) {
-        const next = getTheme();
-        setThemeState(next);
-        applyTheme(next);
-
+    const handleMessage = (event: MessageEvent<unknown>) => {
+      let nextTheme: string | null = null;
+      if (typeof event.data === 'string') {
+        nextTheme = event.data;
+      } else if (event.data && typeof event.data === 'object' && 'theme' in event.data) {
+        const candidate = (event.data as { theme?: unknown }).theme;
+        nextTheme = typeof candidate === 'string' ? candidate : null;
       }
+
+      if (!nextTheme) {
+        return;
+      }
+
+      setThemeState(nextTheme);
+      applyTheme(nextTheme, { broadcast: false });
     };
-    window.addEventListener('storage', handleStorage);
-    return () => window.removeEventListener('storage', handleStorage);
+
+    themeChannel.addEventListener('message', handleMessage as EventListener);
+    return () => {
+      themeChannel.removeEventListener('message', handleMessage as EventListener);
+    };
   }, []);
 
   const setTheme = (next: string) => {
     setThemeState(next);
     applyTheme(next);
-
   };
 
   return { theme, setTheme };

--- a/src/theming/channel.ts
+++ b/src/theming/channel.ts
@@ -1,0 +1,222 @@
+const CHANNEL_NAME = 'theme';
+const STORAGE_PREFIX = 'app:theme-channel';
+
+type Listener = (event: MessageEvent<unknown>) => void;
+
+type ListenerLike = EventListenerOrEventListenerObject;
+
+type ChannelMode = 'broadcast' | 'storage' | 'none';
+
+const supportsBroadcastChannel = (): boolean =>
+  typeof globalThis !== 'undefined' &&
+  typeof (globalThis as typeof globalThis & { BroadcastChannel?: unknown }).BroadcastChannel === 'function';
+
+const createMessageEvent = (data: unknown): MessageEvent<unknown> => {
+  if (typeof MessageEvent === 'function') {
+    return new MessageEvent('message', { data });
+  }
+  return { data } as MessageEvent<unknown>;
+};
+
+const getStorageKey = (name: string): string => `${STORAGE_PREFIX}:${name}`;
+
+class StorageFallbackChannel {
+  public onmessage: Listener | null = null;
+  public readonly storageKey: string;
+
+  private readonly listeners = new Set<Listener>();
+  private listenerMap = new WeakMap<ListenerLike, Listener>();
+  private readonly handleStorage: (event: StorageEvent) => void;
+
+  constructor(storageKey: string) {
+    this.storageKey = storageKey;
+    this.handleStorage = (event: StorageEvent) => {
+      if (event.key !== this.storageKey || !event.newValue) return;
+      try {
+        const payload = JSON.parse(event.newValue) as { data: unknown };
+        this.dispatch(payload.data);
+      } catch {
+        /* ignore malformed storage payloads */
+      }
+    };
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', this.handleStorage);
+    }
+  }
+
+  addEventListener(
+    type: 'message',
+    listener: ListenerLike,
+    _options?: boolean | AddEventListenerOptions,
+  ): void {
+    if (type !== 'message') return;
+    const normalized = this.getListener(listener);
+    this.listeners.add(normalized);
+  }
+
+  removeEventListener(
+    type: 'message',
+    listener: ListenerLike,
+    _options?: boolean | EventListenerOptions,
+  ): void {
+    if (type !== 'message') return;
+    const normalized = this.listenerMap.get(listener);
+    if (!normalized) return;
+    this.listeners.delete(normalized);
+    this.listenerMap.delete(listener);
+  }
+
+  postMessage(message: unknown): void {
+    this.dispatch(message);
+    if (typeof window === 'undefined') return;
+    try {
+      const payload = JSON.stringify({ data: message, timestamp: Date.now() });
+      window.localStorage.setItem(this.storageKey, payload);
+    } catch {
+      /* ignore storage errors */
+    }
+  }
+
+  close(): void {
+    this.listeners.clear();
+    this.listenerMap = new WeakMap();
+    this.onmessage = null;
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('storage', this.handleStorage);
+    }
+  }
+
+  private getListener(listener: ListenerLike): Listener {
+    let normalized = this.listenerMap.get(listener);
+    if (!normalized) {
+      if (typeof listener === 'function') {
+        normalized = listener as Listener;
+      } else {
+        normalized = (event: MessageEvent<unknown>) => {
+          if ('handleEvent' in listener && listener.handleEvent) {
+            listener.handleEvent.call(listener, event);
+          }
+        };
+      }
+      this.listenerMap.set(listener, normalized);
+    }
+    return normalized;
+  }
+
+  private dispatch(message: unknown): void {
+    const event = createMessageEvent(message);
+    this.listeners.forEach((listener) => listener(event));
+    this.onmessage?.(event);
+  }
+}
+
+export interface ThemeChannel {
+  postMessage(message: unknown): void;
+  addEventListener(
+    type: 'message',
+    listener: ListenerLike,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: 'message',
+    listener: ListenerLike,
+    options?: boolean | EventListenerOptions,
+  ): void;
+  close(): void;
+  onmessage: Listener | null;
+  readonly mode: ChannelMode;
+  readonly storageKey?: string;
+}
+
+class ThemeChannelImpl implements ThemeChannel {
+  public readonly mode: ChannelMode;
+  public readonly storageKey?: string;
+
+  private channel: BroadcastChannel | StorageFallbackChannel | null;
+
+  constructor(name: string = CHANNEL_NAME) {
+    if (supportsBroadcastChannel()) {
+      const BroadcastChannelCtor = (globalThis as unknown as { BroadcastChannel: typeof BroadcastChannel })
+        .BroadcastChannel;
+      this.channel = new BroadcastChannelCtor(name);
+      this.mode = 'broadcast';
+    } else if (typeof window !== 'undefined') {
+      this.storageKey = getStorageKey(name);
+      this.channel = new StorageFallbackChannel(this.storageKey);
+      this.mode = 'storage';
+    } else {
+      this.channel = null;
+      this.mode = 'none';
+    }
+  }
+
+  postMessage(message: unknown): void {
+    if (!this.channel) return;
+    if (this.mode === 'broadcast') {
+      (this.channel as BroadcastChannel).postMessage(message);
+    } else {
+      (this.channel as StorageFallbackChannel).postMessage(message);
+    }
+  }
+
+  addEventListener(
+    type: 'message',
+    listener: ListenerLike,
+    options?: boolean | AddEventListenerOptions,
+  ): void {
+    if (!this.channel) return;
+    if (this.mode === 'broadcast') {
+      (this.channel as BroadcastChannel).addEventListener(type, listener as EventListener, options);
+    } else {
+      (this.channel as StorageFallbackChannel).addEventListener(type, listener, options);
+    }
+  }
+
+  removeEventListener(
+    type: 'message',
+    listener: ListenerLike,
+    options?: boolean | EventListenerOptions,
+  ): void {
+    if (!this.channel) return;
+    if (this.mode === 'broadcast') {
+      (this.channel as BroadcastChannel).removeEventListener(type, listener as EventListener, options);
+    } else {
+      (this.channel as StorageFallbackChannel).removeEventListener(type, listener, options);
+    }
+  }
+
+  close(): void {
+    if (!this.channel) return;
+    if (this.mode === 'broadcast') {
+      (this.channel as BroadcastChannel).close();
+    } else {
+      (this.channel as StorageFallbackChannel).close();
+    }
+    this.channel = null;
+  }
+
+  set onmessage(handler: Listener | null) {
+    if (!this.channel) return;
+    if (this.mode === 'broadcast') {
+      (this.channel as BroadcastChannel).onmessage = handler as ((event: MessageEvent) => void) | null;
+    } else {
+      (this.channel as StorageFallbackChannel).onmessage = handler;
+    }
+  }
+
+  get onmessage(): Listener | null {
+    if (!this.channel) return null;
+    if (this.mode === 'broadcast') {
+      return (this.channel as BroadcastChannel).onmessage as Listener | null;
+    }
+    return (this.channel as StorageFallbackChannel).onmessage;
+  }
+}
+
+export const createThemeChannel = (name: string = CHANNEL_NAME): ThemeChannel =>
+  new ThemeChannelImpl(name);
+
+const defaultChannel = createThemeChannel();
+
+export default defaultChannel;

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -1,3 +1,5 @@
+import themeChannel from '@/src/theming/channel';
+
 export const THEME_KEY = 'app:theme';
 
 // Score required to unlock each theme
@@ -27,7 +29,11 @@ export const getTheme = (): string => {
   }
 };
 
-export const setTheme = (theme: string): void => {
+type SetThemeOptions = {
+  broadcast?: boolean;
+};
+
+export const setTheme = (theme: string, options: SetThemeOptions = {}): void => {
   if (typeof window === 'undefined') return;
   try {
     window.localStorage.setItem(THEME_KEY, theme);
@@ -35,6 +41,9 @@ export const setTheme = (theme: string): void => {
     document.documentElement.classList.toggle('dark', isDarkTheme(theme));
   } catch {
     /* ignore storage errors */
+  }
+  if (options.broadcast ?? true) {
+    themeChannel.postMessage(theme);
   }
 };
 


### PR DESCRIPTION
## Summary
- add a theming channel that uses BroadcastChannel when available and falls back to storage events if not
- wire the shared channel into the theme hook and storage helper so theme changes propagate without rebroadcast loops
- cover BroadcastChannel and storage fallback flows with new unit tests

## Testing
- ⚠️ `yarn lint` *(fails due to pre-existing accessibility violations in unrelated files)*
- ✅ `yarn test __tests__/themeChannel.test.ts __tests__/themePersistence.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c9d58f994483289e74c02329e0ab63