### PR TITLE
[apps] add Help Hub guidance app

### DIFF
--- a/__tests__/helpHub.test.tsx
+++ b/__tests__/helpHub.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import HelpHub from '../components/apps/help-hub';
+
+describe('HelpHub', () => {
+  let openSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    openSpy = jest
+      .spyOn(window, 'open')
+      .mockImplementation(() => null as unknown as Window);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+  });
+
+  it('prioritizes direct matches when searching', async () => {
+    render(<HelpHub />);
+    const search = screen.getByLabelText('Search tips');
+    fireEvent.change(search, { target: { value: 'keyboard' } });
+
+    await waitFor(() => {
+      const options = screen.getAllByRole('option');
+      expect(options[0]).toHaveAttribute('data-tip-id', 'keyboard-shortcuts');
+    });
+  });
+
+  it('filters topics by selected tag', async () => {
+    render(<HelpHub />);
+    const tagToggle = screen.getByLabelText('safety');
+    fireEvent.click(tagToggle);
+
+    await waitFor(() => {
+      const options = screen.getAllByRole('option');
+      expect(options).toHaveLength(1);
+      expect(options[0]).toHaveAttribute('data-tip-id', 'simulate-tools-safely');
+    });
+  });
+
+  it('invokes openApp when an action targets an app', () => {
+    const openApp = jest.fn();
+    render(<HelpHub openApp={openApp} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open Settings' }));
+    expect(openApp).toHaveBeenCalledWith('settings');
+  });
+
+  it('opens external links in a new tab when requested', async () => {
+    render(<HelpHub />);
+    const search = screen.getByLabelText('Search tips');
+    fireEvent.change(search, { target: { value: 'keyboard' } });
+    await waitFor(() => {
+      const options = screen.getAllByRole('option');
+      expect(options[0]).toHaveAttribute('data-tip-id', 'keyboard-shortcuts');
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Keyboard-only guidance' }));
+    expect(window.open).toHaveBeenCalledWith(
+      'https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/docs/keyboard-only-test-plan.md',
+      '_blank',
+      'noopener'
+    );
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -70,6 +70,7 @@ const QrApp = createDynamicApp('qr', 'QR Tool');
 const AsciiArtApp = createDynamicApp('ascii_art', 'ASCII Art');
 const QuoteApp = createDynamicApp('quote', 'Quote');
 const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery');
+const HelpHubApp = createDynamicApp('help-hub', 'Help Hub');
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
@@ -160,6 +161,7 @@ const displayQr = createDisplay(QrApp);
 const displayAsciiArt = createDisplay(AsciiArtApp);
 const displayQuote = createDisplay(QuoteApp);
 const displayProjectGallery = createDisplay(ProjectGalleryApp);
+const displayHelpHub = createDisplay(HelpHubApp);
 const displayTrash = createDisplay(TrashApp);
 const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
@@ -204,6 +206,15 @@ const displayKismet = createDisplay(KismetApp);
 
 // Utilities list used for the "Utilities" folder on the desktop
 const utilityList = [
+  {
+    id: 'help-hub',
+    title: 'Help Hub',
+    icon: '/themes/Yaru/apps/help-hub.svg',
+    disabled: false,
+    favourite: true,
+    desktop_shortcut: false,
+    screen: displayHelpHub,
+  },
   {
     id: 'qr',
     title: 'QR Tool',

--- a/components/apps/help-hub/HelpHub.tsx
+++ b/components/apps/help-hub/HelpHub.tsx
@@ -1,0 +1,302 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import tipsData from '../../../data/help-hub/index.json';
+
+type HelpAction =
+  | { kind: 'app'; label: string; target: string }
+  | { kind: 'link'; label: string; target: string; newTab?: boolean };
+
+type HelpVideo = {
+  src: string;
+  type: string;
+  caption?: string;
+  transcript?: string[];
+};
+
+type HelpTip = {
+  id: string;
+  title: string;
+  description: string;
+  tags: string[];
+  video?: HelpVideo;
+  actions?: HelpAction[];
+};
+
+type Props = {
+  openApp?: (id: string) => void;
+};
+
+type ScoredTip = { tip: HelpTip; score: number; index: number };
+
+const getScore = (tip: HelpTip, tokens: string[]): number => {
+  if (!tokens.length) return 0;
+  const haystack = {
+    title: tip.title.toLowerCase(),
+    description: tip.description.toLowerCase(),
+    tags: tip.tags.map((tag) => tag.toLowerCase()),
+    transcript: tip.video?.transcript?.join(' ').toLowerCase() ?? '',
+  };
+  let score = 0;
+  tokens.forEach((token) => {
+    if (haystack.title.includes(token)) score += 5;
+    if (haystack.description.includes(token)) score += 3;
+    if (haystack.tags.some((tag) => tag.includes(token))) score += 2;
+    if (haystack.transcript.includes(token)) score += 1;
+  });
+  return score;
+};
+
+const HelpHub: React.FC<Props> = ({ openApp }) => {
+  const tips = tipsData as HelpTip[];
+  const [query, setQuery] = useState('');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [selectedId, setSelectedId] = useState<string>(tips[0]?.id ?? '');
+  const buttonsRef = useRef<(HTMLButtonElement | null)[]>([]);
+  const liveRegionRef = useRef<HTMLParagraphElement | null>(null);
+
+  const allTags = useMemo(
+    () =>
+      Array.from(new Set(tips.flatMap((tip) => tip.tags))).sort((a, b) =>
+        a.localeCompare(b)
+      ),
+    [tips]
+  );
+
+  const filteredTips = useMemo(() => {
+    const normalizedTags = selectedTags.map((tag) => tag.toLowerCase());
+    const tokens = query
+      .toLowerCase()
+      .split(/\s+/)
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    const matchesTags = (tip: HelpTip) =>
+      normalizedTags.every((tag) => tip.tags.map((t) => t.toLowerCase()).includes(tag));
+
+    if (!tokens.length) {
+      return tips
+        .map<ScoredTip>((tip, index) => ({ tip, score: 0, index }))
+        .filter(({ tip }) => matchesTags(tip));
+    }
+
+    return tips
+      .map<ScoredTip>((tip, index) => ({
+        tip,
+        score: getScore(tip, tokens),
+        index,
+      }))
+      .filter(({ score, tip }) => score > 0 && matchesTags(tip))
+      .sort((a, b) => (b.score === a.score ? a.index - b.index : b.score - a.score));
+  }, [tips, query, selectedTags]);
+
+  const resolvedTips = useMemo(() => filteredTips.map(({ tip }) => tip), [filteredTips]);
+
+  useEffect(() => {
+    const message =
+      resolvedTips.length === 0
+        ? 'No help topics match the current filters.'
+        : `${resolvedTips.length} help topic${resolvedTips.length === 1 ? '' : 's'} available.`;
+    if (liveRegionRef.current) {
+      liveRegionRef.current.textContent = message;
+    }
+  }, [resolvedTips]);
+
+  useEffect(() => {
+    if (resolvedTips.length === 0) {
+      setSelectedId('');
+      return;
+    }
+    if (!resolvedTips.some((tip) => tip.id === selectedId)) {
+      setSelectedId(resolvedTips[0].id);
+    }
+  }, [resolvedTips, selectedId]);
+
+  const selectedTip = useMemo(
+    () => resolvedTips.find((tip) => tip.id === selectedId) ?? resolvedTips[0] ?? null,
+    [resolvedTips, selectedId]
+  );
+
+  const toggleTag = (tag: string) => {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+    );
+  };
+
+  const handleKeyNavigation = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return;
+    event.preventDefault();
+    if (!resolvedTips.length) return;
+    let nextIndex = index;
+    if (event.key === 'ArrowDown') nextIndex = Math.min(index + 1, resolvedTips.length - 1);
+    if (event.key === 'ArrowUp') nextIndex = Math.max(index - 1, 0);
+    if (event.key === 'Home') nextIndex = 0;
+    if (event.key === 'End') nextIndex = resolvedTips.length - 1;
+    buttonsRef.current[nextIndex]?.focus();
+  };
+
+  const handleAction = (action: HelpAction) => {
+    if (action.kind === 'app') {
+      if (openApp) {
+        openApp(action.target);
+      } else {
+        window.dispatchEvent(new CustomEvent('open-app', { detail: action.target }));
+      }
+    } else {
+      const target = action.newTab ? '_blank' : '_self';
+      window.open(action.target, target, action.newTab ? 'noopener' : undefined);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-ub-cool-grey text-white md:flex-row" data-testid="help-hub">
+      <div className="md:w-1/2 md:border-r md:border-ub-grey-dark p-4 space-y-4" role="navigation" aria-label="Help Hub filters and topics">
+        <div>
+          <label htmlFor="help-hub-search" className="text-sm font-semibold block">
+            Search tips
+          </label>
+          <input
+            id="help-hub-search"
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            className="mt-1 w-full rounded bg-black bg-opacity-20 px-3 py-2 text-white placeholder-gray-300 focus:outline-none focus:ring"
+            placeholder="Search by keyword or tag"
+          />
+        </div>
+        <fieldset className="space-y-2" aria-label="Filter by tag">
+          <legend className="text-sm font-semibold">Tags</legend>
+          <div className="flex flex-wrap gap-2" role="list">
+            {allTags.map((tag) => {
+              const checked = selectedTags.includes(tag);
+              return (
+                <label
+                  key={tag}
+                  className={`cursor-pointer rounded-full border px-3 py-1 text-xs uppercase tracking-wide ${
+                    checked ? 'bg-ubt-blue border-ubt-blue text-white' : 'border-ub-grey-dark text-gray-200'
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    className="sr-only"
+                    checked={checked}
+                    onChange={() => toggleTag(tag)}
+                    aria-label={tag}
+                  />
+                  {tag}
+                </label>
+              );
+            })}
+          </div>
+        </fieldset>
+        <div
+          role="listbox"
+          aria-label="Help topics"
+          aria-activedescendant={selectedTip ? `help-topic-${selectedTip.id}` : undefined}
+          className="space-y-2 overflow-auto pr-2"
+        >
+          {resolvedTips.map((tip, index) => (
+            <button
+              key={tip.id}
+              id={`help-topic-${tip.id}`}
+              role="option"
+              aria-selected={tip.id === selectedId}
+              onClick={() => setSelectedId(tip.id)}
+              onKeyDown={(event) => handleKeyNavigation(event, index)}
+              className={`w-full rounded border px-3 py-2 text-left transition focus:outline-none focus:ring ${
+                tip.id === selectedId
+                  ? 'border-ubt-blue bg-ubt-blue bg-opacity-30'
+                  : 'border-ub-grey-dark hover:bg-black hover:bg-opacity-20'
+              }`}
+              ref={(element) => {
+                buttonsRef.current[index] = element;
+              }}
+              data-tip-id={tip.id}
+              aria-describedby={`help-topic-desc-${tip.id}`}
+            >
+              <span className="block text-sm font-semibold">{tip.title}</span>
+              <span id={`help-topic-desc-${tip.id}`} className="mt-1 block text-xs text-gray-200">
+                {tip.description}
+              </span>
+            </button>
+          ))}
+          {resolvedTips.length === 0 && (
+            <p className="rounded border border-dashed border-ub-grey-dark p-4 text-sm text-gray-300">
+              No help topics match the current search and tags.
+            </p>
+          )}
+        </div>
+        <p ref={liveRegionRef} aria-live="polite" className="sr-only" />
+      </div>
+      <div className="flex flex-1 flex-col gap-4 p-4" aria-live="polite" aria-atomic="true">
+        {selectedTip ? (
+          <>
+            <header>
+              <h2 className="text-xl font-semibold" id="help-topic-title">
+                {selectedTip.title}
+              </h2>
+              <p className="mt-2 text-sm text-gray-200">{selectedTip.description}</p>
+              <ul className="mt-2 flex flex-wrap gap-2 text-xs text-gray-300" aria-label="Applied tags">
+                {selectedTip.tags.map((tag) => (
+                  <li key={tag} className="rounded bg-black bg-opacity-30 px-2 py-1">
+                    {tag}
+                  </li>
+                ))}
+              </ul>
+            </header>
+            {selectedTip.video && (
+              <section aria-labelledby="help-topic-title" className="space-y-2">
+                <video
+                  controls
+                  className="w-full rounded"
+                  aria-describedby={selectedTip.video.transcript ? `transcript-${selectedTip.id}` : undefined}
+                >
+                  <source src={selectedTip.video.src} type={selectedTip.video.type} />
+                  {selectedTip.video.caption && (
+                    <track
+                      kind="captions"
+                      src={selectedTip.video.caption}
+                      srcLang="en"
+                      label="English captions"
+                      default
+                    />
+                  )}
+                  Your browser does not support the video tag.
+                </video>
+                {selectedTip.video.transcript && selectedTip.video.transcript.length > 0 && (
+                  <details id={`transcript-${selectedTip.id}`} className="rounded bg-black bg-opacity-40 p-3 text-sm">
+                    <summary className="cursor-pointer font-semibold">Transcript</summary>
+                    <ol className="mt-2 list-decimal space-y-1 pl-4">
+                      {selectedTip.video.transcript.map((line, idx) => (
+                        <li key={idx}>{line}</li>
+                      ))}
+                    </ol>
+                  </details>
+                )}
+              </section>
+            )}
+            {selectedTip.actions && selectedTip.actions.length > 0 && (
+              <section aria-label="Quick actions" className="space-y-2">
+                <h3 className="text-lg font-semibold">Do more</h3>
+                <div className="flex flex-wrap gap-2">
+                  {selectedTip.actions.map((action) => (
+                    <button
+                      key={`${selectedTip.id}-${action.label}`}
+                      type="button"
+                      onClick={() => handleAction(action)}
+                      className="rounded bg-ubt-blue px-3 py-2 text-sm font-semibold text-white focus:outline-none focus:ring"
+                    >
+                      {action.label}
+                    </button>
+                  ))}
+                </div>
+              </section>
+            )}
+          </>
+        ) : (
+          <p className="text-sm text-gray-200">Select a help topic to see detailed guidance.</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default HelpHub;

--- a/components/apps/help-hub/index.ts
+++ b/components/apps/help-hub/index.ts
@@ -1,0 +1,1 @@
+export { default } from './HelpHub';

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -80,6 +80,13 @@ export class Desktop extends Component {
             } else {
                 this.openApp('about-alex');
             }
+            const seenHelpHub = safeLocalStorage?.getItem('help-hub-onboarded');
+            if (!seenHelpHub) {
+                setTimeout(() => {
+                    this.openApp('help-hub');
+                }, 400);
+                safeLocalStorage?.setItem('help-hub-onboarded', '1');
+            }
         });
         this.setContextListeners();
         this.setEventListeners();

--- a/data/help-hub/index.json
+++ b/data/help-hub/index.json
@@ -1,0 +1,89 @@
+[
+  {
+    "id": "personalize-desktop",
+    "title": "Personalize the desktop quickly",
+    "description": "Change wallpaper, accent color, and dock layout so the workspace feels familiar right away.",
+    "tags": ["getting-started", "personalization"],
+    "video": {
+      "src": "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4",
+      "type": "video/mp4",
+      "caption": "/help-hub/captions/personalize-desktop.vtt",
+      "transcript": [
+        "Open the Settings app from the dock or launcher.",
+        "Pick the Appearance tab to swap wallpapers and accent colors.",
+        "Adjust dock size and auto-hide to match how you prefer to work."
+      ]
+    },
+    "actions": [
+      { "kind": "app", "label": "Open Settings", "target": "settings" },
+      {
+        "kind": "link",
+        "label": "Appearance preferences",
+        "target": "/apps/settings#appearance"
+      }
+    ]
+  },
+  {
+    "id": "keyboard-shortcuts",
+    "title": "Master keyboard shortcuts",
+    "description": "Navigate between windows, focus the dock, and trigger app menus without leaving the keyboard.",
+    "tags": ["productivity", "accessibility"],
+    "video": {
+      "src": "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4",
+      "type": "video/mp4",
+      "caption": "/help-hub/captions/keyboard-shortcuts.vtt",
+      "transcript": [
+        "Press Super+Arrow keys to snap the focused window.",
+        "Use Alt+Tab to cycle running apps and Shift to reverse direction.",
+        "Open the shortcut overlay with Ctrl+/."
+      ]
+    },
+    "actions": [
+      {
+        "kind": "link",
+        "label": "Keyboard-only guidance",
+        "target": "https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/docs/keyboard-only-test-plan.md",
+        "newTab": true
+      }
+    ]
+  },
+  {
+    "id": "simulate-tools-safely",
+    "title": "Use the security tool simulators safely",
+    "description": "Every offensive tool is sandboxed. Review canned output, craft commands, and stay within the lab.",
+    "tags": ["simulation", "safety", "security"],
+    "actions": [
+      { "kind": "app", "label": "Open Security Tools", "target": "security-tools" },
+      {
+        "kind": "link",
+        "label": "Read the safety checklist",
+        "target": "https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/docs/tasks.md#security-tool-simulators",
+        "newTab": true
+      }
+    ]
+  },
+  {
+    "id": "explore-projects",
+    "title": "Explore highlighted projects",
+    "description": "Jump into curated labs, write-ups, and dashboards collected from the Project Gallery app.",
+    "tags": ["projects", "showcase"],
+    "video": {
+      "src": "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4",
+      "type": "video/mp4",
+      "caption": "/help-hub/captions/explore-projects.vtt",
+      "transcript": [
+        "Open the Project Gallery from the launcher.",
+        "Filter by stack or tag to find security labs, dashboards, and automation demos.",
+        "Use the compare view to line up two projects side by side."
+      ]
+    },
+    "actions": [
+      { "kind": "app", "label": "Open Project Gallery", "target": "project-gallery" },
+      {
+        "kind": "link",
+        "label": "Project deep link",
+        "target": "/apps/project-gallery#featured"
+      }
+    ]
+  }
+]

--- a/pages/apps/help-hub.jsx
+++ b/pages/apps/help-hub.jsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const HelpHubApp = dynamic(() => import('../../components/apps/help-hub'), {
+  ssr: false,
+  loading: () => <p>Loading Help Hub...</p>,
+});
+
+export default HelpHubApp;

--- a/public/help-hub/captions/explore-projects.vtt
+++ b/public/help-hub/captions/explore-projects.vtt
@@ -1,0 +1,10 @@
+WEBVTT
+
+00:00.000 --> 00:05.000
+Launch the Project Gallery from the Help Hub suggestions.
+
+00:05.000 --> 00:10.000
+Filter by stack or tag to find labs, dashboards, and automation demos.
+
+00:10.000 --> 00:14.000
+Compare two projects side by side to evaluate scope and tooling.

--- a/public/help-hub/captions/keyboard-shortcuts.vtt
+++ b/public/help-hub/captions/keyboard-shortcuts.vtt
@@ -1,0 +1,10 @@
+WEBVTT
+
+00:00.000 --> 00:04.000
+Press Super plus arrow keys to snap the focused window.
+
+00:04.000 --> 00:08.000
+Use Alt plus Tab to cycle open apps, adding Shift to reverse direction.
+
+00:08.000 --> 00:12.000
+Open the shortcut overlay with Control and slash for a searchable list.

--- a/public/help-hub/captions/personalize-desktop.vtt
+++ b/public/help-hub/captions/personalize-desktop.vtt
@@ -1,0 +1,10 @@
+WEBVTT
+
+00:00.000 --> 00:05.000
+Open Settings from the dock and switch to the Appearance tab.
+
+00:05.000 --> 00:10.000
+Pick a wallpaper and accent color that fits your workspace.
+
+00:10.000 --> 00:15.000
+Adjust the dock size and auto-hide toggle to keep frequently used tools nearby.

--- a/public/themes/Yaru/apps/help-hub.svg
+++ b/public/themes/Yaru/apps/help-hub.svg
@@ -1,0 +1,15 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Help Hub icon</title>
+  <desc id="desc">Question mark inside a rounded gradient square</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3b82f6" />
+      <stop offset="100%" stop-color="#9333ea" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="url(#grad)" />
+  <path
+    fill="#f9fafb"
+    d="M32 16c-8.284 0-14 5.048-14 11.6 0 4.116 2.11 7.336 5.88 9.092-.088 1.572-.73 3.632-2.108 5.652a2 2 0 0 0 1.672 3.156c3.716-.176 6.796-1.164 8.924-2.956 5.468-.3 9.632-4.48 9.632-9.944C42 21.048 36.284 16 32 16Zm0 6c2.642 0 6 1.708 6 5.6 0 2.756-1.996 4.4-4.8 4.4h-.4a2 2 0 0 0-1.76 1.032c-.54.94-1.492 1.884-2.908 2.716.484-1.388.76-2.76.76-3.884a2 2 0 0 0-1.24-1.844C26.96 28.988 26 27.724 26 25.6 26 23.708 28.23 22 32 22Zm0 18a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z"
+  />
+</svg>


### PR DESCRIPTION
## Summary
- add a Help Hub desktop app with searchable guidance, tag filters, transcripts, and quick actions
- seed help hub content, register the app plus launcher assets, and expose it on /apps/help-hub
- open Help Hub during onboarding for first-time visitors and cover behaviour with targeted tests

## Testing
- yarn lint *(fails: legacy apps contain many unlabeled controls reported before this change)*
- yarn test --runInBand __tests__/helpHub.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb166bda2c8328892296882dadca09