### PR TITLE
[accessibility] add voice control overlay and settings

### DIFF
--- a/__tests__/voiceControl.test.tsx
+++ b/__tests__/voiceControl.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import Desktop from '../components/ubuntu/Desktop';
+import { SettingsContext } from '../hooks/useSettings';
+
+const desktopMethods = {
+  openApp: jest.fn(),
+  cycleApps: jest.fn(),
+  cycleAppWindows: jest.fn(),
+  closeApp: jest.fn(),
+  minimizeAllWindows: jest.fn(),
+  getFocusedWindowId: jest.fn(() => 'terminal'),
+};
+
+jest.mock('../components/screen/desktop', () => {
+  const React = require('react');
+  const LegacyDesktop = React.forwardRef((_props: any, ref) => {
+    React.useImperativeHandle(ref, () => desktopMethods);
+    return <div data-testid="legacy-desktop" />;
+  });
+  LegacyDesktop.displayName = 'LegacyDesktopMock';
+  return { __esModule: true, default: LegacyDesktop };
+});
+
+const renderWithSettings = () => {
+  const value = {
+    accent: '#1793d1',
+    wallpaper: 'wall-1',
+    density: 'regular' as const,
+    reducedMotion: false,
+    fontScale: 1,
+    highContrast: false,
+    largeHitAreas: false,
+    pongSpin: true,
+    allowNetwork: false,
+    haptics: true,
+    theme: 'default',
+    voiceControlEnabled: true,
+    voiceControlHotkey: 'Ctrl+Shift+Space',
+    voiceConfirmation: true,
+    setAccent: jest.fn(),
+    setWallpaper: jest.fn(),
+    setDensity: jest.fn(),
+    setReducedMotion: jest.fn(),
+    setFontScale: jest.fn(),
+    setHighContrast: jest.fn(),
+    setLargeHitAreas: jest.fn(),
+    setPongSpin: jest.fn(),
+    setAllowNetwork: jest.fn(),
+    setHaptics: jest.fn(),
+    setTheme: jest.fn(),
+    setVoiceControlEnabled: jest.fn(),
+    setVoiceControlHotkey: jest.fn(),
+    setVoiceConfirmation: jest.fn(),
+  };
+  return render(
+    <SettingsContext.Provider value={value as any}>
+      <Desktop bg_image_name="wall-1" changeBackgroundImage={jest.fn()} />
+    </SettingsContext.Provider>,
+  );
+};
+
+describe('voice control desktop integration', () => {
+  beforeEach(() => {
+    Object.values(desktopMethods).forEach((method) => (method as jest.Mock).mockClear?.());
+    desktopMethods.getFocusedWindowId.mockReturnValue('terminal');
+  });
+
+  it('opens apps when matching voice command is received', async () => {
+    renderWithSettings();
+    act(() => {
+      window.dispatchEvent(new CustomEvent('voice:mock-result', { detail: 'open settings' }));
+    });
+    await waitFor(() => expect(desktopMethods.openApp).toHaveBeenCalledWith('settings'));
+  });
+
+  it('cycles windows via navigation commands', async () => {
+    renderWithSettings();
+    act(() => {
+      window.dispatchEvent(new CustomEvent('voice:mock-result', { detail: 'focus next window' }));
+    });
+    await waitFor(() => expect(desktopMethods.cycleApps).toHaveBeenCalledWith(1));
+  });
+
+  it('requires confirmation before closing windows', async () => {
+    renderWithSettings();
+    act(() => {
+      window.dispatchEvent(new CustomEvent('voice:mock-result', { detail: 'close window' }));
+    });
+    expect(desktopMethods.closeApp).not.toHaveBeenCalled();
+    expect(screen.getByText(/confirm “close window”/i)).toBeInTheDocument();
+    act(() => {
+      window.dispatchEvent(new CustomEvent('voice:mock-result', { detail: 'confirm' }));
+    });
+    await waitFor(() => expect(desktopMethods.closeApp).toHaveBeenCalledWith('terminal'));
+  });
+
+  it('inserts dictated text into the focused element', () => {
+    renderWithSettings();
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+    act(() => {
+      window.dispatchEvent(new CustomEvent('voice:mock-result', { detail: 'type hello world' }));
+    });
+    expect(input.value).toBe('hello world');
+    document.body.removeChild(input);
+  });
+});

--- a/components/accessibility/VoiceHUD.tsx
+++ b/components/accessibility/VoiceHUD.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import type { VoiceCommandEvent } from '../../hooks/useVoiceCommands';
+
+interface VoiceHUDProps {
+  listening: boolean;
+  initializing: boolean;
+  transcript: string;
+  partialTranscript?: string;
+  history: VoiceCommandEvent[];
+  pendingConfirmation: VoiceCommandEvent | null;
+  hotkey: string;
+  error?: string | null;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+}
+
+const statusLabel = (listening: boolean, initializing: boolean) => {
+  if (initializing) return 'Loading model…';
+  return listening ? 'Listening' : 'Voice control paused';
+};
+
+const VoiceHUD: React.FC<VoiceHUDProps> = ({
+  listening,
+  initializing,
+  transcript,
+  partialTranscript,
+  history,
+  pendingConfirmation,
+  hotkey,
+  error,
+  onConfirm,
+  onCancel,
+}) => {
+  const recentHistory = history.slice(1, 5);
+  return (
+    <aside
+      aria-live="polite"
+      className="pointer-events-none fixed bottom-4 right-4 z-[60] w-80 max-w-[90vw] text-sm text-white"
+    >
+      <div className="pointer-events-auto overflow-hidden rounded-xl border border-white/10 bg-black/70 shadow-lg backdrop-blur">
+        <header className="flex items-center justify-between gap-2 border-b border-white/10 px-3 py-2">
+          <div className="flex items-center gap-2">
+            <span
+              aria-hidden
+              className={`h-2.5 w-2.5 rounded-full ${
+                listening ? 'bg-green-400 animate-pulse' : initializing ? 'bg-amber-300 animate-pulse' : 'bg-zinc-500'
+              }`}
+            />
+            <p className="text-xs font-semibold uppercase tracking-wide text-white/80">
+              {statusLabel(listening, initializing)}
+            </p>
+          </div>
+          <span className="text-[11px] font-medium text-white/60">Hotkey: {hotkey}</span>
+        </header>
+        <div className="space-y-2 px-3 py-2">
+          {error && (
+            <div role="alert" className="rounded bg-red-500/20 px-2 py-1 text-[11px] text-red-200">
+              {error}
+            </div>
+          )}
+          {partialTranscript && !listening && !initializing && (
+            <p className="text-[11px] text-white/60">{partialTranscript}…</p>
+          )}
+          {transcript && (
+            <div>
+              <p className="text-[11px] uppercase tracking-wide text-white/50">Last command</p>
+              <p className="mt-0.5 text-base text-white">{transcript}</p>
+            </div>
+          )}
+          {pendingConfirmation && (
+            <div className="rounded-lg border border-yellow-400/40 bg-yellow-500/10 px-3 py-2 text-[13px] text-yellow-100">
+              <p className="font-medium">Confirm “{pendingConfirmation.phrase}”?</p>
+              <p className="mt-1 text-[11px] text-yellow-200/80">
+                Say “Confirm” or use the buttons below before closing or deleting windows.
+              </p>
+              <div className="mt-2 flex gap-2">
+                <button
+                  type="button"
+                  onClick={onConfirm}
+                  className="flex-1 rounded bg-green-500/30 px-2 py-1 text-xs font-semibold text-green-100 hover:bg-green-500/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-400"
+                >
+                  Confirm
+                </button>
+                <button
+                  type="button"
+                  onClick={onCancel}
+                  className="flex-1 rounded bg-red-500/30 px-2 py-1 text-xs font-semibold text-red-100 hover:bg-red-500/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-400"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+          {recentHistory.length > 0 && (
+            <div>
+              <p className="text-[11px] uppercase tracking-wide text-white/50">Recent</p>
+              <ul className="mt-1 space-y-1 text-[12px] text-white/70">
+                {recentHistory.map((item, index) => (
+                  <li key={`${item.type}-${index}`} className="flex justify-between gap-2">
+                    <span className="truncate">{item.phrase}</span>
+                    <span className="shrink-0 text-[10px] uppercase text-white/40">{item.type}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          <p className="text-[10px] leading-relaxed text-white/50">
+            Voice control runs locally with the bundled Vosk model. Toggle it with the hotkey above when you need hands-free
+            navigation.
+          </p>
+        </div>
+      </div>
+    </aside>
+  );
+};
+
+export default VoiceHUD;

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,9 +1,10 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
+import VoiceControlSection from './settings/accessibility/VoiceControlSection';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme, voiceControlEnabled, setVoiceControlEnabled, voiceControlHotkey, setVoiceControlHotkey, voiceConfirmation, setVoiceConfirmation } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -176,6 +177,16 @@ export function Settings() {
                     />
                     Pong Spin
                 </label>
+            </div>
+            <div className="flex justify-center">
+                <VoiceControlSection
+                    enabled={voiceControlEnabled}
+                    requireConfirmation={voiceConfirmation}
+                    hotkey={voiceControlHotkey}
+                    onToggleEnabled={setVoiceControlEnabled}
+                    onToggleConfirmation={setVoiceConfirmation}
+                    onHotkeyChange={setVoiceControlHotkey}
+                />
             </div>
             <div className="flex justify-center my-4">
                 <div

--- a/components/apps/settings/accessibility/VoiceControlSection.tsx
+++ b/components/apps/settings/accessibility/VoiceControlSection.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react';
+
+interface VoiceControlSectionProps {
+  enabled: boolean;
+  requireConfirmation: boolean;
+  hotkey: string;
+  onToggleEnabled: (value: boolean) => void;
+  onToggleConfirmation: (value: boolean) => void;
+  onHotkeyChange: (value: string) => void;
+}
+
+const formatKey = (key: string) => {
+  switch (key) {
+    case ' ':
+      return 'Space';
+    case 'Escape':
+      return 'Esc';
+    default:
+      return key.length === 1 ? key.toUpperCase() : key.replace(/(^.|\s.)/g, (match) => match.toUpperCase());
+  }
+};
+
+const VoiceControlSection: React.FC<VoiceControlSectionProps> = ({
+  enabled,
+  requireConfirmation,
+  hotkey,
+  onToggleEnabled,
+  onToggleConfirmation,
+  onHotkeyChange,
+}) => {
+  const [capturing, setCapturing] = useState(false);
+  const [hint, setHint] = useState('Press the hotkey to toggle listening without touching the keyboard.');
+
+  useEffect(() => {
+    if (!capturing) return undefined;
+    const handleKeydown = (event: KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const combo: string[] = [];
+      if (event.ctrlKey) combo.push('Ctrl');
+      if (event.metaKey) combo.push('Meta');
+      if (event.altKey) combo.push('Alt');
+      if (event.shiftKey) combo.push('Shift');
+      const key = event.key;
+      if (!['Control', 'Shift', 'Alt', 'Meta'].includes(key)) {
+        combo.push(formatKey(key === ' ' ? ' ' : key));
+      }
+      const next = combo.join('+');
+      onHotkeyChange(next || 'Ctrl+Shift+Space');
+      setCapturing(false);
+      setHint('Hotkey updated. Try it on the desktop to start listening.');
+    };
+    window.addEventListener('keydown', handleKeydown, true);
+    return () => window.removeEventListener('keydown', handleKeydown, true);
+  }, [capturing, onHotkeyChange]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setHint('Enable voice control to request microphone access and display the HUD.');
+    } else {
+      setHint('Use clear verbs like “Open terminal” or “Close window” to trigger commands.');
+    }
+  }, [enabled]);
+
+  return (
+    <section className="mt-8 w-full max-w-3xl rounded-xl border border-ubt-cool-grey/60 bg-black/30 p-4 text-white shadow-inner">
+      <header className="mb-4 flex items-center justify-between gap-2">
+        <h2 className="text-lg font-semibold">Voice control</h2>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(event) => onToggleEnabled(event.target.checked)}
+            className="h-4 w-4"
+          />
+          Enabled
+        </label>
+      </header>
+      <p className="mb-3 text-sm text-white/70">{hint}</p>
+      <div className="mb-4 flex flex-wrap gap-4">
+        <button
+          type="button"
+          onClick={() => setCapturing(true)}
+          disabled={!enabled}
+          className="rounded border border-white/20 px-3 py-2 text-sm text-white transition hover:bg-white/10 disabled:cursor-not-allowed disabled:border-white/10 disabled:text-white/40"
+        >
+          {capturing ? 'Listening for keys…' : `Hotkey: ${hotkey}`}
+        </button>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            disabled={!enabled}
+            checked={requireConfirmation}
+            onChange={(event) => onToggleConfirmation(event.target.checked)}
+            className="h-4 w-4"
+          />
+          Require “confirm” before closing windows
+        </label>
+      </div>
+      <div className="rounded-lg border border-white/10 bg-white/5 p-3 text-sm text-white/80">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-white/60">Training tips</h3>
+        <ul className="mt-2 space-y-1 list-disc pl-5">
+          <li>Start by saying “Start listening” or press the hotkey after granting microphone permission.</li>
+          <li>Use action phrases like “Open settings”, “Focus next window”, or “Show desktop”.</li>
+          <li>For dictation, begin with “Type” or “Dictate”, then speak your text naturally.</li>
+          <li>Say “Confirm” or “Cancel” when the HUD asks for approval.</li>
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default VoiceControlSection;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -554,6 +554,26 @@ export class Desktop extends Component {
         this.giveFocusToLastApp();
     }
 
+    minimizeAllWindows = () => {
+        const minimized_windows = { ...this.state.minimized_windows };
+        const focused_windows = { ...this.state.focused_windows };
+        let changed = false;
+        for (const key in this.state.closed_windows) {
+            if (!this.state.closed_windows[key]) {
+                minimized_windows[key] = true;
+                if (focused_windows[key]) {
+                    focused_windows[key] = false;
+                }
+                changed = true;
+            }
+        }
+        if (changed) {
+            this.setState({ minimized_windows, focused_windows }, () => {
+                this.hideSideBar(null, false);
+            });
+        }
+    }
+
     giveFocusToLastApp = () => {
         // if there is atleast one app opened, give it focus
         if (!this.checkAllMinimised()) {

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 import BootingScreen from './screen/booting_screen';
-import Desktop from './screen/desktop';
+import Desktop from './ubuntu/Desktop';
 import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';

--- a/components/ubuntu/Desktop.tsx
+++ b/components/ubuntu/Desktop.tsx
@@ -1,0 +1,259 @@
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import LegacyDesktop from '../screen/desktop';
+import VoiceHUD from '../accessibility/VoiceHUD';
+import useVoiceCommands, { VoiceCommandEvent } from '../../hooks/useVoiceCommands';
+import { useSettings } from '../../hooks/useSettings';
+import appsConfig from '../../apps.config';
+
+type LegacyDesktopProps = React.ComponentProps<typeof LegacyDesktop>;
+
+type HotkeyMatcher = {
+  key: string | null;
+  ctrl: boolean;
+  shift: boolean;
+  alt: boolean;
+  meta: boolean;
+};
+
+const normalizeKeyName = (raw: string) => {
+  const value = raw.trim().toLowerCase();
+  switch (value) {
+    case 'ctrl':
+    case 'control':
+      return 'ctrl';
+    case 'shift':
+      return 'shift';
+    case 'alt':
+    case 'option':
+      return 'alt';
+    case 'meta':
+    case 'command':
+    case 'cmd':
+      return 'meta';
+    case 'space':
+    case 'spacebar':
+      return ' ';
+    default:
+      return raw.trim();
+  }
+};
+
+const parseHotkey = (hotkey: string): HotkeyMatcher => {
+  const matcher: HotkeyMatcher = { key: null, ctrl: false, shift: false, alt: false, meta: false };
+  hotkey
+    .split('+')
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .forEach((segment) => {
+      const normalized = normalizeKeyName(segment);
+      switch (normalized.toLowerCase()) {
+        case 'ctrl':
+          matcher.ctrl = true;
+          break;
+        case 'shift':
+          matcher.shift = true;
+          break;
+        case 'alt':
+          matcher.alt = true;
+          break;
+        case 'meta':
+          matcher.meta = true;
+          break;
+        default:
+          matcher.key = normalized;
+      }
+    });
+  return matcher;
+};
+
+const matchesHotkey = (event: KeyboardEvent, matcher: HotkeyMatcher) => {
+  if (matcher.ctrl !== event.ctrlKey) return false;
+  if (matcher.shift !== event.shiftKey) return false;
+  if (matcher.alt !== event.altKey) return false;
+  if (matcher.meta !== event.metaKey) return false;
+  if (!matcher.key) return true;
+  const eventKey = event.key.length === 1 ? event.key : event.key.toLowerCase();
+  const expected = matcher.key.length === 1 ? matcher.key : matcher.key.toLowerCase();
+  if (expected === ' ') {
+    return eventKey === ' ' || eventKey.toLowerCase() === 'spacebar';
+  }
+  return eventKey.toLowerCase() === expected;
+};
+
+const focusableElement = (element: Element | null): (HTMLInputElement | HTMLTextAreaElement | HTMLElement) | null => {
+  if (!element) return null;
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) return element;
+  if ((element as HTMLElement).isContentEditable) return element as HTMLElement;
+  return null;
+};
+
+const insertText = (element: HTMLInputElement | HTMLTextAreaElement | HTMLElement, text: string) => {
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    const start = element.selectionStart ?? element.value.length;
+    const end = element.selectionEnd ?? element.value.length;
+    const nextValue = element.value.slice(0, start) + text + element.value.slice(end);
+    element.value = nextValue;
+    const caret = start + text.length;
+    element.setSelectionRange(caret, caret);
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+    return;
+  }
+
+  if (element.isContentEditable) {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) {
+      document.execCommand('insertText', false, text);
+      return;
+    }
+    selection.deleteFromDocument();
+    selection.getRangeAt(0).insertNode(document.createTextNode(text));
+    selection.collapseToEnd();
+  }
+};
+
+const Desktop: React.FC<LegacyDesktopProps> = (props) => {
+  const desktopRef = useRef<any>(null);
+  const activeElementRef = useRef<HTMLElement | null>(null);
+  const { voiceControlEnabled, voiceControlHotkey, voiceConfirmation } = useSettings();
+
+  const appAliases = useMemo(() => {
+    const map: Record<string, string> = {};
+    const catalog = Array.isArray(appsConfig) ? appsConfig : [];
+    catalog.forEach((app: any) => {
+      if (!app || !app.id) return;
+      const id = String(app.id);
+      const title = typeof app.title === 'string' ? app.title : id;
+      map[id.toLowerCase()] = id;
+      map[id.replace(/[-_]/g, ' ')] = id;
+      map[title.toLowerCase()] = id;
+      if (Array.isArray(app.voiceAliases)) {
+        app.voiceAliases.forEach((alias: string) => {
+          map[alias.toLowerCase()] = id;
+        });
+      }
+    });
+    return map;
+  }, []);
+
+  const handleVoiceIntent = useCallback(
+    (intent: VoiceCommandEvent) => {
+      const target = desktopRef.current;
+      if (!target) return;
+      switch (intent.type) {
+        case 'open-app': {
+          const appId = intent.payload?.appId as string | undefined;
+          if (appId) {
+            target.openApp?.(appId);
+          }
+          break;
+        }
+        case 'cycle-window': {
+          const direction = (intent.payload?.direction as string) === 'previous' ? -1 : 1;
+          target.cycleApps?.(direction);
+          break;
+        }
+        case 'cycle-instance': {
+          const direction = (intent.payload?.direction as string) === 'previous' ? -1 : 1;
+          target.cycleAppWindows?.(direction);
+          break;
+        }
+        case 'close-window': {
+          const focusedId = target.getFocusedWindowId?.();
+          if (focusedId) {
+            target.closeApp?.(focusedId);
+          }
+          break;
+        }
+        case 'show-desktop': {
+          target.minimizeAllWindows?.();
+          break;
+        }
+        case 'dictation': {
+          const text = intent.payload?.text as string | undefined;
+          const element = focusableElement(activeElementRef.current);
+          if (text && element) {
+            insertText(element, text);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [],
+  );
+
+  const voice = useVoiceCommands({
+    enabled: voiceControlEnabled,
+    appAliases,
+    requireConfirmation: voiceConfirmation,
+    onCommand: handleVoiceIntent,
+  });
+
+  const hotkey = voiceControlHotkey || 'Ctrl+Shift+Space';
+  const matcher = useMemo(() => parseHotkey(hotkey), [hotkey]);
+  const {
+    listening,
+    initializing,
+    transcript,
+    partialTranscript,
+    history,
+    pendingConfirmation,
+    error,
+    toggleListening,
+    confirmPending,
+    cancelPending,
+  } = voice;
+
+  useEffect(() => {
+    if (!voiceControlEnabled) return undefined;
+    const handler = (event: KeyboardEvent) => {
+      if (!voiceControlEnabled) return;
+      if (matchesHotkey(event, matcher)) {
+        event.preventDefault();
+        toggleListening();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [matcher, toggleListening, voiceControlEnabled]);
+
+  useEffect(() => {
+    const recordFocus = (event: FocusEvent) => {
+      activeElementRef.current = focusableElement(event.target as HTMLElement) as HTMLElement | null;
+    };
+    const clearFocus = (event: FocusEvent) => {
+      if (activeElementRef.current === event.target) {
+        activeElementRef.current = null;
+      }
+    };
+    document.addEventListener('focusin', recordFocus);
+    document.addEventListener('focusout', clearFocus);
+    return () => {
+      document.removeEventListener('focusin', recordFocus);
+      document.removeEventListener('focusout', clearFocus);
+    };
+  }, []);
+
+  return (
+    <>
+      <LegacyDesktop ref={desktopRef} {...props} />
+      {voiceControlEnabled && (
+        <VoiceHUD
+          listening={listening}
+          initializing={initializing}
+          transcript={transcript}
+          partialTranscript={partialTranscript}
+          history={history}
+          pendingConfirmation={pendingConfirmation}
+          hotkey={hotkey}
+          error={error}
+          onConfirm={confirmPending}
+          onCancel={cancelPending}
+        />
+      )}
+    </>
+  );
+};
+
+export default Desktop;

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,12 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getVoiceControlEnabled as loadVoiceControlEnabled,
+  setVoiceControlEnabled as saveVoiceControlEnabled,
+  getVoiceControlHotkey as loadVoiceControlHotkey,
+  setVoiceControlHotkey as saveVoiceControlHotkey,
+  getVoiceConfirmation as loadVoiceConfirmation,
+  setVoiceConfirmation as saveVoiceConfirmation,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -63,6 +69,9 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  voiceControlEnabled: boolean;
+  voiceControlHotkey: string;
+  voiceConfirmation: boolean;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +83,9 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setVoiceControlEnabled: (value: boolean) => void;
+  setVoiceControlHotkey: (value: string) => void;
+  setVoiceConfirmation: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +100,9 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  voiceControlEnabled: defaults.voiceControlEnabled,
+  voiceControlHotkey: defaults.voiceControlHotkey,
+  voiceConfirmation: defaults.voiceConfirmation,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +114,9 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setVoiceControlEnabled: () => {},
+  setVoiceControlHotkey: () => {},
+  setVoiceConfirmation: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -113,6 +131,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [voiceControlEnabled, setVoiceControlEnabled] = useState<boolean>(defaults.voiceControlEnabled);
+  const [voiceControlHotkey, setVoiceControlHotkey] = useState<string>(defaults.voiceControlHotkey);
+  const [voiceConfirmation, setVoiceConfirmation] = useState<boolean>(defaults.voiceConfirmation);
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -128,6 +149,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
       setTheme(loadTheme());
+      setVoiceControlEnabled(await loadVoiceControlEnabled());
+      setVoiceControlHotkey(await loadVoiceControlHotkey());
+      setVoiceConfirmation(await loadVoiceConfirmation());
     })();
   }, []);
 
@@ -236,6 +260,18 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveVoiceControlEnabled(voiceControlEnabled);
+  }, [voiceControlEnabled]);
+
+  useEffect(() => {
+    saveVoiceControlHotkey(voiceControlHotkey);
+  }, [voiceControlHotkey]);
+
+  useEffect(() => {
+    saveVoiceConfirmation(voiceConfirmation);
+  }, [voiceConfirmation]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -250,6 +286,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        voiceControlEnabled,
+        voiceControlHotkey,
+        voiceConfirmation,
         setAccent,
         setWallpaper,
         setDensity,
@@ -261,6 +300,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setVoiceControlEnabled,
+        setVoiceControlHotkey,
+        setVoiceConfirmation,
       }}
     >
       {children}

--- a/hooks/useVoiceCommands.ts
+++ b/hooks/useVoiceCommands.ts
@@ -1,0 +1,538 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+export type VoiceCommandType =
+  | 'open-app'
+  | 'cycle-window'
+  | 'cycle-instance'
+  | 'close-window'
+  | 'show-desktop'
+  | 'dictation'
+  | 'stop-listening'
+  | 'start-listening'
+  | 'confirm'
+  | 'cancel';
+
+export interface VoiceCommandEvent {
+  type: VoiceCommandType;
+  phrase: string;
+  payload?: Record<string, unknown>;
+  requiresConfirmation?: boolean;
+}
+
+interface UseVoiceCommandsOptions {
+  enabled: boolean;
+  appAliases?: Record<string, string>;
+  requireConfirmation?: boolean;
+  throttleMs?: number;
+  modelUrl?: string;
+  historyLimit?: number;
+  onCommand?: (intent: VoiceCommandEvent) => void;
+  onError?: (message: string) => void;
+}
+
+interface RecognitionMessage {
+  result?: {
+    text?: string;
+    partial?: string;
+  };
+  error?: string;
+}
+
+type VoskModel = {
+  KaldiRecognizer: new () => VoskRecognizer;
+  ready?: boolean;
+  on?: (event: string, handler: (message: RecognitionMessage) => void) => void;
+  terminate?: () => void;
+};
+
+type VoskRecognizer = {
+  on: (event: string, handler: (message: RecognitionMessage) => void) => void;
+  acceptWaveform: (buffer: AudioBuffer) => void;
+  setWords?: (value: boolean) => void;
+  setGrammar?: (grammar: string[]) => void;
+  remove?: () => void;
+};
+
+const DEFAULT_MODEL_URL = '/models/vosk-model-small-en-us-0.15.tar.gz';
+const MOCK_EVENT_NAME = 'voice:mock-result';
+const CONFIRM_PATTERNS = [/^(confirm|yes|do it|please do)$/i];
+const CANCEL_PATTERNS = [/^(cancel|no|stop|never mind)$/i];
+const STOP_PATTERNS = [/^(stop listening|disable voice)$/i];
+const START_PATTERNS = [/^(start listening|enable voice)$/i];
+
+const sanitizeAlias = (value: string) => value.trim().toLowerCase();
+
+const resolveAlias = (target: string, aliases: Record<string, string>): string | null => {
+  const normalized = sanitizeAlias(target);
+  if (!normalized) return null;
+  if (aliases[normalized]) return aliases[normalized];
+  const entry = Object.entries(aliases).find(([key]) => normalized === key || normalized.endsWith(` ${key}`));
+  if (entry) return entry[1];
+  return null;
+};
+
+const nextHistory = (history: VoiceCommandEvent[], item: VoiceCommandEvent, limit: number) => {
+  const items = [item, ...history];
+  if (items.length > limit) {
+    return items.slice(0, limit);
+  }
+  return items;
+};
+
+const useStableCallback = <T extends (...args: any[]) => unknown>(fn: T | undefined) => {
+  const ref = useRef<T | undefined>(fn);
+  useEffect(() => {
+    ref.current = fn;
+  }, [fn]);
+  return useCallback((...args: Parameters<T>) => {
+    if (ref.current) {
+      return ref.current(...args);
+    }
+    return undefined;
+  }, []);
+};
+
+export const useVoiceCommands = ({
+  enabled,
+  appAliases = {},
+  requireConfirmation = true,
+  throttleMs = 1200,
+  modelUrl = DEFAULT_MODEL_URL,
+  historyLimit = 6,
+  onCommand,
+  onError,
+}: UseVoiceCommandsOptions) => {
+  const [listening, setListening] = useState(false);
+  const [initializing, setInitializing] = useState(false);
+  const [transcript, setTranscript] = useState('');
+  const [partialTranscript, setPartialTranscript] = useState('');
+  const [history, setHistory] = useState<VoiceCommandEvent[]>([]);
+  const [pendingConfirmation, setPendingConfirmation] = useState<VoiceCommandEvent | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const onCommandStable = useStableCallback(onCommand);
+  const onErrorStable = useStableCallback(onError);
+
+  const modelRef = useRef<VoskModel | null>(null);
+  const recognizerRef = useRef<VoskRecognizer | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const processorRef = useRef<ScriptProcessorNode | null>(null);
+  const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const pendingRef = useRef<VoiceCommandEvent | null>(null);
+  const lastCommandRef = useRef<{ phrase: string; timestamp: number } | null>(null);
+  const startListeningRef = useRef<() => Promise<void>>(() => Promise.resolve());
+  const handlePhraseRef = useRef<(phrase: string) => void>(() => {});
+
+  const aliasMap = useMemo(() => {
+    const lowerCase: Record<string, string> = {};
+    Object.entries(appAliases).forEach(([key, value]) => {
+      lowerCase[sanitizeAlias(key)] = value;
+    });
+    return lowerCase;
+  }, [appAliases]);
+
+  const emitError = useCallback(
+    (message: string) => {
+      setError(message);
+      if (onErrorStable) {
+        onErrorStable(message);
+      }
+    },
+    [onErrorStable],
+  );
+
+  const destroyAudioGraph = useCallback(() => {
+    processorRef.current?.disconnect();
+    processorRef.current = null;
+
+    sourceRef.current?.disconnect();
+    sourceRef.current = null;
+
+    streamRef.current?.getTracks().forEach((track) => track.stop());
+    streamRef.current = null;
+
+    if (audioContextRef.current) {
+      const ctx = audioContextRef.current;
+      ctx.close().catch(() => undefined);
+      audioContextRef.current = null;
+    }
+  }, []);
+
+  const stopListening = useCallback(() => {
+    destroyAudioGraph();
+    setListening(false);
+    setPartialTranscript('');
+  }, [destroyAudioGraph]);
+
+  const clearRecognition = useCallback(() => {
+    recognizerRef.current?.remove?.();
+    recognizerRef.current = null;
+    modelRef.current?.terminate?.();
+    modelRef.current = null;
+  }, []);
+
+  const handleIntent = useCallback(
+    (intent: VoiceCommandEvent, options?: { bypassThrottle?: boolean; invokeCallback?: boolean }) => {
+      const { bypassThrottle = false, invokeCallback = true } = options ?? {};
+      const normalized = sanitizeAlias(intent.phrase);
+      if (!bypassThrottle) {
+        const now = Date.now();
+        const last = lastCommandRef.current;
+        if (last && last.phrase === normalized && now - last.timestamp < throttleMs) {
+          return;
+        }
+        lastCommandRef.current = { phrase: normalized, timestamp: now };
+      }
+      setHistory((prev) => nextHistory(prev, intent, historyLimit));
+      setTranscript(intent.phrase);
+
+      if (intent.requiresConfirmation) {
+        pendingRef.current = intent;
+        setPendingConfirmation(intent);
+        return;
+      }
+
+      if (intent.type === 'stop-listening') {
+        stopListening();
+        return;
+      }
+
+      if (invokeCallback) {
+        onCommandStable?.(intent);
+      }
+    },
+    [historyLimit, onCommandStable, stopListening, throttleMs],
+  );
+
+  const resolveAppFromTarget = useCallback(
+    (target: string): string | null => resolveAlias(target, aliasMap),
+    [aliasMap],
+  );
+
+  const parsePhrase = useCallback(
+    (phrase: string): VoiceCommandEvent | null => {
+      const normalized = phrase.trim();
+      if (!normalized) return null;
+      const lower = normalized.toLowerCase();
+
+      if (pendingRef.current) {
+        if (CONFIRM_PATTERNS.some((regex) => regex.test(normalized))) {
+          return { type: 'confirm', phrase: normalized };
+        }
+        if (CANCEL_PATTERNS.some((regex) => regex.test(normalized))) {
+          return { type: 'cancel', phrase: normalized };
+        }
+      }
+
+      if (STOP_PATTERNS.some((regex) => regex.test(lower))) {
+        return { type: 'stop-listening', phrase: normalized };
+      }
+      if (START_PATTERNS.some((regex) => regex.test(lower))) {
+        return { type: 'start-listening', phrase: normalized };
+      }
+
+      const openMatch = lower.match(/^(?:open|launch|start|focus|switch to)\s+(?<target>.+)$/);
+      if (openMatch && openMatch.groups?.target) {
+        const appId = resolveAppFromTarget(openMatch.groups.target);
+        if (appId) {
+          return {
+            type: 'open-app',
+            phrase: normalized,
+            payload: { appId, target: openMatch.groups.target },
+          };
+        }
+      }
+
+      if (/^(?:next|focus next|next window|switch window|switch next|cycle window)/.test(lower)) {
+        return { type: 'cycle-window', phrase: normalized, payload: { direction: 'next' } };
+      }
+
+      if (/^(?:previous|focus previous|previous window|last window|cycle back)/.test(lower)) {
+        return { type: 'cycle-window', phrase: normalized, payload: { direction: 'previous' } };
+      }
+
+      if (/^(?:next instance|cycle instance|switch instance)/.test(lower)) {
+        return { type: 'cycle-instance', phrase: normalized, payload: { direction: 'next' } };
+      }
+
+      if (/^(?:previous instance|cycle prior instance)/.test(lower)) {
+        return { type: 'cycle-instance', phrase: normalized, payload: { direction: 'previous' } };
+      }
+
+      if (/(?:close|quit|exit)\s+(?:window|app|application)$/.test(lower) || lower === 'close window') {
+        return { type: 'close-window', phrase: normalized, requiresConfirmation: requireConfirmation };
+      }
+
+      if (/^(?:show|reveal|display)\s+(?:desktop|home)$/i.test(normalized) || lower === 'show desktop') {
+        return { type: 'show-desktop', phrase: normalized };
+      }
+
+      const dictationMatch = lower.match(/^(?:type|dictate|insert)\s+(?<text>.+)$/);
+      if (dictationMatch && dictationMatch.groups?.text) {
+        return {
+          type: 'dictation',
+          phrase: normalized,
+          payload: { text: dictationMatch.groups.text },
+        };
+      }
+
+      if (CONFIRM_PATTERNS.some((regex) => regex.test(normalized))) {
+        return { type: 'confirm', phrase: normalized };
+      }
+
+      if (CANCEL_PATTERNS.some((regex) => regex.test(normalized))) {
+        return { type: 'cancel', phrase: normalized };
+      }
+
+      return null;
+    },
+    [requireConfirmation, resolveAppFromTarget],
+  );
+
+  const handlePhrase = useCallback(
+    (phrase: string) => {
+      setPartialTranscript('');
+      const intent = parsePhrase(phrase);
+      if (!intent) {
+        setTranscript(phrase);
+        return;
+      }
+
+      if (intent.type === 'confirm' && pendingRef.current) {
+        const pending = pendingRef.current;
+        pendingRef.current = null;
+        setPendingConfirmation(null);
+        handleIntent({ ...pending, requiresConfirmation: false }, { bypassThrottle: true });
+        return;
+      }
+
+      if (intent.type === 'cancel' && pendingRef.current) {
+        pendingRef.current = null;
+        setPendingConfirmation(null);
+        setHistory((prev) => nextHistory(prev, intent, historyLimit));
+        setTranscript(intent.phrase);
+        return;
+      }
+
+      if (intent.type === 'start-listening') {
+        void startListeningRef.current?.();
+        handleIntent(intent, { bypassThrottle: true, invokeCallback: false });
+        return;
+      }
+
+      handleIntent(intent);
+    },
+    [handleIntent, historyLimit, parsePhrase],
+  );
+
+  handlePhraseRef.current = handlePhrase;
+
+  const ensureModel = useCallback(async () => {
+    if (typeof window === 'undefined') return null;
+    if (modelRef.current) return modelRef.current;
+    try {
+      const voskModule: any = await import('vosk-browser');
+      const model: VoskModel =
+        typeof voskModule.createModel === 'function'
+          ? await voskModule.createModel(modelUrl)
+          : new voskModule.Model(modelUrl);
+
+      if (model.ready === false && model.on) {
+        await new Promise<void>((resolve, reject) => {
+          model.on?.('load', (message: RecognitionMessage) => {
+            if (message.result) {
+              resolve();
+            } else {
+              reject(new Error('Voice model failed to load'));
+            }
+          });
+          model.on?.('error', (message: RecognitionMessage) => {
+            reject(new Error(message.error || 'Failed to load voice model'));
+          });
+        });
+      }
+
+      modelRef.current = model;
+      return model;
+    } catch (err) {
+      emitError(err instanceof Error ? err.message : 'Unable to load offline model');
+      return null;
+    }
+  }, [emitError, modelUrl]);
+
+  const ensureRecognizer = useCallback(async () => {
+    if (!modelRef.current) {
+      await ensureModel();
+    }
+    const model = modelRef.current;
+    if (!model) return null;
+    if (recognizerRef.current) return recognizerRef.current;
+    const recognizer = new model.KaldiRecognizer();
+    recognizer.setWords?.(false);
+    const aliasGrammar = Object.keys(aliasMap);
+    if (recognizer.setGrammar && aliasGrammar.length) {
+      recognizer.setGrammar([
+        ...aliasGrammar,
+        'open',
+        'launch',
+        'start',
+        'focus',
+        'switch',
+        'next',
+        'previous',
+        'window',
+        'close',
+        'quit',
+        'exit',
+        'show',
+        'desktop',
+        'confirm',
+        'cancel',
+        'type',
+        'dictate',
+        'insert',
+      ]);
+    }
+
+    recognizer.on('result', (message: RecognitionMessage) => {
+      const text = message.result?.text?.trim();
+      if (text) {
+        handlePhraseRef.current(text);
+      }
+    });
+
+    recognizer.on('partialresult', (message: RecognitionMessage) => {
+      const text = message.result?.partial ?? '';
+      setPartialTranscript(text);
+    });
+
+    recognizer.on('error', (message: RecognitionMessage) => {
+      emitError(message.error || 'Voice recognition error');
+    });
+
+    recognizerRef.current = recognizer;
+    return recognizer;
+  }, [aliasMap, emitError, ensureModel]);
+
+  const startListening = useCallback(async () => {
+    if (initializing || listening) return;
+    if (typeof window === 'undefined') return;
+    setInitializing(true);
+    setError(null);
+    try {
+      const recognizer = await ensureRecognizer();
+      if (!recognizer) {
+        setInitializing(false);
+        return;
+      }
+      const mediaStream = await navigator.mediaDevices.getUserMedia({
+        video: false,
+        audio: {
+          channelCount: 1,
+          echoCancellation: true,
+          noiseSuppression: true,
+          sampleRate: 16000,
+        },
+      });
+      streamRef.current = mediaStream;
+      const AudioContextCtor = (window.AudioContext || (window as any).webkitAudioContext) as typeof AudioContext | undefined;
+      if (!AudioContextCtor) {
+        throw new Error('Web Audio API is not available');
+      }
+      const audioContext = new AudioContextCtor();
+      audioContextRef.current = audioContext;
+      const source = audioContext.createMediaStreamSource(mediaStream);
+      sourceRef.current = source;
+      const processor = audioContext.createScriptProcessor(4096, 1, 1);
+      processorRef.current = processor;
+      processor.onaudioprocess = (event) => {
+        try {
+          recognizer.acceptWaveform(event.inputBuffer);
+        } catch (err) {
+          console.error('acceptWaveform failed', err);
+        }
+      };
+      source.connect(processor);
+      processor.connect(audioContext.destination);
+      setListening(true);
+    } catch (err) {
+      emitError(err instanceof Error ? err.message : 'Unable to access microphone');
+      destroyAudioGraph();
+    } finally {
+      setInitializing(false);
+    }
+  }, [destroyAudioGraph, emitError, ensureRecognizer, initializing, listening]);
+
+  const toggleListening = useCallback(() => {
+    if (listening) {
+      stopListening();
+    } else {
+      void startListening();
+    }
+  }, [listening, startListening, stopListening]);
+
+  startListeningRef.current = startListening;
+
+  const confirmPending = useCallback(() => {
+    if (!pendingRef.current) return;
+    const pending = pendingRef.current;
+    pendingRef.current = null;
+    setPendingConfirmation(null);
+    handleIntent({ ...pending, requiresConfirmation: false }, { bypassThrottle: true });
+  }, [handleIntent]);
+
+  const cancelPending = useCallback(() => {
+    pendingRef.current = null;
+    setPendingConfirmation(null);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      stopListening();
+      setHistory([]);
+      pendingRef.current = null;
+      setPendingConfirmation(null);
+    }
+  }, [enabled, stopListening]);
+
+  useEffect(() => {
+    const handleMock = (event: Event) => {
+      const detail = (event as CustomEvent<string>).detail;
+      if (typeof detail === 'string') {
+        handlePhrase(detail);
+      }
+    };
+    window.addEventListener(MOCK_EVENT_NAME, handleMock);
+    return () => {
+      window.removeEventListener(MOCK_EVENT_NAME, handleMock);
+    };
+  }, [handlePhrase]);
+
+  useEffect(
+    () => () => {
+      stopListening();
+      clearRecognition();
+    },
+    [clearRecognition, stopListening],
+  );
+
+  return {
+    listening,
+    initializing,
+    transcript,
+    partialTranscript,
+    history,
+    pendingConfirmation,
+    error,
+    startListening,
+    stopListening,
+    toggleListening,
+    confirmPending,
+    cancelPending,
+  };
+};
+
+export type UseVoiceCommandsReturn = ReturnType<typeof useVoiceCommands>;
+
+export default useVoiceCommands;

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "tailwindcss": "^3.2.4",
     "three": "^0.179.1",
     "turndown": "^7.2.1",
+    "vosk-browser": "^0.0.8",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,9 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  voiceControlEnabled: false,
+  voiceControlHotkey: 'Ctrl+Shift+Space',
+  voiceConfirmation: true,
 };
 
 export async function getAccent() {
@@ -123,6 +126,37 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getVoiceControlEnabled() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.voiceControlEnabled;
+  return window.localStorage.getItem('voice-control-enabled') === 'true';
+}
+
+export async function setVoiceControlEnabled(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('voice-control-enabled', value ? 'true' : 'false');
+}
+
+export async function getVoiceControlHotkey() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.voiceControlHotkey;
+  return window.localStorage.getItem('voice-control-hotkey') || DEFAULT_SETTINGS.voiceControlHotkey;
+}
+
+export async function setVoiceControlHotkey(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('voice-control-hotkey', value);
+}
+
+export async function getVoiceConfirmation() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.voiceConfirmation;
+  const stored = window.localStorage.getItem('voice-control-confirmation');
+  return stored === null ? DEFAULT_SETTINGS.voiceConfirmation : stored === 'true';
+}
+
+export async function setVoiceConfirmation(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('voice-control-confirmation', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +171,9 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('voice-control-enabled');
+  window.localStorage.removeItem('voice-control-hotkey');
+  window.localStorage.removeItem('voice-control-confirmation');
 }
 
 export async function exportSettings() {
@@ -151,6 +188,9 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    voiceControlEnabled,
+    voiceControlHotkey,
+    voiceConfirmation,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +202,9 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getVoiceControlEnabled(),
+    getVoiceControlHotkey(),
+    getVoiceConfirmation(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +218,9 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    voiceControlEnabled,
+    voiceControlHotkey,
+    voiceConfirmation,
     theme,
   });
 }
@@ -199,6 +245,9 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    voiceControlEnabled,
+    voiceControlHotkey,
+    voiceConfirmation,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +260,9 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (voiceControlEnabled !== undefined) await setVoiceControlEnabled(voiceControlEnabled);
+  if (voiceControlHotkey !== undefined) await setVoiceControlHotkey(voiceControlHotkey);
+  if (voiceConfirmation !== undefined) await setVoiceConfirmation(voiceConfirmation);
   if (theme !== undefined) setTheme(theme);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13963,6 +13963,7 @@ __metadata:
     three: "npm:^0.179.1"
     turndown: "npm:^7.2.1"
     typescript: "npm:5.8.2"
+    vosk-browser: "npm:^0.0.8"
     wait-on: "npm:^8.0.4"
     webpack: "npm:^5.92.0"
     workbox-build: "npm:7.1.1"
@@ -14102,6 +14103,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 10c0/8867e438990d1d33ac61093e2e4e3477a2148b844e4fa9e3c2360fa4399292429c4b6ec64537eb1659c97b2d10db349c673ad58b50e2824a11e0d3630de3c056
+  languageName: node
+  linkType: hard
+
 "v8-to-istanbul@npm:^9.0.1":
   version: 9.3.0
   resolution: "v8-to-istanbul@npm:9.3.0"
@@ -14110,6 +14120,15 @@ __metadata:
     "@types/istanbul-lib-coverage": "npm:^2.0.1"
     convert-source-map: "npm:^2.0.0"
   checksum: 10c0/968bcf1c7c88c04df1ffb463c179558a2ec17aa49e49376120504958239d9e9dad5281aa05f2a78542b8557f2be0b0b4c325710262f3b838b40d703d5ed30c23
+  languageName: node
+  linkType: hard
+
+"vosk-browser@npm:^0.0.8":
+  version: 0.0.8
+  resolution: "vosk-browser@npm:0.0.8"
+  dependencies:
+    uuid: "npm:9.0.0"
+  checksum: 10c0/1a434643e5070ef537caa607097276f0d2c9d924cc3180d37a2b4236216d2a3befc539e612aa827fcd3ac93fab161aabb18647a7a24c48be0975cc3909b3c62e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- introduce a voice-command hook backed by the offline vosk model with intent mapping and throttling
- render a voice HUD in the desktop shell, wiring hotkeys, dictation, and safe window actions
- expose voice-control toggles, hotkey capture, and guidance in settings with supporting unit tests

## Testing
- yarn test voiceControl
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label and no-top-level-window violations in legacy apps)*

------
https://chatgpt.com/codex/tasks/task_e_68cb141eb56883288c066ccf38e44484