### PR TITLE
[theme] switch UI assets to Kali icon set

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -207,7 +207,7 @@ const utilityList = [
   {
     id: 'qr',
     title: 'QR Tool',
-    icon: '/themes/Yaru/apps/qr.svg',
+    icon: '/themes/Kali/apps/qr.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -216,7 +216,7 @@ const utilityList = [
   {
     id: 'ascii-art',
     title: 'ASCII Art',
-    icon: '/themes/Yaru/apps/gedit.png',
+    icon: '/themes/Kali/apps/utility.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -225,7 +225,7 @@ const utilityList = [
   {
     id: 'clipboard-manager',
     title: 'Clipboard Manager',
-    icon: '/themes/Yaru/apps/gedit.png',
+    icon: '/themes/Kali/apps/clipboard.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -234,7 +234,7 @@ const utilityList = [
   {
     id: 'figlet',
     title: 'Figlet',
-    icon: '/themes/Yaru/apps/gedit.png',
+    icon: '/themes/Kali/apps/utility.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -243,7 +243,7 @@ const utilityList = [
   {
     id: 'quote',
     title: 'Quote',
-    icon: '/themes/Yaru/apps/quote.svg',
+    icon: '/themes/Kali/apps/quote.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -252,7 +252,7 @@ const utilityList = [
   {
     id: 'project-gallery',
     title: 'Project Gallery',
-    icon: '/themes/Yaru/apps/project-gallery.svg',
+    icon: '/themes/Kali/apps/project.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -261,7 +261,7 @@ const utilityList = [
   {
     id: 'input-lab',
     title: 'Input Lab',
-    icon: '/themes/Yaru/apps/input-lab.svg',
+    icon: '/themes/Kali/apps/utility.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -282,7 +282,7 @@ const gameList = [
   {
     id: '2048',
     title: '2048',
-    icon: '/themes/Yaru/apps/2048.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -293,7 +293,7 @@ const gameList = [
   {
     id: 'asteroids',
     title: 'Asteroids',
-    icon: '/themes/Yaru/apps/asteroids.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -302,7 +302,7 @@ const gameList = [
   {
     id: 'battleship',
     title: 'Battleship',
-    icon: '/themes/Yaru/apps/battleship.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -311,7 +311,7 @@ const gameList = [
   {
     id: 'blackjack',
     title: 'Blackjack',
-    icon: '/themes/Yaru/apps/blackjack.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -321,7 +321,7 @@ const gameList = [
   {
     id: 'breakout',
     title: 'Breakout',
-    icon: '/themes/Yaru/apps/breakout.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -330,7 +330,7 @@ const gameList = [
   {
     id: 'car-racer',
     title: 'Car Racer',
-    icon: '/themes/Yaru/apps/car-racer.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -339,7 +339,7 @@ const gameList = [
   {
     id: 'lane-runner',
     title: 'Lane Runner',
-    icon: '/themes/Yaru/apps/car-racer.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -348,7 +348,7 @@ const gameList = [
   {
     id: 'checkers',
     title: 'Checkers',
-    icon: '/themes/Yaru/apps/checkers.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -357,7 +357,7 @@ const gameList = [
   {
     id: 'chess',
     title: 'Chess',
-    icon: '/themes/Yaru/apps/chess.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -367,7 +367,7 @@ const gameList = [
   {
     id: 'connect-four',
     title: 'Connect Four',
-    icon: '/themes/Yaru/apps/connect-four.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -376,7 +376,7 @@ const gameList = [
   {
     id: 'frogger',
     title: 'Frogger',
-    icon: '/themes/Yaru/apps/frogger.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -385,7 +385,7 @@ const gameList = [
   {
     id: 'hangman',
     title: 'Hangman',
-    icon: '/themes/Yaru/apps/hangman.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -394,7 +394,7 @@ const gameList = [
   {
     id: 'memory',
     title: 'Memory',
-    icon: '/themes/Yaru/apps/memory.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -403,7 +403,7 @@ const gameList = [
   {
     id: 'minesweeper',
     title: 'Minesweeper',
-    icon: '/themes/Yaru/apps/minesweeper.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -412,7 +412,7 @@ const gameList = [
   {
     id: 'pacman',
     title: 'Pacman',
-    icon: '/themes/Yaru/apps/pacman.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -421,7 +421,7 @@ const gameList = [
   {
     id: 'platformer',
     title: 'Platformer',
-    icon: '/themes/Yaru/apps/platformer.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -430,7 +430,7 @@ const gameList = [
   {
     id: 'pong',
     title: 'Pong',
-    icon: '/themes/Yaru/apps/pong.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -439,7 +439,7 @@ const gameList = [
   {
     id: 'reversi',
     title: 'Reversi',
-    icon: '/themes/Yaru/apps/reversi.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -448,7 +448,7 @@ const gameList = [
   {
     id: 'simon',
     title: 'Simon',
-    icon: '/themes/Yaru/apps/simon.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -457,7 +457,7 @@ const gameList = [
   {
     id: 'snake',
     title: 'Snake',
-    icon: '/themes/Yaru/apps/snake.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -466,7 +466,7 @@ const gameList = [
   {
     id: 'sokoban',
     title: 'Sokoban',
-    icon: '/themes/Yaru/apps/sokoban.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -475,7 +475,7 @@ const gameList = [
   {
     id: 'solitaire',
     title: 'Solitaire',
-    icon: '/themes/Yaru/apps/solitaire.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -484,7 +484,7 @@ const gameList = [
   {
     id: 'tictactoe',
     title: 'Tic Tac Toe',
-    icon: '/themes/Yaru/apps/tictactoe.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -494,7 +494,7 @@ const gameList = [
   {
     id: 'tetris',
     title: 'Tetris',
-    icon: '/themes/Yaru/apps/tetris.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -503,7 +503,7 @@ const gameList = [
   {
     id: 'tower-defense',
     title: 'Tower Defense',
-    icon: '/themes/Yaru/apps/tower-defense.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -512,7 +512,7 @@ const gameList = [
   {
     id: 'word-search',
     title: 'Word Search',
-    icon: '/themes/Yaru/apps/word-search.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -521,7 +521,7 @@ const gameList = [
   {
     id: 'wordle',
     title: 'Wordle',
-    icon: '/themes/Yaru/apps/wordle.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -530,7 +530,7 @@ const gameList = [
   {
     id: 'nonogram',
     title: 'Nonogram',
-    icon: '/themes/Yaru/apps/nonogram.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -539,7 +539,7 @@ const gameList = [
   {
     id: 'space-invaders',
     title: 'Space Invaders',
-    icon: '/themes/Yaru/apps/space-invaders.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -548,7 +548,7 @@ const gameList = [
   {
     id: 'sudoku',
     title: 'Sudoku',
-    icon: '/themes/Yaru/apps/sudoku.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -557,7 +557,7 @@ const gameList = [
   {
     id: 'flappy-bird',
     title: 'Flappy Bird',
-    icon: '/themes/Yaru/apps/flappy-bird.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -566,7 +566,7 @@ const gameList = [
   {
     id: 'candy-crush',
     title: 'Candy Crush',
-    icon: '/themes/Yaru/apps/candy-crush.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -575,7 +575,7 @@ const gameList = [
   {
     id: 'gomoku',
     title: 'Gomoku',
-    icon: '/themes/Yaru/apps/gomoku.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -584,7 +584,7 @@ const gameList = [
   {
     id: 'pinball',
     title: 'Pinball',
-    icon: '/themes/Yaru/apps/pinball.svg',
+    icon: '/themes/Kali/apps/games.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -598,7 +598,7 @@ const apps = [
   {
     id: 'chrome',
     title: 'Google Chrome',
-    icon: '/themes/Yaru/apps/chrome.png',
+    icon: '/themes/Kali/apps/browser.svg',
     disabled: false,
     favourite: true,
     desktop_shortcut: true,
@@ -607,7 +607,7 @@ const apps = [
   {
     id: 'calculator',
     title: 'Calculator',
-    icon: '/themes/Yaru/apps/calc.png',
+    icon: '/themes/Kali/apps/calculator.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -620,7 +620,7 @@ const apps = [
   {
     id: 'terminal',
     title: 'Terminal',
-    icon: '/themes/Yaru/apps/bash.png',
+    icon: '/themes/Kali/apps/terminal.svg',
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -630,7 +630,7 @@ const apps = [
     // VSCode app uses a Stack iframe, so no editor dependencies are required
     id: 'vscode',
     title: 'Visual Studio Code',
-    icon: '/themes/Yaru/apps/vscode.png',
+    icon: '/themes/Kali/apps/code.svg',
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -641,7 +641,7 @@ const apps = [
   {
     id: 'x',
     title: 'X',
-    icon: '/themes/Yaru/apps/x.png',
+    icon: '/themes/Kali/apps/browser.svg',
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -650,7 +650,7 @@ const apps = [
   {
     id: 'spotify',
     title: 'Spotify',
-    icon: '/themes/Yaru/apps/spotify.svg',
+    icon: '/themes/Kali/apps/music.svg',
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -659,7 +659,7 @@ const apps = [
   {
     id: 'youtube',
     title: 'YouTube',
-    icon: '/themes/Yaru/apps/youtube.svg',
+    icon: '/themes/Kali/apps/video.svg',
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -668,7 +668,7 @@ const apps = [
   {
     id: 'beef',
     title: 'BeEF',
-    icon: '/themes/Yaru/apps/beef.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -677,7 +677,7 @@ const apps = [
   {
     id: 'about',
     title: 'About Alex',
-    icon: '/themes/Yaru/system/user-home.png',
+    icon: '/themes/Kali/apps/profile.svg',
     disabled: false,
     favourite: true,
     desktop_shortcut: true,
@@ -686,7 +686,7 @@ const apps = [
   {
     id: 'settings',
     title: 'Settings',
-    icon: '/themes/Yaru/apps/gnome-control-center.png',
+    icon: '/themes/Kali/system/settings.svg',
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -695,7 +695,7 @@ const apps = [
   {
     id: 'files',
     title: 'Files',
-    icon: '/themes/Yaru/system/folder.png',
+    icon: '/themes/Kali/system/folder.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -704,7 +704,7 @@ const apps = [
   {
     id: 'resource-monitor',
     title: 'Resource Monitor',
-    icon: '/themes/Yaru/apps/resource-monitor.svg',
+    icon: '/themes/Kali/apps/monitor.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -713,7 +713,7 @@ const apps = [
   {
     id: 'screen-recorder',
     title: 'Screen Recorder',
-    icon: '/themes/Yaru/apps/screen-recorder.svg',
+    icon: '/themes/Kali/apps/record.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -722,7 +722,7 @@ const apps = [
   {
     id: 'ettercap',
     title: 'Ettercap',
-    icon: '/themes/Yaru/apps/ettercap.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -731,7 +731,7 @@ const apps = [
   {
     id: 'ble-sensor',
     title: 'BLE Sensor',
-    icon: '/themes/Yaru/apps/bluetooth.svg',
+    icon: '/themes/Kali/apps/network.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -740,7 +740,7 @@ const apps = [
   {
     id: 'metasploit',
     title: 'Metasploit',
-    icon: '/themes/Yaru/apps/metasploit.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -749,7 +749,7 @@ const apps = [
   {
     id: 'wireshark',
     title: 'Wireshark',
-    icon: '/themes/Yaru/apps/wireshark.svg',
+    icon: '/themes/Kali/apps/network.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -758,7 +758,7 @@ const apps = [
   {
     id: 'todoist',
     title: 'Todoist',
-    icon: '/themes/Yaru/apps/todoist.png',
+    icon: '/themes/Kali/apps/task.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -767,7 +767,7 @@ const apps = [
   {
     id: 'sticky_notes',
     title: 'Sticky Notes',
-    icon: '/themes/Yaru/apps/gedit.png',
+    icon: '/themes/Kali/apps/editor.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -776,7 +776,7 @@ const apps = [
   {
     id: 'trash',
     title: 'Trash',
-    icon: '/themes/Yaru/status/user-trash-symbolic.svg',
+    icon: '/themes/Kali/status/trash-empty.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: true,
@@ -785,7 +785,7 @@ const apps = [
   {
     id: 'gedit',
     title: 'Contact Me',
-    icon: '/themes/Yaru/apps/gedit.png',
+    icon: '/themes/Kali/apps/editor.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: true,
@@ -794,7 +794,7 @@ const apps = [
   {
     id: 'converter',
     title: 'Converter',
-    icon: '/themes/Yaru/apps/calc.png',
+    icon: '/themes/Kali/apps/calculator.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -803,7 +803,7 @@ const apps = [
   {
     id: 'kismet',
     title: 'Kismet',
-    icon: '/themes/Yaru/apps/kismet.svg',
+    icon: '/themes/Kali/apps/network.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -812,7 +812,7 @@ const apps = [
   {
     id: 'nikto',
     title: 'Nikto',
-    icon: '/themes/Yaru/apps/nikto.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -821,7 +821,7 @@ const apps = [
   {
     id: 'autopsy',
     title: 'Autopsy',
-    icon: '/themes/Yaru/apps/autopsy.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -830,7 +830,7 @@ const apps = [
   {
     id: 'plugin-manager',
     title: 'Plugin Manager',
-    icon: '/themes/Yaru/apps/project-gallery.svg',
+    icon: '/themes/Kali/apps/utility.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -838,7 +838,7 @@ const apps = [
   },
   {    id: 'reaver',
     title: 'Reaver',
-    icon: '/themes/Yaru/apps/reaver.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -847,7 +847,7 @@ const apps = [
   {
     id: 'nessus',
     title: 'Nessus',
-    icon: '/themes/Yaru/apps/nessus.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -856,7 +856,7 @@ const apps = [
   {
     id: 'ghidra',
     title: 'Ghidra',
-    icon: '/themes/Yaru/apps/ghidra.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -865,7 +865,7 @@ const apps = [
   {
     id: 'mimikatz',
     title: 'Mimikatz',
-    icon: '/themes/Yaru/apps/mimikatz.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -874,7 +874,7 @@ const apps = [
   {
     id: 'mimikatz/offline',
     title: 'Mimikatz Offline',
-    icon: '/themes/Yaru/apps/mimikatz.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -883,7 +883,7 @@ const apps = [
   {
     id: 'ssh',
     title: 'SSH Builder',
-    icon: '/themes/Yaru/apps/ssh.svg',
+    icon: '/themes/Kali/apps/network.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -892,7 +892,7 @@ const apps = [
   {
     id: 'http',
     title: 'HTTP Builder',
-    icon: '/themes/Yaru/apps/http.svg',
+    icon: '/themes/Kali/apps/network.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -901,7 +901,7 @@ const apps = [
   {
     id: 'html-rewriter',
     title: 'HTML Rewriter',
-    icon: '/themes/Yaru/apps/project-gallery.svg',
+    icon: '/themes/Kali/apps/code.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -910,7 +910,7 @@ const apps = [
   {
     id: 'contact',
     title: 'Contact',
-    icon: '/themes/Yaru/apps/project-gallery.svg',
+    icon: '/themes/Kali/apps/contact.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -919,7 +919,7 @@ const apps = [
   {
     id: 'hydra',
     title: 'Hydra',
-    icon: '/themes/Yaru/apps/hydra.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -928,7 +928,7 @@ const apps = [
   {
     id: 'nmap-nse',
     title: 'Nmap NSE',
-    icon: '/themes/Yaru/apps/nmap-nse.svg',
+    icon: '/themes/Kali/apps/network.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -937,7 +937,7 @@ const apps = [
   {
     id: 'weather',
     title: 'Weather',
-    icon: '/themes/Yaru/apps/weather.svg',
+    icon: '/themes/Kali/apps/weather.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -946,7 +946,7 @@ const apps = [
   {
     id: 'weather-widget',
     title: 'Weather Widget',
-    icon: '/themes/Yaru/apps/weather.svg',
+    icon: '/themes/Kali/apps/weather.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -955,7 +955,7 @@ const apps = [
   {
     id: 'serial-terminal',
     title: 'Serial Terminal',
-    icon: '/themes/Yaru/apps/bash.png',
+    icon: '/themes/Kali/apps/terminal.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -964,7 +964,7 @@ const apps = [
   {
     id: 'radare2',
     title: 'Radare2',
-    icon: '/themes/Yaru/apps/radare2.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -973,7 +973,7 @@ const apps = [
   {
     id: 'volatility',
     title: 'Volatility',
-    icon: '/themes/Yaru/apps/volatility.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -982,7 +982,7 @@ const apps = [
   {
     id: 'hashcat',
     title: 'Hashcat',
-    icon: '/themes/Yaru/apps/hashcat.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -991,7 +991,7 @@ const apps = [
   {
     id: 'msf-post',
     title: 'Metasploit Post',
-    icon: '/themes/Yaru/apps/msf-post.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -1000,7 +1000,7 @@ const apps = [
   {
     id: 'evidence-vault',
     title: 'Evidence Vault',
-    icon: '/themes/Yaru/apps/project-gallery.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -1009,7 +1009,7 @@ const apps = [
   {
     id: 'dsniff',
     title: 'dsniff',
-    icon: '/themes/Yaru/apps/dsniff.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -1018,7 +1018,7 @@ const apps = [
   {
     id: 'john',
     title: 'John the Ripper',
-    icon: '/themes/Yaru/apps/john.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -1027,7 +1027,7 @@ const apps = [
   {
     id: 'openvas',
     title: 'OpenVAS',
-    icon: '/themes/Yaru/apps/openvas.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -1036,7 +1036,7 @@ const apps = [
   {
     id: 'recon-ng',
     title: 'Recon-ng',
-    icon: '/themes/Yaru/apps/reconng.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -1045,7 +1045,7 @@ const apps = [
   {
     id: 'security-tools',
     title: 'Security Tools',
-    icon: '/themes/Yaru/apps/project-gallery.svg',
+    icon: '/themes/Kali/apps/security.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,

--- a/apps/trash/index.tsx
+++ b/apps/trash/index.tsx
@@ -4,9 +4,9 @@ import { useState, useEffect, useCallback } from 'react';
 import useTrashState from './state';
 import HistoryList from './components/HistoryList';
 
-const DEFAULT_ICON = '/themes/Yaru/system/folder.png';
-const EMPTY_ICON = '/themes/Yaru/status/user-trash-symbolic.svg';
-const FULL_ICON = '/themes/Yaru/status/user-trash-full-symbolic.svg';
+const DEFAULT_ICON = '/themes/Kali/system/folder.svg';
+const EMPTY_ICON = '/themes/Kali/status/trash-empty.svg';
+const FULL_ICON = '/themes/Kali/status/trash-full.svg';
 
 export default function Trash({ openApp }: { openApp: (id: string) => void }) {
   const {

--- a/components/apps/wireshark/index.js
+++ b/components/apps/wireshark/index.js
@@ -228,8 +228,8 @@ const WiresharkApp = ({ initialPackets = [] }) => {
               <Image
                 src={
                   iface.type === 'wired'
-                    ? '/themes/Yaru/status/network-wireless-signal-good-symbolic.svg'
-                    : '/themes/Yaru/status/network-wireless-signal-good-symbolic.svg'
+                    ? '/themes/Kali/status/network-wireless-signal-good-symbolic.svg'
+                    : '/themes/Kali/status/network-wireless-signal-good-symbolic.svg'
                 }
                 alt={iface.type}
                 width={24}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -110,7 +110,7 @@ export class Desktop extends Component {
                 apps.push({
                     id: `new-folder-${folder.id}`,
                     title: folder.name,
-                    icon: '/themes/Yaru/system/folder.png',
+                    icon: '/themes/Kali/system/folder.svg',
                     disabled: true,
                     favourite: false,
                     desktop_shortcut: true,
@@ -793,8 +793,8 @@ export class Desktop extends Component {
         const appIndex = apps.findIndex(app => app.id === 'trash');
         if (appIndex !== -1) {
             const icon = trash.length
-                ? '/themes/Yaru/status/user-trash-full-symbolic.svg'
-                : '/themes/Yaru/status/user-trash-symbolic.svg';
+                ? '/themes/Kali/status/trash-full.svg'
+                : '/themes/Kali/status/trash-empty.svg';
             if (apps[appIndex].icon !== icon) {
                 apps[appIndex].icon = icon;
                 this.forceUpdate();
@@ -808,7 +808,7 @@ export class Desktop extends Component {
         apps.push({
             id: `new-folder-${folder_id}`,
             title: folder_name,
-            icon: '/themes/Yaru/system/folder.png',
+            icon: '/themes/Kali/system/folder.svg',
             disabled: true,
             favourite: false,
             desktop_shortcut: true,

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -17,7 +17,7 @@ export default class Navbar extends Component {
 		return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
+                                        <Image src="/themes/Kali/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
                                 <WhiskerMenu />
                                 <div

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -3,7 +3,7 @@ import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
 
-const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
+const VOLUME_ICON = "/themes/Kali/status/audio-volume-medium-symbolic.svg";
 
 export default function Status() {
   const { allowNetwork } = useSettings();
@@ -47,7 +47,7 @@ export default function Status() {
         <Image
           width={16}
           height={16}
-          src={online ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"}
+          src={online ? "/themes/Kali/status/network-wireless-signal-good-symbolic.svg" : "/themes/Kali/status/network-wireless-signal-none-symbolic.svg"}
           alt={online ? "online" : "offline"}
           className="inline status-symbol w-4 h-4"
           sizes="16px"
@@ -70,7 +70,7 @@ export default function Status() {
         <Image
           width={16}
           height={16}
-          src="/themes/Yaru/status/battery-good-symbolic.svg"
+          src="/themes/Kali/status/battery-good-symbolic.svg"
           alt="ubuntu battry"
           className="inline status-symbol w-4 h-4"
           sizes="16px"

--- a/public/themes/Kali/apps/browser.svg
+++ b/public/themes/Kali/apps/browser.svg
@@ -1,0 +1,12 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="browserGradient" x1="8" y1="8" x2="54" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#06172A" />
+      <stop offset="1" stop-color="#22D3EE" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="url(#browserGradient)" />
+  <circle cx="32" cy="32" r="14" stroke="#F8FAFC" stroke-width="3" />
+  <path d="M32 18C36.6667 22.6667 39 27.3333 39 32C39 36.6667 36.6667 41.3333 32 46C27.3333 41.3333 25 36.6667 25 32C25 27.3333 27.3333 22.6667 32 18Z" stroke="#F8FAFC" stroke-width="3" />
+  <path d="M18 32H46" stroke="#F8FAFC" stroke-width="3" stroke-linecap="round" />
+</svg>

--- a/public/themes/Kali/apps/calculator.svg
+++ b/public/themes/Kali/apps/calculator.svg
@@ -1,0 +1,15 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="calculatorGradient" x1="10" y1="6" x2="50" y2="58" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#04101C" />
+      <stop offset="1" stop-color="#0EA5E9" />
+    </linearGradient>
+  </defs>
+  <rect x="16" y="8" width="32" height="48" rx="8" fill="url(#calculatorGradient)" />
+  <rect x="20" y="14" width="24" height="10" rx="3" fill="#F8FAFC" fill-opacity="0.2" />
+  <rect x="20" y="28" width="8" height="8" rx="2" fill="#F8FAFC" />
+  <rect x="32" y="28" width="12" height="4" rx="2" fill="#F8FAFC" />
+  <rect x="32" y="34" width="12" height="4" rx="2" fill="#F8FAFC" />
+  <rect x="20" y="40" width="8" height="8" rx="2" fill="#F8FAFC" fill-opacity="0.6" />
+  <rect x="32" y="40" width="12" height="8" rx="2" fill="#F8FAFC" fill-opacity="0.6" />
+</svg>

--- a/public/themes/Kali/apps/clipboard.svg
+++ b/public/themes/Kali/apps/clipboard.svg
@@ -1,0 +1,13 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="clipboardGradient" x1="12" y1="6" x2="48" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#061728" />
+      <stop offset="1" stop-color="#0EA5E9" />
+    </linearGradient>
+  </defs>
+  <rect x="16" y="10" width="32" height="10" rx="4" fill="#F8FAFC" fill-opacity="0.85" />
+  <rect x="12" y="14" width="40" height="40" rx="8" fill="url(#clipboardGradient)" />
+  <rect x="20" y="24" width="24" height="4" rx="2" fill="#F8FAFC" />
+  <rect x="20" y="32" width="24" height="4" rx="2" fill="#F8FAFC" fill-opacity="0.7" />
+  <rect x="20" y="40" width="16" height="4" rx="2" fill="#F8FAFC" fill-opacity="0.5" />
+</svg>

--- a/public/themes/Kali/apps/code.svg
+++ b/public/themes/Kali/apps/code.svg
@@ -1,0 +1,12 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="codeGradient" x1="8" y1="8" x2="52" y2="52" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#041120" />
+      <stop offset="1" stop-color="#38BDF8" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="url(#codeGradient)" />
+  <path d="M24 24L16 32L24 40" stroke="#F8FAFC" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M40 24L48 32L40 40" stroke="#F8FAFC" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M28 44L36 20" stroke="#38BDF8" stroke-width="3.5" stroke-linecap="round" />
+</svg>

--- a/public/themes/Kali/apps/contact.svg
+++ b/public/themes/Kali/apps/contact.svg
@@ -1,0 +1,14 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="contactGradient" x1="8" y1="10" x2="56" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#04101C" />
+      <stop offset="1" stop-color="#0EA5E9" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="8" width="52" height="40" rx="10" fill="url(#contactGradient)" />
+  <path d="M18 22H46" stroke="#F8FAFC" stroke-width="3" stroke-linecap="round" />
+  <path d="M18 30H34" stroke="#F8FAFC" stroke-width="3" stroke-linecap="round" />
+  <path d="M18 38H28" stroke="#F8FAFC" stroke-width="3" stroke-linecap="round" />
+  <circle cx="44" cy="32" r="10" fill="#0EA5E9" />
+  <path d="M40 30H44V28C44 26.8954 44.8954 26 46 26C47.1046 26 48 26.8954 48 28C48 29.1046 47.1046 30 46 30V34H44V36H46C47.6569 36 49 34.6569 49 33C49 31.3431 47.6569 30 46 30C44.3431 30 43 31.3431 43 33V34H40V30Z" fill="#F8FAFC" />
+</svg>

--- a/public/themes/Kali/apps/editor.svg
+++ b/public/themes/Kali/apps/editor.svg
@@ -1,0 +1,12 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="editorGradient" x1="12" y1="6" x2="48" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#071C2D" />
+      <stop offset="1" stop-color="#22D3EE" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="10" width="52" height="40" rx="8" fill="url(#editorGradient)" />
+  <path d="M20 40L28 36L44 20L40 16L24 32L20 40Z" fill="#F8FAFC" />
+  <path d="M20 40L25.5 38.5L21.5 34.5L20 40Z" fill="#0F172A" fill-opacity="0.4" />
+  <path d="M36 18L40 14L46 20L42 24L36 18Z" fill="#0F172A" fill-opacity="0.4" />
+</svg>

--- a/public/themes/Kali/apps/games.svg
+++ b/public/themes/Kali/apps/games.svg
@@ -1,0 +1,15 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gamesGradient" x1="8" y1="8" x2="56" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1F32" />
+      <stop offset="1" stop-color="#0EA5E9" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="url(#gamesGradient)" />
+  <path d="M20 32H28" stroke="#F8FAFC" stroke-width="3.5" stroke-linecap="round" />
+  <path d="M24 28V36" stroke="#F8FAFC" stroke-width="3.5" stroke-linecap="round" />
+  <path d="M40.5 30.5H40.51" stroke="#F8FAFC" stroke-width="3.5" stroke-linecap="round" />
+  <path d="M45 34H45.01" stroke="#F8FAFC" stroke-width="3.5" stroke-linecap="round" />
+  <path d="M36 38C37.5 35 41.5 35 43 38" stroke="#F8FAFC" stroke-width="3.5" stroke-linecap="round" />
+  <path d="M20 24C24 20 40 20 44 24C46 26 48 30 48 34C48 40 44 44 38 44H26C20 44 16 40 16 34C16 30 18 26 20 24Z" stroke="#F8FAFC" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/public/themes/Kali/apps/monitor.svg
+++ b/public/themes/Kali/apps/monitor.svg
@@ -1,0 +1,11 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="monitorGradient" x1="10" y1="8" x2="54" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#020F1C" />
+      <stop offset="1" stop-color="#22D3EE" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="12" width="52" height="36" rx="8" fill="#020817" stroke="url(#monitorGradient)" stroke-width="3" />
+  <path d="M16 38L24 30L30 34L40 24L48 30" stroke="#38BDF8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+  <rect x="26" y="48" width="12" height="4" rx="2" fill="#38BDF8" />
+</svg>

--- a/public/themes/Kali/apps/music.svg
+++ b/public/themes/Kali/apps/music.svg
@@ -1,0 +1,11 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="musicGradient" x1="12" y1="8" x2="52" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#04101C" />
+      <stop offset="1" stop-color="#2563EB" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="url(#musicGradient)" />
+  <path d="M38 18V38.5C38 42.6421 34.6421 46 30.5 46C26.3579 46 23 42.6421 23 38.5C23 34.3579 26.3579 31 30.5 31C31.6996 31 32.832 31.2904 33.8333 31.8V18H44V22H38Z" fill="#F8FAFC" />
+  <circle cx="44" cy="28" r="4" fill="#F8FAFC" fill-opacity="0.85" />
+</svg>

--- a/public/themes/Kali/apps/network.svg
+++ b/public/themes/Kali/apps/network.svg
@@ -1,0 +1,14 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="networkGradient" x1="10" y1="8" x2="54" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#041120" />
+      <stop offset="1" stop-color="#22D3EE" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="52" height="52" rx="14" fill="url(#networkGradient)" />
+  <circle cx="32" cy="32" r="16" stroke="#F8FAFC" stroke-width="3" />
+  <path d="M24 40C27 36 37 36 40 40" stroke="#38BDF8" stroke-width="3" stroke-linecap="round" />
+  <path d="M20 32C24 28 40 28 44 32" stroke="#38BDF8" stroke-width="3" stroke-linecap="round" />
+  <path d="M16 24C22 20 42 20 48 24" stroke="#38BDF8" stroke-width="3" stroke-linecap="round" />
+  <circle cx="32" cy="44" r="3" fill="#38BDF8" />
+</svg>

--- a/public/themes/Kali/apps/profile.svg
+++ b/public/themes/Kali/apps/profile.svg
@@ -1,0 +1,11 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="profileGradient" x1="8" y1="8" x2="56" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#061728" />
+      <stop offset="1" stop-color="#0EA5E9" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="52" height="52" rx="14" fill="url(#profileGradient)" />
+  <circle cx="32" cy="26" r="10" fill="#F8FAFC" fill-opacity="0.9" />
+  <path d="M16 48C18 40 24 36 32 36C40 36 46 40 48 48" stroke="#F8FAFC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/public/themes/Kali/apps/project.svg
+++ b/public/themes/Kali/apps/project.svg
@@ -1,0 +1,13 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="projectGradient" x1="12" y1="8" x2="52" y2="52" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#071828" />
+      <stop offset="1" stop-color="#0891B2" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="10" width="52" height="40" rx="8" fill="url(#projectGradient)" />
+  <path d="M18 20H46" stroke="#F8FAFC" stroke-width="3" stroke-linecap="round" />
+  <rect x="18" y="26" width="12" height="8" rx="2" fill="#F8FAFC" fill-opacity="0.9" />
+  <rect x="34" y="26" width="12" height="8" rx="2" fill="#F8FAFC" fill-opacity="0.7" />
+  <rect x="26" y="38" width="12" height="6" rx="2" fill="#1F2937" fill-opacity="0.8" />
+</svg>

--- a/public/themes/Kali/apps/qr.svg
+++ b/public/themes/Kali/apps/qr.svg
@@ -1,0 +1,15 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="qrGradient" x1="8" y1="8" x2="56" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#020E1A" />
+      <stop offset="1" stop-color="#0891B2" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="url(#qrGradient)" />
+  <rect x="18" y="18" width="10" height="10" stroke="#F8FAFC" stroke-width="3" />
+  <rect x="36" y="18" width="10" height="10" stroke="#F8FAFC" stroke-width="3" />
+  <rect x="18" y="36" width="10" height="10" stroke="#F8FAFC" stroke-width="3" />
+  <path d="M34 34H46V46H40V40H34V34Z" fill="#F8FAFC" />
+  <rect x="28" y="28" width="4" height="4" fill="#F8FAFC" />
+  <rect x="32" y="44" width="4" height="4" fill="#F8FAFC" />
+</svg>

--- a/public/themes/Kali/apps/quote.svg
+++ b/public/themes/Kali/apps/quote.svg
@@ -1,0 +1,11 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="quoteGradient" x1="8" y1="10" x2="52" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#051425" />
+      <stop offset="1" stop-color="#22D3EE" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="8" width="56" height="48" rx="12" fill="url(#quoteGradient)" />
+  <path d="M20 32C20 28 22 24 26 22V26C23.7909 26 22 27.7909 22 30C22 32.2091 23.7909 34 26 34C28.2091 34 30 32.2091 30 30C30 26.6863 27.3137 24 24 24" stroke="#F8FAFC" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M34 32C34 28 36 24 40 22V26C37.7909 26 36 27.7909 36 30C36 32.2091 37.7909 34 40 34C42.2091 34 44 32.2091 44 30C44 26.6863 41.3137 24 38 24" stroke="#F8FAFC" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/public/themes/Kali/apps/record.svg
+++ b/public/themes/Kali/apps/record.svg
@@ -1,0 +1,12 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="recordGradient" x1="8" y1="12" x2="56" y2="52" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#061728" />
+      <stop offset="1" stop-color="#0EA5E9" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="10" width="52" height="44" rx="12" fill="url(#recordGradient)" />
+  <rect x="18" y="24" width="16" height="20" rx="4" fill="#F8FAFC" />
+  <path d="M42 24L50 20V44L42 40V24Z" fill="#F8FAFC" fill-opacity="0.8" />
+  <circle cx="26" cy="34" r="4" fill="#0EA5E9" />
+</svg>

--- a/public/themes/Kali/apps/security.svg
+++ b/public/themes/Kali/apps/security.svg
@@ -1,0 +1,11 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="securityGradient" x1="10" y1="6" x2="54" y2="58" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#061626" />
+      <stop offset="1" stop-color="#1F9DEE" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="url(#securityGradient)" />
+  <path d="M32 16L46 21V32C46 41 40 46.5 32 52C24 46.5 18 41 18 32V21L32 16Z" stroke="#F8FAFC" stroke-width="3.5" stroke-linejoin="round" />
+  <path d="M32 28C29.7909 28 28 29.7909 28 32C28 33.7314 29.1054 35.2197 30.6667 35.7778V40H33.3333V35.7778C34.8946 35.2197 36 33.7314 36 32C36 29.7909 34.2091 28 32 28Z" fill="#F8FAFC" />
+</svg>

--- a/public/themes/Kali/apps/task.svg
+++ b/public/themes/Kali/apps/task.svg
@@ -1,0 +1,11 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="taskGradient" x1="8" y1="10" x2="56" y2="52" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#041019" />
+      <stop offset="1" stop-color="#2563EB" />
+    </linearGradient>
+  </defs>
+  <rect x="10" y="12" width="44" height="40" rx="10" fill="url(#taskGradient)" />
+  <path d="M20 24L28 32L44 20" stroke="#F8FAFC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M20 38H44" stroke="#93C5FD" stroke-width="3" stroke-linecap="round" />
+</svg>

--- a/public/themes/Kali/apps/terminal.svg
+++ b/public/themes/Kali/apps/terminal.svg
@@ -1,0 +1,11 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="terminalGradient" x1="10" y1="8" x2="50" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#04111F" />
+      <stop offset="1" stop-color="#0EA5E9" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="10" width="52" height="38" rx="6" fill="#020617" stroke="url(#terminalGradient)" stroke-width="3" />
+  <path d="M20 24L28 32L20 40" stroke="#38BDF8" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M32 40H44" stroke="#38BDF8" stroke-width="3.5" stroke-linecap="round" />
+</svg>

--- a/public/themes/Kali/apps/utility.svg
+++ b/public/themes/Kali/apps/utility.svg
@@ -1,0 +1,12 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="utilityGradient" x1="6" y1="10" x2="58" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#071A2E" />
+      <stop offset="1" stop-color="#22D3EE" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="url(#utilityGradient)" />
+  <path d="M24 20L28 24L26 26L31 31L27 35L22 30L20 32L16 28L24 20Z" fill="#F8FAFC" />
+  <path d="M36 24L44 32L32 44L24 36L36 24Z" stroke="#F8FAFC" stroke-width="3.5" stroke-linejoin="round" />
+  <path d="M40 20L44 24L40 28L36 24L40 20Z" fill="#F8FAFC" />
+</svg>

--- a/public/themes/Kali/apps/video.svg
+++ b/public/themes/Kali/apps/video.svg
@@ -1,0 +1,12 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="videoGradient" x1="6" y1="10" x2="58" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#051426" />
+      <stop offset="1" stop-color="#1D4ED8" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="12" width="52" height="36" rx="10" fill="url(#videoGradient)" />
+  <path d="M28 24L40 32L28 40V24Z" fill="#F8FAFC" />
+  <rect x="16" y="24" width="6" height="16" rx="2" fill="#F8FAFC" fill-opacity="0.7" />
+  <rect x="46" y="20" width="6" height="24" rx="2" fill="#F8FAFC" fill-opacity="0.4" />
+</svg>

--- a/public/themes/Kali/apps/weather.svg
+++ b/public/themes/Kali/apps/weather.svg
@@ -1,0 +1,12 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="weatherGradient" x1="10" y1="8" x2="52" y2="52" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#02101C" />
+      <stop offset="1" stop-color="#38BDF8" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="url(#weatherGradient)" />
+  <circle cx="26" cy="26" r="10" fill="#F8FAFC" fill-opacity="0.9" />
+  <path d="M38 28C33 28 29 32 29 37C29 40 31 43 34 44H46C50 44 54 40 54 36C54 32 51 29 47 28C46 22 42 20 38 20C40 22 41 24 41 26C41 26.7 40.9 27.4 40.7 28H38Z" fill="#0F172A" fill-opacity="0.7" />
+  <path d="M20 46H44" stroke="#F8FAFC" stroke-width="3" stroke-linecap="round" />
+</svg>

--- a/public/themes/Kali/status/audio-volume-medium-symbolic.svg
+++ b/public/themes/Kali/status/audio-volume-medium-symbolic.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 9H8L12 6V18L8 15H4V9Z" fill="#38BDF8" />
+  <path d="M16 9C17.6569 10.3431 17.6569 13.6569 16 15" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" />
+  <path d="M18.5 6.5C21.8333 9 21.8333 15 18.5 17.5" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" opacity="0.6" />
+</svg>

--- a/public/themes/Kali/status/battery-good-symbolic.svg
+++ b/public/themes/Kali/status/battery-good-symbolic.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="7" width="16" height="10" rx="2" stroke="#38BDF8" stroke-width="2" />
+  <rect x="19" y="10" width="2" height="4" rx="1" fill="#38BDF8" />
+  <rect x="6" y="10" width="8" height="4" rx="1" fill="#38BDF8" />
+</svg>

--- a/public/themes/Kali/status/network-wireless-signal-good-symbolic.svg
+++ b/public/themes/Kali/status/network-wireless-signal-good-symbolic.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M2 8C6.41828 4.83333 17.5817 4.83333 22 8" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M5 11C8.31371 8.66667 15.6863 8.66667 19 11" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M8.5 14.5C10.3284 13.1667 13.6716 13.1667 15.5 14.5" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="12" cy="18" r="2" fill="#38BDF8" />
+</svg>

--- a/public/themes/Kali/status/network-wireless-signal-none-symbolic.svg
+++ b/public/themes/Kali/status/network-wireless-signal-none-symbolic.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M2 8C6.41828 4.83333 17.5817 4.83333 22 8" stroke="#1E293B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.6" />
+  <path d="M5 11C8.31371 8.66667 15.6863 8.66667 19 11" stroke="#1E293B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.6" />
+  <path d="M8.5 14.5C10.3284 13.1667 13.6716 13.1667 15.5 14.5" stroke="#1E293B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.6" />
+  <path d="M8 18L16 10" stroke="#EF4444" stroke-width="2" stroke-linecap="round" />
+  <path d="M16 18L8 10" stroke="#EF4444" stroke-width="2" stroke-linecap="round" />
+</svg>

--- a/public/themes/Kali/status/trash-empty.svg
+++ b/public/themes/Kali/status/trash-empty.svg
@@ -1,0 +1,12 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="trashEmptyGradient" x1="4" y1="4" x2="28" y2="28" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1F33" />
+      <stop offset="1" stop-color="#38BDF8" />
+    </linearGradient>
+  </defs>
+  <rect x="7" y="8" width="18" height="3" rx="1.5" fill="#38BDF8" />
+  <path d="M10 10L12 26H20L22 10H10Z" stroke="url(#trashEmptyGradient)" stroke-width="2" fill="#071928" />
+  <path d="M14 14V22" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" />
+  <path d="M18 14V22" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" />
+</svg>

--- a/public/themes/Kali/status/trash-full.svg
+++ b/public/themes/Kali/status/trash-full.svg
@@ -1,0 +1,12 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="trashFullGradient" x1="4" y1="4" x2="28" y2="28" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1F33" />
+      <stop offset="1" stop-color="#22D3EE" />
+    </linearGradient>
+  </defs>
+  <rect x="7" y="8" width="18" height="3" rx="1.5" fill="#22D3EE" />
+  <path d="M10 10L12 26H20L22 10H10Z" fill="url(#trashFullGradient)" />
+  <path d="M13 15L19 21" stroke="#0B1F33" stroke-width="2" stroke-linecap="round" />
+  <path d="M19 15L13 21" stroke="#0B1F33" stroke-width="2" stroke-linecap="round" />
+</svg>

--- a/public/themes/Kali/system/folder.svg
+++ b/public/themes/Kali/system/folder.svg
@@ -1,0 +1,10 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="folderGradient" x1="8" y1="14" x2="54" y2="50" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#061728" />
+      <stop offset="1" stop-color="#0EA5E9" />
+    </linearGradient>
+  </defs>
+  <path d="M10 18C10 15.7909 11.7909 14 14 14H26L30 20H50C52.2091 20 54 21.7909 54 24V46C54 48.2091 52.2091 50 50 50H14C11.7909 50 10 48.2091 10 46V18Z" fill="url(#folderGradient)" />
+  <path d="M10 28H54V46C54 48.2091 52.2091 50 50 50H14C11.7909 50 10 48.2091 10 46V28Z" fill="#0B1F33" fill-opacity="0.6" />
+</svg>

--- a/public/themes/Kali/system/settings.svg
+++ b/public/themes/Kali/system/settings.svg
@@ -1,0 +1,11 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="settingsGradient" x1="8" y1="8" x2="56" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#061728" />
+      <stop offset="1" stop-color="#38BDF8" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="52" height="52" rx="14" fill="url(#settingsGradient)" />
+  <path d="M32 22L34 26H40L38 30L40 34H34L32 38L30 34H24L26 30L24 26H30L32 22Z" stroke="#F8FAFC" stroke-width="3" stroke-linejoin="round" />
+  <circle cx="32" cy="30" r="6" fill="#F8FAFC" fill-opacity="0.85" />
+</svg>


### PR DESCRIPTION
## Summary
- add Kali-themed app, status, and system icons under `public/themes/Kali`
- update navbar, status bar, trash, and the app registry to point at the new Kali artwork
- align Wireshark interface indicators with the refreshed status icons

## Testing
- yarn lint *(fails: repository already has numerous jsx-a11y control labeling violations)*
- yarn test *(fails: existing suites for desktop window controls and settings interactions error under jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8e6823a48328acece5c3fac586dc