### PR TITLE
[settings] add focus follows mouse preference

### DIFF
--- a/apps/settings/accessibility/FocusFollowsMouseToggle.tsx
+++ b/apps/settings/accessibility/FocusFollowsMouseToggle.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import ToggleSwitch from "@/components/ToggleSwitch";
+import { useSettings } from "@/hooks/useSettings";
+
+export default function FocusFollowsMouseToggle() {
+  const { focusFollowsMouse, setFocusFollowsMouse } = useSettings();
+
+  return (
+    <div className="flex justify-center my-4 items-start md:items-center gap-4 text-left">
+      <div className="text-ubt-grey max-w-xs">
+        <div className="font-semibold">Focus follows mouse</div>
+        <p className="text-xs opacity-80 mt-1">
+          Hover over a window for about 350 milliseconds to bring it to the front
+          automatically.
+        </p>
+      </div>
+      <ToggleSwitch
+        checked={focusFollowsMouse}
+        onChange={setFocusFollowsMouse}
+        ariaLabel="Focus follows mouse"
+      />
+    </div>
+  );
+}

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import FocusFollowsMouseToggle from "./accessibility/FocusFollowsMouseToggle";
 
 export default function Settings() {
   const {
@@ -31,6 +32,7 @@ export default function Settings() {
     setHaptics,
     theme,
     setTheme,
+    setFocusFollowsMouse,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -80,6 +82,8 @@ export default function Settings() {
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
       if (parsed.theme !== undefined) setTheme(parsed.theme);
+      if (parsed.focusFollowsMouse !== undefined)
+        setFocusFollowsMouse(Boolean(parsed.focusFollowsMouse));
     } catch (err) {
       console.error("Invalid settings", err);
     }
@@ -101,6 +105,7 @@ export default function Settings() {
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
     setTheme("default");
+    setFocusFollowsMouse(defaults.focusFollowsMouse);
   };
 
   const [showKeymap, setShowKeymap] = useState(false);
@@ -252,6 +257,7 @@ export default function Settings() {
               ariaLabel="High Contrast"
             />
           </div>
+          <FocusFollowsMouseToggle />
           <div className="flex justify-center my-4 items-center">
             <span className="mr-2 text-ubt-grey">Haptics:</span>
             <ToggleSwitch

--- a/src/wm/focus.ts
+++ b/src/wm/focus.ts
@@ -1,0 +1,99 @@
+const FOCUS_DWELL_DELAY_MS = 350;
+
+export const HOVER_DWELL_DELAY_MS = FOCUS_DWELL_DELAY_MS;
+
+type FocusPreferenceListener = (enabled: boolean) => void;
+
+let focusFollowsMouseEnabled = false;
+const preferenceListeners = new Set<FocusPreferenceListener>();
+
+export function isFocusFollowsMouseEnabled(): boolean {
+  return focusFollowsMouseEnabled;
+}
+
+export function setFocusFollowsMouseEnabled(enabled: boolean) {
+  if (focusFollowsMouseEnabled === enabled) return;
+  focusFollowsMouseEnabled = enabled;
+  preferenceListeners.forEach((listener) => {
+    listener(enabled);
+  });
+}
+
+export function subscribeFocusFollowsMouse(
+  listener: FocusPreferenceListener
+): () => void {
+  preferenceListeners.add(listener);
+  listener(focusFollowsMouseEnabled);
+  return () => {
+    preferenceListeners.delete(listener);
+  };
+}
+
+export function attachFocusOnHover(
+  element: HTMLElement | null,
+  onFocus: () => void,
+  dwellMs: number = FOCUS_DWELL_DELAY_MS
+): () => void {
+  if (!element || typeof window === 'undefined') {
+    return () => {};
+  }
+
+  let hoverTimer: number | null = null;
+  let pointerInside = false;
+
+  const clearHoverTimer = () => {
+    if (hoverTimer !== null) {
+      window.clearTimeout(hoverTimer);
+      hoverTimer = null;
+    }
+  };
+
+  const scheduleFocus = () => {
+    if (!focusFollowsMouseEnabled || hoverTimer !== null) {
+      return;
+    }
+    hoverTimer = window.setTimeout(() => {
+      hoverTimer = null;
+      if (pointerInside && focusFollowsMouseEnabled) {
+        onFocus();
+      }
+    }, dwellMs);
+  };
+
+  const handlePointerEnter = () => {
+    pointerInside = true;
+    scheduleFocus();
+  };
+
+  const handlePointerLeave = () => {
+    pointerInside = false;
+    clearHoverTimer();
+  };
+
+  const handlePointerDown = () => {
+    pointerInside = false;
+    clearHoverTimer();
+  };
+
+  element.addEventListener('pointerenter', handlePointerEnter);
+  element.addEventListener('pointerleave', handlePointerLeave);
+  element.addEventListener('pointercancel', handlePointerLeave);
+  element.addEventListener('pointerdown', handlePointerDown);
+
+  const unsubscribe = subscribeFocusFollowsMouse((enabled) => {
+    if (!enabled) {
+      clearHoverTimer();
+    } else if (pointerInside) {
+      scheduleFocus();
+    }
+  });
+
+  return () => {
+    clearHoverTimer();
+    unsubscribe();
+    element.removeEventListener('pointerenter', handlePointerEnter);
+    element.removeEventListener('pointerleave', handlePointerLeave);
+    element.removeEventListener('pointercancel', handlePointerLeave);
+    element.removeEventListener('pointerdown', handlePointerDown);
+  };
+}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  focusFollowsMouse: false,
 };
 
 export async function getAccent() {
@@ -91,6 +92,17 @@ export async function setLargeHitAreas(value) {
   window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
 }
 
+export async function getFocusFollowsMouse() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.focusFollowsMouse;
+  const value = window.localStorage.getItem('focus-follows-mouse');
+  return value === null ? DEFAULT_SETTINGS.focusFollowsMouse : value === 'true';
+}
+
+export async function setFocusFollowsMouse(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('focus-follows-mouse', value ? 'true' : 'false');
+}
+
 export async function getHaptics() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
   const val = window.localStorage.getItem('haptics');
@@ -137,6 +149,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('focus-follows-mouse');
 }
 
 export async function exportSettings() {
@@ -151,6 +164,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    focusFollowsMouse,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +176,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getFocusFollowsMouse(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +190,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    focusFollowsMouse,
     theme,
   });
 }
@@ -199,6 +215,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    focusFollowsMouse,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +228,8 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (focusFollowsMouse !== undefined)
+    await setFocusFollowsMouse(focusFollowsMouse);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated focus-follows-mouse toggle to the settings accessibility tab
- persist and hydrate the preference through the settings store/context and notify the focus manager
- introduce a hover dwell helper for the window manager so windows gain focus after 350ms when enabled

## Testing
- yarn lint *(fails: repository has hundreds of existing jsx-a11y/control-has-associated-label and related errors)*
- yarn test *(fails: suite has pre-existing accessibility/unit regressions such as missing alert roles and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ca217ac1a883288cb45cf543814f7d