### PR TITLE
settings: add keyboard shortcut manager

### DIFF
--- a/apps/settings/components/KeymapOverlay.tsx
+++ b/apps/settings/components/KeymapOverlay.tsx
@@ -1,96 +1,22 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import useKeymap from '../keymapRegistry';
+import { KeyboardShortcutSettings } from '../keyboard';
 
 interface KeymapOverlayProps {
   open: boolean;
   onClose: () => void;
 }
 
-const formatEvent = (e: KeyboardEvent) => {
-  const parts = [
-    e.ctrlKey ? 'Ctrl' : '',
-    e.altKey ? 'Alt' : '',
-    e.shiftKey ? 'Shift' : '',
-    e.metaKey ? 'Meta' : '',
-    e.key.length === 1 ? e.key.toUpperCase() : e.key,
-  ];
-  return parts.filter(Boolean).join('+');
-};
-
 export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
-  const { shortcuts, updateShortcut } = useKeymap();
-  const [rebinding, setRebinding] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!rebinding) return;
-    const handler = (e: KeyboardEvent) => {
-      e.preventDefault();
-      const combo = formatEvent(e);
-      updateShortcut(rebinding, combo);
-      setRebinding(null);
-    };
-    window.addEventListener('keydown', handler, { once: true });
-    return () => window.removeEventListener('keydown', handler);
-  }, [rebinding, updateShortcut]);
-
   if (!open) return null;
-
-  const keyCounts = shortcuts.reduce<Map<string, number>>((map, s) => {
-    map.set(s.keys, (map.get(s.keys) || 0) + 1);
-    return map;
-  }, new Map());
-  const conflicts = new Set(
-    Array.from(keyCounts.entries())
-      .filter(([, count]) => count > 1)
-      .map(([key]) => key)
-  );
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/80 text-white p-4 overflow-auto"
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-auto bg-black/80 p-4 text-white"
       role="dialog"
       aria-modal="true"
     >
-      <div className="max-w-lg w-full space-y-4">
-        <div className="flex justify-between items-center">
-          <h2 className="text-xl font-bold">Keyboard Shortcuts</h2>
-          <button
-            type="button"
-            onClick={() => {
-              setRebinding(null);
-              onClose();
-            }}
-            className="text-sm underline"
-          >
-            Close
-          </button>
-        </div>
-        <ul className="space-y-1">
-          {shortcuts.map((s) => (
-            <li
-              key={s.description}
-              data-conflict={conflicts.has(s.keys) ? 'true' : 'false'}
-              className={
-                conflicts.has(s.keys)
-                  ? 'flex justify-between bg-red-600/70 px-2 py-1 rounded'
-                  : 'flex justify-between px-2 py-1'
-              }
-            >
-              <span className="flex-1">{s.description}</span>
-              <span className="font-mono mr-2">{s.keys}</span>
-              <button
-                type="button"
-                onClick={() => setRebinding(s.description)}
-                className="px-2 py-1 bg-ub-orange text-white rounded text-sm"
-              >
-                {rebinding === s.description ? 'Press keys...' : 'Rebind'}
-              </button>
-            </li>
-          ))}
-        </ul>
-      </div>
+      <KeyboardShortcutSettings onClose={onClose} />
     </div>
   );
 }

--- a/apps/settings/keyboard/KeyboardShortcutSettings.tsx
+++ b/apps/settings/keyboard/KeyboardShortcutSettings.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import useKeymap, { type ShortcutEntry } from '../keymapRegistry';
+import { formatKeybinding } from '@/src/system/shortcuts';
+import ShortcutRow from './ShortcutRow';
+
+interface KeyboardShortcutSettingsProps {
+  onClose?: () => void;
+}
+
+const groupShortcuts = (shortcuts: ShortcutEntry[]) => {
+  const groups: { category: string; items: ShortcutEntry[] }[] = [];
+  const index = new Map<string, number>();
+
+  shortcuts.forEach((shortcut) => {
+    if (index.has(shortcut.category)) {
+      const bucket = groups[index.get(shortcut.category)!];
+      bucket.items.push(shortcut);
+      return;
+    }
+    index.set(shortcut.category, groups.length);
+    groups.push({ category: shortcut.category, items: [shortcut] });
+  });
+
+  return groups;
+};
+
+const KeyboardShortcutSettings = ({
+  onClose,
+}: KeyboardShortcutSettingsProps) => {
+  const { shortcuts, updateShortcut, resetShortcut, restoreDefaults } = useKeymap();
+  const [capturingId, setCapturingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!capturingId) return;
+
+    const handler = (event: KeyboardEvent) => {
+      event.preventDefault();
+      if (event.key === 'Escape') {
+        setCapturingId(null);
+        return;
+      }
+
+      const binding = formatKeybinding(event);
+      if (binding) {
+        updateShortcut(capturingId, binding);
+        setCapturingId(null);
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [capturingId, updateShortcut]);
+
+  const grouped = useMemo(() => groupShortcuts(shortcuts), [shortcuts]);
+  const hasConflicts = shortcuts.some((shortcut) => shortcut.conflict);
+
+  return (
+    <div className="w-full max-w-3xl overflow-hidden rounded-lg border border-gray-800 bg-ub-cool-grey text-white shadow-xl">
+      <header className="flex flex-col gap-2 border-b border-gray-800 px-5 py-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Keyboard shortcuts</h2>
+          <p className="text-sm text-ubt-grey">
+            Customize the key bindings for global desktop actions.
+          </p>
+        </div>
+        {onClose && (
+          <button
+            type="button"
+            onClick={() => {
+              setCapturingId(null);
+              onClose();
+            }}
+            className="self-start rounded px-3 py-1 text-sm font-medium text-ub-orange transition hover:text-white"
+          >
+            Close
+          </button>
+        )}
+      </header>
+      <div className="space-y-6 px-5 py-4">
+        {hasConflicts && (
+          <div className="rounded border border-red-500/60 bg-red-900/40 px-3 py-2 text-sm text-red-200">
+            Some shortcuts share the same key combination. Reassign or reset the highlighted rows to
+            resolve the conflict.
+          </div>
+        )}
+        <div className="flex flex-wrap justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              setCapturingId(null);
+              restoreDefaults();
+            }}
+            className="rounded bg-gray-700 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-gray-600"
+          >
+            Restore defaults
+          </button>
+        </div>
+        {grouped.map(({ category, items }) => (
+          <section key={category} className="space-y-2">
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-ubt-grey">
+              {category}
+            </h3>
+            <ul className="divide-y divide-gray-800 overflow-hidden rounded border border-gray-800">
+              {items.map((shortcut) => (
+                <ShortcutRow
+                  key={shortcut.id}
+                  shortcut={shortcut}
+                  capturing={capturingId === shortcut.id}
+                  onStartCapture={() => setCapturingId(shortcut.id)}
+                  onReset={() => {
+                    setCapturingId((current) => (current === shortcut.id ? null : current));
+                    resetShortcut(shortcut.id);
+                  }}
+                />
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default KeyboardShortcutSettings;

--- a/apps/settings/keyboard/ShortcutRow.tsx
+++ b/apps/settings/keyboard/ShortcutRow.tsx
@@ -1,0 +1,89 @@
+import type { ShortcutEntry } from '../keymapRegistry';
+
+interface ShortcutRowProps {
+  shortcut: ShortcutEntry;
+  capturing: boolean;
+  onStartCapture: () => void;
+  onReset: () => void;
+}
+
+const ShortcutRow = ({
+  shortcut,
+  capturing,
+  onStartCapture,
+  onReset,
+}: ShortcutRowProps) => {
+  const { action, description, keys, conflict, conflictsWith, isDefault } = shortcut;
+  const displayKeys = capturing ? 'Press keys…' : keys || 'Not set';
+
+  return (
+    <li
+      className={`flex flex-col gap-2 px-3 py-2 text-sm transition-colors sm:flex-row sm:items-center sm:gap-4 ${
+        conflict ? 'bg-red-900/30' : ''
+      }`}
+      data-conflict={conflict ? 'true' : 'false'}
+    >
+      <div className="flex-1">
+        <p className="font-medium">{action}</p>
+        {description && (
+          <p className="mt-1 text-xs text-ubt-grey" aria-live="polite">
+            {description}
+          </p>
+        )}
+        <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-ubt-grey">
+          {conflict && (
+            <span className="rounded bg-red-900/60 px-2 py-0.5 text-red-100">
+              Conflicts with {conflictsWith.length} other action
+              {conflictsWith.length > 1 ? 's' : ''}
+            </span>
+          )}
+          {!isDefault && !conflict && (
+            <span className="rounded bg-ub-orange/20 px-2 py-0.5 text-ub-orange">
+              Custom
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center gap-2 self-start sm:self-auto">
+        <code
+          className={`rounded border px-2 py-1 font-mono text-xs ${
+            capturing
+              ? 'border-ub-orange text-ub-orange animate-pulse'
+              : 'border-gray-700 text-white'
+          }`}
+          aria-live={capturing ? 'polite' : undefined}
+        >
+          {displayKeys}
+        </code>
+        <button
+          type="button"
+          onClick={() => {
+            if (!capturing) onStartCapture();
+          }}
+          disabled={capturing}
+          className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
+            capturing
+              ? 'cursor-wait bg-ub-orange/40 text-white'
+              : 'bg-ub-orange text-white hover:bg-ub-orange/90'
+          }`}
+        >
+          {capturing ? 'Listening…' : 'Rebind'}
+        </button>
+        <button
+          type="button"
+          onClick={onReset}
+          disabled={isDefault}
+          className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
+            isDefault
+              ? 'cursor-not-allowed bg-gray-700/60 text-gray-400'
+              : 'bg-gray-700 text-white hover:bg-gray-600'
+          }`}
+        >
+          Reset
+        </button>
+      </div>
+    </li>
+  );
+};
+
+export default ShortcutRow;

--- a/apps/settings/keyboard/index.ts
+++ b/apps/settings/keyboard/index.ts
@@ -1,0 +1,1 @@
+export { default as KeyboardShortcutSettings } from './KeyboardShortcutSettings';

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -1,50 +1,80 @@
+import { useCallback, useEffect, useMemo } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
-
-export interface Shortcut {
-  description: string;
-  keys: string;
-}
-
-const DEFAULT_SHORTCUTS: Shortcut[] = [
-  { description: 'Show keyboard shortcuts', keys: '?' },
-  { description: 'Open settings', keys: 'Ctrl+,' },
-];
-
-const validator = (value: unknown): value is Record<string, string> => {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    !Array.isArray(value) &&
-    Object.values(value as Record<string, unknown>).every(
-      (v) => typeof v === 'string'
-    )
-  );
-};
+import {
+  SHORTCUT_DEFINITIONS,
+  SHORTCUT_STORAGE_KEY,
+  createDefaultShortcutMap,
+  detectConflicts,
+  normalizeBinding,
+  resolveShortcuts,
+  shortcutMapValidator,
+  upgradeShortcutMap,
+} from '@/src/system/shortcuts';
 
 export function useKeymap() {
-  const initial = DEFAULT_SHORTCUTS.reduce<Record<string, string>>(
-    (acc, s) => {
-      acc[s.description] = s.keys;
-      return acc;
+  const [map, setMap] = usePersistentState(
+    SHORTCUT_STORAGE_KEY,
+    () => createDefaultShortcutMap(),
+    shortcutMapValidator
+  );
+
+  useEffect(() => {
+    const upgraded = upgradeShortcutMap(map, SHORTCUT_DEFINITIONS);
+    if (upgraded !== map) {
+      setMap(upgraded);
+    }
+  }, [map, setMap]);
+
+  const resolved = useMemo(
+    () => resolveShortcuts(map, SHORTCUT_DEFINITIONS),
+    [map]
+  );
+  const conflicts = useMemo(() => detectConflicts(resolved), [resolved]);
+
+  const shortcuts = useMemo(
+    () =>
+      resolved.map((shortcut) => ({
+        ...shortcut,
+        conflict: shortcut.conflictsWith.length > 0,
+      })),
+    [resolved]
+  );
+
+  const updateShortcut = useCallback(
+    (id: string, keys: string) => {
+      const normalized = normalizeBinding(keys);
+      setMap((prev) => ({
+        ...prev,
+        [id]: normalized,
+      }));
     },
-    {}
+    [setMap]
   );
 
-  const [map, setMap] = usePersistentState<Record<string, string>>(
-    'keymap',
-    initial,
-    validator
+  const resetShortcut = useCallback(
+    (id: string) => {
+      setMap((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+    },
+    [setMap]
   );
 
-  const shortcuts = DEFAULT_SHORTCUTS.map(({ description, keys }) => ({
-    description,
-    keys: map[description] || keys,
-  }));
+  const restoreDefaults = useCallback(() => {
+    setMap(createDefaultShortcutMap(SHORTCUT_DEFINITIONS));
+  }, [setMap]);
 
-  const updateShortcut = (description: string, keys: string) =>
-    setMap({ ...map, [description]: keys });
-
-  return { shortcuts, updateShortcut };
+  return {
+    shortcuts,
+    updateShortcut,
+    resetShortcut,
+    restoreDefaults,
+    conflicts,
+  };
 }
+
+export type ShortcutEntry = ReturnType<typeof useKeymap>['shortcuts'][number];
 
 export default useKeymap;

--- a/src/system/shortcuts.ts
+++ b/src/system/shortcuts.ts
@@ -1,0 +1,315 @@
+import type { Dispatch, SetStateAction } from 'react';
+
+export type ShortcutCategory =
+  | 'System'
+  | 'Windows'
+  | 'Utilities';
+
+export interface ShortcutDefinition {
+  /**
+   * Stable identifier used for persistence.
+   * Slugs are preferred, but legacy string identifiers are also supported via `legacyIds`.
+   */
+  id: string;
+  /**
+   * Friendly label for the action exposed to users.
+   */
+  action: string;
+  /**
+   * Short help text describing what the action does.
+   */
+  description: string;
+  /**
+   * Category heading for grouping related shortcuts in the UI.
+   */
+  category: ShortcutCategory;
+  /**
+   * Default key binding shipped with the system.
+   */
+  defaultKeys: string;
+  /**
+   * Legacy identifiers that should map to the same action.
+   * Useful for migrating existing `localStorage` values.
+   */
+  legacyIds?: string[];
+}
+
+export interface ShortcutMap {
+  [shortcutId: string]: string;
+}
+
+export interface ResolvedShortcut extends ShortcutDefinition {
+  /**
+   * Effective key binding after applying user overrides.
+   */
+  keys: string;
+  /**
+   * Indicates whether the shortcut matches the factory default mapping.
+   */
+  isDefault: boolean;
+  /**
+   * Other shortcuts that use the same key binding.
+   */
+  conflictsWith: string[];
+}
+
+export interface ShortcutUpdate {
+  id: string;
+  keys: string;
+}
+
+export interface ShortcutRegistryHook {
+  shortcuts: ResolvedShortcut[];
+  /**
+   * Conflicts grouped by key binding. The map only contains entries that clash.
+   */
+  conflicts: Map<string, string[]>;
+  updateShortcut: (id: string, keys: string) => void;
+  resetShortcut: (id: string) => void;
+  restoreDefaults: () => void;
+  setMap: Dispatch<SetStateAction<ShortcutMap>>;
+}
+
+export const SHORTCUT_STORAGE_KEY = 'keymap';
+
+export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
+  {
+    id: 'show-shortcuts',
+    action: 'Show keyboard shortcuts',
+    description: 'Toggle the on-screen cheat sheet.',
+    category: 'System',
+    defaultKeys: '?',
+    legacyIds: ['Show keyboard shortcuts'],
+  },
+  {
+    id: 'open-settings',
+    action: 'Open settings',
+    description: 'Launch the system settings window.',
+    category: 'System',
+    defaultKeys: 'Ctrl+,',
+    legacyIds: ['Open settings'],
+  },
+  {
+    id: 'open-clipboard-manager',
+    action: 'Open clipboard manager',
+    description: 'Open the Clipboard Manager utility.',
+    category: 'Utilities',
+    defaultKeys: 'Ctrl+Shift+V',
+  },
+  {
+    id: 'switch-apps',
+    action: 'Switch between apps',
+    description: 'Cycle focus between open application windows.',
+    category: 'Windows',
+    defaultKeys: 'Alt+Tab',
+  },
+  {
+    id: 'cycle-app-windows',
+    action: 'Cycle windows of current app',
+    description: 'Rotate through multiple windows of the focused app.',
+    category: 'Windows',
+    defaultKeys: 'Alt+~',
+  },
+];
+
+const MODIFIER_ORDER: readonly string[] = ['Ctrl', 'Alt', 'Shift', 'Super'];
+
+const KEY_ALIASES: Record<string, string> = {
+  control: 'Ctrl',
+  ctrl: 'Ctrl',
+  alt: 'Alt',
+  option: 'Alt',
+  shift: 'Shift',
+  meta: 'Super',
+  super: 'Super',
+  command: 'Super',
+  cmd: 'Super',
+  win: 'Super',
+  os: 'Super',
+  space: 'Space',
+  ' ': 'Space',
+  esc: 'Escape',
+  escape: 'Escape',
+  enter: 'Enter',
+  return: 'Enter',
+  tab: 'Tab',
+  capslock: 'CapsLock',
+  backspace: 'Backspace',
+  delete: 'Delete',
+  insert: 'Insert',
+  home: 'Home',
+  end: 'End',
+  pageup: 'PageUp',
+  pagedown: 'PageDown',
+  arrowup: 'ArrowUp',
+  arrowdown: 'ArrowDown',
+  arrowleft: 'ArrowLeft',
+  arrowright: 'ArrowRight',
+};
+
+const isModifierKey = (key: string) =>
+  key === 'Control' || key === 'Shift' || key === 'Alt' || key === 'Meta';
+
+const normalizePart = (part: string): string => {
+  const trimmed = part.trim();
+  if (!trimmed) return '';
+  const lower = trimmed.toLowerCase();
+  const alias = KEY_ALIASES[lower];
+  if (alias) return alias;
+  if (trimmed.length === 1) return trimmed.toUpperCase();
+  return trimmed[0].toUpperCase() + trimmed.slice(1);
+};
+
+export const normalizeBinding = (binding: string): string => {
+  if (!binding) return '';
+  const seen = new Set<string>();
+  const modifiers: string[] = [];
+  const keys: string[] = [];
+
+  for (const rawPart of binding.split('+')) {
+    const part = normalizePart(rawPart);
+    if (!part) continue;
+    if (MODIFIER_ORDER.includes(part)) {
+      if (!seen.has(part)) {
+        seen.add(part);
+        modifiers.push(part);
+      }
+    } else {
+      keys.push(part);
+    }
+  }
+
+  modifiers.sort(
+    (a, b) => MODIFIER_ORDER.indexOf(a) - MODIFIER_ORDER.indexOf(b),
+  );
+
+  return [...modifiers, ...keys].join('+');
+};
+
+export interface KeyBindingEventLike {
+  key: string;
+  ctrlKey?: boolean;
+  altKey?: boolean;
+  shiftKey?: boolean;
+  metaKey?: boolean;
+}
+
+export const formatKeybinding = (event: KeyBindingEventLike): string => {
+  const parts: string[] = [];
+  if (event.ctrlKey) parts.push('Ctrl');
+  if (event.altKey) parts.push('Alt');
+  if (event.shiftKey) parts.push('Shift');
+  if (event.metaKey) parts.push('Super');
+
+  const key = event.key || '';
+  if (!isModifierKey(key)) {
+    parts.push(normalizePart(key));
+  } else if (parts.length === 0) {
+    parts.push(normalizePart(key));
+  }
+
+  return normalizeBinding(parts.join('+'));
+};
+
+export const createDefaultShortcutMap = (
+  definitions: ShortcutDefinition[] = SHORTCUT_DEFINITIONS,
+): ShortcutMap => {
+  const map: ShortcutMap = {};
+  for (const shortcut of definitions) {
+    map[shortcut.id] = normalizeBinding(shortcut.defaultKeys);
+  }
+  return map;
+};
+
+export const shortcutMapValidator = (value: unknown): value is ShortcutMap => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  return Object.values(value).every((v) => typeof v === 'string');
+};
+
+export const upgradeShortcutMap = (
+  map: ShortcutMap,
+  definitions: ShortcutDefinition[] = SHORTCUT_DEFINITIONS,
+): ShortcutMap => {
+  let mutated = false;
+  const next: ShortcutMap = { ...map };
+
+  for (const definition of definitions) {
+    if (next[definition.id] !== undefined) continue;
+    const legacy = definition.legacyIds ?? [];
+    for (const legacyId of legacy) {
+      if (next[legacyId] !== undefined) {
+        next[definition.id] = next[legacyId];
+        delete next[legacyId];
+        mutated = true;
+        break;
+      }
+    }
+  }
+
+  return mutated ? next : map;
+};
+
+export const resolveShortcuts = (
+  map: ShortcutMap,
+  definitions: ShortcutDefinition[] = SHORTCUT_DEFINITIONS,
+): ResolvedShortcut[] => {
+  const resolved = definitions.map<ResolvedShortcut>((definition) => {
+    const stored =
+      map[definition.id] ??
+      (definition.legacyIds
+        ? definition.legacyIds
+            .map((legacyId) => map[legacyId])
+            .find((value) => value !== undefined)
+        : undefined);
+    const keys = normalizeBinding(stored ?? definition.defaultKeys);
+    const defaultKeys = normalizeBinding(definition.defaultKeys);
+    return {
+      ...definition,
+      keys,
+      isDefault: keys === defaultKeys,
+      conflictsWith: [],
+    };
+  });
+
+  const collisions = new Map<string, ResolvedShortcut[]>();
+  for (const shortcut of resolved) {
+    if (!shortcut.keys) continue;
+    const list = collisions.get(shortcut.keys) ?? [];
+    list.push(shortcut);
+    collisions.set(shortcut.keys, list);
+  }
+
+  for (const [, list] of collisions) {
+    if (list.length <= 1) continue;
+    const ids = list.map((item) => item.id);
+    for (const item of list) {
+      item.conflictsWith = ids.filter((id) => id !== item.id);
+    }
+  }
+
+  return resolved;
+};
+
+export const detectConflicts = (
+  shortcuts: Iterable<Pick<ResolvedShortcut, 'id' | 'keys'>>,
+): Map<string, string[]> => {
+  const map = new Map<string, string[]>();
+  for (const shortcut of shortcuts) {
+    const binding = shortcut.keys;
+    if (!binding) continue;
+    const list = map.get(binding) ?? [];
+    list.push(shortcut.id);
+    map.set(binding, list);
+  }
+
+  for (const [binding, ids] of Array.from(map.entries())) {
+    if (ids.length <= 1) {
+      map.delete(binding);
+    }
+  }
+
+  return map;
+};
+


### PR DESCRIPTION
## Summary
- add a central shortcuts registry with normalization, conflict detection, and legacy key migration
- build a keyboard shortcut settings panel with conflict warnings and rebind controls
- update shortcut overlays to consume the new registry and export richer shortcut metadata

## Testing
- yarn lint *(fails: numerous pre-existing jsx-a11y and no-top-level-window violations across legacy files)*
- yarn test --watch=false *(fails: existing suites such as window.test.tsx and nmapNse.test.tsx; jsdom localStorage error)*

------
https://chatgpt.com/codex/tasks/task_e_68ca21742044832896c0837646703a50