### PR TITLE
system: throttle resize callbacks

### DIFF
--- a/__tests__/system-resize.test.ts
+++ b/__tests__/system-resize.test.ts
@@ -1,0 +1,134 @@
+import {
+  onWindowResize,
+  onPanelResize,
+  setPanelResizeTarget,
+} from '../src/system/resize';
+
+describe('resize system', () => {
+  let originalRAF: typeof window.requestAnimationFrame;
+  let originalCancelRAF: typeof window.cancelAnimationFrame;
+  let originalResizeObserver: typeof window.ResizeObserver;
+  let originalInnerWidth: number;
+
+  beforeEach(() => {
+    originalRAF = window.requestAnimationFrame;
+    originalCancelRAF = window.cancelAnimationFrame;
+    originalResizeObserver = window.ResizeObserver;
+    originalInnerWidth = window.innerWidth;
+    jest.useFakeTimers();
+    window.requestAnimationFrame = ((cb: FrameRequestCallback) =>
+      window.setTimeout(() => cb(Date.now()), 0)
+    ) as unknown as typeof window.requestAnimationFrame;
+    window.cancelAnimationFrame = ((id: number) => {
+      window.clearTimeout(id);
+    }) as unknown as typeof window.cancelAnimationFrame;
+  });
+
+  afterEach(() => {
+    setPanelResizeTarget(null);
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    window.requestAnimationFrame = originalRAF;
+    window.cancelAnimationFrame = originalCancelRAF;
+    if (originalResizeObserver) {
+      window.ResizeObserver = originalResizeObserver;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete (window as Partial<typeof window>).ResizeObserver;
+    }
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: originalInnerWidth,
+    });
+  });
+
+  it('throttles rapid window resize events to animation frames', () => {
+    const widths: number[] = [];
+    const unsubscribe = onWindowResize(({ width }) => {
+      widths.push(width);
+    });
+
+    expect(widths).toHaveLength(1);
+
+    Object.defineProperty(window, 'innerWidth', { value: 1024, configurable: true });
+    window.dispatchEvent(new Event('resize'));
+    Object.defineProperty(window, 'innerWidth', { value: 960, configurable: true });
+    window.dispatchEvent(new Event('resize'));
+
+    // No immediate callback; events are coalesced until the next frame.
+    expect(widths).toHaveLength(1);
+
+    jest.advanceTimersByTime(16);
+
+    expect(widths).toHaveLength(2);
+    expect(widths[1]).toBe(960);
+
+    unsubscribe();
+  });
+
+  it('notifies panel subscribers with debounced ResizeObserver updates', () => {
+    const panel = document.createElement('div');
+    panel.getBoundingClientRect = () => ({
+      width: 200,
+      height: 32,
+      top: 0,
+      left: 0,
+      right: 200,
+      bottom: 32,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    let observers: MockResizeObserver[];
+
+    class MockResizeObserver {
+      private readonly callback: ResizeObserverCallback;
+
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+        observers.push(this);
+      }
+
+      observe(): void {}
+
+      disconnect(): void {}
+
+      trigger(width: number, height: number) {
+        this.callback([
+          {
+            target: panel,
+            contentRect: { width, height } as DOMRectReadOnly,
+            borderBoxSize: [] as unknown as ReadonlyArray<ResizeObserverSize>,
+            contentBoxSize: [] as unknown as ReadonlyArray<ResizeObserverSize>,
+            devicePixelContentBoxSize: [] as unknown as ReadonlyArray<ResizeObserverSize>,
+          } as ResizeObserverEntry,
+        ]);
+      }
+    }
+
+    observers = [];
+
+    window.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+
+    setPanelResizeTarget(panel);
+
+    const sizes: Array<{ width: number; height: number }> = [];
+    const unsubscribe = onPanelResize(({ width, height }) => {
+      sizes.push({ width, height });
+    });
+
+    expect(sizes).toHaveLength(1);
+    expect(sizes[0]).toEqual({ width: 200, height: 32 });
+
+    const observer = observers[0];
+    observer.trigger(240, 40);
+
+    jest.advanceTimersByTime(16);
+
+    expect(sizes).toHaveLength(2);
+    expect(sizes[1]).toEqual({ width: 240, height: 40 });
+
+    unsubscribe();
+  });
+});

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -11,6 +11,7 @@ import React, {
 import useOPFS from '../../hooks/useOPFS';
 import commandRegistry, { CommandContext } from './commands';
 import TerminalContainer from './components/Terminal';
+import { onWindowResize } from '@/system/resize';
 
 const CopyIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg
@@ -387,9 +388,9 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
       observer = new ResizeObserver(handleResize);
       if (containerRef.current) observer.observe(containerRef.current);
     }
-    window.addEventListener('resize', handleResize);
+    const removeResize = onWindowResize(handleResize);
     return () => {
-      window.removeEventListener('resize', handleResize);
+      removeResize();
       observer?.disconnect();
     };
   }, []);

--- a/components/apps/Games/common/canvas/index.tsx
+++ b/components/apps/Games/common/canvas/index.tsx
@@ -7,6 +7,7 @@ import React, {
   forwardRef,
 } from 'react';
 import { hasOffscreenCanvas } from '../../../../../utils/feature';
+import { onWindowResize } from '@/system/resize';
 
 export interface CanvasHandle {
   getInputCoords: (
@@ -56,10 +57,10 @@ const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         );
 
         resize();
-        window.addEventListener('resize', resize);
+        const removeResize = onWindowResize(resize, { immediate: false });
         return () => {
           worker.terminate();
-          window.removeEventListener('resize', resize);
+          removeResize();
         };
       }
 
@@ -77,8 +78,8 @@ const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       };
 
       resize();
-      window.addEventListener('resize', resize);
-      return () => window.removeEventListener('resize', resize);
+      const removeResize = onWindowResize(resize, { immediate: false });
+      return () => removeResize();
     }, [width, height]);
 
     useImperativeHandle(ref, () => ({

--- a/components/apps/archive/Terminal/index.tsx
+++ b/components/apps/archive/Terminal/index.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
   forwardRef,
 } from 'react';
+import { onWindowResize } from '@/system/resize';
 
 const promptText = 'alex@kali:~$ ';
 
@@ -490,7 +491,7 @@ const TerminalPaneInner = (
       }
 
       const handleResize = () => fitAddon.fit();
-      window.addEventListener('resize', handleResize);
+      const removeResize = onWindowResize(handleResize);
       let resizeObserver: ResizeObserver | null = null;
       if (typeof ResizeObserver !== 'undefined' && containerRef.current) {
         resizeObserver = new ResizeObserver(handleResize);
@@ -498,7 +499,7 @@ const TerminalPaneInner = (
       }
 
       return () => {
-        window.removeEventListener('resize', handleResize);
+        removeResize();
         resizeObserver?.disconnect();
         workerRef.current?.terminate();
         if (rafRef.current) window.cancelAnimationFrame(rafRef.current);

--- a/components/apps/asteroids.js
+++ b/components/apps/asteroids.js
@@ -16,6 +16,7 @@ import GameLayout from './GameLayout';
 import { vibrate } from './Games/common/haptics';
 import { getMapping } from './Games/common/input-remap/useInputMapping';
 import useOPFS from '../../hooks/useOPFS';
+import { onWindowResize } from '@/system/resize';
 
 // Arcade-style tuning constants
 const THRUST = 0.1;
@@ -155,7 +156,7 @@ const Asteroids = () => {
     }
 
     resize();
-    window.addEventListener('resize', resize);
+    const removeResize = onWindowResize(resize, { immediate: false });
     let showDebug = false;
     const handleDebugToggle = (e) => {
       if (e.key === 'c' || e.key === 'C') showDebug = !showDebug;
@@ -793,7 +794,7 @@ const Asteroids = () => {
 
     function cleanup() {
       cancelAnimationFrame(requestRef.current);
-      window.removeEventListener('resize', resize);
+      removeResize();
       window.removeEventListener('keydown', handleDebugToggle);
       window.removeEventListener('keydown', handleInventoryUse);
     }

--- a/components/apps/ettercap/index.js
+++ b/components/apps/ettercap/index.js
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import data from './data.json';
 import ArpLab from './components/ArpLab';
 import vendors from '../kismet/oui.json';
+import { onWindowResize } from '@/system/resize';
 
 const { arpTable, flows } = data;
 const attackerMac = 'aa:aa:aa:aa:aa:aa';
@@ -441,10 +442,10 @@ const EttercapApp = () => {
       animationRef.current = requestAnimationFrame(step);
     };
     animationRef.current = requestAnimationFrame(step);
-    window.addEventListener('resize', computeLines);
+    const removeResize = onWindowResize(computeLines, { immediate: false });
     return () => {
       cancelAnimationFrame(animationRef.current);
-      window.removeEventListener('resize', computeLines);
+      removeResize();
     };
   }, [running, target1, target2]);
 

--- a/components/apps/pacman.js
+++ b/components/apps/pacman.js
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import useAssetLoader from '../../hooks/useAssetLoader';
 import SpeedControls from '../../games/pacman/components/SpeedControls';
+import { onWindowResize } from '@/system/resize';
 
 /**
  * Small Pacman implementation used inside the portfolio. The goal of this
@@ -146,9 +147,8 @@ const Pacman = () => {
       const s = Math.floor(window.innerWidth / WIDTH);
       setScale(s > 1 ? s : 1);
     };
-    updateScale();
-    window.addEventListener('resize', updateScale);
-    return () => window.removeEventListener('resize', updateScale);
+    const removeResize = onWindowResize(updateScale);
+    return () => removeResize();
   }, []);
 
   const tileAt = (tx, ty) => (mazeRef.current[ty] ? mazeRef.current[ty][tx] : 1);

--- a/components/apps/solitaire/index.tsx
+++ b/components/apps/solitaire/index.tsx
@@ -16,6 +16,7 @@ import {
   suits,
 } from './engine';
 import { solve } from './solver';
+import { onWindowResize } from '@/system/resize';
 
 type Variant = 'klondike' | 'spider' | 'freecell';
 type Stats = {
@@ -126,9 +127,8 @@ const Solitaire = () => {
       const minScale = 24 / 64;
       setScale(Math.max(s, minScale));
     };
-    updateScale();
-    window.addEventListener('resize', updateScale);
-    return () => window.removeEventListener('resize', updateScale);
+    const removeListener = onWindowResize(updateScale);
+    return () => removeListener();
   }, []);
 
   useEffect(() => {

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import useWatchLater, {
   Video as WatchLaterVideo,
 } from '../../../apps/youtube/state/watchLater';
+import { onWindowResize } from '@/system/resize';
 
 type Video = WatchLaterVideo;
 
@@ -192,12 +193,11 @@ function VirtualGrid({
       setCols(newCols);
       setRange([startRow * newCols, (startRow + visibleRows) * newCols]);
     };
-    update();
     el.addEventListener('scroll', update);
-    window.addEventListener('resize', update);
+    const removeResize = onWindowResize(update);
     return () => {
       el.removeEventListener('scroll', update);
-      window.removeEventListener('resize', update);
+      removeResize();
     };
   }, [items.length]);
 

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,21 +1,33 @@
-import React, { Component } from 'react';
+import React, { Component, createRef } from 'react';
 import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import { setPanelResizeTarget } from '@/system/resize';
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+        constructor() {
+                super();
+                this.state = {
+                        status_card: false
+                };
+                this.panelRef = createRef();
+        }
+
+        componentDidMount() {
+                if (this.panelRef?.current) {
+                        setPanelResizeTarget(this.panelRef.current);
+                }
+        }
+
+        componentWillUnmount() {
+                setPanelResizeTarget(null);
+        }
 
 	render() {
 		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                        <div ref={this.panelRef} className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>

--- a/hooks/useCanvasResize.ts
+++ b/hooks/useCanvasResize.ts
@@ -1,4 +1,5 @@
 import { useRef, useEffect } from 'react';
+import { onWindowResize } from '@/system/resize';
 
 export default function useCanvasResize(baseWidth: number, baseHeight: number) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -32,9 +33,9 @@ export default function useCanvasResize(baseWidth: number, baseHeight: number) {
     const ro = new ResizeObserver(resize);
     const parent = canvas.parentElement;
     if (parent) ro.observe(parent);
-    window.addEventListener('resize', resize);
+    const removeResizeListener = onWindowResize(resize, { immediate: false });
     return () => {
-      window.removeEventListener('resize', resize);
+      removeResizeListener();
       ro.disconnect();
     };
   }, [baseWidth, baseHeight]);

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "paths": { "@/*": ["./*"] }
+    "paths": {
+      "@/*": ["./*"],
+      "@/system/*": ["src/system/*"]
+    }
   }
 }

--- a/src/system/resize.ts
+++ b/src/system/resize.ts
@@ -1,0 +1,225 @@
+const FRAME_BUDGET_MS = 16;
+
+export type ResizeDimensions = {
+  width: number;
+  height: number;
+};
+
+export type ResizeCallback = (size: ResizeDimensions) => void;
+
+export interface SubscribeOptions {
+  /**
+   * Whether to invoke the callback immediately with the latest known size.
+   * Defaults to true to preserve legacy behaviour where listeners performed an
+   * eager measurement on subscription.
+   */
+  immediate?: boolean;
+}
+
+interface FrameHandle {
+  id: number;
+  raf: boolean;
+}
+
+const runtimeWindow: (Window & typeof globalThis) | undefined =
+  typeof globalThis === 'object' && globalThis !== null &&
+  'addEventListener' in globalThis &&
+  typeof (globalThis as Window & typeof globalThis).addEventListener === 'function'
+    ? (globalThis as Window & typeof globalThis)
+    : undefined;
+
+const windowSubscribers = new Set<ResizeCallback>();
+let windowFrame: FrameHandle | null = null;
+let lastWindowSize: ResizeDimensions | null = null;
+
+const panelSubscribers = new Set<ResizeCallback>();
+let panelElement: HTMLElement | null = null;
+let panelObserver: ResizeObserver | null = null;
+let panelFrame: FrameHandle | null = null;
+let lastPanelSize: ResizeDimensions | null = null;
+
+function requestFrame(callback: () => void): FrameHandle | null {
+  if (!runtimeWindow) return null;
+  if (typeof runtimeWindow.requestAnimationFrame === 'function') {
+    const id = runtimeWindow.requestAnimationFrame(() => callback());
+    return { id, raf: true };
+  }
+  const id = runtimeWindow.setTimeout(callback, FRAME_BUDGET_MS);
+  return { id, raf: false };
+}
+
+function cancelFrame(handle: FrameHandle | null) {
+  if (!handle || !runtimeWindow) return;
+  if (handle.raf && typeof runtimeWindow.cancelAnimationFrame === 'function') {
+    runtimeWindow.cancelAnimationFrame(handle.id);
+  } else {
+    runtimeWindow.clearTimeout(handle.id);
+  }
+}
+
+function measureWindow(): ResizeDimensions | null {
+  if (!runtimeWindow) return null;
+  return { width: runtimeWindow.innerWidth, height: runtimeWindow.innerHeight };
+}
+
+function measurePanel(): ResizeDimensions | null {
+  if (!panelElement) return null;
+  const rect = panelElement.getBoundingClientRect();
+  return { width: rect.width, height: rect.height };
+}
+
+function emit(target: 'window' | 'panel') {
+  if (target === 'window') {
+    if (!lastWindowSize) lastWindowSize = measureWindow();
+    if (!lastWindowSize) return;
+    windowSubscribers.forEach((cb) => cb(lastWindowSize as ResizeDimensions));
+    return;
+  }
+  if (!lastPanelSize) lastPanelSize = measurePanel();
+  if (!lastPanelSize) return;
+  panelSubscribers.forEach((cb) => cb(lastPanelSize as ResizeDimensions));
+}
+
+function scheduleWindowEmit() {
+  if (windowFrame || windowSubscribers.size === 0) return;
+  windowFrame = requestFrame(() => {
+    windowFrame = null;
+    emit('window');
+  });
+}
+
+function schedulePanelEmit() {
+  if (panelFrame || panelSubscribers.size === 0) return;
+  panelFrame = requestFrame(() => {
+    panelFrame = null;
+    emit('panel');
+  });
+}
+
+function handleWindowResize() {
+  lastWindowSize = measureWindow();
+  scheduleWindowEmit();
+  if (!panelElement || (runtimeWindow && typeof runtimeWindow.ResizeObserver === 'function')) return;
+  lastPanelSize = measurePanel();
+  schedulePanelEmit();
+}
+
+function handlePanelResize(entries: ResizeObserverEntry[]) {
+  if (!entries.length) return;
+  const entry = entries[entries.length - 1];
+  const box = Array.isArray(entry.borderBoxSize)
+    ? entry.borderBoxSize[entry.borderBoxSize.length - 1]
+    : (entry.borderBoxSize as ResizeObserverSize | undefined);
+  if (box && typeof box.inlineSize === 'number' && typeof box.blockSize === 'number') {
+    lastPanelSize = { width: box.inlineSize, height: box.blockSize };
+  } else {
+    const { width, height } = entry.contentRect;
+    lastPanelSize = { width, height };
+  }
+  schedulePanelEmit();
+}
+
+function ensureWindowListener() {
+  if (!runtimeWindow || windowSubscribers.size !== 1) return;
+  runtimeWindow.addEventListener('resize', handleWindowResize, { passive: true });
+  lastWindowSize = measureWindow();
+}
+
+function teardownWindowListener() {
+  if (!runtimeWindow || windowSubscribers.size !== 0) return;
+  runtimeWindow.removeEventListener('resize', handleWindowResize);
+  cancelFrame(windowFrame);
+  windowFrame = null;
+}
+
+function ensurePanelObserver() {
+  if (!runtimeWindow || panelSubscribers.size === 0) return;
+  if (!panelElement) return;
+  if (typeof runtimeWindow.ResizeObserver === 'function') {
+    panelObserver?.disconnect();
+    panelObserver = new runtimeWindow.ResizeObserver(handlePanelResize);
+    panelObserver.observe(panelElement);
+    lastPanelSize = measurePanel();
+    schedulePanelEmit();
+    return;
+  }
+  // Fallback: rely on window resize events when ResizeObserver unavailable
+  if (!lastPanelSize) lastPanelSize = measurePanel();
+  schedulePanelEmit();
+}
+
+function teardownPanelObserver() {
+  if (!runtimeWindow || panelSubscribers.size !== 0) return;
+  panelObserver?.disconnect();
+  panelObserver = null;
+  cancelFrame(panelFrame);
+  panelFrame = null;
+}
+
+export function onWindowResize(
+  callback: ResizeCallback,
+  options: SubscribeOptions = {},
+): () => void {
+  if (!runtimeWindow) return () => undefined;
+  windowSubscribers.add(callback);
+  ensureWindowListener();
+  const { immediate = true } = options;
+  if (immediate) {
+    if (!lastWindowSize) lastWindowSize = measureWindow();
+    if (lastWindowSize) callback(lastWindowSize);
+  }
+  return () => {
+    windowSubscribers.delete(callback);
+    if (windowSubscribers.size === 0) {
+      teardownWindowListener();
+    }
+  };
+}
+
+export function onPanelResize(
+  callback: ResizeCallback,
+  options: SubscribeOptions = {},
+): () => void {
+  if (!runtimeWindow) return () => undefined;
+  panelSubscribers.add(callback);
+  ensurePanelObserver();
+  const { immediate = true } = options;
+  if (immediate) {
+    if (!lastPanelSize) lastPanelSize = measurePanel();
+    if (lastPanelSize) callback(lastPanelSize);
+  }
+  return () => {
+    panelSubscribers.delete(callback);
+    if (panelSubscribers.size === 0) {
+      teardownPanelObserver();
+    }
+  };
+}
+
+export function setPanelResizeTarget(element: HTMLElement | null) {
+  if (!runtimeWindow) return;
+  if (panelObserver) {
+    panelObserver.disconnect();
+    panelObserver = null;
+  }
+  panelElement = element;
+  lastPanelSize = element ? measurePanel() : null;
+  if (!panelElement) {
+    cancelFrame(panelFrame);
+    panelFrame = null;
+    return;
+  }
+  if (panelSubscribers.size > 0) {
+    ensurePanelObserver();
+  }
+}
+
+export function getWindowSize(): ResizeDimensions | null {
+  if (!lastWindowSize) lastWindowSize = measureWindow();
+  return lastWindowSize;
+}
+
+export function getPanelSize(): ResizeDimensions | null {
+  if (!lastPanelSize) lastPanelSize = measurePanel();
+  return lastPanelSize;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,8 @@
     "types": [],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
-
+      "@/*": ["./*"],
+      "@/system/*": ["src/system/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types/**/*.d.ts"],


### PR DESCRIPTION
## Summary
- add a resize dispatcher under src/system that throttles window and panel callbacks to animation frames
- update window shell, navbar, terminal apps, and other resize listeners to rely on the shared helper
- cover the new module with unit tests for window and panel debouncing

## Testing
- yarn lint *(fails: pre-existing accessibility and lint violations across app suite)*
- yarn test *(fails: legacy suite issues; aborted after repeated failures)*
- yarn test __tests__/system-resize.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ca21ca4fd08328a59a3351d8350fc1