### PR TITLE
[styles] Refine motion animations

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -1,4 +1,5 @@
 @import './globals.css';
+@import './motion.css';
 
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
@@ -465,35 +466,6 @@ dialog {
 .score-pop {
     display: inline-block;
     animation: score-pop 0.3s ease-out;
-}
-
-@keyframes hangman-draw {
-    from { stroke-dashoffset: 100; }
-    to { stroke-dashoffset: 0; }
-}
-
-.hangman-part {
-    stroke-dasharray: 100;
-    stroke-dashoffset: 100;
-    animation: hangman-draw 0.5s ease-out forwards;
-
-}
-
-@keyframes word-found-highlight {
-    from { background-size: 0% 100%; }
-    to { background-size: 100% 100%; }
-}
-
-.word-found {
-    background: linear-gradient(
-        90deg,
-        color-mix(in srgb, var(--color-accent), transparent 60%) 0%,
-        color-mix(in srgb, var(--color-accent), transparent 60%) 100%
-    );
-    background-repeat: no-repeat;
-    background-size: 0% 100%;
-    animation: word-found-highlight 0.6s forwards;
-    display: inline-block;
 }
 
 /* Highlight currently selected cells in word search */

--- a/styles/motion.css
+++ b/styles/motion.css
@@ -1,0 +1,78 @@
+/* Motion-specific animations refactored for compositor-friendly transforms */
+
+.word-found {
+    position: relative;
+    display: inline-block;
+    z-index: 0;
+    overflow: hidden;
+}
+
+.word-found::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    border-radius: inherit;
+    background: var(--color-accent);
+    background: color-mix(in srgb, var(--color-accent), transparent 60%);
+    opacity: 0;
+    transform: scaleX(0);
+    transform-origin: left center;
+    will-change: transform, opacity;
+    animation: word-found-highlight 0.6s ease-out forwards;
+    pointer-events: none;
+}
+
+@keyframes word-found-highlight {
+    from {
+        transform: scaleX(0);
+        opacity: 0;
+    }
+
+    60% {
+        opacity: 0.6;
+    }
+
+    to {
+        transform: scaleX(1);
+        opacity: 0.6;
+    }
+}
+
+.hangman-part {
+    transform-box: fill-box;
+    transform-origin: center bottom;
+    transform: scaleY(0.65) translateY(20%);
+    opacity: 0;
+    will-change: transform, opacity;
+    animation: hangman-draw 0.5s ease-out forwards;
+}
+
+@keyframes hangman-draw {
+    from {
+        transform: scaleY(0.65) translateY(20%);
+        opacity: 0;
+    }
+
+    to {
+        transform: scaleY(1) translateY(0);
+        opacity: 1;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .word-found::after,
+    .hangman-part {
+        animation: none;
+    }
+
+    .word-found::after {
+        transform: none;
+        opacity: 0.6;
+    }
+
+    .hangman-part {
+        transform: none;
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
## Summary
- move the hangman and word-search highlight animations into a dedicated `styles/motion.css` file and rework them to animate transforms/opacity only
- import the new motion stylesheet from `styles/index.css` so the GPU-friendly animations override the previous implementations
- add pseudo-element based highlight fill and transform-based reveal to avoid layout/paint thrashing while respecting reduced-motion settings

## Testing
- yarn lint *(fails: repository already has numerous accessibility lint errors)*
- yarn test --watch=false *(fails: existing suites fail under jsdom/localStorage configuration)*
- node devtools verification script *(passes: Chrome DevTools metrics stayed at zero for layout/paint counters during animations)*

------
https://chatgpt.com/codex/tasks/task_e_68ca21c26b9083288a1ca479f084effd