### PR TITLE
[files] add duplicate finder tool

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -8,6 +8,7 @@ import { displayGedit } from './components/apps/gedit';
 import { displayTodoist } from './components/apps/todoist';
 import { displayWeather } from './components/apps/weather';
 import { displayClipboardManager } from './components/apps/ClipboardManager';
+import { displayDuplicateFinder } from './components/apps/files/DuplicateFinder';
 import { displayFiglet } from './components/apps/figlet';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayScreenRecorder } from './components/apps/screen-recorder';
@@ -772,6 +773,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayStickyNotes,
+  },
+  {
+    id: 'duplicate-finder',
+    title: 'Duplicate Finder',
+    icon: '/themes/Yaru/apps/radar-symbolic.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayDuplicateFinder,
   },
   {
     id: 'trash',

--- a/apps/trash/state.ts
+++ b/apps/trash/state.ts
@@ -1,12 +1,18 @@
 import { useEffect, useCallback } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
 
+export interface TrashPayload {
+  type: string;
+  [key: string]: unknown;
+}
+
 export interface TrashItem {
   id: string;
   title: string;
   icon?: string;
   image?: string;
   closedAt: number;
+  payload?: TrashPayload;
 }
 
 const ITEMS_KEY = 'window-trash';

--- a/components/apps/files/DuplicateFinder.tsx
+++ b/components/apps/files/DuplicateFinder.tsx
@@ -1,0 +1,685 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import useOPFS from '../../../hooks/useOPFS';
+import useTrashState from '../../../apps/trash/state';
+import {
+  collectFiles,
+  findDuplicates,
+  moveFilesToDuplicateTrash,
+  restoreDuplicateFromTrash,
+  type DuplicateGroup,
+  type DuplicateScanResult,
+  type HeuristicMatch,
+  type ScannedFile,
+  type DuplicateTrashPayload,
+} from '../../../utils/files/duplicateScanner';
+import { logEvent } from '../../../utils/analytics';
+
+const formatBytes = (bytes: number): string => {
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const exponent = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+  const value = bytes / 1024 ** exponent;
+  return `${value.toFixed(exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+};
+
+const formatDate = (timestamp: number): string => new Date(timestamp).toLocaleString();
+
+const normaliseTargetPath = (value: string) => {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === '/') return '';
+  return trimmed.replace(/^\/+|\/+$|^\.\/+/g, '');
+};
+
+const selectionKey = (groupId: string, file: ScannedFile) => `${groupId}|${file.relativePath}`;
+
+const isTextLike = (name: string, type: string) => {
+  if (type.startsWith('text/')) return true;
+  const extension = name.split('.').pop()?.toLowerCase();
+  if (!extension) return false;
+  const textExtensions = [
+    'txt',
+    'md',
+    'json',
+    'js',
+    'ts',
+    'tsx',
+    'jsx',
+    'css',
+    'html',
+    'csv',
+    'log',
+    'yml',
+    'yaml',
+  ];
+  return textExtensions.includes(extension);
+};
+
+interface PreviewState {
+  path: string;
+  type: 'none' | 'text' | 'image' | 'binary';
+  content: string;
+  size: number;
+  mime: string;
+  lastModified: number;
+}
+
+interface RecentRemoval {
+  payload: DuplicateTrashPayload;
+  closedAt: number;
+  name: string;
+}
+
+const DEFAULT_PREVIEW: PreviewState = {
+  path: '',
+  type: 'none',
+  content: '',
+  size: 0,
+  mime: '',
+  lastModified: 0,
+};
+
+const buildInitialSelection = (result: DuplicateScanResult): Record<string, boolean> => {
+  const map: Record<string, boolean> = {};
+  result.confirmed.forEach(group => {
+    group.files.forEach((file, index) => {
+      map[selectionKey(group.id, file)] = index !== 0;
+    });
+  });
+  result.probable.forEach(group => {
+    group.files.forEach(file => {
+      map[selectionKey(group.id, file)] = false;
+    });
+  });
+  return map;
+};
+
+const withDisplayPath = (basePath: string, relative: string) => {
+  const prefix = basePath ? `/${basePath}` : '';
+  return `${prefix}/${relative}`.replace(/\/+/g, '/');
+};
+
+const ensureKeepOne = (
+  group: DuplicateGroup | HeuristicMatch,
+  keyToToggle: string,
+  nextValue: boolean,
+  selected: Record<string, boolean>,
+) => {
+  if (!nextValue) return true;
+  const keys = group.files.map(file => selectionKey(group.id, file));
+  const keepExists = keys.some(key => {
+    if (key === keyToToggle) return false;
+    return !selected[key];
+  });
+  return keepExists;
+};
+
+const pruneGroups = (
+  result: DuplicateScanResult,
+  removedKeys: Set<string>,
+): DuplicateScanResult => ({
+  confirmed: result.confirmed
+    .map(group => ({
+      ...group,
+      files: group.files.filter(file => !removedKeys.has(selectionKey(group.id, file))),
+    }))
+    .filter(group => group.files.length > 1),
+  probable: result.probable
+    .map(group => ({
+      ...group,
+      files: group.files.filter(file => !removedKeys.has(selectionKey(group.id, file))),
+    }))
+    .filter(group => group.files.length > 1),
+});
+
+const DuplicateFinder: React.FC = () => {
+  const { supported, root, getDir } = useOPFS();
+  const { setItems } = useTrashState();
+  const [currentDir, setCurrentDir] = useState<FileSystemDirectoryHandle | null>(null);
+  const [targetPath, setTargetPath] = useState('');
+  const [pathInput, setPathInput] = useState('/');
+  const [scanning, setScanning] = useState(false);
+  const [progress, setProgress] = useState<{ processed: number; total: number }>({ processed: 0, total: 0 });
+  const [result, setResult] = useState<DuplicateScanResult | null>(null);
+  const [selectedMap, setSelectedMap] = useState<Record<string, boolean>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [preview, setPreview] = useState<PreviewState>(DEFAULT_PREVIEW);
+  const previewUrlRef = useRef<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const [recentRemovals, setRecentRemovals] = useState<RecentRemoval[]>([]);
+  const [recoveredBytes, setRecoveredBytes] = useState(0);
+
+  useEffect(() => {
+    if (root) {
+      setCurrentDir(root);
+      setTargetPath('');
+      setPathInput('/');
+    }
+  }, [root]);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const applyPath = useCallback(async () => {
+    if (!root) return;
+    const nextPath = normaliseTargetPath(pathInput);
+    if (!nextPath) {
+      setCurrentDir(root);
+      setTargetPath('');
+      setError(null);
+      return;
+    }
+    try {
+      const handle = await getDir(nextPath, { create: false });
+      if (!handle) {
+        setError(`Directory "/${nextPath}" is not accessible.`);
+        return;
+      }
+      setCurrentDir(handle);
+      setTargetPath(nextPath);
+      setError(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to open directory';
+      setError(message);
+    }
+  }, [root, pathInput, getDir]);
+
+  const startScan = useCallback(async () => {
+    if (!currentDir || !root) return;
+    setMessage(null);
+    setError(null);
+    setPreview(DEFAULT_PREVIEW);
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setScanning(true);
+    try {
+      const files = await collectFiles(currentDir, { signal: controller.signal });
+      if (!files.length) {
+        setResult({ confirmed: [], probable: [] });
+        setSelectedMap({});
+        setProgress({ processed: 0, total: 0 });
+        setMessage('No files detected in this directory.');
+        return;
+      }
+      setProgress({ processed: 0, total: files.length });
+      const found = await findDuplicates(files, {
+        signal: controller.signal,
+        onProgress: (processed, total) => setProgress({ processed, total }),
+      });
+      setResult(found);
+      setSelectedMap(buildInitialSelection(found));
+      if (!found.confirmed.length && !found.probable.length) {
+        setMessage('No duplicates detected.');
+      }
+    } catch (err) {
+      if ((err as DOMException)?.name === 'AbortError') {
+        setMessage('Scan cancelled.');
+      } else {
+        const message = err instanceof Error ? err.message : 'Failed to scan directory';
+        setError(message);
+      }
+    } finally {
+      setScanning(false);
+      abortRef.current = null;
+    }
+  }, [currentDir, root]);
+
+  const cancelScan = useCallback(() => {
+    if (scanning) {
+      abortRef.current?.abort();
+    }
+  }, [scanning]);
+
+  const groupsSummary = useMemo(() => {
+    if (!result) return { confirmed: 0, probable: 0 };
+    return {
+      confirmed: result.confirmed.length,
+      probable: result.probable.length,
+    };
+  }, [result]);
+
+  const selectionSummary = useMemo(() => {
+    if (!result) return { count: 0, bytes: 0 };
+    let count = 0;
+    let bytes = 0;
+    result.confirmed.forEach(group => {
+      group.files.forEach(file => {
+        if (selectedMap[selectionKey(group.id, file)]) {
+          count += 1;
+          bytes += file.size;
+        }
+      });
+    });
+    result.probable.forEach(group => {
+      group.files.forEach(file => {
+        if (selectedMap[selectionKey(group.id, file)]) {
+          count += 1;
+          bytes += file.size;
+        }
+      });
+    });
+    return { count, bytes };
+  }, [result, selectedMap]);
+
+  const toggleSelection = useCallback(
+    (group: DuplicateGroup | HeuristicMatch, file: ScannedFile) => {
+      setSelectedMap(prev => {
+        const key = selectionKey(group.id, file);
+        const current = prev[key] ?? false;
+        const nextValue = !current;
+        if (nextValue && !ensureKeepOne(group, key, nextValue, prev)) {
+          alert('Keep at least one copy from each group.');
+          return prev;
+        }
+        return { ...prev, [key]: nextValue };
+      });
+    },
+    [],
+  );
+
+  const handlePreview = useCallback(
+    async (group: DuplicateGroup | HeuristicMatch, file: ScannedFile) => {
+      try {
+        const blob = await file.handle.getFile();
+        if (previewUrlRef.current) {
+          URL.revokeObjectURL(previewUrlRef.current);
+          previewUrlRef.current = null;
+        }
+        if (blob.type.startsWith('image/')) {
+          const url = URL.createObjectURL(blob);
+          previewUrlRef.current = url;
+          setPreview({
+            path: withDisplayPath(targetPath, file.relativePath),
+            type: 'image',
+            content: url,
+            size: blob.size,
+            mime: blob.type,
+            lastModified: blob.lastModified ?? Date.now(),
+          });
+          return;
+        }
+        if (isTextLike(file.name, blob.type)) {
+          const text = await blob.text();
+          setPreview({
+            path: withDisplayPath(targetPath, file.relativePath),
+            type: 'text',
+            content: text.slice(0, 4000),
+            size: blob.size,
+            mime: blob.type || 'text/plain',
+            lastModified: blob.lastModified ?? Date.now(),
+          });
+          return;
+        }
+        setPreview({
+          path: withDisplayPath(targetPath, file.relativePath),
+          type: 'binary',
+          content: `Binary file (${formatBytes(blob.size)})`,
+          size: blob.size,
+          mime: blob.type || 'application/octet-stream',
+          lastModified: blob.lastModified ?? Date.now(),
+        });
+      } catch {
+        setError('Unable to load preview for this file.');
+      }
+    },
+    [targetPath],
+  );
+
+  useEffect(
+    () => () => {
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current);
+        previewUrlRef.current = null;
+      }
+    },
+    [],
+  );
+
+  const deleteSelected = useCallback(async () => {
+    if (!result || !root) return;
+    const toDelete: { group: DuplicateGroup | HeuristicMatch; file: ScannedFile }[] = [];
+    result.confirmed.forEach(group => {
+      group.files.forEach(file => {
+        if (selectedMap[selectionKey(group.id, file)]) {
+          toDelete.push({ group, file });
+        }
+      });
+    });
+    result.probable.forEach(group => {
+      group.files.forEach(file => {
+        if (selectedMap[selectionKey(group.id, file)]) {
+          toDelete.push({ group, file });
+        }
+      });
+    });
+
+    if (!toDelete.length) {
+      setMessage('Select at least one file to move to Trash.');
+      return;
+    }
+
+    const totalBytes = toDelete.reduce((sum, entry) => sum + entry.file.size, 0);
+    const confirm = window.confirm(
+      `Move ${toDelete.length} file${toDelete.length === 1 ? '' : 's'} (${formatBytes(
+        totalBytes,
+      )}) to Trash?`,
+    );
+    if (!confirm) return;
+
+    try {
+      const files = toDelete.map(entry => entry.file);
+      const outcome = await moveFilesToDuplicateTrash(files, root, targetPath);
+      const removedKeys = new Set<string>();
+
+      if (outcome.successes.length) {
+        setItems(items => [...outcome.successes.map(success => success.trashItem), ...items]);
+        setRecentRemovals(prev => {
+          const additions: RecentRemoval[] = outcome.successes.map(success => ({
+            payload: success.payload,
+            closedAt: success.trashItem.closedAt,
+            name: success.trashItem.title,
+          }));
+          return [...additions, ...prev].slice(0, 6);
+        });
+        setRecoveredBytes(prev => prev + outcome.bytesMoved);
+        logEvent({
+          category: 'DuplicateFinder',
+          action: 'cleanup',
+          label: 'moved-to-trash',
+          value: Math.round(outcome.bytesMoved / 1024),
+        });
+        outcome.successes.forEach(success => {
+          const groupEntry = toDelete.find(entry => entry.file === success.file);
+          if (groupEntry) {
+            removedKeys.add(selectionKey(groupEntry.group.id, success.file));
+          }
+        });
+        setResult(prev => (prev ? pruneGroups(prev, removedKeys) : prev));
+        setSelectedMap(prev => {
+          const copy = { ...prev };
+          removedKeys.forEach(key => delete copy[key]);
+          return copy;
+        });
+        setMessage(`${outcome.successes.length} file(s) moved to Trash.`);
+        window.dispatchEvent(new Event('trash-change'));
+      }
+
+      if (outcome.failures.length) {
+        setError(
+          `Failed to move ${outcome.failures.length} file${
+            outcome.failures.length === 1 ? '' : 's'
+          } to Trash.`,
+        );
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to move files to Trash';
+      setError(message);
+    }
+  }, [result, root, selectedMap, targetPath, setItems, setRecentRemovals]);
+
+  const undoRemoval = useCallback(
+    async (entry: RecentRemoval) => {
+      if (!root) return;
+      const restored = await restoreDuplicateFromTrash(entry.payload, root);
+      if (!restored) {
+        setError('Unable to restore file from Trash backup.');
+        return;
+      }
+      setItems(items =>
+        items.filter(
+          item =>
+            item.payload?.type !== 'duplicate-file' ||
+            (item.payload as DuplicateTrashPayload).backupName !== entry.payload.backupName,
+        ),
+      );
+      setRecentRemovals(prev =>
+        prev.filter(existing => existing.payload.backupName !== entry.payload.backupName),
+      );
+      window.dispatchEvent(new Event('trash-change'));
+      setMessage(`${entry.name} restored to ${entry.payload.relativePath}`);
+    },
+    [root, setItems],
+  );
+
+  return (
+    <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white">
+      <header className="border-b border-black border-opacity-30 px-4 py-3 flex flex-col space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <h1 className="text-lg font-semibold">Duplicate Finder</h1>
+          <span className="text-xs bg-black bg-opacity-40 px-2 py-0.5 rounded">
+            {supported ? 'OPFS enabled' : 'File System API unavailable'}
+          </span>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <label htmlFor="duplicate-path" className="sr-only">
+            Directory path
+          </label>
+          <input
+            id="duplicate-path"
+            className="bg-black bg-opacity-40 px-2 py-1 rounded outline-none focus:ring-2 focus:ring-ubt-blue min-w-[10rem]"
+            value={pathInput}
+            onChange={event => setPathInput(event.target.value)}
+            placeholder="/"
+          />
+          <button
+            onClick={applyPath}
+            className="px-3 py-1 bg-ubt-blue rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ubt-blue"
+          >
+            Change directory
+          </button>
+          <button
+            onClick={startScan}
+            disabled={!supported || !currentDir || scanning}
+            className="px-3 py-1 bg-green-600 rounded hover:bg-green-500 focus:outline-none focus:ring-2 focus:ring-green-400 disabled:opacity-50"
+          >
+            {scanning ? 'Scanning…' : 'Scan for duplicates'}
+          </button>
+          {scanning && (
+            <button
+              onClick={cancelScan}
+              className="px-3 py-1 bg-yellow-600 rounded hover:bg-yellow-500 focus:outline-none focus:ring-2 focus:ring-yellow-400"
+            >
+              Cancel
+            </button>
+          )}
+          <span className="ml-auto text-xs text-gray-300">
+            Current: {withDisplayPath(targetPath, '') || '/'}
+          </span>
+        </div>
+        {scanning && (
+          <div className="text-xs text-gray-300">
+            Processing {progress.processed} of {progress.total}
+          </div>
+        )}
+        {message && <div className="text-xs text-green-300">{message}</div>}
+        {error && <div className="text-xs text-red-300">{error}</div>}
+        {recoveredBytes > 0 && (
+          <div className="text-xs text-gray-200">
+            Recovered space: {formatBytes(recoveredBytes)}
+          </div>
+        )}
+      </header>
+      <div className="flex flex-1 overflow-hidden">
+        <section className="flex-1 overflow-y-auto p-4 space-y-6">
+          <div className="flex items-center justify-between">
+            <h2 className="text-md font-semibold">Confirmed duplicates</h2>
+            <span className="text-xs text-gray-300">Groups: {groupsSummary.confirmed}</span>
+          </div>
+          {result?.confirmed.length ? (
+            result.confirmed.map(group => (
+              <div key={group.id} className="bg-black bg-opacity-30 rounded border border-black border-opacity-20">
+                <header className="px-3 py-2 flex items-center justify-between border-b border-black border-opacity-20">
+                  <div>
+                    <h3 className="font-semibold text-sm">SHA-256: {group.hash.slice(0, 12)}…</h3>
+                    <p className="text-xs text-gray-300">{group.reasons.join(', ')}</p>
+                  </div>
+                  <span className="text-xs text-gray-300">{group.files.length} copies</span>
+                </header>
+                <ul>
+                  {group.files.map(file => {
+                    const key = selectionKey(group.id, file);
+                    const isSelected = !!selectedMap[key];
+                    return (
+                      <li
+                        key={file.relativePath}
+                        className="flex items-center gap-3 px-3 py-2 text-sm hover:bg-black hover:bg-opacity-30"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => toggleSelection(group, file)}
+                          className="accent-ubt-blue"
+                          aria-label={`Select ${file.name}`}
+                        />
+                        <button
+                          type="button"
+                          className="text-left flex-1 truncate hover:underline"
+                          onClick={() => handlePreview(group, file)}
+                        >
+                          {file.name}
+                        </button>
+                        <span className="text-xs text-gray-300">{formatBytes(file.size)}</span>
+                        <span className="text-xs text-gray-300">{formatDate(file.lastModified)}</span>
+                        <span className="text-xs text-gray-300">{withDisplayPath(targetPath, file.relativePath)}</span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            ))
+          ) : (
+            <p className="text-xs text-gray-300">No confirmed duplicates detected.</p>
+          )}
+
+          <div className="flex items-center justify-between mt-4">
+            <h2 className="text-md font-semibold">Likely duplicates</h2>
+            <span className="text-xs text-gray-300">Groups: {groupsSummary.probable}</span>
+          </div>
+          {result?.probable.length ? (
+            result.probable.map(group => (
+              <div key={group.id} className="bg-black bg-opacity-20 rounded border border-black border-opacity-10">
+                <header className="px-3 py-2 flex items-center justify-between border-b border-black border-opacity-10">
+                  <div>
+                    <h3 className="font-semibold text-sm">{group.key}</h3>
+                    <p className="text-xs text-yellow-200">
+                      Confidence {Math.round(group.confidence * 100)}% — {group.reasons.join(', ')}
+                    </p>
+                  </div>
+                  <span className="text-xs text-gray-300">{group.files.length} matches</span>
+                </header>
+                <ul>
+                  {group.files.map(file => {
+                    const key = selectionKey(group.id, file);
+                    const isSelected = !!selectedMap[key];
+                    return (
+                      <li
+                        key={file.relativePath}
+                        className="flex items-center gap-3 px-3 py-2 text-sm hover:bg-black hover:bg-opacity-30"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => toggleSelection(group, file)}
+                          className="accent-yellow-400"
+                          aria-label={`Select ${file.name}`}
+                        />
+                        <button
+                          type="button"
+                          className="text-left flex-1 truncate hover:underline"
+                          onClick={() => handlePreview(group, file)}
+                        >
+                          {file.name}
+                        </button>
+                        <span className="text-xs text-gray-300">{formatBytes(file.size)}</span>
+                        <span className="text-xs text-gray-300">{formatDate(file.lastModified)}</span>
+                        <span className="text-xs text-gray-300">{withDisplayPath(targetPath, file.relativePath)}</span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            ))
+          ) : (
+            <p className="text-xs text-gray-300">No heuristic matches currently flagged.</p>
+          )}
+        </section>
+        <aside className="w-80 border-l border-black border-opacity-30 bg-black bg-opacity-20 p-4 flex flex-col gap-4">
+          <div>
+            <h2 className="font-semibold text-sm mb-2">Selection</h2>
+            <p className="text-xs text-gray-200">
+              {selectionSummary.count} file{selectionSummary.count === 1 ? '' : 's'} selected —{' '}
+              {formatBytes(selectionSummary.bytes)}
+            </p>
+            <button
+              onClick={deleteSelected}
+              disabled={selectionSummary.count === 0}
+              className="mt-2 w-full px-3 py-2 bg-red-600 rounded hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-400 disabled:opacity-50"
+            >
+              Move selected to Trash
+            </button>
+          </div>
+
+          <div>
+            <h2 className="font-semibold text-sm mb-2">Preview</h2>
+            {preview.type === 'image' && (
+              <img
+                src={preview.content}
+                alt={preview.path}
+                className="w-full rounded border border-black border-opacity-20"
+              />
+            )}
+            {preview.type === 'text' && (
+              <pre className="whitespace-pre-wrap text-xs bg-black bg-opacity-30 rounded p-2 max-h-60 overflow-auto">
+                {preview.content}
+              </pre>
+            )}
+            {preview.type === 'binary' && (
+              <p className="text-xs text-gray-200">{preview.content}</p>
+            )}
+            {preview.type === 'none' && (
+              <p className="text-xs text-gray-400">Select a file to preview its contents.</p>
+            )}
+            {preview.type !== 'none' && (
+              <dl className="mt-2 text-xs text-gray-300 space-y-1">
+                <div className="flex justify-between"><span>Path</span><span className="truncate">{preview.path}</span></div>
+                <div className="flex justify-between"><span>Size</span><span>{formatBytes(preview.size)}</span></div>
+                <div className="flex justify-between"><span>Type</span><span>{preview.mime || 'Unknown'}</span></div>
+                <div className="flex justify-between"><span>Modified</span><span>{formatDate(preview.lastModified)}</span></div>
+              </dl>
+            )}
+          </div>
+
+          <div>
+            <h2 className="font-semibold text-sm mb-2">Recent removals</h2>
+            {recentRemovals.length ? (
+              <ul className="space-y-2 text-xs">
+                {recentRemovals.map(entry => (
+                  <li key={entry.payload.backupName} className="flex items-center justify-between gap-2">
+                    <div className="truncate" title={entry.payload.relativePath}>
+                      {entry.name}
+                      <span className="block text-gray-400">{entry.payload.relativePath}</span>
+                    </div>
+                    <button
+                      onClick={() => undoRemoval(entry)}
+                      className="px-2 py-1 bg-blue-600 rounded hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    >
+                      Undo
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-xs text-gray-400">No recent actions.</p>
+            )}
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+};
+
+export const displayDuplicateFinder = () => <DuplicateFinder />;
+
+export default DuplicateFinder;

--- a/components/apps/trash/index.tsx
+++ b/components/apps/trash/index.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
-
-interface TrashItem {
-  id: string;
-  title: string;
-  icon?: string;
-  image?: string;
-  closedAt: number;
-}
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import useTrashState, { TrashItem } from '../../../apps/trash/state';
+import useOPFS from '../../../hooks/useOPFS';
+import {
+  discardDuplicateTrashPayload,
+  isDuplicateTrashPayload,
+  restoreDuplicateFromTrash,
+} from '../../../utils/files/duplicateScanner';
 
 const formatAge = (closedAt: number): string => {
   const diff = Date.now() - closedAt;
@@ -21,82 +20,128 @@ const formatAge = (closedAt: number): string => {
   return 'Just now';
 };
 
+const DEFAULT_ICON = '/themes/Yaru/status/user-trash-symbolic.svg';
+
+const notifyTrashChange = () => window.dispatchEvent(new Event('trash-change'));
+
+async function restoreTrashItem(
+  item: TrashItem,
+  openApp: (id: string) => void,
+  root: FileSystemDirectoryHandle | null,
+): Promise<boolean> {
+  if (isDuplicateTrashPayload(item.payload)) {
+    if (!root) {
+      alert('Unable to access storage to restore this file.');
+      return false;
+    }
+    const restored = await restoreDuplicateFromTrash(item.payload, root);
+    if (!restored) {
+      alert('Unable to restore file from backup. It may have been removed.');
+      return false;
+    }
+    return true;
+  }
+
+  openApp(item.id);
+  return true;
+}
+
+async function discardTrashPayload(
+  item: TrashItem,
+  root: FileSystemDirectoryHandle | null,
+): Promise<void> {
+  if (isDuplicateTrashPayload(item.payload) && root) {
+    await discardDuplicateTrashPayload(item.payload, root);
+  }
+}
+
 export default function Trash({ openApp }: { openApp: (id: string) => void }) {
-  const [items, setItems] = useState<TrashItem[]>([]);
+  const { items, setItems, pushHistory } = useTrashState();
+  const { root } = useOPFS();
   const [selected, setSelected] = useState<number | null>(null);
 
-  useEffect(() => {
-    const purgeDays = parseInt(localStorage.getItem('trash-purge-days') || '30', 10);
-    const ms = purgeDays * 24 * 60 * 60 * 1000;
-    const now = Date.now();
-    let data: TrashItem[] = [];
-    try {
-      data = JSON.parse(localStorage.getItem('window-trash') || '[]');
-    } catch {
-      data = [];
-    }
-    data = data.filter((item) => now - item.closedAt <= ms);
-    localStorage.setItem('window-trash', JSON.stringify(data));
-    setItems(data);
-  }, []);
+  const sortedItems = useMemo(
+    () => [...items].sort((a, b) => b.closedAt - a.closedAt),
+    [items],
+  );
 
-  const persist = (next: TrashItem[]) => {
-    setItems(next);
-    localStorage.setItem('window-trash', JSON.stringify(next));
-  };
+  const selectedItem = selected !== null ? sortedItems[selected] : undefined;
 
-  const restore = useCallback(() => {
+  const restore = useCallback(async () => {
     if (selected === null) return;
-    const item = items[selected];
+    const item = sortedItems[selected];
+    if (!item) return;
     if (!window.confirm(`Restore ${item.title}?`)) return;
-    openApp(item.id);
-    const next = items.filter((_, i) => i !== selected);
-    persist(next);
+    const didRestore = await restoreTrashItem(item, openApp, root);
+    if (!didRestore) return;
+    setItems(prev => prev.filter(existing => existing.closedAt !== item.closedAt));
     setSelected(null);
-  }, [items, selected, openApp]);
+    notifyTrashChange();
+  }, [selected, sortedItems, openApp, root, setItems]);
 
-  const remove = useCallback(() => {
+  const remove = useCallback(async () => {
     if (selected === null) return;
-    const item = items[selected];
+    const item = sortedItems[selected];
+    if (!item) return;
     if (!window.confirm(`Delete ${item.title}?`)) return;
-    const next = items.filter((_, i) => i !== selected);
-    persist(next);
+    await discardTrashPayload(item, root);
+    setItems(prev => prev.filter(existing => existing.closedAt !== item.closedAt));
+    pushHistory(item);
     setSelected(null);
-  }, [items, selected]);
+    notifyTrashChange();
+  }, [selected, sortedItems, root, setItems, pushHistory]);
 
-  const restoreAll = () => {
-    if (items.length === 0) return;
-    if (!window.confirm('Restore all windows?')) return;
-    items.forEach((item) => openApp(item.id));
-    persist([]);
+  const restoreAll = useCallback(async () => {
+    if (!sortedItems.length) return;
+    if (!window.confirm('Restore all items?')) return;
+    for (const item of sortedItems) {
+      const restored = await restoreTrashItem(item, openApp, root);
+      if (!restored) {
+        // stop if one fails to avoid partial ambiguity
+        return;
+      }
+    }
+    setItems([]);
     setSelected(null);
-  };
+    notifyTrashChange();
+  }, [sortedItems, openApp, root, setItems]);
 
-  const empty = () => {
-    if (items.length === 0) return;
-    if (!window.confirm('Empty trash?')) return;
-    persist([]);
+  const empty = useCallback(async () => {
+    if (!sortedItems.length) return;
+    if (!window.confirm('Empty trash? This will permanently delete items.')) return;
+    for (const item of sortedItems) {
+      await discardTrashPayload(item, root);
+      pushHistory(item);
+    }
+    setItems([]);
     setSelected(null);
-  };
+    notifyTrashChange();
+  }, [sortedItems, root, setItems, pushHistory]);
 
   const handleKey = useCallback(
-    (e: KeyboardEvent) => {
+    (event: KeyboardEvent) => {
       if (selected === null) return;
-      if (e.key === 'Delete' || e.key === 'Backspace') {
-        e.preventDefault();
+      if (event.key === 'Delete' || event.key === 'Backspace') {
+        event.preventDefault();
         remove();
-      } else if (e.key === 'Enter' || e.key.toLowerCase() === 'r') {
-        e.preventDefault();
+      } else if (event.key === 'Enter' || event.key.toLowerCase() === 'r') {
+        event.preventDefault();
         restore();
       }
     },
-    [selected, remove, restore]
+    [selected, remove, restore],
   );
 
   useEffect(() => {
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
   }, [handleKey]);
+
+  useEffect(() => {
+    if (selected !== null && selected >= sortedItems.length) {
+      setSelected(sortedItems.length ? 0 : null);
+    }
+  }, [sortedItems, selected]);
 
   return (
     <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white select-none">
@@ -105,28 +150,28 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
         <div className="flex">
           <button
             onClick={restore}
-            disabled={selected === null}
+            disabled={selectedItem == null}
             className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
           >
             Restore
           </button>
           <button
             onClick={restoreAll}
-            disabled={items.length === 0}
+            disabled={sortedItems.length === 0}
             className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
           >
             Restore All
           </button>
           <button
             onClick={remove}
-            disabled={selected === null}
+            disabled={selectedItem == null}
             className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
           >
             Delete
           </button>
           <button
             onClick={empty}
-            disabled={items.length === 0}
+            disabled={sortedItems.length === 0}
             className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
           >
             Empty
@@ -134,29 +179,40 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
         </div>
       </div>
       <div className="flex flex-wrap content-start p-2 overflow-auto">
-        {items.length === 0 && <div className="w-full text-center mt-10">Trash is empty</div>}
-        {items.map((item, idx) => (
-          <div
-            key={item.closedAt}
-            tabIndex={0}
-            onClick={() => setSelected(idx)}
-            className={`m-2 border p-1 w-32 cursor-pointer ${selected === idx ? 'bg-ub-drk-abrgn' : ''}`}
-          >
-            {item.image ? (
-              <img src={item.image} alt={item.title} className="h-20 w-full object-cover" />
-            ) : item.icon ? (
-              <img src={item.icon} alt={item.title} className="h-20 w-20 mx-auto object-contain" />
-            ) : null}
-            <p className="text-center text-xs truncate mt-1" title={item.title}>
-              {item.title}
-            </p>
-            <p className="text-center text-[10px] text-gray-400" aria-label={`Closed ${formatAge(item.closedAt)}`}>
-              {formatAge(item.closedAt)}
-            </p>
-          </div>
-        ))}
+        {sortedItems.length === 0 && (
+          <div className="w-full text-center mt-10">Trash is empty</div>
+        )}
+        {sortedItems.map((item, idx) => {
+          const isSelected = idx === selected;
+          const previewIcon = item.image || item.icon || DEFAULT_ICON;
+          return (
+            <div
+              key={item.closedAt}
+              tabIndex={0}
+              onClick={() => setSelected(idx)}
+              className={`m-2 border p-1 w-32 cursor-pointer ${isSelected ? 'bg-ub-drk-abrgn' : ''}`}
+            >
+              {previewIcon ? (
+                <img src={previewIcon} alt={item.title} className="h-20 w-20 mx-auto object-contain" />
+              ) : null}
+              <p className="text-center text-xs truncate mt-1" title={item.title}>
+                {item.title}
+              </p>
+              <p
+                className="text-center text-[10px] text-gray-400"
+                aria-label={`Closed ${formatAge(item.closedAt)}`}
+              >
+                {formatAge(item.closedAt)}
+              </p>
+              {isDuplicateTrashPayload(item.payload) && (
+                <p className="text-center text-[10px] text-ubt-blue mt-1" title={item.payload.relativePath}>
+                  From {item.payload.relativePath}
+                </p>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );
 }
-

--- a/utils/files/duplicateScanner.ts
+++ b/utils/files/duplicateScanner.ts
@@ -1,0 +1,528 @@
+import type { TrashItem } from '../../apps/trash/state';
+
+export const DUPLICATE_TRASH_DIR = '.duplicate-finder-trash';
+const DEFAULT_QUICK_SAMPLE_BYTES = 64 * 1024;
+const DEFAULT_TEXT_SAMPLE_BYTES = 2 * 1024;
+
+export interface ScannedFile {
+  handle: FileSystemFileHandle;
+  directory: FileSystemDirectoryHandle;
+  name: string;
+  relativePath: string;
+  size: number;
+  lastModified: number;
+  type: string;
+}
+
+export interface DuplicateGroup {
+  id: string;
+  hash: string;
+  files: ScannedFile[];
+  confidence: number;
+  reasons: string[];
+  size: number;
+}
+
+export interface HeuristicMatch {
+  id: string;
+  key: string;
+  files: ScannedFile[];
+  confidence: number;
+  reasons: string[];
+  size: number;
+}
+
+export interface DuplicateScanResult {
+  confirmed: DuplicateGroup[];
+  probable: HeuristicMatch[];
+}
+
+export interface ScanOptions {
+  quickSampleBytes?: number;
+  sampleTextBytes?: number;
+  signal?: AbortSignal;
+  onProgress?: (processed: number, total: number) => void;
+}
+
+export interface CollectOptions {
+  signal?: AbortSignal;
+  currentPath?: string;
+  skipDirectories?: string[];
+  maxFiles?: number;
+}
+
+export interface DuplicateTrashPayload {
+  type: 'duplicate-file';
+  relativePath: string;
+  backupName: string;
+  size: number;
+}
+
+export interface MoveToTrashSuccess {
+  file: ScannedFile;
+  trashItem: TrashItem;
+  payload: DuplicateTrashPayload;
+}
+
+export interface MoveToTrashFailure {
+  file: ScannedFile;
+  error: string;
+}
+
+export interface MoveToTrashOutcome {
+  successes: MoveToTrashSuccess[];
+  failures: MoveToTrashFailure[];
+  bytesMoved: number;
+}
+
+export type TrashPayload = DuplicateTrashPayload;
+
+const DEFAULT_SKIP_DIRS = [DUPLICATE_TRASH_DIR, '.Trash', '.trash'];
+
+const shouldAbort = (signal?: AbortSignal) => signal?.aborted ?? false;
+
+const throwIfAborted = (signal?: AbortSignal) => {
+  if (shouldAbort(signal)) {
+    throw new DOMException('Operation aborted', 'AbortError');
+  }
+};
+
+const bufferToHex = (buffer: ArrayBuffer) => {
+  const bytes = new Uint8Array(buffer);
+  return Array.from(bytes)
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join('');
+};
+
+const fallbackDigest = (buffer: ArrayBuffer) => {
+  const view = new Uint8Array(buffer);
+  let hash = 0;
+  for (let i = 0; i < view.length; i += 1) {
+    hash = (hash * 31 + view[i]) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+};
+
+const computeDigest = async (buffer: ArrayBuffer) => {
+  try {
+    if (typeof crypto !== 'undefined' && crypto.subtle) {
+      const digest = await crypto.subtle.digest('SHA-256', buffer);
+      return bufferToHex(digest);
+    }
+  } catch {
+    // fall back below
+  }
+  return fallbackDigest(buffer);
+};
+
+const normalisePath = (value: string) => value.replace(/\\/g, '/').replace(/\/+/g, '/');
+
+const joinPath = (...parts: string[]) => {
+  const sanitised = parts
+    .map(part => normalisePath(part).trim())
+    .filter(Boolean)
+    .map(part => part.replace(/^\/+|\/+$|^\.\/+/g, ''));
+  return sanitised.join('/') || '';
+};
+
+const normaliseName = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/\.[^.]+$/, '')
+    .replace(/copy|final|edited|backup|duplicate/g, '')
+    .replace(/[_\-\s]+/g, ' ')
+    .replace(/\d+/g, '')
+    .trim();
+
+const computeSampleSimilarity = (a: string, b: string) => {
+  if (!a || !b) return 0;
+  const len = Math.min(a.length, b.length, 1024);
+  if (len === 0) return 0;
+  let matches = 0;
+  for (let i = 0; i < len; i += 1) {
+    if (a.charCodeAt(i) === b.charCodeAt(i)) matches += 1;
+  }
+  return matches / len;
+};
+
+const formatReason = (name: string, value: string | number) => `${name}: ${value}`;
+
+const ensureDirectoryPath = async (
+  root: FileSystemDirectoryHandle,
+  segments: string[],
+  options: FileSystemGetDirectoryOptions = { create: true },
+) => {
+  let dir = root;
+  for (const segment of segments) {
+    if (!segment) continue;
+    dir = await dir.getDirectoryHandle(segment, options);
+  }
+  return dir;
+};
+
+const getFileInfo = async (handle: FileSystemFileHandle) => {
+  const file = await handle.getFile();
+  return {
+    file,
+    size: file.size,
+    lastModified: file.lastModified || Date.now(),
+    type: file.type || '',
+  };
+};
+
+const readTextSample = async (file: File, bytes: number) => {
+  try {
+    const slice = file.slice(0, bytes);
+    return await slice.text();
+  } catch {
+    return '';
+  }
+};
+
+const computeQuickHash = async (
+  file: File,
+  quickSampleBytes: number,
+  signal?: AbortSignal,
+) => {
+  throwIfAborted(signal);
+  const slice = file.slice(0, quickSampleBytes);
+  const buffer = await slice.arrayBuffer();
+  return computeDigest(buffer);
+};
+
+const computeFullHash = async (file: File, signal?: AbortSignal) => {
+  throwIfAborted(signal);
+  const buffer = await file.arrayBuffer();
+  return computeDigest(buffer);
+};
+
+interface Candidate extends ScannedFile {
+  file: File;
+  quickHash: string;
+  sample: string;
+}
+
+const buildCandidate = async (
+  file: ScannedFile,
+  quickSampleBytes: number,
+  textSampleBytes: number,
+  signal?: AbortSignal,
+): Promise<Candidate> => {
+  const { file: blob, size, lastModified, type } = await getFileInfo(file.handle);
+  const quickHash = await computeQuickHash(blob, quickSampleBytes, signal);
+  const sample = await readTextSample(blob, textSampleBytes);
+  return {
+    ...file,
+    size,
+    lastModified,
+    type,
+    file: blob,
+    quickHash,
+    sample,
+  };
+};
+
+const evaluateHeuristicScore = (a: Candidate, b: Candidate) => {
+  const reasons: string[] = [];
+  let score = 0;
+
+  if (Math.abs(a.size - b.size) <= 64) {
+    score += 0.35;
+    reasons.push(formatReason('size', `${a.size}`));
+  }
+
+  const nameA = normaliseName(a.name);
+  const nameB = normaliseName(b.name);
+  if (nameA && nameA === nameB) {
+    score += 0.35;
+    reasons.push('name variant match');
+  }
+
+  const extA = a.name.split('.').pop()?.toLowerCase();
+  const extB = b.name.split('.').pop()?.toLowerCase();
+  if (extA && extA === extB) {
+    score += 0.1;
+    reasons.push(`extension: .${extA}`);
+  }
+
+  if (Math.abs(a.lastModified - b.lastModified) <= 5 * 60 * 1000) {
+    score += 0.1;
+    reasons.push('modified within 5m');
+  }
+
+  const similarity = computeSampleSimilarity(a.sample, b.sample);
+  if (similarity >= 0.92) {
+    score += 0.15;
+    reasons.push(formatReason('sample similarity', similarity.toFixed(2)));
+  }
+
+  return { score: Math.min(score, 1), reasons };
+};
+
+export async function collectFiles(
+  dir: FileSystemDirectoryHandle,
+  options: CollectOptions = {},
+): Promise<ScannedFile[]> {
+  const { signal, currentPath = '', skipDirectories = DEFAULT_SKIP_DIRS, maxFiles } = options;
+  const files: ScannedFile[] = [];
+  const skips = new Set(skipDirectories.map(name => name.toLowerCase()));
+  let count = 0;
+
+  const walk = async (handle: FileSystemDirectoryHandle, prefix: string) => {
+    throwIfAborted(signal);
+    for await (const [name, entry] of handle.entries()) {
+      throwIfAborted(signal);
+      if (entry.kind === 'directory') {
+        if (skips.has(name.toLowerCase())) continue;
+        const nextPrefix = joinPath(prefix, name);
+        await walk(entry as FileSystemDirectoryHandle, nextPrefix);
+      } else if (entry.kind === 'file') {
+        const relativePath = joinPath(prefix, name);
+        files.push({
+          handle: entry as FileSystemFileHandle,
+          directory: handle,
+          name,
+          relativePath,
+          size: 0,
+          lastModified: Date.now(),
+          type: '',
+        });
+        count += 1;
+        if (maxFiles && count >= maxFiles) {
+          return;
+        }
+      }
+    }
+  };
+
+  await walk(dir, currentPath ? normalisePath(currentPath) : '');
+
+  return files;
+}
+
+export async function findDuplicates(
+  files: ScannedFile[],
+  options: ScanOptions = {},
+): Promise<DuplicateScanResult> {
+  const {
+    quickSampleBytes = DEFAULT_QUICK_SAMPLE_BYTES,
+    sampleTextBytes = DEFAULT_TEXT_SAMPLE_BYTES,
+    signal,
+    onProgress,
+  } = options;
+
+  if (!files.length) return { confirmed: [], probable: [] };
+
+  const candidatesBySize = new Map<number, Candidate[]>();
+  let processed = 0;
+
+  for (const file of files) {
+    throwIfAborted(signal);
+    const candidate = await buildCandidate(file, quickSampleBytes, sampleTextBytes, signal);
+    const list = candidatesBySize.get(candidate.size) ?? [];
+    list.push(candidate);
+    candidatesBySize.set(candidate.size, list);
+    processed += 1;
+    onProgress?.(processed, files.length);
+  }
+
+  const confirmed: DuplicateGroup[] = [];
+  const probable: HeuristicMatch[] = [];
+
+  for (const [size, group] of candidatesBySize) {
+    if (group.length <= 1) continue;
+
+    const quickMap = new Map<string, Candidate[]>();
+    group.forEach(candidate => {
+      const list = quickMap.get(candidate.quickHash) ?? [];
+      list.push(candidate);
+      quickMap.set(candidate.quickHash, list);
+    });
+
+    const confirmedInGroup = new Set<string>();
+
+    for (const [, quickGroup] of quickMap) {
+      if (quickGroup.length <= 1) continue;
+
+      const hashMap = new Map<string, Candidate[]>();
+      for (const candidate of quickGroup) {
+        const hash = await computeFullHash(candidate.file, signal);
+        const list = hashMap.get(hash) ?? [];
+        list.push(candidate);
+        hashMap.set(hash, list);
+      }
+
+      for (const [hash, matches] of hashMap) {
+        if (matches.length <= 1) continue;
+        const id = `hash:${hash}`;
+        confirmed.push({
+          id,
+          hash,
+          files: matches.map(({ file: _file, sample: _sample, quickHash: _quick, ...rest }) => rest),
+          confidence: 1,
+          reasons: ['Identical SHA-256 hash'],
+          size,
+        });
+        matches.forEach(match => confirmedInGroup.add(match.relativePath));
+      }
+    }
+
+    const leftovers = group.filter(candidate => !confirmedInGroup.has(candidate.relativePath));
+    if (leftovers.length <= 1) continue;
+
+    const heuristicsMap = new Map<string, { members: Candidate[]; reasons: Set<string>; confidence: number }>();
+
+    for (let i = 0; i < leftovers.length; i += 1) {
+      for (let j = i + 1; j < leftovers.length; j += 1) {
+        const a = leftovers[i];
+        const b = leftovers[j];
+        const { score, reasons } = evaluateHeuristicScore(a, b);
+        if (score >= 0.8) {
+          const key = normaliseName(a.name) || normaliseName(b.name) || `${a.name}|${b.name}`;
+          const entry = heuristicsMap.get(key) ?? {
+            members: [],
+            reasons: new Set<string>(),
+            confidence: 0,
+          };
+          entry.members.push(a, b);
+          reasons.forEach(reason => entry.reasons.add(reason));
+          entry.confidence = Math.max(entry.confidence, score);
+          heuristicsMap.set(key, entry);
+        }
+      }
+    }
+
+    heuristicsMap.forEach((value, key) => {
+      const uniqueMembers: Candidate[] = [];
+      const seen = new Set<string>();
+      value.members.forEach(member => {
+        if (seen.has(member.relativePath)) return;
+        seen.add(member.relativePath);
+        uniqueMembers.push(member);
+      });
+      if (uniqueMembers.length <= 1) return;
+      probable.push({
+        id: `heuristic:${key}:${size}`,
+        key,
+        files: uniqueMembers.map(({ file: _file, sample: _sample, quickHash: _quick, ...rest }) => rest),
+        confidence: Math.min(1, value.confidence + 0.05),
+        reasons: Array.from(value.reasons),
+        size,
+      });
+    });
+  }
+
+  return {
+    confirmed,
+    probable,
+  };
+}
+
+const uniqueSlug = (path: string) =>
+  path
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+
+const ensureTrashDir = async (root: FileSystemDirectoryHandle) =>
+  ensureDirectoryPath(root, [DUPLICATE_TRASH_DIR]);
+
+export async function moveFilesToDuplicateTrash(
+  files: ScannedFile[],
+  root: FileSystemDirectoryHandle,
+  basePath = '',
+  options: { signal?: AbortSignal; icon?: string } = {},
+): Promise<MoveToTrashOutcome> {
+  const { signal, icon } = options;
+  if (!files.length) return { successes: [], failures: [], bytesMoved: 0 };
+  const trashDir = await ensureTrashDir(root);
+  const successes: MoveToTrashSuccess[] = [];
+  const failures: MoveToTrashFailure[] = [];
+  let bytesMoved = 0;
+  const now = Date.now();
+
+  for (let index = 0; index < files.length; index += 1) {
+    const file = files[index];
+    try {
+      throwIfAborted(signal);
+      const { file: blob } = await getFileInfo(file.handle);
+      const backupName = `${now}-${index}-${uniqueSlug(joinPath(basePath, file.relativePath)) || 'file'}`;
+      const backupHandle = await trashDir.getFileHandle(backupName, { create: true });
+      const writer = await backupHandle.createWritable();
+      await writer.write(blob);
+      await writer.close();
+      await file.directory.removeEntry(file.name);
+
+      const payload: DuplicateTrashPayload = {
+        type: 'duplicate-file',
+        relativePath: joinPath(basePath, file.relativePath),
+        backupName,
+        size: blob.size,
+      };
+
+      const trashItem: TrashItem = {
+        id: 'duplicate-finder',
+        title: file.name,
+        icon: icon || '/themes/Yaru/apps/radar-symbolic.svg',
+        closedAt: Date.now(),
+        payload,
+      };
+
+      successes.push({ file, trashItem, payload });
+      bytesMoved += blob.size;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      failures.push({ file, error: message });
+    }
+  }
+
+  return { successes, failures, bytesMoved };
+}
+
+export async function restoreDuplicateFromTrash(
+  payload: DuplicateTrashPayload,
+  root: FileSystemDirectoryHandle,
+): Promise<boolean> {
+  try {
+    const trashDir = await ensureTrashDir(root);
+    const backupHandle = await trashDir.getFileHandle(payload.backupName);
+    const file = await backupHandle.getFile();
+    const targetPath = normalisePath(payload.relativePath);
+    const segments = targetPath.split('/');
+    const fileName = segments.pop();
+    if (!fileName) return false;
+    const targetDir = await ensureDirectoryPath(root, segments);
+    const targetHandle = await targetDir.getFileHandle(fileName, { create: true });
+    const writer = await targetHandle.createWritable();
+    await writer.write(file);
+    await writer.close();
+    await trashDir.removeEntry(payload.backupName);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function discardDuplicateTrashPayload(
+  payload: DuplicateTrashPayload,
+  root: FileSystemDirectoryHandle,
+): Promise<boolean> {
+  try {
+    const trashDir = await ensureTrashDir(root);
+    await trashDir.removeEntry(payload.backupName);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export const isDuplicateTrashPayload = (
+  payload: unknown,
+): payload is DuplicateTrashPayload =>
+  typeof payload === 'object' &&
+  payload !== null &&
+  (payload as { type?: unknown }).type === 'duplicate-file' &&
+  typeof (payload as { backupName?: unknown }).backupName === 'string' &&
+  typeof (payload as { relativePath?: unknown }).relativePath === 'string';
+


### PR DESCRIPTION
## Summary
- add hash- and heuristic-based duplicate scanning utilities with trash support
- create a Duplicate Finder window with previews, safe delete, analytics, and undo hooks
- update trash state and UI to understand duplicate payload restores and register the app

## Testing
- yarn lint *(fails: existing repository accessibility/DOM lint errors)*
- yarn test *(fails: pre-existing suite failures in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cb468826ac8328a4f52103a5e83955