### PR TITLE
[monitor] add INP & FID rum tracking

### DIFF
--- a/__tests__/rum.test.ts
+++ b/__tests__/rum.test.ts
@@ -1,0 +1,54 @@
+import {
+  addRumSample,
+  computeRollingP75,
+  getRating,
+  getRumState,
+  resetRumStore,
+  type RumSample,
+} from '../src/rum';
+import { MAX_HISTORY } from '../src/rum/constants';
+
+describe('RUM utilities', () => {
+  beforeEach(() => {
+    resetRumStore();
+  });
+
+  it('computes rolling p75 for the provided window', () => {
+    const samples: RumSample[] = [10, 30, 50, 70, 90].map((value, index) => ({
+      id: `INP-${index}`,
+      name: 'INP',
+      value,
+      rating: 'good',
+      timestamp: index,
+    }));
+
+    expect(computeRollingP75(samples, 4)).toBeCloseTo(75);
+    expect(computeRollingP75(samples, 2)).toBeCloseTo(85);
+    expect(computeRollingP75([], 2)).toBeNull();
+  });
+
+  it('caps the history size per metric', () => {
+    for (let i = 0; i < MAX_HISTORY + 10; i += 1) {
+      addRumSample({
+        id: `INP-${i}`,
+        name: 'INP',
+        value: i,
+        rating: getRating('INP', i),
+        timestamp: i,
+      });
+    }
+
+    const state = getRumState();
+    expect(state.history.INP).toHaveLength(MAX_HISTORY);
+    expect(state.history.INP[0].id).toBe(`INP-${10}`);
+  });
+
+  it('returns qualitative ratings for thresholds', () => {
+    expect(getRating('FID', 80)).toBe('good');
+    expect(getRating('FID', 220)).toBe('needs-improvement');
+    expect(getRating('FID', 400)).toBe('poor');
+    expect(getRating('INP', 150)).toBe('good');
+    expect(getRating('INP', 300)).toBe('needs-improvement');
+    expect(getRating('INP', 550)).toBe('poor');
+  });
+});

--- a/apps/monitor/rum/index.tsx
+++ b/apps/monitor/rum/index.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React, { useEffect, useMemo } from 'react';
+import { useSyncExternalStore } from 'react';
+import {
+  METRIC_LABELS,
+  METRIC_TARGETS,
+  RUM_METRICS,
+  computeRollingP75,
+  getRating,
+  getRumState,
+  getServerRumState,
+  startRumSession,
+  subscribeRum,
+  type RumMetricName,
+  type RumSample,
+} from '../../../src/rum';
+
+import MetricCard from './metric-card';
+import RecentInteractions from './recent-interactions';
+
+const ROLLING_WINDOW = 20;
+
+function useRumStore() {
+  return useSyncExternalStore(subscribeRum, getRumState, getServerRumState);
+}
+
+type MetricSummary = {
+  name: RumMetricName;
+  label: string;
+  target: number;
+  p75: number | null;
+  samples: number;
+  rating: ReturnType<typeof getRating> | 'no-data';
+  latest?: RumSample;
+};
+
+export default function RumMonitorApp(): React.ReactElement {
+  const state = useRumStore();
+
+  useEffect(() => {
+    startRumSession();
+  }, []);
+
+  const summaries = useMemo<MetricSummary[]>(
+    () =>
+      RUM_METRICS.map((name) => {
+        const history = state.history[name];
+        const p75 = computeRollingP75(history, ROLLING_WINDOW);
+        const target = METRIC_TARGETS[name];
+        const rating =
+          typeof p75 === 'number' ? getRating(name, p75) : ('no-data' as const);
+        const latest = history.length > 0 ? history[history.length - 1] : undefined;
+        return {
+          name,
+          label: METRIC_LABELS[name],
+          target,
+          p75,
+          samples: history.length,
+          rating,
+          latest,
+        } satisfies MetricSummary;
+      }),
+    [state],
+  );
+
+  const interactions = useMemo(() => {
+    const merged: RumSample[] = [];
+    RUM_METRICS.forEach((name) => {
+      merged.push(...state.history[name]);
+    });
+    return merged
+      .slice()
+      .sort((a, b) => b.timestamp - a.timestamp)
+      .slice(0, 8);
+  }, [state]);
+
+  return (
+    <div className="h-full w-full bg-ub-cool-grey text-white overflow-auto">
+      <div className="p-4 space-y-4">
+        <header>
+          <h1 className="text-lg font-bold">Real User Monitoring</h1>
+          <p className="text-xs text-gray-300 max-w-xl">
+            Capture Interaction to Next Paint (INP) and First Input Delay (FID) metrics
+            directly from the browser. Interact with the desktop to populate samples and
+            track how the rolling p75 compares to Core Web Vitals targets.
+          </p>
+        </header>
+
+        <section className="grid gap-3 sm:grid-cols-2">
+          {summaries.map((summary) => (
+            <MetricCard
+              key={summary.name}
+              summary={summary}
+              rollingWindow={ROLLING_WINDOW}
+            />
+          ))}
+        </section>
+
+        <RecentInteractions interactions={interactions} />
+      </div>
+    </div>
+  );
+}

--- a/apps/monitor/rum/metric-card.tsx
+++ b/apps/monitor/rum/metric-card.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import type { RumMetricName, RumSample } from '../../../src/rum';
+
+type MetricCardProps = {
+  summary: {
+    name: RumMetricName;
+    label: string;
+    target: number;
+    p75: number | null;
+    samples: number;
+    rating: 'good' | 'needs-improvement' | 'poor' | 'no-data';
+    latest?: RumSample;
+  };
+  rollingWindow: number;
+};
+
+const ratingClasses: Record<MetricCardProps['summary']['rating'], string> = {
+  good: 'text-green-400',
+  'needs-improvement': 'text-yellow-300',
+  poor: 'text-red-400',
+  'no-data': 'text-gray-400',
+};
+
+function formatMs(value: number | null): string {
+  if (value == null || Number.isNaN(value)) return '—';
+  return `${Math.round(value)} ms`;
+}
+
+export default function MetricCard({ summary, rollingWindow }: MetricCardProps) {
+  const { label, target, p75, samples, rating, latest } = summary;
+  const statusLabel =
+    rating === 'no-data'
+      ? 'Awaiting samples'
+      : rating === 'good'
+      ? 'On target'
+      : rating === 'needs-improvement'
+      ? 'Needs improvement'
+      : 'Off target';
+
+  return (
+    <article className="rounded border border-gray-700 bg-[var(--kali-panel)] p-3 shadow-lg">
+      <header className="mb-2 flex items-baseline justify-between">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-200">
+          {label}
+        </h2>
+        <span className={`text-xs font-medium ${ratingClasses[rating]}`}>{statusLabel}</span>
+      </header>
+      <dl className="space-y-1 text-xs text-gray-300">
+        <div className="flex items-center">
+          <dt className="w-24 text-gray-400">Rolling p75</dt>
+          <dd className={`font-semibold ${ratingClasses[rating]}`}>{formatMs(p75)}</dd>
+        </div>
+        <div className="flex items-center">
+          <dt className="w-24 text-gray-400">Target ≤</dt>
+          <dd className="font-semibold text-green-300">{formatMs(target)}</dd>
+        </div>
+        <div className="flex items-center">
+          <dt className="w-24 text-gray-400">Samples</dt>
+          <dd>{samples}</dd>
+        </div>
+        <div className="flex items-center">
+          <dt className="w-24 text-gray-400">Window</dt>
+          <dd>Last {rollingWindow} interactions</dd>
+        </div>
+      </dl>
+      <footer className="mt-3 rounded border border-gray-700 bg-black/30 p-2 text-[11px] leading-relaxed text-gray-300">
+        {latest ? (
+          <>
+            <div>
+              Latest sample:{' '}
+              <span className="font-semibold text-white">{formatMs(latest.value)}</span>
+              {latest.attribution?.eventType && (
+                <span className="text-gray-400"> · {latest.attribution.eventType}</span>
+              )}
+            </div>
+            {latest.attribution?.target && (
+              <div className="truncate text-gray-400">Target: {latest.attribution.target}</div>
+            )}
+          </>
+        ) : (
+          <div>Interact with the desktop to gather data.</div>
+        )}
+      </footer>
+    </article>
+  );
+}

--- a/apps/monitor/rum/recent-interactions.tsx
+++ b/apps/monitor/rum/recent-interactions.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import type { RumSample } from '../../../src/rum';
+import { METRIC_LABELS } from '../../../src/rum';
+
+function formatMs(value: number): string {
+  return `${Math.round(value)} ms`;
+}
+
+function formatTime(timestamp: number): string {
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+type RecentInteractionsProps = {
+  interactions: RumSample[];
+};
+
+export default function RecentInteractions({ interactions }: RecentInteractionsProps) {
+  return (
+    <section className="rounded border border-gray-700 bg-[var(--kali-panel)] p-3">
+      <header className="mb-2 flex items-baseline justify-between">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-200">
+          Recent Interactions
+        </h2>
+        <span className="text-[11px] text-gray-400">
+          Showing last {interactions.length} samples
+        </span>
+      </header>
+      {interactions.length === 0 ? (
+        <p className="text-xs text-gray-400">
+          No metrics captured yet. Click, tap, or type within the desktop to record measurements.
+        </p>
+      ) : (
+        <ul className="divide-y divide-gray-800 text-xs">
+          {interactions.map((sample) => (
+            <li key={`${sample.name}-${sample.id}`} className="py-2">
+              <div className="flex items-center gap-2">
+                <span className="rounded bg-black/30 px-2 py-0.5 text-[11px] font-semibold text-gray-200">
+                  {sample.name}
+                </span>
+                <span className="font-medium text-white">{formatMs(sample.value)}</span>
+                <span className="text-[11px] text-gray-400">
+                  {METRIC_LABELS[sample.name]} · {formatTime(sample.timestamp)}
+                </span>
+              </div>
+              <div className="mt-1 flex flex-wrap gap-x-2 text-[11px] text-gray-400">
+                {sample.attribution?.eventType && <span>Event: {sample.attribution.eventType}</span>}
+                {sample.attribution?.target && <span>Target: {sample.attribution.target}</span>}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/rum/constants.ts
+++ b/src/rum/constants.ts
@@ -1,0 +1,29 @@
+import type { RumMetricName } from './types';
+
+export const RUM_METRICS: RumMetricName[] = ['INP', 'FID'];
+
+export const METRIC_TARGETS: Record<RumMetricName, number> = {
+  INP: 200,
+  FID: 100,
+};
+
+export const METRIC_THRESHOLDS: Record<
+  RumMetricName,
+  { good: number; needsImprovement: number }
+> = {
+  INP: {
+    good: 200,
+    needsImprovement: 500,
+  },
+  FID: {
+    good: 100,
+    needsImprovement: 300,
+  },
+};
+
+export const METRIC_LABELS: Record<RumMetricName, string> = {
+  INP: 'Interaction to Next Paint',
+  FID: 'First Input Delay',
+};
+
+export const MAX_HISTORY = 120;

--- a/src/rum/index.ts
+++ b/src/rum/index.ts
@@ -1,0 +1,17 @@
+export { startRumSession } from './observers';
+export {
+  addRumSample,
+  getRumState,
+  getServerRumState,
+  resetRumStore,
+  subscribeRum,
+} from './store';
+export { computeRollingP75 } from './summaries';
+export { getRating } from './ratings';
+export {
+  METRIC_LABELS,
+  METRIC_TARGETS,
+  METRIC_THRESHOLDS,
+  RUM_METRICS,
+} from './constants';
+export type { RumAttribution, RumSample, RumState, RumMetricName, RumRating } from './types';

--- a/src/rum/math.ts
+++ b/src/rum/math.ts
@@ -1,0 +1,12 @@
+export function percentile(values: number[], percentileRank: number): number | null {
+  const filtered = values.filter((v) => Number.isFinite(v));
+  if (filtered.length === 0) return null;
+  const sorted = [...filtered].sort((a, b) => a - b);
+  const rank = Math.min(Math.max(percentileRank, 0), 1);
+  const index = (sorted.length - 1) * rank;
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) return sorted[lower];
+  const weight = index - lower;
+  return sorted[lower] + (sorted[upper] - sorted[lower]) * weight;
+}

--- a/src/rum/observers.ts
+++ b/src/rum/observers.ts
@@ -1,0 +1,114 @@
+import { getRating } from './ratings';
+import { addRumSample } from './store';
+import type { RumSample } from './types';
+
+let started = false;
+
+const timeOrigin = (() => {
+  if (typeof performance === 'undefined') return Date.now();
+  return performance.timeOrigin || performance.timing?.navigationStart || Date.now();
+})();
+
+function describeTarget(target: EventTarget | null): string | undefined {
+  if (!target) return undefined;
+  if (!(target instanceof Element)) return undefined;
+  const parts: string[] = [target.tagName.toLowerCase()];
+  if (target.id) {
+    parts.push(`#${target.id}`);
+  }
+  if (target.classList?.length) {
+    const classes = Array.from(target.classList)
+      .slice(0, 2)
+      .map((cls) => `.${cls}`);
+    parts.push(...classes);
+  }
+  return parts.join('');
+}
+
+function recordSample(sample: RumSample): void {
+  addRumSample(sample);
+}
+
+function observeFirstInput(): void {
+  if (typeof PerformanceObserver === 'undefined') return;
+  const supported = (PerformanceObserver as any).supportedEntryTypes as string[] | undefined;
+  if (supported && !supported.includes('first-input')) return;
+
+  try {
+    const observer = new PerformanceObserver((list) => {
+      const entries = list.getEntries();
+      const entry = entries[entries.length - 1] as PerformanceEventTiming | undefined;
+      if (!entry) return;
+      const value = entry.processingStart - entry.startTime;
+      if (!Number.isFinite(value) || value < 0) return;
+      const sample: RumSample = {
+        id: `FID-${Math.round(entry.startTime)}`,
+        name: 'FID',
+        value,
+        rating: getRating('FID', value),
+        timestamp: timeOrigin + entry.startTime,
+        attribution: {
+          eventType: entry.name,
+          target: describeTarget((entry as any).target ?? null),
+        },
+      };
+      recordSample(sample);
+      observer.disconnect();
+    });
+    observer.observe({ type: 'first-input', buffered: true } as PerformanceObserverInit);
+  } catch {
+    // noop
+  }
+}
+
+function observeInp(): void {
+  if (typeof PerformanceObserver === 'undefined') return;
+  const supported = (PerformanceObserver as any).supportedEntryTypes as string[] | undefined;
+  if (supported && !supported.includes('event')) return;
+
+  const bestByInteraction = new Map<number, RumSample>();
+
+  try {
+    const observer = new PerformanceObserver((list) => {
+      list.getEntries().forEach((entry) => {
+        const event = entry as PerformanceEventTiming;
+        const interactionId = (event as any).interactionId as number | undefined;
+        if (!interactionId || interactionId <= 0) return;
+        const duration = event.duration;
+        if (!Number.isFinite(duration) || duration <= 0) return;
+        const sample: RumSample = {
+          id: `INP-${interactionId}`,
+          name: 'INP',
+          value: duration,
+          rating: getRating('INP', duration),
+          timestamp: timeOrigin + event.startTime,
+          attribution: {
+            eventType: event.name,
+            target: describeTarget((event as any).target ?? null),
+            interactionId,
+          },
+        };
+        const previous = bestByInteraction.get(interactionId);
+        if (!previous || duration >= previous.value) {
+          bestByInteraction.set(interactionId, sample);
+          recordSample(sample);
+        }
+      });
+    });
+    observer.observe({
+      type: 'event',
+      buffered: true,
+      durationThreshold: 16,
+    } as PerformanceObserverInit);
+  } catch {
+    // noop
+  }
+}
+
+export function startRumSession(): void {
+  if (started) return;
+  started = true;
+  if (typeof window === 'undefined') return;
+  observeFirstInput();
+  observeInp();
+}

--- a/src/rum/ratings.ts
+++ b/src/rum/ratings.ts
@@ -1,0 +1,9 @@
+import { METRIC_THRESHOLDS } from './constants';
+import type { RumMetricName, RumRating } from './types';
+
+export function getRating(name: RumMetricName, value: number): RumRating {
+  const thresholds = METRIC_THRESHOLDS[name];
+  if (value <= thresholds.good) return 'good';
+  if (value <= thresholds.needsImprovement) return 'needs-improvement';
+  return 'poor';
+}

--- a/src/rum/store.ts
+++ b/src/rum/store.ts
@@ -1,0 +1,64 @@
+import { MAX_HISTORY, RUM_METRICS } from './constants';
+import type { RumMetricName, RumSample, RumState } from './types';
+
+const history: Record<RumMetricName, RumSample[]> = {
+  INP: [],
+  FID: [],
+};
+
+const listeners = new Set<() => void>();
+
+function cloneHistory(): Record<RumMetricName, RumSample[]> {
+  return {
+    INP: [...history.INP],
+    FID: [...history.FID],
+  };
+}
+
+function emit(): void {
+  listeners.forEach((listener) => listener());
+}
+
+export function addRumSample(sample: RumSample): void {
+  const list = history[sample.name];
+  const existingIndex = list.findIndex((item) => item.id === sample.id);
+  if (existingIndex >= 0) {
+    list[existingIndex] = sample;
+  } else {
+    list.push(sample);
+  }
+  list.sort((a, b) => a.timestamp - b.timestamp);
+  if (list.length > MAX_HISTORY) {
+    list.splice(0, list.length - MAX_HISTORY);
+  }
+  emit();
+}
+
+export function getRumState(): RumState {
+  return {
+    history: cloneHistory(),
+  };
+}
+
+export function getServerRumState(): RumState {
+  return {
+    history: {
+      INP: [],
+      FID: [],
+    },
+  };
+}
+
+export function subscribeRum(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function resetRumStore(): void {
+  RUM_METRICS.forEach((metric) => {
+    history[metric] = [];
+  });
+  emit();
+}

--- a/src/rum/summaries.ts
+++ b/src/rum/summaries.ts
@@ -1,0 +1,16 @@
+import { percentile } from './math';
+import type { RumSample } from './types';
+
+export function computeRollingP75(
+  samples: RumSample[],
+  windowSize = 20,
+): number | null {
+  if (!samples.length) return null;
+  const window = windowSize > 0 ? samples.slice(-windowSize) : samples;
+  return percentile(
+    window
+      .map((sample) => sample.value)
+      .filter((value) => Number.isFinite(value)),
+    0.75,
+  );
+}

--- a/src/rum/types.ts
+++ b/src/rum/types.ts
@@ -1,0 +1,22 @@
+export type RumMetricName = 'INP' | 'FID';
+
+export type RumRating = 'good' | 'needs-improvement' | 'poor';
+
+export interface RumAttribution {
+  eventType?: string;
+  target?: string;
+  interactionId?: number;
+}
+
+export interface RumSample {
+  id: string;
+  name: RumMetricName;
+  value: number;
+  rating: RumRating;
+  timestamp: number;
+  attribution?: RumAttribution;
+}
+
+export interface RumState {
+  history: Record<RumMetricName, RumSample[]>;
+}


### PR DESCRIPTION
## Summary
- add RUM collectors that record FID and INP events with thresholds and rolling history helpers
- expose percentiles, ratings, and store utilities for reuse through the new `src/rum` module
- build a monitor UI that surfaces rolling p75 targets alongside recent interaction samples and add unit coverage

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window lint violations in legacy apps)*
- yarn test *(fails: existing suites such as window, nmap NSE, PopularModules, PdfViewer, contact API)*
- yarn test rum.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68ca21c3095483289192fcf8eeec33ae