### PR TITLE
feat(theme): add gallery with import/export and token schema

### DIFF
--- a/__tests__/themeGallery.test.ts
+++ b/__tests__/themeGallery.test.ts
@@ -1,0 +1,60 @@
+import JSZip from 'jszip';
+import { createThemeArchive, parseThemeArchive } from '../components/apps/theme-gallery/themeIO';
+import { defaultTheme } from '../styles/themes';
+import type { ThemeDefinition } from '../styles/themes';
+
+const createLowContrastTheme = (): ThemeDefinition => ({
+  metadata: {
+    id: 'custom-low-contrast',
+    name: 'Failing Contrast',
+    description: 'Intentionally fails WCAG requirements.',
+    version: '1.0.0',
+    mode: 'dark',
+    attribution: {
+      author: 'Test Suite',
+    },
+  },
+  colors: {
+    ...defaultTheme.colors,
+    background: '#000000',
+    surface: '#010101',
+    surfaceAlt: '#020202',
+    text: '#050505',
+    textMuted: '#080808',
+  },
+  typography: { ...defaultTheme.typography },
+});
+
+const createCustomTheme = (): ThemeDefinition => ({
+  ...defaultTheme,
+  metadata: {
+    ...defaultTheme.metadata,
+    id: 'default-export-copy',
+    name: 'Kali Nightfall Copy',
+  },
+});
+
+describe('theme gallery import/export', () => {
+  it('rejects archives missing required structure', async () => {
+    const zip = new JSZip();
+    zip.file('theme.json', JSON.stringify({ foo: 'bar' }));
+    const buffer = await zip.generateAsync({ type: 'arraybuffer' });
+    await expect(parseThemeArchive(buffer)).rejects.toThrow('Theme metadata is missing.');
+  });
+
+  it('preserves theme metadata when exporting and importing', async () => {
+    const theme = createCustomTheme();
+    const blob = await createThemeArchive(theme);
+    const parsed = await parseThemeArchive(blob);
+    expect(parsed.metadata).toEqual(theme.metadata);
+    expect(parsed.colors.accent).toBe(theme.colors.accent);
+  });
+
+  it('rejects themes that fail contrast guardrails', async () => {
+    const badTheme = createLowContrastTheme();
+    const zip = new JSZip();
+    zip.file('theme.json', JSON.stringify(badTheme));
+    const buffer = await zip.generateAsync({ type: 'arraybuffer' });
+    await expect(parseThemeArchive(buffer)).rejects.toThrow('Theme contrast requirements failed');
+  });
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import ThemeGallery from "../../components/apps/theme-gallery/ThemeGallery";
 
 export default function Settings() {
   const {
@@ -29,7 +30,6 @@ export default function Settings() {
     setHighContrast,
     haptics,
     setHaptics,
-    theme,
     setTheme,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -121,18 +121,8 @@ export default function Settings() {
               backgroundPosition: "center center",
             }}
           ></div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Theme:</label>
-            <select
-              value={theme}
-              onChange={(e) => setTheme(e.target.value)}
-              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-            >
-              <option value="default">Default</option>
-              <option value="dark">Dark</option>
-              <option value="neon">Neon</option>
-              <option value="matrix">Matrix</option>
-            </select>
+          <div className="px-4 pt-4">
+            <ThemeGallery />
           </div>
           <div className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Accent:</label>

--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -3,25 +3,26 @@
 import Image from 'next/image';
 import ExternalFrame from '../../components/ExternalFrame';
 import { CloseIcon, MaximizeIcon, MinimizeIcon } from '../../components/ToolbarIcons';
-import { kaliTheme } from '../../styles/themes/kali';
+import { defaultTheme } from '../../styles/themes';
 import { SIDEBAR_WIDTH, ICON_SIZE } from './utils';
 
 export default function VsCode() {
+  const theme = defaultTheme.colors;
   return (
     <div
       className="flex flex-col min-[1366px]:flex-row h-full w-full max-w-full"
-      style={{ backgroundColor: kaliTheme.background, color: kaliTheme.text }}
+      style={{ backgroundColor: theme.background, color: theme.text }}
     >
       <aside
         className="flex flex-col items-center gap-2 p-1"
-        style={{ width: SIDEBAR_WIDTH, backgroundColor: kaliTheme.sidebar }}
+        style={{ width: SIDEBAR_WIDTH, backgroundColor: theme.surface }}
       >
         <div
           className="rounded"
           style={{
             width: ICON_SIZE,
             height: ICON_SIZE,
-            backgroundColor: kaliTheme.accent,
+            backgroundColor: theme.accent,
           }}
         />
         <div
@@ -29,14 +30,14 @@ export default function VsCode() {
           style={{
             width: ICON_SIZE,
             height: ICON_SIZE,
-            backgroundColor: kaliTheme.accent,
+            backgroundColor: theme.accent,
           }}
         />
       </aside>
       <div className="flex-1 flex flex-col border border-black/20 rounded-md overflow-hidden">
         <div
           className="flex items-center justify-end gap-2 px-2 py-1 border-b border-black/20"
-          style={{ backgroundColor: kaliTheme.background }}
+          style={{ backgroundColor: theme.background }}
         >
           <button aria-label="Minimize">
             <MinimizeIcon />
@@ -48,7 +49,7 @@ export default function VsCode() {
             <CloseIcon />
           </button>
         </div>
-        <div className="relative flex-1" style={{ backgroundColor: kaliTheme.background }}>
+        <div className="relative flex-1" style={{ backgroundColor: theme.background }}>
           <ExternalFrame
             src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
             title="VsCode"
@@ -67,7 +68,7 @@ export default function VsCode() {
         </div>
         <div
           className="flex items-center gap-2 px-2 py-1 border-t border-black/20"
-          style={{ backgroundColor: kaliTheme.sidebar }}
+          style={{ backgroundColor: theme.surface }}
         >
           <span className="flex items-center gap-1 text-[12px] uppercase bg-black/30 px-[6px] py-[2px] rounded-full">
             <svg

--- a/components/apps/theme-gallery/ThemeGallery.tsx
+++ b/components/apps/theme-gallery/ThemeGallery.tsx
@@ -1,0 +1,434 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSettings } from '../../../hooks/useSettings';
+import {
+  BUILT_IN_THEMES,
+  ThemeDefinition,
+} from '../../../styles/themes';
+import {
+  applyAccentColor,
+  applyThemeTokens,
+  getContrastWarnings,
+  getCustomThemes,
+  removeCustomTheme,
+  upsertCustomTheme,
+} from '../../../utils/themeTokens';
+import { createThemeArchive, parseThemeArchive } from './themeIO';
+
+const BUILT_IN_IDS = new Set(BUILT_IN_THEMES.map((theme) => theme.metadata.id));
+
+type Status = { type: 'success' | 'error'; message: string } | null;
+
+type ThemeGalleryProps = {
+  className?: string;
+};
+
+const formatRatio = (value: number) => value.toFixed(2);
+
+const isCustomTheme = (theme: ThemeDefinition) => !BUILT_IN_IDS.has(theme.metadata.id);
+
+const classNames = (
+  ...classes: Array<string | false | null | undefined>
+): string => classes.filter(Boolean).join(' ');
+
+export default function ThemeGallery({ className }: ThemeGalleryProps) {
+  const { theme: activeThemeId, setTheme, setAccent, accent } = useSettings();
+  const [customThemes, setCustomThemes] = useState<ThemeDefinition[]>([]);
+  const [selectedId, setSelectedId] = useState<string>(activeThemeId);
+  const [previewId, setPreviewId] = useState<string | null>(null);
+  const [status, setStatus] = useState<Status>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    setCustomThemes(getCustomThemes());
+  }, []);
+
+  useEffect(() => {
+    setSelectedId(activeThemeId);
+  }, [activeThemeId]);
+
+  const sortedCustomThemes = useMemo(
+    () =>
+      [...customThemes].sort((a, b) =>
+        a.metadata.name.localeCompare(b.metadata.name),
+      ),
+    [customThemes],
+  );
+
+  const themes = useMemo(
+    () => [...BUILT_IN_THEMES, ...sortedCustomThemes],
+    [sortedCustomThemes],
+  );
+
+  const fallbackTheme = BUILT_IN_THEMES[0];
+
+  const activeTheme = useMemo(
+    () => themes.find((item) => item.metadata.id === activeThemeId) ?? fallbackTheme,
+    [themes, activeThemeId, fallbackTheme],
+  );
+
+  const selectedTheme = useMemo(
+    () => themes.find((item) => item.metadata.id === selectedId) ?? activeTheme,
+    [themes, selectedId, activeTheme],
+  );
+
+  const activeThemeRef = useRef<ThemeDefinition>(activeTheme);
+  const accentRef = useRef<string>(accent);
+
+  useEffect(() => {
+    activeThemeRef.current = activeTheme;
+  }, [activeTheme]);
+
+  useEffect(() => {
+    accentRef.current = accent;
+  }, [accent]);
+
+  const stopPreview = useCallback(() => {
+    const fallback = activeThemeRef.current ?? fallbackTheme;
+    applyThemeTokens(fallback);
+    applyAccentColor(accentRef.current);
+    setPreviewId(null);
+  }, [fallbackTheme]);
+
+  useEffect(() => () => stopPreview(), [stopPreview]);
+
+  const previewTheme = useCallback(
+    (theme: ThemeDefinition | null) => {
+      if (!theme) {
+        stopPreview();
+        return;
+      }
+      setPreviewId(theme.metadata.id);
+      applyThemeTokens(theme, { includeAccent: true });
+    },
+    [stopPreview],
+  );
+
+  const showStatus = useCallback((next: Status) => {
+    setStatus(next);
+  }, []);
+
+  const handleApplyTheme = useCallback(
+    (theme: ThemeDefinition) => {
+      setPreviewId(null);
+      setTheme(theme.metadata.id, theme);
+      setAccent(theme.colors.accent);
+      showStatus({
+        type: 'success',
+        message: `Applied theme “${theme.metadata.name}”.`,
+      });
+    },
+    [setAccent, setTheme, showStatus],
+  );
+
+  const handleExportTheme = useCallback(async (theme: ThemeDefinition) => {
+    try {
+      const blob = await createThemeArchive(theme);
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `${theme.metadata.id}.zip`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+      showStatus({
+        type: 'success',
+        message: `Exported “${theme.metadata.name}” as ZIP.`,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Export failed.';
+      showStatus({ type: 'error', message });
+    }
+  }, [showStatus]);
+
+  const handleShareTheme = useCallback(async (theme: ThemeDefinition) => {
+    try {
+      const blob = await createThemeArchive(theme);
+      if (
+        typeof window !== 'undefined' &&
+        'navigator' in window &&
+        typeof navigator.share === 'function'
+      ) {
+        const file = new File([blob], `${theme.metadata.id}.zip`, {
+          type: 'application/zip',
+        });
+        if ((navigator as any).canShare?.({ files: [file] })) {
+          await navigator.share({
+            title: theme.metadata.name,
+            text: theme.metadata.description,
+            files: [file],
+          });
+          showStatus({
+            type: 'success',
+            message: `Shared “${theme.metadata.name}”.`,
+          });
+          return;
+        }
+      }
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `${theme.metadata.id}.zip`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+      showStatus({
+        type: 'success',
+        message: `Download ready for “${theme.metadata.name}”.`,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Share failed.';
+      showStatus({ type: 'error', message });
+    }
+  }, [showStatus]);
+
+  const handleImportTheme = useCallback(async (file: File) => {
+    try {
+      const parsed = await parseThemeArchive(file);
+      const updated = upsertCustomTheme(parsed);
+      setCustomThemes(updated);
+      setSelectedId(parsed.metadata.id);
+      previewTheme(parsed);
+      showStatus({
+        type: 'success',
+        message: `Imported “${parsed.metadata.name}”. Preview before applying.`,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Import failed.';
+      showStatus({ type: 'error', message });
+    }
+  }, [previewTheme, showStatus]);
+
+  const handleRemoveTheme = useCallback(
+    (theme: ThemeDefinition) => {
+      const updated = removeCustomTheme(theme.metadata.id);
+      setCustomThemes(updated);
+      const removingActive = theme.metadata.id === activeThemeId;
+      if (theme.metadata.id === selectedId) {
+        setSelectedId(removingActive ? 'default' : activeThemeId);
+      }
+      if (removingActive) {
+        setTheme('default');
+        setAccent(BUILT_IN_THEMES[0].colors.accent);
+      }
+      showStatus({
+        type: 'success',
+        message: `Removed custom theme “${theme.metadata.name}”.`,
+      });
+    },
+    [activeThemeId, selectedId, setAccent, setTheme, showStatus],
+  );
+
+  const contrastWarnings = useMemo(
+    () => getContrastWarnings(selectedTheme),
+    [selectedTheme],
+  );
+
+  return (
+    <section className={classNames('space-y-4', className)}>
+      <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-ubt-grey">Theme Gallery</h2>
+          <p className="text-sm text-ubt-cool-grey">
+            Explore accessible presets or import your own desktop themes.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="rounded bg-ub-cool-grey px-3 py-2 text-sm text-ubt-grey border border-ubt-cool-grey hover:border-ub-orange focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange"
+          >
+            Import ZIP
+          </button>
+          {selectedTheme && (
+            <button
+              type="button"
+              onClick={() => handleExportTheme(selectedTheme)}
+              className="rounded bg-ub-cool-grey px-3 py-2 text-sm text-ubt-grey border border-ubt-cool-grey hover:border-ub-orange focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange"
+            >
+              Export
+            </button>
+          )}
+          {selectedTheme && (
+            <button
+              type="button"
+              onClick={() => handleShareTheme(selectedTheme)}
+              className="rounded bg-ub-cool-grey px-3 py-2 text-sm text-ubt-grey border border-ubt-cool-grey hover:border-ub-orange focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange"
+            >
+              Share
+            </button>
+          )}
+        </div>
+      </header>
+
+      {status && (
+        <div
+          role="status"
+          className={classNames(
+            'rounded border px-3 py-2 text-sm',
+            status.type === 'error'
+              ? 'border-red-500/60 bg-red-900/20 text-red-300'
+              : 'border-green-500/50 bg-green-900/20 text-green-200',
+          )}
+        >
+          {status.message}
+        </div>
+      )}
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {themes.map((theme) => {
+          const isSelected = selectedId === theme.metadata.id;
+          const isActive = activeThemeId === theme.metadata.id;
+          const isPreviewing = previewId === theme.metadata.id;
+          const swatches = [
+            theme.colors.background,
+            theme.colors.surface,
+            theme.colors.accent,
+            theme.colors.text,
+          ];
+
+          return (
+            <button
+              key={theme.metadata.id}
+              type="button"
+              aria-pressed={isSelected}
+              onClick={() => setSelectedId(theme.metadata.id)}
+              onMouseEnter={() => previewTheme(theme)}
+              onMouseLeave={() => previewTheme(null)}
+              onFocus={() => previewTheme(theme)}
+              onBlur={() => previewTheme(null)}
+              className={classNames(
+                'relative flex h-full flex-col gap-3 rounded border px-4 py-3 text-left transition',
+                'bg-ub-cool-grey/60 hover:border-ub-orange focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange',
+                isSelected ? 'border-ub-orange' : 'border-ubt-cool-grey/40',
+              )}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-ubt-cool-grey">
+                    {theme.metadata.mode === 'dark' ? 'Dark mode' : 'Light mode'}
+                  </p>
+                  <h3 className="text-lg font-medium text-ubt-grey">
+                    {theme.metadata.name}
+                  </h3>
+                  {theme.metadata.description && (
+                    <p className="text-xs text-ubt-cool-grey line-clamp-2">
+                      {theme.metadata.description}
+                    </p>
+                  )}
+                </div>
+                <span
+                  className="rounded-full px-2 py-1 text-xs font-semibold"
+                  style={{
+                    backgroundColor: theme.colors.accent,
+                    color: theme.colors.accentContrast,
+                  }}
+                >
+                  {theme.metadata.tags?.[0] ?? theme.metadata.mode}
+                </span>
+              </div>
+              <div className="flex gap-2">
+                {swatches.map((color) => (
+                  <span
+                    key={color}
+                    className="h-6 flex-1 rounded"
+                    style={{ backgroundColor: color }}
+                  />
+                ))}
+              </div>
+              {(isActive || isPreviewing) && (
+                <span
+                  className={classNames(
+                    'absolute right-3 top-3 rounded-full px-2 py-0.5 text-xs font-semibold uppercase',
+                    isPreviewing
+                      ? 'bg-yellow-500/80 text-black'
+                      : 'bg-ub-orange text-black',
+                  )}
+                >
+                  {isPreviewing ? 'Preview' : 'Active'}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="rounded border border-ubt-cool-grey/40 bg-ub-cool-grey/40 p-4">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-2">
+            <h3 className="text-lg font-medium text-ubt-grey">{selectedTheme.metadata.name}</h3>
+            <dl className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 text-sm text-ubt-cool-grey">
+              <dt>Version</dt>
+              <dd>{selectedTheme.metadata.version}</dd>
+              <dt>Author</dt>
+              <dd>{selectedTheme.metadata.attribution.author}</dd>
+              {selectedTheme.metadata.attribution.source && (
+                <>
+                  <dt>Source</dt>
+                  <dd>{selectedTheme.metadata.attribution.source}</dd>
+                </>
+              )}
+              {selectedTheme.metadata.attribution.license && (
+                <>
+                  <dt>License</dt>
+                  <dd>{selectedTheme.metadata.attribution.license}</dd>
+                </>
+              )}
+            </dl>
+          </div>
+          <div className="flex flex-col gap-2 md:items-end">
+            <button
+              type="button"
+              className="rounded bg-ub-orange px-4 py-2 text-sm font-semibold text-black hover:bg-ub-orange/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange"
+              onClick={() => handleApplyTheme(selectedTheme)}
+            >
+              Apply Theme
+            </button>
+            {isCustomTheme(selectedTheme) && (
+              <button
+                type="button"
+                onClick={() => handleRemoveTheme(selectedTheme)}
+                className="text-xs text-ubt-cool-grey underline hover:text-ubt-grey"
+              >
+                Remove custom theme
+              </button>
+            )}
+          </div>
+        </div>
+        <div className="mt-4">
+          {contrastWarnings.length === 0 ? (
+            <p className="text-sm text-green-300">
+              All contrast checks pass WCAG AA thresholds.
+            </p>
+          ) : (
+            <div className="space-y-1 text-sm text-red-300">
+              <p className="font-semibold">Contrast adjustments required:</p>
+              <ul className="list-disc pl-6">
+                {contrastWarnings.map((warning) => (
+                  <li key={warning.pair}>
+                    {warning.pair} {formatRatio(warning.value)} (needs ≥{' '}
+                    {formatRatio(warning.minimum)})
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="application/zip,.zip"
+        className="hidden"
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          if (file) {
+            void handleImportTheme(file);
+          }
+          event.target.value = '';
+        }}
+      />
+    </section>
+  );
+}

--- a/components/apps/theme-gallery/themeIO.ts
+++ b/components/apps/theme-gallery/themeIO.ts
@@ -1,0 +1,64 @@
+import JSZip from 'jszip';
+import type { ThemeDefinition } from '../../../styles/themes';
+import { validateThemeDefinition } from '../../../utils/themeTokens';
+
+export const THEME_ARCHIVE_FILENAME = 'theme.json';
+
+const serializeTheme = (theme: ThemeDefinition): string =>
+  JSON.stringify(theme, null, 2);
+
+export const createThemeArchive = async (theme: ThemeDefinition): Promise<Blob> => {
+  const zip = new JSZip();
+  zip.file(THEME_ARCHIVE_FILENAME, serializeTheme(theme));
+  return zip.generateAsync({ type: 'blob' });
+};
+
+const toArrayBuffer = async (input: ArrayBuffer | Blob): Promise<ArrayBuffer> => {
+  if (input instanceof Blob) {
+    if (typeof input.arrayBuffer === 'function') {
+      return input.arrayBuffer();
+    }
+    if (typeof FileReader === 'function') {
+      return new Promise<ArrayBuffer>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const result = reader.result;
+          if (result instanceof ArrayBuffer) {
+            resolve(result);
+          } else {
+            reject(new Error('Failed to read theme archive.'));
+          }
+        };
+        reader.onerror = () => {
+          reject(reader.error ?? new Error('Failed to read theme archive.'));
+        };
+        reader.readAsArrayBuffer(input);
+      });
+    }
+    return new Response(input).arrayBuffer();
+  }
+  return input;
+};
+
+export const parseThemeArchive = async (
+  input: ArrayBuffer | Blob,
+): Promise<ThemeDefinition> => {
+  const data = await toArrayBuffer(input);
+  const zip = await JSZip.loadAsync(data);
+  const entry = zip.file(THEME_ARCHIVE_FILENAME);
+  if (!entry) {
+    throw new Error('Theme archive missing theme.json');
+  }
+  let parsed: unknown;
+  try {
+    const raw = await entry.async('string');
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error('Theme archive contains invalid JSON');
+  }
+  const validation = validateThemeDefinition(parsed);
+  if (!validation.valid) {
+    throw new Error(validation.errors.join('\n'));
+  }
+  return parsed as ThemeDefinition;
+};

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -23,6 +23,7 @@ import {
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+import { applyAccentColor } from '../utils/themeTokens';
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
@@ -34,22 +35,6 @@ export const ACCENT_OPTIONS = [
   '#805ad5', // purple
   '#ed64a6', // pink
 ];
-
-// Utility to lighten or darken a hex color by a percentage
-const shadeColor = (color: string, percent: number): string => {
-  const f = parseInt(color.slice(1), 16);
-  const t = percent < 0 ? 0 : 255;
-  const p = Math.abs(percent);
-  const R = f >> 16;
-  const G = (f >> 8) & 0x00ff;
-  const B = f & 0x0000ff;
-  const newR = Math.round((t - R) * p) + R;
-  const newG = Math.round((t - G) * p) + G;
-  const newB = Math.round((t - B) * p) + B;
-  return `#${(0x1000000 + newR * 0x10000 + newG * 0x100 + newB)
-    .toString(16)
-    .slice(1)}`;
-};
 
 interface SettingsContextValue {
   accent: string;
@@ -136,19 +121,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [theme]);
 
   useEffect(() => {
-    const border = shadeColor(accent, -0.2);
-    const vars: Record<string, string> = {
-      '--color-ub-orange': accent,
-      '--color-ub-border-orange': border,
-      '--color-primary': accent,
-      '--color-accent': accent,
-      '--color-focus-ring': accent,
-      '--color-selection': accent,
-      '--color-control-accent': accent,
-    };
-    Object.entries(vars).forEach(([key, value]) => {
-      document.documentElement.style.setProperty(key, value);
-    });
+    applyAccentColor(accent);
     saveAccent(accent);
   }, [accent]);
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "idb": "7.1.1",
     "idb-keyval": "^6.2.1",
     "jspdf": "^3.0.2",
+    "jszip": "^3.10.1",
     "kaitai-struct": "^0.10.0",
     "leaflet": "^1.9.4",
     "marked": "^16.2.1",

--- a/styles/themes/dark.ts
+++ b/styles/themes/dark.ts
@@ -1,0 +1,46 @@
+import { ThemeDefinition } from './types';
+
+export const darkTheme: ThemeDefinition = {
+  metadata: {
+    id: 'dark',
+    name: 'Obsidian Terminal',
+    description: 'Matte black surfaces with neon lilac highlights for late-night operators.',
+    version: '1.0.0',
+    mode: 'dark',
+    tags: ['dark', 'high-contrast'],
+    createdAt: '2024-01-01T00:00:00.000Z',
+    attribution: {
+      author: 'Kali Linux Portfolio Maintainers',
+      license: 'CC BY-SA 4.0',
+      source: 'Custom dark variant tuned for WCAG AA compliance',
+    },
+  },
+  colors: {
+    background: '#000000',
+    surface: '#121212',
+    surfaceAlt: '#0a0a0a',
+    muted: '#1f1f1f',
+    text: '#e5e5e5',
+    textMuted: '#bdbdbd',
+    accent: '#bb86fc',
+    accentMuted: '#6c4ab6',
+    accentContrast: '#000000',
+    border: '#333333',
+    borderStrong: '#6c4ab6',
+    focus: '#bb86fc',
+    selection: '#1e88e5',
+    success: '#4caf50',
+    warning: '#ff9800',
+    danger: '#ef5350',
+    info: '#64b5f6',
+    terminal: '#00ff00',
+  },
+  typography: {
+    fontFamily: "'Ubuntu', sans-serif",
+    headingFamily: "'Ubuntu', sans-serif",
+    monospaceFamily: "'Fira Code', 'Ubuntu Mono', monospace",
+    baseFontSize: '16px',
+    lineHeight: 1.6,
+    letterSpacing: '0.01em',
+  },
+};

--- a/styles/themes/index.ts
+++ b/styles/themes/index.ts
@@ -1,0 +1,23 @@
+import { defaultTheme } from './kali';
+import { darkTheme } from './dark';
+import { neonTheme } from './neon';
+import { matrixTheme } from './matrix';
+import type { ThemeDefinition } from './types';
+
+export const BUILT_IN_THEMES: ThemeDefinition[] = [
+  defaultTheme,
+  darkTheme,
+  neonTheme,
+  matrixTheme,
+];
+
+export const BUILT_IN_THEME_MAP: Record<string, ThemeDefinition> = Object.fromEntries(
+  BUILT_IN_THEMES.map((theme) => [theme.metadata.id, theme]),
+);
+
+export type { ThemeDefinition } from './types';
+export * from './types';
+export { defaultTheme };
+export { darkTheme };
+export { neonTheme };
+export { matrixTheme };

--- a/styles/themes/kali.ts
+++ b/styles/themes/kali.ts
@@ -1,8 +1,49 @@
-export const kaliTheme = {
-  background: 'var(--color-bg)',
-  text: 'var(--color-text)',
-  accent: 'var(--color-primary)',
-  sidebar: 'var(--color-secondary)',
+import { ThemeDefinition } from './types';
+
+export const defaultTheme: ThemeDefinition = {
+  metadata: {
+    id: 'default',
+    name: 'Kali Nightfall',
+    description: 'Default Kali Linux inspired desktop with cool navy surfaces and electric blue highlights.',
+    version: '1.0.0',
+    mode: 'dark',
+    tags: ['official', 'kali', 'dark'],
+    createdAt: '2024-01-01T00:00:00.000Z',
+    attribution: {
+      author: 'Alex Unnippillil',
+      url: 'https://unnippillil.com',
+      source: 'Kali Linux brand palette',
+      license: 'CC BY-SA 4.0',
+    },
+  },
+  colors: {
+    background: '#0f1317',
+    surface: '#1a1f26',
+    surfaceAlt: '#13171b',
+    muted: '#2a2e36',
+    text: '#f5f5f5',
+    textMuted: '#b1b7bd',
+    accent: '#1793d1',
+    accentMuted: '#0f6fa0',
+    accentContrast: '#ffffff',
+    border: '#2a2e36',
+    borderStrong: '#0f6fa0',
+    focus: '#1793d1',
+    selection: '#1793d1',
+    success: '#15803d',
+    warning: '#d97706',
+    danger: '#b91c1c',
+    info: '#62a0ea',
+    terminal: '#00ff00',
+  },
+  typography: {
+    fontFamily: "'Ubuntu', sans-serif",
+    headingFamily: "'Ubuntu', sans-serif",
+    monospaceFamily: "'Fira Code', 'Ubuntu Mono', monospace",
+    baseFontSize: '16px',
+    lineHeight: 1.5,
+    letterSpacing: '0em',
+  },
 };
 
-export type KaliTheme = typeof kaliTheme;
+export const kaliTheme = defaultTheme;

--- a/styles/themes/matrix.ts
+++ b/styles/themes/matrix.ts
@@ -1,0 +1,46 @@
+import { ThemeDefinition } from './types';
+
+export const matrixTheme: ThemeDefinition = {
+  metadata: {
+    id: 'matrix',
+    name: 'Matrix Rain',
+    description: 'Monochrome phosphor greens inspired by falling code rain.',
+    version: '1.0.0',
+    mode: 'dark',
+    tags: ['matrix', 'terminal', 'dark'],
+    createdAt: '2024-01-01T00:00:00.000Z',
+    attribution: {
+      author: 'Kali Linux Portfolio Maintainers',
+      license: 'CC BY-SA 4.0',
+      source: 'Classic sci-fi green terminal aesthetic',
+    },
+  },
+  colors: {
+    background: '#000000',
+    surface: '#001100',
+    surfaceAlt: '#002200',
+    muted: '#003300',
+    text: '#00ff00',
+    textMuted: '#66ff66',
+    accent: '#00ff00',
+    accentMuted: '#009900',
+    accentContrast: '#001100',
+    border: '#003300',
+    borderStrong: '#00ff00',
+    focus: '#00ff00',
+    selection: '#004400',
+    success: '#00ff66',
+    warning: '#ccff33',
+    danger: '#ff4d4d',
+    info: '#2ee59d',
+    terminal: '#00ff00',
+  },
+  typography: {
+    fontFamily: "'Ubuntu', sans-serif",
+    headingFamily: "'Ubuntu', sans-serif",
+    monospaceFamily: "'Source Code Pro', 'Fira Code', monospace",
+    baseFontSize: '16px',
+    lineHeight: 1.5,
+    letterSpacing: '0.03em',
+  },
+};

--- a/styles/themes/neon.ts
+++ b/styles/themes/neon.ts
@@ -1,0 +1,46 @@
+import { ThemeDefinition } from './types';
+
+export const neonTheme: ThemeDefinition = {
+  metadata: {
+    id: 'neon',
+    name: 'Synthwave Grid',
+    description: 'High energy neon palette with laser magenta accents for retro futurism vibes.',
+    version: '1.0.0',
+    mode: 'dark',
+    tags: ['neon', 'retro', 'dark'],
+    createdAt: '2024-01-01T00:00:00.000Z',
+    attribution: {
+      author: 'Kali Linux Portfolio Maintainers',
+      license: 'CC BY-SA 4.0',
+      source: 'Inspired by classic synthwave poster palettes',
+    },
+  },
+  colors: {
+    background: '#000000',
+    surface: '#111111',
+    surfaceAlt: '#1a1a1a',
+    muted: '#222222',
+    text: '#ffffff',
+    textMuted: '#d4d4d4',
+    accent: '#ff00ff',
+    accentMuted: '#b300ff',
+    accentContrast: '#0a0a0a',
+    border: '#333333',
+    borderStrong: '#ff00ff',
+    focus: '#ff00ff',
+    selection: '#39ff14',
+    success: '#39ff14',
+    warning: '#ffb347',
+    danger: '#ff4f81',
+    info: '#39c0ff',
+    terminal: '#39ff14',
+  },
+  typography: {
+    fontFamily: "'Ubuntu', sans-serif",
+    headingFamily: "'Orbitron', 'Ubuntu', sans-serif",
+    monospaceFamily: "'Fira Code', 'Ubuntu Mono', monospace",
+    baseFontSize: '16px',
+    lineHeight: 1.55,
+    letterSpacing: '0.02em',
+  },
+};

--- a/styles/themes/types.ts
+++ b/styles/themes/types.ts
@@ -1,0 +1,67 @@
+export type ThemeMode = 'light' | 'dark';
+
+export interface ThemeAttribution {
+  author: string;
+  url?: string;
+  email?: string;
+  source?: string;
+  license?: string;
+}
+
+export interface ThemeMetadata {
+  /** Unique identifier used for persistence */
+  id: string;
+  /** Human friendly name shown in the gallery */
+  name: string;
+  /** Short marketing style description */
+  description?: string;
+  /** Semver style version for compatibility checks */
+  version: string;
+  /** Indicates whether the palette is light or dark biased */
+  mode: ThemeMode;
+  /** Optional tags exposed in filters */
+  tags?: string[];
+  /** Attribution details surfaced in the UI */
+  attribution: ThemeAttribution;
+  /** Optional preview image or swatch reference */
+  previewImage?: string;
+  /** ISO8601 string used when sharing */
+  createdAt?: string;
+}
+
+export interface ThemeColorTokens {
+  background: string;
+  surface: string;
+  surfaceAlt: string;
+  muted: string;
+  text: string;
+  textMuted: string;
+  accent: string;
+  accentMuted: string;
+  accentContrast: string;
+  border: string;
+  borderStrong: string;
+  focus: string;
+  selection: string;
+  success: string;
+  warning: string;
+  danger: string;
+  info: string;
+  terminal: string;
+}
+
+export interface ThemeTypographyTokens {
+  fontFamily: string;
+  headingFamily: string;
+  monospaceFamily: string;
+  baseFontSize: string;
+  lineHeight: number;
+  letterSpacing: string;
+}
+
+export interface ThemeDefinition {
+  metadata: ThemeMetadata;
+  colors: ThemeColorTokens;
+  typography: ThemeTypographyTokens;
+  notes?: string;
+}

--- a/utils/themeTokens.ts
+++ b/utils/themeTokens.ts
@@ -1,0 +1,336 @@
+import { contrastRatio } from '../components/apps/Games/common/theme';
+import {
+  BUILT_IN_THEME_MAP,
+  BUILT_IN_THEMES,
+  ThemeDefinition,
+  ThemeColorTokens,
+  ThemeTypographyTokens,
+} from '../styles/themes';
+
+const CUSTOM_THEME_STORAGE_KEY = 'app:themes';
+
+export interface ContrastWarning {
+  pair: string;
+  value: number;
+  minimum: number;
+}
+
+export interface ThemeValidationResult {
+  valid: boolean;
+  errors: string[];
+  contrastWarnings: ContrastWarning[];
+}
+
+const COLOR_KEYS: (keyof ThemeColorTokens)[] = [
+  'background',
+  'surface',
+  'surfaceAlt',
+  'muted',
+  'text',
+  'textMuted',
+  'accent',
+  'accentMuted',
+  'accentContrast',
+  'border',
+  'borderStrong',
+  'focus',
+  'selection',
+  'success',
+  'warning',
+  'danger',
+  'info',
+  'terminal',
+];
+
+const TYPOGRAPHY_KEYS: (keyof ThemeTypographyTokens)[] = [
+  'fontFamily',
+  'headingFamily',
+  'monospaceFamily',
+  'baseFontSize',
+  'lineHeight',
+  'letterSpacing',
+];
+
+const HEX_COLOR_REGEX = /^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+const THEME_ID_REGEX = /^[a-z0-9-]+$/i;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const readLocalStorage = (key: string): string | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+};
+
+const writeLocalStorage = (key: string, value: string): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    /* swallow storage errors */
+  }
+};
+
+export const shadeColor = (color: string, percent: number): string => {
+  const normalized = color.startsWith('#') ? color.slice(1) : color;
+  const base = parseInt(normalized, 16);
+  const target = percent < 0 ? 0 : 255;
+  const ratio = Math.abs(percent);
+  const r = base >> 16;
+  const g = (base >> 8) & 0x00ff;
+  const b = base & 0x0000ff;
+  const mix = (channel: number) => Math.round((target - channel) * ratio) + channel;
+  const [nr, ng, nb] = [r, g, b].map(mix);
+  return `#${((1 << 24) + (nr << 16) + (ng << 8) + nb).toString(16).slice(1)}`;
+};
+
+const COLOR_VARIABLE_MAP: Record<keyof ThemeColorTokens, string[]> = {
+  background: ['--color-bg', '--color-ub-grey', '--kali-bg'],
+  surface: ['--color-surface', '--color-ub-cool-grey', '--color-ub-lite-abrgn'],
+  surfaceAlt: ['--color-ub-dark-grey'],
+  muted: ['--color-muted'],
+  text: ['--color-text', '--color-ubt-grey'],
+  textMuted: ['--color-ubt-cool-grey', '--color-ubt-warm-grey', '--color-ub-warm-grey'],
+  accent: [],
+  accentMuted: ['--color-secondary', '--color-ub-gedit-dark'],
+  accentContrast: ['--color-inverse'],
+  border: ['--color-border'],
+  borderStrong: [],
+  focus: ['--focus-outline-color'],
+  selection: [],
+  success: ['--game-color-success', '--color-ubt-green'],
+  warning: ['--game-color-warning', '--color-ubt-gedit-orange'],
+  danger: ['--game-color-danger'],
+  info: ['--game-color-secondary', '--color-ubt-blue', '--color-ubt-gedit-blue'],
+  terminal: ['--color-terminal'],
+};
+
+const TYPOGRAPHY_VARIABLE_MAP: Record<keyof ThemeTypographyTokens, string> = {
+  fontFamily: '--font-family-base',
+  headingFamily: '--font-family-heading',
+  monospaceFamily: '--font-family-mono',
+  baseFontSize: '--theme-font-size',
+  lineHeight: '--theme-line-height',
+  letterSpacing: '--theme-letter-spacing',
+};
+
+export const applyAccentColor = (accent: string): void => {
+  if (typeof document === 'undefined') return;
+  const border = shadeColor(accent, -0.2);
+  const vars: Record<string, string> = {
+    '--color-ub-orange': accent,
+    '--color-ub-border-orange': border,
+    '--color-primary': accent,
+    '--color-accent': accent,
+    '--color-control-accent': accent,
+    '--color-focus-ring': accent,
+    '--color-selection': accent,
+  };
+  Object.entries(vars).forEach(([key, value]) => {
+    document.documentElement.style.setProperty(key, value);
+  });
+  document.documentElement.style.setProperty('accent-color', accent);
+};
+
+export const applyThemeTokens = (
+  theme: ThemeDefinition,
+  options: { includeAccent?: boolean } = {},
+): void => {
+  if (typeof document === 'undefined') return;
+  const { includeAccent = false } = options;
+  document.documentElement.dataset.theme = theme.metadata.id;
+  document.documentElement.classList.toggle('dark', theme.metadata.mode === 'dark');
+
+  Object.entries(COLOR_VARIABLE_MAP).forEach(([token, variables]) => {
+    const value = theme.colors[token as keyof ThemeColorTokens];
+    variables.forEach((cssVar) => {
+      document.documentElement.style.setProperty(cssVar, value);
+    });
+  });
+
+  Object.entries(TYPOGRAPHY_VARIABLE_MAP).forEach(([token, variable]) => {
+    const value = theme.typography[token as keyof ThemeTypographyTokens];
+    document.documentElement.style.setProperty(variable, String(value));
+  });
+
+  if (includeAccent) {
+    applyAccentColor(theme.colors.accent);
+  }
+};
+
+export const getContrastWarnings = (theme: ThemeDefinition): ContrastWarning[] => {
+  const warnings: ContrastWarning[] = [];
+  const bodyContrast = contrastRatio(theme.colors.text, theme.colors.background);
+  if (bodyContrast < 4.5) {
+    warnings.push({ pair: 'text/background', value: bodyContrast, minimum: 4.5 });
+  }
+
+  const surfaceContrast = contrastRatio(theme.colors.text, theme.colors.surface);
+  if (surfaceContrast < 4.5) {
+    warnings.push({ pair: 'text/surface', value: surfaceContrast, minimum: 4.5 });
+  }
+
+  const mutedContrast = contrastRatio(theme.colors.textMuted, theme.colors.background);
+  if (mutedContrast < 3) {
+    warnings.push({ pair: 'muted text/background', value: mutedContrast, minimum: 3 });
+  }
+
+  const accentBgContrast = contrastRatio(
+    theme.colors.accent,
+    theme.colors.background,
+  );
+  if (accentBgContrast < 3) {
+    warnings.push({ pair: 'accent/background', value: accentBgContrast, minimum: 3 });
+  }
+
+  const accentTextContrast = contrastRatio(
+    theme.colors.accentContrast,
+    theme.colors.accent,
+  );
+  if (accentTextContrast < 3) {
+    warnings.push({ pair: 'accent contrast/accent', value: accentTextContrast, minimum: 3 });
+  }
+
+  return warnings;
+};
+
+export const validateThemeDefinition = (theme: unknown): ThemeValidationResult => {
+  const errors: string[] = [];
+  const contrastWarnings: ContrastWarning[] = [];
+
+  if (!isRecord(theme)) {
+    return { valid: false, errors: ['Theme data must be an object.'], contrastWarnings };
+  }
+
+  const metadata = theme.metadata;
+  if (!isRecord(metadata)) {
+    errors.push('Theme metadata is missing.');
+  } else {
+    if (typeof metadata.id !== 'string' || !metadata.id.trim()) {
+      errors.push('Theme metadata.id is required.');
+    } else if (!THEME_ID_REGEX.test(metadata.id)) {
+      errors.push('Theme id must use alphanumeric or dash characters.');
+    }
+    if (typeof metadata.name !== 'string' || !metadata.name.trim()) {
+      errors.push('Theme metadata.name is required.');
+    }
+    if (typeof metadata.version !== 'string' || !metadata.version.trim()) {
+      errors.push('Theme metadata.version is required.');
+    }
+    if (metadata.mode !== 'light' && metadata.mode !== 'dark') {
+      errors.push('Theme metadata.mode must be "light" or "dark".');
+    }
+    if (!isRecord(metadata.attribution)) {
+      errors.push('Theme metadata.attribution is required.');
+    } else if (
+      typeof metadata.attribution.author !== 'string' ||
+      !metadata.attribution.author.trim()
+    ) {
+      errors.push('Theme attribution author is required.');
+    }
+    if (BUILT_IN_THEME_MAP[metadata.id]) {
+      errors.push('Theme id conflicts with a built-in theme. Choose another id.');
+    }
+  }
+
+  const colors = theme.colors;
+  if (!isRecord(colors)) {
+    errors.push('Theme colors are missing.');
+  } else {
+    for (const key of COLOR_KEYS) {
+      const value = colors[key];
+      if (typeof value !== 'string' || !value.trim()) {
+        errors.push(`Theme colors.${key} is required.`);
+      } else if (!HEX_COLOR_REGEX.test(value.trim())) {
+        errors.push(`Theme colors.${key} must be a hex color value.`);
+      }
+    }
+  }
+
+  const typography = theme.typography;
+  if (!isRecord(typography)) {
+    errors.push('Theme typography is missing.');
+  } else {
+    for (const key of TYPOGRAPHY_KEYS) {
+      const value = typography[key];
+      if (key === 'lineHeight') {
+        if (typeof value !== 'number' || Number.isNaN(value)) {
+          errors.push('Theme typography.lineHeight must be a number.');
+        }
+      } else if (typeof value !== 'string' || !value.trim()) {
+        errors.push(`Theme typography.${key} is required.`);
+      }
+    }
+  }
+
+  if (errors.length === 0) {
+    const definition = theme as ThemeDefinition;
+    contrastWarnings.push(...getContrastWarnings(definition));
+  }
+
+  if (contrastWarnings.length > 0) {
+    contrastWarnings.forEach((warning) => {
+      errors.push(
+        `Contrast warning for ${warning.pair}: ${warning.value.toFixed(2)} (requires ≥ ${warning.minimum.toFixed(2)}).`,
+      );
+    });
+    errors.push(
+      'Theme contrast requirements failed. Adjust colors to meet WCAG thresholds.',
+    );
+  }
+
+  return { valid: errors.length === 0, errors, contrastWarnings };
+};
+
+export const getCustomThemes = (): ThemeDefinition[] => {
+  const raw = readLocalStorage(CUSTOM_THEME_STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    const valid: ThemeDefinition[] = [];
+    parsed.forEach((item) => {
+      const result = validateThemeDefinition(item);
+      if (result.valid) {
+        valid.push(item as ThemeDefinition);
+      }
+    });
+    return valid;
+  } catch {
+    return [];
+  }
+};
+
+export const saveCustomThemes = (themes: ThemeDefinition[]): void => {
+  writeLocalStorage(CUSTOM_THEME_STORAGE_KEY, JSON.stringify(themes));
+};
+
+export const upsertCustomTheme = (theme: ThemeDefinition): ThemeDefinition[] => {
+  const themes = getCustomThemes();
+  const filtered = themes.filter((item) => item.metadata.id !== theme.metadata.id);
+  filtered.push(theme);
+  saveCustomThemes(filtered);
+  return filtered;
+};
+
+export const removeCustomTheme = (id: string): ThemeDefinition[] => {
+  const themes = getCustomThemes().filter((theme) => theme.metadata.id !== id);
+  saveCustomThemes(themes);
+  return themes;
+};
+
+export const getThemeDefinition = (id: string): ThemeDefinition | undefined => {
+  const builtIn = BUILT_IN_THEME_MAP[id];
+  if (builtIn) return builtIn;
+  const custom = getCustomThemes().find((theme) => theme.metadata.id === id);
+  return custom;
+};
+
+export const getAllThemes = (): ThemeDefinition[] => [
+  ...BUILT_IN_THEMES,
+  ...getCustomThemes(),
+];

--- a/yarn.lock
+++ b/yarn.lock
@@ -5791,6 +5791,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-util-is@npm:~1.0.0":
+  version: 1.0.3
+  resolution: "core-util-is@npm:1.0.3"
+  checksum: 10c0/90a0e40abbddfd7618f8ccd63a74d88deea94e77d0e8dbbea059fa7ebebb8fbb4e2909667fe26f3a467073de1a542ebe6ae4c73a73745ac5833786759cd906c9
+  languageName: node
+  linkType: hard
+
 "cose-base@npm:^1.0.0":
   version: 1.0.3
   resolution: "cose-base@npm:1.0.3"
@@ -8095,6 +8102,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immediate@npm:~3.0.5":
+  version: 3.0.6
+  resolution: "immediate@npm:3.0.6"
+  checksum: 10c0/f8ba7ede69bee9260241ad078d2d535848745ff5f6995c7c7cb41cfdc9ccc213f66e10fa5afb881f90298b24a3f7344b637b592beb4f54e582770cdce3f1f039
+  languageName: node
+  linkType: hard
+
 "import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
   version: 3.3.1
   resolution: "import-fresh@npm:3.3.1"
@@ -8135,6 +8149,13 @@ __metadata:
   version: 1.4.2
   resolution: "index-array-by@npm:1.4.2"
   checksum: 10c0/70cfb089148678236c620f471f75b3bec85da65f24cd44ea601c1eae8f6e0da5e1899cee08ed3a276bea1943b6f910fe6fa388276bca4667c6738bb44eae08cb
+  languageName: node
+  linkType: hard
+
+"inherits@npm:~2.0.3":
+  version: 2.0.4
+  resolution: "inherits@npm:2.0.4"
+  checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
   languageName: node
   linkType: hard
 
@@ -8531,6 +8552,13 @@ __metadata:
   version: 2.0.5
   resolution: "isarray@npm:2.0.5"
   checksum: 10c0/4199f14a7a13da2177c66c31080008b7124331956f47bca57dd0b6ea9f11687aa25e565a2c7a2b519bc86988d10398e3049a1f5df13c9f6b7664154690ae79fd
+  languageName: node
+  linkType: hard
+
+"isarray@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "isarray@npm:1.0.0"
+  checksum: 10c0/18b5be6669be53425f0b84098732670ed4e727e3af33bc7f948aac01782110eb9a18b3b329c5323bcdd3acdaae547ee077d3951317e7f133bff7105264b3003d
   languageName: node
   linkType: hard
 
@@ -9417,6 +9445,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jszip@npm:^3.10.1":
+  version: 3.10.1
+  resolution: "jszip@npm:3.10.1"
+  dependencies:
+    lie: "npm:~3.3.0"
+    pako: "npm:~1.0.2"
+    readable-stream: "npm:~2.3.6"
+    setimmediate: "npm:^1.0.5"
+  checksum: 10c0/58e01ec9c4960383fb8b38dd5f67b83ccc1ec215bf74c8a5b32f42b6e5fb79fada5176842a11409c4051b5b94275044851814a31076bf49e1be218d3ef57c863
+  languageName: node
+  linkType: hard
+
 "kaitai-struct@npm:^0.10.0":
   version: 0.10.0
   resolution: "kaitai-struct@npm:0.10.0"
@@ -9523,6 +9563,15 @@ __metadata:
     prelude-ls: "npm:~1.1.2"
     type-check: "npm:~0.3.2"
   checksum: 10c0/e440df9de4233da0b389cd55bd61f0f6aaff766400bebbccd1231b81801f6dbc1d816c676ebe8d70566394b749fa624b1ed1c68070e9c94999f0bdecc64cb676
+  languageName: node
+  linkType: hard
+
+"lie@npm:~3.3.0":
+  version: 3.3.0
+  resolution: "lie@npm:3.3.0"
+  dependencies:
+    immediate: "npm:~3.0.5"
+  checksum: 10c0/56dd113091978f82f9dc5081769c6f3b947852ecf9feccaf83e14a123bc630c2301439ce6182521e5fbafbde88e88ac38314327a4e0493a1bea7e0699a7af808
   languageName: node
   linkType: hard
 
@@ -10663,6 +10712,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pako@npm:~1.0.2":
+  version: 1.0.11
+  resolution: "pako@npm:1.0.11"
+  checksum: 10c0/86dd99d8b34c3930345b8bbeb5e1cd8a05f608eeb40967b293f72fe469d0e9c88b783a8777e4cc7dc7c91ce54c5e93d88ff4b4f060e6ff18408fd21030d9ffbe
+  languageName: node
+  linkType: hard
+
 "parent-module@npm:^1.0.0":
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
@@ -11080,6 +11136,13 @@ __metadata:
   version: 5.0.0
   resolution: "proc-log@npm:5.0.0"
   checksum: 10c0/bbe5edb944b0ad63387a1d5b1911ae93e05ce8d0f60de1035b218cdcceedfe39dbd2c697853355b70f1a090f8f58fe90da487c85216bf9671f9499d1a897e9e3
+  languageName: node
+  linkType: hard
+
+"process-nextick-args@npm:~2.0.0":
+  version: 2.0.1
+  resolution: "process-nextick-args@npm:2.0.1"
+  checksum: 10c0/bec089239487833d46b59d80327a1605e1c5287eaad770a291add7f45fda1bb5e28b38e0e061add0a1d0ee0984788ce74fa394d345eed1c420cacf392c554367
   languageName: node
   linkType: hard
 
@@ -12009,6 +12072,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readable-stream@npm:~2.3.6":
+  version: 2.3.8
+  resolution: "readable-stream@npm:2.3.8"
+  dependencies:
+    core-util-is: "npm:~1.0.0"
+    inherits: "npm:~2.0.3"
+    isarray: "npm:~1.0.0"
+    process-nextick-args: "npm:~2.0.0"
+    safe-buffer: "npm:~5.1.1"
+    string_decoder: "npm:~1.1.1"
+    util-deprecate: "npm:~1.0.1"
+  checksum: 10c0/7efdb01f3853bc35ac62ea25493567bf588773213f5f4a79f9c365e1ad13bab845ac0dae7bc946270dc40c3929483228415e92a3fc600cc7e4548992f41ee3fa
+  languageName: node
+  linkType: hard
+
 "readdirp@npm:~3.6.0":
   version: 3.6.0
   resolution: "readdirp@npm:3.6.0"
@@ -12335,6 +12413,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
+  version: 5.1.2
+  resolution: "safe-buffer@npm:5.1.2"
+  checksum: 10c0/780ba6b5d99cc9a40f7b951d47152297d0e260f0df01472a1b99d4889679a4b94a13d644f7dbc4f022572f09ae9005fa2fbb93bbbd83643316f365a3e9a45b21
+  languageName: node
+  linkType: hard
+
 "safe-push-apply@npm:^1.0.0":
   version: 1.0.0
   resolution: "safe-push-apply@npm:1.0.0"
@@ -12491,6 +12576,13 @@ __metadata:
     es-errors: "npm:^1.3.0"
     es-object-atoms: "npm:^1.0.0"
   checksum: 10c0/ca5c3ccbba479d07c30460e367e66337cec825560b11e8ba9c5ebe13a2a0d6021ae34eddf94ff3dfe17a3104dc1f191519cb6c48378b503e5c3f36393938776a
+  languageName: node
+  linkType: hard
+
+"setimmediate@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "setimmediate@npm:1.0.5"
+  checksum: 10c0/5bae81bfdbfbd0ce992893286d49c9693c82b1bcc00dcaaf3a09c8f428fdeacf4190c013598b81875dfac2b08a572422db7df779a99332d0fce186d15a3e4d49
   languageName: node
   linkType: hard
 
@@ -12964,6 +13056,15 @@ __metadata:
     define-properties: "npm:^1.2.1"
     es-object-atoms: "npm:^1.0.0"
   checksum: 10c0/d53af1899959e53c83b64a5fd120be93e067da740e7e75acb433849aa640782fb6c7d4cd5b84c954c84413745a3764df135a8afeb22908b86a835290788d8366
+  languageName: node
+  linkType: hard
+
+"string_decoder@npm:~1.1.1":
+  version: 1.1.1
+  resolution: "string_decoder@npm:1.1.1"
+  dependencies:
+    safe-buffer: "npm:~5.1.0"
+  checksum: 10c0/b4f89f3a92fd101b5653ca3c99550e07bdf9e13b35037e9e2a1c7b47cec4e55e06ff3fc468e314a0b5e80bfbaf65c1ca5a84978764884ae9413bec1fc6ca924e
   languageName: node
   linkType: hard
 
@@ -13920,6 +14021,7 @@ __metadata:
     jest: "npm:30.0.5"
     jest-environment-jsdom: "npm:30.0.5"
     jspdf: "npm:^3.0.2"
+    jszip: "npm:^3.10.1"
     kaitai-struct: "npm:^0.10.0"
     leaflet: "npm:^1.9.4"
     magic-string: "npm:0.30.18"
@@ -14086,7 +14188,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util-deprecate@npm:^1.0.2":
+"util-deprecate@npm:^1.0.2, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942


### PR DESCRIPTION
## Summary
- define a typed theme token schema and register Kali, dark, neon, and matrix presets with attribution
- add a Theme Gallery experience for previewing, importing, exporting, and sharing theme archives with contrast guardrails
- wire the gallery into Settings, centralize token application utilities, and cover import/contrast flows with unit tests

## Testing
- yarn lint
- yarn test __tests__/themeGallery.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cb141cb9f08328be9f27b91f63a9aa