### PR TITLE
feat(desktop): add marquee icon selection overlay

### DIFF
--- a/__tests__/IconsLayer.test.tsx
+++ b/__tests__/IconsLayer.test.tsx
@@ -1,0 +1,107 @@
+import React, { createRef } from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import IconsLayer from '../components/desktop/IconsLayer';
+
+describe('IconsLayer marquee selection', () => {
+  it('highlights icons inside the marquee and shows a selection count', async () => {
+    const containerRef = createRef<HTMLDivElement>();
+    render(
+      <div
+        data-testid="desktop"
+        ref={containerRef}
+        style={{ position: 'relative', width: 400, height: 300 }}
+      >
+        <IconsLayer
+          containerRef={containerRef}
+          onOpen={() => {}}
+          icons={[
+            { id: 'terminal', title: 'Terminal', icon: '/terminal.png' },
+            { id: 'notes', title: 'Notes', icon: '/notes.png' },
+            { id: 'calculator', title: 'Calculator', icon: '/calculator.png' },
+          ]}
+        />
+      </div>,
+    );
+
+    const desktop = screen.getByTestId('desktop') as HTMLElement;
+    desktop.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      right: 400,
+      bottom: 300,
+      width: 400,
+      height: 300,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    const terminal = document.getElementById('app-terminal') as HTMLElement;
+    const notes = document.getElementById('app-notes') as HTMLElement;
+    const calculator = document.getElementById('app-calculator') as HTMLElement;
+
+    terminal.getBoundingClientRect = () => ({
+      left: 20,
+      top: 20,
+      right: 84,
+      bottom: 84,
+      width: 64,
+      height: 64,
+      x: 20,
+      y: 20,
+      toJSON: () => ({}),
+    });
+
+    notes.getBoundingClientRect = () => ({
+      left: 110,
+      top: 30,
+      right: 174,
+      bottom: 94,
+      width: 64,
+      height: 64,
+      x: 110,
+      y: 30,
+      toJSON: () => ({}),
+    });
+
+    calculator.getBoundingClientRect = () => ({
+      left: 260,
+      top: 160,
+      right: 324,
+      bottom: 224,
+      width: 64,
+      height: 64,
+      x: 260,
+      y: 160,
+      toJSON: () => ({}),
+    });
+
+    const user = userEvent.setup();
+
+    await act(async () => {
+      await user.pointer([
+        { target: desktop, coords: { x: 10, y: 10 }, pointerId: 1, keys: '[MouseLeft>]' },
+        { target: desktop, coords: { x: 190, y: 120 }, pointerId: 1 },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(terminal).toHaveAttribute('data-selected', 'true');
+      expect(notes).toHaveAttribute('data-selected', 'true');
+    });
+    expect(calculator).not.toHaveAttribute('data-selected', 'true');
+    expect(screen.getByText('2')).toBeInTheDocument();
+
+    await act(async () => {
+      await user.pointer([{ target: desktop, pointerId: 1, keys: '[/MouseLeft]' }]);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('2')).not.toBeInTheDocument();
+    });
+
+    expect(terminal).toHaveAttribute('data-selected', 'true');
+    expect(notes).toHaveAttribute('data-selected', 'true');
+  });
+});

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -31,18 +31,25 @@ export class UbuntuApp extends Component {
     }
 
     render() {
+        const isSelected = Boolean(this.props.isSelected);
+        const baseClasses = "p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active ";
+        const launchingClass = this.state.launching ? "app-icon-launch " : "";
+        const draggingClass = this.state.dragging ? "opacity-70 " : "";
+        const selectedClass = isSelected ? "bg-opacity-20 ring-2 ring-ub-orange ring-offset-2 ring-offset-transparent " : "";
+
         return (
             <div
                 role="button"
                 aria-label={this.props.name}
                 aria-disabled={this.props.disabled}
+                aria-selected={isSelected ? 'true' : undefined}
                 data-context="app"
                 data-app-id={this.props.id}
+                data-selected={isSelected ? 'true' : undefined}
                 draggable
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
-                className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                className={baseClasses + launchingClass + draggingClass + selectedClass}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
@@ -64,5 +71,9 @@ export class UbuntuApp extends Component {
         )
     }
 }
+
+UbuntuApp.defaultProps = {
+    isSelected: false,
+};
 
 export default UbuntuApp

--- a/components/desktop/IconsLayer.tsx
+++ b/components/desktop/IconsLayer.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import UbuntuApp from '../base/ubuntu_app';
+
+interface DesktopIcon {
+  id: string;
+  title: string;
+  icon: string;
+  disabled?: boolean;
+  prefetch?: () => void;
+}
+
+interface IconsLayerProps {
+  icons: DesktopIcon[];
+  onOpen: (id: string) => void;
+  containerRef: React.RefObject<HTMLElement | null>;
+}
+
+interface SelectionRect {
+  relative: {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  };
+  absolute: {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+  };
+}
+
+interface DragState {
+  pointerId: number | null;
+  origin: { x: number; y: number } | null;
+  containerRect: DOMRect | null;
+  hasMoved: boolean;
+}
+
+const DRAG_THRESHOLD_PX = 4;
+
+const intersects = (
+  rect: SelectionRect['absolute'],
+  box: DOMRect,
+): boolean =>
+  rect.left <= box.right &&
+  rect.right >= box.left &&
+  rect.top <= box.bottom &&
+  rect.bottom >= box.top;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const IconsLayer: React.FC<IconsLayerProps> = ({
+  icons,
+  onOpen,
+  containerRef,
+}) => {
+  const iconsRef = useRef(icons);
+  const dragStateRef = useRef<DragState>({
+    pointerId: null,
+    origin: null,
+    containerRect: null,
+    hasMoved: false,
+  });
+
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [marquee, setMarquee] = useState<SelectionRect | null>(null);
+
+  useEffect(() => {
+    iconsRef.current = icons;
+    setSelectedIds(prev =>
+      prev.filter(id => icons.some(icon => icon.id === id)),
+    );
+  }, [icons]);
+
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const updateSelection = (absoluteRect: SelectionRect['absolute']) => {
+      const nextSelected: string[] = [];
+      for (const icon of iconsRef.current) {
+        const node = document.getElementById(`app-${icon.id}`);
+        if (!node) continue;
+        const box = node.getBoundingClientRect();
+        if (intersects(absoluteRect, box)) {
+          nextSelected.push(icon.id);
+        }
+      }
+      setSelectedIds(prev => {
+        if (
+          prev.length === nextSelected.length &&
+          prev.every((value, idx) => value === nextSelected[idx])
+        ) {
+          return prev;
+        }
+        return nextSelected;
+      });
+    };
+
+    const clearDragListeners = () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerEnd);
+      window.removeEventListener('pointercancel', handlePointerEnd);
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const drag = dragStateRef.current;
+      if (
+        drag.pointerId !== event.pointerId ||
+        !drag.origin ||
+        !drag.containerRect
+      ) {
+        return;
+      }
+
+      const deltaX = event.clientX - drag.origin.x;
+      const deltaY = event.clientY - drag.origin.y;
+
+      if (!drag.hasMoved) {
+        if (
+          Math.abs(deltaX) < DRAG_THRESHOLD_PX &&
+          Math.abs(deltaY) < DRAG_THRESHOLD_PX
+        ) {
+          return;
+        }
+        drag.hasMoved = true;
+      }
+
+      const left = Math.min(drag.origin.x, event.clientX);
+      const top = Math.min(drag.origin.y, event.clientY);
+      const right = Math.max(drag.origin.x, event.clientX);
+      const bottom = Math.max(drag.origin.y, event.clientY);
+
+      const relativeLeft = left - drag.containerRect.left;
+      const relativeTop = top - drag.containerRect.top;
+      const relativeRight = right - drag.containerRect.left;
+      const relativeBottom = bottom - drag.containerRect.top;
+
+      setMarquee({
+        relative: {
+          left: relativeLeft,
+          top: relativeTop,
+          width: Math.max(0, relativeRight - relativeLeft),
+          height: Math.max(0, relativeBottom - relativeTop),
+        },
+        absolute: { left, top, right, bottom },
+      });
+
+      updateSelection({ left, top, right, bottom });
+    };
+
+    const handlePointerEnd = (event: PointerEvent) => {
+      const drag = dragStateRef.current;
+      if (drag.pointerId !== event.pointerId) return;
+
+      if (!drag.hasMoved) {
+        setSelectedIds([]);
+      }
+
+      drag.pointerId = null;
+      drag.origin = null;
+      drag.containerRect = null;
+      drag.hasMoved = false;
+
+      setMarquee(null);
+      clearDragListeners();
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (event.button !== 0) return;
+      if (!(event.target instanceof Element)) return;
+
+      const iconTarget = event.target.closest('[data-context="app"]');
+      if (iconTarget) {
+        const iconId = iconTarget.getAttribute('data-app-id');
+        if (iconId) {
+          setSelectedIds(prev =>
+            prev.length === 1 && prev[0] === iconId ? prev : [iconId],
+          );
+        }
+        return;
+      }
+
+      event.preventDefault();
+
+      const containerRect = container.getBoundingClientRect();
+      dragStateRef.current = {
+        pointerId: event.pointerId,
+        origin: { x: event.clientX, y: event.clientY },
+        containerRect,
+        hasMoved: false,
+      };
+
+      setSelectedIds([]);
+      setMarquee(null);
+
+      window.addEventListener('pointermove', handlePointerMove);
+      window.addEventListener('pointerup', handlePointerEnd);
+      window.addEventListener('pointercancel', handlePointerEnd);
+    };
+
+    container.addEventListener('pointerdown', handlePointerDown);
+
+    return () => {
+      container.removeEventListener('pointerdown', handlePointerDown);
+      clearDragListeners();
+      dragStateRef.current = {
+        pointerId: null,
+        origin: null,
+        containerRect: null,
+        hasMoved: false,
+      };
+    };
+  }, [containerRef]);
+
+  const badgePosition = useMemo(() => {
+    if (!marquee) return null;
+    const { relative } = marquee;
+    const top = relative.top - 28;
+    const left = relative.left;
+    return {
+      top,
+      left,
+    };
+  }, [marquee]);
+
+  const badgeStyle = useMemo(() => {
+    if (!badgePosition || !containerRef.current) return undefined;
+    const container = containerRef.current.getBoundingClientRect();
+    const maxLeft = container.width - 32;
+    return {
+      left: `${clamp(badgePosition.left, 0, Math.max(0, maxLeft))}px`,
+      top: `${clamp(badgePosition.top, 0, container.height)}px`,
+    } as React.CSSProperties;
+  }, [badgePosition, containerRef]);
+
+  return (
+    <>
+      {icons.map(icon => (
+        <UbuntuApp
+          key={icon.id}
+          id={icon.id}
+          name={icon.title}
+          icon={icon.icon}
+          disabled={icon.disabled}
+          openApp={() => onOpen(icon.id)}
+          prefetch={icon.prefetch}
+          isSelected={selectedSet.has(icon.id)}
+        />
+      ))}
+      {marquee ? (
+        <div className="pointer-events-none absolute inset-0 z-30">
+          <div
+            className="absolute rounded-sm border border-ub-orange bg-ub-orange/20"
+            style={{
+              left: `${marquee.relative.left}px`,
+              top: `${marquee.relative.top}px`,
+              width: `${marquee.relative.width}px`,
+              height: `${marquee.relative.height}px`,
+            }}
+          />
+          {selectedIds.length > 0 && badgeStyle ? (
+            <div
+              className="absolute flex h-6 min-w-[1.5rem] items-center justify-center rounded-full bg-ub-orange px-2 text-xs font-semibold text-black shadow-md"
+              style={badgeStyle}
+            >
+              {selectedIds.length}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </>
+  );
+};
+
+export default IconsLayer;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -10,7 +10,7 @@ const BackgroundImage = dynamic(
 import SideBar from './side_bar';
 import apps, { games } from '../../apps.config';
 import Window from '../base/window';
-import UbuntuApp from '../base/ubuntu_app';
+import IconsLayer from '../desktop/IconsLayer';
 import AllApplications from '../screen/all-applications'
 import ShortcutSelector from '../screen/shortcut-selector'
 import WindowSwitcher from '../screen/window-switcher'
@@ -27,6 +27,7 @@ import { useSnapSetting } from '../../hooks/usePersistentState';
 export class Desktop extends Component {
     constructor() {
         super();
+        this.desktopRef = React.createRef();
         this.app_stack = [];
         this.initFavourite = {};
         this.allWindowClosed = false;
@@ -432,26 +433,27 @@ export class Desktop extends Component {
     }
 
     renderDesktopApps = () => {
-        if (Object.keys(this.state.closed_windows).length === 0) return;
-        let appsJsx = [];
-        apps.forEach((app, index) => {
-            if (this.state.desktop_apps.includes(app.id)) {
+        if (Object.keys(this.state.closed_windows).length === 0) return null;
 
-                const props = {
-                    name: app.title,
-                    id: app.id,
-                    icon: app.icon,
-                    openApp: this.openApp,
-                    disabled: this.state.disabled_apps[app.id],
-                    prefetch: app.screen?.prefetch,
-                }
+        const desktopIcons = apps
+            .filter((app) => this.state.desktop_apps.includes(app.id))
+            .map((app) => ({
+                id: app.id,
+                title: app.title,
+                icon: app.icon,
+                disabled: this.state.disabled_apps[app.id],
+                prefetch: app.screen?.prefetch,
+            }));
 
-                appsJsx.push(
-                    <UbuntuApp key={app.id} {...props} />
-                );
-            }
-        });
-        return appsJsx;
+        if (!desktopIcons.length) return null;
+
+        return (
+            <IconsLayer
+                containerRef={this.desktopRef}
+                icons={desktopIcons}
+                onOpen={this.openApp}
+            />
+        );
     }
 
     renderWindows = () => {
@@ -865,7 +867,7 @@ export class Desktop extends Component {
 
     render() {
         return (
-            <main id="desktop" role="main" className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
+            <main id="desktop" role="main" ref={this.desktopRef} className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
 
                 {/* Window Area */}
                 <div


### PR DESCRIPTION
## Summary
- add a dedicated IconsLayer component that tracks pointer drags, renders the marquee, and computes selection badges
- highlight UbuntuApp tiles when selected so marquee results are clearly visible
- wire the desktop shell to use the new layer and cover the selection flow with a focused test

## Testing
- yarn test __tests__/IconsLayer.test.tsx
- yarn lint *(fails: pre-existing jsx-a11y/no-top-level-window violations)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2179f6308328a71a99f1c61d0487