### PR TITLE
[theme] auto accent extraction from wallpapers

### DIFF
--- a/components/apps/theme/AccentPrompt.tsx
+++ b/components/apps/theme/AccentPrompt.tsx
@@ -1,0 +1,121 @@
+import { FC } from 'react';
+import { WallpaperStatus } from '../../../hooks/useWallpaper';
+
+interface AccentPromptProps {
+  open: boolean;
+  wallpaper: string;
+  accent: string;
+  currentAccent: string;
+  palette: string[];
+  status: WallpaperStatus;
+  onAccept: () => void;
+  onDismiss: () => void;
+  error?: string | null;
+}
+
+const statusMessage = (status: WallpaperStatus, error?: string | null) => {
+  if (status === 'loading') return 'Analyzing wallpaper…';
+  if (status === 'error') return error ?? 'Unable to analyze wallpaper';
+  return null;
+};
+
+const AccentPrompt: FC<AccentPromptProps> = ({
+  open,
+  wallpaper,
+  accent,
+  currentAccent,
+  palette,
+  status,
+  onAccept,
+  onDismiss,
+  error,
+}) => {
+  if (!open) return null;
+
+  const swatches = palette.filter(Boolean).slice(0, 4);
+  const message = statusMessage(status, error);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-live="polite"
+      aria-label="Wallpaper accent suggestion"
+      className="fixed bottom-6 right-6 z-50 max-w-sm rounded-lg border border-ubt-cool-grey bg-[var(--color-surface)] text-[var(--color-text)] shadow-lg backdrop-blur"
+    >
+      <div className="flex items-start gap-4 p-4">
+        <div className="h-12 w-12 overflow-hidden rounded"
+          style={{ backgroundColor: 'var(--color-muted)' }}
+        >
+          <img
+            src={`/wallpapers/${wallpaper}.webp`}
+            alt="Wallpaper preview"
+            className="h-full w-full object-cover"
+          />
+        </div>
+        <div className="flex-1">
+          <p className="text-sm font-semibold">Apply wallpaper accent?</p>
+          <p className="mt-1 text-xs text-ubt-grey">
+            We found a highlight color in your wallpaper. Update focus rings and buttons to use it?
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <Swatch color={currentAccent} label="Current" />
+            <Swatch color={accent} label="Suggested" highlight />
+            {swatches.length > 0 && (
+              <div className="flex items-center gap-1" aria-hidden="true">
+                {swatches.map((color) => (
+                  <span
+                    key={color}
+                    className="h-4 w-4 rounded-full border border-ubt-cool-grey"
+                    style={{ backgroundColor: color }}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={onAccept}
+              className="rounded bg-accent px-3 py-1 text-sm font-medium text-[var(--color-accent-contrast)] transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              Apply accent
+            </button>
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="rounded px-3 py-1 text-sm text-ubt-grey transition-colors hover:text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              Not now
+            </button>
+            {message && (
+              <span
+                className={`text-xs ${status === 'error' ? 'text-red-400' : 'text-ubt-grey'}`}
+                role={status === 'error' ? 'alert' : undefined}
+              >
+                {message}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const Swatch: FC<{ color: string; label: string; highlight?: boolean }> = ({
+  color,
+  label,
+  highlight = false,
+}) => (
+  <div className="flex items-center gap-2">
+    <span
+      className={`h-6 w-6 rounded-full border border-ubt-cool-grey ${highlight ? 'ring-2 ring-accent' : ''}`}
+      style={{ backgroundColor: color }}
+      aria-hidden="true"
+    />
+    <span className="text-xs text-ubt-grey">{label}</span>
+  </div>
+);
+
+export default AccentPrompt;

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -1,51 +1,50 @@
 "use client";
 
-import React, { useEffect, useState } from 'react'
-import { useSettings } from '../../hooks/useSettings';
+import React from 'react';
+import { useWallpaper } from '../../hooks/useWallpaper';
+import AccentPrompt from '../apps/theme/AccentPrompt';
 
 export default function BackgroundImage() {
-    const { wallpaper } = useSettings();
-    const [needsOverlay, setNeedsOverlay] = useState(false);
+    const {
+        wallpaper,
+        accent,
+        accentCandidate,
+        needsOverlay,
+        palette,
+        status,
+        promptOpen,
+        acceptAccent,
+        dismissAccent,
+        error,
+    } = useWallpaper();
 
-    useEffect(() => {
-        const img = new Image();
-        img.src = `/wallpapers/${wallpaper}.webp`;
-        img.onload = () => {
-            const canvas = document.createElement('canvas');
-            canvas.width = img.width;
-            canvas.height = img.height;
-            const ctx = canvas.getContext('2d');
-            if (!ctx) return;
-            ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-            const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
-            let r = 0, g = 0, b = 0, count = 0;
-            for (let i = 0; i < data.length; i += 40) {
-                r += data[i];
-                g += data[i + 1];
-                b += data[i + 2];
-                count++;
-            }
-            const avgR = r / count, avgG = g / count, avgB = b / count;
-            const toLinear = (c) => {
-                c /= 255;
-                return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
-            };
-            const lum = 0.2126 * toLinear(avgR) + 0.7152 * toLinear(avgG) + 0.0722 * toLinear(avgB);
-            const contrast = (1.05) / (lum + 0.05); // white text luminance is 1
-            setNeedsOverlay(contrast < 4.5);
-        };
-    }, [wallpaper]);
+    const source = wallpaper ? `/wallpapers/${wallpaper}.webp` : '';
 
     return (
         <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
-            <img
-                src={`/wallpapers/${wallpaper}.webp`}
-                alt=""
-                className="w-full h-full object-cover"
-            />
+            {source && (
+                <img
+                    src={source}
+                    alt=""
+                    className="w-full h-full object-cover"
+                />
+            )}
             {needsOverlay && (
                 <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>
             )}
+            {accentCandidate && (
+                <AccentPrompt
+                    open={promptOpen}
+                    wallpaper={wallpaper}
+                    accent={accentCandidate}
+                    currentAccent={accent}
+                    palette={palette}
+                    status={status}
+                    onAccept={acceptAccent}
+                    onDismiss={dismissAccent}
+                    error={error}
+                />
+            )}
         </div>
-    )
+    );
 }

--- a/hooks/useWallpaper.ts
+++ b/hooks/useWallpaper.ts
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSettings } from './useSettings';
+import {
+  AccentAnalysis,
+  extractAccent,
+} from '../utils/color/extractAccent';
+
+export type WallpaperStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+interface WallpaperState {
+  analysis: AccentAnalysis | null;
+  status: WallpaperStatus;
+  error: string | null;
+  promptOpen: boolean;
+}
+
+const initialState: WallpaperState = {
+  analysis: null,
+  status: 'idle',
+  error: null,
+  promptOpen: false,
+};
+
+export const useWallpaper = () => {
+  const { wallpaper, accent, setAccent } = useSettings();
+  const [state, setState] = useState<WallpaperState>(initialState);
+  const requestRef = useRef(0);
+  const dismissedRef = useRef<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!wallpaper || typeof window === 'undefined') {
+      setState(initialState);
+      return;
+    }
+
+    const requestId = ++requestRef.current;
+    setState((prev) => ({
+      ...prev,
+      status: 'loading',
+      error: null,
+      promptOpen: false,
+    }));
+
+    extractAccent(wallpaper)
+      .then((analysis) => {
+        if (requestRef.current !== requestId) return;
+        setState((prev) => {
+          const nextPrompt = shouldPromptUpdate({
+            analysis,
+            accent,
+            wallpaper,
+            dismissed: dismissedRef.current,
+          });
+          return {
+            analysis,
+            status: 'ready',
+            error: null,
+            promptOpen: nextPrompt,
+          };
+        });
+      })
+      .catch((error: unknown) => {
+        if (requestRef.current !== requestId) return;
+        setState({
+          analysis: null,
+          status: 'error',
+          error: error instanceof Error ? error.message : 'Accent extraction failed',
+          promptOpen: false,
+        });
+        console.error('Failed to analyse wallpaper', error);
+      });
+
+  }, [wallpaper, accent]);
+
+  const accentCandidate = state.analysis?.accent ?? null;
+  const shouldPrompt = useMemo(
+    () =>
+      shouldPromptUpdate({
+        analysis: state.analysis,
+        accent,
+        wallpaper,
+        dismissed: dismissedRef.current,
+      }),
+    [state.analysis, accent, wallpaper],
+  );
+
+  useEffect(() => {
+    setState((prev) =>
+      prev.promptOpen === shouldPrompt ? prev : { ...prev, promptOpen: shouldPrompt },
+    );
+  }, [shouldPrompt]);
+
+  const acceptAccent = useCallback(() => {
+    if (!accentCandidate) return;
+    setAccent(accentCandidate);
+    if (wallpaper) {
+      delete dismissedRef.current[wallpaper];
+    }
+    setState((prev) => ({ ...prev, promptOpen: false }));
+  }, [accentCandidate, setAccent, wallpaper]);
+
+  const dismissAccent = useCallback(() => {
+    if (accentCandidate && wallpaper) {
+      dismissedRef.current[wallpaper] = accentCandidate.toLowerCase();
+    }
+    setState((prev) => ({ ...prev, promptOpen: false }));
+  }, [accentCandidate, wallpaper]);
+
+  const needsOverlay = state.analysis?.needsOverlay ?? false;
+
+  return {
+    wallpaper,
+    accent,
+    accentCandidate,
+    needsOverlay,
+    palette: state.analysis?.palette ?? [],
+    status: state.status,
+    error: state.error,
+    promptOpen: state.promptOpen && Boolean(accentCandidate),
+    acceptAccent,
+    dismissAccent,
+  };
+};
+
+interface PromptCheck {
+  analysis: AccentAnalysis | null;
+  accent: string;
+  wallpaper: string;
+  dismissed: Record<string, string>;
+}
+
+const shouldPromptUpdate = ({
+  analysis,
+  accent,
+  wallpaper,
+  dismissed,
+}: PromptCheck): boolean => {
+  if (!analysis || !analysis.accent || !wallpaper) return false;
+  if (analysis.accent.toLowerCase() === accent.toLowerCase()) return false;
+  const dismissedAccent = dismissed[wallpaper];
+  if (dismissedAccent && dismissedAccent === analysis.accent.toLowerCase()) {
+    return false;
+  }
+  return true;
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,6 +19,8 @@
   --color-focus-ring: var(--color-accent);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
+  --color-accent-contrast: #0f1317;
+  --tw-ring-color: var(--color-focus-ring);
   accent-color: var(--color-control-accent);
 }
 
@@ -35,6 +37,7 @@ html[data-theme='dark'] {
   --color-border: #333333;
   --color-terminal: #00ff00;
   --color-dark: #0a0a0a;
+  --color-accent-contrast: #0f1317;
 }
 
 /* Neon theme */
@@ -50,6 +53,7 @@ html[data-theme='neon'] {
   --color-border: #333333;
   --color-terminal: #39ff14;
   --color-dark: #000000;
+  --color-accent-contrast: #0f1317;
 }
 
 /* Matrix theme */
@@ -65,7 +69,7 @@ html[data-theme='matrix'] {
   --color-border: #003300;
   --color-terminal: #00ff00;
   --color-dark: #000000;
-
+  --color-accent-contrast: #0f1317;
 }
 
 ::selection {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,6 +36,13 @@ module.exports = {
         'ubt-gedit-dark': 'var(--color-ubt-gedit-dark)',
         'ub-border-orange': 'var(--color-ub-border-orange)',
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
+        accent: 'var(--color-accent)',
+        'accent-contrast': 'var(--color-accent-contrast)',
+        surface: 'var(--color-surface)',
+        muted: 'var(--color-muted)',
+      },
+      ringColor: {
+        accent: 'var(--color-focus-ring)',
       },
       fontFamily: {
         ubuntu: ['Ubuntu', 'sans-serif'],

--- a/utils/color/extractAccent.ts
+++ b/utils/color/extractAccent.ts
@@ -1,0 +1,305 @@
+import { contrastRatio } from '../../components/apps/Games/common/theme';
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+const rgbToHex = (r: number, g: number, b: number): string => {
+  const toHex = (c: number) =>
+    clamp(Math.round(c), 0, 255).toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+};
+
+const hexToRgb = (hex: string): [number, number, number] => {
+  const normalized = hex.replace('#', '');
+  const expanded =
+    normalized.length === 3
+      ? normalized
+          .split('')
+          .map((char) => char + char)
+          .join('')
+      : normalized;
+  const value = parseInt(expanded, 16);
+  if (Number.isNaN(value)) {
+    throw new Error(`Invalid hex color: ${hex}`);
+  }
+  const r = (value >> 16) & 0xff;
+  const g = (value >> 8) & 0xff;
+  const b = value & 0xff;
+  return [r, g, b];
+};
+
+const rgbToHsl = (r: number, g: number, b: number): [number, number, number] => {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  const delta = max - min;
+  if (delta !== 0) {
+    s = l > 0.5 ? delta / (2 - max - min) : delta / (max + min);
+    switch (max) {
+      case rn:
+        h = (gn - bn) / delta + (gn < bn ? 6 : 0);
+        break;
+      case gn:
+        h = (bn - rn) / delta + 2;
+        break;
+      default:
+        h = (rn - gn) / delta + 4;
+    }
+    h /= 6;
+  }
+
+  return [h, s, l];
+};
+
+const hueToRgb = (p: number, q: number, t: number): number => {
+  if (t < 0) t += 1;
+  if (t > 1) t -= 1;
+  if (t < 1 / 6) return p + (q - p) * 6 * t;
+  if (t < 1 / 2) return q;
+  if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+  return p;
+};
+
+const hslToRgb = (h: number, s: number, l: number): [number, number, number] => {
+  if (s === 0) {
+    const gray = Math.round(l * 255);
+    return [gray, gray, gray];
+  }
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  const r = hueToRgb(p, q, h + 1 / 3);
+  const g = hueToRgb(p, q, h);
+  const b = hueToRgb(p, q, h - 1 / 3);
+  return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
+};
+
+const luminance = (hex: string): number => {
+  const [r, g, b] = hexToRgb(hex);
+  const channel = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+};
+
+const ensureContrast = (
+  h: number,
+  s: number,
+  l: number,
+  backgrounds: string[],
+  minRatio: number,
+): { hex: string; lightness: number } => {
+  let currentL = clamp(l, 0, 1);
+  let hex = rgbToHex(...hslToRgb(h, s, currentL));
+  const maxIterations = 24;
+  const step = 0.02;
+
+  const passes = () =>
+    backgrounds.every((bg) => contrastRatio(hex, bg) >= minRatio);
+
+  let iterations = 0;
+  while (!passes() && iterations < maxIterations) {
+    iterations += 1;
+    const worst = backgrounds.reduce(
+      (lowest, bg) => {
+        const ratio = contrastRatio(hex, bg);
+        if (ratio < lowest.ratio) {
+          return { bg, ratio };
+        }
+        return lowest;
+      },
+      { bg: backgrounds[0], ratio: Number.POSITIVE_INFINITY },
+    );
+    const accentIsDarker = luminance(hex) < luminance(worst.bg);
+    currentL = clamp(currentL + (accentIsDarker ? 1 : -1) * step, 0.2, 0.8);
+    hex = rgbToHex(...hslToRgb(h, s, currentL));
+  }
+
+  return { hex, lightness: currentL };
+};
+
+const DEFAULT_BACKGROUNDS = ['#0f1317', '#1a1f26'];
+const DEFAULT_MIN_CONTRAST = 3.5;
+
+export interface AccentAnalysis {
+  accent: string | null;
+  average: string;
+  palette: string[];
+  needsOverlay: boolean;
+}
+
+export interface AccentExtractionOptions {
+  sampleStep?: number;
+  minSaturation?: number;
+  maxPaletteSize?: number;
+  backgrounds?: string[];
+  minContrast?: number;
+}
+
+export const extractAccent = async (
+  wallpaper: string,
+  options: AccentExtractionOptions = {},
+): Promise<AccentAnalysis> => {
+  if (typeof window === 'undefined') {
+    return {
+      accent: null,
+      average: '#000000',
+      palette: [],
+      needsOverlay: false,
+    };
+  }
+
+  const {
+    sampleStep = 12,
+    minSaturation = 0.25,
+    maxPaletteSize = 6,
+    backgrounds: backgroundOverrides = DEFAULT_BACKGROUNDS,
+    minContrast = DEFAULT_MIN_CONTRAST,
+  } = options;
+
+  const backgrounds = backgroundOverrides.length
+    ? backgroundOverrides
+    : DEFAULT_BACKGROUNDS;
+
+  const source = wallpaper.startsWith('http')
+    ? wallpaper
+    : `/wallpapers/${wallpaper}.webp`;
+
+  const image = await new Promise<HTMLImageElement>((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Failed to load wallpaper image'));
+    img.src = source;
+  });
+
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  if (!ctx) {
+    return {
+      accent: null,
+      average: '#000000',
+      palette: [],
+      needsOverlay: false,
+    };
+  }
+
+  const maxDimension = 256;
+  const scale = Math.min(1, maxDimension / Math.max(image.width, image.height));
+  canvas.width = Math.max(1, Math.floor(image.width * scale));
+  canvas.height = Math.max(1, Math.floor(image.height * scale));
+
+  ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+  const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+
+  const buckets = new Map<string, { r: number; g: number; b: number; count: number }>();
+  let totalR = 0;
+  let totalG = 0;
+  let totalB = 0;
+  let totalCount = 0;
+
+  const stride = Math.max(1, Math.floor(sampleStep));
+  for (let i = 0; i < data.length; i += stride * 4) {
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+    totalR += r;
+    totalG += g;
+    totalB += b;
+    totalCount += 1;
+
+    const key = `${Math.round(r / 32)}-${Math.round(g / 32)}-${Math.round(b / 32)}`;
+    const bucket = buckets.get(key);
+    if (bucket) {
+      bucket.r += r;
+      bucket.g += g;
+      bucket.b += b;
+      bucket.count += 1;
+    } else {
+      buckets.set(key, { r, g, b, count: 1 });
+    }
+  }
+
+  const average = totalCount
+    ? rgbToHex(totalR / totalCount, totalG / totalCount, totalB / totalCount)
+    : '#000000';
+
+  const palette = Array.from(buckets.values())
+    .map(({ r, g, b, count }) => {
+      const avgR = r / count;
+      const avgG = g / count;
+      const avgB = b / count;
+      const [h, s, l] = rgbToHsl(avgR, avgG, avgB);
+      return {
+        hex: rgbToHex(avgR, avgG, avgB),
+        count,
+        h,
+        s,
+        l,
+      };
+    })
+    .sort((a, b) => b.count - a.count)
+    .slice(0, maxPaletteSize * 3);
+
+  let best = palette
+    .filter((entry) => entry.s >= minSaturation)
+    .sort((a, b) => {
+      const score = (item: typeof a) =>
+        item.count * (0.6 * item.s + 0.4 * (1 - Math.abs(item.l - 0.5)));
+      return score(b) - score(a);
+    })[0];
+
+  if (!best && palette.length) {
+    best = palette[0];
+  }
+
+  let accent: string | null = null;
+  if (best) {
+    const baseS = clamp(best.s, 0.35, 0.8);
+    const baseL = clamp(best.l, 0.28, 0.65);
+    const { hex } = ensureContrast(best.h, baseS, baseL, backgrounds, minContrast);
+    accent = hex;
+  }
+
+  const needsOverlay = contrastRatio('#ffffff', average) < 4.5;
+
+  const paletteHex = palette
+    .sort((a, b) => b.count - a.count)
+    .slice(0, maxPaletteSize)
+    .map((entry) => entry.hex);
+
+  return {
+    accent,
+    average,
+    palette: paletteHex,
+    needsOverlay,
+  };
+};
+
+type NormalizeOptions = Partial<Pick<AccentExtractionOptions, 'backgrounds' | 'minContrast'>>;
+
+export const normalizeAccentColor = (
+  color: string,
+  options: NormalizeOptions = {},
+): string => {
+  try {
+    const [r, g, b] = hexToRgb(color);
+    const [h, s, l] = rgbToHsl(r, g, b);
+    const backgrounds = options.backgrounds && options.backgrounds.length
+      ? options.backgrounds
+      : DEFAULT_BACKGROUNDS;
+    const minContrast = options.minContrast ?? DEFAULT_MIN_CONTRAST;
+    const baseS = clamp(s, 0.35, 0.8);
+    const baseL = clamp(l, 0.28, 0.65);
+    return ensureContrast(h, baseS, baseL, backgrounds, minContrast).hex;
+  } catch (error) {
+    console.warn('[theme] Failed to normalize accent color', error);
+    return color;
+  }
+};


### PR DESCRIPTION
## Summary
- add a color analysis utility that extracts and normalizes wallpaper accents
- observe wallpaper changes to propose new accents with an approval prompt
- extend theme tokens and Tailwind colors so the accent drives focus states

## Testing
- yarn lint *(fails: pre-existing accessibility errors across many apps)*
- yarn test *(fails: legacy suites and jsdom environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_68cb466f46388328abfb28d6012be87e