### PR TITLE
[ui] apply kali gradient backgrounds

### DIFF
--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -9,7 +9,7 @@ function BootingScreen(props) {
                 ...(props.visible || props.isShutDown ? { zIndex: "100" } : { zIndex: "-20" }),
                 contentVisibility: 'auto',
             }}
-            className={(props.visible || props.isShutDown ? " visible opacity-100" : " invisible opacity-0 ") + " absolute duration-500 select-none flex flex-col justify-around items-center top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen bg-black"}>
+            className={(props.visible || props.isShutDown ? " visible opacity-100" : " invisible opacity-0 ") + " absolute duration-500 select-none flex flex-col justify-around items-center top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen bg-[var(--color-bg)] bg-gradient-to-br from-[var(--color-bg-gradient-start)] to-[var(--color-bg-gradient-end)]"}>
             <Image
                 width={400}
                 height={400}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -865,7 +865,7 @@ export class Desktop extends Component {
 
     render() {
         return (
-            <main id="desktop" role="main" className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
+            <main id="desktop" role="main" className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-[var(--color-bg)] bg-gradient-to-br from-[var(--color-bg-gradient-start)] to-[var(--color-bg-gradient-end)] relative overflow-hidden overscroll-none window-parent"}>
 
                 {/* Window Area */}
                 <div

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -15,11 +15,15 @@ export default function LockScreen(props) {
         <div
             id="ubuntu-lock-screen"
             style={{ zIndex: "100", contentVisibility: 'auto' }}
-            className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
+            className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-[var(--color-bg)] bg-gradient-to-br from-[var(--color-bg-gradient-start)] to-[var(--color-bg-gradient-end)] transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
             <img
                 src={`/wallpapers/${wallpaper}.webp`}
                 alt=""
                 className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+            />
+            <div
+                className="absolute inset-0 z-30 pointer-events-none opacity-90 bg-gradient-to-br from-[var(--color-bg-gradient-start)] to-[var(--color-bg-gradient-end)]"
+                aria-hidden="true"
             />
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
                 <div className=" text-7xl">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,7 +3,9 @@
 /* Accessible theme color palette meeting WCAG AA contrast ratios */
 :root {
   /* Base colors */
-  --color-bg: #0f1317; /* kali background */
+  --color-bg-gradient-start: #0d1b2a; /* kali gradient start */
+  --color-bg-gradient-end: #1b263b; /* kali gradient end */
+  --color-bg: var(--color-bg-gradient-start); /* kali background */
   --color-text: #f5f5f5; /* text on dark backgrounds */
   /* Brand accents */
   --color-primary: #1793d1; /* kali blue accent */
@@ -24,6 +26,8 @@
 
 /* Dark theme */
 html[data-theme='dark'] {
+  --color-bg-gradient-start: #000000;
+  --color-bg-gradient-end: #000000;
   --color-bg: #000000;
   --color-text: #e5e5e5;
   --color-primary: #1e88e5;
@@ -39,6 +43,8 @@ html[data-theme='dark'] {
 
 /* Neon theme */
 html[data-theme='neon'] {
+  --color-bg-gradient-start: #000000;
+  --color-bg-gradient-end: #111111;
   --color-bg: #000000;
   --color-text: #ffffff;
   --color-primary: #39ff14;
@@ -54,6 +60,8 @@ html[data-theme='neon'] {
 
 /* Matrix theme */
 html[data-theme='matrix'] {
+  --color-bg-gradient-start: #000000;
+  --color-bg-gradient-end: #000000;
   --color-bg: #000000;
   --color-text: #00ff00;
   --color-primary: #00ff00;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -23,9 +23,11 @@
   --color-ubt-gedit-dark: #003B70;
   --color-ub-border-orange: #1793d1;
   --color-ub-dark-grey: #2a2e36;
-  --color-bg: #0f1317;
+  --color-bg-gradient-start: #0d1b2a;
+  --color-bg-gradient-end: #1b263b;
+  --color-bg: var(--color-bg-gradient-start);
   --color-text: #F5F5F5;
-  --kali-bg: rgba(15, 19, 23, 0.85);
+  --kali-bg: rgba(13, 27, 42, 0.85);
 
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
@@ -64,6 +66,8 @@
 
 /* High contrast theme */
 .high-contrast {
+  --color-bg-gradient-start: #000000;
+  --color-bg-gradient-end: #000000;
   --color-bg: #000000;
   --color-text: #ffffff;
   --color-ub-grey: #000000;
@@ -107,6 +111,8 @@
 /* Optional high contrast via media query */
 @media (prefers-contrast: more) {
   :root {
+    --color-bg-gradient-start: #000000;
+    --color-bg-gradient-end: #000000;
     --color-bg: #000000;
     --color-text: #ffffff;
     --color-ub-grey: #000000;


### PR DESCRIPTION
## Summary
- introduce Kali blue gradient tokens and expose start/end CSS variables
- apply the gradient background across boot, lock, and desktop containers with a lock overlay
- keep theme overrides aligned with the new gradient variables

## Testing
- yarn lint *(fails: pre-existing accessibility violations across app bundle)*
- yarn test *(fails: pre-existing suite failures; run aborted after repeated errors)*
- manual verification: loaded boot, lock, and desktop states in browser (see attached screenshots)


------
https://chatgpt.com/codex/tasks/task_e_68ca915710c4832889c98e5e463674dd