### PR TITLE
feat: add disk analyzer app

### DIFF
--- a/__tests__/utils/export.test.ts
+++ b/__tests__/utils/export.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from '@jest/globals';
+import { DiskNode } from '@/types/disk';
+import { buildDiskUsageRows, exportDiskUsage, formatBytes, toCSV } from '@/utils/export';
+
+const sampleTree: DiskNode = {
+  id: '/',
+  name: 'root',
+  path: [],
+  parentId: null,
+  type: 'directory',
+  size: 3000,
+  fileCount: 2,
+  dirCount: 1,
+  children: [
+    {
+      id: '/docs',
+      name: 'docs',
+      path: ['docs'],
+      parentId: '/',
+      type: 'directory',
+      size: 2000,
+      fileCount: 1,
+      dirCount: 0,
+      children: [
+        {
+          id: '/docs/readme.md',
+          name: 'readme.md',
+          path: ['docs', 'readme.md'],
+          parentId: '/docs',
+          type: 'file',
+          size: 2000,
+          fileCount: 1,
+          dirCount: 0,
+        },
+      ],
+    },
+    {
+      id: '/todo.txt',
+      name: 'todo.txt',
+      path: ['todo.txt'],
+      parentId: '/',
+      type: 'file',
+      size: 1000,
+      fileCount: 1,
+      dirCount: 0,
+    },
+  ],
+};
+
+describe('formatBytes', () => {
+  it('formats byte values using binary units', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(1024 ** 2 * 1.5, 2)).toBe('1.50 MB');
+    expect(formatBytes(-1536)).toBe('-1.5 KB');
+  });
+});
+
+describe('toCSV', () => {
+  it('escapes delimiters and quotes', () => {
+    const csv = toCSV(
+      [
+        { path: '/docs', name: 'Docs, Reports', note: 'He said "hello"' },
+      ],
+      [
+        { key: 'path', label: 'Path' },
+        { key: 'name', label: 'Name' },
+        { key: 'note', label: 'Note' },
+      ],
+    );
+    expect(csv).toBe('Path,Name,Note\r\n/docs,"Docs, Reports","He said ""hello"""');
+  });
+});
+
+describe('buildDiskUsageRows', () => {
+  it('flattens the tree with cumulative metrics', () => {
+    const rows = buildDiskUsageRows(sampleTree);
+    expect(rows).toHaveLength(4);
+    const docs = rows.find((row) => row.path === '/docs');
+    expect(docs?.size).toBe(2000);
+    expect(docs?.percent).toBeCloseTo((2000 / 3000) * 100, 5);
+    const rootRow = rows.find((row) => row.path === '/');
+    expect(rootRow?.size).toBe(3000);
+  });
+});
+
+describe('exportDiskUsage', () => {
+  it('returns a BOM-prefixed CSV string without triggering download', () => {
+    const csv = exportDiskUsage(sampleTree, { download: false, filename: 'test.csv' });
+    expect(csv.startsWith('\ufeff')).toBe(true);
+    expect(csv).toContain('Size (bytes)');
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -10,6 +10,7 @@ import { displayWeather } from './components/apps/weather';
 import { displayClipboardManager } from './components/apps/ClipboardManager';
 import { displayFiglet } from './components/apps/figlet';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
+import { displayDiskAnalyzer } from './components/apps/disk-analyzer';
 import { displayScreenRecorder } from './components/apps/screen-recorder';
 import { displayNikto } from './components/apps/nikto';
 
@@ -709,6 +710,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayResourceMonitor,
+  },
+  {
+    id: 'disk-analyzer',
+    title: 'Disk Analyzer',
+    icon: '/themes/Yaru/apps/disk-analyzer.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayDiskAnalyzer,
   },
   {
     id: 'screen-recorder',

--- a/apps/disk-analyzer/index.tsx
+++ b/apps/disk-analyzer/index.tsx
@@ -1,0 +1,708 @@
+'use client';
+
+import React, {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import AutoSizer from 'react-virtualized-auto-sizer';
+import { List, ListChildComponentProps } from 'react-window';
+import {
+  DiskNode,
+  DiskScanProgress,
+  DiskScanRequestMessage,
+  DiskScanResponseMessage,
+} from '@/types/disk';
+import { exportDiskUsage, formatBytes } from '@/utils/export';
+import { isBrowser } from '@/utils/isBrowser';
+import {
+  buildArcPath,
+  colorForNode,
+  computeSunburst,
+  computeTreemap,
+  TreemapRect,
+  SunburstArc,
+} from './layout';
+import { sampleDiskData } from './sampleData';
+
+interface VirtualListData {
+  items: DiskNode[];
+  parentSize: number;
+  onSelect: (node: DiskNode) => void;
+  onDrill: (node: DiskNode) => void;
+  selectedId: string | null;
+}
+
+const mergeNodes = (base: DiskNode, incoming: DiskNode): DiskNode => {
+  if (base.id === incoming.id) {
+    return incoming;
+  }
+  if (!base.children || base.children.length === 0) {
+    return base;
+  }
+  let changed = false;
+  const children = base.children.map((child) => {
+    if (child.id === incoming.id || incoming.id.startsWith(`${child.id}/`)) {
+      const merged = mergeNodes(child, incoming);
+      if (merged !== child) changed = true;
+      return merged;
+    }
+    return child;
+  });
+  return changed ? { ...base, children } : base;
+};
+
+const formatPercent = (value: number) => `${value.toFixed(2)}%`;
+
+const TreemapView: React.FC<{
+  root: DiskNode;
+  highlightId: string | null;
+  onSelect: (node: DiskNode) => void;
+  onHover: (node: DiskNode | null) => void;
+}> = ({ root, highlightId, onSelect, onHover }) => (
+  <AutoSizer>
+    {({ width, height }) => {
+      if (!width || !height) {
+        return <div className="flex h-full items-center justify-center text-sm text-gray-300">No data</div>;
+      }
+      return (
+        <TreemapCanvas
+          width={width}
+          height={height}
+          root={root}
+          highlightId={highlightId}
+          onSelect={onSelect}
+          onHover={onHover}
+        />
+      );
+    }}
+  </AutoSizer>
+);
+
+const TreemapCanvas: React.FC<{
+  width: number;
+  height: number;
+  root: DiskNode;
+  highlightId: string | null;
+  onSelect: (node: DiskNode) => void;
+  onHover: (node: DiskNode | null) => void;
+}> = ({ width, height, root, highlightId, onSelect, onHover }) => {
+  const rects = useMemo<TreemapRect[]>(() => computeTreemap(root, width, height), [root, width, height]);
+
+  if (!rects.length) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-gray-300">
+        Not enough data to build a treemap yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-full w-full overflow-hidden rounded-md bg-black/30">
+      {rects.map((rect) => {
+        if (rect.width < 8 || rect.height < 8) return null;
+        const area = rect.width * rect.height;
+        const isHighlighted = rect.node.id === highlightId;
+        const color = colorForNode(rect.node, rect.depth);
+        const showLabel = area > 2800;
+        const percent = root.size > 0 ? (rect.node.size / root.size) * 100 : 0;
+        return (
+          <button
+            key={`${rect.node.id}-${rect.depth}`}
+            type="button"
+            style={{
+              left: rect.x,
+              top: rect.y,
+              width: rect.width,
+              height: rect.height,
+            }}
+            className={`absolute overflow-hidden rounded-sm border border-white/10 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange ${
+              isHighlighted ? 'ring-2 ring-ub-orange' : 'hover:border-white/30'
+            }`}
+            onClick={() => onSelect(rect.node)}
+            onMouseEnter={() => onHover(rect.node)}
+            onMouseLeave={() => onHover(null)}
+            title={`${rect.node.name}\n${formatBytes(rect.node.size)} · ${formatPercent(percent)}`}
+          >
+            <div
+              className="h-full w-full"
+              style={{
+                background: color,
+                mixBlendMode: 'screen',
+              }}
+            />
+            {showLabel && (
+              <div className="pointer-events-none absolute inset-0 flex flex-col justify-between p-1 text-[11px] text-black/80">
+                <span className="truncate font-semibold drop-shadow">{rect.node.name}</span>
+                <span className="text-[10px] font-medium drop-shadow">
+                  {formatBytes(rect.node.size)} · {formatPercent(percent)}
+                </span>
+              </div>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+const SunburstView: React.FC<{
+  root: DiskNode;
+  highlightId: string | null;
+  onSelect: (node: DiskNode) => void;
+  onHover: (node: DiskNode | null) => void;
+}> = ({ root, highlightId, onSelect, onHover }) => (
+  <AutoSizer>
+    {({ width, height }) => {
+      if (!width || !height) {
+        return <div className="flex h-full items-center justify-center text-sm text-gray-300">No data</div>;
+      }
+      const size = Math.min(width, height);
+      return (
+        <SunburstCanvas
+          width={width}
+          height={height}
+          radius={size / 2 - 8}
+          root={root}
+          highlightId={highlightId}
+          onSelect={onSelect}
+          onHover={onHover}
+        />
+      );
+    }}
+  </AutoSizer>
+);
+
+const SunburstCanvas: React.FC<{
+  width: number;
+  height: number;
+  radius: number;
+  root: DiskNode;
+  highlightId: string | null;
+  onSelect: (node: DiskNode) => void;
+  onHover: (node: DiskNode | null) => void;
+}> = ({ width, height, radius, root, highlightId, onSelect, onHover }) => {
+  const arcs = useMemo<SunburstArc[]>(() => computeSunburst(root, Math.max(0, radius), 6), [root, radius]);
+
+  if (!arcs.length) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-gray-300">
+        Not enough data to build a sunburst yet.
+      </div>
+    );
+  }
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`${-width / 2} ${-height / 2} ${width} ${height}`}
+      role="presentation"
+      className="rounded-md bg-black/30"
+    >
+      {arcs.map((arc) => {
+        const path = buildArcPath(arc.innerRadius, arc.outerRadius, arc.startAngle, arc.endAngle);
+        const percent = root.size > 0 ? (arc.node.size / root.size) * 100 : 0;
+        const highlighted = arc.node.id === highlightId;
+        return (
+          <path
+            key={`${arc.node.id}-${arc.depth}`}
+            d={path}
+            fill={colorForNode(arc.node, arc.depth)}
+            stroke="rgba(255,255,255,0.15)"
+            strokeWidth={highlighted ? 2 : 1}
+            className="cursor-pointer transition focus:outline-none"
+            onClick={() => onSelect(arc.node)}
+            onMouseEnter={() => onHover(arc.node)}
+            onMouseLeave={() => onHover(null)}
+            aria-label={`${arc.node.name} ${formatBytes(arc.node.size)} (${formatPercent(percent)})`}
+          >
+            <title>
+              {arc.node.name} · {formatBytes(arc.node.size)} · {formatPercent(percent)}
+            </title>
+          </path>
+        );
+      })}
+    </svg>
+  );
+};
+
+const Row: React.FC<ListChildComponentProps<VirtualListData>> = ({ index, style, data }) => {
+  const item = data.items[index];
+  if (!item) return null;
+  const percent = data.parentSize > 0 ? (item.size / data.parentSize) * 100 : 0;
+  const isSelected = data.selectedId === item.id;
+  return (
+    <div
+      style={style}
+      className={`flex items-center justify-between gap-2 px-3 text-sm ${
+        isSelected ? 'bg-ub-orange/20 text-white' : 'text-gray-100'
+      }`}
+    >
+      <button
+        type="button"
+        onClick={() => data.onSelect(item)}
+        className="flex flex-1 flex-col items-start truncate focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange"
+      >
+        <span className="truncate font-medium">{item.name}</span>
+        <span className="text-xs text-gray-300">
+          {formatBytes(item.size)} · {formatPercent(percent)}
+        </span>
+      </button>
+      {item.type === 'directory' && (
+        <button
+          type="button"
+          onClick={() => data.onDrill(item)}
+          className="rounded border border-white/20 px-2 py-1 text-xs text-white transition hover:border-white/40 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange"
+        >
+          Open
+        </button>
+      )}
+    </div>
+  );
+};
+
+const buildNodeIndex = (root: DiskNode): Map<string, DiskNode> => {
+  const map = new Map<string, DiskNode>();
+  const traverse = (node: DiskNode) => {
+    map.set(node.id, node);
+    node.children?.forEach(traverse);
+  };
+  traverse(root);
+  return map;
+};
+
+const cloneSample = (node: DiskNode): DiskNode => {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(node) as DiskNode;
+  }
+  return JSON.parse(JSON.stringify(node)) as DiskNode;
+};
+
+const DiskAnalyzerApp: React.FC = () => {
+  const workerRef = useRef<Worker | null>(null);
+  const [root, setRoot] = useState<DiskNode | null>(null);
+  const [status, setStatus] = useState<'idle' | 'scanning' | 'ready' | 'error'>('idle');
+  const [progress, setProgress] = useState<DiskScanProgress | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [nodeIndex, setNodeIndex] = useState<Map<string, DiskNode>>(new Map());
+  const [currentPath, setCurrentPath] = useState<string | null>(null);
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [hoveredNode, setHoveredNode] = useState<DiskNode | null>(null);
+
+  const terminateWorker = useCallback(() => {
+    workerRef.current?.terminate();
+    workerRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    if (!isBrowser || typeof Worker === 'undefined') return terminateWorker;
+    const worker = new Worker(new URL('../../workers/diskScan.ts', import.meta.url), {
+      type: 'module',
+    });
+    workerRef.current = worker;
+    worker.onmessage = (event: MessageEvent<DiskScanResponseMessage>) => {
+      const { data } = event;
+      if (!data) return;
+      if (data.type === 'progress') {
+        setProgress(data.progress);
+      } else if (data.type === 'chunk') {
+        setRoot((prev) => {
+          if (!prev) {
+            return data.node.parentId ? prev : data.node;
+          }
+          return mergeNodes(prev, data.node);
+        });
+      } else if (data.type === 'complete') {
+        setProgress(data.progress);
+        setRoot(data.root);
+        setStatus('ready');
+        setError(null);
+      } else if (data.type === 'error') {
+        setStatus('error');
+        setError(data.error);
+      } else if (data.type === 'cancelled') {
+        setStatus('idle');
+      }
+    };
+    return terminateWorker;
+  }, [terminateWorker]);
+
+  useEffect(() => {
+    if (!root) {
+      setNodeIndex(new Map());
+      setCurrentPath(null);
+      setSelectedPath(null);
+      return;
+    }
+    const map = buildNodeIndex(root);
+    setNodeIndex(map);
+    setCurrentPath((prev) => (prev && map.has(prev) ? prev : root.id));
+    setSelectedPath((prev) => (prev && map.has(prev) ? prev : root.id));
+  }, [root]);
+
+  const currentNode = useMemo(() => {
+    if (!currentPath) return root ?? null;
+    return nodeIndex.get(currentPath) ?? null;
+  }, [currentPath, nodeIndex, root]);
+
+  const selectedNode = useMemo(() => {
+    if (selectedPath) return nodeIndex.get(selectedPath) ?? null;
+    return currentNode;
+  }, [selectedPath, nodeIndex, currentNode]);
+
+  const focusNode = hoveredNode ?? selectedNode ?? currentNode ?? root;
+
+  const handleSelect = useCallback((node: DiskNode) => {
+    setSelectedPath(node.id);
+    if (node.type === 'directory') {
+      setCurrentPath(node.id);
+    }
+  }, []);
+
+  const handleDrill = useCallback((node: DiskNode) => {
+    if (node.type !== 'directory') return;
+    setCurrentPath(node.id);
+    setSelectedPath(node.id);
+  }, []);
+
+  const handleBreadcrumb = useCallback((id: string) => {
+    setCurrentPath(id);
+    setSelectedPath(id);
+  }, []);
+
+  const handleExport = useCallback(() => {
+    if (!root) return;
+    exportDiskUsage(root, {
+      filename: `disk-usage-${new Date().toISOString()}.csv`,
+      download: true,
+    });
+  }, [root]);
+
+  const handleLoadSample = useCallback(() => {
+    const clone = cloneSample(sampleDiskData);
+    setRoot(clone);
+    setStatus('ready');
+    setProgress(null);
+    setError(null);
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    workerRef.current?.postMessage({ type: 'cancel' } satisfies DiskScanRequestMessage);
+    setStatus('idle');
+  }, []);
+
+  const handleScan = useCallback(async () => {
+    if (!isBrowser) {
+      setError('Disk scanning is only available in the browser.');
+      setStatus('error');
+      return;
+    }
+    const picker = (
+      window as typeof window & {
+        showDirectoryPicker?: () => Promise<FileSystemDirectoryHandle>;
+      }
+    ).showDirectoryPicker;
+    if (!picker) {
+      setError('Your browser does not support the File System Access API.');
+      setStatus('error');
+      return;
+    }
+    try {
+      const handle = await picker();
+      if (!handle) return;
+      if (!workerRef.current) {
+        setError('Scanning worker is not available.');
+        return;
+      }
+      setRoot(null);
+      setStatus('scanning');
+      setError(null);
+      setProgress(null);
+      setSelectedPath(null);
+      setCurrentPath(null);
+      const message: DiskScanRequestMessage = {
+        type: 'start',
+        handle,
+        options: {
+          chunkSize: 64,
+        },
+      };
+      workerRef.current.postMessage(message);
+    } catch (err) {
+      if ((err as Error)?.name === 'AbortError') {
+        return;
+      }
+      console.error('Failed to open directory', err);
+      setError('Unable to access the selected directory.');
+      setStatus('error');
+    }
+  }, []);
+
+  const breadcrumbs = useMemo(() => {
+    if (!currentNode || !nodeIndex.size) return [] as { id: string; label: string }[];
+    const crumbs: { id: string; label: string }[] = [];
+    let node: DiskNode | undefined | null = currentNode;
+    while (node) {
+      crumbs.unshift({ id: node.id, label: node.path.length === 0 ? node.name : node.name });
+      node = node.parentId ? nodeIndex.get(node.parentId) ?? null : null;
+    }
+    if (!crumbs.length && root) {
+      crumbs.push({ id: root.id, label: root.name });
+    }
+    return crumbs;
+  }, [currentNode, nodeIndex, root]);
+
+  const listItems = useMemo(() => currentNode?.children ?? [], [currentNode]);
+  const listHeight = Math.max(200, Math.min(360, listItems.length * 48 || 200));
+
+  const listData = useMemo<VirtualListData>(
+    () => ({
+      items: listItems,
+      parentSize: currentNode?.size ?? 0,
+      onSelect: handleSelect,
+      onDrill: handleDrill,
+      selectedId: selectedNode?.id ?? null,
+    }),
+    [listItems, currentNode?.size, handleSelect, handleDrill, selectedNode?.id],
+  );
+
+  const progressDuration = progress ? (progress.updatedAt - progress.startedAt) / 1000 : 0;
+  const throughput = progressDuration > 0 ? formatBytes(progress.bytes / progressDuration) : '0 B';
+  const highlightId = focusNode?.id ?? null;
+
+  const topConsumers = useMemo(() => {
+    if (!root?.children?.length) return [] as DiskNode[];
+    return [...root.children].sort((a, b) => b.size - a.size).slice(0, 5);
+  }, [root]);
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden bg-ub-cool-grey text-white">
+      <header className="border-b border-black/40 bg-black/30 p-4">
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h1 className="text-lg font-semibold">Disk Analyzer</h1>
+            <p className="text-sm text-gray-300">
+              Visualise disk usage with treemap and sunburst layouts, then drill into large folders.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={handleScan}
+              className="rounded bg-ub-orange px-4 py-2 text-sm font-semibold text-black transition hover:bg-ub-orange/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange"
+            >
+              Scan directory
+            </button>
+            <button
+              type="button"
+              onClick={handleLoadSample}
+              className="rounded border border-white/30 px-4 py-2 text-sm text-white transition hover:border-white/60 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange"
+            >
+              Load sample data
+            </button>
+            <button
+              type="button"
+              onClick={handleExport}
+              disabled={!root}
+              className="rounded border border-white/30 px-4 py-2 text-sm text-white transition hover:border-white/60 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange disabled:cursor-not-allowed disabled:border-white/10 disabled:text-gray-400"
+            >
+              Export CSV
+            </button>
+            {status === 'scanning' && (
+              <button
+                type="button"
+                onClick={handleCancel}
+                className="rounded border border-red-400 px-4 py-2 text-sm text-red-200 transition hover:bg-red-500/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-300"
+              >
+                Cancel scan
+              </button>
+            )}
+          </div>
+        </div>
+        {error && <p className="mt-3 text-sm text-red-300">{error}</p>}
+        {progress && (
+          <div className="mt-4 grid gap-3 text-xs text-gray-200 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="rounded bg-black/30 p-3">
+              <p className="text-[11px] uppercase tracking-wide text-gray-400">Files scanned</p>
+              <p className="text-base font-semibold">{progress.files.toLocaleString()}</p>
+            </div>
+            <div className="rounded bg-black/30 p-3">
+              <p className="text-[11px] uppercase tracking-wide text-gray-400">Folders traversed</p>
+              <p className="text-base font-semibold">{progress.directories.toLocaleString()}</p>
+            </div>
+            <div className="rounded bg-black/30 p-3">
+              <p className="text-[11px] uppercase tracking-wide text-gray-400">Bytes measured</p>
+              <p className="text-base font-semibold">{formatBytes(progress.bytes)}</p>
+            </div>
+            <div className="rounded bg-black/30 p-3">
+              <p className="text-[11px] uppercase tracking-wide text-gray-400">Throughput</p>
+              <p className="text-base font-semibold">{throughput}/s</p>
+            </div>
+          </div>
+        )}
+      </header>
+
+      <main className="flex flex-1 flex-col gap-4 overflow-auto p-4 lg:flex-row">
+        <div className="flex flex-1 flex-col gap-4">
+          <section className="flex min-h-[260px] flex-1 flex-col gap-2 rounded-lg bg-black/20 p-3" onMouseLeave={() => setHoveredNode(null)}>
+            <div className="flex items-center justify-between text-sm font-semibold">
+              <span>Treemap</span>
+              <span className="text-xs font-normal text-gray-300">Click on a block to explore a folder</span>
+            </div>
+            <div className="relative flex-1">
+              {currentNode ? (
+                <TreemapView
+                  root={currentNode}
+                  highlightId={highlightId}
+                  onSelect={handleSelect}
+                  onHover={setHoveredNode}
+                />
+              ) : (
+                <div className="flex h-full items-center justify-center text-sm text-gray-300">
+                  Start a scan or load the sample dataset.
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section className="flex min-h-[260px] flex-1 flex-col gap-2 rounded-lg bg-black/20 p-3" onMouseLeave={() => setHoveredNode(null)}>
+            <div className="flex items-center justify-between text-sm font-semibold">
+              <span>Sunburst</span>
+              <span className="text-xs font-normal text-gray-300">Hover to inspect usage, click to focus</span>
+            </div>
+            <div className="relative flex-1">
+              {currentNode ? (
+                <SunburstView
+                  root={currentNode}
+                  highlightId={highlightId}
+                  onSelect={handleSelect}
+                  onHover={setHoveredNode}
+                />
+              ) : (
+                <div className="flex h-full items-center justify-center text-sm text-gray-300">
+                  Start a scan or load the sample dataset.
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section className="flex flex-col gap-3 rounded-lg bg-black/20 p-3">
+            <div className="flex items-center justify-between">
+              <h2 className="text-sm font-semibold">Directory contents</h2>
+              {currentNode?.parentId && (
+                <button
+                  type="button"
+                  onClick={() => handleBreadcrumb(currentNode.parentId!)}
+                  className="rounded border border-white/20 px-2 py-1 text-xs text-white transition hover:border-white/40 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange"
+                >
+                  Go up
+                </button>
+              )}
+            </div>
+            <div className="flex flex-wrap items-center gap-1 text-xs text-gray-300">
+              {breadcrumbs.length ? (
+                breadcrumbs.map((crumb, idx) => (
+                  <Fragment key={crumb.id}>
+                    {idx > 0 && <span>/</span>}
+                    <button
+                      type="button"
+                      onClick={() => handleBreadcrumb(crumb.id)}
+                      className={`rounded px-1 py-0.5 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange ${
+                        currentPath === crumb.id ? 'bg-ub-orange text-black' : 'hover:bg-white/10'
+                      }`}
+                    >
+                      {crumb.label}
+                    </button>
+                  </Fragment>
+                ))
+              ) : (
+                <span>/</span>
+              )}
+            </div>
+            <div className="rounded-md border border-white/10 bg-black/30">
+              {listItems.length ? (
+                <List
+                  height={listHeight}
+                  itemCount={listItems.length}
+                  itemSize={48}
+                  width="100%"
+                  itemData={listData}
+                >
+                  {Row}
+                </List>
+              ) : (
+                <div className="flex h-40 items-center justify-center text-sm text-gray-300">
+                  No files in this folder.
+                </div>
+              )}
+            </div>
+          </section>
+        </div>
+
+        <aside className="flex w-full flex-shrink-0 flex-col gap-4 lg:w-80">
+          <section className="rounded-lg bg-black/20 p-4">
+            <h2 className="text-sm font-semibold">Selection details</h2>
+            {focusNode ? (
+              <dl className="mt-3 space-y-2 text-xs text-gray-200">
+                <div>
+                  <dt className="text-gray-400">Name</dt>
+                  <dd className="font-semibold text-white">{focusNode.name}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-400">Path</dt>
+                  <dd className="break-all text-white/90">{focusNode.id}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-400">Size</dt>
+                  <dd className="text-white">
+                    {formatBytes(focusNode.size)} ({formatPercent(root?.size ? (focusNode.size / root.size) * 100 : 0)})
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-gray-400">Contains</dt>
+                  <dd className="text-white">
+                    {focusNode.fileCount.toLocaleString()} files · {focusNode.dirCount.toLocaleString()} directories
+                  </dd>
+                </div>
+                {focusNode.modified && (
+                  <div>
+                    <dt className="text-gray-400">Last modified</dt>
+                    <dd className="text-white">{new Date(focusNode.modified).toLocaleString()}</dd>
+                  </div>
+                )}
+              </dl>
+            ) : (
+              <p className="mt-2 text-sm text-gray-300">Select a file or folder to inspect details.</p>
+            )}
+          </section>
+
+          {topConsumers.length > 0 && (
+            <section className="rounded-lg bg-black/20 p-4">
+              <h2 className="text-sm font-semibold">Largest items</h2>
+              <ul className="mt-3 space-y-2 text-xs text-gray-200">
+                {topConsumers.map((node) => (
+                  <li key={node.id} className="flex items-center justify-between gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleSelect(node)}
+                      className="truncate text-left text-white hover:underline"
+                    >
+                      {node.name}
+                    </button>
+                    <span className="text-gray-300">{formatBytes(node.size)}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </aside>
+      </main>
+    </div>
+  );
+};
+
+export default DiskAnalyzerApp;

--- a/apps/disk-analyzer/layout.ts
+++ b/apps/disk-analyzer/layout.ts
@@ -1,0 +1,185 @@
+import { DiskNode, pathToId } from '@/types/disk';
+
+export interface TreemapRect {
+  node: DiskNode;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  depth: number;
+}
+
+export interface SunburstArc {
+  node: DiskNode;
+  startAngle: number;
+  endAngle: number;
+  innerRadius: number;
+  outerRadius: number;
+  depth: number;
+}
+
+const hashString = (input: string): number => {
+  let hash = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash * 31 + input.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+};
+
+export const colorForNode = (node: DiskNode, depth: number): string => {
+  const base = hashString(node.id || pathToId(node.path));
+  const hue = base % 360;
+  const lightness = Math.max(28, 68 - depth * 8);
+  return `hsl(${hue}, 62%, ${lightness}%)`;
+};
+
+const collectChildren = (node: DiskNode): DiskNode[] =>
+  (node.children ?? []).filter((child) => child.size > 0);
+
+export const computeTreemap = (
+  root: DiskNode,
+  width: number,
+  height: number,
+  maxDepth = 4,
+): TreemapRect[] => {
+  const rects: TreemapRect[] = [];
+  if (width <= 0 || height <= 0) return rects;
+
+  const traverse = (
+    node: DiskNode,
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+    depth: number,
+    horizontal: boolean,
+  ) => {
+    const children = collectChildren(node);
+    const total = children.reduce((sum, child) => sum + child.size, 0);
+    if (!children.length || depth >= maxDepth) {
+      return;
+    }
+
+    let offset = 0;
+    children.forEach((child) => {
+      if (child.size <= 0 || total <= 0) return;
+      const ratio = child.size / total;
+      const childWidth = horizontal ? w * ratio : w;
+      const childHeight = horizontal ? h : h * ratio;
+      const childX = horizontal ? x + offset : x;
+      const childY = horizontal ? y : y + offset;
+      rects.push({
+        node: child,
+        x: childX,
+        y: childY,
+        width: childWidth,
+        height: childHeight,
+        depth: depth + 1,
+      });
+      if ((child.children?.length ?? 0) > 0 && depth + 1 < maxDepth) {
+        traverse(child, childX, childY, childWidth, childHeight, depth + 1, !horizontal);
+      }
+      offset += horizontal ? childWidth : childHeight;
+    });
+  };
+
+  traverse(root, 0, 0, width, height, 0, width >= height);
+  return rects;
+};
+
+export const getMaxDepth = (node: DiskNode): number => {
+  if (!node.children || node.children.length === 0) {
+    return 1;
+  }
+  return (
+    1 +
+    node.children.reduce((max, child) => {
+      const depth = getMaxDepth(child);
+      return depth > max ? depth : max;
+    }, 0)
+  );
+};
+
+export const computeSunburst = (
+  root: DiskNode,
+  radius: number,
+  maxDepth = getMaxDepth(root),
+): SunburstArc[] => {
+  const arcs: SunburstArc[] = [];
+  if (radius <= 0) return arcs;
+  const depthLimit = Math.max(1, maxDepth);
+  const ring = radius / depthLimit;
+
+  const traverse = (
+    node: DiskNode,
+    startAngle: number,
+    endAngle: number,
+    depth: number,
+  ) => {
+    const span = endAngle - startAngle;
+    if (span <= 0) return;
+    const inner = ring * depth;
+    const outer = ring * (depth + 1);
+    arcs.push({
+      node,
+      startAngle,
+      endAngle,
+      innerRadius: inner,
+      outerRadius: outer,
+      depth,
+    });
+
+    if (depth + 1 >= depthLimit) return;
+
+    const children = collectChildren(node);
+    if (!children.length) return;
+    const total = children.reduce((sum, child) => sum + child.size, 0);
+    if (total <= 0) return;
+    let current = startAngle;
+    children.forEach((child) => {
+      const ratio = child.size / total;
+      if (ratio <= 0) return;
+      const childSpan = span * ratio;
+      const next = current + childSpan;
+      traverse(child, current, next, depth + 1);
+      current = next;
+    });
+  };
+
+  traverse(root, 0, Math.PI * 2, 0);
+  return arcs.filter((arc) => arc.endAngle - arc.startAngle > 0);
+};
+
+export const polarToCartesian = (radius: number, angle: number) => {
+  const adjusted = angle - Math.PI / 2;
+  return {
+    x: Math.cos(adjusted) * radius,
+    y: Math.sin(adjusted) * radius,
+  };
+};
+
+export const buildArcPath = (
+  innerRadius: number,
+  outerRadius: number,
+  startAngle: number,
+  endAngle: number,
+): string => {
+  const startOuter = polarToCartesian(outerRadius, startAngle);
+  const endOuter = polarToCartesian(outerRadius, endAngle);
+  const startInner = polarToCartesian(innerRadius, endAngle);
+  const endInner = polarToCartesian(innerRadius, startAngle);
+  const largeArc = endAngle - startAngle > Math.PI ? 1 : 0;
+
+  const path = [
+    `M ${startOuter.x} ${startOuter.y}`,
+    `A ${outerRadius} ${outerRadius} 0 ${largeArc} 1 ${endOuter.x} ${endOuter.y}`,
+    `L ${startInner.x} ${startInner.y}`,
+  ];
+
+  if (innerRadius > 0) {
+    path.push(`A ${innerRadius} ${innerRadius} 0 ${largeArc} 0 ${endInner.x} ${endInner.y}`);
+  }
+  path.push('Z');
+
+  return path.join(' ');
+};

--- a/apps/disk-analyzer/sampleData.ts
+++ b/apps/disk-analyzer/sampleData.ts
@@ -1,0 +1,136 @@
+import { DiskNode, DiskEntryKind, pathToId } from '@/types/disk';
+
+interface RawNode {
+  name: string;
+  type: DiskEntryKind;
+  size?: number;
+  modified?: number;
+  children?: RawNode[];
+}
+
+const now = Date.now();
+
+const rawSample: RawNode = {
+  name: 'Sample Disk',
+  type: 'directory',
+  children: [
+    {
+      name: 'Home',
+      type: 'directory',
+      children: [
+        {
+          name: 'Pictures',
+          type: 'directory',
+          children: [
+            { name: 'vacation.jpg', type: 'file', size: 18_728_448, modified: now - 1000 * 60 * 60 * 24 * 8 },
+            { name: 'wallpaper.png', type: 'file', size: 6_553_600, modified: now - 1000 * 60 * 60 * 24 * 30 },
+            { name: 'family.png', type: 'file', size: 12_582_912, modified: now - 1000 * 60 * 60 * 24 * 12 },
+          ],
+        },
+        {
+          name: 'Documents',
+          type: 'directory',
+          children: [
+            { name: 'resume.pdf', type: 'file', size: 327_680, modified: now - 1000 * 60 * 60 * 24 * 2 },
+            { name: 'project-proposal.docx', type: 'file', size: 1_572_864, modified: now - 1000 * 60 * 60 * 24 * 20 },
+            { name: 'budget.xlsx', type: 'file', size: 2_416_640, modified: now - 1000 * 60 * 60 * 24 * 40 },
+          ],
+        },
+        {
+          name: 'Archive',
+          type: 'directory',
+          children: [
+            { name: 'logs-2022.zip', type: 'file', size: 54_231_808, modified: now - 1000 * 60 * 60 * 24 * 200 },
+            { name: 'training.tar', type: 'file', size: 102_760_448, modified: now - 1000 * 60 * 60 * 24 * 160 },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'Projects',
+      type: 'directory',
+      children: [
+        {
+          name: 'kali-portfolio',
+          type: 'directory',
+          children: [
+            { name: 'node_modules', type: 'directory', children: [] },
+            { name: 'dist', type: 'directory', children: [] },
+            { name: 'README.md', type: 'file', size: 15_360, modified: now - 1000 * 60 * 60 * 6 },
+            { name: 'package.json', type: 'file', size: 4_096, modified: now - 1000 * 60 * 60 * 6 },
+            { name: 'yarn.lock', type: 'file', size: 1_572_864, modified: now - 1000 * 60 * 60 * 6 },
+          ],
+        },
+        {
+          name: 'threat-model',
+          type: 'directory',
+          children: [
+            { name: 'diagram.drawio', type: 'file', size: 4_743_168, modified: now - 1000 * 60 * 60 * 24 * 15 },
+            { name: 'notes.md', type: 'file', size: 86_016, modified: now - 1000 * 60 * 60 * 24 * 11 },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'Media',
+      type: 'directory',
+      children: [
+        { name: 'podcast.mp3', type: 'file', size: 87_312_384, modified: now - 1000 * 60 * 60 * 24 * 5 },
+        { name: 'conference.mp4', type: 'file', size: 452_984_832, modified: now - 1000 * 60 * 60 * 24 * 45 },
+        { name: 'camera-roll.mov', type: 'file', size: 1_024_000_000, modified: now - 1000 * 60 * 60 * 24 * 90 },
+      ],
+    },
+    {
+      name: 'Backups',
+      type: 'directory',
+      children: [
+        { name: 'full-backup-2023.img', type: 'file', size: 1_500_000_000, modified: now - 1000 * 60 * 60 * 24 * 180 },
+        { name: 'incremental-2024-01.img', type: 'file', size: 740_000_000, modified: now - 1000 * 60 * 60 * 24 * 120 },
+      ],
+    },
+    { name: 'system.log', type: 'file', size: 42_000_000, modified: now - 1000 * 60 * 60 * 24 },
+    { name: 'package-cache.tar', type: 'file', size: 280_000_000, modified: now - 1000 * 60 * 60 * 24 * 32 },
+  ],
+};
+
+const buildNode = (raw: RawNode, path: string[]): DiskNode => {
+  const parentId = path.length ? pathToId(path.slice(0, -1)) : null;
+  if (raw.type === 'file') {
+    return {
+      id: pathToId(path),
+      name: raw.name,
+      path,
+      parentId,
+      type: 'file',
+      size: raw.size ?? 0,
+      fileCount: 1,
+      dirCount: 0,
+      modified: raw.modified,
+    };
+  }
+
+  const children = (raw.children ?? []).map((child) => buildNode(child, [...path, child.name]));
+  const size = children.reduce((sum, child) => sum + child.size, 0);
+  const fileCount = children.reduce((sum, child) => sum + child.fileCount, 0);
+  const dirCount = children.reduce(
+    (sum, child) => sum + (child.type === 'directory' ? 1 + child.dirCount : child.dirCount),
+    0,
+  );
+  const latestChild = Math.max(0, ...children.map((child) => child.modified ?? 0));
+  const modified = raw.modified ?? (latestChild > 0 ? latestChild : undefined);
+
+  return {
+    id: pathToId(path),
+    name: raw.name,
+    path,
+    parentId,
+    type: 'directory',
+    size,
+    fileCount,
+    dirCount,
+    children,
+    modified,
+  };
+};
+
+export const sampleDiskData: DiskNode = buildNode(rawSample, []);

--- a/components/apps/disk-analyzer.tsx
+++ b/components/apps/disk-analyzer.tsx
@@ -1,0 +1,14 @@
+import dynamic from 'next/dynamic';
+
+const DiskAnalyzerApp = dynamic(() => import('../../apps/disk-analyzer'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-full w-full items-center justify-center bg-ub-cool-grey text-white">
+      Loading Disk Analyzer...
+    </div>
+  ),
+});
+
+export default DiskAnalyzerApp;
+
+export const displayDiskAnalyzer = () => <DiskAnalyzerApp />;

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -61,6 +61,12 @@ Tools to cover: **BeEF, Ettercap, Metasploit, Wireshark, Kismet, Nikto, Autopsy,
 - Display `performance.memory` data and FPS from `performance.now()` deltas.
 - Show CPU synthetic load graph using `requestAnimationFrame` buckets.
 
+### Disk Analyzer
+- Use a treemap to surface the largest directories. The block area represents total size; hover to read percent of the scanned volume.
+- Pair the treemap with a sunburst chart so analysts can track depth—each ring represents a deeper folder level.
+- Allow breadcrumb drill-down so the table view always reflects the focused branch and highlights the heaviest offenders first.
+- CSV exports should include absolute sizes, human-readable strings, file/folder counts, and relative percentages for offline reporting.
+
 ### Project Gallery
 - Load projects from `projects.json`; add filters and buttons for repo and live demo.
 

--- a/pages/apps/disk-analyzer.tsx
+++ b/pages/apps/disk-analyzer.tsx
@@ -1,0 +1,15 @@
+import dynamic from 'next/dynamic';
+
+const DiskAnalyzerPage = dynamic(
+  () =>
+    import('../../apps/disk-analyzer').catch((err) => {
+      console.error('Failed to load Disk Analyzer app', err);
+      throw err;
+    }),
+  {
+    ssr: false,
+    loading: () => <p>Loading Disk Analyzer...</p>,
+  },
+);
+
+export default DiskAnalyzerPage;

--- a/public/themes/Yaru/apps/disk-analyzer.svg
+++ b/public/themes/Yaru/apps/disk-analyzer.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="title">
+  <title>Disk Analyzer</title>
+  <defs>
+    <linearGradient id="treemap" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f9a825" />
+      <stop offset="100%" stop-color="#f57c00" />
+    </linearGradient>
+    <linearGradient id="sunburst" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#42a5f5" />
+      <stop offset="100%" stop-color="#1e88e5" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="84" height="84" rx="18" fill="#1c1f2b" />
+  <g transform="translate(16 16)">
+    <rect x="0" y="0" width="36" height="36" fill="#263238" rx="6" />
+    <rect x="0" y="0" width="20" height="18" fill="url(#treemap)" rx="4" />
+    <rect x="22" y="0" width="14" height="10" fill="#ffb300" rx="3" />
+    <rect x="22" y="12" width="14" height="22" fill="#ffca28" rx="3" />
+    <rect x="0" y="20" width="20" height="16" fill="#ff6f00" rx="4" />
+  </g>
+  <g transform="translate(52 28)">
+    <circle cx="20" cy="20" r="20" fill="#0d47a1" />
+    <path d="M20 0A20 20 0 0 1 34.142 5.858L20 20Z" fill="#90caf9" />
+    <path d="M34.142 5.858A20 20 0 0 1 38 20H20Z" fill="#64b5f6" />
+    <path d="M38 20A20 20 0 0 1 24 38L20 20Z" fill="#1e88e5" />
+    <path d="M24 38A20 20 0 0 1 20 40V20Z" fill="#0d47a1" />
+    <circle cx="20" cy="20" r="7" fill="url(#sunburst)" />
+  </g>
+  <rect x="22" y="64" width="52" height="12" rx="6" fill="#263238" />
+  <rect x="22" y="64" width="28" height="12" rx="6" fill="#66bb6a" />
+  <circle cx="24" cy="24" r="4" fill="#ffeb3b" />
+  <circle cx="30" cy="24" r="4" fill="#29b6f6" />
+  <circle cx="36" cy="24" r="4" fill="#ab47bc" />
+</svg>

--- a/types/disk.ts
+++ b/types/disk.ts
@@ -1,0 +1,53 @@
+export type DiskEntryKind = 'file' | 'directory';
+
+export interface DiskNode {
+  id: string;
+  name: string;
+  path: string[];
+  parentId: string | null;
+  type: DiskEntryKind;
+  size: number;
+  children?: DiskNode[];
+  fileCount: number;
+  dirCount: number;
+  modified?: number;
+}
+
+export interface DiskScanOptions {
+  maxDepth?: number;
+  followSymlinks?: boolean;
+  chunkSize?: number;
+}
+
+export interface DiskScanProgress {
+  files: number;
+  directories: number;
+  bytes: number;
+  queueSize: number;
+  currentPath: string;
+  startedAt: number;
+  updatedAt: number;
+}
+
+export interface DiskScanStartMessage {
+  type: 'start';
+  handle?: FileSystemDirectoryHandle;
+  snapshot?: DiskNode;
+  options?: DiskScanOptions;
+}
+
+export interface DiskScanCancelMessage {
+  type: 'cancel';
+}
+
+export type DiskScanRequestMessage = DiskScanStartMessage | DiskScanCancelMessage;
+
+export type DiskScanResponseMessage =
+  | { type: 'progress'; progress: DiskScanProgress }
+  | { type: 'chunk'; node: DiskNode }
+  | { type: 'complete'; root: DiskNode; progress: DiskScanProgress }
+  | { type: 'cancelled' }
+  | { type: 'error'; error: string };
+
+export const pathToId = (segments: string[]): string =>
+  segments.length ? `/${segments.join('/')}` : '/';

--- a/utils/export.ts
+++ b/utils/export.ts
@@ -1,0 +1,169 @@
+import { DiskEntryKind, DiskNode, pathToId } from '@/types/disk';
+
+export interface CsvHeader {
+  key: string;
+  label: string;
+  formatter?: (value: unknown, row: Record<string, unknown>) => string;
+}
+
+export interface CsvOptions {
+  delimiter?: string;
+  includeHeader?: boolean;
+  newline?: string;
+  bom?: boolean;
+}
+
+export interface DiskUsageCsvRow {
+  path: string;
+  name: string;
+  type: DiskEntryKind;
+  size: number;
+  sizeHuman: string;
+  percent: number;
+  fileCount: number;
+  dirCount: number;
+  modified?: string;
+}
+
+export interface DiskExportOptions {
+  filename?: string;
+  download?: boolean;
+  headers?: CsvHeader[];
+}
+
+const DEFAULT_HEADERS: CsvHeader[] = [
+  { key: 'path', label: 'Path' },
+  { key: 'name', label: 'Name' },
+  { key: 'type', label: 'Type' },
+  {
+    key: 'size',
+    label: 'Size (bytes)',
+  },
+  {
+    key: 'sizeHuman',
+    label: 'Size (human)',
+  },
+  {
+    key: 'percent',
+    label: 'Relative %',
+    formatter: (value) =>
+      typeof value === 'number' ? value.toFixed(4) : String(value ?? ''),
+  },
+  { key: 'fileCount', label: 'Files' },
+  { key: 'dirCount', label: 'Directories' },
+  { key: 'modified', label: 'Last Modified' },
+];
+
+export const formatBytes = (bytes: number, decimals = 1): string => {
+  if (!Number.isFinite(bytes)) return '0 B';
+  const sign = bytes < 0 ? -1 : 1;
+  const absolute = Math.abs(bytes);
+  if (absolute < 1024) {
+    return `${(sign * absolute).toFixed(0)} B`;
+  }
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+  const exponent = Math.min(Math.floor(Math.log(absolute) / Math.log(1024)), units.length - 1);
+  const value = (absolute / 1024 ** exponent) * sign;
+  return `${value.toFixed(decimals)} ${units[exponent]}`;
+};
+
+export const toCSV = (
+  rows: Record<string, unknown>[],
+  headers: CsvHeader[] = [],
+  options: CsvOptions = {},
+): string => {
+  const delimiter = options.delimiter ?? ',';
+  const newline = options.newline ?? '\r\n';
+  const includeHeader = options.includeHeader ?? true;
+  const resolvedHeaders = headers.length
+    ? headers
+    : Object.keys(rows[0] ?? {}).map((key) => ({ key, label: key }));
+
+  const escapeCell = (value: unknown): string => {
+    if (value === null || value === undefined) return '';
+    const str = String(value);
+    if (str.includes('"') || str.includes(delimiter) || /[\r\n]/.test(str)) {
+      return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+  };
+
+  const headerLine = includeHeader
+    ? resolvedHeaders.map((header) => escapeCell(header.label)).join(delimiter)
+    : null;
+
+  const bodyLines = rows.map((row) =>
+    resolvedHeaders
+      .map((header) => {
+        const raw = row[header.key];
+        return escapeCell(header.formatter ? header.formatter(raw, row) : raw);
+      })
+      .join(delimiter),
+  );
+
+  const content = [headerLine, ...bodyLines].filter((line): line is string => Boolean(line)).join(newline);
+  return options.bom ? `\ufeff${content}` : content;
+};
+
+export const downloadCSV = (csv: string, filename: string): void => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.rel = 'noopener';
+  link.style.display = 'none';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+export const buildDiskUsageRows = (
+  root: DiskNode,
+  totalBytes: number = root.size,
+): DiskUsageCsvRow[] => {
+  const rows: DiskUsageCsvRow[] = [];
+
+  const walk = (node: DiskNode) => {
+    const percent = totalBytes > 0 ? (node.size / totalBytes) * 100 : 0;
+    const row: DiskUsageCsvRow = {
+      path: pathToId(node.path),
+      name: node.name,
+      type: node.type,
+      size: node.size,
+      sizeHuman: formatBytes(node.size),
+      percent,
+      fileCount: node.fileCount,
+      dirCount: node.dirCount,
+      modified: node.modified ? new Date(node.modified).toISOString() : undefined,
+    };
+    rows.push(row);
+    node.children?.forEach((child) => walk(child));
+  };
+
+  walk(root);
+  return rows;
+};
+
+export const exportDiskUsage = (
+  root: DiskNode,
+  options: DiskExportOptions = {},
+): string => {
+  const rows = buildDiskUsageRows(root);
+  const headers = options.headers ?? DEFAULT_HEADERS;
+  const csv = toCSV(rows as unknown as Record<string, unknown>[], headers, {
+    includeHeader: true,
+    delimiter: ',',
+    newline: '\r\n',
+    bom: true,
+  });
+
+  if (options.download !== false && typeof window !== 'undefined') {
+    const filename = options.filename ?? 'disk-usage.csv';
+    downloadCSV(csv, filename);
+  }
+
+  return csv;
+};

--- a/workers/diskScan.ts
+++ b/workers/diskScan.ts
@@ -1,0 +1,239 @@
+import {
+  DiskNode,
+  DiskScanOptions,
+  DiskScanRequestMessage,
+  DiskScanResponseMessage,
+  DiskScanStartMessage,
+  pathToId,
+} from '@/types/disk';
+
+const ctx: DedicatedWorkerGlobalScope = self as unknown as DedicatedWorkerGlobalScope;
+
+const delay = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+interface ScanState {
+  cancelled: boolean;
+  options: DiskScanOptions;
+  progress: {
+    files: number;
+    directories: number;
+    bytes: number;
+    queueSize: number;
+    currentPath: string;
+    startedAt: number;
+    updatedAt: number;
+  };
+  pendingDirs: number;
+}
+
+const initialState = (): ScanState => ({
+  cancelled: false,
+  options: {},
+  progress: {
+    files: 0,
+    directories: 0,
+    bytes: 0,
+    queueSize: 0,
+    currentPath: '/',
+    startedAt: Date.now(),
+    updatedAt: Date.now(),
+  },
+  pendingDirs: 0,
+});
+
+let state = initialState();
+
+const reportProgress = (path: string) => {
+  state.progress.currentPath = path;
+  state.progress.updatedAt = Date.now();
+  const message: DiskScanResponseMessage = {
+    type: 'progress',
+    progress: { ...state.progress },
+  };
+  ctx.postMessage(message);
+};
+
+const createDirectoryNode = (name: string, path: string[]): DiskNode => ({
+  id: pathToId(path),
+  name,
+  path,
+  parentId: path.length ? pathToId(path.slice(0, -1)) : null,
+  type: 'directory',
+  size: 0,
+  fileCount: 0,
+  dirCount: 0,
+  children: [],
+});
+
+const createFileNode = (
+  name: string,
+  path: string[],
+  size: number,
+  modified?: number,
+): DiskNode => ({
+  id: pathToId(path),
+  name,
+  path,
+  parentId: path.length ? pathToId(path.slice(0, -1)) : null,
+  type: 'file',
+  size,
+  fileCount: 1,
+  dirCount: 0,
+  modified,
+});
+
+const scanFile = async (
+  handle: FileSystemFileHandle,
+  parentPath: string[],
+): Promise<DiskNode> => {
+  let fileSize = 0;
+  let modified: number | undefined;
+  try {
+    const file = await handle.getFile();
+    fileSize = file.size ?? 0;
+    modified = file.lastModified;
+  } catch (error) {
+    console.warn('Unable to read file handle', error);
+  }
+  state.progress.files += 1;
+  state.progress.bytes += fileSize;
+  return createFileNode(handle.name, [...parentPath, handle.name], fileSize, modified);
+};
+
+const iterateDirectory = (
+  handle: FileSystemDirectoryHandle,
+): AsyncIterable<FileSystemHandle> => {
+  if ('values' in handle && typeof handle.values === 'function') {
+    return handle.values();
+  }
+  if ('entries' in handle && typeof handle.entries === 'function') {
+    return handle.entries();
+  }
+  throw new Error('Directory handle does not support iteration');
+};
+
+const scanDirectory = async (
+  handle: FileSystemDirectoryHandle,
+  path: string[],
+  depth: number,
+): Promise<DiskNode> => {
+  if (state.cancelled) {
+    return createDirectoryNode(handle.name ?? path[path.length - 1] ?? 'root', path);
+  }
+
+  state.pendingDirs += 1;
+  state.progress.queueSize = state.pendingDirs;
+  state.progress.directories += 1;
+
+  const node = createDirectoryNode(handle.name ?? path[path.length - 1] ?? 'root', path);
+  const chunkSize = state.options.chunkSize ?? 48;
+  let processedSinceYield = 0;
+
+  try {
+    for await (const entry of iterateDirectory(handle)) {
+      if (state.cancelled) break;
+      const childPath = [...path, entry.name];
+      if (entry.kind === 'file') {
+        const fileNode = await scanFile(entry as FileSystemFileHandle, path);
+        node.children?.push(fileNode);
+        node.size += fileNode.size;
+        node.fileCount += 1;
+      } else if (entry.kind === 'directory') {
+        if (state.options.maxDepth !== undefined && depth >= state.options.maxDepth) {
+          const placeholder = createDirectoryNode(entry.name, childPath);
+          node.children?.push(placeholder);
+          node.dirCount += 1;
+        } else {
+          const childNode = await scanDirectory(entry as FileSystemDirectoryHandle, childPath, depth + 1);
+          node.children?.push(childNode);
+          node.size += childNode.size;
+          node.fileCount += childNode.fileCount;
+          node.dirCount += childNode.dirCount + 1;
+        }
+      }
+
+      processedSinceYield += 1;
+      if (processedSinceYield >= chunkSize) {
+        reportProgress(pathToId(childPath));
+        processedSinceYield = 0;
+        await delay();
+      }
+    }
+  } catch (error) {
+    console.warn('Failed to read directory', error);
+  }
+
+  node.children?.sort((a, b) => b.size - a.size);
+
+  state.pendingDirs -= 1;
+  state.progress.queueSize = Math.max(0, state.pendingDirs);
+
+  ctx.postMessage({ type: 'chunk', node } satisfies DiskScanResponseMessage);
+  return node;
+};
+
+const handleStart = async (message: DiskScanStartMessage) => {
+  state = initialState();
+  state.options = message.options ?? {};
+  state.progress.startedAt = Date.now();
+  state.progress.updatedAt = state.progress.startedAt;
+  state.cancelled = false;
+
+  if (message.snapshot) {
+    const progressSnapshot = {
+      ...state.progress,
+      files: message.snapshot.fileCount,
+      directories: message.snapshot.dirCount + 1,
+      bytes: message.snapshot.size,
+      currentPath: pathToId(message.snapshot.path),
+      updatedAt: Date.now(),
+    };
+    const completeMessage: DiskScanResponseMessage = {
+      type: 'complete',
+      root: message.snapshot,
+      progress: progressSnapshot,
+    };
+    ctx.postMessage(completeMessage);
+    return;
+  }
+
+  if (!message.handle) {
+    ctx.postMessage({ type: 'error', error: 'No directory handle provided' } satisfies DiskScanResponseMessage);
+    return;
+  }
+
+  try {
+    const rootNode = await scanDirectory(message.handle, [], 0);
+    if (state.cancelled) {
+      ctx.postMessage({ type: 'cancelled' } satisfies DiskScanResponseMessage);
+      return;
+    }
+    reportProgress(pathToId(rootNode.path));
+    const completeMessage: DiskScanResponseMessage = {
+      type: 'complete',
+      root: rootNode,
+      progress: { ...state.progress },
+    };
+    ctx.postMessage(completeMessage);
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    ctx.postMessage({ type: 'error', error: err.message } satisfies DiskScanResponseMessage);
+  }
+};
+
+ctx.onmessage = (event: MessageEvent<DiskScanRequestMessage>) => {
+  const message = event.data;
+  if (!message) return;
+  if (message.type === 'cancel') {
+    state.cancelled = true;
+    return;
+  }
+  if (message.type === 'start') {
+    handleStart(message).catch((error) => {
+      const err = error instanceof Error ? error : new Error(String(error));
+      ctx.postMessage({ type: 'error', error: err.message } satisfies DiskScanResponseMessage);
+    });
+  }
+};
+
+export {};


### PR DESCRIPTION
## Summary
- add a Disk Analyzer window with treemap, sunburst, drill-down table, CSV export controls, and worker-driven scanning UI
- implement reusable layout helpers and sample data powering the charts
- wire up disk scan worker, shared types, CSV utility with tests, and register the app plus documentation updates

## Testing
- yarn lint *(fails: existing repo lint errors)*
- yarn test --runTestsByPath __tests__/utils/export.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68cb4688d7a88328ab6a394cd7edf1fb