### PR TITLE
[desktop] widen window resize handles

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -702,7 +702,9 @@ export class WindowYBorder extends Component {
     render() {
             return (
                 <div
-                    className={`${styles.windowYBorder} cursor-[e-resize] border-transparent border-1 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2`}
+                    className={`${styles.windowResizeHandle} ${styles.windowYBorder} absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2`}
+                    draggable
+                    aria-hidden="true"
                     onDragStart={(e) => { e.dataTransfer.setDragImage(this.trpImg, 0, 0) }}
                     onDrag={this.props.resize}
                 ></div>
@@ -721,7 +723,9 @@ export class WindowXBorder extends Component {
     render() {
             return (
                 <div
-                    className={`${styles.windowXBorder} cursor-[n-resize] border-transparent border-1 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2`}
+                    className={`${styles.windowResizeHandle} ${styles.windowXBorder} absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2`}
+                    draggable
+                    aria-hidden="true"
                     onDragStart={(e) => { e.dataTransfer.setDragImage(this.trpImg, 0, 0) }}
                     onDrag={this.props.resize}
                 ></div>

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -1,9 +1,70 @@
+.windowResizeHandle {
+  position: absolute;
+  pointer-events: auto;
+  touch-action: none;
+  --window-resize-highlight: rgba(56, 189, 248, 0.85);
+}
+
+.windowResizeHandle::before,
+.windowResizeHandle::after {
+  content: '';
+  position: absolute;
+  background-color: transparent;
+  transition: background-color 120ms ease-in-out;
+}
+
+.windowResizeHandle:hover::before,
+.windowResizeHandle:hover::after,
+.windowResizeHandle:focus-visible::before,
+.windowResizeHandle:focus-visible::after {
+  background-color: var(--window-resize-highlight);
+}
+
 .windowYBorder {
-  height: calc(100% - 10px);
-  width: calc(100% + 10px);
+  height: calc(100% - 24px);
+  width: calc(100% + 24px);
+  cursor: ew-resize;
+}
+
+.windowYBorder::before,
+.windowYBorder::after {
+  width: 1px;
+  top: -12px;
+  bottom: -12px;
+}
+
+.windowYBorder::before {
+  left: 12px;
+}
+
+.windowYBorder::after {
+  right: 12px;
 }
 
 .windowXBorder {
-  height: calc(100% + 10px);
-  width: calc(100% - 10px);
+  height: calc(100% + 24px);
+  width: calc(100% - 24px);
+  cursor: ns-resize;
+}
+
+.windowXBorder::before,
+.windowXBorder::after {
+  height: 1px;
+  left: -12px;
+  right: -12px;
+}
+
+.windowXBorder::before {
+  top: 12px;
+}
+
+.windowXBorder::after {
+  bottom: 12px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .windowResizeHandle::before,
+  .windowResizeHandle::after {
+    transition: none;
+  }
 }


### PR DESCRIPTION
## Summary
- expand the window resize hit areas to 12px and surface hover highlights for every edge
- apply accessible resize cursors and hover visuals through the shared resize handle styles

## Testing
- yarn lint *(fails: existing repo lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ca217fa5d083288fa3fa1ba96d00bd