### PR TITLE
[ui] make breadcrumbs editable

### DIFF
--- a/__tests__/Breadcrumbs.test.tsx
+++ b/__tests__/Breadcrumbs.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import Breadcrumbs from '../components/ui/Breadcrumbs';
+
+const buildPath = () => [
+  { name: '/' },
+  { name: 'home' },
+  { name: 'projects' },
+];
+
+describe('Breadcrumbs', () => {
+  it('focuses the path input when entering edit mode', () => {
+    render(<Breadcrumbs path={buildPath()} onNavigate={jest.fn()} />);
+
+    const nav = screen.getByLabelText(/breadcrumb/i);
+    fireEvent.click(nav);
+
+    const input = screen.getByRole('textbox', { name: /current path/i });
+    expect(input).toHaveFocus();
+    expect(input).toHaveValue('/home/projects');
+  });
+
+  it('navigates to a matched path when submitted', () => {
+    const onNavigate = jest.fn();
+    render(<Breadcrumbs path={buildPath()} onNavigate={onNavigate} />);
+
+    fireEvent.click(screen.getByLabelText(/breadcrumb/i));
+    const input = screen.getByRole('textbox', { name: /current path/i });
+    fireEvent.change(input, { target: { value: '/home' } });
+
+    const form = input.closest('form');
+    expect(form).not.toBeNull();
+    if (form) {
+      fireEvent.submit(form);
+    }
+
+    expect(onNavigate).toHaveBeenCalledWith(1);
+    expect(screen.queryByRole('textbox', { name: /current path/i })).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/breadcrumb/i)).toBeInTheDocument();
+  });
+
+  it('shows an error and retains focus for invalid paths', () => {
+    const onNavigate = jest.fn();
+    render(<Breadcrumbs path={buildPath()} onNavigate={onNavigate} />);
+
+    fireEvent.click(screen.getByLabelText(/breadcrumb/i));
+    const input = screen.getByRole('textbox', { name: /current path/i });
+    fireEvent.change(input, { target: { value: '/unknown' } });
+
+    const form = input.closest('form');
+    expect(form).not.toBeNull();
+    if (form) {
+      fireEvent.submit(form);
+    }
+
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent(/invalid path/i);
+    expect(input).toHaveFocus();
+  });
+
+  it('keeps breadcrumb navigation working when clicking segments', () => {
+    const onNavigate = jest.fn();
+    render(<Breadcrumbs path={buildPath()} onNavigate={onNavigate} />);
+
+    const crumb = screen.getByRole('button', { name: 'home' });
+    fireEvent.click(crumb);
+
+    expect(onNavigate).toHaveBeenCalledWith(1);
+    expect(screen.queryByRole('textbox', { name: /current path/i })).not.toBeInTheDocument();
+  });
+});

--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FormEvent, useEffect, useId, useMemo, useRef, useState } from 'react';
 
 interface Segment {
   name: string;
@@ -9,22 +9,169 @@ interface Props {
   onNavigate: (index: number) => void;
 }
 
+const canonicalizePath = (value: string): string => {
+  const trimmed = value.trim().replace(/\\/g, '/');
+  if (!trimmed) return '/';
+
+  let sanitized = trimmed.replace(/\/{2,}/g, '/');
+  sanitized = sanitized.replace(/^\/+/, '/');
+  if (!sanitized.startsWith('/')) {
+    sanitized = `/${sanitized}`;
+  }
+  if (sanitized.length > 1 && sanitized.endsWith('/')) {
+    sanitized = sanitized.slice(0, -1);
+  }
+  return sanitized || '/';
+};
+
+const segmentsToString = (segments: Segment[]): string => {
+  if (!segments.length) return '/';
+
+  const parts = segments.map((segment, index) => {
+    const raw = (segment.name ?? '').trim();
+    if (index === 0 && (raw === '' || raw === '/')) {
+      return '';
+    }
+    return raw.replace(/^\/+|\/+$/g, '');
+  });
+
+  const joined = parts.filter((part, index) => part || index === 0).join('/');
+  return joined || '/';
+};
+
 const Breadcrumbs: React.FC<Props> = ({ path, onNavigate }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const errorId = useId();
+
+  const options = useMemo(
+    () => path.map((_, index) => canonicalizePath(segmentsToString(path.slice(0, index + 1)))),
+    [path]
+  );
+  const currentPath = options[options.length - 1] ?? '/';
+  const baseInputClass =
+    'px-2 py-1 rounded bg-black bg-opacity-40 focus:outline-none focus:ring-2 focus:ring-blue-400 text-sm text-white';
+
+  useEffect(() => {
+    if (isEditing) {
+      setInputValue(currentPath);
+    }
+  }, [currentPath, isEditing]);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      const input = inputRef.current;
+      input.focus();
+      input.select();
+    }
+  }, [isEditing]);
+
+  const stopEditing = () => {
+    setIsEditing(false);
+    setError(null);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const canonicalInput = canonicalizePath(inputValue);
+    const targetIndex = options.findIndex((option) => option === canonicalInput);
+
+    if (targetIndex === -1) {
+      setError('Invalid path');
+      if (inputRef.current) {
+        inputRef.current.focus();
+        inputRef.current.select();
+      }
+      return;
+    }
+
+    stopEditing();
+    onNavigate(targetIndex);
+  };
+
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    if (error) {
+      event.preventDefault();
+      setTimeout(() => {
+        if (inputRef.current) {
+          inputRef.current.focus();
+          inputRef.current.select();
+        }
+      }, 0);
+      return;
+    }
+    stopEditing();
+  };
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (error) {
+      setError(null);
+    }
+    setInputValue(event.target.value);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      stopEditing();
+    }
+  };
+
+  const startEditing = () => {
+    setError(null);
+    setIsEditing(true);
+  };
+
   return (
-    <nav className="flex items-center space-x-1 text-white" aria-label="Breadcrumb">
-      {path.map((seg, idx) => (
-        <React.Fragment key={idx}>
-          <button
-            type="button"
-            onClick={() => onNavigate(idx)}
-            className="hover:underline focus:outline-none"
-          >
-            {seg.name || '/'}
-          </button>
-          {idx < path.length - 1 && <span>/</span>}
-        </React.Fragment>
-      ))}
-    </nav>
+    <div className="flex flex-col text-white">
+      {isEditing ? (
+        <>
+          <form className="flex items-center space-x-2" onSubmit={handleSubmit}>
+            <input
+              ref={inputRef}
+              aria-label="Current path"
+              value={inputValue}
+              onChange={handleInputChange}
+              onBlur={handleBlur}
+              onKeyDown={handleKeyDown}
+              className={`${baseInputClass}${error ? ' border border-red-400' : ''}`}
+              aria-invalid={error ? 'true' : 'false'}
+              aria-describedby={error ? `${errorId}-error` : undefined}
+              autoComplete="off"
+            />
+          </form>
+          {error && (
+            <p id={`${errorId}-error`} role="alert" className="mt-1 text-xs text-red-300">
+              {error}
+            </p>
+          )}
+        </>
+      ) : (
+        <nav
+          className="flex items-center space-x-1 text-white cursor-text"
+          aria-label="Breadcrumb"
+          onClick={startEditing}
+        >
+          {path.map((seg, idx) => (
+            <React.Fragment key={idx}>
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onNavigate(idx);
+                }}
+                className="hover:underline focus:outline-none"
+              >
+                {seg.name || '/'}
+              </button>
+              {idx < path.length - 1 && <span>/</span>}
+            </React.Fragment>
+          ))}
+        </nav>
+      )}
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- allow the breadcrumb navigation to toggle into an editable path input with validation before navigation
- add focus management, escape handling, and inline error messaging for invalid path submissions
- cover the editable breadcrumb behaviour with dedicated unit tests

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label and no-top-level-window errors across unrelated files)*
- yarn test --runTestsByPath __tests__/Breadcrumbs.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68caa9f5085483288fdfe41c8c670fdb