### PR TITLE
[desktop] add assertive live region to switcher

### DIFF
--- a/components/desktop/DesktopSwitcher.tsx
+++ b/components/desktop/DesktopSwitcher.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef } from "react";
+
+export interface DesktopOption {
+  id: string;
+  name: string;
+}
+
+export interface DesktopSwitcherProps {
+  desktops: readonly DesktopOption[];
+  activeDesktopId: string;
+  onDesktopChange?: (desktopId: string) => void;
+  className?: string;
+}
+
+const DesktopSwitcher: React.FC<DesktopSwitcherProps> = ({
+  desktops,
+  activeDesktopId,
+  onDesktopChange,
+  className = "",
+}) => {
+  const liveRegionRef = useRef<HTMLDivElement | null>(null);
+  const previousDesktopIdRef = useRef<string | null>(null);
+
+  const activeDesktop = useMemo(
+    () => desktops.find((desktop) => desktop.id === activeDesktopId) ?? null,
+    [desktops, activeDesktopId],
+  );
+
+  useEffect(() => {
+    if (!liveRegionRef.current) return;
+    if (previousDesktopIdRef.current === activeDesktopId) return;
+
+    previousDesktopIdRef.current = activeDesktopId;
+
+    const message = activeDesktop
+      ? `Switched to ${activeDesktop.name} desktop`
+      : "Desktop changed";
+
+    // Clear the region first so assistive tech re-announces repeated updates.
+    liveRegionRef.current.textContent = "";
+    liveRegionRef.current.textContent = message;
+  }, [activeDesktopId, activeDesktop]);
+
+  const handleDesktopClick = (desktopId: string) => {
+    if (desktopId === activeDesktopId) return;
+    onDesktopChange?.(desktopId);
+  };
+
+  return (
+    <div className={className}>
+      <div
+        ref={liveRegionRef}
+        className="sr-only"
+        role="status"
+        aria-live="assertive"
+        aria-atomic="true"
+      />
+      <ul className="flex gap-2" role="tablist" aria-label="Virtual desktops">
+        {desktops.map((desktop) => {
+          const isActive = desktop.id === activeDesktopId;
+          return (
+            <li key={desktop.id}>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => handleDesktopClick(desktop.id)}
+                className={`px-2 py-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ub-orange ${
+                  isActive
+                    ? "bg-ub-orange text-black"
+                    : "bg-ub-cool-grey text-white hover:bg-ub-cool-grey/80"
+                }`}
+              >
+                <span className="sr-only">
+                  {isActive ? "Current desktop:" : "Switch to desktop"}
+                </span>
+                {" "}
+                {desktop.name}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default DesktopSwitcher;


### PR DESCRIPTION
## Summary
- add a DesktopSwitcher component that announces the active workspace name through an assertive live region
- expose typed props so the switcher can notify listeners when the desktop selection changes

## Testing
- yarn lint *(fails: repository has hundreds of existing jsx-a11y violations unrelated to this change)*
- yarn test *(partially ran; aborted after multiple pre-existing failures and extended runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2192449c8328913f4750c4af50b6