### PR TITLE
[ui] add detachable tabbed windows

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -62,7 +62,7 @@ const SpaceInvadersApp = createDynamicApp('space-invaders', 'Space Invaders');
 const NonogramApp = createDynamicApp('nonogram', 'Nonogram');
 const TetrisApp = createDynamicApp('tetris', 'Tetris');
 const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
-const FileExplorerApp = createDynamicApp('file-explorer', 'Files');
+const FileExplorerApp = createDynamicApp('files', 'Files');
 const Radare2App = createDynamicApp('radare2', 'Radare2');
 const AboutAlexApp = createDynamicApp('alex', 'About Alex');
 

--- a/apps/files/index.tsx
+++ b/apps/files/index.tsx
@@ -1,33 +1,33 @@
 'use client';
 
 import React, { useCallback, useRef, useState } from 'react';
-import TabbedWindow from '../../../components/ui/TabbedWindow';
-import type { AppTabDefinition } from '../../../types/apps';
-import Terminal, { TerminalProps } from '..';
+import TabbedWindow from '../../components/ui/TabbedWindow';
+import type { AppTabDefinition } from '../../types/apps';
+import FileExplorer from '../../components/apps/file-explorer';
 
-const TerminalTabs: React.FC<TerminalProps> = ({ openApp }) => {
-  const windowCountRef = useRef(0);
-  const sessionCountRef = useRef(1);
+const FilesApp: React.FC = () => {
+  const windowCounterRef = useRef(0);
+  const tabCounterRef = useRef(1);
 
   const makeTab = useCallback((): AppTabDefinition => {
-    const id = `terminal-${Date.now()}-${sessionCountRef.current}`;
-    const title = `Session ${sessionCountRef.current}`;
-    sessionCountRef.current += 1;
+    const id = `files-${Date.now()}-${tabCounterRef.current}`;
+    const title = `Window ${tabCounterRef.current}`;
+    tabCounterRef.current += 1;
     return {
       id,
       title,
-      content: <Terminal openApp={openApp} key={id} />,
+      content: <FileExplorer key={id} />,
     };
-  }, [openApp]);
+  }, []);
 
   const [windows, setWindows] = useState(() => [
-    { id: `terminal-window-${windowCountRef.current++}`, initialTabs: [makeTab()] },
+    { id: `files-window-${windowCounterRef.current++}`, initialTabs: [makeTab()] },
   ]);
 
   const handleDetach = useCallback((tab: AppTabDefinition) => {
     setWindows((prev) => [
       ...prev,
-      { id: `terminal-window-${windowCountRef.current++}`, initialTabs: [tab] },
+      { id: `files-window-${windowCounterRef.current++}`, initialTabs: [tab] },
     ]);
   }, []);
 
@@ -55,4 +55,4 @@ const TerminalTabs: React.FC<TerminalProps> = ({ openApp }) => {
   );
 };
 
-export default TerminalTabs;
+export default FilesApp;

--- a/apps/http/index.tsx
+++ b/apps/http/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useRef, useState } from 'react';
-import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import TabbedWindow from '../../components/ui/TabbedWindow';
+import type { AppTabDefinition } from '../../types/apps';
 
 const HTTPBuilder: React.FC = () => {
   const [method, setMethod] = useState('GET');
@@ -66,7 +67,7 @@ const HTTPBuilder: React.FC = () => {
 const HTTPPreview: React.FC = () => {
   const countRef = useRef(1);
 
-  const createTab = (): TabDefinition => {
+  const createTab = (): AppTabDefinition => {
     const id = Date.now().toString();
     return { id, title: `Request ${countRef.current++}`, content: <HTTPBuilder /> };
   };

--- a/apps/hydra/index.tsx
+++ b/apps/hydra/index.tsx
@@ -1,14 +1,15 @@
 'use client';
 
 import React, { useRef } from 'react';
-import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import TabbedWindow from '../../components/ui/TabbedWindow';
+import type { AppTabDefinition } from '../../types/apps';
 import HydraApp from '../../components/apps/hydra';
 import StrategyTrainer from './components/StrategyTrainer';
 
 const HydraPreview: React.FC = () => {
   const countRef = useRef(1);
 
-  const createTab = (): TabDefinition => {
+  const createTab = (): AppTabDefinition => {
     const id = Date.now().toString();
     return {
       id,

--- a/apps/reaver/index.tsx
+++ b/apps/reaver/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
-import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import TabbedWindow from '../../components/ui/TabbedWindow';
+import type { AppTabDefinition } from '../../types/apps';
 import RouterProfiles, {
   ROUTER_PROFILES,
   RouterProfile,
@@ -357,7 +358,7 @@ const ReaverApp: React.FC = () => {
 const ReaverPage: React.FC = () => {
   const countRef = useRef(1);
 
-  const createTab = (): TabDefinition => {
+  const createTab = (): AppTabDefinition => {
     const id = Date.now().toString();
     return { id, title: `Session ${countRef.current++}`, content: <ReaverApp /> };
   };

--- a/apps/ssh/index.tsx
+++ b/apps/ssh/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useRef, useState } from 'react';
-import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import TabbedWindow from '../../components/ui/TabbedWindow';
+import type { AppTabDefinition } from '../../types/apps';
 
 const SSHBuilder: React.FC = () => {
   const [user, setUser] = useState('');
@@ -75,7 +76,7 @@ const SSHBuilder: React.FC = () => {
 const SSHPreview: React.FC = () => {
   const countRef = useRef(1);
 
-  const createTab = (): TabDefinition => {
+  const createTab = (): AppTabDefinition => {
     const id = Date.now().toString();
     return { id, title: `Session ${countRef.current++}`, content: <SSHBuilder /> };
   };

--- a/components/apps/files.tsx
+++ b/components/apps/files.tsx
@@ -1,0 +1,14 @@
+import dynamic from 'next/dynamic';
+
+const FilesApp = dynamic(() => import('../../apps/files'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-full w-full items-center justify-center bg-ub-cool-grey text-white">
+      Loading Files...
+    </div>
+  ),
+});
+
+export default function Files() {
+  return <FilesApp />;
+}

--- a/components/core/TabbedTitlebar.tsx
+++ b/components/core/TabbedTitlebar.tsx
@@ -1,0 +1,319 @@
+'use client';
+
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type { AppTabDefinition, DraggedTabPayload } from '../../types/apps';
+
+const DRAG_MIME = 'application/x-kali-tab';
+
+const dragRegistry = new Map<string, DraggedTabPayload>();
+
+function registerDrag(payload: DraggedTabPayload) {
+  const dragId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  dragRegistry.set(dragId, payload);
+  return dragId;
+}
+
+function takeDrag(dragId: string) {
+  const payload = dragRegistry.get(dragId);
+  if (payload) dragRegistry.delete(dragId);
+  return payload;
+}
+
+interface DragData {
+  dragId: string;
+  sourceWindowId: string;
+}
+
+function parseDragData(event: React.DragEvent): DragData | null {
+  const raw = event.dataTransfer.getData(DRAG_MIME);
+  if (!raw) return null;
+  try {
+    const data = JSON.parse(raw) as DragData;
+    return typeof data.dragId === 'string' && typeof data.sourceWindowId === 'string'
+      ? data
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+interface TabbedTitlebarProps {
+  windowId: string;
+  tabs: AppTabDefinition[];
+  activeTabId: string;
+  onSelect: (tabId: string) => void;
+  onClose: (tabId: string) => void;
+  onReorder: (tabId: string, beforeTabId?: string) => void;
+  onDropExternal: (payload: DraggedTabPayload, beforeTabId?: string) => void;
+  requestDetach: (payload: DraggedTabPayload) => void;
+  requestNewTab?: () => void;
+  getDragPayload: (tabId: string) => DraggedTabPayload | null;
+}
+
+export default function TabbedTitlebar({
+  windowId,
+  tabs,
+  activeTabId,
+  onSelect,
+  onClose,
+  onReorder,
+  onDropExternal,
+  requestDetach,
+  requestNewTab,
+  getDragPayload,
+}: TabbedTitlebarProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const overflowButtonRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const currentDragRef = useRef<{ tabId: string; dragId: string } | null>(null);
+  const [hasOverflow, setHasOverflow] = useState(false);
+  const [overflowOpen, setOverflowOpen] = useState(false);
+
+  const tabIds = useMemo(() => tabs.map((tab) => tab.id), [tabs]);
+
+  useLayoutEffect(() => {
+    const node = containerRef.current;
+    if (!node || typeof ResizeObserver === 'undefined') return;
+    const update = () => {
+      setHasOverflow(node.scrollWidth > node.clientWidth + 1);
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [tabs]);
+
+  useEffect(() => {
+    if (!overflowOpen) return;
+    const handlePointer = (event: MouseEvent) => {
+      const menu = menuRef.current;
+      const trigger = overflowButtonRef.current;
+      if (!menu || !trigger) return;
+      if (!menu.contains(event.target as Node) && !trigger.contains(event.target as Node)) {
+        setOverflowOpen(false);
+      }
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOverflowOpen(false);
+    };
+    document.addEventListener('mousedown', handlePointer);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handlePointer);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [overflowOpen]);
+
+  const focusRelativeTab = useCallback(
+    (direction: number) => {
+      if (!tabIds.length) return;
+      const currentIndex = tabIds.indexOf(activeTabId);
+      const nextIndex = (currentIndex + direction + tabIds.length) % tabIds.length;
+      onSelect(tabIds[nextIndex]);
+    },
+    [activeTabId, onSelect, tabIds],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!tabIds.length) return;
+      switch (event.key) {
+        case 'ArrowLeft':
+          event.preventDefault();
+          focusRelativeTab(-1);
+          break;
+        case 'ArrowRight':
+          event.preventDefault();
+          focusRelativeTab(1);
+          break;
+        case 'Home':
+          event.preventDefault();
+          onSelect(tabIds[0]);
+          break;
+        case 'End':
+          event.preventDefault();
+          onSelect(tabIds[tabIds.length - 1]);
+          break;
+        default:
+          break;
+      }
+    },
+    [focusRelativeTab, onSelect, tabIds],
+  );
+
+  const handleDragStart = useCallback(
+    (tabId: string) => (event: React.DragEvent) => {
+      const payload = getDragPayload(tabId);
+      if (!payload) {
+        event.preventDefault();
+        return;
+      }
+      const dragId = registerDrag(payload);
+      currentDragRef.current = { tabId, dragId };
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData(
+        DRAG_MIME,
+        JSON.stringify({ dragId, sourceWindowId: payload.sourceWindowId }),
+      );
+    },
+    [getDragPayload],
+  );
+
+  const handleDragEnd = useCallback(
+    (event: React.DragEvent) => {
+      const entry = currentDragRef.current;
+      currentDragRef.current = null;
+      if (!entry) return;
+      if (event.dataTransfer.dropEffect === 'none') {
+        const payload = takeDrag(entry.dragId);
+        if (payload && payload.onDetach) {
+          requestDetach(payload);
+        }
+      } else {
+        takeDrag(entry.dragId);
+      }
+    },
+    [requestDetach],
+  );
+
+  const handleDrop = useCallback(
+    (beforeTabId?: string) => (event: React.DragEvent) => {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'move';
+      const data = parseDragData(event);
+      if (!data) return;
+      const payload = takeDrag(data.dragId);
+      if (!payload) return;
+      if (payload.sourceWindowId === windowId) {
+        const sourceId = payload.tab.id;
+        if (sourceId !== beforeTabId) {
+          onReorder(sourceId, beforeTabId);
+        }
+      } else {
+        onDropExternal(payload, beforeTabId);
+      }
+    },
+    [onDropExternal, onReorder, windowId],
+  );
+
+  const handleDragOver = useCallback((event: React.DragEvent) => {
+    if (!event.dataTransfer.types.includes(DRAG_MIME)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  }, []);
+
+  return (
+    <div className="flex items-center gap-1 bg-gray-900 text-gray-100 px-2 py-1" onKeyDown={handleKeyDown}>
+      <div
+        ref={containerRef}
+        className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden"
+        role="tablist"
+        aria-label="Window tabs"
+        onDragOver={handleDragOver}
+        onDrop={handleDrop()}
+      >
+        {tabs.map((tab) => (
+          <div
+            key={tab.id}
+            className={`flex max-w-[180px] items-center rounded px-3 py-1 text-sm transition-colors ${
+              tab.id === activeTabId ? 'bg-gray-700 text-white' : 'bg-gray-800 text-gray-300'
+            }`}
+            role="tab"
+            aria-selected={tab.id === activeTabId}
+            tabIndex={tab.id === activeTabId ? 0 : -1}
+            onClick={() => onSelect(tab.id)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                onSelect(tab.id);
+              }
+            }}
+            draggable
+            onDragStart={handleDragStart(tab.id)}
+            onDragEnd={handleDragEnd}
+            onDrop={handleDrop(tab.id)}
+            onDragOver={handleDragOver}
+            data-tab-id={tab.id}
+          >
+            <span className="truncate" title={tab.title}>
+              {tab.title}
+            </span>
+            {tab.closable !== false && (
+              <button
+                type="button"
+                className="ml-2 text-gray-400 hover:text-white"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onClose(tab.id);
+                }}
+                aria-label={`Close ${tab.title}`}
+              >
+                ×
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+      {requestNewTab && (
+        <button
+          type="button"
+          className="rounded bg-gray-800 px-2 py-1 text-sm text-gray-200 hover:bg-gray-700"
+          onClick={requestNewTab}
+          aria-label="New tab"
+        >
+          +
+        </button>
+      )}
+      {hasOverflow && (
+        <div className="relative">
+          <button
+            type="button"
+            ref={overflowButtonRef}
+            className="rounded bg-gray-800 px-2 py-1 text-sm text-gray-200 hover:bg-gray-700"
+            aria-haspopup="menu"
+            aria-expanded={overflowOpen}
+            onClick={() => setOverflowOpen((open) => !open)}
+          >
+            ⋯
+          </button>
+          {overflowOpen && (
+            <div
+              ref={menuRef}
+              role="menu"
+              className="absolute right-0 z-20 mt-1 w-48 rounded-md border border-gray-700 bg-gray-900 py-1 shadow-lg"
+            >
+              {tabs.map((tab) => (
+                <Fragment key={`overflow-${tab.id}`}>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={`flex w-full items-center justify-between px-3 py-1 text-left text-sm ${
+                      tab.id === activeTabId ? 'bg-gray-700 text-white' : 'text-gray-200 hover:bg-gray-800'
+                    }`}
+                    onClick={() => {
+                      onSelect(tab.id);
+                      setOverflowOpen(false);
+                    }}
+                  >
+                    <span className="truncate" title={tab.title}>
+                      {tab.title}
+                    </span>
+                    {tab.closable !== false && <span aria-hidden="true">×</span>}
+                  </button>
+                </Fragment>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/apps/files.tsx
+++ b/pages/apps/files.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const FilesApp = dynamic(() => import('../../components/apps/files'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function FilesPage() {
+  return <FilesApp />;
+}

--- a/pages/apps/terminal.tsx
+++ b/pages/apps/terminal.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const TerminalApp = dynamic(() => import('../../components/apps/terminal'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function TerminalPage() {
+  return <TerminalApp />;
+}

--- a/tests/tabbed-windows.spec.ts
+++ b/tests/tabbed-windows.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+const windowLocator = '[data-testid="tabbed-window"]';
+
+test.describe('terminal tabbed windows', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/apps/terminal');
+    await page.waitForSelector(windowLocator);
+  });
+
+  test('creates a new session tab', async ({ page }) => {
+    const tabs = page.locator(windowLocator).first().locator('[role="tab"]');
+    const initialCount = await tabs.count();
+    await page
+      .locator(windowLocator)
+      .first()
+      .locator('button[aria-label="New tab"]')
+      .click();
+    await expect(tabs).toHaveCount(initialCount + 1);
+  });
+
+  test('detaches and merges tabs across windows', async ({ page }) => {
+    const windows = page.locator(windowLocator);
+    await expect(windows).toHaveCount(1);
+
+    const firstTab = windows.first().locator('[role="tab"]').first();
+    await firstTab.dragTo(page.locator('body'), { force: true });
+    await expect(windows).toHaveCount(2);
+
+    const secondWindowTab = windows.nth(1).locator('[role="tab"]').first();
+    const firstWindowTablist = windows.first().locator('[role="tablist"]');
+    await secondWindowTab.dragTo(firstWindowTablist, { force: true });
+    await expect(windows).toHaveCount(1);
+  });
+});

--- a/types/apps.ts
+++ b/types/apps.ts
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react';
+
+export interface TabLifecycleHooks {
+  onActivate?: () => void;
+  onDeactivate?: () => void;
+  onClose?: () => void;
+}
+
+export interface AppTabDefinition extends TabLifecycleHooks {
+  id: string;
+  title: string;
+  icon?: ReactNode;
+  closable?: boolean;
+  content: ReactNode;
+}
+
+export interface DraggedTabPayload {
+  tab: AppTabDefinition;
+  sourceWindowId: string;
+  onRemove: (targetWindowId: string, beforeTabId?: string) => AppTabDefinition | null;
+  onDetach?: () => AppTabDefinition | null;
+}


### PR DESCRIPTION
## Summary
- add a shared tab descriptor type and a tabbed title bar with drag, merge, and overflow affordances
- rework the shared TabbedWindow to use the new title bar, support detaching/merging tabs, and expose window metadata
- update the terminal and files experiences (including their pages and registry entries) to render detachable multi-window tab stacks and add Playwright coverage for the flow

## Testing
- `yarn lint` *(fails: existing repository lint errors about unlabeled controls and no-top-level-window usage)*
- `yarn test` *(fails: existing Jest suites require jsdom storage mocks and other historical issues)*
- `npx playwright test` *(fails: Playwright browsers not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb467068f48328add6f1ba282a3e7f