### PR TITLE
[browser] add omnibox suggestions

### DIFF
--- a/apps/browser/Omnibox.tsx
+++ b/apps/browser/Omnibox.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import {
+  aggregateSearchIndex,
+  AppRecord,
+  HistoryRecord,
+  matchSearchResults,
+  SearchResult,
+  SearchResultType,
+  SuggestionRecord,
+} from '@/src/search';
+import {
+  FormEvent,
+  KeyboardEvent,
+  MouseEvent,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from 'react';
+
+export type OmniboxSubmitPayload =
+  | { type: 'query'; value: string }
+  | SearchResult;
+
+interface OmniboxProps {
+  value: string;
+  onChange: (nextValue: string) => void;
+  onSubmit: (payload: OmniboxSubmitPayload) => void;
+  apps?: AppRecord[];
+  history?: HistoryRecord[];
+  searchSuggestions?: SuggestionRecord[];
+  placeholder?: string;
+  autoFocus?: boolean;
+  suggestionLimit?: number;
+  className?: string;
+}
+
+const TYPE_LABELS: Record<SearchResultType, string> = {
+  app: 'App',
+  history: 'History',
+  suggestion: 'Search',
+};
+
+export default function Omnibox({
+  value,
+  onChange,
+  onSubmit,
+  apps,
+  history,
+  searchSuggestions,
+  placeholder = 'Search the web or enter a site',
+  autoFocus = false,
+  suggestionLimit = 8,
+  className,
+}: OmniboxProps) {
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const listId = useId();
+
+  const searchIndex = useMemo(
+    () =>
+      aggregateSearchIndex({
+        apps,
+        history,
+        suggestions: searchSuggestions,
+      }),
+    [apps, history, searchSuggestions],
+  );
+
+  const suggestions = useMemo(
+    () => matchSearchResults(value, searchIndex, { limit: suggestionLimit }),
+    [value, searchIndex, suggestionLimit],
+  );
+
+  useEffect(() => {
+    if (activeIndex === -1) return;
+    if (suggestions.length === 0) {
+      setActiveIndex(-1);
+      return;
+    }
+    if (activeIndex >= suggestions.length) {
+      setActiveIndex(suggestions.length - 1);
+    }
+  }, [activeIndex, suggestions]);
+
+  useEffect(() => {
+    setActiveIndex(-1);
+  }, [value]);
+
+  const commitQuery = () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onChange(trimmed);
+    onSubmit({ type: 'query', value: trimmed });
+    setActiveIndex(-1);
+  };
+
+  const commitSuggestion = (suggestion: SearchResult) => {
+    onChange(suggestion.value);
+    onSubmit(suggestion);
+    setActiveIndex(-1);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (activeIndex >= 0 && suggestions[activeIndex]) {
+      commitSuggestion(suggestions[activeIndex]);
+      return;
+    }
+    commitQuery();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'ArrowDown') {
+      if (suggestions.length === 0) return;
+      event.preventDefault();
+      setActiveIndex((prev) => {
+        const next = prev + 1;
+        if (next >= suggestions.length || next < 0) return 0;
+        return next;
+      });
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      if (suggestions.length === 0) return;
+      event.preventDefault();
+      setActiveIndex((prev) => {
+        if (prev <= 0) return suggestions.length - 1;
+        return prev - 1;
+      });
+      return;
+    }
+
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      if (activeIndex >= 0 && suggestions[activeIndex]) {
+        commitSuggestion(suggestions[activeIndex]);
+      } else {
+        commitQuery();
+      }
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      setActiveIndex(-1);
+    }
+  };
+
+  const handleSuggestionMouseDown = (
+    suggestion: SearchResult,
+  ) => (event: MouseEvent<HTMLLIElement>) => {
+    event.preventDefault();
+    commitSuggestion(suggestion);
+  };
+
+  const handleSuggestionHover = (index: number) => () => {
+    setActiveIndex(index);
+  };
+
+  const activeId =
+    activeIndex >= 0 ? `${listId}-item-${activeIndex}` : undefined;
+
+  const formClassName = [
+    'relative flex flex-col rounded-md bg-white shadow-md',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <form onSubmit={handleSubmit} className={formClassName}>
+      <input
+        type="text"
+        className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+        role="combobox"
+        aria-expanded={suggestions.length > 0}
+        aria-controls={suggestions.length > 0 ? listId : undefined}
+        aria-activedescendant={activeId}
+        aria-autocomplete="list"
+      />
+      {suggestions.length > 0 && (
+        <ul
+          id={listId}
+          role="listbox"
+          className="absolute top-full z-10 mt-1 w-full max-h-64 overflow-y-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+        >
+          {suggestions.map((suggestion, index) => {
+            const isActive = index === activeIndex;
+            const itemClassName = [
+              'flex cursor-pointer items-center justify-between gap-3 px-3 py-2 text-sm transition-colors',
+              isActive ? 'bg-blue-50 text-blue-700' : 'hover:bg-gray-100',
+            ].join(' ');
+
+            return (
+              <li
+                id={`${listId}-item-${index}`}
+                key={`${suggestion.type}-${suggestion.id}`}
+                role="option"
+                aria-selected={isActive}
+                className={itemClassName}
+                onMouseDown={handleSuggestionMouseDown(suggestion)}
+                onMouseEnter={handleSuggestionHover(index)}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="truncate font-medium">{suggestion.label}</div>
+                  {suggestion.secondaryLabel && (
+                    <div className="truncate text-xs text-gray-500">
+                      {suggestion.secondaryLabel}
+                    </div>
+                  )}
+                </div>
+                <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+                  {TYPE_LABELS[suggestion.type]}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </form>
+  );
+}

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -1,0 +1,304 @@
+export type SearchResultType = 'app' | 'history' | 'suggestion';
+
+export interface AppRecord {
+  id?: string;
+  name: string;
+  url?: string;
+  description?: string;
+  icon?: string;
+  keywords?: string[];
+}
+
+export interface HistoryRecord {
+  url: string;
+  title?: string;
+  lastVisitedAt?: number;
+  visitCount?: number;
+}
+
+export type SuggestionRecord =
+  | string
+  | {
+      value: string;
+      label?: string;
+      icon?: string;
+      keywords?: string[];
+      metadata?: Record<string, unknown>;
+    };
+
+export interface SearchResult {
+  id: string;
+  type: SearchResultType;
+  value: string;
+  label: string;
+  secondaryLabel?: string;
+  icon?: string;
+  keywords?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface AggregateParams {
+  apps?: AppRecord[];
+  history?: HistoryRecord[];
+  suggestions?: SuggestionRecord[];
+  limit?: number;
+}
+
+export interface SearchIndex {
+  apps: SearchResult[];
+  history: SearchResult[];
+  suggestions: SearchResult[];
+  all: SearchResult[];
+}
+
+export interface MatchOptions {
+  limit?: number;
+  includeTypes?: SearchResultType[];
+}
+
+const normalizeKeywords = (
+  ...tokens: Array<string | undefined | string[]>
+): string[] => {
+  const keywords = new Set<string>();
+
+  const add = (value: string) => {
+    const normalized = value.trim().toLowerCase();
+    if (normalized) keywords.add(normalized);
+  };
+
+  tokens.forEach((token) => {
+    if (!token) return;
+    if (Array.isArray(token)) {
+      token.forEach((entry) => {
+        if (typeof entry === 'string') {
+          entry
+            .split(/[\s,]+/)
+            .map((piece) => piece.trim())
+            .filter(Boolean)
+            .forEach(add);
+        }
+      });
+      return;
+    }
+
+    token
+      .split(/[\s,]+/)
+      .map((piece) => piece.trim())
+      .filter(Boolean)
+      .forEach(add);
+  });
+
+  return Array.from(keywords);
+};
+
+const mapApps = (apps: AppRecord[] = []): SearchResult[] =>
+  apps
+    .map((app, index) => {
+      const label = app.name?.trim();
+      const value = app.url?.trim() || app.id?.trim() || label;
+
+      if (!label || !value) {
+        return null;
+      }
+
+      const secondaryLabel = app.url && app.url !== label ? app.url : undefined;
+      const keywords = normalizeKeywords(app.name, app.description, app.keywords);
+
+      return {
+        id: app.id?.trim() || `app-${index}`,
+        type: 'app' as const,
+        value,
+        label,
+        secondaryLabel,
+        icon: app.icon,
+        keywords,
+        metadata: { ...app },
+      };
+    })
+    .filter((entry): entry is SearchResult => Boolean(entry));
+
+const mapHistory = (history: HistoryRecord[] = []): SearchResult[] =>
+  history
+    .map((entry, index) => {
+      const value = entry.url?.trim();
+      if (!value) return null;
+
+      const label = entry.title?.trim() || value;
+      const secondaryLabel = entry.title ? value : undefined;
+      const keywords = normalizeKeywords(entry.title, entry.url);
+
+      return {
+        id: value || `history-${index}`,
+        type: 'history' as const,
+        value,
+        label,
+        secondaryLabel,
+        keywords,
+        metadata: {
+          lastVisitedAt: entry.lastVisitedAt,
+          visitCount: entry.visitCount,
+        },
+      };
+    })
+    .filter((entry): entry is SearchResult => Boolean(entry));
+
+const mapSuggestions = (suggestions: SuggestionRecord[] = []): SearchResult[] =>
+  suggestions
+    .map((suggestion, index) => {
+      if (typeof suggestion === 'string') {
+        const value = suggestion.trim();
+        if (!value) return null;
+        return {
+          id: `suggestion-${index}`,
+          type: 'suggestion' as const,
+          value,
+          label: value,
+          keywords: normalizeKeywords(value),
+        };
+      }
+
+      const value = suggestion.value?.trim();
+      if (!value) return null;
+
+      const label = suggestion.label?.trim() || value;
+      const keywords = normalizeKeywords(label, value, suggestion.keywords);
+
+      return {
+        id: `suggestion-${index}`,
+        type: 'suggestion' as const,
+        value,
+        label,
+        icon: suggestion.icon,
+        keywords,
+        metadata: suggestion.metadata,
+      };
+    })
+    .filter((entry): entry is SearchResult => Boolean(entry));
+
+const dedupe = (sections: SearchResult[][]): SearchResult[] => {
+  const seen = new Set<string>();
+  const ordered: SearchResult[] = [];
+
+  sections.forEach((section) => {
+    section.forEach((item) => {
+      const key = item.value.trim().toLowerCase();
+      if (seen.has(key)) return;
+      seen.add(key);
+      ordered.push(item);
+    });
+  });
+
+  return ordered;
+};
+
+export const aggregateSearchIndex = ({
+  apps,
+  history,
+  suggestions,
+  limit,
+}: AggregateParams = {}): SearchIndex => {
+  const appResults = mapApps(apps);
+  const historyResults = mapHistory(history);
+  const suggestionResults = mapSuggestions(suggestions);
+
+  const all = dedupe([appResults, historyResults, suggestionResults]);
+  const limitedAll =
+    typeof limit === 'number' && limit >= 0 ? all.slice(0, limit) : all;
+
+  return {
+    apps: appResults,
+    history: historyResults,
+    suggestions: suggestionResults,
+    all: limitedAll,
+  };
+};
+
+interface ScoreWeights {
+  exact: number;
+  startsWith: number;
+  contains: number;
+}
+
+const evaluate = (
+  text: string | undefined,
+  query: string,
+  weights: ScoreWeights,
+): number => {
+  if (!text) return 0;
+  const normalized = text.trim().toLowerCase();
+  if (!normalized) return 0;
+  if (normalized === query) return weights.exact;
+  if (normalized.startsWith(query)) return weights.startsWith;
+  if (normalized.includes(query)) return weights.contains;
+  return 0;
+};
+
+const scoreResult = (item: SearchResult, query: string): number => {
+  const scores = [
+    evaluate(item.label, query, { exact: 10, startsWith: 7, contains: 3 }),
+    evaluate(item.value, query, { exact: 9, startsWith: 6, contains: 2 }),
+  ];
+
+  if (item.secondaryLabel) {
+    scores.push(
+      evaluate(item.secondaryLabel, query, {
+        exact: 8,
+        startsWith: 5,
+        contains: 2,
+      }),
+    );
+  }
+
+  if (item.keywords) {
+    item.keywords.forEach((keyword) => {
+      scores.push(
+        evaluate(keyword, query, {
+          exact: 7,
+          startsWith: 5,
+          contains: 1,
+        }),
+      );
+    });
+  }
+
+  return Math.max(0, ...scores);
+};
+
+export const matchSearchResults = (
+  query: string,
+  index: SearchIndex,
+  options: MatchOptions = {},
+): SearchResult[] => {
+  const { limit, includeTypes } = options;
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const dataset = includeTypes
+    ? index.all.filter((item) => includeTypes.includes(item.type))
+    : index.all;
+
+  if (!normalizedQuery) {
+    const results = [...dataset];
+    return typeof limit === 'number' && limit >= 0
+      ? results.slice(0, limit)
+      : results;
+  }
+
+  const matches = dataset
+    .map((item, position) => ({
+      item,
+      position,
+      score: scoreResult(item, normalizedQuery),
+    }))
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => {
+      if (b.score === a.score) return a.position - b.position;
+      return b.score - a.score;
+    })
+    .map(({ item }) => item);
+
+  if (typeof limit === 'number' && limit >= 0) {
+    return matches.slice(0, limit);
+  }
+
+  return matches;
+};


### PR DESCRIPTION
## Summary
- aggregate app, history, and suggestion metadata into a typed search index
- render omnibox suggestions with keyboard navigation and submit handling in the browser app

## Testing
- yarn lint *(fails: existing repo accessibility and no-top-level-window lint errors outside this change)*
- yarn test *(fails: pre-existing suites such as Modal.test.tsx and nmapNse.test.tsx; run aborted after repeated failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ca216be5f48328816bad217930ea80