### PR TITLE
[ui] align interactive states with xfce tokens

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -86,12 +86,16 @@ export class SideBarApp extends Component {
     };
 
     render() {
+        const isActive = this.props.isClose[this.id] === false && this.props.isFocus[this.id];
+        const isRunning = this.props.isClose[this.id] === false;
+
         return (
             <button
                 type="button"
                 aria-label={this.props.title}
                 data-context="app"
                 data-app-id={this.props.id}
+                aria-pressed={isActive}
                 onClick={this.openApp}
                 onMouseEnter={() => {
                     this.captureThumbnail();
@@ -100,8 +104,8 @@ export class SideBarApp extends Component {
                 onMouseLeave={() => {
                     this.setState({ showTitle: false, thumbnail: null });
                 }}
-                className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
-                    " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
+                data-state={isActive ? 'active' : undefined}
+                className="w-auto p-2 relative rounded m-1 interactive-surface"
                 id={"sidebar-" + this.props.id}
             >
                 <Image
@@ -120,13 +124,12 @@ export class SideBarApp extends Component {
                     alt=""
                     sizes="28px"
                 />
-                {
-                    (
-                        this.props.isClose[this.id] === false
-                            ? <div className=" w-2 h-1 absolute bottom-0 left-1/2 transform -translate-x-1/2 bg-white rounded-md"></div>
-                            : null
-                    )
-                }
+                {isRunning && (
+                    <div
+                        className="w-2 h-1 absolute bottom-0 left-1/2 transform -translate-x-1/2 rounded-md"
+                        style={{ backgroundColor: 'var(--color-active)' }}
+                    ></div>
+                )}
                 {this.state.thumbnail && (
                     <div
                         className={

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -42,7 +42,7 @@ export class UbuntuApp extends Component {
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
                 className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                    " p-1 m-px z-10 border border-transparent rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white interactive-surface cursor-pointer "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -110,7 +110,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
             item.onSelect();
             setOpen(false);
           }}
-          className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+          className="context-menu-item mb-1.5"
         >
           {item.label}
         </button>

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -35,7 +35,7 @@ function AppMenu(props) {
                 onClick={handlePin}
                 role="menuitem"
                 aria-label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="context-menu-item mb-1.5"
             >
                 <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
             </button>

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -30,7 +30,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Linkedin"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="context-menu-item mb-1.5"
             >
                 <span className="ml-5">🙋‍♂️</span> <span className="ml-2">Follow on <strong>Linkedin</strong></span>
             </a>
@@ -40,7 +40,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Github"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="context-menu-item mb-1.5"
             >
                 <span className="ml-5">🤝</span> <span className="ml-2">Follow on <strong>Github</strong></span>
             </a>
@@ -50,7 +50,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Contact Me"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="context-menu-item mb-1.5"
             >
                 <span className="ml-5">📥</span> <span className="ml-2">Contact Me</span>
             </a>
@@ -60,7 +60,7 @@ function DefaultMenu(props) {
                 onClick={() => { localStorage.clear(); window.location.reload() }}
                 role="menuitem"
                 aria-label="Reset Kali Linux"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="context-menu-item mb-1.5"
             >
                 <span className="ml-5">🧹</span> <span className="ml-2">Reset Kali Linux</span>
             </button>

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -55,7 +55,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="New Folder"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="context-menu-item mb-1.5"
             >
                 <span className="ml-5">New Folder</span>
             </button>
@@ -64,16 +64,16 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Create Shortcut"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="context-menu-item mb-1.5"
             >
                 <span className="ml-5">Create Shortcut...</span>
             </button>
             <Devider />
-            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="context-menu-item mb-1.5 text-gray-400">
                 <span className="ml-5">Paste</span>
             </div>
             <Devider />
-            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="context-menu-item mb-1.5 text-gray-400">
                 <span className="ml-5">Show Desktop in Files</span>
             </div>
             <button
@@ -81,7 +81,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Open in Terminal"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="context-menu-item mb-1.5"
             >
                 <span className="ml-5">Open in Terminal</span>
             </button>
@@ -91,12 +91,12 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Change Background"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="context-menu-item mb-1.5"
             >
                 <span className="ml-5">Change Background...</span>
             </button>
             <Devider />
-            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="context-menu-item mb-1.5 text-gray-400">
                 <span className="ml-5">Display Settings</span>
             </div>
             <button
@@ -104,7 +104,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Settings"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="context-menu-item mb-1.5"
             >
                 <span className="ml-5">Settings</span>
             </button>
@@ -114,7 +114,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label={isFullScreen ? "Exit Full Screen" : "Enter Full Screen"}
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="context-menu-item mb-1.5"
             >
                 <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
             </button>
@@ -124,7 +124,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Clear Session"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="context-menu-item mb-1.5"
             >
                 <span className="ml-5">Clear Session</span>
             </button>

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -37,7 +37,7 @@ function TaskbarMenu(props) {
                 onClick={handleMinimize}
                 role="menuitem"
                 aria-label={props.minimized ? 'Restore Window' : 'Minimize Window'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="context-menu-item mb-1.5"
             >
                 <span className="ml-5">{props.minimized ? 'Restore' : 'Minimize'}</span>
             </button>
@@ -46,7 +46,7 @@ function TaskbarMenu(props) {
                 onClick={handleClose}
                 role="menuitem"
                 aria-label="Close Window"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="context-menu-item mb-1.5"
             >
                 <span className="ml-5">Close</span>
             </button>

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -17,31 +17,38 @@ export default function Taskbar(props) {
 
     return (
         <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => (
-                <button
-                    key={app.id}
-                    type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
-                    onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
-                    />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
-                </button>
-            ))}
+            {runningApps.map(app => {
+                const isActive = props.focused_windows[app.id] && !props.minimized_windows[app.id];
+                return (
+                    <button
+                        key={app.id}
+                        type="button"
+                        aria-label={app.title}
+                        aria-pressed={isActive}
+                        data-context="taskbar"
+                        data-app-id={app.id}
+                        data-state={isActive ? 'active' : undefined}
+                        onClick={() => handleClick(app)}
+                        className="relative flex items-center mx-1 px-2 py-1 rounded interactive-surface"
+                    >
+                        <Image
+                            width={24}
+                            height={24}
+                            className="w-5 h-5"
+                            src={app.icon.replace('./', '/')}
+                            alt=""
+                            sizes="24px"
+                        />
+                        <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                        {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
+                            <span
+                                className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 rounded"
+                                style={{ backgroundColor: 'var(--color-active)' }}
+                            />
+                        )}
+                    </button>
+                );
+            })}
         </div>
     );
 }

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -4,16 +4,85 @@
 
 @layer utilities {
   .transition-hover {
-    @apply transition ease-out duration-150;
+    transition-property: color, background-color, border-color, box-shadow, transform;
+    transition-duration: var(--motion-fast);
+    transition-timing-function: ease-out;
   }
+
   .transition-active {
-    @apply transition ease-out duration-100;
+    transition-property: color, background-color, border-color, box-shadow, transform;
+    transition-duration: var(--motion-fast);
+    transition-timing-function: ease-out;
+  }
+}
+
+@layer components {
+  .interactive-surface {
+    background-color: transparent;
+    border-color: transparent;
+    color: inherit;
+    outline: none;
+    transition-property: color, background-color, border-color, box-shadow, transform;
+    transition-duration: var(--motion-fast);
+    transition-timing-function: ease-out;
+  }
+
+  .interactive-surface:hover,
+  .interactive-surface:focus-visible {
+    background-color: var(--color-hover);
+  }
+
+  .interactive-surface:active,
+  .interactive-surface[data-state='active'] {
+    background-color: var(--color-active);
+  }
+
+  .interactive-surface:focus-visible {
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline-offset: 2px;
+  }
+
+  .context-menu-item {
+    display: block;
+    width: 100%;
+    padding: 0.375rem 0.75rem;
+    border-radius: var(--radius-sm);
+    text-align: left;
+    cursor: default;
+    color: inherit;
+    transition-property: color, background-color, border-color, box-shadow, transform;
+    transition-duration: var(--motion-fast);
+    transition-timing-function: ease-out;
+  }
+
+  .context-menu-item:hover,
+  .context-menu-item:focus-visible {
+    background-color: var(--color-hover);
+  }
+
+  .context-menu-item:active {
+    background-color: var(--color-active);
+  }
+
+  .context-menu-item:focus-visible {
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline-offset: 1px;
+  }
+
+  .context-menu-item[aria-disabled='true'],
+  .context-menu-item[aria-disabled='true']:hover,
+  .context-menu-item[aria-disabled='true']:focus-visible,
+  .context-menu-item[aria-disabled='true']:active {
+    background-color: transparent;
+    cursor: not-allowed;
+    opacity: 0.6;
+    pointer-events: none;
   }
 }
 
 @layer base {
   button {
-    @apply transition-hover transition-active;
+    @apply transition-hover;
   }
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -26,6 +26,9 @@
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
   --kali-bg: rgba(15, 19, 23, 0.85);
+  /* Interaction surfaces inspired by Xfce Greybird highlight */
+  --color-hover: rgba(82, 148, 226, 0.18);
+  --color-active: rgba(82, 148, 226, 0.32);
 
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
@@ -77,6 +80,8 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --color-hover: rgba(255, 255, 0, 0.5);
+  --color-active: rgba(255, 255, 0, 0.75);
 }
 
 /* Dyslexia-friendly fonts */
@@ -116,5 +121,7 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+    --color-hover: rgba(255, 255, 0, 0.5);
+    --color-active: rgba(255, 255, 0, 0.75);
   }
 }


### PR DESCRIPTION
## Summary
- add XFCE-inspired hover and active tokens plus shared interactive-surface utilities for consistent motion
- apply the shared context menu item styling across desktop context menus
- update the taskbar and dock app surfaces to consume the new tokens and expose their active state

## Testing
- yarn lint *(fails: existing accessibility and browser global lint violations)*
- yarn test *(fails: existing suites that require act wrappers/localStorage mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68ca915c75d48328b1b915160d159cd7