### PR TITLE
[sticky-notes] Add JSON import/export with conflict merge UI

### DIFF
--- a/apps/sticky_notes/index.tsx
+++ b/apps/sticky_notes/index.tsx
@@ -9,9 +9,34 @@ export default function StickyNotes() {
   }, []);
 
   return (
-    <div>
-      <button id="add-note">Add Note</button>
+    <div className="sticky-notes-app" role="application" aria-label="Sticky notes">
+      <div
+        className="sticky-notes-toolbar"
+        role="toolbar"
+        aria-label="Sticky notes actions"
+      >
+        <button id="add-note" type="button">
+          Add Note
+        </button>
+        <button id="export-notes" type="button">
+          Export JSON
+        </button>
+        <button id="import-notes" type="button">
+          Import JSON
+        </button>
+        <button id="undo-merge" type="button" disabled>
+          Undo Merge
+        </button>
+        <input
+          id="import-notes-input"
+          type="file"
+          accept="application/json"
+          hidden
+        />
+      </div>
+      <div id="notes-status" className="sticky-notes-status" role="status" aria-live="polite" />
       <div id="notes" />
+      <div id="merge-root" aria-hidden="true" />
     </div>
   );
 }

--- a/apps/sticky_notes/main.js
+++ b/apps/sticky_notes/main.js
@@ -3,22 +3,41 @@
 import { isBrowser } from '../../utils/env';
 import { getDb } from '../../utils/safeIDB';
 
+const DB_NAME = 'stickyNotes';
+const STORE_NAME = 'notes';
+const DB_VERSION = 1;
+const MAX_HISTORY = 10;
+
 let notesContainer = null;
 let addNoteBtn = null;
+let exportBtn = null;
+let importBtn = null;
+let importInput = null;
+let undoBtn = null;
+let statusRegion = null;
+let mergeRoot = null;
+
+let dbPromise = null;
+let notes = [];
+const mergeHistory = [];
+let pendingMerge = null;
+let statusTimer = null;
+let lastGeneratedId = Date.now();
 
 function initDom() {
   if (!isBrowser) return;
   notesContainer = document.getElementById('notes');
   addNoteBtn = document.getElementById('add-note');
+  exportBtn = document.getElementById('export-notes');
+  importBtn = document.getElementById('import-notes');
+  importInput = document.getElementById('import-notes-input');
+  undoBtn = document.getElementById('undo-merge');
+  statusRegion = document.getElementById('notes-status');
+  mergeRoot = document.getElementById('merge-root');
 }
 
 initDom();
 
-const DB_NAME = 'stickyNotes';
-const STORE_NAME = 'notes';
-const DB_VERSION = 1;
-
-let dbPromise = null;
 function getDB() {
   if (!dbPromise) {
     dbPromise = getDb(DB_NAME, DB_VERSION, {
@@ -38,7 +57,52 @@ function getDB() {
   return dbPromise;
 }
 
-let notes = [];
+function updateIdSeedFromValue(value) {
+  const matches = String(value ?? '')
+    .match(/\d+/g)
+    ?.map((chunk) => Number.parseInt(chunk, 10))
+    .filter((num) => Number.isFinite(num));
+  if (!matches || matches.length === 0) return;
+  const candidate = Math.max(...matches);
+  if (candidate > lastGeneratedId) {
+    lastGeneratedId = candidate;
+  }
+}
+
+function generateNoteId() {
+  lastGeneratedId += 1;
+  return `note-${lastGeneratedId}`;
+}
+
+function cloneNotes(value) {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+function normalizeNote(raw) {
+  const x = Number(raw?.x);
+  const y = Number(raw?.y);
+  const width = Number(raw?.width);
+  const height = Number(raw?.height);
+  const updatedAt = Number(raw?.updatedAt);
+  const note = {
+    id:
+      raw && raw.id !== undefined && raw.id !== null
+        ? String(raw.id)
+        : generateNoteId(),
+    content: typeof raw?.content === 'string' ? raw.content : '',
+    x: Number.isFinite(x) ? x : 50,
+    y: Number.isFinite(y) ? y : 50,
+    color: typeof raw?.color === 'string' ? raw.color : '#fffa65',
+    width: Number.isFinite(width) ? width : 200,
+    height: Number.isFinite(height) ? height : 200,
+    updatedAt: Number.isFinite(updatedAt) ? updatedAt : Date.now(),
+  };
+  updateIdSeedFromValue(note.id);
+  return note;
+}
 
 async function saveNotes() {
   try {
@@ -56,15 +120,73 @@ async function saveNotes() {
   }
 }
 
+function renderNotes() {
+  if (!notesContainer) return;
+  notesContainer.innerHTML = '';
+  notes.forEach((note) => {
+    createNoteElement(note);
+  });
+}
+
+function announce(message, persistent = false) {
+  if (!statusRegion) {
+    if (message) console.info(message);
+    return;
+  }
+  if (statusTimer) {
+    window.clearTimeout(statusTimer);
+    statusTimer = null;
+  }
+  if (message) {
+    statusRegion.textContent = message;
+    statusRegion.dataset.visible = 'true';
+    if (!persistent) {
+      statusTimer = window.setTimeout(() => {
+        if (statusRegion) {
+          statusRegion.textContent = '';
+          statusRegion.dataset.visible = 'false';
+        }
+      }, 5000);
+    }
+  } else {
+    statusRegion.textContent = '';
+    statusRegion.dataset.visible = 'false';
+  }
+}
+
+function updateUndoButton() {
+  if (!undoBtn) return;
+  undoBtn.disabled = mergeHistory.length === 0;
+}
+
+function pushHistory() {
+  mergeHistory.push(cloneNotes(notes));
+  if (mergeHistory.length > MAX_HISTORY) {
+    mergeHistory.shift();
+  }
+  updateUndoButton();
+}
+
+function undoMerge() {
+  if (!mergeHistory.length) return;
+  const previous = mergeHistory.pop();
+  if (!previous) return;
+  notes = previous.map((note) => normalizeNote(note));
+  renderNotes();
+  void saveNotes();
+  announce('Merge undone.');
+  updateUndoButton();
+}
+
 function createNoteElement(note) {
   if (!notesContainer) return;
   const el = document.createElement('div');
   el.className = 'note';
-  el.style.left = note.x + 'px';
-  el.style.top = note.y + 'px';
+  el.style.left = `${note.x}px`;
+  el.style.top = `${note.y}px`;
   el.style.backgroundColor = note.color;
-  el.style.width = (note.width || 200) + 'px';
-  el.style.height = (note.height || 200) + 'px';
+  el.style.width = `${note.width || 200}px`;
+  el.style.height = `${note.height || 200}px`;
   el.dataset.id = note.id;
 
   const controls = document.createElement('div');
@@ -75,6 +197,7 @@ function createNoteElement(note) {
   colorInput.value = note.color;
   colorInput.addEventListener('input', (e) => {
     note.color = e.target.value;
+    note.updatedAt = Date.now();
     el.style.backgroundColor = note.color;
     void saveNotes();
   });
@@ -86,6 +209,7 @@ function createNoteElement(note) {
     notes = notes.filter((n) => n.id !== note.id);
     el.remove();
     void saveNotes();
+    announce('Note deleted.');
   });
 
   controls.appendChild(colorInput);
@@ -96,13 +220,15 @@ function createNoteElement(note) {
   textarea.value = note.content;
   textarea.addEventListener('input', (e) => {
     note.content = e.target.value;
+    note.updatedAt = Date.now();
     void saveNotes();
   });
   el.appendChild(textarea);
   el.addEventListener('mouseup', () => {
     note.width = el.offsetWidth;
     note.height = el.offsetHeight;
-    saveNotes();
+    note.updatedAt = Date.now();
+    void saveNotes();
   });
 
   enableDrag(el, note);
@@ -111,21 +237,24 @@ function createNoteElement(note) {
 
 function addNote(content = '') {
   const note = {
-    id: Date.now(),
+    id: generateNoteId(),
     content,
     x: 50,
     y: 50,
     color: '#fffa65',
     width: 200,
     height: 200,
+    updatedAt: Date.now(),
   };
   notes.push(note);
   createNoteElement(note);
   void saveNotes();
+  announce('Note added.');
 }
 
 function enableDrag(el, note) {
-  let offsetX, offsetY;
+  let offsetX;
+  let offsetY;
   function onMouseDown(e) {
     if (['TEXTAREA', 'INPUT', 'BUTTON'].includes(e.target.tagName)) return;
     offsetX = e.clientX - el.offsetLeft;
@@ -136,35 +265,36 @@ function enableDrag(el, note) {
   function onMouseMove(e) {
     note.x = e.clientX - offsetX;
     note.y = e.clientY - offsetY;
-    el.style.left = note.x + 'px';
-    el.style.top = note.y + 'px';
+    el.style.left = `${note.x}px`;
+    el.style.top = `${note.y}px`;
   }
   function onMouseUp() {
     document.removeEventListener('mousemove', onMouseMove);
     document.removeEventListener('mouseup', onMouseUp);
+    note.updatedAt = Date.now();
     void saveNotes();
   }
   el.addEventListener('mousedown', onMouseDown);
 }
+
 async function init() {
   try {
     const dbp = getDB();
     if (!dbp) return;
     const db = await dbp;
-    notes = await db.getAll(STORE_NAME);
+    const stored = await db.getAll(STORE_NAME);
+    notes = Array.isArray(stored) ? stored.map((note) => normalizeNote(note)) : [];
 
     if (notes.length === 0) {
-      const legacyNotes = JSON.parse(
-        localStorage.getItem('stickyNotes') || '[]',
-      );
+      const legacyNotes = JSON.parse(localStorage.getItem('stickyNotes') || '[]');
       if (legacyNotes.length) {
-        notes = legacyNotes;
+        notes = legacyNotes.map((note) => normalizeNote(note));
         await saveNotes();
         localStorage.removeItem('stickyNotes');
       }
     }
 
-    notes.forEach(createNoteElement);
+    renderNotes();
 
     const params = new URLSearchParams(location.search);
     const sharedText = params.get('text');
@@ -175,15 +305,383 @@ async function init() {
   } catch (err) {
     console.error('Failed to load notes', err);
     try {
-      notes = JSON.parse(localStorage.getItem('stickyNotes') || '[]');
-      notes.forEach(createNoteElement);
+      const fallback = JSON.parse(localStorage.getItem('stickyNotes') || '[]');
+      notes = Array.isArray(fallback)
+        ? fallback.map((note) => normalizeNote(note))
+        : [];
+      renderNotes();
     } catch (e) {
       console.error('Failed to load legacy notes', e);
     }
   }
 }
 
-if (isBrowser && addNoteBtn) {
-  addNoteBtn.addEventListener('click', addNote);
+function exportNotes() {
+  if (!notes.length) {
+    announce('There are no notes to export.');
+    return;
+  }
+  try {
+    const data = JSON.stringify(notes, null, 2);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const filename = `sticky-notes-${timestamp}.json`;
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(url);
+    announce(`Exported ${notes.length} note${notes.length === 1 ? '' : 's'} as ${filename}.`);
+  } catch (err) {
+    console.error('Failed to export notes', err);
+    announce('Failed to export notes.');
+  }
+}
+
+function parseImportedNotes(text) {
+  const data = JSON.parse(text);
+  if (!Array.isArray(data)) {
+    throw new Error('Import file must be a JSON array.');
+  }
+  return data.map((note) => normalizeNote(note));
+}
+
+async function handleImportChange(event) {
+  const input = event.target;
+  const file = input.files?.[0];
+  if (!file) return;
+
+  try {
+    const text = await file.text();
+    const imported = parseImportedNotes(text);
+    processImportedNotes(imported);
+  } catch (err) {
+    console.error('Failed to import notes', err);
+    announce(err instanceof Error ? err.message : 'Failed to import notes.');
+  } finally {
+    input.value = '';
+  }
+}
+
+function processImportedNotes(imported) {
+  if (!imported.length) {
+    announce('Import file was empty.');
+    return;
+  }
+
+  const existingMap = new Map(notes.map((note) => [note.id, note]));
+  const seenConflictIds = new Set();
+  const additions = [];
+  const conflicts = [];
+
+  imported.forEach((note) => {
+    const existing = existingMap.get(note.id);
+    if (!existing) {
+      additions.push({ ...note });
+      return;
+    }
+    if (!notesAreEqual(existing, note)) {
+      if (seenConflictIds.has(note.id)) {
+        additions.push({ ...note });
+      } else {
+        conflicts.push({ existing, incoming: { ...note } });
+        seenConflictIds.add(note.id);
+      }
+    }
+  });
+
+  if (conflicts.length === 0) {
+    if (!additions.length) {
+      announce('Nothing new to import.');
+      return;
+    }
+    pushHistory();
+    const existingIds = new Set(notes.map((note) => note.id));
+    const added = applyAdditions(additions, existingIds);
+    renderNotes();
+    void saveNotes();
+    announce(`Imported ${added} new note${added === 1 ? '' : 's'}.`);
+    return;
+  }
+
+  pendingMerge = { conflicts, additions };
+  showConflictResolver(conflicts, additions);
+}
+
+function applyAdditions(additions, existingIds) {
+  let added = 0;
+  additions.forEach((note) => {
+    const candidate = { ...note };
+    while (existingIds.has(candidate.id)) {
+      candidate.id = generateNoteId();
+    }
+    updateIdSeedFromValue(candidate.id);
+    notes.push(candidate);
+    existingIds.add(candidate.id);
+    added += 1;
+  });
+  return added;
+}
+
+function notesAreEqual(a, b) {
+  return (
+    a.content === b.content &&
+    a.color === b.color &&
+    Math.round(a.x) === Math.round(b.x) &&
+    Math.round(a.y) === Math.round(b.y) &&
+    Math.round(a.width) === Math.round(b.width) &&
+    Math.round(a.height) === Math.round(b.height)
+  );
+}
+
+function showConflictResolver(conflicts, additions) {
+  if (!mergeRoot) return;
+  mergeRoot.innerHTML = '';
+  mergeRoot.classList.add('active');
+  mergeRoot.setAttribute('aria-hidden', 'false');
+
+  const overlay = document.createElement('div');
+  overlay.className = 'merge-overlay';
+
+  const dialog = document.createElement('div');
+  dialog.className = 'merge-dialog';
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+  dialog.setAttribute('aria-labelledby', 'merge-dialog-title');
+
+  const title = document.createElement('h2');
+  title.id = 'merge-dialog-title';
+  title.textContent = `Resolve ${conflicts.length} import conflict${
+    conflicts.length === 1 ? '' : 's'
+  }`;
+  dialog.appendChild(title);
+
+  const intro = document.createElement('p');
+  intro.className = 'merge-intro';
+  intro.textContent = 'Choose how to merge notes that share the same identifier.';
+  dialog.appendChild(intro);
+
+  if (additions.length) {
+    const additionsInfo = document.createElement('p');
+    additionsInfo.className = 'merge-additions';
+    additionsInfo.textContent = `${additions.length} new note${
+      additions.length === 1 ? '' : 's'
+    } will be imported automatically.`;
+    dialog.appendChild(additionsInfo);
+  }
+
+  const list = document.createElement('div');
+  list.className = 'merge-conflict-list';
+
+  conflicts.forEach((conflict, index) => {
+    const section = document.createElement('section');
+    section.className = 'conflict-item';
+    section.dataset.index = String(index);
+
+    const heading = document.createElement('h3');
+    heading.textContent = `Note ${conflict.existing.id}`;
+    section.appendChild(heading);
+
+    const options = document.createElement('div');
+    options.className = 'conflict-options';
+
+    options.appendChild(
+      createConflictOption(`conflict-${index}`, 'existing', 'Keep current note', true),
+    );
+    options.appendChild(
+      createConflictOption(`conflict-${index}`, 'incoming', 'Replace with imported'),
+    );
+    options.appendChild(
+      createConflictOption(
+        `conflict-${index}`,
+        'both',
+        'Keep both (duplicate imported note)',
+      ),
+    );
+    section.appendChild(options);
+
+    const previews = document.createElement('div');
+    previews.className = 'conflict-previews';
+    previews.appendChild(createConflictPreview('Current note', conflict.existing));
+    previews.appendChild(createConflictPreview('Imported note', conflict.incoming));
+    section.appendChild(previews);
+
+    list.appendChild(section);
+  });
+
+  dialog.appendChild(list);
+
+  const actions = document.createElement('div');
+  actions.className = 'merge-actions';
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.type = 'button';
+  cancelBtn.className = 'merge-cancel';
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', cancelMerge);
+  actions.appendChild(cancelBtn);
+
+  const confirmBtn = document.createElement('button');
+  confirmBtn.type = 'button';
+  confirmBtn.className = 'merge-confirm';
+  confirmBtn.textContent = 'Finish Merge';
+  confirmBtn.addEventListener('click', finalizeMerge);
+  actions.appendChild(confirmBtn);
+
+  dialog.appendChild(actions);
+  overlay.appendChild(dialog);
+  mergeRoot.appendChild(overlay);
+
+  window.setTimeout(() => {
+    confirmBtn.focus();
+  }, 0);
+}
+
+function createConflictOption(name, value, label, checked = false) {
+  const wrapper = document.createElement('label');
+  wrapper.className = 'conflict-option';
+
+  const input = document.createElement('input');
+  input.type = 'radio';
+  input.name = name;
+  input.value = value;
+  input.defaultChecked = checked;
+
+  const span = document.createElement('span');
+  span.textContent = label;
+
+  wrapper.appendChild(input);
+  wrapper.appendChild(span);
+  return wrapper;
+}
+
+function createConflictPreview(title, note) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'conflict-preview';
+
+  const heading = document.createElement('h4');
+  heading.textContent = title;
+  wrapper.appendChild(heading);
+
+  const text = document.createElement('textarea');
+  text.readOnly = true;
+  text.value = note.content || '(empty)';
+  wrapper.appendChild(text);
+
+  const meta = document.createElement('dl');
+  meta.className = 'conflict-meta';
+
+  const entries = [
+    ['Color', note.color],
+    ['Position', `${Math.round(note.x)}, ${Math.round(note.y)}`],
+    ['Size', `${Math.round(note.width)} × ${Math.round(note.height)}`],
+  ];
+
+  entries.forEach(([label, value]) => {
+    const dt = document.createElement('dt');
+    dt.textContent = label;
+    const dd = document.createElement('dd');
+    dd.textContent = value;
+    meta.appendChild(dt);
+    meta.appendChild(dd);
+  });
+
+  wrapper.appendChild(meta);
+  return wrapper;
+}
+
+function hideMergeUi() {
+  if (!mergeRoot) return;
+  mergeRoot.classList.remove('active');
+  mergeRoot.setAttribute('aria-hidden', 'true');
+  mergeRoot.innerHTML = '';
+}
+
+function cancelMerge() {
+  hideMergeUi();
+  pendingMerge = null;
+  announce('Import cancelled. No changes applied.');
+}
+
+function finalizeMerge() {
+  if (!pendingMerge || !mergeRoot) return;
+  const { conflicts, additions } = pendingMerge;
+  const selections = conflicts.map((conflict, index) => {
+    const choice = mergeRoot.querySelector(
+      `input[name="conflict-${index}"]:checked`,
+    )?.value;
+    return { conflict, choice: choice || 'existing' };
+  });
+
+  applyMergeSelections(conflicts, additions, selections);
+  pendingMerge = null;
+  hideMergeUi();
+}
+
+function applyMergeSelections(conflicts, additions, selections) {
+  pushHistory();
+  const existingIds = new Set(notes.map((note) => note.id));
+  const idToIndex = new Map(notes.map((note, index) => [note.id, index]));
+
+  let replaced = 0;
+  let duplicated = 0;
+
+  selections.forEach(({ conflict, choice }) => {
+    const index = idToIndex.get(conflict.existing.id);
+    if (index === undefined) return;
+    if (choice === 'incoming') {
+      const updated = { ...conflict.incoming, id: conflict.existing.id };
+      updateIdSeedFromValue(updated.id);
+      notes[index] = updated;
+      replaced += 1;
+    } else if (choice === 'both') {
+      const duplicate = { ...conflict.incoming };
+      while (existingIds.has(duplicate.id)) {
+        duplicate.id = generateNoteId();
+      }
+      updateIdSeedFromValue(duplicate.id);
+      notes.push(duplicate);
+      existingIds.add(duplicate.id);
+      duplicated += 1;
+    }
+  });
+
+  const added = applyAdditions(additions, existingIds);
+  renderNotes();
+  void saveNotes();
+
+  const parts = [];
+  if (replaced) parts.push(`replaced ${replaced} note${replaced === 1 ? '' : 's'}`);
+  if (duplicated)
+    parts.push(`kept ${duplicated} imported copy${duplicated === 1 ? '' : 'ies'}`);
+  if (added) parts.push(`added ${added} new note${added === 1 ? '' : 's'}`);
+  if (!parts.length) {
+    parts.push('kept existing notes');
+  }
+  announce(`Merge complete: ${parts.join(', ')}.`);
+}
+
+function handleKeydown(event) {
+  if (event.key === 'Escape' && pendingMerge) {
+    event.preventDefault();
+    cancelMerge();
+  }
+}
+
+if (isBrowser) {
+  if (!notesContainer) {
+    initDom();
+  }
+  addNoteBtn?.addEventListener('click', () => addNote());
+  exportBtn?.addEventListener('click', exportNotes);
+  if (importBtn && importInput) {
+    importBtn.addEventListener('click', () => importInput.click());
+    importInput.addEventListener('change', handleImportChange);
+  }
+  undoBtn?.addEventListener('click', undoMerge);
+  document.addEventListener('keydown', handleKeydown);
+  updateUndoButton();
   void init();
 }

--- a/apps/sticky_notes/styles.css
+++ b/apps/sticky_notes/styles.css
@@ -1,24 +1,63 @@
-body {
-  font-family: sans-serif;
-  margin: 0;
-  padding: 0;
-  height: 100vh;
-  background: var(--color-bg);
+
+.sticky-notes-app {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  height: 100%;
+  min-height: 100%;
 }
 
-#add-note {
-  position: fixed;
-  top: 10px;
-  left: 10px;
-  z-index: 1000;
-  padding: 8px 12px;
+.sticky-notes-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--color-surface), transparent 10%);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-inverse), transparent 90%);
+}
+
+.sticky-notes-toolbar button {
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.4rem;
+  border: 1px solid color-mix(in srgb, var(--color-inverse), transparent 80%);
+  background: color-mix(in srgb, var(--color-surface), transparent 5%);
+  color: inherit;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.sticky-notes-toolbar button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.sticky-notes-toolbar button:not(:disabled):hover,
+.sticky-notes-toolbar button:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 2px 4px color-mix(in srgb, var(--color-inverse), transparent 85%);
 }
 
 #notes {
   position: relative;
+  flex: 1;
+  min-height: 0;
   width: 100%;
-  height: 100%;
   container-type: inline-size;
+}
+
+.sticky-notes-status {
+  min-height: 1.25rem;
+  padding: 0 0.75rem;
+  font-size: 0.9rem;
+  color: color-mix(in srgb, var(--color-text), transparent 20%);
+  transition: opacity 150ms ease;
+  opacity: 0;
+}
+
+.sticky-notes-status[data-visible='true'] {
+  opacity: 1;
 }
 
 .note {
@@ -52,6 +91,159 @@ body {
   background: transparent;
   border: none;
   cursor: pointer;
+}
+
+#merge-root {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1rem, 2vw, 2rem);
+  background: color-mix(in srgb, var(--color-bg), transparent 35%);
+  backdrop-filter: blur(4px);
+  z-index: 2000;
+}
+
+#merge-root.active {
+  display: flex;
+}
+
+.merge-overlay {
+  width: min(780px, 100%);
+  max-height: 90vh;
+}
+
+.merge-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: clamp(1rem, 2vw, 1.5rem);
+  border-radius: 1rem;
+  background: color-mix(in srgb, var(--color-surface), transparent 6%);
+  box-shadow: 0 12px 28px color-mix(in srgb, var(--color-inverse), transparent 82%);
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.merge-intro,
+.merge-additions {
+  margin: 0;
+  color: color-mix(in srgb, var(--color-text), transparent 20%);
+  font-size: 0.95rem;
+}
+
+.merge-conflict-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.conflict-item {
+  border: 1px solid color-mix(in srgb, var(--color-inverse), transparent 85%);
+  border-radius: 0.9rem;
+  padding: 0.9rem;
+  background: color-mix(in srgb, var(--color-bg), transparent 10%);
+}
+
+.conflict-item h3 {
+  margin-top: 0;
+  margin-bottom: 0.65rem;
+  font-size: 1.05rem;
+}
+
+.conflict-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+@media (min-width: 720px) {
+  .conflict-options {
+    flex-direction: row;
+  }
+}
+
+.conflict-option {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.6rem;
+  background: color-mix(in srgb, var(--color-surface), transparent 12%);
+}
+
+.conflict-option input {
+  accent-color: var(--color-accent, #3f8cff);
+}
+
+.conflict-previews {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.conflict-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.conflict-preview textarea {
+  width: 100%;
+  min-height: 6rem;
+  border-radius: 0.6rem;
+  border: 1px solid color-mix(in srgb, var(--color-inverse), transparent 85%);
+  background: color-mix(in srgb, var(--color-surface), transparent 8%);
+  color: inherit;
+  resize: vertical;
+  padding: 0.5rem;
+}
+
+.conflict-preview h4 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.conflict-meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.25rem 0.65rem;
+  font-size: 0.8rem;
+  color: color-mix(in srgb, var(--color-text), transparent 30%);
+}
+
+.conflict-meta dt {
+  font-weight: 600;
+}
+
+.conflict-meta dd {
+  margin: 0;
+}
+
+.merge-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.merge-actions button {
+  padding: 0.4rem 0.9rem;
+  border-radius: 0.5rem;
+  border: 1px solid color-mix(in srgb, var(--color-inverse), transparent 80%);
+  background: color-mix(in srgb, var(--color-surface), transparent 8%);
+  cursor: pointer;
+}
+
+.merge-confirm {
+  background: color-mix(in srgb, var(--color-accent, #3f8cff), transparent 35%);
+  color: var(--color-on-accent, #fff);
+  border-color: transparent;
+}
+
+.merge-cancel {
+  background: transparent;
 }
 
 @container (max-width: 400px) {


### PR DESCRIPTION
## Summary
- add a sticky notes toolbar that surfaces add, export, import, and undo actions
- implement JSON export/import with merge conflict resolution, undo history, and status feedback in the sticky notes script
- refresh sticky notes styling to support the new toolbar and conflict resolution dialog

## Testing
- yarn lint *(fails: pre-existing accessibility and window/document lint violations across unrelated apps)*
- yarn test *(fails: pre-existing window snapping/nmap suites and jsdom localStorage crash)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2196a5608328b6472d502bd0bdf7