### PR TITLE
feat(accessibility): add high-contrast focus ring tokens

### DIFF
--- a/apps/calculator/index.tsx
+++ b/apps/calculator/index.tsx
@@ -23,7 +23,7 @@ export default function Calculator() {
   );
 
   const btnCls =
-    'btn min-h-12 w-12 transition-transform duration-150 hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:ring-white';
+    'btn min-h-12 w-12 transition-transform duration-150 hover:-translate-y-0.5 focus-ring';
 
   useEffect(() => {
     let evaluate: any;

--- a/apps/hashcat/index.tsx
+++ b/apps/hashcat/index.tsx
@@ -206,7 +206,7 @@ const Hashcat: React.FC = () => {
                 key={t}
                 type="button"
                 onClick={() => appendMask(t)}
-                className="px-2 py-1 bg-blue-600 rounded focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+                className="px-2 py-1 bg-blue-600 rounded focus-ring"
               >
                 {t}
               </button>
@@ -310,7 +310,7 @@ const Hashcat: React.FC = () => {
         <button
           type="button"
           onClick={running ? stop : start}
-          className="px-4 py-2 bg-green-600 rounded focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-500"
+          className="px-4 py-2 bg-green-600 rounded focus-ring"
         >
           {running ? 'Stop' : 'Start'}
         </button>

--- a/apps/password_generator/index.tsx
+++ b/apps/password_generator/index.tsx
@@ -92,12 +92,12 @@ const PasswordGenerator: React.FC<PasswordGeneratorProps> = ({ getDailySeed }) =
           type="text"
           readOnly
           value={password}
-          className="flex-1 text-black px-2 py-1 font-mono leading-[1.2] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+          className="flex-1 text-black px-2 py-1 font-mono leading-[1.2] focus-ring"
         />
         <button
           type="button"
           onClick={copyToClipboard}
-          className="px-3 py-1 bg-blue-600 rounded focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+          className="px-3 py-1 bg-blue-600 rounded focus-ring"
         >
           Copy
         </button>
@@ -115,7 +115,7 @@ const PasswordGenerator: React.FC<PasswordGeneratorProps> = ({ getDailySeed }) =
         <button
           type="button"
           onClick={generatePassword}
-          className="w-full px-4 py-2 bg-green-600 rounded"
+          className="w-full px-4 py-2 bg-green-600 rounded focus-ring"
         >
           Generate
         </button>

--- a/apps/project-gallery/components/FilterChip.tsx
+++ b/apps/project-gallery/components/FilterChip.tsx
@@ -11,7 +11,7 @@ export default function FilterChip({ label, active, onClick, icon }: FilterChipP
   return (
     <button
       onClick={onClick}
-      className={`flex items-center gap-1 px-3 py-1 rounded-full border focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 ${
+      className={`flex items-center gap-1 px-3 py-1 rounded-full border focus-ring ${
         active ? 'bg-blue-600 text-white' : 'bg-gray-200 text-black'
       }`}
     >

--- a/apps/trash/components/HistoryList.tsx
+++ b/apps/trash/components/HistoryList.tsx
@@ -19,7 +19,7 @@ export default function HistoryList({ history, onRestore, onRestoreAll }: Props)
           onClick={() => {
             if (window.confirm('Restore all windows?')) onRestoreAll();
           }}
-          className="border border-black bg-black bg-opacity-50 px-2 py-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange"
+          className="border border-black bg-black bg-opacity-50 px-2 py-1 rounded hover:bg-opacity-80 focus-ring"
         >
           Restore All
         </button>

--- a/apps/trash/index.tsx
+++ b/apps/trash/index.tsx
@@ -145,21 +145,21 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
             <button
               onClick={restore}
               disabled={selected === null}
-              className="px-3 py-1 my-1 rounded bg-blue-600 text-white hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:opacity-50"
+              className="px-3 py-1 my-1 rounded bg-blue-600 text-white hover:bg-blue-500 focus-ring disabled:opacity-50"
             >
               Restore
             </button>
             <button
               onClick={remove}
               disabled={selected === null}
-              className="px-3 py-1 my-1 ml-3 rounded bg-red-600 text-white hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-400 disabled:opacity-50"
+              className="px-3 py-1 my-1 ml-3 rounded bg-red-600 text-white hover:bg-red-500 focus-ring disabled:opacity-50"
             >
               Delete
             </button>
             <button
               onClick={purge}
               disabled={selected === null}
-              className="px-3 py-1 my-1 ml-3 rounded bg-yellow-600 text-white hover:bg-yellow-500 focus:outline-none focus:ring-2 focus:ring-yellow-400 disabled:opacity-50"
+              className="px-3 py-1 my-1 ml-3 rounded bg-yellow-600 text-white hover:bg-yellow-500 focus-ring disabled:opacity-50"
             >
               Purge
             </button>
@@ -167,14 +167,14 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
           <button
             onClick={restoreAll}
             disabled={items.length === 0}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus-ring disabled:opacity-50"
           >
             Restore All
           </button>
           <button
             onClick={empty}
             disabled={items.length === 0 || emptyCountdown !== null}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus-ring disabled:opacity-50"
           >
             {emptyCountdown !== null ? `Emptying in ${emptyCountdown}` : 'Empty'}
           </button>

--- a/apps/x/index.tsx
+++ b/apps/x/index.tsx
@@ -284,7 +284,7 @@ export default function XTimeline() {
             <button
               type="button"
               onClick={() => setShowSetup(false)}
-              className="px-3 py-1 rounded text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+              className="px-3 py-1 rounded text-[var(--color-text)] focus-ring"
               style={{ backgroundColor: accent }}
             >
               Close
@@ -329,18 +329,18 @@ export default function XTimeline() {
             value={tweetText}
             onChange={(e) => setTweetText(e.target.value)}
             placeholder="Tweet text"
-            className="w-full p-2 rounded border bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+            className="w-full p-2 rounded border bg-transparent focus-ring"
           />
           <div className="flex gap-2 items-center">
             <input
               type="datetime-local"
               value={tweetTime}
               onChange={(e) => setTweetTime(e.target.value)}
-              className="flex-1 p-2 rounded border bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+              className="flex-1 p-2 rounded border bg-transparent focus-ring"
             />
             <button
               type="submit"
-              className="px-3 py-1 rounded text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+              className="px-3 py-1 rounded text-[var(--color-text)] focus-ring"
               style={{ backgroundColor: accent }}
             >
               Schedule
@@ -355,7 +355,7 @@ export default function XTimeline() {
                   tabIndex={0}
                   data-scheduled-item
                   onKeyDown={(e) => handleScheduledKey(e, t.id)}
-                  className="flex justify-between items-center p-2 rounded border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+                  className="flex justify-between items-center p-2 rounded border focus-ring"
                 >
                   <span>
                     {t.text} - {new Date(t.time).toLocaleString()}
@@ -363,7 +363,7 @@ export default function XTimeline() {
                   <button
                     type="button"
                     onClick={() => removeScheduled(t.id)}
-                    className="ml-2 px-2 py-1 rounded bg-[var(--color-muted)] text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+                    className="ml-2 px-2 py-1 rounded bg-[var(--color-muted)] text-[var(--color-text)] focus-ring"
                   >
                     ×
                   </button>
@@ -376,7 +376,7 @@ export default function XTimeline() {
           <button
             type="button"
             onClick={() => setTimelineType('profile')}
-            className={`px-2 py-1 rounded text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] ${
+            className={`px-2 py-1 rounded text-sm focus-ring ${
               timelineType === 'profile'
                 ? 'text-[var(--color-text)]'
                 : 'bg-[var(--color-muted)]'
@@ -390,7 +390,7 @@ export default function XTimeline() {
           <button
             type="button"
             onClick={() => setTimelineType('list')}
-            className={`px-2 py-1 rounded text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] ${
+            className={`px-2 py-1 rounded text-sm focus-ring ${
               timelineType === 'list'
                 ? 'text-[var(--color-text)]'
                 : 'bg-[var(--color-muted)]'
@@ -411,11 +411,11 @@ export default function XTimeline() {
                 ? 'Add screen name'
                 : 'Add list (owner/slug or id)'
             }
-            className="flex-1 p-2 rounded border bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+            className="flex-1 p-2 rounded border bg-transparent focus-ring"
           />
           <button
             type="submit"
-            className="px-3 py-1 rounded text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+            className="px-3 py-1 rounded text-[var(--color-text)] focus-ring"
             style={{ backgroundColor: accent }}
           >
             Save
@@ -430,7 +430,7 @@ export default function XTimeline() {
                 onClick={() => {
                   setFeed(p);
                 }}
-                className={`px-2 py-1 rounded-full text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] ${
+                className={`px-2 py-1 rounded-full text-sm focus-ring ${
                   feed === p
                     ? 'text-[var(--color-text)]'
                     : 'bg-[var(--color-muted)]'
@@ -449,7 +449,7 @@ export default function XTimeline() {
               setLoaded(true);
               if (scriptLoaded) loadTimeline();
             }}
-            className="px-4 py-2 rounded text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+            className="px-4 py-2 rounded text-[var(--color-text)] focus-ring"
             style={{ backgroundColor: accent }}
           >
             Load timeline

--- a/components/ExternalFrame.js
+++ b/components/ExternalFrame.js
@@ -56,7 +56,7 @@ export default function ExternalFrame({ src, title, prefetch = false, onLoad: on
             href={src}
             target="_blank"
             rel="noopener noreferrer"
-            className="absolute top-2 right-2 z-10 px-2 py-1 text-xs bg-white text-black rounded opacity-0 focus-visible:opacity-100"
+            className="absolute top-2 right-2 z-10 px-2 py-1 text-xs bg-white text-black rounded opacity-0 focus-ring focus-visible:opacity-100"
           >
             Open Externally
           </a>

--- a/components/HelpPanel.tsx
+++ b/components/HelpPanel.tsx
@@ -55,7 +55,7 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
         aria-label="Help"
         aria-expanded={open}
         onClick={toggle}
-        className="fixed top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+        className="fixed top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus-ring"
       >
         ?
       </button>

--- a/components/PopularModules.tsx
+++ b/components/PopularModules.tsx
@@ -188,7 +188,7 @@ const PopularModules: React.FC = () => {
       <div className="flex items-center gap-2">
         <button
           onClick={handleUpdate}
-          className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          className="px-2 py-1 text-sm rounded bg-gray-700 focus-ring"
         >
           Update Modules
         </button>
@@ -208,7 +208,7 @@ const PopularModules: React.FC = () => {
       <div className="flex flex-wrap gap-2">
         <button
           onClick={() => setFilter('')}
-          className={`px-2 py-1 text-sm rounded focus:outline-none focus:ring-2 focus:ring-blue-400 ${
+          className={`px-2 py-1 text-sm rounded focus-ring ${
             filter === '' ? 'bg-blue-600' : 'bg-gray-700'
           }`}
         >
@@ -218,7 +218,7 @@ const PopularModules: React.FC = () => {
           <button
             key={t}
             onClick={() => setFilter(t)}
-            className={`px-2 py-1 text-sm rounded focus:outline-none focus:ring-2 focus:ring-blue-400 ${
+            className={`px-2 py-1 text-sm rounded focus-ring ${
               filter === t ? 'bg-blue-600' : 'bg-gray-700'
             }`}
           >
@@ -231,7 +231,7 @@ const PopularModules: React.FC = () => {
           <button
             key={m.id}
             onClick={() => handleSelect(m)}
-            className="p-3 text-left bg-ub-grey rounded border border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+            className="p-3 text-left bg-ub-grey rounded border border-gray-700 focus-ring"
           >
             <h3 className="font-semibold">{m.name}</h3>
             <p className="text-sm text-gray-300">{m.description}</p>
@@ -276,7 +276,7 @@ const PopularModules: React.FC = () => {
             <button
               type="button"
               onClick={copyCommand}
-              className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+              className="px-2 py-1 text-sm rounded bg-gray-700 focus-ring"
             >
               Copy
             </button>
@@ -295,7 +295,7 @@ const PopularModules: React.FC = () => {
             <button
               type="button"
               onClick={copyLogs}
-              className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+              className="px-2 py-1 text-sm rounded bg-gray-700 focus-ring"
             >
               Copy Logs
             </button>

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -217,44 +217,44 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           <div
             className="absolute inset-0 bg-black bg-opacity-75 z-50 flex items-center justify-center"
             role="dialog"
-          aria-modal="true"
-        >
-          <button
-            type="button"
-            onClick={resume}
-            className="px-4 py-2 bg-gray-700 text-white rounded focus:outline-none focus:ring"
-            autoFocus
+            aria-modal="true"
           >
-            Resume
-          </button>
-        </div>
-      )}
+            <button
+              type="button"
+              onClick={resume}
+              className="px-4 py-2 bg-gray-700 text-white rounded focus-ring"
+              autoFocus
+            >
+              Resume
+            </button>
+          </div>
+        )}
       <div className="absolute top-2 right-2 z-40 flex space-x-2">
         <button
           type="button"
           onClick={() => setPaused((p) => !p)}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          className="px-2 py-1 bg-gray-700 text-white rounded focus-ring"
         >
           {paused ? 'Resume' : 'Pause'}
         </button>
         <button
           type="button"
           onClick={snapshot}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          className="px-2 py-1 bg-gray-700 text-white rounded focus-ring"
         >
           Snapshot
         </button>
         <button
           type="button"
           onClick={replay}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          className="px-2 py-1 bg-gray-700 text-white rounded focus-ring"
         >
           Replay
         </button>
         <button
           type="button"
           onClick={shareApp}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          className="px-2 py-1 bg-gray-700 text-white rounded focus-ring"
         >
           Share
         </button>
@@ -262,7 +262,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           <button
             type="button"
             onClick={shareScore}
-            className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+            className="px-2 py-1 bg-gray-700 text-white rounded focus-ring"
           >
             Share Score
           </button>
@@ -272,7 +272,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           aria-label="Help"
           aria-expanded={showHelp}
           onClick={toggle}
-          className="bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+          className="bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus-ring"
         >
           ?
         </button>

--- a/components/apps/Games/common/input-remap/InputRemap.tsx
+++ b/components/apps/Games/common/input-remap/InputRemap.tsx
@@ -32,7 +32,7 @@ const InputRemap: React.FC<Props> = ({ mapping, setKey, actions }) => {
           <button
             type="button"
             onClick={() => capture(action)}
-            className="px-2 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+            className="px-2 py-1 bg-gray-700 rounded focus-ring"
           >
             {waiting === action ? 'Press key...' : mapping[action]}
           </button>

--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -244,7 +244,7 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
         )}
         <button
           onClick={onClose}
-          className="mt-4 px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+          className="mt-4 px-3 py-1 bg-gray-700 rounded focus-ring"
         >
           Close
         </button>

--- a/components/apps/beef/GuideOverlay.js
+++ b/components/apps/beef/GuideOverlay.js
@@ -62,7 +62,7 @@ export default function GuideOverlay({ onClose }) {
             type="button"
             onClick={prev}
             disabled={step === 0}
-            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus-ring"
           >
             Prev
           </button>
@@ -71,7 +71,7 @@ export default function GuideOverlay({ onClose }) {
             type="button"
             onClick={next}
             disabled={step === STEPS.length - 1}
-            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus-ring"
           >
             Next
           </button>
@@ -86,7 +86,7 @@ export default function GuideOverlay({ onClose }) {
         </label>
         <button
           onClick={handleClose}
-          className="mt-4 px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+          className="mt-4 px-3 py-1 bg-gray-700 rounded focus-ring"
         >
           Close
         </button>

--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -601,31 +601,31 @@ const CarRacer = () => {
       </div>
       <div className="absolute bottom-2 left-2 space-x-2 z-10 text-sm">
         <button
-          className="bg-gray-700 px-2 focus:outline-none focus:ring-2 focus:ring-white"
+          className="bg-gray-700 px-2 focus-ring"
           onClick={openCustomization}
         >
           Reset
         </button>
         <button
-          className="bg-gray-700 px-2 focus:outline-none focus:ring-2 focus:ring-white"
+          className="bg-gray-700 px-2 focus-ring"
           onClick={togglePause}
         >
           {paused ? 'Resume' : 'Pause'}
         </button>
         <button
-          className="bg-gray-700 px-2 focus:outline-none focus:ring-2 focus:ring-white"
+          className="bg-gray-700 px-2 focus-ring"
           onClick={toggleSound}
         >
           {sound ? 'Sound: on' : 'Sound: off'}
         </button>
         <button
-          className="bg-gray-700 px-2 focus:outline-none focus:ring-2 focus:ring-white"
+          className="bg-gray-700 px-2 focus-ring"
           onClick={toggleLaneAssist}
         >
           {laneAssist ? 'Lane Assist: on' : 'Lane Assist: off'}
         </button>
         <button
-          className="bg-gray-700 px-2 focus:outline-none focus:ring-2 focus:ring-white"
+          className="bg-gray-700 px-2 focus-ring"
           onClick={triggerBoost}
         >
           Boost

--- a/components/apps/checkers/index.tsx
+++ b/components/apps/checkers/index.tsx
@@ -458,7 +458,7 @@ const Checkers = () => {
                 {...pointerHandlers(() =>
                   selected ? tryMove(r, c) : selectPiece(r, c)
                 )}
-                className={`w-12 h-12 md:w-14 md:h-14 flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-white ${
+                className={`w-12 h-12 md:w-14 md:h-14 flex items-center justify-center focus-ring ${
                   isDark ? 'bg-gray-700' : 'bg-gray-400'
                 } ${
                   showMove

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -302,7 +302,7 @@ const ContactApp: React.FC = () => {
         <div className="relative">
           <input
             id="contact-name"
-            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
+            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus-ring"
             value={name}
             onChange={(e) => setName(e.target.value)}
             required
@@ -319,7 +319,7 @@ const ContactApp: React.FC = () => {
           <input
             id="contact-email"
             type="email"
-            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
+            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus-ring"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
@@ -342,7 +342,7 @@ const ContactApp: React.FC = () => {
         <div className="relative">
           <textarea
             id="contact-message"
-            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
+            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus-ring"
             rows={4}
             value={message}
             onChange={(e) => setMessage(e.target.value)}

--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -354,7 +354,7 @@ const Dsniff = () => {
         <h1 className="text-lg">dsniff</h1>
         <button
           onClick={exportSummary}
-          className="px-2 py-1 bg-ub-grey rounded text-xs focus:outline-none focus:ring-2 focus:ring-yellow-400"
+          className="px-2 py-1 bg-ub-grey rounded text-xs focus-ring"
         >
           Export summary
         </button>
@@ -435,7 +435,7 @@ const Dsniff = () => {
             <span className="font-bold text-sm">Sample command</span>
             <button
               onClick={copySampleCommand}
-              className="px-2 py-1 bg-ub-grey rounded text-xs focus:outline-none focus:ring-2 focus:ring-yellow-400"
+              className="px-2 py-1 bg-ub-grey rounded text-xs focus-ring"
             >
               Copy sample command
             </button>
@@ -490,7 +490,7 @@ const Dsniff = () => {
         <button
           onClick={copySelectedPacket}
           disabled={selectedPacket === null}
-          className="mb-2 px-2 py-1 bg-ub-grey rounded text-xs focus:outline-none focus:ring-2 focus:ring-yellow-400 disabled:opacity-50"
+          className="mb-2 px-2 py-1 bg-ub-grey rounded text-xs focus-ring disabled:opacity-50"
         >
           Copy selected row
         </button>

--- a/components/apps/hangman.js
+++ b/components/apps/hangman.js
@@ -553,7 +553,7 @@ const Hangman = () => {
                 type="button"
                 onClick={() => handleGuess(l)}
                 style={{ backgroundColor: color }}
-                className={`w-6 h-6 flex items-center justify-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange ${guessedAlready ? 'opacity-50' : ''}`}
+                className={`w-6 h-6 flex items-center justify-center rounded focus-ring ${guessedAlready ? 'opacity-50' : ''}`}
                 aria-pressed={guessedAlready}
                 disabled={guessedAlready || wrong >= maxWrong || won || paused}
               >

--- a/components/apps/nessus/HostBubbleChart.js
+++ b/components/apps/nessus/HostBubbleChart.js
@@ -65,7 +65,7 @@ const HostBubbleChart = ({ hosts = sampleHosts }) => {
             key={level}
             onClick={() => setFilter(level)}
             aria-pressed={filter === level}
-            className={`px-3 py-1 rounded-full text-sm border focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
+            className={`px-3 py-1 rounded-full text-sm border focus-ring ${
               filter === level
                 ? 'bg-white text-black border-gray-300'
                 : 'bg-gray-800 text-white border-gray-600'

--- a/components/apps/nessus/PluginFeedViewer.js
+++ b/components/apps/nessus/PluginFeedViewer.js
@@ -25,7 +25,7 @@ const PluginFeedViewer = ({ plugins = sampleReport }) => {
             key={level}
             onClick={() => setFilter(level)}
             aria-pressed={filter === level}
-            className={`px-3 py-1 rounded-full text-sm border focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
+            className={`px-3 py-1 rounded-full text-sm border focus-ring ${
               filter === level
                 ? 'bg-white text-black border-gray-300'
                 : 'bg-gray-800 text-white border-gray-600'

--- a/components/apps/nmap-nse/index.js
+++ b/components/apps/nmap-nse/index.js
@@ -265,7 +265,7 @@ const NmapNSEApp = () => {
                 key={p.label}
                 type="button"
                 onClick={() => setPortFlag(p.flag)}
-                className={`px-2 py-1 rounded text-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow ${
+                className={`px-2 py-1 rounded text-black focus-ring ${
                   portFlag === p.flag ? 'bg-ub-yellow' : 'bg-ub-grey'
                 }`}
               >
@@ -281,7 +281,7 @@ const NmapNSEApp = () => {
           <button
             type="button"
             onClick={copyCommand}
-            className="ml-2 px-2 py-1 bg-ub-grey text-black rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
+            className="ml-2 px-2 py-1 bg-ub-grey text-black rounded focus-ring"
           >
             Copy Command
           </button>
@@ -329,14 +329,14 @@ const NmapNSEApp = () => {
                     )
                   )
                 }
-                className="px-2 py-1 bg-ub-grey text-black rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
+                className="px-2 py-1 bg-ub-grey text-black rounded focus-ring"
               >
                 Step
               </button>
               <button
                 type="button"
                 onClick={() => setPhaseStep(0)}
-                className="px-2 py-1 bg-ub-grey text-black rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
+                className="px-2 py-1 bg-ub-grey text-black rounded focus-ring"
               >
                 Reset
               </button>
@@ -422,14 +422,14 @@ const NmapNSEApp = () => {
           <button
             type="button"
             onClick={copyOutput}
-            className="px-2 py-1 bg-ub-grey text-black rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
+            className="px-2 py-1 bg-ub-grey text-black rounded focus-ring"
           >
             Copy Output
           </button>
           <button
             type="button"
             onClick={selectOutput}
-            className="px-2 py-1 bg-ub-grey text-black rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
+            className="px-2 py-1 bg-ub-grey text-black rounded focus-ring"
           >
             Select All
           </button>

--- a/components/apps/openvas/index.js
+++ b/components/apps/openvas/index.js
@@ -349,7 +349,7 @@ const OpenVASApp = () => {
               key={h.host}
               type="button"
               onClick={() => setActiveHost(h)}
-              className="p-4 bg-gray-800 rounded text-left focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="p-4 bg-gray-800 rounded text-left focus-ring"
             >
               <div className="font-bold mb-1">{h.host}</div>
               <div className="mb-1">
@@ -452,7 +452,7 @@ const OpenVASApp = () => {
                       type="button"
                       onClick={() => handleCellClick(likelihood, impact)}
                       disabled={count === 0}
-                      className={`p-2 ${color(i, j)} text-white focus:outline-none w-full ${
+                      className={`p-2 ${color(i, j)} text-white focus-ring w-full ${
                         reduceMotion.current ? '' : 'transition-transform hover:scale-105'
                       } ${
                         filter &&
@@ -480,7 +480,7 @@ const OpenVASApp = () => {
                 key={level}
                 onClick={() => handleSeverityChange(level)}
                 aria-pressed={severity === level}
-                className={`px-3 py-1 rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
+                className={`px-3 py-1 rounded-full text-sm focus-ring ${
                   severity === level
                     ? 'bg-white text-black'
                     : 'bg-gray-800 text-white'
@@ -515,7 +515,7 @@ const OpenVASApp = () => {
               <button
                 type="button"
                 onClick={() => setSelected(f)}
-                className="w-full text-left focus:outline-none"
+                className="w-full text-left focus-ring"
               >
                 <div className="flex items-center justify-between">
                   <span

--- a/components/apps/radare2/GuideOverlay.js
+++ b/components/apps/radare2/GuideOverlay.js
@@ -56,7 +56,7 @@ export default function GuideOverlay({ onClose }) {
             type="button"
             onClick={prev}
             disabled={step === 0}
-            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus-ring"
           >
             Prev
           </button>
@@ -65,7 +65,7 @@ export default function GuideOverlay({ onClose }) {
             type="button"
             onClick={next}
             disabled={step === STEPS.length - 1}
-            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus-ring"
           >
             Next
           </button>
@@ -89,7 +89,7 @@ export default function GuideOverlay({ onClose }) {
           </a>
           <button
             onClick={handleClose}
-            className="px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded focus-ring"
           >
             Close
           </button>

--- a/components/apps/radare2/HexEditor.js
+++ b/components/apps/radare2/HexEditor.js
@@ -181,7 +181,7 @@ const HexEditor = ({ hex, theme }) => {
                       onMouseDown={() => handleMouseDown(idx)}
                       onMouseEnter={() => handleMouseEnter(idx)}
                       onDoubleClick={() => handleEdit(idx, b)}
-                      className="w-6 h-6 flex items-center justify-center rounded focus:outline-none focus-visible:ring-2"
+                      className="w-6 h-6 flex items-center justify-center rounded focus-ring"
                       style={{
                         backgroundColor: selected
                           ? 'var(--r2-accent)'

--- a/components/apps/solitaire/index.tsx
+++ b/components/apps/solitaire/index.tsx
@@ -671,7 +671,7 @@ const Solitaire = () => {
           <button
             type="button"
             onClick={resume}
-            className="px-4 py-2 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+            className="px-4 py-2 bg-gray-700 text-white rounded focus-ring"
             autoFocus
           >
             Resume

--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -587,7 +587,7 @@ export default function Todoist() {
           draggable
           onDragStart={handleDragStart(group, task)}
           onKeyDown={handleKeyDown(group, task)}
-          className="rounded shadow bg-white text-black flex items-center px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="rounded shadow bg-white text-black flex items-center px-2 py-1.5 focus-ring"
           role="listitem"
         >
           <label className="mr-2 inline-flex items-center">
@@ -596,7 +596,7 @@ export default function Todoist() {
               aria-label="Toggle completion"
               checked={!!task.completed}
               onChange={() => toggleCompleted(group, task.id)}
-              className="w-6 h-6 focus:ring-2 focus:ring-blue-500"
+              className="w-6 h-6 focus-ring"
             />
           </label>
           <div className="flex-1">
@@ -831,7 +831,7 @@ export default function Todoist() {
           />
           <button
             type="submit"
-            className="px-2 py-1 bg-blue-600 text-white rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="px-2 py-1 bg-blue-600 text-white rounded focus-ring"
           >
             Add
           </button>
@@ -886,7 +886,7 @@ export default function Todoist() {
           </select>
           <button
             type="submit"
-            className="px-2 py-1 bg-blue-600 text-white rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="px-2 py-1 bg-blue-600 text-white rounded focus-ring"
           >
             Add
           </button>

--- a/components/apps/trash/index.tsx
+++ b/components/apps/trash/index.tsx
@@ -106,28 +106,28 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
           <button
             onClick={restore}
             disabled={selected === null}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus-ring disabled:opacity-50"
           >
             Restore
           </button>
           <button
             onClick={restoreAll}
             disabled={items.length === 0}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus-ring disabled:opacity-50"
           >
             Restore All
           </button>
           <button
             onClick={remove}
             disabled={selected === null}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus-ring disabled:opacity-50"
           >
             Delete
           </button>
           <button
             onClick={empty}
             disabled={items.length === 0}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus-ring disabled:opacity-50"
           >
             Empty
           </button>

--- a/components/apps/volatility/MemoryHeatmap.js
+++ b/components/apps/volatility/MemoryHeatmap.js
@@ -109,10 +109,10 @@ const MemoryHeatmap = ({ data }) => {
             key={key}
             onClick={() => toggle(key)}
             aria-pressed={filters[key]}
-            className={`px-3 py-1 rounded-full text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+            className={`px-3 py-1 rounded-full text-sm font-medium focus-ring ${
               filters[key]
-                ? `${chipColors[key]} text-white focus:ring-white`
-                : 'bg-gray-200 text-gray-800 focus:ring-black'
+                ? `${chipColors[key]} text-white`
+                : 'bg-gray-200 text-gray-800'
             }`}
           >
             {categories[key]}
@@ -126,7 +126,7 @@ const MemoryHeatmap = ({ data }) => {
         tabIndex={0}
         role="img"
         aria-label="Heatmap of memory regions. Use arrow keys to pan."
-        className="border border-gray-500 w-full h-40 focus:outline-none"
+        className="border border-gray-500 w-full h-40 focus-ring"
       />
       <div className="sr-only" aria-live="polite">
         {announcement}

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -44,7 +44,7 @@ const AppsPage = () => {
           <Link
             key={app.id}
             href={`/apps/${app.id}`}
-            className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
+            className="flex flex-col items-center rounded border p-4 text-center focus-ring"
             aria-label={app.title}
           >
             {app.icon && (

--- a/pages/network-topology.tsx
+++ b/pages/network-topology.tsx
@@ -10,7 +10,7 @@ const NetworkTopology: React.FC = () => {
       <main className="bg-ub-cool-grey text-white min-h-screen p-4 space-y-4">
         <button
           onClick={() => setMitigated((m) => !m)}
-          className="px-4 py-2 bg-blue-600 rounded focus:outline-none focus:ring-2 focus:ring-blue-400"
+          className="px-4 py-2 bg-blue-600 rounded focus-ring"
         >
           {mitigated ? 'Disable Mitigation' : 'Enable Mitigation'}
         </button>

--- a/pages/spoofing.tsx
+++ b/pages/spoofing.tsx
@@ -12,7 +12,7 @@ const ToolTile = ({ title, link, children }: TileProps) => (
     href={link}
     target="_blank"
     rel="noopener noreferrer"
-    className="block p-4 bg-ub-grey text-white rounded shadow hover:bg-black focus:outline-none focus:ring"
+    className="block p-4 bg-ub-grey text-white rounded shadow hover:bg-black focus-ring"
   >
     <h2 className="text-xl mb-2">{title}</h2>
     {children}

--- a/pages/video-gallery.tsx
+++ b/pages/video-gallery.tsx
@@ -64,7 +64,7 @@ const VideoGallery: React.FC = () => {
           <button
             key={video.id}
             type="button"
-            className="text-left rounded outline outline-2 outline-offset-2 outline-transparent hover:outline-blue-500 focus-visible:outline-blue-500"
+            className="text-left rounded outline outline-2 outline-offset-2 outline-transparent hover:outline-blue-500 focus-ring"
             onClick={() => setPlaying(video.id)}
           >
             <Image

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,10 +16,12 @@
   --color-border: #2a2e36; /* subtle borders */
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
-  --color-focus-ring: var(--color-accent);
+  --color-focus-ring: var(--focus-ring-color);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   accent-color: var(--color-control-accent);
+  --tw-ring-color: var(--focus-ring-color);
+  --tw-ring-offset-color: var(--focus-ring-offset-color);
 }
 
 /* Dark theme */
@@ -74,6 +76,14 @@ html[data-theme='matrix'] {
 }
 
 *:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
-  outline-offset: 2px;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color) !important;
+  outline-offset: var(--focus-ring-offset);
+  transition: var(--focus-ring-transition);
+}
+
+.focus-ring:focus-visible {
+  outline: none !important;
+  box-shadow: 0 0 0 var(--focus-ring-offset) var(--focus-ring-offset-color),
+    0 0 0 calc(var(--focus-ring-offset) + var(--focus-ring-width)) var(--focus-ring-color);
+  border-radius: inherit;
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -18,8 +18,8 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
 
 a:focus-visible,
 button:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
-    outline-offset: 2px;
+    outline: var(--focus-ring-width) solid var(--focus-ring-color) !important;
+    outline-offset: var(--focus-ring-offset);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -512,8 +512,8 @@ pre {
 /* Visible focus rings for copy buttons and text areas */
 button:focus-visible,
 textarea:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color);
-    outline-offset: 2px;
+    outline: var(--focus-ring-width) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
 }
 
 /* Enable scroll snapping for gallery containers */

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -57,9 +57,15 @@
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;
-  /* Focus outline */
-  --focus-outline-color: var(--color-ubt-blue);
-  --focus-outline-width: 2px;
+  /* Focus ring */
+  --focus-ring-color: #0a84ff;
+  --focus-ring-offset-color: rgba(255, 255, 255, 0.35);
+  --focus-ring-width: 3px;
+  --focus-ring-offset: 3px;
+  --focus-ring-transition: outline-color var(--motion-fast) ease-out,
+    box-shadow var(--motion-fast) ease-out;
+  --focus-outline-color: var(--focus-ring-color);
+  --focus-outline-width: var(--focus-ring-width);
 }
 
 /* High contrast theme */
@@ -77,6 +83,12 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --focus-ring-color: #ff4f64;
+  --focus-ring-offset-color: #ffffff;
+  --focus-ring-width: 4px;
+  --focus-ring-offset: 4px;
+  --focus-outline-color: var(--focus-ring-color);
+  --focus-outline-width: var(--focus-ring-width);
 }
 
 /* Dyslexia-friendly fonts */
@@ -116,5 +128,11 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+    --focus-ring-color: #ff4f64;
+    --focus-ring-offset-color: #ffffff;
+    --focus-ring-width: 4px;
+    --focus-ring-offset: 4px;
+    --focus-outline-color: var(--focus-ring-color);
+    --focus-outline-width: var(--focus-ring-width);
   }
 }


### PR DESCRIPTION
## Summary
- introduce reusable focus ring tokens and a `.focus-ring` utility so outlines meet 3:1 contrast requirements across themes
- align shared CSS helpers with the new tokens and surface the utility for button/textarea defaults
- replace bespoke focus styling with `.focus-ring` on interactive components (for example PopularModules, Nmap NSE tools, the password generator, and the video gallery)

## Testing
- yarn lint *(fails: pre-existing jsx-a11y and no-top-level-window issues across unrelated files)*
- yarn test *(fails: existing suites that access window/localStorage or miss act() wrappers)*

------
https://chatgpt.com/codex/tasks/task_e_68ca21afc58c8328996e3aa430749e97