### PR TITLE
[focus] add focus scheduling and notification bundling

### DIFF
--- a/components/apps/notifications/SummaryBundleCard.tsx
+++ b/components/apps/notifications/SummaryBundleCard.tsx
@@ -1,0 +1,85 @@
+import React, { useMemo } from 'react';
+import apps from '../../../apps.config';
+import { NotificationAction, SummaryBundle } from './types';
+
+const appLookup = new Map(apps.map(app => [app.id, app]));
+
+interface SummaryBundleCardProps {
+  bundle: SummaryBundle;
+  onClear?: (bundleId: string) => void;
+}
+
+const SummaryBundleCard: React.FC<SummaryBundleCardProps> = ({ bundle, onClear }) => {
+  const appMeta = appLookup.get(bundle.appId);
+  const title = appMeta?.title ?? bundle.appId;
+  const icon = appMeta?.icon;
+
+  const previewMessages = useMemo(() => {
+    if (bundle.messages.length <= 3) return bundle.messages;
+    return bundle.messages.slice(0, 3);
+  }, [bundle.messages]);
+
+  const remaining = bundle.messages.length - previewMessages.length;
+
+  const handleAction = (action: NotificationAction) => {
+    action.handler();
+    onClear?.(bundle.id);
+  };
+
+  return (
+    <div className="max-w-sm min-w-[260px] overflow-hidden rounded-md border border-gray-700 bg-black/80 text-white shadow-xl backdrop-blur">
+      <div className="flex items-center gap-3 border-b border-gray-700 px-3 py-2">
+        {icon ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={icon} alt="" className="h-6 w-6 rounded" />
+        ) : (
+          <div className="flex h-6 w-6 items-center justify-center rounded bg-gray-700 text-xs uppercase">
+            {title.slice(0, 2)}
+          </div>
+        )}
+        <div className="flex-1">
+          <div className="text-sm font-medium leading-tight">{title}</div>
+          <div className="text-xs text-gray-300">{bundle.count} notifications bundled</div>
+        </div>
+        <button
+          type="button"
+          onClick={() => onClear?.(bundle.id)}
+          className="rounded px-2 py-1 text-xs font-medium text-gray-300 transition hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-blue-400"
+        >
+          Dismiss
+        </button>
+      </div>
+      <div className="px-3 py-2 text-sm text-gray-200">
+        <ul className="space-y-1">
+          {previewMessages.map((message, idx) => (
+            <li key={`${bundle.id}-message-${idx}`} className="truncate">
+              {message}
+            </li>
+          ))}
+          {remaining > 0 && (
+            <li className="text-xs text-gray-400">+{remaining} more</li>
+          )}
+        </ul>
+      </div>
+      {bundle.actions.length > 0 && (
+        <div className="flex flex-wrap gap-2 border-t border-gray-700 px-3 py-2">
+          {bundle.actions.map(action => (
+            <button
+              key={action.id}
+              type="button"
+              onClick={() => handleAction(action)}
+              className="rounded bg-blue-600 px-2 py-1 text-xs font-medium transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+      <div className="border-t border-gray-700 px-3 py-1 text-[10px] uppercase tracking-wide text-gray-400">
+        Delivered {new Date(bundle.releasedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+      </div>
+    </div>
+  );
+};
+
+export default SummaryBundleCard;

--- a/components/apps/notifications/SummaryBundleList.tsx
+++ b/components/apps/notifications/SummaryBundleList.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import SummaryBundleCard from './SummaryBundleCard';
+import { SummaryBundle } from './types';
+
+interface SummaryBundleListProps {
+  bundles: SummaryBundle[];
+  onClear: (bundleId: string) => void;
+}
+
+const SummaryBundleList: React.FC<SummaryBundleListProps> = ({ bundles, onClear }) => {
+  if (!bundles.length) return null;
+  return (
+    <div className="fixed bottom-4 right-4 z-40 flex max-h-[80vh] w-full max-w-sm flex-col gap-3 overflow-y-auto pr-2">
+      {bundles.map(bundle => (
+        <SummaryBundleCard key={bundle.id} bundle={bundle} onClear={onClear} />
+      ))}
+    </div>
+  );
+};
+
+export default SummaryBundleList;

--- a/components/apps/notifications/index.ts
+++ b/components/apps/notifications/index.ts
@@ -1,0 +1,3 @@
+export { default as SummaryBundleCard } from './SummaryBundleCard';
+export { default as SummaryBundleList } from './SummaryBundleList';
+export * from './types';

--- a/components/apps/notifications/types.ts
+++ b/components/apps/notifications/types.ts
@@ -1,0 +1,14 @@
+export interface NotificationAction {
+  id: string;
+  label: string;
+  handler: () => void;
+}
+
+export interface SummaryBundle {
+  id: string;
+  appId: string;
+  count: number;
+  messages: string[];
+  releasedAt: number;
+  actions: NotificationAction[];
+}

--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -1,53 +1,225 @@
-import React, { createContext, useCallback, useEffect, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { SummaryBundleList } from '../apps/notifications';
+import { SummaryBundle, NotificationAction } from '../apps/notifications/types';
+import { useFocusMode } from '../../hooks/useFocusMode';
 
 export interface AppNotification {
   id: string;
+  appId: string;
   message: string;
   date: number;
+  priority: 'critical' | 'normal';
+  actions: NotificationAction[];
+  respectFocus: boolean;
+}
+
+export interface NotificationActionInput {
+  label: string;
+  handler: () => void;
+}
+
+export interface PushOptions {
+  priority?: 'critical' | 'normal';
+  actions?: NotificationActionInput[];
+  respectFocus?: boolean;
 }
 
 interface NotificationsContextValue {
   notifications: Record<string, AppNotification[]>;
-  pushNotification: (appId: string, message: string) => void;
+  pushNotification: (appId: string, message: string, options?: PushOptions) => void;
   clearNotifications: (appId?: string) => void;
 }
 
 export const NotificationsContext = createContext<NotificationsContextValue | null>(null);
 
-export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
-  const [notifications, setNotifications] = useState<Record<string, AppNotification[]>>({});
+const computeNextOccurrence = (times: string[]): number | null => {
+  if (!times.length) return null;
+  const now = new Date();
+  const nowMinutes = now.getHours() * 60 + now.getMinutes();
+  const sortedMinutes = times
+    .map(time => {
+      const [h, m] = time.split(':').map(Number);
+      if (Number.isNaN(h) || Number.isNaN(m)) return null;
+      return h * 60 + m;
+    })
+    .filter((value): value is number => value !== null)
+    .sort((a, b) => a - b);
+  if (!sortedMinutes.length) return null;
+  for (const minutes of sortedMinutes) {
+    if (minutes >= nowMinutes) {
+      const target = new Date(now);
+      target.setHours(Math.floor(minutes / 60), minutes % 60, 0, 0);
+      return target.getTime();
+    }
+  }
+  const target = new Date(now);
+  target.setDate(target.getDate() + 1);
+  const first = sortedMinutes[0];
+  target.setHours(Math.floor(first / 60), first % 60, 0, 0);
+  return target.getTime();
+};
 
-  const pushNotification = useCallback((appId: string, message: string) => {
-    setNotifications(prev => {
-      const list = prev[appId] ?? [];
-      const next = {
-        ...prev,
-        [appId]: [
-          ...list,
-          {
-            id: `${Date.now()}-${Math.random()}`,
-            message,
-            date: Date.now(),
-          },
-        ],
+const dedupeActions = (actions: NotificationAction[]): NotificationAction[] => {
+  const seen = new Map<string, NotificationAction>();
+  actions.forEach(action => {
+    if (!seen.has(action.label)) {
+      seen.set(action.label, action);
+    }
+  });
+  return Array.from(seen.values());
+};
+
+export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const {
+    enabled,
+    getDeliveryPolicy,
+    recordSuppressedNotification,
+    recordSummaryDelivery,
+  } = useFocusMode();
+  const [notifications, setNotifications] = useState<Record<string, AppNotification[]>>({});
+  const [queued, setQueued] = useState<Record<string, AppNotification[]>>({});
+  const [bundles, setBundles] = useState<SummaryBundle[]>([]);
+  const releaseTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const releaseAtRef = useRef<Map<string, number>>(new Map());
+
+  const pushNotification = useCallback(
+    (appId: string, message: string, options: PushOptions = {}) => {
+      const { priority = 'normal', actions = [], respectFocus = true } = options;
+      const timestamp = Date.now();
+      const actionEntries: NotificationAction[] = actions.map((action, index) => ({
+        id: `${appId}-${timestamp}-${index}-${Math.random().toString(36).slice(2)}`,
+        label: action.label,
+        handler: action.handler,
+      }));
+
+      const notification: AppNotification = {
+        id: `${timestamp}-${Math.random().toString(36).slice(2)}`,
+        appId,
+        message,
+        date: timestamp,
+        priority,
+        actions: actionEntries,
+        respectFocus,
       };
-      return next;
-    });
-  }, []);
+
+      if (!enabled || !respectFocus || priority === 'critical') {
+        setNotifications(prev => {
+          const list = prev[appId] ?? [];
+          return {
+            ...prev,
+            [appId]: [...list, notification],
+          };
+        });
+        return;
+      }
+
+      const policy = getDeliveryPolicy(appId);
+      if (policy.mode === 'immediate') {
+        setNotifications(prev => {
+          const list = prev[appId] ?? [];
+          return {
+            ...prev,
+            [appId]: [...list, notification],
+          };
+        });
+        return;
+      }
+
+      if (policy.mode === 'mute') {
+        recordSuppressedNotification(appId);
+        return;
+      }
+
+      recordSuppressedNotification(appId);
+      setQueued(prev => {
+        const list = prev[appId] ?? [];
+        return {
+          ...prev,
+          [appId]: [...list, notification],
+        };
+      });
+    },
+    [enabled, getDeliveryPolicy, recordSuppressedNotification]
+  );
+
+  const releaseBundle = useCallback(
+    (appId: string) => {
+      setQueued(prev => {
+        const list = prev[appId];
+        if (!list || list.length === 0) return prev;
+        const bundle: SummaryBundle = {
+          id: `summary-${appId}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+          appId,
+          count: list.length,
+          messages: list.map(item => item.message),
+          releasedAt: Date.now(),
+          actions: dedupeActions(list.flatMap(item => item.actions)),
+        };
+        setBundles(prevBundles => [...prevBundles, bundle]);
+        recordSummaryDelivery(appId, list.length);
+        const next = { ...prev };
+        delete next[appId];
+        return next;
+      });
+      const timer = releaseTimers.current.get(appId);
+      if (timer) {
+        clearTimeout(timer);
+        releaseTimers.current.delete(appId);
+        releaseAtRef.current.delete(appId);
+      }
+    },
+    [recordSummaryDelivery]
+  );
 
   const clearNotifications = useCallback((appId?: string) => {
+    if (!appId) {
+      setNotifications({});
+      setQueued({});
+      setBundles([]);
+      releaseTimers.current.forEach(timer => clearTimeout(timer));
+      releaseTimers.current.clear();
+      releaseAtRef.current.clear();
+      return;
+    }
     setNotifications(prev => {
-      if (!appId) return {};
+      if (!prev[appId]) return prev;
       const next = { ...prev };
       delete next[appId];
       return next;
     });
+    setQueued(prev => {
+      if (!prev[appId]) return prev;
+      const next = { ...prev };
+      delete next[appId];
+      return next;
+    });
+    setBundles(prev => prev.filter(bundle => bundle.appId !== appId));
+    const timer = releaseTimers.current.get(appId);
+    if (timer) {
+      clearTimeout(timer);
+      releaseTimers.current.delete(appId);
+      releaseAtRef.current.delete(appId);
+    }
   }, []);
 
-  const totalCount = Object.values(notifications).reduce(
-    (sum, list) => sum + list.length,
-    0
-  );
+  const totalCount = useMemo(() => {
+    const immediate = Object.values(notifications).reduce(
+      (sum, list) => sum + list.length,
+      0
+    );
+    const queuedCount = Object.values(queued).reduce(
+      (sum, list) => sum + list.length,
+      0
+    );
+    return immediate + queuedCount;
+  }, [notifications, queued]);
 
   useEffect(() => {
     const nav: any = navigator;
@@ -57,23 +229,98 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
     }
   }, [totalCount]);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const timers = releaseTimers.current;
+    const releaseAt = releaseAtRef.current;
+
+    timers.forEach((timer, appId) => {
+      const list = queued[appId];
+      const policy = getDeliveryPolicy(appId);
+      if (!enabled || !list?.length || policy.mode !== 'bundle') {
+        clearTimeout(timer);
+        timers.delete(appId);
+        releaseAt.delete(appId);
+      }
+    });
+
+    if (!enabled) {
+      Object.keys(queued).forEach(appId => {
+        if (queued[appId]?.length) {
+          releaseBundle(appId);
+        }
+      });
+      return;
+    }
+
+    Object.entries(queued).forEach(([appId, list]) => {
+      if (!list.length) return;
+      const policy = getDeliveryPolicy(appId);
+      if (policy.mode !== 'bundle') {
+        releaseBundle(appId);
+        return;
+      }
+      const nextRelease = computeNextOccurrence(policy.schedule);
+      if (!nextRelease) {
+        releaseBundle(appId);
+        return;
+      }
+      const existingAt = releaseAt.get(appId);
+      if (existingAt && Math.abs(existingAt - nextRelease) < 1000) {
+        return;
+      }
+      const existingTimer = timers.get(appId);
+      if (existingTimer) {
+        clearTimeout(existingTimer);
+      }
+      const delay = Math.max(nextRelease - Date.now(), 0);
+      const timeoutId = window.setTimeout(() => {
+        releaseAt.delete(appId);
+        timers.delete(appId);
+        releaseBundle(appId);
+      }, delay);
+      timers.set(appId, timeoutId);
+      releaseAt.set(appId, nextRelease);
+    });
+  }, [enabled, getDeliveryPolicy, queued, releaseBundle]);
+
+  useEffect(() => {
+    return () => {
+      releaseTimers.current.forEach(timer => clearTimeout(timer));
+      releaseTimers.current.clear();
+      releaseAtRef.current.clear();
+    };
+  }, []);
+
+  const handleClearSummary = useCallback((bundleId: string) => {
+    setBundles(prev => prev.filter(bundle => bundle.id !== bundleId));
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({ notifications, pushNotification, clearNotifications }),
+    [notifications, pushNotification, clearNotifications]
+  );
+
+  const hasImmediate = useMemo(() => Object.keys(notifications).length > 0, [notifications]);
+
   return (
-    <NotificationsContext.Provider
-      value={{ notifications, pushNotification, clearNotifications }}
-    >
+    <NotificationsContext.Provider value={contextValue}>
       {children}
-      <div className="notification-center">
-        {Object.entries(notifications).map(([appId, list]) => (
-          <section key={appId} className="notification-group">
-            <h3>{appId}</h3>
-            <ul>
-              {list.map(n => (
-                <li key={n.id}>{n.message}</li>
-              ))}
-            </ul>
-          </section>
-        ))}
-      </div>
+      <SummaryBundleList bundles={bundles} onClear={handleClearSummary} />
+      {hasImmediate && (
+        <div className="fixed top-4 right-4 z-30 w-full max-w-sm space-y-2 rounded-md border border-gray-700 bg-black/80 p-3 text-sm text-white shadow-xl backdrop-blur">
+          {Object.entries(notifications).map(([appId, list]) => (
+            <section key={appId} className="border-b border-gray-700 pb-2 last:border-b-0 last:pb-0">
+              <header className="mb-1 text-xs uppercase tracking-wide text-gray-400">{appId}</header>
+              <ul className="space-y-1">
+                {list.map(n => (
+                  <li key={n.id}>{n.message}</li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      )}
     </NotificationsContext.Provider>
   );
 };

--- a/hooks/useFocusMode.tsx
+++ b/hooks/useFocusMode.tsx
@@ -1,0 +1,230 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { logEvent } from '../utils/analytics';
+import {
+  defaultFocusSettings,
+  loadFocusSettings,
+  normalizeTime,
+  sanitizeOverride,
+  saveFocusSettings,
+} from '../utils/focusStore';
+import { FocusAppOverride, FocusSettingsState } from '../types/focus';
+
+export interface FocusDeliveryPolicy {
+  mode: 'immediate' | 'bundle' | 'mute';
+  schedule: string[];
+}
+
+export interface FocusSessionMetrics {
+  suppressed: number;
+  delivered: number;
+  startedAt: number | null;
+  lastSummaryAt: number | null;
+}
+
+interface FocusModeContextValue {
+  enabled: boolean;
+  schedule: string[];
+  perAppOverrides: Record<string, FocusAppOverride>;
+  setEnabled: (value: boolean) => void;
+  addScheduleTime: (value: string) => void;
+  removeScheduleTime: (value: string) => void;
+  updateOverride: (appId: string, override: FocusAppOverride) => void;
+  removeOverride: (appId: string) => void;
+  getDeliveryPolicy: (appId: string) => FocusDeliveryPolicy;
+  recordSuppressedNotification: (appId: string) => void;
+  recordSummaryDelivery: (appId: string, count: number) => void;
+  sessionMetrics: FocusSessionMetrics;
+  shouldSilenceToasts: boolean;
+}
+
+const FocusModeContext = createContext<FocusModeContextValue | undefined>(undefined);
+
+const getFallbackSchedule = (schedule: string[]): string[] =>
+  schedule.length ? schedule : defaultFocusSettings.schedule;
+
+export const FocusModeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [settings, setSettings] = useState<FocusSettingsState>(defaultFocusSettings);
+  const [hydrated, setHydrated] = useState(false);
+  const [session, setSession] = useState<FocusSessionMetrics>({
+    suppressed: 0,
+    delivered: 0,
+    startedAt: null,
+    lastSummaryAt: null,
+  });
+
+  useEffect(() => {
+    const data = loadFocusSettings();
+    setSettings(data);
+    setHydrated(true);
+    if (data.enabled) {
+      setSession({
+        suppressed: 0,
+        delivered: 0,
+        startedAt: Date.now(),
+        lastSummaryAt: null,
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    saveFocusSettings(settings);
+  }, [hydrated, settings]);
+
+  const setEnabled = useCallback((value: boolean) => {
+    let changed = false;
+    setSettings(prev => {
+      if (prev.enabled === value) return prev;
+      changed = true;
+      return { ...prev, enabled: value };
+    });
+    if (!changed) return;
+    setSession(prev => {
+      if (value) {
+        logEvent({ category: 'FocusMode', action: 'enabled' });
+        return {
+          suppressed: 0,
+          delivered: 0,
+          startedAt: Date.now(),
+          lastSummaryAt: null,
+        };
+      }
+      logEvent({
+        category: 'FocusMode',
+        action: 'disabled',
+        value: prev.suppressed,
+      });
+      return { ...prev, startedAt: null };
+    });
+  }, []);
+
+  const addScheduleTime = useCallback((value: string) => {
+    const normalized = normalizeTime(value);
+    if (!normalized) return;
+    setSettings(prev => {
+      if (prev.schedule.includes(normalized)) return prev;
+      const next = [...prev.schedule, normalized].sort();
+      return { ...prev, schedule: next };
+    });
+  }, []);
+
+  const removeScheduleTime = useCallback((value: string) => {
+    setSettings(prev => {
+      if (!prev.schedule.includes(value)) return prev;
+      const next = prev.schedule.filter(time => time !== value);
+      return { ...prev, schedule: next };
+    });
+  }, []);
+
+  const updateOverride = useCallback((appId: string, override: FocusAppOverride) => {
+    setSettings(prev => {
+      const next = {
+        ...prev.perAppOverrides,
+        [appId]: sanitizeOverride(override),
+      };
+      return { ...prev, perAppOverrides: next };
+    });
+  }, []);
+
+  const removeOverride = useCallback((appId: string) => {
+    setSettings(prev => {
+      if (!prev.perAppOverrides[appId]) return prev;
+      const next = { ...prev.perAppOverrides };
+      delete next[appId];
+      return { ...prev, perAppOverrides: next };
+    });
+  }, []);
+
+  const recordSuppressedNotification = useCallback(() => {
+    setSession(prev => ({ ...prev, suppressed: prev.suppressed + 1 }));
+  }, []);
+
+  const recordSummaryDelivery = useCallback((appId: string, count: number) => {
+    setSession(prev => ({
+      ...prev,
+      delivered: prev.delivered + count,
+      lastSummaryAt: Date.now(),
+    }));
+    logEvent({
+      category: 'FocusMode',
+      action: 'summary-delivered',
+      label: appId,
+      value: count,
+    });
+  }, []);
+
+  const getDeliveryPolicy = useCallback(
+    (appId: string): FocusDeliveryPolicy => {
+      if (!settings.enabled) {
+        return { mode: 'immediate', schedule: [] };
+      }
+      const override = settings.perAppOverrides[appId];
+      if (!override || override.mode === 'inherit') {
+        return { mode: 'bundle', schedule: getFallbackSchedule(settings.schedule) };
+      }
+      if (override.mode === 'custom') {
+        const schedule = getFallbackSchedule(override.schedule ?? settings.schedule);
+        return { mode: 'bundle', schedule };
+      }
+      if (override.mode === 'mute') {
+        return { mode: 'mute', schedule: [] };
+      }
+      return { mode: 'immediate', schedule: [] };
+    },
+    [settings]
+  );
+
+  const value = useMemo<FocusModeContextValue>(
+    () => ({
+      enabled: settings.enabled,
+      schedule: settings.schedule,
+      perAppOverrides: settings.perAppOverrides,
+      setEnabled,
+      addScheduleTime,
+      removeScheduleTime,
+      updateOverride,
+      removeOverride,
+      getDeliveryPolicy,
+      recordSuppressedNotification,
+      recordSummaryDelivery,
+      sessionMetrics: session,
+      shouldSilenceToasts: settings.enabled,
+    }),
+    [
+      addScheduleTime,
+      getDeliveryPolicy,
+      recordSummaryDelivery,
+      recordSuppressedNotification,
+      removeOverride,
+      removeScheduleTime,
+      session,
+      setEnabled,
+      settings.enabled,
+      settings.perAppOverrides,
+      settings.schedule,
+      updateOverride,
+    ]
+  );
+
+  return (
+    <FocusModeContext.Provider value={value}>
+      {children}
+    </FocusModeContext.Provider>
+  );
+};
+
+export const useFocusMode = (): FocusModeContextValue => {
+  const ctx = useContext(FocusModeContext);
+  if (!ctx) {
+    throw new Error('useFocusMode must be used within a FocusModeProvider');
+  }
+  return ctx;
+};
+

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -1,5 +1,10 @@
 import { useContext } from 'react';
-import { NotificationsContext } from '../components/common/NotificationCenter';
+import {
+  NotificationsContext,
+  type PushOptions,
+  type AppNotification,
+  type NotificationActionInput,
+} from '../components/common/NotificationCenter';
 
 export const useNotifications = () => {
   const ctx = useContext(NotificationsContext);
@@ -10,3 +15,5 @@ export const useNotifications = () => {
 };
 
 export default useNotifications;
+
+export type { PushOptions, AppNotification, NotificationActionInput };

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,11 +11,13 @@ import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import { FocusModeProvider } from '../hooks/useFocusMode';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import NotificationCenter from '../components/common/NotificationCenter';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -157,21 +159,25 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+          <FocusModeProvider>
+            <NotificationCenter>
+              <PipPortalProvider>
+                <div aria-live="polite" id="live-region" />
+                <Component {...pageProps} />
+                <ShortcutOverlay />
+                <Analytics
+                  beforeSend={(e) => {
+                    if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                    const evt = e;
+                    if (evt.metadata?.email) delete evt.metadata.email;
+                    return e;
+                  }}
+                />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
+                {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+              </PipPortalProvider>
+            </NotificationCenter>
+          </FocusModeProvider>
         </SettingsProvider>
       </div>
     </ErrorBoundary>

--- a/pages/apps/focus.tsx
+++ b/pages/apps/focus.tsx
@@ -1,0 +1,406 @@
+import React, { useMemo, useState } from 'react';
+import Head from 'next/head';
+import apps from '../../apps.config';
+import { useFocusMode } from '../../hooks/useFocusMode';
+import { FocusAppOverride } from '../../types/focus';
+
+const appLookup = new Map(apps.map(app => [app.id, app]));
+
+const overrideModes: FocusAppOverride['mode'][] = [
+  'inherit',
+  'custom',
+  'immediate',
+  'mute',
+];
+
+const FocusModePage: React.FC = () => {
+  const {
+    enabled,
+    setEnabled,
+    schedule,
+    addScheduleTime,
+    removeScheduleTime,
+    perAppOverrides,
+    updateOverride,
+    removeOverride,
+    sessionMetrics,
+  } = useFocusMode();
+
+  const [newTime, setNewTime] = useState('09:00');
+  const [overrideApp, setOverrideApp] = useState('');
+  const [overrideMode, setOverrideMode] = useState<FocusAppOverride['mode']>('inherit');
+  const [overrideTimeInput, setOverrideTimeInput] = useState('09:00');
+  const [overrideTimes, setOverrideTimes] = useState<string[]>([]);
+  const [perAppTimeInputs, setPerAppTimeInputs] = useState<Record<string, string>>({});
+
+  const availableApps = useMemo(() => {
+    const taken = new Set(Object.keys(perAppOverrides));
+    return apps
+      .filter(app => !taken.has(app.id))
+      .map(app => ({ id: app.id, title: app.title }))
+      .sort((a, b) => a.title.localeCompare(b.title));
+  }, [perAppOverrides]);
+
+  const sortedOverrides = useMemo(
+    () =>
+      Object.entries(perAppOverrides).sort((a, b) => {
+        const aTitle = appLookup.get(a[0])?.title ?? a[0];
+        const bTitle = appLookup.get(b[0])?.title ?? b[0];
+        return aTitle.localeCompare(bTitle);
+      }),
+    [perAppOverrides]
+  );
+
+  const handleAddSchedule = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!newTime) return;
+    addScheduleTime(newTime);
+  };
+
+  const handleAddOverride = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!overrideApp) return;
+    const scheduleTimes = overrideMode === 'custom' ? overrideTimes : undefined;
+    updateOverride(overrideApp, { mode: overrideMode, schedule: scheduleTimes });
+    setOverrideApp('');
+    setOverrideMode('inherit');
+    setOverrideTimes([]);
+    setOverrideTimeInput('09:00');
+  };
+
+  const handleAddOverrideTime = () => {
+    if (!overrideTimeInput) return;
+    setOverrideTimes(prev => {
+      if (prev.includes(overrideTimeInput)) return prev;
+      return [...prev, overrideTimeInput].sort();
+    });
+  };
+
+  const handleRemoveOverrideTime = (time: string) => {
+    setOverrideTimes(prev => prev.filter(item => item !== time));
+  };
+
+  const formatTime = (time?: number | null) => {
+    if (!time) return '—';
+    try {
+      return new Date(time).toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    } catch {
+      return '—';
+    }
+  };
+
+  const sessionDuration = useMemo(() => {
+    if (!sessionMetrics.startedAt) return '—';
+    const seconds = Math.max(0, Math.floor((Date.now() - sessionMetrics.startedAt) / 1000));
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `${minutes}m ${remainingSeconds}s`;
+  }, [sessionMetrics.startedAt]);
+
+  const handlePerAppTimeChange = (appId: string, value: string) => {
+    setPerAppTimeInputs(prev => ({ ...prev, [appId]: value }));
+  };
+
+  const handlePerAppTimeAdd = (appId: string, existing: FocusAppOverride, value: string) => {
+    if (!value) return;
+    const nextTimes = [...(existing.schedule ?? []), value];
+    updateOverride(appId, { mode: 'custom', schedule: nextTimes });
+    setPerAppTimeInputs(prev => ({ ...prev, [appId]: '09:00' }));
+  };
+
+  const handlePerAppTimeRemove = (appId: string, existing: FocusAppOverride, time: string) => {
+    const nextTimes = (existing.schedule ?? []).filter(item => item !== time);
+    updateOverride(appId, {
+      mode: nextTimes.length ? 'custom' : 'inherit',
+      schedule: nextTimes,
+    });
+  };
+
+  return (
+    <div className="h-full overflow-y-auto bg-ub-grey text-white">
+      <Head>
+        <title>Focus Mode</title>
+      </Head>
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-6 py-8">
+        <header className="flex flex-col gap-2">
+          <h1 className="text-2xl font-semibold">Focus mode control center</h1>
+          <p className="text-sm text-gray-300">
+            Configure summary delivery windows, per-app overrides, and review telemetry to ensure your focus sessions stay
+            interruption-free.
+          </p>
+        </header>
+
+        <section className="rounded-lg border border-gray-700 bg-black/30 p-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold">Focus session</h2>
+              <p className="text-sm text-gray-300">
+                When enabled, non-critical notifications are bundled and released on your schedule.
+              </p>
+            </div>
+            <label className="inline-flex items-center gap-2">
+              <span className="text-sm text-gray-300">{enabled ? 'Enabled' : 'Disabled'}</span>
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={event => setEnabled(event.target.checked)}
+                className="h-5 w-10 cursor-pointer appearance-none rounded-full bg-gray-600 transition focus:outline-none focus:ring-2 focus:ring-blue-400"
+                style={{ backgroundColor: enabled ? '#2563eb' : undefined }}
+              />
+            </label>
+          </div>
+          <dl className="mt-4 grid grid-cols-1 gap-4 text-sm sm:grid-cols-3">
+            <div className="rounded border border-gray-700 bg-black/40 p-3">
+              <dt className="text-xs uppercase tracking-wide text-gray-400">Suppressed</dt>
+              <dd className="mt-1 text-lg font-semibold">{sessionMetrics.suppressed}</dd>
+            </div>
+            <div className="rounded border border-gray-700 bg-black/40 p-3">
+              <dt className="text-xs uppercase tracking-wide text-gray-400">Delivered summaries</dt>
+              <dd className="mt-1 text-lg font-semibold">{sessionMetrics.delivered}</dd>
+            </div>
+            <div className="rounded border border-gray-700 bg-black/40 p-3">
+              <dt className="text-xs uppercase tracking-wide text-gray-400">Last summary</dt>
+              <dd className="mt-1 text-lg font-semibold">{formatTime(sessionMetrics.lastSummaryAt)}</dd>
+            </div>
+          </dl>
+          <p className="mt-3 text-xs text-gray-400">Current session runtime: {sessionDuration}</p>
+        </section>
+
+        <section className="rounded-lg border border-gray-700 bg-black/30 p-5">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold">Summary schedule</h2>
+              <p className="text-sm text-gray-300">
+                Summaries are released at these times while focus mode is active.
+              </p>
+            </div>
+          </div>
+          <form onSubmit={handleAddSchedule} className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end">
+            <label className="flex flex-col text-sm">
+              <span className="mb-1 text-gray-300">Add time</span>
+              <input
+                type="time"
+                value={newTime}
+                onChange={event => setNewTime(event.target.value)}
+                className="rounded border border-gray-600 bg-black/50 px-3 py-2 text-white focus:border-blue-400 focus:outline-none"
+              />
+            </label>
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded bg-blue-600 px-4 py-2 text-sm font-medium transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+            >
+              Add window
+            </button>
+          </form>
+          <ul className="mt-4 flex flex-wrap gap-3 text-sm">
+            {schedule.length === 0 && <li className="text-gray-400">No windows configured. Add at least one time to receive summaries.</li>}
+            {schedule.map(time => (
+              <li key={time} className="flex items-center gap-2 rounded border border-gray-600 bg-black/40 px-3 py-1">
+                <span>{time}</span>
+                <button
+                  type="button"
+                  onClick={() => removeScheduleTime(time)}
+                  className="text-xs text-gray-300 transition hover:text-white focus:outline-none focus:underline"
+                >
+                  Remove
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="rounded-lg border border-gray-700 bg-black/30 p-5">
+          <h2 className="text-lg font-semibold">Per-app overrides</h2>
+          <p className="text-sm text-gray-300">
+            Override the global schedule for specific apps. Choose immediate delivery, muting, or a custom schedule.
+          </p>
+
+          <form onSubmit={handleAddOverride} className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-[2fr_1fr_auto]">
+            <label className="flex flex-col text-sm">
+              <span className="mb-1 text-gray-300">Application</span>
+              <select
+                value={overrideApp}
+                onChange={event => setOverrideApp(event.target.value)}
+                className="rounded border border-gray-600 bg-black/50 px-3 py-2 text-white focus:border-blue-400 focus:outline-none"
+              >
+                <option value="">Select an app</option>
+                {availableApps.map(app => (
+                  <option key={app.id} value={app.id}>
+                    {app.title}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="flex flex-col text-sm">
+              <span className="mb-1 text-gray-300">Delivery</span>
+              <select
+                value={overrideMode}
+                onChange={event => {
+                  const value = event.target.value as FocusAppOverride['mode'];
+                  setOverrideMode(value);
+                  if (value !== 'custom') {
+                    setOverrideTimes([]);
+                  }
+                }}
+                className="rounded border border-gray-600 bg-black/50 px-3 py-2 text-white focus:border-blue-400 focus:outline-none"
+              >
+                {overrideModes.map(mode => (
+                  <option key={mode} value={mode}>
+                    {mode === 'inherit' && 'Follow summary schedule'}
+                    {mode === 'custom' && 'Custom summary times'}
+                    {mode === 'immediate' && 'Deliver immediately'}
+                    {mode === 'mute' && 'Mute during focus'}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <button
+              type="submit"
+              className="self-end rounded bg-blue-600 px-4 py-2 text-sm font-medium transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:cursor-not-allowed disabled:bg-gray-600"
+              disabled={!overrideApp}
+            >
+              Save override
+            </button>
+          </form>
+
+          {overrideMode === 'custom' && (
+            <div className="mt-3 rounded border border-gray-700 bg-black/40 p-3">
+              <h3 className="text-sm font-semibold">Custom times for new override</h3>
+              <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-end">
+                <label className="flex flex-col text-sm">
+                  <span className="mb-1 text-gray-300">Time</span>
+                  <input
+                    type="time"
+                    value={overrideTimeInput}
+                    onChange={event => setOverrideTimeInput(event.target.value)}
+                    className="rounded border border-gray-600 bg-black/50 px-3 py-2 text-white focus:border-blue-400 focus:outline-none"
+                  />
+                </label>
+                <button
+                  type="button"
+                  onClick={handleAddOverrideTime}
+                  className="inline-flex items-center justify-center rounded bg-blue-600 px-4 py-2 text-sm font-medium transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                >
+                  Add time
+                </button>
+              </div>
+              <ul className="mt-2 flex flex-wrap gap-2 text-sm">
+                {overrideTimes.length === 0 && <li className="text-gray-400">No custom times yet.</li>}
+                {overrideTimes.map(time => (
+                  <li key={time} className="flex items-center gap-2 rounded border border-gray-600 bg-black/30 px-3 py-1">
+                    <span>{time}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveOverrideTime(time)}
+                      className="text-xs text-gray-300 transition hover:text-white focus:outline-none focus:underline"
+                    >
+                      Remove
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="mt-6 space-y-4">
+            {sortedOverrides.length === 0 && (
+              <p className="text-sm text-gray-400">No overrides configured yet.</p>
+            )}
+            {sortedOverrides.map(([appId, override]) => {
+              const appMeta = appLookup.get(appId);
+              const perAppValue = perAppTimeInputs[appId] ?? '09:00';
+              const scheduleTimes = override.schedule ?? [];
+              return (
+                <div key={appId} className="rounded border border-gray-700 bg-black/30 p-4">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <h3 className="text-base font-semibold">{appMeta?.title ?? appId}</h3>
+                      <p className="text-xs text-gray-400">Override: {override.mode}</p>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <label className="text-sm text-gray-300">
+                        <span className="sr-only">Delivery mode</span>
+                        <select
+                          value={override.mode}
+                          onChange={event => {
+                            const mode = event.target.value as FocusAppOverride['mode'];
+                            updateOverride(appId, {
+                              mode,
+                              schedule: mode === 'custom' ? scheduleTimes : undefined,
+                            });
+                          }}
+                          className="rounded border border-gray-600 bg-black/50 px-3 py-2 text-white focus:border-blue-400 focus:outline-none"
+                        >
+                          {overrideModes.map(mode => (
+                            <option key={mode} value={mode}>
+                              {mode === 'inherit' && 'Follow summary schedule'}
+                              {mode === 'custom' && 'Custom summary times'}
+                              {mode === 'immediate' && 'Deliver immediately'}
+                              {mode === 'mute' && 'Mute during focus'}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <button
+                        type="button"
+                        onClick={() => removeOverride(appId)}
+                        className="rounded bg-red-600 px-3 py-2 text-sm font-medium transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-400"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  </div>
+                  {override.mode === 'custom' && (
+                    <div className="mt-3 rounded border border-gray-700 bg-black/40 p-3 text-sm">
+                      <h4 className="font-medium">Custom schedule</h4>
+                      <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-end">
+                        <label className="flex flex-col text-sm">
+                          <span className="mb-1 text-gray-300">Add time</span>
+                          <input
+                            type="time"
+                            value={perAppValue}
+                            onChange={event => handlePerAppTimeChange(appId, event.target.value)}
+                            className="rounded border border-gray-600 bg-black/50 px-3 py-2 text-white focus:border-blue-400 focus:outline-none"
+                          />
+                        </label>
+                        <button
+                          type="button"
+                          onClick={() => handlePerAppTimeAdd(appId, override, perAppValue)}
+                          className="inline-flex items-center justify-center rounded bg-blue-600 px-4 py-2 text-sm font-medium transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                        >
+                          Add
+                        </button>
+                      </div>
+                      <ul className="mt-2 flex flex-wrap gap-2">
+                        {scheduleTimes.length === 0 && <li className="text-gray-400">No custom times configured.</li>}
+                        {scheduleTimes.map(time => (
+                          <li key={time} className="flex items-center gap-2 rounded border border-gray-600 bg-black/30 px-3 py-1">
+                            <span>{time}</span>
+                            <button
+                              type="button"
+                              onClick={() => handlePerAppTimeRemove(appId, override, time)}
+                              className="text-xs text-gray-300 transition hover:text-white focus:outline-none focus:underline"
+                            >
+                              Remove
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default FocusModePage;

--- a/types/focus.ts
+++ b/types/focus.ts
@@ -1,0 +1,12 @@
+export type FocusOverrideMode = 'inherit' | 'custom' | 'immediate' | 'mute';
+
+export interface FocusAppOverride {
+  mode: FocusOverrideMode;
+  schedule?: string[];
+}
+
+export interface FocusSettingsState {
+  enabled: boolean;
+  schedule: string[];
+  perAppOverrides: Record<string, FocusAppOverride>;
+}

--- a/utils/focusStore.ts
+++ b/utils/focusStore.ts
@@ -1,0 +1,90 @@
+import { FocusAppOverride, FocusSettingsState } from '../types/focus';
+import { safeLocalStorage } from './safeStorage';
+
+export const FOCUS_STORAGE_KEY = 'focus-settings-v1';
+
+export const defaultFocusSettings: FocusSettingsState = {
+  enabled: false,
+  schedule: ['09:00', '13:00', '17:00'],
+  perAppOverrides: {},
+};
+
+export const normalizeTime = (input: string): string | null => {
+  if (!input) return null;
+  const match = input.trim().match(/^(\d{1,2})(?::(\d{1,2}))?$/);
+  if (!match) return null;
+  const hours = Number(match[1]);
+  const minutes = Number(match[2] ?? '0');
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) return null;
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null;
+  const pad = (value: number) => value.toString().padStart(2, '0');
+  return `${pad(hours)}:${pad(minutes)}`;
+};
+
+const sanitizeTimes = (times?: string[]): string[] => {
+  if (!Array.isArray(times)) return [];
+  const seen = new Set<string>();
+  times.forEach((value) => {
+    const normalized = normalizeTime(value);
+    if (normalized) {
+      seen.add(normalized);
+    }
+  });
+  return Array.from(seen).sort();
+};
+
+export const sanitizeOverride = (override: FocusAppOverride): FocusAppOverride => {
+  if (override.mode === 'custom') {
+    const schedule = sanitizeTimes(override.schedule);
+    return {
+      mode: schedule.length ? 'custom' : 'inherit',
+      schedule,
+    };
+  }
+  return { mode: override.mode };
+};
+
+const sanitizeOverrides = (
+  overrides?: Record<string, FocusAppOverride>
+): Record<string, FocusAppOverride> => {
+  if (!overrides) return {};
+  return Object.entries(overrides).reduce<Record<string, FocusAppOverride>>(
+    (acc, [appId, override]) => {
+      if (!override || typeof override !== 'object') return acc;
+      acc[appId] = sanitizeOverride(override);
+      return acc;
+    },
+    {}
+  );
+};
+
+export const loadFocusSettings = (): FocusSettingsState => {
+  try {
+    if (!safeLocalStorage) return { ...defaultFocusSettings };
+    const raw = safeLocalStorage.getItem(FOCUS_STORAGE_KEY);
+    if (!raw) return { ...defaultFocusSettings };
+    const parsed = JSON.parse(raw);
+    return {
+      enabled: Boolean(parsed.enabled),
+      schedule: sanitizeTimes(parsed.schedule),
+      perAppOverrides: sanitizeOverrides(parsed.perAppOverrides),
+    };
+  } catch (error) {
+    console.warn('Failed to load focus settings', error);
+    return { ...defaultFocusSettings };
+  }
+};
+
+export const saveFocusSettings = (settings: FocusSettingsState): void => {
+  try {
+    if (!safeLocalStorage) return;
+    const payload: FocusSettingsState = {
+      enabled: settings.enabled,
+      schedule: sanitizeTimes(settings.schedule),
+      perAppOverrides: sanitizeOverrides(settings.perAppOverrides),
+    };
+    safeLocalStorage.setItem(FOCUS_STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.warn('Failed to persist focus settings', error);
+  }
+};


### PR DESCRIPTION
## Summary
- add a focus mode provider with persisted schedules, per-app overrides, and telemetry hooks
- build a focus mode settings app to manage schedules, overrides, and session metrics
- rework the notification center to queue during focus, render summary bundles, and silence toasts when appropriate

## Testing
- yarn lint *(fails: existing repository lint errors unrelated to this change)*
- yarn test *(fails: existing window snapping and nmap clipboard tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cb466a5e608328a1ca0a6b32091fb2