### PR TITLE
[weather] add typeahead search and location helper

### DIFF
--- a/apps/weather/index.tsx
+++ b/apps/weather/index.tsx
@@ -16,6 +16,22 @@ interface ReadingUpdate {
   time: number;
 }
 
+interface Suggestion {
+  id: string;
+  title: string;
+  subtitle?: string;
+  fullLabel: string;
+  lat: number;
+  lon: number;
+}
+
+type HelperTone = 'info' | 'error' | 'success';
+
+interface HelperMessage {
+  tone: HelperTone;
+  message: string;
+}
+
 function CityTile({ city }: { city: City }) {
   return (
     <div>
@@ -43,6 +59,12 @@ export default function WeatherApp() {
   );
   const [selected, setSelected] = useState<City | null>(null);
   const dragSrc = useRef<number | null>(null);
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const skipNextSearch = useRef(false);
+  const [helper, setHelper] = useState<HelperMessage | null>(null);
+  const [geoLoading, setGeoLoading] = useState(false);
 
   useEffect(() => {
     if (!currentGroup) return;
@@ -92,19 +114,127 @@ export default function WeatherApp() {
           // ignore fetch errors
         });
     });
-    }, [offline, cities, setCities]);
+  }, [offline, cities, setCities]);
+
+  useEffect(() => {
+    if (skipNextSearch.current) {
+      skipNextSearch.current = false;
+      setIsSearching(false);
+      return;
+    }
+
+    const trimmed = name.trim();
+    if (trimmed.length === 0) {
+      setSuggestions([]);
+      setSearchError(null);
+      setIsSearching(false);
+      return;
+    }
+
+    if (trimmed.length < 3) {
+      setSuggestions([]);
+      setSearchError(null);
+      setIsSearching(false);
+      return;
+    }
+
+    if (offline) {
+      setSuggestions([]);
+      setIsSearching(false);
+      setSearchError(
+        'Search is unavailable while offline. Enter coordinates manually.',
+      );
+      return;
+    }
+
+    let canceled = false;
+    const controller = new AbortController();
+    setIsSearching(true);
+    setSearchError(null);
+
+    const timeout = window.setTimeout(() => {
+      fetch(
+        `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(
+          trimmed,
+        )}&count=5&language=en&format=json`,
+        { signal: controller.signal },
+      )
+        .then((res) => {
+          if (!res.ok) throw new Error('search_failed');
+          return res.json();
+        })
+        .then((data) => {
+          if (canceled || controller.signal.aborted) return;
+          const results: Suggestion[] = Array.isArray(data?.results)
+            ? data.results.map((item: any) => {
+                const subtitleParts = [item.admin1, item.country]
+                  .filter((part) => typeof part === 'string' && part.length)
+                  .map((part) => part as string);
+                const fullLabel = subtitleParts.length
+                  ? `${item.name}, ${subtitleParts.join(', ')}`
+                  : String(item.name);
+                return {
+                  id: String(item.id ?? `${item.latitude}-${item.longitude}`),
+                  title: String(item.name ?? ''),
+                  subtitle: subtitleParts.join(', ') || undefined,
+                  fullLabel,
+                  lat: Number(item.latitude),
+                  lon: Number(item.longitude),
+                };
+              })
+            : [];
+          setSuggestions(results);
+          if (!results.length) {
+            setSearchError(
+              `No matches found for “${trimmed}”. Try adjusting your search or enter coordinates manually.`,
+            );
+          }
+        })
+        .catch((err) => {
+          if (canceled || controller.signal.aborted) return;
+          console.error(err);
+          setSuggestions([]);
+          setSearchError(
+            'Unable to fetch suggestions right now. Try again later or enter coordinates manually.',
+          );
+        })
+        .finally(() => {
+          if (!canceled && !controller.signal.aborted) {
+            setIsSearching(false);
+          }
+        });
+    }, 300);
+
+    return () => {
+      canceled = true;
+      controller.abort();
+      window.clearTimeout(timeout);
+    };
+  }, [name, offline]);
 
   const addCity = () => {
     const latNum = parseFloat(lat);
     const lonNum = parseFloat(lon);
-    if (!name || Number.isNaN(latNum) || Number.isNaN(lonNum)) return;
-    setCities([
-      ...cities,
+    if (!name || Number.isNaN(latNum) || Number.isNaN(lonNum)) {
+      setHelper({
+        tone: 'error',
+        message: 'Enter a name, latitude, and longitude to add a city.',
+      });
+      return;
+    }
+    setCities((prev) => [
+      ...prev,
       { id: `${name}-${lat}-${lon}`, name, lat: latNum, lon: lonNum },
     ]);
     setName('');
     setLat('');
     setLon('');
+    setSuggestions([]);
+    setSearchError(null);
+    setHelper({
+      tone: 'success',
+      message: `${name} saved. Fetching the latest weather…`,
+    });
   };
 
   const onDragStart = (i: number) => {
@@ -142,6 +272,106 @@ export default function WeatherApp() {
     }
   };
 
+  const useMyLocation = () => {
+    if (geoLoading) return;
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      setHelper({
+        tone: 'error',
+        message:
+          'Geolocation is not supported in this browser. Search for a city instead.',
+      });
+      return;
+    }
+
+    setGeoLoading(true);
+    setHelper({
+      tone: 'info',
+      message: 'Requesting permission to access your location…',
+    });
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const { latitude, longitude } = position.coords;
+        const latStr = latitude.toFixed(4);
+        const lonStr = longitude.toFixed(4);
+        setLat(latStr);
+        setLon(lonStr);
+        setSuggestions([]);
+        setSearchError(null);
+        skipNextSearch.current = true;
+
+        if (offline) {
+          setName('My location');
+          setHelper({
+            tone: 'info',
+            message:
+              'Coordinates captured. Name this location and click Add to save it.',
+          });
+          setGeoLoading(false);
+          return;
+        }
+
+        void (async () => {
+          try {
+            const res = await fetch(
+              `https://geocoding-api.open-meteo.com/v1/reverse?latitude=${latitude}&longitude=${longitude}&count=1&language=en&format=json`,
+            );
+            if (!res.ok) throw new Error('reverse_failed');
+            const data = await res.json();
+            const first = Array.isArray(data?.results)
+              ? data.results[0]
+              : null;
+            const subtitleParts = [first?.admin1, first?.country]
+              .filter((part) => typeof part === 'string' && part.length)
+              .map((part) => part as string);
+            const label = first?.name
+              ? subtitleParts.length
+                ? `${first.name}, ${subtitleParts.join(', ')}`
+                : String(first.name)
+              : `Lat ${latStr}, Lon ${lonStr}`;
+            setName(label);
+            setHelper({
+              tone: 'success',
+              message: `Located ${label}. Click Add to save it to your dashboard.`,
+            });
+          } catch (err) {
+            console.error(err);
+            setName('My location');
+            setHelper({
+              tone: 'info',
+              message:
+                'Coordinates captured. We could not determine the nearest city—add a name and click Add.',
+            });
+          } finally {
+            setGeoLoading(false);
+          }
+        })();
+      },
+      (error) => {
+        setGeoLoading(false);
+        let message =
+          'We could not access your location. Try again later or search for a city.';
+        switch (error.code) {
+          case 1:
+            message =
+              'Location access was denied. Update your browser permissions or add a city manually.';
+            break;
+          case 2:
+            message =
+              'We could not determine your position. Try again or search for a city.';
+            break;
+          case 3:
+            message = 'The location request timed out. Try again or search for a city.';
+            break;
+          default:
+            break;
+        }
+        setHelper({ tone: 'error', message });
+      },
+      { enableHighAccuracy: false, timeout: 10000 },
+    );
+  };
+
   return (
     <div className="p-4 text-white">
       <div className="flex gap-2 mb-4">
@@ -166,13 +396,51 @@ export default function WeatherApp() {
           </button>
         ))}
       </div>
-      <div className="flex gap-2 mb-4">
-        <input
-          className="text-black px-1"
-          placeholder="Name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
+      <p className="mb-2 text-sm text-white/70">
+        Type a city name (3+ letters) to search or enter coordinates manually.
+        We only request your location when you choose “Use my location”.
+      </p>
+      <div className="flex flex-wrap gap-2 mb-2 items-end">
+        <div className="relative flex-1 min-w-[200px]">
+          <input
+            className="text-black px-1 w-full"
+            placeholder="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          {(isSearching || suggestions.length > 0) && (
+            <div className="absolute z-20 mt-1 w-full rounded border border-white/10 bg-neutral-900/95 shadow-lg max-h-56 overflow-y-auto">
+              {isSearching && (
+                <div className="px-2 py-1 text-sm text-white/70">
+                  Searching…
+                </div>
+              )}
+              {!isSearching &&
+                suggestions.map((suggestion) => (
+                  <button
+                    key={suggestion.id}
+                    type="button"
+                    className="block w-full px-2 py-1 text-left text-sm hover:bg-white/10"
+                    onClick={() => {
+                      skipNextSearch.current = true;
+                      setName(suggestion.fullLabel);
+                      setLat(suggestion.lat.toFixed(4));
+                      setLon(suggestion.lon.toFixed(4));
+                      setSuggestions([]);
+                      setSearchError(null);
+                    }}
+                  >
+                    <div className="font-medium">{suggestion.title}</div>
+                    {suggestion.subtitle && (
+                      <div className="text-xs text-white/70">
+                        {suggestion.subtitle}
+                      </div>
+                    )}
+                  </button>
+                ))}
+            </div>
+          )}
+        </div>
         <input
           className="text-black px-1 w-20"
           placeholder="Lat"
@@ -188,7 +456,32 @@ export default function WeatherApp() {
         <button className="bg-blue-600 px-2 rounded" onClick={addCity}>
           Add
         </button>
+        <button
+          className={`px-2 rounded border border-white/20 ${
+            geoLoading ? 'opacity-60 cursor-not-allowed' : 'hover:bg-white/10'
+          }`}
+          onClick={useMyLocation}
+          disabled={geoLoading}
+        >
+          {geoLoading ? 'Locating…' : 'Use my location'}
+        </button>
       </div>
+      {searchError && (
+        <div className="mb-2 text-sm text-red-300">{searchError}</div>
+      )}
+      {helper && (
+        <div
+          className={`mb-4 text-sm ${
+            helper.tone === 'error'
+              ? 'text-red-300'
+              : helper.tone === 'success'
+              ? 'text-green-300'
+              : 'text-blue-200'
+          }`}
+        >
+          {helper.message}
+        </div>
+      )}
       <div className="grid grid-cols-2 gap-4">
         {cities.map((city, i) => (
           <div


### PR DESCRIPTION
## Summary
- add an Open-Meteo typeahead lookup with suggestions for the weather city input
- surface permission copy and helper messaging for search, add, and location flows
- wire a "Use my location" button that requests geolocation, reverse geocodes, and guides the user through errors

## Testing
- yarn lint *(fails: repository-wide accessibility lint errors in unrelated files)*
- yarn test *(fails: existing Jest suites and interrupted after extended runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2195e058832884af60ddf01b97a7