### PR TITLE
[projects] add JSON-LD metadata support for MDX entries

### DIFF
--- a/__tests__/projectJsonLd.test.ts
+++ b/__tests__/projectJsonLd.test.ts
@@ -1,0 +1,109 @@
+import { createProjectJsonLd, inferProjectSchemaType } from '../lib/jsonld/project';
+import type { ProjectFrontmatter } from '../lib/jsonld/types';
+
+describe('createProjectJsonLd', () => {
+  const originalSiteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://example.com';
+  });
+
+  afterAll(() => {
+    process.env.NEXT_PUBLIC_SITE_URL = originalSiteUrl;
+  });
+
+  it('builds Article JSON-LD when the frontmatter is marked as an article', () => {
+    const frontMatter: ProjectFrontmatter = {
+      title: 'Writing Tools',
+      type: 'article',
+      author: 'Alex Writer',
+      description: 'Deep dive on internal writing utilities.',
+      tags: ['security', 'guides'],
+      image: '/hero.png',
+      datePublished: '2024-12-01',
+      dateModified: '2024-12-05',
+      section: 'Guides',
+    };
+
+    const jsonLd = createProjectJsonLd(frontMatter, 'writing-tools');
+
+    expect(jsonLd['@type']).toBe('Article');
+    expect(jsonLd.headline).toBe('Writing Tools');
+    expect(jsonLd.author).toEqual({ '@type': 'Person', name: 'Alex Writer' });
+    expect(jsonLd.url).toBe('https://example.com/projects/writing-tools');
+    expect(jsonLd.mainEntityOfPage).toEqual({
+      '@type': 'WebPage',
+      '@id': 'https://example.com/projects/writing-tools',
+    });
+    expect(jsonLd.keywords).toEqual(['security', 'guides']);
+    expect(jsonLd.image).toBe('/hero.png');
+    expect(jsonLd.articleSection).toBe('Guides');
+  });
+
+  it('builds SoftwareSourceCode JSON-LD for software projects', () => {
+    const frontMatter: ProjectFrontmatter = {
+      title: 'Packet Analyzer',
+      type: 'software',
+      author: { name: 'Alex Dev', url: 'https://example.com/about' },
+      repo: 'https://github.com/example/packet-analyzer',
+      programmingLanguage: 'TypeScript',
+      runtime: 'Node.js',
+      operatingSystem: 'Cross-platform',
+      applicationCategory: 'SecurityTool',
+      downloadUrl: 'https://example.com/downloads/packet-analyzer.zip',
+      version: '1.2.0',
+      tags: ['security', 'network'],
+      sameAs: ['https://github.com/example/packet-analyzer', 'https://github.com/example/packet-analyzer'],
+    };
+
+    const jsonLd = createProjectJsonLd(frontMatter, 'packet-analyzer', 'https://projects.example.com');
+
+    expect(jsonLd['@type']).toBe('SoftwareSourceCode');
+    expect(jsonLd.name).toBe('Packet Analyzer');
+    expect(jsonLd.author).toEqual({
+      '@type': 'Person',
+      name: 'Alex Dev',
+      url: 'https://example.com/about',
+    });
+    expect(jsonLd.codeRepository).toBe('https://github.com/example/packet-analyzer');
+    expect(jsonLd.programmingLanguage).toBe('TypeScript');
+    expect(jsonLd.runtimePlatform).toBe('Node.js');
+    expect(jsonLd.operatingSystem).toBe('Cross-platform');
+    expect(jsonLd.applicationCategory).toBe('SecurityTool');
+    expect(jsonLd.downloadUrl).toBe('https://example.com/downloads/packet-analyzer.zip');
+    expect(jsonLd.version).toBe('1.2.0');
+    expect(jsonLd.keywords).toEqual(['security', 'network']);
+    expect(jsonLd.sameAs).toEqual(['https://github.com/example/packet-analyzer']);
+    expect(jsonLd.url).toBe('https://projects.example.com/projects/packet-analyzer');
+  });
+
+  it('falls back to sensible defaults when optional fields are missing', () => {
+    const jsonLd = createProjectJsonLd({}, 'untitled-project', 'https://portfolio.example');
+
+    expect(jsonLd['@type']).toBe('SoftwareSourceCode');
+    expect(jsonLd.headline).toBe('Untitled Project');
+    expect(jsonLd.author).toEqual({ '@type': 'Person', name: 'Alex Unnippillil' });
+    expect(jsonLd.url).toBe('https://portfolio.example/projects/untitled-project');
+    expect(jsonLd.mainEntityOfPage).toEqual({
+      '@type': 'WebPage',
+      '@id': 'https://portfolio.example/projects/untitled-project',
+    });
+    expect(jsonLd).not.toHaveProperty('description');
+    expect(jsonLd).not.toHaveProperty('keywords');
+    expect(jsonLd).not.toHaveProperty('image');
+  });
+});
+
+describe('inferProjectSchemaType', () => {
+  it('detects article from layout hint', () => {
+    expect(
+      inferProjectSchemaType({
+        layout: 'Article',
+      }),
+    ).toBe('Article');
+  });
+
+  it('defaults to software when hints are missing', () => {
+    expect(inferProjectSchemaType({})).toBe('SoftwareSourceCode');
+  });
+});

--- a/lib/jsonld/project.ts
+++ b/lib/jsonld/project.ts
@@ -1,0 +1,317 @@
+import type {
+  ArticleJsonLd,
+  JsonLdAuthor,
+  JsonLdOrganization,
+  JsonLdPerson,
+  ProjectFrontmatter,
+  ProjectJsonLd,
+  SoftwareSourceCodeJsonLd,
+} from './types';
+
+const DEFAULT_AUTHOR: JsonLdPerson = {
+  '@type': 'Person',
+  name: 'Alex Unnippillil',
+};
+
+const DEFAULT_BASE_URL = 'https://unnippillil.com';
+
+const ARTICLE_HINTS = new Set([
+  'article',
+  'articles',
+  'blog',
+  'blogpost',
+  'blogposting',
+  'news',
+  'newsarticle',
+  'post',
+  'writing',
+]);
+
+const SOFTWARE_HINTS = new Set([
+  'app',
+  'application',
+  'code',
+  'library',
+  'project',
+  'software',
+  'softwaresourcecode',
+  'tool',
+]);
+
+export function inferProjectSchemaType(
+  frontMatter: ProjectFrontmatter | undefined,
+): ArticleJsonLd['@type'] | SoftwareSourceCodeJsonLd['@type'] {
+  const hints = [
+    frontMatter?.jsonLdType,
+    frontMatter?.schemaType,
+    frontMatter?.contentType,
+    frontMatter?.type,
+    frontMatter?.layout,
+  ];
+
+  for (const hint of hints) {
+    const normalized = normalizeType(hint);
+    if (!normalized) continue;
+    if (ARTICLE_HINTS.has(normalized)) {
+      return 'Article';
+    }
+    if (SOFTWARE_HINTS.has(normalized)) {
+      return 'SoftwareSourceCode';
+    }
+  }
+
+  return 'SoftwareSourceCode';
+}
+
+export function createProjectJsonLd(
+  frontMatter: ProjectFrontmatter | undefined,
+  slug?: string,
+  siteUrl?: string,
+): ProjectJsonLd {
+  const fm = frontMatter ?? {};
+  const schemaType = inferProjectSchemaType(fm);
+  const resolvedSlug = normalizeString(slug) ?? fm.slug ?? undefined;
+  const baseUrl = resolveBaseUrl(siteUrl);
+  const canonicalUrl = fm.url ?? (resolvedSlug ? `${baseUrl}/projects/${resolvedSlug}` : undefined);
+  const headline = fm.headline ?? fm.title ?? formatHeadline(resolvedSlug);
+  const description = fm.description ?? fm.summary ?? fm.excerpt;
+  const keywords = dedupeStrings([
+    ...toStringArray(fm.keywords),
+    ...toStringArray(fm.tags),
+    ...toStringArray(fm.topics),
+  ]);
+  const images = dedupeStrings([
+    ...toStringArray(fm.image),
+    ...toStringArray(fm.images),
+    ...toStringArray(fm.cover),
+    ...toStringArray(fm.coverImage),
+    ...toStringArray(fm.hero),
+    ...toStringArray(fm.banner),
+    ...toStringArray(fm.thumbnail),
+  ]);
+  const sameAs = dedupeStrings([
+    ...toStringArray(fm.sameAs),
+    ...toStringArray(fm.links),
+  ]);
+  const datePublished = fm.datePublished ?? fm.published ?? fm.date;
+  const dateModified = fm.dateModified ?? fm.updated ?? fm.lastModified;
+  const author = resolveAuthors(fm);
+
+  const base: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': schemaType,
+    headline,
+    author,
+    description,
+    url: canonicalUrl,
+    mainEntityOfPage: canonicalUrl
+      ? {
+          '@type': 'WebPage',
+          '@id': canonicalUrl,
+        }
+      : undefined,
+    image: images.length ? (images.length === 1 ? images[0] : images) : undefined,
+    keywords: keywords.length ? keywords : undefined,
+    datePublished,
+    dateModified,
+  };
+
+  if (schemaType === 'Article') {
+    const section = fm.articleSection ?? fm.section ?? chooseArticleSection(fm.category);
+    return compactObject({
+      ...base,
+      articleSection: section,
+    }) as ArticleJsonLd;
+  }
+
+  const codeRepository = fm.codeRepository ?? fm.repo ?? fm.repository;
+  const programmingLanguage = fm.programmingLanguage ?? fm.language;
+  const runtimePlatform = fm.runtimePlatform ?? fm.runtime;
+  const operatingSystem = fm.operatingSystem ?? fm.os ?? fm.platform;
+  const applicationCategory = fm.applicationCategory ?? fm.categoryLabel;
+  const downloadUrl = fm.downloadUrl ?? fm.download;
+  const version = fm.softwareVersion ?? fm.version;
+  const license = fm.license;
+  const name = fm.title ?? headline;
+
+  return compactObject({
+    ...base,
+    name,
+    codeRepository,
+    programmingLanguage,
+    runtimePlatform,
+    operatingSystem,
+    applicationCategory,
+    downloadUrl,
+    version,
+    license,
+    sameAs: sameAs.length ? sameAs : undefined,
+  }) as SoftwareSourceCodeJsonLd;
+}
+
+function resolveAuthors(fm: ProjectFrontmatter): JsonLdAuthor | JsonLdAuthor[] {
+  const candidates = [fm.author, fm.authors, fm.by, fm.creator];
+  const parsed = dedupeAuthors(
+    candidates.flatMap((candidate) => toAuthorArray(candidate)),
+  );
+  if (!parsed.length) {
+    return DEFAULT_AUTHOR;
+  }
+  return parsed.length === 1 ? parsed[0] : parsed;
+}
+
+function toAuthorArray(candidate: unknown): JsonLdAuthor[] {
+  if (candidate == null) return [];
+  if (Array.isArray(candidate)) {
+    return candidate.flatMap((entry) => toAuthorArray(entry));
+  }
+  const parsed = parseAuthor(candidate);
+  return parsed ? [parsed] : [];
+}
+
+function parseAuthor(value: unknown): JsonLdAuthor | null {
+  if (typeof value === 'string') {
+    const name = normalizeString(value);
+    if (!name) return null;
+    return { ...DEFAULT_AUTHOR, name };
+  }
+  if (isPlainObject(value)) {
+    const record = value as Record<string, unknown>;
+    const name = normalizeString(record.name);
+    const url = normalizeString(record.url);
+    const rawType = normalizeString(record['@type'] ?? record.type);
+    const type: JsonLdAuthor['@type'] = rawType === 'organization' ? 'Organization' : 'Person';
+    if (!name) {
+      return null;
+    }
+    const author: JsonLdAuthor = type === 'Organization'
+      ? ({ '@type': 'Organization', name } as JsonLdOrganization)
+      : ({ '@type': 'Person', name } as JsonLdPerson);
+    if (url) {
+      author.url = url;
+    }
+    return author;
+  }
+  return null;
+}
+
+function dedupeAuthors(authors: JsonLdAuthor[]): JsonLdAuthor[] {
+  const seen = new Set<string>();
+  const result: JsonLdAuthor[] = [];
+  for (const author of authors) {
+    const key = `${author['@type']}|${author.name}|${author.url ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(author);
+  }
+  return result;
+}
+
+function chooseArticleSection(category: unknown): string | undefined {
+  const value = normalizeString(category);
+  if (!value) return undefined;
+  const compact = value.replace(/\s+/g, '').toLowerCase();
+  if (ARTICLE_HINTS.has(compact) || SOFTWARE_HINTS.has(compact)) {
+    return undefined;
+  }
+  return value;
+}
+
+function normalizeType(value: unknown): string | undefined {
+  const raw = normalizeString(value);
+  if (!raw) return undefined;
+  return raw.replace(/[^a-z]/gi, '').toLowerCase();
+}
+
+function resolveBaseUrl(siteUrl?: string): string {
+  const provided = normalizeString(siteUrl) ?? normalizeString(process.env.NEXT_PUBLIC_SITE_URL);
+  const base = provided ?? DEFAULT_BASE_URL;
+  return base.replace(/\/+$/, '');
+}
+
+function formatHeadline(slug?: string, fallback = 'Project'): string {
+  if (!slug) return fallback;
+  const normalized = slug.trim();
+  if (!normalized) return fallback;
+  const parts = normalized
+    .split(/[\/_-]+/g)
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1));
+  return parts.length ? parts.join(' ') : fallback;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (value == null) return [];
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => toStringArray(item));
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function dedupeStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const normalized = normalizeString(value);
+    if (!normalized) continue;
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}
+
+function normalizeString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : undefined;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function compactObject<T extends Record<string, unknown>>(input: T): T {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    const cleaned = compactValue(value);
+    if (cleaned !== undefined) {
+      result[key] = cleaned;
+    }
+  }
+  return result as T;
+}
+
+function compactValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    const cleaned = value
+      .map((item) => compactValue(item))
+      .filter((item) => item !== undefined);
+    if (!cleaned.length) return undefined;
+    return cleaned;
+  }
+  if (isPlainObject(value)) {
+    const entries: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      const cleaned = compactValue(entry);
+      if (cleaned !== undefined) {
+        entries[key] = cleaned;
+      }
+    }
+    return Object.keys(entries).length ? entries : undefined;
+  }
+  if (typeof value === 'string') {
+    return normalizeString(value);
+  }
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  return value;
+}

--- a/lib/jsonld/types.ts
+++ b/lib/jsonld/types.ts
@@ -1,0 +1,129 @@
+export type AuthorInput =
+  | string
+  | AuthorDescriptor
+  | Array<string | AuthorDescriptor>;
+
+export interface AuthorDescriptor {
+  name?: string;
+  url?: string;
+  type?: 'Person' | 'Organization';
+  ['@type']?: 'Person' | 'Organization';
+}
+
+export interface ProjectFrontmatter {
+  title?: string;
+  headline?: string;
+  summary?: string;
+  description?: string;
+  excerpt?: string;
+  type?: string;
+  contentType?: string;
+  layout?: string;
+  schemaType?: string;
+  jsonLdType?: string;
+  author?: AuthorInput;
+  authors?: AuthorInput;
+  by?: AuthorInput;
+  creator?: AuthorInput;
+  tags?: string[] | string;
+  keywords?: string[] | string;
+  topics?: string[] | string;
+  image?: string | string[];
+  images?: string | string[];
+  cover?: string | string[];
+  coverImage?: string | string[];
+  hero?: string | string[];
+  thumbnail?: string;
+  banner?: string | string[];
+  date?: string;
+  published?: string;
+  datePublished?: string;
+  lastModified?: string;
+  updated?: string;
+  dateModified?: string;
+  repo?: string;
+  repository?: string;
+  codeRepository?: string;
+  programmingLanguage?: string;
+  language?: string;
+  runtime?: string;
+  runtimePlatform?: string;
+  operatingSystem?: string;
+  os?: string;
+  platform?: string;
+  applicationCategory?: string;
+  categoryLabel?: string;
+  downloadUrl?: string;
+  download?: string;
+  version?: string;
+  softwareVersion?: string;
+  license?: string;
+  url?: string;
+  articleSection?: string;
+  section?: string;
+  category?: string;
+  sameAs?: string[] | string;
+  links?: string[] | string;
+  slug?: string;
+}
+
+export interface JsonLdPerson {
+  '@type': 'Person';
+  name: string;
+  url?: string;
+}
+
+export interface JsonLdOrganization {
+  '@type': 'Organization';
+  name: string;
+  url?: string;
+}
+
+export type JsonLdAuthor = JsonLdPerson | JsonLdOrganization;
+
+export interface ArticleJsonLd {
+  '@context': 'https://schema.org';
+  '@type': 'Article';
+  headline: string;
+  author: JsonLdAuthor | JsonLdAuthor[];
+  description?: string;
+  url?: string;
+  mainEntityOfPage?: {
+    '@type': 'WebPage';
+    '@id': string;
+  };
+  image?: string | string[];
+  keywords?: string[];
+  datePublished?: string;
+  dateModified?: string;
+  articleSection?: string;
+}
+
+export interface SoftwareSourceCodeJsonLd {
+  '@context': 'https://schema.org';
+  '@type': 'SoftwareSourceCode';
+  headline: string;
+  name: string;
+  author: JsonLdAuthor | JsonLdAuthor[];
+  description?: string;
+  url?: string;
+  mainEntityOfPage?: {
+    '@type': 'WebPage';
+    '@id': string;
+  };
+  image?: string | string[];
+  keywords?: string[];
+  datePublished?: string;
+  dateModified?: string;
+  codeRepository?: string;
+  programmingLanguage?: string;
+  runtimePlatform?: string;
+  operatingSystem?: string;
+  applicationCategory?: string;
+  downloadUrl?: string;
+  version?: string;
+  license?: string;
+  sameAs?: string[];
+}
+
+export type ProjectJsonLd = ArticleJsonLd | SoftwareSourceCodeJsonLd;

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "dompurify": "^3.2.6",
     "fast-xml-parser": "^4.3.5",
     "figlet": "^1.8.2",
+    "gray-matter": "^4.0.3",
     "hash-wasm": "^4.12.0",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -1,0 +1,172 @@
+import fs from 'fs/promises';
+import matter from 'gray-matter';
+import type { GetStaticPaths, GetStaticProps } from 'next';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import path from 'path';
+import { marked } from 'marked';
+
+import { createProjectJsonLd, inferProjectSchemaType } from '../../lib/jsonld/project';
+import type { ProjectFrontmatter } from '../../lib/jsonld/types';
+import { getCspNonce } from '../../utils/csp';
+
+interface ProjectPageProps {
+  slug?: string;
+  frontMatter?: ProjectFrontmatter;
+  contentHtml?: string;
+}
+
+const PROJECTS_DIR = path.join(process.cwd(), 'projects');
+
+export default function ProjectPage({ slug: initialSlug, frontMatter, contentHtml }: ProjectPageProps) {
+  const router = useRouter();
+  const slug = initialSlug ?? (typeof router.query.slug === 'string' ? router.query.slug : undefined);
+  const fm = frontMatter ?? {};
+  const jsonLd = createProjectJsonLd(fm, slug);
+  const nonce = getCspNonce();
+  const headline = fm.title ?? fm.headline ?? formatHeadline(slug);
+  const description = fm.description ?? fm.summary ?? fm.excerpt;
+  const schemaLabel = inferProjectSchemaType(fm) === 'Article' ? 'Article' : 'Software Project';
+  const primaryImage = Array.isArray(jsonLd.image) ? jsonLd.image[0] : jsonLd.image;
+
+  return (
+    <>
+      <Head>
+        <title>{`${headline} | Projects | Alex Unnippillil`}</title>
+        {description ? <meta name="description" content={description} /> : null}
+        {primaryImage ? <meta property="og:image" content={primaryImage} /> : null}
+        {jsonLd ? (
+          <script
+            type="application/ld+json"
+            nonce={nonce}
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          />
+        ) : null}
+      </Head>
+      <main className="min-h-screen bg-[#0f1317] text-white">
+        <article className="mx-auto max-w-3xl px-4 py-10 space-y-8">
+          <header className="space-y-3">
+            <p className="text-sm uppercase tracking-wide text-blue-300">{schemaLabel}</p>
+            <h1 className="text-3xl font-semibold leading-tight">{headline}</h1>
+            {description ? <p className="text-lg text-gray-300">{description}</p> : null}
+            {(fm.datePublished || fm.dateModified) && (
+              <dl className="flex flex-wrap gap-4 text-sm text-gray-400">
+                {fm.datePublished ? (
+                  <div>
+                    <dt className="sr-only">Published</dt>
+                    <dd>{`Published ${formatDate(fm.datePublished)}`}</dd>
+                  </div>
+                ) : null}
+                {fm.dateModified ? (
+                  <div>
+                    <dt className="sr-only">Updated</dt>
+                    <dd>{`Updated ${formatDate(fm.dateModified)}`}</dd>
+                  </div>
+                ) : null}
+              </dl>
+            )}
+          </header>
+          {contentHtml ? (
+            <div
+              className="space-y-4 leading-relaxed text-gray-200"
+              dangerouslySetInnerHTML={{ __html: contentHtml }}
+            />
+          ) : (
+            <p className="text-gray-300">
+              This project entry is coming soon. Check back later for the full write-up.
+            </p>
+          )}
+        </article>
+      </main>
+    </>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  try {
+    const files = await fs.readdir(PROJECTS_DIR);
+    const paths = files
+      .filter((file) => file.endsWith('.md') || file.endsWith('.mdx'))
+      .map((file) => file.replace(/\.(md|mdx)$/i, ''))
+      .map((slug) => ({ params: { slug } }));
+    return { paths, fallback: 'blocking' };
+  } catch {
+    return { paths: [], fallback: 'blocking' };
+  }
+};
+
+export const getStaticProps: GetStaticProps<ProjectPageProps> = async ({ params }) => {
+  const slugParam = params?.slug;
+  const slug = Array.isArray(slugParam) ? slugParam[0] : slugParam;
+  if (!slug || typeof slug !== 'string') {
+    return { notFound: true };
+  }
+
+  const filePath = await findProjectFile(slug);
+  if (!filePath) {
+    return { notFound: true };
+  }
+
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    const parsed = matter(raw);
+    const frontMatter: ProjectFrontmatter = {
+      ...(parsed.data as ProjectFrontmatter),
+      slug,
+    };
+    if (!frontMatter.dateModified) {
+      const stats = await fs.stat(filePath);
+      frontMatter.dateModified = stats.mtime.toISOString();
+    }
+    const contentHtml = parsed.content ? (marked.parse(parsed.content) as string) : '';
+
+    return {
+      props: {
+        slug,
+        frontMatter,
+        contentHtml,
+      },
+      revalidate: 60,
+    };
+  } catch {
+    return { notFound: true };
+  }
+};
+
+async function findProjectFile(slug: string): Promise<string | null> {
+  const candidates = [`${slug}.mdx`, `${slug}.md`];
+  for (const candidate of candidates) {
+    const fullPath = path.join(PROJECTS_DIR, candidate);
+    try {
+      await fs.access(fullPath);
+      return fullPath;
+    } catch {
+      // continue searching
+    }
+  }
+  return null;
+}
+
+function formatHeadline(slug?: string): string {
+  if (!slug) return 'Project';
+  const normalized = slug.trim();
+  if (!normalized) return 'Project';
+  const parts = normalized
+    .split(/[\/_-]+/g)
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1));
+  return parts.length ? parts.join(' ') : 'Project';
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  try {
+    return new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(date);
+  } catch {
+    return value;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7210,6 +7210,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"extend-shallow@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "extend-shallow@npm:2.0.1"
+  dependencies:
+    is-extendable: "npm:^0.1.0"
+  checksum: 10c0/ee1cb0a18c9faddb42d791b2d64867bd6cfd0f3affb711782eb6e894dd193e2934a7f529426aac7c8ddb31ac5d38000a00aa2caf08aa3dfc3e1c8ff6ba340bd9
+  languageName: node
+  linkType: hard
+
 "extract-zip@npm:^2.0.1":
   version: 2.0.1
   resolution: "extract-zip@npm:2.0.1"
@@ -7879,6 +7888,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gray-matter@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "gray-matter@npm:4.0.3"
+  dependencies:
+    js-yaml: "npm:^3.13.1"
+    kind-of: "npm:^6.0.2"
+    section-matter: "npm:^1.0.0"
+    strip-bom-string: "npm:^1.0.0"
+  checksum: 10c0/e38489906dad4f162ca01e0dcbdbed96d1a53740cef446b9bf76d80bec66fa799af07776a18077aee642346c5e1365ed95e4c91854a12bf40ba0d4fb43a625a6
+  languageName: node
+  linkType: hard
+
 "gzip-size@npm:^6.0.0":
   version: 6.0.0
   resolution: "gzip-size@npm:6.0.0"
@@ -8302,6 +8323,13 @@ __metadata:
     call-bound: "npm:^1.0.2"
     has-tostringtag: "npm:^1.0.2"
   checksum: 10c0/1a4d199c8e9e9cac5128d32e6626fa7805175af9df015620ac0d5d45854ccf348ba494679d872d37301032e35a54fc7978fba1687e8721b2139aea7870cafa2f
+  languageName: node
+  linkType: hard
+
+"is-extendable@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "is-extendable@npm:0.1.1"
+  checksum: 10c0/dd5ca3994a28e1740d1e25192e66eed128e0b2ff161a7ea348e87ae4f616554b486854de423877a2a2c171d5f7cd6e8093b91f54533bc88a59ee1c9838c43879
   languageName: node
   linkType: hard
 
@@ -9448,6 +9476,13 @@ __metadata:
   dependencies:
     json-buffer: "npm:3.0.1"
   checksum: 10c0/aa52f3c5e18e16bb6324876bb8b59dd02acf782a4b789c7b2ae21107fab95fab3890ed448d4f8dba80ce05391eeac4bfabb4f02a20221342982f806fa2cf271e
+  languageName: node
+  linkType: hard
+
+"kind-of@npm:^6.0.0, kind-of@npm:^6.0.2":
+  version: 6.0.3
+  resolution: "kind-of@npm:6.0.3"
+  checksum: 10c0/61cdff9623dabf3568b6445e93e31376bee1cdb93f8ba7033d86022c2a9b1791a1d9510e026e6465ebd701a6dd2f7b0808483ad8838341ac52f003f512e0b4c4
   languageName: node
   linkType: hard
 
@@ -12407,6 +12442,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"section-matter@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "section-matter@npm:1.0.0"
+  dependencies:
+    extend-shallow: "npm:^2.0.1"
+    kind-of: "npm:^6.0.0"
+  checksum: 10c0/8007f91780adc5aaa781a848eaae50b0f680bbf4043b90cf8a96778195b8fab690c87fe7a989e02394ce69890e330811ec8dab22397d384673ce59f7d750641d
+  languageName: node
+  linkType: hard
+
 "seedrandom@npm:^3.0.5":
   version: 3.0.5
   resolution: "seedrandom@npm:3.0.5"
@@ -12993,6 +13038,13 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.0.1"
   checksum: 10c0/a198c3762e8832505328cbf9e8c8381de14a4fa50a4f9b2160138158ea88c0f5549fb50cb13c651c3088f47e63a108b34622ec18c0499b6c8c3a5ddf6b305ac4
+  languageName: node
+  linkType: hard
+
+"strip-bom-string@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "strip-bom-string@npm:1.0.0"
+  checksum: 10c0/5c5717e2643225aa6a6d659d34176ab2657037f1fe2423ac6fcdb488f135e14fef1022030e426d8b4d0989e09adbd5c3288d5d3b9c632abeefd2358dfc512bca
   languageName: node
   linkType: hard
 
@@ -13911,6 +13963,7 @@ __metadata:
     fast-glob: "npm:^3.3.3"
     fast-xml-parser: "npm:^4.3.5"
     figlet: "npm:^1.8.2"
+    gray-matter: "npm:^4.0.3"
     hash-wasm: "npm:^4.12.0"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"


### PR DESCRIPTION
## Summary
- add a JSON-LD builder that inspects MDX frontmatter and emits Article or SoftwareSourceCode data
- introduce reusable types for project metadata and schema.org payloads
- render structured data on the project slug page while loading frontmatter from MDX and convert content to HTML
- cover JSON-LD generation with unit tests and add gray-matter for parsing

## Testing
- yarn lint *(fails: repository has hundreds of pre-existing jsx-a11y and window/document lint violations unrelated to this change)*
- yarn test *(fails: existing suites such as window.test.tsx and nmapNse.test.tsx break along with jsdom localStorage access in useSettings.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d5799ab48328a852b38ea602cd4d