### PR TITLE
feat: add open history analytics and recommendations

### DIFF
--- a/__tests__/OpenWithDialog.test.tsx
+++ b/__tests__/OpenWithDialog.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import OpenWithDialog, {
+  type OpenWithOption,
+} from '../components/ui/OpenWithDialog';
+import {
+  APP_SUGGESTIONS_STORAGE_KEY,
+  clearHistory,
+  recordOpen,
+} from '../utils/analytics/openHistory';
+
+describe('OpenWithDialog', () => {
+  const options: OpenWithOption[] = [
+    { id: 'gedit', name: 'Text Editor', description: 'Plain text editor' },
+    { id: 'code', name: 'Code Studio', description: 'Developer IDE' },
+    { id: 'viewer', name: 'Image Viewer' },
+  ];
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    clearHistory();
+  });
+
+  test('renders last used and popular sections with explanations', async () => {
+    const now = Date.now();
+    recordOpen('text/plain', 'gedit', now - 60_000);
+    recordOpen('text/plain', 'code', now - 30_000);
+    recordOpen('text/plain', 'code', now - 5_000);
+
+    render(
+      <OpenWithDialog
+        isOpen
+        type="text/plain"
+        options={options}
+        onSelect={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Last used/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText(/Recently used/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Popular for this type/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Do not suggest Text Editor/i })).toBeInTheDocument();
+  });
+
+  test('do not suggest removes the app from recommendations', async () => {
+    const now = Date.now();
+    recordOpen('text/plain', 'gedit', now - 1_000);
+    render(
+      <OpenWithDialog
+        isOpen
+        type="text/plain"
+        options={options}
+        onSelect={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+
+    const dismissButton = await screen.findByRole('button', {
+      name: /Do not suggest Text Editor/i,
+    });
+    fireEvent.click(dismissButton);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: /Do not suggest Text Editor/i }),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.getByText(/Hidden from suggestions/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Allow again/i })).toBeInTheDocument();
+  });
+
+  test('honours disabled suggestions flag', async () => {
+    window.localStorage.setItem(APP_SUGGESTIONS_STORAGE_KEY, 'false');
+    render(
+      <OpenWithDialog
+        isOpen
+        type="text/plain"
+        options={options}
+        onSelect={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+
+    const disabledMessage = await screen.findByText(
+      /App suggestions are disabled in Privacy settings/i,
+    );
+    expect(disabledMessage).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /Last used/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/openHistory.test.ts
+++ b/__tests__/openHistory.test.ts
@@ -1,0 +1,50 @@
+import {
+  areSuggestionsEnabled,
+  clearHistory,
+  getHistory,
+  getRecommendations,
+  recordOpen,
+  setDoNotSuggest,
+} from '../utils/analytics/openHistory';
+
+describe('openHistory analytics store', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    clearHistory();
+  });
+
+  test('records usage per type with counts', () => {
+    recordOpen('text/plain', 'gedit', 1_000);
+    recordOpen('text/plain', 'gedit', 2_000);
+    recordOpen('image/png', 'viewer', 3_000);
+
+    const textHistory = getHistory('text/plain');
+    expect(textHistory).toHaveLength(1);
+    expect(textHistory[0]).toMatchObject({ appId: 'gedit', count: 2, lastUsed: 2_000 });
+
+    const imageHistory = getHistory('image/png');
+    expect(imageHistory).toHaveLength(1);
+    expect(imageHistory[0].appId).toBe('viewer');
+  });
+
+  test('honours do-not-suggest preferences in recommendations', () => {
+    recordOpen('text/plain', 'gedit', Date.now() - 5_000);
+    recordOpen('text/plain', 'code', Date.now() - 2_000);
+
+    let recommendations = getRecommendations('text/plain');
+    expect(recommendations.lastUsed.map(entry => entry.appId)).toContain('code');
+
+    setDoNotSuggest('text/plain', 'code', true);
+    recommendations = getRecommendations('text/plain');
+    expect(recommendations.lastUsed.map(entry => entry.appId)).not.toContain('code');
+    expect(recommendations.popular.map(entry => entry.appId)).not.toContain('code');
+  });
+
+  test('clearHistory removes stored analytics', () => {
+    recordOpen('text/plain', 'gedit', 10_000);
+    expect(getHistory('text/plain')).toHaveLength(1);
+    clearHistory('text/plain');
+    expect(getHistory('text/plain')).toHaveLength(0);
+    expect(areSuggestionsEnabled()).toBe(true);
+  });
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import { clearHistory as clearOpenHistory } from "../../utils/analytics/openHistory";
 
 export default function Settings() {
   const {
@@ -29,6 +30,8 @@ export default function Settings() {
     setHighContrast,
     haptics,
     setHaptics,
+    suggestionsEnabled,
+    setSuggestionsEnabled,
     theme,
     setTheme,
   } = useSettings();
@@ -100,6 +103,7 @@ export default function Settings() {
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
+    setSuggestionsEnabled(defaults.suggestionsEnabled);
     setTheme("default");
   };
 
@@ -285,6 +289,40 @@ export default function Settings() {
             >
               Import Settings
             </button>
+          </div>
+          <div className="flex flex-col items-center my-4 space-y-2">
+            <div className="flex items-center space-x-3">
+              <span className="text-ubt-grey">Show app suggestions</span>
+              <ToggleSwitch
+                checked={suggestionsEnabled}
+                onChange={setSuggestionsEnabled}
+                ariaLabel="Enable app suggestions"
+              />
+            </div>
+            <p className="text-xs text-ubt-grey text-center max-w-md">
+              When enabled, compatible apps highlight “Last used” and “Popular”
+              choices based on on-device history only.
+            </p>
+          </div>
+          <div className="flex flex-col items-center my-4 space-y-2">
+            <button
+              onClick={() => {
+                if (
+                  window.confirm(
+                    "Clear app suggestion history? This will remove last used and popular recommendations.",
+                  )
+                ) {
+                  clearOpenHistory();
+                }
+              }}
+              className="px-4 py-2 rounded bg-ub-orange text-white"
+            >
+              Clear Suggestion History
+            </button>
+            <p className="text-xs text-ubt-grey text-center max-w-md">
+              Removes per-type open history and resets recommendations. This
+              does not delete your files.
+            </p>
           </div>
         </>
       )}

--- a/components/ui/OpenWithDialog.tsx
+++ b/components/ui/OpenWithDialog.tsx
@@ -1,0 +1,321 @@
+import { Fragment, MouseEvent, useEffect, useId, useMemo, useState } from 'react';
+import {
+  APP_SUGGESTIONS_STORAGE_KEY,
+  areSuggestionsEnabled,
+  getDoNotSuggest,
+  getRecommendations,
+  recordOpen,
+  setDoNotSuggest,
+  type RecommendationEntry,
+} from '../../utils/analytics/openHistory';
+
+export interface OpenWithOption {
+  id: string;
+  name: string;
+  description?: string;
+  icon?: string;
+}
+
+export interface OpenWithDialogProps {
+  isOpen: boolean;
+  type: string;
+  options: OpenWithOption[];
+  onSelect: (option: OpenWithOption) => void;
+  onClose: () => void;
+  title?: string;
+}
+
+const reasonLabel = (reason: RecommendationEntry['reason']): string =>
+  reason === 'lastUsed' ? 'Recently used' : 'Popular choice';
+
+const OpenWithDialog: React.FC<OpenWithDialogProps> = ({
+  isOpen,
+  type,
+  options,
+  onSelect,
+  onClose,
+  title = 'Open with',
+}) => {
+  const titleId = useId();
+  const [suggestionsEnabled, setSuggestionsEnabled] = useState(false);
+  const [blocked, setBlocked] = useState<Set<string>>(new Set());
+
+  const optionMap = useMemo(
+    () => new Map(options.map(option => [option.id, option])),
+    [options],
+  );
+
+  const sortedOptions = useMemo(
+    () => [...options].sort((a, b) => a.name.localeCompare(b.name)),
+    [options],
+  );
+
+  const blockSignature = useMemo(
+    () => [...blocked].sort().join('|'),
+    [blocked],
+  );
+
+  const recommendations = useMemo(() => {
+    if (!isOpen || !suggestionsEnabled) {
+      return { lastUsed: [] as RecommendationEntry[], popular: [] as RecommendationEntry[] };
+    }
+    const { lastUsed, popular } = getRecommendations(type, {
+      lastUsedLimit: 3,
+      popularLimit: 4,
+    });
+    const availableLastUsed = lastUsed.filter(entry => optionMap.has(entry.appId));
+    const seen = new Set(availableLastUsed.map(entry => entry.appId));
+    const availablePopular = popular
+      .filter(entry => optionMap.has(entry.appId) && !seen.has(entry.appId));
+    return { lastUsed: availableLastUsed, popular: availablePopular };
+  }, [isOpen, suggestionsEnabled, type, optionMap, blockSignature]);
+
+  const recommendedIds = useMemo(() => {
+    const ids = new Set<string>();
+    recommendations.lastUsed.forEach(entry => ids.add(entry.appId));
+    recommendations.popular.forEach(entry => ids.add(entry.appId));
+    return ids;
+  }, [recommendations]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setSuggestionsEnabled(areSuggestionsEnabled());
+    setBlocked(new Set(getDoNotSuggest(type)));
+  }, [isOpen, type]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (
+      event: KeyboardEvent | { key?: string; preventDefault?: () => void },
+    ) => {
+      if (event.key === 'Escape') {
+        if (typeof event.preventDefault === 'function') {
+          event.preventDefault();
+        }
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === APP_SUGGESTIONS_STORAGE_KEY) {
+        setSuggestionsEnabled(areSuggestionsEnabled());
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleSelect = (option: OpenWithOption) => {
+    recordOpen(type, option.id);
+    onSelect(option);
+    onClose();
+  };
+
+  const handleDoNotSuggest = (event: MouseEvent<HTMLButtonElement>, appId: string) => {
+    event.stopPropagation();
+    setDoNotSuggest(type, appId, true);
+    setBlocked(prev => {
+      const next = new Set(prev);
+      next.add(appId);
+      return next;
+    });
+  };
+
+  const handleAllowSuggestion = (event: MouseEvent<HTMLButtonElement>, appId: string) => {
+    event.stopPropagation();
+    setDoNotSuggest(type, appId, false);
+    setBlocked(prev => {
+      const next = new Set(prev);
+      next.delete(appId);
+      return next;
+    });
+  };
+
+  const renderRecommendation = (entry: RecommendationEntry) => {
+    const option = optionMap.get(entry.appId);
+    if (!option) return null;
+    return (
+      <li key={entry.appId}>
+        <div className="rounded-md bg-black bg-opacity-30 px-3 py-2">
+          <button
+            type="button"
+            onClick={() => handleSelect(option)}
+            className="flex w-full items-center gap-3 rounded-md px-1 py-1 text-left transition hover:bg-black/20 focus:outline-none focus:ring-2 focus:ring-ub-orange"
+          >
+            {option.icon ? (
+              <img
+                src={option.icon}
+                alt=""
+                aria-hidden="true"
+                className="h-6 w-6 rounded"
+              />
+            ) : (
+              <span className="flex h-6 w-6 items-center justify-center rounded bg-black bg-opacity-40 text-xs font-bold uppercase">
+                {option.name.slice(0, 2)}
+              </span>
+            )}
+            <div>
+              <div className="text-sm font-medium text-white">{option.name}</div>
+              <div className="text-xs text-ubt-grey">
+                <span className="font-semibold">{reasonLabel(entry.reason)}</span>
+                {`: ${entry.reasonDescription}`}
+              </div>
+            </div>
+          </button>
+          <div className="mt-2 flex justify-end">
+            <button
+              type="button"
+              onClick={event => handleDoNotSuggest(event, entry.appId)}
+              className="text-xs font-medium text-ubt-grey transition hover:text-white"
+              aria-label={`Do not suggest ${option.name}`}
+            >
+              Do not suggest
+            </button>
+          </div>
+        </div>
+      </li>
+    );
+  };
+
+  const renderOption = (option: OpenWithOption) => {
+    const isBlocked = blocked.has(option.id);
+    const isRecommended = recommendedIds.has(option.id);
+    return (
+      <li key={option.id}>
+        <div
+          className={`rounded-md px-3 py-2 ${
+            isRecommended
+              ? 'bg-black bg-opacity-40'
+              : 'bg-black bg-opacity-20'
+          }`}
+        >
+          <button
+            type="button"
+            onClick={() => handleSelect(option)}
+            className="flex w-full items-start gap-3 rounded-md px-1 py-1 text-left transition hover:bg-black/20 focus:outline-none focus:ring-2 focus:ring-ub-orange"
+          >
+            {option.icon ? (
+              <img
+                src={option.icon}
+                alt=""
+                aria-hidden="true"
+                className="mt-0.5 h-6 w-6 rounded"
+              />
+            ) : (
+              <span className="mt-0.5 flex h-6 w-6 items-center justify-center rounded bg-black bg-opacity-40 text-xs font-bold uppercase">
+                {option.name.slice(0, 2)}
+              </span>
+            )}
+            <div className="flex-1">
+              <div className="text-sm font-medium text-white">{option.name}</div>
+              {option.description && (
+                <div className="text-xs text-ubt-grey">{option.description}</div>
+              )}
+            </div>
+          </button>
+          {isBlocked && (
+            <div className="mt-1 flex items-center justify-between text-xs text-ubt-grey">
+              <span>Hidden from suggestions</span>
+              <button
+                type="button"
+                onClick={event => handleAllowSuggestion(event, option.id)}
+                className="font-medium text-ubt-grey underline-offset-2 transition hover:text-white"
+              >
+                Allow again
+              </button>
+            </div>
+          )}
+        </div>
+      </li>
+    );
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60 p-4"
+      onMouseDown={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="w-full max-w-xl rounded-lg border border-black border-opacity-50 bg-ub-cool-grey text-white shadow-2xl"
+        onMouseDown={event => event.stopPropagation()}
+      >
+        <header className="flex items-center justify-between border-b border-black border-opacity-40 px-4 py-3">
+          <h2 id={titleId} className="text-lg font-semibold">
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-8 w-8 rounded-full text-xl leading-none text-ubt-grey transition hover:bg-black hover:bg-opacity-30 hover:text-white focus:outline-none focus:ring-2 focus:ring-ub-orange"
+            aria-label="Close dialog"
+          >
+            ×
+          </button>
+        </header>
+        <div className="max-h-[70vh] overflow-y-auto px-4 py-5 space-y-5">
+          {suggestionsEnabled ? (
+            <Fragment>
+              <section>
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-ubt-grey">
+                  Last used
+                </h3>
+                {recommendations.lastUsed.length > 0 ? (
+                  <ul className="mt-2 space-y-2">
+                    {recommendations.lastUsed.map(renderRecommendation)}
+                  </ul>
+                ) : (
+                  <p className="mt-2 text-xs text-ubt-grey">
+                    No recent history yet. Launch an app below to see it here.
+                  </p>
+                )}
+              </section>
+              <section>
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-ubt-grey">
+                  Popular for this type
+                </h3>
+                {recommendations.popular.length > 0 ? (
+                  <ul className="mt-2 space-y-2">
+                    {recommendations.popular.map(renderRecommendation)}
+                  </ul>
+                ) : (
+                  <p className="mt-2 text-xs text-ubt-grey">
+                    No popular picks yet. We will suggest frequently used apps once you start opening files of this type.
+                  </p>
+                )}
+              </section>
+            </Fragment>
+          ) : (
+            <p className="text-xs text-ubt-grey">
+              App suggestions are disabled in Privacy settings. Enable them to see
+              “Last used” and “Popular” recommendations.
+            </p>
+          )}
+          <section>
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-ubt-grey">
+              All applications
+            </h3>
+            {sortedOptions.length > 0 ? (
+              <ul className="mt-2 space-y-2">
+                {sortedOptions.map(renderOption)}
+              </ul>
+            ) : (
+              <p className="mt-2 text-xs text-ubt-grey">No compatible applications available.</p>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OpenWithDialog;

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getSuggestionsEnabled as loadSuggestionsEnabled,
+  setSuggestionsEnabled as saveSuggestionsEnabled,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +64,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  suggestionsEnabled: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +76,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setSuggestionsEnabled: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +91,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  suggestionsEnabled: defaults.suggestionsEnabled,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +103,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setSuggestionsEnabled: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +118,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [suggestionsEnabled, setSuggestionsEnabled] = useState<boolean>(
+    defaults.suggestionsEnabled,
+  );
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +136,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setSuggestionsEnabled(await loadSuggestionsEnabled());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +246,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveSuggestionsEnabled(suggestionsEnabled);
+  }, [suggestionsEnabled]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +263,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        suggestionsEnabled,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +275,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setSuggestionsEnabled,
         setTheme,
       }}
     >

--- a/utils/analytics/openHistory.ts
+++ b/utils/analytics/openHistory.ts
@@ -1,0 +1,294 @@
+import { safeLocalStorage } from '../safeStorage';
+
+export const APP_SUGGESTIONS_STORAGE_KEY = 'preferences:app-suggestions-enabled';
+const OPEN_HISTORY_STORAGE_KEY = 'analytics:open-history';
+const OPEN_HISTORY_BLOCKLIST_KEY = 'analytics:open-history-blocklist';
+const MAX_ENTRIES_PER_TYPE = 20;
+
+type HistoryMap = Record<string, Record<string, AppHistoryRecord>>;
+type BlockMap = Record<string, string[]>;
+
+export interface AppHistoryRecord {
+  lastUsed: number;
+  count: number;
+}
+
+export interface HistoryEntry {
+  appId: string;
+  lastUsed: number;
+  count: number;
+}
+
+export type RecommendationReason = 'lastUsed' | 'popular';
+
+export interface RecommendationEntry extends HistoryEntry {
+  reason: RecommendationReason;
+  reasonDescription: string;
+}
+
+export interface RecommendationSections {
+  lastUsed: RecommendationEntry[];
+  popular: RecommendationEntry[];
+}
+
+interface RecommendationOptions {
+  lastUsedLimit?: number;
+  popularLimit?: number;
+}
+
+const isBrowserEnvironment = () => typeof window !== 'undefined';
+
+const getStorage = () => (isBrowserEnvironment() ? safeLocalStorage : undefined);
+
+const parseHistory = (raw: unknown): HistoryMap => {
+  if (!raw || typeof raw !== 'object') return {};
+  const map: HistoryMap = {};
+  for (const [type, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!value || typeof value !== 'object') continue;
+    const entries: Record<string, AppHistoryRecord> = {};
+    for (const [appId, record] of Object.entries(value as Record<string, unknown>)) {
+      if (!record || typeof record !== 'object') continue;
+      const { lastUsed, count } = record as Partial<AppHistoryRecord>;
+      if (typeof lastUsed !== 'number' || typeof count !== 'number') continue;
+      if (!Number.isFinite(lastUsed) || !Number.isFinite(count)) continue;
+      entries[appId] = { lastUsed, count };
+    }
+    if (Object.keys(entries).length > 0) {
+      map[type] = entries;
+    }
+  }
+  return map;
+};
+
+const parseBlockMap = (raw: unknown): BlockMap => {
+  if (!raw || typeof raw !== 'object') return {};
+  const map: BlockMap = {};
+  for (const [type, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!Array.isArray(value)) continue;
+    const ids = value.filter((v): v is string => typeof v === 'string');
+    if (ids.length > 0) {
+      map[type] = Array.from(new Set(ids));
+    }
+  }
+  return map;
+};
+
+const loadHistory = (): HistoryMap => {
+  const storage = getStorage();
+  if (!storage) return {};
+  try {
+    const stored = storage.getItem(OPEN_HISTORY_STORAGE_KEY);
+    if (!stored) return {};
+    return parseHistory(JSON.parse(stored));
+  } catch {
+    return {};
+  }
+};
+
+const loadBlockMap = (): BlockMap => {
+  const storage = getStorage();
+  if (!storage) return {};
+  try {
+    const stored = storage.getItem(OPEN_HISTORY_BLOCKLIST_KEY);
+    if (!stored) return {};
+    return parseBlockMap(JSON.parse(stored));
+  } catch {
+    return {};
+  }
+};
+
+const saveHistory = (history: HistoryMap) => {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(OPEN_HISTORY_STORAGE_KEY, JSON.stringify(history));
+  } catch {
+    // Ignore storage write failures
+  }
+};
+
+const saveBlockMap = (map: BlockMap) => {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(OPEN_HISTORY_BLOCKLIST_KEY, JSON.stringify(map));
+  } catch {
+    // Ignore storage write failures
+  }
+};
+
+const toEntries = (records: Record<string, AppHistoryRecord> | undefined): HistoryEntry[] => {
+  if (!records) return [];
+  return Object.entries(records).map(([appId, record]) => ({
+    appId,
+    lastUsed: record.lastUsed,
+    count: record.count,
+  }));
+};
+
+const sortByLastUsed = (entries: HistoryEntry[]) =>
+  [...entries].sort((a, b) => b.lastUsed - a.lastUsed);
+
+const sortByPopularity = (entries: HistoryEntry[]) =>
+  [...entries].sort((a, b) => {
+    if (b.count === a.count) return b.lastUsed - a.lastUsed;
+    return b.count - a.count;
+  });
+
+const trimEntries = (records: Record<string, AppHistoryRecord>) => {
+  const entries = sortByPopularity(toEntries(records));
+  if (entries.length <= MAX_ENTRIES_PER_TYPE) return;
+  for (let i = MAX_ENTRIES_PER_TYPE; i < entries.length; i += 1) {
+    delete records[entries[i].appId];
+  }
+};
+
+const relativeTime = (timestamp: number): string => {
+  const now = Date.now();
+  const diff = Math.max(0, now - timestamp);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (diff < minute) return 'Used just now';
+  if (diff < 2 * minute) return 'Used a minute ago';
+  if (diff < hour) {
+    const minutes = Math.round(diff / minute);
+    return `Used ${minutes} minutes ago`;
+  }
+  if (diff < 2 * hour) return 'Used an hour ago';
+  if (diff < day) {
+    const hours = Math.round(diff / hour);
+    return `Used ${hours} hours ago`;
+  }
+  if (diff < 2 * day) return 'Used yesterday';
+  if (diff < 7 * day) {
+    const days = Math.round(diff / day);
+    return `Used ${days} days ago`;
+  }
+  const date = new Date(timestamp);
+  return `Used on ${date.toLocaleDateString()}`;
+};
+
+const popularReason = (count: number): string => {
+  if (count <= 1) {
+    return 'Opened once recently';
+  }
+  return `Opened ${count} times recently`;
+};
+
+export const areSuggestionsEnabled = (): boolean => {
+  if (!isBrowserEnvironment()) return false;
+  const storage = getStorage();
+  if (!storage) return false;
+  const stored = storage.getItem(APP_SUGGESTIONS_STORAGE_KEY);
+  if (stored === null) return true;
+  return stored !== 'false';
+};
+
+export const recordOpen = (type: string, appId: string, timestamp: number = Date.now()): void => {
+  if (!type || !appId) return;
+  if (!areSuggestionsEnabled()) return;
+  const storage = getStorage();
+  if (!storage) return;
+  const history = loadHistory();
+  const records = history[type] ?? {};
+  const current = records[appId];
+  records[appId] = {
+    lastUsed: timestamp,
+    count: current ? current.count + 1 : 1,
+  };
+  trimEntries(records);
+  history[type] = records;
+  saveHistory(history);
+};
+
+export const setDoNotSuggest = (type: string, appId: string, value: boolean): void => {
+  if (!type || !appId) return;
+  const storage = getStorage();
+  if (!storage) return;
+  const blockMap = loadBlockMap();
+  const current = new Set(blockMap[type] ?? []);
+  if (value) {
+    current.add(appId);
+  } else {
+    current.delete(appId);
+  }
+  if (current.size === 0) {
+    delete blockMap[type];
+  } else {
+    blockMap[type] = Array.from(current);
+  }
+  saveBlockMap(blockMap);
+};
+
+export const getDoNotSuggest = (type: string): string[] => {
+  const blockMap = loadBlockMap();
+  return blockMap[type] ?? [];
+};
+
+export const isBlocked = (type: string, appId: string): boolean => {
+  if (!type || !appId) return false;
+  const blockMap = loadBlockMap();
+  return blockMap[type]?.includes(appId) ?? false;
+};
+
+export const getHistory = (type: string): HistoryEntry[] => {
+  const history = loadHistory();
+  return sortByLastUsed(toEntries(history[type]));
+};
+
+export const getPopular = (type: string): HistoryEntry[] => {
+  const history = loadHistory();
+  return sortByPopularity(toEntries(history[type]));
+};
+
+export const getRecommendations = (
+  type: string,
+  options: RecommendationOptions = {},
+): RecommendationSections => {
+  const history = loadHistory();
+  const blockMap = loadBlockMap();
+  const blocked = new Set(blockMap[type] ?? []);
+  const records = history[type];
+  if (!records) {
+    return { lastUsed: [], popular: [] };
+  }
+  const entries = toEntries(records).filter(entry => !blocked.has(entry.appId));
+  const lastUsed = sortByLastUsed(entries)
+    .slice(0, options.lastUsedLimit ?? 3)
+    .map<RecommendationEntry>(entry => ({
+      ...entry,
+      reason: 'lastUsed',
+      reasonDescription: relativeTime(entry.lastUsed),
+    }));
+  const seen = new Set(lastUsed.map(entry => entry.appId));
+  const popular = sortByPopularity(entries)
+    .filter(entry => !seen.has(entry.appId))
+    .slice(0, options.popularLimit ?? 4)
+    .map<RecommendationEntry>(entry => ({
+      ...entry,
+      reason: 'popular',
+      reasonDescription: popularReason(entry.count),
+    }));
+  return { lastUsed, popular };
+};
+
+export const clearHistory = (type?: string): void => {
+  const storage = getStorage();
+  if (!storage) return;
+  if (!type) {
+    storage.removeItem(OPEN_HISTORY_STORAGE_KEY);
+    storage.removeItem(OPEN_HISTORY_BLOCKLIST_KEY);
+    return;
+  }
+  const history = loadHistory();
+  if (history[type]) {
+    delete history[type];
+    saveHistory(history);
+  }
+  const blockMap = loadBlockMap();
+  if (blockMap[type]) {
+    delete blockMap[type];
+    saveBlockMap(blockMap);
+  }
+};

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -2,6 +2,10 @@
 
 import { get, set, del } from 'idb-keyval';
 import { getTheme, setTheme } from './theme';
+import {
+  APP_SUGGESTIONS_STORAGE_KEY,
+  clearHistory as clearOpenHistory,
+} from './analytics/openHistory';
 
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
@@ -14,6 +18,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  suggestionsEnabled: true,
 };
 
 export async function getAccent() {
@@ -123,6 +128,21 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getSuggestionsEnabled() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.suggestionsEnabled;
+  const stored = window.localStorage.getItem(APP_SUGGESTIONS_STORAGE_KEY);
+  if (stored === null) return DEFAULT_SETTINGS.suggestionsEnabled;
+  return stored !== 'false';
+}
+
+export async function setSuggestionsEnabled(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(
+    APP_SUGGESTIONS_STORAGE_KEY,
+    value ? 'true' : 'false',
+  );
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +157,8 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem(APP_SUGGESTIONS_STORAGE_KEY);
+  clearOpenHistory();
 }
 
 export async function exportSettings() {
@@ -151,6 +173,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    suggestionsEnabled,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +185,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getSuggestionsEnabled(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -176,6 +200,7 @@ export async function exportSettings() {
     allowNetwork,
     haptics,
     theme,
+    suggestionsEnabled,
   });
 }
 
@@ -200,6 +225,7 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    suggestionsEnabled,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -212,6 +238,8 @@ export async function importSettings(json) {
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
+  if (suggestionsEnabled !== undefined)
+    await setSuggestionsEnabled(suggestionsEnabled);
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- add a persistent open-history analytics helper that records per-type usage, supports do-not-suggest lists and returns structured recommendations
- build a dedicated OpenWithDialog component that surfaces "Last used" and "Popular for this type" sections with contextual messaging and controls to stop or restore suggestions
- extend settings storage/provider and privacy UI with an app suggestions toggle plus a clear-history action, and cover the new logic with focused tests

## Testing
- yarn lint *(fails: legacy eslint violations outside the change scope)*
- yarn test *(fails: existing window/modal/about accessibility test issues unrelated to this change)*
- yarn test __tests__/openHistory.test.ts __tests__/OpenWithDialog.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb467436408328820441be1ac19ac9