### PR TITLE
[ui] add reusable kali button style

### DIFF
--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -215,68 +215,52 @@ const GameLayout: React.FC<GameLayoutProps> = ({
         {showHelp && <HelpOverlay gameId={gameId} onClose={close} />}
         {paused && (
           <div
-            className="absolute inset-0 bg-black bg-opacity-75 z-50 flex items-center justify-center"
+            className="absolute inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75"
             role="dialog"
-          aria-modal="true"
-        >
+            aria-modal="true"
+          >
+            <button
+              type="button"
+              onClick={resume}
+              className="kali-button px-4 py-2 text-base"
+              autoFocus
+            >
+              Resume
+            </button>
+          </div>
+        )}
+        <div className="absolute top-2 right-2 z-40 flex space-x-2">
           <button
             type="button"
-            onClick={resume}
-            className="px-4 py-2 bg-gray-700 text-white rounded focus:outline-none focus:ring"
-            autoFocus
+            onClick={() => setPaused((p) => !p)}
+            className="kali-button px-2 py-1"
           >
-            Resume
+            {paused ? 'Resume' : 'Pause'}
+          </button>
+          <button type="button" onClick={snapshot} className="kali-button px-2 py-1">
+            Snapshot
+          </button>
+          <button type="button" onClick={replay} className="kali-button px-2 py-1">
+            Replay
+          </button>
+          <button type="button" onClick={shareApp} className="kali-button px-2 py-1">
+            Share
+          </button>
+          {highScore !== undefined && (
+            <button type="button" onClick={shareScore} className="kali-button px-2 py-1">
+              Share Score
+            </button>
+          )}
+          <button
+            type="button"
+            aria-label="Help"
+            aria-expanded={showHelp}
+            onClick={toggle}
+            className="kali-button flex h-8 w-8 items-center justify-center rounded-full p-0"
+          >
+            ?
           </button>
         </div>
-      )}
-      <div className="absolute top-2 right-2 z-40 flex space-x-2">
-        <button
-          type="button"
-          onClick={() => setPaused((p) => !p)}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
-        >
-          {paused ? 'Resume' : 'Pause'}
-        </button>
-        <button
-          type="button"
-          onClick={snapshot}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
-        >
-          Snapshot
-        </button>
-        <button
-          type="button"
-          onClick={replay}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
-        >
-          Replay
-        </button>
-        <button
-          type="button"
-          onClick={shareApp}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
-        >
-          Share
-        </button>
-        {highScore !== undefined && (
-          <button
-            type="button"
-            onClick={shareScore}
-            className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
-          >
-            Share Score
-          </button>
-        )}
-        <button
-          type="button"
-          aria-label="Help"
-          aria-expanded={showHelp}
-          onClick={toggle}
-          className="bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
-        >
-          ?
-        </button>
-      </div>
       {children}
       <div className="absolute top-2 left-2 z-10 text-sm space-y-1">
         {stage !== undefined && <div>Stage: {stage}</div>}

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -278,21 +278,21 @@ const ContactApp: React.FC = () => {
           <button
             type="button"
             onClick={() => copyToClipboard(EMAIL)}
-            className="underline mr-2"
+            className="kali-button mr-2 px-2 py-1 text-xs"
           >
             Copy address
           </button>
           <button
             type="button"
             onClick={() => copyToClipboard(message)}
-            className="underline mr-2"
+            className="kali-button mr-2 px-2 py-1 text-xs"
           >
             Copy message
           </button>
           <button
             type="button"
             onClick={() => openMailto(EMAIL, '', message)}
-            className="underline"
+            className="kali-button px-2 py-1 text-xs"
           >
             Open email app
           </button>
@@ -386,7 +386,7 @@ const ContactApp: React.FC = () => {
         <button
           type="submit"
           disabled={submitting}
-          className="flex items-center justify-center rounded bg-blue-600 px-4 py-2 disabled:opacity-50"
+          className="kali-button flex justify-center px-4 py-2 disabled:opacity-60"
         >
           {submitting ? (
             <div className="h-5 w-5 border-2 border-white border-t-transparent rounded-full animate-spin" />

--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -17,7 +17,7 @@ const Breadcrumbs: React.FC<Props> = ({ path, onNavigate }) => {
           <button
             type="button"
             onClick={() => onNavigate(idx)}
-            className="hover:underline focus:outline-none"
+            className="kali-button px-2 py-1 text-xs"
           >
             {seg.name || '/'}
           </button>

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -29,7 +29,7 @@ const QuickSettings = ({ open }: Props) => {
     >
       <div className="px-4 pb-2">
         <button
-          className="w-full flex justify-between"
+          className="kali-button w-full justify-between"
           onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
         >
           <span>Theme</span>

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -184,7 +184,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
             <span className="max-w-[150px]">{middleEllipsis(t.title)}</span>
             {t.closable !== false && tabs.length > 1 && (
               <button
-                className="p-0.5"
+                className="kali-button h-6 w-6 rounded-full p-0"
                 onClick={(e) => {
                   e.stopPropagation();
                   closeTab(t.id);
@@ -198,7 +198,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
         ))}
         {onNewTab && (
           <button
-            className="px-2 py-1 bg-gray-800 hover:bg-gray-700"
+            className="kali-button px-2 py-1"
             onClick={addTab}
             aria-label="New Tab"
           >

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -38,7 +38,7 @@ const Toast: React.FC<ToastProps> = ({
       {onAction && actionLabel && (
         <button
           onClick={onAction}
-          className="ml-4 underline focus:outline-none"
+          className="kali-button ml-4 px-3 py-1 text-sm"
         >
           {actionLabel}
         </button>

--- a/components/ui/VideoPlayer.tsx
+++ b/components/ui/VideoPlayer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { CSSProperties, useEffect, useRef, useState } from "react";
 import PipPortalProvider, { usePipPortal } from "../common/PipPortal";
 
 interface VideoPlayerProps {
@@ -19,6 +19,11 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
   const [pipSupported, setPipSupported] = useState(false);
   const [docPipSupported, setDocPipSupported] = useState(false);
   const [isPip, setIsPip] = useState(false);
+  const overlayButtonVars: CSSProperties = {
+    "--kali-button-bg": "rgba(10, 16, 23, 0.85)",
+    "--kali-button-border": "rgba(255, 255, 255, 0.2)",
+    "--kali-button-shadow-outer": "none",
+  };
 
   useEffect(() => {
     const video = videoRef.current;
@@ -93,6 +98,12 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
       const [vol, setVol] = useState(initialVolume);
       const send = (msg: any) =>
         window.opener?.postMessage({ source: "doc-pip", ...msg }, "*");
+      const buttonVars: CSSProperties = {
+        "--kali-button-bg": "#10161f",
+        "--kali-button-border": "rgba(255, 255, 255, 0.25)",
+        "--kali-button-shadow-outer": "none",
+      };
+
       return (
         <div
           style={{
@@ -105,9 +116,27 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
             alignItems: "center",
           }}
         >
-          <button onClick={() => send({ type: "toggle" })}>Play/Pause</button>
-          <button onClick={() => send({ type: "seek", delta: -5 })}>-5s</button>
-          <button onClick={() => send({ type: "seek", delta: 5 })}>+5s</button>
+          <button
+            className="kali-button px-2 py-1 text-xs"
+            style={buttonVars}
+            onClick={() => send({ type: "toggle" })}
+          >
+            Play/Pause
+          </button>
+          <button
+            className="kali-button px-2 py-1 text-xs"
+            style={buttonVars}
+            onClick={() => send({ type: "seek", delta: -5 })}
+          >
+            -5s
+          </button>
+          <button
+            className="kali-button px-2 py-1 text-xs"
+            style={buttonVars}
+            onClick={() => send({ type: "seek", delta: 5 })}
+          >
+            +5s
+          </button>
           <input
             type="range"
             min={0}
@@ -134,7 +163,8 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
         <button
           type="button"
           onClick={togglePiP}
-          className="absolute bottom-2 right-2 rounded bg-black bg-opacity-50 px-2 py-1 text-xs text-white"
+          className="kali-button absolute bottom-2 right-2 px-2 py-1 text-xs"
+          style={overlayButtonVars}
         >
           {isPip ? "Exit PiP" : "PiP"}
         </button>
@@ -143,7 +173,8 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
         <button
           type="button"
           onClick={openDocPip}
-          className="absolute bottom-2 right-16 rounded bg-black bg-opacity-50 px-2 py-1 text-xs text-white"
+          className="kali-button absolute bottom-2 right-16 px-2 py-1 text-xs"
+          style={overlayButtonVars}
         >
           Doc-PiP
         </button>

--- a/docs/internal-layouts.md
+++ b/docs/internal-layouts.md
@@ -20,3 +20,27 @@ Offsets are also available through `offset-*` classes.
   <div class="col-4 offset-4">Centered</div>
 </div>
 ```
+
+## Kali button token
+
+Use the global `kali-button` utility for actions that should match Kali's flat control style. It ships with inset highlights,
+rounded corners, and a focus ring derived from the accent color.
+
+```jsx
+<button className="kali-button">Launch</button>
+```
+
+You can override its CSS custom properties for contextual variants:
+
+```jsx
+<button
+  className="kali-button"
+  style={{
+    '--kali-button-bg': 'rgba(10,16,23,0.8)',
+    '--kali-button-border': 'rgba(255,255,255,0.25)',
+    '--kali-button-shadow-outer': 'none',
+  }}
+>
+  Overlay action
+</button>
+```

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,6 +19,14 @@
   --color-focus-ring: var(--color-accent);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
+  --kali-button-bg: #1b2733;
+  --kali-button-bg-hover: #223143;
+  --kali-button-bg-active: #161e2a;
+  --kali-button-text: var(--color-text);
+  --kali-button-border: rgba(255, 255, 255, 0.1);
+  --kali-button-shadow-top: rgba(255, 255, 255, 0.12);
+  --kali-button-shadow-bottom: rgba(0, 0, 0, 0.55);
+  --kali-button-shadow-outer: 0 1px 0 rgba(0, 0, 0, 0.35);
   accent-color: var(--color-control-accent);
 }
 
@@ -35,6 +43,10 @@ html[data-theme='dark'] {
   --color-border: #333333;
   --color-terminal: #00ff00;
   --color-dark: #0a0a0a;
+  --kali-button-bg: #1a1a1a;
+  --kali-button-bg-hover: #1f1f1f;
+  --kali-button-bg-active: #141414;
+  --kali-button-border: rgba(255, 255, 255, 0.14);
 }
 
 /* Neon theme */
@@ -50,6 +62,10 @@ html[data-theme='neon'] {
   --color-border: #333333;
   --color-terminal: #39ff14;
   --color-dark: #000000;
+  --kali-button-bg: #111111;
+  --kali-button-bg-hover: #171717;
+  --kali-button-bg-active: #0a0a0a;
+  --kali-button-border: rgba(255, 255, 255, 0.2);
 }
 
 /* Matrix theme */
@@ -65,6 +81,10 @@ html[data-theme='matrix'] {
   --color-border: #003300;
   --color-terminal: #00ff00;
   --color-dark: #000000;
+  --kali-button-bg: #0d0f0d;
+  --kali-button-bg-hover: #131613;
+  --kali-button-bg-active: #080a08;
+  --kali-button-border: rgba(0, 255, 0, 0.2);
 
 }
 
@@ -76,4 +96,41 @@ html[data-theme='matrix'] {
 *:focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
+}
+
+@layer components {
+  .kali-button {
+    @apply inline-flex items-center justify-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-0;
+    background: var(--kali-button-bg);
+    color: var(--kali-button-text);
+    border-color: var(--kali-button-border);
+    box-shadow: inset 0 1px 0 var(--kali-button-shadow-top),
+      inset 0 -1px 0 var(--kali-button-shadow-bottom),
+      var(--kali-button-shadow-outer);
+  }
+
+  .kali-button:hover {
+    background: var(--kali-button-bg-hover);
+  }
+
+  .kali-button:active {
+    background: var(--kali-button-bg-active);
+    box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.55),
+      inset 0 -1px 0 rgba(255, 255, 255, 0.08),
+      0 0 0 1px rgba(23, 147, 209, 0.45);
+  }
+
+  .kali-button:focus-visible {
+    box-shadow: inset 0 1px 0 var(--kali-button-shadow-top),
+      inset 0 -1px 0 var(--kali-button-shadow-bottom),
+      0 0 0 1px rgba(23, 147, 209, 0.55);
+  }
+
+  .kali-button:disabled,
+  .kali-button[aria-disabled='true'] {
+    cursor: not-allowed;
+    opacity: 0.55;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06),
+      inset 0 -1px 0 rgba(0, 0, 0, 0.45);
+  }
 }


### PR DESCRIPTION
## Summary
- add a global `kali-button` utility with kali-inspired hover, focus, and pressed states
- refactor shared UI buttons (quick settings, breadcrumbs, tabbed window, toast, video controls) and key app surfaces to use the new utility
- document the utility and demonstrate overriding the CSS vars for contextual variants

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window lint errors in legacy apps and public assets)*
- yarn test *(fails/interrupted: numerous pre-existing suite failures and jest watch mode; aborted after reporting failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ca915d736c83289580d49a53810cd9