### PR TITLE
resource-monitor: add textured charts

### DIFF
--- a/components/apps/resource-monitor/Charts.tsx
+++ b/components/apps/resource-monitor/Charts.tsx
@@ -1,0 +1,384 @@
+'use client';
+
+import React, { useEffect, useId, useMemo, useState } from 'react';
+import { CHART_TEXTURES, ChartTextureToken, ChartTextureKey } from '@/data/design-system/charts';
+
+export type ChartSeriesKey = Extract<ChartTextureKey, 'cpu' | 'memory' | 'disk' | 'network'>;
+
+interface ResourceSeriesMeta {
+  key: ChartSeriesKey;
+  label: string;
+  unit: string;
+  defaultMax: number;
+  color: string;
+}
+
+const SERIES: ResourceSeriesMeta[] = [
+  {
+    key: 'cpu',
+    label: 'CPU',
+    unit: '%',
+    defaultMax: 100,
+    color: 'var(--chart-series-cpu, #16a34a)',
+  },
+  {
+    key: 'memory',
+    label: 'Memory',
+    unit: '%',
+    defaultMax: 100,
+    color: 'var(--chart-series-memory, #fbbf24)',
+  },
+  {
+    key: 'disk',
+    label: 'Disk',
+    unit: '%',
+    defaultMax: 100,
+    color: 'var(--chart-series-disk, #38bdf8)',
+  },
+  {
+    key: 'network',
+    label: 'Network',
+    unit: 'Mbps',
+    defaultMax: 100,
+    color: 'var(--chart-series-network, #c084fc)',
+  },
+];
+
+const VIEWBOX = {
+  width: 100,
+  height: 60,
+};
+
+const GRID_STEPS = 4;
+
+const formatter = new Intl.NumberFormat(undefined, {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 1,
+});
+
+type ChartsProps = {
+  data: Record<ChartSeriesKey, number[]>;
+  sampleRateMs?: number;
+};
+
+type ChartStats = {
+  latest: number;
+  min: number;
+  max: number;
+  avg: number;
+};
+
+function calculateStats(values: number[]): ChartStats {
+  if (!values.length) {
+    return { latest: 0, min: 0, max: 0, avg: 0 };
+  }
+
+  const latest = values[values.length - 1];
+  let min = values[0];
+  let max = values[0];
+  let sum = 0;
+
+  for (const value of values) {
+    if (value < min) min = value;
+    if (value > max) max = value;
+    sum += value;
+  }
+
+  return {
+    latest,
+    min,
+    max,
+    avg: sum / values.length,
+  };
+}
+
+function formatValue(value: number, unit: string) {
+  return `${formatter.format(value)}${unit}`;
+}
+
+function createLinePath(values: number[], maxValue: number) {
+  if (!values.length) return '';
+  const denominator = Math.max(values.length - 1, 1);
+  return values
+    .map((value, index) => {
+      const x = (index / denominator) * VIEWBOX.width;
+      const clamped = Number.isFinite(value) ? value : 0;
+      const y = VIEWBOX.height - (clamped / maxValue) * VIEWBOX.height;
+      const command = index === 0 ? 'M' : 'L';
+      return `${command}${x.toFixed(3)},${y.toFixed(3)}`;
+    })
+    .join(' ');
+}
+
+function createAreaPath(values: number[], maxValue: number) {
+  if (!values.length) return '';
+  const line = createLinePath(values, maxValue);
+  return `${line} L${VIEWBOX.width},${VIEWBOX.height} L0,${VIEWBOX.height} Z`;
+}
+
+function renderPatternShapes(token: ChartTextureToken) {
+  const ink = token.foreground;
+
+  if (token.type === 'forward-diagonal') {
+    const offsets = [-token.spacing, 0, token.spacing];
+    return offsets.map((offset, index) => (
+      <line
+        key={`diag-${index}`}
+        x1={offset}
+        y1={token.size}
+        x2={offset + token.size}
+        y2={0}
+        stroke={ink}
+        strokeWidth={token.strokeWidth}
+      />
+    ));
+  }
+
+  if (token.type === 'dot-grid') {
+    const dots = [] as React.ReactNode[];
+    for (let x = token.spacing / 2; x < token.size; x += token.spacing) {
+      for (let y = token.spacing / 2; y < token.size; y += token.spacing) {
+        dots.push(
+          <circle
+            key={`dot-${x}-${y}`}
+            cx={x}
+            cy={y}
+            r={token.radius}
+            fill={ink}
+          />,
+        );
+      }
+    }
+    return dots;
+  }
+
+  if (token.type === 'cross-hatch') {
+    const offsets = [-token.spacing, 0, token.spacing];
+    return offsets.flatMap((offset, index) => [
+      <line
+        key={`cross-forward-${index}`}
+        x1={offset}
+        y1={token.size}
+        x2={offset + token.size}
+        y2={0}
+        stroke={ink}
+        strokeWidth={token.strokeWidth}
+      />,
+      <line
+        key={`cross-back-${index}`}
+        x1={offset}
+        y1={0}
+        x2={offset + token.size}
+        y2={token.size}
+        stroke={ink}
+        strokeWidth={token.strokeWidth}
+      />,
+    ]);
+  }
+
+  // horizontal-band
+  const lines = [] as React.ReactNode[];
+  for (let y = 0; y <= token.size; y += token.spacing) {
+    lines.push(
+      <line
+        key={`band-${y}`}
+        x1={0}
+        y1={y}
+        x2={token.size}
+        y2={y}
+        stroke={ink}
+        strokeWidth={token.strokeWidth}
+      />,
+    );
+  }
+  return lines;
+}
+
+interface PatternDefProps {
+  token: ChartTextureToken;
+  patternId: string;
+}
+
+function PatternDef({ token, patternId }: PatternDefProps) {
+  return (
+    <pattern
+      id={patternId}
+      patternUnits="userSpaceOnUse"
+      width={token.size}
+      height={token.size}
+    >
+      <rect width={token.size} height={token.size} fill={token.background} />
+      {renderPatternShapes(token)}
+    </pattern>
+  );
+}
+
+interface ChartCardProps {
+  series: ResourceSeriesMeta;
+  values: number[];
+}
+
+function ChartCard({ series, values }: ChartCardProps) {
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+  const chartInstanceId = useId();
+  const texture = CHART_TEXTURES[series.key];
+  const stats = useMemo(() => calculateStats(values), [values]);
+  const maxValue = useMemo(() => {
+    const target = Math.max(series.defaultMax, stats.max || 0);
+    return Number.isFinite(target) && target > 0 ? target : series.defaultMax;
+  }, [series.defaultMax, stats.max]);
+
+  const linePath = useMemo(() => createLinePath(values, maxValue), [values, maxValue]);
+  const areaPath = useMemo(() => createAreaPath(values, maxValue), [values, maxValue]);
+  const hasData = values.length > 0 && !!linePath;
+
+  const titleId = `${series.key}-title-${chartInstanceId}`;
+  const srDescriptionId = `${series.key}-sr-${chartInstanceId}`;
+  const tooltipId = `${series.key}-tooltip-${chartInstanceId}`;
+  const patternId = `${texture.id}-${chartInstanceId}`;
+
+  return (
+    <figure className="relative flex flex-col gap-3 rounded-lg bg-[var(--kali-panel)]/80 p-3 text-white shadow-inner">
+      <header className="flex items-center justify-between">
+        <span id={titleId} className="text-sm font-semibold uppercase tracking-wide">
+          {series.label}
+        </span>
+        <span className="text-sm text-[var(--chart-label-muted, #94a3b8)]">
+          {hasData ? formatValue(stats.latest, series.unit) : 'Awaiting data'}
+        </span>
+      </header>
+      <div
+        className="relative"
+        onMouseEnter={() => setTooltipVisible(true)}
+        onMouseLeave={() => setTooltipVisible(false)}
+        onFocus={() => setTooltipVisible(true)}
+        onBlur={() => setTooltipVisible(false)}
+        tabIndex={0}
+        role="group"
+        aria-describedby={`${srDescriptionId} ${tooltipId}`}
+      >
+        <svg
+          viewBox={`0 0 ${VIEWBOX.width} ${VIEWBOX.height}`}
+          className="h-32 w-full"
+          role="img"
+          aria-labelledby={titleId}
+        >
+          <defs>
+            <PatternDef token={texture} patternId={patternId} />
+          </defs>
+          <rect
+            width={VIEWBOX.width}
+            height={VIEWBOX.height}
+            fill="var(--chart-surface, rgba(15,23,42,0.35))"
+            rx={4}
+          />
+          {Array.from({ length: GRID_STEPS - 1 }).map((_, index) => {
+            const y = ((index + 1) / GRID_STEPS) * VIEWBOX.height;
+            return (
+              <line
+                key={`grid-${y}`}
+                x1={0}
+                x2={VIEWBOX.width}
+                y1={y}
+                y2={y}
+                stroke="var(--chart-grid, rgba(148,163,184,0.2))"
+                strokeWidth={0.5}
+              />
+            );
+          })}
+          {hasData ? (
+            <>
+              <path
+                d={areaPath}
+                fill={`url(#${patternId})`}
+                fillOpacity={0.9}
+              />
+              <path
+                d={linePath}
+                fill="none"
+                stroke={series.color}
+                strokeWidth={1.5}
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              />
+            </>
+          ) : (
+            <text
+              x={VIEWBOX.width / 2}
+              y={VIEWBOX.height / 2}
+              fill="var(--chart-label-muted, #94a3b8)"
+              fontSize={8}
+              textAnchor="middle"
+            >
+              No samples yet
+            </text>
+          )}
+        </svg>
+        <div id={srDescriptionId} className="sr-only">
+          {`${series.label} uses ${texture.description}. Latest sample ${formatValue(
+            stats.latest,
+            series.unit,
+          )}. Range ${formatValue(stats.min, series.unit)} to ${formatValue(stats.max, series.unit)}.`}
+        </div>
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className={`pointer-events-none absolute left-3 top-3 max-w-[12rem] rounded-md border border-white/10 bg-black/80 p-2 text-xs shadow-lg transition-opacity duration-150 ${
+            tooltipVisible ? 'opacity-100' : 'opacity-0'
+          }`}
+        >
+          <p className="font-semibold tracking-wide text-[0.65rem] uppercase text-white/80">
+            {series.label} Trend
+          </p>
+          <p className="mt-1 text-white">Latest {formatValue(stats.latest, series.unit)}</p>
+          <p className="text-[var(--chart-label-muted, #94a3b8)]">
+            Min {formatValue(stats.min, series.unit)} · Max {formatValue(stats.max, series.unit)}
+          </p>
+          <p className="text-[var(--chart-label-muted, #94a3b8)]">
+            Avg {formatValue(stats.avg, series.unit)}
+          </p>
+          <p className="mt-1 text-[var(--chart-label-muted, #94a3b8)]">Texture: {texture.description}</p>
+        </div>
+      </div>
+    </figure>
+  );
+}
+
+const EMPTY_SERIES: Record<ChartSeriesKey, number[]> = {
+  cpu: [],
+  memory: [],
+  disk: [],
+  network: [],
+};
+
+export default function Charts({ data, sampleRateMs = 1000 }: ChartsProps) {
+  const safeData = data ?? EMPTY_SERIES;
+
+  const liveAnnouncement = useMemo(() => {
+    return SERIES.map((series) => {
+      const seriesValues = safeData[series.key] ?? [];
+      const stats = calculateStats(seriesValues);
+      return `${series.label} ${formatValue(stats.latest, series.unit)}`;
+    }).join(' • ');
+  }, [safeData]);
+
+  const [announcement, setAnnouncement] = useState(liveAnnouncement);
+  useEffect(() => {
+    setAnnouncement(liveAnnouncement);
+  }, [liveAnnouncement, sampleRateMs]);
+
+  return (
+    <div className="flex w-full flex-col gap-4" aria-live="polite">
+      <span className="sr-only">{announcement}</span>
+      <div className="grid gap-4 md:grid-cols-2">
+        {SERIES.map((series) => (
+          <ChartCard
+            key={series.key}
+            series={series}
+            values={safeData[series.key] ?? []}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/data/design-system/charts.ts
+++ b/data/design-system/charts.ts
@@ -1,0 +1,93 @@
+export type ChartTextureKey = 'cpu' | 'memory' | 'disk' | 'network';
+
+export type ChartTextureType =
+  | 'forward-diagonal'
+  | 'dot-grid'
+  | 'cross-hatch'
+  | 'horizontal-band';
+
+export interface ChartTextureToken {
+  /**
+   * Unique base id used when rendering the SVG pattern.
+   */
+  id: string;
+  /**
+   * Description that explains the semantic meaning behind the texture.
+   */
+  description: string;
+  /**
+   * Base size of the tile. When consumed by `<pattern />` this becomes both width and height.
+   */
+  size: number;
+  /**
+   * Background colour. Use alpha so the underlying theme colour still shines through.
+   */
+  background: string;
+  /**
+   * Foreground colour for lines and dots.
+   */
+  foreground: string;
+  /**
+   * Token specific type that determines how the renderer builds the pattern.
+   */
+  type: ChartTextureType;
+  /**
+   * Distance in pixels between repeated shapes (lines or dots).
+   */
+  spacing: number;
+  /**
+   * Stroke width for lines. Dot radius is derived from this for circular motifs.
+   */
+  strokeWidth: number;
+  /**
+   * Explicit radius for dotted textures.
+   */
+  radius?: number;
+}
+
+const SURFACE = 'var(--chart-texture-surface, rgba(148, 163, 184, 0.12))';
+const INK = 'var(--chart-texture-ink, rgba(226, 232, 240, 0.65))';
+
+export const CHART_TEXTURES: Record<ChartTextureKey, ChartTextureToken> = {
+  cpu: {
+    id: 'chart-texture-cpu',
+    description: 'Forward-leaning diagonal stripes signalling active CPU slices.',
+    size: 10,
+    background: SURFACE,
+    foreground: INK,
+    type: 'forward-diagonal',
+    spacing: 5,
+    strokeWidth: 1.5,
+  },
+  memory: {
+    id: 'chart-texture-memory',
+    description: 'Evenly spaced circular markers visualising chunk-based memory allocations.',
+    size: 12,
+    background: SURFACE,
+    foreground: INK,
+    type: 'dot-grid',
+    spacing: 6,
+    strokeWidth: 1,
+    radius: 1.4,
+  },
+  disk: {
+    id: 'chart-texture-disk',
+    description: 'Cross-hatched sweeps representing read/write passes across the disk platter.',
+    size: 10,
+    background: SURFACE,
+    foreground: INK,
+    type: 'cross-hatch',
+    spacing: 5,
+    strokeWidth: 1.2,
+  },
+  network: {
+    id: 'chart-texture-network',
+    description: 'Horizontal bursts capturing the cadence of network throughput.',
+    size: 8,
+    background: SURFACE,
+    foreground: INK,
+    type: 'horizontal-band',
+    spacing: 3,
+    strokeWidth: 1.6,
+  },
+};

--- a/docs/design-portal/layout.md
+++ b/docs/design-portal/layout.md
@@ -1,0 +1,19 @@
+# Layout guidelines
+
+Layout rules for the resource monitor ensure the new textured charts remain legible and accessible.
+
+## Grid
+
+- Charts sit in a responsive two-column grid (`md:grid-cols-2`). On narrow screens they stack vertically with `1.5rem` gaps.
+- Each card uses `var(--kali-panel)` with `80%` opacity to preserve contrast between the textured fill and the background wallpaper.
+
+## Texture accessibility
+
+- Reserve distinct textures for CPU (forward diagonals), memory (dot grid), disk (cross hatch), and network (horizontal bands).
+- Tooltips must reiterate the texture description ("Texture: cross-hatch pattern") so monochrome printouts and screen readers convey the same meaning.
+- Keep the chart background at or below `rgba(15,23,42,0.35)` so the white ink from the texture has at least a 4.5:1 contrast ratio.
+
+## Tooltip placement
+
+- Pin tooltips to the top-left of each card so they do not obstruct the latest samples. The pointer-events should remain disabled while hidden to avoid trapping focus.
+- Include hidden `sr-only` descriptions linking pattern semantics to the latest value. This ensures assistive tech can interpret the layout without relying on colour or motion cues.

--- a/docs/design-portal/motion.md
+++ b/docs/design-portal/motion.md
@@ -1,0 +1,18 @@
+# Motion guidelines
+
+The design portal tracks motion heuristics for interactive telemetry panels like the resource monitor.
+
+## Chart animation
+
+- Charts update once per second. Interpolate values in JavaScript rather than CSS transitions to honour the app's reduced-motion setting.
+- When `prefers-reduced-motion` is enabled, freeze the trend lines and only update the textual counters. Tooltips still surface the latest values so nothing is lost for screen-reader users.
+
+## Stress-mode overlays
+
+- The floating stress-test windows should never occlude the charts for longer than a single frame. If the effect is enabled, keep their alpha below 30% and pause them when `prefers-reduced-motion` is detected.
+- Announce the mode change via the existing FPS label (e.g. "Stress mode on") so screen readers can catch the transition without relying on visuals.
+
+## Tooltip behaviour
+
+- Tooltips fade in/out over 150ms. That duration gives enough affordance while avoiding vestibular issues.
+- Each tooltip is tied to a focusable wrapper. Keyboard focus must trigger the same animation as hover.

--- a/tests/manual/resource-monitor.md
+++ b/tests/manual/resource-monitor.md
@@ -1,0 +1,26 @@
+# Resource monitor manual design tests
+
+These checks validate that the resource monitor charts remain distinguishable when colour is removed.
+
+## 1. Pattern contrast in monochrome
+
+1. Open the Resource Monitor app and let the charts gather at least 30 seconds of samples.
+2. Open the browser print dialog (or use a built-in "Save to PDF" option).
+3. Switch the preview to black-and-white / grayscale mode.
+4. Confirm each series has a unique texture:
+   - CPU: forward diagonal stripes.
+   - Memory: dotted grid.
+   - Disk: cross-hatch pattern.
+   - Network: horizontal bands.
+5. Ensure the textures stay visible when the preview zoom is set to 80% and 200%.
+
+## 2. Tooltip legibility
+
+1. Return to the live view and focus each chart card (use <kbd>Tab</kbd> or hover).
+2. Confirm the tooltip lists the latest, min, max, and average values along with the texture description.
+3. With a screen reader running, focus each chart and verify the description announces the texture and most recent value.
+
+## 3. Stress mode regression check
+
+1. Enable the stress test and confirm the animated windows do not obscure the tooltip or charts.
+2. Toggle stress mode off and verify the charts continue to update with textured fills.


### PR DESCRIPTION
## Summary
- replace the legacy canvas plots in the resource monitor with a reusable textured chart component that exposes screen-reader friendly tooltips
- introduce chart texture design tokens and document motion/layout accessibility guidance along with a monochrome print manual test

## Testing
- `yarn lint` *(fails: repository contains many pre-existing jsx-a11y/no-top-level-window violations)*
- `yarn test` *(fails: existing suites for contact API, nmap NSE, popular modules, and settings store abort in CI)*
- `npx eslint components/apps/resource_monitor.js components/apps/resource-monitor/Charts.tsx data/design-system/charts.ts`


------
https://chatgpt.com/codex/tasks/task_e_68cb467dbe108328a91c889700840ed0