### PR TITLE
[ui] standardize panel spacing tokens

### DIFF
--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -1,9 +1,11 @@
 .windowYBorder {
-  height: calc(100% - 10px);
-  width: calc(100% + 10px);
+  --window-chrome-offset: calc(var(--panel-gap) * 2.5);
+  height: calc(100% - var(--window-chrome-offset));
+  width: calc(100% + var(--window-chrome-offset));
 }
 
 .windowXBorder {
-  height: calc(100% + 10px);
-  width: calc(100% - 10px);
+  --window-chrome-offset: calc(var(--panel-gap) * 2.5);
+  height: calc(100% + var(--window-chrome-offset));
+  width: calc(100% - var(--window-chrome-offset));
 }

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -15,14 +15,14 @@ export default class Navbar extends Component {
 
 	render() {
 		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
+                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50 px-[var(--panel-padding)]">
+                                <div className="pr-[var(--panel-gap)]">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
                                 <WhiskerMenu />
                                 <div
                                         className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                                'px-[calc(var(--panel-gap)*2)] text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
                                         }
                                 >
                                         <Clock />
@@ -35,7 +35,7 @@ export default class Navbar extends Component {
                                                 this.setState({ status_card: !this.state.status_card });
                                         }}
                                         className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
+                                                'relative px-[calc(var(--panel-gap)*3)] outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
                                         }
                                 >
                                         <Status />

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -16,7 +16,7 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40 px-[var(--panel-padding)] gap-[var(--panel-gap)]" role="toolbar">
             {runningApps.map(app => (
                 <button
                     key={app.id}
@@ -25,8 +25,7 @@ export default function Taskbar(props) {
                     data-context="taskbar"
                     data-app-id={app.id}
                     onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                    className={`relative flex items-center px-[calc(var(--panel-gap)*2)] py-1 rounded hover:bg-white hover:bg-opacity-10${props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20' : ''}`}
                 >
                     <Image
                         width={24}
@@ -36,7 +35,7 @@ export default function Taskbar(props) {
                         alt=""
                         sizes="24px"
                     />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                    <span className="ml-[var(--panel-gap)] text-sm text-white whitespace-nowrap">{app.title}</span>
                     {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
                         <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
                     )}

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -40,6 +40,9 @@
   --space-4: 1rem;
   --space-5: 1.5rem;
   --space-6: 2rem;
+  /* Kali panel measurements: 12px outer padding, 4px inter-item gap */
+  --panel-padding: 0.75rem;
+  --panel-gap: 0.25rem;
 
   /* Radius */
   --radius-sm: 2px;
@@ -60,6 +63,19 @@
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;
+}
+
+@media (max-width: 768px) {
+  :root {
+    --panel-padding: 0.625rem;
+  }
+}
+
+@media (max-width: 480px) {
+  :root {
+    --panel-padding: 0.5rem;
+    --panel-gap: 0.1875rem;
+  }
 }
 
 /* High contrast theme */


### PR DESCRIPTION
## Summary
- add reusable panel spacing tokens with responsive tweaks to `styles/tokens.css`
- apply the panel padding and gap tokens to the navbar, taskbar, and window chrome for consistent layout spacing

## Testing
- yarn lint *(fails: repository already reports many `control-has-associated-label` and other lint errors)*
- yarn test *(fails: existing window snapping and Nmap NSE tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ca91645d2c832888c4c5b9fb07e327