### PR TITLE
terminal: persist sessions across restarts

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -36,17 +36,29 @@ import React, { createRef, act } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import Terminal from '../apps/terminal';
 import TerminalTabs from '../apps/terminal/tabs';
+import createTerminalSessionManager from '../modules/terminal/sessionStore';
 
 describe('Terminal component', () => {
   const openApp = jest.fn();
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    if (typeof window.confirm === 'function') {
+      jest.spyOn(window, 'confirm').mockReturnValue(false);
+    }
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
   it('renders container and exposes runCommand', async () => {
     const ref = createRef<any>();
     render(<Terminal ref={ref} openApp={openApp} />);
     await act(async () => {});
     expect(ref.current).toBeTruthy();
-    act(() => {
-      ref.current.runCommand('help');
+    await act(async () => {
+      await ref.current.runCommand('help');
     });
     expect(ref.current.getContent()).toContain('help');
   });
@@ -55,8 +67,8 @@ describe('Terminal component', () => {
     const ref = createRef<any>();
     render(<Terminal ref={ref} openApp={openApp} />);
     await act(async () => {});
-    act(() => {
-      ref.current.runCommand('open calculator');
+    await act(async () => {
+      await ref.current.runCommand('open calculator');
     });
     expect(openApp).toHaveBeenCalledWith('calculator');
   });
@@ -75,5 +87,54 @@ describe('Terminal component', () => {
 
     fireEvent.keyDown(root, { ctrlKey: true, key: 'w' });
     expect(container.querySelectorAll('.flex.items-center.cursor-pointer').length).toBe(1);
+  });
+
+  it('restores session state after simulated power loss', async () => {
+    const manager = createTerminalSessionManager({ profileId: 'test-profile' });
+    const tab = manager.createTab();
+    const pane = tab.panes.find((p) => p.id === tab.activePaneId)!;
+
+    const ref = createRef<any>();
+    const onSnapshot = jest.fn((snapshot) =>
+      manager.updatePaneSnapshot(tab.id, snapshot),
+    );
+    const { unmount } = render(
+      <Terminal
+        ref={ref}
+        openApp={openApp}
+        sessionId={pane.id}
+        tabId={tab.id}
+        onSnapshot={onSnapshot}
+        snapshotIntervalMs={0}
+        restoreBehavior="never"
+      />,
+    );
+    await act(async () => {
+      await ref.current.runCommand('help');
+    });
+    await act(async () => {
+      unmount();
+    });
+
+    const layout = manager.getLayout();
+    const restoredTab = layout.tabs.find((t) => t.id === tab.id)!;
+    const restoredPane =
+      restoredTab.panes.find((p) => p.id === restoredTab.activePaneId) ??
+      restoredTab.panes[0];
+
+    const ref2 = createRef<any>();
+    render(
+      <Terminal
+        ref={ref2}
+        openApp={openApp}
+        sessionId={restoredPane.id}
+        tabId={restoredTab.id}
+        initialSnapshot={restoredPane}
+        restoreBehavior="never"
+      />,
+    );
+    await act(async () => {});
+
+    expect(ref2.current.getContent()).toContain('Available commands');
   });
 });

--- a/apps/terminal/commands/types.ts
+++ b/apps/terminal/commands/types.ts
@@ -5,6 +5,8 @@ export interface CommandContext {
   aliases: Record<string, string>;
   setAlias: (name: string, value: string) => void;
   runWorker: (command: string) => Promise<void>;
+  cwd: string;
+  setCwd: (dir: string) => void;
 }
 
 export type CommandHandler = (args: string, ctx: CommandContext) => void | Promise<void>;

--- a/apps/terminal/tabs/index.tsx
+++ b/apps/terminal/tabs/index.tsx
@@ -1,26 +1,110 @@
 'use client';
 
-import React, { useRef } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../../components/ui/TabbedWindow';
-import Terminal, { TerminalProps } from '..';
+import Terminal from '..';
+import createTerminalSessionManager, {
+  type TerminalTabSnapshot,
+} from '../../../modules/terminal/sessionStore';
+import { getTerminalSettings } from '../../../utils/settings/terminal';
 
-const TerminalTabs: React.FC<TerminalProps> = ({ openApp }) => {
-  const countRef = useRef(1);
+interface TerminalTabsProps {
+  openApp?: (id: string) => void;
+  profileId?: string;
+}
 
-  const createTab = (): TabDefinition => {
-    const id = Date.now().toString();
+const TerminalTabs: React.FC<TerminalTabsProps> = ({
+  openApp,
+  profileId = 'default',
+}) => {
+  const settings = useMemo(() => getTerminalSettings(profileId), [profileId]);
+  const persistenceEnabled = settings.persistSessions;
+  const fallbackCountRef = useRef(1);
+  const createEphemeralTab = useCallback((): TabDefinition => {
+    const id = `session-${Date.now().toString(36)}-${fallbackCountRef.current}`;
+    const title = `Session ${fallbackCountRef.current++}`;
     return {
       id,
-      title: `Session ${countRef.current++}`,
-      content: <Terminal openApp={openApp} />,
+      title,
+      content: <Terminal key={id} openApp={openApp} />,
     };
-  };
+  }, [openApp]);
+  const [fallbackInitialTab] = useState<TabDefinition>(() => createEphemeralTab());
+
+  const managerRef = useRef(createTerminalSessionManager({ profileId }));
+  const [initialSnapshots] = useState<TerminalTabSnapshot[]>(() => {
+    if (!persistenceEnabled) return [];
+    const layout = managerRef.current.loadFromStorage();
+    if (!layout.tabs.length) {
+      const tab = managerRef.current.createTab();
+      return [tab];
+    }
+    return layout.tabs;
+  });
+  const initialActiveId = useMemo(() => {
+    if (!persistenceEnabled) return undefined;
+    const layout = managerRef.current.getLayout();
+    return layout.activeTabId ?? initialSnapshots[0]?.id;
+  }, [initialSnapshots, persistenceEnabled]);
+
+  const buildTabDefinition = useCallback(
+    (tab: TerminalTabSnapshot): TabDefinition => {
+      const pane = tab.panes.find((p) => p.id === tab.activePaneId) ?? tab.panes[0];
+      const title = tab.lastCommand?.trim() ? tab.lastCommand : tab.title;
+      return {
+        id: tab.id,
+        title,
+        content: (
+          <Terminal
+            key={`${tab.id}-${pane.id}`}
+            openApp={openApp}
+            sessionId={pane.id}
+            initialSnapshot={pane}
+            onSnapshot={(snapshot) =>
+              managerRef.current.updatePaneSnapshot(tab.id, snapshot)
+            }
+            snapshotIntervalMs={settings.snapshotIntervalMs}
+            restoreBehavior={settings.restoreBehavior}
+          />
+        ),
+        onActivate: () => managerRef.current.setActiveTab(tab.id),
+        onClose: () => managerRef.current.removeTab(tab.id),
+      };
+    },
+    [openApp, settings.restoreBehavior, settings.snapshotIntervalMs],
+  );
+
+  const persistentInitialTabs = useMemo(
+    () => initialSnapshots.map((tab) => buildTabDefinition(tab)),
+    [initialSnapshots, buildTabDefinition],
+  );
+
+  const handleTabsChange = useCallback((tabs: TabDefinition[]) => {
+    managerRef.current.reorderTabs(tabs.map((t) => t.id));
+  }, []);
+
+  const handleNewTab = useCallback(() => {
+    const tab = managerRef.current.createTab();
+    return buildTabDefinition(tab);
+  }, [buildTabDefinition]);
+
+  if (!persistenceEnabled) {
+    return (
+      <TabbedWindow
+        className="h-full w-full"
+        initialTabs={[fallbackInitialTab]}
+        onNewTab={createEphemeralTab}
+      />
+    );
+  }
 
   return (
     <TabbedWindow
       className="h-full w-full"
-      initialTabs={[createTab()]}
-      onNewTab={createTab}
+      initialTabs={persistentInitialTabs}
+      initialActiveId={initialActiveId}
+      onNewTab={handleNewTab}
+      onTabsChange={handleTabsChange}
     />
   );
 };

--- a/modules/terminal/sessionStore.ts
+++ b/modules/terminal/sessionStore.ts
@@ -1,0 +1,360 @@
+import { safeLocalStorage } from '../../utils/safeStorage';
+
+const STORAGE_PREFIX = 'terminal:sessions:';
+const CURRENT_VERSION = 1;
+
+function now() {
+  return Date.now();
+}
+
+function createId(prefix: string) {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+  return `${prefix}-${Math.random().toString(36).slice(2)}-${now().toString(36)}`;
+}
+
+export interface TerminalPaneSnapshot {
+  id: string;
+  scrollback: string;
+  history: string[];
+  cwd: string;
+  lastCommand?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface TerminalTabSnapshot {
+  id: string;
+  title: string;
+  panes: TerminalPaneSnapshot[];
+  activePaneId: string;
+  lastCommand?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface TerminalLayoutSnapshot {
+  version: number;
+  tabs: TerminalTabSnapshot[];
+  activeTabId?: string;
+  updatedAt: number;
+}
+
+export interface TerminalSessionManagerOptions {
+  profileId?: string;
+  storage?: Storage | undefined;
+}
+
+export interface TerminalSessionManager {
+  profileId: string;
+  storageKey: string;
+  getLayout: () => TerminalLayoutSnapshot;
+  loadFromStorage: () => TerminalLayoutSnapshot;
+  createTab: (title?: string) => TerminalTabSnapshot;
+  updatePaneSnapshot: (
+    tabId: string,
+    pane: TerminalPaneSnapshot,
+  ) => TerminalTabSnapshot | undefined;
+  recordCommand: (tabId: string, command: string) => void;
+  setActiveTab: (tabId: string | null | undefined) => void;
+  removeTab: (tabId: string) => void;
+  reorderTabs: (order: string[]) => void;
+  clear: () => void;
+}
+
+function sanitizePane(value: any): TerminalPaneSnapshot {
+  const timestamp = now();
+  const history = Array.isArray(value?.history)
+    ? value.history.filter((entry: unknown) => typeof entry === 'string')
+    : [];
+  const lastCommandCandidate =
+    typeof value?.lastCommand === 'string' && value.lastCommand.trim()
+      ? value.lastCommand
+      : history[history.length - 1];
+  return {
+    id: typeof value?.id === 'string' ? value.id : createId('pane'),
+    scrollback: typeof value?.scrollback === 'string' ? value.scrollback : '',
+    history,
+    cwd: typeof value?.cwd === 'string' && value.cwd.trim() ? value.cwd : '~',
+    lastCommand: lastCommandCandidate,
+    createdAt:
+      typeof value?.createdAt === 'number' && Number.isFinite(value.createdAt)
+        ? value.createdAt
+        : timestamp,
+    updatedAt:
+      typeof value?.updatedAt === 'number' && Number.isFinite(value.updatedAt)
+        ? value.updatedAt
+        : timestamp,
+  };
+}
+
+function sanitizeTab(value: any, index: number): TerminalTabSnapshot {
+  const timestamp = now();
+  const panesRaw = Array.isArray(value?.panes) ? value.panes : [];
+  const panes = panesRaw.length
+    ? panesRaw.map((pane: any) => sanitizePane(pane))
+    : [sanitizePane(undefined)];
+  const activePaneCandidate =
+    typeof value?.activePaneId === 'string' &&
+    panes.some((p) => p.id === value.activePaneId)
+      ? value.activePaneId
+      : panes[0].id;
+  const lastCommandCandidate =
+    typeof value?.lastCommand === 'string' && value.lastCommand.trim()
+      ? value.lastCommand
+      : panes.find((pane) => pane.id === activePaneCandidate)?.lastCommand;
+  return {
+    id: typeof value?.id === 'string' ? value.id : createId('tab'),
+    title:
+      typeof value?.title === 'string' && value.title.trim()
+        ? value.title
+        : `Session ${index + 1}`,
+    panes,
+    activePaneId: activePaneCandidate,
+    lastCommand: lastCommandCandidate,
+    createdAt:
+      typeof value?.createdAt === 'number' && Number.isFinite(value.createdAt)
+        ? value.createdAt
+        : timestamp,
+    updatedAt:
+      typeof value?.updatedAt === 'number' && Number.isFinite(value.updatedAt)
+        ? value.updatedAt
+        : timestamp,
+  };
+}
+
+function sanitizeLayout(value: any): TerminalLayoutSnapshot {
+  const timestamp = now();
+  const tabsRaw = Array.isArray(value?.tabs) ? value.tabs : [];
+  const tabs = tabsRaw.map((tab: any, index: number) => sanitizeTab(tab, index));
+  const activeTabCandidate =
+    typeof value?.activeTabId === 'string' &&
+    tabs.some((tab) => tab.id === value.activeTabId)
+      ? value.activeTabId
+      : tabs[0]?.id;
+  return {
+    version:
+      typeof value?.version === 'number' && Number.isFinite(value.version)
+        ? value.version
+        : CURRENT_VERSION,
+    tabs,
+    activeTabId: activeTabCandidate,
+    updatedAt:
+      typeof value?.updatedAt === 'number' && Number.isFinite(value.updatedAt)
+        ? value.updatedAt
+        : timestamp,
+  };
+}
+
+function createEmptyLayout(): TerminalLayoutSnapshot {
+  return {
+    version: CURRENT_VERSION,
+    tabs: [],
+    activeTabId: undefined,
+    updatedAt: now(),
+  };
+}
+
+function createPaneSnapshot(
+  overrides: Partial<TerminalPaneSnapshot> = {},
+): TerminalPaneSnapshot {
+  const timestamp = now();
+  return sanitizePane({
+    id: overrides.id ?? createId('pane'),
+    scrollback: overrides.scrollback ?? '',
+    history: overrides.history ?? [],
+    cwd: overrides.cwd ?? '~',
+    lastCommand: overrides.lastCommand,
+    createdAt: overrides.createdAt ?? timestamp,
+    updatedAt: overrides.updatedAt ?? timestamp,
+  });
+}
+
+function createTabSnapshot(
+  index: number,
+  overrides: Partial<TerminalTabSnapshot> = {},
+): TerminalTabSnapshot {
+  const pane = overrides.panes?.[0] ?? createPaneSnapshot();
+  return sanitizeTab(
+    {
+      id: overrides.id ?? createId('tab'),
+      title: overrides.title ?? `Session ${index + 1}`,
+      panes: overrides.panes ?? [pane],
+      activePaneId: overrides.activePaneId ?? pane.id,
+      lastCommand: overrides.lastCommand ?? pane.lastCommand,
+      createdAt: overrides.createdAt,
+      updatedAt: overrides.updatedAt,
+    },
+    index,
+  );
+}
+
+export function createTerminalSessionManager(
+  options: TerminalSessionManagerOptions = {},
+): TerminalSessionManager {
+  const { profileId = 'default', storage = safeLocalStorage } = options;
+  const storageKey = `${STORAGE_PREFIX}${profileId}`;
+
+  const loadFromStorageInternal = () => {
+    if (!storage) return createEmptyLayout();
+    try {
+      const raw = storage.getItem(storageKey);
+      if (!raw) return createEmptyLayout();
+      const parsed = JSON.parse(raw);
+      return sanitizeLayout(parsed);
+    } catch {
+      return createEmptyLayout();
+    }
+  };
+
+  let layout = loadFromStorageInternal();
+
+  const persist = () => {
+    if (!storage) return;
+    try {
+      storage.setItem(storageKey, JSON.stringify(layout));
+    } catch {
+      // ignore storage failures (quota, privacy, etc.)
+    }
+  };
+
+  const getLayout = () => layout;
+
+  const setLayout = (next: TerminalLayoutSnapshot) => {
+    layout = {
+      ...next,
+      version: CURRENT_VERSION,
+      updatedAt: now(),
+    };
+    persist();
+    return layout;
+  };
+
+  const createTab = (title?: string) => {
+    const current = getLayout();
+    const tab = createTabSnapshot(current.tabs.length, {
+      title: title ?? `Session ${current.tabs.length + 1}`,
+    });
+    const nextTabs = [...current.tabs, tab];
+    setLayout({ ...current, tabs: nextTabs, activeTabId: tab.id });
+    return tab;
+  };
+
+  const updatePaneSnapshot = (
+    tabId: string,
+    pane: TerminalPaneSnapshot,
+  ): TerminalTabSnapshot | undefined => {
+    const current = getLayout();
+    let updatedTab: TerminalTabSnapshot | undefined;
+    const nextTabs = current.tabs.map((tab) => {
+      if (tab.id !== tabId) return tab;
+      const sanitized = sanitizePane(pane);
+      const panes = tab.panes.some((p) => p.id === sanitized.id)
+        ? tab.panes.map((p) => (p.id === sanitized.id ? sanitized : p))
+        : [...tab.panes, sanitized];
+      const nextTab: TerminalTabSnapshot = {
+        ...tab,
+        panes,
+        activePaneId: sanitized.id,
+        lastCommand: sanitized.lastCommand ?? tab.lastCommand,
+        title:
+          sanitized.lastCommand && sanitized.lastCommand.trim()
+            ? sanitized.lastCommand
+            : tab.title,
+        updatedAt: now(),
+      };
+      updatedTab = nextTab;
+      return nextTab;
+    });
+    if (updatedTab) {
+      setLayout({ ...current, tabs: nextTabs });
+    }
+    return updatedTab;
+  };
+
+  const recordCommand = (tabId: string, command: string) => {
+    const trimmed = command.trim();
+    const current = getLayout();
+    const nextTabs = current.tabs.map((tab) => {
+      if (tab.id !== tabId) return tab;
+      const updatedPanes = tab.panes.map((pane) =>
+        pane.id === tab.activePaneId
+          ? {
+              ...pane,
+              lastCommand: trimmed || pane.lastCommand,
+              updatedAt: now(),
+            }
+          : pane,
+      );
+      return {
+        ...tab,
+        panes: updatedPanes,
+        lastCommand: trimmed || tab.lastCommand,
+        title: trimmed || tab.title,
+        updatedAt: now(),
+      };
+    });
+    setLayout({ ...current, tabs: nextTabs });
+  };
+
+  const setActiveTab = (tabId: string | null | undefined) => {
+    const current = getLayout();
+    if (current.activeTabId === tabId) return;
+    setLayout({ ...current, activeTabId: tabId ?? undefined });
+  };
+
+  const removeTab = (tabId: string) => {
+    const current = getLayout();
+    const nextTabs = current.tabs.filter((tab) => tab.id !== tabId);
+    const nextActive =
+      current.activeTabId === tabId ? nextTabs[0]?.id : current.activeTabId;
+    setLayout({ ...current, tabs: nextTabs, activeTabId: nextActive });
+  };
+
+  const reorderTabs = (order: string[]) => {
+    const current = getLayout();
+    if (!order.length) return;
+    const tabMap = new Map(current.tabs.map((tab) => [tab.id, tab] as const));
+    const nextTabs: TerminalTabSnapshot[] = [];
+    for (const id of order) {
+      const tab = tabMap.get(id);
+      if (tab) {
+        nextTabs.push(tab);
+        tabMap.delete(id);
+      }
+    }
+    // append remaining tabs that were not specified in the new order
+    nextTabs.push(...tabMap.values());
+    setLayout({ ...current, tabs: nextTabs });
+  };
+
+  const clear = () => {
+    layout = createEmptyLayout();
+    if (!storage) return;
+    try {
+      storage.removeItem(storageKey);
+    } catch {
+      // ignore
+    }
+  };
+
+  return {
+    profileId,
+    storageKey,
+    getLayout,
+    loadFromStorage: () => {
+      layout = loadFromStorageInternal();
+      return layout;
+    },
+    createTab,
+    updatePaneSnapshot,
+    recordCommand,
+    setActiveTab,
+    removeTab,
+    reorderTabs,
+    clear,
+  };
+}
+
+export default createTerminalSessionManager;

--- a/utils/settings/terminal.ts
+++ b/utils/settings/terminal.ts
@@ -1,0 +1,124 @@
+import { safeLocalStorage } from '../safeStorage';
+
+export type CommandRestoreBehavior = 'prompt' | 'always' | 'never';
+
+export interface TerminalProfileSettings {
+  persistSessions: boolean;
+  restoreBehavior: CommandRestoreBehavior;
+  snapshotIntervalMs: number;
+}
+
+const DEFAULT_SETTINGS: TerminalProfileSettings = {
+  persistSessions: true,
+  restoreBehavior: 'prompt',
+  snapshotIntervalMs: 15000,
+};
+
+const STORAGE_PREFIX = 'terminal:settings:';
+
+function storageKey(profileId: string) {
+  return `${STORAGE_PREFIX}${profileId}`;
+}
+
+function mergeSettings(
+  base: TerminalProfileSettings,
+  overrides?: Partial<TerminalProfileSettings> | null,
+): TerminalProfileSettings {
+  if (!overrides) return base;
+  const merged: TerminalProfileSettings = {
+    persistSessions:
+      typeof overrides.persistSessions === 'boolean'
+        ? overrides.persistSessions
+        : base.persistSessions,
+    restoreBehavior:
+      overrides.restoreBehavior === 'always' ||
+      overrides.restoreBehavior === 'never' ||
+      overrides.restoreBehavior === 'prompt'
+        ? overrides.restoreBehavior
+        : base.restoreBehavior,
+    snapshotIntervalMs:
+      typeof overrides.snapshotIntervalMs === 'number' &&
+      Number.isFinite(overrides.snapshotIntervalMs) &&
+      overrides.snapshotIntervalMs > 0
+        ? overrides.snapshotIntervalMs
+        : base.snapshotIntervalMs,
+  };
+  return merged;
+}
+
+export function getTerminalSettings(
+  profileId = 'default',
+): TerminalProfileSettings {
+  if (!safeLocalStorage) return { ...DEFAULT_SETTINGS };
+  try {
+    const raw = safeLocalStorage.getItem(storageKey(profileId));
+    if (!raw) return { ...DEFAULT_SETTINGS };
+    const parsed = JSON.parse(raw);
+    return mergeSettings({ ...DEFAULT_SETTINGS }, parsed);
+  } catch {
+    return { ...DEFAULT_SETTINGS };
+  }
+}
+
+export function updateTerminalSettings(
+  profileId: string,
+  patch: Partial<TerminalProfileSettings>,
+): TerminalProfileSettings {
+  const next = mergeSettings(getTerminalSettings(profileId), patch);
+  if (safeLocalStorage) {
+    try {
+      safeLocalStorage.setItem(storageKey(profileId), JSON.stringify(next));
+    } catch {
+      // ignore storage write failures
+    }
+  }
+  return next;
+}
+
+export function setTerminalPersistence(
+  profileId: string,
+  enabled: boolean,
+): TerminalProfileSettings {
+  return updateTerminalSettings(profileId, { persistSessions: enabled });
+}
+
+export function isTerminalPersistenceEnabled(profileId = 'default') {
+  return getTerminalSettings(profileId).persistSessions;
+}
+
+export function getRestoreBehavior(
+  profileId = 'default',
+): CommandRestoreBehavior {
+  return getTerminalSettings(profileId).restoreBehavior;
+}
+
+export function setRestoreBehavior(
+  profileId: string,
+  behavior: CommandRestoreBehavior,
+) {
+  return updateTerminalSettings(profileId, { restoreBehavior: behavior });
+}
+
+export function getSnapshotInterval(profileId = 'default') {
+  return getTerminalSettings(profileId).snapshotIntervalMs;
+}
+
+export function setSnapshotInterval(
+  profileId: string,
+  intervalMs: number,
+) {
+  return updateTerminalSettings(profileId, { snapshotIntervalMs: intervalMs });
+}
+
+export function resetTerminalSettings(profileId = 'default') {
+  if (safeLocalStorage) {
+    try {
+      safeLocalStorage.removeItem(storageKey(profileId));
+    } catch {
+      // ignore
+    }
+  }
+  return { ...DEFAULT_SETTINGS };
+}
+
+export { DEFAULT_SETTINGS as DEFAULT_TERMINAL_SETTINGS };


### PR DESCRIPTION
## Summary
* add a terminal session store that serializes tab, pane, and history metadata for persistence【F:modules/terminal/sessionStore.ts†L1-L210】
* expose per-profile terminal settings so users can opt in/out of persistence and control restore prompts【F:utils/settings/terminal.ts†L1-L124】
* update the terminal app, tabbed window, and tab launcher to capture snapshots, prompt before replaying commands, and label tabs with the last command【F:apps/terminal/index.tsx†L69-L563】【F:components/ui/TabbedWindow.tsx†L19-L237】【F:apps/terminal/tabs/index.tsx†L1-L110】
* expand the terminal test suite to verify recovery after simulated power loss【F:__tests__/terminal.test.tsx†L55-L139】

## Testing
* ⚠️ `yarn lint` *(fails due to pre-existing accessibility and window API lint errors throughout the repository)*【6050fc†L1-L120】
* ✅ `yarn test --watch=false __tests__/terminal.test.tsx`【70d926†L1-L33】

------
https://chatgpt.com/codex/tasks/task_e_68cb468246fc8328bc62e84e28e9ba12