### PR TITLE
[a11y] Improve Kali theme contrast

### DIFF
--- a/apps/resource-monitor/components/NetworkInsights.tsx
+++ b/apps/resource-monitor/components/NetworkInsights.tsx
@@ -32,9 +32,12 @@ export default function NetworkInsights() {
   }, [setHistory]);
 
   return (
-    <div className="p-2 text-xs text-white bg-[var(--kali-bg)]">
+    <div className="p-2 text-xs bg-[var(--kali-bg)] text-[var(--color-terminal-text)]">
       <h2 className="font-bold mb-1">Active Fetches</h2>
-      <ul className="mb-2 divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
+      <ul
+        className="mb-2 divide-y divide-gray-700 border rounded bg-[var(--kali-panel)]"
+        style={{ borderColor: 'var(--color-terminal-border)' }}
+      >
         {active.length === 0 && <li className="p-1 text-gray-400">None</li>}
         {active.map((f) => (
           <li key={f.id} className="p-1">
@@ -52,11 +55,18 @@ export default function NetworkInsights() {
         <button
           onClick={() => exportMetrics(history)}
           className="ml-auto px-2 py-1 rounded bg-[var(--kali-panel)]"
+          style={{
+            border: '1px solid var(--color-terminal-border)',
+            color: 'var(--color-terminal-text)',
+          }}
         >
           Export
         </button>
       </div>
-      <ul className="divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
+      <ul
+        className="divide-y divide-gray-700 border rounded bg-[var(--kali-panel)]"
+        style={{ borderColor: 'var(--color-terminal-border)' }}
+      >
         {history.length === 0 && <li className="p-1 text-gray-400">No requests</li>}
         {history.map((f) => (
           <li key={f.id} className="p-1">

--- a/apps/settings/components/KeymapOverlay.tsx
+++ b/apps/settings/components/KeymapOverlay.tsx
@@ -83,7 +83,7 @@ export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
               <button
                 type="button"
                 onClick={() => setRebinding(s.description)}
-                className="px-2 py-1 bg-ub-orange text-white rounded text-sm"
+                className="px-2 py-1 bg-ub-orange text-black rounded text-sm"
               >
                 {rebinding === s.description ? 'Press keys...' : 'Rebind'}
               </button>

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -202,7 +202,7 @@ export default function Settings() {
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
             <button
               onClick={handleReset}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
+              className="px-4 py-2 rounded bg-ub-orange text-black"
             >
               Reset Desktop
             </button>
@@ -263,7 +263,7 @@ export default function Settings() {
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
             <button
               onClick={() => setShowKeymap(true)}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
+              className="px-4 py-2 rounded bg-ub-orange text-black"
             >
               Edit Shortcuts
             </button>
@@ -275,13 +275,13 @@ export default function Settings() {
           <div className="flex justify-center my-4 space-x-4">
             <button
               onClick={handleExport}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
+              className="px-4 py-2 rounded bg-ub-orange text-black"
             >
               Export Settings
             </button>
             <button
               onClick={() => fileInputRef.current?.click()}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
+              className="px-4 py-2 rounded bg-ub-orange text-black"
             >
               Import Settings
             </button>

--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -9,11 +9,12 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
     <div
       ref={ref}
       data-testid="xterm-container"
-      className={`text-white ${className}`}
+      className={className}
       style={{
         background: 'var(--kali-bg)',
+        color: 'var(--color-terminal-text)',
         backdropFilter: 'blur(4px)',
-        border: '1px solid var(--color-border)',
+        border: '1px solid var(--color-terminal-border)',
         fontFamily: 'monospace',
         fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
         lineHeight: 1.4,

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -29,7 +29,7 @@ export default function Tabs<T extends string>({
           tabIndex={active === t.id ? 0 : -1}
           onClick={() => onChange(t.id)}
           className={`px-4 py-2 focus:outline-none ${
-            active === t.id ? "bg-ub-orange text-white" : "text-ubt-grey"
+            active === t.id ? "bg-ub-orange text-black" : "text-ubt-grey"
           }`}
         >
           {t.label}

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -231,13 +231,13 @@ export function Settings() {
                         a.click();
                         URL.revokeObjectURL(url);
                     }}
-                    className="px-4 py-2 rounded bg-ub-orange text-white"
+                    className="px-4 py-2 rounded bg-ub-orange text-black"
                 >
                     Export Settings
                 </button>
                 <button
                     onClick={() => fileInput.current && fileInput.current.click()}
-                    className="px-4 py-2 rounded bg-ub-orange text-white"
+                    className="px-4 py-2 rounded bg-ub-orange text-black"
                 >
                     Import Settings
                 </button>
@@ -253,7 +253,7 @@ export function Settings() {
                         setHighContrast(defaults.highContrast);
                         setTheme('default');
                     }}
-                    className="px-4 py-2 rounded bg-ub-orange text-white"
+                    className="px-4 py-2 rounded bg-ub-orange text-black"
                 >
                     Reset Desktop
                 </button>

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -15,7 +15,15 @@ export default class Navbar extends Component {
 
 	render() {
 		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                        <div
+                                className="main-navbar-vp absolute top-0 right-0 w-screen border-b shadow-lg flex flex-nowrap justify-between items-center text-sm select-none z-50"
+                                style={{
+                                        backgroundColor: 'var(--color-navbar-bg)',
+                                        color: 'var(--color-navbar-text)',
+                                        borderColor: 'var(--color-navbar-border)',
+                                        backdropFilter: 'blur(6px)',
+                                }}
+                        >
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -35,6 +35,14 @@ html[data-theme='dark'] {
   --color-border: #333333;
   --color-terminal: #00ff00;
   --color-dark: #0a0a0a;
+  --kali-bg: rgba(0, 0, 0, 0.92);
+  --kali-panel: rgba(20, 20, 20, 0.95);
+  --color-terminal-bg: #050505;
+  --color-terminal-text: #f0f0f0;
+  --color-terminal-border: #333333;
+  --color-navbar-bg: #050505;
+  --color-navbar-text: #e5e5e5;
+  --color-navbar-border: #333333;
 }
 
 /* Neon theme */
@@ -50,6 +58,14 @@ html[data-theme='neon'] {
   --color-border: #333333;
   --color-terminal: #39ff14;
   --color-dark: #000000;
+  --kali-bg: rgba(0, 0, 0, 0.92);
+  --kali-panel: rgba(17, 17, 17, 0.95);
+  --color-terminal-bg: #050505;
+  --color-terminal-text: #f8f8ff;
+  --color-terminal-border: #ff00ff;
+  --color-navbar-bg: #111111;
+  --color-navbar-text: #ffffff;
+  --color-navbar-border: #ff00ff;
 }
 
 /* Matrix theme */
@@ -65,6 +81,14 @@ html[data-theme='matrix'] {
   --color-border: #003300;
   --color-terminal: #00ff00;
   --color-dark: #000000;
+  --kali-bg: rgba(0, 17, 0, 0.94);
+  --kali-panel: rgba(0, 17, 0, 0.92);
+  --color-terminal-bg: #000000;
+  --color-terminal-text: #00ff00;
+  --color-terminal-border: #003300;
+  --color-navbar-bg: #001100;
+  --color-navbar-text: #00ff00;
+  --color-navbar-border: #003300;
 
 }
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -158,10 +158,11 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 /* Terminal enhancements */
 .crt-terminal {
-    background: var(--color-inverse);
-    color: var(--color-terminal);
-    text-shadow: 0 0 2px var(--color-terminal);
-    box-shadow: 0 0 10px color-mix(in srgb, var(--color-terminal), transparent 50%);
+    background: var(--color-terminal-bg);
+    color: var(--color-terminal-text);
+    border: 1px solid var(--color-terminal-border);
+    text-shadow: 0 0 2px color-mix(in srgb, var(--color-terminal), transparent 40%);
+    box-shadow: 0 0 10px color-mix(in srgb, var(--color-terminal), transparent 55%);
 }
 
 .crt-terminal .xterm-screen,

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -15,7 +15,7 @@
   --color-ub-gedit-darker: #010D1A;
   --color-ubt-grey: #F6F6F5;
   --color-ubt-warm-grey: #AEA79F;
-  --color-ubt-cool-grey: #333333;
+  --color-ubt-cool-grey: #949ba6;
   --color-ubt-blue: #62A0EA;
   --color-ubt-green: #73D216;
   --color-ubt-gedit-orange: #F39A21;
@@ -25,7 +25,14 @@
   --color-ub-dark-grey: #2a2e36;
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
-  --kali-bg: rgba(15, 19, 23, 0.85);
+  --kali-bg: rgba(11, 18, 26, 0.94);
+  --kali-panel: rgba(18, 27, 38, 0.95);
+  --color-terminal-bg: #0b1624;
+  --color-terminal-text: #f5faff;
+  --color-terminal-border: #1f2f3d;
+  --color-navbar-bg: #0b141d;
+  --color-navbar-text: #f5f7fa;
+  --color-navbar-border: #1c2834;
 
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
@@ -73,6 +80,14 @@
   --color-ub-orange: #ffff00;
   --color-ub-lite-abrgn: #00ffff;
   --color-ub-border-orange: #ffff00;
+  --kali-bg: rgba(0, 0, 0, 0.95);
+  --kali-panel: rgba(0, 0, 0, 0.95);
+  --color-terminal-bg: #000000;
+  --color-terminal-text: #ffffff;
+  --color-terminal-border: #ffffff;
+  --color-navbar-bg: #000000;
+  --color-navbar-text: #ffffff;
+  --color-navbar-border: #ffffff;
   --game-color-secondary: #ffff00;
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
@@ -116,5 +131,13 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+    --kali-bg: rgba(0, 0, 0, 0.95);
+    --kali-panel: rgba(0, 0, 0, 0.95);
+    --color-terminal-bg: #000000;
+    --color-terminal-text: #ffffff;
+    --color-terminal-border: #ffffff;
+    --color-navbar-bg: #000000;
+    --color-navbar-text: #ffffff;
+    --color-navbar-border: #ffffff;
   }
 }


### PR DESCRIPTION
## Summary
- update Kali design tokens to use higher-contrast text colors and introduce variables for navbar and terminal surfaces
- adjust global theme overrides and terminal styling to use the new variables and improve pane legibility
- switch application buttons using the Kali accent color to dark text for WCAG compliance and refresh navbar styles

## Testing
- `yarn lint` *(fails: repository has numerous pre-existing jsx-a11y/control-has-associated-label and other errors)*
- `yarn test` *(fails: existing suites such as nmapNse.test.tsx and other environment-dependent tests do not pass locally)*

------
https://chatgpt.com/codex/tasks/task_e_68ca916407a483289a56d43b880ffa5c