### PR TITLE
desktop: adaptive icon labels and wallpaper contrast

### DIFF
--- a/__tests__/contrast.test.ts
+++ b/__tests__/contrast.test.ts
@@ -1,0 +1,22 @@
+import { contrastRatio, pickTextColor, meetsContrast } from '../utils/color/contrast';
+
+describe('contrast helpers', () => {
+  it('calculates contrast ratio between black and white', () => {
+    expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(21, 2);
+  });
+
+  it('detects WCAG compliance', () => {
+    expect(meetsContrast('#000000', '#ffffff')).toBe(true);
+    expect(meetsContrast('#777777', '#888888')).toBe(false);
+  });
+
+  it('picks accessible text color for bright and dark backgrounds', () => {
+    const darkBackground = pickTextColor('#111111');
+    expect(darkBackground.color).toBe('#ffffff');
+    expect(darkBackground.isAccessible).toBe(true);
+
+    const lightBackground = pickTextColor('#f5f5f5');
+    expect(lightBackground.color).toBe('#000000');
+    expect(lightBackground.isAccessible).toBe(true);
+  });
+});

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,9 +1,11 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
+import { useHideLabelsWhenTidySetting } from '../../utils/settings/desktop';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
     const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const [hideLabelsWhenTidy, setHideLabelsWhenTidy] = useHideLabelsWhenTidySetting();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -131,6 +133,17 @@ export function Settings() {
                         className="mr-2"
                     />
                     Large Hit Areas
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={hideLabelsWhenTidy}
+                        onChange={(e) => setHideLabelsWhenTidy(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Hide desktop icon labels when grid is tidy
                 </label>
             </div>
             <div className="flex justify-center my-4">

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import Image from 'next/image'
+import DesktopIcon from '../core/DesktopIcon'
 
 export class UbuntuApp extends Component {
     constructor() {
@@ -32,35 +32,19 @@ export class UbuntuApp extends Component {
 
     render() {
         return (
-            <div
-                role="button"
-                aria-label={this.props.name}
-                aria-disabled={this.props.disabled}
-                data-context="app"
-                data-app-id={this.props.id}
-                draggable
+            <DesktopIcon
+                id={this.props.id}
+                icon={this.props.icon}
+                label={this.props.displayName || this.props.name}
+                disabled={this.props.disabled}
+                launching={this.state.launching}
+                dragging={this.state.dragging}
+                snapEnabled={this.props.snapEnabled}
+                onActivate={this.openApp}
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
-                className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
-                id={"app-" + this.props.id}
-                onDoubleClick={this.openApp}
-                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
-                tabIndex={this.props.disabled ? -1 : 0}
-                onMouseEnter={this.handlePrefetch}
-                onFocus={this.handlePrefetch}
-            >
-                <Image
-                    width={40}
-                    height={40}
-                    className="mb-1 w-10"
-                    src={this.props.icon.replace('./', '/')}
-                    alt={"Kali " + this.props.name}
-                    sizes="40px"
-                />
-                {this.props.displayName || this.props.name}
-
-            </div>
+                onPrefetch={this.handlePrefetch}
+            />
         )
     }
 }

--- a/components/core/DesktopIcon.tsx
+++ b/components/core/DesktopIcon.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import Image from 'next/image';
+import {
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { useSettings } from '../../hooks/useSettings';
+import { pickTextColor } from '../../utils/color/contrast';
+import { useHideLabelsWhenTidySetting } from '../../utils/settings/desktop';
+
+type DesktopIconProps = {
+  id: string;
+  icon: string;
+  label: string;
+  disabled?: boolean;
+  launching?: boolean;
+  dragging?: boolean;
+  snapEnabled?: boolean;
+  onActivate: () => void;
+  onDragStart?: () => void;
+  onDragEnd?: () => void;
+  onPrefetch?: () => void;
+};
+
+type Swatch = {
+  hex: string;
+};
+
+const wallpaperSwatchCache = new Map<string, Swatch>();
+const wallpaperPromises = new Map<string, Promise<Swatch | null>>();
+
+const rgbToHex = (r: number, g: number, b: number): string =>
+  `#${[r, g, b]
+    .map((channel) => channel.toString(16).padStart(2, '0'))
+    .join('')}`;
+
+const loadImage = (src: string) =>
+  new Promise<HTMLImageElement>((resolve, reject) => {
+    const img = new Image();
+    img.decoding = 'async';
+    img.crossOrigin = 'anonymous';
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error(`Failed to load ${src}`));
+    img.src = src;
+  });
+
+const sampleImage = async (img: HTMLImageElement): Promise<string | null> => {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  if (!ctx) return null;
+  const size = 64;
+  canvas.width = size;
+  canvas.height = size;
+  try {
+    ctx.drawImage(img, 0, 0, size, size);
+    const data = ctx.getImageData(0, 0, size, size).data;
+    let r = 0;
+    let g = 0;
+    let b = 0;
+    const pixels = data.length / 4;
+    for (let i = 0; i < data.length; i += 4) {
+      r += data[i];
+      g += data[i + 1];
+      b += data[i + 2];
+    }
+    if (!pixels) return null;
+    return rgbToHex(
+      Math.round(r / pixels),
+      Math.round(g / pixels),
+      Math.round(b / pixels),
+    );
+  } catch {
+    return null;
+  }
+};
+
+const fetchSwatch = async (wallpaper: string): Promise<Swatch | null> => {
+  if (wallpaperSwatchCache.has(wallpaper)) {
+    return wallpaperSwatchCache.get(wallpaper)!;
+  }
+  if (wallpaperPromises.has(wallpaper)) {
+    return wallpaperPromises.get(wallpaper)!;
+  }
+  const url = `/wallpapers/${wallpaper}.webp`;
+  const promise = loadImage(url)
+    .then(sampleImage)
+    .then((hex) => {
+      if (!hex) return null;
+      const swatch = { hex };
+      wallpaperSwatchCache.set(wallpaper, swatch);
+      return swatch;
+    })
+    .catch(() => null)
+    .finally(() => {
+      wallpaperPromises.delete(wallpaper);
+    });
+  wallpaperPromises.set(wallpaper, promise);
+  return promise;
+};
+
+const useWallpaperSwatch = (wallpaper: string): Swatch | null => {
+  const [swatch, setSwatch] = useState<Swatch | null>(() =>
+    typeof window === 'undefined'
+      ? null
+      : wallpaperSwatchCache.get(wallpaper) ?? null,
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    let cancelled = false;
+    const cached = wallpaperSwatchCache.get(wallpaper);
+    if (cached) {
+      setSwatch(cached);
+      return undefined;
+    }
+    fetchSwatch(wallpaper).then((value) => {
+      if (cancelled || !value) return;
+      setSwatch(value);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [wallpaper]);
+
+  return swatch;
+};
+
+const buildLabelStyle = (hex: string) => {
+  const { color, ratio, isAccessible } = pickTextColor(hex);
+  const shadowBase =
+    color === '#ffffff'
+      ? '0 1px 3px rgba(0,0,0,0.7)'
+      : '0 1px 3px rgba(255,255,255,0.5)';
+  if (isAccessible) {
+    return {
+      color,
+      textShadow: shadowBase,
+    } as const;
+  }
+  const backdrop =
+    color === '#ffffff'
+      ? 'rgba(0, 0, 0, 0.55)'
+      : 'rgba(255, 255, 255, 0.65)';
+  const outline =
+    color === '#ffffff' ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.25)';
+  return {
+    color,
+    textShadow: shadowBase,
+    backgroundColor: backdrop,
+    borderRadius: '0.5rem',
+    padding: '0.2rem 0.4rem',
+    boxShadow: `0 0 0 1px ${outline}`,
+    backdropFilter: 'blur(6px)',
+  } as const;
+};
+
+const DEFAULT_SWATCH = '#10141a';
+
+const DesktopIcon = ({
+  id,
+  icon,
+  label,
+  disabled = false,
+  launching = false,
+  dragging = false,
+  snapEnabled = false,
+  onActivate,
+  onDragStart,
+  onDragEnd,
+  onPrefetch,
+}: DesktopIconProps) => {
+  const { wallpaper } = useSettings();
+  const [hideLabelsWhenTidy] = useHideLabelsWhenTidySetting();
+  const swatch = useWallpaperSwatch(wallpaper);
+  const labelStyles = useMemo(
+    () => buildLabelStyle(swatch?.hex ?? DEFAULT_SWATCH),
+    [swatch?.hex],
+  );
+
+  const hidden = hideLabelsWhenTidy && snapEnabled;
+
+  const handleActivate = useCallback(() => {
+    if (disabled) return;
+    onActivate();
+  }, [disabled, onActivate]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        handleActivate();
+      }
+    },
+    [handleActivate],
+  );
+
+  const handlePrefetch = useCallback(() => {
+    if (onPrefetch) onPrefetch();
+  }, [onPrefetch]);
+
+  const className = [
+    launching ? 'app-icon-launch' : '',
+    dragging ? 'opacity-70' : '',
+    'p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      role="button"
+      aria-label={label}
+      aria-disabled={disabled}
+      data-context="app"
+      data-app-id={id}
+      draggable
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      className={className}
+      id={`app-${id}`}
+      onDoubleClick={handleActivate}
+      onKeyDown={handleKeyDown}
+      tabIndex={disabled ? -1 : 0}
+      onMouseEnter={handlePrefetch}
+      onFocus={handlePrefetch}
+      title={label}
+    >
+      <Image
+        width={40}
+        height={40}
+        className="mb-1 w-10"
+        src={icon.replace('./', '/')}
+        alt={`Kali ${label}`}
+        sizes="40px"
+        priority={false}
+      />
+      {hidden ? (
+        <span className="sr-only">{label}</span>
+      ) : (
+        <span
+          className="mt-1 text-xs font-medium leading-tight text-center break-words"
+          style={labelStyles as Record<string, string | number>}
+        >
+          {label}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default DesktopIcon;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -444,6 +444,7 @@ export class Desktop extends Component {
                     openApp: this.openApp,
                     disabled: this.state.disabled_apps[app.id],
                     prefetch: app.screen?.prefetch,
+                    snapEnabled: this.props.snapEnabled,
                 }
 
                 appsJsx.push(

--- a/docs/design-portal.md
+++ b/docs/design-portal.md
@@ -1,0 +1,7 @@
+# Design Portal
+
+## Content
+- **Icon labels** sample the active wallpaper to determine text treatment. Use a light text shadow on high-contrast scenes and automatically switch to a blurred, translucent plate when the sampled contrast ratio falls below 4.5:1.
+- **Label visibility** obeys the “Hide labels when grid is tidy” preference stored in `desktop:settings`. When enabled, tidy (snap-to-grid) layouts only show tooltips on hover and screen readers use the icon `aria-label`.
+- **Accessibility** rely on the shared `utils/color/contrast` helpers for luminance and contrast checks. Never ship custom math that doesn’t meet WCAG AA.
+- **Caching** reuse wallpaper swatches so that icon rendering stays under 4 ms per frame on mid-tier hardware. Only re-sample when the wallpaper changes.

--- a/utils/color/contrast.ts
+++ b/utils/color/contrast.ts
@@ -1,0 +1,74 @@
+const HEX_PATTERN = /^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+const expandHex = (hex: string): string => {
+  const match = HEX_PATTERN.exec(hex.trim());
+  if (!match) return '#000000';
+  const value = match[1];
+  if (value.length === 3) {
+    const [r, g, b] = value.split('');
+    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase();
+  }
+  return `#${value.toLowerCase()}`;
+};
+
+const hexToRgb = (hex: string): [number, number, number] => {
+  const expanded = expandHex(hex);
+  const value = expanded.slice(1);
+  return [
+    parseInt(value.slice(0, 2), 16),
+    parseInt(value.slice(2, 4), 16),
+    parseInt(value.slice(4, 6), 16),
+  ];
+};
+
+const toLinear = (channel: number): number => {
+  const s = channel / 255;
+  return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+};
+
+export const relativeLuminance = (hex: string): number => {
+  const [r, g, b] = hexToRgb(hex);
+  const [lr, lg, lb] = [r, g, b].map(toLinear);
+  return 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+};
+
+export const contrastRatio = (foreground: string, background: string): number => {
+  const l1 = relativeLuminance(foreground);
+  const l2 = relativeLuminance(background);
+  const [light, dark] = l1 > l2 ? [l1, l2] : [l2, l1];
+  return (light + 0.05) / (dark + 0.05);
+};
+
+export const meetsContrast = (foreground: string, background: string, minimum = 4.5): boolean =>
+  contrastRatio(foreground, background) >= minimum;
+
+type PickOptions = {
+  light?: string;
+  dark?: string;
+  minRatio?: number;
+};
+
+export const pickTextColor = (
+  background: string,
+  options: PickOptions = {},
+): { color: string; ratio: number; isAccessible: boolean } => {
+  const { light = '#ffffff', dark = '#000000', minRatio = 4.5 } = options;
+  const normalizedBackground = expandHex(background);
+  const lightColor = expandHex(light);
+  const darkColor = expandHex(dark);
+
+  const lightRatio = contrastRatio(lightColor, normalizedBackground);
+  const darkRatio = contrastRatio(darkColor, normalizedBackground);
+
+  const best = lightRatio >= darkRatio
+    ? { color: lightColor, ratio: lightRatio }
+    : { color: darkColor, ratio: darkRatio };
+
+  return { ...best, isAccessible: best.ratio >= minRatio };
+};
+
+export const toRgba = (hex: string, alpha: number): string => {
+  const [r, g, b] = hexToRgb(hex);
+  return `rgba(${r}, ${g}, ${b}, ${Math.min(Math.max(alpha, 0), 1)})`;
+};
+

--- a/utils/settings/desktop.ts
+++ b/utils/settings/desktop.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface DesktopSettings {
+  hideLabelsWhenTidy: boolean;
+}
+
+const STORAGE_KEY = 'desktop:settings';
+const DEFAULT_SETTINGS: DesktopSettings = {
+  hideLabelsWhenTidy: false,
+};
+
+type Listener = (settings: DesktopSettings) => void;
+const listeners = new Set<Listener>();
+let cache: DesktopSettings | null = null;
+
+const readFromStorage = (): DesktopSettings => {
+  if (cache) return { ...cache };
+  if (typeof window === 'undefined') return { ...DEFAULT_SETTINGS };
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed?.hideLabelsWhenTidy === 'boolean') {
+        cache = { hideLabelsWhenTidy: parsed.hideLabelsWhenTidy };
+        return { ...cache };
+      }
+    }
+  } catch {
+    // ignore parse errors and fall back to defaults
+  }
+  cache = { ...DEFAULT_SETTINGS };
+  return { ...cache };
+};
+
+const writeToStorage = (settings: DesktopSettings) => {
+  cache = { ...settings };
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(cache));
+    } catch {
+      // ignore storage errors
+    }
+  }
+  listeners.forEach((listener) => listener({ ...cache! }));
+};
+
+export const getDesktopSettings = (): DesktopSettings => readFromStorage();
+
+export const setDesktopSettings = (partial: Partial<DesktopSettings>) => {
+  const current = readFromStorage();
+  writeToStorage({ ...current, ...partial });
+};
+
+export const getHideLabelsWhenTidy = (): boolean => readFromStorage().hideLabelsWhenTidy;
+
+export const setHideLabelsWhenTidy = (value: boolean) => {
+  setDesktopSettings({ hideLabelsWhenTidy: value });
+};
+
+export const subscribeDesktopSettings = (listener: Listener): (() => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+export const useHideLabelsWhenTidySetting = (): [boolean, (value: boolean) => void] => {
+  const [value, setValue] = useState<boolean>(() => getHideLabelsWhenTidy());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    // ensure we sync with any updates that happened before hydration
+    setValue(getHideLabelsWhenTidy());
+    const unsubscribe = subscribeDesktopSettings((settings) => {
+      setValue(settings.hideLabelsWhenTidy);
+    });
+    return unsubscribe;
+  }, []);
+
+  const update = useCallback((next: boolean) => {
+    setValue(next);
+    setHideLabelsWhenTidy(next);
+  }, []);
+
+  return [value, update];
+};
+
+export const shouldHideIconLabels = (tidy: boolean): boolean => tidy && getHideLabelsWhenTidy();
+
+export const desktopDefaults = { ...DEFAULT_SETTINGS };


### PR DESCRIPTION
## Summary
- replace the desktop icon markup with a client component that samples the wallpaper and adjusts text plate/shadow styles for 4.5:1 contrast
- add desktop settings helpers and UI toggle to hide labels whenever the grid snap mode is active
- document icon label guidance in the design portal and cover the shared contrast helpers with a unit test

## Testing
- `yarn lint` *(fails: pre-existing accessibility and no-top-level-window violations across legacy apps)*
- `yarn test --runInBand --watch=false` *(fails: existing window keyboard handler and Nmap NSE clipboard assertions)*


------
https://chatgpt.com/codex/tasks/task_e_68cb466f765c8328ad8ae99e3783a2e9