### PR TITLE
[settings] Add sticky modifier toggle and keyboard latch logic

### DIFF
--- a/apps/settings/accessibility/StickyModifiersToggle.tsx
+++ b/apps/settings/accessibility/StickyModifiersToggle.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import ToggleSwitch from "@/components/ToggleSwitch";
+import { useSettings } from "@/hooks/useSettings";
+import {
+  subscribeStickyModifierChanges,
+  type ModifierKey,
+} from "@/src/system/keyboard";
+
+const formatLatched = (latched: ModifierKey[]) => {
+  if (latched.length === 0) {
+    return "No modifiers latched.";
+  }
+  return `Latched: ${latched.join(" + ")}`;
+};
+
+export default function StickyModifiersToggle() {
+  const { stickyModifiers, setStickyModifiers } = useSettings();
+  const [latched, setLatched] = useState<ModifierKey[]>([]);
+
+  useEffect(() => {
+    if (!stickyModifiers) {
+      setLatched([]);
+      return undefined;
+    }
+
+    const unsubscribe = subscribeStickyModifierChanges((state) => {
+      setLatched(state.latched);
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [stickyModifiers]);
+
+  return (
+    <div className="px-4 my-4">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <span className="block text-ubt-grey font-medium">
+            Sticky modifier keys
+          </span>
+          <p className="text-xs text-ubt-grey/80">
+            Tap Shift, Ctrl, Alt, or Meta to latch the modifier for the next
+            key press.
+          </p>
+        </div>
+        <ToggleSwitch
+          checked={stickyModifiers}
+          onChange={setStickyModifiers}
+          ariaLabel="Sticky modifier keys"
+        />
+      </div>
+      {stickyModifiers && (
+        <p className="mt-2 text-xs text-ubt-grey" role="status">
+          {formatLatched(latched)}
+        </p>
+      )}
+    </div>
+  );
+}
+

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import StickyModifiersToggle from "./accessibility/StickyModifiersToggle";
 
 export default function Settings() {
   const {
@@ -29,6 +30,7 @@ export default function Settings() {
     setHighContrast,
     haptics,
     setHaptics,
+    setStickyModifiers,
     theme,
     setTheme,
   } = useSettings();
@@ -79,6 +81,8 @@ export default function Settings() {
       if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
+      if (parsed.stickyModifiers !== undefined)
+        setStickyModifiers(parsed.stickyModifiers);
       if (parsed.theme !== undefined) setTheme(parsed.theme);
     } catch (err) {
       console.error("Invalid settings", err);
@@ -100,6 +104,7 @@ export default function Settings() {
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
+    setStickyModifiers(defaults.stickyModifiers);
     setTheme("default");
   };
 
@@ -252,6 +257,7 @@ export default function Settings() {
               ariaLabel="High Contrast"
             />
           </div>
+          <StickyModifiersToggle />
           <div className="flex justify-center my-4 items-center">
             <span className="mr-2 text-ubt-grey">Haptics:</span>
             <ToggleSwitch

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,9 +20,12 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getStickyModifiers as loadStickyModifiers,
+  setStickyModifiers as saveStickyModifiers,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+import { setStickyModifiersEnabled } from '@/src/system/keyboard';
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
@@ -62,6 +65,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  stickyModifiers: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +77,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setStickyModifiers: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +92,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  stickyModifiers: defaults.stickyModifiers,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +104,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setStickyModifiers: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +119,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [stickyModifiers, setStickyModifiers] = useState<boolean>(defaults.stickyModifiers);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +135,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setStickyModifiers(await loadStickyModifiers());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +245,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveStickyModifiers(stickyModifiers);
+    setStickyModifiersEnabled(stickyModifiers);
+  }, [stickyModifiers]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +263,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        stickyModifiers,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +275,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setStickyModifiers,
         setTheme,
       }}
     >

--- a/src/system/keyboard.ts
+++ b/src/system/keyboard.ts
@@ -1,0 +1,354 @@
+type ModifierKey = "Shift" | "Control" | "Alt" | "Meta";
+
+export type { ModifierKey };
+
+export interface ModifierLatchState {
+  enabled: boolean;
+  latched: ModifierKey[];
+}
+
+type StickyChangeListener = (state: ModifierLatchState) => void;
+
+const SHIFTED_KEY_MAP: Record<string, string> = {
+  "1": "!",
+  "2": "@",
+  "3": "#",
+  "4": "$",
+  "5": "%",
+  "6": "^",
+  "7": "&",
+  "8": "*",
+  "9": "(",
+  "0": ")",
+  "-": "_",
+  "=": "+",
+  "[": "{",
+  "]": "}",
+  "\\": "|",
+  ";": ":",
+  "'": '"',
+  ",": "<",
+  ".": ">",
+  "/": "?",
+  "`": "~",
+};
+
+const KEY_TO_MODIFIER: Record<string, ModifierKey> = {
+  Shift: "Shift",
+  Control: "Control",
+  Ctrl: "Control",
+  Alt: "Alt",
+  AltGraph: "Alt",
+  Meta: "Meta",
+  OS: "Meta",
+  Super: "Meta",
+};
+
+const CODE_TO_MODIFIER: Record<string, ModifierKey> = {
+  ShiftLeft: "Shift",
+  ShiftRight: "Shift",
+  ControlLeft: "Control",
+  ControlRight: "Control",
+  AltLeft: "Alt",
+  AltRight: "Alt",
+  MetaLeft: "Meta",
+  MetaRight: "Meta",
+};
+
+const normalizeModifierKey = (input: string): ModifierKey | null => {
+  return KEY_TO_MODIFIER[input] ?? CODE_TO_MODIFIER[input] ?? null;
+};
+
+const getModifierFromEvent = (event: KeyboardEvent): ModifierKey | null => {
+  return normalizeModifierKey(event.key) ?? normalizeModifierKey(event.code);
+};
+
+const overrideBooleanProperty = (
+  event: KeyboardEvent,
+  key: "shiftKey" | "ctrlKey" | "altKey" | "metaKey",
+  value: boolean,
+) => {
+  try {
+    Object.defineProperty(event, key, {
+      configurable: true,
+      enumerable: true,
+      value,
+    });
+  } catch {
+    try {
+      Object.defineProperty(event, key, {
+        configurable: true,
+        enumerable: true,
+        get: () => value,
+      });
+    } catch {
+      // Swallow errors on platforms where KeyboardEvent props are immutable.
+    }
+  }
+};
+
+const overrideKey = (event: KeyboardEvent, value: string) => {
+  try {
+    Object.defineProperty(event, "key", {
+      configurable: true,
+      enumerable: true,
+      value,
+    });
+  } catch {
+    try {
+      Object.defineProperty(event, "key", {
+        configurable: true,
+        enumerable: true,
+        get: () => value,
+      });
+    } catch {
+      /* ignore */
+    }
+  }
+};
+
+const computeShiftedKey = (key: string): string | null => {
+  if (key.length !== 1) return null;
+  if (SHIFTED_KEY_MAP[key] !== undefined) {
+    return SHIFTED_KEY_MAP[key];
+  }
+  const upper = key.toUpperCase();
+  if (upper !== key) {
+    return upper;
+  }
+  return null;
+};
+
+class KeyboardSystem {
+  private stickyEnabled = false;
+  private latched = new Set<ModifierKey>();
+  private held = new Set<ModifierKey>();
+  private usedDuringHold = new Map<ModifierKey, boolean>();
+  private resetAfterNextKey = false;
+  private listeners = new Set<StickyChangeListener>();
+
+  constructor() {
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleKeyUp = this.handleKeyUp.bind(this);
+    this.handleWindowBlur = this.handleWindowBlur.bind(this);
+    this.handleVisibilityChange = this.handleVisibilityChange.bind(this);
+
+    window.addEventListener("keydown", this.handleKeyDown, true);
+    window.addEventListener("keyup", this.handleKeyUp, true);
+    window.addEventListener("blur", this.handleWindowBlur);
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", this.handleVisibilityChange);
+    }
+  }
+
+  subscribe(listener: StickyChangeListener) {
+    this.listeners.add(listener);
+    listener(this.snapshot());
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  setStickyModifiersEnabled(enabled: boolean) {
+    if (this.stickyEnabled === enabled) return;
+    this.stickyEnabled = enabled;
+    if (!enabled) {
+      this.latched.clear();
+      this.held.clear();
+      this.usedDuringHold.clear();
+      this.resetAfterNextKey = false;
+    }
+    this.emitChange();
+  }
+
+  isLatched(modifier: ModifierKey) {
+    return this.latched.has(modifier);
+  }
+
+  getState(): ModifierLatchState {
+    return this.snapshot();
+  }
+
+  reset() {
+    if (
+      this.latched.size === 0 &&
+      this.held.size === 0 &&
+      !this.resetAfterNextKey
+    ) {
+      this.usedDuringHold.clear();
+      return;
+    }
+    this.latched.clear();
+    this.held.clear();
+    this.usedDuringHold.clear();
+    this.resetAfterNextKey = false;
+    this.emitChange();
+  }
+
+  private handleKeyDown(event: KeyboardEvent) {
+    const modifier = getModifierFromEvent(event);
+    if (modifier) {
+      if (event.repeat) return;
+      this.held.add(modifier);
+      this.usedDuringHold.set(modifier, false);
+      return;
+    }
+
+    if (!this.stickyEnabled || this.latched.size === 0) {
+      return;
+    }
+
+    const originalShift = event.shiftKey;
+    const originalCtrl = event.ctrlKey;
+    const originalAlt = event.altKey;
+    const originalMeta = event.metaKey;
+
+    if (this.latched.has("Shift") && !originalShift) {
+      overrideBooleanProperty(event, "shiftKey", true);
+    }
+    if (this.latched.has("Control") && !originalCtrl) {
+      overrideBooleanProperty(event, "ctrlKey", true);
+    }
+    if (this.latched.has("Alt") && !originalAlt) {
+      overrideBooleanProperty(event, "altKey", true);
+    }
+    if (this.latched.has("Meta") && !originalMeta) {
+      overrideBooleanProperty(event, "metaKey", true);
+    }
+
+    const originalGetModifierState = event.getModifierState
+      ? event.getModifierState.bind(event)
+      : undefined;
+    event.getModifierState = (key: string) => {
+      const normalized = normalizeModifierKey(key);
+      if (normalized && this.latched.has(normalized)) {
+        return true;
+      }
+      return originalGetModifierState ? originalGetModifierState(key) : false;
+    };
+
+    if (this.latched.has("Shift") && !originalShift) {
+      const shiftedKey = computeShiftedKey(event.key);
+      if (shiftedKey) {
+        overrideKey(event, shiftedKey);
+      }
+    }
+
+    if (this.held.size > 0) {
+      this.held.forEach((mod) => {
+        this.usedDuringHold.set(mod, true);
+      });
+    }
+
+    this.resetAfterNextKey = true;
+  }
+
+  private handleKeyUp(event: KeyboardEvent) {
+    const modifier = getModifierFromEvent(event);
+    if (!modifier) {
+      if (this.resetAfterNextKey) {
+        this.resetAfterNextKey = false;
+        if (this.latched.size > 0) {
+          this.latched.clear();
+          this.emitChange();
+        }
+      }
+      return;
+    }
+
+    if (event.repeat) return;
+
+    this.held.delete(modifier);
+    const used = this.usedDuringHold.get(modifier);
+    this.usedDuringHold.delete(modifier);
+
+    if (!this.stickyEnabled) {
+      return;
+    }
+
+    if (used) {
+      return;
+    }
+
+    if (this.latched.has(modifier)) {
+      this.latched.delete(modifier);
+    } else {
+      this.latched.add(modifier);
+    }
+    this.emitChange();
+  }
+
+  private handleWindowBlur() {
+    this.reset();
+  }
+
+  private handleVisibilityChange() {
+    if (typeof document === "undefined") return;
+    if (document.visibilityState === "hidden") {
+      this.reset();
+    }
+  }
+
+  private emitChange() {
+    if (this.listeners.size === 0) return;
+    const snapshot = this.snapshot();
+    this.listeners.forEach((listener) => listener(snapshot));
+  }
+
+  private snapshot(): ModifierLatchState {
+    return {
+      enabled: this.stickyEnabled,
+      latched: Array.from(this.latched),
+    };
+  }
+}
+
+type KeyboardSystemWithMarker = KeyboardSystem & { __isStickyManager?: true };
+
+let instance: KeyboardSystem | null = null;
+
+const ensureKeyboard = (): KeyboardSystem | null => {
+  if (instance) return instance;
+  if (typeof window === "undefined") return null;
+  const global = window as typeof window & {
+    __stickyKeyboard?: KeyboardSystemWithMarker;
+  };
+  if (global.__stickyKeyboard) {
+    instance = global.__stickyKeyboard;
+    return instance;
+  }
+  instance = new KeyboardSystem();
+  global.__stickyKeyboard = instance as KeyboardSystemWithMarker;
+  return instance;
+};
+
+export const setStickyModifiersEnabled = (enabled: boolean) => {
+  const keyboard = ensureKeyboard();
+  keyboard?.setStickyModifiersEnabled(enabled);
+};
+
+export const resetStickyModifiers = () => {
+  const keyboard = ensureKeyboard();
+  keyboard?.reset();
+};
+
+export const isModifierLatched = (modifier: ModifierKey): boolean => {
+  const keyboard = ensureKeyboard();
+  return keyboard?.isLatched(modifier) ?? false;
+};
+
+export const getStickyModifierState = (): ModifierLatchState => {
+  const keyboard = ensureKeyboard();
+  return keyboard?.getState() ?? { enabled: false, latched: [] };
+};
+
+export const subscribeStickyModifierChanges = (
+  listener: StickyChangeListener,
+): (() => void) => {
+  const keyboard = ensureKeyboard();
+  if (!keyboard) {
+    return () => {};
+  }
+  return keyboard.subscribe(listener);
+};
+

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  stickyModifiers: false,
 };
 
 export async function getAccent() {
@@ -102,6 +103,17 @@ export async function setHaptics(value) {
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+export async function getStickyModifiers() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.stickyModifiers;
+  const val = window.localStorage.getItem('sticky-modifiers');
+  return val === null ? DEFAULT_SETTINGS.stickyModifiers : val === 'true';
+}
+
+export async function setStickyModifiers(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('sticky-modifiers', value ? 'true' : 'false');
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -137,6 +149,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('sticky-modifiers');
 }
 
 export async function exportSettings() {
@@ -151,6 +164,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    stickyModifiers,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +176,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getStickyModifiers(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +190,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    stickyModifiers,
     theme,
   });
 }
@@ -199,6 +215,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    stickyModifiers,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +228,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (stickyModifiers !== undefined) await setStickyModifiers(stickyModifiers);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add an accessibility toggle for sticky modifier keys with live latch feedback
- persist the sticky modifier preference in the settings store and context
- implement a keyboard system helper that latches modifiers and clears them after use

## Testing
- yarn lint *(fails: repository already has numerous jsx-a11y and no-top-level-window violations)*
- yarn test *(fails: existing suites depend on browser globals such as localStorage during SSR)*

------
https://chatgpt.com/codex/tasks/task_e_68ca21724e088328af95fd8b420f9e73