### PR TITLE
Add crash reporting pipeline

### DIFF
--- a/__tests__/crashReporting.test.ts
+++ b/__tests__/crashReporting.test.ts
@@ -1,0 +1,58 @@
+import { createCrashReport, generateCrashId } from '../modules/crash/reporting';
+import { REDACTION_TEXT, scrubSensitiveData, scrubSensitiveText } from '../utils/logs/privacy';
+
+describe('crash reporting', () => {
+  it('creates a crash report with a crash id and summary', () => {
+    const report = createCrashReport({
+      error: new Error('Disk failure at /Users/alex/secrets'),
+      app: 'Crash Reporter',
+      route: '/apps/crash-reporter',
+      action: 'Opening crash summary',
+      logs: ['POST https://api.example.com/upload?apiKey=abcdef1234567890'],
+      metadata: {
+        path: '/Users/alex/.ssh/id_rsa',
+        token: 'Bearer token-value',
+      },
+      userSteps: ['Opened the crash reporter', 'Clicked export'],
+    });
+
+    expect(report.details.crashId).toMatch(/^CRASH-/);
+    expect(report.summary).toContain('Crash ID:');
+    expect(report.summary).toContain(REDACTION_TEXT);
+    expect(report.summary).not.toContain('/Users/alex');
+    expect(report.summary).toContain('Crash Reporter');
+  });
+
+  it('generates reasonably unique crash ids', () => {
+    const first = generateCrashId(1711939200000);
+    const second = generateCrashId(1711939200000);
+    expect(first).not.toEqual(second);
+    expect(first.startsWith('CRASH-')).toBe(true);
+    expect(second.startsWith('CRASH-')).toBe(true);
+  });
+});
+
+describe('privacy scrubber', () => {
+  it('scrubs sensitive paths and secrets from text', () => {
+    const sample = 'User home /Users/tester/Downloads and token=abcdef1234567890';
+    const result = scrubSensitiveText(sample);
+    expect(result).not.toContain('/Users/tester');
+    expect(result).toContain(REDACTION_TEXT);
+  });
+
+  it('redacts deeply nested secrets', () => {
+    const payload = {
+      service: {
+        credentials: {
+          apiKey: 'abcdef1234567890',
+          nested: { path: String.raw`C:\Users\victim\Desktop\secret.txt` },
+        },
+      },
+    };
+
+    const result = scrubSensitiveData(payload);
+    const stringified = JSON.stringify(result);
+    expect(stringified).not.toContain('victim');
+    expect(stringified).toContain(REDACTION_TEXT);
+  });
+});

--- a/components/apps/crash-reporter/CrashSummary.tsx
+++ b/components/apps/crash-reporter/CrashSummary.tsx
@@ -1,0 +1,122 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import Modal from '../../base/Modal';
+import { copyToClipboard } from '../../../utils/clipboard';
+
+export interface CrashSummaryProps {
+  isOpen: boolean;
+  onClose: () => void;
+  summary: string;
+  crashId: string;
+  title?: string;
+}
+
+const useCopyState = () => {
+  const [status, setStatus] = useState<'idle' | 'copied' | 'error'>('idle');
+
+  const trigger = useCallback(async (value: string) => {
+    const success = await copyToClipboard(value);
+    setStatus(success ? 'copied' : 'error');
+    setTimeout(() => setStatus('idle'), 2000);
+    return success;
+  }, []);
+
+  return { status, trigger } as const;
+};
+
+const CrashSummary: React.FC<CrashSummaryProps> = ({
+  isOpen,
+  onClose,
+  summary,
+  crashId,
+  title = 'Crash report ready',
+}) => {
+  const summaryCopy = useCopyState();
+  const idCopy = useCopyState();
+
+  const combined = useMemo(
+    () => `Crash ID: ${crashId}\n\n${summary}`.trim(),
+    [crashId, summary],
+  );
+
+  const handleCopySummary = useCallback(() => summaryCopy.trigger(combined), [combined, summaryCopy]);
+  const handleCopyId = useCallback(() => idCopy.trigger(crashId), [crashId, idCopy]);
+
+  const renderCopyHint = (status: 'idle' | 'copied' | 'error') => {
+    if (status === 'copied') return <span className="text-green-400 text-sm" role="status">Copied</span>;
+    if (status === 'error') return <span className="text-red-400 text-sm" role="status">Copy failed</span>;
+    return null;
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="fixed inset-0 z-50 flex items-center justify-center">
+        <div
+          className="absolute inset-0 bg-black/60"
+          aria-hidden="true"
+          onClick={onClose}
+        />
+        <div className="relative z-10 max-w-2xl w-full mx-4 rounded-lg bg-gray-900 text-gray-100 shadow-xl">
+          <div className="flex items-start justify-between border-b border-gray-700 px-5 py-4">
+            <div>
+              <h2 className="text-lg font-semibold" id="crash-summary-heading">{title}</h2>
+              <p className="text-sm text-gray-300">Share the crash ID and summary with the maintainer.</p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-gray-300 hover:text-white focus:outline-none"
+              aria-label="Close crash summary dialog"
+            >
+              ✕
+            </button>
+          </div>
+          <div className="px-5 py-4 space-y-4" aria-labelledby="crash-summary-heading">
+            <section>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-400">Crash ID</h3>
+              <div className="mt-2 flex flex-wrap items-center gap-3">
+                <code className="flex-1 rounded bg-gray-800 px-3 py-2 text-sm break-words">{crashId}</code>
+                <button
+                  type="button"
+                  onClick={handleCopyId}
+                  className="px-3 py-2 rounded bg-blue-600 hover:bg-blue-500 text-sm font-medium"
+                >
+                  Copy ID
+                </button>
+                {renderCopyHint(idCopy.status)}
+              </div>
+            </section>
+            <section>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-400">Summary</h3>
+              <div className="mt-2 rounded border border-gray-700 bg-gray-800/70 max-h-72 overflow-y-auto">
+                <pre className="whitespace-pre-wrap break-words px-3 py-2 text-sm text-gray-100">
+                  {summary}
+                </pre>
+              </div>
+              <div className="mt-2 flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={handleCopySummary}
+                  className="px-3 py-2 rounded bg-blue-600 hover:bg-blue-500 text-sm font-medium"
+                >
+                  Copy summary
+                </button>
+                {renderCopyHint(summaryCopy.status)}
+              </div>
+            </section>
+          </div>
+          <div className="flex justify-end gap-2 border-t border-gray-700 px-5 py-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-sm font-medium"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default CrashSummary;

--- a/docs/support/crash-reporter.md
+++ b/docs/support/crash-reporter.md
@@ -1,0 +1,76 @@
+# Crash reporter flow
+
+This document explains how crash reports are captured, sanitised, and presented in the Kali Linux Portfolio desktop.
+
+## Overview
+
+1. The crash handler (`modules/crash/reporting.ts`) normalises raw errors, generates a crash ID, and builds a human readable
+   summary.
+2. Sensitive information is scrubbed with `utils/logs/privacy.ts` before it is logged, displayed, or exported.
+3. The crash reporter worker (`workers/crashReporter.ts`) and API endpoint (`pages/api/crash/report.ts`) both rely on the
+   crash handler to keep responses consistent across environments.
+4. The UI dialog (`components/apps/crash-reporter/CrashSummary.tsx`) presents the formatted summary with one-click copy
+   helpers for the crash ID and combined summary.
+
+## Crash handler
+
+- `createCrashReport(payload)` accepts a `CrashPayload` containing the error, optional metadata, user steps, and logs.
+- `generateCrashId()` produces IDs shaped like `CRASH-<timestamp base36>-<random>`. The timestamp is derived from the payload
+  when provided so that server-side logs and UI reports can line up.
+- The handler automatically:
+  - Normalises the error object/string into `{ name, message, stack }`.
+  - Sanitises strings, metadata, logs, and stack traces through the privacy scrubber.
+  - Produces a structured `CrashReport` with a `summary` string and `details` block for downstream consumers.
+
+The summary layout includes severity, location (app/component/route), captured time, last action, stack snippet, user steps,
+context metadata, and recent logs. Only the first few entries of each section are kept so reports stay readable.
+
+## Privacy scrubber
+
+`utils/logs/privacy.ts` exports two helpers:
+
+- `scrubSensitiveText(text)` masks home directory paths, file URIs, bearer tokens, API keys, session tokens, and common
+  environment secrets. Windows, macOS, and Linux style paths are covered.
+- `scrubSensitiveData(payload)` recursively walks objects/arrays to redact nested values while avoiding circular references.
+
+Both functions return new values, so callers can safely store or transmit the sanitised payload.
+
+## Worker usage
+
+`workers/crashReporter.ts` listens for `{ type: 'report-crash', payload }` messages, creates a crash report, then posts back one
+of the following:
+
+- `{ type: 'crash-report', report }` with the sanitised `CrashReport`.
+- `{ type: 'crash-report-error', error }` if the report could not be created.
+
+Use this worker when crash formatting work should stay off the main thread (e.g., while capturing heavy stack traces).
+
+## API endpoint
+
+`POST /api/crash/report` accepts a `CrashPayload` JSON body and returns `{ crashId, summary, report }`. The response is
+sanitised by the crash handler and matches what the worker posts back. Non-POST requests receive `405 Method Not Allowed`.
+
+## UI dialog
+
+`CrashSummary` wraps the base `Modal` component and exposes:
+
+```tsx
+<CrashSummary
+  isOpen={isOpen}
+  onClose={handleClose}
+  summary={report.summary}
+  crashId={report.details.crashId}
+/>
+```
+
+The dialog contains:
+
+- Title + helper text encouraging users to share the crash information.
+- Crash ID section with inline copy button feedback.
+- Scrollable summary block with copy support (`summary` + crash ID) and sanitized multiline formatting.
+- Close button plus an overlay that also closes when clicked.
+
+## Testing
+
+Jest coverage lives in `__tests__/crashReporting.test.ts` and verifies both the crash handler output and the privacy scrubber.
+Run `yarn test crashReporting` (or `yarn test` for the full suite) before shipping updates.

--- a/modules/crash/reporting.ts
+++ b/modules/crash/reporting.ts
@@ -1,0 +1,254 @@
+import { scrubSensitiveData, scrubSensitiveText } from '../../utils/logs/privacy';
+
+export type CrashSeverity = 'fatal' | 'error' | 'warning';
+
+export interface CrashPayload {
+  error?: unknown;
+  message?: string;
+  name?: string;
+  stack?: string;
+  severity?: CrashSeverity;
+  app?: string;
+  component?: string;
+  route?: string;
+  action?: string;
+  userSteps?: Array<string | number>;
+  metadata?: Record<string, unknown>;
+  logs?: unknown[];
+  timestamp?: number;
+  environment?: string;
+}
+
+export interface CrashDetails {
+  crashId: string;
+  timestamp: number;
+  severity: CrashSeverity;
+  name?: string;
+  message: string;
+  stack?: string;
+  app?: string;
+  component?: string;
+  route?: string;
+  action?: string;
+  userSteps: string[];
+  metadata: Record<string, unknown>;
+  logs: string[];
+  environment?: string;
+}
+
+export interface CrashReport {
+  summary: string;
+  details: CrashDetails;
+}
+
+const DEFAULT_APP_NAME = 'the Kali Linux portfolio desktop';
+const CRASH_ID_PREFIX = 'CRASH';
+
+const getTimestamp = (value?: number) => (
+  typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : Date.now()
+);
+
+const normaliseError = (error: unknown): { message: string; name?: string; stack?: string } => {
+  if (!error) {
+    return { message: 'Unknown crash' };
+  }
+
+  if (typeof error === 'string') {
+    return { message: error };
+  }
+
+  if (error instanceof Error) {
+    return {
+      message: error.message || 'Unknown crash',
+      name: error.name,
+      stack: error.stack || undefined,
+    };
+  }
+
+  if (typeof error === 'object') {
+    const value = error as Record<string, unknown>;
+    const message = typeof value.message === 'string'
+      ? value.message
+      : JSON.stringify(value);
+    const name = typeof value.name === 'string' ? value.name : undefined;
+    const stack = typeof value.stack === 'string' ? value.stack : undefined;
+    return {
+      message: message || 'Unknown crash',
+      name,
+      stack,
+    };
+  }
+
+  return { message: String(error) };
+};
+
+const ensureStringArray = (value: unknown): string[] => {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => {
+        if (item == null) return '';
+        const text = String(item).trim();
+        return text;
+      })
+      .filter((item) => item.length > 0);
+  }
+  const text = String(value).trim();
+  return text ? [text] : [];
+};
+
+const coerceLogs = (logs: unknown): string[] => {
+  if (!logs) return [];
+  if (Array.isArray(logs)) {
+    return logs
+      .map((entry) => {
+        if (typeof entry === 'string') return entry;
+        if (entry instanceof Error) {
+          return entry.stack || entry.message;
+        }
+        if (entry && typeof entry === 'object') {
+          try {
+            return JSON.stringify(entry);
+          } catch {
+            return String(entry);
+          }
+        }
+        return String(entry);
+      })
+      .map((entry) => scrubSensitiveText(entry))
+      .filter((entry) => entry.trim().length > 0);
+  }
+  if (typeof logs === 'string') {
+    const cleaned = scrubSensitiveText(logs);
+    return cleaned ? [cleaned] : [];
+  }
+  return [];
+};
+
+const truncateStack = (stack?: string): string | undefined => {
+  if (!stack) return undefined;
+  const lines = stack.split('\n').map((line) => line.trim()).filter(Boolean);
+  if (lines.length === 0) return undefined;
+  const maxLines = 8;
+  const truncated = lines.slice(0, maxLines).join('\n');
+  return truncated;
+};
+
+export const generateCrashId = (timestamp: number = Date.now()): string => {
+  const base = timestamp.toString(36).toUpperCase();
+  const random = Math.random().toString(36).slice(2, 8).toUpperCase();
+  return `${CRASH_ID_PREFIX}-${base}-${random}`;
+};
+
+const buildLocationSentence = (details: CrashDetails): string => {
+  const segments: string[] = [];
+  if (details.app) segments.push(`app "${details.app}"`);
+  if (details.component) segments.push(`component "${details.component}"`);
+  if (details.route) segments.push(`route ${details.route}`);
+  const location = segments.length > 0
+    ? segments.join(' · ')
+    : DEFAULT_APP_NAME;
+  const severityLabel = details.severity === 'fatal'
+    ? 'Fatal error'
+    : details.severity === 'warning'
+      ? 'Warning'
+      : 'Error';
+  return `${severityLabel} crash detected in ${location}.`;
+};
+
+const formatMetadata = (metadata: Record<string, unknown>): string[] => {
+  return Object.entries(metadata)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .slice(0, 10)
+    .map(([key, value]) => {
+      if (typeof value === 'string') {
+        return `${key}: ${scrubSensitiveText(value)}`;
+      }
+      try {
+        return `${key}: ${scrubSensitiveText(JSON.stringify(value))}`;
+      } catch {
+        return `${key}: [unserializable]`;
+      }
+    });
+};
+
+export const buildCrashSummary = (details: CrashDetails): string => {
+  const lines: string[] = [];
+  lines.push(buildLocationSentence(details));
+  lines.push(`Crash ID: ${details.crashId}`);
+  lines.push(`Captured at ${new Date(details.timestamp).toISOString()}.`);
+  if (details.environment) {
+    lines.push(`Environment: ${details.environment}`);
+  }
+  lines.push('');
+  lines.push(`Message: ${details.message || 'No error message provided.'}`);
+  if (details.action) {
+    lines.push(`Last action before crash: ${details.action}`);
+  }
+  if (details.stack) {
+    const stackSnippet = truncateStack(details.stack);
+    if (stackSnippet) {
+      lines.push('Stack trace (sanitized):');
+      lines.push(stackSnippet);
+    }
+  }
+  if (details.userSteps.length > 0) {
+    lines.push('');
+    lines.push('Steps leading up to the crash:');
+    details.userSteps.slice(0, 6).forEach((step, index) => {
+      lines.push(`${index + 1}. ${step}`);
+    });
+  }
+  const metadataLines = formatMetadata(details.metadata);
+  if (metadataLines.length > 0) {
+    lines.push('');
+    lines.push('Context:');
+    metadataLines.forEach((entry) => lines.push(`- ${entry}`));
+  }
+  if (details.logs.length > 0) {
+    lines.push('');
+    lines.push('Recent logs:');
+    details.logs.slice(-6).forEach((log) => {
+      lines.push(`• ${log}`);
+    });
+  }
+  return lines.join('\n').trim();
+};
+
+export const createCrashReport = (payload: CrashPayload): CrashReport => {
+  const timestamp = getTimestamp(payload.timestamp);
+  const errorDetails = normaliseError(payload.error ?? payload.message);
+  const baseDetails: CrashDetails = {
+    crashId: generateCrashId(timestamp),
+    timestamp,
+    severity: payload.severity || 'error',
+    name: payload.name || errorDetails.name,
+    message: payload.message || errorDetails.message,
+    stack: payload.stack || errorDetails.stack,
+    app: payload.app,
+    component: payload.component,
+    route: payload.route,
+    action: payload.action,
+    userSteps: ensureStringArray(payload.userSteps),
+    metadata: payload.metadata || {},
+    logs: coerceLogs(payload.logs),
+    environment: payload.environment,
+  };
+
+  const sanitisedDetails = scrubSensitiveData({
+    ...baseDetails,
+    message: scrubSensitiveText(baseDetails.message),
+    stack: baseDetails.stack ? scrubSensitiveText(baseDetails.stack) : undefined,
+  });
+
+  const summary = buildCrashSummary(sanitisedDetails);
+
+  return {
+    summary,
+    details: sanitisedDetails,
+  };
+};
+
+export default createCrashReport;

--- a/pages/api/crash/report.ts
+++ b/pages/api/crash/report.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import createCrashReport from '../../../modules/crash/reporting';
+import type { CrashPayload, CrashReport } from '../../../modules/crash/reporting';
+
+interface CrashApiResponse {
+  crashId: string;
+  summary: string;
+  report: CrashReport;
+}
+
+interface CrashApiError {
+  error: string;
+}
+
+const parsePayload = (req: NextApiRequest): CrashPayload => {
+  if (typeof req.body === 'string') {
+    try {
+      return JSON.parse(req.body) as CrashPayload;
+    } catch (error) {
+      throw new Error('Invalid JSON payload');
+    }
+  }
+  return req.body as CrashPayload;
+};
+
+const crashHandler = (req: NextApiRequest, res: NextApiResponse<CrashApiResponse | CrashApiError>) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  try {
+    const payload = parsePayload(req);
+    const report = createCrashReport(payload || {});
+    res.status(200).json({
+      crashId: report.details.crashId,
+      summary: report.summary,
+      report,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to process crash report';
+    res.status(400).json({ error: message });
+  }
+};
+
+export default crashHandler;

--- a/utils/logs/privacy.ts
+++ b/utils/logs/privacy.ts
@@ -1,0 +1,121 @@
+export const REDACTION_TEXT = '[redacted]';
+
+const UNIX_HOME_PATH_REGEX = /(\/)(Users|home|var\/www|opt)\/([^\s\/]+)(?=\/?)/gi;
+const WINDOWS_DRIVE_HOME_REGEX = /([A-Za-z]:\\Users\\)([A-Za-z0-9_.-]+)/gi;
+const WINDOWS_SERVER_HOME_REGEX = /(\\\\[^\\]+\\Users\\)([A-Za-z0-9_.-]+)/gi;
+const WINDOWS_USERS_HOME_REGEX = /(\\\\Users\\)([A-Za-z0-9_.-]+)/gi;
+const FILE_URI_REGEX = /(file:\/\/)([^\s]+?)(?=\s|$)/gi;
+
+const SECRET_KEYS = [
+  'token',
+  'secret',
+  'password',
+  'passphrase',
+  'apiKey',
+  'api_key',
+  'apikey',
+  'authorization',
+  'auth',
+  'session',
+  'bearer',
+  'supabase',
+  'service_role',
+  'client_secret',
+  'access_key',
+  'secret_key',
+];
+
+const KEY_VALUE_PATTERN = new RegExp(
+  `\\b(${SECRET_KEYS.join('|')})\\s*([:=])\\s*(['\"]?)([^'\"\s;&]+)\\3`,
+  'gi',
+);
+const JSON_SECRET_PATTERN = new RegExp(
+  `"(${SECRET_KEYS.join('|')})"\\s*:\\s*"([^"]*)"`,
+  'gi',
+);
+const QUERY_SECRET_PATTERN = new RegExp(
+  `([?&])(${SECRET_KEYS.join('|')})=([^&\s#]+)`,
+  'gi',
+);
+const BEARER_PATTERN = /Bearer\s+[A-Za-z0-9._\-+/=]+/gi;
+
+const scrubPath = (text: string): string => text
+  .replace(UNIX_HOME_PATH_REGEX, (_match, prefix, base) => `${prefix}${base}/${REDACTION_TEXT}`)
+  .replace(WINDOWS_DRIVE_HOME_REGEX, (_match, prefix) => `${prefix}${REDACTION_TEXT}`)
+  .replace(WINDOWS_SERVER_HOME_REGEX, (_match, prefix) => `${prefix}${REDACTION_TEXT}`)
+  .replace(WINDOWS_USERS_HOME_REGEX, (_match, prefix) => `${prefix}${REDACTION_TEXT}`);
+
+const scrubFileUri = (text: string): string => text.replace(
+  FILE_URI_REGEX,
+  (_match, prefix) => `${prefix}${REDACTION_TEXT}`,
+);
+
+const scrubSecrets = (text: string): string => text
+  .replace(KEY_VALUE_PATTERN, (_match, key, separator, quote) => `${key}${separator}${quote}${REDACTION_TEXT}${quote}`)
+  .replace(JSON_SECRET_PATTERN, (_match, key) => `"${key}":"${REDACTION_TEXT}"`)
+  .replace(QUERY_SECRET_PATTERN, (_match, prefix, key) => `${prefix}${key}=${REDACTION_TEXT}`)
+  .replace(BEARER_PATTERN, () => `Bearer ${REDACTION_TEXT}`);
+
+const scrubEnvironmentVariables = (text: string): string => text.replace(
+  /(export\s+)?([A-Z0-9_]{3,})=([^\s]+)/g,
+  (match, prefix, key, value) => {
+    const lowered = key.toLowerCase();
+    const isSensitive = SECRET_KEYS.some((candidate) => lowered.includes(candidate));
+    const looksSensitive = value.length > 16 && /^[A-Za-z0-9+/=_-]+$/.test(value);
+    if (isSensitive || looksSensitive) {
+      return `${prefix || ''}${key}=${REDACTION_TEXT}`;
+    }
+    return match;
+  },
+);
+
+export const scrubSensitiveText = (input: string): string => {
+  if (!input) return input;
+  let sanitised = input;
+  sanitised = scrubPath(sanitised);
+  sanitised = scrubFileUri(sanitised);
+  sanitised = scrubSecrets(sanitised);
+  sanitised = scrubEnvironmentVariables(sanitised);
+  return sanitised;
+};
+
+type AnyRecord = Record<string, unknown>;
+
+type Visited = WeakSet<object>;
+
+const scrubValue = (value: unknown, visited: Visited): unknown => {
+  if (typeof value === 'string') {
+    return scrubSensitiveText(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => scrubValue(item, visited));
+  }
+  if (value instanceof Date) {
+    return new Date(value.getTime());
+  }
+  if (value instanceof RegExp) {
+    return new RegExp(value.source, value.flags);
+  }
+  if (value && typeof value === 'object') {
+    if (visited.has(value)) {
+      return '[circular]';
+    }
+    visited.add(value);
+    const entries = Object.entries(value as AnyRecord);
+    const result: AnyRecord = {};
+    entries.forEach(([key, inner]) => {
+      result[key] = scrubValue(inner, visited);
+    });
+    visited.delete(value);
+    return result;
+  }
+  return value;
+};
+
+export const scrubSensitiveData = <T>(payload: T): T => {
+  if (payload == null) return payload;
+  const visited: Visited = new WeakSet();
+  return scrubValue(payload, visited) as T;
+};
+
+export default scrubSensitiveData;

--- a/workers/crashReporter.ts
+++ b/workers/crashReporter.ts
@@ -1,0 +1,26 @@
+import { createCrashReport } from '../modules/crash/reporting';
+import type { CrashPayload, CrashReport } from '../modules/crash/reporting';
+
+type WorkerRequest =
+  | { type: 'report-crash'; payload: CrashPayload };
+
+type WorkerResponse =
+  | { type: 'crash-report'; report: CrashReport }
+  | { type: 'crash-report-error'; error: string };
+
+self.onmessage = (event: MessageEvent<WorkerRequest>) => {
+  const message = event.data;
+  if (!message || message.type !== 'report-crash') {
+    return;
+  }
+
+  try {
+    const report = createCrashReport(message.payload);
+    self.postMessage({ type: 'crash-report', report } as WorkerResponse);
+  } catch (error) {
+    const messageText = error instanceof Error ? error.message : 'Failed to create crash report';
+    self.postMessage({ type: 'crash-report-error', error: messageText } as WorkerResponse);
+  }
+};
+
+export {};


### PR DESCRIPTION
## Summary
- add a crash reporting module that normalises errors, generates crash IDs, and produces sanitised summaries
- introduce a privacy scrubber, crash-report worker/API endpoint, and UI dialog for copying crash details safely
- cover the workflow with targeted Jest tests and document the crash reporter flow for support teams

## Testing
- yarn lint *(fails: repository already contains widespread jsx-a11y/no-top-level-window violations in existing apps)*
- yarn test crashReporting

------
https://chatgpt.com/codex/tasks/task_e_68cb4663d0b48328a402d3b9589490fd