### PR TITLE
[terminal] add kali banner and font stack

### DIFF
--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -14,7 +14,8 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
         background: 'var(--kali-bg)',
         backdropFilter: 'blur(4px)',
         border: '1px solid var(--color-border)',
-        fontFamily: 'monospace',
+        fontFamily:
+          '"Hack", "DejaVu Sans Mono", "Liberation Mono", "Menlo", monospace',
         fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
         lineHeight: 1.4,
         ...style,

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -76,6 +76,28 @@ const files: Record<string, string> = {
   'README.md': 'Welcome to the web terminal.\nThis is a fake file used for demos.',
 };
 
+const kaliDragonBanner = [
+  '\\x1b[38;5;39m..............\'\\x1b[0m',
+  '\\x1b[38;5;39m.........\'   \'\\x1b[0m',
+  '\\x1b[38;5;39m......\'.........\\x1b[0m',
+  '\\x1b[38;5;39m.....\'..\'........\\x1b[0m',
+  '\\x1b[38;5;39m....\'..\'..........\\x1b[0m',
+  '\\x1b[38;5;39m...\'..\'............\\x1b[0m',
+  '\\x1b[38;5;39m..\'..\'..............\\x1b[0m',
+  '\\x1b[38;5;39m.\'..\'.......;;;....\\x1b[0m',
+  '\\x1b[38;5;39m\'..\'.......;::::;..\\x1b[0m',
+  '\\x1b[38;5;39m.\'........;::::;;..\\x1b[0m',
+  '\\x1b[38;5;39m.\'......,;::::;,,..\\x1b[0m',
+  '\\x1b[38;5;39m......,:::::::;,,..\\x1b[0m',
+  '\\x1b[38;5;39m....,:::::::::;,..\\x1b[0m',
+  '\\x1b[38;5;39m...:::::::::::;.\\x1b[0m',
+];
+
+const kaliGuidance = [
+  '\\x1b[1;37mKali Linux (web) — simulated terminal session.\\x1b[0m',
+  '\\x1b[90mType "help" to explore commands or Ctrl+Shift+P for the palette.\\x1b[0m',
+];
+
 const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<any>(null);
@@ -308,7 +330,8 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
         scrollback: 1000,
         cols: 80,
         rows: 24,
-        fontFamily: '"Fira Code", monospace',
+        fontFamily:
+          '"Hack", "DejaVu Sans Mono", "Liberation Mono", "Menlo", monospace',
         theme: {
           background: '#0f1317',
           foreground: '#f5f5f5',
@@ -340,8 +363,9 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
             : `${existing}\n`;
         }
       }
-      writeLine('Welcome to the web terminal!');
-      writeLine('Type "help" to see available commands.');
+      [...kaliDragonBanner, '', ...kaliGuidance].forEach((line) => {
+        writeLine(line);
+      });
       prompt();
       term.onData((d: string) => handleInput(d));
       term.onKey(({ domEvent }: any) => {


### PR DESCRIPTION
## Summary
- replace the initial terminal greeting with a Kali dragon ASCII banner plus guidance text
- switch the terminal container and xterm.js font stacks to the Hack/DejaVu monospace family

## Testing
- yarn lint *(fails: existing repo lint errors around unlabeled controls and no-top-level-window rule)*
- yarn test *(fails: existing suite failures in window, nmapNse, pdfviewer, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8e6979bc83288608e87e693482e0