### PR TITLE
[accessibility] add visual assist overlays and persistence

### DIFF
--- a/__tests__/accessibility/useAccessibilityPrefs.test.tsx
+++ b/__tests__/accessibility/useAccessibilityPrefs.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+import {
+  AccessibilityPrefsProvider,
+  useAccessibilityPrefs,
+  ACCESSIBILITY_PREFS_STORAGE_KEY,
+} from "../../hooks/useAccessibilityPrefs";
+
+describe("useAccessibilityPrefs", () => {
+  const Harness = () => {
+    const {
+      hoverLensEnabled,
+      fullScreenMagnifierEnabled,
+      activeFilters,
+    } = useAccessibilityPrefs();
+    return (
+      <div>
+        <span data-testid="hover">{hoverLensEnabled ? "on" : "off"}</span>
+        <span data-testid="full">
+          {fullScreenMagnifierEnabled ? "on" : "off"}
+        </span>
+        <span data-testid="filters">
+          {activeFilters.length ? activeFilters.join(",") : "none"}
+        </span>
+      </div>
+    );
+  };
+
+  const renderHarness = () =>
+    render(
+      <AccessibilityPrefsProvider>
+        <Harness />
+      </AccessibilityPrefsProvider>,
+    );
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("toggles modes via keyboard shortcuts", async () => {
+    renderHarness();
+
+    fireEvent.keyDown(window, { key: "L", altKey: true, shiftKey: true });
+    await waitFor(() => expect(screen.getByTestId("hover")).toHaveTextContent("on"));
+
+    fireEvent.keyDown(window, { key: "M", altKey: true, shiftKey: true });
+    await waitFor(() => expect(screen.getByTestId("full")).toHaveTextContent("on"));
+
+    fireEvent.keyDown(window, { key: "G", altKey: true, shiftKey: true });
+    await waitFor(() =>
+      expect(screen.getByTestId("filters")).toHaveTextContent("grayscale"),
+    );
+
+    fireEvent.keyDown(window, { key: "G", altKey: true, shiftKey: true });
+    await waitFor(() =>
+      expect(screen.getByTestId("filters")).toHaveTextContent("none"),
+    );
+  });
+
+  it("persists preferences to localStorage and rehydrates", async () => {
+    const { unmount } = renderHarness();
+
+    fireEvent.keyDown(window, { key: "L", altKey: true, shiftKey: true });
+    fireEvent.keyDown(window, { key: "M", altKey: true, shiftKey: true });
+    fireEvent.keyDown(window, { key: "1", altKey: true, shiftKey: true });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("filters")).toHaveTextContent("protanopia"),
+    );
+
+    const stored = window.localStorage.getItem(ACCESSIBILITY_PREFS_STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    expect(stored).toContain("\"hoverLensEnabled\":true");
+
+    unmount();
+
+    renderHarness();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("hover")).toHaveTextContent("on"),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("full")).toHaveTextContent("on"),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("filters")).toHaveTextContent("protanopia"),
+    );
+  });
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,14 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import {
+  useAccessibilityPrefs,
+  HOVER_ZOOM_MIN,
+  HOVER_ZOOM_MAX,
+  FULLSCREEN_ZOOM_MIN,
+  FULLSCREEN_ZOOM_MAX,
+  type ColorFilter,
+} from "../../hooks/useAccessibilityPrefs";
 
 export default function Settings() {
   const {
@@ -32,6 +40,21 @@ export default function Settings() {
     theme,
     setTheme,
   } = useSettings();
+  const {
+    hoverLensEnabled,
+    fullScreenMagnifierEnabled,
+    hoverZoom,
+    fullscreenZoom,
+    filterStyle,
+    toggleHoverLens,
+    toggleFullscreenMagnifier,
+    setHoverZoom,
+    setFullscreenZoom,
+    toggleFilter,
+    isFilterActive,
+    reset: resetVisualAssist,
+    shortcuts: accessibilityShortcuts,
+  } = useAccessibilityPrefs();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const tabs = [
@@ -267,6 +290,140 @@ export default function Settings() {
             >
               Edit Shortcuts
             </button>
+          </div>
+          <div className="border-t border-gray-900 mt-6 pt-6 px-4 space-y-4">
+            <div className="text-center">
+              <h3 className="text-lg font-semibold text-ubt-grey">
+                Visual Assist
+              </h3>
+              <p className="text-sm text-ubt-grey/80">
+                Magnify content and apply color filters for additional clarity.
+              </p>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-ubt-grey">Hover lens</span>
+                  <ToggleSwitch
+                    checked={hoverLensEnabled}
+                    onChange={toggleHoverLens}
+                    ariaLabel="Hover lens"
+                  />
+                </div>
+                <label className="block text-left text-sm text-ubt-grey">
+                  Lens zoom
+                  <input
+                    type="range"
+                    min={HOVER_ZOOM_MIN}
+                    max={HOVER_ZOOM_MAX}
+                    step={0.1}
+                    value={hoverZoom}
+                    onChange={(event) =>
+                      setHoverZoom(parseFloat(event.target.value))
+                    }
+                    className="mt-1 w-full ubuntu-slider"
+                    aria-label="Hover lens zoom"
+                    disabled={!hoverLensEnabled}
+                  />
+                  <span className="text-xs text-ubt-grey/70">
+                    {hoverZoom.toFixed(1)}x magnification
+                  </span>
+                </label>
+                <div className="flex items-center justify-between pt-2">
+                  <span className="text-ubt-grey">Full-screen magnifier</span>
+                  <ToggleSwitch
+                    checked={fullScreenMagnifierEnabled}
+                    onChange={toggleFullscreenMagnifier}
+                    ariaLabel="Full-screen magnifier"
+                  />
+                </div>
+                <label className="block text-left text-sm text-ubt-grey">
+                  Magnifier zoom
+                  <input
+                    type="range"
+                    min={FULLSCREEN_ZOOM_MIN}
+                    max={FULLSCREEN_ZOOM_MAX}
+                    step={0.1}
+                    value={fullscreenZoom}
+                    onChange={(event) =>
+                      setFullscreenZoom(parseFloat(event.target.value))
+                    }
+                    className="mt-1 w-full ubuntu-slider"
+                    aria-label="Full-screen magnifier zoom"
+                    disabled={!fullScreenMagnifierEnabled}
+                  />
+                  <span className="text-xs text-ubt-grey/70">
+                    {fullscreenZoom.toFixed(1)}x magnification
+                  </span>
+                </label>
+              </div>
+              <div className="space-y-4">
+                <div>
+                  <span className="block text-sm text-ubt-grey mb-2">
+                    Color filters
+                  </span>
+                  <div className="flex flex-wrap gap-2">
+                    {(
+                      [
+                        { key: "protanopia", label: "Protanopia" },
+                        { key: "deuteranopia", label: "Deuteranopia" },
+                        { key: "tritanopia", label: "Tritanopia" },
+                        { key: "grayscale", label: "Grayscale" },
+                      ] as { key: ColorFilter; label: string }[]
+                    ).map((option) => (
+                      <button
+                        key={option.key}
+                        type="button"
+                        onClick={() => toggleFilter(option.key)}
+                        className={`px-3 py-2 rounded border transition-colors ${
+                          isFilterActive(option.key)
+                            ? "bg-ub-orange text-white border-ub-orange"
+                            : "bg-ub-cool-grey text-ubt-grey border-gray-700"
+                        }`}
+                        aria-pressed={isFilterActive(option.key)}
+                        aria-label={`Toggle ${option.label} filter`}
+                      >
+                        {option.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div
+                  className="rounded border border-gray-700 bg-black/40 p-4 text-left"
+                  style={{
+                    filter: filterStyle === "none" ? undefined : filterStyle,
+                  }}
+                  aria-label="Color filter preview"
+                >
+                  <p className="text-base font-semibold text-white">
+                    Visual Assist preview
+                  </p>
+                  <p className="mt-1 text-sm text-ubt-grey">
+                    Explore the interface with your selected filters to ensure
+                    comfortable contrast.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <button
+                onClick={resetVisualAssist}
+                className="rounded bg-gray-800 px-3 py-2 text-sm text-white hover:bg-gray-700"
+                type="button"
+              >
+                Reset Visual Assist
+              </button>
+              <ul className="flex flex-wrap gap-3 text-xs text-ubt-grey/80">
+                {accessibilityShortcuts.map((shortcut) => (
+                  <li key={shortcut.id} className="flex items-center gap-1">
+                    <span>{shortcut.description}:</span>
+                    <kbd className="rounded bg-gray-800 px-2 py-1 font-mono text-white">
+                      {shortcut.combo}
+                    </kbd>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </div>
         </>
       )}

--- a/components/accessibility/VisualAssist.tsx
+++ b/components/accessibility/VisualAssist.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import {
+  Fragment,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+import { useAccessibilityPrefs } from "../../hooks/useAccessibilityPrefs";
+
+const LENS_SIZE = 280;
+
+type Html2Canvas = typeof import("html2canvas") extends { default: infer D }
+  ? D
+  : never;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const useViewport = () => {
+  const [viewport, setViewport] = useState({
+    width: typeof window !== "undefined" ? window.innerWidth : 0,
+    height: typeof window !== "undefined" ? window.innerHeight : 0,
+  });
+
+  useEffect(() => {
+    const handle = () =>
+      setViewport({ width: window.innerWidth, height: window.innerHeight });
+    window.addEventListener("resize", handle);
+    return () => window.removeEventListener("resize", handle);
+  }, []);
+
+  return viewport;
+};
+
+interface VisualAssistProps {
+  children: ReactNode;
+}
+
+const VisualAssist = ({ children }: VisualAssistProps) => {
+  const {
+    hoverLensEnabled,
+    fullScreenMagnifierEnabled,
+    hoverZoom,
+    fullscreenZoom,
+    filterStyle,
+  } = useAccessibilityPrefs();
+  const viewport = useViewport();
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [cursor, setCursor] = useState({
+    x: viewport.width / 2,
+    y: viewport.height / 2,
+  });
+  const [lensSnapshot, setLensSnapshot] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!hoverLensEnabled && !fullScreenMagnifierEnabled) return;
+
+    const update = (event: PointerEvent) => {
+      setCursor({ x: event.clientX, y: event.clientY });
+    };
+
+    window.addEventListener("pointermove", update, { passive: true });
+    return () => window.removeEventListener("pointermove", update);
+  }, [hoverLensEnabled, fullScreenMagnifierEnabled]);
+
+  useEffect(() => {
+    setCursor({ x: viewport.width / 2, y: viewport.height / 2 });
+  }, [viewport.height, viewport.width]);
+
+  useEffect(() => {
+    if (!hoverLensEnabled) {
+      setLensSnapshot(null);
+      return;
+    }
+
+    let mounted = true;
+    let timer: number | undefined;
+    let html2canvasInstance: Html2Canvas | null = null;
+
+    const ensureCanvas = async () => {
+      if (html2canvasInstance) return html2canvasInstance;
+      const module = await import("html2canvas");
+      html2canvasInstance = module.default;
+      return html2canvasInstance;
+    };
+
+    const capture = async () => {
+      if (!mounted || !contentRef.current) return;
+      try {
+        const html2canvas = await ensureCanvas();
+        const canvas = await html2canvas(contentRef.current, {
+          backgroundColor: null,
+          scale: window.devicePixelRatio,
+        });
+        if (mounted) {
+          setLensSnapshot(canvas.toDataURL("image/png"));
+        }
+      } catch (error) {
+        console.error("Visual assist lens capture failed", error);
+      }
+    };
+
+    capture();
+    timer = window.setInterval(capture, 1200);
+
+    return () => {
+      mounted = false;
+      if (timer) window.clearInterval(timer);
+    };
+  }, [hoverLensEnabled, fullscreenZoom, hoverZoom, filterStyle]);
+
+  const transform = useMemo(() => {
+    if (!fullScreenMagnifierEnabled || fullscreenZoom === 1) return "none";
+    const offsetX = clamp(
+      cursor.x * (fullscreenZoom - 1),
+      0,
+      viewport.width * (fullscreenZoom - 1),
+    );
+    const offsetY = clamp(
+      cursor.y * (fullscreenZoom - 1),
+      0,
+      viewport.height * (fullscreenZoom - 1),
+    );
+    return `translate3d(${-offsetX}px, ${-offsetY}px, 0) scale(${fullscreenZoom})`;
+  }, [cursor.x, cursor.y, fullScreenMagnifierEnabled, fullscreenZoom, viewport.height, viewport.width]);
+
+  const filterValue = filterStyle === "none" ? undefined : filterStyle;
+
+  const lensStyle = useMemo((): CSSProperties => {
+    if (!hoverLensEnabled || !lensSnapshot) return { display: "none" };
+    const radius = LENS_SIZE / 2;
+    const backgroundWidth = viewport.width * hoverZoom;
+    const backgroundHeight = viewport.height * hoverZoom;
+    const bgX = -cursor.x * hoverZoom + radius;
+    const bgY = -cursor.y * hoverZoom + radius;
+    return {
+      position: "fixed",
+      width: `${LENS_SIZE}px`,
+      height: `${LENS_SIZE}px`,
+      top: 0,
+      left: 0,
+      transform: `translate3d(${cursor.x - radius}px, ${cursor.y - radius}px, 0)`,
+      borderRadius: "50%",
+      border: "2px solid rgba(255,255,255,0.7)",
+      boxShadow: "0 12px 28px rgba(0,0,0,0.45)",
+      backgroundImage: `url(${lensSnapshot})`,
+      backgroundRepeat: "no-repeat",
+      backgroundSize: `${backgroundWidth}px ${backgroundHeight}px`,
+      backgroundPosition: `${bgX}px ${bgY}px`,
+      pointerEvents: "none",
+      zIndex: 2147483000,
+      filter: filterValue,
+    };
+  }, [cursor.x, cursor.y, filterValue, hoverLensEnabled, hoverZoom, lensSnapshot, viewport.height, viewport.width]);
+
+  return (
+    <Fragment>
+      <div
+        ref={contentRef}
+        className="relative min-h-screen w-full"
+        style={{
+          transform: transform === "none" ? undefined : transform,
+          transformOrigin: "0 0",
+          transition: "transform 150ms ease-out",
+          filter: filterValue,
+          overflow: fullScreenMagnifierEnabled ? "hidden" : undefined,
+        }}
+      >
+        {children}
+      </div>
+      <div style={lensStyle} aria-hidden />
+      <svg
+        aria-hidden
+        width={0}
+        height={0}
+        style={{ position: "absolute" }}
+      >
+        <defs>
+          <filter id="va-filter-protanopia">
+            <feColorMatrix
+              type="matrix"
+              values="0.567 0.433 0 0 0 0.558 0.442 0 0 0 0 0.242 0.758 0 0 0 0 0 1 0"
+            />
+          </filter>
+          <filter id="va-filter-deuteranopia">
+            <feColorMatrix
+              type="matrix"
+              values="0.625 0.375 0 0 0 0.7 0.3 0 0 0 0 0.3 0.7 0 0 0 0 0 1 0"
+            />
+          </filter>
+          <filter id="va-filter-tritanopia">
+            <feColorMatrix
+              type="matrix"
+              values="0.95 0.05 0 0 0 0 0.433 0.567 0 0 0 0.475 0.525 0 0 0 0 0 1 0"
+            />
+          </filter>
+        </defs>
+      </svg>
+    </Fragment>
+  );
+};
+
+export default VisualAssist;

--- a/hooks/useAccessibilityPrefs.tsx
+++ b/hooks/useAccessibilityPrefs.tsx
@@ -1,0 +1,359 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { safeLocalStorage } from "../utils/safeStorage";
+
+export type ColorFilter =
+  | "protanopia"
+  | "deuteranopia"
+  | "tritanopia"
+  | "grayscale";
+
+interface AccessibilityState {
+  hoverLensEnabled: boolean;
+  fullScreenMagnifierEnabled: boolean;
+  hoverZoom: number;
+  fullscreenZoom: number;
+  filters: ColorFilter[];
+}
+
+export interface VisualAssistShortcut {
+  id:
+    | "hoverLens"
+    | "fullScreenMagnifier"
+    | "protanopia"
+    | "deuteranopia"
+    | "tritanopia"
+    | "grayscale";
+  combo: string;
+  description: string;
+}
+
+interface AccessibilityPrefsValue {
+  hoverLensEnabled: boolean;
+  fullScreenMagnifierEnabled: boolean;
+  hoverZoom: number;
+  fullscreenZoom: number;
+  activeFilters: ColorFilter[];
+  filterStyle: string;
+  toggleHoverLens: () => void;
+  toggleFullscreenMagnifier: () => void;
+  setHoverZoom: (zoom: number) => void;
+  setFullscreenZoom: (zoom: number) => void;
+  toggleFilter: (filter: ColorFilter) => void;
+  isFilterActive: (filter: ColorFilter) => boolean;
+  reset: () => void;
+  shortcuts: VisualAssistShortcut[];
+}
+
+export const ACCESSIBILITY_PREFS_STORAGE_KEY = "visual-assist-preferences";
+export const HOVER_ZOOM_MIN = 1.5;
+export const HOVER_ZOOM_MAX = 4;
+export const FULLSCREEN_ZOOM_MIN = 1;
+export const FULLSCREEN_ZOOM_MAX = 3;
+
+const defaultState: AccessibilityState = {
+  hoverLensEnabled: false,
+  fullScreenMagnifierEnabled: false,
+  hoverZoom: 2,
+  fullscreenZoom: 1.5,
+  filters: [],
+};
+
+const filterOrder: ColorFilter[] = [
+  "protanopia",
+  "deuteranopia",
+  "tritanopia",
+  "grayscale",
+];
+
+const COLOR_FILTER_MAP: Record<ColorFilter, string> = {
+  protanopia: "url(#va-filter-protanopia)",
+  deuteranopia: "url(#va-filter-deuteranopia)",
+  tritanopia: "url(#va-filter-tritanopia)",
+  grayscale: "grayscale(1)",
+};
+
+const AccessibilityPrefsContext =
+  createContext<AccessibilityPrefsValue | null>(null);
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const sanitizeFilters = (filters: unknown): ColorFilter[] => {
+  if (!Array.isArray(filters)) return [];
+  const unique = new Set<ColorFilter>();
+  filters.forEach((item) => {
+    if (filterOrder.includes(item as ColorFilter)) {
+      unique.add(item as ColorFilter);
+    }
+  });
+  return filterOrder.filter((filter) => unique.has(filter));
+};
+
+const readStoredState = (): AccessibilityState => {
+  if (!safeLocalStorage) return defaultState;
+  try {
+    const raw = safeLocalStorage.getItem(ACCESSIBILITY_PREFS_STORAGE_KEY);
+    if (!raw) return defaultState;
+    const parsed = JSON.parse(raw) as Partial<AccessibilityState>;
+    return {
+      hoverLensEnabled:
+        typeof parsed.hoverLensEnabled === "boolean"
+          ? parsed.hoverLensEnabled
+          : defaultState.hoverLensEnabled,
+      fullScreenMagnifierEnabled:
+        typeof parsed.fullScreenMagnifierEnabled === "boolean"
+          ? parsed.fullScreenMagnifierEnabled
+          : defaultState.fullScreenMagnifierEnabled,
+      hoverZoom:
+        typeof parsed.hoverZoom === "number"
+          ? clamp(parsed.hoverZoom, HOVER_ZOOM_MIN, HOVER_ZOOM_MAX)
+          : defaultState.hoverZoom,
+      fullscreenZoom:
+        typeof parsed.fullscreenZoom === "number"
+          ? clamp(
+              parsed.fullscreenZoom,
+              FULLSCREEN_ZOOM_MIN,
+              FULLSCREEN_ZOOM_MAX,
+            )
+          : defaultState.fullscreenZoom,
+      filters: sanitizeFilters(parsed.filters),
+    };
+  } catch (error) {
+    console.error("Failed to read accessibility prefs", error);
+    return defaultState;
+  }
+};
+
+const useAccessibilityPrefsState = (): AccessibilityPrefsValue => {
+  const [state, setState] = useState<AccessibilityState>(defaultState);
+  const hydratedRef = useRef(false);
+
+  useEffect(() => {
+    if (hydratedRef.current) return;
+    const stored = readStoredState();
+    setState(stored);
+    hydratedRef.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (!hydratedRef.current || !safeLocalStorage) return;
+    try {
+      safeLocalStorage.setItem(
+        ACCESSIBILITY_PREFS_STORAGE_KEY,
+        JSON.stringify(state),
+      );
+    } catch (error) {
+      console.error("Failed to persist accessibility prefs", error);
+    }
+  }, [state]);
+
+  const toggleHoverLens = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      hoverLensEnabled: !prev.hoverLensEnabled,
+    }));
+  }, []);
+
+  const toggleFullscreenMagnifier = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      fullScreenMagnifierEnabled: !prev.fullScreenMagnifierEnabled,
+    }));
+  }, []);
+
+  const setHoverZoom = useCallback((zoom: number) => {
+    setState((prev) => ({
+      ...prev,
+      hoverZoom: clamp(zoom, HOVER_ZOOM_MIN, HOVER_ZOOM_MAX),
+    }));
+  }, []);
+
+  const setFullscreenZoom = useCallback((zoom: number) => {
+    setState((prev) => ({
+      ...prev,
+      fullscreenZoom: clamp(
+        zoom,
+        FULLSCREEN_ZOOM_MIN,
+        FULLSCREEN_ZOOM_MAX,
+      ),
+    }));
+  }, []);
+
+  const toggleFilter = useCallback((filter: ColorFilter) => {
+    setState((prev) => {
+      const exists = prev.filters.includes(filter);
+      return {
+        ...prev,
+        filters: exists
+          ? prev.filters.filter((entry) => entry !== filter)
+          : [...prev.filters, filter],
+      };
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    setState(defaultState);
+    if (!safeLocalStorage) return;
+    try {
+      safeLocalStorage.removeItem(ACCESSIBILITY_PREFS_STORAGE_KEY);
+    } catch (error) {
+      console.error("Failed to reset accessibility prefs", error);
+    }
+  }, []);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (!event.altKey || !event.shiftKey) return;
+      const key = event.key.toLowerCase();
+      switch (key) {
+        case "l":
+          event.preventDefault();
+          toggleHoverLens();
+          break;
+        case "m":
+          event.preventDefault();
+          toggleFullscreenMagnifier();
+          break;
+        case "1":
+          event.preventDefault();
+          toggleFilter("protanopia");
+          break;
+        case "2":
+          event.preventDefault();
+          toggleFilter("deuteranopia");
+          break;
+        case "3":
+          event.preventDefault();
+          toggleFilter("tritanopia");
+          break;
+        case "g":
+          event.preventDefault();
+          toggleFilter("grayscale");
+          break;
+        default:
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [toggleFilter, toggleFullscreenMagnifier, toggleHoverLens]);
+
+  const filterStyle = useMemo(() => {
+    if (!state.filters.length) return "none";
+    return state.filters
+      .map((filter) => COLOR_FILTER_MAP[filter])
+      .join(" ");
+  }, [state.filters]);
+
+  const shortcuts = useMemo<VisualAssistShortcut[]>(
+    () => [
+      {
+        id: "hoverLens",
+        combo: "Alt+Shift+L",
+        description: "Toggle hover lens",
+      },
+      {
+        id: "fullScreenMagnifier",
+        combo: "Alt+Shift+M",
+        description: "Toggle full-screen magnifier",
+      },
+      {
+        id: "protanopia",
+        combo: "Alt+Shift+1",
+        description: "Toggle protanopia filter",
+      },
+      {
+        id: "deuteranopia",
+        combo: "Alt+Shift+2",
+        description: "Toggle deuteranopia filter",
+      },
+      {
+        id: "tritanopia",
+        combo: "Alt+Shift+3",
+        description: "Toggle tritanopia filter",
+      },
+      {
+        id: "grayscale",
+        combo: "Alt+Shift+G",
+        description: "Toggle grayscale filter",
+      },
+    ],
+    [],
+  );
+
+  const value = useMemo<AccessibilityPrefsValue>(
+    () => ({
+      hoverLensEnabled: state.hoverLensEnabled,
+      fullScreenMagnifierEnabled: state.fullScreenMagnifierEnabled,
+      hoverZoom: state.hoverZoom,
+      fullscreenZoom: state.fullscreenZoom,
+      activeFilters: state.filters,
+      filterStyle,
+      toggleHoverLens,
+      toggleFullscreenMagnifier,
+      setHoverZoom,
+      setFullscreenZoom,
+      toggleFilter,
+      isFilterActive: (filter: ColorFilter) => state.filters.includes(filter),
+      reset,
+      shortcuts,
+    }),
+    [
+      filterStyle,
+      reset,
+      setFullscreenZoom,
+      setHoverZoom,
+      shortcuts,
+      state.filters,
+      state.fullScreenMagnifierEnabled,
+      state.fullscreenZoom,
+      state.hoverLensEnabled,
+      state.hoverZoom,
+      toggleFilter,
+      toggleFullscreenMagnifier,
+      toggleHoverLens,
+    ],
+  );
+
+  return value;
+};
+
+export const AccessibilityPrefsProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const value = useAccessibilityPrefsState();
+  return (
+    <AccessibilityPrefsContext.Provider value={value}>
+      {children}
+    </AccessibilityPrefsContext.Provider>
+  );
+};
+
+export const useAccessibilityPrefs = () => {
+  const context = useContext(AccessibilityPrefsContext);
+  if (!context) {
+    throw new Error(
+      "useAccessibilityPrefs must be used within an AccessibilityPrefsProvider",
+    );
+  }
+  return context;
+};
+
+export const getFilterStyle = (filters: ColorFilter[]) => {
+  if (!filters.length) return "none";
+  return filters.map((filter) => COLOR_FILTER_MAP[filter]).join(" ");
+};

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,8 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import VisualAssist from '../components/accessibility/VisualAssist';
+import { AccessibilityPrefsProvider } from '../hooks/useAccessibilityPrefs';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -157,21 +159,29 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+          <AccessibilityPrefsProvider>
+            <PipPortalProvider>
+              <VisualAssist>
+                <>
+                  <div aria-live="polite" id="live-region" />
+                  <Component {...pageProps} />
+                  <ShortcutOverlay />
+                  <Analytics
+                    beforeSend={(e) => {
+                      if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                      const evt = e;
+                      if (evt.metadata?.email) delete evt.metadata.email;
+                      return e;
+                    }}
+                  />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
+                  {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && (
+                    <SpeedInsights />
+                  )}
+                </>
+              </VisualAssist>
+            </PipPortalProvider>
+          </AccessibilityPrefsProvider>
         </SettingsProvider>
       </div>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- add a VisualAssist overlay to support hover lens, full-screen magnifier, and color filter stacking
- persist accessibility preferences with keyboard shortcuts for toggling modes
- expose Visual Assist controls and previews inside the accessibility settings panel

## Testing
- yarn lint *(fails: pre-existing accessibility lint errors across legacy app files)*
- yarn test --runTestsByPath __tests__/accessibility/useAccessibilityPrefs.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb142068a48328925eeeaad0cf1baa