### PR TITLE
[apps] Add default app control center and handler registry

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -87,6 +87,7 @@ const MetasploitApp = createDynamicApp('metasploit', 'Metasploit');
 
 const AutopsyApp = createDynamicApp('autopsy', 'Autopsy');
 const PluginManagerApp = createDynamicApp('plugin-manager', 'Plugin Manager');
+const DefaultAppsApp = createDynamicApp('default-apps', 'Default Apps');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
@@ -170,6 +171,7 @@ const displayGhidra = createDisplay(GhidraApp);
 
 const displayAutopsy = createDisplay(AutopsyApp);
 const displayPluginManager = createDisplay(PluginManagerApp);
+const displayDefaultApps = createDisplay(DefaultAppsApp);
 
 const displayWireshark = createDisplay(WiresharkApp);
 const displayBleSensor = createDisplay(BleSensorApp);
@@ -691,6 +693,15 @@ const apps = [
     favourite: true,
     desktop_shortcut: false,
     screen: displaySettings,
+  },
+  {
+    id: 'default-apps',
+    title: 'Default Apps',
+    icon: '/themes/Yaru/apps/gnome-control-center.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayDefaultApps,
   },
   {
     id: 'files',

--- a/apps/default-apps/index.tsx
+++ b/apps/default-apps/index.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import DefaultAppsControlCenter from '../../components/apps/default-apps';
+
+const DefaultAppsApp = () => {
+  return <DefaultAppsControlCenter />;
+};
+
+export default DefaultAppsApp;
+

--- a/components/apps/chrome/index.tsx
+++ b/components/apps/chrome/index.tsx
@@ -121,6 +121,38 @@ const Chrome: React.FC = () => {
   }, []);
 
   useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ url?: string }>).detail;
+      if (!detail?.url) return;
+      const url = detail.url;
+      const newId = Date.now();
+      setTabs((prev) => [
+        ...prev,
+        {
+          id: newId,
+          url,
+          history: [url],
+          historyIndex: 0,
+          scroll: 0,
+          blocked: false,
+          muted: false,
+        },
+      ]);
+      setActiveId(newId);
+      setAddress(url);
+      try {
+        sessionStorage.setItem('chrome-last-url', url);
+      } catch {
+        /* ignore */
+      }
+    };
+    window.addEventListener('chrome:navigate', handler as EventListener);
+    return () => {
+      window.removeEventListener('chrome:navigate', handler as EventListener);
+    };
+  }, [setAddress, setTabs, setActiveId]);
+
+  useEffect(() => {
     (async () => {
       try {
         if (!(typeof navigator !== 'undefined' && navigator.storage?.getDirectory)) return;

--- a/components/apps/default-apps.tsx
+++ b/components/apps/default-apps.tsx
@@ -1,0 +1,331 @@
+'use client';
+
+import {
+  ChangeEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  getRegistrySnapshot,
+  HandlerDescriptor,
+  openLink,
+} from '../../modules/system/linkHandler';
+import {
+  DefaultAppKind,
+  DEFAULT_APPS_EVENT,
+  exportDefaultApps,
+  getAllDefaultApps,
+  getBuiltinDefault,
+  importDefaultApps,
+  resetDefaultApps,
+  setDefaultApp,
+} from '../../utils/settings/defaultApps';
+
+type PreferenceRow = {
+  kind: DefaultAppKind;
+  type: string;
+  handlers: HandlerDescriptor[];
+  selected: string;
+  builtin?: string;
+};
+
+const ASK_VALUE = 'ask';
+
+const friendlyHandlerName = (handlers: HandlerDescriptor[], id?: string) => {
+  if (!id) return undefined;
+  const match = handlers.find((handler) => handler.id === id);
+  return match?.label;
+};
+
+const protocolSamples: Record<string, string> = {
+  http: 'http://example.com',
+  https: 'https://example.com',
+  mailto: 'mailto:demo@example.com',
+  ssh: 'ssh://demo@example.com',
+};
+
+const buildSampleUrl = (type: string) => protocolSamples[type] ?? `${type}://demo`;
+
+const DefaultAppsControlCenter = () => {
+  const [protocolRows, setProtocolRows] = useState<PreferenceRow[]>([]);
+  const [mimeRows, setMimeRows] = useState<PreferenceRow[]>([]);
+  const [status, setStatus] = useState<string>('');
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const refresh = useCallback(() => {
+    const snapshot = getRegistrySnapshot();
+    const defaults = getAllDefaultApps();
+    const buildRows = (
+      kind: DefaultAppKind,
+      descriptors: Record<string, HandlerDescriptor[]>,
+    ): PreferenceRow[] => {
+      const defaultMap = defaults[kind];
+      const keys = new Set([
+        ...Object.keys(descriptors),
+        ...Object.keys(defaultMap),
+      ]);
+      return Array.from(keys)
+        .sort((a, b) => a.localeCompare(b))
+        .map((type) => ({
+          kind,
+          type,
+          handlers: descriptors[type] || [],
+          selected: defaultMap[type] ?? ASK_VALUE,
+          builtin: getBuiltinDefault(kind, type),
+        }));
+    };
+    setProtocolRows(buildRows('protocol', snapshot.protocols));
+    setMimeRows(buildRows('mime', snapshot.mimes));
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const handler = () => refresh();
+    window.addEventListener(DEFAULT_APPS_EVENT, handler as EventListener);
+    return () => {
+      window.removeEventListener(DEFAULT_APPS_EVENT, handler as EventListener);
+    };
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!status) return undefined;
+    const timer = window.setTimeout(() => setStatus(''), 4000);
+    return () => window.clearTimeout(timer);
+  }, [status]);
+
+  const onChangeSelection = useCallback(
+    (row: PreferenceRow, value: string) => {
+      setDefaultApp(row.kind, row.type, value);
+      setProtocolRows((rows) =>
+        rows.map((entry) =>
+          entry.kind === row.kind && entry.type === row.type
+            ? { ...entry, selected: value }
+            : entry,
+        ),
+      );
+      setMimeRows((rows) =>
+        rows.map((entry) =>
+          entry.kind === row.kind && entry.type === row.type
+            ? { ...entry, selected: value }
+            : entry,
+        ),
+      );
+      setStatus('Preference saved');
+    },
+    [],
+  );
+
+  const handleExport = useCallback(() => {
+    const data = exportDefaultApps(true);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'default-apps.json';
+    anchor.click();
+    URL.revokeObjectURL(url);
+    setStatus('Export complete');
+  }, []);
+
+  const handleImport = useCallback(async (file: File) => {
+    const text = await file.text();
+    if (importDefaultApps(text)) {
+      refresh();
+      setStatus('Imported preferences');
+    } else {
+      setStatus('Invalid configuration file');
+    }
+  }, [refresh]);
+
+  const triggerImport = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+      void handleImport(file);
+      event.target.value = '';
+    },
+    [handleImport],
+  );
+
+  const handleReset = useCallback(() => {
+    if (!window.confirm('Reset all default app overrides?')) return;
+    resetDefaultApps();
+    refresh();
+    setStatus('Restored built-in defaults');
+  }, [refresh]);
+
+  const handleTest = useCallback(async (row: PreferenceRow) => {
+    if (row.selected === ASK_VALUE) {
+      setStatus('Choose a handler before testing.');
+      return;
+    }
+    if (row.selected === 'system-mail') {
+      setStatus('The system email handler opens outside the desktop.');
+      return;
+    }
+    const request = row.kind === 'protocol'
+      ? { url: buildSampleUrl(row.type), allowPrompt: false }
+      : { mimeType: row.type, allowPrompt: false };
+    const success = await openLink(request);
+    if (!success) {
+      setStatus('Launch was cancelled or blocked.');
+    }
+  }, []);
+
+  const renderRows = useCallback(
+    (rows: PreferenceRow[], title: string, emptyLabel: string) => (
+      <section>
+        <h2 className="text-lg font-semibold text-white mb-3">{title}</h2>
+        {rows.length === 0 ? (
+          <p className="text-sm text-ubt-grey">{emptyLabel}</p>
+        ) : (
+          <div className="space-y-4">
+            {rows.map((row) => {
+              const activeDescription =
+                row.selected !== ASK_VALUE
+                  ? row.handlers.find((handler) => handler.id === row.selected)?.description
+                  : undefined;
+              const builtinLabel = friendlyHandlerName(row.handlers, row.builtin) || row.builtin;
+              return (
+                <div
+                  key={`${row.kind}-${row.type}`}
+                  className="rounded border border-black/40 bg-black/30 p-4 shadow-sm"
+                >
+                  <div className="flex flex-wrap justify-between gap-3">
+                    <div>
+                      <span className="text-xs uppercase tracking-wide text-ubt-grey">
+                        {row.kind === 'protocol' ? 'Protocol' : 'MIME type'}
+                      </span>
+                      <h3 className="text-base md:text-lg font-semibold text-white">
+                        {row.type}
+                      </h3>
+                      {builtinLabel && (
+                        <p className="text-xs text-ubt-grey mt-1">
+                          Built-in: {builtinLabel}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex flex-col items-start gap-2 min-w-[12rem]">
+                      <label
+                        htmlFor={`${row.kind}-${row.type}-select`}
+                        className="text-xs uppercase tracking-wide text-ubt-grey"
+                      >
+                        Default handler
+                      </label>
+                      <select
+                        id={`${row.kind}-${row.type}-select`}
+                        value={row.selected}
+                        onChange={(event) => onChangeSelection(row, event.target.value)}
+                        className="bg-ub-cool-grey border border-black/40 rounded px-2 py-1 text-sm text-white focus:outline-none focus:ring-2 focus:ring-ub-orange/60"
+                      >
+                        <option value={ASK_VALUE}>Ask every time</option>
+                        {row.handlers.map((handler) => (
+                          <option key={handler.id} value={handler.id}>
+                            {handler.label}
+                            {row.builtin === handler.id ? ' (built-in)' : ''}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        type="button"
+                        onClick={() => void handleTest(row)}
+                        className="text-xs text-ubt-grey underline disabled:text-gray-600"
+                        disabled={row.selected === ASK_VALUE}
+                      >
+                        Test handler
+                      </button>
+                      {row.selected === ASK_VALUE ? (
+                        <p className="text-xs text-ubt-grey">
+                          You will be prompted whenever this type is opened.
+                        </p>
+                      ) : activeDescription ? (
+                        <p className="text-xs text-ubt-grey">{activeDescription}</p>
+                      ) : null}
+                    </div>
+                  </div>
+                  <div className="mt-3 text-xs text-gray-300 space-y-1">
+                    {row.handlers.length ? (
+                      row.handlers.map((handler) => (
+                        <div key={handler.id}>
+                          <span className="font-semibold text-white">{handler.label}</span>
+                          {handler.description ? ` — ${handler.description}` : null}
+                        </div>
+                      ))
+                    ) : (
+                      <p>No installed apps are registered for this type.</p>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    ),
+    [handleTest, onChangeSelection],
+  );
+
+  const actionBar = useMemo(
+    () => (
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={handleExport}
+          className="rounded bg-black/30 px-3 py-1 text-sm text-white border border-black/40 hover:bg-black/40"
+        >
+          Export
+        </button>
+        <button
+          type="button"
+          onClick={triggerImport}
+          className="rounded bg-black/30 px-3 py-1 text-sm text-white border border-black/40 hover:bg-black/40"
+        >
+          Import
+        </button>
+        <button
+          type="button"
+          onClick={handleReset}
+          className="rounded bg-black/30 px-3 py-1 text-sm text-white border border-black/40 hover:bg-black/40"
+        >
+          Reset overrides
+        </button>
+        {status && <span className="text-xs text-ubt-grey">{status}</span>}
+      </div>
+    ),
+    [handleExport, handleReset, status, triggerImport],
+  );
+
+  return (
+    <div className="flex h-full flex-col bg-ub-cool-grey text-white windowMainScreen overflow-y-auto">
+      <header className="border-b border-black/40 px-5 py-4">
+        <h1 className="text-xl font-semibold">Default Apps</h1>
+        <p className="mt-1 text-sm text-ubt-grey">
+          Manage which applications handle links and content types. Choose “Ask every time”
+          to require confirmation before launching unfamiliar items.
+        </p>
+        <div className="mt-3">{actionBar}</div>
+      </header>
+      <main className="flex-1 overflow-y-auto px-5 py-4 space-y-8">
+        {renderRows(protocolRows, 'Protocol handlers', 'No protocols registered.')}
+        {renderRows(mimeRows, 'MIME handlers', 'No MIME handlers registered.')}
+      </main>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="application/json"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+    </div>
+  );
+};
+
+export default DefaultAppsControlCenter;
+

--- a/modules/system/linkHandler.ts
+++ b/modules/system/linkHandler.ts
@@ -1,0 +1,303 @@
+import {
+  DefaultAppKind,
+  getDefaultApp,
+  setDefaultApp,
+  getBuiltinDefault,
+} from '../../utils/settings/defaultApps';
+
+export interface LinkLaunchRequest {
+  url?: string;
+  mimeType?: string;
+  payload?: Record<string, unknown>;
+  referrer?: string;
+  allowPrompt?: boolean;
+}
+
+interface HandlerDefinition {
+  id: string;
+  label: string;
+  description?: string;
+  launch: (request: LinkLaunchRequest) => boolean | Promise<boolean>;
+}
+
+export interface HandlerDescriptor {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+interface RegistrySnapshot {
+  protocols: Record<string, HandlerDescriptor[]>;
+  mimes: Record<string, HandlerDescriptor[]>;
+}
+
+interface InternalRegistry {
+  protocol: Record<string, HandlerDefinition[]>;
+  mime: Record<string, HandlerDefinition[]>;
+}
+
+const registry: InternalRegistry = {
+  protocol: {},
+  mime: {},
+};
+
+const registeredHandlers = new Set<string>();
+
+const SYSTEM_MAIL_HANDLER_ID = 'system-mail';
+const EXTERNAL_BROWSER_HANDLER_ID = 'external-browser';
+
+const isBrowser = () => typeof window !== 'undefined';
+
+const dispatchOpenApp = (id: string) => {
+  if (!isBrowser()) return false;
+  window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
+  return true;
+};
+
+const navigateChrome = (url: string) => {
+  if (!isBrowser()) return false;
+  try {
+    // Throw for malformed URLs so handlers can abort gracefully.
+    // eslint-disable-next-line no-new
+    new URL(url);
+  } catch {
+    return false;
+  }
+  try {
+    window.sessionStorage?.setItem('chrome-last-url', url);
+  } catch {
+    /* ignore sessionStorage issues */
+  }
+  const detail = { url };
+  try {
+    window.dispatchEvent(new CustomEvent('chrome:navigate', { detail }));
+    // Fire again on the next task in case the browser isn't mounted yet.
+    setTimeout(() => {
+      window.dispatchEvent(new CustomEvent('chrome:navigate', { detail }));
+    }, 0);
+  } catch {
+    /* ignore */
+  }
+  dispatchOpenApp('chrome');
+  return true;
+};
+
+const openExternalTab = (url: string) => {
+  if (!isBrowser()) return false;
+  try {
+    const parsed = new URL(url);
+    if (!/^https?:$/i.test(parsed.protocol)) return false;
+  } catch {
+    return false;
+  }
+  window.open(url, '_blank', 'noopener,noreferrer');
+  return true;
+};
+
+const openMailto = (url: string) => {
+  if (!isBrowser()) return false;
+  if (!/^mailto:/i.test(url)) return false;
+  window.location.href = url;
+  return true;
+};
+
+const registerHandler = (kind: DefaultAppKind, type: string, handler: HandlerDefinition) => {
+  const key = `${kind}:${type}:${handler.id}`;
+  if (registeredHandlers.has(key)) return;
+  registeredHandlers.add(key);
+  if (!registry[kind][type]) {
+    registry[kind][type] = [];
+  }
+  registry[kind][type].push(handler);
+};
+
+const getHandlers = (kind: DefaultAppKind, type: string) => registry[kind][type] || [];
+
+const toDescriptor = (handler: HandlerDefinition): HandlerDescriptor => ({
+  id: handler.id,
+  label: handler.label,
+  description: handler.description,
+});
+
+const promptForHandler = (
+  kind: DefaultAppKind,
+  type: string,
+  handlers: HandlerDefinition[],
+): HandlerDefinition | null => {
+  if (!isBrowser()) return null;
+  const header =
+    kind === 'protocol'
+      ? `Choose how to open ${type} links:`
+      : `Choose how to open ${type} content:`;
+  const body = handlers
+    .map((handler, index) => `${index + 1}. ${handler.label}`)
+    .join('\n');
+  const message = `${header}\n${body}\nCancel to abort.`;
+  const selection = window.prompt(message, '1');
+  if (!selection) {
+    // Preserve ask-every-time behaviour.
+    setDefaultApp(kind, type, 'ask');
+    return null;
+  }
+  const index = Number.parseInt(selection, 10) - 1;
+  if (Number.isNaN(index) || index < 0 || index >= handlers.length) {
+    return null;
+  }
+  const chosen = handlers[index];
+  const remember = window.confirm('Remember this choice for future items?');
+  setDefaultApp(kind, type, remember ? chosen.id : 'ask');
+  return chosen;
+};
+
+const resolveHandler = (
+  kind: DefaultAppKind,
+  type: string,
+  allowPrompt: boolean,
+): HandlerDefinition | null => {
+  const candidates = getHandlers(kind, type);
+  if (!candidates.length) return null;
+  const pref = getDefaultApp(kind, type);
+  if (pref && pref !== 'ask') {
+    const match = candidates.find((handler) => handler.id === pref);
+    if (match) return match;
+  }
+  if (!allowPrompt) return null;
+  return promptForHandler(kind, type, candidates);
+};
+
+const extractScheme = (url: string): string | null => {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol.replace(/:$/, '').toLowerCase();
+  } catch {
+    const match = /^([a-z0-9+.-]+):/i.exec(url);
+    return match ? match[1].toLowerCase() : null;
+  }
+};
+
+export const openLink = async (
+  request: LinkLaunchRequest,
+): Promise<boolean> => {
+  const { url, mimeType, allowPrompt = true } = request;
+  if (url) {
+    const scheme = extractScheme(url);
+    if (scheme) {
+      const handler = resolveHandler('protocol', scheme, allowPrompt);
+      if (handler) {
+        const result = await handler.launch(request);
+        return result !== false;
+      }
+    }
+  }
+  if (mimeType) {
+    const handler = resolveHandler('mime', mimeType.toLowerCase(), allowPrompt);
+    if (handler) {
+      const result = await handler.launch(request);
+      return result !== false;
+    }
+  }
+  if (allowPrompt && url) {
+    const scheme = extractScheme(url);
+    const options = (scheme && getHandlers('protocol', scheme)) || [];
+    if (options.length && isBrowser()) {
+      window.alert(
+        `No handler selected for ${scheme} links. Configure one in Default Apps.`,
+      );
+    }
+  }
+  return false;
+};
+
+export const getRegistrySnapshot = (): RegistrySnapshot => {
+  const build = (kind: DefaultAppKind): Record<string, HandlerDescriptor[]> => {
+    const source = registry[kind];
+    return Object.keys(source)
+      .sort((a, b) => a.localeCompare(b))
+      .reduce<Record<string, HandlerDescriptor[]>>((acc, key) => {
+        acc[key] = source[key].map(toDescriptor);
+        return acc;
+      }, {});
+  };
+  return {
+    protocols: build('protocol'),
+    mimes: build('mime'),
+  };
+};
+
+const chromeHandler: HandlerDefinition = {
+  id: 'chrome',
+  label: 'Kali Browser',
+  description: 'Open inside the simulated browser.',
+  launch: ({ url }) => (url ? navigateChrome(url) : false),
+};
+
+const externalHandler: HandlerDefinition = {
+  id: EXTERNAL_BROWSER_HANDLER_ID,
+  label: 'Open in new tab',
+  description: 'Launch in a separate browser tab.',
+  launch: ({ url }) => (url ? openExternalTab(url) : false),
+};
+
+const contactHandler: HandlerDefinition = {
+  id: 'contact',
+  label: 'Contact app',
+  description: 'Use the built-in contact form.',
+  launch: () => dispatchOpenApp('contact'),
+};
+
+const mailHandler: HandlerDefinition = {
+  id: SYSTEM_MAIL_HANDLER_ID,
+  label: 'System email client',
+  description: 'Delegate to the browser mailto handler.',
+  launch: ({ url }) => (url ? openMailto(url) : false),
+};
+
+const sshHandler: HandlerDefinition = {
+  id: 'ssh',
+  label: 'SSH command builder',
+  description: 'Open the SSH helper to craft commands.',
+  launch: () => dispatchOpenApp('ssh'),
+};
+
+const vscodeHandler: HandlerDefinition = {
+  id: 'vscode',
+  label: 'VS Code sandbox',
+  description: 'Open the in-browser editor.',
+  launch: () => dispatchOpenApp('vscode'),
+};
+
+// Register built-in mappings.
+registerHandler('protocol', 'http', chromeHandler);
+registerHandler('protocol', 'http', externalHandler);
+registerHandler('protocol', 'https', chromeHandler);
+registerHandler('protocol', 'https', externalHandler);
+registerHandler('protocol', 'mailto', mailHandler);
+registerHandler('protocol', 'mailto', contactHandler);
+registerHandler('protocol', 'ssh', sshHandler);
+
+registerHandler('mime', 'text/html', chromeHandler);
+registerHandler('mime', 'text/plain', vscodeHandler);
+registerHandler('mime', 'application/json', vscodeHandler);
+
+export const getHandlerOptions = (
+  kind: DefaultAppKind,
+  type: string,
+): HandlerDescriptor[] => getHandlers(kind, type).map(toDescriptor);
+
+export const getBuiltinHandlerId = (kind: DefaultAppKind, type: string): string | undefined =>
+  getBuiltinDefault(kind, type);
+
+export const handlersForKind = (
+  kind: DefaultAppKind,
+): Record<string, HandlerDescriptor[]> => {
+  const entries = registry[kind];
+  return Object.keys(entries).reduce<Record<string, HandlerDescriptor[]>>(
+    (acc, key) => {
+      acc[key] = entries[key].map(toDescriptor);
+      return acc;
+    },
+    {},
+  );
+};
+

--- a/pages/apps/default-apps.tsx
+++ b/pages/apps/default-apps.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const DefaultApps = dynamic(() => import('../../apps/default-apps'), { ssr: false });
+
+export default function DefaultAppsPage() {
+  return <DefaultApps />;
+}
+

--- a/utils/mailto.ts
+++ b/utils/mailto.ts
@@ -1,3 +1,5 @@
+import { openLink } from '../modules/system/linkHandler';
+
 export const openMailto = (
   email: string,
   subject = '',
@@ -8,7 +10,12 @@ export const openMailto = (
   if (body) params.set('body', body);
   const query = params.toString();
   const href = `mailto:${email}${query ? `?${query}` : ''}`;
-  window.location.href = href;
+  if (typeof window === 'undefined') return;
+  void openLink({
+    url: href,
+    allowPrompt: true,
+    payload: { email, subject, body },
+  });
 };
 
 export default openMailto;

--- a/utils/settings/defaultApps.ts
+++ b/utils/settings/defaultApps.ts
@@ -1,0 +1,186 @@
+import { safeLocalStorage } from '../safeStorage';
+
+export type DefaultAppKind = 'protocol' | 'mime';
+export type DefaultAppValue = string; // either handler id or 'ask'
+
+export interface DefaultAppSettings {
+  protocol: Record<string, DefaultAppValue>;
+  mime: Record<string, DefaultAppValue>;
+}
+
+const STORAGE_KEY = 'default-app-preferences';
+
+const DEFAULT_SETTINGS: DefaultAppSettings = {
+  protocol: {
+    http: 'chrome',
+    https: 'chrome',
+    mailto: 'system-mail',
+    ssh: 'ssh',
+  },
+  mime: {
+    'text/html': 'chrome',
+    'text/plain': 'vscode',
+    'application/json': 'vscode',
+  },
+};
+
+export const DEFAULT_APPS_EVENT = 'default-apps:change';
+
+type Overrides = Partial<Record<DefaultAppKind, Record<string, DefaultAppValue>>>;
+
+const kinds: DefaultAppKind[] = ['protocol', 'mime'];
+
+const cloneSettings = (settings: DefaultAppSettings): DefaultAppSettings => ({
+  protocol: { ...settings.protocol },
+  mime: { ...settings.mime },
+});
+
+const normalizeType = (type: string): string => type.trim().toLowerCase();
+
+const sanitizeRecord = (value: unknown): Record<string, DefaultAppValue> => {
+  if (!value || typeof value !== 'object') return {};
+  const result: Record<string, DefaultAppValue> = {};
+  Object.entries(value as Record<string, unknown>).forEach(([rawKey, rawVal]) => {
+    if (typeof rawKey !== 'string') return;
+    if (typeof rawVal !== 'string') return;
+    const key = normalizeType(rawKey);
+    if (!key) return;
+    result[key] = rawVal.trim();
+  });
+  return result;
+};
+
+const loadOverrides = (): Overrides => {
+  if (!safeLocalStorage) return {};
+  try {
+    const raw = safeLocalStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return {
+      protocol: sanitizeRecord(parsed?.protocol),
+      mime: sanitizeRecord(parsed?.mime),
+    };
+  } catch {
+    return {};
+  }
+};
+
+const emitChange = (detail: { kind: DefaultAppKind | 'all'; type?: string; value?: string }) => {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(DEFAULT_APPS_EVENT, { detail }));
+};
+
+const persistOverrides = (source: Overrides) => {
+  if (!safeLocalStorage) return;
+  const payload: DefaultAppSettings = { protocol: {}, mime: {} };
+  kinds.forEach((kind) => {
+    const section = source[kind];
+    if (!section) return;
+    Object.entries(section).forEach(([rawType, rawValue]) => {
+      if (typeof rawValue !== 'string') return;
+      const type = normalizeType(rawType);
+      if (!type) return;
+      const value = rawValue.trim();
+      const builtin = DEFAULT_SETTINGS[kind][type] ?? 'ask';
+      if (value === builtin) return;
+      payload[kind][type] = value;
+    });
+  });
+  const hasProtocol = Object.keys(payload.protocol).length > 0;
+  const hasMime = Object.keys(payload.mime).length > 0;
+  if (!hasProtocol && !hasMime) {
+    safeLocalStorage.removeItem(STORAGE_KEY);
+  } else {
+    safeLocalStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  }
+};
+
+export const getDefaultApp = (kind: DefaultAppKind, type: string): DefaultAppValue => {
+  const key = normalizeType(type);
+  const overrides = loadOverrides();
+  const override = overrides[kind]?.[key];
+  if (override) return override;
+  return DEFAULT_SETTINGS[kind][key] ?? 'ask';
+};
+
+export const getBuiltinDefault = (
+  kind: DefaultAppKind,
+  type: string,
+): DefaultAppValue | undefined => {
+  const key = normalizeType(type);
+  return DEFAULT_SETTINGS[kind][key];
+};
+
+export const setDefaultApp = (kind: DefaultAppKind, type: string, value: string): void => {
+  const key = normalizeType(type);
+  if (!key) return;
+  const overrides = loadOverrides();
+  if (!overrides[kind]) overrides[kind] = {};
+  const builtin = DEFAULT_SETTINGS[kind][key] ?? 'ask';
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === builtin) {
+    delete overrides[kind]![key];
+  } else {
+    overrides[kind]![key] = trimmed;
+  }
+  persistOverrides(overrides);
+  emitChange({ kind, type: key, value: getDefaultApp(kind, key) });
+};
+
+export const resetDefaultApps = (): void => {
+  if (!safeLocalStorage) return;
+  safeLocalStorage.removeItem(STORAGE_KEY);
+  emitChange({ kind: 'all' });
+};
+
+export const getAllDefaultApps = (): DefaultAppSettings => {
+  const overrides = loadOverrides();
+  const result: DefaultAppSettings = { protocol: {}, mime: {} };
+  kinds.forEach((kind) => {
+    const keys = new Set([
+      ...Object.keys(DEFAULT_SETTINGS[kind]),
+      ...Object.keys(overrides[kind] || {}),
+    ]);
+    keys.forEach((key) => {
+      result[kind][key] = overrides[kind]?.[key] ?? DEFAULT_SETTINGS[kind][key] ?? 'ask';
+    });
+  });
+  return result;
+};
+
+export const exportDefaultApps = (includeDefaults = true): string => {
+  if (includeDefaults) {
+    return JSON.stringify(getAllDefaultApps(), null, 2);
+  }
+  const overrides = loadOverrides();
+  const payload: DefaultAppSettings = { protocol: {}, mime: {} };
+  kinds.forEach((kind) => {
+    Object.assign(payload[kind], overrides[kind] || {});
+  });
+  return JSON.stringify(payload, null, 2);
+};
+
+export const importDefaultApps = (data: string | DefaultAppSettings): boolean => {
+  let parsed: unknown = data;
+  if (typeof data === 'string') {
+    try {
+      parsed = JSON.parse(data);
+    } catch {
+      return false;
+    }
+  }
+  const source = parsed as Partial<DefaultAppSettings> | null;
+  if (!source || typeof source !== 'object') return false;
+  const overrides: Overrides = {};
+  kinds.forEach((kind) => {
+    const section = sanitizeRecord((source as any)[kind]);
+    if (!Object.keys(section).length) return;
+    overrides[kind] = section;
+  });
+  persistOverrides(overrides);
+  emitChange({ kind: 'all' });
+  return true;
+};
+
+export const getDefaultSettings = (): DefaultAppSettings => cloneSettings(DEFAULT_SETTINGS);
+


### PR DESCRIPTION
## Summary
- add a Default Apps control center with protocol and MIME handler overrides
- centralize link handling and preferences persistence
- wire Chrome navigation and mailto helper through the new handler system

## Testing
- yarn lint *(fails: existing jsx-a11y violations across repo)*
- yarn test *(fails: existing suite failures; aborted after reporting failures)*

------
https://chatgpt.com/codex/tasks/task_e_68cb467399fc8328a24b504ce855d1f9