### PR TITLE
desktop: add snap layout overlay

### DIFF
--- a/__tests__/SnapOverlay.test.tsx
+++ b/__tests__/SnapOverlay.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import SnapOverlay from '../components/desktop/SnapOverlay';
+
+describe('SnapOverlay', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders layout presets with keyboard hints', () => {
+    render(<SnapOverlay visible />);
+
+    expect(screen.getByText('Halves')).toBeInTheDocument();
+    expect(screen.getByText('Thirds')).toBeInTheDocument();
+    expect(screen.getByText('Grid 2×2')).toBeInTheDocument();
+    expect(screen.getByText('Q')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /snap to bottom right quadrant/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('button')).toHaveLength(9);
+  });
+
+  it('dispatches a snap-region event when confirming with Enter', () => {
+    const activeWindow = document.createElement('div');
+    activeWindow.id = 'active-window';
+    activeWindow.className = 'opened-window z-30';
+    document.body.appendChild(activeWindow);
+
+    const snapListener = jest.fn();
+    activeWindow.addEventListener('snap-region', snapListener);
+    const onClose = jest.fn();
+
+    render(<SnapOverlay visible onClose={onClose} />);
+    const leftHalf = screen.getByRole('button', { name: /snap to left half/i });
+    leftHalf.focus();
+    fireEvent.keyDown(leftHalf, { key: 'Enter' });
+
+    expect(snapListener).toHaveBeenCalledTimes(1);
+    const event = snapListener.mock.calls[0][0] as CustomEvent;
+    expect(event.detail.region).toBe('half-left');
+    expect(event.detail.windowId).toBe('active-window');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('invokes provided snapActiveWindow callback when supplied', () => {
+    const snapActiveWindow = jest.fn();
+    render(<SnapOverlay visible snapActiveWindow={snapActiveWindow} />);
+
+    const rightHalf = screen.getByRole('button', { name: /snap to right half/i });
+    fireEvent.click(rightHalf);
+
+    expect(snapActiveWindow).toHaveBeenCalledWith('half-right');
+  });
+});

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -253,6 +253,92 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.width).toBe(60);
     expect(ref.current!.state.height).toBe(85);
   });
+
+  it('applies third layout when receiving snap-region event', async () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {}
+    });
+
+    await act(async () => {
+      (ref.current as any).handleSnapRegion({
+        detail: { region: 'third-middle', windowId: 'test-window' }
+      });
+    });
+
+    expect(ref.current!.state.snapped).toBe('third-middle');
+    expect(ref.current!.state.width).toBeCloseTo(33.33, 2);
+    expect(ref.current!.state.height).toBeCloseTo(96.3, 1);
+    const expectedX = window.innerWidth / 3 + -1;
+    const expectedY = -2;
+    expect(winEl.style.transform).toBe(`translate(${expectedX}px, ${expectedY}px)`);
+  });
+
+  it('applies quadrant layout when receiving snap-region event', async () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {}
+    });
+
+    await act(async () => {
+      (ref.current as any).handleSnapRegion({
+        detail: { region: 'grid-bottom-right', windowId: 'test-window' }
+      });
+    });
+
+    expect(ref.current!.state.snapped).toBe('grid-bottom-right');
+    expect(ref.current!.state.width).toBe(50);
+    expect(ref.current!.state.height).toBeCloseTo(48.15, 2);
+    const expectedX = window.innerWidth / 2 + -1;
+    const expectedY = window.innerHeight / 2 + -2;
+    expect(winEl.style.transform).toBe(`translate(${expectedX}px, ${expectedY}px)`);
+  });
 });
 
 describe('Window keyboard dragging', () => {

--- a/components/desktop/SnapOverlay.tsx
+++ b/components/desktop/SnapOverlay.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+
+export type SnapRegionId =
+  | 'half-left'
+  | 'half-right'
+  | 'third-left'
+  | 'third-middle'
+  | 'third-right'
+  | 'grid-top-left'
+  | 'grid-top-right'
+  | 'grid-bottom-left'
+  | 'grid-bottom-right';
+
+type LayoutRegion = {
+  id: SnapRegionId;
+  label: string;
+  hint: string;
+  className: string;
+};
+
+type LayoutPreset = {
+  id: string;
+  label: string;
+  hint: string;
+  gridClass: string;
+  regions: LayoutRegion[];
+};
+
+const LAYOUT_PRESETS: LayoutPreset[] = [
+  {
+    id: 'halves',
+    label: 'Halves',
+    hint: '1',
+    gridClass: 'grid grid-cols-2 gap-1 h-24',
+    regions: [
+      {
+        id: 'half-left',
+        label: 'Snap to left half',
+        hint: 'Q',
+        className: 'col-start-1 row-start-1',
+      },
+      {
+        id: 'half-right',
+        label: 'Snap to right half',
+        hint: 'W',
+        className: 'col-start-2 row-start-1',
+      },
+    ],
+  },
+  {
+    id: 'thirds',
+    label: 'Thirds',
+    hint: '2',
+    gridClass: 'grid grid-cols-3 gap-1 h-24',
+    regions: [
+      {
+        id: 'third-left',
+        label: 'Snap to left third',
+        hint: 'A',
+        className: 'col-start-1 row-start-1',
+      },
+      {
+        id: 'third-middle',
+        label: 'Snap to middle third',
+        hint: 'S',
+        className: 'col-start-2 row-start-1',
+      },
+      {
+        id: 'third-right',
+        label: 'Snap to right third',
+        hint: 'D',
+        className: 'col-start-3 row-start-1',
+      },
+    ],
+  },
+  {
+    id: 'grid',
+    label: 'Grid 2×2',
+    hint: '3',
+    gridClass: 'grid grid-cols-2 grid-rows-2 gap-1 h-24',
+    regions: [
+      {
+        id: 'grid-top-left',
+        label: 'Snap to top left quadrant',
+        hint: 'Z',
+        className: 'col-start-1 row-start-1',
+      },
+      {
+        id: 'grid-top-right',
+        label: 'Snap to top right quadrant',
+        hint: 'X',
+        className: 'col-start-2 row-start-1',
+      },
+      {
+        id: 'grid-bottom-left',
+        label: 'Snap to bottom left quadrant',
+        hint: 'C',
+        className: 'col-start-1 row-start-2',
+      },
+      {
+        id: 'grid-bottom-right',
+        label: 'Snap to bottom right quadrant',
+        hint: 'V',
+        className: 'col-start-2 row-start-2',
+      },
+    ],
+  },
+];
+
+export interface SnapOverlayProps {
+  anchor?: DOMRect | { top: number; left: number; width: number; height: number } | null;
+  visible?: boolean;
+  onClose?: () => void;
+  snapActiveWindow?: (region: SnapRegionId) => void;
+  autoFocusFirst?: boolean;
+}
+
+const SnapOverlay: React.FC<SnapOverlayProps> = ({
+  anchor,
+  visible = true,
+  onClose,
+  snapActiveWindow,
+  autoFocusFirst = true,
+}) => {
+  const firstRegionRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!visible) return;
+    if (autoFocusFirst && firstRegionRef.current) {
+      firstRegionRef.current.focus();
+    }
+  }, [visible, autoFocusFirst]);
+
+  useEffect(() => {
+    if (!visible) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose?.();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [visible, onClose]);
+
+  const positionStyle = useMemo(() => {
+    if (!anchor) {
+      return { top: '1.5rem', right: '1.5rem' } as const;
+    }
+    const { top, left, width } = anchor;
+    const computedTop = top;
+    const computedLeft = left + width + 12;
+    return { top: `${Math.max(computedTop, 12)}px`, left: `${computedLeft}px` } as const;
+  }, [anchor]);
+
+  const applySnap = useCallback(
+    (region: SnapRegionId) => {
+      if (typeof snapActiveWindow === 'function') {
+        snapActiveWindow(region);
+      } else if (typeof window !== 'undefined') {
+        const target = document.querySelector<HTMLElement>('.opened-window.z-30:not(.closed-window)');
+        if (target) {
+          const detail: { region: SnapRegionId; windowId?: string } = {
+            region,
+            windowId: target.id || undefined,
+          };
+          const eventInit: CustomEventInit<typeof detail> = { detail };
+          target.dispatchEvent(new CustomEvent('snap-region', eventInit));
+          window.dispatchEvent(new CustomEvent('desktop:snap-region', eventInit));
+        }
+      }
+      onClose?.();
+    },
+    [snapActiveWindow, onClose]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>, region: SnapRegionId) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        event.stopPropagation();
+        applySnap(region);
+      }
+    },
+    [applySnap]
+  );
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed z-50"
+      style={positionStyle}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Snap layout options"
+      data-testid="snap-overlay"
+    >
+      <div className="w-72 space-y-3 rounded-lg bg-black/80 p-3 text-white shadow-2xl backdrop-blur">
+        {LAYOUT_PRESETS.map((preset, presetIndex) => (
+          <div key={preset.id} className="space-y-2">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-200">
+              <kbd className="rounded bg-white/10 px-1.5 py-0.5 text-[10px] font-semibold text-white">
+                {preset.hint}
+              </kbd>
+              <span>{preset.label}</span>
+            </div>
+            <div className={preset.gridClass} role="grid">
+              {preset.regions.map((region, regionIndex) => (
+                <button
+                  key={region.id}
+                  type="button"
+                  ref={presetIndex === 0 && regionIndex === 0 ? firstRegionRef : undefined}
+                  className={
+                    'relative flex items-center justify-center rounded border border-white/15 bg-white/10 text-xs text-white/70 transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 ' +
+                    region.className
+                  }
+                  aria-label={region.label}
+                  data-region={region.id}
+                  onClick={() => applySnap(region.id)}
+                  onKeyDown={(event) => handleKeyDown(event, region.id)}
+                >
+                  <span className="pointer-events-none absolute left-1 top-1 rounded bg-black/50 px-1 text-[10px] font-semibold uppercase tracking-widest text-gray-100">
+                    {region.hint}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SnapOverlay;


### PR DESCRIPTION
## Summary
- add a SnapOverlay component that renders half, third and quadrant presets with keyboard hints
- extend Window snapping logic to handle overlay events and map new layout regions
- add unit tests covering overlay interactions and snapping from external triggers

## Testing
- yarn lint *(fails: repo has pre-existing accessibility and no-top-level-window lint errors)*
- yarn test --runInBand *(fails: existing nmapNse test expects an alert role)*
- yarn test SnapOverlay.test.tsx --runInBand
- yarn test __tests__/window.test.tsx -t "applies third layout" --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ca217d6ba48328966e3392f8fe62a1