### PR TITLE
[desktop] show taskbar recents

### DIFF
--- a/components/desktop/TaskbarItemMenu.tsx
+++ b/components/desktop/TaskbarItemMenu.tsx
@@ -1,0 +1,216 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+import {
+  clearTaskbarRecentEntries,
+  getTaskbarRecentEntries,
+  supportsTaskbarRecents,
+  TaskbarRecentEntry,
+} from '../../utils/taskbarRecents';
+
+interface TaskbarItemMenuProps {
+  /** Whether the menu is visible */
+  active: boolean;
+  /** ID of the app represented by the taskbar item */
+  appId?: string | null;
+  /** Whether the taskbar item is currently minimized */
+  minimized?: boolean;
+  /** Minimize or restore the window */
+  onMinimize?: () => void;
+  /** Close the window */
+  onClose?: () => void;
+  /** Close the menu */
+  onCloseMenu?: () => void;
+  /** Optional handler invoked when a recent entry is selected */
+  onOpenRecent?: (entry: TaskbarRecentEntry) => void;
+}
+
+const TaskbarItemMenu: React.FC<TaskbarItemMenuProps> = ({
+  active,
+  appId,
+  minimized = false,
+  onMinimize,
+  onClose,
+  onCloseMenu,
+  onOpenRecent,
+}) => {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(menuRef as React.RefObject<HTMLElement>, active);
+  useRovingTabIndex(menuRef as React.RefObject<HTMLElement>, active, 'vertical');
+
+  const recentsSupported = useMemo(() => supportsTaskbarRecents(appId), [appId]);
+  const [recentEntries, setRecentEntries] = useState<TaskbarRecentEntry[]>([]);
+  const [loadingRecents, setLoadingRecents] = useState(false);
+  const [recentsError, setRecentsError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    let cancelled = false;
+
+    (async () => {
+      if (!recentsSupported) {
+        setRecentEntries([]);
+        setRecentsError(null);
+        return;
+      }
+      setLoadingRecents(true);
+      setRecentsError(null);
+      try {
+        const entries = await getTaskbarRecentEntries(appId ?? null);
+        if (!cancelled) {
+          setRecentEntries(entries);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          console.error('Failed to load recent entries for taskbar menu', err);
+          setRecentEntries([]);
+          setRecentsError('Unable to load recent files.');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingRecents(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [active, appId, recentsSupported]);
+
+  useEffect(() => {
+    if (!active) {
+      setRecentsError(null);
+    }
+  }, [active]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Escape') {
+        onCloseMenu?.();
+      }
+    },
+    [onCloseMenu],
+  );
+
+  const handleMinimize = useCallback(() => {
+    onMinimize?.();
+    onCloseMenu?.();
+  }, [onMinimize, onCloseMenu]);
+
+  const handleClose = useCallback(() => {
+    onClose?.();
+    onCloseMenu?.();
+  }, [onClose, onCloseMenu]);
+
+  const handleRecentSelect = useCallback(
+    (entry: TaskbarRecentEntry) => {
+      if (onOpenRecent) {
+        onOpenRecent(entry);
+      } else if (typeof window !== 'undefined' && appId) {
+        window.dispatchEvent(
+          new CustomEvent('taskbar-open-recent', {
+            detail: { appId, entry },
+          }),
+        );
+      }
+      onCloseMenu?.();
+    },
+    [onCloseMenu, onOpenRecent, appId],
+  );
+
+  const handleClearRecents = useCallback(async () => {
+    if (!recentsSupported) return;
+    await clearTaskbarRecentEntries(appId ?? null);
+    setRecentEntries([]);
+    setRecentsError(null);
+    if (typeof window !== 'undefined' && appId) {
+      window.dispatchEvent(
+        new CustomEvent('taskbar-recents-cleared', {
+          detail: { appId },
+        }),
+      );
+    }
+  }, [appId, recentsSupported]);
+
+  return (
+    <div
+      id="taskbar-item-menu"
+      role="menu"
+      aria-hidden={!active}
+      ref={menuRef}
+      onKeyDown={handleKeyDown}
+      className={(active ? ' block ' : ' hidden ') +
+        'cursor-default w-60 context-menu-bg border text-left border-gray-900 rounded text-white py-3 absolute z-50 text-sm'}
+    >
+      <button
+        type="button"
+        onClick={handleMinimize}
+        role="menuitem"
+        aria-label={minimized ? 'Restore window' : 'Minimize window'}
+        className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+      >
+        <span className="ml-5">{minimized ? 'Restore' : 'Minimize'}</span>
+      </button>
+      <button
+        type="button"
+        onClick={handleClose}
+        role="menuitem"
+        aria-label="Close window"
+        className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+      >
+        <span className="ml-5">Close</span>
+      </button>
+
+      {recentsSupported && (
+        <div className="mt-2 border-t border-gray-800 pt-2" role="presentation">
+          <div className="px-5 pb-1 text-xs uppercase tracking-wide text-gray-400" role="presentation">
+            Recent Files
+          </div>
+          {loadingRecents && (
+            <div className="px-5 py-1 text-gray-300 text-xs" role="presentation">
+              Loading…
+            </div>
+          )}
+          {recentsError && !loadingRecents && (
+            <div className="px-5 py-1 text-red-400 text-xs" role="presentation">
+              {recentsError}
+            </div>
+          )}
+          {!loadingRecents && !recentsError && recentEntries.length === 0 && (
+            <div className="px-5 py-1 text-gray-400 text-xs" role="presentation">
+              No recent files
+            </div>
+          )}
+          {!loadingRecents && !recentsError &&
+            recentEntries.map((entry) => (
+              <button
+                key={entry.id}
+                type="button"
+                role="menuitem"
+                onClick={() => handleRecentSelect(entry)}
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+              >
+                <span className="ml-5">{entry.label}</span>
+                {entry.description && (
+                  <span className="ml-5 block text-xs text-gray-400">{entry.description}</span>
+                )}
+              </button>
+            ))}
+          {recentEntries.length > 0 && !loadingRecents && (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={handleClearRecents}
+              className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mt-1"
+            >
+              <span className="ml-5">Clear List</span>
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TaskbarItemMenu;

--- a/utils/taskbarRecents.ts
+++ b/utils/taskbarRecents.ts
@@ -1,0 +1,113 @@
+import { getDb } from './safeIDB';
+
+export interface TaskbarRecentEntry<T = unknown> {
+  /** Unique identifier for rendering */
+  id: string;
+  /** Label shown to the user */
+  label: string;
+  /** Optional secondary description */
+  description?: string;
+  /** Raw payload returned by the provider */
+  payload?: T;
+}
+
+type TaskbarRecentsProvider<T = unknown> = {
+  load: () => Promise<TaskbarRecentEntry<T>[]>;
+  clear: () => Promise<void>;
+};
+
+const providers: Record<string, TaskbarRecentsProvider<any>> = {};
+
+const FILE_EXPLORER_DB = 'file-explorer';
+const FILE_EXPLORER_STORE = 'recent';
+
+interface FileExplorerRecentEntry {
+  name: string;
+  handle?: FileSystemDirectoryHandle;
+}
+
+async function openFileExplorerDb() {
+  try {
+    const dbp = getDb(FILE_EXPLORER_DB, 1, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(FILE_EXPLORER_STORE)) {
+          db.createObjectStore(FILE_EXPLORER_STORE, { autoIncrement: true });
+        }
+      },
+    });
+    if (!dbp) return null;
+    return await dbp;
+  } catch {
+    return null;
+  }
+}
+
+registerTaskbarRecentsProvider('file-explorer', {
+  async load() {
+    try {
+      const db = await openFileExplorerDb();
+      if (!db) return [];
+      const entries = (await db.getAll(FILE_EXPLORER_STORE)) as FileExplorerRecentEntry[];
+      if (!Array.isArray(entries)) return [];
+      return entries
+        .map((entry, index) => ({
+          id: `${entry?.name || 'recent'}-${index}`,
+          label: entry?.name || 'Recent folder',
+          payload: entry,
+        }))
+        .reverse();
+    } catch {
+      return [];
+    }
+  },
+  async clear() {
+    try {
+      const db = await openFileExplorerDb();
+      if (!db) return;
+      await db.clear(FILE_EXPLORER_STORE);
+    } catch {
+      // ignore failures
+    }
+  },
+});
+
+export function registerTaskbarRecentsProvider<T = unknown>(
+  appId: string,
+  provider: TaskbarRecentsProvider<T>,
+) {
+  providers[appId] = provider;
+}
+
+export function unregisterTaskbarRecentsProvider(appId: string) {
+  delete providers[appId];
+}
+
+export function supportsTaskbarRecents(appId: string | null | undefined) {
+  if (!appId) return false;
+  return Boolean(providers[appId]);
+}
+
+export async function getTaskbarRecentEntries<T = unknown>(
+  appId: string | null | undefined,
+): Promise<TaskbarRecentEntry<T>[]> {
+  if (!appId) return [];
+  const provider = providers[appId];
+  if (!provider) return [];
+  try {
+    const entries = await provider.load();
+    return Array.isArray(entries) ? entries : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function clearTaskbarRecentEntries(appId: string | null | undefined): Promise<void> {
+  if (!appId) return;
+  const provider = providers[appId];
+  if (!provider) return;
+  try {
+    await provider.clear();
+  } catch {
+    // ignore failures
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable taskbar item menu that loads per-app recent entries and exposes clear handling
- provide an IndexedDB-backed recents registry with a default file explorer provider and helper hooks

## Testing
- yarn lint *(fails: repo contains pre-existing accessibility violations across many app components)*
- yarn test *(fails: existing suites such as Modal and nmap NSE tests currently red in main)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2176b65083288253a51451b34717