### PR TITLE
[kiosk] add kiosk manager and presentation mode

### DIFF
--- a/__tests__/kioskManager.test.ts
+++ b/__tests__/kioskManager.test.ts
@@ -1,0 +1,36 @@
+import kioskManager from '../modules/kiosk/manager';
+
+describe('kioskManager', () => {
+  beforeEach(() => {
+    kioskManager.listProfiles().forEach(profile => kioskManager.deleteProfile(profile.id));
+    kioskManager.deactivateProfile('');
+  });
+
+  it('activates profiles and restricts apps', () => {
+    const profile = kioskManager.createProfile({
+      name: 'Demo kiosk',
+      allowedApps: ['terminal'],
+      restrictions: { disableAppSwitching: true },
+      exitCredentials: { type: 'pin', secret: '1234' },
+    });
+    expect(kioskManager.canLaunchApp('about-alex')).toBe(true);
+    expect(kioskManager.activateProfile(profile.id)).toBe(true);
+    expect(kioskManager.canLaunchApp('terminal')).toBe(true);
+    expect(kioskManager.canLaunchApp('about-alex')).toBe(false);
+    expect(kioskManager.isRestrictionEnabled('disableAppSwitching')).toBe(true);
+  });
+
+  it('requires credentials to exit kiosk mode', () => {
+    const profile = kioskManager.createProfile({
+      name: 'Secure kiosk',
+      allowedApps: ['settings'],
+      restrictions: {},
+      exitCredentials: { type: 'password', secret: 'letmein' },
+    });
+    kioskManager.activateProfile(profile.id);
+    expect(kioskManager.deactivateProfile('wrong')).toBe(false);
+    expect(kioskManager.getActiveProfile()).not.toBeNull();
+    expect(kioskManager.deactivateProfile('letmein')).toBe(true);
+    expect(kioskManager.getActiveProfile()).toBeNull();
+  });
+});

--- a/__tests__/presentationMode.test.tsx
+++ b/__tests__/presentationMode.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { NotificationCenter } from '../components/common/NotificationCenter';
+import { PresentationModeProvider, usePresentationMode } from '../components/common/PresentationModeContext';
+import useNotifications from '../hooks/useNotifications';
+
+describe('presentation mode', () => {
+  const Harness: React.FC = () => {
+    const { pushNotification } = useNotifications();
+    const { toggle, enabled } = usePresentationMode();
+    return (
+      <div>
+        <button data-testid="notify-hello" onClick={() => pushNotification('demo', 'Hello notification')}>
+          Notify hello
+        </button>
+        <button data-testid="notify-hidden" onClick={() => pushNotification('demo', 'Hidden notification')}>
+          Notify hidden
+        </button>
+        <button data-testid="toggle" onClick={() => toggle()}>
+          {enabled ? 'Disable presentation' : 'Enable presentation'}
+        </button>
+      </div>
+    );
+  };
+
+  const renderHarness = () =>
+    render(
+      <NotificationCenter>
+        <PresentationModeProvider>
+          <Harness />
+        </PresentationModeProvider>
+      </NotificationCenter>,
+    );
+
+  it('suppresses notifications when enabled', () => {
+    renderHarness();
+    fireEvent.click(screen.getByTestId('notify-hello'));
+    expect(screen.getByText('Hello notification')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('toggle'));
+    expect(screen.getByText(/Notifications muted/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('notify-hidden'));
+    expect(screen.queryByText('Hidden notification')).not.toBeInTheDocument();
+  });
+
+  it('dims the pointer while active', () => {
+    renderHarness();
+    fireEvent.click(screen.getByTestId('toggle'));
+    fireEvent.pointerMove(document, { clientX: 100, clientY: 120 });
+    expect(document.body.classList.contains('presentation-mode')).toBe(true);
+    expect(document.querySelector('.presentation-pointer')).not.toBeNull();
+
+    fireEvent.click(screen.getByTestId('toggle'));
+    expect(document.body.classList.contains('presentation-mode')).toBe(false);
+  });
+});

--- a/components/apps/security-tools/index.js
+++ b/components/apps/security-tools/index.js
@@ -4,6 +4,7 @@ import CommandBuilder from '../../CommandBuilder';
 import FixturesLoader from '../../FixturesLoader';
 import ResultViewer from '../../ResultViewer';
 import ExplainerPane from '../../ExplainerPane';
+import KioskProfilePanel from '../../common/KioskProfilePanel';
 
 const tabs = [
   { id: 'repeater', label: 'Repeater' },
@@ -129,7 +130,8 @@ export default function SecurityTools() {
   return (
     <LabMode>
       <div className="w-full h-full bg-ub-dark text-white p-2 overflow-auto flex">
-        <div className="flex-1 pr-2">
+        <div className="flex-1 pr-2 space-y-3">
+          <KioskProfilePanel compact />
           <input
             value={query}
             onChange={e => setQuery(e.target.value)}

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
+import KioskProfilePanel from '../common/KioskProfilePanel';
 
 export function Settings() {
     const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
@@ -56,6 +57,7 @@ export function Settings() {
     }, [accent, accentText, contrastRatio]);
 
     return (
+        <>
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
             <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
             </div>
@@ -284,6 +286,8 @@ export function Settings() {
                 className="hidden"
             />
         </div>
+        <KioskProfilePanel />
+        </>
     )
 }
 

--- a/components/common/KioskProfilePanel.tsx
+++ b/components/common/KioskProfilePanel.tsx
@@ -1,0 +1,277 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import kioskManager, { KioskProfile } from '../../modules/kiosk/manager';
+import useKiosk from '../../hooks/useKiosk';
+
+interface Props {
+  compact?: boolean;
+}
+
+interface FormState {
+  name: string;
+  allowedApps: string;
+  disableContextMenus: boolean;
+  disableAppSwitching: boolean;
+  disableQuickSettings: boolean;
+  exitSecret: string;
+}
+
+const defaultForm: FormState = {
+  name: '',
+  allowedApps: '',
+  disableContextMenus: true,
+  disableAppSwitching: true,
+  disableQuickSettings: false,
+  exitSecret: '',
+};
+
+const parseList = (value: string) =>
+  value
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean);
+
+const KioskProfilePanel: React.FC<Props> = ({ compact }) => {
+  const { profiles, activeProfile, restrictions } = useKiosk();
+  const [form, setForm] = useState<FormState>(defaultForm);
+  const [exitValue, setExitValue] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const sortedProfiles = useMemo(
+    () => profiles.slice().sort((a, b) => a.name.localeCompare(b.name)),
+    [profiles],
+  );
+
+  const handleCreate = (event: React.FormEvent) => {
+    event.preventDefault();
+    const allowed = parseList(form.allowedApps);
+    const exitSecret = form.exitSecret.trim();
+    kioskManager.createProfile({
+      name: form.name || 'Kiosk Profile',
+      allowedApps: allowed,
+      restrictions: {
+        disableContextMenus: form.disableContextMenus,
+        disableAppSwitching: form.disableAppSwitching,
+        disableQuickSettings: form.disableQuickSettings,
+      },
+      exitCredentials: {
+        type: exitSecret.length > 4 ? 'password' : 'pin',
+        secret: exitSecret,
+      },
+    });
+    setForm(defaultForm);
+    setMessage('Profile created');
+  };
+
+  const handleDelete = (profile: KioskProfile) => {
+    kioskManager.deleteProfile(profile.id);
+    setMessage(`Removed ${profile.name}`);
+  };
+
+  const handleActivate = (profile: KioskProfile) => {
+    kioskManager.activateProfile(profile.id);
+    setMessage(`Activated ${profile.name}`);
+  };
+
+  const handleExport = () => {
+    const data = kioskManager.exportProfiles();
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'kiosk-profiles.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport: React.ChangeEventHandler<HTMLInputElement> = async event => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    kioskManager.importProfiles(text);
+    event.target.value = '';
+    setMessage('Imported kiosk profiles');
+  };
+
+  const handleExit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const ok = kioskManager.deactivateProfile(exitValue.trim());
+    if (!ok) {
+      setMessage('Invalid kiosk credentials');
+      return;
+    }
+    setExitValue('');
+    setMessage('Kiosk mode disabled');
+  };
+
+  return (
+    <section
+      aria-label="Kiosk profiles"
+      className={`rounded border border-gray-800 bg-black bg-opacity-40 text-white ${compact ? 'p-3' : 'p-5 mt-6'}`}
+    >
+      <header className="mb-3 flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Kiosk Profiles</h2>
+        <div className="flex gap-2 text-xs">
+          <button
+            type="button"
+            className="rounded bg-ub-orange px-2 py-1 text-black"
+            onClick={handleExport}
+          >
+            Export
+          </button>
+          <label className="rounded bg-ub-orange px-2 py-1 text-black cursor-pointer">
+            Import
+            <input
+              type="file"
+              accept="application/json"
+              className="hidden"
+              onChange={handleImport}
+            />
+          </label>
+        </div>
+      </header>
+      {message && <p className="mb-2 text-xs text-ubt-grey">{message}</p>}
+      <form onSubmit={handleCreate} className="mb-4 space-y-2 text-sm">
+        <div className="flex flex-col">
+          <label className="mb-1 font-medium" htmlFor="kiosk-name">
+            Profile name
+          </label>
+          <input
+            id="kiosk-name"
+            value={form.name}
+            onChange={event => setForm(current => ({ ...current, name: event.target.value }))}
+            className="rounded bg-ub-cool-grey px-2 py-1 text-white"
+          />
+        </div>
+        <div className="flex flex-col">
+          <label className="mb-1 font-medium" htmlFor="kiosk-apps">
+            Allowed apps (comma separated IDs)
+          </label>
+          <input
+            id="kiosk-apps"
+            value={form.allowedApps}
+            onChange={event => setForm(current => ({ ...current, allowedApps: event.target.value }))}
+            className="rounded bg-ub-cool-grey px-2 py-1 text-white"
+            placeholder="settings, weather"
+          />
+        </div>
+        <fieldset className="grid gap-2 md:grid-cols-2">
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={form.disableContextMenus}
+              onChange={event =>
+                setForm(current => ({ ...current, disableContextMenus: event.target.checked }))
+              }
+            />
+            Disable context menus
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={form.disableAppSwitching}
+              onChange={event =>
+                setForm(current => ({ ...current, disableAppSwitching: event.target.checked }))
+              }
+            />
+            Disable app switching
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={form.disableQuickSettings}
+              onChange={event =>
+                setForm(current => ({ ...current, disableQuickSettings: event.target.checked }))
+              }
+            />
+            Disable quick settings
+          </label>
+        </fieldset>
+        <div className="flex flex-col">
+          <label className="mb-1 font-medium" htmlFor="kiosk-exit">
+            Exit PIN or password
+          </label>
+          <input
+            id="kiosk-exit"
+            type="password"
+            value={form.exitSecret}
+            onChange={event => setForm(current => ({ ...current, exitSecret: event.target.value }))}
+            className="rounded bg-ub-cool-grey px-2 py-1 text-white"
+          />
+        </div>
+        <button type="submit" className="rounded bg-ub-orange px-3 py-1 text-black">
+          Save profile
+        </button>
+      </form>
+
+      <div className="space-y-3 text-sm">
+        {sortedProfiles.length === 0 && <p>No kiosk profiles configured.</p>}
+        {sortedProfiles.map(profile => {
+          const active = profile.id === activeProfile?.id;
+          return (
+            <article
+              key={profile.id}
+              className={`rounded border border-gray-700 p-3 ${active ? 'bg-ub-cool-grey bg-opacity-40' : 'bg-transparent'}`}
+            >
+              <header className="flex items-center justify-between">
+                <div>
+                  <h3 className="font-semibold">{profile.name}</h3>
+                  <p className="text-xs text-ubt-grey">Allowed: {profile.allowedApps.join(', ') || 'All apps'}</p>
+                </div>
+                <div className="flex gap-2 text-xs">
+                  <button
+                    type="button"
+                    className="rounded bg-ub-orange px-2 py-1 text-black disabled:opacity-50"
+                    onClick={() => handleActivate(profile)}
+                    disabled={active}
+                  >
+                    {active ? 'Active' : 'Activate'}
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded bg-red-700 px-2 py-1"
+                    onClick={() => handleDelete(profile)}
+                  >
+                    Remove
+                  </button>
+                </div>
+              </header>
+              <ul className="mt-2 space-y-1 text-xs text-ubt-grey">
+                <li>Context menus: {profile.restrictions.disableContextMenus ? 'Disabled' : 'Allowed'}</li>
+                <li>App switching: {profile.restrictions.disableAppSwitching ? 'Disabled' : 'Allowed'}</li>
+                <li>Quick settings: {profile.restrictions.disableQuickSettings ? 'Disabled' : 'Allowed'}</li>
+              </ul>
+            </article>
+          );
+        })}
+      </div>
+
+      {activeProfile && (
+        <form onSubmit={handleExit} className="mt-4 space-y-2 border-t border-gray-800 pt-3 text-sm">
+          <h3 className="font-semibold">Exit kiosk mode</h3>
+          <p className="text-xs text-ubt-grey">
+            Active profile: {activeProfile.name}. Context menus are
+            {restrictions.disableContextMenus ? ' disabled' : ' enabled'}, app switching is
+            {restrictions.disableAppSwitching ? ' disabled' : ' enabled'}.
+          </p>
+          <label className="flex flex-col gap-1" htmlFor="kiosk-exit-confirm">
+            Enter credentials to exit
+            <input
+              id="kiosk-exit-confirm"
+              type={activeProfile.exitCredentials.type === 'password' ? 'password' : 'tel'}
+              value={exitValue}
+              onChange={event => setExitValue(event.target.value)}
+              className="rounded bg-ub-cool-grey px-2 py-1 text-white"
+            />
+          </label>
+          <button type="submit" className="rounded bg-ub-orange px-3 py-1 text-black">
+            Exit kiosk
+          </button>
+        </form>
+      )}
+    </section>
+  );
+};
+
+export default KioskProfilePanel;

--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -10,14 +10,18 @@ interface NotificationsContextValue {
   notifications: Record<string, AppNotification[]>;
   pushNotification: (appId: string, message: string) => void;
   clearNotifications: (appId?: string) => void;
+  muted: boolean;
+  setMuted: (value: boolean) => void;
 }
 
 export const NotificationsContext = createContext<NotificationsContextValue | null>(null);
 
 export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   const [notifications, setNotifications] = useState<Record<string, AppNotification[]>>({});
+  const [muted, setMuted] = useState(false);
 
   const pushNotification = useCallback((appId: string, message: string) => {
+    if (muted) return;
     setNotifications(prev => {
       const list = prev[appId] ?? [];
       const next = {
@@ -33,7 +37,7 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
       };
       return next;
     });
-  }, []);
+  }, [muted]);
 
   const clearNotifications = useCallback((appId?: string) => {
     setNotifications(prev => {
@@ -59,10 +63,15 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
 
   return (
     <NotificationsContext.Provider
-      value={{ notifications, pushNotification, clearNotifications }}
+      value={{ notifications, pushNotification, clearNotifications, muted, setMuted }}
     >
       {children}
       <div className="notification-center">
+        {muted && (
+          <div className="notification-muted" role="status">
+            Notifications muted for presentation mode
+          </div>
+        )}
         {Object.entries(notifications).map(([appId, list]) => (
           <section key={appId} className="notification-group">
             <h3>{appId}</h3>

--- a/components/common/PresentationModeContext.tsx
+++ b/components/common/PresentationModeContext.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import useNotifications from '../../hooks/useNotifications';
+
+interface PresentationModeValue {
+  enabled: boolean;
+  enable: () => void;
+  disable: () => void;
+  toggle: () => void;
+}
+
+const PresentationModeContext = createContext<PresentationModeValue | null>(null);
+
+export const PresentationModeProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const { setMuted } = useNotifications();
+  const [enabled, setEnabled] = useState(false);
+  const [pointerVisible, setPointerVisible] = useState(false);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+
+  useEffect(() => {
+    setMuted(enabled);
+  }, [enabled, setMuted]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    if (!enabled) {
+      document.body.classList.remove('presentation-mode');
+      return;
+    }
+    document.body.classList.add('presentation-mode');
+    const handleMove = (event: PointerEvent) => {
+      setPosition({ x: event.clientX, y: event.clientY });
+      setPointerVisible(true);
+    };
+    const handleLeave = () => setPointerVisible(false);
+    document.addEventListener('pointermove', handleMove);
+    document.addEventListener('pointerdown', handleMove);
+    document.addEventListener('pointerleave', handleLeave);
+    return () => {
+      document.body.classList.remove('presentation-mode');
+      document.removeEventListener('pointermove', handleMove);
+      document.removeEventListener('pointerdown', handleMove);
+      document.removeEventListener('pointerleave', handleLeave);
+    };
+  }, [enabled]);
+
+  const enable = useCallback(() => setEnabled(true), []);
+  const disable = useCallback(() => setEnabled(false), []);
+  const toggle = useCallback(() => setEnabled(value => !value), []);
+
+  const value = useMemo<PresentationModeValue>(
+    () => ({ enabled, enable, disable, toggle }),
+    [enabled, enable, disable, toggle],
+  );
+
+  return (
+    <PresentationModeContext.Provider value={value}>
+      {children}
+      {enabled && pointerVisible && (
+        <div
+          className="presentation-pointer"
+          style={{ left: `${position.x}px`, top: `${position.y}px` }}
+          aria-hidden="true"
+        />
+      )}
+    </PresentationModeContext.Provider>
+  );
+};
+
+export const usePresentationMode = (): PresentationModeValue => {
+  const ctx = useContext(PresentationModeContext);
+  if (!ctx) {
+    throw new Error('usePresentationMode must be used within PresentationModeProvider');
+  }
+  return ctx;
+};
+
+export default PresentationModeContext;

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -3,6 +3,8 @@ import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import useKiosk from '../../hooks/useKiosk';
+import kioskManager from '../../modules/kiosk/manager';
 
 type AppMeta = {
   id: string;
@@ -27,6 +29,7 @@ const WhiskerMenu: React.FC = () => {
   const [highlight, setHighlight] = useState(0);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const { activeProfile } = useKiosk();
 
   const allApps: AppMeta[] = apps as any;
   const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
@@ -63,8 +66,11 @@ const WhiskerMenu: React.FC = () => {
       const q = query.toLowerCase();
       list = list.filter(a => a.title.toLowerCase().includes(q));
     }
+    if (activeProfile) {
+      list = list.filter(app => kioskManager.canLaunchApp(app.id));
+    }
     return list;
-  }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps]);
+  }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps, activeProfile]);
 
   useEffect(() => {
     if (!open) return;

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -4,6 +4,7 @@ import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import kioskManager from '../../modules/kiosk/manager';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -32,6 +33,10 @@ export default class Navbar extends Component {
                                         id="status-bar"
                                         aria-label="System status"
                                         onClick={() => {
+                                                if (kioskManager.isRestrictionEnabled('disableQuickSettings')) {
+                                                        this.setState({ status_card: false });
+                                                        return;
+                                                }
                                                 this.setState({ status_card: !this.state.status_card });
                                         }}
                                         className={

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,8 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import { usePresentationMode } from '../common/PresentationModeContext';
+import useKiosk from '../../hooks/useKiosk';
 
 interface Props {
   open: boolean;
@@ -12,6 +14,9 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const { enabled: presentationEnabled, toggle: togglePresentation } = usePresentationMode();
+  const { restrictions } = useKiosk();
+  const quickSettingsLocked = restrictions.disableQuickSettings;
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -27,10 +32,16 @@ const QuickSettings = ({ open }: Props) => {
         open ? '' : 'hidden'
       }`}
     >
+      {quickSettingsLocked && (
+        <p className="px-4 pb-3 text-xs text-ubt-grey">
+          Controlled by kiosk profile. Presentation mode and toggles are locked.
+        </p>
+      )}
       <div className="px-4 pb-2">
         <button
           className="w-full flex justify-between"
-          onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+          onClick={() => !quickSettingsLocked && setTheme(theme === 'light' ? 'dark' : 'light')}
+          disabled={quickSettingsLocked}
         >
           <span>Theme</span>
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
@@ -38,11 +49,21 @@ const QuickSettings = ({ open }: Props) => {
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
+        <input
+          type="checkbox"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+          disabled={quickSettingsLocked}
+        />
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+        <input
+          type="checkbox"
+          checked={online}
+          onChange={() => setOnline(!online)}
+          disabled={quickSettingsLocked}
+        />
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>
@@ -50,6 +71,16 @@ const QuickSettings = ({ open }: Props) => {
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
+          disabled={quickSettingsLocked}
+        />
+      </div>
+      <div className="px-4 pt-2 flex justify-between">
+        <span>Presentation mode</span>
+        <input
+          type="checkbox"
+          checked={presentationEnabled}
+          onChange={() => togglePresentation()}
+          disabled={quickSettingsLocked}
         />
       </div>
     </div>

--- a/hooks/useKiosk.ts
+++ b/hooks/useKiosk.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import kioskManager, { KioskManagerState } from '../modules/kiosk/manager';
+
+export const useKiosk = () => {
+  const [state, setState] = useState<KioskManagerState>(() => kioskManager.getState());
+
+  useEffect(() => {
+    return kioskManager.subscribe(setState);
+  }, []);
+
+  return state;
+};
+
+export default useKiosk;

--- a/modules/kiosk/manager.ts
+++ b/modules/kiosk/manager.ts
@@ -1,0 +1,271 @@
+import { safeLocalStorage } from '../../utils/safeStorage';
+
+export type KioskRestrictionKey =
+  | 'disableContextMenus'
+  | 'disableAppSwitching'
+  | 'disableQuickSettings';
+
+export interface KioskRestrictions {
+  disableContextMenus: boolean;
+  disableAppSwitching: boolean;
+  disableQuickSettings: boolean;
+}
+
+export interface KioskExitCredentials {
+  type: 'pin' | 'password';
+  secret: string;
+}
+
+export interface KioskProfile {
+  id: string;
+  name: string;
+  allowedApps: string[];
+  restrictions: Partial<KioskRestrictions>;
+  exitCredentials: KioskExitCredentials;
+}
+
+export interface KioskManagerState {
+  profiles: KioskProfile[];
+  activeProfile: KioskProfile | null;
+  restrictions: KioskRestrictions;
+}
+
+const STORAGE_KEY = 'kiosk-profiles';
+const ACTIVE_KEY = 'kiosk-active-profile';
+const DEFAULT_RESTRICTIONS: KioskRestrictions = {
+  disableContextMenus: false,
+  disableAppSwitching: false,
+  disableQuickSettings: false,
+};
+
+const normalizeRestrictions = (
+  restrictions?: Partial<KioskRestrictions>,
+): KioskRestrictions => ({
+  ...DEFAULT_RESTRICTIONS,
+  ...(restrictions ?? {}),
+});
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+const parseAllowedApps = (allowedApps: unknown): string[] => {
+  if (Array.isArray(allowedApps)) {
+    return allowedApps
+      .map(app => (isNonEmptyString(app) ? app.trim() : null))
+      .filter((app): app is string => Boolean(app));
+  }
+  if (isNonEmptyString(allowedApps)) {
+    return allowedApps
+      .split(',')
+      .map(entry => entry.trim())
+      .filter(Boolean);
+  }
+  return [];
+};
+
+const generateId = () => `kiosk-${Math.random().toString(36).slice(2, 11)}`;
+
+class KioskProfileManager {
+  private profiles: Map<string, KioskProfile> = new Map();
+  private activeProfileId: string | null = null;
+  private listeners: Set<(state: KioskManagerState) => void> = new Set();
+
+  constructor() {
+    this.load();
+  }
+
+  private load() {
+    try {
+      const raw = safeLocalStorage?.getItem(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          parsed.forEach(profile => {
+            const normalized = this.normalizeProfile(profile);
+            this.profiles.set(normalized.id, normalized);
+          });
+        }
+      }
+      const active = safeLocalStorage?.getItem(ACTIVE_KEY);
+      if (active && this.profiles.has(active)) {
+        this.activeProfileId = active;
+      }
+    } catch {
+      this.profiles.clear();
+      this.activeProfileId = null;
+    }
+  }
+
+  private persist() {
+    try {
+      const serialized = JSON.stringify(this.listProfiles());
+      safeLocalStorage?.setItem(STORAGE_KEY, serialized);
+      if (this.activeProfileId) {
+        safeLocalStorage?.setItem(ACTIVE_KEY, this.activeProfileId);
+      } else {
+        safeLocalStorage?.removeItem(ACTIVE_KEY);
+      }
+    } catch {
+      // ignore persistence errors (e.g., private browsing)
+    }
+  }
+
+  private notify() {
+    const snapshot = this.getState();
+    this.listeners.forEach(listener => listener(snapshot));
+  }
+
+  private normalizeProfile(input: any): KioskProfile {
+    const id = isNonEmptyString(input?.id) ? input.id : generateId();
+    const name = isNonEmptyString(input?.name) ? input.name.trim() : 'Untitled Kiosk Profile';
+    const allowedApps = parseAllowedApps(input?.allowedApps);
+    const restrictions = normalizeRestrictions(input?.restrictions);
+    const exitType: KioskExitCredentials['type'] =
+      input?.exitCredentials?.type === 'password' ? 'password' : 'pin';
+    const secret = isNonEmptyString(input?.exitCredentials?.secret)
+      ? input.exitCredentials.secret
+      : '';
+
+    return {
+      id,
+      name,
+      allowedApps,
+      restrictions,
+      exitCredentials: {
+        type: exitType,
+        secret,
+      },
+    };
+  }
+
+  getState(): KioskManagerState {
+    return {
+      profiles: this.listProfiles(),
+      activeProfile: this.getActiveProfile(),
+      restrictions: this.getRestrictions(),
+    };
+  }
+
+  subscribe(listener: (state: KioskManagerState) => void): () => void {
+    this.listeners.add(listener);
+    listener(this.getState());
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  listProfiles(): KioskProfile[] {
+    return Array.from(this.profiles.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  getProfile(id: string): KioskProfile | null {
+    return this.profiles.get(id) ?? null;
+  }
+
+  getActiveProfile(): KioskProfile | null {
+    if (!this.activeProfileId) return null;
+    return this.profiles.get(this.activeProfileId) ?? null;
+  }
+
+  getRestrictions(): KioskRestrictions {
+    const active = this.getActiveProfile();
+    return normalizeRestrictions(active?.restrictions);
+  }
+
+  canLaunchApp(appId: string): boolean {
+    const active = this.getActiveProfile();
+    if (!active) return true;
+    const { allowedApps } = active;
+    if (!allowedApps.length || allowedApps.includes('*')) {
+      return true;
+    }
+    return allowedApps.includes(appId);
+  }
+
+  isRestrictionEnabled(key: KioskRestrictionKey): boolean {
+    const restrictions = this.getRestrictions();
+    return Boolean(restrictions[key]);
+  }
+
+  createProfile(profile: Partial<KioskProfile>): KioskProfile {
+    const normalized = this.normalizeProfile(profile);
+    this.profiles.set(normalized.id, normalized);
+    this.persist();
+    this.notify();
+    return normalized;
+  }
+
+  updateProfile(id: string, patch: Partial<KioskProfile>): KioskProfile | null {
+    const existing = this.profiles.get(id);
+    if (!existing) return null;
+    const updated = this.normalizeProfile({ ...existing, ...patch, id });
+    this.profiles.set(id, updated);
+    if (this.activeProfileId === id) {
+      this.activeProfileId = updated.id;
+    }
+    this.persist();
+    this.notify();
+    return updated;
+  }
+
+  deleteProfile(id: string) {
+    if (!this.profiles.has(id)) return;
+    this.profiles.delete(id);
+    if (this.activeProfileId === id) {
+      this.activeProfileId = null;
+    }
+    this.persist();
+    this.notify();
+  }
+
+  activateProfile(id: string): boolean {
+    if (!this.profiles.has(id)) return false;
+    this.activeProfileId = id;
+    this.persist();
+    this.notify();
+    return true;
+  }
+
+  deactivateProfile(secret: string): boolean {
+    const active = this.getActiveProfile();
+    if (!active) return true;
+    if (active.exitCredentials.secret && active.exitCredentials.secret !== secret) {
+      return false;
+    }
+    this.activeProfileId = null;
+    this.persist();
+    this.notify();
+    return true;
+  }
+
+  exportProfiles(pretty = true): string {
+    const spaces = pretty ? 2 : 0;
+    return JSON.stringify(this.listProfiles(), null, spaces);
+  }
+
+  importProfiles(data: string) {
+    try {
+      const parsed = JSON.parse(data);
+      const profiles = Array.isArray(parsed)
+        ? parsed
+        : Array.isArray(parsed?.profiles)
+        ? parsed.profiles
+        : [];
+      profiles.forEach(profile => {
+        const normalized = this.normalizeProfile(profile);
+        this.profiles.set(normalized.id, normalized);
+      });
+      if (this.activeProfileId && !this.profiles.has(this.activeProfileId)) {
+        this.activeProfileId = null;
+      }
+      this.persist();
+      this.notify();
+    } catch {
+      throw new Error('Invalid kiosk profile data');
+    }
+  }
+}
+
+const kioskManager = new KioskProfileManager();
+
+export default kioskManager;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,8 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { NotificationCenter } from '../components/common/NotificationCenter';
+import { PresentationModeProvider } from '../components/common/PresentationModeContext';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -156,23 +158,27 @@ function MyApp(props) {
         >
           Skip to app grid
         </a>
-        <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+        <NotificationCenter>
+          <PresentationModeProvider>
+            <SettingsProvider>
+              <PipPortalProvider>
+                <div aria-live="polite" id="live-region" />
+                <Component {...pageProps} />
+                <ShortcutOverlay />
+                <Analytics
+                  beforeSend={(e) => {
+                    if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                    const evt = e;
+                    if (evt.metadata?.email) delete evt.metadata.email;
+                    return e;
+                  }}
+                />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
-        </SettingsProvider>
+                {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+              </PipPortalProvider>
+            </SettingsProvider>
+          </PresentationModeProvider>
+        </NotificationCenter>
       </div>
     </ErrorBoundary>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -77,3 +77,26 @@ html[data-theme='matrix'] {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
+
+body.presentation-mode {
+  cursor: none !important;
+}
+
+body.presentation-mode * {
+  cursor: none !important;
+}
+
+.presentation-pointer {
+  position: fixed;
+  width: 160px;
+  height: 160px;
+  pointer-events: none;
+  border-radius: 50%;
+  border: 2px solid var(--color-accent, #1793d1);
+  background: radial-gradient(circle, rgba(23, 147, 209, 0.25) 0%, rgba(23, 147, 209, 0.15) 40%, rgba(0, 0, 0, 0.55) 80%);
+  box-shadow: 0 0 0 200vmax rgba(0, 0, 0, 0.5);
+  transform: translate(-50%, -50%);
+  opacity: 0.85;
+  transition: opacity 0.2s ease;
+  z-index: 9999;
+}


### PR DESCRIPTION
## Summary
- introduce a kiosk profile manager with persistent storage, allowed app enforcement, and exit credentials that hook into the desktop lifecycle
- add a presentation mode provider that mutes notifications and highlights the pointer, exposing controls through quick settings and the notification center
- surface kiosk management UI inside settings and security tools panels and cover the new behaviors with focused unit tests

## Testing
- yarn lint *(fails: repository has pre-existing accessibility errors surfaced during lint)*
- yarn test kioskManager.test.ts
- yarn test presentationMode.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb166d424c8328b7b88a974ca69301