### PR TITLE
share: add share target manager and sheet

### DIFF
--- a/__tests__/shareTargetsSettings.test.ts
+++ b/__tests__/shareTargetsSettings.test.ts
@@ -1,0 +1,29 @@
+describe('share target settings persistence', () => {
+  const modulePath = '../utils/settings/shareTargets';
+
+  beforeEach(() => {
+    localStorage.clear();
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    localStorage.clear();
+  });
+
+  it('persists custom ordering across sessions', async () => {
+    const first = await import(modulePath);
+    const initial = first
+      .getShareTargetsForManagement()
+      .map((target) => target.id);
+    const rotated = [...initial.slice(1), initial[0]];
+    first.reorderShareTargets(rotated);
+
+    jest.resetModules();
+    const second = await import(modulePath);
+    const after = second
+      .getShareTargetsForManagement()
+      .map((target) => target.id);
+    expect(after).toEqual(rotated);
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -72,6 +72,10 @@ const QuoteApp = createDynamicApp('quote', 'Quote');
 const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery');
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
+const ShareTargetsManagerApp = createDynamicApp(
+  'share-targets',
+  'Share Targets'
+);
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
@@ -165,6 +169,7 @@ const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
+const displayShareTargets = createDisplay(ShareTargetsManagerApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 
@@ -266,6 +271,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayInputLab,
+  },
+  {
+    id: 'share-targets',
+    title: 'Share Targets',
+    icon: '/themes/Yaru/apps/share-targets.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayShareTargets,
   },
 ];
 

--- a/apps/share-targets/index.tsx
+++ b/apps/share-targets/index.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import React, {
+  useCallback,
+  useMemo,
+  useSyncExternalStore,
+  useRef,
+} from "react";
+import {
+  shareTargetStore,
+  getShareTargetsForManagement,
+  reorderShareTargets,
+  setShareTargetVisibility,
+  resetShareTargetSettings,
+  ShareTargetWithState,
+  ShareTargetsSnapshot,
+} from "../../utils/settings/shareTargets";
+
+const ShareTargetsApp: React.FC = () => {
+  const snapshot = useSyncExternalStore<ShareTargetsSnapshot>(
+    shareTargetStore.subscribe,
+    shareTargetStore.getSnapshot,
+    shareTargetStore.getServerSnapshot
+  );
+
+  const targets = useMemo(
+    () => getShareTargetsForManagement(snapshot),
+    [snapshot]
+  );
+
+  const visibleCount = useMemo(
+    () => targets.filter((target) => target.visible).length,
+    [targets]
+  );
+
+  const dragIndex = useRef<number | null>(null);
+
+  const handleDragStart = useCallback(
+    (index: number) => (event: React.DragEvent<HTMLLIElement>) => {
+      dragIndex.current = index;
+      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData("text/plain", targets[index].id);
+    },
+    [targets]
+  );
+
+  const handleDragOver = useCallback(
+    (index: number) => (event: React.DragEvent<HTMLLIElement>) => {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "move";
+    },
+    []
+  );
+
+  const handleDragEnd = useCallback(() => {
+    dragIndex.current = null;
+  }, []);
+
+  const handleDrop = useCallback(
+    (index: number) => (event: React.DragEvent<HTMLLIElement>) => {
+      event.preventDefault();
+      const source = dragIndex.current;
+      dragIndex.current = null;
+      if (source === null || source === index) return;
+      const order = [...targets];
+      const [moved] = order.splice(source, 1);
+      order.splice(index, 0, moved);
+      reorderShareTargets(order.map((target) => target.id));
+    },
+    [targets]
+  );
+
+  const toggleVisibility = useCallback((target: ShareTargetWithState) => {
+    setShareTargetVisibility(target.id, !target.visible);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    if (
+      window.confirm(
+        "Reset share targets to their default order and visibility?"
+      )
+    ) {
+      resetShareTargetSettings();
+    }
+  }, []);
+
+  return (
+    <div className="flex h-full w-full flex-col bg-ub-cool-grey text-white">
+      <div className="border-b border-black/60 px-6 py-5">
+        <h1 className="text-xl font-semibold leading-6">Share Targets</h1>
+        <p className="mt-1 text-sm text-white/70">
+          Drag targets to reorder them. Toggle visibility to remove entries
+          from the share sheet without uninstalling the app.
+        </p>
+        <p className="mt-2 text-xs uppercase tracking-wide text-white/50">
+          Visible {visibleCount} / {targets.length}
+        </p>
+      </div>
+      <div className="flex-1 overflow-y-auto px-6 py-4">
+        {targets.length === 0 ? (
+          <p className="text-sm text-white/70">
+            No share targets are installed for this profile.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {targets.map((target, index) => {
+              const accentBg = `${target.accent}33`;
+              return (
+                <li
+                  key={target.id}
+                  draggable
+                  onDragStart={handleDragStart(index)}
+                  onDragOver={handleDragOver(index)}
+                  onDrop={handleDrop(index)}
+                  onDragEnd={handleDragEnd}
+                  className={`flex items-center justify-between gap-4 rounded-xl border border-white/10 bg-black/30 px-4 py-3 transition hover:border-white/20 ${
+                    target.visible ? "" : "opacity-60"
+                  }`}
+                >
+                  <div className="flex items-center gap-4">
+                    <span
+                      className="cursor-grab text-lg text-white/40"
+                      aria-hidden
+                    >
+                      ☰
+                    </span>
+                    <span
+                      className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-lg text-2xl"
+                      style={{ backgroundColor: accentBg, color: target.accent }}
+                    >
+                      <span aria-hidden>{target.emoji}</span>
+                      <span className="sr-only">{target.title}</span>
+                    </span>
+                    <span>
+                      <span className="block text-base font-medium text-white">
+                        {target.title}
+                      </span>
+                      <span className="block text-sm text-white/70">
+                        {target.description}
+                      </span>
+                    </span>
+                  </div>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={target.visible}
+                      onChange={() => toggleVisibility(target)}
+                      className="h-4 w-4"
+                    />
+                    <span>{target.visible ? "Visible" : "Hidden"}</span>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+      <div className="border-t border-black/60 px-6 py-4 text-right">
+        <button
+          type="button"
+          onClick={handleReset}
+          className="inline-flex items-center rounded-md border border-white/20 bg-white/10 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+        >
+          Reset to defaults
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ShareTargetsApp;

--- a/components/apps/share/ShareSheet.tsx
+++ b/components/apps/share/ShareSheet.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useSyncExternalStore,
+} from "react";
+import {
+  shareTargetStore,
+  getVisibleShareTargets,
+  getRecentShareTargetIds,
+  recordShareTargetUse,
+  ShareTargetDefinition,
+  ShareTargetsSnapshot,
+  ShareCapability,
+} from "../../../utils/settings/shareTargets";
+
+export interface SharePayload {
+  title?: string;
+  text?: string;
+  url?: string;
+  files?: File[];
+}
+
+interface ShareSheetProps {
+  payload?: SharePayload;
+  onSelect?: (target: ShareTargetDefinition) => void;
+  onClose?: () => void;
+  headline?: string;
+  subhead?: string;
+}
+
+const deriveCapabilities = (payload: SharePayload | undefined) => {
+  const capabilities = new Set<ShareCapability>();
+  if (!payload) return capabilities;
+  if (payload.text && payload.text.trim().length > 0) {
+    capabilities.add("text");
+  }
+  if (payload.title && payload.title.trim().length > 0) {
+    capabilities.add("text");
+  }
+  if (payload.url && payload.url.trim().length > 0) {
+    capabilities.add("url");
+  }
+  if (payload.files && payload.files.length > 0) {
+    capabilities.add("file");
+  }
+  return capabilities;
+};
+
+const ShareTargetButton = React.memo(
+  ({
+    target,
+    onSelect,
+  }: {
+    target: ShareTargetDefinition;
+    onSelect: (target: ShareTargetDefinition) => void;
+  }) => {
+    const accentBg = `${target.accent}33`;
+    return (
+      <button
+        type="button"
+        onClick={() => onSelect(target)}
+        className="flex items-center gap-4 rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-left transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-black/20"
+      >
+        <span
+          className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-lg text-2xl"
+          style={{ backgroundColor: accentBg, color: target.accent }}
+        >
+          <span aria-hidden>{target.emoji}</span>
+          <span className="sr-only">{target.title}</span>
+        </span>
+        <span className="flex flex-col">
+          <span className="text-base font-medium text-white">{target.title}</span>
+          <span className="text-sm text-white/70">{target.description}</span>
+        </span>
+      </button>
+    );
+  }
+);
+ShareTargetButton.displayName = "ShareTargetButton";
+
+const ShareSheet: React.FC<ShareSheetProps> = ({
+  payload,
+  onSelect,
+  onClose,
+  headline = "Share",
+  subhead = "Choose a destination",
+}) => {
+  const snapshot = useSyncExternalStore<ShareTargetsSnapshot>(
+    shareTargetStore.subscribe,
+    shareTargetStore.getSnapshot,
+    shareTargetStore.getServerSnapshot
+  );
+
+  const capabilities = useMemo(() => deriveCapabilities(payload), [payload]);
+  const visibleTargets = useMemo(
+    () => getVisibleShareTargets(snapshot),
+    [snapshot]
+  );
+  const recentIds = useMemo(
+    () => getRecentShareTargetIds(snapshot),
+    [snapshot]
+  );
+
+  const prioritizedTargets = useMemo(() => {
+    if (visibleTargets.length === 0) return [] as ShareTargetDefinition[];
+    const map = new Map(visibleTargets.map((target) => [target.id, target]));
+    const ordered: ShareTargetDefinition[] = [];
+    const seen = new Set<string>();
+    for (const id of recentIds) {
+      const target = map.get(id);
+      if (target && !seen.has(target.id)) {
+        ordered.push(target);
+        seen.add(target.id);
+      }
+    }
+    for (const target of visibleTargets) {
+      if (!seen.has(target.id)) {
+        ordered.push(target);
+        seen.add(target.id);
+      }
+    }
+    return ordered;
+  }, [recentIds, visibleTargets]);
+
+  const compatibleTargets = useMemo(() => {
+    if (capabilities.size === 0) return prioritizedTargets;
+    return prioritizedTargets.filter((target) =>
+      target.accepts.some((cap) => capabilities.has(cap))
+    );
+  }, [capabilities, prioritizedTargets]);
+
+  const handleSelect = useCallback(
+    (target: ShareTargetDefinition) => {
+      recordShareTargetUse(target.id);
+      onSelect?.(target);
+    },
+    [onSelect]
+  );
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose?.();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const stopPropagation = useCallback((event: React.MouseEvent) => {
+    event.stopPropagation();
+  }, []);
+
+  return (
+    <div
+      className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <div
+        className="w-[min(520px,90vw)] max-h-[80vh] overflow-hidden rounded-2xl bg-ub-cool-grey text-white shadow-2xl"
+        onClick={stopPropagation}
+      >
+        <div className="flex items-start justify-between gap-4 border-b border-white/10 px-5 pb-4 pt-5">
+          <div>
+            <h2 className="text-lg font-semibold leading-6">{headline}</h2>
+            <p className="text-sm text-white/70">{subhead}</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1 text-white/60 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+            aria-label="Close share sheet"
+          >
+            ×
+          </button>
+        </div>
+        <div className="max-h-[60vh] overflow-y-auto px-5 py-4">
+          {compatibleTargets.length === 0 ? (
+            <p className="text-sm text-white/70">
+              No compatible share targets are currently enabled.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {compatibleTargets.map((target) => (
+                <ShareTargetButton
+                  key={target.id}
+                  target={target}
+                  onSelect={handleSelect}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShareSheet;

--- a/pages/apps/share-targets.tsx
+++ b/pages/apps/share-targets.tsx
@@ -1,0 +1,9 @@
+import dynamic from 'next/dynamic';
+
+const ShareTargetsApp = dynamic(() => import('../../apps/share-targets'), {
+  ssr: false,
+});
+
+export default function ShareTargetsPage() {
+  return <ShareTargetsApp />;
+}

--- a/public/themes/Yaru/apps/share-targets.svg
+++ b/public/themes/Yaru/apps/share-targets.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="18" fill="#111827"/>
+  <path d="M72 68L50 42L28 64" fill="none" stroke="#F9FAFB" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" opacity="0.8"/>
+  <circle cx="50" cy="36" r="14" fill="#38bdf8"/>
+  <circle cx="28" cy="64" r="12" fill="#6366f1"/>
+  <circle cx="72" cy="68" r="12" fill="#22c55e"/>
+  <path d="M50 25v22" stroke="#111827" stroke-width="5" stroke-linecap="round" opacity="0.55"/>
+  <path d="M28 53v22" stroke="#111827" stroke-width="4" stroke-linecap="round" opacity="0.55"/>
+  <path d="M72 57v22" stroke="#111827" stroke-width="4" stroke-linecap="round" opacity="0.55"/>
+</svg>

--- a/utils/settings/shareTargets.ts
+++ b/utils/settings/shareTargets.ts
@@ -1,0 +1,251 @@
+"use client";
+
+import { safeLocalStorage } from "../safeStorage";
+
+export type ShareCapability = "text" | "url" | "file";
+
+export interface ShareTargetDefinition {
+  id: string;
+  title: string;
+  description: string;
+  emoji: string;
+  accent: string;
+  accepts: ShareCapability[];
+  appId?: string;
+  href?: string;
+}
+
+export interface ShareTargetWithState extends ShareTargetDefinition {
+  visible: boolean;
+}
+
+export interface ShareTargetState {
+  order: string[];
+  hidden: string[];
+  recents: string[];
+}
+
+const STORAGE_KEY = "share-target-preferences";
+const RECENT_LIMIT = 4;
+
+const INSTALLED_SHARE_TARGETS: ShareTargetDefinition[] = [
+  {
+    id: "input-hub",
+    title: "Input Hub",
+    description: "Route shared items to the intake console",
+    emoji: "📥",
+    accent: "#2563eb",
+    accepts: ["text", "url", "file"],
+    href: "/input-hub",
+  },
+  {
+    id: "clipboard-manager",
+    title: "Clipboard Manager",
+    description: "Append the share to clipboard history",
+    emoji: "📋",
+    accent: "#10b981",
+    accepts: ["text", "url"],
+    appId: "clipboard-manager",
+  },
+  {
+    id: "sticky_notes",
+    title: "Sticky Notes",
+    description: "Create a note from the shared text",
+    emoji: "🗒️",
+    accent: "#f59e0b",
+    accepts: ["text", "url"],
+    appId: "sticky_notes",
+  },
+  {
+    id: "gedit",
+    title: "Text Editor",
+    description: "Open the share in a new Gedit document",
+    emoji: "✏️",
+    accent: "#ec4899",
+    accepts: ["text"],
+    appId: "gedit",
+  },
+  {
+    id: "qr",
+    title: "QR Tool",
+    description: "Transform the share into a QR code",
+    emoji: "🔳",
+    accent: "#0ea5e9",
+    accepts: ["text", "url"],
+    appId: "qr",
+  },
+  {
+    id: "contact",
+    title: "Contact",
+    description: "Send the share through the contact console",
+    emoji: "✉️",
+    accent: "#8b5cf6",
+    accepts: ["text", "url", "file"],
+    appId: "contact",
+  },
+];
+
+const TARGET_MAP = new Map(
+  INSTALLED_SHARE_TARGETS.map((target) => [target.id, target])
+);
+
+const defaultOrder = INSTALLED_SHARE_TARGETS.map((target) => target.id);
+
+const dedupe = (ids: string[]) => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const id of ids) {
+    if (TARGET_MAP.has(id) && !seen.has(id)) {
+      seen.add(id);
+      result.push(id);
+    }
+  }
+  return result;
+};
+
+const sanitizeState = (
+  incoming?: Partial<ShareTargetState>
+): ShareTargetState => {
+  const order = dedupe([...(incoming?.order ?? []), ...defaultOrder]);
+  const hidden = dedupe(incoming?.hidden ?? []);
+  const recents = dedupe(incoming?.recents ?? []).slice(0, RECENT_LIMIT);
+  return {
+    order: order.length ? order : [...defaultOrder],
+    hidden,
+    recents,
+  };
+};
+
+const createDefaultState = (): ShareTargetState => ({
+  order: [...defaultOrder],
+  hidden: [],
+  recents: [],
+});
+
+const loadFromStorage = (): ShareTargetState => {
+  if (!safeLocalStorage) return createDefaultState();
+  try {
+    const raw = safeLocalStorage.getItem(STORAGE_KEY);
+    if (!raw) return createDefaultState();
+    const parsed = JSON.parse(raw) as Partial<ShareTargetState>;
+    return sanitizeState(parsed);
+  } catch {
+    return createDefaultState();
+  }
+};
+
+let state: ShareTargetState = loadFromStorage();
+
+const listeners = new Set<() => void>();
+
+const emit = () => {
+  listeners.forEach((listener) => listener());
+};
+
+const persist = () => {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // ignore storage quota errors
+  }
+};
+
+const updateState = (partial: Partial<ShareTargetState>) => {
+  state = sanitizeState({ ...state, ...partial });
+  persist();
+  emit();
+};
+
+export const shareTargetStore = {
+  subscribe(listener: () => void) {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+  getSnapshot(): ShareTargetState {
+    return state;
+  },
+  getServerSnapshot(): ShareTargetState {
+    return createDefaultState();
+  },
+};
+
+const normalizeSnapshot = (
+  snapshot: ShareTargetState
+): ShareTargetState => {
+  if (snapshot === state) return state;
+  return sanitizeState(snapshot);
+};
+
+export const getShareTargetsForManagement = (
+  snapshot: ShareTargetState = state
+): ShareTargetWithState[] => {
+  const normalized = normalizeSnapshot(snapshot);
+  const hiddenSet = new Set(normalized.hidden);
+  return normalized.order
+    .map((id) => {
+      const definition = TARGET_MAP.get(id);
+      if (!definition) return null;
+      return { ...definition, visible: !hiddenSet.has(id) };
+    })
+    .filter(Boolean) as ShareTargetWithState[];
+};
+
+export const getVisibleShareTargets = (
+  snapshot: ShareTargetState = state
+): ShareTargetDefinition[] => {
+  const normalized = normalizeSnapshot(snapshot);
+  const hiddenSet = new Set(normalized.hidden);
+  return normalized.order
+    .filter((id) => !hiddenSet.has(id))
+    .map((id) => TARGET_MAP.get(id)!)
+    .filter(Boolean);
+};
+
+export const getRecentShareTargetIds = (
+  snapshot: ShareTargetState = state
+): string[] => {
+  const normalized = normalizeSnapshot(snapshot);
+  return [...normalized.recents];
+};
+
+export const recordShareTargetUse = (id: string) => {
+  if (!TARGET_MAP.has(id)) return;
+  const existing = state.recents.filter((entry) => entry !== id);
+  const recents = [id, ...existing].slice(0, RECENT_LIMIT);
+  updateState({ recents });
+};
+
+export const reorderShareTargets = (order: string[]) => {
+  const sanitized = dedupe(order);
+  updateState({ order: sanitized });
+};
+
+export const setShareTargetVisibility = (id: string, visible: boolean) => {
+  if (!TARGET_MAP.has(id)) return;
+  const hidden = new Set(state.hidden);
+  if (!visible) {
+    hidden.add(id);
+  } else {
+    hidden.delete(id);
+  }
+  updateState({ hidden: [...hidden] });
+};
+
+export const getShareTargetDefinition = (id: string) => TARGET_MAP.get(id);
+
+export const getAllShareTargets = () => INSTALLED_SHARE_TARGETS;
+
+export const resetShareTargetSettings = () => {
+  state = createDefaultState();
+  if (safeLocalStorage) {
+    try {
+      safeLocalStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // ignore storage errors
+    }
+  }
+  emit();
+};
+
+export type { ShareTargetState as ShareTargetsSnapshot };


### PR DESCRIPTION
## Summary
- add a share target settings store that persists ordering, visibility, and recents
- build a drag-to-reorder Share Targets management app and register it in the utilities catalog
- update the share sheet to respect custom ordering, bubble recent targets, and add a persistence test

## Testing
- yarn lint *(fails: repository already contains hundreds of jsx-a11y and no-top-level-window errors)*
- yarn test --watch=false *(fails: existing suites crash with jsdom localStorage access issues)*
- yarn test __tests__/shareTargetsSettings.test.ts *(fails for same upstream suites, though the new test itself passes)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4675863c8328b80a532b50d91078