### PR TITLE
[apps] add media manager playlists

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -24,6 +24,7 @@ const TerminalApp = createDynamicApp('terminal', 'Terminal');
 // VSCode app uses a Stack iframe, so no editor dependencies are required
 const VsCodeApp = createDynamicApp('vscode', 'VsCode');
 const YouTubeApp = createDynamicApp('youtube', 'YouTube');
+const MediaApp = createDynamicApp('media', 'Media Manager');
 const CalculatorApp = createDynamicApp('calculator', 'Calculator');
 const ConverterApp = createDynamicApp('converter', 'Converter');
 const TicTacToeApp = createDynamicApp('tictactoe', 'Tic Tac Toe');
@@ -118,6 +119,7 @@ const ContactApp = createDynamicApp('contact', 'Contact');
 const displayTerminal = createDisplay(TerminalApp);
 const displayVsCode = createDisplay(VsCodeApp);
 const displayYouTube = createDisplay(YouTubeApp);
+const displayMedia = createDisplay(MediaApp);
 const displayCalculator = createDisplay(CalculatorApp);
 const displayConverter = createDisplay(ConverterApp);
 const displayTicTacToe = createDisplay(TicTacToeApp);
@@ -664,6 +666,15 @@ const apps = [
     favourite: true,
     desktop_shortcut: false,
     screen: displayYouTube,
+  },
+  {
+    id: 'media',
+    title: 'Media Manager',
+    icon: '/themes/Yaru/apps/media.svg',
+    disabled: false,
+    favourite: true,
+    desktop_shortcut: false,
+    screen: displayMedia,
   },
   {
     id: 'beef',

--- a/apps/media/components/MediaLibrary.tsx
+++ b/apps/media/components/MediaLibrary.tsx
@@ -1,0 +1,121 @@
+import { useMemo, useState } from 'react';
+import { MediaItem } from '../types';
+
+interface MediaLibraryProps {
+  library: MediaItem[];
+  addedIds: Set<string>;
+  onAdd: (mediaId: string) => void;
+  canAdd: boolean;
+  activePlaylistName?: string | null;
+}
+
+const MediaLibrary = ({
+  library,
+  addedIds,
+  onAdd,
+  canAdd,
+  activePlaylistName,
+}: MediaLibraryProps) => {
+  const [query, setQuery] = useState('');
+  const [formatFilter, setFormatFilter] = useState<'all' | string>('all');
+
+  const formats = useMemo(() => {
+    const unique = new Set<string>();
+    library.forEach((item) => unique.add(item.format));
+    return ['all', ...Array.from(unique).sort()];
+  }, [library]);
+
+  const filtered = useMemo(() => {
+    const search = query.trim().toLowerCase();
+    return library.filter((item) => {
+      if (formatFilter !== 'all' && item.format !== formatFilter) {
+        return false;
+      }
+      if (!search) return true;
+      return (
+        item.title.toLowerCase().includes(search) ||
+        item.description.toLowerCase().includes(search) ||
+        item.tags.some((tag) => tag.toLowerCase().includes(search))
+      );
+    });
+  }, [formatFilter, library, query]);
+
+  return (
+    <section className="flex h-full flex-col rounded-lg border border-[var(--color-border)] bg-[color-mix(in_oklab,var(--color-surface),transparent_8%)] p-4">
+      <header className="space-y-3">
+        <div>
+          <h2 className="text-lg font-semibold">Media Library</h2>
+          <p className="text-xs text-[color-mix(in_oklab,var(--color-text),transparent_45%)]">
+            {canAdd
+              ? activePlaylistName
+                ? `Adding to: ${activePlaylistName}`
+                : 'Select a playlist to start building it.'
+              : 'Create or select a playlist before adding items.'}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2 text-sm">
+          <label className="flex flex-1 items-center gap-2 min-w-[12rem]">
+            <span className="text-xs uppercase tracking-wide opacity-70">Search</span>
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              className="flex-1 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1"
+              placeholder="Filter by title, tag, or description"
+              aria-label="Search media library"
+            />
+          </label>
+          <label className="flex items-center gap-2">
+            <span className="text-xs uppercase tracking-wide opacity-70">Format</span>
+            <select
+              value={formatFilter}
+              onChange={(event) => setFormatFilter(event.target.value)}
+              className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1"
+              aria-label="Filter by media format"
+            >
+              {formats.map((format) => (
+                <option key={format} value={format}>
+                  {format === 'all' ? 'All formats' : format.charAt(0).toUpperCase() + format.slice(1)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </header>
+      <div className="mt-4 flex-1 overflow-auto rounded border border-dashed border-[color-mix(in_oklab,var(--color-border),transparent_50%)]">
+        <ul className="divide-y divide-[color-mix(in_oklab,var(--color-border),transparent_40%)]">
+          {filtered.map((item) => {
+            const disabled = addedIds.has(item.id) || !canAdd;
+            return (
+              <li key={item.id} className="flex flex-col gap-2 px-4 py-3 text-sm sm:flex-row sm:items-center sm:justify-between">
+                <div className="space-y-1">
+                  <p className="font-medium">{item.title}</p>
+                  <p className="text-xs text-[color-mix(in_oklab,var(--color-text),transparent_35%)]">
+                    {item.duration} • {item.format.toUpperCase()} • {item.tags.join(', ')}
+                  </p>
+                  <p className="text-xs text-[color-mix(in_oklab,var(--color-text),transparent_50%)]">
+                    {item.description}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onAdd(item.id)}
+                  disabled={disabled}
+                  className="self-start rounded border border-[var(--color-border)] px-3 py-1 text-xs font-medium hover:bg-[color-mix(in_oklab,var(--color-surface),transparent_30%)] disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {addedIds.has(item.id) ? 'Already added' : canAdd ? 'Add to playlist' : 'Select a playlist'}
+                </button>
+              </li>
+            );
+          })}
+          {filtered.length === 0 ? (
+            <li className="p-6 text-center text-sm text-[color-mix(in_oklab,var(--color-text),transparent_45%)]">
+              No media matches your filters.
+            </li>
+          ) : null}
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default MediaLibrary;

--- a/apps/media/components/PlaylistEditor.tsx
+++ b/apps/media/components/PlaylistEditor.tsx
@@ -1,0 +1,139 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { ResolvedPlaylistItem } from '../types';
+
+interface PlaylistEditorProps {
+  name: string;
+  updatedAt: string;
+  items: ResolvedPlaylistItem[];
+  onRename: (name: string) => void;
+  onRemove: (index: number) => void;
+  onMove: (from: number, to: number) => void;
+  onClear: () => void;
+}
+
+const formatTimestamp = (timestamp: string) => {
+  try {
+    const date = new Date(timestamp);
+    return date.toLocaleString();
+  } catch {
+    return timestamp;
+  }
+};
+
+const PlaylistEditor = ({
+  name,
+  updatedAt,
+  items,
+  onRename,
+  onRemove,
+  onMove,
+  onClear,
+}: PlaylistEditorProps) => {
+  const [draftName, setDraftName] = useState(name);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  useEffect(() => {
+    setDraftName(name);
+  }, [name]);
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const trimmed = draftName.trim();
+    if (!trimmed) {
+      setFeedback('Playlist name cannot be empty.');
+      return;
+    }
+    if (trimmed !== name) {
+      onRename(trimmed);
+    }
+    setFeedback(null);
+  };
+
+  return (
+    <section className="flex h-full flex-col rounded-lg border border-[var(--color-border)] bg-[color-mix(in_oklab,var(--color-surface),transparent_8%)] p-4">
+      <header className="space-y-2">
+        <form onSubmit={handleSubmit} className="flex flex-wrap items-center gap-2">
+          <input
+            value={draftName}
+            onChange={(event) => setDraftName(event.target.value)}
+            className="min-w-[12rem] flex-1 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-lg font-semibold"
+            aria-label="Playlist name"
+          />
+          <button
+            type="submit"
+            className="rounded bg-[var(--color-accent)] px-3 py-1 text-sm font-medium text-black"
+          >
+            Save name
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              if (items.length === 0 || window.confirm('Remove all items from this playlist?')) {
+                onClear();
+              }
+            }}
+            className="rounded border border-[var(--color-border)] px-3 py-1 text-sm hover:bg-[color-mix(in_oklab,var(--color-surface),transparent_30%)]"
+          >
+            Clear playlist
+          </button>
+        </form>
+        {feedback ? <p className="text-xs text-red-300">{feedback}</p> : null}
+        <p className="text-xs text-[color-mix(in_oklab,var(--color-text),transparent_40%)]">
+          Updated {formatTimestamp(updatedAt)}
+        </p>
+      </header>
+      <div className="mt-4 flex-1 overflow-auto rounded border border-dashed border-[color-mix(in_oklab,var(--color-border),transparent_50%)] bg-[color-mix(in_oklab,var(--color-surface),transparent_30%)]">
+        {items.length === 0 ? (
+          <div className="flex h-full items-center justify-center p-8 text-center text-sm text-[color-mix(in_oklab,var(--color-text),transparent_40%)]">
+            Use the media library to add items to this playlist.
+          </div>
+        ) : (
+          <ol className="divide-y divide-[color-mix(in_oklab,var(--color-border),transparent_40%)]">
+            {items.map(({ entry, media }, index) => (
+              <li key={`${entry.mediaId}-${index}`} className="flex items-start justify-between gap-3 px-3 py-3">
+                <div className="flex-1">
+                  <p className="font-medium">
+                    <span className="mr-2 text-xs opacity-60">{index + 1}.</span>
+                    {media ? media.title : 'Missing media item'}
+                  </p>
+                  <p className="text-xs text-[color-mix(in_oklab,var(--color-text),transparent_35%)]">
+                    {media
+                      ? `${media.duration} • ${media.format.toUpperCase()}${media.tags.length ? ` • ${media.tags.join(', ')}` : ''}`
+                      : entry.mediaId}
+                  </p>
+                </div>
+                <div className="flex flex-col gap-1 text-xs">
+                  <button
+                    type="button"
+                    onClick={() => onMove(index, index - 1)}
+                    disabled={index === 0}
+                    className="rounded border border-[var(--color-border)] px-2 py-1 disabled:opacity-40"
+                  >
+                    ↑ Move up
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onMove(index, index + 1)}
+                    disabled={index === items.length - 1}
+                    className="rounded border border-[var(--color-border)] px-2 py-1 disabled:opacity-40"
+                  >
+                    ↓ Move down
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onRemove(index)}
+                    className="rounded border border-[var(--color-border)] px-2 py-1 text-red-300 hover:bg-[color-mix(in_oklab,var(--color-surface),transparent_30%)]"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default PlaylistEditor;

--- a/apps/media/components/PlaylistSidebar.tsx
+++ b/apps/media/components/PlaylistSidebar.tsx
@@ -1,0 +1,108 @@
+import { FormEvent, useState } from 'react';
+import { Playlist } from '../types';
+
+interface PlaylistSidebarProps {
+  playlists: Playlist[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onCreate: (name: string) => { ok: boolean; message?: string };
+  onDelete: (id: string) => void;
+}
+
+const PlaylistSidebar = ({
+  playlists,
+  activeId,
+  onSelect,
+  onCreate,
+  onDelete,
+}: PlaylistSidebarProps) => {
+  const [name, setName] = useState('');
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const result = onCreate(name);
+    if (result.ok) {
+      setName('');
+      setFeedback(null);
+    } else if (result.message) {
+      setFeedback(result.message);
+    }
+  };
+
+  return (
+    <aside className="md:w-64 w-full border-b md:border-b-0 md:border-r border-[var(--color-border)] bg-[color-mix(in_oklab,var(--color-surface),transparent_10%)] p-4 space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold mb-2">Playlists</h2>
+        <form onSubmit={handleSubmit} className="space-y-2">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              className="flex-1 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm"
+              placeholder="New playlist name"
+              aria-label="New playlist name"
+            />
+            <button
+              type="submit"
+              className="rounded bg-[var(--color-accent)] px-3 py-1 text-sm font-medium text-black disabled:opacity-50"
+              disabled={!name.trim()}
+            >
+              Create
+            </button>
+          </div>
+          {feedback ? (
+            <p className="text-xs text-red-300" role="status">
+              {feedback}
+            </p>
+          ) : null}
+        </form>
+      </div>
+      <ul className="space-y-2 overflow-auto pr-1 max-h-[calc(100vh-14rem)] md:max-h-[calc(100vh-12rem)]">
+        {playlists.length === 0 ? (
+          <li className="text-sm text-[color-mix(in_oklab,var(--color-text),transparent_40%)]">
+            No playlists yet. Create one to get started.
+          </li>
+        ) : (
+          playlists.map((playlist) => {
+            const isActive = playlist.id === activeId;
+            return (
+              <li key={playlist.id}>
+                <div
+                  className={`flex items-center justify-between rounded border border-[var(--color-border)] px-3 py-2 text-sm ${
+                    isActive
+                      ? 'bg-[color-mix(in_oklab,var(--color-accent),transparent_80%)] text-[var(--color-text-strong)]'
+                      : 'bg-[var(--color-surface)]'
+                  }`}
+                >
+                  <button
+                    type="button"
+                    onClick={() => onSelect(playlist.id)}
+                    className="flex-1 text-left"
+                  >
+                    <span className="block font-medium">{playlist.name}</span>
+                    <span className="block text-xs opacity-75">
+                      {playlist.items.length} {playlist.items.length === 1 ? 'item' : 'items'}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onDelete(playlist.id)}
+                    className="ml-3 text-xs text-[color-mix(in_oklab,var(--color-text),transparent_30%)] hover:text-red-300"
+                    aria-label={`Delete ${playlist.name}`}
+                    title="Delete playlist"
+                  >
+                    ✕
+                  </button>
+                </div>
+              </li>
+            );
+          })
+        )}
+      </ul>
+    </aside>
+  );
+};
+
+export default PlaylistSidebar;

--- a/apps/media/data.ts
+++ b/apps/media/data.ts
@@ -1,0 +1,119 @@
+import { MediaItem, Playlist } from './types';
+
+export const MEDIA_LIBRARY: MediaItem[] = [
+  {
+    id: 'kali-field-manual',
+    title: 'Kali Field Manual: Triage Essentials',
+    description:
+      'A guided tour through the Kali desktop, terminal shortcuts, and the workflows used during incident response triage.',
+    duration: '12:34',
+    format: 'video',
+    url: 'https://example.com/media/kali-field-manual',
+    tags: ['workflow', 'basics', 'triage'],
+    published: '2024-01-04',
+  },
+  {
+    id: 'wireless-recon',
+    title: 'Wireless Recon Live Lab',
+    description:
+      'Streamed walk-through of gathering wireless intelligence safely using simulated APs and replay captures.',
+    duration: '26:18',
+    format: 'livestream',
+    url: 'https://example.com/media/wireless-recon',
+    tags: ['wireless', 'recon', 'simulation'],
+    published: '2023-11-19',
+  },
+  {
+    id: 'purple-team-digest',
+    title: 'Purple Team Digest – Episode 14',
+    description:
+      'Podcast recap covering log analysis tactics and how the lab automates alert enrichment in the Kali workspace.',
+    duration: '18:02',
+    format: 'audio',
+    url: 'https://example.com/media/purple-team-digest',
+    tags: ['podcast', 'defense'],
+    published: '2023-12-08',
+  },
+  {
+    id: 'memory-forensics-cookbook',
+    title: 'Memory Forensics Cookbook',
+    description:
+      'Hands-on demonstration of carving volatile evidence with Volatility and visualizing artifacts using the built-in heatmap.',
+    duration: '32:45',
+    format: 'video',
+    url: 'https://example.com/media/memory-forensics-cookbook',
+    tags: ['forensics', 'memory'],
+    published: '2024-02-12',
+  },
+  {
+    id: 'web-lab-simulation',
+    title: 'Web Lab Simulation: Harden the Stack',
+    description:
+      'Scenario-based challenge that walks through patch triage, reverse proxy hardening, and monitoring updates.',
+    duration: '24:11',
+    format: 'clip',
+    url: 'https://example.com/media/web-lab-simulation',
+    tags: ['web', 'hardening'],
+    published: '2024-03-05',
+  },
+  {
+    id: 'reporting-blueprint',
+    title: 'Reporting Blueprint Workshop',
+    description:
+      'Workshop on collecting findings across the desktop apps and assembling them into a concise incident briefing.',
+    duration: '15:09',
+    format: 'video',
+    url: 'https://example.com/media/reporting-blueprint',
+    tags: ['reporting', 'process'],
+    published: '2023-09-28',
+  },
+  {
+    id: 'radar-quick-wins',
+    title: 'Radar Quick Wins – Threat Intel Highlights',
+    description:
+      'Five minute round-up of notable detection wins, curated from the simulated SOC event feed.',
+    duration: '05:12',
+    format: 'clip',
+    url: 'https://example.com/media/radar-quick-wins',
+    tags: ['intel', 'highlights'],
+    published: '2024-01-26',
+  },
+  {
+    id: 'playbook-design-lab',
+    title: 'Playbook Design Lab',
+    description:
+      'Long-form lab session that stitches together automation, reporting, and post-mortem workflows using the portfolio apps.',
+    duration: '41:07',
+    format: 'livestream',
+    url: 'https://example.com/media/playbook-design-lab',
+    tags: ['automation', 'workflow'],
+    published: '2023-10-13',
+  },
+];
+
+const timestamp = new Date().toISOString();
+
+export const DEFAULT_PLAYLISTS: Playlist[] = [
+  {
+    id: 'daily-brief',
+    name: 'Daily Brief',
+    items: [
+      { mediaId: 'radar-quick-wins' },
+      { mediaId: 'kali-field-manual' },
+      { mediaId: 'reporting-blueprint' },
+    ],
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  },
+  {
+    id: 'deep-dive',
+    name: 'Deep Dive Lab',
+    items: [
+      { mediaId: 'memory-forensics-cookbook' },
+      { mediaId: 'playbook-design-lab' },
+      { mediaId: 'wireless-recon' },
+    ],
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  },
+];

--- a/apps/media/index.tsx
+++ b/apps/media/index.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useEffect, useMemo } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+import MediaLibrary from './components/MediaLibrary';
+import PlaylistEditor from './components/PlaylistEditor';
+import PlaylistSidebar from './components/PlaylistSidebar';
+import { DEFAULT_PLAYLISTS, MEDIA_LIBRARY } from './data';
+import {
+  Playlist,
+  ResolvedPlaylistItem,
+  isPlaylistArray,
+} from './types';
+
+const isStringOrNull = (value: unknown): value is string | null =>
+  value === null || typeof value === 'string';
+
+const MediaApp = () => {
+  const [playlists, setPlaylists] = usePersistentState<Playlist[]>(
+    'media:playlists',
+    () => DEFAULT_PLAYLISTS,
+    isPlaylistArray,
+  );
+  const [activePlaylistId, setActivePlaylistId] = usePersistentState<string | null>(
+    'media:active-playlist',
+    () => DEFAULT_PLAYLISTS[0]?.id ?? null,
+    isStringOrNull,
+  );
+
+  useEffect(() => {
+    if (!playlists.length) {
+      if (activePlaylistId !== null) {
+        setActivePlaylistId(null);
+      }
+      return;
+    }
+    const exists = playlists.some((playlist) => playlist.id === activePlaylistId);
+    if (!exists) {
+      setActivePlaylistId(playlists[0].id);
+    }
+  }, [playlists, activePlaylistId, setActivePlaylistId]);
+
+  const mediaMap = useMemo(
+    () => new Map(MEDIA_LIBRARY.map((item) => [item.id, item])),
+    [],
+  );
+
+  const activePlaylist = useMemo(
+    () => playlists.find((playlist) => playlist.id === activePlaylistId) ?? null,
+    [playlists, activePlaylistId],
+  );
+
+  const resolvedItems: ResolvedPlaylistItem[] = useMemo(() => {
+    if (!activePlaylist) return [];
+    return activePlaylist.items.map((entry) => ({
+      entry,
+      media: mediaMap.get(entry.mediaId),
+    }));
+  }, [activePlaylist, mediaMap]);
+
+  const addedIds = useMemo(() => {
+    if (!activePlaylist) return new Set<string>();
+    return new Set(activePlaylist.items.map((item) => item.mediaId));
+  }, [activePlaylist]);
+
+  const createPlaylist = (rawName: string) => {
+    const name = rawName.trim();
+    if (!name) {
+      return { ok: false, message: 'Enter a name for the playlist.' };
+    }
+    if (
+      playlists.some((playlist) => playlist.name.toLowerCase() === name.toLowerCase())
+    ) {
+      return { ok: false, message: 'A playlist with that name already exists.' };
+    }
+    const id = `playlist-${Date.now().toString(36)}-${Math.random()
+      .toString(36)
+      .slice(2, 6)}`;
+    const timestamp = new Date().toISOString();
+    const newPlaylist: Playlist = {
+      id,
+      name,
+      items: [],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    setPlaylists((current) => [...current, newPlaylist]);
+    setActivePlaylistId(id);
+    return { ok: true as const };
+  };
+
+  const deletePlaylist = (id: string) => {
+    const index = playlists.findIndex((playlist) => playlist.id === id);
+    if (index === -1) {
+      return;
+    }
+    const fallback = playlists[index + 1] ?? playlists[index - 1] ?? null;
+    setPlaylists((current) => current.filter((playlist) => playlist.id !== id));
+    setActivePlaylistId((current) =>
+      current === id ? fallback?.id ?? null : current,
+    );
+  };
+
+  const renamePlaylist = (name: string) => {
+    if (!activePlaylist) return;
+    setPlaylists((current) =>
+      current.map((playlist) =>
+        playlist.id === activePlaylist.id
+          ? {
+              ...playlist,
+              name,
+              updatedAt: new Date().toISOString(),
+            }
+          : playlist,
+      ),
+    );
+  };
+
+  const removeItem = (index: number) => {
+    if (!activePlaylist) return;
+    setPlaylists((current) =>
+      current.map((playlist) => {
+        if (playlist.id !== activePlaylist.id) {
+          return playlist;
+        }
+        if (index < 0 || index >= playlist.items.length) {
+          return playlist;
+        }
+        const nextItems = playlist.items.filter((_, itemIndex) => itemIndex !== index);
+        return {
+          ...playlist,
+          items: nextItems,
+          updatedAt: new Date().toISOString(),
+        };
+      }),
+    );
+  };
+
+  const moveItem = (from: number, to: number) => {
+    if (!activePlaylist) return;
+    setPlaylists((current) =>
+      current.map((playlist) => {
+        if (playlist.id !== activePlaylist.id) {
+          return playlist;
+        }
+        if (
+          from === to ||
+          from < 0 ||
+          to < 0 ||
+          from >= playlist.items.length ||
+          to >= playlist.items.length
+        ) {
+          return playlist;
+        }
+        const items = [...playlist.items];
+        const [moved] = items.splice(from, 1);
+        items.splice(to, 0, moved);
+        return {
+          ...playlist,
+          items,
+          updatedAt: new Date().toISOString(),
+        };
+      }),
+    );
+  };
+
+  const clearPlaylist = () => {
+    if (!activePlaylist) return;
+    setPlaylists((current) =>
+      current.map((playlist) =>
+        playlist.id === activePlaylist.id
+          ? {
+              ...playlist,
+              items: [],
+              updatedAt: new Date().toISOString(),
+            }
+          : playlist,
+      ),
+    );
+  };
+
+  const addToPlaylist = (mediaId: string) => {
+    if (!activePlaylist) return;
+    setPlaylists((current) =>
+      current.map((playlist) => {
+        if (playlist.id !== activePlaylist.id) {
+          return playlist;
+        }
+        if (playlist.items.some((item) => item.mediaId === mediaId)) {
+          return playlist;
+        }
+        return {
+          ...playlist,
+          items: [...playlist.items, { mediaId }],
+          updatedAt: new Date().toISOString(),
+        };
+      }),
+    );
+  };
+
+  return (
+    <div className="flex h-full w-full flex-col bg-[var(--color-bg)] text-[var(--color-text)] md:flex-row">
+      <PlaylistSidebar
+        playlists={playlists}
+        activeId={activePlaylistId}
+        onSelect={setActivePlaylistId}
+        onCreate={createPlaylist}
+        onDelete={(id) => {
+          if (window.confirm('Delete this playlist?')) {
+            deletePlaylist(id);
+          }
+        }}
+      />
+      <div className="flex-1 overflow-hidden">
+        <div className="grid h-full grid-rows-[minmax(0,1fr)_minmax(0,1fr)] gap-4 p-4 lg:grid-cols-2 lg:grid-rows-1">
+          {activePlaylist ? (
+            <PlaylistEditor
+              name={activePlaylist.name}
+              updatedAt={activePlaylist.updatedAt}
+              items={resolvedItems}
+              onRename={renamePlaylist}
+              onRemove={removeItem}
+              onMove={moveItem}
+              onClear={clearPlaylist}
+            />
+          ) : (
+            <div className="flex h-full flex-col items-center justify-center rounded-lg border border-[var(--color-border)] bg-[color-mix(in_oklab,var(--color-surface),transparent_8%)] p-6 text-center text-sm text-[color-mix(in_oklab,var(--color-text),transparent_45%)]">
+              <p className="font-medium">Create your first playlist</p>
+              <p className="mt-2 max-w-sm">
+                Use the panel on the left to create a playlist. Once selected, you can
+                reorder entries and build mixes from the media library.
+              </p>
+            </div>
+          )}
+          <MediaLibrary
+            library={MEDIA_LIBRARY}
+            addedIds={addedIds}
+            onAdd={addToPlaylist}
+            canAdd={Boolean(activePlaylist)}
+            activePlaylistName={activePlaylist?.name ?? null}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MediaApp;

--- a/apps/media/types.ts
+++ b/apps/media/types.ts
@@ -1,0 +1,59 @@
+export type MediaFormat = 'video' | 'audio' | 'livestream' | 'clip';
+
+export interface MediaItem {
+  id: string;
+  title: string;
+  description: string;
+  duration: string;
+  format: MediaFormat;
+  url: string;
+  tags: string[];
+  published: string;
+}
+
+export interface PlaylistItem {
+  mediaId: string;
+  note?: string;
+}
+
+export interface Playlist {
+  id: string;
+  name: string;
+  items: PlaylistItem[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ResolvedPlaylistItem {
+  entry: PlaylistItem;
+  media?: MediaItem;
+}
+
+export const isPlaylistArray = (value: unknown): value is Playlist[] => {
+  if (!Array.isArray(value)) return false;
+
+  return value.every((playlist) => {
+    if (!playlist || typeof playlist !== 'object') return false;
+    const candidate = playlist as Partial<Playlist>;
+    if (typeof candidate.id !== 'string' || typeof candidate.name !== 'string') return false;
+    if (
+      typeof candidate.createdAt !== 'string' ||
+      typeof candidate.updatedAt !== 'string'
+    ) {
+      return false;
+    }
+    if (!Array.isArray(candidate.items)) return false;
+    return candidate.items.every((item) => {
+      if (!item || typeof item !== 'object') return false;
+      const playlistItem = item as Partial<PlaylistItem>;
+      if (typeof playlistItem.mediaId !== 'string') return false;
+      if (
+        playlistItem.note !== undefined &&
+        typeof playlistItem.note !== 'string'
+      ) {
+        return false;
+      }
+      return true;
+    });
+  });
+};

--- a/pages/apps/media.jsx
+++ b/pages/apps/media.jsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const MediaApp = dynamic(() => import('../../apps/media'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default MediaApp;

--- a/public/themes/Yaru/apps/media.svg
+++ b/public/themes/Yaru/apps/media.svg
@@ -1,0 +1,36 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Media Manager Icon</title>
+  <desc id="desc">Stylised play button and stacked cards representing playlists.</desc>
+  <rect x="12" y="18" width="88" height="92" rx="12" fill="url(#paint0)" />
+  <rect x="24" y="30" width="76" height="18" rx="6" fill="url(#paint1)" />
+  <rect x="24" y="56" width="64" height="14" rx="6" fill="#0f172a" opacity="0.85" />
+  <rect x="24" y="78" width="52" height="14" rx="6" fill="#0f172a" opacity="0.65" />
+  <g filter="url(#shadow)">
+    <circle cx="90" cy="82" r="26" fill="url(#paint2)" />
+    <path d="M83 82V72.5C83 71.1193 84.1193 70 85.5 70C85.9456 70 86.3848 70.132 86.7639 70.3795L98.7639 78.3795C99.9391 79.1641 100.259 80.7736 99.4745 81.9488C99.278 82.2428 99.0197 82.4985 98.7157 82.7004L86.7157 90.7004C85.554 91.4688 84.0196 91.1544 83.2511 89.9927C83.0868 89.7414 83 89.4454 83 89.1426V82Z" fill="#0f172a" />
+  </g>
+  <defs>
+    <linearGradient id="paint0" x1="12" y1="18" x2="120" y2="126" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0f172a" />
+      <stop offset="1" stop-color="#1e3a8a" />
+    </linearGradient>
+    <linearGradient id="paint1" x1="24" y1="30" x2="100" y2="48" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#38bdf8" />
+      <stop offset="1" stop-color="#22d3ee" />
+    </linearGradient>
+    <linearGradient id="paint2" x1="64" y1="56" x2="112" y2="104" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#38bdf8" />
+      <stop offset="1" stop-color="#0ea5e9" />
+    </linearGradient>
+    <filter id="shadow" x="60" y="52" width="60" height="60" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
+      <feOffset dy="2" />
+      <feGaussianBlur stdDeviation="4" />
+      <feComposite in2="hardAlpha" operator="out" />
+      <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0.6 0 0 0 0 0.9 0 0 0 0.3 0" />
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow" />
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape" />
+    </filter>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary
- add a new media manager app that lets users build, reorder, and persist playlists in local storage
- seed the experience with sample media items and default playlists to restore on load
- register the media app in the launcher and add a themed icon for the desktop

## Testing
- yarn lint *(fails: repository already has numerous accessibility and no-top-level-window violations)*
- yarn test *(fails: existing window/act warnings and ReconNG storage assumptions in current test suite)*
- npx eslint apps/media/index.tsx apps/media/components/MediaLibrary.tsx apps/media/components/PlaylistEditor.tsx apps/media/components/PlaylistSidebar.tsx apps/media/data.ts


------
https://chatgpt.com/codex/tasks/task_e_68ca21a7f9288328b23c14f1dcf683b0