### PR TITLE
[desktop] add download manager ui and store

### DIFF
--- a/__tests__/downloadManager.test.tsx
+++ b/__tests__/downloadManager.test.tsx
@@ -1,0 +1,104 @@
+import type { ReactNode } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { DownloadManagerProvider } from '../components/common/DownloadManager';
+import useDownloads from '../hooks/useDownloads';
+
+describe('DownloadManagerProvider', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  const setup = () =>
+    renderHook(() => useDownloads(), {
+      wrapper: ({ children }: { children?: ReactNode }) => (
+        <DownloadManagerProvider>{children}</DownloadManagerProvider>
+      ),
+    });
+
+  it('tracks progress, pause, resume, and completion', () => {
+    const { result } = setup();
+
+    let id = '';
+    act(() => {
+      id = result.current.startDownload({
+        label: 'Test asset',
+        totalBytes: 1000,
+        chunkSize: 250,
+        intervalMs: 100,
+      });
+    });
+
+    const getDownload = () => result.current.getDownload(id)!;
+
+    expect(getDownload().status).toBe('downloading');
+    expect(getDownload().progress).toBe(0);
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    expect(getDownload().bytesDownloaded).toBeGreaterThan(0);
+    expect(getDownload().status).toBe('downloading');
+
+    act(() => {
+      result.current.pauseDownload(id);
+    });
+
+    const pausedProgress = getDownload().bytesDownloaded;
+    expect(getDownload().status).toBe('paused');
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(getDownload().bytesDownloaded).toBe(pausedProgress);
+
+    act(() => {
+      result.current.resumeDownload(id);
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(getDownload().status).toBe('completed');
+    expect(getDownload().bytesDownloaded).toBe(1000);
+    expect(getDownload().progress).toBe(1);
+  });
+
+  it('handles failures and allows retrying a download', () => {
+    const { result } = setup();
+
+    let id = '';
+    act(() => {
+      id = result.current.startDownload({
+        label: 'Fragile asset',
+        totalBytes: 800,
+        chunkSize: 200,
+        intervalMs: 50,
+        failAtBytes: 500,
+      });
+    });
+
+    const getDownload = () => result.current.getDownload(id)!;
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(getDownload().status).toBe('failed');
+    expect(getDownload().error).toMatch(/simulated network error/i);
+    const failedBytes = getDownload().bytesDownloaded;
+
+    act(() => {
+      result.current.retryDownload(id);
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(getDownload().status).toBe('completed');
+    expect(getDownload().bytesDownloaded).toBe(800);
+    expect(getDownload().bytesDownloaded).toBeGreaterThanOrEqual(failedBytes);
+  });
+});

--- a/components/common/DownloadManager.tsx
+++ b/components/common/DownloadManager.tsx
@@ -1,0 +1,456 @@
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+} from 'react';
+import {
+  SimulatedDownloadController,
+  createSimulatedDownload,
+} from '../../modules/downloads/simulatedApi';
+
+export type DownloadStatus = 'downloading' | 'paused' | 'completed' | 'failed';
+
+export interface StartDownloadRequest {
+  /** Optional custom identifier. A generated id will be used if omitted. */
+  id?: string;
+  /** Short label shown to the user. */
+  label: string;
+  /** Optional descriptor of where the download originated. */
+  source?: string;
+  /** Total size in bytes that the simulated transfer should complete. */
+  totalBytes: number;
+  /**
+   * Optional chunk size override. If omitted, the simulation will transfer a
+   * twentieth of the total size (min 1 byte) per interval.
+   */
+  chunkSize?: number;
+  /** Interval between progress updates in milliseconds. Defaults to 250ms. */
+  intervalMs?: number;
+  /** Optional point (in bytes) where the simulation should fail. */
+  failAtBytes?: number;
+  /** Optional callback invoked on each progress update. */
+  onProgress?: (downloadedBytes: number) => void;
+  /** Optional callback invoked when the download completes. */
+  onComplete?: () => void;
+  /** Optional callback invoked when the download fails. */
+  onError?: (error: Error) => void;
+}
+
+export interface DownloadItem {
+  id: string;
+  label: string;
+  source?: string;
+  status: DownloadStatus;
+  bytesDownloaded: number;
+  totalBytes: number;
+  progress: number;
+  startedAt: number;
+  updatedAt: number;
+  completedAt?: number;
+  error?: string;
+}
+
+interface DownloadCallbacks {
+  onProgress?: (downloadedBytes: number) => void;
+  onComplete?: () => void;
+  onError?: (error: Error) => void;
+}
+
+interface DownloadConfig {
+  totalBytes: number;
+  chunkSize?: number;
+  intervalMs?: number;
+  failAtBytes?: number;
+}
+
+interface DownloadsState {
+  order: string[];
+  items: Record<string, DownloadItem>;
+}
+
+const initialState: DownloadsState = {
+  order: [],
+  items: {},
+};
+
+type Action =
+  | { type: 'ADD'; payload: DownloadItem }
+  | { type: 'PROGRESS'; id: string; bytesDownloaded: number }
+  | { type: 'PAUSE'; id: string }
+  | { type: 'RESUME'; id: string }
+  | { type: 'COMPLETE'; id: string; completedAt: number }
+  | { type: 'FAIL'; id: string; error: string; at: number }
+  | { type: 'RETRY'; id: string; startedAt: number }
+  | { type: 'REMOVE'; id: string };
+
+function downloadsReducer(state: DownloadsState, action: Action): DownloadsState {
+  switch (action.type) {
+    case 'ADD': {
+      const nextOrder = [action.payload.id, ...state.order.filter(id => id !== action.payload.id)];
+      return {
+        order: nextOrder,
+        items: {
+          ...state.items,
+          [action.payload.id]: action.payload,
+        },
+      };
+    }
+    case 'PROGRESS': {
+      const item = state.items[action.id];
+      if (!item || item.status === 'completed' || item.status === 'failed') {
+        return state;
+      }
+      const bytes = Math.max(item.bytesDownloaded, Math.min(action.bytesDownloaded, item.totalBytes));
+      const progress = item.totalBytes > 0 ? Math.min(1, bytes / item.totalBytes) : 0;
+      const updated: DownloadItem = {
+        ...item,
+        bytesDownloaded: bytes,
+        progress,
+        status: 'downloading',
+        updatedAt: Date.now(),
+      };
+      return {
+        ...state,
+        items: {
+          ...state.items,
+          [action.id]: updated,
+        },
+      };
+    }
+    case 'PAUSE': {
+      const item = state.items[action.id];
+      if (!item || item.status !== 'downloading') return state;
+      return {
+        ...state,
+        items: {
+          ...state.items,
+          [action.id]: {
+            ...item,
+            status: 'paused',
+            updatedAt: Date.now(),
+          },
+        },
+      };
+    }
+    case 'RESUME': {
+      const item = state.items[action.id];
+      if (!item || item.status !== 'paused') return state;
+      return {
+        ...state,
+        items: {
+          ...state.items,
+          [action.id]: {
+            ...item,
+            status: 'downloading',
+            updatedAt: Date.now(),
+          },
+        },
+      };
+    }
+    case 'COMPLETE': {
+      const item = state.items[action.id];
+      if (!item) return state;
+      return {
+        ...state,
+        items: {
+          ...state.items,
+          [action.id]: {
+            ...item,
+            status: 'completed',
+            bytesDownloaded: item.totalBytes,
+            progress: 1,
+            updatedAt: action.completedAt,
+            completedAt: action.completedAt,
+            error: undefined,
+          },
+        },
+      };
+    }
+    case 'FAIL': {
+      const item = state.items[action.id];
+      if (!item) return state;
+      return {
+        ...state,
+        items: {
+          ...state.items,
+          [action.id]: {
+            ...item,
+            status: 'failed',
+            error: action.error,
+            updatedAt: action.at,
+          },
+        },
+      };
+    }
+    case 'RETRY': {
+      const item = state.items[action.id];
+      if (!item) return state;
+      return {
+        ...state,
+        items: {
+          ...state.items,
+          [action.id]: {
+            ...item,
+            status: 'downloading',
+            bytesDownloaded: 0,
+            progress: 0,
+            error: undefined,
+            startedAt: action.startedAt,
+            updatedAt: action.startedAt,
+            completedAt: undefined,
+          },
+        },
+      };
+    }
+    case 'REMOVE': {
+      if (!state.items[action.id]) return state;
+      const { [action.id]: _removed, ...rest } = state.items;
+      return {
+        order: state.order.filter(id => id !== action.id),
+        items: rest,
+      };
+    }
+    default:
+      return state;
+  }
+}
+
+export interface DownloadManagerContextValue {
+  downloads: DownloadItem[];
+  hasActiveDownloads: boolean;
+  startDownload: (request: StartDownloadRequest) => string;
+  pauseDownload: (id: string) => void;
+  resumeDownload: (id: string) => void;
+  removeDownload: (id: string) => void;
+  retryDownload: (id: string) => void;
+  getDownload: (id: string) => DownloadItem | undefined;
+}
+
+export const DownloadManagerContext =
+  createContext<DownloadManagerContextValue | null>(null);
+
+const generateId = () => `download-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+export const DownloadManagerProvider: React.FC<{ children?: React.ReactNode }> = ({
+  children,
+}) => {
+  const [state, dispatch] = useReducer(downloadsReducer, initialState);
+  const controllersRef = useRef<Map<string, SimulatedDownloadController>>(new Map());
+  const configsRef = useRef<Map<string, DownloadConfig>>(new Map());
+  const callbacksRef = useRef<Map<string, DownloadCallbacks>>(new Map());
+
+  useEffect(() => {
+    return () => {
+      controllersRef.current.forEach(controller => controller.cancel());
+      controllersRef.current.clear();
+      configsRef.current.clear();
+      callbacksRef.current.clear();
+    };
+  }, []);
+
+  const getDownload = useCallback<DownloadManagerContextValue['getDownload']>(
+    id => state.items[id],
+    [state.items]
+  );
+
+  const startDownload = useCallback<DownloadManagerContextValue['startDownload']>(
+    request => {
+      const id = request.id ?? generateId();
+      const now = Date.now();
+      const totalBytes = Math.max(0, Math.floor(request.totalBytes));
+      const failAtBytes =
+        typeof request.failAtBytes === 'number'
+          ? Math.max(0, Math.floor(request.failAtBytes))
+          : undefined;
+      const chunkSize =
+        typeof request.chunkSize === 'number' && request.chunkSize > 0
+          ? Math.max(1, Math.floor(request.chunkSize))
+          : undefined;
+      const intervalMs =
+        typeof request.intervalMs === 'number' && request.intervalMs > 0
+          ? Math.max(1, Math.floor(request.intervalMs))
+          : undefined;
+      const config: DownloadConfig = {
+        totalBytes,
+        chunkSize,
+        intervalMs,
+        failAtBytes,
+      };
+
+      controllersRef.current.get(id)?.cancel();
+      controllersRef.current.delete(id);
+
+      configsRef.current.set(id, config);
+      callbacksRef.current.set(id, {
+        onProgress: request.onProgress,
+        onComplete: request.onComplete,
+        onError: request.onError,
+      });
+
+      dispatch({
+        type: 'ADD',
+        payload: {
+          id,
+          label: request.label,
+          source: request.source,
+          status: 'downloading',
+          bytesDownloaded: 0,
+          totalBytes,
+          progress: 0,
+          startedAt: now,
+          updatedAt: now,
+        },
+      });
+
+      const controller = createSimulatedDownload({
+        totalBytes: config.totalBytes,
+        chunkSize: config.chunkSize,
+        intervalMs: config.intervalMs,
+        failAtBytes: config.failAtBytes,
+        onProgress: downloadedBytes => {
+          dispatch({ type: 'PROGRESS', id, bytesDownloaded: downloadedBytes });
+          callbacksRef.current.get(id)?.onProgress?.(downloadedBytes);
+        },
+        onComplete: () => {
+          const completedAt = Date.now();
+          dispatch({ type: 'COMPLETE', id, completedAt });
+          callbacksRef.current.get(id)?.onComplete?.();
+          controllersRef.current.delete(id);
+          configsRef.current.delete(id);
+          callbacksRef.current.delete(id);
+        },
+        onError: error => {
+          const at = Date.now();
+          dispatch({ type: 'FAIL', id, error: error.message, at });
+          callbacksRef.current.get(id)?.onError?.(error);
+          controllersRef.current.delete(id);
+          configsRef.current.set(id, { ...config, failAtBytes: undefined });
+        },
+      });
+
+      controllersRef.current.set(id, controller);
+      controller.start();
+
+      return id;
+    },
+    []
+  );
+
+  const pauseDownload = useCallback<DownloadManagerContextValue['pauseDownload']>(
+    id => {
+      const controller = controllersRef.current.get(id);
+      if (!controller) return;
+      controller.pause();
+      dispatch({ type: 'PAUSE', id });
+    },
+    []
+  );
+
+  const resumeDownload = useCallback<DownloadManagerContextValue['resumeDownload']>(
+    id => {
+      const controller = controllersRef.current.get(id);
+      if (!controller) return;
+      controller.resume();
+      dispatch({ type: 'RESUME', id });
+    },
+    []
+  );
+
+  const removeDownload = useCallback<DownloadManagerContextValue['removeDownload']>(
+    id => {
+      const controller = controllersRef.current.get(id);
+      controller?.cancel();
+      controllersRef.current.delete(id);
+      configsRef.current.delete(id);
+      callbacksRef.current.delete(id);
+      dispatch({ type: 'REMOVE', id });
+    },
+    []
+  );
+
+  const retryDownload = useCallback<DownloadManagerContextValue['retryDownload']>(
+    id => {
+      const config = configsRef.current.get(id);
+      if (!config) return;
+
+      const activeConfig: DownloadConfig = { ...config };
+      configsRef.current.set(id, activeConfig);
+
+      controllersRef.current.get(id)?.cancel();
+
+      const callbacks = callbacksRef.current.get(id);
+      const now = Date.now();
+      dispatch({ type: 'RETRY', id, startedAt: now });
+
+      const controller = createSimulatedDownload({
+        totalBytes: activeConfig.totalBytes,
+        chunkSize: activeConfig.chunkSize,
+        intervalMs: activeConfig.intervalMs,
+        failAtBytes: activeConfig.failAtBytes,
+        onProgress: downloadedBytes => {
+          dispatch({ type: 'PROGRESS', id, bytesDownloaded: downloadedBytes });
+          callbacks?.onProgress?.(downloadedBytes);
+        },
+        onComplete: () => {
+          const completedAt = Date.now();
+          dispatch({ type: 'COMPLETE', id, completedAt });
+          callbacks?.onComplete?.();
+          controllersRef.current.delete(id);
+          configsRef.current.delete(id);
+          callbacksRef.current.delete(id);
+        },
+        onError: error => {
+          const at = Date.now();
+          dispatch({ type: 'FAIL', id, error: error.message, at });
+          callbacks?.onError?.(error);
+          controllersRef.current.delete(id);
+          configsRef.current.set(id, { ...activeConfig, failAtBytes: undefined });
+        },
+      });
+
+      controllersRef.current.set(id, controller);
+      controller.start();
+    },
+    []
+  );
+
+  const downloads = useMemo(() => state.order.map(id => state.items[id]).filter(Boolean), [
+    state.order,
+    state.items,
+  ]);
+
+  const hasActiveDownloads = useMemo(
+    () => downloads.some(item => item.status === 'downloading' || item.status === 'paused'),
+    [downloads]
+  );
+
+  const value = useMemo<DownloadManagerContextValue>(
+    () => ({
+      downloads,
+      hasActiveDownloads,
+      startDownload,
+      pauseDownload,
+      resumeDownload,
+      removeDownload,
+      retryDownload,
+      getDownload,
+    }),
+    [
+      downloads,
+      hasActiveDownloads,
+      startDownload,
+      pauseDownload,
+      resumeDownload,
+      removeDownload,
+      retryDownload,
+      getDownload,
+    ]
+  );
+
+  return <DownloadManagerContext.Provider value={value}>{children}</DownloadManagerContext.Provider>;
+};
+
+export default DownloadManagerProvider;

--- a/components/common/DownloadPanel.tsx
+++ b/components/common/DownloadPanel.tsx
@@ -1,0 +1,198 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import useDownloads from '../../hooks/useDownloads';
+
+const statusLabels: Record<string, string> = {
+  downloading: 'Downloading',
+  paused: 'Paused',
+  completed: 'Completed',
+  failed: 'Failed',
+};
+
+const formatBytes = (bytes: number) => {
+  if (bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / Math.pow(1024, exponent);
+  return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+};
+
+const DownloadPanel: React.FC = () => {
+  const { downloads, pauseDownload, resumeDownload, retryDownload, removeDownload } = useDownloads();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const totalCount = downloads.length;
+  const activeCount = useMemo(
+    () =>
+      downloads.filter(item => item.status === 'downloading' || item.status === 'paused').length,
+    [downloads]
+  );
+  const failedCount = useMemo(
+    () => downloads.filter(item => item.status === 'failed').length,
+    [downloads]
+  );
+
+  useEffect(() => {
+    if (downloads.length > 0) {
+      setIsOpen(true);
+    }
+  }, [downloads.length]);
+
+  const toggle = () => setIsOpen(prev => !prev);
+
+  if (!totalCount) {
+    return (
+      <aside className="fixed top-20 right-0 z-50 pointer-events-none">
+        <div className="pointer-events-auto flex items-start">
+          <button
+            type="button"
+            onClick={toggle}
+            className="mr-2 rounded-l bg-slate-800/80 px-3 py-2 text-xs font-medium uppercase tracking-wide text-slate-200 hover:bg-slate-700"
+            aria-expanded={isOpen}
+            aria-controls="download-panel"
+          >
+            Downloads
+          </button>
+          {isOpen && (
+            <div
+              id="download-panel"
+              className="w-80 max-w-sm rounded-l bg-slate-900/95 text-slate-100 shadow-lg ring-1 ring-slate-700"
+            >
+              <header className="flex items-center justify-between border-b border-slate-700 px-4 py-3">
+                <h2 className="text-sm font-semibold uppercase tracking-wide">Downloads</h2>
+                <button
+                  type="button"
+                  onClick={toggle}
+                  className="rounded bg-slate-800 px-2 py-1 text-xs font-medium uppercase tracking-wide text-slate-300 hover:bg-slate-700"
+                >
+                  Close
+                </button>
+              </header>
+              <div className="px-4 py-6 text-sm text-slate-400">No downloads yet.</div>
+            </div>
+          )}
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="fixed top-20 right-0 z-50 pointer-events-none">
+      <div className="pointer-events-auto flex items-start">
+        <button
+          type="button"
+          onClick={toggle}
+          className="mr-2 rounded-l bg-slate-800/80 px-3 py-2 text-xs font-medium uppercase tracking-wide text-slate-200 hover:bg-slate-700"
+          aria-expanded={isOpen}
+          aria-controls="download-panel"
+        >
+          Downloads
+          <span className="ml-2 inline-flex items-center justify-center rounded-full bg-slate-600 px-2 py-0.5 text-[10px] font-semibold text-white">
+            {totalCount}
+          </span>
+        </button>
+        <div
+          id="download-panel"
+          className={`w-80 max-w-sm transform rounded-l bg-slate-900/95 text-slate-100 shadow-lg ring-1 ring-slate-700 transition-transform duration-200 ease-out ${
+            isOpen ? 'translate-x-0' : 'translate-x-full'
+          }`}
+        >
+          <header className="flex items-center justify-between border-b border-slate-700 px-4 py-3">
+            <div>
+              <h2 className="text-sm font-semibold uppercase tracking-wide">Downloads</h2>
+              <p className="text-xs text-slate-400">
+                {activeCount > 0 ? `${activeCount} active` : 'Idle'}
+                {failedCount > 0 ? ` • ${failedCount} failed` : ''}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={toggle}
+              className="rounded bg-slate-800 px-2 py-1 text-xs font-medium uppercase tracking-wide text-slate-300 hover:bg-slate-700"
+            >
+              Close
+            </button>
+          </header>
+          <ul className="max-h-[70vh] space-y-2 overflow-y-auto px-4 py-3" aria-live="polite">
+            {downloads.map(download => {
+              const percent = Math.round(download.progress * 100);
+              const statusLabel = statusLabels[download.status] ?? download.status;
+              const progressColor =
+                download.status === 'failed'
+                  ? 'bg-red-500'
+                  : download.status === 'completed'
+                  ? 'bg-emerald-500'
+                  : 'bg-sky-500';
+
+              return (
+                <li key={download.id} className="rounded border border-slate-800 bg-slate-900/70 p-3 shadow-sm">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold text-slate-100" title={download.label}>
+                        {download.label}
+                      </p>
+                      <p className="mt-1 text-xs text-slate-400">
+                        {statusLabel}
+                        {download.status !== 'completed' && ` • ${percent}%`}
+                      </p>
+                      <p className="mt-1 text-xs text-slate-500">
+                        {formatBytes(download.bytesDownloaded)} / {formatBytes(download.totalBytes)}
+                      </p>
+                      {download.error && (
+                        <p className="mt-2 text-xs text-red-400" role="alert">
+                          {download.error}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex flex-col items-end gap-2">
+                      {download.status === 'downloading' && (
+                        <button
+                          type="button"
+                          onClick={() => pauseDownload(download.id)}
+                          className="rounded bg-slate-800 px-2 py-1 text-xs font-medium uppercase tracking-wide text-slate-200 hover:bg-slate-700"
+                        >
+                          Pause
+                        </button>
+                      )}
+                      {download.status === 'paused' && (
+                        <button
+                          type="button"
+                          onClick={() => resumeDownload(download.id)}
+                          className="rounded bg-slate-800 px-2 py-1 text-xs font-medium uppercase tracking-wide text-slate-200 hover:bg-slate-700"
+                        >
+                          Resume
+                        </button>
+                      )}
+                      {download.status === 'failed' && (
+                        <button
+                          type="button"
+                          onClick={() => retryDownload(download.id)}
+                          className="rounded bg-red-500/80 px-2 py-1 text-xs font-medium uppercase tracking-wide text-white hover:bg-red-500"
+                        >
+                          Retry
+                        </button>
+                      )}
+                      {(download.status === 'completed' || download.status === 'failed') && (
+                        <button
+                          type="button"
+                          onClick={() => removeDownload(download.id)}
+                          className="rounded bg-slate-800 px-2 py-1 text-xs font-medium uppercase tracking-wide text-slate-200 hover:bg-slate-700"
+                        >
+                          Clear
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                  <div className="mt-3 h-2 w-full rounded bg-slate-800" role="progressbar" aria-valuenow={percent} aria-valuemin={0} aria-valuemax={100}>
+                    <div className={`h-full rounded ${progressColor}`} style={{ width: `${percent}%` }} />
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </div>
+    </aside>
+  );
+};
+
+export default DownloadPanel;

--- a/hooks/useDownloads.ts
+++ b/hooks/useDownloads.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { DownloadManagerContext } from '../components/common/DownloadManager';
+
+export const useDownloads = () => {
+  const ctx = useContext(DownloadManagerContext);
+  if (!ctx) {
+    throw new Error('useDownloads must be used within DownloadManagerProvider');
+  }
+  return ctx;
+};
+
+export default useDownloads;

--- a/modules/downloads/simulatedApi.ts
+++ b/modules/downloads/simulatedApi.ts
@@ -1,0 +1,146 @@
+export type SimulatedDownloadStatus =
+  | 'idle'
+  | 'running'
+  | 'paused'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+export interface SimulatedDownloadCallbacks {
+  onProgress: (downloadedBytes: number) => void;
+  onComplete: () => void;
+  onError: (error: Error) => void;
+}
+
+export interface SimulatedDownloadOptions extends SimulatedDownloadCallbacks {
+  totalBytes: number;
+  /**
+   * Number of bytes transferred per interval. Defaults to a twentieth of the
+   * total size (min 1 byte).
+   */
+  chunkSize?: number;
+  /** Interval in milliseconds between progress updates. Defaults to 250ms. */
+  intervalMs?: number;
+  /**
+   * Optional byte offset that will trigger a simulated failure once the
+   * transfer reaches or exceeds it.
+   */
+  failAtBytes?: number;
+  /**
+   * Optional seed for resuming an existing download. Allows the simulation to
+   * start from a non-zero offset.
+   */
+  startingBytes?: number;
+  /** Custom error message when the simulation fails. */
+  errorMessage?: string;
+}
+
+export interface SimulatedDownloadController {
+  start: () => void;
+  pause: () => void;
+  resume: () => void;
+  cancel: () => void;
+  status: () => SimulatedDownloadStatus;
+  downloadedBytes: () => number;
+}
+
+const DEFAULT_INTERVAL = 250;
+
+export function createSimulatedDownload({
+  totalBytes,
+  chunkSize,
+  intervalMs,
+  failAtBytes,
+  startingBytes = 0,
+  errorMessage = 'Simulated network error',
+  onProgress,
+  onComplete,
+  onError,
+}: SimulatedDownloadOptions): SimulatedDownloadController {
+  const clampedTotal = Math.max(0, Math.floor(totalBytes));
+  const sizePerChunk = Math.max(
+    1,
+    chunkSize && chunkSize > 0
+      ? Math.floor(chunkSize)
+      : Math.max(1, Math.floor(clampedTotal / 20))
+  );
+  const interval = intervalMs && intervalMs > 0 ? intervalMs : DEFAULT_INTERVAL;
+  let downloaded = Math.max(0, Math.min(clampedTotal, Math.floor(startingBytes)));
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let state: SimulatedDownloadStatus = 'idle';
+  let failed = false;
+
+  const clearTimer = () => {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+
+  const finalize = (nextState: SimulatedDownloadStatus) => {
+    state = nextState;
+    clearTimer();
+  };
+
+  const step = () => {
+    if (state !== 'running') return;
+    const nextBytes = Math.min(clampedTotal, downloaded + sizePerChunk);
+
+    if (
+      typeof failAtBytes === 'number' &&
+      !failed &&
+      nextBytes >= failAtBytes &&
+      failAtBytes >= 0
+    ) {
+      failed = true;
+      downloaded = Math.min(clampedTotal, Math.max(downloaded, Math.floor(failAtBytes)));
+      onProgress(downloaded);
+      finalize('failed');
+      onError(new Error(errorMessage));
+      return;
+    }
+
+    downloaded = nextBytes;
+    onProgress(downloaded);
+
+    if (downloaded >= clampedTotal) {
+      finalize('completed');
+      onComplete();
+    }
+  };
+
+  const startInterval = () => {
+    if (timer || state === 'completed' || state === 'failed' || state === 'cancelled') {
+      return;
+    }
+    state = 'running';
+    timer = setInterval(step, interval);
+  };
+
+  return {
+    start: () => {
+      if (state === 'idle' || state === 'paused') {
+        startInterval();
+      }
+    },
+    pause: () => {
+      if (state === 'running') {
+        state = 'paused';
+        clearTimer();
+      }
+    },
+    resume: () => {
+      if (state === 'paused' || state === 'idle') {
+        startInterval();
+      }
+    },
+    cancel: () => {
+      if (state === 'completed' || state === 'failed' || state === 'cancelled') {
+        return;
+      }
+      finalize('cancelled');
+    },
+    status: () => state,
+    downloadedBytes: () => downloaded,
+  };
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,11 +11,13 @@ import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import { DownloadManagerProvider } from '../components/common/DownloadManager';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import DownloadPanel from '../components/common/DownloadPanel';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -157,10 +159,12 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
+          <DownloadManagerProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <DownloadPanel />
             <Analytics
               beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;
@@ -170,8 +174,9 @@ function MyApp(props) {
               }}
             />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </DownloadManagerProvider>
         </SettingsProvider>
       </div>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- add a download manager context backed by simulated transfers to track progress, pause, resume, and failures
- surface a desktop side panel that lists downloads with per-item actions and status indicators
- cover the state transitions with unit tests and expose a hook for other apps to register downloads

## Testing
- yarn lint *(fails: existing accessibility and top-level window lint errors in unrelated apps)*
- yarn test *(fails: pre-existing failures in suites like window keyboard handling and nmap simulator, plus jsdom localStorage access)*
- yarn test __tests__/downloadManager.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68caa9eee22c8328850184cde2431075