### PR TITLE
[ui] align border radius tokens with Kali theme

### DIFF
--- a/apps/calculator/styles.css
+++ b/apps/calculator/styles.css
@@ -11,7 +11,7 @@ body {
 .calculator {
   background: var(--color-surface);
   padding: 1rem;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   box-shadow: 0 2px 10px color-mix(in srgb, var(--color-inverse), transparent 90%);
   width: 100%;
   max-width: 240px;
@@ -25,7 +25,7 @@ body {
   padding: 0.5rem;
   text-align: right;
   font-size: 1.2rem;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   overflow-x: auto;
   width: 100%;
   box-sizing: border-box;
@@ -41,7 +41,7 @@ body {
   padding: 0.5rem;
   border: none;
   background: var(--color-muted);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
 }
 
@@ -68,7 +68,7 @@ body {
   padding: 0.75rem;
   background: var(--color-muted);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   font-size: 1rem;
   cursor: pointer;
   min-height: 48px;

--- a/apps/color_picker/index.css
+++ b/apps/color_picker/index.css
@@ -10,7 +10,7 @@ h1 {
   width: 80px;
   height: 80px;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   transition: transform 0.2s ease;
@@ -28,7 +28,7 @@ h1 {
   width: 40px;
   height: 40px;
   border: 1px solid #ccc;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }

--- a/apps/sticky_notes/styles.css
+++ b/apps/sticky_notes/styles.css
@@ -30,7 +30,7 @@ body {
   overflow: auto;
   box-shadow: 0 4px 6px color-mix(in srgb, var(--color-inverse), transparent 90%),
     0 1px 3px color-mix(in srgb, var(--color-inverse), transparent 92%);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 .note textarea {

--- a/apps/timer_stopwatch/index.css
+++ b/apps/timer_stopwatch/index.css
@@ -34,7 +34,7 @@ li {
   background: #fff;
   margin: 2px 0;
   padding: 5px 10px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   font-family: 'Courier New', monospace;
 }
 .hidden {

--- a/apps/timer_stopwatch/styles.css
+++ b/apps/timer_stopwatch/styles.css
@@ -51,7 +51,7 @@ li {
   background: var(--color-surface);
   margin: 2px 0;
   padding: 5px 10px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   font-family: 'Courier New', monospace;
 }
 

--- a/apps/weather_widget/styles.css
+++ b/apps/weather_widget/styles.css
@@ -10,7 +10,7 @@ body {
 
 .widget-container {
   background: var(--color-surface);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   box-shadow: 0 4px 10px color-mix(in srgb, var(--color-inverse), transparent 90%);
   padding: 20px;
   display: flex;

--- a/styles/index.css
+++ b/styles/index.css
@@ -144,7 +144,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 .windowMainScreen::-webkit-scrollbar-thumb {
     background-color: var(--color-border);
-    border-radius: 5px;
+    border-radius: var(--radius-sm);
 }
 
 /* SideBarApp Scale image onClick */
@@ -268,7 +268,7 @@ dialog {
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: 0.25rem;
+    border-radius: var(--radius-sm);
 }
 
 .card-front {
@@ -315,7 +315,7 @@ dialog {
 .chip {
     width: 2.5rem;
     height: 2.5rem;
-    border-radius: 9999px;
+    border-radius: var(--radius-round);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -42,9 +42,9 @@
   --space-6: 2rem;
 
   /* Radius */
-  --radius-sm: 2px;
-  --radius-md: 4px;
-  --radius-lg: 8px;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
   --radius-round: 9999px;
 
   /* Motion durations */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -37,6 +37,17 @@ module.exports = {
         'ub-border-orange': 'var(--color-ub-border-orange)',
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
       },
+      borderRadius: {
+        none: '0px',
+        sm: 'var(--radius-sm)',
+        DEFAULT: 'var(--radius-md)',
+        md: 'var(--radius-md)',
+        lg: 'var(--radius-lg)',
+        xl: 'calc(var(--radius-lg) + 4px)',
+        '2xl': 'calc(var(--radius-lg) + 8px)',
+        '3xl': 'calc(var(--radius-lg) + 12px)',
+        full: 'var(--radius-round)',
+      },
       fontFamily: {
         ubuntu: ['Ubuntu', 'sans-serif'],
       },


### PR DESCRIPTION
## Summary
- tune the shared border radius tokens to the Kali XFCE curvature scale
- wire Tailwind rounded utilities to the tokens so windows follow the shared values
- replace hard-coded radii in legacy CSS with the shared tokens for consistency

## Testing
- yarn lint *(fails: existing unlabeled control and top-level window/document lint violations)*
- yarn test *(fails: existing nmap NSE and localStorage dependent suites)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9164e6208328bf241493e0843172