### PR TITLE
feat(desktop): add window grouping workspace store

### DIFF
--- a/components/core/DesktopWindows.tsx
+++ b/components/core/DesktopWindows.tsx
@@ -1,0 +1,490 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import HelpPanel from '../HelpPanel';
+import useWorkspaceStore from '../../hooks/useWorkspaceStore';
+import {
+  DesktopGroup,
+  DesktopWindow,
+  DesktopWindowSeed,
+  GroupId,
+  WorkspaceId,
+} from '../../types/desktop';
+
+const WINDOW_DRAG_TYPE = 'application/x-desktop-window';
+const GROUP_DRAG_TYPE = 'application/x-desktop-group';
+
+interface DesktopWindowsProps {
+  workspaceId?: WorkspaceId;
+  initialWindows?: DesktopWindowSeed[];
+}
+
+const formatGroupName = (title: string, fallbackIndex: number) => {
+  const trimmed = title.trim();
+  if (!trimmed) return `Group ${fallbackIndex}`;
+  const firstWord = trimmed.split(/\s+/)[0];
+  return `${firstWord} Stack`;
+};
+
+const iconFallback = (title: string) => title.trim().slice(0, 1).toUpperCase() || '?';
+
+const DesktopWindowCard = ({
+  window: win,
+  onDragStart,
+  onDragEnd,
+  onDrop,
+  onClose,
+  onFocus,
+}: {
+  window: DesktopWindow;
+  onDragStart: (windowId: string) => (event: React.DragEvent<HTMLDivElement>) => void;
+  onDragEnd: () => void;
+  onDrop: (windowId: string) => (event: React.DragEvent<HTMLDivElement>) => void;
+  onClose: (windowId: string) => void;
+  onFocus: (windowId: string) => void;
+}) => (
+  <div
+    key={win.id}
+    draggable
+    onDragStart={onDragStart(win.id)}
+    onDragEnd={onDragEnd}
+    onDrop={onDrop(win.id)}
+    onDragOver={(event) => {
+      if (event.dataTransfer.types.includes(WINDOW_DRAG_TYPE)) {
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'move';
+      }
+    }}
+    onClick={() => onFocus(win.id)}
+    className={`flex flex-col rounded border border-gray-700 bg-gray-900/80 text-gray-100 shadow-lg transition-shadow focus:outline-none focus:ring ${
+      win.groupId ? 'ring-2 ring-ub-orange' : ''
+    }`}
+    role="listitem"
+  >
+    <div className="flex items-center justify-between gap-2 border-b border-gray-700 px-3 py-2 text-sm">
+      <div className="flex items-center gap-2 truncate">
+        {win.icon ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={win.icon} alt="" className="h-5 w-5" />
+        ) : (
+          <span className="grid h-5 w-5 place-items-center rounded bg-gray-700 text-xs">
+            {iconFallback(win.title)}
+          </span>
+        )}
+        <span className="truncate" title={win.title}>
+          {win.title}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        {win.groupId && (
+          <span className="rounded bg-gray-800 px-2 py-0.5 text-xs" aria-label="Group">
+            {win.groupIndex !== null ? `#${win.groupIndex + 1}` : '#'}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onClose(win.id);
+          }}
+          aria-label={`Close ${win.title}`}
+          className="rounded px-1 py-0.5 text-xs text-gray-300 transition hover:bg-red-600 hover:text-white"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+    <div className="flex flex-1 flex-col gap-2 p-3 text-xs">
+      <p className="text-gray-400">
+        Workspace order: <span className="text-gray-200">{win.order + 1}</span>
+      </p>
+      <p className="text-gray-400">
+        Position: <span className="text-gray-200">{win.bounds.x.toFixed(0)}×{win.bounds.y.toFixed(0)}</span>
+      </p>
+      <p className="text-gray-400">
+        Size: <span className="text-gray-200">{win.bounds.width.toFixed(0)}×{win.bounds.height.toFixed(0)}</span>
+      </p>
+      {win.groupId ? (
+        <p className="text-gray-400">
+          Group ID: <span className="text-gray-200">{win.groupId}</span>
+        </p>
+      ) : (
+        <p className="text-gray-500">Not grouped</p>
+      )}
+    </div>
+  </div>
+);
+
+const GroupChip = ({
+  id,
+  name,
+  members,
+  onDrop,
+  onDragStart,
+  onRename,
+  onDissolve,
+  index,
+}: {
+  id: GroupId;
+  name: string;
+  members: DesktopWindow[];
+  onDrop: (groupId: GroupId, index: number) => (event: React.DragEvent<HTMLDivElement>) => void;
+  onDragStart: (groupId: GroupId) => (event: React.DragEvent<HTMLDivElement>) => void;
+  onRename: (groupId: GroupId, currentName: string) => void;
+  onDissolve: (groupId: GroupId) => void;
+  index: number;
+}) => (
+  <div
+    key={id}
+    className="flex min-w-[9rem] flex-col gap-2 rounded border border-gray-700 bg-gray-900/80 p-2 text-sm text-gray-100 shadow"
+    draggable
+    onDragStart={onDragStart(id)}
+    onDrop={onDrop(id, index)}
+    onDragOver={(event) => {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'move';
+    }}
+    role="listitem"
+  >
+    <div className="flex items-center justify-between gap-1">
+      <span className="truncate" title={name}>
+        {name}
+      </span>
+      <div className="flex gap-1">
+        <button
+          type="button"
+          onClick={() => onRename(id, name)}
+          className="rounded px-1 text-xs text-gray-300 transition hover:bg-gray-700"
+          aria-label={`Rename ${name}`}
+        >
+          ✎
+        </button>
+        <button
+          type="button"
+          onClick={() => onDissolve(id)}
+          className="rounded px-1 text-xs text-gray-300 transition hover:bg-red-600 hover:text-white"
+          aria-label={`Dissolve ${name}`}
+        >
+          ⌦
+        </button>
+      </div>
+    </div>
+    <div className="flex items-center gap-1" aria-label={`Windows in ${name}`}>
+      {members.map((member) => (
+        <div key={member.id} className="flex h-7 w-7 items-center justify-center rounded bg-gray-800">
+          {member.icon ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={member.icon} alt="" className="h-5 w-5" />
+          ) : (
+            <span className="text-xs text-gray-200">{iconFallback(member.title)}</span>
+          )}
+        </div>
+      ))}
+      {members.length === 0 && <span className="text-xs text-gray-400">Empty</span>}
+    </div>
+  </div>
+);
+
+const DesktopWindows: React.FC<DesktopWindowsProps> = ({ workspaceId, initialWindows = [] }) => {
+  const {
+    activeWorkspace,
+    activeWorkspaceId,
+    setActiveWorkspace,
+    openWindow,
+    closeWindow,
+    focusWindow,
+    moveWindowToGroup,
+    createGroup,
+    renameGroup,
+    dissolveGroup,
+    moveGroup,
+  } = useWorkspaceStore();
+
+  const [draggingWindow, setDraggingWindow] = useState<string | null>(null);
+  const seededInitialWindows = useRef(false);
+
+  useEffect(() => {
+    if (workspaceId && workspaceId !== activeWorkspaceId) {
+      setActiveWorkspace(workspaceId);
+    }
+  }, [workspaceId, activeWorkspaceId, setActiveWorkspace]);
+
+  useEffect(() => {
+    seededInitialWindows.current = false;
+  }, [activeWorkspaceId]);
+
+  useEffect(() => {
+    if (seededInitialWindows.current) return;
+    if (!initialWindows.length) return;
+    initialWindows.forEach((seed, index) => {
+      if (!activeWorkspace.windows[seed.id]) {
+        openWindow({
+          ...seed,
+          bounds: {
+            x: seed.bounds?.x ?? 120 + index * 40,
+            y: seed.bounds?.y ?? 120 + index * 32,
+            width: seed.bounds?.width ?? 720,
+            height: seed.bounds?.height ?? 480,
+          },
+        });
+      }
+    });
+    seededInitialWindows.current = true;
+  }, [initialWindows, activeWorkspace.windows, openWindow]);
+
+  const windows = useMemo(
+    () =>
+      activeWorkspace.windowOrder
+        .map((id) => activeWorkspace.windows[id])
+        .filter((win): win is DesktopWindow => Boolean(win)),
+    [activeWorkspace],
+  );
+
+  const groups = useMemo(
+    () =>
+      activeWorkspace.groupOrder
+        .map((id) => {
+          const group = activeWorkspace.groups[id];
+          if (!group) return null;
+          const members = group.windowIds
+            .map((windowId) => activeWorkspace.windows[windowId])
+            .filter((win): win is DesktopWindow => Boolean(win));
+          return { group, members } as { group: DesktopGroup; members: DesktopWindow[] };
+        })
+        .filter((entry): entry is { group: DesktopGroup; members: DesktopWindow[] } => Boolean(entry)),
+    [activeWorkspace],
+  );
+
+  const onWindowDragStart = useCallback(
+    (windowId: string) => (event: React.DragEvent<HTMLDivElement>) => {
+      event.dataTransfer.setData(WINDOW_DRAG_TYPE, windowId);
+      event.dataTransfer.effectAllowed = 'move';
+      setDraggingWindow(windowId);
+    },
+    [],
+  );
+
+  const onWindowDrop = useCallback(
+    (targetId: string) => (event: React.DragEvent<HTMLDivElement>) => {
+      if (!event.dataTransfer.types.includes(WINDOW_DRAG_TYPE)) return;
+      event.preventDefault();
+      const sourceId = event.dataTransfer.getData(WINDOW_DRAG_TYPE);
+      setDraggingWindow(null);
+      if (!sourceId || sourceId === targetId) return;
+      const target = activeWorkspace.windows[targetId];
+      const source = activeWorkspace.windows[sourceId];
+      if (!target || !source) return;
+
+      if (target.groupId) {
+        moveWindowToGroup(sourceId, target.groupId);
+        return;
+      }
+
+      const defaultName = formatGroupName(target.title, groups.length + 1);
+      const created = createGroup(defaultName, [targetId, sourceId]);
+      if (!created && source.groupId) {
+        moveWindowToGroup(sourceId, source.groupId);
+      }
+    },
+    [activeWorkspace.windows, createGroup, groups.length, moveWindowToGroup],
+  );
+
+  const handleCloseWindow = useCallback(
+    (windowId: string) => {
+      closeWindow(windowId);
+      setDraggingWindow((current) => (current === windowId ? null : current));
+    },
+    [closeWindow],
+  );
+
+  const handleGroupDrop = useCallback(
+    (groupId: GroupId, index: number) => (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      if (event.dataTransfer.types.includes(WINDOW_DRAG_TYPE)) {
+        const windowId = event.dataTransfer.getData(WINDOW_DRAG_TYPE);
+        if (windowId) {
+          moveWindowToGroup(windowId, groupId);
+        }
+        setDraggingWindow(null);
+        return;
+      }
+      if (event.dataTransfer.types.includes(GROUP_DRAG_TYPE)) {
+        const draggedId = event.dataTransfer.getData(GROUP_DRAG_TYPE);
+        if (draggedId && draggedId !== groupId) {
+          moveGroup(draggedId, index);
+        }
+      }
+    },
+    [moveGroup, moveWindowToGroup],
+  );
+
+  const handleGroupDragStart = useCallback(
+    (groupId: GroupId) => (event: React.DragEvent<HTMLDivElement>) => {
+      event.dataTransfer.setData(GROUP_DRAG_TYPE, groupId);
+      event.dataTransfer.effectAllowed = 'move';
+    },
+    [],
+  );
+
+  const handleUngroupDrop = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (!event.dataTransfer.types.includes(WINDOW_DRAG_TYPE)) return;
+      event.preventDefault();
+      const windowId = event.dataTransfer.getData(WINDOW_DRAG_TYPE);
+      if (windowId) {
+        moveWindowToGroup(windowId, null);
+      }
+      setDraggingWindow(null);
+    },
+    [moveWindowToGroup],
+  );
+
+  const handleCreateGroup = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    const name = window.prompt('Name for the new group', `Group ${groups.length + 1}`);
+    if (name === null) return;
+    createGroup(name);
+  }, [createGroup, groups.length]);
+
+  const handleDropNewGroup = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (!event.dataTransfer.types.includes(WINDOW_DRAG_TYPE)) return;
+      event.preventDefault();
+      const windowId = event.dataTransfer.getData(WINDOW_DRAG_TYPE);
+      if (!windowId) return;
+      const windowTitle = activeWorkspace.windows[windowId]?.title ?? 'New';
+      let proposed = `Group ${groups.length + 1}`;
+      if (windowTitle) {
+        proposed = formatGroupName(windowTitle, groups.length + 1);
+      }
+      let name = proposed;
+      if (typeof window !== 'undefined') {
+        const response = window.prompt('Name for the new group', proposed);
+        if (response === null) {
+          setDraggingWindow(null);
+          return;
+        }
+        name = response.trim() || proposed;
+      }
+      createGroup(name, [windowId]);
+      setDraggingWindow(null);
+    },
+    [activeWorkspace.windows, createGroup, groups.length],
+  );
+
+  const handleRenameGroup = useCallback(
+    (groupId: GroupId, currentName: string) => {
+      if (typeof window === 'undefined') return;
+      const response = window.prompt('Rename group', currentName);
+      if (response === null) return;
+      const trimmed = response.trim();
+      if (trimmed) {
+        renameGroup(groupId, trimmed);
+      }
+    },
+    [renameGroup],
+  );
+
+  const handleDissolveGroup = useCallback(
+    (groupId: GroupId) => {
+      if (typeof window !== 'undefined') {
+        const confirmed = window.confirm('Remove this group? Windows will remain open.');
+        if (!confirmed) return;
+      }
+      dissolveGroup(groupId);
+    },
+    [dissolveGroup],
+  );
+
+  return (
+    <section className="flex h-full flex-col gap-3 bg-gradient-to-b from-black/60 via-gray-900 to-black/60 p-4 text-gray-100">
+      <header className="flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Window Groups</h2>
+          <div className="flex items-center gap-2">
+            <div
+              onDrop={handleUngroupDrop}
+              onDragOver={(event) => {
+                if (event.dataTransfer.types.includes(WINDOW_DRAG_TYPE)) {
+                  event.preventDefault();
+                  event.dataTransfer.dropEffect = 'move';
+                }
+              }}
+              className={`rounded border border-dashed border-gray-600 px-3 py-1 text-sm transition ${
+                draggingWindow ? 'bg-gray-800 text-white' : 'bg-gray-900 text-gray-300'
+              }`}
+              role="button"
+              aria-label="Ungroup window"
+            >
+              Drop to ungroup
+            </div>
+            <button
+              type="button"
+              onClick={handleCreateGroup}
+              className="rounded bg-ub-orange px-3 py-1 text-sm font-medium text-black transition hover:bg-ub-orange/80"
+            >
+              New Group
+            </button>
+          </div>
+        </div>
+        <div
+          className="flex gap-3 overflow-x-auto"
+          role="list"
+          aria-label="Window groups"
+        >
+          {groups.map(({ group, members }, index) => (
+            <GroupChip
+              key={group.id}
+              id={group.id}
+              name={group.name}
+              members={members}
+              onDrop={handleGroupDrop}
+              onDragStart={handleGroupDragStart}
+              onRename={handleRenameGroup}
+              onDissolve={handleDissolveGroup}
+              index={index}
+            />
+          ))}
+          <div
+            onDrop={handleDropNewGroup}
+            onDragOver={(event) => {
+              if (event.dataTransfer.types.includes(WINDOW_DRAG_TYPE)) {
+                event.preventDefault();
+                event.dataTransfer.dropEffect = 'copy';
+              }
+            }}
+            className={`flex min-w-[9rem] cursor-pointer flex-col items-center justify-center gap-2 rounded border border-dashed border-gray-600 p-4 text-sm text-gray-300 transition ${
+              draggingWindow ? 'bg-gray-800 text-white' : 'bg-gray-900'
+            }`}
+            role="button"
+            aria-label="Create group from dropped window"
+          >
+            <span className="text-lg">＋</span>
+            <span>Drop here for new group</span>
+          </div>
+        </div>
+      </header>
+      <main className="grid flex-1 grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3" role="list">
+        {windows.map((win) => (
+          <DesktopWindowCard
+            key={win.id}
+            window={win}
+            onDragStart={onWindowDragStart}
+            onDragEnd={() => setDraggingWindow(null)}
+            onDrop={onWindowDrop}
+            onClose={handleCloseWindow}
+            onFocus={focusWindow}
+          />
+        ))}
+        {windows.length === 0 && (
+          <p className="text-sm text-gray-400" role="status">
+            No windows are open in this workspace.
+          </p>
+        )}
+      </main>
+      <HelpPanel appId="desktop-window-groups" docPath="/docs/desktop-window-groups.md" />
+    </section>
+  );
+};
+
+export default DesktopWindows;

--- a/hooks/useWorkspaceStore.ts
+++ b/hooks/useWorkspaceStore.ts
@@ -1,0 +1,434 @@
+"use client";
+
+import { useCallback, useEffect, useMemo } from 'react';
+import usePersistentState from './usePersistentState';
+import {
+  DesktopGroup,
+  DesktopWindow,
+  DesktopWindowSeed,
+  GroupId,
+  WorkspaceId,
+  WorkspaceSnapshot,
+  WorkspaceState,
+  WindowBounds,
+  WindowId,
+} from '../types/desktop';
+
+const STORAGE_KEY = 'desktop-workspaces';
+export const DEFAULT_WORKSPACE_ID: WorkspaceId = 'workspace-main';
+
+const defaultBounds: WindowBounds = { x: 160, y: 120, width: 720, height: 480 };
+
+const createWorkspace = (id: WorkspaceId, name: string): WorkspaceSnapshot => ({
+  id,
+  name,
+  windows: {},
+  windowOrder: [],
+  groups: {},
+  groupOrder: [],
+});
+
+const initialState: WorkspaceState = {
+  activeWorkspaceId: DEFAULT_WORKSPACE_ID,
+  workspaces: {
+    [DEFAULT_WORKSPACE_ID]: createWorkspace(DEFAULT_WORKSPACE_ID, 'Workspace 1'),
+  },
+};
+
+function isWorkspaceState(value: unknown): value is WorkspaceState {
+  if (!value || typeof value !== 'object') return false;
+  const state = value as WorkspaceState;
+  if (typeof state.activeWorkspaceId !== 'string' || typeof state.workspaces !== 'object') {
+    return false;
+  }
+  return true;
+}
+
+const cloneWorkspace = (workspace: WorkspaceSnapshot): WorkspaceSnapshot => ({
+  ...workspace,
+  windows: Object.fromEntries(
+    Object.entries(workspace.windows).map(([id, win]) => [
+      id,
+      {
+        ...win,
+        bounds: { ...win.bounds },
+      },
+    ]),
+  ),
+  windowOrder: [...workspace.windowOrder],
+  groups: Object.fromEntries(
+    Object.entries(workspace.groups).map(([id, group]) => [
+      id,
+      {
+        ...group,
+        windowIds: [...group.windowIds],
+      },
+    ]),
+  ),
+  groupOrder: [...workspace.groupOrder],
+});
+
+const syncWindowOrdering = (workspace: WorkspaceSnapshot) => {
+  workspace.windowOrder = workspace.windowOrder.filter((id) => workspace.windows[id]);
+  workspace.windowOrder.forEach((id, index) => {
+    const win = workspace.windows[id];
+    if (win) {
+      win.order = index;
+      win.zIndex = index;
+    }
+  });
+};
+
+const detachWindowFromGroup = (workspace: WorkspaceSnapshot, windowId: WindowId) => {
+  const win = workspace.windows[windowId];
+  if (!win || !win.groupId) return;
+  const group = workspace.groups[win.groupId];
+  if (group) {
+    group.windowIds = group.windowIds.filter((id) => id !== windowId);
+    if (group.windowIds.length === 0) {
+      delete workspace.groups[group.id];
+      workspace.groupOrder = workspace.groupOrder.filter((id) => id !== group.id);
+    }
+  }
+  win.groupId = null;
+  win.groupIndex = null;
+};
+
+const syncGroupOrdering = (workspace: WorkspaceSnapshot) => {
+  const seen = new Set<GroupId>();
+  workspace.groupOrder = workspace.groupOrder.filter((id) => workspace.groups[id]);
+  workspace.groupOrder = workspace.groupOrder.filter((id) => {
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
+
+  Object.values(workspace.groups).forEach((group) => {
+    group.windowIds = group.windowIds.filter((id) => workspace.windows[id]);
+  });
+
+  workspace.groupOrder.forEach((groupId, idx) => {
+    const group = workspace.groups[groupId];
+    if (!group) return;
+    group.order = idx;
+    group.windowIds.forEach((windowId, windowIdx) => {
+      const win = workspace.windows[windowId];
+      if (win) {
+        win.groupId = group.id;
+        win.groupIndex = windowIdx;
+      }
+    });
+  });
+
+  Object.values(workspace.windows).forEach((win) => {
+    if (!win.groupId || !workspace.groups[win.groupId]) {
+      win.groupId = null;
+      win.groupIndex = null;
+    }
+  });
+};
+
+const createDesktopGroup = (
+  id: GroupId,
+  name: string,
+  order: number,
+  windowIds: WindowId[] = [],
+): DesktopGroup => ({
+  id,
+  name,
+  order,
+  windowIds: [...windowIds],
+  createdAt: Date.now(),
+});
+
+const buildWindow = (seed: DesktopWindowSeed, order: number): DesktopWindow => ({
+  id: seed.id,
+  appId: seed.appId,
+  title: seed.title,
+  icon: seed.icon,
+  bounds: {
+    x: seed.bounds?.x ?? defaultBounds.x,
+    y: seed.bounds?.y ?? defaultBounds.y,
+    width: seed.bounds?.width ?? defaultBounds.width,
+    height: seed.bounds?.height ?? defaultBounds.height,
+  },
+  groupId: seed.groupId ?? null,
+  groupIndex: null,
+  order,
+  zIndex: order,
+  isMinimized: seed.isMinimized ?? false,
+  createdAt: Date.now(),
+});
+
+const generateGroupId = () => `group-${Math.random().toString(36).slice(2, 10)}`;
+
+const ensureUniqueWindows = (workspace: WorkspaceSnapshot, ids: WindowId[]) =>
+  Array.from(new Set(ids.filter((id) => !!workspace.windows[id])));
+
+interface WorkspaceStore {
+  state: WorkspaceState;
+  activeWorkspace: WorkspaceSnapshot;
+  activeWorkspaceId: WorkspaceId;
+  setActiveWorkspace: (workspaceId: WorkspaceId, name?: string) => void;
+  openWindow: (seed: DesktopWindowSeed) => DesktopWindow;
+  closeWindow: (windowId: WindowId) => void;
+  focusWindow: (windowId: WindowId) => void;
+  moveWindowToGroup: (windowId: WindowId, groupId: GroupId | null, index?: number) => void;
+  createGroup: (name: string, windowIds?: WindowId[]) => DesktopGroup | null;
+  renameGroup: (groupId: GroupId, name: string) => void;
+  dissolveGroup: (groupId: GroupId) => void;
+  moveGroup: (groupId: GroupId, targetIndex: number) => void;
+}
+
+export default function useWorkspaceStore(): WorkspaceStore {
+  const [state, setState] = usePersistentState<WorkspaceState>(
+    STORAGE_KEY,
+    initialState,
+    isWorkspaceState,
+  );
+
+  useEffect(() => {
+    setState((prev) => {
+      if (prev.activeWorkspaceId && prev.workspaces[prev.activeWorkspaceId]) return prev;
+      return {
+        ...prev,
+        activeWorkspaceId: DEFAULT_WORKSPACE_ID,
+        workspaces: {
+          ...prev.workspaces,
+          [DEFAULT_WORKSPACE_ID]: prev.workspaces[DEFAULT_WORKSPACE_ID] ?? createWorkspace(DEFAULT_WORKSPACE_ID, 'Workspace 1'),
+        },
+      };
+    });
+  }, [setState]);
+
+  const withWorkspace = useCallback(
+    <T,>(workspaceId: WorkspaceId, updater: (workspace: WorkspaceSnapshot) => T): T => {
+      let payload: T | undefined;
+      setState((prev) => {
+        const current = prev.workspaces[workspaceId] ?? createWorkspace(
+          workspaceId,
+          `Workspace ${Object.keys(prev.workspaces).length + (prev.workspaces[workspaceId] ? 0 : 1)}`,
+        );
+        const clone = cloneWorkspace(current);
+        payload = updater(clone);
+        return {
+          ...prev,
+          workspaces: {
+            ...prev.workspaces,
+            [workspaceId]: clone,
+          },
+        };
+      });
+      return payload as T;
+    },
+    [setState],
+  );
+
+  const activeWorkspaceId = state.activeWorkspaceId;
+  const activeWorkspace = useMemo(() => {
+    const workspace = state.workspaces[activeWorkspaceId];
+    return workspace ? cloneWorkspace(workspace) : createWorkspace(activeWorkspaceId, 'Workspace');
+  }, [state.workspaces, activeWorkspaceId]);
+
+  const setActiveWorkspace = useCallback(
+    (workspaceId: WorkspaceId, name?: string) => {
+      setState((prev) => {
+        if (prev.activeWorkspaceId === workspaceId && prev.workspaces[workspaceId]) {
+          return prev;
+        }
+        const hasWorkspace = !!prev.workspaces[workspaceId];
+        return {
+          ...prev,
+          activeWorkspaceId: workspaceId,
+          workspaces: hasWorkspace
+            ? prev.workspaces
+            : {
+                ...prev.workspaces,
+                [workspaceId]: createWorkspace(
+                  workspaceId,
+                  name ?? `Workspace ${Object.keys(prev.workspaces).length + 1}`,
+                ),
+              },
+        };
+      });
+    },
+    [setState],
+  );
+
+  const openWindow = useCallback(
+    (seed: DesktopWindowSeed): DesktopWindow =>
+      withWorkspace(activeWorkspaceId, (workspace) => {
+        const existing = workspace.windows[seed.id];
+        if (existing) {
+          existing.title = seed.title ?? existing.title;
+          if (seed.icon !== undefined) existing.icon = seed.icon;
+          if (seed.bounds) {
+            existing.bounds = {
+              ...existing.bounds,
+              ...seed.bounds,
+            };
+          }
+          return existing;
+        }
+
+        const next = buildWindow(seed, workspace.windowOrder.length);
+        workspace.windows[next.id] = next;
+        workspace.windowOrder.push(next.id);
+        syncWindowOrdering(workspace);
+
+        if (next.groupId) {
+          const group = workspace.groups[next.groupId];
+          if (group) {
+            group.windowIds.push(next.id);
+          } else {
+            const newGroup = createDesktopGroup(next.groupId, next.groupId, workspace.groupOrder.length, [next.id]);
+            workspace.groups[newGroup.id] = newGroup;
+            workspace.groupOrder.push(newGroup.id);
+          }
+          syncGroupOrdering(workspace);
+        }
+
+        return next;
+      }),
+    [withWorkspace, activeWorkspaceId],
+  );
+
+  const closeWindow = useCallback(
+    (windowId: WindowId) => {
+      withWorkspace(activeWorkspaceId, (workspace) => {
+        if (!workspace.windows[windowId]) return;
+        detachWindowFromGroup(workspace, windowId);
+        delete workspace.windows[windowId];
+        workspace.windowOrder = workspace.windowOrder.filter((id) => id !== windowId);
+        syncWindowOrdering(workspace);
+        syncGroupOrdering(workspace);
+      });
+    },
+    [withWorkspace, activeWorkspaceId],
+  );
+
+  const focusWindow = useCallback(
+    (windowId: WindowId) => {
+      withWorkspace(activeWorkspaceId, (workspace) => {
+        if (!workspace.windowOrder.includes(windowId)) return;
+        workspace.windowOrder = workspace.windowOrder.filter((id) => id !== windowId);
+        workspace.windowOrder.push(windowId);
+        syncWindowOrdering(workspace);
+      });
+    },
+    [withWorkspace, activeWorkspaceId],
+  );
+
+  const moveWindowToGroup = useCallback(
+    (windowId: WindowId, groupId: GroupId | null, index?: number) => {
+      withWorkspace(activeWorkspaceId, (workspace) => {
+        const win = workspace.windows[windowId];
+        if (!win) return;
+        detachWindowFromGroup(workspace, windowId);
+        if (groupId === null) {
+          syncGroupOrdering(workspace);
+          return;
+        }
+        const group = workspace.groups[groupId];
+        if (!group) return;
+        const insertIndex = index === undefined ? group.windowIds.length : Math.max(0, Math.min(index, group.windowIds.length));
+        if (group.windowIds.includes(windowId)) {
+          const currentIndex = group.windowIds.indexOf(windowId);
+          group.windowIds.splice(currentIndex, 1);
+          group.windowIds.splice(insertIndex, 0, windowId);
+        } else {
+          group.windowIds.splice(insertIndex, 0, windowId);
+        }
+        syncGroupOrdering(workspace);
+      });
+    },
+    [withWorkspace, activeWorkspaceId],
+  );
+
+  const createGroup = useCallback(
+    (name: string, windowIds: WindowId[] = []): DesktopGroup | null =>
+      withWorkspace(activeWorkspaceId, (workspace) => {
+        const id = generateGroupId();
+        const cleanedName = name.trim() || `Group ${workspace.groupOrder.length + 1}`;
+        const uniqueWindows = ensureUniqueWindows(workspace, windowIds);
+        const group = createDesktopGroup(id, cleanedName, workspace.groupOrder.length, uniqueWindows);
+        workspace.groups[id] = group;
+        workspace.groupOrder.push(id);
+        uniqueWindows.forEach((windowId, idx) => {
+          detachWindowFromGroup(workspace, windowId);
+          const win = workspace.windows[windowId];
+          if (win) {
+            win.groupId = id;
+            win.groupIndex = idx;
+          }
+        });
+        syncGroupOrdering(workspace);
+        return workspace.groups[id] ?? null;
+      }),
+    [withWorkspace, activeWorkspaceId],
+  );
+
+  const renameGroup = useCallback(
+    (groupId: GroupId, name: string) => {
+      withWorkspace(activeWorkspaceId, (workspace) => {
+        const group = workspace.groups[groupId];
+        if (!group) return;
+        const trimmed = name.trim();
+        if (trimmed) {
+          group.name = trimmed;
+        }
+      });
+    },
+    [withWorkspace, activeWorkspaceId],
+  );
+
+  const dissolveGroup = useCallback(
+    (groupId: GroupId) => {
+      withWorkspace(activeWorkspaceId, (workspace) => {
+        const group = workspace.groups[groupId];
+        if (!group) return;
+        group.windowIds.forEach((windowId) => {
+          const win = workspace.windows[windowId];
+          if (win) {
+            win.groupId = null;
+            win.groupIndex = null;
+          }
+        });
+        delete workspace.groups[groupId];
+        workspace.groupOrder = workspace.groupOrder.filter((id) => id !== groupId);
+        syncGroupOrdering(workspace);
+      });
+    },
+    [withWorkspace, activeWorkspaceId],
+  );
+
+  const moveGroup = useCallback(
+    (groupId: GroupId, targetIndex: number) => {
+      withWorkspace(activeWorkspaceId, (workspace) => {
+        const currentIndex = workspace.groupOrder.indexOf(groupId);
+        if (currentIndex === -1) return;
+        const boundedTarget = Math.max(0, Math.min(targetIndex, workspace.groupOrder.length));
+        workspace.groupOrder.splice(currentIndex, 1);
+        const insertIndex = boundedTarget >= workspace.groupOrder.length ? workspace.groupOrder.length : boundedTarget;
+        workspace.groupOrder.splice(insertIndex, 0, groupId);
+        syncGroupOrdering(workspace);
+      });
+    },
+    [withWorkspace, activeWorkspaceId],
+  );
+
+  return {
+    state,
+    activeWorkspace,
+    activeWorkspaceId,
+    setActiveWorkspace,
+    openWindow,
+    closeWindow,
+    focusWindow,
+    moveWindowToGroup,
+    createGroup,
+    renameGroup,
+    dissolveGroup,
+    moveGroup,
+  };
+}

--- a/public/docs/desktop-window-groups.md
+++ b/public/docs/desktop-window-groups.md
@@ -1,0 +1,31 @@
+# Window stacks and groups
+
+The desktop now supports organizing windows into named stacks. Use the toolbar controls at the top of the desktop window area to
+create groups, rename them, or dissolve them when you are finished.
+
+## Creating a group
+
+1. Drag any window card onto another window to stack them together.
+2. Alternatively, drag a window into the "Drop here for new group" target in the toolbar and give the stack a name.
+3. Use the **New Group** button to create an empty stack first, then drag windows into it.
+
+Each group shows its member icons in the toolbar. Dragging a window onto a group adds it to that stack while preserving the order
+of existing members.
+
+## Renaming or reordering groups
+
+* Drag group chips left or right to reorder the toolbar.
+* Use the pencil button on a group chip to rename it. The change is stored with the workspace, so switching away and back keeps
+your custom labels.
+
+## Dissolving a group
+
+* Select the trash icon on a group chip. The windows stay open and revert to solo mode.
+* You can also drop a grouped window on the "Drop to ungroup" target to pull it out without deleting the entire stack.
+
+## Workspace awareness
+
+Window stacks are stored per workspace. When you switch between workspaces, each one restores the stack membership, order, and
+last-known window positions.
+
+> Tip: The help overlay is available via the **?** button or by pressing `Shift + /`.

--- a/types/desktop.ts
+++ b/types/desktop.ts
@@ -1,0 +1,87 @@
+export type WindowId = string;
+export type GroupId = string;
+export type WorkspaceId = string;
+
+export interface WindowBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface DesktopWindow {
+  id: WindowId;
+  appId: string;
+  title: string;
+  icon?: string;
+  bounds: WindowBounds;
+  /**
+   * Identifier of the group the window is assigned to.
+   * `null` when the window is not stacked with others.
+   */
+  groupId: GroupId | null;
+  /**
+   * Index of the window within its group ordering. `null` when ungrouped.
+   */
+  groupIndex: number | null;
+  /**
+   * Ordering index in the workspace stack. Lower numbers render below higher ones.
+   */
+  order: number;
+  /**
+   * z-index tracking to maintain visual stacking between sessions/workspaces.
+   */
+  zIndex: number;
+  /**
+   * Whether the window is minimized in the workspace.
+   */
+  isMinimized: boolean;
+  /**
+   * Timestamp used for deterministic merges and hydration.
+   */
+  createdAt: number;
+}
+
+export interface DesktopGroup {
+  id: GroupId;
+  name: string;
+  /**
+   * Ordering index for the group bar UI.
+   */
+  order: number;
+  /**
+   * Window identifiers in the group in their explicit ordering.
+   */
+  windowIds: WindowId[];
+  createdAt: number;
+}
+
+export interface WorkspaceSnapshot {
+  id: WorkspaceId;
+  name: string;
+  windows: Record<WindowId, DesktopWindow>;
+  /**
+   * Z-ordered stack of window identifiers for the workspace.
+   */
+  windowOrder: WindowId[];
+  groups: Record<GroupId, DesktopGroup>;
+  /**
+   * Ordered list of group identifiers for deterministic rendering.
+   */
+  groupOrder: GroupId[];
+}
+
+export interface WorkspaceState {
+  activeWorkspaceId: WorkspaceId;
+  workspaces: Record<WorkspaceId, WorkspaceSnapshot>;
+}
+
+export interface DesktopWindowSeed {
+  id: WindowId;
+  appId: string;
+  title: string;
+  icon?: string;
+  bounds?: Partial<WindowBounds>;
+  groupId?: GroupId | null;
+  isMinimized?: boolean;
+}


### PR DESCRIPTION
## Summary
- define desktop window, group, and workspace types with ordering metadata
- add a persistent workspace store that tracks window stacks, group membership, and group ordering across workspaces
- introduce a DesktopWindows component with drag-and-drop grouping controls and document the workflow for the help overlay

## Testing
- yarn lint *(fails: repository has pre-existing accessibility and no-top-level-window lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cb466011d08328980a548c6d1c981a