### PR TITLE
[desktop] dim inactive windows with tokens

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -612,6 +612,20 @@ export class Window extends Component {
     }
 
     render() {
+        const isInactive = !this.props.isFocused && !this.props.minimized && !this.state.grabbed;
+        const blurToken = isInactive ? '--window-blur-inactive' : '--window-blur-active';
+        const windowStyle = {
+            width: `${this.state.width}%`,
+            height: `${this.state.height}%`,
+            backdropFilter: `blur(var(${blurToken}))`,
+            WebkitBackdropFilter: `blur(var(${blurToken}))`,
+            ...(isInactive
+                ? { opacity: 'var(--window-opacity-inactive)' }
+                : !this.state.grabbed && !this.props.minimized
+                    ? { opacity: 'var(--window-opacity-active)' }
+                    : {}),
+        };
+
         return (
             <>
                 {this.state.snapPreview && (
@@ -634,7 +648,7 @@ export class Window extends Component {
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
                 >
                     <div
-                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
+                        style={windowStyle}
                         className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
                         role="dialog"

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -52,6 +52,12 @@
   --motion-medium: 300ms;
   --motion-slow: 500ms;
 
+  /* Window states */
+  --window-opacity-active: 1;
+  --window-opacity-inactive: 0.92;
+  --window-blur-active: 18px;
+  --window-blur-inactive: 10px;
+
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
   --font-multiplier: 1;


### PR DESCRIPTION
## Summary
- add window opacity and blur tokens to the global design token sheet
- update the window component to consume the new tokens and dim inactive windows

## Testing
- yarn lint *(fails: repo has numerous pre-existing accessibility rule violations)*
- yarn test *(fails: existing suites such as nmapNse and settingsStore trigger known issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ca217ca0b88328b4ae1db3e6a4abd3