### PR TITLE
[lock] Refresh lock screen experience

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -29,6 +29,8 @@ export default function Settings() {
     setHighContrast,
     haptics,
     setHaptics,
+    showNotificationPreviews,
+    setShowNotificationPreviews,
     theme,
     setTheme,
   } = useSettings();
@@ -285,6 +287,19 @@ export default function Settings() {
             >
               Import Settings
             </button>
+          </div>
+          <div className="flex flex-col items-center gap-2 text-center text-ubt-grey px-4">
+            <div className="flex items-center gap-3">
+              <span>Show notification previews on lock screen</span>
+              <ToggleSwitch
+                checked={showNotificationPreviews}
+                onChange={setShowNotificationPreviews}
+                ariaLabel="Toggle lock screen notification previews"
+              />
+            </div>
+            <p className="max-w-xl text-sm text-ubt-grey/80">
+              When disabled, the lock screen only shows app summaries and hides sensitive content until you unlock.
+            </p>
           </div>
         </>
       )}

--- a/components/apps/media/LockControls.tsx
+++ b/components/apps/media/LockControls.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+
+export interface LockControlsProps {
+  title: string;
+  artist: string;
+  album?: string;
+  coverArt?: string;
+  accentColor?: string;
+  isPlaying: boolean;
+  elapsed: number;
+  duration: number;
+  onPrevious: () => void;
+  onNext: () => void;
+  onTogglePlay: () => void;
+  className?: string;
+}
+
+const clampProgress = (value: number) => {
+  if (Number.isNaN(value) || !Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+};
+
+const formatTime = (seconds: number) => {
+  const safe = Number.isFinite(seconds) && seconds >= 0 ? seconds : 0;
+  const mins = Math.floor(safe / 60);
+  const secs = Math.floor(safe % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+};
+
+const LockControls: React.FC<LockControlsProps> = ({
+  title,
+  artist,
+  album,
+  coverArt,
+  accentColor = "#38bdf8",
+  isPlaying,
+  elapsed,
+  duration,
+  onPrevious,
+  onNext,
+  onTogglePlay,
+  className = "",
+}) => {
+  const progress = clampProgress(duration > 0 ? elapsed / duration : 0);
+  const gradientBackground = `linear-gradient(135deg, ${accentColor}, rgba(15, 23, 42, 0.85))`;
+
+  return (
+    <section
+      aria-label="Lock screen media controls"
+      className={`flex flex-col gap-4 rounded-3xl bg-slate-900/50 p-5 text-white shadow-2xl backdrop-blur-xl transition-colors duration-300 ${className}`}
+    >
+      <div className="flex items-center gap-4">
+        <div
+          className="h-20 w-20 flex-shrink-0 overflow-hidden rounded-2xl border border-white/10 shadow-lg"
+          aria-hidden="true"
+        >
+          {coverArt ? (
+            <img
+              src={coverArt}
+              alt=""
+              className="h-full w-full object-cover"
+              loading="lazy"
+            />
+          ) : (
+            <div
+              className="h-full w-full"
+              style={{ background: gradientBackground }}
+            />
+          )}
+        </div>
+        <div className="min-w-0">
+          <p className="text-xs uppercase tracking-[0.4em] text-slate-300">
+            Now Playing
+          </p>
+          <h3 className="mt-1 truncate text-lg font-semibold leading-tight">
+            {title}
+          </h3>
+          <p className="truncate text-sm text-slate-200">
+            {artist}
+            {album ? ` • ${album}` : ""}
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div
+          className="relative h-2 w-full overflow-hidden rounded-full bg-white/10"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={duration}
+          aria-valuenow={Math.round(progress * duration)}
+        >
+          <div
+            className="absolute inset-y-0 left-0 rounded-full bg-white/80"
+            style={{ width: `${progress * 100}%` }}
+          />
+        </div>
+        <div className="flex items-center justify-between text-[0.7rem] tracking-wide text-slate-300">
+          <span>{formatTime(elapsed)}</span>
+          <span>{formatTime(duration)}</span>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-center gap-5">
+        <button
+          type="button"
+          onClick={onPrevious}
+          className="rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-medium uppercase tracking-wide text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
+          aria-label="Play previous track"
+        >
+          <span aria-hidden="true">⏮</span>
+        </button>
+        <button
+          type="button"
+          onClick={onTogglePlay}
+          className="rounded-full bg-white px-6 py-3 text-lg font-semibold uppercase tracking-wider text-slate-900 shadow-lg transition hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
+          aria-label={isPlaying ? "Pause playback" : "Resume playback"}
+        >
+          <span aria-hidden="true">{isPlaying ? "⏸" : "▶"}</span>
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          className="rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-medium uppercase tracking-wide text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
+          aria-label="Play next track"
+        >
+          <span aria-hidden="true">⏭</span>
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default LockControls;

--- a/data/lockNotifications.ts
+++ b/data/lockNotifications.ts
@@ -1,0 +1,48 @@
+export interface LockNotification {
+  id: string;
+  app: string;
+  summary: string;
+  message: string;
+  timestamp: string;
+  sensitive?: boolean;
+}
+
+export const lockNotifications: LockNotification[] = [
+  {
+    id: "mail-1",
+    app: "Mail",
+    summary: "New message from Maya",
+    message: "Maya sent: Lunch is moved to 13:30 at the community lab.",
+    timestamp: "2025-02-15T09:24:00",
+    sensitive: true,
+  },
+  {
+    id: "calendar-1",
+    app: "Calendar",
+    summary: "Stand-up starts in 5 minutes",
+    message: "Daily stand-up with Red Team begins at 09:30 in War Room 2.",
+    timestamp: "2025-02-15T09:25:00",
+  },
+  {
+    id: "alerts-1",
+    app: "Alerts",
+    summary: "Lab sensors nominal",
+    message: "Biosensor sweep complete — all vitals within tolerance thresholds.",
+    timestamp: "2025-02-15T09:18:00",
+  },
+  {
+    id: "messages-1",
+    app: "Signal",
+    summary: "2 new encrypted threads",
+    message: "Nova: Reviewed your draft. Check the secure folder before publishing.",
+    timestamp: "2025-02-15T09:12:00",
+    sensitive: true,
+  },
+  {
+    id: "tasks-1",
+    app: "Tasks",
+    summary: "Server patch window",
+    message: "Apply patches to perimeter nodes between 22:00-23:30 tonight.",
+    timestamp: "2025-02-15T08:55:00",
+  },
+];

--- a/docs/design-portal.md
+++ b/docs/design-portal.md
@@ -1,0 +1,50 @@
+# Design Portal — Lock Screen Refresh
+
+The lock screen now follows a two-column desktop layout that keeps the hero clock
+prominent while stacking actionable controls and notification summaries on the side.
+This document captures the approved layout, states, and visual guidance for the
+implementation in `/pages/lock.tsx`.
+
+![Lock screen mockups](../public/docs/mockups/lock-screen-mockups.svg)
+
+## Layout blueprint
+
+- **Clock column** (left)
+  - Large, center-aligned clock (`Clock` component) with day/date badge underneath.
+  - Instructional copy transitions from “Press any key or click Unlock” to
+    “Enter your passcode” once interaction starts.
+  - Unlock button emphasises keyboard and pointer parity. When active, a glassmorphism
+    dialog slides in with passcode entry, hint copy, and `Escape` handling to dismiss.
+- **Info column** (right)
+  - `LockControls` renders the media controls card with gradients keyed to the
+    current track accent colour.
+  - Notifications card uses 12px rounded cells, uppercase app labels, and
+    summary/body text sized for readability at DPI breakpoints.
+
+## Interaction notes
+
+- First pointer or keyboard input reveals the authentication sheet; the visible
+  button remains for explicit access.
+- Passcode form accepts any non-empty value. Success messaging keeps the user on the
+  lock screen to reinforce that this is a portfolio simulation.
+- `Escape`, the close button, or success state closes the sheet and clears timers.
+- Notification previews respect the privacy toggle from **Settings → Privacy**:
+  - When previews are disabled, sensitive messages swap to summaries and a banner
+    explains that content is hidden until unlock.
+  - When enabled, full bodies render but still inherit the privacy badge chip.
+
+## Responsive guidance
+
+- Grid collapses to a single column under `lg:` while maintaining spacing with
+  `gap-6` and `px` utilities.
+- Text sizes use `sm:` and `md:` overrides to keep the clock legible on tablets
+  and high-DPI monitors without overwhelming the viewport.
+- Both cards rely on `backdrop-blur` and `bg-white/5` overlays to preserve contrast
+  regardless of wallpaper imagery.
+
+## Assets
+
+- `LockControls` lives in `components/apps/media/LockControls.tsx` and exposes props
+  for title, artist, album, accent colour, playback state, and callbacks.
+- Mockups are vector `.svg` documents stored at `public/docs/mockups/lock-screen-mockups.svg`
+  so they can be referenced in additional design documentation without raster loss.

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getShowNotificationPreviews as loadShowNotificationPreviews,
+  setShowNotificationPreviews as saveShowNotificationPreviews,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +64,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  showNotificationPreviews: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +76,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setShowNotificationPreviews: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +91,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  showNotificationPreviews: defaults.showNotificationPreviews,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +103,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setShowNotificationPreviews: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +118,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [showNotificationPreviews, setShowNotificationPreviews] = useState<boolean>(
+    defaults.showNotificationPreviews,
+  );
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +136,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setShowNotificationPreviews(await loadShowNotificationPreviews());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +246,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveShowNotificationPreviews(showNotificationPreviews);
+  }, [showNotificationPreviews]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +263,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        showNotificationPreviews,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +275,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setShowNotificationPreviews,
         setTheme,
       }}
     >

--- a/pages/lock.tsx
+++ b/pages/lock.tsx
@@ -1,0 +1,419 @@
+import Head from "next/head";
+import {
+  FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import Clock from "../components/util-components/clock";
+import LockControls from "../components/apps/media/LockControls";
+import { useSettings } from "../hooks/useSettings";
+import { lockNotifications } from "../data/lockNotifications";
+
+type UnlockStatus = "idle" | "processing" | "error" | "success";
+
+type PlaylistEntry = {
+  title: string;
+  artist: string;
+  album?: string;
+  duration: number;
+  accentColor: string;
+};
+
+const PLAYLIST: PlaylistEntry[] = [
+  {
+    title: "Zero-Day Dawn",
+    artist: "Pulsewidth Collective",
+    album: "Midnight Audit",
+    duration: 242,
+    accentColor: "#38bdf8",
+  },
+  {
+    title: "Circuit Sleep",
+    artist: "Aria Chen",
+    album: "Blue Team Field Notes",
+    duration: 214,
+    accentColor: "#f97316",
+  },
+  {
+    title: "Signals After Dark",
+    artist: "Encrypted Choir",
+    album: "Northern Node",
+    duration: 198,
+    accentColor: "#a855f7",
+  },
+];
+
+const NON_TRIGGER_KEYS = new Set([
+  "Shift",
+  "Control",
+  "Alt",
+  "Meta",
+  "CapsLock",
+  "Tab",
+]);
+
+const LockScreenPage = () => {
+  const { wallpaper, showNotificationPreviews } = useSettings();
+  const [trackIndex, setTrackIndex] = useState(0);
+  const [elapsed, setElapsed] = useState(48);
+  const [isPlaying, setIsPlaying] = useState(true);
+  const [authVisible, setAuthVisible] = useState(false);
+  const [passcode, setPasscode] = useState("");
+  const [unlockStatus, setUnlockStatus] = useState<UnlockStatus>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const unlockButtonRef = useRef<HTMLButtonElement>(null);
+  const passcodeRef = useRef<HTMLInputElement>(null);
+  const verifyTimeout = useRef<number | null>(null);
+  const resetTimeout = useRef<number | null>(null);
+
+  const currentTrack = PLAYLIST[trackIndex] ?? PLAYLIST[0];
+
+  useEffect(() => {
+    unlockButtonRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (!authVisible) return;
+    passcodeRef.current?.focus();
+  }, [authVisible]);
+
+  const clearTimers = useCallback(() => {
+    if (verifyTimeout.current) {
+      window.clearTimeout(verifyTimeout.current);
+      verifyTimeout.current = null;
+    }
+    if (resetTimeout.current) {
+      window.clearTimeout(resetTimeout.current);
+      resetTimeout.current = null;
+    }
+  }, []);
+
+  const closeAuth = useCallback(() => {
+    clearTimers();
+    setAuthVisible(false);
+    setPasscode("");
+    setUnlockStatus("idle");
+    setErrorMessage(null);
+  }, [clearTimers]);
+
+  useEffect(() => {
+    if (authVisible) return;
+
+    const handlePointer = () => setAuthVisible(true);
+    const handleKey = (event: KeyboardEvent) => {
+      if (NON_TRIGGER_KEYS.has(event.key)) return;
+      setAuthVisible(true);
+    };
+
+    window.addEventListener("pointerdown", handlePointer, { once: true });
+    window.addEventListener("keydown", handleKey, { once: true });
+
+    return () => {
+      window.removeEventListener("pointerdown", handlePointer);
+      window.removeEventListener("keydown", handleKey);
+    };
+  }, [authVisible]);
+
+  useEffect(() => {
+    if (!authVisible) return;
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeAuth();
+      }
+    };
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [authVisible, closeAuth]);
+
+  useEffect(() => () => clearTimers(), [clearTimers]);
+
+  useEffect(() => {
+    if (!isPlaying) return;
+    const interval = window.setInterval(() => {
+      setElapsed((prev) => {
+        const track = PLAYLIST[trackIndex];
+        if (!track) return prev;
+        const next = prev + 1;
+        if (next >= track.duration) {
+          setTrackIndex((index) => (index + 1) % PLAYLIST.length);
+          return 0;
+        }
+        return next;
+      });
+    }, 1000);
+    return () => window.clearInterval(interval);
+  }, [isPlaying, trackIndex]);
+
+  const handleNext = useCallback(() => {
+    setTrackIndex((index) => (index + 1) % PLAYLIST.length);
+    setElapsed(0);
+    setIsPlaying(true);
+  }, []);
+
+  const handlePrevious = useCallback(() => {
+    setTrackIndex((index) => (index - 1 + PLAYLIST.length) % PLAYLIST.length);
+    setElapsed(0);
+    setIsPlaying(true);
+  }, []);
+
+  const handleTogglePlay = useCallback(() => {
+    setIsPlaying((prev) => !prev);
+  }, []);
+
+  const notifications = useMemo(() => {
+    const formatter = new Intl.DateTimeFormat(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+
+    return [...lockNotifications]
+      .sort(
+        (a, b) =>
+          new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+      )
+      .map((notification) => {
+        const timeLabel = formatter.format(new Date(notification.timestamp));
+        const hidden = Boolean(
+          notification.sensitive && !showNotificationPreviews
+        );
+        const display =
+          showNotificationPreviews || !notification.sensitive
+            ? notification.message
+            : notification.summary;
+        return {
+          ...notification,
+          timeLabel,
+          hidden,
+          display,
+        };
+      });
+  }, [showNotificationPreviews]);
+
+  const hasHiddenContent = notifications.some((item) => item.hidden);
+
+  const handleUnlock = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      clearTimers();
+      if (!passcode.trim()) {
+        setErrorMessage("Enter your passcode to continue.");
+        setUnlockStatus("error");
+        return;
+      }
+      setErrorMessage(null);
+      setUnlockStatus("processing");
+      verifyTimeout.current = window.setTimeout(() => {
+        setUnlockStatus("success");
+        resetTimeout.current = window.setTimeout(() => {
+          closeAuth();
+        }, 1400);
+      }, 650);
+    },
+    [clearTimers, closeAuth, passcode]
+  );
+
+  const privacyBadge = showNotificationPreviews
+    ? {
+        label: "Previews enabled",
+        tone: "bg-emerald-400",
+      }
+    : {
+        label: "Privacy mode",
+        tone: "bg-amber-400",
+      };
+
+  return (
+    <>
+      <Head>
+        <title>Kali Portfolio — Lock Screen</title>
+      </Head>
+      <div className="relative min-h-screen overflow-hidden">
+        <div className="absolute inset-0" aria-hidden="true">
+          <div
+            className="absolute inset-0 scale-105 bg-cover bg-center transition-transform duration-1000"
+            style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)` }}
+          />
+          <div className="absolute inset-0 bg-slate-950/70 backdrop-blur-sm" />
+          <div className="absolute inset-0 bg-gradient-to-br from-slate-900/40 via-slate-900/60 to-black/70" />
+        </div>
+
+        <main className="relative z-10 flex min-h-screen flex-col px-6 py-10 sm:px-10 lg:px-20">
+          <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col justify-between gap-12 py-6 md:py-12">
+            <div className="grid flex-1 grid-cols-1 items-start gap-10 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1fr)]">
+              <section className="flex flex-col items-start justify-center gap-8 text-left text-white">
+                <div className="space-y-4">
+                  <p className="text-xs uppercase tracking-[0.6em] text-slate-200/80">
+                    Secure Session
+                  </p>
+                  <div className="text-6xl font-semibold sm:text-7xl md:text-8xl">
+                    <Clock onlyTime />
+                  </div>
+                  <div className="text-xl font-medium tracking-[0.45em] text-slate-200 sm:text-2xl">
+                    <Clock onlyDay />
+                  </div>
+                </div>
+                <div className="space-y-4">
+                  <p className="text-sm text-slate-200/80">
+                    {authVisible
+                      ? "Enter your passcode to unlock the desktop."
+                      : "Press any key or click Unlock to begin."}
+                  </p>
+                  {!authVisible && (
+                    <button
+                      ref={unlockButtonRef}
+                      type="button"
+                      onClick={() => setAuthVisible(true)}
+                      className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-6 py-3 text-sm font-semibold uppercase tracking-[0.4em] text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
+                    >
+                      Unlock
+                    </button>
+                  )}
+                </div>
+                {authVisible && (
+                  <div
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby="unlock-title"
+                    className="w-full max-w-md rounded-3xl border border-white/10 bg-slate-900/70 p-6 shadow-2xl backdrop-blur-xl"
+                  >
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <h2
+                          id="unlock-title"
+                          className="text-lg font-semibold tracking-wide text-white"
+                        >
+                          Unlock Desktop
+                        </h2>
+                        <p className="mt-1 text-sm text-slate-300">
+                          Authentication is simulated for this portfolio.
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={closeAuth}
+                        className="rounded-full border border-white/20 bg-white/10 px-2 py-1 text-xs uppercase tracking-[0.3em] text-slate-200 transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                        aria-label="Cancel unlock"
+                      >
+                        ✕
+                      </button>
+                    </div>
+                    <form className="mt-5 space-y-4" onSubmit={handleUnlock}>
+                      <label className="block text-sm font-medium text-slate-200" htmlFor="lock-passcode">
+                        Passcode
+                      </label>
+                      <input
+                        id="lock-passcode"
+                        ref={passcodeRef}
+                        type="password"
+                        value={passcode}
+                        onChange={(event) => setPasscode(event.target.value)}
+                        className="w-full rounded-xl border border-white/10 bg-slate-950/50 px-4 py-3 text-base text-white shadow-inner focus:border-white/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                        placeholder="Enter passcode"
+                        autoComplete="off"
+                      />
+                      <div className="flex items-center justify-between text-xs text-slate-300">
+                        <span>Hint: any non-empty entry unlocks the demo.</span>
+                        <span className="uppercase tracking-[0.3em] text-slate-400">
+                          Demo Mode
+                        </span>
+                      </div>
+                      <button
+                        type="submit"
+                        className="flex w-full items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold uppercase tracking-[0.4em] text-slate-900 shadow-lg transition hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                      >
+                        {unlockStatus === "processing" ? "Verifying…" : "Unlock"}
+                      </button>
+                      <div className="space-y-1">
+                        {unlockStatus === "error" && (
+                          <p className="text-sm text-amber-300" role="alert">
+                            {errorMessage}
+                          </p>
+                        )}
+                        {unlockStatus === "processing" && (
+                          <p className="text-sm text-slate-200" aria-live="polite">
+                            Checking credentials…
+                          </p>
+                        )}
+                        {unlockStatus === "success" && (
+                          <p className="text-sm text-emerald-300" aria-live="polite">
+                            Desktop unlocked — staying on the lock screen for demo purposes.
+                          </p>
+                        )}
+                      </div>
+                    </form>
+                  </div>
+                )}
+              </section>
+
+              <section className="flex flex-col gap-6 text-white">
+                <LockControls
+                  title={currentTrack.title}
+                  artist={currentTrack.artist}
+                  album={currentTrack.album}
+                  isPlaying={isPlaying}
+                  elapsed={elapsed}
+                  duration={currentTrack.duration}
+                  accentColor={currentTrack.accentColor}
+                  onNext={handleNext}
+                  onPrevious={handlePrevious}
+                  onTogglePlay={handleTogglePlay}
+                />
+
+                <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-white shadow-xl backdrop-blur-xl">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <h2 className="text-lg font-semibold uppercase tracking-[0.4em] text-slate-100">
+                      Notifications
+                    </h2>
+                    <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[0.7rem] uppercase tracking-[0.3em] text-slate-100">
+                      <span
+                        className={`h-2 w-2 rounded-full ${privacyBadge.tone}`}
+                        aria-hidden="true"
+                      />
+                      {privacyBadge.label}
+                    </span>
+                  </div>
+                  {hasHiddenContent && (
+                    <p className="mt-2 text-xs text-amber-200">
+                      Sensitive previews are hidden until you unlock.
+                    </p>
+                  )}
+                  <ul className="mt-5 space-y-4">
+                    {notifications.map((notification) => (
+                      <li
+                        key={notification.id}
+                        className="rounded-2xl border border-white/10 bg-slate-950/40 p-4 shadow-inner"
+                      >
+                        <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-300">
+                          <span>{notification.app}</span>
+                          <time
+                            dateTime={notification.timestamp}
+                            suppressHydrationWarning
+                          >
+                            {notification.timeLabel}
+                          </time>
+                        </div>
+                        <p className="mt-2 text-sm text-slate-100">
+                          {notification.display}
+                        </p>
+                        {notification.hidden && (
+                          <p className="mt-2 text-xs text-slate-300">
+                            Preview hidden — unlock to read securely.
+                          </p>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </section>
+            </div>
+          </div>
+        </main>
+      </div>
+    </>
+  );
+};
+
+export default LockScreenPage;

--- a/public/docs/mockups/lock-screen-mockups.svg
+++ b/public/docs/mockups/lock-screen-mockups.svg
@@ -1,0 +1,60 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg-day" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a" />
+      <stop offset="1" stop-color="#020617" />
+    </linearGradient>
+    <linearGradient id="bg-night" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1e1b4b" />
+      <stop offset="1" stop-color="#0b1120" />
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="rgba(255,255,255,0.32)" />
+      <stop offset="1" stop-color="rgba(15,23,42,0.48)" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="720" fill="url(#bg-day)" />
+  <rect x="640" width="640" height="720" fill="url(#bg-night)" />
+  <g font-family="'Ubuntu', 'Segoe UI', sans-serif" font-weight="500">
+    <!-- Day variant -->
+    <text x="80" y="88" font-size="24" fill="#cbd5f5" letter-spacing="12">LOCKED</text>
+    <text x="80" y="176" font-size="96" fill="#f8fafc">09:27</text>
+    <text x="82" y="220" font-size="28" fill="#cbd5f5" letter-spacing="10">SAT · FEB 15</text>
+    <rect x="80" y="268" width="232" height="56" rx="28" fill="rgba(255,255,255,0.08)" stroke="rgba(255,255,255,0.35)" stroke-width="2" />
+    <text x="116" y="305" font-size="18" fill="#e2e8f0" letter-spacing="8">UNLOCK</text>
+    <rect x="80" y="360" width="400" height="220" rx="32" fill="rgba(2,6,23,0.55)" stroke="rgba(148,163,184,0.35)" stroke-width="2" />
+    <text x="120" y="412" font-size="20" fill="#cbd5f5" letter-spacing="5">AUTH DIALOG</text>
+    <rect x="120" y="430" width="320" height="60" rx="18" fill="rgba(15,23,42,0.72)" />
+    <rect x="120" y="508" width="160" height="44" rx="22" fill="#f8fafc" />
+    <text x="153" y="537" font-size="16" fill="#0f172a" letter-spacing="6">UNLOCK</text>
+
+    <!-- Night variant -->
+    <text x="720" y="88" font-size="24" fill="#a5b4fc" letter-spacing="12">LOCKED</text>
+    <rect x="720" y="140" width="440" height="150" rx="36" fill="rgba(15,23,42,0.55)" stroke="rgba(226,232,240,0.25)" stroke-width="2" />
+    <circle cx="780" cy="215" r="55" fill="#38bdf8" opacity="0.85" />
+    <text x="856" y="210" font-size="26" fill="#e2e8f0">Zero-Day Dawn</text>
+    <text x="856" y="240" font-size="18" fill="#cbd5f5">Pulsewidth Collective</text>
+    <rect x="856" y="254" width="264" height="12" rx="6" fill="rgba(255,255,255,0.2)" />
+    <rect x="856" y="254" width="160" height="12" rx="6" fill="#f8fafc" />
+    <g fill="#f8fafc" font-size="18" letter-spacing="10">
+      <text x="768" y="292">⏮</text>
+      <text x="810" y="292">⏯</text>
+      <text x="852" y="292">⏭</text>
+    </g>
+
+    <rect x="720" y="332" width="440" height="300" rx="36" fill="rgba(15,23,42,0.55)" stroke="rgba(226,232,240,0.25)" stroke-width="2" />
+    <text x="760" y="378" font-size="20" fill="#cbd5f5" letter-spacing="6">NOTIFICATIONS</text>
+    <rect x="760" y="396" width="140" height="24" rx="12" fill="rgba(56,189,248,0.35)" />
+    <text x="780" y="414" font-size="12" fill="#0f172a" letter-spacing="4">PREVIEWS ON</text>
+
+    <g font-size="16">
+      <rect x="760" y="430" width="360" height="60" rx="20" fill="rgba(15,23,42,0.65)" stroke="rgba(148,163,184,0.35)" />
+      <text x="788" y="456" fill="#cbd5f5" letter-spacing="6">MAIL</text>
+      <text x="788" y="482" fill="#e2e8f0">Lunch moved to 13:30 at the lab.</text>
+
+      <rect x="760" y="502" width="360" height="60" rx="20" fill="rgba(15,23,42,0.65)" stroke="rgba(148,163,184,0.35)" />
+      <text x="788" y="528" fill="#cbd5f5" letter-spacing="6">SIGNAL</text>
+      <text x="788" y="554" fill="#e2e8f0">Preview hidden — unlock to read.</text>
+    </g>
+  </g>
+</svg>

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  showNotificationPreviews: false,
 };
 
 export async function getAccent() {
@@ -102,6 +103,17 @@ export async function setHaptics(value) {
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+export async function getShowNotificationPreviews() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.showNotificationPreviews;
+  const val = window.localStorage.getItem('show-notification-previews');
+  return val === null ? DEFAULT_SETTINGS.showNotificationPreviews : val === 'true';
+}
+
+export async function setShowNotificationPreviews(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('show-notification-previews', value ? 'true' : 'false');
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -137,6 +149,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('show-notification-previews');
 }
 
 export async function exportSettings() {
@@ -151,6 +164,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    showNotificationPreviews,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +176,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getShowNotificationPreviews(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +190,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    showNotificationPreviews,
     theme,
   });
 }
@@ -199,6 +215,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    showNotificationPreviews,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +228,8 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (showNotificationPreviews !== undefined)
+    await setShowNotificationPreviews(showNotificationPreviews);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated `/lock` page with the hero clock, unlock workflow, privacy-aware notifications, and media controls
- introduce reusable `LockControls` and seeded lock screen notifications that hide sensitive previews unless allowed
- extend settings/storage to manage the lock screen preview toggle and document the new design with updated mockups

## Testing
- ⚠️ yarn lint *(fails: repository currently has numerous jsx-a11y control labelling and window usage violations outside this change)*
- ⚠️ yarn test *(fails: existing suites hit jsdom localStorage `_origin` null errors in settings store)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4679bac0832898d49a36500d697c