### PR TITLE
[build] gate dev helpers to development

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@
 // Allows external badges and same-origin PDF embedding.
 // Update README (section "CSP External Domains") when editing domains below.
 
+const path = require('path');
 const { validateServerEnv: validateEnv } = require('./lib/validate.js');
 
 const ContentSecurityPolicy = [
@@ -88,7 +89,7 @@ const isStaticExport = process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true';
 const isProd = process.env.NODE_ENV === 'production';
 
 // Merge experiment settings and production optimizations into a single function.
-function configureWebpack(config, { isServer }) {
+function configureWebpack(config, { isServer, dev }) {
   // Enable WebAssembly loading and avoid JSON destructuring bug
   config.experiments = {
     ...(config.experiments || {}),
@@ -103,7 +104,11 @@ function configureWebpack(config, { isServer }) {
   };
   config.resolve.alias = {
     ...(config.resolve.alias || {}),
-    'react-dom$': require('path').resolve(__dirname, 'lib/react-dom-shim.js'),
+    'react-dom$': path.resolve(__dirname, 'lib/react-dom-shim.js'),
+    '@/dev/runtime': path.resolve(
+      __dirname,
+      dev ? 'src/dev/runtime.ts' : 'src/dev/runtime.noop.ts'
+    ),
   };
   if (isProd) {
     config.optimization = {

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -81,6 +81,36 @@ function MyApp(props) {
   }, []);
 
   useEffect(() => {
+    if (process.env.NODE_ENV !== 'development') {
+      return undefined;
+    }
+
+    let cleanup;
+    let cancelled = false;
+
+    const setupDevRuntime = async () => {
+      try {
+        const { initDevRuntime } = await import('@/dev/runtime');
+        if (cancelled) return;
+        cleanup = await initDevRuntime({ logger: console });
+      } catch (error) {
+        console.warn('Failed to initialize dev helpers', error);
+      }
+    };
+
+    setupDevRuntime();
+
+    return () => {
+      cancelled = true;
+      if (typeof cleanup === 'function') {
+        Promise.resolve(cleanup()).catch((error) => {
+          console.error('Failed to clean up dev helpers', error);
+        });
+      }
+    };
+  }, []);
+
+  useEffect(() => {
     const liveRegion = document.getElementById('live-region');
     if (!liveRegion) return;
 

--- a/src/dev/client/hotkeys.ts
+++ b/src/dev/client/hotkeys.ts
@@ -1,0 +1,49 @@
+import type { DevLogger } from '../types';
+
+const HOTKEYS = {
+  grid: 'KeyG',
+  focus: 'KeyL',
+  clear: 'KeyC',
+} as const;
+
+export function installDebugHotkeys(logger: DevLogger = console) {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  const handler = (event: KeyboardEvent) => {
+    if (!event.altKey || !event.shiftKey) {
+      return;
+    }
+
+    const helpers = window.__DEV_HELPERS__;
+    if (!helpers) {
+      return;
+    }
+
+    switch (event.code) {
+      case HOTKEYS.grid:
+        event.preventDefault();
+        helpers.toggleGridOverlay();
+        logger.info?.('[dev] Toggled layout debug grid');
+        break;
+      case HOTKEYS.focus:
+        event.preventDefault();
+        helpers.logActiveElement();
+        break;
+      case HOTKEYS.clear:
+        event.preventDefault();
+        helpers.clearPersistedState();
+        logger.info?.('[dev] Cleared persisted state');
+        break;
+      default:
+        break;
+    }
+  };
+
+  window.addEventListener('keydown', handler);
+
+  return () => {
+    window.removeEventListener('keydown', handler);
+  };
+}

--- a/src/dev/client/index.ts
+++ b/src/dev/client/index.ts
@@ -1,0 +1,47 @@
+import type { CleanupResult, DevLogger, DevRuntimeOptions } from '../types';
+
+function pushCleanup(cleanups: Array<() => void | Promise<void>>, cleanup?: CleanupResult) {
+  if (typeof cleanup === 'function') {
+    cleanups.push(cleanup);
+  }
+}
+
+async function runCleanup(cleanup: () => void | Promise<void>, logger: DevLogger) {
+  try {
+    await cleanup();
+  } catch (error) {
+    logger.error?.('[dev] Cleanup failed', error);
+  }
+}
+
+export async function initClientRuntime(options: DevRuntimeOptions = {}): Promise<CleanupResult> {
+  const logger = options.logger ?? console;
+  const cleanups: Array<() => void | Promise<void>> = [];
+
+  try {
+    const { exposeDevHelpers } = await import('./window-helpers');
+    pushCleanup(cleanups, exposeDevHelpers(logger));
+  } catch (error) {
+    logger.warn?.('[dev] Failed to expose helper API', error);
+  }
+
+  try {
+    const { installDebugHotkeys } = await import('./hotkeys');
+    pushCleanup(cleanups, installDebugHotkeys(logger));
+  } catch (error) {
+    logger.warn?.('[dev] Failed to install dev hotkeys', error);
+  }
+
+  try {
+    const { registerToolbar } = await import('./toolbar');
+    pushCleanup(cleanups, await registerToolbar({ nonce: options.nonce, logger }));
+  } catch (error) {
+    logger.warn?.('[dev] Failed to initialize Vercel toolbar', error);
+  }
+
+  if (cleanups.length === 0) {
+    return undefined;
+  }
+
+  return () => Promise.all(cleanups.map((cleanup) => runCleanup(cleanup, logger))).then(() => undefined);
+}

--- a/src/dev/client/toolbar.ts
+++ b/src/dev/client/toolbar.ts
@@ -1,0 +1,53 @@
+import type { DevLogger, CleanupResult } from '../types';
+
+interface ToolbarOptions {
+  nonce?: string;
+  logger?: DevLogger;
+}
+
+function hasToolbarConfiguration() {
+  if (typeof process === 'undefined') {
+    return false;
+  }
+
+  const ownerId = process.env.NEXT_PUBLIC_VERCEL_TOOLBAR_OWNER_ID;
+  const projectId = process.env.NEXT_PUBLIC_VERCEL_TOOLBAR_PROJECT_ID;
+  const deploymentId =
+    process.env.NEXT_PUBLIC_VERCEL_TOOLBAR_DEPLOYMENT_ID || process.env.NEXT_PUBLIC_VERCEL_DEPLOYMENT_ID;
+
+  return Boolean((ownerId && projectId) || deploymentId);
+}
+
+export async function registerToolbar(options: ToolbarOptions = {}): Promise<CleanupResult> {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  const logger = options.logger ?? console;
+
+  if (!hasToolbarConfiguration()) {
+    logger.debug?.('[dev] Skipping Vercel toolbar: configuration not provided');
+    return undefined;
+  }
+
+  const { mountVercelToolbar, unmountVercelToolbar, isVercelToolbarMounted } = await import('@vercel/toolbar');
+
+  if (isVercelToolbarMounted()) {
+    logger.debug?.('[dev] Vercel toolbar already mounted');
+    return () => {
+      if (isVercelToolbarMounted()) {
+        unmountVercelToolbar();
+      }
+    };
+  }
+
+  mountVercelToolbar({ nonce: options.nonce });
+  logger.info?.('[dev] Mounted Vercel toolbar');
+
+  return () => {
+    if (isVercelToolbarMounted()) {
+      unmountVercelToolbar();
+      logger.info?.('[dev] Unmounted Vercel toolbar');
+    }
+  };
+}

--- a/src/dev/client/window-helpers.ts
+++ b/src/dev/client/window-helpers.ts
@@ -1,0 +1,86 @@
+import type { CleanupResult, DevHelpers, DevLogger } from '../types';
+
+const STYLE_ID = 'dev-grid-overlay-style';
+const GRID_CLASS = 'dev-grid-overlay';
+
+function ensureStyleElement(): HTMLStyleElement {
+  const existing = document.getElementById(STYLE_ID) as HTMLStyleElement | null;
+  if (existing) {
+    return existing;
+  }
+
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    .${GRID_CLASS} * {
+      outline: 1px dashed rgba(99, 102, 241, 0.5);
+      outline-offset: -1px;
+    }
+  `;
+  return style;
+}
+
+function attachHelpers(logger: DevLogger): DevHelpers {
+  let gridEnabled = false;
+  const styleElement = ensureStyleElement();
+
+  const helpers: DevHelpers = {
+    toggleGridOverlay() {
+      const root = document.documentElement;
+      gridEnabled = !gridEnabled;
+      if (gridEnabled) {
+        if (!styleElement.parentElement) {
+          document.head.appendChild(styleElement);
+        }
+        root.classList.add(GRID_CLASS);
+      } else {
+        root.classList.remove(GRID_CLASS);
+      }
+      logger.info?.(`[dev] Layout grid ${gridEnabled ? 'enabled' : 'disabled'}`);
+    },
+    logActiveElement() {
+      const active = document.activeElement;
+      if (active) {
+        logger.info?.('[dev] Active element', active);
+      } else {
+        logger.info?.('[dev] No active element detected');
+      }
+    },
+    clearPersistedState() {
+      try {
+        window.localStorage?.clear();
+        window.sessionStorage?.clear();
+        logger.info?.('[dev] Cleared local and session storage');
+      } catch (error) {
+        logger.warn?.('[dev] Failed to clear storage', error);
+      }
+    },
+  };
+
+  return helpers;
+}
+
+export function exposeDevHelpers(logger: DevLogger = console): CleanupResult {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  const global = window as Window & { __DEV_HELPERS__?: DevHelpers };
+  if (global.__DEV_HELPERS__) {
+    logger.debug?.('[dev] Helper API already registered');
+    return undefined;
+  }
+
+  const helpers = attachHelpers(logger);
+  global.__DEV_HELPERS__ = helpers;
+  logger.info?.('[dev] Dev helpers attached to window.__DEV_HELPERS__');
+
+  return () => {
+    delete global.__DEV_HELPERS__;
+    document.documentElement.classList.remove(GRID_CLASS);
+    const style = document.getElementById(STYLE_ID);
+    if (style) {
+      style.remove();
+    }
+  };
+}

--- a/src/dev/runtime.noop.ts
+++ b/src/dev/runtime.noop.ts
@@ -1,0 +1,5 @@
+import type { CleanupResult, DevRuntimeOptions } from './types';
+
+export async function initDevRuntime(_options: DevRuntimeOptions = {}): Promise<CleanupResult> {
+  return undefined;
+}

--- a/src/dev/runtime.ts
+++ b/src/dev/runtime.ts
@@ -1,0 +1,15 @@
+import type { CleanupResult, DevRuntimeOptions } from './types';
+
+export async function initDevRuntime(options: DevRuntimeOptions = {}): Promise<CleanupResult> {
+  if (process.env.NODE_ENV !== 'development') {
+    return undefined;
+  }
+
+  if (typeof window === 'undefined') {
+    const { initServerRuntime } = await import('./server');
+    return initServerRuntime(options);
+  }
+
+  const { initClientRuntime } = await import('./client');
+  return initClientRuntime(options);
+}

--- a/src/dev/server/index.ts
+++ b/src/dev/server/index.ts
@@ -1,0 +1,9 @@
+import type { CleanupResult, DevRuntimeOptions } from '../types';
+
+export async function initServerRuntime(options: DevRuntimeOptions = {}): Promise<CleanupResult> {
+  const logger = options.logger ?? console;
+  logger.info?.('[dev] Server runtime initialized');
+  return () => {
+    logger.info?.('[dev] Server runtime cleaned up');
+  };
+}

--- a/src/dev/types.ts
+++ b/src/dev/types.ts
@@ -1,0 +1,25 @@
+export type DevLogger = Pick<
+  Console,
+  'log' | 'info' | 'warn' | 'error' | 'debug'
+>;
+
+export interface DevRuntimeOptions {
+  nonce?: string;
+  logger?: DevLogger;
+}
+
+export type CleanupResult = void | (() => void | Promise<void>);
+
+export interface DevHelpers {
+  toggleGridOverlay(): void;
+  logActiveElement(): void;
+  clearPersistedState(): void;
+}
+
+declare global {
+  interface Window {
+    __DEV_HELPERS__?: DevHelpers;
+  }
+}
+
+export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,8 @@
     "types": [],
     "baseUrl": ".",
     "paths": {
+      "@/dev/*": ["src/dev/*"],
       "@/*": ["./*"]
-
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types/**/*.d.ts"],


### PR DESCRIPTION
## Summary
- add a dev runtime entry point with a production noop so dev helpers can be imported safely
- expose browser hotkeys, toolbar mounting, and helper APIs that register only while developing
- alias the runtime to the noop build in production and update TS paths to keep dev modules isolated

## Testing
- yarn lint *(fails: repository contains numerous existing accessibility lint violations)*
- yarn test *(fails: existing suites such as window/nmap accessibility and jsdom localStorage issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ca21d8b4c48328a0a7de5ab097159b