### PR TITLE
feat(files): add cross-window drag drop handling

### DIFF
--- a/__tests__/dragdropRegistry.test.ts
+++ b/__tests__/dragdropRegistry.test.ts
@@ -1,0 +1,82 @@
+import { dragDropRegistry } from '../src/system/dragdrop';
+
+const itemsPayload = { items: ['alpha', 'bravo'] };
+
+describe('DragDropRegistry', () => {
+  afterEach(() => {
+    dragDropRegistry.reset();
+  });
+
+  it('notifies source and target when dropping across windows', async () => {
+    const sourceEvents: string[] = [];
+    const targetEvents: string[] = [];
+
+    dragDropRegistry.registerSource({
+      windowId: 'window-a',
+      callbacks: {
+        onDropComplete: (_session, result, context) => {
+          sourceEvents.push(`${result?.operation}:${context.target.windowId}`);
+        },
+      },
+    });
+
+    dragDropRegistry.registerTarget({
+      id: 'target-b',
+      windowId: 'window-b',
+      onDrop: (context) => {
+        targetEvents.push(`${context.session.sourceWindowId}:${context.target.windowId}`);
+        return { operation: 'move' };
+      },
+    });
+
+    dragDropRegistry.beginDrag({ sourceWindowId: 'window-a', payload: itemsPayload });
+    await dragDropRegistry.drop('target-b');
+
+    expect(targetEvents).toEqual(['window-a:window-b']);
+    expect(sourceEvents).toEqual(['move:window-b']);
+    expect(dragDropRegistry.getActiveSession()).toBeUndefined();
+  });
+
+  it('tracks hover state and accepts modifier updates', () => {
+    const events: string[] = [];
+
+    dragDropRegistry.registerSource({ windowId: 'window-a' });
+
+    dragDropRegistry.registerTarget({
+      id: 'target-a',
+      windowId: 'window-b',
+      onDragEnter: (context) => {
+        events.push(`enter:${context.modifiers.ctrlKey ? 'ctrl' : 'none'}`);
+      },
+      onDragLeave: (context) => {
+        events.push(`leave:${context.modifiers.ctrlKey ? 'ctrl' : 'none'}`);
+      },
+      onDrop: () => ({ operation: 'move' }),
+    });
+
+    dragDropRegistry.beginDrag({ sourceWindowId: 'window-a', payload: itemsPayload });
+
+    expect(dragDropRegistry.setHoverTarget('target-a', { ctrlKey: true })).toBe(true);
+    expect(dragDropRegistry.setHoverTarget('target-a', { ctrlKey: false })).toBe(true);
+    dragDropRegistry.cancelDrag({ ctrlKey: true });
+
+    expect(events).toEqual(['enter:ctrl', 'leave:ctrl']);
+  });
+
+  it('calls cancel handler when cancelled without drop', () => {
+    const cancelEvents: string[] = [];
+
+    dragDropRegistry.registerSource({
+      windowId: 'window-x',
+      callbacks: {
+        onDragCancel: () => cancelEvents.push('cancelled'),
+      },
+    });
+
+    dragDropRegistry.beginDrag({ sourceWindowId: 'window-x', payload: itemsPayload });
+    dragDropRegistry.cancelDrag();
+
+    expect(cancelEvents).toEqual(['cancelled']);
+    expect(dragDropRegistry.getActiveSession()).toBeUndefined();
+  });
+});

--- a/__tests__/filesOperations.test.ts
+++ b/__tests__/filesOperations.test.ts
@@ -1,0 +1,117 @@
+import { dragDropRegistry } from '../src/system/dragdrop';
+import {
+  createExplorerController,
+  createOperationAnnouncement,
+  determineOperation,
+  type ExplorerItem,
+} from '../apps/files';
+
+describe('File explorer drag and drop', () => {
+  afterEach(() => {
+    dragDropRegistry.reset();
+  });
+
+  const sampleItem: ExplorerItem = {
+    id: '1',
+    name: 'notes.txt',
+    path: '/src/notes.txt',
+    kind: 'file',
+  };
+
+  it('determines copy operation when modifier is pressed', () => {
+    expect(determineOperation()).toBe('move');
+    expect(determineOperation({ ctrlKey: true })).toBe('copy');
+    expect(determineOperation({ metaKey: true })).toBe('copy');
+    expect(determineOperation({ shiftKey: true })).toBe('move');
+  });
+
+  it('builds announcements with correct perspective', () => {
+    const targetMessage = createOperationAnnouncement({
+      operation: 'move',
+      items: [sampleItem],
+      destinationLabel: 'Documents',
+      sourceWindowId: 'window-a',
+      targetWindowId: 'window-b',
+      perspective: 'target',
+    });
+
+    const sourceMessage = createOperationAnnouncement({
+      operation: 'copy',
+      items: [sampleItem],
+      destinationLabel: 'Downloads',
+      sourceWindowId: 'window-a',
+      targetWindowId: 'window-b',
+      perspective: 'source',
+    });
+
+    expect(targetMessage).toBe('Moved notes.txt into Documents from window-a.');
+    expect(sourceMessage).toBe('Copied notes.txt to Downloads in window-b.');
+  });
+
+  it('announces cross-window copy operations and respects modifiers', async () => {
+    const sourceAnnouncements: string[] = [];
+    const targetAnnouncements: string[] = [];
+
+    const sourceController = createExplorerController({
+      windowId: 'window-a',
+      announce: (message) => sourceAnnouncements.push(message),
+      operations: {
+        move: jest.fn(),
+        copy: jest.fn(),
+      },
+    });
+
+    const targetOperations = {
+      move: jest.fn(),
+      copy: jest.fn(),
+    };
+
+    const targetController = createExplorerController({
+      windowId: 'window-b',
+      announce: (message) => targetAnnouncements.push(message),
+      operations: targetOperations,
+    });
+
+    targetController.registerDropTarget({ id: 'folder', path: '/dest', label: 'Documents' });
+
+    sourceController.beginDrag([sampleItem], '/src');
+    await targetController.drop('folder', { ctrlKey: true });
+
+    expect(targetOperations.copy).toHaveBeenCalledWith([sampleItem], {
+      path: '/dest',
+      windowId: 'window-b',
+    });
+    expect(targetAnnouncements).toEqual(['Copied notes.txt into Documents from window-a.']);
+    expect(sourceAnnouncements).toEqual(['Copied notes.txt to Documents in window-b.']);
+
+    sourceController.dispose();
+    targetController.dispose();
+  });
+
+  it('announces single-window move once', async () => {
+    const announcements: string[] = [];
+    const operations = {
+      move: jest.fn(),
+      copy: jest.fn(),
+    };
+
+    const controller = createExplorerController({
+      windowId: 'window-a',
+      announce: (message) => announcements.push(message),
+      operations,
+    });
+
+    controller.registerDropTarget({ id: 'folder', path: '/dest', label: 'Documents' });
+
+    controller.beginDrag([sampleItem], '/src');
+    await controller.drop('folder');
+
+    expect(operations.move).toHaveBeenCalledWith([sampleItem], {
+      path: '/dest',
+      windowId: 'window-a',
+    });
+    expect(announcements).toEqual(['Moved notes.txt into Documents.']);
+
+    controller.dispose();
+  });
+});

--- a/apps/files/announcements.ts
+++ b/apps/files/announcements.ts
@@ -1,0 +1,39 @@
+import type { ExplorerItem } from './types';
+
+export type OperationKind = 'copy' | 'move';
+export type AnnouncementPerspective = 'target' | 'source';
+
+export interface OperationAnnouncementOptions {
+  operation: OperationKind;
+  items: ExplorerItem[];
+  destinationLabel: string;
+  sourceWindowId: string;
+  targetWindowId: string;
+  perspective?: AnnouncementPerspective;
+}
+
+function formatItemSummary(items: ExplorerItem[]) {
+  if (!items.length) return 'items';
+  if (items.length === 1) return items[0].name;
+  return `${items.length} items`;
+}
+
+export function createOperationAnnouncement({
+  operation,
+  items,
+  destinationLabel,
+  sourceWindowId,
+  targetWindowId,
+  perspective = 'target',
+}: OperationAnnouncementOptions) {
+  const verb = operation === 'copy' ? 'Copied' : 'Moved';
+  const summary = formatItemSummary(items);
+
+  if (perspective === 'target') {
+    const fromWindow = sourceWindowId !== targetWindowId ? ` from ${sourceWindowId}` : '';
+    return `${verb} ${summary} into ${destinationLabel}${fromWindow}.`;
+  }
+
+  const inWindow = sourceWindowId !== targetWindowId ? ` in ${targetWindowId}` : '';
+  return `${verb} ${summary} to ${destinationLabel}${inWindow}.`;
+}

--- a/apps/files/index.ts
+++ b/apps/files/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export { createExplorerController, determineOperation } from './operations';
+export { createOperationAnnouncement } from './announcements';

--- a/apps/files/operations.ts
+++ b/apps/files/operations.ts
@@ -1,0 +1,127 @@
+import {
+  dragDropRegistry,
+  ModifierState,
+  type DropContext,
+  type DragSession,
+} from '../../src/system/dragdrop';
+import { createOperationAnnouncement, type OperationKind } from './announcements';
+import type {
+  ExplorerController,
+  ExplorerDestination,
+  ExplorerDragPayload,
+  ExplorerDropTarget,
+  ExplorerItem,
+  ExplorerWindowOptions,
+} from './types';
+
+export function determineOperation(modifiers: ModifierState = {}): OperationKind {
+  if (modifiers.metaKey || modifiers.ctrlKey) return 'copy';
+  return 'move';
+}
+
+function getDestination(target: ExplorerDropTarget, windowId: string): ExplorerDestination {
+  return { path: target.path, windowId };
+}
+
+function getDestinationLabel(
+  target: ExplorerDropTarget | undefined,
+  context: DropContext<ExplorerDragPayload, ExplorerDropTarget>
+) {
+  if (target?.label) return target.label;
+  if (target?.path) return target.path;
+  return context.target.id;
+}
+
+function getPayload(session: DragSession<ExplorerDragPayload>): ExplorerDragPayload {
+  return session.payload;
+}
+
+export function createExplorerController(options: ExplorerWindowOptions): ExplorerController {
+  const { windowId, announce, operations } = options;
+  const targetDisposers = new Map<string, () => void>();
+
+  const unregisterSource = dragDropRegistry.registerSource<ExplorerDragPayload, ExplorerDropTarget>({
+    windowId,
+    callbacks: {
+      onDropComplete: (session, result, context) => {
+        if (!result || result.operation === 'none') return;
+        if (!context || context.target.windowId === windowId) return;
+        const payload = getPayload(session);
+        const operation = (result.operation as OperationKind) ?? determineOperation(context.modifiers);
+        const destinationLabel = getDestinationLabel(context.target.data, context);
+        announce(
+          createOperationAnnouncement({
+            operation,
+            items: payload.items,
+            destinationLabel,
+            sourceWindowId: windowId,
+            targetWindowId: context.target.windowId,
+            perspective: 'source',
+          })
+        );
+      },
+    },
+  });
+
+  return {
+    beginDrag(items: ExplorerItem[], originPath?: string) {
+      const payload: ExplorerDragPayload = { items, originPath };
+      dragDropRegistry.beginDrag({ sourceWindowId: windowId, payload });
+    },
+    registerDropTarget(target: ExplorerDropTarget) {
+      const dispose = dragDropRegistry.registerTarget<ExplorerDragPayload, ExplorerDropTarget>({
+        id: target.id,
+        windowId,
+        data: target,
+        onDrop: async (context) => {
+          const payload = getPayload(context.session);
+          const operation = determineOperation(context.modifiers);
+          const destination = getDestination(target, windowId);
+          if (operation === 'copy') {
+            await operations.copy(payload.items, destination);
+          } else {
+            await operations.move(payload.items, destination);
+          }
+          const destinationLabel = getDestinationLabel(target, context);
+          announce(
+            createOperationAnnouncement({
+              operation,
+              items: payload.items,
+              destinationLabel,
+              sourceWindowId: context.session.sourceWindowId,
+              targetWindowId: windowId,
+              perspective: 'target',
+            })
+          );
+          return {
+            operation,
+            targetId: target.id,
+            targetWindowId: windowId,
+            sourceWindowId: context.session.sourceWindowId,
+          };
+        },
+      });
+      targetDisposers.set(target.id, dispose);
+      return () => {
+        dispose();
+        targetDisposers.delete(target.id);
+      };
+    },
+    hoverTarget(targetId, modifiers) {
+      return dragDropRegistry.setHoverTarget(targetId, modifiers);
+    },
+    async drop(targetId, modifiers) {
+      await dragDropRegistry.drop(targetId, modifiers);
+    },
+    cancelDrag() {
+      dragDropRegistry.cancelDrag();
+    },
+    dispose() {
+      unregisterSource();
+      for (const dispose of targetDisposers.values()) {
+        dispose();
+      }
+      targetDisposers.clear();
+    },
+  };
+}

--- a/apps/files/types.ts
+++ b/apps/files/types.ts
@@ -1,0 +1,46 @@
+import type { ModifierState } from '../../src/system/dragdrop';
+
+export type ExplorerItemKind = 'file' | 'directory';
+
+export interface ExplorerItem {
+  id: string;
+  name: string;
+  path: string;
+  kind: ExplorerItemKind;
+}
+
+export interface ExplorerDragPayload {
+  items: ExplorerItem[];
+  originPath?: string;
+}
+
+export interface ExplorerDropTarget {
+  id: string;
+  path: string;
+  label?: string;
+}
+
+export interface ExplorerDestination {
+  path: string;
+  windowId: string;
+}
+
+export interface ExplorerWindowOperations {
+  move: (items: ExplorerItem[], destination: ExplorerDestination) => Promise<void> | void;
+  copy: (items: ExplorerItem[], destination: ExplorerDestination) => Promise<void> | void;
+}
+
+export interface ExplorerWindowOptions {
+  windowId: string;
+  announce: (message: string) => void;
+  operations: ExplorerWindowOperations;
+}
+
+export interface ExplorerController {
+  beginDrag: (items: ExplorerItem[], originPath?: string) => void;
+  registerDropTarget: (target: ExplorerDropTarget) => () => void;
+  hoverTarget: (targetId: string, modifiers?: ModifierState) => boolean;
+  drop: (targetId: string, modifiers?: ModifierState) => Promise<void>;
+  cancelDrag: () => void;
+  dispose: () => void;
+}

--- a/src/system/dragdrop/index.ts
+++ b/src/system/dragdrop/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+import { DragDropRegistry } from './registry';
+export { DragDropRegistry } from './registry';
+
+export const dragDropRegistry = new DragDropRegistry();

--- a/src/system/dragdrop/registry.ts
+++ b/src/system/dragdrop/registry.ts
@@ -1,0 +1,186 @@
+import { DragSession, DragSource, DragTarget, DropContext, ModifierState } from './types';
+
+interface ActiveSession<TPayload = unknown> extends DragSession<TPayload> {}
+
+type SourceMap = Map<string, DragSource<any, any>>;
+type TargetMap = Map<string, DragTarget<any, any>>;
+
+function createId() {
+  return `drag-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+export class DragDropRegistry {
+  private sources: SourceMap = new Map();
+  private targets: TargetMap = new Map();
+  private activeSession?: ActiveSession;
+  private hoverTargetId?: string;
+  private lastModifiers: ModifierState = {};
+
+  registerSource<TPayload, TData = unknown>(source: DragSource<TPayload, TData>) {
+    this.sources.set(source.windowId, source as DragSource<any, any>);
+    return () => {
+      const stored = this.sources.get(source.windowId);
+      if (stored && stored === source) {
+        this.sources.delete(source.windowId);
+      }
+    };
+  }
+
+  registerTarget<TPayload, TData = unknown>(target: DragTarget<TPayload, TData>) {
+    this.targets.set(target.id, target as DragTarget<any, any>);
+    return () => {
+      const stored = this.targets.get(target.id);
+      if (!stored) return;
+      if (this.hoverTargetId === target.id) {
+        this.emitDragLeave(target.id, this.lastModifiers);
+        this.hoverTargetId = undefined;
+      }
+      this.targets.delete(target.id);
+    };
+  }
+
+  beginDrag<TPayload>(options: { sourceWindowId: string; payload: TPayload; id?: string }) {
+    const { sourceWindowId, payload, id } = options;
+    if (this.activeSession) {
+      this.cancelDrag();
+    }
+    const session: ActiveSession<TPayload> = {
+      id: id ?? createId(),
+      sourceWindowId,
+      payload,
+    };
+    this.activeSession = session;
+    this.lastModifiers = {};
+    this.hoverTargetId = undefined;
+    const source = this.sources.get(sourceWindowId);
+    source?.callbacks?.onDragStart?.(session);
+    return session;
+  }
+
+  setHoverTarget(targetId: string, modifiers: ModifierState = {}) {
+    const session = this.requireSession();
+    const target = this.requireTarget(targetId);
+    if (target.accepts && !target.accepts(session)) {
+      if (this.hoverTargetId === targetId) {
+        this.emitDragLeave(targetId, modifiers);
+        this.hoverTargetId = undefined;
+      }
+      return false;
+    }
+
+    if (this.hoverTargetId === targetId) {
+      this.lastModifiers = { ...modifiers };
+      return true;
+    }
+
+    if (this.hoverTargetId) {
+      this.emitDragLeave(this.hoverTargetId, modifiers);
+    }
+
+    this.hoverTargetId = targetId;
+    this.lastModifiers = { ...modifiers };
+    target.onDragEnter?.(this.createContext(target, modifiers));
+    return true;
+  }
+
+  async drop(targetId: string, modifiers: ModifierState = {}) {
+    const session = this.requireSession();
+    const target = this.requireTarget(targetId);
+
+    if (target.accepts && !target.accepts(session)) {
+      return undefined;
+    }
+
+    if (this.hoverTargetId && this.hoverTargetId !== targetId) {
+      this.emitDragLeave(this.hoverTargetId, modifiers);
+    }
+
+    this.hoverTargetId = targetId;
+    this.lastModifiers = { ...modifiers };
+
+    const context = this.createContext(target, modifiers);
+    const source = this.sources.get(session.sourceWindowId);
+
+    try {
+      const result = await target.onDrop(context);
+      const finalResult = result ?? { operation: 'none' };
+      source?.callbacks?.onDropComplete?.(session, finalResult, context);
+      return finalResult;
+    } catch (err) {
+      source?.callbacks?.onDragCancel?.(session);
+      throw err;
+    } finally {
+      try {
+        target.onDragLeave?.(context);
+      } finally {
+        source?.callbacks?.onDragEnd?.(session);
+        this.activeSession = undefined;
+        this.hoverTargetId = undefined;
+        this.lastModifiers = {};
+      }
+    }
+  }
+
+  cancelDrag(modifiers: ModifierState = {}) {
+    const session = this.activeSession;
+    if (!session) return;
+    const source = this.sources.get(session.sourceWindowId);
+    if (this.hoverTargetId) {
+      this.emitDragLeave(this.hoverTargetId, modifiers);
+    }
+    source?.callbacks?.onDragCancel?.(session);
+    source?.callbacks?.onDragEnd?.(session);
+    this.activeSession = undefined;
+    this.hoverTargetId = undefined;
+    this.lastModifiers = {};
+  }
+
+  reset() {
+    this.sources.clear();
+    this.targets.clear();
+    this.activeSession = undefined;
+    this.hoverTargetId = undefined;
+    this.lastModifiers = {};
+  }
+
+  getActiveSession() {
+    return this.activeSession;
+  }
+
+  private requireSession(): ActiveSession {
+    if (!this.activeSession) {
+      throw new Error('No active drag session');
+    }
+    return this.activeSession;
+  }
+
+  private requireTarget(targetId: string) {
+    const target = this.targets.get(targetId);
+    if (!target) {
+      throw new Error(`Unknown drag target: ${targetId}`);
+    }
+    return target;
+  }
+
+  private createContext<TPayload, TData>(
+    target: DragTarget<TPayload, TData>,
+    modifiers: ModifierState
+  ): DropContext<TPayload, TData> {
+    const session = this.requireSession() as DragSession<TPayload>;
+    return {
+      session,
+      target: {
+        id: target.id,
+        windowId: target.windowId,
+        data: target.data as TData,
+      },
+      modifiers,
+    };
+  }
+
+  private emitDragLeave(targetId: string, modifiers: ModifierState) {
+    const target = this.targets.get(targetId);
+    if (!target || !this.activeSession) return;
+    target.onDragLeave?.(this.createContext(target, modifiers));
+  }
+}

--- a/src/system/dragdrop/types.ts
+++ b/src/system/dragdrop/types.ts
@@ -1,0 +1,55 @@
+export type ModifierState = {
+  altKey?: boolean;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  shiftKey?: boolean;
+};
+
+export interface DragSession<TPayload = unknown> {
+  id: string;
+  sourceWindowId: string;
+  payload: TPayload;
+}
+
+export interface SourceCallbacks<TPayload = unknown, TData = unknown> {
+  onDragStart?: (session: DragSession<TPayload>) => void;
+  onDragEnd?: (session: DragSession<TPayload>) => void;
+  onDropComplete?: (
+    session: DragSession<TPayload>,
+    result: DropResult | undefined,
+    context: DropContext<TPayload, TData>
+  ) => void;
+  onDragCancel?: (session: DragSession<TPayload>) => void;
+}
+
+export interface DragSource<TPayload = unknown, TData = unknown> {
+  windowId: string;
+  callbacks?: SourceCallbacks<TPayload, TData>;
+}
+
+export interface DropResult {
+  operation: string;
+  [key: string]: unknown;
+}
+
+export interface DropContext<TPayload = unknown, TData = unknown> {
+  session: DragSession<TPayload>;
+  target: {
+    id: string;
+    windowId: string;
+    data?: TData;
+  };
+  modifiers: ModifierState;
+}
+
+export interface DragTarget<TPayload = unknown, TData = unknown> {
+  id: string;
+  windowId: string;
+  data?: TData;
+  accepts?: (session: DragSession<TPayload>) => boolean;
+  onDragEnter?: (context: DropContext<TPayload, TData>) => void;
+  onDragLeave?: (context: DropContext<TPayload, TData>) => void;
+  onDrop: (
+    context: DropContext<TPayload, TData>
+  ) => Promise<DropResult | void> | DropResult | void;
+}


### PR DESCRIPTION
## Summary
- add a drag and drop registry that tracks sources, targets, hover state, and drops across windows
- expose file explorer helpers that announce copy/move operations and honour modifier keys
- cover the new behaviour with focused unit tests for the registry and file explorer utilities

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label and no-top-level-window rules across unrelated apps)*
- yarn test --runTestsByPath __tests__/dragdropRegistry.test.ts __tests__/filesOperations.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68ca21bb7148832880038a9c77f93aa9