### PR TITLE
[system] Add templated screenshot naming controls

### DIFF
--- a/docs/workflows/screenshots.md
+++ b/docs/workflows/screenshots.md
@@ -1,0 +1,77 @@
+# Screenshot capture workflow
+
+This guide explains how screenshot naming works across the desktop simulation and how teams can customise file names with templates.
+
+## Overview
+
+Screenshots can be captured from any app window or the entire desktop. The capture pipeline lives in `modules/system/screenshotter.ts` and uses [`html2canvas`](https://www.npmjs.com/package/html2canvas) to render DOM nodes into images. After the capture completes the module generates a filename from the active template, sanitises it for all supported file systems, and downloads the image to the user.
+
+Templates are persisted client-side using the `screenshot-template` key in `localStorage`. The Settings app exposes a dedicated screen at `/apps/settings/screenshots` so every teammate can review and adjust the naming convention without touching code.
+
+## Template syntax
+
+Filenames are rendered from the template string stored in `localStorage`. Templates support a small set of variables that are replaced at capture time:
+
+| Token | Description | Example |
+| --- | --- | --- |
+| `{date}` | Local date in `YYYY-MM-DD` format. | `2024-03-08` |
+| `{time}` | Local time in `HH-mm-ss` format. Colons are replaced to stay cross-platform friendly. | `14-37-52` |
+| `{app}` | Name or identifier of the app that initiated the capture. | `terminal` |
+| `{window}` | Active window title or document name. Falls back to `{app}` when missing. | `Session-root` |
+| `{monitor}` | Label or index of the display being captured. | `Display-1` |
+
+Unknown tokens are left verbatim so authors can introduce static text such as prefixes (`audit-{date}`).
+
+## Sanitising rules
+
+Filename safety is handled in `utils/capture/screenshotNames.ts` by the `formatScreenshotName` helper.
+
+* Illegal characters for Windows, macOS and Linux (e.g. `<`, `>`, `:`, `/`, `\\`, `?`, `*`) are replaced with hyphens.
+* Control characters and trailing dots/spaces are stripped.
+* Repeated separators collapse into a single `-`.
+* Reserved DOS names (`CON`, `PRN`, `AUX`, `NUL`, `COM*`, `LPT*`) gain a `-file` suffix so they remain valid on Windows.
+* Non-empty output is limited to 180 characters before the extension to leave room for suffixes.
+
+The Settings UI shows a live preview of the next filename and flags any invalid characters that will be substituted automatically. This keeps users aware of sanitising behaviour while avoiding disruptive validation errors.
+
+## Working with the template UI
+
+1. Open the Settings application and navigate to **Screenshot naming** (`/apps/settings/screenshots`).
+2. Enter or edit the template in the **Filename template** field. The preview updates immediately using mock data (app `Terminal`, window `root@demo:~`, monitor `Display-1`).
+3. Use the **Insert token** controls next to each available variable to append the token to the template without memorising syntax.
+4. If you want to restore defaults, select **Reset to default**. This resets the template to `{app}-{date}-{time}` and updates local storage.
+
+All changes persist automatically. The next capture will consume the stored template without further configuration.
+
+## Using the capture helper
+
+To capture a DOM element and download it with the templated filename:
+
+```ts
+import captureScreenshot from '@/modules/system/screenshotter';
+
+await captureScreenshot({
+  target: document.getElementById('window-terminal'),
+  context: {
+    app: 'terminal',
+    windowTitle: 'root@demo:~',
+    monitor: 'Display-1',
+  },
+  format: 'png',
+});
+```
+
+* `target` accepts either a DOM node or a selector. If omitted, the entire document is captured.
+* `context` fills the template variables. Any omitted values use safe defaults.
+* `format` supports `png` (default) or `jpeg`.
+* Set `download: false` when you only need the `Blob` payload and will handle the download manually.
+
+The helper returns an object containing the `filename` and `blob`, making it easy to feed captures into custom storage flows.
+
+## Troubleshooting
+
+* **Invalid characters warning** – The Settings UI highlights characters that will be swapped during sanitisation. You can keep them (the capture succeeds) or remove them if you want a cleaner template.
+* **Blank captures** – Ensure the target element exists and is visible. `captureScreenshot` throws an error if it cannot resolve the selector.
+* **Transparent backgrounds** – Pass `backgroundColor: null` so `html2canvas` preserves transparency rather than painting the default dark backdrop.
+
+With templates in place teams can enforce consistent filenames across labs, demos, and documentation without relying on manual renaming.

--- a/modules/system/screenshotter.ts
+++ b/modules/system/screenshotter.ts
@@ -1,0 +1,137 @@
+'use client';
+
+import type { Options as Html2CanvasOptions } from 'html2canvas';
+
+import {
+  ScreenshotTemplateContext,
+  formatScreenshotName,
+  readStoredTemplate,
+} from '@/utils/capture/screenshotNames';
+
+export type ScreenshotImageFormat = 'png' | 'jpeg';
+
+export interface ScreenshotCaptureOptions {
+  /** Element or selector to capture. Defaults to document.documentElement. */
+  target?: HTMLElement | string;
+  /** Override the stored filename template. */
+  template?: string;
+  /** Context applied to template variables. */
+  context?: ScreenshotTemplateContext;
+  /** Image output format. Defaults to png. */
+  format?: ScreenshotImageFormat;
+  /** Quality value forwarded to canvas.toBlob when format is jpeg. */
+  quality?: number;
+  /** html2canvas background colour. Pass null to keep transparency. */
+  backgroundColor?: string | null;
+  /** Optional scale override for html2canvas. */
+  scale?: number;
+  /** Skip the automatic download when false. */
+  download?: boolean;
+  /** Additional html2canvas overrides. */
+  canvasOptions?: Partial<Html2CanvasOptions>;
+}
+
+export interface ScreenshotCaptureResult {
+  filename: string;
+  blob: Blob;
+}
+
+const formatToMime = (format: ScreenshotImageFormat) =>
+  format === 'jpeg' ? 'image/jpeg' : 'image/png';
+
+const formatToExtension = (format: ScreenshotImageFormat) =>
+  (format === 'jpeg' ? 'jpg' : 'png');
+
+const getDocument = (): Document | undefined => {
+  if (typeof globalThis === 'undefined') return undefined;
+  return (globalThis as { document?: Document }).document;
+};
+
+const getDevicePixelRatio = () => {
+  if (typeof globalThis === 'undefined') return 1;
+  const candidate = globalThis as { devicePixelRatio?: number };
+  return candidate.devicePixelRatio ?? 1;
+};
+
+const canvasToBlob = (
+  canvas: HTMLCanvasElement,
+  format: ScreenshotImageFormat,
+  quality?: number,
+) =>
+  new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error('Failed to create screenshot blob.'));
+          return;
+        }
+        resolve(blob);
+      },
+      formatToMime(format),
+      quality,
+    );
+  });
+
+const resolveTarget = (
+  target: HTMLElement | string | null | undefined,
+  doc: Document,
+) => {
+  if (!target) return doc.documentElement;
+  if (typeof target === 'string') {
+    return doc.querySelector(target) as HTMLElement | null;
+  }
+  return target;
+};
+
+export const captureScreenshot = async (
+  options: ScreenshotCaptureOptions = {},
+): Promise<ScreenshotCaptureResult> => {
+  const doc = getDocument();
+  if (!doc) {
+    throw new Error('captureScreenshot can only run in a browser context.');
+  }
+
+  const element = resolveTarget(options.target, doc);
+  if (!element) {
+    throw new Error('Unable to resolve a capture target element.');
+  }
+
+  const { default: html2canvas } = await import('html2canvas');
+
+  const format = options.format ?? 'png';
+  const now = options.context?.now ?? new Date();
+  const context: ScreenshotTemplateContext = { ...options.context, now };
+  const template = options.template ?? readStoredTemplate();
+
+  const canvas = await html2canvas(element, {
+    backgroundColor:
+      options.backgroundColor === undefined
+        ? '#0B0B0B'
+        : options.backgroundColor,
+    useCORS: true,
+    logging: false,
+    scale: options.scale ?? getDevicePixelRatio(),
+    ...options.canvasOptions,
+  });
+
+  const blob = await canvasToBlob(canvas, format, options.quality);
+  const filename = formatScreenshotName(
+    template,
+    context,
+    formatToExtension(format),
+  );
+
+  if (options.download ?? true) {
+    const url = URL.createObjectURL(blob);
+    const anchor = doc.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.rel = 'noopener';
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return { blob, filename };
+};
+
+export default captureScreenshot;

--- a/pages/apps/settings/screenshots.tsx
+++ b/pages/apps/settings/screenshots.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useMemo, type ChangeEvent } from 'react';
+
+import usePersistentState from '@/hooks/usePersistentState';
+import {
+  DEFAULT_SCREENSHOT_TEMPLATE,
+  SCREENSHOT_TEMPLATE_STORAGE_KEY,
+  TEMPLATE_VARIABLES,
+  describeInvalidCharacter,
+  findInvalidTemplateCharacters,
+  formatScreenshotName,
+  type ScreenshotTemplateContext,
+} from '@/utils/capture/screenshotNames';
+
+const PREVIEW_CONTEXT: ScreenshotTemplateContext = {
+  app: 'Terminal',
+  windowTitle: 'root@demo:~',
+  monitor: 'Display-1',
+};
+
+export default function ScreenshotSettingsPage() {
+  const [template, setTemplate, resetTemplate] = usePersistentState<string>(
+    SCREENSHOT_TEMPLATE_STORAGE_KEY,
+    () => DEFAULT_SCREENSHOT_TEMPLATE,
+    (value): value is string => typeof value === 'string',
+  );
+
+  const invalidCharacters = useMemo(
+    () => findInvalidTemplateCharacters(template),
+    [template],
+  );
+
+  const invalidMessage = useMemo(() => {
+    if (invalidCharacters.length === 0) return '';
+    const parts = invalidCharacters.map((char) => describeInvalidCharacter(char));
+    return `Invalid filename characters will be replaced automatically: ${parts.join(', ')}`;
+  }, [invalidCharacters]);
+
+  const preview = useMemo(
+    () =>
+      formatScreenshotName(
+        template,
+        {
+          ...PREVIEW_CONTEXT,
+          now: new Date(),
+        },
+        'png',
+      ),
+    [template],
+  );
+
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setTemplate(event.target.value);
+  };
+
+  const warningId = invalidCharacters.length > 0 ? 'screenshot-template-warning' : undefined;
+
+  return (
+    <main className="min-h-screen bg-ub-cool-grey text-ubt-grey">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-6 py-10">
+        <header className="space-y-2">
+          <h1 className="text-2xl font-semibold text-white">Screenshot naming</h1>
+          <p className="max-w-2xl text-sm text-ubt-grey">
+            Control how filenames are generated when you capture windows or entire displays.
+            Templates support dynamic variables so teams can keep captures organised automatically.
+          </p>
+        </header>
+
+        <section className="space-y-4 rounded-lg border border-gray-800 bg-black/30 p-6">
+          <div className="flex flex-col gap-2">
+            <label htmlFor="screenshot-template" className="text-sm font-medium text-white">
+              Filename template
+            </label>
+            <input
+              id="screenshot-template"
+              type="text"
+              value={template}
+              onChange={onChange}
+              aria-invalid={invalidCharacters.length > 0}
+              aria-describedby={warningId}
+              className="w-full rounded border border-gray-700 bg-black/40 px-3 py-2 text-white focus:border-ubt-cool-grey focus:outline-none focus:ring-2 focus:ring-ub-orange"
+              placeholder="{app}-{date}-{time}"
+              autoComplete="off"
+            />
+            <div className="flex flex-wrap gap-2 text-xs">
+              <button
+                type="button"
+                onClick={() => resetTemplate()}
+                className="rounded border border-gray-700 px-2 py-1 text-ubt-grey transition hover:border-ub-orange hover:text-white"
+              >
+                Reset to default
+              </button>
+            </div>
+            {warningId && (
+              <p id={warningId} className="text-xs text-amber-300">
+                {invalidMessage}
+              </p>
+            )}
+          </div>
+
+          <div className="rounded-md bg-black/60 p-4 text-sm">
+            <p className="mb-2 text-ubt-grey">Next filename preview</p>
+            <code className="block break-words rounded bg-black/40 px-3 py-2 text-emerald-300">
+              {preview}
+            </code>
+            <p className="mt-2 text-xs text-ubt-grey">
+              Preview shows how the next PNG capture will be named. Screenshot downloads automatically apply the same sanitising rules across Windows, macOS and Linux.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-3 rounded-lg border border-gray-800 bg-black/20 p-6">
+          <h2 className="text-lg font-semibold text-white">Available template variables</h2>
+          <p className="text-sm text-ubt-grey">
+            Insert these tokens into the template field above. They will be replaced with contextual data right before a screenshot is saved.
+          </p>
+          <ul className="space-y-3">
+            {TEMPLATE_VARIABLES.map((variable) => (
+              <li key={variable.token} className="flex flex-col gap-1 rounded border border-gray-800 bg-black/30 p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <code className="rounded bg-black/50 px-2 py-1 text-sm text-ub-orange">
+                    {`{${variable.token}}`}
+                  </code>
+                  <span className="text-xs uppercase tracking-wide text-ubt-grey">{variable.label}</span>
+                </div>
+                <p className="text-sm text-ubt-grey">{variable.description}</p>
+                <p className="text-xs text-ubt-grey">
+                  Example:&nbsp;
+                  <code className="rounded bg-black/40 px-2 py-0.5 text-emerald-300">{variable.example}</code>
+                </p>
+                <div className="pt-1 text-right">
+                  <button
+                    type="button"
+                    onClick={() => setTemplate((value) => `${value}{${variable.token}}`)}
+                    className="text-xs font-medium text-ub-orange transition hover:text-white"
+                  >
+                    Insert token
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/utils/capture/screenshotNames.ts
+++ b/utils/capture/screenshotNames.ts
@@ -1,0 +1,221 @@
+export type ScreenshotTemplateToken =
+  | 'date'
+  | 'time'
+  | 'app'
+  | 'window'
+  | 'monitor';
+
+export interface ScreenshotTemplateVariable {
+  token: ScreenshotTemplateToken;
+  label: string;
+  description: string;
+  example: string;
+}
+
+export interface ScreenshotTemplateContext {
+  /** Optional override for the current time */
+  now?: Date;
+  /** Application name owning the captured window */
+  app?: string;
+  /** Window title or label */
+  windowTitle?: string;
+  /** Monitor label or index */
+  monitor?: string;
+}
+
+export const SCREENSHOT_TEMPLATE_STORAGE_KEY = 'screenshot-template';
+
+export const DEFAULT_SCREENSHOT_TEMPLATE = '{app}-{date}-{time}';
+const DEFAULT_BASENAME = 'screenshot';
+
+const RESERVED_WINDOWS_NAMES = new Set([
+  'CON',
+  'PRN',
+  'AUX',
+  'NUL',
+  'COM1',
+  'COM2',
+  'COM3',
+  'COM4',
+  'COM5',
+  'COM6',
+  'COM7',
+  'COM8',
+  'COM9',
+  'LPT1',
+  'LPT2',
+  'LPT3',
+  'LPT4',
+  'LPT5',
+  'LPT6',
+  'LPT7',
+  'LPT8',
+  'LPT9',
+]);
+
+const INVALID_FILENAME_CHARS = /[<>:"/\\|?*\u0000-\u001F]/g;
+const CONTROL_CHARS = /[\u0000-\u001F\u007F]/g;
+
+const collapseWhitespace = (value: string) => value.replace(/\s+/g, ' ').trim();
+
+const sanitizeSegment = (value: string) =>
+  collapseWhitespace(value)
+    .replace(INVALID_FILENAME_CHARS, '-')
+    .replace(CONTROL_CHARS, '-')
+    .replace(/\.+/g, '.')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-.]+/, '')
+    .replace(/[-.]+$/, '');
+
+const sanitizeBasename = (value: string) => {
+  const cleaned = sanitizeSegment(value);
+  if (!cleaned) return DEFAULT_BASENAME;
+  const upper = cleaned.toUpperCase();
+  if (RESERVED_WINDOWS_NAMES.has(upper)) {
+    return `${cleaned}-file`;
+  }
+  return cleaned.slice(0, 180);
+};
+
+const formatDate = (now: Date) => {
+  const year = now.getFullYear();
+  const month = `${now.getMonth() + 1}`.padStart(2, '0');
+  const day = `${now.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const formatTime = (now: Date) => {
+  const hours = `${now.getHours()}`.padStart(2, '0');
+  const minutes = `${now.getMinutes()}`.padStart(2, '0');
+  const seconds = `${now.getSeconds()}`.padStart(2, '0');
+  return `${hours}-${minutes}-${seconds}`;
+};
+
+export const TEMPLATE_VARIABLES: ScreenshotTemplateVariable[] = [
+  {
+    token: 'date',
+    label: 'Date',
+    description: 'Current date formatted as YYYY-MM-DD.',
+    example: '2024-03-08',
+  },
+  {
+    token: 'time',
+    label: 'Time',
+    description: 'Current time formatted as HH-mm-ss.',
+    example: '14-37-52',
+  },
+  {
+    token: 'app',
+    label: 'App name',
+    description: 'Application identifier or friendly title.',
+    example: 'terminal',
+  },
+  {
+    token: 'window',
+    label: 'Window title',
+    description: 'Active window title or document name.',
+    example: 'Session-root',
+  },
+  {
+    token: 'monitor',
+    label: 'Monitor label',
+    description: 'Display label or index when capturing multiple screens.',
+    example: 'Display-1',
+  },
+];
+
+const resolveWindowTitle = (context: ScreenshotTemplateContext) => {
+  if (context.windowTitle && context.windowTitle.trim()) {
+    return context.windowTitle;
+  }
+  const alias = (context as Record<string, unknown>)['window'];
+  if (typeof alias === 'string' && alias.trim()) {
+    return alias;
+  }
+  return context.app || 'window';
+};
+
+const TOKEN_RESOLVERS: Record<
+  ScreenshotTemplateToken,
+  (context: ScreenshotTemplateContext, now: Date) => string
+> = {
+  date: (_, now) => formatDate(now),
+  time: (_, now) => formatTime(now),
+  app: (context) => context.app || 'desktop',
+  ['window']: (context) => resolveWindowTitle(context),
+  monitor: (context) => context.monitor || 'screen',
+};
+
+const TOKEN_PATTERN = /\{(date|time|app|window|monitor)\}/gi;
+
+export const findInvalidTemplateCharacters = (template: string): string[] => {
+  const matches = template.match(INVALID_FILENAME_CHARS) || [];
+  const uniques = new Set(matches);
+  return Array.from(uniques);
+};
+
+const getLocalStorage = (): Storage | undefined => {
+  if (typeof globalThis === 'undefined') return undefined;
+  const candidate = globalThis as { localStorage?: Storage };
+  return candidate.localStorage;
+};
+
+export const describeInvalidCharacter = (char: string) => {
+  switch (char) {
+    case '\n':
+      return 'line break (\\n)';
+    case '\r':
+      return 'carriage return (\\r)';
+    case '\t':
+      return 'tab (\\t)';
+    default:
+      if (char.trim() === '') {
+        const code = char.codePointAt(0);
+        return code ? `U+${code.toString(16).toUpperCase().padStart(4, '0')}` : 'whitespace';
+      }
+      return char;
+  }
+};
+
+export const ensureTemplate = (template?: string | null) =>
+  template && template.trim() ? template : DEFAULT_SCREENSHOT_TEMPLATE;
+
+export const readStoredTemplate = () => {
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SCREENSHOT_TEMPLATE;
+  const stored = storage.getItem(SCREENSHOT_TEMPLATE_STORAGE_KEY);
+  if (!stored) return DEFAULT_SCREENSHOT_TEMPLATE;
+  try {
+    const parsed = JSON.parse(stored);
+    if (typeof parsed === 'string' && parsed.trim()) {
+      return parsed;
+    }
+  } catch {
+    // ignore parse errors and use default
+  }
+  return DEFAULT_SCREENSHOT_TEMPLATE;
+};
+
+export const formatScreenshotName = (
+  templateInput: string,
+  context: ScreenshotTemplateContext = {},
+  extension?: string,
+) => {
+  const now = context.now ?? new Date();
+  const template = ensureTemplate(templateInput);
+
+  const resolved = template.replace(TOKEN_PATTERN, (match) => {
+    const key = match.slice(1, -1).toLowerCase() as ScreenshotTemplateToken;
+    const raw = TOKEN_RESOLVERS[key](context, now);
+    return sanitizeSegment(raw);
+  });
+
+  const basename = sanitizeBasename(resolved);
+  if (!extension) return basename;
+  const normalizedExt = extension.startsWith('.')
+    ? extension.slice(1)
+    : extension;
+  return `${basename}.${sanitizeSegment(normalizedExt) || 'png'}`;
+};
+


### PR DESCRIPTION
## Summary
- add a capture naming utility that exposes template variables and sanitises filenames
- introduce a screenshot naming screen in Settings with live preview and invalid character guidance
- apply templated filenames inside the screenshotter module and document the workflow for teams

## Testing
- yarn lint *(fails: existing repository lint violations outside the touched files)*
- yarn test *(fails: existing jsdom localStorage errors in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68cb468c7c6483288db52188226c7cc9