### PR TITLE
[desktop] add peek gesture support

### DIFF
--- a/__tests__/gestures.test.ts
+++ b/__tests__/gestures.test.ts
@@ -1,0 +1,52 @@
+import { addPeekStateListener, initializePeekGestures } from '../src/system/gestures';
+
+describe('peek gesture detection', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('emits peek state while the meta key is held', () => {
+    const events: boolean[] = [];
+    const removeListener = addPeekStateListener(({ active }) => {
+      events.push(active);
+    });
+
+    const cleanup = initializePeekGestures({ holdDelay: 100 });
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Meta' }));
+    jest.advanceTimersByTime(50);
+    expect(events).toEqual([]);
+
+    jest.advanceTimersByTime(60);
+    expect(events).toEqual([true]);
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Meta' }));
+    expect(events).toEqual([true, false]);
+
+    removeListener();
+    cleanup();
+  });
+
+  it('cancels the peek if the key is released before the hold delay', () => {
+    const events: boolean[] = [];
+    const removeListener = addPeekStateListener(({ active }) => {
+      events.push(active);
+    });
+
+    const cleanup = initializePeekGestures({ holdDelay: 120 });
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Meta' }));
+    jest.advanceTimersByTime(60);
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Meta' }));
+
+    expect(events).toEqual([]);
+
+    removeListener();
+    cleanup();
+  });
+});

--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -2,7 +2,7 @@ import React, { act } from 'react';
 import { render, screen } from '@testing-library/react';
 import Ubuntu from '../components/ubuntu';
 
-jest.mock('../components/screen/desktop', () => function DesktopMock() {
+jest.mock('../components/desktop/Desktop', () => function DesktopMock() {
   return <div data-testid="desktop" />;
 });
 jest.mock('../components/screen/navbar', () => function NavbarMock() {

--- a/components/desktop/Desktop.tsx
+++ b/components/desktop/Desktop.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import type { ComponentProps } from 'react';
+
+import LegacyDesktop from '../screen/desktop';
+import { addPeekStateListener, initializePeekGestures } from '@/src/system/gestures';
+
+type LegacyDesktopProps = ComponentProps<typeof LegacyDesktop>;
+
+const applyPeekClass = (container: HTMLElement | null, active: boolean) => {
+  if (!container) {
+    return;
+  }
+  container.classList.toggle('desktop-peeking', active);
+};
+
+export default function Desktop(props: LegacyDesktopProps) {
+  const [isPeeking, setIsPeeking] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return () => {};
+    }
+
+    const removeListener = addPeekStateListener(({ active }) => {
+      setIsPeeking(active);
+    });
+
+    const cleanupGestures = initializePeekGestures();
+
+    return () => {
+      removeListener();
+      cleanupGestures();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return () => {};
+    }
+
+    const container = document.getElementById('window-area');
+    applyPeekClass(container, isPeeking);
+
+    return () => {
+      applyPeekClass(container, false);
+    };
+  }, [isPeeking]);
+
+  return <LegacyDesktop {...props} />;
+}

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 import BootingScreen from './screen/booting_screen';
-import Desktop from './screen/desktop';
+import Desktop from './desktop/Desktop';
 import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';

--- a/src/system/gestures.ts
+++ b/src/system/gestures.ts
@@ -1,0 +1,231 @@
+export const PEEK_EVENT_NAME = 'desktop:peek';
+
+export type PeekOrigin = 'meta-hold' | 'three-finger-swipe';
+
+export interface PeekEventDetail {
+  active: boolean;
+  origin: PeekOrigin;
+}
+
+type PeekListener = (detail: PeekEventDetail) => void;
+
+type CleanupFn = () => void;
+
+const noop = () => {};
+
+type PeekWindow = Window & typeof globalThis;
+
+const resolveWindow = (): PeekWindow | undefined => {
+  if (typeof globalThis === 'undefined') {
+    return undefined;
+  }
+
+  const candidate = (globalThis as { window?: PeekWindow }).window;
+  return typeof candidate === 'undefined' ? undefined : candidate;
+};
+
+const createEvent = (detail: PeekEventDetail) =>
+  new CustomEvent<PeekEventDetail>(PEEK_EVENT_NAME, { detail });
+
+const dispatchPeekEvent = (detail: PeekEventDetail) => {
+  const targetWindow = resolveWindow();
+  if (!targetWindow) {
+    return;
+  }
+  targetWindow.dispatchEvent(createEvent(detail));
+};
+
+export const addPeekStateListener = (listener: PeekListener): CleanupFn => {
+  const targetWindow = resolveWindow();
+  if (!targetWindow) {
+    return noop;
+  }
+
+  const handler = (event: Event) => {
+    const customEvent = event as CustomEvent<PeekEventDetail>;
+    listener(customEvent.detail);
+  };
+
+  targetWindow.addEventListener(PEEK_EVENT_NAME, handler as EventListener);
+
+  return () => {
+    targetWindow.removeEventListener(PEEK_EVENT_NAME, handler as EventListener);
+  };
+};
+
+export interface PeekGestureOptions {
+  holdDelay?: number;
+  swipeThreshold?: number;
+  target?: PeekWindow;
+}
+
+const DEFAULT_HOLD_DELAY = 250;
+const DEFAULT_SWIPE_THRESHOLD = 70;
+
+const averageTouchPoint = (touches: TouchList) => {
+  let totalX = 0;
+  let totalY = 0;
+  const { length } = touches;
+
+  for (let index = 0; index < length; index += 1) {
+    const touch = touches.item(index);
+    if (!touch) continue;
+    totalX += touch.clientX;
+    totalY += touch.clientY;
+  }
+
+  return {
+    x: totalX / length,
+    y: totalY / length,
+  };
+};
+
+export const initializePeekGestures = (
+  options: PeekGestureOptions = {},
+): CleanupFn => {
+  const targetWindow = options.target ?? resolveWindow();
+  if (!targetWindow) {
+    return noop;
+  }
+
+  const { holdDelay = DEFAULT_HOLD_DELAY, swipeThreshold = DEFAULT_SWIPE_THRESHOLD } = options;
+  const doc = targetWindow.document;
+
+  let metaTimer: ReturnType<typeof targetWindow.setTimeout> | null = null;
+  let metaActive = false;
+  let touchActive = false;
+  let trackingTouch = false;
+  let touchOrigin: { x: number; y: number } | null = null;
+
+  const overallActive = () => metaActive || touchActive;
+
+  const emitStateChange = (origin: PeekOrigin, active: boolean) => {
+    const previouslyActive = overallActive();
+
+    if (origin === 'meta-hold') {
+      metaActive = active;
+    } else {
+      touchActive = active;
+    }
+
+    const nextActive = overallActive();
+
+    if (previouslyActive !== nextActive) {
+      dispatchPeekEvent({ active: nextActive, origin });
+    }
+  };
+
+  const cancelMetaTimer = () => {
+    if (metaTimer !== null) {
+      targetWindow.clearTimeout(metaTimer);
+      metaTimer = null;
+    }
+  };
+
+  const cancelMetaPeek = () => {
+    cancelMetaTimer();
+    if (metaActive) {
+      emitStateChange('meta-hold', false);
+    }
+  };
+
+  const cancelTouchPeek = () => {
+    trackingTouch = false;
+    touchOrigin = null;
+    if (touchActive) {
+      emitStateChange('three-finger-swipe', false);
+    }
+  };
+
+  const cancelAll = () => {
+    cancelMetaPeek();
+    cancelTouchPeek();
+  };
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== 'Meta' || metaTimer !== null || metaActive || event.repeat) {
+      return;
+    }
+
+    metaTimer = targetWindow.setTimeout(() => {
+      metaTimer = null;
+      emitStateChange('meta-hold', true);
+    }, holdDelay);
+  };
+
+  const onKeyUp = (event: KeyboardEvent) => {
+    if (event.key !== 'Meta') {
+      return;
+    }
+    cancelMetaPeek();
+  };
+
+  const onTouchStart = (event: TouchEvent) => {
+    if (event.touches.length >= 3) {
+      trackingTouch = true;
+      touchOrigin = averageTouchPoint(event.touches);
+    } else {
+      cancelTouchPeek();
+    }
+  };
+
+  const onTouchMove = (event: TouchEvent) => {
+    if (!trackingTouch) {
+      return;
+    }
+
+    if (event.touches.length < 3) {
+      cancelTouchPeek();
+      return;
+    }
+
+    if (!touchOrigin) {
+      touchOrigin = averageTouchPoint(event.touches);
+      return;
+    }
+
+    const current = averageTouchPoint(event.touches);
+    const deltaX = current.x - touchOrigin.x;
+    const deltaY = current.y - touchOrigin.y;
+    const distance = Math.hypot(deltaX, deltaY);
+
+    if (!touchActive && distance >= swipeThreshold) {
+      emitStateChange('three-finger-swipe', true);
+    }
+  };
+
+  const onTouchEnd = (event: TouchEvent) => {
+    if (event.touches.length < 3) {
+      cancelTouchPeek();
+    }
+  };
+
+  const onVisibilityChange = () => {
+    if (doc.hidden) {
+      cancelAll();
+    }
+  };
+
+  targetWindow.addEventListener('keydown', onKeyDown as EventListener);
+  targetWindow.addEventListener('keyup', onKeyUp as EventListener);
+  targetWindow.addEventListener('blur', cancelAll as EventListener);
+  targetWindow.addEventListener('touchstart', onTouchStart as EventListener, { passive: true });
+  targetWindow.addEventListener('touchmove', onTouchMove as EventListener, { passive: true });
+  targetWindow.addEventListener('touchend', onTouchEnd as EventListener);
+  targetWindow.addEventListener('touchcancel', cancelTouchPeek as EventListener);
+  doc.addEventListener('visibilitychange', onVisibilityChange);
+
+  const cleanup = () => {
+    cancelAll();
+    targetWindow.removeEventListener('keydown', onKeyDown as EventListener);
+    targetWindow.removeEventListener('keyup', onKeyUp as EventListener);
+    targetWindow.removeEventListener('blur', cancelAll as EventListener);
+    targetWindow.removeEventListener('touchstart', onTouchStart as EventListener);
+    targetWindow.removeEventListener('touchmove', onTouchMove as EventListener);
+    targetWindow.removeEventListener('touchend', onTouchEnd as EventListener);
+    targetWindow.removeEventListener('touchcancel', cancelTouchPeek as EventListener);
+    doc.removeEventListener('visibilitychange', onVisibilityChange);
+  };
+
+  return cleanup;
+};

--- a/styles/index.css
+++ b/styles/index.css
@@ -370,6 +370,29 @@ dialog {
     background-color: color-mix(in srgb, var(--color-bg), transparent 15%); /* Fallback for unsupported browsers */
 }
 
+#window-area .opened-window {
+    transition: opacity 150ms ease, filter 150ms ease;
+}
+
+#window-area.desktop-peeking {
+    pointer-events: none;
+}
+
+#window-area.desktop-peeking .opened-window {
+    opacity: 0.12;
+    filter: saturate(0) brightness(1.4);
+}
+
+#window-area.desktop-peeking .opened-window::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 2px solid rgba(255, 255, 255, 0.45);
+    pointer-events: none;
+    mix-blend-mode: screen;
+}
+
 @supports ((-webkit-backdrop-filter: blur(0)) or (backdrop-filter: blur(0))) {
     .context-menu-bg,
     .windowMainScreen {


### PR DESCRIPTION
## Summary
- add a gesture controller that emits a desktop peek event when the meta key is held or a three-finger swipe is detected
- wrap the desktop shell so it listens for peek events and toggles outline visuals during the transient peek state
- add CSS for the peek effect and update Ubuntu wiring plus unit coverage for the new controller

## Testing
- yarn lint *(fails: thousands of pre-existing accessibility violations across legacy apps)*
- yarn eslint src/system/gestures.ts components/desktop/Desktop.tsx components/ubuntu.js __tests__/ubuntu.test.tsx __tests__/gestures.test.ts --max-warnings=0
- yarn test *(fails: numerous suites expect DOM APIs like localStorage in JSDOM)*

------
https://chatgpt.com/codex/tasks/task_e_68ca218069688328931e767aefaf7d86