### PR TITLE
[settings] add telemetry controls and buffering

### DIFF
--- a/__tests__/analytics.test.ts
+++ b/__tests__/analytics.test.ts
@@ -1,5 +1,17 @@
 import ReactGA from 'react-ga4';
-import { logEvent, logGameStart, logGameEnd, logGameError } from '../utils/analytics';
+import {
+  getAnalyticsBufferStats,
+  logEvent,
+  logGameStart,
+  logGameEnd,
+  logGameError,
+  flushAnalyticsEvents,
+} from '../utils/analytics';
+import {
+  resetTelemetryPreferences,
+  setTelemetryPreference,
+} from '../modules/telemetry/preferences';
+import { resetTelemetryBuffer } from '../modules/telemetry/buffer';
 
 jest.mock('react-ga4', () => ({
   event: jest.fn(),
@@ -10,32 +22,67 @@ describe('analytics utilities', () => {
 
   beforeEach(() => {
     mockEvent.mockReset();
+    process.env.NEXT_PUBLIC_ENABLE_ANALYTICS = 'true';
+    window.localStorage.clear();
+    resetTelemetryBuffer();
+    resetTelemetryPreferences();
   });
 
-  it('logs generic events', () => {
+  it('does not enqueue events when analytics is disabled by default', () => {
     const event = { category: 'test', action: 'act' } as any;
-    logEvent(event);
-    expect(mockEvent).toHaveBeenCalledWith(event);
+    const result = logEvent(event);
+    expect(result).toBe(false);
+    expect(getAnalyticsBufferStats().totalEvents).toBe(0);
+    expect(mockEvent).not.toHaveBeenCalled();
   });
 
   it('logs game start', () => {
+    setTelemetryPreference('analytics', true);
     logGameStart('chess');
-    expect(mockEvent).toHaveBeenCalledWith({ category: 'chess', action: 'start' });
+    const stats = getAnalyticsBufferStats();
+    expect(stats.totalEvents).toBe(1);
+    expect(mockEvent).not.toHaveBeenCalled();
   });
 
   it('logs game end with label', () => {
+    setTelemetryPreference('analytics', true);
     logGameEnd('chess', 'win');
-    expect(mockEvent).toHaveBeenCalledWith({ category: 'chess', action: 'end', label: 'win' });
+    const stats = getAnalyticsBufferStats();
+    expect(stats.totalEvents).toBe(1);
+    expect(stats.totalBytes).toBeGreaterThan(0);
   });
 
   it('logs game error with message', () => {
+    setTelemetryPreference('analytics', true);
     logGameError('chess', 'oops');
-    expect(mockEvent).toHaveBeenCalledWith({ category: 'chess', action: 'error', label: 'oops' });
+    expect(getAnalyticsBufferStats().totalEvents).toBe(1);
   });
 
   it('handles errors from ReactGA.event without throwing', () => {
-    mockEvent.mockImplementationOnce(() => { throw new Error('fail'); });
-    expect(() => logEvent({ category: 't', action: 'a' } as any)).not.toThrow();
+    mockEvent.mockImplementationOnce(() => {
+      throw new Error('fail');
+    });
+    setTelemetryPreference('analytics', true);
+    logEvent({ category: 't', action: 'a' } as any);
+    expect(() => flushAnalyticsEvents()).not.toThrow();
+  });
+
+  it('flushes analytics events and clears the buffer', () => {
+    setTelemetryPreference('analytics', true);
+    logEvent({ category: 'test', action: 'act' } as any);
+    expect(getAnalyticsBufferStats().totalEvents).toBe(1);
+    const sent = flushAnalyticsEvents();
+    expect(sent).toBe(1);
+    expect(mockEvent).toHaveBeenCalledTimes(1);
+    expect(getAnalyticsBufferStats().totalEvents).toBe(0);
+  });
+
+  it('purges telemetry buffer without dispatching', () => {
+    setTelemetryPreference('analytics', true);
+    logEvent({ category: 'test', action: 'act' } as any);
+    resetTelemetryBuffer();
+    expect(mockEvent).not.toHaveBeenCalled();
+    expect(getAnalyticsBufferStats().totalEvents).toBe(0);
   });
 });
 

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import TelemetryControls from "../../components/apps/settings/privacy/TelemetryControls";
 
 export default function Settings() {
   const {
@@ -271,7 +272,8 @@ export default function Settings() {
         </>
       )}
       {activeTab === "privacy" && (
-        <>
+        <div className="space-y-6">
+          <TelemetryControls />
           <div className="flex justify-center my-4 space-x-4">
             <button
               onClick={handleExport}
@@ -286,7 +288,7 @@ export default function Settings() {
               Import Settings
             </button>
           </div>
-        </>
+        </div>
       )}
         <input
           type="file"

--- a/components/apps/settings/privacy/TelemetryControls.tsx
+++ b/components/apps/settings/privacy/TelemetryControls.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import ToggleSwitch from "../../../ToggleSwitch";
+import {
+  TELEMETRY_CATEGORIES,
+  type TelemetryPreferences,
+  getTelemetryPreferences,
+  setTelemetryPreference,
+  subscribeToTelemetryPreferences,
+} from "../../../../modules/telemetry/preferences";
+import {
+  getBufferStats,
+  subscribeToTelemetryBuffer,
+  resetTelemetryBuffer,
+  type BufferStats,
+} from "../../../../modules/telemetry/buffer";
+import { flushAnalyticsEvents } from "../../../../utils/analytics";
+
+const formatBytes = (bytes: number): string => {
+  if (!bytes) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** index;
+  const precision = index === 0 ? 0 : value < 10 ? 1 : 0;
+  return `${value.toFixed(precision)} ${units[index]}`;
+};
+
+const channelTitles: Record<string, string> = TELEMETRY_CATEGORIES.reduce(
+  (acc, category) => {
+    acc[category.id] = category.title;
+    return acc;
+  },
+  {} as Record<string, string>,
+);
+
+export default function TelemetryControls() {
+  const [preferences, setPreferences] = useState<TelemetryPreferences>(() =>
+    getTelemetryPreferences(),
+  );
+  const [stats, setStats] = useState<BufferStats>(() => getBufferStats());
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToTelemetryPreferences(setPreferences);
+    return () => unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToTelemetryBuffer(setStats);
+    return () => unsubscribe();
+  }, []);
+
+  const analyticsStats = stats.byChannel.analytics;
+
+  const handleToggle = (channel: keyof TelemetryPreferences, enabled: boolean) => {
+    setTelemetryPreference(channel, enabled);
+    setStatusMessage(null);
+  };
+
+  const handleFlush = () => {
+    const sent = flushAnalyticsEvents();
+    if (sent > 0) {
+      setStatusMessage(`Dispatched ${sent} analytics event${sent === 1 ? "" : "s"}.`);
+    } else {
+      setStatusMessage(
+        "No analytics events ready to send or analytics dispatch is disabled.",
+      );
+    }
+  };
+
+  const handlePurge = () => {
+    resetTelemetryBuffer();
+    setStatusMessage("Telemetry buffer cleared without sending data.");
+  };
+
+  return (
+    <section className="space-y-4 px-4 py-4 text-ubt-grey">
+      <header className="space-y-2 rounded border border-ubt-cool-grey bg-black/20 p-4">
+        <h2 className="text-lg font-semibold text-white">Telemetry & Privacy</h2>
+        <p>
+          Telemetry is <strong>opt-in</strong>. Categories stay off until you flip a
+          switch. All events are anonymized and stored locally in an in-memory buffer
+          until you decide to flush or purge them.
+        </p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {TELEMETRY_CATEGORIES.map((category) => {
+          const descriptionId = `${category.id}-description`;
+          return (
+            <article
+              key={category.id}
+              className="space-y-2 rounded border border-ubt-cool-grey bg-black/10 p-4"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <h3 className="text-base font-semibold text-white">{category.title}</h3>
+                  <p id={descriptionId} className="text-sm text-ubt-grey">
+                    {category.description}
+                  </p>
+                </div>
+                <ToggleSwitch
+                  ariaLabel={`Toggle ${category.title}`}
+                  checked={preferences[category.id]}
+                  onChange={(value) => handleToggle(category.id, value)}
+                />
+              </div>
+              <details className="rounded bg-black/30 p-3 text-xs text-ubt-grey">
+                <summary className="cursor-pointer text-white">
+                  What this includes
+                </summary>
+                <p className="pt-2 leading-relaxed">{category.documentation}</p>
+              </details>
+              <footer className="text-xs text-ubt-grey">
+                Buffered {channelTitles[category.id]} events: {stats.byChannel[category.id].events} (
+                {formatBytes(stats.byChannel[category.id].bytes)})
+              </footer>
+            </article>
+          );
+        })}
+      </div>
+
+      <div className="space-y-3 rounded border border-ubt-cool-grey bg-black/20 p-4">
+        <h3 className="text-base font-semibold text-white">Telemetry buffer</h3>
+        <p className="text-sm">
+          Currently queued events: <strong>{stats.totalEvents}</strong> totaling{' '}
+          <strong>{formatBytes(stats.totalBytes)}</strong> across all categories.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={handleFlush}
+            disabled={analyticsStats.events === 0}
+            className="rounded bg-ub-orange px-4 py-2 text-sm font-semibold text-white disabled:opacity-40"
+          >
+            Flush analytics events
+          </button>
+          <button
+            type="button"
+            onClick={handlePurge}
+            disabled={stats.totalEvents === 0}
+            className="rounded border border-ub-orange px-4 py-2 text-sm font-semibold text-ub-orange disabled:opacity-40"
+          >
+            Purge all buffered data
+          </button>
+        </div>
+        <p className="text-xs text-ubt-grey">
+          Flushing sends opted-in analytics events to their destination. Purging clears
+          the buffer locally without sending anything.
+        </p>
+        {statusMessage && (
+          <p role="status" className="text-xs text-ubt-grey">
+            {statusMessage}
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/modules/telemetry/buffer.ts
+++ b/modules/telemetry/buffer.ts
@@ -1,0 +1,181 @@
+import type { TelemetryChannel, TelemetryPreferences } from './preferences';
+import {
+  getTelemetryPreferences,
+  subscribeToTelemetryPreferences,
+} from './preferences';
+
+export interface TelemetryEventRecord {
+  channel: TelemetryChannel;
+  timestamp: number;
+  payload: Record<string, unknown>;
+  bytes: number;
+}
+
+export interface BufferStats {
+  totalEvents: number;
+  totalBytes: number;
+  byChannel: Record<
+    TelemetryChannel,
+    {
+      events: number;
+      bytes: number;
+    }
+  >;
+}
+
+type BufferListener = (stats: BufferStats) => void;
+
+const buffer: TelemetryEventRecord[] = [];
+const listeners = new Set<BufferListener>();
+let preferences: TelemetryPreferences = getTelemetryPreferences();
+
+subscribeToTelemetryPreferences((prefs) => {
+  preferences = prefs;
+});
+
+const encoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
+
+const toBytes = (value: unknown): number => {
+  const text = typeof value === 'string' ? value : JSON.stringify(value);
+  if (!text) return 0;
+  if (encoder) {
+    return encoder.encode(text).length;
+  }
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(text).length;
+  }
+  return text.length;
+};
+
+const sanitizeEvent = (payload: Record<string, unknown>): Record<string, unknown> => {
+  const safe: Record<string, unknown> = {};
+  Object.entries(payload).forEach(([key, value]) => {
+    if (value === null || value === undefined) {
+      return;
+    }
+    if (typeof value === 'string') {
+      safe[key] = value.slice(0, 200);
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
+      safe[key] = value;
+    } else if (value instanceof Date) {
+      safe[key] = value.toISOString();
+    } else if (typeof value === 'object') {
+      safe[key] = JSON.parse(JSON.stringify(value, (_k, v) => {
+        if (v === null || v === undefined) return undefined;
+        if (typeof v === 'string') return v.slice(0, 200);
+        if (typeof v === 'number' || typeof v === 'boolean') return v;
+        return undefined;
+      }));
+    }
+  });
+  return safe;
+};
+
+const emit = (): void => {
+  const snapshot = getBufferStats();
+  listeners.forEach((listener) => listener(snapshot));
+};
+
+export const enqueueTelemetryEvent = (
+  channel: TelemetryChannel,
+  payload: Record<string, unknown>,
+): boolean => {
+  if (!preferences[channel]) {
+    return false;
+  }
+  const sanitized = sanitizeEvent(payload);
+  const bytes = toBytes(sanitized);
+  buffer.push({ channel, payload: sanitized, timestamp: Date.now(), bytes });
+  emit();
+  return true;
+};
+
+export const getBufferSnapshot = (): TelemetryEventRecord[] => buffer.slice();
+
+export const getBufferStats = (channel?: TelemetryChannel): BufferStats => {
+  const base: BufferStats = {
+    totalEvents: 0,
+    totalBytes: 0,
+    byChannel: {
+      analytics: { events: 0, bytes: 0 },
+      usage: { events: 0, bytes: 0 },
+      diagnostics: { events: 0, bytes: 0 },
+    },
+  };
+
+  buffer.forEach((record) => {
+    if (channel && record.channel !== channel) {
+      return;
+    }
+    base.totalEvents += 1;
+    base.totalBytes += record.bytes;
+    base.byChannel[record.channel].events += 1;
+    base.byChannel[record.channel].bytes += record.bytes;
+  });
+
+  if (channel) {
+    base.totalEvents = base.byChannel[channel].events;
+    base.totalBytes = base.byChannel[channel].bytes;
+  }
+
+  return base;
+};
+
+export const purgeBuffer = (channel?: TelemetryChannel): void => {
+  if (!buffer.length) return;
+  if (!channel) {
+    buffer.splice(0, buffer.length);
+  } else {
+    for (let i = buffer.length - 1; i >= 0; i -= 1) {
+      if (buffer[i].channel === channel) {
+        buffer.splice(i, 1);
+      }
+    }
+  }
+  emit();
+};
+
+export const flushBuffer = (
+  dispatcher: (payload: Record<string, unknown>) => void,
+  channel?: TelemetryChannel,
+): number => {
+  const toFlush: TelemetryEventRecord[] = [];
+  for (let i = 0; i < buffer.length; i += 1) {
+    const record = buffer[i];
+    if (channel && record.channel !== channel) continue;
+    if (!preferences[record.channel]) continue;
+    toFlush.push(record);
+  }
+  if (!toFlush.length) {
+    return 0;
+  }
+  toFlush.forEach((record) => {
+    try {
+      dispatcher(record.payload);
+    } catch (error) {
+      console.warn('Telemetry dispatcher failed', error);
+    }
+  });
+  const flushed = new Set(toFlush);
+  for (let i = buffer.length - 1; i >= 0; i -= 1) {
+    if (flushed.has(buffer[i])) {
+      buffer.splice(i, 1);
+    }
+  }
+  emit();
+  return toFlush.length;
+};
+
+export const subscribeToTelemetryBuffer = (
+  listener: BufferListener,
+): (() => void) => {
+  listeners.add(listener);
+  listener(getBufferStats());
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const resetTelemetryBuffer = (): void => {
+  purgeBuffer();
+};

--- a/modules/telemetry/preferences.ts
+++ b/modules/telemetry/preferences.ts
@@ -1,0 +1,134 @@
+export type TelemetryChannel = 'analytics' | 'usage' | 'diagnostics';
+
+export interface TelemetryPreferences {
+  analytics: boolean;
+  usage: boolean;
+  diagnostics: boolean;
+}
+
+export const TELEMETRY_CATEGORIES: ReadonlyArray<{
+  id: TelemetryChannel;
+  title: string;
+  description: string;
+  documentation: string;
+}> = [
+  {
+    id: 'analytics',
+    title: 'Product analytics',
+    description:
+      'Counts high-level interactions such as app launches or completed challenges. Data is aggregated and never contains personal identifiers.',
+    documentation:
+      'These events help prioritize which simulations people open most often. No IP addresses, emails, or command output is collected.',
+  },
+  {
+    id: 'usage',
+    title: 'Anonymized usage metrics',
+    description:
+      'Captures coarse session timing, viewport sizes, and control preferences to keep demos usable across devices.',
+    documentation:
+      'Usage metrics are averaged before review and only include derived values such as duration buckets or UI density choices.',
+  },
+  {
+    id: 'diagnostics',
+    title: 'Crash diagnostics',
+    description:
+      'Stores stack traces when a mini-app throws so we can reproduce bugs locally without raw user content.',
+    documentation:
+      'Only framework error messages are buffered. Command history, form input, and uploaded files are explicitly excluded.',
+  },
+];
+
+export const TELEMETRY_DEFAULTS: TelemetryPreferences = {
+  analytics: false,
+  usage: false,
+  diagnostics: false,
+};
+
+const STORAGE_KEY = 'telemetry-preferences';
+
+type PreferencesListener = (prefs: TelemetryPreferences) => void;
+const listeners = new Set<PreferencesListener>();
+
+const clonePreferences = (prefs: TelemetryPreferences): TelemetryPreferences => ({
+  analytics: prefs.analytics,
+  usage: prefs.usage,
+  diagnostics: prefs.diagnostics,
+});
+
+export const getTelemetryPreferences = (): TelemetryPreferences => {
+  if (typeof window === 'undefined') {
+    return clonePreferences(TELEMETRY_DEFAULTS);
+  }
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return clonePreferences(TELEMETRY_DEFAULTS);
+    }
+    const parsed = JSON.parse(stored) as Partial<TelemetryPreferences>;
+    return {
+      analytics:
+        typeof parsed.analytics === 'boolean'
+          ? parsed.analytics
+          : TELEMETRY_DEFAULTS.analytics,
+      usage:
+        typeof parsed.usage === 'boolean' ? parsed.usage : TELEMETRY_DEFAULTS.usage,
+      diagnostics:
+        typeof parsed.diagnostics === 'boolean'
+          ? parsed.diagnostics
+          : TELEMETRY_DEFAULTS.diagnostics,
+    };
+  } catch (error) {
+    console.warn('Unable to read telemetry preferences', error);
+    return clonePreferences(TELEMETRY_DEFAULTS);
+  }
+};
+
+const saveTelemetryPreferences = (prefs: TelemetryPreferences): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+};
+
+const notifyListeners = (prefs: TelemetryPreferences): void => {
+  const snapshot = clonePreferences(prefs);
+  listeners.forEach((listener) => listener(snapshot));
+};
+
+export const setTelemetryPreference = (
+  channel: TelemetryChannel,
+  enabled: boolean,
+): TelemetryPreferences => {
+  const current = getTelemetryPreferences();
+  if (current[channel] === enabled) {
+    return current;
+  }
+  const next = { ...current, [channel]: enabled } as TelemetryPreferences;
+  saveTelemetryPreferences(next);
+  notifyListeners(next);
+  return next;
+};
+
+export const setTelemetryPreferences = (
+  prefs: Partial<TelemetryPreferences>,
+): TelemetryPreferences => {
+  const next = { ...getTelemetryPreferences(), ...prefs } as TelemetryPreferences;
+  saveTelemetryPreferences(next);
+  notifyListeners(next);
+  return next;
+};
+
+export const subscribeToTelemetryPreferences = (
+  listener: PreferencesListener,
+): (() => void) => {
+  listeners.add(listener);
+  listener(clonePreferences(getTelemetryPreferences()));
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const resetTelemetryPreferences = (): void => {
+  saveTelemetryPreferences(clonePreferences(TELEMETRY_DEFAULTS));
+  notifyListeners(clonePreferences(TELEMETRY_DEFAULTS));
+};

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -1,6 +1,18 @@
 import ReactGA from 'react-ga4';
+import type { TelemetryChannel } from '../modules/telemetry/preferences';
+import {
+  enqueueTelemetryEvent,
+  flushBuffer,
+  getBufferStats,
+  purgeBuffer,
+} from '../modules/telemetry/buffer';
 
 type EventInput = Parameters<typeof ReactGA.event>[0];
+
+const ANALYTICS_CHANNEL: TelemetryChannel = 'analytics';
+
+const shouldDispatch = (): boolean =>
+  typeof process !== 'undefined' && process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true';
 
 const safeEvent = (...args: Parameters<typeof ReactGA.event>): void => {
   try {
@@ -13,9 +25,43 @@ const safeEvent = (...args: Parameters<typeof ReactGA.event>): void => {
   }
 };
 
-export const logEvent = (event: EventInput): void => {
-  safeEvent(event);
+const normalizeEvent = (event: EventInput): Record<string, unknown> => {
+  const payload: Record<string, unknown> = {};
+  Object.entries(event as Record<string, unknown>).forEach(([key, value]) => {
+    if (value === undefined || value === null) {
+      return;
+    }
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      payload[key] = value;
+    }
+  });
+  if (!payload.category) {
+    payload.category = 'uncategorized';
+  }
+  if (!payload.action) {
+    payload.action = 'event';
+  }
+  return payload;
 };
+
+export const logEvent = (event: EventInput): boolean => {
+  const normalized = normalizeEvent(event);
+  return enqueueTelemetryEvent(ANALYTICS_CHANNEL, normalized);
+};
+
+export const flushAnalyticsEvents = (): number => {
+  if (!shouldDispatch()) {
+    purgeBuffer(ANALYTICS_CHANNEL);
+    return 0;
+  }
+  return flushBuffer((payload) => safeEvent(payload as EventInput), ANALYTICS_CHANNEL);
+};
+
+export const purgeAnalyticsBuffer = (): void => {
+  purgeBuffer(ANALYTICS_CHANNEL);
+};
+
+export const getAnalyticsBufferStats = () => getBufferStats(ANALYTICS_CHANNEL);
 
 export const logGameStart = (game: string): void => {
   logEvent({ category: game, action: 'start' });

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -2,6 +2,12 @@
 
 import { get, set, del } from 'idb-keyval';
 import { getTheme, setTheme } from './theme';
+import {
+  getTelemetryPreferences,
+  resetTelemetryPreferences,
+  setTelemetryPreferences,
+  TELEMETRY_DEFAULTS,
+} from '../modules/telemetry/preferences';
 
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
@@ -14,6 +20,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  telemetry: TELEMETRY_DEFAULTS,
 };
 
 export async function getAccent() {
@@ -137,6 +144,8 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('telemetry-preferences');
+  resetTelemetryPreferences();
 }
 
 export async function exportSettings() {
@@ -151,6 +160,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    telemetry,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +172,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    Promise.resolve(getTelemetryPreferences()),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -176,6 +187,7 @@ export async function exportSettings() {
     allowNetwork,
     haptics,
     theme,
+    telemetry,
   });
 }
 
@@ -200,6 +212,7 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    telemetry,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -212,6 +225,9 @@ export async function importSettings(json) {
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
+  if (telemetry && typeof telemetry === 'object') {
+    setTelemetryPreferences(telemetry);
+  }
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- add a privacy-focused telemetry controls panel with opt-in categories, documentation, buffer stats, and flush/purge actions
- introduce a shared telemetry preference store and in-memory buffer that respects opt-in toggles and integrates with settings import/export
- route analytics helpers through the buffer, provide manual flush utilities, and expand tests to verify defaults, gating, stats, and purge behavior

## Testing
- yarn lint *(fails: repo currently reports hundreds of pre-existing jsx-a11y/no-top-level-window errors)*
- yarn test __tests__/analytics.test.ts --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cb142b91348328815c27f169908cd3