### PR TITLE
[focus] queue notifications during focus mode

### DIFF
--- a/__tests__/notificationCenter.test.tsx
+++ b/__tests__/notificationCenter.test.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect } from 'react';
+import { act, render, screen } from '@testing-library/react';
+import NotificationCenter from '../components/common/NotificationCenter';
+import { SettingsContext } from '../hooks/useSettings';
+import { defaults } from '../utils/settingsStore';
+import { DEFAULT_FOCUS_MODE, FocusModeSettings } from '../utils/focusSchedule';
+import useNotifications from '../hooks/useNotifications';
+
+jest.mock('../utils/analytics.ts', () => ({
+  logEvent: jest.fn(),
+}));
+
+const focusSettings: FocusModeSettings = {
+  ...DEFAULT_FOCUS_MODE,
+  enabled: true,
+  queueNonCritical: true,
+  defaultCadenceMinutes: 1,
+};
+
+const Wrapper: React.FC<{ focusMode?: FocusModeSettings }> = ({
+  children,
+  focusMode = focusSettings,
+}) => {
+  const value = {
+    accent: defaults.accent,
+    wallpaper: defaults.wallpaper,
+    density: defaults.density,
+    reducedMotion: defaults.reducedMotion,
+    fontScale: defaults.fontScale,
+    highContrast: defaults.highContrast,
+    largeHitAreas: defaults.largeHitAreas,
+    pongSpin: defaults.pongSpin,
+    allowNetwork: defaults.allowNetwork,
+    haptics: defaults.haptics,
+    theme: 'default',
+    focusMode,
+    setAccent: jest.fn(),
+    setWallpaper: jest.fn(),
+    setDensity: jest.fn(),
+    setReducedMotion: jest.fn(),
+    setFontScale: jest.fn(),
+    setHighContrast: jest.fn(),
+    setLargeHitAreas: jest.fn(),
+    setPongSpin: jest.fn(),
+    setAllowNetwork: jest.fn(),
+    setHaptics: jest.fn(),
+    setTheme: jest.fn(),
+    setFocusMode: jest.fn(),
+    updateFocusOverride: jest.fn(),
+  };
+  return (
+    <SettingsContext.Provider value={value}>
+      <NotificationCenter>{children}</NotificationCenter>
+    </SettingsContext.Provider>
+  );
+};
+
+const Trigger: React.FC = () => {
+  const { pushNotification } = useNotifications();
+  useEffect(() => {
+    pushNotification('test-app', 'queued message');
+  }, [pushNotification]);
+  return null;
+};
+
+describe('NotificationCenter focus queueing', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.resetModules();
+  });
+
+  it('bundles non-critical notifications into summaries', async () => {
+    render(
+      <Wrapper>
+        <Trigger />
+      </Wrapper>,
+    );
+
+    expect(screen.queryByText('queued message')).toBeNull();
+
+    await act(async () => {
+      jest.advanceTimersByTime(60 * 1000);
+    });
+
+    expect(
+      await screen.findByText(/test-app summary \(1\)/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText('queued message')).toBeInTheDocument();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -36,6 +36,7 @@ const FlappyBirdApp = createDynamicApp('flappy-bird', 'Flappy Bird');
 const Game2048App = createDynamicApp('2048', '2048');
 const SnakeApp = createDynamicApp('snake', 'Snake');
 const MemoryApp = createDynamicApp('memory', 'Memory');
+const FocusModeApp = createDynamicApp('focus', 'Focus Mode');
 // Classic puzzle where players clear a minefield.
 const MinesweeperApp = createDynamicApp('minesweeper', 'Minesweeper');
 const PongApp = createDynamicApp('pong', 'Pong');
@@ -165,6 +166,7 @@ const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
+const displayFocusMode = createDisplay(FocusModeApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 
@@ -266,6 +268,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayInputLab,
+  },
+  {
+    id: 'focus',
+    title: 'Focus Mode',
+    icon: '/themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayFocusMode,
   },
 ];
 

--- a/apps/focus/index.tsx
+++ b/apps/focus/index.tsx
@@ -1,0 +1,450 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSettings } from '../../hooks/useSettings';
+import {
+  FocusModeSettings,
+  FocusAppOverride,
+  formatSchedulePreview,
+  sanitizeSummaryTimes,
+} from '../../utils/focusSchedule';
+import { logEvent } from '../../utils/analytics';
+
+const CADENCE_OPTIONS = [15, 30, 45, 60, 90, 120];
+
+const buildOverride = (base?: FocusAppOverride): FocusAppOverride => ({
+  cadenceMinutes: base?.cadenceMinutes ?? 0,
+  summaryTimes: base?.summaryTimes ?? [],
+  deliverImmediately: base?.deliverImmediately ?? false,
+});
+
+const FocusModeApp = () => {
+  const { focusMode, setFocusMode } = useSettings();
+  const [draft, setDraft] = useState<FocusModeSettings>(focusMode);
+  const [newOverrideId, setNewOverrideId] = useState('');
+  const [expandedOverride, setExpandedOverride] = useState<string | null>(null);
+
+  useEffect(() => {
+    setDraft(focusMode);
+  }, [focusMode]);
+
+  const commit = useCallback(
+    (updater: (prev: FocusModeSettings) => FocusModeSettings) => {
+      setDraft(prev => {
+        const next = updater(prev);
+        setFocusMode(next);
+        return next;
+      });
+    },
+    [setFocusMode],
+  );
+
+  const toggleFocus = useCallback(() => {
+    commit(prev => {
+      const next = { ...prev, enabled: !prev.enabled };
+      logEvent({
+        category: 'focus-mode',
+        action: next.enabled ? 'enabled' : 'disabled',
+      });
+      return next;
+    });
+  }, [commit]);
+
+  const updateCadence = useCallback(
+    (minutes: number) => {
+      commit(prev => ({ ...prev, defaultCadenceMinutes: minutes }));
+    },
+    [commit],
+  );
+
+  const updateSummaryTime = useCallback(
+    (index: number, value: string) => {
+      commit(prev => {
+        const times = [...prev.summaryTimes];
+        times[index] = value;
+        return {
+          ...prev,
+          summaryTimes: sanitizeSummaryTimes(times),
+        };
+      });
+    },
+    [commit],
+  );
+
+  const addSummaryTime = useCallback(() => {
+    commit(prev => ({
+      ...prev,
+      summaryTimes: sanitizeSummaryTimes([...prev.summaryTimes, '09:00']),
+    }));
+  }, [commit]);
+
+  const removeSummaryTime = useCallback(
+    (index: number) => {
+      commit(prev => ({
+        ...prev,
+        summaryTimes: prev.summaryTimes.filter((_, i) => i !== index),
+      }));
+    },
+    [commit],
+  );
+
+  const toggleQueue = useCallback(() => {
+    commit(prev => {
+      const next = { ...prev, queueNonCritical: !prev.queueNonCritical };
+      logEvent({
+        category: 'focus-mode',
+        action: next.queueNonCritical ? 'queue-enabled' : 'queue-disabled',
+      });
+      return next;
+    });
+  }, [commit]);
+
+  const toggleSilentToast = useCallback(() => {
+    commit(prev => ({ ...prev, suppressToasts: !prev.suppressToasts }));
+  }, [commit]);
+
+  const addOverride = useCallback(() => {
+    const trimmed = newOverrideId.trim();
+    if (!trimmed) return;
+    let added = false;
+    commit(prev => {
+      if (prev.overrides[trimmed]) return prev;
+      added = true;
+      return {
+        ...prev,
+        overrides: {
+          ...prev.overrides,
+          [trimmed]: buildOverride(),
+        },
+      };
+    });
+    setNewOverrideId('');
+    if (trimmed && added) setExpandedOverride(trimmed);
+  }, [commit, newOverrideId]);
+
+  const removeOverride = useCallback(
+    (id: string) => {
+      commit(prev => {
+        if (!prev.overrides[id]) return prev;
+        const overrides = { ...prev.overrides };
+        delete overrides[id];
+        return { ...prev, overrides };
+      });
+      if (expandedOverride === id) setExpandedOverride(null);
+    },
+    [commit, expandedOverride],
+  );
+
+  const updateOverride = useCallback(
+    (id: string, changes: Partial<FocusAppOverride>) => {
+      commit(prev => {
+        const base = buildOverride(prev.overrides[id]);
+        const summaryTimes =
+          changes.summaryTimes !== undefined
+            ? sanitizeSummaryTimes(changes.summaryTimes)
+            : base.summaryTimes;
+        const updated: FocusAppOverride = {
+          ...base,
+          ...changes,
+          summaryTimes,
+        };
+        return {
+          ...prev,
+          overrides: {
+            ...prev.overrides,
+            [id]: updated,
+          },
+        };
+      });
+    },
+    [commit],
+  );
+
+  const nextDefaultSummary = useMemo(
+    () => formatSchedulePreview(draft, '__default__'),
+    [draft],
+  );
+
+  return (
+    <div className="p-6 space-y-6 text-white">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Focus sessions</h1>
+        <p className="text-sm text-gray-300">
+          Keep distractions low by batching non-critical alerts into summaries and
+          choosing which apps are allowed to break through.
+        </p>
+      </header>
+
+      <section className="bg-ub-grey bg-opacity-80 rounded-lg p-4 space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-medium">Focus mode</h2>
+            <p className="text-sm text-gray-300">
+              When enabled, non-critical notifications are queued and delivered
+              as scheduled summaries.
+            </p>
+          </div>
+          <button
+            className={`px-4 py-2 rounded ${
+              draft.enabled ? 'bg-green-500 text-black' : 'bg-gray-700'
+            }`}
+            type="button"
+            onClick={toggleFocus}
+          >
+            {draft.enabled ? 'Disable' : 'Enable'}
+          </button>
+        </div>
+
+        <dl className="grid gap-3 sm:grid-cols-2 text-sm">
+          <div>
+            <dt className="text-gray-300">Default summary cadence</dt>
+            <dd className="mt-1 flex items-center space-x-2">
+              <select
+                value={draft.defaultCadenceMinutes}
+                onChange={e => updateCadence(Number(e.target.value))}
+                className="bg-black bg-opacity-30 px-2 py-1 rounded border border-gray-700"
+              >
+                {CADENCE_OPTIONS.map(value => (
+                  <option key={value} value={value}>
+                    Every {value} minutes
+                  </option>
+                ))}
+              </select>
+              <span className="text-gray-400">Next summary around {nextDefaultSummary}</span>
+            </dd>
+          </div>
+          <div>
+            <dt className="text-gray-300">Queue notifications</dt>
+            <dd className="mt-1">
+                <label className="inline-flex items-center space-x-2">
+                  <input
+                    type="checkbox"
+                    checked={draft.queueNonCritical}
+                    onChange={toggleQueue}
+                    aria-label="Queue non-critical notifications"
+                  />
+                  <span>Pause non-critical toasts until summaries fire</span>
+                </label>
+            </dd>
+          </div>
+          <div>
+            <dt className="text-gray-300">Silence toast popups</dt>
+            <dd className="mt-1">
+                <label className="inline-flex items-center space-x-2">
+                  <input
+                    type="checkbox"
+                    checked={draft.suppressToasts}
+                    onChange={toggleSilentToast}
+                    aria-label="Hide toast banners during focus"
+                  />
+                  <span>Hide banners while focus is active</span>
+                </label>
+            </dd>
+          </div>
+        </dl>
+
+        <div className="space-y-2">
+          <h3 className="text-md font-medium">Scheduled delivery times</h3>
+          <p className="text-sm text-gray-300">
+            Optional times of day to release summaries. Leave empty to only use
+            the cadence.
+          </p>
+          <div className="space-y-2">
+            {draft.summaryTimes.map((time, index) => (
+              <div key={`${time}-${index}`} className="flex space-x-2">
+                <input
+                  type="time"
+                  value={time}
+                  aria-label={`Summary time ${index + 1}`}
+                  onChange={e => updateSummaryTime(index, e.target.value)}
+                  className="bg-black bg-opacity-30 px-2 py-1 rounded border border-gray-700"
+                />
+                <button
+                  type="button"
+                  className="px-3 py-1 bg-red-600 rounded"
+                  onClick={() => removeSummaryTime(index)}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              className="px-3 py-1 bg-gray-700 rounded"
+              onClick={addSummaryTime}
+            >
+              Add summary time
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-ub-grey bg-opacity-80 rounded-lg p-4 space-y-4">
+        <header className="space-y-1">
+          <h2 className="text-lg font-medium">Per-app overrides</h2>
+          <p className="text-sm text-gray-300">
+            Give individual apps their own schedule, or let important apps break
+            through immediately.
+          </p>
+        </header>
+
+        <div className="flex space-x-2">
+          <input
+            value={newOverrideId}
+            onChange={event => setNewOverrideId(event.target.value)}
+            placeholder="App identifier"
+            className="flex-1 bg-black bg-opacity-30 px-2 py-1 rounded border border-gray-700"
+            type="text"
+            aria-label="Override app identifier"
+          />
+          <button
+            type="button"
+            className="px-3 py-1 bg-gray-700 rounded"
+            onClick={addOverride}
+          >
+            Add override
+          </button>
+        </div>
+
+        {Object.entries(draft.overrides).length === 0 && (
+          <p className="text-sm text-gray-300">
+            No overrides configured yet. Add an app ID to customize its
+            delivery.
+          </p>
+        )}
+
+        <div className="space-y-3">
+          {Object.entries(draft.overrides).map(([id, override]) => {
+            const nextSummary = formatSchedulePreview(draft, id);
+            const expanded = expandedOverride === id;
+            return (
+              <article
+                key={id}
+                className="bg-black bg-opacity-30 border border-gray-700 rounded-lg"
+              >
+                <header
+                  className="flex items-center justify-between px-4 py-3 cursor-pointer"
+                  onClick={() =>
+                    setExpandedOverride(expanded ? null : id)
+                  }
+                >
+                  <div>
+                    <h3 className="font-medium">{id}</h3>
+                    <p className="text-xs text-gray-400">
+                      Next summary around {nextSummary}
+                    </p>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    {override.deliverImmediately && (
+                      <span className="text-xs uppercase tracking-wide text-green-300">
+                        Breakthrough
+                      </span>
+                    )}
+                    <button
+                      type="button"
+                      onClick={event => {
+                        event.stopPropagation();
+                        removeOverride(id);
+                      }}
+                      className="px-2 py-1 bg-red-600 rounded"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </header>
+                {expanded && (
+                  <div className="px-4 pb-4 space-y-3 text-sm">
+                      <label className="flex items-center space-x-2">
+                        <input
+                          type="checkbox"
+                          checked={override.deliverImmediately ?? false}
+                          onChange={event =>
+                            updateOverride(id, {
+                              deliverImmediately: event.target.checked,
+                            })
+                          }
+                          aria-label={`Deliver ${id} notifications immediately`}
+                        />
+                        <span>Deliver immediately (bypass summaries)</span>
+                      </label>
+
+                    <div>
+                      <span className="block text-gray-300">
+                        Custom cadence
+                      </span>
+                      <select
+                        value={override.cadenceMinutes ?? 0}
+                        onChange={event =>
+                          updateOverride(id, {
+                            cadenceMinutes: Number(event.target.value),
+                          })
+                        }
+                        className="mt-1 bg-black bg-opacity-30 px-2 py-1 rounded border border-gray-700"
+                      >
+                        <option value={0}>Inherit global cadence</option>
+                        {CADENCE_OPTIONS.map(value => (
+                          <option key={value} value={value}>
+                            Every {value} minutes
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div className="space-y-2">
+                      <span className="block text-gray-300">
+                        Custom delivery times
+                      </span>
+                      {(override.summaryTimes ?? []).map((time, index) => (
+                        <div className="flex space-x-2" key={`${id}-${time}-${index}`}>
+                          <input
+                            type="time"
+                            value={time}
+                            aria-label={`Custom summary time ${index + 1} for ${id}`}
+                            onChange={event => {
+                              const updated = [...(override.summaryTimes ?? [])];
+                              updated[index] = event.target.value;
+                              updateOverride(id, {
+                                summaryTimes: updated,
+                              });
+                            }}
+                            className="bg-black bg-opacity-30 px-2 py-1 rounded border border-gray-700"
+                          />
+                          <button
+                            type="button"
+                            className="px-3 py-1 bg-red-600 rounded"
+                            onClick={() => {
+                              const updated = (override.summaryTimes ?? []).filter(
+                                (_, i) => i !== index,
+                              );
+                              updateOverride(id, {
+                                summaryTimes: updated,
+                              });
+                            }}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      ))}
+                      <button
+                        type="button"
+                        className="px-3 py-1 bg-gray-700 rounded"
+                        onClick={() => {
+                          const updated = [...(override.summaryTimes ?? []), '09:00'];
+                          updateOverride(id, {
+                            summaryTimes: updated,
+                          });
+                        }}
+                      >
+                        Add delivery time
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </article>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default FocusModeApp;

--- a/components/apps/notifications/SummaryBundleCard.tsx
+++ b/components/apps/notifications/SummaryBundleCard.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { NotificationBundle } from './types';
+
+interface SummaryBundleCardProps {
+  bundle: NotificationBundle;
+  expanded: boolean;
+  onToggle: () => void;
+  onDismiss: () => void;
+}
+
+const SummaryBundleCard: React.FC<SummaryBundleCardProps> = ({
+  bundle,
+  expanded,
+  onToggle,
+  onDismiss,
+}) => {
+  const count = bundle.notifications.length;
+  const preview = bundle.notifications[0]?.message ?? 'No details available';
+  const deliveredTime = new Date(bundle.deliveredAt).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  return (
+    <article className="mt-3 rounded-lg border border-gray-700 bg-black bg-opacity-40">
+      <header className="flex items-center justify-between px-4 py-3">
+        <div>
+          <h3 className="text-sm font-medium text-white">
+            {bundle.appId} summary ({count})
+          </h3>
+          <p className="text-xs text-gray-400">
+            Delivered at {deliveredTime} · {preview}
+          </p>
+        </div>
+        <div className="flex space-x-2">
+          <button
+            type="button"
+            onClick={onToggle}
+            className="rounded bg-gray-700 px-3 py-1 text-xs text-white hover:bg-gray-600"
+          >
+            {expanded ? 'Hide' : 'Review'}
+          </button>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="rounded bg-red-600 px-3 py-1 text-xs text-white hover:bg-red-500"
+          >
+            Dismiss
+          </button>
+        </div>
+      </header>
+      {expanded && (
+        <div className="px-4 pb-4">
+          <ul className="space-y-2 text-sm text-gray-100">
+            {bundle.notifications.map(item => (
+              <li key={item.id} className="rounded bg-black bg-opacity-50 px-3 py-2">
+                <div className="flex items-center justify-between">
+                  <span>{item.message}</span>
+                  <time className="text-xs text-gray-400">
+                    {new Date(item.date).toLocaleTimeString([], {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </time>
+                </div>
+                {item.actions && item.actions.length > 0 && (
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {item.actions.map(action => (
+                      <button
+                        key={action.label}
+                        type="button"
+                        className="text-xs underline"
+                        onClick={action.onClick}
+                      >
+                        {action.label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </article>
+  );
+};
+
+export default SummaryBundleCard;

--- a/components/apps/notifications/SummaryBundleList.tsx
+++ b/components/apps/notifications/SummaryBundleList.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import SummaryBundleCard from './SummaryBundleCard';
+import { NotificationBundle } from './types';
+
+interface SummaryBundleListProps {
+  bundles: NotificationBundle[];
+  expandedId: string | null;
+  onToggle: (bundleId: string | null) => void;
+  onDismiss: (bundleId: string) => void;
+}
+
+const SummaryBundleList: React.FC<SummaryBundleListProps> = ({
+  bundles,
+  expandedId,
+  onToggle,
+  onDismiss,
+}) => (
+  <div className="space-y-2">
+    {bundles.map(bundle => (
+      <SummaryBundleCard
+        key={bundle.id}
+        bundle={bundle}
+        expanded={bundle.id === expandedId}
+        onToggle={() =>
+          onToggle(bundle.id === expandedId ? null : bundle.id)
+        }
+        onDismiss={() => onDismiss(bundle.id)}
+      />
+    ))}
+  </div>
+);
+
+export default SummaryBundleList;

--- a/components/apps/notifications/index.ts
+++ b/components/apps/notifications/index.ts
@@ -1,0 +1,3 @@
+export { default as SummaryBundleCard } from './SummaryBundleCard';
+export { default as SummaryBundleList } from './SummaryBundleList';
+export * from './types';

--- a/components/apps/notifications/types.ts
+++ b/components/apps/notifications/types.ts
@@ -1,0 +1,19 @@
+export interface NotificationAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface NotificationMessage {
+  id: string;
+  message: string;
+  date: number;
+  critical?: boolean;
+  actions?: NotificationAction[];
+}
+
+export interface NotificationBundle {
+  id: string;
+  appId: string;
+  deliveredAt: number;
+  notifications: NotificationMessage[];
+}

--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -1,53 +1,284 @@
-import React, { createContext, useCallback, useEffect, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import SummaryBundleList from '../apps/notifications/SummaryBundleList';
+import {
+  NotificationAction,
+  NotificationBundle,
+  NotificationMessage,
+} from '../apps/notifications/types';
+import { useSettings } from '../../hooks/useSettings';
+import { computeNextSummary } from '../../utils/focusSchedule';
+import { logEvent } from '../../utils/analytics';
 
-export interface AppNotification {
-  id: string;
-  message: string;
-  date: number;
+export interface NotificationOptions {
+  critical?: boolean;
+  actions?: NotificationAction[];
 }
 
-interface NotificationsContextValue {
-  notifications: Record<string, AppNotification[]>;
-  pushNotification: (appId: string, message: string) => void;
+export interface NotificationsContextValue {
+  notifications: Record<string, NotificationMessage[]>;
+  bundles: NotificationBundle[];
+  pushNotification: (
+    appId: string,
+    message: string,
+    options?: NotificationOptions,
+  ) => void;
   clearNotifications: (appId?: string) => void;
+  clearBundle: (bundleId: string) => void;
 }
 
-export const NotificationsContext = createContext<NotificationsContextValue | null>(null);
+export const NotificationsContext =
+  createContext<NotificationsContextValue | null>(null);
 
-export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
-  const [notifications, setNotifications] = useState<Record<string, AppNotification[]>>({});
+const buildMessage = (
+  message: string,
+  options?: NotificationOptions,
+): NotificationMessage => ({
+  id: `${Date.now()}-${Math.random()}`,
+  message,
+  date: Date.now(),
+  critical: options?.critical ?? false,
+  actions: options?.actions ?? [],
+});
 
-  const pushNotification = useCallback((appId: string, message: string) => {
-    setNotifications(prev => {
-      const list = prev[appId] ?? [];
-      const next = {
-        ...prev,
-        [appId]: [
-          ...list,
-          {
-            id: `${Date.now()}-${Math.random()}`,
-            message,
-            date: Date.now(),
-          },
-        ],
-      };
-      return next;
-    });
-  }, []);
+export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({
+  children,
+}) => {
+  const { focusMode } = useSettings();
+  const [notifications, setNotifications] = useState<
+    Record<string, NotificationMessage[]>
+  >({});
+  const [bundles, setBundles] = useState<NotificationBundle[]>([]);
+  const [queued, setQueued] = useState<Record<string, NotificationMessage[]>>({});
+  const [expandedBundle, setExpandedBundle] = useState<string | null>(null);
 
-  const clearNotifications = useCallback((appId?: string) => {
-    setNotifications(prev => {
-      if (!appId) return {};
-      const next = { ...prev };
-      delete next[appId];
-      return next;
-    });
-  }, []);
+  const timersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const lastDeliveredRef = useRef<Record<string, number>>({});
+  const queuedRef = useRef<Record<string, NotificationMessage[]>>({});
 
-  const totalCount = Object.values(notifications).reduce(
-    (sum, list) => sum + list.length,
-    0
+  const updateQueued = useCallback(
+    (
+      updater:
+        | Record<string, NotificationMessage[]>
+        | ((prev: Record<string, NotificationMessage[]>) => Record<string, NotificationMessage[]>)
+    ) => {
+      setQueued(prev => {
+        const next =
+          typeof updater === 'function'
+            ? (updater as (
+                prev: Record<string, NotificationMessage[]>,
+              ) => Record<string, NotificationMessage[]>)(prev)
+            : updater;
+        queuedRef.current = next;
+        return next;
+      });
+    },
+    [],
   );
+
+  const releaseBundle = useCallback(
+    (appId: string) => {
+      let delivered: NotificationMessage[] = [];
+      updateQueued(prev => {
+        const list = prev[appId] ?? [];
+        if (!list.length) return prev;
+        delivered = list;
+        const next = { ...prev };
+        delete next[appId];
+        return next;
+      });
+
+      if (!delivered.length) {
+        if (timersRef.current[appId]) {
+          clearTimeout(timersRef.current[appId]);
+          delete timersRef.current[appId];
+        }
+        return;
+      }
+
+      const bundle: NotificationBundle = {
+        id: `${appId}-${Date.now()}`,
+        appId,
+        notifications: delivered,
+        deliveredAt: Date.now(),
+      };
+
+      setBundles(prev => [...prev, bundle]);
+      lastDeliveredRef.current[appId] = bundle.deliveredAt;
+      logEvent({
+        category: 'focus-mode',
+        action: 'summary-delivered',
+        label: appId,
+        value: delivered.length,
+      });
+
+      if (timersRef.current[appId]) {
+        clearTimeout(timersRef.current[appId]);
+        delete timersRef.current[appId];
+      }
+    },
+    [updateQueued],
+  );
+
+  const scheduleDelivery = useCallback(
+    (appId: string) => {
+      if (!focusMode.enabled) return;
+      const override = focusMode.overrides[appId];
+      if (override?.deliverImmediately) return;
+
+      const queue = queuedRef.current[appId] ?? [];
+      if (!queue.length) return;
+
+      const now = new Date();
+      const target = computeNextSummary(
+        focusMode,
+        appId,
+        lastDeliveredRef.current[appId],
+        now,
+      );
+      const delay = Math.max(target.getTime() - now.getTime(), 0);
+
+      if (timersRef.current[appId]) {
+        clearTimeout(timersRef.current[appId]);
+      }
+
+      timersRef.current[appId] = setTimeout(() => {
+        releaseBundle(appId);
+      }, delay);
+    },
+    [focusMode, releaseBundle],
+  );
+
+  const pushNotification = useCallback<
+    NotificationsContextValue['pushNotification']
+  >(
+    (appId, message, options) => {
+      const entry = buildMessage(message, options);
+
+      const shouldQueue =
+        focusMode.enabled &&
+        focusMode.queueNonCritical &&
+        !entry.critical &&
+        !focusMode.overrides[appId]?.deliverImmediately;
+
+      if (!shouldQueue) {
+        setNotifications(prev => {
+          const list = prev[appId] ?? [];
+          return {
+            ...prev,
+            [appId]: [...list, entry],
+          };
+        });
+        return;
+      }
+
+      updateQueued(prev => {
+        const list = prev[appId] ?? [];
+        const next = {
+          ...prev,
+          [appId]: [...list, entry],
+        };
+        return next;
+      });
+      logEvent({
+        category: 'focus-mode',
+        action: 'notification-queued',
+        label: appId,
+      });
+      scheduleDelivery(appId);
+    },
+    [focusMode, scheduleDelivery, updateQueued],
+  );
+
+  const clearNotifications = useCallback<
+    NotificationsContextValue['clearNotifications']
+  >(
+    appId => {
+      if (!appId) {
+        setNotifications({});
+        updateQueued({});
+        setBundles([]);
+        Object.values(timersRef.current).forEach(timer => clearTimeout(timer));
+        timersRef.current = {};
+        lastDeliveredRef.current = {};
+        return;
+      }
+
+      setNotifications(prev => {
+        const next = { ...prev };
+        delete next[appId];
+        return next;
+      });
+      updateQueued(prev => {
+        const next = { ...prev };
+        delete next[appId];
+        return next;
+      });
+      setBundles(prev => prev.filter(bundle => bundle.appId !== appId));
+      if (timersRef.current[appId]) {
+        clearTimeout(timersRef.current[appId]);
+        delete timersRef.current[appId];
+      }
+      delete lastDeliveredRef.current[appId];
+    },
+    [updateQueued],
+  );
+
+  const clearBundle = useCallback<NotificationsContextValue['clearBundle']>(
+    bundleId => {
+      setBundles(prev => prev.filter(bundle => bundle.id !== bundleId));
+      if (expandedBundle === bundleId) setExpandedBundle(null);
+      logEvent({
+        category: 'focus-mode',
+        action: 'summary-dismissed',
+        label: bundleId,
+      });
+    },
+    [expandedBundle],
+  );
+
+  useEffect(() => {
+    if (!focusMode.enabled) {
+      Object.keys(queuedRef.current).forEach(releaseBundle);
+      return;
+    }
+    Object.keys(queuedRef.current).forEach(appId => scheduleDelivery(appId));
+  }, [focusMode.enabled, releaseBundle, scheduleDelivery]);
+
+  useEffect(() => {
+    if (!focusMode.enabled) return;
+    Object.keys(queuedRef.current).forEach(appId => scheduleDelivery(appId));
+  }, [
+    focusMode.defaultCadenceMinutes,
+    focusMode.summaryTimes,
+    focusMode.overrides,
+    focusMode.enabled,
+    scheduleDelivery,
+  ]);
+
+  useEffect(() => {
+    if (!focusMode.queueNonCritical) {
+      Object.keys(queuedRef.current).forEach(releaseBundle);
+    }
+  }, [focusMode.queueNonCritical, releaseBundle]);
+
+  const totalCount = useMemo(() => {
+    const direct = Object.values(notifications).reduce(
+      (sum, list) => sum + list.length,
+      0,
+    );
+    const queuedCount = Object.values(queued).reduce(
+      (sum, list) => sum + list.length,
+      0,
+    );
+    return direct + queuedCount;
+  }, [notifications, queued]);
 
   useEffect(() => {
     const nav: any = navigator;
@@ -59,21 +290,70 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
 
   return (
     <NotificationsContext.Provider
-      value={{ notifications, pushNotification, clearNotifications }}
+      value={{
+        notifications,
+        bundles,
+        pushNotification,
+        clearNotifications,
+        clearBundle,
+      }}
     >
       {children}
-      <div className="notification-center">
-        {Object.entries(notifications).map(([appId, list]) => (
-          <section key={appId} className="notification-group">
-            <h3>{appId}</h3>
-            <ul>
-              {list.map(n => (
-                <li key={n.id}>{n.message}</li>
-              ))}
-            </ul>
-          </section>
-        ))}
-      </div>
+      {(bundles.length > 0 || Object.keys(notifications).length > 0) && (
+        <div className="notification-center space-y-4">
+          {bundles.length > 0 && (
+            <section className="notification-group">
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-300">
+                Focus summaries
+              </h2>
+              <SummaryBundleList
+                bundles={bundles}
+                expandedId={expandedBundle}
+                onToggle={setExpandedBundle}
+                onDismiss={clearBundle}
+              />
+            </section>
+          )}
+
+          {Object.entries(notifications).map(([appId, list]) => (
+            <section key={appId} className="notification-group">
+              <h3 className="text-sm font-semibold text-gray-200">{appId}</h3>
+              <ul className="mt-2 space-y-1 text-sm text-gray-100">
+                {list.map(entry => (
+                  <li
+                    key={entry.id}
+                    className="bg-black bg-opacity-40 rounded px-3 py-2"
+                  >
+                    <div className="flex items-center justify-between">
+                      <span>{entry.message}</span>
+                      <time className="text-xs text-gray-400">
+                        {new Date(entry.date).toLocaleTimeString([], {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                        })}
+                      </time>
+                    </div>
+                    {entry.actions && entry.actions.length > 0 && (
+                      <div className="mt-2 flex space-x-2">
+                        {entry.actions.map(action => (
+                          <button
+                            key={action.label}
+                            className="text-xs underline"
+                            type="button"
+                            onClick={action.onClick}
+                          >
+                            {action.label}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      )}
     </NotificationsContext.Provider>
   );
 };

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useSettings } from '../../hooks/useSettings';
 
 interface ToastProps {
   message: string;
@@ -17,8 +18,19 @@ const Toast: React.FC<ToastProps> = ({
 }) => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [visible, setVisible] = useState(false);
+  const { focusMode } = useSettings();
+  const suppressToast = focusMode.enabled && focusMode.suppressToasts;
 
   useEffect(() => {
+    if (suppressToast) {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      setVisible(false);
+      if (onClose) onClose();
+      return;
+    }
     setVisible(true);
     timeoutRef.current = setTimeout(() => {
       onClose && onClose();
@@ -26,7 +38,11 @@ const Toast: React.FC<ToastProps> = ({
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
-  }, [duration, onClose]);
+  }, [duration, onClose, suppressToast]);
+
+  if (suppressToast) {
+    return null;
+  }
 
   return (
     <div

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -1,7 +1,11 @@
 import { useContext } from 'react';
-import { NotificationsContext } from '../components/common/NotificationCenter';
+import {
+  NotificationsContext,
+  NotificationsContextValue,
+  NotificationOptions,
+} from '../components/common/NotificationCenter';
 
-export const useNotifications = () => {
+export const useNotifications = (): NotificationsContextValue => {
   const ctx = useContext(NotificationsContext);
   if (!ctx) {
     throw new Error('useNotifications must be used within NotificationCenter');
@@ -10,3 +14,4 @@ export const useNotifications = () => {
 };
 
 export default useNotifications;
+export type { NotificationOptions, NotificationsContextValue };

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,6 +11,7 @@ import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import NotificationCenter from '../components/common/NotificationCenter';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
@@ -157,21 +158,23 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
+          <NotificationCenter>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;
                 const evt = e;
                 if (evt.metadata?.email) delete evt.metadata.email;
                 return e;
-              }}
-            />
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </NotificationCenter>
         </SettingsProvider>
       </div>
     </ErrorBoundary>

--- a/pages/apps/focus.tsx
+++ b/pages/apps/focus.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const FocusApp = dynamic(() => import('../../apps/focus'), { ssr: false });
+
+const FocusPage = () => <FocusApp />;
+
+export default FocusPage;

--- a/utils/focusSchedule.ts
+++ b/utils/focusSchedule.ts
@@ -1,0 +1,136 @@
+export interface FocusAppOverride {
+  cadenceMinutes?: number;
+  summaryTimes?: string[];
+  deliverImmediately?: boolean;
+}
+
+export interface FocusModeSettings {
+  enabled: boolean;
+  defaultCadenceMinutes: number;
+  summaryTimes: string[];
+  overrides: Record<string, FocusAppOverride>;
+  suppressToasts: boolean;
+  queueNonCritical: boolean;
+}
+
+const MINUTE_IN_MS = 60 * 1000;
+
+const normalizeTime = (value: string): string => {
+  if (!value) return '';
+  const [hours, minutes] = value.split(':').map(Number);
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) return '';
+  const safeHours = Math.max(0, Math.min(23, hours));
+  const safeMinutes = Math.max(0, Math.min(59, minutes));
+  return `${safeHours.toString().padStart(2, '0')}:${safeMinutes
+    .toString()
+    .padStart(2, '0')}`;
+};
+
+export const sanitizeSummaryTimes = (times: string[]): string[] => {
+  if (!Array.isArray(times)) return [];
+  const seen = new Set<string>();
+  return times
+    .map(normalizeTime)
+    .filter(time => time && !seen.has(time) && seen.add(time));
+};
+
+const minutesFromTime = (time: string): number | null => {
+  if (!time) return null;
+  const [hours, minutes] = time.split(':').map(Number);
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) return null;
+  return hours * 60 + minutes;
+};
+
+const buildTargetDate = (base: Date, minutesFromMidnight: number): Date => {
+  const target = new Date(base);
+  target.setHours(0, 0, 0, 0);
+  target.setMinutes(minutesFromMidnight, 0, 0);
+  return target;
+};
+
+export const getNextTimeOfDay = (
+  times: string[],
+  now: Date = new Date(),
+): Date | null => {
+  const normalized = sanitizeSummaryTimes(times);
+  if (!normalized.length) return null;
+  const currentMinutes = now.getHours() * 60 + now.getMinutes();
+  const ordered = normalized
+    .map(minutesFromTime)
+    .filter((value): value is number => value !== null)
+    .sort((a, b) => a - b);
+  if (!ordered.length) return null;
+  const next = ordered.find(value => value > currentMinutes);
+  if (next !== undefined) {
+    return buildTargetDate(now, next);
+  }
+  // Wrap to the following day
+  const tomorrow = buildTargetDate(now, ordered[0]);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  return tomorrow;
+};
+
+const resolveCadence = (
+  focus: FocusModeSettings,
+  appId: string,
+): number => {
+  const override = focus.overrides[appId];
+  if (override?.cadenceMinutes && override.cadenceMinutes > 0) {
+    return override.cadenceMinutes;
+  }
+  if (focus.defaultCadenceMinutes > 0) {
+    return focus.defaultCadenceMinutes;
+  }
+  return 60;
+};
+
+export const computeNextSummary = (
+  focus: FocusModeSettings,
+  appId: string,
+  lastDelivered?: number,
+  now: Date = new Date(),
+): Date => {
+  const override = focus.overrides[appId];
+  const overrideTimes = override?.summaryTimes && override.summaryTimes.length > 0;
+  const globalTimes = focus.summaryTimes && focus.summaryTimes.length > 0;
+
+  if (overrideTimes) {
+    const target = getNextTimeOfDay(override!.summaryTimes!, now);
+    if (target) return target;
+  }
+
+  if (globalTimes) {
+    const target = getNextTimeOfDay(focus.summaryTimes, now);
+    if (target) return target;
+  }
+
+  const cadence = resolveCadence(focus, appId);
+  const baseline = lastDelivered ? new Date(lastDelivered) : now;
+  const candidate = baseline.getTime() + cadence * MINUTE_IN_MS;
+  if (candidate <= now.getTime()) {
+    return new Date(now.getTime() + Math.max(cadence, 1) * MINUTE_IN_MS);
+  }
+  return new Date(candidate);
+};
+
+export const formatSchedulePreview = (
+  focus: FocusModeSettings,
+  appId: string,
+  lastDelivered?: number,
+): string => {
+  try {
+    const next = computeNextSummary(focus, appId, lastDelivered);
+    return next.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return '—';
+  }
+};
+
+export const DEFAULT_FOCUS_MODE: FocusModeSettings = {
+  enabled: false,
+  defaultCadenceMinutes: 60,
+  summaryTimes: [],
+  overrides: {},
+  suppressToasts: true,
+  queueNonCritical: true,
+};


### PR DESCRIPTION
## Summary
- add a focus mode scheduling surface with per-app overrides and persistence helpers
- queue non-critical notifications while focus mode is active and emit bundled summaries with new UI components
- silence toast banners during focus and add coverage around the new focus behaviours

## Testing
- yarn eslint apps/focus/index.tsx components/common/NotificationCenter.tsx components/ui/Toast.tsx components/apps/notifications --ext .ts,.tsx
- yarn test # fails in upstream suites (window, nmap NSE)

------
https://chatgpt.com/codex/tasks/task_e_68cb466b88108328b3e96e18eb956282