### PR TITLE
[desktop] Add drag animations and drop highlights

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -31,6 +31,13 @@ export class UbuntuApp extends Component {
     }
 
     render() {
+        const classes = [
+            this.state.launching ? 'app-icon-launch' : '',
+            'drag-animate',
+            this.state.dragging ? 'drag-animate--active opacity-70' : '',
+            'p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active',
+        ].filter(Boolean).join(' ');
+
         return (
             <div
                 role="button"
@@ -38,11 +45,11 @@ export class UbuntuApp extends Component {
                 aria-disabled={this.props.disabled}
                 data-context="app"
                 data-app-id={this.props.id}
+                data-desktop-draggable="true"
                 draggable
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
-                className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                className={classes}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}

--- a/styles/index.css
+++ b/styles/index.css
@@ -178,6 +178,33 @@ dialog {
     flex-direction: column;
 }
 
+.drag-animate {
+    cursor: grab;
+    transition: transform 150ms ease, box-shadow 150ms ease, filter 150ms ease;
+    will-change: transform, box-shadow;
+}
+
+.drag-animate--active {
+    cursor: grabbing;
+    transform: translate3d(0, -4px, 0) scale(1.05);
+    box-shadow: 0 18px 32px rgba(0, 0, 0, 0.45);
+    filter: brightness(1.05);
+}
+
+.drop-target {
+    transition: box-shadow 150ms ease, background-color 150ms ease;
+}
+
+.drop-target-ready {
+    background-color: color-mix(in srgb, var(--color-primary), transparent 92%);
+}
+
+.drop-target--active {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary), transparent 45%),
+        0 12px 24px rgba(23, 147, 209, 0.25);
+    background-color: color-mix(in srgb, var(--color-primary), transparent 85%);
+}
+
 /* High contrast handling for precipitation text */
 .precip-text {
     color: var(--color-primary);
@@ -200,6 +227,15 @@ dialog {
 @media (prefers-reduced-motion: reduce) {
     .xterm .xterm-cursor {
         animation: none;
+    }
+
+    .drag-animate {
+        transition: none;
+    }
+
+    .drag-animate--active {
+        transform: none;
+        box-shadow: none;
     }
 }
 


### PR DESCRIPTION
## Summary
- add shared drag animation and drop target styling
- animate desktop launcher icons and highlight the desktop surface while dragging
- improve file explorer drag feedback and directory drop target handling

## Testing
- yarn lint *(fails: repository has pre-existing accessibility and lint errors)*
- yarn test *(fails: existing test failures and watch-mode warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ca91775e208328a97a4668f4ea477f