### PR TITLE
feat(a11y): enforce 44px touch targets

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -5,6 +5,7 @@ import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import '../styles/tailwind.css';
 import '../styles/globals.css';
+import '../styles/components.css';
 import '../styles/index.css';
 import '../styles/resume-print.css';
 import '../styles/print.css';

--- a/styles/components.css
+++ b/styles/components.css
@@ -1,0 +1,11 @@
+/* Global component-level styles */
+
+button,
+[role="button"],
+input[type="button"],
+input[type="submit"],
+input[type="reset"],
+.hit-area {
+  min-width: var(--hit-area, 44px);
+  min-height: var(--hit-area, 44px);
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,4 +1,5 @@
 @import './globals.css';
+@import './components.css';
 
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
@@ -12,8 +13,8 @@ body{
 }
 
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
-    min-width: var(--hit-area);
-    min-height: var(--hit-area);
+    min-width: var(--hit-area, 44px);
+    min-height: var(--hit-area, 44px);
 }
 
 a:focus-visible,

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -56,7 +56,7 @@
   --font-family-base: 'Ubuntu', sans-serif;
   --font-multiplier: 1;
   /* Minimum interactive target size */
-  --hit-area: 32px;
+  --hit-area: 44px;
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;
@@ -86,7 +86,7 @@
 
 /* Larger hit areas */
 .large-hit-area {
-  --hit-area: 48px;
+  --hit-area: 56px;
 }
 
 /* Reduced motion */

--- a/tests/a11y/targets.spec.ts
+++ b/tests/a11y/targets.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from '@playwright/test';
+import path from 'path';
+import { readFile } from 'fs/promises';
+
+const MIN_TOUCH_TARGET = 44;
+const SIZE_TOLERANCE = 0.5;
+
+const SAMPLE_TARGETS = [
+  { label: 'button', tag: 'button', text: 'Button' },
+  {
+    label: '[role="button"]',
+    tag: 'div',
+    text: 'Role button',
+    attributes: { role: 'button' },
+    tabIndex: 0,
+    style: { display: 'inline-flex', alignItems: 'center', justifyContent: 'center' },
+  },
+  { label: 'input[type="button"]', tag: 'input', text: 'Input button', attributes: { type: 'button' } },
+  { label: 'input[type="submit"]', tag: 'input', text: 'Submit', attributes: { type: 'submit' } },
+  { label: 'input[type="reset"]', tag: 'input', text: 'Reset', attributes: { type: 'reset' } },
+  {
+    label: '.hit-area',
+    tag: 'div',
+    text: 'Hit area',
+    className: 'hit-area',
+    style: { display: 'inline-flex', alignItems: 'center', justifyContent: 'center' },
+  },
+] as const;
+
+test.describe('Touch target sizing', () => {
+  test('interactive controls are at least 44x44px', async ({ page }) => {
+    test.setTimeout(120_000);
+
+    const rootDir = path.resolve(__dirname, '../../');
+    const [tokensCss, componentsCss] = await Promise.all([
+      readFile(path.join(rootDir, 'styles/tokens.css'), 'utf8'),
+      readFile(path.join(rootDir, 'styles/components.css'), 'utf8'),
+    ]);
+
+    await page.setContent('<!DOCTYPE html><html><head></head><body></body></html>');
+    await page.addStyleTag({ content: `${tokensCss}\n${componentsCss}` });
+
+    const samples = await page.evaluate((targets) => {
+      const container = document.createElement('div');
+      container.id = 'touch-target-test-container';
+      container.style.position = 'absolute';
+      container.style.top = '0';
+      container.style.left = '0';
+      container.style.display = 'flex';
+      container.style.flexWrap = 'wrap';
+      container.style.gap = '8px';
+      container.style.padding = '4px';
+      container.style.background = 'transparent';
+      container.style.zIndex = '2147483647';
+
+      document.body.appendChild(container);
+
+      const created = targets.map((target) => {
+        const element = document.createElement(target.tag);
+
+        if (target.className) element.className = target.className;
+        if (typeof target.tabIndex === 'number') element.tabIndex = target.tabIndex;
+        if (target.attributes) {
+          Object.entries(target.attributes).forEach(([key, value]) => {
+            element.setAttribute(key, value);
+          });
+        }
+
+        if (target.text) {
+          if (target.tag === 'input') {
+            element.setAttribute('value', target.text);
+          } else {
+            element.textContent = target.text;
+          }
+        }
+
+        if (target.style) {
+          Object.entries(target.style).forEach(([key, value]) => {
+            element.style.setProperty(key, value);
+          });
+        }
+
+        container.appendChild(element);
+        const rect = element.getBoundingClientRect();
+
+        const styles = window.getComputedStyle(element);
+
+        return {
+          label: target.label,
+          width: rect.width,
+          height: rect.height,
+          minWidth: styles.minWidth,
+          minHeight: styles.minHeight,
+        };
+      });
+
+      const containerRect = container.getBoundingClientRect();
+      const snapshot = { containerWidth: containerRect.width, containerHeight: containerRect.height };
+      container.remove();
+      return { created, snapshot };
+    }, SAMPLE_TARGETS);
+
+    for (const sample of samples.created) {
+      expect
+        .soft(sample.width, `${sample.label} width`)
+        .toBeGreaterThanOrEqual(MIN_TOUCH_TARGET - SIZE_TOLERANCE);
+      expect
+        .soft(sample.height, `${sample.label} height`)
+        .toBeGreaterThanOrEqual(MIN_TOUCH_TARGET - SIZE_TOLERANCE);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- set a shared 44px minimum hit area rule for button-like controls and import it globally
- raise the default --hit-area token to 44px and bump the large mode override to 56px
- add a Playwright check that loads the CSS in isolation and verifies sample controls meet 44px sizing

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label and no-top-level-window violations)*
- npx playwright test tests/a11y/targets.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68ca21701ff4832891b74e17f853e588