### PR TITLE
feat(terminal): add persistent sessions with splits and detachable tabs

### DIFF
--- a/__tests__/terminal-layout.test.tsx
+++ b/__tests__/terminal-layout.test.tsx
@@ -1,0 +1,95 @@
+jest.mock(
+  '@xterm/xterm',
+  () => ({
+    Terminal: jest.fn().mockImplementation(() => ({
+      open: jest.fn(),
+      focus: jest.fn(),
+      loadAddon: jest.fn(),
+      write: jest.fn(),
+      writeln: jest.fn(),
+      onData: jest.fn(),
+      onKey: jest.fn(),
+      dispose: jest.fn(),
+      clear: jest.fn(),
+    })),
+  }),
+  { virtual: true },
+);
+jest.mock(
+  '@xterm/addon-fit',
+  () => ({
+    FitAddon: jest.fn().mockImplementation(() => ({ fit: jest.fn() })),
+  }),
+  { virtual: true },
+);
+jest.mock(
+  '@xterm/addon-search',
+  () => ({
+    SearchAddon: jest.fn().mockImplementation(() => ({ findNext: jest.fn() })),
+  }),
+  { virtual: true },
+);
+jest.mock('@xterm/xterm/css/xterm.css', () => ({}), { virtual: true });
+
+import React, { act } from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import TerminalTabs from '../apps/terminal/tabs';
+import { listSessions, resetSessions } from '../apps/terminal/state';
+
+const createDataTransfer = () => {
+  const data: Record<string, string> = {};
+  return {
+    data,
+    setData: (type: string, value: string) => {
+      data[type] = value;
+    },
+    getData: (type: string) => data[type],
+    clearData: () => {
+      Object.keys(data).forEach((key) => delete data[key]);
+    },
+    dropEffect: 'move',
+    effectAllowed: 'all',
+  } as unknown as DataTransfer;
+};
+
+describe('Terminal layout interactions', () => {
+  beforeEach(() => {
+    resetSessions();
+  });
+
+  it('creates split windows and sessions', async () => {
+    render(<TerminalTabs openApp={jest.fn()} />);
+    await act(async () => {});
+    expect(listSessions().length).toBe(1);
+
+    const splitButton = screen.getByLabelText('Add split to the right');
+    fireEvent.click(splitButton);
+    await act(async () => {});
+
+    expect(screen.getAllByTestId(/terminal-window-/)).toHaveLength(2);
+    expect(listSessions().length).toBe(2);
+  });
+
+  it('detaches tabs without losing session state', async () => {
+    render(<TerminalTabs openApp={jest.fn()} />);
+    await act(async () => {});
+    const [session] = listSessions();
+    expect(session).toBeDefined();
+
+    await act(async () => {
+      await session?.runCommand?.('help');
+    });
+
+    const tabHeader = document.querySelector('.flex.items-center.cursor-pointer') as HTMLElement;
+    expect(tabHeader).toBeTruthy();
+    const detachZone = screen.getByLabelText('Detach Tab');
+    const dataTransfer = createDataTransfer();
+    fireEvent.dragStart(tabHeader, { dataTransfer });
+    fireEvent.dragOver(detachZone, { dataTransfer });
+    fireEvent.drop(detachZone, { dataTransfer });
+    await act(async () => {});
+
+    expect(screen.getAllByTestId(/terminal-window-/)).toHaveLength(2);
+    expect(session?.historyRef.current).toContain('help');
+  });
+});

--- a/apps/terminal/commands/index.ts
+++ b/apps/terminal/commands/index.ts
@@ -44,6 +44,24 @@ const registry: Record<string, CommandHandler> = {
   cat: (args, ctx) => ctx.runWorker(`cat ${args}`),
   grep: (args, ctx) => ctx.runWorker(`grep ${args}`),
   jq: (args, ctx) => ctx.runWorker(`jq ${args}`),
+  split: (args, ctx) => {
+    const input = args.trim().toLowerCase();
+    const direction = input === 'vertical' || input === 'down' ? 'vertical' : 'horizontal';
+    if (ctx.splitPane) ctx.splitPane(direction);
+    else ctx.writeLine('splitting not supported in this context');
+  },
+  detach: (_args, ctx) => {
+    if (ctx.detachPane) ctx.detachPane();
+    else ctx.writeLine('detaching not supported in this context');
+  },
+  rename: (args, ctx) => {
+    const title = args.trim();
+    if (!title) {
+      ctx.writeLine('usage: rename <title>');
+      return;
+    }
+    if (ctx.renameSession) ctx.renameSession(title);
+  },
 };
 
 export default registry;

--- a/apps/terminal/commands/types.ts
+++ b/apps/terminal/commands/types.ts
@@ -5,6 +5,9 @@ export interface CommandContext {
   aliases: Record<string, string>;
   setAlias: (name: string, value: string) => void;
   runWorker: (command: string) => Promise<void>;
+  splitPane?: (direction: 'horizontal' | 'vertical') => void;
+  detachPane?: () => void;
+  renameSession?: (title: string) => void;
 }
 
 export type CommandHandler = (args: string, ctx: CommandContext) => void | Promise<void>;

--- a/apps/terminal/state.ts
+++ b/apps/terminal/state.ts
@@ -1,0 +1,141 @@
+'use client';
+
+import React from 'react';
+
+import type { CommandContext } from './commands';
+
+export type SplitDirection = 'horizontal' | 'vertical';
+
+export interface TerminalSessionRuntime {
+  id: string;
+  title: string;
+  commandRef: React.MutableRefObject<string>;
+  contentRef: React.MutableRefObject<string>;
+  filesRef: React.MutableRefObject<Record<string, string>>;
+  aliasesRef: React.MutableRefObject<Record<string, string>>;
+  historyRef: React.MutableRefObject<string[]>;
+  registryRef: React.MutableRefObject<Record<string, any>>;
+  contextRef: React.MutableRefObject<CommandContext & {
+    splitPane?: (direction: SplitDirection) => void;
+    detachPane?: () => void;
+    renameSession?: (title: string) => void;
+  }>;
+  workerRef: React.MutableRefObject<Worker | null>;
+  termRef: React.MutableRefObject<any | null>;
+  fitRef: React.MutableRefObject<any | null>;
+  searchRef: React.MutableRefObject<any | null>;
+  dirRef: React.MutableRefObject<FileSystemDirectoryHandle | null>;
+  overflowRef: React.MutableRefObject<{ top: boolean; bottom: boolean }>;
+  runCommand?: (command: string) => Promise<void> | void;
+  getContent?: () => string;
+}
+
+const sessions = new Map<string, TerminalSessionRuntime>();
+
+let sessionCounter = 1;
+
+const defaultFiles = {
+  'README.md': 'Welcome to the web terminal.\nThis is a fake file used for demos.',
+};
+
+function createMutable<T>(value: T): React.MutableRefObject<T> {
+  return { current: value };
+}
+
+function buildContext(): CommandContext & {
+  splitPane?: (direction: SplitDirection) => void;
+  detachPane?: () => void;
+  renameSession?: (title: string) => void;
+} {
+  return {
+    writeLine: () => {},
+    files: {},
+    history: [],
+    aliases: {},
+    setAlias: () => {},
+    runWorker: async () => {},
+  };
+}
+
+export function createSessionId() {
+  return `terminal-session-${sessionCounter++}`;
+}
+
+export function createSession(sessionId = createSessionId()): TerminalSessionRuntime {
+  if (sessions.has(sessionId)) {
+    return sessions.get(sessionId)!;
+  }
+
+  const context = buildContext();
+  const session: TerminalSessionRuntime = {
+    id: sessionId,
+    title: `Session ${sessionCounter - 1}`,
+    commandRef: createMutable(''),
+    contentRef: createMutable(''),
+    filesRef: createMutable({ ...defaultFiles }),
+    aliasesRef: createMutable({}),
+    historyRef: createMutable([]),
+    registryRef: createMutable({}),
+    contextRef: createMutable(context),
+    workerRef: createMutable<Worker | null>(null),
+    termRef: createMutable<any | null>(null),
+    fitRef: createMutable<any | null>(null),
+    searchRef: createMutable<any | null>(null),
+    dirRef: createMutable<FileSystemDirectoryHandle | null>(null),
+    overflowRef: createMutable({ top: false, bottom: false }),
+  };
+  context.files = session.filesRef.current;
+  context.history = session.historyRef.current;
+  context.aliases = session.aliasesRef.current;
+  sessions.set(sessionId, session);
+  return session;
+}
+
+export function getSession(sessionId: string) {
+  return sessions.get(sessionId);
+}
+
+export function ensureSession(sessionId: string) {
+  return sessions.get(sessionId) ?? createSession(sessionId);
+}
+
+export function destroySession(sessionId: string) {
+  const session = sessions.get(sessionId);
+  if (!session) return;
+  try {
+    session.workerRef.current?.terminate();
+  } catch (err) {
+    console.error('Failed to terminate terminal worker', err);
+  }
+  try {
+    session.termRef.current?.dispose?.();
+  } catch (err) {
+    console.error('Failed to dispose terminal', err);
+  }
+  sessions.delete(sessionId);
+}
+
+export function updateSessionTitle(sessionId: string, title: string) {
+  const session = sessions.get(sessionId);
+  if (session) {
+    session.title = title;
+  }
+}
+
+export function listSessions() {
+  return Array.from(sessions.values());
+}
+
+export function resetSessions() {
+  sessions.forEach((session) => {
+    try {
+      session.workerRef.current?.terminate();
+    } catch {}
+    try {
+      session.termRef.current?.dispose?.();
+    } catch {}
+  });
+  sessions.clear();
+  sessionCounter = 1;
+}
+

--- a/apps/terminal/tabs/index.tsx
+++ b/apps/terminal/tabs/index.tsx
@@ -1,27 +1,228 @@
 'use client';
 
-import React, { useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../../components/ui/TabbedWindow';
-import Terminal, { TerminalProps } from '..';
+import Terminal from '..';
+import { createSession, destroySession, updateSessionTitle } from '../state';
 
-const TerminalTabs: React.FC<TerminalProps> = ({ openApp }) => {
+interface TerminalWindowState {
+  id: string;
+  tabs: TabDefinition[];
+}
+
+const createWindowId = (() => {
+  let counter = 1;
+  return () => `terminal-window-${counter++}`;
+})();
+
+const createTabId = (sessionId: string) => `terminal-tab-${sessionId}`;
+
+const TerminalTabs: React.FC<{ openApp?: (id: string) => void }> = ({ openApp }) => {
   const countRef = useRef(1);
+  const [orientation, setOrientation] = useState<'row' | 'column'>('row');
+  const [windows, setWindows] = useState<TerminalWindowState[]>([]);
 
-  const createTab = (): TabDefinition => {
-    const id = Date.now().toString();
+  const renameTab = useCallback((sessionId: string, title: string) => {
+    updateSessionTitle(sessionId, title);
+    setWindows((prev) =>
+      prev.map((win) => ({
+        ...win,
+        tabs: win.tabs.map((tab) =>
+          tab.data?.sessionId === sessionId ? { ...tab, title } : tab,
+        ),
+      })),
+    );
+  }, []);
+
+  const detachSession = useCallback((sessionId: string) => {
+    setOrientation('row');
+    setWindows((prev) => {
+      let moved: TabDefinition | undefined;
+      const remaining = prev
+        .map((win) => {
+          const idx = win.tabs.findIndex((tab) => tab.data?.sessionId === sessionId);
+          if (idx !== -1) {
+            const nextTabs = [...win.tabs];
+            [moved] = nextTabs.splice(idx, 1);
+            return { ...win, tabs: nextTabs };
+          }
+          return win;
+        })
+        .filter((win) => win.tabs.length > 0);
+      if (!moved) return prev;
+      return [...remaining, { id: createWindowId(), tabs: [moved] }];
+    });
+  }, []);
+
+  const handleSplit = useCallback(
+    (sessionId: string, direction: 'horizontal' | 'vertical') => {
+      const session = createSession();
+      const title = `Session ${countRef.current++}`;
+      updateSessionTitle(session.id, title);
+      const newTab: TabDefinition = {
+        id: createTabId(session.id),
+        title,
+        data: { sessionId: session.id },
+        content: (
+          <Terminal
+            key={session.id}
+            sessionId={session.id}
+            openApp={openApp}
+            onSplit={(nextDirection) => handleSplit(session.id, nextDirection)}
+            onDetach={() => detachSession(session.id)}
+            onRename={(newTitle) => renameTab(session.id, newTitle)}
+          />
+        ),
+        onClose: () => destroySession(session.id),
+      };
+      setOrientation(direction === 'vertical' ? 'column' : 'row');
+      setWindows((prev) => {
+        let inserted = false;
+        const next = prev.map((win) => {
+          if (win.tabs.some((tab) => tab.data?.sessionId === sessionId)) {
+            inserted = true;
+            return { ...win, tabs: [...win.tabs, newTab] };
+          }
+          return win;
+        });
+        if (!inserted) {
+          next.push({ id: createWindowId(), tabs: [newTab] });
+        }
+        return next;
+      });
+    },
+    [detachSession, openApp, renameTab],
+  );
+
+  const createTab = useCallback((): TabDefinition => {
+    const session = createSession();
+    const title = `Session ${countRef.current++}`;
+    updateSessionTitle(session.id, title);
     return {
-      id,
-      title: `Session ${countRef.current++}`,
-      content: <Terminal openApp={openApp} />,
+      id: createTabId(session.id),
+      title,
+      data: { sessionId: session.id },
+      content: (
+        <Terminal
+          key={session.id}
+          sessionId={session.id}
+          openApp={openApp}
+          onSplit={(direction) => handleSplit(session.id, direction)}
+          onDetach={() => detachSession(session.id)}
+          onRename={(newTitle) => renameTab(session.id, newTitle)}
+        />
+      ),
+      onClose: () => destroySession(session.id),
     };
-  };
+  }, [detachSession, handleSplit, openApp, renameTab]);
+
+  useEffect(() => {
+    if (windows.length === 0) {
+      const tab = createTab();
+      setWindows([{ id: createWindowId(), tabs: [tab] }]);
+    }
+  }, [createTab, windows.length]);
+
+  const addTab = useCallback(
+    (windowId: string) => {
+      const tab = createTab();
+      setWindows((prev) =>
+        prev.map((win) =>
+          win.id === windowId ? { ...win, tabs: [...win.tabs, tab] } : win,
+        ),
+      );
+      return tab;
+    },
+    [createTab],
+  );
+
+  const handleTabsChange = useCallback(
+    (windowId: string, nextTabs: TabDefinition[]) => {
+      setWindows((prev) => {
+        const updated = prev
+          .map((win) => (win.id === windowId ? { ...win, tabs: nextTabs } : win))
+          .filter((win) => win.tabs.length > 0);
+        if (updated.length === 0) {
+          const tab = createTab();
+          return [{ id: createWindowId(), tabs: [tab] }];
+        }
+        return updated;
+      });
+    },
+    [createTab],
+  );
+
+  const detachTab = useCallback(
+    (windowId: string, tab: TabDefinition) => {
+      setOrientation('row');
+      setWindows((prev) => {
+        const next = prev
+          .map((win) =>
+            win.id === windowId
+              ? { ...win, tabs: win.tabs.filter((t) => t.id !== tab.id) }
+              : win,
+          )
+          .filter((win) => win.tabs.length > 0);
+        return [...next, { id: createWindowId(), tabs: [tab] }];
+      });
+    },
+    [],
+  );
+
+  const createSplitWindow = useCallback(
+    (direction: 'horizontal' | 'vertical') => {
+      const tab = createTab();
+      setOrientation(direction === 'vertical' ? 'column' : 'row');
+      setWindows((prev) => [...prev, { id: createWindowId(), tabs: [tab] }]);
+    },
+    [createTab],
+  );
+
+  if (windows.length === 0) {
+    return null;
+  }
 
   return (
-    <TabbedWindow
-      className="h-full w-full"
-      initialTabs={[createTab()]}
-      onNewTab={createTab}
-    />
+    <div className="flex flex-col h-full w-full">
+      <div className="flex items-center gap-2 bg-gray-900 text-white text-xs px-2 py-1">
+        <button
+          className="px-2 py-1 bg-gray-800 rounded"
+          onClick={() => createSplitWindow('horizontal')}
+          aria-label="Add split to the right"
+        >
+          Split Right
+        </button>
+        <button
+          className="px-2 py-1 bg-gray-800 rounded"
+          onClick={() => createSplitWindow('vertical')}
+          aria-label="Add split below"
+        >
+          Split Down
+        </button>
+      </div>
+      <div
+        className={`flex flex-1 gap-2 overflow-hidden ${
+          orientation === 'column' ? 'flex-col' : 'flex-row'
+        }`}
+      >
+        {windows.map((win) => (
+        <div
+            key={win.id}
+            data-testid={`terminal-window-${win.id}`}
+            className="flex-1 min-w-0 bg-gray-900/40 border border-gray-700 rounded overflow-hidden"
+          >
+            <TabbedWindow
+              className="h-full"
+              initialTabs={win.tabs}
+              tabs={win.tabs}
+              onNewTab={() => addTab(win.id)}
+              onTabsChange={(tabs) => handleTabsChange(win.id, tabs)}
+              onDetachTab={(tab) => detachTab(win.id, tab)}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
   );
 };
 

--- a/components/apps/terminal.tsx
+++ b/components/apps/terminal.tsx
@@ -16,11 +16,11 @@ const TerminalApp = dynamic(() => import('../../apps/terminal/tabs'), {
  * overflows. The actual indicator/scroll handling lives inside the terminal
  * app, this wrapper just provides the necessary container styles.
  */
-export default function Terminal() {
+export default function Terminal({ openApp }: { openApp?: (id: string) => void }) {
   return (
     <div className="h-full w-full overflow-y-auto">
       <HelpPanel appId="terminal" />
-      <TerminalApp />
+      <TerminalApp openApp={openApp} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a shared terminal session store so xterm state and workers persist when tabs move
- rework the terminal UI with split buttons, detach hooks, and context-aware commands
- extend the tabbed window component for controlled tabs and detach drop zone, plus new layout tests

## Testing
- yarn lint *(fails: repo has existing accessibility/window lint errors)*
- yarn test --watch=false __tests__/terminal.test.tsx __tests__/terminal-layout.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68caaa0532008328aa3c3fffd935d751