### PR TITLE
[notifications] redesign notification center timeline

### DIFF
--- a/__tests__/components/common/NotificationCenter.test.tsx
+++ b/__tests__/components/common/NotificationCenter.test.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import NotificationCenter from '../../../components/common/NotificationCenter';
+import {
+  NotificationMessage,
+  NotificationProvider,
+  NotificationThread,
+  NotificationsByApp,
+} from '../../../components/common/NotificationProvider';
+
+const createThread = ({
+  id,
+  appId,
+  title,
+  collapsed = false,
+  notifications,
+  actions = [],
+  lastTimestamp,
+  meta,
+}: {
+  id: string;
+  appId: string;
+  title: string;
+  collapsed?: boolean;
+  notifications: NotificationMessage[];
+  actions?: NotificationThread['actions'];
+  lastTimestamp?: number;
+  meta?: Record<string, unknown>;
+}): NotificationThread => {
+  const derivedLast =
+    lastTimestamp ??
+    notifications.reduce((max, note) => Math.max(max, note.timestamp), 0);
+  const unreadCount = notifications.filter(note => !note.read).length;
+  const withDismiss =
+    actions.some(action => action.id === 'dismiss')
+      ? actions
+      : [
+          ...actions,
+          {
+            id: 'dismiss',
+            label: 'Dismiss',
+          },
+        ];
+  return {
+    id,
+    appId,
+    title,
+    collapsed,
+    notifications,
+    actions: withDismiss,
+    meta,
+    unreadCount,
+    lastTimestamp: derivedLast,
+  };
+};
+
+const renderCenter = (initialState: NotificationsByApp) =>
+  render(
+    <NotificationProvider initialState={initialState}>
+      <NotificationCenter />
+    </NotificationProvider>
+  );
+
+describe('NotificationCenter', () => {
+  it('groups threads by app and shows unread counts', () => {
+    const state: NotificationsByApp = {
+      terminal: [
+        createThread({
+          id: 'alerts',
+          appId: 'terminal',
+          title: 'Terminal Alerts',
+          notifications: [
+            {
+              id: 't1',
+              message: 'Root login detected',
+              timestamp: 100,
+              read: false,
+            },
+          ],
+        }),
+      ],
+      mail: [
+        createThread({
+          id: 'inbox',
+          appId: 'mail',
+          title: 'Inbox',
+          collapsed: true,
+          notifications: [
+            { id: 'm1', message: 'Welcome', timestamp: 200, read: false },
+            { id: 'm2', message: 'Patch notes', timestamp: 300, read: false },
+          ],
+        }),
+      ],
+    };
+
+    renderCenter(state);
+
+    expect(
+      screen.getByRole('heading', { level: 3, name: /terminal/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 3, name: /mail/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Terminal Alerts')).toBeInTheDocument();
+    expect(screen.getByText('Inbox')).toBeInTheDocument();
+    expect(screen.getByText('1 unread')).toBeInTheDocument();
+    expect(screen.getByText('2 unread')).toBeInTheDocument();
+    expect(screen.getByText('Root login detected')).toBeInTheDocument();
+    expect(screen.queryByText('Welcome')).not.toBeInTheDocument();
+  });
+
+  it('supports expanding and collapsing threads', () => {
+    const state: NotificationsByApp = {
+      terminal: [
+        createThread({
+          id: 'alerts',
+          appId: 'terminal',
+          title: 'Terminal Alerts',
+          collapsed: true,
+          notifications: [
+            {
+              id: 't1',
+              message: 'Root login detected',
+              timestamp: 100,
+              read: false,
+            },
+          ],
+        }),
+      ],
+    };
+
+    renderCenter(state);
+
+    const toggle = screen.getByRole('button', { name: /terminal alerts/i });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('Root login detected')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Root login detected')).toBeInTheDocument();
+    expect(screen.queryByText(/unread/)).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('Root login detected')).not.toBeInTheDocument();
+  });
+
+  it('filters notifications based on the search input', () => {
+    const state: NotificationsByApp = {
+      terminal: [
+        createThread({
+          id: 'alerts',
+          appId: 'terminal',
+          title: 'Terminal Alerts',
+          notifications: [
+            { id: 't1', message: 'Kernel updated', timestamp: 100, read: true },
+          ],
+        }),
+      ],
+      mail: [
+        createThread({
+          id: 'inbox',
+          appId: 'mail',
+          title: 'Inbox',
+          notifications: [
+            { id: 'm1', message: 'Team meeting tomorrow', timestamp: 200, read: false },
+          ],
+        }),
+      ],
+    };
+
+    renderCenter(state);
+
+    const search = screen.getByLabelText(/search notifications/i);
+    fireEvent.change(search, { target: { value: 'team' } });
+
+    expect(screen.getByText('Inbox')).toBeInTheDocument();
+    expect(screen.getByText('Team meeting tomorrow')).toBeInTheDocument();
+    expect(screen.queryByText('Terminal Alerts')).not.toBeInTheDocument();
+  });
+
+  it('dispatches quick actions and falls back to dismiss when unspecified', async () => {
+    const resolve = jest.fn(({ dismiss }: { dismiss: () => void }) => dismiss());
+    const state: NotificationsByApp = {
+      terminal: [
+        createThread({
+          id: 'alerts',
+          appId: 'terminal',
+          title: 'Terminal Alerts',
+          notifications: [
+            { id: 't1', message: 'Root login detected', timestamp: 100, read: false },
+          ],
+          actions: [
+            {
+              id: 'resolve',
+              label: 'Resolve',
+              handler: resolve,
+            },
+          ],
+        }),
+      ],
+      mail: [
+        createThread({
+          id: 'inbox',
+          appId: 'mail',
+          title: 'Inbox',
+          notifications: [
+            { id: 'm1', message: 'Team meeting tomorrow', timestamp: 200, read: false },
+          ],
+        }),
+      ],
+    };
+
+    renderCenter(state);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve' }));
+
+    await waitFor(() => expect(resolve).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.queryByText('Terminal Alerts')).not.toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    await waitFor(() =>
+      expect(screen.getByText('No notifications')).toBeInTheDocument()
+    );
+  });
+});

--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -1,80 +1,256 @@
-import React, { createContext, useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import useNotifications from '../../hooks/useNotifications';
+import { NotificationMessage, NotificationThread } from './NotificationProvider';
 
-export interface AppNotification {
-  id: string;
-  message: string;
-  date: number;
+interface DisplayThread {
+  thread: NotificationThread;
+  visibleNotifications: NotificationMessage[];
 }
 
-interface NotificationsContextValue {
-  notifications: Record<string, AppNotification[]>;
-  pushNotification: (appId: string, message: string) => void;
-  clearNotifications: (appId?: string) => void;
+interface AppGroup {
+  appId: string;
+  unreadCount: number;
+  threads: DisplayThread[];
 }
 
-export const NotificationsContext = createContext<NotificationsContextValue | null>(null);
+const matchesQuery = (value: string, query: string) =>
+  value.toLowerCase().includes(query);
 
-export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
-  const [notifications, setNotifications] = useState<Record<string, AppNotification[]>>({});
+const formatTimestamp = (value: number) =>
+  new Date(value).toLocaleString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    day: 'numeric',
+    month: 'short',
+  });
 
-  const pushNotification = useCallback((appId: string, message: string) => {
-    setNotifications(prev => {
-      const list = prev[appId] ?? [];
-      const next = {
-        ...prev,
-        [appId]: [
-          ...list,
-          {
-            id: `${Date.now()}-${Math.random()}`,
-            message,
-            date: Date.now(),
-          },
-        ],
-      };
-      return next;
+const NotificationCenter: React.FC = () => {
+  const { apps, toggleThreadCollapse, runAction } = useNotifications();
+  const [search, setSearch] = useState('');
+  const query = search.trim().toLowerCase();
+  const threadRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const groups = useMemo<AppGroup[]>(() => {
+    const result: AppGroup[] = [];
+    const entries = Object.entries(apps);
+
+    entries.forEach(([appId, threads]) => {
+      const filteredThreads: DisplayThread[] = threads
+        .map(thread => {
+          if (!query) {
+            return {
+              thread,
+              visibleNotifications: thread.notifications,
+            };
+          }
+          const appMatches = appId.toLowerCase().includes(query);
+          const titleMatches = thread.title.toLowerCase().includes(query);
+          const matchingNotifications = thread.notifications.filter(note =>
+            matchesQuery(note.message, query)
+          );
+          if (!appMatches && !titleMatches && matchingNotifications.length === 0) {
+            return null;
+          }
+          return {
+            thread,
+            visibleNotifications:
+              matchingNotifications.length > 0
+                ? matchingNotifications
+                : thread.notifications,
+          };
+        })
+        .filter((value): value is DisplayThread => value !== null)
+        .sort((a, b) => b.thread.lastTimestamp - a.thread.lastTimestamp);
+
+      if (filteredThreads.length > 0) {
+        result.push({
+          appId,
+          unreadCount: filteredThreads.reduce(
+            (sum, entry) => sum + entry.thread.unreadCount,
+            0
+          ),
+          threads: filteredThreads,
+        });
+      }
     });
-  }, []);
 
-  const clearNotifications = useCallback((appId?: string) => {
-    setNotifications(prev => {
-      if (!appId) return {};
-      const next = { ...prev };
-      delete next[appId];
-      return next;
+    result.sort((a, b) => {
+      const aLatest = a.threads[0]?.thread.lastTimestamp ?? 0;
+      const bLatest = b.threads[0]?.thread.lastTimestamp ?? 0;
+      return bLatest - aLatest;
     });
-  }, []);
 
-  const totalCount = Object.values(notifications).reduce(
-    (sum, list) => sum + list.length,
-    0
+    return result;
+  }, [apps, query]);
+
+  const totalThreads = useMemo(
+    () => groups.reduce((sum, group) => sum + group.threads.length, 0),
+    [groups]
   );
 
   useEffect(() => {
-    const nav: any = navigator;
-    if (nav && nav.setAppBadge) {
-      if (totalCount > 0) nav.setAppBadge(totalCount).catch(() => {});
-      else nav.clearAppBadge?.().catch(() => {});
+    threadRefs.current = threadRefs.current.slice(0, totalThreads);
+  }, [totalThreads]);
+
+  const handleThreadKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    index: number
+  ) => {
+    if (!threadRefs.current.length) return;
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      const next = (index + 1) % threadRefs.current.length;
+      const nextButton = threadRefs.current[next];
+      nextButton?.focus();
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      const previous =
+        (index - 1 + threadRefs.current.length) % threadRefs.current.length;
+      const previousButton = threadRefs.current[previous];
+      previousButton?.focus();
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      const firstButton = threadRefs.current[0];
+      firstButton?.focus();
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      const lastButton = threadRefs.current[threadRefs.current.length - 1];
+      lastButton?.focus();
     }
-  }, [totalCount]);
+  };
+
+  const handleAction = (appId: string, threadId: string, actionId: string) => {
+    Promise.resolve(runAction(appId, threadId, actionId)).catch(() => {});
+  };
+
+  let threadIndex = -1;
 
   return (
-    <NotificationsContext.Provider
-      value={{ notifications, pushNotification, clearNotifications }}
+    <section
+      aria-label="Notification center"
+      className="flex h-full flex-col bg-black/60 text-sm text-white"
     >
-      {children}
-      <div className="notification-center">
-        {Object.entries(notifications).map(([appId, list]) => (
-          <section key={appId} className="notification-group">
-            <h3>{appId}</h3>
-            <ul>
-              {list.map(n => (
-                <li key={n.id}>{n.message}</li>
-              ))}
-            </ul>
-          </section>
-        ))}
+      <div className="sticky top-0 z-10 border-b border-white/10 bg-black/80 px-4 py-3 backdrop-blur">
+        <label htmlFor="notification-search" className="mb-1 block text-xs uppercase tracking-wide text-white/60">
+          Search notifications
+        </label>
+        <input
+          id="notification-search"
+          type="search"
+          value={search}
+          onChange={event => setSearch(event.target.value)}
+          placeholder="Filter by app, thread, or message"
+          className="w-full rounded border border-white/20 bg-black/40 px-3 py-2 text-sm text-white placeholder-white/40 focus:border-sky-400 focus:outline-none focus:ring-1 focus:ring-sky-400"
+        />
       </div>
-    </NotificationsContext.Provider>
+      <div className="flex-1 overflow-y-auto px-4 py-6" role="tree">
+        {groups.length === 0 ? (
+          <p className="text-center text-white/50" role="status">
+            No notifications
+          </p>
+        ) : (
+          <ol className="space-y-8" role="list">
+            {groups.map(group => (
+              <li key={group.appId}>
+                <div className="mb-3 flex items-baseline justify-between gap-3">
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-white/60">
+                    {group.appId}
+                  </h3>
+                  {group.unreadCount > 0 && (
+                    <span className="rounded-full bg-sky-500/20 px-2 py-0.5 text-xs font-medium text-sky-200">
+                      {group.unreadCount} unread
+                    </span>
+                  )}
+                </div>
+                <ol className="space-y-6" role="group">
+                  {group.threads.map(displayThread => {
+                    threadIndex += 1;
+                    const currentIndex = threadIndex;
+                    const thread = displayThread.thread;
+                    const panelId = `${group.appId}-${thread.id}-panel`;
+                    return (
+                      <li key={thread.id} className="relative pl-6">
+                        <span
+                          aria-hidden
+                          className="absolute left-0 top-3 block h-2 w-2 -translate-x-1/2 rounded-full bg-sky-400"
+                        />
+                        <span
+                          aria-hidden
+                          className="absolute left-0 top-5 bottom-0 w-px bg-white/10"
+                        />
+                        <div className="flex items-start justify-between gap-3">
+                          <button
+                            type="button"
+                            ref={element => {
+                              threadRefs.current[currentIndex] = element;
+                            }}
+                            className="flex-1 rounded border border-transparent bg-white/5 px-3 py-2 text-left transition hover:border-white/20 focus:border-sky-400 focus:outline-none focus:ring-1 focus:ring-sky-400"
+                            aria-expanded={!thread.collapsed}
+                            aria-controls={panelId}
+                            onClick={() => toggleThreadCollapse(group.appId, thread.id)}
+                            onKeyDown={event => handleThreadKeyDown(event, currentIndex)}
+                          >
+                            <div className="flex items-center justify-between gap-3">
+                              <div>
+                                <p className="font-medium text-white">{thread.title}</p>
+                                <p className="text-xs text-white/50">
+                                  {formatTimestamp(thread.lastTimestamp)}
+                                </p>
+                              </div>
+                              {thread.unreadCount > 0 && (
+                                <span className="rounded-full bg-sky-500/30 px-2 py-0.5 text-xs font-semibold text-sky-100">
+                                  {thread.unreadCount}
+                                </span>
+                              )}
+                            </div>
+                          </button>
+                          {thread.actions.length > 0 && (
+                            <div className="flex shrink-0 flex-wrap items-center gap-2">
+                              {thread.actions.map(action => (
+                                <button
+                                  key={action.id}
+                                  type="button"
+                                  className="rounded border border-white/20 bg-white/10 px-2 py-1 text-xs font-medium text-white transition hover:border-sky-400 hover:bg-sky-500/20 focus:border-sky-400 focus:outline-none focus:ring-1 focus:ring-sky-400"
+                                  onClick={() => handleAction(group.appId, thread.id, action.id)}
+                                >
+                                  {action.label}
+                                </button>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                        {!thread.collapsed && (
+                          <div id={panelId} role="group" className="mt-3 space-y-3">
+                            <ol className="space-y-2" role="list">
+                              {displayThread.visibleNotifications
+                                .slice()
+                                .sort((a, b) => a.timestamp - b.timestamp)
+                                .map(notification => (
+                                  <li
+                                    key={notification.id}
+                                    className="rounded border border-white/10 bg-white/5 px-3 py-2"
+                                  >
+                                    <div className="flex items-baseline justify-between gap-3">
+                                      <p className="text-white/90">{notification.message}</p>
+                                      <time className="text-xs text-white/50" dateTime={new Date(notification.timestamp).toISOString()}>
+                                        {formatTimestamp(notification.timestamp)}
+                                      </time>
+                                    </div>
+                                  </li>
+                                ))}
+                            </ol>
+                          </div>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ol>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </section>
   );
 };
 

--- a/components/common/NotificationProvider.tsx
+++ b/components/common/NotificationProvider.tsx
@@ -1,0 +1,327 @@
+import React, { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+export interface NotificationMessage {
+  id: string;
+  message: string;
+  timestamp: number;
+  read: boolean;
+}
+
+export interface QuickActionContext {
+  appId: string;
+  thread: NotificationThread;
+  dismiss: () => void;
+  markRead: () => void;
+}
+
+export interface QuickAction {
+  id: string;
+  label: string;
+  icon?: React.ReactNode;
+  handler?: (context: QuickActionContext) => void | Promise<void>;
+}
+
+export interface NotificationThread {
+  id: string;
+  appId: string;
+  title: string;
+  collapsed: boolean;
+  unreadCount: number;
+  lastTimestamp: number;
+  notifications: NotificationMessage[];
+  actions: QuickAction[];
+  meta?: Record<string, unknown>;
+}
+
+export type NotificationsByApp = Record<string, NotificationThread[]>;
+
+export interface PushNotificationInput {
+  threadId: string;
+  title: string;
+  message: string;
+  timestamp?: number;
+  id?: string;
+  actions?: QuickAction[];
+  meta?: Record<string, unknown>;
+  markRead?: boolean;
+  collapsed?: boolean;
+}
+
+export interface NotificationsContextValue {
+  apps: NotificationsByApp;
+  perAppUnread: Record<string, number>;
+  totalUnread: number;
+  pushNotification: (appId: string, payload: PushNotificationInput) => string;
+  toggleThreadCollapse: (appId: string, threadId: string) => void;
+  markThreadRead: (appId: string, threadId: string) => void;
+  runAction: (appId: string, threadId: string, actionId: string) => Promise<void> | void;
+  dismissThread: (appId: string, threadId: string) => void;
+  clearNotifications: (appId?: string) => void;
+}
+
+const ensureDismissAction = (actions: QuickAction[]): QuickAction[] => {
+  const withoutDismiss = actions.filter(action => action.id !== 'dismiss');
+  const dismiss = actions.find(action => action.id === 'dismiss');
+  return [
+    ...withoutDismiss,
+    dismiss ?? {
+      id: 'dismiss',
+      label: 'Dismiss',
+    },
+  ];
+};
+
+const mergeActions = (existing: QuickAction[], incoming: QuickAction[]): QuickAction[] => {
+  const next: QuickAction[] = [];
+  const seen = new Set<string>();
+
+  incoming.forEach(action => {
+    if (seen.has(action.id)) return;
+    next.push(action);
+    seen.add(action.id);
+  });
+
+  existing.forEach(action => {
+    if (seen.has(action.id)) return;
+    next.push(action);
+    seen.add(action.id);
+  });
+
+  return ensureDismissAction(next);
+};
+
+const cloneState = (state: NotificationsByApp): NotificationsByApp =>
+  Object.entries(state).reduce<NotificationsByApp>((acc, [appId, threads]) => {
+    acc[appId] = threads.map(thread => ({
+      ...thread,
+      notifications: thread.notifications.map(note => ({ ...note })),
+      actions: ensureDismissAction(thread.actions.map(action => ({ ...action }))),
+      meta: thread.meta ? { ...thread.meta } : undefined,
+    }));
+    return acc;
+  }, {});
+
+export const NotificationsContext = createContext<NotificationsContextValue | null>(null);
+
+export interface NotificationProviderProps {
+  children?: React.ReactNode;
+  initialState?: NotificationsByApp;
+}
+
+export const NotificationProvider: React.FC<NotificationProviderProps> = ({
+  children,
+  initialState = {},
+}) => {
+  const [apps, setApps] = useState<NotificationsByApp>(() => cloneState(initialState));
+  const appsRef = useRef(apps);
+
+  useEffect(() => {
+    appsRef.current = apps;
+  }, [apps]);
+
+  const markThreadRead = useCallback((appId: string, threadId: string) => {
+    setApps(prev => {
+      const threads = prev[appId];
+      if (!threads) return prev;
+      const index = threads.findIndex(thread => thread.id === threadId);
+      if (index === -1) return prev;
+      const thread = threads[index];
+      if (thread.unreadCount === 0) return prev;
+      const updatedThread: NotificationThread = {
+        ...thread,
+        unreadCount: 0,
+        notifications: thread.notifications.map(note => ({ ...note, read: true })),
+      };
+      const nextThreads = [...threads];
+      nextThreads[index] = updatedThread;
+      return {
+        ...prev,
+        [appId]: nextThreads,
+      };
+    });
+  }, []);
+
+  const dismissThread = useCallback((appId: string, threadId: string) => {
+    setApps(prev => {
+      const threads = prev[appId];
+      if (!threads) return prev;
+      const nextThreads = threads.filter(thread => thread.id !== threadId);
+      if (nextThreads.length === threads.length) return prev;
+      const nextState = { ...prev };
+      if (nextThreads.length > 0) nextState[appId] = nextThreads;
+      else delete nextState[appId];
+      return nextState;
+    });
+  }, []);
+
+  const toggleThreadCollapse = useCallback((appId: string, threadId: string) => {
+    setApps(prev => {
+      const threads = prev[appId];
+      if (!threads) return prev;
+      const index = threads.findIndex(thread => thread.id === threadId);
+      if (index === -1) return prev;
+      const thread = threads[index];
+      const collapsed = !thread.collapsed;
+      const notifications = collapsed
+        ? thread.notifications
+        : thread.notifications.map(note => ({ ...note, read: true }));
+      const unreadCount = collapsed ? thread.unreadCount : 0;
+      const updatedThread: NotificationThread = {
+        ...thread,
+        collapsed,
+        notifications,
+        unreadCount,
+      };
+      const nextThreads = [...threads];
+      nextThreads[index] = updatedThread;
+      return {
+        ...prev,
+        [appId]: nextThreads,
+      };
+    });
+  }, []);
+
+  const pushNotification = useCallback(
+    (appId: string, payload: PushNotificationInput) => {
+      const id = payload.id ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      const timestamp = payload.timestamp ?? Date.now();
+      const message: NotificationMessage = {
+        id,
+        message: payload.message,
+        timestamp,
+        read: Boolean(payload.markRead),
+      };
+
+      setApps(prev => {
+        const threads = prev[appId] ?? [];
+        const index = threads.findIndex(thread => thread.id === payload.threadId);
+        const actions = ensureDismissAction(payload.actions ? [...payload.actions] : []);
+
+        if (index === -1) {
+          const newThread: NotificationThread = {
+            id: payload.threadId,
+            appId,
+            title: payload.title,
+            collapsed: payload.collapsed ?? false,
+            unreadCount: message.read ? 0 : 1,
+            lastTimestamp: timestamp,
+            notifications: [message],
+            actions,
+            meta: payload.meta ? { ...payload.meta } : undefined,
+          };
+          return {
+            ...prev,
+            [appId]: [...threads, newThread].sort(
+              (a, b) => b.lastTimestamp - a.lastTimestamp
+            ),
+          };
+        }
+
+        const thread = threads[index];
+        const nextNotifications = [...thread.notifications, message];
+        const unreadCount = nextNotifications.reduce(
+          (count, note) => count + (note.read ? 0 : 1),
+          0
+        );
+        const updatedThread: NotificationThread = {
+          ...thread,
+          title: payload.title ?? thread.title,
+          collapsed: payload.collapsed ?? thread.collapsed,
+          notifications: nextNotifications,
+          unreadCount,
+          lastTimestamp: Math.max(thread.lastTimestamp, timestamp),
+          actions: mergeActions(thread.actions, actions),
+          meta: payload.meta ? { ...thread.meta, ...payload.meta } : thread.meta,
+        };
+        const nextThreads = [...threads];
+        nextThreads[index] = updatedThread;
+        nextThreads.sort((a, b) => b.lastTimestamp - a.lastTimestamp);
+        return {
+          ...prev,
+          [appId]: nextThreads,
+        };
+      });
+
+      return id;
+    },
+    []
+  );
+
+  const clearNotifications = useCallback((appId?: string) => {
+    setApps(prev => {
+      if (!appId) return {};
+      if (!prev[appId]) return prev;
+      const next = { ...prev };
+      delete next[appId];
+      return next;
+    });
+  }, []);
+
+  const runAction = useCallback<NotificationsContextValue['runAction']>(
+    async (appId, threadId, actionId) => {
+      const threads = appsRef.current[appId];
+      if (!threads) return;
+      const thread = threads.find(item => item.id === threadId);
+      if (!thread) return;
+      const action = thread.actions.find(item => item.id === actionId);
+      if (!action) return;
+      const context: QuickActionContext = {
+        appId,
+        thread,
+        dismiss: () => dismissThread(appId, threadId),
+        markRead: () => markThreadRead(appId, threadId),
+      };
+      try {
+        if (action.handler) {
+          await action.handler(context);
+        } else {
+          dismissThread(appId, threadId);
+        }
+      } finally {
+        markThreadRead(appId, threadId);
+      }
+    },
+    [dismissThread, markThreadRead]
+  );
+
+  const perAppUnread = useMemo(() => {
+    return Object.entries(apps).reduce<Record<string, number>>((acc, [appId, threads]) => {
+      acc[appId] = threads.reduce((sum, thread) => sum + thread.unreadCount, 0);
+      return acc;
+    }, {});
+  }, [apps]);
+
+  const totalUnread = useMemo(
+    () => Object.values(perAppUnread).reduce((sum, count) => sum + count, 0),
+    [perAppUnread]
+  );
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined') return;
+    const nav: any = navigator;
+    if (totalUnread > 0 && nav?.setAppBadge) {
+      nav.setAppBadge(totalUnread).catch(() => {});
+    } else if (totalUnread === 0 && nav?.clearAppBadge) {
+      nav.clearAppBadge().catch(() => {});
+    }
+  }, [totalUnread]);
+
+  const value = useMemo<NotificationsContextValue>(
+    () => ({
+      apps,
+      perAppUnread,
+      totalUnread,
+      pushNotification,
+      toggleThreadCollapse,
+      markThreadRead,
+      runAction,
+      dismissThread,
+      clearNotifications,
+    }),
+    [apps, perAppUnread, totalUnread, pushNotification, toggleThreadCollapse, markThreadRead, runAction, dismissThread, clearNotifications]
+  );
+
+  return <NotificationsContext.Provider value={value}>{children}</NotificationsContext.Provider>;
+};
+
+export default NotificationProvider;

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { NotificationsContext } from '../components/common/NotificationCenter';
+import { NotificationsContext } from '../components/common/NotificationProvider';
 
 export const useNotifications = () => {
   const ctx = useContext(NotificationsContext);


### PR DESCRIPTION
## Summary
- add a dedicated notification provider that tracks per-app threads, unread counts, and quick action handlers
- replace the notification center UI with a searchable timeline layout that supports keyboard navigation
- cover grouping, collapsing, filtering, and quick actions with new Jest tests

## Testing
- yarn test --watch=false __tests__/components/common/NotificationCenter.test.tsx
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label violations in unrelated apps)*

------
https://chatgpt.com/codex/tasks/task_e_68cb141b8d04832881d3c956741e8bfa