### PR TITLE
[apps] Add emoji picker overlay and input bridge

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -72,6 +72,7 @@ const QuoteApp = createDynamicApp('quote', 'Quote');
 const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery');
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
+const EmojiPickerApp = createDynamicApp('emoji/Picker', 'Emoji Picker');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
@@ -165,6 +166,7 @@ const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
+const displayEmojiPicker = createDisplay(EmojiPickerApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 
@@ -266,6 +268,19 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayInputLab,
+  },
+  {
+    id: 'emoji-picker',
+    title: 'Emoji Picker',
+    icon: '/themes/Yaru/apps/emoji-picker.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayEmojiPicker,
+    resizable: false,
+    allowMaximize: false,
+    defaultWidth: 40,
+    defaultHeight: 65,
   },
 ];
 

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -8,6 +8,7 @@ export interface Shortcut {
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
+  { description: 'Open emoji picker', keys: 'Ctrl+.' },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {

--- a/components/apps/emoji/Picker.tsx
+++ b/components/apps/emoji/Picker.tsx
@@ -1,0 +1,403 @@
+'use client';
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import emojiDataset from '@/data/emoji.json';
+import copyToClipboard from '@/utils/clipboard';
+import {
+  addRecentEmoji,
+  clearRecentEmojis,
+  getPreferredSkinTone,
+  getRecentEmojis,
+  setPreferredSkinTone,
+  SKIN_TONE_OPTIONS,
+  DEFAULT_SKIN_TONE,
+  type EmojiRecent,
+  type RecentEmojiInput,
+  type SkinTone,
+} from '@/utils/settings/emoji';
+import {
+  ensureInputBridge,
+  insertText,
+  subscribeToInputTarget,
+  INPUT_BRIDGE_IGNORE_ATTRIBUTE,
+  type InputTargetSnapshot,
+} from '@/modules/desktop/inputBridge';
+
+type EmojiRecord = {
+  id: string;
+  char: string;
+  name: string;
+  shortcodes: string[];
+  keywords?: string[];
+  skins?: string[];
+};
+
+type EmojiCategory = {
+  id: string;
+  label: string;
+  items: EmojiRecord[];
+};
+
+type EmojiDataset = {
+  categories: EmojiCategory[];
+};
+
+type EmojiSource = {
+  id: string;
+  char: string;
+  name: string;
+  shortcodes: string[];
+  skins?: string[];
+};
+
+const dataset = emojiDataset as EmojiDataset;
+
+const BRIDGE_IGNORE_ATTRIBUTE = {
+  [INPUT_BRIDGE_IGNORE_ATTRIBUTE]: 'true',
+} as const;
+
+const GRID_TEMPLATE =
+  'grid grid-cols-4 gap-2 sm:grid-cols-6 md:grid-cols-7 lg:grid-cols-8 xl:grid-cols-9';
+
+const normaliseQuery = (value: string) =>
+  value
+    .toLowerCase()
+    .trim()
+    .replace(/^:+|:+$/g, '');
+
+const formatShortcodes = (shortcodes: string[]) =>
+  shortcodes.length ? shortcodes.map((code) => `:${code}:`).join(' ') : '';
+
+const hasToneVariants = (source: EmojiSource) =>
+  Boolean(source.skins && source.skins.length > 1);
+
+const getEmojiForTone = (source: EmojiSource, tone: SkinTone) => {
+  if (!source.skins || source.skins.length === 0) return source.char;
+  const index = SKIN_TONE_OPTIONS.findIndex((option) => option.id === tone);
+  const safeIndex = index < 0 ? 0 : Math.min(index, source.skins.length - 1);
+  return source.skins[safeIndex] || source.char;
+};
+
+const toRecentInput = (
+  source: EmojiSource,
+  tone: SkinTone,
+  char: string
+): RecentEmojiInput => ({
+  id: source.id,
+  char,
+  name: source.name,
+  shortcodes: source.shortcodes,
+  skinTone: hasToneVariants(source) ? tone : DEFAULT_SKIN_TONE,
+  skins: source.skins,
+});
+
+const Picker: React.FC = () => {
+  const [skinTone, setSkinTone] = useState<SkinTone>(DEFAULT_SKIN_TONE);
+  const [recents, setRecents] = useState<EmojiRecent[]>([]);
+  const [query, setQuery] = useState('');
+  const [status, setStatus] = useState<string | null>(null);
+  const [target, setTarget] = useState<InputTargetSnapshot | null>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const emojiMap = useMemo(() => {
+    const map = new Map<string, EmojiRecord>();
+    dataset.categories.forEach((category) => {
+      category.items.forEach((item) => {
+        map.set(item.id, item);
+      });
+    });
+    return map;
+  }, []);
+
+  const terms = useMemo(() => {
+    if (!query.trim()) return [] as string[];
+    return query
+      .split(/\s+/)
+      .map(normaliseQuery)
+      .filter(Boolean);
+  }, [query]);
+
+  const matchesQuery = useCallback(
+    (item: EmojiRecord) => {
+      if (!terms.length) return true;
+      const haystack = [
+        item.name,
+        ...item.shortcodes,
+        ...(item.keywords ?? []),
+      ]
+        .join(' ')
+        .toLowerCase();
+      return terms.every((term) => haystack.includes(term));
+    },
+    [terms]
+  );
+
+  const filteredCategories = useMemo(() => {
+    if (!terms.length) return dataset.categories;
+    return dataset.categories
+      .map((category) => ({
+        ...category,
+        items: category.items.filter(matchesQuery),
+      }))
+      .filter((category) => category.items.length > 0);
+  }, [matchesQuery, terms.length]);
+
+  const matchingRecents = useMemo(() => {
+    if (!recents.length) return [] as EmojiRecent[];
+    if (!terms.length) return recents;
+    return recents.filter((recent) => {
+      const source = emojiMap.get(recent.id);
+      const haystack = [
+        source?.name ?? recent.name,
+        ...(source?.shortcodes ?? recent.shortcodes),
+        ...(source?.keywords ?? []),
+      ]
+        .join(' ')
+        .toLowerCase();
+      return terms.every((term) => haystack.includes(term));
+    });
+  }, [emojiMap, recents, terms]);
+
+  useEffect(() => {
+    setSkinTone(getPreferredSkinTone());
+    setRecents(getRecentEmojis());
+    ensureInputBridge();
+    const unsubscribe = subscribeToInputTarget(setTarget);
+    searchRef.current?.focus();
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    if (!status) return;
+    const timer = window.setTimeout(() => setStatus(null), 2400);
+    return () => window.clearTimeout(timer);
+  }, [status]);
+
+  const handleSkinToneChange = useCallback(
+    (tone: SkinTone) => {
+      if (tone === skinTone) return;
+      setSkinTone(tone);
+      setPreferredSkinTone(tone);
+    },
+    [skinTone]
+  );
+
+  const handleInsert = useCallback(
+    (source: EmojiSource) => {
+      const toneToUse = hasToneVariants(source) ? skinTone : DEFAULT_SKIN_TONE;
+      const char = getEmojiForTone(source, toneToUse);
+      if (!char) return;
+      const inserted = insertText(char);
+      if (!inserted) {
+        setStatus('Focus a text field to insert emoji.');
+        return;
+      }
+      const next = addRecentEmoji(toRecentInput(source, toneToUse, char));
+      setRecents(next);
+      setStatus(`Inserted ${char}`);
+    },
+    [skinTone]
+  );
+
+  const handleCopy = useCallback(
+    async (source: EmojiSource) => {
+      const toneToUse = hasToneVariants(source) ? skinTone : DEFAULT_SKIN_TONE;
+      const char = getEmojiForTone(source, toneToUse);
+      const copied = await copyToClipboard(char);
+      if (!copied) {
+        setStatus('Clipboard access is unavailable.');
+        return;
+      }
+      const next = addRecentEmoji(toRecentInput(source, toneToUse, char));
+      setRecents(next);
+      setStatus(`Copied ${char} to clipboard`);
+    },
+    [skinTone]
+  );
+
+  const handleClearRecents = useCallback(() => {
+    clearRecentEmojis();
+    setRecents([]);
+    setStatus('Cleared recently used emoji.');
+  }, []);
+
+  const handleSearchKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        if (matchingRecents.length > 0) {
+          const recent = matchingRecents[0];
+          const fallback: EmojiSource = {
+            id: recent.id,
+            char: recent.char,
+            name: recent.name,
+            shortcodes: recent.shortcodes,
+            skins: recent.skins,
+          };
+          const source = emojiMap.get(recent.id) ?? fallback;
+          handleInsert(source);
+          return;
+        }
+        const firstCategory = filteredCategories[0];
+        if (firstCategory && firstCategory.items.length > 0) {
+          handleInsert(firstCategory.items[0]);
+        }
+      } else if (event.key === 'Escape') {
+        event.currentTarget.blur();
+      }
+    },
+    [emojiMap, filteredCategories, handleInsert, matchingRecents]
+  );
+
+  const renderTile = useCallback(
+    (source: EmojiSource, key?: React.Key) => {
+      const toneToUse = hasToneVariants(source) ? skinTone : DEFAULT_SKIN_TONE;
+      const char = getEmojiForTone(source, toneToUse);
+      const shortLabel = formatShortcodes(source.shortcodes);
+      return (
+        <div
+          key={key ?? source.id}
+          className="rounded-lg bg-black/30 p-2 transition hover:bg-black/40 focus-within:ring-2 focus-within:ring-blue-500"
+        >
+          <button
+            type="button"
+            onClick={() => handleInsert(source)}
+            title={shortLabel ? `${source.name} ${shortLabel}` : source.name}
+            className="flex w-full flex-col items-center gap-1 text-center"
+          >
+            <span className="text-3xl" aria-hidden="true">
+              {char}
+            </span>
+            <span className="text-[11px] leading-snug text-gray-200">
+              {source.name}
+            </span>
+          </button>
+          <div className="mt-2 flex items-center justify-between text-[11px] text-gray-400">
+            <span className="truncate" title={shortLabel}>
+              {shortLabel}
+            </span>
+            <button
+              type="button"
+              onClick={() => {
+                void handleCopy(source);
+              }}
+              className="rounded px-1 py-0.5 text-gray-300 hover:text-white focus-visible:outline focus-visible:outline-1 focus-visible:outline-white"
+            >
+              Copy
+            </button>
+          </div>
+        </div>
+      );
+    },
+    [handleCopy, handleInsert, skinTone]
+  );
+
+  const hasResults =
+    matchingRecents.length > 0 || filteredCategories.some((category) => category.items.length > 0);
+
+  return (
+    <div
+      {...BRIDGE_IGNORE_ATTRIBUTE}
+      className="flex h-full flex-col bg-ub-cool-grey text-white"
+    >
+      <header className="space-y-3 border-b border-black/30 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h1 className="text-lg font-semibold">Emoji Picker</h1>
+          <span className="text-xs text-gray-300">
+            {target
+              ? `Active field: ${target.label}`
+              : 'Focus a text field to enable direct insert.'}
+          </span>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <input
+            ref={searchRef}
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleSearchKeyDown}
+            placeholder="Search by name or :shortcode:"
+            className="min-w-[200px] flex-1 rounded-md bg-black/30 px-3 py-2 text-sm text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <div className="flex items-center gap-1">
+            {SKIN_TONE_OPTIONS.map((tone) => {
+              const active = tone.id === skinTone;
+              return (
+                <button
+                  key={tone.id}
+                  type="button"
+                  onClick={() => handleSkinToneChange(tone.id)}
+                  className={`flex h-10 w-10 items-center justify-center rounded-md border transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 ${
+                    active
+                      ? 'border-blue-400 bg-black/40'
+                      : 'border-transparent bg-black/20 hover:border-blue-300'
+                  }`}
+                  aria-pressed={active}
+                  aria-label={`Use ${tone.label} skin tone`}
+                >
+                  <span aria-hidden="true" className="text-xl">
+                    {tone.sample}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+        {status ? <p className="text-xs text-gray-300">{status}</p> : null}
+      </header>
+      <main className="flex-1 space-y-6 overflow-y-auto p-4">
+        {matchingRecents.length > 0 && (
+          <section>
+            <div className="mb-2 flex items-center justify-between text-xs uppercase tracking-wider text-gray-300">
+              <h2 className="font-semibold text-gray-200">Recents</h2>
+              <button
+                type="button"
+                onClick={handleClearRecents}
+                className="rounded px-2 py-1 text-[11px] text-gray-400 hover:bg-black/30 hover:text-white"
+              >
+                Clear
+              </button>
+            </div>
+            <div className={GRID_TEMPLATE}>
+              {matchingRecents.map((recent) => {
+                const fallback: EmojiSource = {
+                  id: recent.id,
+                  char: recent.char,
+                  name: recent.name,
+                  shortcodes: recent.shortcodes,
+                  skins: recent.skins,
+                };
+                const source = emojiMap.get(recent.id) ?? fallback;
+                return renderTile(source, `recent-${recent.id}`);
+              })}
+            </div>
+          </section>
+        )}
+        {filteredCategories.map((category) => (
+          <section key={category.id} className="space-y-2">
+            <div className="flex items-center justify-between text-xs uppercase tracking-wider text-gray-300">
+              <h2 className="font-semibold text-gray-200">{category.label}</h2>
+              <span className="text-[11px] text-gray-400">{category.items.length}</span>
+            </div>
+            <div className={GRID_TEMPLATE}>
+              {category.items.map((item) => renderTile(item))}
+            </div>
+          </section>
+        ))}
+        {!hasResults && (
+          <p className="text-center text-sm text-gray-300">
+            No emoji matched “{query.trim()}”.
+          </p>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default Picker;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -23,6 +23,7 @@ import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { useSnapSetting } from '../../hooks/usePersistentState';
+import { ensureInputBridge } from '../../modules/desktop/inputBridge';
 
 export class Desktop extends Component {
     constructor() {
@@ -58,6 +59,8 @@ export class Desktop extends Component {
     componentDidMount() {
         // google analytics
         ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+
+        ensureInputBridge();
 
         this.fetchAppsData(() => {
             const session = this.props.session || {};
@@ -155,6 +158,9 @@ export class Desktop extends Component {
         } else if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'v') {
             e.preventDefault();
             this.openApp('clipboard-manager');
+        } else if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && e.key === '.') {
+            e.preventDefault();
+            this.openApp('emoji-picker');
         }
         else if (e.altKey && e.key === 'Tab') {
             e.preventDefault();

--- a/data/emoji.json
+++ b/data/emoji.json
@@ -1,0 +1,634 @@
+{
+  "categories": [
+    {
+      "id": "smileys",
+      "label": "Smileys & Emotion",
+      "items": [
+        {
+          "id": "grinning_face",
+          "char": "😀",
+          "name": "Grinning face",
+          "shortcodes": ["grinning"],
+          "keywords": ["happy", "smile", "joy"]
+        },
+        {
+          "id": "beaming_face_with_smiling_eyes",
+          "char": "😁",
+          "name": "Beaming face with smiling eyes",
+          "shortcodes": ["grin"],
+          "keywords": ["happy", "beaming", "smile"]
+        },
+        {
+          "id": "face_with_tears_of_joy",
+          "char": "😂",
+          "name": "Face with tears of joy",
+          "shortcodes": ["joy"],
+          "keywords": ["lol", "cry", "tears"]
+        },
+        {
+          "id": "rolling_on_the_floor_laughing",
+          "char": "🤣",
+          "name": "Rolling on the floor laughing",
+          "shortcodes": ["rofl"],
+          "keywords": ["laugh", "rolling", "happy"]
+        },
+        {
+          "id": "smiling_face_with_smiling_eyes",
+          "char": "😊",
+          "name": "Smiling face with smiling eyes",
+          "shortcodes": ["blush"],
+          "keywords": ["smile", "blush", "warm"]
+        },
+        {
+          "id": "smiling_face_with_heart_eyes",
+          "char": "😍",
+          "name": "Smiling face with heart-eyes",
+          "shortcodes": ["heart_eyes"],
+          "keywords": ["love", "hearts", "smile"]
+        },
+        {
+          "id": "face_blowing_a_kiss",
+          "char": "😘",
+          "name": "Face blowing a kiss",
+          "shortcodes": ["kissing_heart"],
+          "keywords": ["kiss", "affection", "love"]
+        },
+        {
+          "id": "smiling_face_with_sunglasses",
+          "char": "😎",
+          "name": "Smiling face with sunglasses",
+          "shortcodes": ["sunglasses"],
+          "keywords": ["cool", "smile", "shades"]
+        },
+        {
+          "id": "thinking_face",
+          "char": "🤔",
+          "name": "Thinking face",
+          "shortcodes": ["thinking"],
+          "keywords": ["ponder", "hmm", "consider"]
+        },
+        {
+          "id": "pleading_face",
+          "char": "🥺",
+          "name": "Pleading face",
+          "shortcodes": ["pleading_face"],
+          "keywords": ["please", "begging", "sad"]
+        }
+      ]
+    },
+    {
+      "id": "people",
+      "label": "People & Body",
+      "items": [
+        {
+          "id": "waving_hand",
+          "char": "👋",
+          "name": "Waving hand",
+          "shortcodes": ["wave"],
+          "keywords": ["hello", "goodbye", "hi"],
+          "skins": ["👋", "👋🏻", "👋🏼", "👋🏽", "👋🏾", "👋🏿"]
+        },
+        {
+          "id": "thumbs_up",
+          "char": "👍",
+          "name": "Thumbs up",
+          "shortcodes": ["+1", "thumbsup"],
+          "keywords": ["approve", "ok", "like"],
+          "skins": ["👍", "👍🏻", "👍🏼", "👍🏽", "👍🏾", "👍🏿"]
+        },
+        {
+          "id": "thumbs_down",
+          "char": "👎",
+          "name": "Thumbs down",
+          "shortcodes": ["-1", "thumbsdown"],
+          "keywords": ["disapprove", "no", "dislike"],
+          "skins": ["👎", "👎🏻", "👎🏼", "👎🏽", "👎🏾", "👎🏿"]
+        },
+        {
+          "id": "clapping_hands",
+          "char": "👏",
+          "name": "Clapping hands",
+          "shortcodes": ["clap"],
+          "keywords": ["applause", "praise", "bravo"],
+          "skins": ["👏", "👏🏻", "👏🏼", "👏🏽", "👏🏾", "👏🏿"]
+        },
+        {
+          "id": "folded_hands",
+          "char": "🙏",
+          "name": "Folded hands",
+          "shortcodes": ["pray", "please"],
+          "keywords": ["thanks", "request", "hope"],
+          "skins": ["🙏", "🙏🏻", "🙏🏼", "🙏🏽", "🙏🏾", "🙏🏿"]
+        },
+        {
+          "id": "ok_hand",
+          "char": "👌",
+          "name": "OK hand",
+          "shortcodes": ["ok_hand"],
+          "keywords": ["agree", "perfect", "ok"],
+          "skins": ["👌", "👌🏻", "👌🏼", "👌🏽", "👌🏾", "👌🏿"]
+        },
+        {
+          "id": "raised_fist",
+          "char": "✊",
+          "name": "Raised fist",
+          "shortcodes": ["fist"],
+          "keywords": ["power", "solidarity", "resist"],
+          "skins": ["✊", "✊🏻", "✊🏼", "✊🏽", "✊🏾", "✊🏿"]
+        },
+        {
+          "id": "victory_hand",
+          "char": "✌️",
+          "name": "Victory hand",
+          "shortcodes": ["v"],
+          "keywords": ["peace", "victory", "hand"],
+          "skins": ["✌️", "✌🏻", "✌🏼", "✌🏽", "✌🏾", "✌🏿"]
+        }
+      ]
+    },
+    {
+      "id": "animals",
+      "label": "Animals & Nature",
+      "items": [
+        {
+          "id": "dog_face",
+          "char": "🐶",
+          "name": "Dog face",
+          "shortcodes": ["dog"],
+          "keywords": ["pet", "puppy", "animal"]
+        },
+        {
+          "id": "cat_face",
+          "char": "🐱",
+          "name": "Cat face",
+          "shortcodes": ["cat"],
+          "keywords": ["kitten", "pet", "animal"]
+        },
+        {
+          "id": "monkey_face",
+          "char": "🐵",
+          "name": "Monkey face",
+          "shortcodes": ["monkey"],
+          "keywords": ["playful", "animal", "cheeky"]
+        },
+        {
+          "id": "panda_face",
+          "char": "🐼",
+          "name": "Panda face",
+          "shortcodes": ["panda_face"],
+          "keywords": ["bear", "bamboo", "animal"]
+        },
+        {
+          "id": "fox_face",
+          "char": "🦊",
+          "name": "Fox face",
+          "shortcodes": ["fox_face"],
+          "keywords": ["cunning", "animal", "wild"]
+        },
+        {
+          "id": "lion_face",
+          "char": "🦁",
+          "name": "Lion face",
+          "shortcodes": ["lion"],
+          "keywords": ["king", "animal", "wild"]
+        },
+        {
+          "id": "unicorn_face",
+          "char": "🦄",
+          "name": "Unicorn face",
+          "shortcodes": ["unicorn"],
+          "keywords": ["myth", "magical", "fantasy"]
+        },
+        {
+          "id": "koala",
+          "char": "🐨",
+          "name": "Koala",
+          "shortcodes": ["koala"],
+          "keywords": ["bear", "australia", "animal"]
+        },
+        {
+          "id": "butterfly",
+          "char": "🦋",
+          "name": "Butterfly",
+          "shortcodes": ["butterfly"],
+          "keywords": ["insect", "nature", "wings"]
+        },
+        {
+          "id": "hatching_chick",
+          "char": "🐣",
+          "name": "Hatching chick",
+          "shortcodes": ["hatching_chick"],
+          "keywords": ["bird", "easter", "baby"]
+        }
+      ]
+    },
+    {
+      "id": "food",
+      "label": "Food & Drink",
+      "items": [
+        {
+          "id": "red_apple",
+          "char": "🍎",
+          "name": "Red apple",
+          "shortcodes": ["apple"],
+          "keywords": ["fruit", "healthy", "food"]
+        },
+        {
+          "id": "green_apple",
+          "char": "🍏",
+          "name": "Green apple",
+          "shortcodes": ["green_apple"],
+          "keywords": ["fruit", "sour", "food"]
+        },
+        {
+          "id": "avocado",
+          "char": "🥑",
+          "name": "Avocado",
+          "shortcodes": ["avocado"],
+          "keywords": ["fruit", "toast", "healthy"]
+        },
+        {
+          "id": "pizza",
+          "char": "🍕",
+          "name": "Slice of pizza",
+          "shortcodes": ["pizza"],
+          "keywords": ["slice", "cheese", "food"]
+        },
+        {
+          "id": "hamburger",
+          "char": "🍔",
+          "name": "Hamburger",
+          "shortcodes": ["hamburger"],
+          "keywords": ["burger", "fast", "food"]
+        },
+        {
+          "id": "taco",
+          "char": "🌮",
+          "name": "Taco",
+          "shortcodes": ["taco"],
+          "keywords": ["mexican", "food", "spicy"]
+        },
+        {
+          "id": "sushi",
+          "char": "🍣",
+          "name": "Sushi",
+          "shortcodes": ["sushi"],
+          "keywords": ["fish", "roll", "japanese"]
+        },
+        {
+          "id": "birthday_cake",
+          "char": "🎂",
+          "name": "Birthday cake",
+          "shortcodes": ["birthday"],
+          "keywords": ["dessert", "celebrate", "cake"]
+        },
+        {
+          "id": "hot_beverage",
+          "char": "☕",
+          "name": "Hot beverage",
+          "shortcodes": ["coffee"],
+          "keywords": ["tea", "espresso", "drink"]
+        },
+        {
+          "id": "bubble_tea",
+          "char": "🧋",
+          "name": "Bubble tea",
+          "shortcodes": ["bubble_tea"],
+          "keywords": ["drink", "boba", "milk"]
+        }
+      ]
+    },
+    {
+      "id": "activities",
+      "label": "Activities & Entertainment",
+      "items": [
+        {
+          "id": "soccer_ball",
+          "char": "⚽",
+          "name": "Soccer ball",
+          "shortcodes": ["soccer"],
+          "keywords": ["sports", "football", "game"]
+        },
+        {
+          "id": "basketball",
+          "char": "🏀",
+          "name": "Basketball",
+          "shortcodes": ["basketball"],
+          "keywords": ["sports", "game", "hoop"]
+        },
+        {
+          "id": "trophy",
+          "char": "🏆",
+          "name": "Trophy",
+          "shortcodes": ["trophy"],
+          "keywords": ["award", "win", "prize"]
+        },
+        {
+          "id": "musical_keyboard",
+          "char": "🎹",
+          "name": "Musical keyboard",
+          "shortcodes": ["musical_keyboard"],
+          "keywords": ["music", "piano", "instrument"]
+        },
+        {
+          "id": "video_game",
+          "char": "🎮",
+          "name": "Video game",
+          "shortcodes": ["video_game"],
+          "keywords": ["controller", "gaming", "play"]
+        },
+        {
+          "id": "joystick",
+          "char": "🕹️",
+          "name": "Joystick",
+          "shortcodes": ["joystick"],
+          "keywords": ["retro", "arcade", "game"]
+        },
+        {
+          "id": "performing_arts",
+          "char": "🎭",
+          "name": "Performing arts",
+          "shortcodes": ["performing_arts"],
+          "keywords": ["theater", "mask", "stage"]
+        },
+        {
+          "id": "artist_palette",
+          "char": "🎨",
+          "name": "Artist palette",
+          "shortcodes": ["art"],
+          "keywords": ["paint", "creative", "color"]
+        },
+        {
+          "id": "headphone",
+          "char": "🎧",
+          "name": "Headphone",
+          "shortcodes": ["headphones"],
+          "keywords": ["music", "listen", "audio"]
+        },
+        {
+          "id": "microphone",
+          "char": "🎤",
+          "name": "Microphone",
+          "shortcodes": ["microphone"],
+          "keywords": ["sing", "karaoke", "audio"]
+        }
+      ]
+    },
+    {
+      "id": "travel",
+      "label": "Travel & Places",
+      "items": [
+        {
+          "id": "automobile",
+          "char": "🚗",
+          "name": "Automobile",
+          "shortcodes": ["car"],
+          "keywords": ["drive", "vehicle", "road"]
+        },
+        {
+          "id": "bus",
+          "char": "🚌",
+          "name": "Bus",
+          "shortcodes": ["bus"],
+          "keywords": ["transit", "vehicle", "ride"]
+        },
+        {
+          "id": "police_car",
+          "char": "🚓",
+          "name": "Police car",
+          "shortcodes": ["police_car"],
+          "keywords": ["law", "vehicle", "sirens"]
+        },
+        {
+          "id": "train",
+          "char": "🚆",
+          "name": "Train",
+          "shortcodes": ["train"],
+          "keywords": ["rail", "transport", "vehicle"]
+        },
+        {
+          "id": "airplane",
+          "char": "✈️",
+          "name": "Airplane",
+          "shortcodes": ["airplane"],
+          "keywords": ["fly", "plane", "travel"]
+        },
+        {
+          "id": "rocket",
+          "char": "🚀",
+          "name": "Rocket",
+          "shortcodes": ["rocket"],
+          "keywords": ["space", "launch", "ship"]
+        },
+        {
+          "id": "sailboat",
+          "char": "⛵",
+          "name": "Sailboat",
+          "shortcodes": ["sailboat"],
+          "keywords": ["boat", "sail", "water"]
+        },
+        {
+          "id": "bicycle",
+          "char": "🚲",
+          "name": "Bicycle",
+          "shortcodes": ["bike"],
+          "keywords": ["ride", "cycle", "transport"]
+        },
+        {
+          "id": "camping",
+          "char": "🏕️",
+          "name": "Camping",
+          "shortcodes": ["camping"],
+          "keywords": ["tent", "outdoors", "night"]
+        },
+        {
+          "id": "earth_globe_europe_africa",
+          "char": "🌍",
+          "name": "Globe showing Europe-Africa",
+          "shortcodes": ["earth_africa"],
+          "keywords": ["planet", "world", "global"]
+        }
+      ]
+    },
+    {
+      "id": "objects",
+      "label": "Objects",
+      "items": [
+        {
+          "id": "light_bulb",
+          "char": "💡",
+          "name": "Light bulb",
+          "shortcodes": ["bulb"],
+          "keywords": ["idea", "bright", "energy"]
+        },
+        {
+          "id": "laptop",
+          "char": "💻",
+          "name": "Laptop",
+          "shortcodes": ["computer"],
+          "keywords": ["work", "technology", "pc"]
+        },
+        {
+          "id": "desktop_computer",
+          "char": "🖥️",
+          "name": "Desktop computer",
+          "shortcodes": ["desktop_computer"],
+          "keywords": ["pc", "workstation", "screen"]
+        },
+        {
+          "id": "keyboard",
+          "char": "⌨️",
+          "name": "Keyboard",
+          "shortcodes": ["keyboard"],
+          "keywords": ["typing", "keys", "input"]
+        },
+        {
+          "id": "mobile_phone",
+          "char": "📱",
+          "name": "Mobile phone",
+          "shortcodes": ["iphone"],
+          "keywords": ["smartphone", "call", "device"]
+        },
+        {
+          "id": "battery",
+          "char": "🔋",
+          "name": "Battery",
+          "shortcodes": ["battery"],
+          "keywords": ["power", "charge", "energy"]
+        },
+        {
+          "id": "package",
+          "char": "📦",
+          "name": "Package",
+          "shortcodes": ["package"],
+          "keywords": ["delivery", "box", "mail"]
+        },
+        {
+          "id": "gear",
+          "char": "⚙️",
+          "name": "Gear",
+          "shortcodes": ["gear"],
+          "keywords": ["settings", "cog", "mechanical"]
+        },
+        {
+          "id": "hammer_and_wrench",
+          "char": "🛠️",
+          "name": "Hammer and wrench",
+          "shortcodes": ["hammer_and_wrench"],
+          "keywords": ["tools", "fix", "build"]
+        },
+        {
+          "id": "magnet",
+          "char": "🧲",
+          "name": "Magnet",
+          "shortcodes": ["magnet"],
+          "keywords": ["attract", "magnetic", "force"]
+        }
+      ]
+    },
+    {
+      "id": "symbols",
+      "label": "Symbols",
+      "items": [
+        {
+          "id": "red_heart",
+          "char": "❤️",
+          "name": "Red heart",
+          "shortcodes": ["heart"],
+          "keywords": ["love", "like", "affection"]
+        },
+        {
+          "id": "orange_heart",
+          "char": "🧡",
+          "name": "Orange heart",
+          "shortcodes": ["orange_heart"],
+          "keywords": ["heart", "love", "warm"]
+        },
+        {
+          "id": "yellow_heart",
+          "char": "💛",
+          "name": "Yellow heart",
+          "shortcodes": ["yellow_heart"],
+          "keywords": ["friendship", "heart", "bright"]
+        },
+        {
+          "id": "green_heart",
+          "char": "💚",
+          "name": "Green heart",
+          "shortcodes": ["green_heart"],
+          "keywords": ["eco", "heart", "support"]
+        },
+        {
+          "id": "blue_heart",
+          "char": "💙",
+          "name": "Blue heart",
+          "shortcodes": ["blue_heart"],
+          "keywords": ["trust", "heart", "calm"]
+        },
+        {
+          "id": "purple_heart",
+          "char": "💜",
+          "name": "Purple heart",
+          "shortcodes": ["purple_heart"],
+          "keywords": ["love", "heart", "care"]
+        },
+        {
+          "id": "sparkles",
+          "char": "✨",
+          "name": "Sparkles",
+          "shortcodes": ["sparkles"],
+          "keywords": ["shine", "magic", "glitter"]
+        },
+        {
+          "id": "collision",
+          "char": "💥",
+          "name": "Collision",
+          "shortcodes": ["boom"],
+          "keywords": ["explosion", "impact", "pow"]
+        },
+        {
+          "id": "warning",
+          "char": "⚠️",
+          "name": "Warning",
+          "shortcodes": ["warning"],
+          "keywords": ["alert", "danger", "sign"]
+        },
+        {
+          "id": "check_mark_button",
+          "char": "✅",
+          "name": "Check mark button",
+          "shortcodes": ["white_check_mark"],
+          "keywords": ["confirm", "check", "done"]
+        },
+        {
+          "id": "cross_mark",
+          "char": "❌",
+          "name": "Cross mark",
+          "shortcodes": ["x"],
+          "keywords": ["cancel", "close", "incorrect"]
+        },
+        {
+          "id": "recycling_symbol",
+          "char": "♻️",
+          "name": "Recycling symbol",
+          "shortcodes": ["recycle"],
+          "keywords": ["green", "reuse", "cycle"]
+        },
+        {
+          "id": "yin_yang",
+          "char": "☯️",
+          "name": "Yin yang",
+          "shortcodes": ["yin_yang"],
+          "keywords": ["balance", "tao", "symbol"]
+        },
+        {
+          "id": "infinity",
+          "char": "♾️",
+          "name": "Infinity",
+          "shortcodes": ["infinity"],
+          "keywords": ["forever", "loop", "symbol"]
+        }
+      ]
+    }
+  ]
+}

--- a/modules/desktop/inputBridge.ts
+++ b/modules/desktop/inputBridge.ts
@@ -1,0 +1,280 @@
+const INPUT_BRIDGE_IGNORE_ATTRIBUTE = 'data-input-bridge-ignore';
+
+export type BridgeTargetType = 'input' | 'textarea' | 'contenteditable';
+
+export interface InputTargetSnapshot {
+  type: BridgeTargetType;
+  label: string;
+}
+
+type InputLikeElement = HTMLInputElement | HTMLTextAreaElement;
+type EditableElement = InputLikeElement | HTMLElement;
+
+interface StoredTarget {
+  element: EditableElement;
+  type: BridgeTargetType;
+  label: string;
+  selectionStart?: number;
+  selectionEnd?: number;
+  selectionDirection?: 'forward' | 'backward' | 'none';
+  range?: Range | null;
+}
+
+type Subscriber = (target: InputTargetSnapshot | null) => void;
+
+let listenersAttached = false;
+let currentTarget: StoredTarget | null = null;
+const subscribers = new Set<Subscriber>();
+
+const isInputElement = (element: Element): element is HTMLInputElement =>
+  element.tagName === 'INPUT';
+
+const isTextareaElement = (element: Element): element is HTMLTextAreaElement =>
+  element.tagName === 'TEXTAREA';
+
+const isContentEditableElement = (element: Element): element is HTMLElement =>
+  (element as HTMLElement).isContentEditable;
+
+const isEditableElement = (
+  element: Element | null
+): element is EditableElement => {
+  if (!element) return false;
+  return (
+    isInputElement(element) ||
+    isTextareaElement(element) ||
+    isContentEditableElement(element)
+  );
+};
+
+const isIgnoredElement = (element: Element | null) =>
+  !!element?.closest(`[${INPUT_BRIDGE_IGNORE_ATTRIBUTE}]`);
+
+const computeType = (element: EditableElement): BridgeTargetType => {
+  if (isTextareaElement(element)) return 'textarea';
+  if (isInputElement(element)) return 'input';
+  return 'contenteditable';
+};
+
+const computeLabel = (element: EditableElement): string => {
+  if (isInputElement(element) || isTextareaElement(element)) {
+    const label =
+      element.getAttribute('aria-label') ||
+      element.placeholder ||
+      element.name ||
+      element.id;
+    if (label && label.trim().length > 0) return label;
+    return isTextareaElement(element) ? 'text area' : 'input field';
+  }
+
+  const label =
+    element.getAttribute('aria-label') ||
+    element.getAttribute('data-placeholder') ||
+    element.getAttribute('placeholder') ||
+    element.id;
+  if (label && label.trim().length > 0) return label;
+  return 'content editable region';
+};
+
+const cloneRange = (range: Range | null | undefined) =>
+  range ? range.cloneRange() : null;
+
+const notifySubscribers = () => {
+  const snapshot =
+    currentTarget && currentTarget.element.isConnected
+      ? { type: currentTarget.type, label: currentTarget.label }
+      : null;
+  subscribers.forEach((cb) => cb(snapshot));
+};
+
+const captureSelection = (element: EditableElement) => {
+  if (!currentTarget || currentTarget.element !== element) return;
+  if (isInputElement(element) || isTextareaElement(element)) {
+    currentTarget.selectionStart = element.selectionStart ?? element.value.length;
+    currentTarget.selectionEnd = element.selectionEnd ?? element.value.length;
+    currentTarget.selectionDirection = element.selectionDirection ?? 'none';
+    return;
+  }
+
+  if (typeof window === 'undefined') return;
+  const selection = window.getSelection();
+  if (selection && selection.rangeCount > 0) {
+    currentTarget.range = cloneRange(selection.getRangeAt(0));
+  } else {
+    currentTarget.range = null;
+  }
+};
+
+const setTarget = (element: EditableElement) => {
+  currentTarget = {
+    element,
+    type: computeType(element),
+    label: computeLabel(element),
+  };
+  captureSelection(element);
+  notifySubscribers();
+};
+
+const clearTargetIfDetached = () => {
+  if (currentTarget && !currentTarget.element.isConnected) {
+    currentTarget = null;
+    notifySubscribers();
+  }
+};
+
+const captureActiveSelection = () => {
+  if (typeof document === 'undefined') return;
+  const active = document.activeElement;
+  if (!active || !isEditableElement(active) || isIgnoredElement(active)) {
+    clearTargetIfDetached();
+    return;
+  }
+  if (!currentTarget || currentTarget.element !== active) {
+    setTarget(active);
+  } else {
+    captureSelection(active);
+  }
+};
+
+const handleFocusIn = (event: FocusEvent) => {
+  const target = event.target as Element | null;
+  if (!isEditableElement(target) || isIgnoredElement(target)) {
+    return;
+  }
+  setTarget(target);
+};
+
+const ensureListeners = () => {
+  if (listenersAttached || typeof document === 'undefined') return;
+  document.addEventListener('focusin', handleFocusIn, true);
+  document.addEventListener('selectionchange', captureActiveSelection);
+  document.addEventListener('keyup', captureActiveSelection, true);
+  document.addEventListener('mouseup', captureActiveSelection, true);
+  listenersAttached = true;
+
+  captureActiveSelection();
+};
+
+export const ensureInputBridge = () => {
+  ensureListeners();
+};
+
+export const subscribeToInputTarget = (
+  subscriber: Subscriber
+): (() => void) => {
+  ensureListeners();
+  subscribers.add(subscriber);
+  subscriber(
+    currentTarget && currentTarget.element.isConnected
+      ? { type: currentTarget.type, label: currentTarget.label }
+      : null
+  );
+  return () => {
+    subscribers.delete(subscriber);
+  };
+};
+
+export const insertText = (text: string): boolean => {
+  ensureListeners();
+  if (!currentTarget) return false;
+  const { element } = currentTarget;
+  if (!element.isConnected) {
+    currentTarget = null;
+    notifySubscribers();
+    return false;
+  }
+
+  if (isInputElement(element) || isTextareaElement(element)) {
+    element.focus();
+    const start = currentTarget.selectionStart ?? element.value.length;
+    const end = currentTarget.selectionEnd ?? element.value.length;
+    const prefix = element.value.slice(0, start);
+    const suffix = element.value.slice(end);
+    element.value = `${prefix}${text}${suffix}`;
+    const caret = start + text.length;
+    element.setSelectionRange(caret, caret, currentTarget.selectionDirection);
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+    captureSelection(element);
+    return true;
+  }
+
+  if (typeof document === 'undefined') return false;
+  const editable = element as HTMLElement;
+  editable.focus();
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  let range = cloneRange(currentTarget.range);
+  if (!range) {
+    range = document.createRange();
+    range.selectNodeContents(editable);
+    range.collapse(false);
+  }
+  selection?.addRange(range);
+
+  let inserted = false;
+  try {
+    inserted = document.execCommand('insertText', false, text);
+  } catch (err) {
+    inserted = false;
+  }
+
+  if (!inserted && range) {
+    range.deleteContents();
+    range.insertNode(document.createTextNode(text));
+    selection?.collapseToEnd();
+    inserted = true;
+  }
+
+  if (inserted) {
+    captureSelection(editable);
+  }
+  return inserted;
+};
+
+export const focusLastTarget = (): boolean => {
+  ensureListeners();
+  if (!currentTarget) return false;
+  const { element } = currentTarget;
+  if (!element.isConnected) {
+    currentTarget = null;
+    notifySubscribers();
+    return false;
+  }
+
+  element.focus();
+  if (isInputElement(element) || isTextareaElement(element)) {
+    const position =
+      currentTarget.selectionEnd ??
+      currentTarget.selectionStart ??
+      element.value.length;
+    element.setSelectionRange(position, position, currentTarget.selectionDirection);
+    return true;
+  }
+
+  if (typeof document === 'undefined') return false;
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  const range = cloneRange(currentTarget.range);
+  if (range) {
+    selection?.addRange(range);
+  } else {
+    const fallback = document.createRange();
+    fallback.selectNodeContents(element);
+    fallback.collapse(false);
+    selection?.addRange(fallback);
+  }
+  return true;
+};
+
+export const hasEditableTarget = (): boolean => {
+  ensureListeners();
+  return !!(currentTarget && currentTarget.element.isConnected);
+};
+
+export const getInputTargetSnapshot = (): InputTargetSnapshot | null => {
+  ensureListeners();
+  return currentTarget && currentTarget.element.isConnected
+    ? { type: currentTarget.type, label: currentTarget.label }
+    : null;
+};
+
+export { INPUT_BRIDGE_IGNORE_ATTRIBUTE };

--- a/public/themes/Yaru/apps/emoji-picker.svg
+++ b/public/themes/Yaru/apps/emoji-picker.svg
@@ -1,0 +1,24 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title>Emoji Picker Icon</title>
+  <rect width="64" height="64" rx="12" fill="#1f2937" />
+  <circle cx="32" cy="32" r="22" fill="#facc15" />
+  <circle cx="24" cy="28" r="4" fill="#111827" />
+  <circle cx="40" cy="28" r="4" fill="#111827" />
+  <path
+    d="M20 38c3.2 5.6 7.6 8.5 12 8.5s8.8-2.9 12-8.5"
+    fill="none"
+    stroke="#111827"
+    stroke-width="3"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M16 46c4.6 6 10 9 16 9s11.4-3 16-9"
+    fill="none"
+    stroke="#f59e0b"
+    stroke-width="2"
+    stroke-linecap="round"
+  />
+  <circle cx="21" cy="18" r="4" fill="#f97316" opacity="0.4" />
+  <circle cx="45" cy="16" r="5" fill="#fb7185" opacity="0.45" />
+</svg>

--- a/utils/settings/emoji.ts
+++ b/utils/settings/emoji.ts
@@ -1,0 +1,115 @@
+import { safeLocalStorage } from '../safeStorage';
+
+export const SKIN_TONE_OPTIONS = [
+  { id: 'default', label: 'Default', sample: '👍' },
+  { id: 'light', label: 'Light', sample: '👍🏻' },
+  { id: 'medium-light', label: 'Medium-Light', sample: '👍🏼' },
+  { id: 'medium', label: 'Medium', sample: '👍🏽' },
+  { id: 'medium-dark', label: 'Medium-Dark', sample: '👍🏾' },
+  { id: 'dark', label: 'Dark', sample: '👍🏿' },
+] as const;
+
+export type SkinTone = (typeof SKIN_TONE_OPTIONS)[number]['id'];
+
+export const DEFAULT_SKIN_TONE: SkinTone = 'default';
+
+const SKIN_TONE_KEY = 'emoji-skin-tone';
+const RECENTS_KEY = 'emoji-recents';
+export const MAX_RECENT_EMOJIS = 24;
+
+export interface EmojiRecent {
+  id: string;
+  char: string;
+  name: string;
+  shortcodes: string[];
+  skinTone: SkinTone;
+  skins?: string[];
+  updatedAt: number;
+}
+
+export type RecentEmojiInput = Omit<EmojiRecent, 'updatedAt'>;
+
+const isSkinTone = (value: unknown): value is SkinTone =>
+  typeof value === 'string' &&
+  SKIN_TONE_OPTIONS.some((option) => option.id === value);
+
+const parseRecents = (raw: string | null): EmojiRecent[] => {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed
+      .map((item) => {
+        if (!item || typeof item !== 'object') return null;
+        const {
+          id,
+          char,
+          name,
+          shortcodes,
+          skinTone,
+          skins,
+          updatedAt,
+        } = item as Partial<EmojiRecent> & { shortcodes?: unknown };
+
+        if (typeof id !== 'string' || typeof char !== 'string' || typeof name !== 'string') {
+          return null;
+        }
+        if (
+          !Array.isArray(shortcodes) ||
+          !shortcodes.every((code) => typeof code === 'string')
+        ) {
+          return null;
+        }
+        if (!isSkinTone(skinTone)) return null;
+
+        const validSkins = Array.isArray(skins)
+          ? skins.filter((value): value is string => typeof value === 'string')
+          : undefined;
+        const timestamp = typeof updatedAt === 'number' ? updatedAt : 0;
+
+        return {
+          id,
+          char,
+          name,
+          shortcodes,
+          skinTone,
+          skins: validSkins,
+          updatedAt: timestamp,
+        };
+      })
+      .filter((value): value is EmojiRecent => Boolean(value))
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+  } catch {
+    return [];
+  }
+};
+
+export const getPreferredSkinTone = (): SkinTone => {
+  const stored = safeLocalStorage?.getItem(SKIN_TONE_KEY);
+  if (isSkinTone(stored)) return stored;
+  return DEFAULT_SKIN_TONE;
+};
+
+export const setPreferredSkinTone = (tone: SkinTone) => {
+  if (!safeLocalStorage) return;
+  safeLocalStorage.setItem(SKIN_TONE_KEY, tone);
+};
+
+export const getRecentEmojis = (): EmojiRecent[] => {
+  if (!safeLocalStorage) return [];
+  return parseRecents(safeLocalStorage.getItem(RECENTS_KEY));
+};
+
+export const addRecentEmoji = (recent: RecentEmojiInput): EmojiRecent[] => {
+  const entry: EmojiRecent = { ...recent, updatedAt: Date.now() };
+  const existing = getRecentEmojis();
+  const filtered = existing.filter((item) => item.id !== entry.id);
+  const next = [entry, ...filtered].slice(0, MAX_RECENT_EMOJIS);
+  safeLocalStorage?.setItem(RECENTS_KEY, JSON.stringify(next));
+  return next;
+};
+
+export const clearRecentEmojis = () => {
+  safeLocalStorage?.removeItem?.(RECENTS_KEY);
+};


### PR DESCRIPTION
## Summary
- add an emoji picker overlay component with search, tone selection, recents, and clipboard actions
- bundle a local emoji dataset plus settings helpers for skin tone and recently used emoji
- register the picker in the desktop shell with a Ctrl+. shortcut, dedicated icon, and input bridge support

## Testing
- yarn lint *(fails: existing jsx-a11y/no-top-level-window violations in unrelated apps)*
- yarn test *(fails: existing window/nmap/modal test failures; Jest left in watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_68cb466b77f083288b32223e7750ff3d