### PR TITLE
feat(desktop): add preset window layouts and snap targets

### DIFF
--- a/__tests__/desktop.smoke.test.tsx
+++ b/__tests__/desktop.smoke.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import SnapTargets from '@/components/core/SnapTargets';
+import {
+  WindowManager,
+  type SnapTarget,
+  type Rect,
+} from '@/modules/desktop/windowManager';
+import { createMemoryWindowLayoutRepository } from '@/utils/storage/windowLayouts';
+
+describe('Desktop window layout presets', () => {
+  const viewport: Rect = { x: 0, y: 0, width: 1920, height: 1080 };
+
+  it('applies preset layouts and persists assignments per display', () => {
+    const repository = createMemoryWindowLayoutRepository();
+    const manager = new WindowManager({
+      displayId: 'display-1',
+      viewport,
+      repository,
+    });
+
+    manager.registerWindow('one');
+    manager.registerWindow('two');
+
+    const placements = manager.applyPreset('split-50-50');
+    expect(placements.one.width).toBeCloseTo(960, 5);
+    expect(placements.two.x).toBeCloseTo(960, 5);
+
+    const stored = repository.load('display-1');
+    expect(stored?.preset).toBe('split-50-50');
+    expect(stored?.assignments.one.slot).toBe(0);
+
+    const nextPreset = manager.cyclePreset();
+    expect(nextPreset).toBe('thirds');
+
+    const targets = manager.getSnapTargets({ includeAll: true });
+    expect(targets).toHaveLength(14);
+
+    const followUp = new WindowManager({
+      displayId: 'display-1',
+      viewport,
+      repository,
+    });
+    followUp.registerWindow('one');
+    followUp.registerWindow('two');
+
+    const restored = followUp.getWindowBounds('one');
+    expect(restored?.width).toBeCloseTo(960, 5);
+
+    followUp.snapWindowToTarget('one', 'grid-2x2:3');
+    const updated = repository.load('display-1');
+    expect(updated?.assignments.one.preset).toBe('grid-2x2');
+    expect(updated?.assignments.one.slot).toBe(3);
+  });
+});
+
+describe('SnapTargets overlay affordances', () => {
+  const baseTargets: SnapTarget[] = [
+    {
+      id: 'split-50-50:0',
+      preset: 'split-50-50',
+      slotIndex: 0,
+      rect: { x: 0, y: 0, width: 960, height: 1080 },
+      label: '50/50 Split 1 of 2',
+    },
+    {
+      id: 'split-50-50:1',
+      preset: 'split-50-50',
+      slotIndex: 1,
+      rect: { x: 960, y: 0, width: 960, height: 1080 },
+      label: '50/50 Split 2 of 2',
+    },
+  ];
+
+  it('reveals targets while dragging and invokes selection callback', () => {
+    const handleSelect = jest.fn();
+    render(
+      <SnapTargets targets={baseTargets} isDragging onSelect={handleSelect} />
+    );
+
+    const overlay = screen.getByTestId('snap-targets-overlay');
+    expect(overlay).toHaveAttribute('aria-hidden', 'false');
+
+    fireEvent.click(screen.getByTestId('snap-target-split-50-50:0'));
+    expect(handleSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'split-50-50:0' })
+    );
+  });
+
+  it('supports keyboard toggling, cycling, and committing selections', () => {
+    const handleSelect = jest.fn();
+    const handleCancel = jest.fn();
+    render(
+      <SnapTargets
+        targets={baseTargets}
+        onSelect={handleSelect}
+        onCancel={handleCancel}
+      />
+    );
+
+    const overlay = screen.getByTestId('snap-targets-overlay');
+    expect(overlay).toHaveAttribute('aria-hidden', 'true');
+
+    fireEvent.keyDown(window, { key: ' ', ctrlKey: true, altKey: true });
+    expect(overlay).toHaveAttribute('aria-hidden', 'false');
+    expect(
+      screen.getByTestId('snap-target-split-50-50:0')
+    ).toHaveAttribute('aria-current', 'true');
+
+    fireEvent.keyDown(window, {
+      key: 'ArrowRight',
+      ctrlKey: true,
+      altKey: true,
+    });
+    expect(
+      screen.getByTestId('snap-target-split-50-50:1')
+    ).toHaveAttribute('aria-current', 'true');
+
+    fireEvent.keyDown(window, { key: 'Enter', ctrlKey: true, altKey: true });
+    expect(handleSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'split-50-50:1' })
+    );
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(handleCancel).toHaveBeenCalled();
+    expect(overlay).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/components/core/SnapTargets.tsx
+++ b/components/core/SnapTargets.tsx
@@ -1,0 +1,264 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import type { SnapTarget } from '@/modules/desktop/windowManager';
+import { useGlobalShortcuts, ShortcutDescriptor } from '@/hooks/useGlobalShortcuts';
+
+interface KeyboardShortcutConfig {
+  toggle?: ShortcutDescriptor;
+  next?: ShortcutDescriptor;
+  previous?: ShortcutDescriptor;
+  confirm?: ShortcutDescriptor;
+  cancel?: ShortcutDescriptor;
+}
+
+export interface SnapTargetsProps {
+  targets: SnapTarget[];
+  isDragging?: boolean;
+  onSelect?: (target: SnapTarget) => void;
+  onCancel?: () => void;
+  keyboard?: KeyboardShortcutConfig;
+  showLabels?: boolean;
+}
+
+const defaultShortcuts: Required<KeyboardShortcutConfig> = {
+  toggle: {
+    key: ' ',
+    ctrlKey: true,
+    altKey: true,
+    preventDefault: true,
+  },
+  next: {
+    key: 'ArrowRight',
+    ctrlKey: true,
+    altKey: true,
+    preventDefault: true,
+  },
+  previous: {
+    key: 'ArrowLeft',
+    ctrlKey: true,
+    altKey: true,
+    preventDefault: true,
+  },
+  confirm: {
+    key: 'Enter',
+    ctrlKey: true,
+    altKey: true,
+    preventDefault: true,
+  },
+  cancel: {
+    key: 'Escape',
+    preventDefault: true,
+  },
+};
+
+const srOnlyStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};
+
+const baseTargetStyle: React.CSSProperties = {
+  position: 'absolute',
+  borderRadius: '0.75rem',
+  border: '2px dashed rgba(59, 130, 246, 0.45)',
+  backgroundColor: 'rgba(59, 130, 246, 0.12)',
+  color: '#f8fafc',
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'flex-start',
+  fontSize: '0.75rem',
+  padding: '0.5rem',
+  pointerEvents: 'auto',
+  transition: 'border-color 120ms ease, background-color 120ms ease',
+};
+
+const activeTargetStyle: React.CSSProperties = {
+  border: '2px solid rgba(37, 99, 235, 0.95)',
+  backgroundColor: 'rgba(37, 99, 235, 0.2)',
+  boxShadow: '0 0 0 4px rgba(59, 130, 246, 0.2)',
+};
+
+const SnapTargets: React.FC<SnapTargetsProps> = ({
+  targets,
+  isDragging = false,
+  onSelect,
+  onCancel,
+  keyboard,
+  showLabels = true,
+}) => {
+  const shortcuts = useMemo(() => ({
+    toggle: keyboard?.toggle ?? defaultShortcuts.toggle,
+    next: keyboard?.next ?? defaultShortcuts.next,
+    previous: keyboard?.previous ?? defaultShortcuts.previous,
+    confirm: keyboard?.confirm ?? defaultShortcuts.confirm,
+    cancel: keyboard?.cancel ?? defaultShortcuts.cancel,
+  }), [keyboard]);
+
+  const [keyboardMode, setKeyboardMode] = useState(false);
+  const [activeIndex, setActiveIndex] = useState<number>(-1);
+
+  const visible = isDragging || keyboardMode;
+
+  useEffect(() => {
+    if (!targets.length) {
+      setActiveIndex(-1);
+      setKeyboardMode(false);
+    } else if (keyboardMode && activeIndex >= targets.length) {
+      setActiveIndex(targets.length - 1);
+    }
+  }, [targets, keyboardMode, activeIndex]);
+
+  useEffect(() => {
+    if (!keyboardMode && !isDragging) {
+      setActiveIndex(-1);
+    }
+  }, [keyboardMode, isDragging]);
+
+  const commitSelection = useCallback(() => {
+    if (activeIndex < 0 || activeIndex >= targets.length) return;
+    const target = targets[activeIndex];
+    if (!target) return;
+    onSelect?.(target);
+  }, [activeIndex, onSelect, targets]);
+
+  const toggleKeyboard = useCallback(() => {
+    setKeyboardMode((prev) => {
+      const next = !prev;
+      if (next && targets.length) {
+        setActiveIndex((index) => (index >= 0 ? index : 0));
+      }
+      if (!next) {
+        setActiveIndex(-1);
+        onCancel?.();
+      }
+      return next;
+    });
+  }, [targets.length, onCancel]);
+
+  const cycle = useCallback((direction: 1 | -1) => {
+    if (!targets.length) return;
+    setKeyboardMode(true);
+    setActiveIndex((prev) => {
+      if (prev < 0) {
+        return direction > 0 ? 0 : targets.length - 1;
+      }
+      const next = (prev + direction + targets.length) % targets.length;
+      return next;
+    });
+  }, [targets.length]);
+
+  const handleCancel = useCallback(() => {
+    if (!keyboardMode) return;
+    setKeyboardMode(false);
+    setActiveIndex(-1);
+    onCancel?.();
+  }, [keyboardMode, onCancel]);
+
+  useGlobalShortcuts([
+    {
+      ...shortcuts.toggle,
+      handler: () => toggleKeyboard(),
+    },
+    {
+      ...shortcuts.next,
+      enabled: keyboardMode || visible,
+      handler: () => cycle(1),
+    },
+    {
+      ...shortcuts.previous,
+      enabled: keyboardMode || visible,
+      handler: () => cycle(-1),
+    },
+    {
+      ...shortcuts.confirm,
+      enabled: keyboardMode,
+      handler: () => {
+        commitSelection();
+        setKeyboardMode(false);
+        setActiveIndex(-1);
+      },
+    },
+    {
+      ...shortcuts.cancel,
+      enabled: keyboardMode,
+      handler: () => handleCancel(),
+    },
+  ], [keyboardMode, visible, cycle, commitSelection, handleCancel, toggleKeyboard]);
+
+  const handleTargetClick = useCallback(
+    (target: SnapTarget, index: number) => {
+      onSelect?.(target);
+      setKeyboardMode(false);
+      setActiveIndex(index);
+    },
+    [onSelect]
+  );
+
+  return (
+    <div
+      data-testid="snap-targets-overlay"
+      aria-hidden={!visible}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 40,
+        pointerEvents: visible ? 'auto' : 'none',
+        opacity: visible ? 1 : 0,
+        transition: 'opacity 120ms ease',
+      }}
+    >
+      {targets.map((target, index) => {
+        const isActive = index === activeIndex && (keyboardMode || isDragging);
+        return (
+          <button
+            type="button"
+            key={target.id}
+            data-testid={`snap-target-${target.id}`}
+            aria-label={target.label}
+            aria-current={isActive}
+            onClick={() => handleTargetClick(target, index)}
+            onMouseEnter={() => setActiveIndex(index)}
+            onFocus={() => setActiveIndex(index)}
+            onMouseLeave={() => {
+              if (!keyboardMode && !isDragging) {
+                setActiveIndex(-1);
+              }
+            }}
+            onBlur={() => {
+              if (!keyboardMode && !isDragging) {
+                setActiveIndex(-1);
+              }
+            }}
+            style={{
+              ...baseTargetStyle,
+              ...(isActive ? activeTargetStyle : {}),
+              left: `${target.rect.x}px`,
+              top: `${target.rect.y}px`,
+              width: `${target.rect.width}px`,
+              height: `${target.rect.height}px`,
+            }}
+          >
+            <span style={srOnlyStyle}>{target.label}</span>
+            {showLabels && (
+              <span aria-hidden className="text-xs font-semibold text-slate-100">
+                {target.label}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default SnapTargets;

--- a/hooks/useGlobalShortcuts.ts
+++ b/hooks/useGlobalShortcuts.ts
@@ -1,0 +1,93 @@
+import { DependencyList, useEffect, useMemo } from 'react';
+
+export interface ShortcutDescriptor {
+  key: string;
+  altKey?: boolean;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  shiftKey?: boolean;
+  allowRepeat?: boolean;
+  preventDefault?: boolean;
+  stopPropagation?: boolean;
+  enabled?: boolean;
+  handler: (event: KeyboardEvent) => void;
+}
+
+const normalizeKey = (key: string): string => key.toLowerCase();
+
+const matchesShortcut = (
+  event: KeyboardEvent,
+  shortcut: ShortcutDescriptor
+): boolean => {
+  if (normalizeKey(event.key) !== normalizeKey(shortcut.key)) {
+    return false;
+  }
+
+  const expectsAlt = shortcut.altKey ?? false;
+  const expectsCtrl = shortcut.ctrlKey ?? false;
+  const expectsMeta = shortcut.metaKey ?? false;
+  const expectsShift = shortcut.shiftKey ?? false;
+
+  return (
+    event.altKey === expectsAlt &&
+    event.ctrlKey === expectsCtrl &&
+    event.metaKey === expectsMeta &&
+    event.shiftKey === expectsShift
+  );
+};
+
+const isEnabled = (shortcut: ShortcutDescriptor): boolean =>
+  shortcut.enabled !== false;
+
+const toArray = (
+  shortcuts: ShortcutDescriptor[] | ShortcutDescriptor
+): ShortcutDescriptor[] =>
+  Array.isArray(shortcuts) ? shortcuts : [shortcuts];
+
+const serialize = (shortcut: ShortcutDescriptor): string =>
+  [
+    normalizeKey(shortcut.key),
+    shortcut.altKey ? '1' : '0',
+    shortcut.ctrlKey ? '1' : '0',
+    shortcut.metaKey ? '1' : '0',
+    shortcut.shiftKey ? '1' : '0',
+    shortcut.allowRepeat ? '1' : '0',
+  ].join('');
+
+export const useGlobalShortcuts = (
+  shortcuts: ShortcutDescriptor[] | ShortcutDescriptor,
+  deps: DependencyList = []
+): void => {
+  const list = useMemo(() => toArray(shortcuts), [shortcuts]);
+  const signature = useMemo(
+    () => list.map(serialize).join('|'),
+    [list]
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!list.length) return;
+
+    const handler = (event: KeyboardEvent) => {
+      for (const shortcut of list) {
+        if (!isEnabled(shortcut)) continue;
+        if (!matchesShortcut(event, shortcut)) continue;
+        if (!shortcut.allowRepeat && event.repeat) continue;
+
+        if (shortcut.preventDefault !== false) {
+          event.preventDefault();
+        }
+        if (shortcut.stopPropagation) {
+          event.stopPropagation();
+        }
+        shortcut.handler(event);
+        break;
+      }
+    };
+
+    window.addEventListener('keydown', handler, { passive: false });
+    return () => {
+      window.removeEventListener('keydown', handler);
+    };
+  }, [list, signature, ...deps]);
+};

--- a/modules/desktop/windowManager.ts
+++ b/modules/desktop/windowManager.ts
@@ -1,0 +1,516 @@
+import {
+  LAYOUT_PRESET_LABELS,
+  LAYOUT_PRESETS,
+  LayoutPresetName,
+  StoredRect,
+  StoredWindowLayout,
+  WindowLayoutRepository,
+  createWindowLayoutRepository,
+} from '@/utils/storage/windowLayouts';
+
+export type Rect = StoredRect;
+
+export interface WindowPlacement extends Rect {
+  id: string;
+}
+
+export interface WindowPresetAssignment {
+  preset: LayoutPresetName;
+  slotIndex: number;
+}
+
+export interface SnapTarget {
+  id: string;
+  preset: LayoutPresetName;
+  slotIndex: number;
+  rect: Rect;
+  label: string;
+}
+
+export interface WindowManagerOptions {
+  displayId: string;
+  viewport: Rect;
+  repository?: WindowLayoutRepository;
+  initialOrder?: string[];
+  defaultPreset?: LayoutPresetName | null;
+}
+
+const isLayoutPreset = (value: string): value is LayoutPresetName =>
+  (LAYOUT_PRESETS as readonly string[]).includes(value);
+
+const normalizeRect = (rect: Rect): Rect => ({
+  x: rect.x,
+  y: rect.y,
+  width: rect.width,
+  height: rect.height,
+});
+
+const formatTargetLabel = (
+  preset: LayoutPresetName,
+  index: number,
+  total: number
+): string => {
+  const base = LAYOUT_PRESET_LABELS[preset];
+  if (total <= 1) return base;
+  return `${base} ${index + 1} of ${total}`;
+};
+
+const DEFAULT_MAIN_RATIO = 2 / 3;
+
+const computePresetRects = (
+  preset: LayoutPresetName,
+  viewport: Rect,
+  count: number
+): Rect[] => {
+  const { x, y, width, height } = viewport;
+  const full: Rect = { x, y, width, height };
+
+  switch (preset) {
+    case 'split-50-50': {
+      if (count <= 1) return [full];
+      const halfWidth = width / 2;
+      return [
+        { x, y, width: halfWidth, height },
+        { x: x + halfWidth, y, width: width - halfWidth, height },
+      ];
+    }
+    case 'thirds': {
+      const columnWidth = width / 3;
+      return [
+        { x, y, width: columnWidth, height },
+        { x: x + columnWidth, y, width: columnWidth, height },
+        { x: x + columnWidth * 2, y, width: width - columnWidth * 2, height },
+      ];
+    }
+    case 'seventy-thirty': {
+      if (count <= 1) return [full];
+      const mainWidth = width * 0.7;
+      return [
+        { x, y, width: mainWidth, height },
+        { x: x + mainWidth, y, width: width - mainWidth, height },
+      ];
+    }
+    case 'grid-2x2': {
+      const halfWidth = width / 2;
+      const halfHeight = height / 2;
+      return [
+        { x, y, width: halfWidth, height: halfHeight },
+        { x: x + halfWidth, y, width: width - halfWidth, height: halfHeight },
+        { x, y: y + halfHeight, width: halfWidth, height: height - halfHeight },
+        {
+          x: x + halfWidth,
+          y: y + halfHeight,
+          width: width - halfWidth,
+          height: height - halfHeight,
+        },
+      ];
+    }
+    case 'main-plus-side': {
+      if (count <= 1) return [full];
+      const mainWidth = width * DEFAULT_MAIN_RATIO;
+      const sideWidth = width - mainWidth;
+      const sideHeight = height / 2;
+      return [
+        { x, y, width: mainWidth, height },
+        { x: x + mainWidth, y, width: sideWidth, height: sideHeight },
+        {
+          x: x + mainWidth,
+          y: y + sideHeight,
+          width: sideWidth,
+          height: height - sideHeight,
+        },
+      ];
+    }
+    default:
+      return [full];
+  }
+};
+
+const cloneRect = (rect: Rect): Rect => ({ ...rect });
+
+export class WindowManager {
+  private repository: WindowLayoutRepository;
+  private windows = new Map<string, Rect>();
+  private assignments = new Map<string, WindowPresetAssignment>();
+  private order: string[] = [];
+  private snapshotLoaded = false;
+  private snapshot: StoredWindowLayout | null = null;
+  private currentPreset: LayoutPresetName | null;
+  private viewport: Rect;
+
+  constructor(private options: WindowManagerOptions) {
+    this.viewport = cloneRect(options.viewport);
+    this.repository = options.repository ?? createWindowLayoutRepository();
+    this.currentPreset = options.defaultPreset ?? null;
+    if (options.initialOrder) {
+      this.order = [...options.initialOrder];
+    }
+  }
+
+  private get displayId(): string {
+    return this.options.displayId;
+  }
+
+  private ensureSnapshot(): void {
+    if (this.snapshotLoaded) return;
+    this.snapshotLoaded = true;
+    this.snapshot = this.repository.load(this.displayId) ?? null;
+    if (!this.snapshot) return;
+
+    this.currentPreset = this.snapshot.preset;
+    this.order = [...this.snapshot.order];
+
+    Object.entries(this.snapshot.positions).forEach(([id, rect]) => {
+      this.windows.set(id, cloneRect(rect));
+    });
+
+    Object.entries(this.snapshot.assignments).forEach(
+      ([id, assignment]) => {
+        this.assignments.set(id, {
+          preset: assignment.preset,
+          slotIndex: assignment.slot,
+        });
+      }
+    );
+  }
+
+  private ensureWindowOrder(windowId: string, toFront = false): void {
+    this.order = this.order.filter((id) => id !== windowId);
+    if (toFront) {
+      this.order.unshift(windowId);
+    } else {
+      this.order.push(windowId);
+    }
+    this.order = Array.from(new Set(this.order));
+  }
+
+  private defaultBounds(): Rect {
+    const width = this.viewport.width * 0.6;
+    const height = this.viewport.height * 0.6;
+    const x = this.viewport.x + (this.viewport.width - width) / 2;
+    const y = this.viewport.y + (this.viewport.height - height) / 2;
+    return { x, y, width, height };
+  }
+
+  private persist(): void {
+    if (!this.repository) return;
+    const positions: Record<string, Rect> = {};
+    for (const [id, rect] of this.windows.entries()) {
+      positions[id] = cloneRect(rect);
+    }
+    const assignments: StoredWindowLayout['assignments'] = {};
+    for (const [id, assignment] of this.assignments.entries()) {
+      assignments[id] = {
+        preset: assignment.preset,
+        slot: assignment.slotIndex,
+      };
+    }
+
+    const order = this.order.filter((id) => this.windows.has(id));
+
+    const snapshot: StoredWindowLayout = {
+      preset: this.currentPreset ?? null,
+      order,
+      positions,
+      assignments,
+      updatedAt: Date.now(),
+    };
+
+    this.repository.save(this.displayId, snapshot);
+  }
+
+  private refreshPreset(
+    preset: LayoutPresetName,
+    priority?: string
+  ): void {
+    const entries = Array.from(this.assignments.entries()).filter(
+      ([, assignment]) => assignment.preset === preset
+    );
+    if (!entries.length) return;
+
+    const slots = computePresetRects(
+      preset,
+      this.viewport,
+      Math.max(entries.length, 1)
+    );
+    const slotCount = slots.length || 1;
+    const used = new Set<number>();
+
+    const assignSlot = (windowId: string, desired: number) => {
+      let slotIndex = ((desired % slotCount) + slotCount) % slotCount;
+      if (slotCount > 0 && used.size < slotCount) {
+        let attempts = 0;
+        while (used.has(slotIndex) && attempts < slotCount) {
+          slotIndex = (slotIndex + 1) % slotCount;
+          attempts += 1;
+        }
+      }
+      used.add(slotIndex);
+      const rect = slots[slotIndex] ?? cloneRect(this.viewport);
+      this.assignments.set(windowId, { preset, slotIndex });
+      this.windows.set(windowId, cloneRect(rect));
+    };
+
+    if (priority) {
+      const entry = entries.find(([id]) => id === priority);
+      if (entry) {
+        assignSlot(entry[0], entry[1].slotIndex);
+      }
+    }
+
+    for (const [id, assignment] of entries) {
+      if (id === priority) continue;
+      assignSlot(id, assignment.slotIndex);
+    }
+  }
+
+  private resolveTarget(target: SnapTarget | string): SnapTarget | null {
+    if (typeof target !== 'string') {
+      return target;
+    }
+    const [presetKey, slotPart] = target.split(':');
+    if (!presetKey || !slotPart || !isLayoutPreset(presetKey)) {
+      return null;
+    }
+    const slotIndex = Number.parseInt(slotPart, 10);
+    if (Number.isNaN(slotIndex)) return null;
+
+    const slots = computePresetRects(
+      presetKey,
+      this.viewport,
+      Math.max(this.windows.size, slotIndex + 1, 1)
+    );
+    const rect = slots[slotIndex];
+    if (!rect) {
+      return null;
+    }
+    return {
+      id: `${presetKey}:${slotIndex}`,
+      preset: presetKey,
+      slotIndex,
+      rect,
+      label: formatTargetLabel(presetKey, slotIndex, slots.length),
+    };
+  }
+
+  public getCurrentPreset(): LayoutPresetName | null {
+    this.ensureSnapshot();
+    return this.currentPreset;
+  }
+
+  public setViewport(viewport: Rect, options: { reflow?: boolean } = {}): void {
+    this.viewport = cloneRect(viewport);
+    if (options.reflow !== false) {
+      const presets = new Set<LayoutPresetName>();
+      for (const assignment of this.assignments.values()) {
+        presets.add(assignment.preset);
+      }
+      presets.forEach((preset) => this.refreshPreset(preset));
+      this.persist();
+    }
+  }
+
+  public registerWindow(windowId: string, initialBounds?: Rect): Rect {
+    this.ensureSnapshot();
+
+    if (!this.windows.has(windowId)) {
+      const stored = this.snapshot?.positions?.[windowId];
+      const rect = stored
+        ? cloneRect(stored)
+        : initialBounds
+        ? cloneRect(initialBounds)
+        : this.defaultBounds();
+      this.windows.set(windowId, normalizeRect(rect));
+    } else if (initialBounds) {
+      this.windows.set(windowId, cloneRect(initialBounds));
+    }
+
+    if (this.snapshot?.assignments?.[windowId]) {
+      const assignment = this.snapshot.assignments[windowId];
+      this.assignments.set(windowId, {
+        preset: assignment.preset,
+        slotIndex: assignment.slot,
+      });
+      this.currentPreset = assignment.preset;
+    }
+
+    this.ensureWindowOrder(windowId);
+    return cloneRect(this.windows.get(windowId)!);
+  }
+
+  public unregisterWindow(windowId: string): void {
+    this.ensureSnapshot();
+    this.windows.delete(windowId);
+    this.assignments.delete(windowId);
+    this.order = this.order.filter((id) => id !== windowId);
+    this.persist();
+  }
+
+  public updateWindowBounds(windowId: string, rect: Rect): void {
+    this.ensureSnapshot();
+    this.windows.set(windowId, cloneRect(rect));
+    this.persist();
+  }
+
+  public getWindowBounds(windowId: string): Rect | undefined {
+    this.ensureSnapshot();
+    const rect = this.windows.get(windowId);
+    return rect ? cloneRect(rect) : undefined;
+  }
+
+  public getWindows(): WindowPlacement[] {
+    this.ensureSnapshot();
+    const seen = new Set<string>();
+    const ordered: WindowPlacement[] = [];
+    for (const id of this.order) {
+      const rect = this.windows.get(id);
+      if (!rect) continue;
+      ordered.push({ id, ...cloneRect(rect) });
+      seen.add(id);
+    }
+    for (const [id, rect] of this.windows.entries()) {
+      if (seen.has(id)) continue;
+      ordered.push({ id, ...cloneRect(rect) });
+    }
+    return ordered;
+  }
+
+  public applyPreset(
+    preset: LayoutPresetName,
+    options: { persist?: boolean } = {}
+  ): Record<string, Rect> {
+    this.ensureSnapshot();
+    const windows = this.getWindows();
+    if (!windows.length) {
+      this.currentPreset = preset;
+      if (options.persist !== false) {
+        this.persist();
+      }
+      return {};
+    }
+
+    const slots = computePresetRects(preset, this.viewport, windows.length);
+    const slotCount = slots.length || 1;
+    const placements: Record<string, Rect> = {};
+
+    this.assignments.clear();
+
+    windows.forEach((window, index) => {
+      const slotIndex = slotCount ? index % slotCount : 0;
+      const rect = slots[slotIndex] ?? cloneRect(this.viewport);
+      this.windows.set(window.id, cloneRect(rect));
+      this.assignments.set(window.id, { preset, slotIndex });
+      placements[window.id] = cloneRect(rect);
+    });
+
+    this.currentPreset = preset;
+    if (options.persist !== false) {
+      this.persist();
+    }
+    return placements;
+  }
+
+  public cyclePreset(step = 1): LayoutPresetName {
+    this.ensureSnapshot();
+    const current = this.currentPreset;
+    const currentIndex = current ? LAYOUT_PRESETS.indexOf(current) : -1;
+    const nextIndex =
+      (currentIndex + step + LAYOUT_PRESETS.length) % LAYOUT_PRESETS.length;
+    const nextPreset = LAYOUT_PRESETS[nextIndex];
+    this.applyPreset(nextPreset);
+    return nextPreset;
+  }
+
+  public getAssignments(): Record<string, WindowPresetAssignment> {
+    this.ensureSnapshot();
+    const result: Record<string, WindowPresetAssignment> = {};
+    for (const [id, assignment] of this.assignments.entries()) {
+      result[id] = { ...assignment };
+    }
+    return result;
+  }
+
+  public getSnapTargets(options: {
+    preset?: LayoutPresetName;
+    includeAll?: boolean;
+  } = {}): SnapTarget[] {
+    this.ensureSnapshot();
+    const count = Math.max(this.windows.size, 1);
+    const { preset, includeAll = false } = options;
+
+    const buildTargets = (layout: LayoutPresetName): SnapTarget[] => {
+      const slots = computePresetRects(layout, this.viewport, count);
+      return slots.map((rect, index) => ({
+        id: `${layout}:${index}`,
+        preset: layout,
+        slotIndex: index,
+        rect: cloneRect(rect),
+        label: formatTargetLabel(layout, index, slots.length),
+      }));
+    };
+
+    if (includeAll) {
+      return LAYOUT_PRESETS.flatMap((name) => buildTargets(name));
+    }
+
+    const activePreset = preset ?? this.currentPreset ?? 'split-50-50';
+    return buildTargets(activePreset);
+  }
+
+  public snapWindowToTarget(
+    windowId: string,
+    target: SnapTarget | string
+  ): Rect | null {
+    this.ensureSnapshot();
+    if (!this.windows.has(windowId)) {
+      this.registerWindow(windowId);
+    }
+    const resolved = this.resolveTarget(target);
+    if (!resolved) return null;
+
+    this.assignments.set(windowId, {
+      preset: resolved.preset,
+      slotIndex: resolved.slotIndex,
+    });
+    this.currentPreset = resolved.preset;
+    this.ensureWindowOrder(windowId, true);
+    this.refreshPreset(resolved.preset, windowId);
+    this.persist();
+    return cloneRect(this.windows.get(windowId)!);
+  }
+
+  public clearPersistentLayout(): void {
+    this.assignments.clear();
+    this.currentPreset = null;
+    this.repository.clear(this.displayId);
+    this.persist();
+  }
+
+  public exportLayout(): StoredWindowLayout {
+    this.ensureSnapshot();
+    const positions: Record<string, Rect> = {};
+    for (const [id, rect] of this.windows.entries()) {
+      positions[id] = cloneRect(rect);
+    }
+    const assignments: StoredWindowLayout['assignments'] = {};
+    for (const [id, assignment] of this.assignments.entries()) {
+      assignments[id] = {
+        preset: assignment.preset,
+        slot: assignment.slotIndex,
+      };
+    }
+    return {
+      preset: this.currentPreset,
+      order: this.order.filter((id) => this.windows.has(id)),
+      positions,
+      assignments,
+      updatedAt: Date.now(),
+    };
+  }
+}
+
+export const getPresetRects = (
+  preset: LayoutPresetName,
+  viewport: Rect,
+  count: number
+): Rect[] => computePresetRects(preset, viewport, count);

--- a/utils/storage/windowLayouts.ts
+++ b/utils/storage/windowLayouts.ts
@@ -1,0 +1,133 @@
+import { safeLocalStorage } from '../safeStorage';
+
+export const WINDOW_LAYOUT_STORAGE_KEY = 'desktop:window-layouts';
+
+export type LayoutPresetName =
+  | 'split-50-50'
+  | 'thirds'
+  | 'seventy-thirty'
+  | 'grid-2x2'
+  | 'main-plus-side';
+
+export const LAYOUT_PRESETS: LayoutPresetName[] = [
+  'split-50-50',
+  'thirds',
+  'seventy-thirty',
+  'grid-2x2',
+  'main-plus-side',
+];
+
+export const LAYOUT_PRESET_LABELS: Record<LayoutPresetName, string> = {
+  'split-50-50': '50/50 Split',
+  thirds: 'Thirds',
+  'seventy-thirty': '70/30 Split',
+  'grid-2x2': '2x2 Grid',
+  'main-plus-side': 'Main with Side Rail',
+};
+
+export interface StoredRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface StoredWindowAssignment {
+  preset: LayoutPresetName;
+  slot: number;
+}
+
+export interface StoredWindowLayout {
+  preset: LayoutPresetName | null;
+  order: string[];
+  positions: Record<string, StoredRect>;
+  assignments: Record<string, StoredWindowAssignment>;
+  updatedAt: number;
+}
+
+export type StoredWindowLayouts = Record<string, StoredWindowLayout>;
+
+export interface WindowLayoutRepository {
+  load(displayId: string): StoredWindowLayout | undefined;
+  save(displayId: string, layout: StoredWindowLayout): void;
+  clear(displayId: string): void;
+  all(): StoredWindowLayouts;
+}
+
+const readState = (storage: Storage | undefined): StoredWindowLayouts => {
+  if (!storage) return {};
+  try {
+    const raw = storage.getItem(WINDOW_LAYOUT_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as StoredWindowLayouts;
+    if (parsed && typeof parsed === 'object') {
+      return parsed;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+};
+
+const writeState = (
+  storage: Storage | undefined,
+  state: StoredWindowLayouts
+): void => {
+  if (!storage) return;
+  try {
+    storage.setItem(WINDOW_LAYOUT_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // ignore storage errors (quota, privacy settings, etc.)
+  }
+};
+
+export const createWindowLayoutRepository = (
+  storage: Storage | undefined = safeLocalStorage
+): WindowLayoutRepository => {
+  return {
+    load(displayId) {
+      const state = readState(storage);
+      return state[displayId];
+    },
+    save(displayId, layout) {
+      const state = readState(storage);
+      state[displayId] = layout;
+      writeState(storage, state);
+    },
+    clear(displayId) {
+      const state = readState(storage);
+      if (displayId in state) {
+        delete state[displayId];
+        writeState(storage, state);
+      }
+    },
+    all() {
+      const state = readState(storage);
+      return { ...state };
+    },
+  };
+};
+
+export const createMemoryWindowLayoutRepository = (
+  initial: StoredWindowLayouts = {}
+): WindowLayoutRepository => {
+  let state: StoredWindowLayouts = { ...initial };
+  return {
+    load(displayId) {
+      return state[displayId];
+    },
+    save(displayId, layout) {
+      state = { ...state, [displayId]: { ...layout } };
+    },
+    clear(displayId) {
+      if (!(displayId in state)) return;
+      const { [displayId]: _removed, ...rest } = state;
+      state = rest;
+    },
+    all() {
+      return { ...state };
+    },
+  };
+};
+
+export const windowLayoutRepository = createWindowLayoutRepository();


### PR DESCRIPTION
## Summary
- add a desktop window manager that can tile windows using preset layouts, persist assignments per display, and expose snap targets
- introduce a SnapTargets overlay with keyboard-driven cycling and selection backed by a global shortcuts hook
- persist layout metadata in windowLayouts storage utilities and cover snap/persistence flows with a new desktop smoke test

## Testing
- yarn lint *(fails: numerous pre-existing accessibility and no-top-level-window lint violations throughout apps and public bundles)*
- yarn test --watch=false *(fails: existing suites such as nmapNse and desktop/window snapshots, run aborted after ~188s due to long execution)*

------
https://chatgpt.com/codex/tasks/task_e_68cb465ea8148328adf43f59c1da0fc1