### PR TITLE
feat(terminal): confirm shell links and manage trusted paths

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -12,6 +12,16 @@ jest.mock(
       onPaste: jest.fn(),
       dispose: jest.fn(),
       clear: jest.fn(),
+      registerLinkProvider: jest
+        .fn()
+        .mockReturnValue({ dispose: jest.fn() }),
+      buffer: {
+        active: {
+          getLine: jest.fn(() => ({
+            translateToString: () => '',
+          })),
+        },
+      },
     })),
   }),
   { virtual: true }
@@ -32,18 +42,53 @@ jest.mock(
 );
 jest.mock('@xterm/xterm/css/xterm.css', () => ({}), { virtual: true });
 
+jest.mock('../utils/analytics', () => ({
+  logEvent: jest.fn(),
+}));
+
+jest.mock('../utils/settings/terminalLinks', () => {
+  const actual = jest.requireActual('../utils/settings/terminalLinks');
+  return {
+    ...actual,
+    getTrustedPaths: jest.fn().mockResolvedValue(actual.DEFAULT_TRUSTED_PATHS),
+    getSecurePasteEnabled: jest.fn().mockResolvedValue(actual.DEFAULT_SECURE_PASTE),
+    addTrustedPath: jest
+      .fn()
+      .mockImplementation(async (path: string) => [...actual.DEFAULT_TRUSTED_PATHS, actual.normalizePath(path)]),
+    setSecurePasteEnabled: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
 import React, { createRef, act } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import Terminal from '../apps/terminal';
 import TerminalTabs from '../apps/terminal/tabs';
 
+
+const originalError = console.error;
+let consoleErrorSpy: jest.SpyInstance | undefined;
+
+beforeAll(() => {
+  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((...args) => {
+    if (typeof args[0] === 'string' && args[0].includes('not wrapped in act')) {
+      return;
+    }
+    originalError(...args as Parameters<typeof console.error>);
+  });
+});
+
+afterAll(() => {
+  consoleErrorSpy?.mockRestore();
+});
 describe('Terminal component', () => {
   const openApp = jest.fn();
 
   it('renders container and exposes runCommand', async () => {
     const ref = createRef<any>();
     render(<Terminal ref={ref} openApp={openApp} />);
-    await act(async () => {});
+    await act(async () => {
+      await Promise.resolve();
+    });
     expect(ref.current).toBeTruthy();
     act(() => {
       ref.current.runCommand('help');
@@ -54,7 +99,9 @@ describe('Terminal component', () => {
   it('invokes openApp for open command', async () => {
     const ref = createRef<any>();
     render(<Terminal ref={ref} openApp={openApp} />);
-    await act(async () => {});
+    await act(async () => {
+      await Promise.resolve();
+    });
     act(() => {
       ref.current.runCommand('open calculator');
     });
@@ -63,7 +110,9 @@ describe('Terminal component', () => {
 
   it('supports tab management shortcuts', async () => {
     const { container } = render(<TerminalTabs openApp={openApp} />);
-    await act(async () => {});
+    await act(async () => {
+      await Promise.resolve();
+    });
     const root = container.firstChild as HTMLElement;
     root.focus();
     fireEvent.keyDown(root, { ctrlKey: true, key: 't' });

--- a/__tests__/terminal/links.test.ts
+++ b/__tests__/terminal/links.test.ts
@@ -1,0 +1,63 @@
+import { classifyTerminalLink, findSuspiciousLinks } from '../../apps/terminal/utils/linkSecurity';
+import {
+  isTrustedPath,
+  normalizePath,
+} from '../../utils/settings/terminalLinks';
+
+describe('terminal link classification', () => {
+  it('classifies shell protocol links as requiring a prompt', () => {
+    const result = classifyTerminalLink('ssh://kali@127.0.0.1');
+    expect(result.kind).toBe('shell');
+    expect(result.requiresPrompt).toBe(true);
+  });
+
+  it('normalizes file protocol links', () => {
+    const result = classifyTerminalLink('file:///etc/passwd');
+    expect(result.kind).toBe('file');
+    expect(result.requiresPrompt).toBe(true);
+    expect(result.normalizedPath).toBe('/etc/passwd');
+  });
+
+  it('detects unix and windows style local paths', () => {
+    const unix = classifyTerminalLink('/usr/local/bin/tool');
+    const windows = classifyTerminalLink('C:\\Users\\Admin\\scripts\\run.ps1');
+    expect(unix.kind).toBe('file');
+    expect(unix.normalizedPath).toBe('/usr/local/bin/tool');
+    expect(windows.kind).toBe('file');
+    expect(windows.normalizedPath).toBe('c:/Users/Admin/scripts/run.ps1');
+  });
+
+  it('ignores regular web links', () => {
+    const result = classifyTerminalLink('https://example.com');
+    expect(result.kind).toBe('url');
+    expect(result.requiresPrompt).toBe(false);
+  });
+});
+
+describe('terminal link detection helpers', () => {
+  it('finds shell and file links in terminal output', () => {
+    const line = 'Connect via ssh://kali@host and inspect /tmp/report.txt';
+    const matches = findSuspiciousLinks(line);
+    expect(matches).toHaveLength(2);
+    expect(matches[0].classification.kind).toBe('shell');
+    expect(matches[1].classification.kind).toBe('file');
+  });
+
+  it('handles UNC paths and trims punctuation', () => {
+    const line = 'Log file located at \\\\SERVER\\Share\\audit.log.';
+    const matches = findSuspiciousLinks(line);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].text).toBe('\\\\SERVER\\Share\\audit.log');
+  });
+});
+
+describe('trusted path helpers', () => {
+  it('normalizes and compares trusted paths', () => {
+    const stored = [' /tmp ', 'C:/tools '];
+    const normalized = stored.map((p) => normalizePath(p));
+    expect(normalized).toEqual(['/tmp', 'c:/tools']);
+    expect(isTrustedPath('/tmp/scripts/run.sh', stored)).toBe(true);
+    expect(isTrustedPath('c:/tools/run.bat', stored)).toBe(true);
+    expect(isTrustedPath('/etc/passwd', stored)).toBe(false);
+  });
+});

--- a/apps/terminal/utils/linkSecurity.ts
+++ b/apps/terminal/utils/linkSecurity.ts
@@ -1,0 +1,154 @@
+import { normalizePath } from '../../../utils/settings/terminalLinks';
+
+export type TerminalLinkKind = 'shell' | 'file' | 'url' | 'unknown';
+
+export interface TerminalLinkClassification {
+  kind: TerminalLinkKind;
+  requiresPrompt: boolean;
+  normalizedPath?: string;
+  protocol?: string;
+}
+
+export interface TerminalLinkMatch {
+  text: string;
+  startIndex: number;
+  endIndex: number;
+  classification: TerminalLinkClassification;
+}
+
+const SHELL_PROTOCOLS = new Set(['ssh', 'sftp', 'scp', 'telnet', 'ftp']);
+
+const URI_REGEX = /\b[a-z][a-z0-9+.-]*:\/\/[^\s<'"\)\]]+/gi;
+const UNIX_PATH_REGEX = /(?:^|[\s([\{\u201c"'])(~\/[^\s"'<>]+|\.{1,2}\/[^\s"'<>]+|\/[^\s"'<>]+)/g;
+const WINDOWS_PATH_REGEX = /(?:^|[\s([\{\u201c"'])([a-zA-Z]:\\[^\s"'<>]+)/g;
+const UNC_PATH_REGEX = /\\\\[^\\\s]+(?:\\[^\s"'<>]+)+/g;
+
+const LEADING_TRIM = /^['"\u201c\u201d]+/;
+const TRAILING_TRIM = /['"\u201c\u201d.,;:)\]\}]+$/;
+
+const WINDOWS_DRIVE_PATTERN = /^[a-zA-Z]:[\\/]/;
+const WINDOWS_UNC_PATTERN = /^\\\\/;
+
+const classifyScheme = (value: string): TerminalLinkClassification => {
+  const schemeMatch = /^([a-z][a-z0-9+.-]*):/i.exec(value);
+  if (!schemeMatch) {
+    return { kind: 'unknown', requiresPrompt: false };
+  }
+  const protocol = schemeMatch[1].toLowerCase();
+  if (protocol === 'file') {
+    const normalizedPath = normalizePath(value);
+    return { kind: 'file', normalizedPath, requiresPrompt: true, protocol };
+  }
+  if (SHELL_PROTOCOLS.has(protocol)) {
+    return { kind: 'shell', requiresPrompt: true, protocol };
+  }
+  return { kind: 'url', requiresPrompt: false, protocol };
+};
+
+const looksLikeLocalPath = (value: string): boolean => {
+  if (/^(?:~\/|\.\.?\/|\/)/.test(value)) return true;
+  if (WINDOWS_DRIVE_PATTERN.test(value)) return true;
+  if (WINDOWS_UNC_PATTERN.test(value)) return true;
+  return false;
+};
+
+export const classifyTerminalLink = (raw: string): TerminalLinkClassification => {
+  const value = raw.trim();
+  if (!value) return { kind: 'unknown', requiresPrompt: false };
+  if (looksLikeLocalPath(value)) {
+    const normalizedPath = normalizePath(value);
+    return { kind: 'file', normalizedPath, requiresPrompt: true };
+  }
+  if (/^[a-z][a-z0-9+.-]*:/i.test(value)) {
+    return classifyScheme(value);
+  }
+  return { kind: 'unknown', requiresPrompt: false };
+};
+
+const trimBoundaries = (input: string): { text: string; lead: number } => {
+  let start = 0;
+  let end = input.length;
+  while (start < end && LEADING_TRIM.test(input[start])) start += 1;
+  while (end > start && TRAILING_TRIM.test(input[end - 1])) end -= 1;
+  const text = input.slice(start, end);
+  return { text, lead: start };
+};
+
+const makeMatch = (
+  source: string,
+  index: number,
+  classification: TerminalLinkClassification,
+): TerminalLinkMatch | null => {
+  const { text, lead } = trimBoundaries(source);
+  if (!text) return null;
+  const startIndex = index + lead;
+  const endIndex = startIndex + text.length;
+  return { text, startIndex, endIndex, classification };
+};
+
+export const findSuspiciousLinks = (line: string): TerminalLinkMatch[] => {
+  const matches: TerminalLinkMatch[] = [];
+  const seen = new Set<string>();
+
+  const addMatch = (candidate: TerminalLinkMatch | null) => {
+    if (!candidate) return;
+    const key = `${candidate.startIndex}:${candidate.text}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    matches.push(candidate);
+  };
+
+  if (!line) return matches;
+
+  let uriMatch: RegExpExecArray | null;
+  while ((uriMatch = URI_REGEX.exec(line))) {
+    const raw = uriMatch[0];
+    const classification = classifyTerminalLink(raw);
+    if (!classification.requiresPrompt) continue;
+    addMatch(makeMatch(raw, uriMatch.index, classification));
+  }
+  URI_REGEX.lastIndex = 0;
+
+  let unixMatch: RegExpExecArray | null;
+  while ((unixMatch = UNIX_PATH_REGEX.exec(line))) {
+    const raw = unixMatch[1];
+    if (!raw) continue;
+    const classification = classifyTerminalLink(raw);
+    if (!classification.requiresPrompt) continue;
+    const preceding = unixMatch[0];
+    const offset = unixMatch.index + preceding.indexOf(raw);
+    addMatch(makeMatch(raw, offset, classification));
+  }
+  UNIX_PATH_REGEX.lastIndex = 0;
+
+  let winMatch: RegExpExecArray | null;
+  while ((winMatch = WINDOWS_PATH_REGEX.exec(line))) {
+    const raw = winMatch[1];
+    if (!raw) continue;
+    const classification = classifyTerminalLink(raw);
+    if (!classification.requiresPrompt) continue;
+    const preceding = winMatch[0];
+    const offset = winMatch.index + preceding.indexOf(raw);
+    addMatch(makeMatch(raw, offset, classification));
+  }
+  WINDOWS_PATH_REGEX.lastIndex = 0;
+
+  let uncMatch: RegExpExecArray | null;
+  while ((uncMatch = UNC_PATH_REGEX.exec(line))) {
+    const raw = uncMatch[0];
+    if (!raw) continue;
+    const start = uncMatch.index;
+    if (start > 0) {
+      const before = line[start - 1];
+      if (before && !/[\s([\{\u201c"']/.test(before)) {
+        continue;
+      }
+    }
+    const classification = classifyTerminalLink(raw);
+    if (!classification.requiresPrompt) continue;
+    addMatch(makeMatch(raw, start, classification));
+  }
+  UNC_PATH_REGEX.lastIndex = 0;
+
+  return matches;
+};

--- a/components/ui/ConfirmDialog.tsx
+++ b/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,116 @@
+import { ReactNode, useEffect, useId, useRef } from 'react';
+
+interface SecondaryAction {
+  label: string;
+  onAction: () => void;
+  disabled?: boolean;
+  title?: string;
+}
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  secondaryAction?: SecondaryAction;
+  children?: ReactNode;
+}
+
+const ConfirmDialog = ({
+  open,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  destructive = false,
+  onConfirm,
+  onCancel,
+  secondaryAction,
+  children,
+}: ConfirmDialogProps) => {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+  const titleId = useId();
+  const descriptionId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onCancel();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [open, onCancel]);
+
+  useEffect(() => {
+    if (!open) return;
+    const id = window.setTimeout(() => {
+      confirmRef.current?.focus();
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={description ? descriptionId : undefined}
+    >
+      <div className="w-full max-w-lg rounded-md border border-gray-700 bg-gray-900 p-4 shadow-lg">
+        <h2 id={titleId} className="text-lg font-semibold text-white">
+          {title}
+        </h2>
+        {description && (
+          <div id={descriptionId} className="mt-2 text-sm text-gray-300">
+            {description}
+          </div>
+        )}
+        {children && <div className="mt-3 text-sm text-gray-200">{children}</div>}
+        <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-md border border-gray-600 px-3 py-1.5 text-sm font-medium text-gray-200 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900"
+          >
+            {cancelLabel}
+          </button>
+          {secondaryAction && (
+            <button
+              type="button"
+              onClick={secondaryAction.onAction}
+              disabled={secondaryAction.disabled}
+              title={secondaryAction.title}
+              className="rounded-md border border-gray-600 px-3 py-1.5 text-sm font-medium text-gray-200 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {secondaryAction.label}
+            </button>
+          )}
+          <button
+            type="button"
+            ref={confirmRef}
+            onClick={onConfirm}
+            className={`rounded-md px-3 py-1.5 text-sm font-medium text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 ${
+              destructive
+                ? 'bg-red-600 hover:bg-red-500 focus:ring-red-400'
+                : 'bg-blue-600 hover:bg-blue-500 focus:ring-blue-400'
+            }`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDialog;

--- a/utils/settings/terminalLinks.ts
+++ b/utils/settings/terminalLinks.ts
@@ -1,0 +1,140 @@
+const TRUSTED_PATHS_KEY = 'terminal-trusted-paths';
+const SECURE_PASTE_KEY = 'terminal-secure-paste';
+
+const LEADING_TRIM = /^(?:['"\u201c\u201d]+)/;
+const TRAILING_TRIM = /(?:['"\u201c\u201d\]\)\}.,;:]+)$/;
+
+export const DEFAULT_TRUSTED_PATHS: string[] = [];
+export const DEFAULT_SECURE_PASTE = true;
+
+const hasWindow = () => typeof window !== 'undefined' && !!window.localStorage;
+
+const sanitizePaths = (paths: string[]): string[] => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const path of paths) {
+    const normalized = normalizePath(path);
+    if (!normalized) continue;
+    const key = normalizedKey(normalized);
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(normalized);
+    }
+  }
+  return result;
+};
+
+const readStorage = (key: string): any => {
+  if (!hasWindow()) return undefined;
+  try {
+    const value = window.localStorage.getItem(key);
+    return value ? JSON.parse(value) : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const writeStorage = (key: string, value: any) => {
+  if (!hasWindow()) return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // ignore storage errors
+  }
+};
+
+const normalizedKey = (value: string): string => {
+  return /^[a-z]:/i.test(value) ? value.toLowerCase() : value;
+};
+
+export const normalizePath = (input: string): string => {
+  if (!input) return '';
+  let value = input.trim();
+  value = value.replace(/^file:\/\//i, '');
+  value = value.replace(LEADING_TRIM, '');
+  value = value.replace(TRAILING_TRIM, '');
+  value = value.replace(/\\/g, '/');
+  if (!value.startsWith('//')) {
+    value = value.replace(/\/+/g, '/');
+  } else {
+    const [, rest] = value.match(/^(\/\/)(.*)$/) || ['', '', value];
+    value = `//${rest.replace(/\/+/g, '/')}`;
+  }
+  if (/^[a-z]:/i.test(value)) {
+    return `${value.charAt(0).toLowerCase()}${value.slice(1)}`;
+  }
+  return value;
+};
+
+export const isTrustedPath = (path: string, whitelist: string[]): boolean => {
+  const target = normalizePath(path);
+  if (!target) return false;
+  const targetKey = normalizedKey(target);
+  for (const entry of whitelist) {
+    const normalizedEntry = normalizePath(entry);
+    if (!normalizedEntry) continue;
+    const entryKey = normalizedKey(normalizedEntry);
+    if (targetKey === entryKey) return true;
+    const prefix = entryKey.endsWith('/') ? entryKey : `${entryKey}/`;
+    if (targetKey.startsWith(prefix)) return true;
+  }
+  return false;
+};
+
+export const getTrustedPaths = async (): Promise<string[]> => {
+  const stored = readStorage(TRUSTED_PATHS_KEY);
+  if (Array.isArray(stored)) {
+    return sanitizePaths(stored);
+  }
+  return [...DEFAULT_TRUSTED_PATHS];
+};
+
+const persistTrustedPaths = async (paths: string[]): Promise<string[]> => {
+  const sanitized = sanitizePaths(paths);
+  if (hasWindow()) {
+    writeStorage(TRUSTED_PATHS_KEY, sanitized);
+  }
+  return sanitized;
+};
+
+export const setTrustedPaths = async (
+  paths: string[],
+): Promise<string[]> => persistTrustedPaths(paths);
+
+export const addTrustedPath = async (path: string): Promise<string[]> => {
+  const normalized = normalizePath(path);
+  if (!normalized) return getTrustedPaths();
+  const current = await getTrustedPaths();
+  if (current.some((entry) => normalizedKey(entry) === normalizedKey(normalized))) {
+    return current;
+  }
+  return persistTrustedPaths([...current, normalized]);
+};
+
+export const removeTrustedPath = async (path: string): Promise<string[]> => {
+  const normalized = normalizePath(path);
+  if (!normalized) return getTrustedPaths();
+  const current = await getTrustedPaths();
+  const targetKey = normalizedKey(normalized);
+  return persistTrustedPaths(
+    current.filter((entry) => normalizedKey(entry) !== targetKey),
+  );
+};
+
+export const getSecurePasteEnabled = async (): Promise<boolean> => {
+  const stored = readStorage(SECURE_PASTE_KEY);
+  if (typeof stored === 'boolean') return stored;
+  if (typeof stored === 'string') return stored === 'true';
+  return DEFAULT_SECURE_PASTE;
+};
+
+export const setSecurePasteEnabled = async (
+  value: boolean,
+): Promise<void> => {
+  if (!hasWindow()) return;
+  try {
+    window.localStorage.setItem(SECURE_PASTE_KEY, value ? 'true' : 'false');
+  } catch {
+    // ignore
+  }
+};


### PR DESCRIPTION
## Summary
- add a dedicated ConfirmDialog component and wire the terminal renderer to prompt before opening shell protocols or local file paths
- persist secure paste preferences and a trusted path whitelist so future clicks can bypass confirmations when safe
- add link classification utilities and targeted unit tests to cover shell, drive, and UNC path detection

## Testing
- ⚠️ `yarn lint` *(fails due to numerous pre-existing accessibility violations in unrelated components and public scripts)*
- ✅ `yarn test __tests__/terminal/links.test.ts __tests__/terminal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68cb467f431c8328b1b1973fa30df667