### PR TITLE
[terminal] Add multi-line paste safeguards

### DIFF
--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -8,6 +8,7 @@ import React, {
   useImperativeHandle,
   useCallback,
 } from 'react';
+import { trackEvent } from '@/lib/analytics-client';
 import useOPFS from '../../hooks/useOPFS';
 import commandRegistry, { CommandContext } from './commands';
 import TerminalContainer from './components/Terminal';
@@ -67,6 +68,84 @@ export interface TerminalProps {
   openApp?: (id: string) => void;
 }
 
+const TRUST_STORAGE_KEY = 'terminal:trustedOriginsOnce';
+
+interface PendingPaste {
+  payload: string;
+  lines: string[];
+  lineCount: number;
+  origin?: string;
+  sourceLabel: string;
+  trigger: 'paste' | 'toolbar' | 'keyboard';
+}
+
+interface LineModeProgress {
+  current: number;
+  total: number;
+}
+
+const normalizeText = (text: string) => text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+const trimTrailingBlankLines = (lines: string[]) => {
+  const trimmed = [...lines];
+  while (trimmed.length > 0 && trimmed[trimmed.length - 1].trim() === '') {
+    trimmed.pop();
+  }
+  return trimmed;
+};
+
+const formatOriginLabel = (origin?: string, fallback = 'Clipboard') => {
+  if (!origin) return fallback;
+  try {
+    const url = new URL(origin);
+    return url.host || origin;
+  } catch {
+    return origin;
+  }
+};
+
+const extractSourceOrigin = (html?: string | null): string | undefined => {
+  if (!html) return undefined;
+  const sourceMatch = html.match(/SourceURL:(.*)/i);
+  if (sourceMatch?.[1]) {
+    const rawUrl = sourceMatch[1].trim();
+    if (rawUrl) {
+      try {
+        return new URL(rawUrl).origin;
+      } catch {
+        return rawUrl;
+      }
+    }
+  }
+  const httpMatch = html.match(/https?:\/\/[^\s"'>]+/i);
+  if (httpMatch?.[0]) {
+    const rawUrl = httpMatch[0];
+    try {
+      return new URL(rawUrl).origin;
+    } catch {
+      return rawUrl;
+    }
+  }
+  if (typeof window !== 'undefined') {
+    try {
+      const parser = new DOMParser();
+      const firstTag = html.indexOf('<');
+      const markup = firstTag >= 0 ? html.slice(firstTag) : html;
+      const doc = parser.parseFromString(markup, 'text/html');
+      const candidate =
+        doc.querySelector('base[href]')?.getAttribute('href') ||
+        doc.querySelector('link[rel="canonical"]')?.getAttribute('href') ||
+        doc.querySelector('meta[property="og:url" i]')?.getAttribute('content');
+      if (candidate) {
+        return new URL(candidate, window.location.href).origin;
+      }
+    } catch {
+      // ignore parse failures
+    }
+  }
+  return undefined;
+};
+
 export interface TerminalHandle {
   runCommand: (cmd: string) => void;
   getContent: () => string;
@@ -101,10 +180,67 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [paletteInput, setPaletteInput] = useState('');
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [pendingPaste, setPendingPaste] = useState<PendingPaste | null>(null);
+  const [pendingTrustOnce, setPendingTrustOnce] = useState(false);
+  const [lineModeProgress, setLineModeProgress] = useState<LineModeProgress | null>(null);
   const { supported: opfsSupported, getDir, readFile, writeFile, deleteFile } =
     useOPFS();
   const dirRef = useRef<FileSystemDirectoryHandle | null>(null);
   const [overflow, setOverflow] = useState({ top: false, bottom: false });
+  const trustedOriginsRef = useRef<Set<string>>(new Set());
+  const lineModeCancelRef = useRef(false);
+  const persistTrustedOrigins = useCallback((origins: Set<string>) => {
+    if (typeof window === 'undefined') return;
+    try {
+      sessionStorage.setItem(
+        TRUST_STORAGE_KEY,
+        JSON.stringify(Array.from(origins)),
+      );
+    } catch {
+      // ignore storage errors
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = sessionStorage.getItem(TRUST_STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+          trustedOriginsRef.current = new Set(
+            parsed.filter((item): item is string => typeof item === 'string'),
+          );
+        }
+      }
+    } catch {
+      trustedOriginsRef.current = new Set();
+    }
+  }, []);
+
+  const addTrustedOrigin = useCallback(
+    (origin: string) => {
+      if (!origin) return;
+      const next = new Set(trustedOriginsRef.current);
+      next.add(origin);
+      trustedOriginsRef.current = next;
+      persistTrustedOrigins(next);
+    },
+    [persistTrustedOrigins],
+  );
+
+  const consumeTrustedOrigin = useCallback(
+    (origin?: string) => {
+      if (!origin) return false;
+      const next = new Set(trustedOriginsRef.current);
+      if (!next.has(origin)) return false;
+      next.delete(origin);
+      trustedOriginsRef.current = next;
+      persistTrustedOrigins(next);
+      return true;
+    },
+    [persistTrustedOrigins],
+  );
   const ansiColors = [
     '#000000',
     '#AA0000',
@@ -155,13 +291,6 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
 
   const handleCopy = () => {
     navigator.clipboard.writeText(contentRef.current).catch(() => {});
-  };
-
-  const handlePaste = async () => {
-    try {
-      const text = await navigator.clipboard.readText();
-      handleInput(text);
-    } catch {}
   };
 
   const runWorker = useCallback(
@@ -269,7 +398,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
     const handleInput = useCallback(
       (data: string) => {
         for (const ch of data) {
-          if (ch === '\r') {
+          if (ch === '\r' || ch === '\n') {
             termRef.current?.writeln('');
             runCommand(commandRef.current.trim());
             commandRef.current = '';
@@ -288,6 +417,178 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
       [runCommand, prompt],
     );
 
+    const clearPending = useCallback(() => {
+      setPendingPaste(null);
+      setPendingTrustOnce(false);
+      setLineModeProgress(null);
+      termRef.current?.focus();
+    }, []);
+
+    const stageInput = useCallback(
+      (
+        rawData: string,
+        meta: { origin?: string; sourceLabel?: string; trigger: 'keyboard' | 'paste' | 'toolbar' },
+      ) => {
+        if (!rawData) return;
+        const normalized = normalizeText(rawData);
+        const rawLines = normalized.split('\n');
+        const lines = trimTrailingBlankLines(rawLines);
+        const lineCount = lines.length;
+        const payloadBase = lines.join('\r');
+        const payload =
+          payloadBase.length > 0
+            ? `${payloadBase}${normalized.endsWith('\n') ? '\r' : ''}`
+            : normalized.endsWith('\n')
+            ? '\r'
+            : '';
+        if (lineCount <= 1) {
+          handleInput(payload);
+          return;
+        }
+        const originKey = meta.origin;
+        trackEvent('terminal_paste_detected', {
+          origin: originKey ?? 'unknown',
+          lines: lineCount,
+          mechanism: meta.trigger,
+        });
+        if (consumeTrustedOrigin(originKey)) {
+          trackEvent('terminal_paste_bypassed', {
+            origin: originKey ?? 'unknown',
+            lines: lineCount,
+            via: 'trusted_once',
+          });
+          handleInput(payload);
+          return;
+        }
+        setPendingTrustOnce(false);
+        setPendingPaste({
+          payload,
+          lines,
+          lineCount,
+          origin: originKey,
+          sourceLabel: meta.sourceLabel || originKey || 'Clipboard',
+          trigger: meta.trigger,
+        });
+      },
+      [consumeTrustedOrigin, handleInput],
+    );
+
+    const executeLineByLine = useCallback(
+      async (pending: PendingPaste) => {
+        lineModeCancelRef.current = false;
+        const total = pending.lines.length;
+        if (total === 0) {
+          clearPending();
+          return;
+        }
+        for (let i = 0; i < total; i += 1) {
+          if (lineModeCancelRef.current) break;
+          setLineModeProgress({ current: i, total });
+          const line = pending.lines[i];
+          if (line) {
+            handleInput(`${line}\r`);
+          } else {
+            handleInput('\r');
+          }
+          await new Promise<void>((resolve) => setTimeout(resolve, 120));
+        }
+        const wasCancelled = lineModeCancelRef.current;
+        lineModeCancelRef.current = false;
+        setLineModeProgress(null);
+        if (!wasCancelled) {
+          clearPending();
+        }
+      },
+      [clearPending, handleInput],
+    );
+
+    const confirmPaste = useCallback(
+      (mode: 'all' | 'line', via: 'button' | 'chord') => {
+        if (!pendingPaste) return;
+        const { payload, lines, lineCount, origin } = pendingPaste;
+        if (pendingTrustOnce && origin) {
+          addTrustedOrigin(origin);
+        }
+        if (mode === 'all') {
+          trackEvent('terminal_paste_confirmed', {
+            origin: origin ?? 'unknown',
+            lines: lineCount,
+            mode: 'all',
+            via,
+          });
+          clearPending();
+          handleInput(payload);
+        } else {
+          trackEvent('terminal_paste_confirmed', {
+            origin: origin ?? 'unknown',
+            lines: lineCount,
+            mode: 'line',
+            via,
+          });
+          void executeLineByLine(pendingPaste);
+        }
+      },
+      [pendingPaste, pendingTrustOnce, addTrustedOrigin, clearPending, handleInput, executeLineByLine],
+    );
+
+    const handleCancelPaste = useCallback(() => {
+      if (!pendingPaste) return;
+      if (lineModeProgress) {
+        lineModeCancelRef.current = true;
+      }
+      trackEvent('terminal_paste_cancelled', {
+        origin: pendingPaste.origin ?? 'unknown',
+        lines: pendingPaste.lineCount,
+        mode: lineModeProgress ? 'line' : 'all',
+      });
+      clearPending();
+    }, [pendingPaste, lineModeProgress, clearPending]);
+
+    const handlePaste = useCallback(async () => {
+      try {
+        let html: string | undefined;
+        let text = '';
+        const advancedClipboard = navigator.clipboard as Clipboard & {
+          read?: () => Promise<ClipboardItem[]>;
+        };
+        if (typeof advancedClipboard.read === 'function') {
+          const items = await advancedClipboard.read();
+          for (const item of items) {
+            if (!text && item.types.includes('text/plain')) {
+              const blob = await item.getType('text/plain');
+              text = await blob.text();
+            }
+            if (!html && item.types.includes('text/html')) {
+              const blob = await item.getType('text/html');
+              html = await blob.text();
+            }
+          }
+        }
+        if (!text) {
+          text = await navigator.clipboard.readText();
+        }
+        if (!text) return;
+        const origin = extractSourceOrigin(html);
+        stageInput(text, {
+          origin,
+          sourceLabel: origin || 'Clipboard',
+          trigger: 'toolbar',
+        });
+      } catch {
+        try {
+          const fallback = await navigator.clipboard.readText();
+          if (fallback) {
+            stageInput(fallback, {
+              trigger: 'toolbar',
+              sourceLabel: 'Clipboard',
+            });
+          }
+        } catch {
+          // ignore clipboard errors
+        }
+      }
+    }, [stageInput]);
+
   useImperativeHandle(ref, () => ({
     runCommand: (c: string) => runCommand(c),
     getContent: () => contentRef.current,
@@ -295,6 +596,8 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
 
   useEffect(() => {
     let disposed = false;
+    let cleanupTextarea: HTMLTextAreaElement | null = null;
+    let cleanupPaste: ((event: ClipboardEvent) => void) | null = null;
     (async () => {
       const [{ Terminal: XTerm }, { FitAddon }, { SearchAddon }] = await Promise.all([
         import('@xterm/xterm'),
@@ -343,7 +646,27 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
       writeLine('Welcome to the web terminal!');
       writeLine('Type "help" to see available commands.');
       prompt();
-      term.onData((d: string) => handleInput(d));
+      term.onData((d: string) => stageInput(d, { trigger: 'keyboard' }));
+      const textarea =
+        (term.textarea ||
+          (term.element?.querySelector('textarea') as HTMLTextAreaElement | null)) ?? null;
+      const handleDomPaste = (event: ClipboardEvent) => {
+        if (!event.clipboardData) return;
+        const text =
+          event.clipboardData.getData('text/plain') ||
+          event.clipboardData.getData('text');
+        if (!text) return;
+        event.preventDefault();
+        const origin = extractSourceOrigin(event.clipboardData.getData('text/html'));
+        stageInput(text, {
+          origin,
+          sourceLabel: origin || 'Clipboard',
+          trigger: 'paste',
+        });
+      };
+      textarea?.addEventListener('paste', handleDomPaste);
+      cleanupTextarea = textarea;
+      cleanupPaste = handleDomPaste;
       term.onKey(({ domEvent }: any) => {
         if (domEvent.key === 'Tab') {
           domEvent.preventDefault();
@@ -376,9 +699,21 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
     })();
     return () => {
       disposed = true;
+      if (cleanupTextarea && cleanupPaste) {
+        cleanupTextarea.removeEventListener('paste', cleanupPaste);
+      }
       termRef.current?.dispose();
     };
-    }, [opfsSupported, getDir, readFile, writeLine, prompt, handleInput, autocomplete, updateOverflow]);
+    }, [
+      opfsSupported,
+      getDir,
+      readFile,
+      writeLine,
+      prompt,
+      stageInput,
+      autocomplete,
+      updateOverflow,
+    ]);
 
   useEffect(() => {
     const handleResize = () => fitRef.current?.fit();
@@ -410,8 +745,125 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
     return () => window.removeEventListener('keydown', listener);
   }, [paletteOpen]);
 
+  useEffect(() => {
+    if (!pendingPaste) return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleCancelPaste();
+      } else if (event.ctrlKey && event.shiftKey && event.key === 'Enter') {
+        event.preventDefault();
+        confirmPaste('all', 'chord');
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [pendingPaste, handleCancelPaste, confirmPaste]);
+
+  const originLabel = pendingPaste
+    ? formatOriginLabel(pendingPaste.origin, pendingPaste.sourceLabel)
+    : '';
+  const previewLines = pendingPaste ? pendingPaste.lines.slice(0, 20) : [];
+  const totalPreviewLines = pendingPaste ? pendingPaste.lines.length : 0;
+  const lineDigits = totalPreviewLines ? Math.max(2, String(totalPreviewLines).length) : 2;
+  const remainingPreviewLines = Math.max(totalPreviewLines - previewLines.length, 0);
+
   return (
     <div className="relative h-full w-full">
+      {pendingPaste && (
+        <div className="absolute inset-0 z-20 flex items-start justify-center bg-black/70 p-4">
+          <div className="mt-10 w-full max-w-3xl rounded-lg border border-blue-500 bg-gray-900 text-white shadow-xl">
+            <div className="border-b border-blue-500/50 p-4">
+              <h2 className="text-lg font-semibold">Multi-line paste detected</h2>
+              <p className="mt-1 text-sm text-blue-200">
+                {pendingPaste.lineCount} line{pendingPaste.lineCount === 1 ? '' : 's'} from {originLabel}.
+                Review before running.
+              </p>
+            </div>
+            <div className="max-h-64 overflow-y-auto border-b border-blue-500/40 bg-black/40 p-4 font-mono text-sm">
+              {previewLines.map((line, idx) => (
+                <div
+                  key={idx}
+                  className={`flex gap-3 ${
+                    lineModeProgress?.current === idx ? 'bg-blue-900/40' : ''
+                  }`}
+                >
+                  <span className="w-12 shrink-0 text-right text-blue-300">
+                    {String(idx + 1).padStart(lineDigits, ' ')}
+                  </span>
+                  <span className="whitespace-pre-wrap break-words text-gray-100">
+                    {line.length > 0 ? line : <span className="text-gray-500">[blank]</span>}
+                  </span>
+                </div>
+              ))}
+              {remainingPreviewLines > 0 && (
+                <div className="mt-2 text-xs text-blue-200">
+                  +{remainingPreviewLines} more line{remainingPreviewLines === 1 ? '' : 's'} not shown
+                </div>
+              )}
+            </div>
+            {lineModeProgress && (
+              <div className="border-b border-blue-500/40 bg-blue-900/20 px-4 py-2 text-sm text-blue-200">
+                Running line {lineModeProgress.current + 1} of {lineModeProgress.total}
+              </div>
+            )}
+            <div className="flex flex-col gap-3 p-4 md:flex-row md:items-center md:justify-between">
+              <div className="flex flex-col gap-2 text-sm">
+                <div className="text-blue-100">
+                  Press{' '}
+                  <kbd className="rounded bg-blue-800 px-1 py-0.5 text-xs">Ctrl</kbd>
+                  +
+                  <kbd className="rounded bg-blue-800 px-1 py-0.5 text-xs">Shift</kbd>
+                  +
+                  <kbd className="rounded bg-blue-800 px-1 py-0.5 text-xs">Enter</kbd>{' '}
+                  to run everything.
+                </div>
+                {pendingPaste.origin ? (
+                  <label className="inline-flex items-center gap-2 text-blue-100">
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 rounded border-blue-400 bg-gray-800"
+                      checked={pendingTrustOnce}
+                      onChange={(event) => setPendingTrustOnce(event.target.checked)}
+                      disabled={Boolean(lineModeProgress)}
+                    />
+                    <span>Trust {originLabel} for the next paste only</span>
+                  </label>
+                ) : (
+                  <span className="text-xs text-blue-200">
+                    Origin unknown — trust toggle unavailable for this paste.
+                  </span>
+                )}
+              </div>
+              <div className="flex flex-wrap justify-end gap-2">
+                <button
+                  type="button"
+                  className="rounded bg-gray-700 px-3 py-2 text-sm"
+                  onClick={handleCancelPaste}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="rounded bg-blue-700 px-3 py-2 text-sm disabled:opacity-60"
+                  onClick={() => confirmPaste('line', 'button')}
+                  disabled={Boolean(lineModeProgress)}
+                >
+                  Run line by line
+                </button>
+                <button
+                  type="button"
+                  className="rounded bg-green-600 px-3 py-2 text-sm disabled:opacity-60"
+                  onClick={() => confirmPaste('all', 'button')}
+                  disabled={Boolean(lineModeProgress)}
+                >
+                  Run all lines
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
       {paletteOpen && (
         <div className="absolute inset-0 bg-black bg-opacity-75 flex items-start justify-center z-10">
           <div className="mt-10 w-80 bg-gray-800 p-4 rounded">

--- a/lib/analytics-client.ts
+++ b/lib/analytics-client.ts
@@ -4,7 +4,11 @@ export type EventName =
   | 'contact_submit'
   | 'contact_submit_error'
   | 'outbound_link_click'
-  | 'download_click';
+  | 'download_click'
+  | 'terminal_paste_detected'
+  | 'terminal_paste_confirmed'
+  | 'terminal_paste_cancelled'
+  | 'terminal_paste_bypassed';
 
 export function trackEvent(
   name: EventName,

--- a/public/docs/apps/terminal.md
+++ b/public/docs/apps/terminal.md
@@ -5,3 +5,11 @@ This terminal emulates basic shell commands. Type commands and press Enter to ex
 - Use arrow keys to navigate history.
 - Press `Ctrl+C` to cancel a running command.
 - The `help` command lists available commands.
+
+## Multi-line paste safety
+
+- Pasting more than one line triggers a review banner that lists the number of commands and shows a preview with line numbers.
+- Choose **Run all** to execute the entire snippet, or **Run line by line** to step through each command with a live progress indicator.
+- Press **Ctrl+Shift+Enter** while the banner is visible to approve the paste without clicking.
+- Select **Trust _origin_ for the next paste only** to skip the next warning from that site. The trust record is stored per origin and consumed after one bypass.
+- The banner can be dismissed with **Cancel** or the `Esc` key if the paste was accidental.


### PR DESCRIPTION
## Summary
- detect multi-line clipboard input in the terminal, gate execution behind a confirmation banner, and surface previews
- add line-by-line execution, trust-once toggles keyed by origin, and telemetry hooks for paste outcomes
- document terminal safety best practices for multi-line pastes

## Testing
- yarn lint *(fails: repository has many pre-existing accessibility violations outside this change)*
- yarn test *(fails: suite already contains multiple failing tests prior to this change)*
- yarn test __tests__/terminal.test.tsx --runTestsByPath


------
https://chatgpt.com/codex/tasks/task_e_68cb46839d9c8328adea441c97a0031c