### PR TITLE
feat(files): add tag metadata and smart folders

### DIFF
--- a/__tests__/filesystemMetadata.test.ts
+++ b/__tests__/filesystemMetadata.test.ts
@@ -1,0 +1,57 @@
+import {
+  addTagToFile,
+  removeTagFromFile,
+  getMetadataSnapshot,
+  subscribeToMetadata,
+  listFilesForTag,
+  clearProfileMetadata,
+} from '../modules/filesystem/metadata';
+
+const PROFILE_ID = 'metadata-test-profile';
+
+describe('filesystem metadata tag sync', () => {
+  beforeEach(async () => {
+    await clearProfileMetadata(PROFILE_ID);
+  });
+
+  afterEach(async () => {
+    await clearProfileMetadata(PROFILE_ID);
+  });
+
+  it('persists tags and notifies subscribers with the latest state', async () => {
+    const updates: string[][] = [];
+    const unsubscribe = subscribeToMetadata(PROFILE_ID, (metadata) => {
+      const tags = metadata.files['/docs/report.txt']?.tags ?? [];
+      updates.push(tags);
+    });
+
+    await addTagToFile(PROFILE_ID, { path: '/docs/report.txt', name: 'report.txt' }, 'project');
+    await addTagToFile(PROFILE_ID, { path: '/docs/report.txt', name: 'report.txt' }, 'security');
+    await removeTagFromFile(PROFILE_ID, '/docs/report.txt', 'project');
+
+    const snapshot = await getMetadataSnapshot(PROFILE_ID);
+    expect(snapshot.files['/docs/report.txt'].tags).toEqual(['security']);
+
+    const taggedFiles = await listFilesForTag(PROFILE_ID, 'security');
+    expect(taggedFiles.map((file) => file.path)).toEqual(['/docs/report.txt']);
+
+    expect(updates.length).toBeGreaterThanOrEqual(1);
+    expect(updates[updates.length - 1]).toEqual(['security']);
+
+    unsubscribe();
+  });
+
+  it('isolates metadata by profile identifier', async () => {
+    await addTagToFile(PROFILE_ID, { path: '/notes/todo.txt', name: 'todo.txt' }, 'work');
+    await addTagToFile('other-profile', { path: '/notes/todo.txt', name: 'todo.txt' }, 'personal');
+
+    const first = await getMetadataSnapshot(PROFILE_ID);
+    const second = await getMetadataSnapshot('other-profile');
+
+    expect(first.files['/notes/todo.txt'].tags).toEqual(['work']);
+    expect(second.files['/notes/todo.txt'].tags).toEqual(['personal']);
+
+    await clearProfileMetadata('other-profile');
+  });
+});
+

--- a/__tests__/savedSearches.test.ts
+++ b/__tests__/savedSearches.test.ts
@@ -1,0 +1,84 @@
+import {
+  addTagToFile,
+  clearProfileMetadata,
+  getMetadataSnapshot,
+} from '../modules/filesystem/metadata';
+import {
+  createSavedSearch,
+  subscribeToSavedSearches,
+  clearSavedSearches,
+  evaluateSavedSearch,
+} from '../utils/files/savedSearches';
+
+const PROFILE_ID = 'saved-search-test';
+
+describe('saved search definitions', () => {
+  beforeEach(async () => {
+    await clearProfileMetadata(PROFILE_ID);
+    await clearSavedSearches(PROFILE_ID);
+  });
+
+  afterEach(async () => {
+    await clearProfileMetadata(PROFILE_ID);
+    await clearSavedSearches(PROFILE_ID);
+  });
+
+  it('updates smart folder results when metadata changes', async () => {
+    const observations: number[] = [];
+    const unsubscribe = subscribeToSavedSearches(PROFILE_ID, (searches) => {
+      const smartFolder = searches.find((search) => search.name === 'Logs');
+      if (smartFolder) observations.push(smartFolder.results.length);
+    });
+
+    await addTagToFile(PROFILE_ID, { path: '/archive/log1.txt', name: 'log1.txt' }, 'logs');
+    await addTagToFile(PROFILE_ID, { path: '/archive/log2.txt', name: 'log2.txt' }, 'logs');
+    await createSavedSearch(PROFILE_ID, { name: 'Logs', tags: ['logs'] });
+    await addTagToFile(PROFILE_ID, { path: '/archive/log3.txt', name: 'log3.txt' }, 'logs');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const metadata = await getMetadataSnapshot(PROFILE_ID);
+    const latest = metadata.tagIndex.logs || [];
+    expect(latest.sort()).toEqual([
+      '/archive/log1.txt',
+      '/archive/log2.txt',
+      '/archive/log3.txt',
+    ]);
+
+    expect(observations.some((count) => count === 3)).toBe(true);
+
+    unsubscribe();
+  });
+
+  it('evaluates saved searches using the smallest candidate set', async () => {
+    for (let i = 0; i < 100; i += 1) {
+      await addTagToFile(PROFILE_ID, { path: `/bulk/file-${i}.txt`, name: `file-${i}.txt` }, 'heavy');
+    }
+    for (let i = 0; i < 5; i += 1) {
+      await addTagToFile(PROFILE_ID, { path: `/focus/file-${i}.txt`, name: `focus-${i}.txt` }, 'heavy');
+      await addTagToFile(PROFILE_ID, { path: `/focus/file-${i}.txt`, name: `focus-${i}.txt` }, 'narrow');
+    }
+
+    const metadata = await getMetadataSnapshot(PROFILE_ID);
+    const definition = {
+      id: 'combo',
+      name: 'Combo',
+      tags: ['heavy', 'narrow'],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    const { stats, results } = evaluateSavedSearch(definition, metadata, {
+      collectStats: true,
+    });
+
+    expect(stats?.scanned).toBeLessThanOrEqual(5);
+    expect(results.map((file) => file.path).sort()).toEqual([
+      '/focus/file-0.txt',
+      '/focus/file-1.txt',
+      '/focus/file-2.txt',
+      '/focus/file-3.txt',
+      '/focus/file-4.txt',
+    ]);
+  });
+});
+

--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -1,9 +1,20 @@
 "use client";
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import useOPFS from '../../hooks/useOPFS';
 import { getDb } from '../../utils/safeIDB';
 import Breadcrumbs from '../ui/Breadcrumbs';
+import Sidebar from './files/Sidebar';
+import {
+  addTagToFile,
+  removeTagFromFile,
+  subscribeToMetadata,
+} from '../../modules/filesystem/metadata';
+import {
+  subscribeToSavedSearches,
+  createSavedSearch,
+  deleteSavedSearch,
+} from '../../utils/files/savedSearches';
 
 export async function openFileDialog(options = {}) {
   if (typeof window !== 'undefined' && window.showOpenFilePicker) {
@@ -61,6 +72,7 @@ export async function saveFileDialog(options = {}) {
 
 const DB_NAME = 'file-explorer';
 const STORE_NAME = 'recent';
+const PROFILE_ID = 'default-profile';
 
 function openDB() {
   return getDb(DB_NAME, 1, {
@@ -102,6 +114,11 @@ export default function FileExplorer() {
   const [content, setContent] = useState('');
   const [query, setQuery] = useState('');
   const [results, setResults] = useState([]);
+  const [metadata, setMetadata] = useState(null);
+  const [savedSearches, setSavedSearches] = useState([]);
+  const [activeTags, setActiveTags] = useState([]);
+  const [activeSavedSearchId, setActiveSavedSearchId] = useState(null);
+  const [selectedEntry, setSelectedEntry] = useState(null);
   const workerRef = useRef(null);
   const fallbackInputRef = useRef(null);
 
@@ -123,14 +140,36 @@ export default function FileExplorer() {
   }, []);
 
   useEffect(() => {
+    const unsubscribe = subscribeToMetadata(PROFILE_ID, setMetadata);
+    return () => unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToSavedSearches(PROFILE_ID, setSavedSearches);
+    return () => unsubscribe();
+  }, []);
+
+  useEffect(() => {
     if (!opfsSupported || !root) return;
     (async () => {
       setUnsavedDir(await getDir('unsaved'));
       setDirHandle(root);
-      setPath([{ name: root.name || '/', handle: root }]);
-      await readDir(root);
+      const rootPath = '/';
+      setPath([{ name: root.name || '/', handle: root, path: rootPath }]);
+      await readDir(root, rootPath);
     })();
   }, [opfsSupported, root, getDir]);
+
+  useEffect(() => {
+    const sortedActive = [...activeTags].sort((a, b) => a.localeCompare(b));
+    const match = savedSearches.find(
+      (search) =>
+        search.tags.length === sortedActive.length &&
+        search.tags.every((tag, index) => tag === sortedActive[index]),
+    );
+    const nextId = match ? match.id : null;
+    if (nextId !== activeSavedSearchId) setActiveSavedSearchId(nextId);
+  }, [activeTags, savedSearches, activeSavedSearchId]);
 
   const saveBuffer = async (name, data) => {
     if (unsavedDir) await opfsWrite(name, data, unsavedDir);
@@ -159,8 +198,11 @@ export default function FileExplorer() {
       setDirHandle(handle);
       addRecentDir(handle);
       setRecent(await getRecentDirs());
-      setPath([{ name: handle.name || '/', handle }]);
-      await readDir(handle);
+      const rootPath = '/';
+      setPath([{ name: handle.name || '/', handle, path: rootPath }]);
+      setSelectedEntry(null);
+      setCurrentFile(null);
+      await readDir(handle, rootPath);
     } catch {}
   };
 
@@ -169,12 +211,16 @@ export default function FileExplorer() {
       const perm = await entry.handle.requestPermission({ mode: 'readwrite' });
       if (perm !== 'granted') return;
       setDirHandle(entry.handle);
-      setPath([{ name: entry.name, handle: entry.handle }]);
-      await readDir(entry.handle);
+      const rootPath = '/';
+      setPath([{ name: entry.name, handle: entry.handle, path: rootPath }]);
+      setSelectedEntry(null);
+      setCurrentFile(null);
+      await readDir(entry.handle, rootPath);
     } catch {}
   };
 
   const openFile = async (file) => {
+    setSelectedEntry(file);
     setCurrentFile(file);
     let text = '';
     if (opfsSupported) {
@@ -188,29 +234,39 @@ export default function FileExplorer() {
     setContent(text);
   };
 
-  const readDir = async (handle) => {
+  const readDir = async (handle, basePath) => {
     const ds = [];
     const fs = [];
+    const parentPath = basePath || path[path.length - 1]?.path || '/';
     for await (const [name, h] of handle.entries()) {
-      if (h.kind === 'file') fs.push({ name, handle: h });
-      else if (h.kind === 'directory') ds.push({ name, handle: h });
+      const entryPath = parentPath === '/' ? `/${name}` : `${parentPath}/${name}`;
+      const entry = { name, handle: h, path: entryPath };
+      if (h.kind === 'file') fs.push(entry);
+      else if (h.kind === 'directory') ds.push(entry);
     }
     setDirs(ds);
     setFiles(fs);
   };
 
   const openDir = async (dir) => {
+    const parentPath = path[path.length - 1]?.path || '/';
+    const fullPath = parentPath === '/' ? `/${dir.name}` : `${parentPath}/${dir.name}`;
     setDirHandle(dir.handle);
-    setPath((p) => [...p, { name: dir.name, handle: dir.handle }]);
-    await readDir(dir.handle);
+    setSelectedEntry(null);
+    setCurrentFile(null);
+    setPath((p) => [...p, { name: dir.name, handle: dir.handle, path: fullPath }]);
+    await readDir(dir.handle, fullPath);
   };
 
   const navigateTo = async (index) => {
     const target = path[index];
     if (!target) return;
     setDirHandle(target.handle);
-    setPath(path.slice(0, index + 1));
-    await readDir(target.handle);
+    setSelectedEntry(null);
+    setCurrentFile(null);
+    const nextPath = path.slice(0, index + 1);
+    setPath(nextPath);
+    await readDir(target.handle, target.path);
   };
 
   const goBack = async () => {
@@ -219,7 +275,9 @@ export default function FileExplorer() {
     const prev = newPath[newPath.length - 1];
     setPath(newPath);
     setDirHandle(prev.handle);
-    await readDir(prev.handle);
+    setSelectedEntry(null);
+    setCurrentFile(null);
+    await readDir(prev.handle, prev.path);
   };
 
   const saveFile = async () => {
@@ -258,6 +316,50 @@ export default function FileExplorer() {
   };
 
   useEffect(() => () => workerRef.current?.terminate(), []);
+
+  const toggleFilterTag = (tag) => {
+    setActiveTags((prev) => {
+      if (prev.includes(tag)) return prev.filter((t) => t !== tag);
+      return [...prev, tag].sort((a, b) => a.localeCompare(b));
+    });
+  };
+
+  const clearFilters = () => setActiveTags([]);
+
+  const addTagToSelection = async (tag) => {
+    if (!selectedEntry) return;
+    await addTagToFile(PROFILE_ID, { path: selectedEntry.path, name: selectedEntry.name }, tag);
+  };
+
+  const removeTagFromSelection = async (tag) => {
+    if (!selectedEntry) return;
+    await removeTagFromFile(PROFILE_ID, selectedEntry.path, tag);
+  };
+
+  const handleSelectSavedSearch = (search) => {
+    setActiveTags([...search.tags]);
+  };
+
+  const handleCreateSavedSearch = async ({ name, tags }) => {
+    if (!tags.length) return;
+    await createSavedSearch(PROFILE_ID, { name, tags });
+  };
+
+  const handleDeleteSavedSearch = async (id) => {
+    await deleteSavedSearch(PROFILE_ID, id);
+  };
+
+  const filteredFiles = useMemo(() => {
+    if (!activeTags.length || !metadata) return files;
+    return files.filter((file) => {
+      const entry = metadata.files[file.path];
+      if (!entry) return false;
+      return activeTags.every((tag) => entry.tags.includes(tag));
+    });
+  }, [files, activeTags, metadata]);
+
+  const selectedPath = selectedEntry?.path || currentFile?.path || null;
+  const selectedName = selectedEntry?.name || currentFile?.name || null;
 
   if (!supported) {
     return (
@@ -314,58 +416,95 @@ export default function FileExplorer() {
         )}
       </div>
       <div className="flex flex-1 overflow-hidden">
-        <div className="w-40 overflow-auto border-r border-gray-600">
-          <div className="p-2 font-bold">Recent</div>
-          {recent.map((r, i) => (
-            <div
-              key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openRecent(r)}
-            >
-              {r.name}
-            </div>
-          ))}
-          <div className="p-2 font-bold">Directories</div>
-          {dirs.map((d, i) => (
-            <div
-              key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openDir(d)}
-            >
-              {d.name}
-            </div>
-          ))}
-          <div className="p-2 font-bold">Files</div>
-          {files.map((f, i) => (
-            <div
-              key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openFile(f)}
-            >
-              {f.name}
-            </div>
-          ))}
-        </div>
-        <div className="flex-1 flex flex-col">
-          {currentFile && (
-            <textarea className="flex-1 p-2 bg-ub-cool-grey outline-none" value={content} onChange={onChange} />
-          )}
-          <div className="p-2 border-t border-gray-600">
-            <input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Find in files"
-              className="px-1 py-0.5 text-black"
-            />
-            <button onClick={runSearch} className="ml-2 px-2 py-1 bg-black bg-opacity-50 rounded">
-              Search
-            </button>
-            <div className="max-h-40 overflow-auto mt-2">
-              {results.map((r, i) => (
-                <div key={i}>
-                  <span className="font-bold">{r.file}:{r.line}</span> {r.text}
+        <Sidebar
+          metadata={metadata}
+          selectedPath={selectedPath}
+          selectedName={selectedName}
+          onAddTag={addTagToSelection}
+          onRemoveTag={removeTagFromSelection}
+          activeTags={activeTags}
+          onToggleFilterTag={toggleFilterTag}
+          onClearFilters={clearFilters}
+          savedSearches={savedSearches}
+          onSelectSavedSearch={handleSelectSavedSearch}
+          onDeleteSavedSearch={handleDeleteSavedSearch}
+          onCreateSavedSearch={handleCreateSavedSearch}
+          activeSavedSearchId={activeSavedSearchId}
+        />
+        <div className="flex flex-1 overflow-hidden">
+          <div className="w-56 overflow-auto border-r border-black border-opacity-20 bg-black bg-opacity-20">
+            <div className="p-2 font-bold">Recent</div>
+            {recent.length === 0 && (
+              <div className="px-2 text-xs text-white/60">No recent directories.</div>
+            )}
+            {recent.map((r, i) => (
+              <div
+                key={`${r.name}-${i}`}
+                className="px-2 py-1 cursor-pointer rounded hover:bg-black hover:bg-opacity-40"
+                onClick={() => openRecent(r)}
+              >
+                {r.name}
+              </div>
+            ))}
+            <div className="p-2 font-bold">Directories</div>
+            {dirs.length === 0 && (
+              <div className="px-2 text-xs text-white/60">No subdirectories.</div>
+            )}
+            {dirs.map((d) => (
+              <div
+                key={d.path}
+                className="px-2 py-1 cursor-pointer rounded hover:bg-black hover:bg-opacity-40"
+                onClick={() => openDir(d)}
+              >
+                {d.name}
+              </div>
+            ))}
+            <div className="p-2 font-bold">Files</div>
+            {filteredFiles.length === 0 && (
+              <div className="px-2 text-xs text-white/60">No files match the current filter.</div>
+            )}
+            {filteredFiles.map((f) => {
+              const isSelected = selectedEntry?.path === f.path;
+              return (
+                <div
+                  key={f.path}
+                  className={`px-2 py-1 cursor-pointer rounded transition-colors ${
+                    isSelected
+                      ? 'bg-ubt-blue text-white'
+                      : 'hover:bg-black hover:bg-opacity-40'
+                  }`}
+                  onClick={() => openFile(f)}
+                >
+                  {f.name}
                 </div>
-              ))}
+              );
+            })}
+          </div>
+          <div className="flex-1 flex flex-col">
+            {currentFile && (
+              <textarea
+                className="flex-1 p-2 bg-ub-cool-grey outline-none"
+                value={content}
+                onChange={onChange}
+              />
+            )}
+            <div className="p-2 border-t border-gray-600">
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Find in files"
+                className="px-1 py-0.5 text-black"
+              />
+              <button onClick={runSearch} className="ml-2 px-2 py-1 bg-black bg-opacity-50 rounded">
+                Search
+              </button>
+              <div className="max-h-40 overflow-auto mt-2 space-y-1">
+                {results.map((r, i) => (
+                  <div key={`${r.file}-${r.line}-${i}`}>
+                    <span className="font-bold">{r.file}:{r.line}</span> {r.text}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
         </div>

--- a/components/apps/files/Sidebar.tsx
+++ b/components/apps/files/Sidebar.tsx
@@ -1,0 +1,238 @@
+import React, { useMemo, useState } from 'react';
+import type { ProfileMetadata } from '../../../modules/filesystem/metadata';
+import type { SavedSearchWithResults } from '../../../utils/files/savedSearches';
+
+interface SidebarProps {
+  metadata: ProfileMetadata | null;
+  selectedPath?: string | null;
+  selectedName?: string | null;
+  onAddTag?: (tag: string) => Promise<void> | void;
+  onRemoveTag?: (tag: string) => Promise<void> | void;
+  activeTags: string[];
+  onToggleFilterTag: (tag: string) => void;
+  onClearFilters: () => void;
+  savedSearches: SavedSearchWithResults[];
+  onSelectSavedSearch: (search: SavedSearchWithResults) => void;
+  onDeleteSavedSearch: (id: string) => void;
+  onCreateSavedSearch: (payload: { name: string; tags: string[] }) => void;
+  activeSavedSearchId: string | null;
+}
+
+const Sidebar: React.FC<SidebarProps> = ({
+  metadata,
+  selectedPath,
+  selectedName,
+  onAddTag,
+  onRemoveTag,
+  activeTags,
+  onToggleFilterTag,
+  onClearFilters,
+  savedSearches,
+  onSelectSavedSearch,
+  onDeleteSavedSearch,
+  onCreateSavedSearch,
+  activeSavedSearchId,
+}) => {
+  const [newTag, setNewTag] = useState('');
+  const [tagQuery, setTagQuery] = useState('');
+
+  const currentTags = useMemo(() => {
+    if (!metadata || !selectedPath) return [];
+    return metadata.files[selectedPath]?.tags || [];
+  }, [metadata, selectedPath]);
+
+  const tagEntries = useMemo(() => {
+    if (!metadata) return [];
+    const query = tagQuery.trim().toLowerCase();
+    return Object.entries(metadata.tagIndex)
+      .map(([tag, paths]) => ({ tag, count: paths.length }))
+      .filter((entry) => (!query ? true : entry.tag.includes(query)))
+      .sort((a, b) => a.tag.localeCompare(b.tag));
+  }, [metadata, tagQuery]);
+
+  const handleAddTag = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!onAddTag) return;
+    const tag = newTag.trim();
+    if (!tag) return;
+    await onAddTag(tag);
+    setNewTag('');
+  };
+
+  const handleRemoveTag = async (tag: string) => {
+    if (!onRemoveTag) return;
+    await onRemoveTag(tag);
+  };
+
+  const handleCreateSmartFolder = () => {
+    if (!activeTags.length) return;
+    const defaultName = `${activeTags.join(', ')} smart folder`;
+    const name =
+      typeof window !== 'undefined'
+        ? window.prompt('Name your smart folder', defaultName)
+        : defaultName;
+    if (!name) return;
+    onCreateSavedSearch({ name, tags: activeTags });
+  };
+
+  return (
+    <aside className="w-64 bg-ub-warm-grey bg-opacity-30 border-r border-black border-opacity-20 flex flex-col overflow-hidden">
+      <div className="p-3 border-b border-black border-opacity-20">
+        <h2 className="text-sm font-semibold text-white mb-2">Current File</h2>
+        {selectedPath ? (
+          <div>
+            <div className="text-xs text-ubt-blue truncate" title={selectedPath}>
+              {selectedName || selectedPath}
+            </div>
+            <form onSubmit={handleAddTag} className="mt-2 flex items-center space-x-2">
+              <input
+                value={newTag}
+                onChange={(e) => setNewTag(e.target.value)}
+                placeholder="Add tag"
+                className="flex-1 px-2 py-1 rounded bg-ub-cool-grey text-white text-xs focus:outline-none focus:ring"
+              />
+              <button
+                type="submit"
+                className="px-2 py-1 bg-ubt-blue text-white rounded text-xs hover:bg-ubt-blue/80"
+              >
+                Add
+              </button>
+            </form>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {currentTags.length === 0 && (
+                <span className="text-xs text-white/60">No tags assigned</span>
+              )}
+              {currentTags.map((tag) => (
+                <button
+                  key={tag}
+                  type="button"
+                  onClick={() => handleRemoveTag(tag)}
+                  className="px-2 py-0.5 bg-black bg-opacity-40 rounded text-xs text-white hover:bg-opacity-60"
+                >
+                  {tag}
+                  <span className="ml-1 text-white/70">×</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <p className="text-xs text-white/60">Select a file to manage tags.</p>
+        )}
+      </div>
+
+      <div className="p-3 border-b border-black border-opacity-20">
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="text-sm font-semibold text-white">Tags</h3>
+          {activeTags.length > 0 && (
+            <button
+              type="button"
+              onClick={onClearFilters}
+              className="text-xs text-ubt-blue hover:underline"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+        <input
+          value={tagQuery}
+          onChange={(e) => setTagQuery(e.target.value)}
+          placeholder="Filter tags"
+          className="w-full px-2 py-1 rounded bg-ub-cool-grey text-white text-xs focus:outline-none focus:ring"
+        />
+        <div className="mt-3 space-y-1 max-h-48 overflow-auto pr-1">
+          {tagEntries.length === 0 && (
+            <p className="text-xs text-white/60">No tags yet.</p>
+          )}
+          {tagEntries.map(({ tag, count }) => {
+            const active = activeTags.includes(tag);
+            return (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => onToggleFilterTag(tag)}
+                className={`w-full flex items-center justify-between px-2 py-1 rounded text-xs transition-colors ${
+                  active
+                    ? 'bg-ubt-blue text-white'
+                    : 'bg-black bg-opacity-30 text-white hover:bg-opacity-50'
+                }`}
+              >
+                <span className="truncate" title={tag}>
+                  {tag}
+                </span>
+                <span className="ml-2 text-white/70">{count}</span>
+              </button>
+            );
+          })}
+        </div>
+        <button
+          type="button"
+          onClick={handleCreateSmartFolder}
+          disabled={activeTags.length === 0}
+          className={`mt-3 w-full px-2 py-1 rounded text-xs font-semibold transition-colors ${
+            activeTags.length === 0
+              ? 'bg-black bg-opacity-20 text-white/40 cursor-not-allowed'
+              : 'bg-ubt-blue text-white hover:bg-ubt-blue/80'
+          }`}
+        >
+          Save current filter
+        </button>
+      </div>
+
+      <div className="p-3 flex-1 overflow-auto">
+        <h3 className="text-sm font-semibold text-white mb-2">Smart Folders</h3>
+        {savedSearches.length === 0 ? (
+          <p className="text-xs text-white/60">Create smart folders from your tag filters.</p>
+        ) : (
+          <ul className="space-y-1">
+            {savedSearches.map((search) => {
+              const active = search.id === activeSavedSearchId;
+              return (
+                <li
+                  key={search.id}
+                  className={`group flex items-center justify-between px-2 py-1 rounded text-xs ${
+                    active
+                      ? 'bg-ubt-blue text-white'
+                      : 'bg-black bg-opacity-20 text-white hover:bg-opacity-40'
+                  }`}
+                >
+                  <button
+                    type="button"
+                    className="flex-1 text-left"
+                    onClick={() => onSelectSavedSearch(search)}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="truncate" title={search.name}>
+                        {search.name}
+                      </span>
+                      <span className="ml-2 text-white/70">{search.results.length}</span>
+                    </div>
+                    {search.tags.length > 0 && (
+                      <div className="mt-1 flex flex-wrap gap-1 text-[10px] text-white/70">
+                        {search.tags.map((tag) => (
+                          <span key={tag} className="px-1 py-0.5 bg-black/30 rounded">
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onDeleteSavedSearch(search.id)}
+                    className="ml-2 px-1 py-0.5 text-white/70 hover:text-white"
+                    aria-label={`Delete smart folder ${search.name}`}
+                  >
+                    ×
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+};
+
+export default Sidebar;
+

--- a/modules/filesystem/metadata.ts
+++ b/modules/filesystem/metadata.ts
@@ -1,0 +1,357 @@
+import { get, set, del } from 'idb-keyval';
+import { isBrowser } from '../../utils/isBrowser';
+
+export interface FileMetadata {
+  path: string;
+  name: string;
+  tags: string[];
+  updatedAt: number;
+}
+
+export interface ProfileMetadata {
+  files: Record<string, FileMetadata>;
+  tagIndex: Record<string, string[]>;
+  updatedAt: number;
+}
+
+type MetadataListener = (metadata: ProfileMetadata) => void;
+
+interface BroadcastPayload {
+  profileId: string;
+  metadata: ProfileMetadata;
+}
+
+interface StoredProfileMetadata {
+  files: Record<string, FileMetadata>;
+  tagIndex: Record<string, string[]>;
+  updatedAt: number;
+}
+
+const STORAGE_PREFIX = 'fs:metadata:';
+const metadataChannel =
+  isBrowser && 'BroadcastChannel' in self
+    ? new BroadcastChannel('fs-metadata')
+    : null;
+
+const profileCache = new Map<string, ProfileMetadata>();
+const loadingProfiles = new Map<string, Promise<ProfileMetadata>>();
+const listenerMap = new Map<string, Set<MetadataListener>>();
+const metadataSnapshots = new Map<string, ProfileMetadata>();
+
+const now = () => Date.now();
+
+const storageKey = (profileId: string): string => `${STORAGE_PREFIX}${profileId}`;
+
+const cloneMetadata = (metadata: ProfileMetadata): ProfileMetadata =>
+  structuredClone(metadata);
+
+const createEmptyMetadata = (): ProfileMetadata => ({
+  files: {},
+  tagIndex: {},
+  updatedAt: now(),
+});
+
+const normalizeTag = (tag: string): string => tag.trim().replace(/\s+/g, ' ').toLowerCase();
+
+const dedupeAndSortTags = (tags: string[]): string[] => {
+  const seen = new Set<string>();
+  for (const tag of tags) {
+    const normalized = normalizeTag(tag);
+    if (normalized) seen.add(normalized);
+  }
+  return [...seen].sort();
+};
+
+const deriveName = (path: string, provided?: string): string => {
+  if (provided?.trim()) return provided.trim();
+  const segments = path.split('/').filter(Boolean);
+  return segments[segments.length - 1] || path;
+};
+
+const ensureListenerSet = (profileId: string): Set<MetadataListener> => {
+  const existing = listenerMap.get(profileId);
+  if (existing) return existing;
+  const created = new Set<MetadataListener>();
+  listenerMap.set(profileId, created);
+  return created;
+};
+
+const addToIndex = (
+  index: Record<string, string[]>,
+  tag: string,
+  path: string,
+): void => {
+  const current = index[tag];
+  if (current) {
+    if (current.includes(path)) return;
+    index[tag] = [...current, path].sort();
+  } else {
+    index[tag] = [path];
+  }
+};
+
+const removeFromIndex = (
+  index: Record<string, string[]>,
+  tag: string,
+  path: string,
+): void => {
+  const current = index[tag];
+  if (!current) return;
+  const next = current.filter((entry) => entry !== path);
+  if (next.length) index[tag] = next;
+  else delete index[tag];
+};
+
+const ensureFileEntry = (
+  metadata: ProfileMetadata,
+  path: string,
+  name?: string,
+): FileMetadata => {
+  const existing = metadata.files[path];
+  if (existing) {
+    if (name && existing.name !== name) existing.name = deriveName(path, name);
+    return existing;
+  }
+  const entry: FileMetadata = {
+    path,
+    name: deriveName(path, name),
+    tags: [],
+    updatedAt: now(),
+  };
+  metadata.files[path] = entry;
+  return entry;
+};
+
+const sanitizeMetadata = (stored?: StoredProfileMetadata): ProfileMetadata => {
+  if (!stored) return createEmptyMetadata();
+
+  const sanitized: ProfileMetadata = {
+    files: {},
+    tagIndex: {},
+    updatedAt: stored.updatedAt || now(),
+  };
+
+  for (const [path, file] of Object.entries(stored.files || {})) {
+    const tags = dedupeAndSortTags(file.tags || []);
+    const entry: FileMetadata = {
+      path,
+      name: deriveName(path, file.name),
+      tags,
+      updatedAt: file.updatedAt || stored.updatedAt || now(),
+    };
+    sanitized.files[path] = entry;
+    for (const tag of tags) addToIndex(sanitized.tagIndex, tag, path);
+  }
+
+  // Rebuild tag index in case stored data drifted.
+  for (const [tag, paths] of Object.entries(stored.tagIndex || {})) {
+    for (const path of paths) {
+      if (sanitized.files[path]) addToIndex(sanitized.tagIndex, tag, path);
+    }
+  }
+
+  return sanitized;
+};
+
+const dispatchMetadata = (
+  profileId: string,
+  metadata: ProfileMetadata,
+  broadcast: boolean,
+): void => {
+  const snapshot = cloneMetadata(metadata);
+  metadataSnapshots.set(profileId, snapshot);
+  const listeners = listenerMap.get(profileId);
+  if (listeners) {
+    for (const listener of listeners) listener(cloneMetadata(snapshot));
+  }
+  if (broadcast) metadataChannel?.postMessage({ profileId, metadata: snapshot });
+};
+
+const persistMetadata = async (
+  profileId: string,
+  metadata: ProfileMetadata,
+  broadcast: boolean,
+): Promise<void> => {
+  profileCache.set(profileId, metadata);
+  metadataSnapshots.set(profileId, cloneMetadata(metadata));
+  await set(storageKey(profileId), cloneMetadata(metadata));
+  dispatchMetadata(profileId, metadata, broadcast);
+};
+
+const ensureProfile = async (profileId: string): Promise<ProfileMetadata> => {
+  if (profileCache.has(profileId)) return profileCache.get(profileId)!;
+
+  let loader = loadingProfiles.get(profileId);
+  if (!loader) {
+    loader = (async () => {
+      const stored = (await get<StoredProfileMetadata>(storageKey(profileId))) || undefined;
+      const metadata = sanitizeMetadata(stored);
+      profileCache.set(profileId, metadata);
+      metadataSnapshots.set(profileId, cloneMetadata(metadata));
+      return metadata;
+    })();
+    loadingProfiles.set(profileId, loader);
+  }
+
+  const metadata = await loader;
+  return metadata;
+};
+
+metadataChannel?.addEventListener('message', (event: MessageEvent<BroadcastPayload>) => {
+  const { profileId, metadata } = event.data;
+  const sanitized = sanitizeMetadata(metadata);
+  profileCache.set(profileId, sanitized);
+  metadataSnapshots.set(profileId, cloneMetadata(sanitized));
+  dispatchMetadata(profileId, sanitized, false);
+});
+
+export const getMetadataSnapshot = async (
+  profileId: string,
+): Promise<ProfileMetadata> => {
+  const metadata = await ensureProfile(profileId);
+  return cloneMetadata(metadata);
+};
+
+export const subscribeToMetadata = (
+  profileId: string,
+  listener: MetadataListener,
+): (() => void) => {
+  const listeners = ensureListenerSet(profileId);
+  listeners.add(listener);
+  ensureProfile(profileId).then(() => {
+    const snapshot = metadataSnapshots.get(profileId);
+    if (snapshot) listener(cloneMetadata(snapshot));
+  });
+  return () => {
+    const set = listenerMap.get(profileId);
+    set?.delete(listener);
+    if (set && set.size === 0) listenerMap.delete(profileId);
+  };
+};
+
+const updateFileTags = async (
+  profileId: string,
+  path: string,
+  tags: string[],
+  name?: string,
+): Promise<FileMetadata> => {
+  const metadata = await ensureProfile(profileId);
+  const entry = ensureFileEntry(metadata, path, name);
+  const normalized = dedupeAndSortTags(tags);
+  const previous = new Set(entry.tags);
+  entry.tags = normalized;
+  entry.updatedAt = now();
+  metadata.updatedAt = entry.updatedAt;
+
+  for (const tag of previous) {
+    if (!normalized.includes(tag)) removeFromIndex(metadata.tagIndex, tag, path);
+  }
+  for (const tag of normalized) addToIndex(metadata.tagIndex, tag, path);
+
+  await persistMetadata(profileId, metadata, true);
+  return cloneMetadata(entry);
+};
+
+export const addTagToFile = async (
+  profileId: string,
+  file: { path: string; name?: string },
+  tag: string,
+): Promise<FileMetadata> => {
+  const normalizedTag = normalizeTag(tag);
+  if (!normalizedTag) {
+    const metadata = await ensureProfile(profileId);
+    return cloneMetadata(ensureFileEntry(metadata, file.path, file.name));
+  }
+  const metadata = await ensureProfile(profileId);
+  const entry = ensureFileEntry(metadata, file.path, file.name);
+  if (entry.tags.includes(normalizedTag)) return cloneMetadata(entry);
+
+  entry.tags = dedupeAndSortTags([...entry.tags, normalizedTag]);
+  entry.updatedAt = now();
+  metadata.updatedAt = entry.updatedAt;
+  addToIndex(metadata.tagIndex, normalizedTag, entry.path);
+  await persistMetadata(profileId, metadata, true);
+  return cloneMetadata(entry);
+};
+
+export const removeTagFromFile = async (
+  profileId: string,
+  path: string,
+  tag: string,
+): Promise<FileMetadata | undefined> => {
+  const metadata = await ensureProfile(profileId);
+  const entry = metadata.files[path];
+  if (!entry) return undefined;
+  const normalizedTag = normalizeTag(tag);
+  if (!normalizedTag || !entry.tags.includes(normalizedTag)) return cloneMetadata(entry);
+
+  entry.tags = entry.tags.filter((t) => t !== normalizedTag);
+  entry.updatedAt = now();
+  metadata.updatedAt = entry.updatedAt;
+  removeFromIndex(metadata.tagIndex, normalizedTag, path);
+  await persistMetadata(profileId, metadata, true);
+  return cloneMetadata(entry);
+};
+
+export const setFileTags = async (
+  profileId: string,
+  file: { path: string; name?: string },
+  tags: string[],
+): Promise<FileMetadata> => updateFileTags(profileId, file.path, tags, file.name);
+
+export const getFileMetadata = async (
+  profileId: string,
+  path: string,
+): Promise<FileMetadata | undefined> => {
+  const metadata = await ensureProfile(profileId);
+  const entry = metadata.files[path];
+  return entry ? cloneMetadata(entry) : undefined;
+};
+
+export const listFilesForTag = async (
+  profileId: string,
+  tag: string,
+): Promise<FileMetadata[]> => {
+  const metadata = await ensureProfile(profileId);
+  const paths = metadata.tagIndex[normalizeTag(tag)] || [];
+  return paths
+    .map((path) => metadata.files[path])
+    .filter((entry): entry is FileMetadata => Boolean(entry))
+    .map((entry) => cloneMetadata(entry));
+};
+
+export const listTags = async (
+  profileId: string,
+): Promise<{ tag: string; count: number }[]> => {
+  const metadata = await ensureProfile(profileId);
+  return Object.entries(metadata.tagIndex)
+    .map(([tag, paths]) => ({ tag, count: paths.length }))
+    .sort((a, b) => a.tag.localeCompare(b.tag));
+};
+
+export const clearProfileMetadata = async (profileId?: string): Promise<void> => {
+  if (profileId) {
+    profileCache.delete(profileId);
+    metadataSnapshots.delete(profileId);
+    listenerMap.delete(profileId);
+    loadingProfiles.delete(profileId);
+    await del(storageKey(profileId));
+    dispatchMetadata(profileId, createEmptyMetadata(), false);
+    return;
+  }
+
+  const keys = Array.from(profileCache.keys());
+  profileCache.clear();
+  metadataSnapshots.clear();
+  listenerMap.clear();
+  loadingProfiles.clear();
+  for (const key of keys) {
+    await del(storageKey(key));
+  }
+};
+
+export const __internal = {
+  normalizeTag,
+  dedupeAndSortTags,
+};
+

--- a/utils/files/savedSearches.ts
+++ b/utils/files/savedSearches.ts
@@ -1,0 +1,346 @@
+import { get, set, del } from 'idb-keyval';
+import { isBrowser } from '../../utils/isBrowser';
+import {
+  type FileMetadata,
+  type ProfileMetadata,
+  getMetadataSnapshot,
+  subscribeToMetadata,
+  __internal as metadataInternal,
+} from '../../modules/filesystem/metadata';
+
+const { dedupeAndSortTags } = metadataInternal;
+
+export interface SavedSearchDefinition {
+  id: string;
+  name: string;
+  tags: string[];
+  term?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface SavedSearchWithResults extends SavedSearchDefinition {
+  results: FileMetadata[];
+}
+
+export interface EvaluationStats {
+  scanned: number;
+}
+
+type SavedSearchListener = (searches: SavedSearchWithResults[]) => void;
+
+interface StoredSavedSearches {
+  definitions: SavedSearchDefinition[];
+}
+
+interface SavedSearchState {
+  definitions: SavedSearchDefinition[];
+  results: Map<string, FileMetadata[]>;
+}
+
+interface BroadcastPayload {
+  profileId: string;
+  definitions: SavedSearchDefinition[];
+}
+
+const STORAGE_PREFIX = 'fs:saved-searches:';
+const savedSearchChannel =
+  isBrowser && 'BroadcastChannel' in self
+    ? new BroadcastChannel('fs-saved-searches')
+    : null;
+
+const savedSearchCache = new Map<string, SavedSearchState>();
+const loadingStates = new Map<string, Promise<SavedSearchState>>();
+const listenersMap = new Map<string, Set<SavedSearchListener>>();
+const metadataSnapshots = new Map<string, ProfileMetadata>();
+const metadataUnsubscribers = new Map<string, () => void>();
+
+const storageKey = (profileId: string): string => `${STORAGE_PREFIX}${profileId}`;
+
+const now = (): number => Date.now();
+
+const generateId = (): string => {
+  if (isBrowser && 'crypto' in self && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `search-${Math.random().toString(36).slice(2)}-${now()}`;
+};
+
+const cloneFile = (file: FileMetadata): FileMetadata => structuredClone(file);
+
+const cloneSearch = (search: SavedSearchWithResults): SavedSearchWithResults => ({
+  ...search,
+  tags: [...search.tags],
+  results: search.results.map(cloneFile),
+});
+
+const cloneDefinition = (definition: SavedSearchDefinition): SavedSearchDefinition => ({
+  ...definition,
+  tags: [...definition.tags],
+});
+
+const normalizeDefinition = (
+  definition: SavedSearchDefinition,
+): SavedSearchDefinition => {
+  const normalizedTags = dedupeAndSortTags(definition.tags || []);
+  const name = definition.name?.trim() || 'Smart Folder';
+  const term = definition.term?.trim();
+  return {
+    ...definition,
+    id: definition.id || generateId(),
+    name,
+    tags: normalizedTags,
+    term: term || undefined,
+    createdAt: definition.createdAt || now(),
+    updatedAt: definition.updatedAt || definition.createdAt || now(),
+  };
+};
+
+const ensureListenerSet = (profileId: string): Set<SavedSearchListener> => {
+  const existing = listenersMap.get(profileId);
+  if (existing) return existing;
+  const created = new Set<SavedSearchListener>();
+  listenersMap.set(profileId, created);
+  return created;
+};
+
+const evaluateDefinition = (
+  definition: SavedSearchDefinition,
+  metadata: ProfileMetadata,
+  options?: { collectStats?: boolean },
+): { results: FileMetadata[]; stats?: EvaluationStats } => {
+  const normalizedTags = dedupeAndSortTags(definition.tags || []);
+  const term = definition.term?.trim().toLowerCase();
+  let scanned = 0;
+
+  const matchesTerm = (file: FileMetadata): boolean => {
+    if (!term) return true;
+    return (
+      file.name.toLowerCase().includes(term) ||
+      file.path.toLowerCase().includes(term)
+    );
+  };
+
+  if (normalizedTags.length === 0) {
+    const files = Object.values(metadata.files).filter(matchesTerm);
+    scanned = options?.collectStats ? files.length : 0;
+    return {
+      results: files.map(cloneFile),
+      stats: options?.collectStats ? { scanned } : undefined,
+    };
+  }
+
+  const sortedTags = [...normalizedTags].sort((a, b) => {
+    const lenA = metadata.tagIndex[a]?.length ?? Number.MAX_SAFE_INTEGER;
+    const lenB = metadata.tagIndex[b]?.length ?? Number.MAX_SAFE_INTEGER;
+    return lenA - lenB;
+  });
+
+  const primaryTag = sortedTags[0];
+  const primaryCandidates = metadata.tagIndex[primaryTag] || [];
+  scanned = options?.collectStats ? primaryCandidates.length : 0;
+
+  let candidatePaths = [...primaryCandidates];
+  for (let i = 1; i < sortedTags.length; i += 1) {
+    if (!candidatePaths.length) break;
+    const currentTag = sortedTags[i];
+    const currentSet = new Set(metadata.tagIndex[currentTag] || []);
+    candidatePaths = candidatePaths.filter((path) => currentSet.has(path));
+  }
+
+  const matches = candidatePaths
+    .map((path) => metadata.files[path])
+    .filter((file): file is FileMetadata => Boolean(file))
+    .filter(matchesTerm)
+    .map(cloneFile);
+
+  return {
+    results: matches,
+    stats: options?.collectStats ? { scanned } : undefined,
+  };
+};
+
+const recomputeResults = (profileId: string, state: SavedSearchState): void => {
+  const metadata = metadataSnapshots.get(profileId);
+  if (!metadata) return;
+  const nextResults = new Map<string, FileMetadata[]>();
+  for (const definition of state.definitions) {
+    const evaluation = evaluateDefinition(definition, metadata);
+    nextResults.set(definition.id, evaluation.results);
+  }
+  state.results = nextResults;
+};
+
+const notifyListeners = (profileId: string): void => {
+  const state = savedSearchCache.get(profileId);
+  if (!state) return;
+  const listeners = listenersMap.get(profileId);
+  if (!listeners || listeners.size === 0) return;
+  const payload = state.definitions.map((definition) => ({
+    ...cloneDefinition(definition),
+    results: (state.results.get(definition.id) || []).map(cloneFile),
+  }));
+  for (const listener of listeners) listener(payload.map(cloneSearch));
+};
+
+const persistState = async (
+  profileId: string,
+  state: SavedSearchState,
+  broadcast: boolean,
+): Promise<void> => {
+  const definitions = state.definitions.map(cloneDefinition);
+  await set(storageKey(profileId), { definitions });
+  if (broadcast)
+    savedSearchChannel?.postMessage({ profileId, definitions } as BroadcastPayload);
+  notifyListeners(profileId);
+};
+
+const ensureMetadataSubscription = (profileId: string): void => {
+  if (metadataUnsubscribers.has(profileId)) return;
+  const unsubscribe = subscribeToMetadata(profileId, (metadata) => {
+    metadataSnapshots.set(profileId, metadata);
+    const state = savedSearchCache.get(profileId);
+    if (!state) return;
+    recomputeResults(profileId, state);
+    notifyListeners(profileId);
+  });
+  metadataUnsubscribers.set(profileId, unsubscribe);
+};
+
+const ensureState = async (profileId: string): Promise<SavedSearchState> => {
+  if (savedSearchCache.has(profileId)) return savedSearchCache.get(profileId)!;
+
+  let loader = loadingStates.get(profileId);
+  if (!loader) {
+    loader = (async () => {
+      const stored = (await get<StoredSavedSearches>(storageKey(profileId))) || {
+        definitions: [],
+      };
+      const definitions = (stored.definitions || []).map(normalizeDefinition);
+      const state: SavedSearchState = {
+        definitions,
+        results: new Map(),
+      };
+      const metadata = await getMetadataSnapshot(profileId);
+      metadataSnapshots.set(profileId, metadata);
+      savedSearchCache.set(profileId, state);
+      recomputeResults(profileId, state);
+      ensureMetadataSubscription(profileId);
+      return state;
+    })();
+    loadingStates.set(profileId, loader);
+  }
+
+  return loader;
+};
+
+savedSearchChannel?.addEventListener('message', (event: MessageEvent<BroadcastPayload>) => {
+  const { profileId, definitions } = event.data;
+  const state = savedSearchCache.get(profileId) || {
+    definitions: [],
+    results: new Map(),
+  };
+  state.definitions = definitions.map(normalizeDefinition);
+  savedSearchCache.set(profileId, state);
+  recomputeResults(profileId, state);
+  notifyListeners(profileId);
+});
+
+export const getSavedSearchesSnapshot = async (
+  profileId: string,
+): Promise<SavedSearchWithResults[]> => {
+  const state = await ensureState(profileId);
+  return state.definitions.map((definition) => ({
+    ...cloneDefinition(definition),
+    results: (state.results.get(definition.id) || []).map(cloneFile),
+  }));
+};
+
+export const subscribeToSavedSearches = (
+  profileId: string,
+  listener: SavedSearchListener,
+): (() => void) => {
+  const listeners = ensureListenerSet(profileId);
+  listeners.add(listener);
+  ensureState(profileId).then(() => {
+    const state = savedSearchCache.get(profileId);
+    if (!state) return;
+    const payload = state.definitions.map((definition) => ({
+      ...cloneDefinition(definition),
+      results: (state.results.get(definition.id) || []).map(cloneFile),
+    }));
+    listener(payload.map(cloneSearch));
+  });
+  return () => {
+    const set = listenersMap.get(profileId);
+    set?.delete(listener);
+    if (set && set.size === 0) listenersMap.delete(profileId);
+  };
+};
+
+export const createSavedSearch = async (
+  profileId: string,
+  definition: Omit<SavedSearchDefinition, 'id' | 'createdAt' | 'updatedAt'> & {
+    id?: string;
+  },
+): Promise<SavedSearchDefinition> => {
+  const state = await ensureState(profileId);
+  const normalized = normalizeDefinition({
+    ...definition,
+    id: definition.id || generateId(),
+    createdAt: now(),
+    updatedAt: now(),
+  });
+  state.definitions = [...state.definitions, normalized];
+  recomputeResults(profileId, state);
+  await persistState(profileId, state, true);
+  return cloneDefinition(normalized);
+};
+
+export const deleteSavedSearch = async (
+  profileId: string,
+  searchId: string,
+): Promise<void> => {
+  const state = await ensureState(profileId);
+  const nextDefinitions = state.definitions.filter((definition) => definition.id !== searchId);
+  if (nextDefinitions.length === state.definitions.length) return;
+  state.definitions = nextDefinitions;
+  state.results.delete(searchId);
+  await persistState(profileId, state, true);
+};
+
+export const evaluateSavedSearch = (
+  definition: SavedSearchDefinition,
+  metadata: ProfileMetadata,
+  options?: { collectStats?: boolean },
+): { results: FileMetadata[]; stats?: EvaluationStats } =>
+  evaluateDefinition(definition, metadata, options);
+
+export const clearSavedSearches = async (profileId?: string): Promise<void> => {
+  if (profileId) {
+    savedSearchCache.delete(profileId);
+    loadingStates.delete(profileId);
+    listenersMap.delete(profileId);
+    metadataSnapshots.delete(profileId);
+    metadataUnsubscribers.get(profileId)?.();
+    metadataUnsubscribers.delete(profileId);
+    await del(storageKey(profileId));
+    return;
+  }
+  const profiles = Array.from(savedSearchCache.keys());
+  savedSearchCache.clear();
+  loadingStates.clear();
+  listenersMap.clear();
+  for (const [id, unsubscribe] of metadataUnsubscribers.entries()) unsubscribe();
+  metadataUnsubscribers.clear();
+  metadataSnapshots.clear();
+  for (const id of profiles) {
+    await del(storageKey(id));
+  }
+};
+
+export const __internal = {
+  normalizeDefinition,
+  generateId,
+};
+


### PR DESCRIPTION
## Summary
- add a filesystem metadata store that tracks tags per profile with broadcast updates
- implement saved search persistence with fast tag-based evaluation and expose a tagging sidebar for the Files app
- update the file explorer UI to support tag filters, smart folders, and new tag management tests

## Testing
- yarn lint *(fails: repository has pre-existing accessibility violations)*
- yarn test *(fails: existing test suite failures unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4685e1b88328b15f8d39b4ceab68