### PR TITLE
[shell] add contrast auditor developer tool

### DIFF
--- a/__tests__/utils/colorAudit.test.ts
+++ b/__tests__/utils/colorAudit.test.ts
@@ -1,0 +1,86 @@
+import { auditDocument, contrastRatio, parseColor } from '../../utils/colorAudit';
+
+const mockRect = (element: HTMLElement) => {
+  element.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 120,
+      bottom: 24,
+      width: 120,
+      height: 24,
+      toJSON: () => {},
+    }) as DOMRect;
+};
+
+describe('colorAudit utilities', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    document.body.removeAttribute('style');
+  });
+
+  it('computes contrast ratios using WCAG formula', () => {
+    const white = parseColor('#ffffff');
+    const black = parseColor('#000000');
+    expect(white).not.toBeNull();
+    expect(black).not.toBeNull();
+    expect(contrastRatio(white!, black!)).toBeCloseTo(21, 5);
+  });
+
+  it('detects text below the minimum contrast threshold', () => {
+    document.body.style.backgroundColor = '#F6F6F5';
+
+    const failing = document.createElement('div');
+    failing.textContent = 'Low contrast copy';
+    Object.assign(failing.style, {
+      color: '#7D7F83',
+      backgroundColor: '#F6F6F5',
+      fontSize: '16px',
+    });
+    mockRect(failing);
+    document.body.appendChild(failing);
+
+    const passing = document.createElement('div');
+    passing.textContent = 'Accessible text';
+    Object.assign(passing.style, {
+      color: '#333333',
+      backgroundColor: '#F6F6F5',
+      fontSize: '16px',
+    });
+    mockRect(passing);
+    document.body.appendChild(passing);
+
+    const reports = auditDocument(document);
+    expect(reports).toHaveLength(1);
+    const [issue] = reports;
+    expect(issue.text).toContain('Low contrast');
+    expect(issue.ratio).toBeLessThan(issue.threshold);
+    expect(issue.foreground).toBe('#7D7F83');
+    expect(issue.background).toBe('#F6F6F5');
+  });
+
+  it('maps failing colors to token suggestions', () => {
+    document.body.style.backgroundColor = '#F6F6F5';
+
+    const paragraph = document.createElement('p');
+    paragraph.textContent = 'Needs better contrast';
+    Object.assign(paragraph.style, {
+      color: '#7D7F83',
+      backgroundColor: '#F6F6F5',
+      fontSize: '16px',
+    });
+    mockRect(paragraph);
+    document.body.appendChild(paragraph);
+
+    const reports = auditDocument(document);
+    expect(reports).toHaveLength(1);
+    const [issue] = reports;
+    expect(issue).toBeDefined();
+    expect(issue.tokenLink?.token).toBe('--color-ub-warm-grey');
+    expect(issue.suggestions.length).toBeGreaterThan(0);
+    const suggestionTokens = issue.suggestions.map(suggestion => suggestion.token);
+    expect(suggestionTokens).toContain('--color-ubt-cool-grey');
+  });
+});

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import DeveloperMenu from '../ui/DeveloperMenu';
 import WhiskerMenu from '../menu/WhiskerMenu';
 
 export default class Navbar extends Component {
@@ -41,7 +42,8 @@ export default class Navbar extends Component {
                                         <Status />
                                         <QuickSettings open={this.state.status_card} />
                                 </button>
-			</div>
-		);
-	}
+                                <DeveloperMenu />
+                        </div>
+                );
+        }
 }

--- a/components/tools/ContrastAuditor.tsx
+++ b/components/tools/ContrastAuditor.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  DEVTOOLS_IGNORE_ATTR,
+  auditDocument,
+  type ContrastReport,
+} from '../../utils/colorAudit';
+import { useDeveloperTools } from '../../hooks/useDeveloperTools';
+
+const PANEL_MAX_HEIGHT = '60vh';
+
+const ContrastAuditor = (): JSX.Element | null => {
+  const { tools, setTool } = useDeveloperTools();
+  const [reports, setReports] = useState<ContrastReport[]>([]);
+
+  const runAudit = useCallback(() => {
+    if (typeof document === 'undefined') return;
+    const nextReports = auditDocument(document);
+    setReports(nextReports);
+  }, []);
+
+  useEffect(() => {
+    if (!tools.contrastAuditor) {
+      setReports([]);
+      return;
+    }
+
+    runAudit();
+
+    const handle = () => {
+      window.requestAnimationFrame(runAudit);
+    };
+
+    window.addEventListener('resize', handle);
+    window.addEventListener('scroll', handle, true);
+
+    const observer = new MutationObserver(handle);
+    observer.observe(document.body, {
+      subtree: true,
+      childList: true,
+      characterData: true,
+      attributes: true,
+    });
+
+    return () => {
+      window.removeEventListener('resize', handle);
+      window.removeEventListener('scroll', handle, true);
+      observer.disconnect();
+    };
+  }, [runAudit, tools.contrastAuditor]);
+
+  const ignoreAttr = useMemo(
+    () => ({ [DEVTOOLS_IGNORE_ATTR]: 'true' } as Record<string, string>),
+    [],
+  );
+
+  if (!tools.contrastAuditor) {
+    return null;
+  }
+
+  const violationSummary =
+    reports.length > 0
+      ? `${reports.length} text block${reports.length === 1 ? '' : 's'} below WCAG thresholds`
+      : 'No violations detected';
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-0 z-[1200]"
+      {...ignoreAttr}
+      aria-hidden="true"
+    >
+      {reports.map((report, index) => (
+        <div
+          key={`${report.selector}-${index}`}
+          className="absolute pointer-events-none border border-red-500/80 bg-red-500/10"
+          style={{
+            top: report.bounding.top,
+            left: report.bounding.left,
+            width: report.bounding.width,
+            height: report.bounding.height,
+          }}
+          {...ignoreAttr}
+        >
+          <div
+            className="absolute -top-6 left-0 px-2 py-1 bg-red-600 text-xs text-white rounded shadow pointer-events-none"
+            {...ignoreAttr}
+          >
+            {report.ratio.toFixed(2)} : 1
+          </div>
+        </div>
+      ))}
+
+      <aside
+        className="pointer-events-auto fixed bottom-4 right-4 w-80 max-w-full text-sm bg-ub-grey/95 text-white rounded-md border border-white/20 shadow-lg"
+        {...ignoreAttr}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-white/10">
+          <div>
+            <h2 className="text-base font-semibold">Contrast auditor</h2>
+            <p className="text-xs text-ubt-warm-grey">{violationSummary}</p>
+          </div>
+          <button
+            type="button"
+            className="text-xs underline"
+            onClick={() => setTool('contrastAuditor', false)}
+          >
+            Close
+          </button>
+        </div>
+        <div
+          className="px-4 py-3 space-y-3 overflow-y-auto"
+          style={{ maxHeight: PANEL_MAX_HEIGHT }}
+        >
+          <button
+            type="button"
+            className="text-xs px-2 py-1 bg-black/30 rounded"
+            onClick={runAudit}
+          >
+            Re-run analysis
+          </button>
+          {reports.length === 0 ? (
+            <p className="text-xs text-ubt-warm-grey">
+              All sampled text meets the minimum contrast requirement.
+            </p>
+          ) : (
+            <ul className="space-y-3">
+              {reports.map((report, index) => (
+                <li key={`${report.selector}-summary-${index}`} className="border border-white/10 rounded p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-mono text-xs break-all">{report.selector}</span>
+                    <span className="text-xs font-semibold text-red-300">
+                      {report.ratio.toFixed(2)} : 1
+                    </span>
+                  </div>
+                  <p className="mt-2 text-xs text-ubt-warm-grey">
+                    {report.text}
+                  </p>
+                  <p className="mt-2 text-xs">
+                    <span className="block">Foreground: {report.foreground}</span>
+                    <span className="block">Background: {report.background}</span>
+                    <span className="block">
+                      Required: {report.threshold.toFixed(1)} : 1
+                    </span>
+                  </p>
+                  {report.tokenLink && (
+                    <a
+                      href={report.tokenLink.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="mt-2 inline-block text-xs text-ubt-blue underline"
+                    >
+                      View token {report.tokenLink.token}
+                    </a>
+                  )}
+                  {report.suggestions.length > 0 && (
+                    <div className="mt-2">
+                      <p className="text-xs text-ubt-warm-grey">Suggested tokens:</p>
+                      <ul className="mt-1 space-y-1">
+                        {report.suggestions.map(token => (
+                          <li key={token.token}>
+                            <a
+                              href={token.url}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="text-xs text-ubt-blue underline"
+                            >
+                              {token.token} · {token.value}
+                            </a>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+};
+
+export default ContrastAuditor;

--- a/components/ui/DeveloperMenu.tsx
+++ b/components/ui/DeveloperMenu.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useRef, useState } from 'react';
+import { useDeveloperTools } from '../../hooks/useDeveloperTools';
+import { DEVTOOLS_IGNORE_ATTR } from '../../utils/colorAudit';
+
+const DeveloperMenu = (): JSX.Element => {
+  const { tools, setTool } = useDeveloperTools();
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (!menuRef.current || !buttonRef.current) return;
+      if (
+        !menuRef.current.contains(target) &&
+        !buttonRef.current.contains(target)
+      ) {
+        setOpen(false);
+      }
+    };
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open]);
+
+  const ignoreAttr = { [DEVTOOLS_IGNORE_ATTR]: 'true' } as Record<string, string>;
+
+  return (
+    <div className="relative" data-devtools-menu="true" {...ignoreAttr}>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-controls="developer-menu"
+      >
+        Dev Tools
+      </button>
+      {open && (
+        <div
+          ref={menuRef}
+          id="developer-menu"
+          role="menu"
+          className="absolute right-0 mt-1 z-50 w-64 bg-ub-grey text-white border border-black/60 rounded shadow-lg"
+          {...ignoreAttr}
+        >
+          <div className="px-4 py-3 border-b border-white/10">
+            <h3 className="text-sm font-semibold">Developer Utilities</h3>
+            <p className="mt-1 text-xs text-ubt-warm-grey">
+              Experimental overlays to help audit the desktop shell.
+            </p>
+          </div>
+          <label
+            className="flex items-start gap-2 px-4 py-3 text-sm hover:bg-white/5 cursor-pointer"
+            role="menuitemcheckbox"
+            aria-checked={tools.contrastAuditor}
+            {...ignoreAttr}
+          >
+            <input
+              type="checkbox"
+              className="mt-0.5"
+              checked={tools.contrastAuditor}
+              onChange={event => setTool('contrastAuditor', event.target.checked)}
+            />
+            <span>
+              <span className="block font-medium">Contrast auditor</span>
+              <span className="block text-xs text-ubt-warm-grey">
+                Highlights text nodes with insufficient WCAG 2.1 contrast ratios.
+              </span>
+            </span>
+          </label>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DeveloperMenu;

--- a/data/design-portal.json
+++ b/data/design-portal.json
@@ -1,0 +1,62 @@
+[
+  {
+    "token": "--color-ub-grey",
+    "value": "#0F1317",
+    "name": "Surface / Base",
+    "url": "https://design.unnippillil.com/tokens/color-ub-grey"
+  },
+  {
+    "token": "--color-ub-cool-grey",
+    "value": "#1A1F26",
+    "name": "Surface / Raised",
+    "url": "https://design.unnippillil.com/tokens/color-ub-cool-grey"
+  },
+  {
+    "token": "--color-ub-warm-grey",
+    "value": "#7D7F83",
+    "name": "Neutral / Warm Grey",
+    "url": "https://design.unnippillil.com/tokens/color-ub-warm-grey"
+  },
+  {
+    "token": "--color-ubt-grey",
+    "value": "#F6F6F5",
+    "name": "Text / Primary",
+    "url": "https://design.unnippillil.com/tokens/color-ubt-grey"
+  },
+  {
+    "token": "--color-ubt-cool-grey",
+    "value": "#333333",
+    "name": "Text / Secondary",
+    "url": "https://design.unnippillil.com/tokens/color-ubt-cool-grey"
+  },
+  {
+    "token": "--color-text",
+    "value": "#F5F5F5",
+    "name": "Text / Default",
+    "url": "https://design.unnippillil.com/tokens/color-text"
+  },
+  {
+    "token": "--color-ub-orange",
+    "value": "#1793D1",
+    "name": "Accent / Primary",
+    "url": "https://design.unnippillil.com/tokens/color-ub-orange"
+  },
+  {
+    "token": "--game-color-success",
+    "value": "#15803D",
+    "name": "Game / Success",
+    "url": "https://design.unnippillil.com/tokens/game-color-success"
+  },
+  {
+    "token": "--game-color-warning",
+    "value": "#D97706",
+    "name": "Game / Warning",
+    "url": "https://design.unnippillil.com/tokens/game-color-warning"
+  },
+  {
+    "token": "--game-color-danger",
+    "value": "#B91C1C",
+    "name": "Game / Danger",
+    "url": "https://design.unnippillil.com/tokens/game-color-danger"
+  }
+]

--- a/hooks/useDeveloperTools.ts
+++ b/hooks/useDeveloperTools.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { createContext, useContext, useMemo, type PropsWithChildren } from 'react';
+import usePersistentState from './usePersistentState';
+
+export type DeveloperToolsState = {
+  contrastAuditor: boolean;
+};
+
+const DEFAULT_STATE: DeveloperToolsState = {
+  contrastAuditor: false,
+};
+
+const isValidState = (value: unknown): value is DeveloperToolsState =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as DeveloperToolsState).contrastAuditor === 'boolean';
+
+type DeveloperToolKey = keyof DeveloperToolsState;
+
+export interface DeveloperToolsContextValue {
+  tools: DeveloperToolsState;
+  setTool: (tool: DeveloperToolKey, value: boolean) => void;
+  toggleTool: (tool: DeveloperToolKey) => void;
+  reset: () => void;
+}
+
+const DeveloperToolsContext = createContext<DeveloperToolsContextValue>({
+  tools: DEFAULT_STATE,
+  setTool: () => {},
+  toggleTool: () => {},
+  reset: () => {},
+});
+
+export const DeveloperToolsProvider = ({ children }: PropsWithChildren): JSX.Element => {
+  const [tools, setTools, resetTools] = usePersistentState<DeveloperToolsState>(
+    'developer-tools',
+    DEFAULT_STATE,
+    isValidState,
+  );
+
+  const value = useMemo<DeveloperToolsContextValue>(() => {
+    const setTool: DeveloperToolsContextValue['setTool'] = (tool, value) => {
+      setTools(prev => ({
+        ...prev,
+        [tool]: value,
+      }));
+    };
+
+    const toggleTool: DeveloperToolsContextValue['toggleTool'] = tool => {
+      setTools(prev => ({
+        ...prev,
+        [tool]: !prev[tool],
+      }));
+    };
+
+    const reset = () => {
+      resetTools();
+    };
+
+    return {
+      tools,
+      setTool,
+      toggleTool,
+      reset,
+    };
+  }, [resetTools, setTools, tools]);
+
+  return <DeveloperToolsContext.Provider value={value}>{children}</DeveloperToolsContext.Provider>;
+};
+
+export const useDeveloperTools = (): DeveloperToolsContextValue => useContext(DeveloperToolsContext);

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,11 +11,13 @@ import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import { DeveloperToolsProvider } from '../hooks/useDeveloperTools';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import ContrastAuditor from '../components/tools/ContrastAuditor';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -157,21 +159,24 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+          <DeveloperToolsProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <ContrastAuditor />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </DeveloperToolsProvider>
         </SettingsProvider>
       </div>
     </ErrorBoundary>

--- a/utils/colorAudit.ts
+++ b/utils/colorAudit.ts
@@ -1,0 +1,355 @@
+import designPortal from '../data/design-portal.json';
+
+export const DEVTOOLS_IGNORE_ATTR = 'data-devtools-ignore';
+
+export interface RGBA {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+export interface TokenLink {
+  token: string;
+  name: string;
+  value: string;
+  url: string;
+}
+
+export interface ContrastReport {
+  selector: string;
+  text: string;
+  ratio: number;
+  threshold: number;
+  isLargeText: boolean;
+  foreground: string;
+  background: string;
+  bounding: {
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+  };
+  tokenLink?: TokenLink;
+  suggestions: TokenLink[];
+}
+
+interface DesignPortalEntry {
+  token: string;
+  value: string;
+  name: string;
+  url: string;
+  category?: string;
+}
+
+const isDesignPortalEntry = (value: unknown): value is DesignPortalEntry => {
+  if (!value || typeof value !== 'object') return false;
+  const entry = value as Partial<DesignPortalEntry>;
+  return (
+    typeof entry.token === 'string' &&
+    typeof entry.value === 'string' &&
+    typeof entry.name === 'string' &&
+    typeof entry.url === 'string'
+  );
+};
+
+const designEntries: DesignPortalEntry[] = Array.isArray(designPortal)
+  ? designPortal.filter(isDesignPortalEntry)
+  : [];
+
+const DEFAULT_BACKGROUND: RGBA = { r: 255, g: 255, b: 255, a: 1 };
+
+const normalizeHex = (value: string): string => {
+  let hex = value.trim();
+  if (!hex.startsWith('#')) {
+    return hex.toUpperCase();
+  }
+  hex = hex.slice(1);
+  if (hex.length === 3) {
+    hex = hex
+      .split('')
+      .map(ch => ch + ch)
+      .join('');
+  }
+  if (hex.length !== 6) return `#${hex}`.toUpperCase();
+  return `#${hex.toUpperCase()}`;
+};
+
+export const parseColor = (value: string | null | undefined): RGBA | null => {
+  if (!value) return null;
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) return null;
+  if (trimmed === 'transparent' || trimmed === 'none') {
+    return { ...DEFAULT_BACKGROUND, a: 0 };
+  }
+  if (trimmed.startsWith('#')) {
+    let hex = trimmed.slice(1);
+    if (hex.length === 3) {
+      hex = hex
+        .split('')
+        .map(ch => ch + ch)
+        .join('');
+    }
+    if (hex.length === 6) {
+      const int = parseInt(hex, 16);
+      return {
+        r: (int >> 16) & 255,
+        g: (int >> 8) & 255,
+        b: int & 255,
+        a: 1,
+      };
+    }
+    return null;
+  }
+
+  const match = trimmed.match(/rgba?\(([^)]+)\)/);
+  if (!match) return null;
+
+  const parts = match[1]
+    .split(/[\s,\/]+/)
+    .map(part => part.trim())
+    .filter(Boolean)
+    .map(part => (part.endsWith('%') ? (parseFloat(part) / 100) * 255 : parseFloat(part)));
+
+  if (parts.length < 3) return null;
+
+  const [r, g, b, alpha] = parts;
+  return {
+    r: Math.max(0, Math.min(255, Math.round(r))),
+    g: Math.max(0, Math.min(255, Math.round(g))),
+    b: Math.max(0, Math.min(255, Math.round(b))),
+    a: typeof alpha === 'number' && !Number.isNaN(alpha) ? Math.max(0, Math.min(1, alpha)) : 1,
+  };
+};
+
+export const relativeLuminance = ({ r, g, b }: RGBA): number => {
+  const toLinear = (channel: number) => {
+    const srgb = channel / 255;
+    return srgb <= 0.03928 ? srgb / 12.92 : Math.pow((srgb + 0.055) / 1.055, 2.4);
+  };
+  const R = toLinear(r);
+  const G = toLinear(g);
+  const B = toLinear(b);
+  return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+};
+
+export const contrastRatio = (foreground: RGBA, background: RGBA): number => {
+  const lum1 = relativeLuminance(foreground);
+  const lum2 = relativeLuminance(background);
+  const lighter = Math.max(lum1, lum2);
+  const darker = Math.min(lum1, lum2);
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+const blend = (foreground: RGBA, background: RGBA): RGBA => {
+  const alpha = foreground.a + background.a * (1 - foreground.a);
+  if (alpha <= 0) {
+    return { r: 0, g: 0, b: 0, a: 0 };
+  }
+  return {
+    r: Math.round((foreground.r * foreground.a + background.r * background.a * (1 - foreground.a)) / alpha),
+    g: Math.round((foreground.g * foreground.a + background.g * background.a * (1 - foreground.a)) / alpha),
+    b: Math.round((foreground.b * foreground.a + background.b * background.a * (1 - foreground.a)) / alpha),
+    a: alpha,
+  };
+};
+
+const rgbaToHex = (color: RGBA): string =>
+  `#${[color.r, color.g, color.b]
+    .map(channel => channel.toString(16).padStart(2, '0'))
+    .join('')}`.toUpperCase();
+
+const tokenByValue: Map<string, TokenLink> = new Map();
+
+designEntries.forEach(entry => {
+  const hex = normalizeHex(entry.value);
+  if (!tokenByValue.has(hex)) {
+    tokenByValue.set(hex, {
+      token: entry.token,
+      name: entry.name,
+      value: hex,
+      url: entry.url,
+    });
+  }
+});
+
+const tokenList: TokenLink[] = Array.from(tokenByValue.values());
+
+const getEffectiveBackground = (element: Element | null): RGBA => {
+  let current: Element | null = element;
+  while (current) {
+    const style = window.getComputedStyle(current);
+    const color = parseColor(style.backgroundColor);
+    if (color && color.a > 0) {
+      if (color.a < 1) {
+        const parentColor = getEffectiveBackground(current.parentElement);
+        return blend(color, parentColor);
+      }
+      return color;
+    }
+    current = current.parentElement;
+  }
+
+  const rootStyle = window.getComputedStyle(document.documentElement);
+  const rootColor = parseColor(rootStyle.backgroundColor);
+  if (rootColor) {
+    if (rootColor.a < 1) return blend(rootColor, DEFAULT_BACKGROUND);
+    return rootColor;
+  }
+
+  const bodyStyle = window.getComputedStyle(document.body);
+  const bodyColor = parseColor(bodyStyle.backgroundColor);
+  if (bodyColor) {
+    if (bodyColor.a < 1) return blend(bodyColor, DEFAULT_BACKGROUND);
+    return bodyColor;
+  }
+
+  return DEFAULT_BACKGROUND;
+};
+
+const buildSelector = (element: Element): string => {
+  if (element.id) {
+    return `#${element.id.replace(/[^a-zA-Z0-9_-]/g, '_')}`;
+  }
+  const segments: string[] = [];
+  let current: Element | null = element;
+  while (current && segments.length < 4) {
+    const tag = current.tagName.toLowerCase();
+    let segment = tag;
+    if (current.classList.length > 0) {
+      segment += `.${Array.from(current.classList)
+        .map(cls => cls.replace(/[^a-zA-Z0-9_-]/g, ''))
+        .filter(Boolean)
+        .slice(0, 1)
+        .join('.')}`;
+    }
+    const parent = current.parentElement;
+    if (parent) {
+      const siblings = Array.from(parent.children).filter(child => child.tagName === current!.tagName);
+      if (siblings.length > 1) {
+        const index = siblings.indexOf(current) + 1;
+        segment += `:nth-of-type(${index})`;
+      }
+    }
+    segments.unshift(segment);
+    current = current.parentElement;
+  }
+  return segments.join(' > ');
+};
+
+const textSnippet = (element: Element): string => {
+  const text = element.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+  const MAX_LENGTH = 140;
+  if (text.length <= MAX_LENGTH) return text;
+  return `${text.slice(0, MAX_LENGTH - 1)}…`;
+};
+
+const hasVisibleText = (element: Element): boolean => {
+  for (const node of Array.from(element.childNodes)) {
+    if (node.nodeType === Node.TEXT_NODE && node.textContent?.trim()) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const isLargeText = (style: CSSStyleDeclaration): boolean => {
+  const fontSize = parseFloat(style.fontSize || '0');
+  const weightValue = style.fontWeight || '400';
+  const weight = parseInt(weightValue, 10);
+  const isBold = Number.isNaN(weight) ? /bold/i.test(weightValue) : weight >= 700;
+  return fontSize >= 24 || (fontSize >= 18.66 && isBold);
+};
+
+const isElementVisible = (style: CSSStyleDeclaration, rect: DOMRect): boolean => {
+  if (style.display === 'none') return false;
+  if (style.visibility === 'hidden' || style.visibility === 'collapse') return false;
+  if (parseFloat(style.opacity || '1') === 0) return false;
+  if (rect.width === 0 || rect.height === 0) return false;
+  return true;
+};
+
+const suggestTokens = (background: RGBA, minRatio: number, exclude: string[]): TokenLink[] => {
+  const suggestions = tokenList
+    .map(token => {
+      const color = parseColor(token.value);
+      if (!color) return null;
+      const ratio = contrastRatio(color, background);
+      return { token, ratio } as const;
+    })
+    .filter((entry): entry is { token: TokenLink; ratio: number } =>
+      Boolean(entry && entry.ratio >= minRatio && !exclude.includes(entry.token.token)),
+    )
+    .sort((a, b) => b.ratio - a.ratio)
+    .slice(0, 3)
+    .map(entry => entry.token);
+
+  return suggestions;
+};
+
+export const auditDocument = (root: Document | ShadowRoot = document): ContrastReport[] => {
+  if (typeof window === 'undefined' || !root) {
+    return [];
+  }
+
+  const reports: ContrastReport[] = [];
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+
+  let current = walker.nextNode();
+  while (current) {
+    const element = current as Element;
+    current = walker.nextNode();
+
+    if (element.closest(`[${DEVTOOLS_IGNORE_ATTR}]`)) {
+      continue;
+    }
+
+    if (!hasVisibleText(element)) continue;
+
+    const style = window.getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    if (!isElementVisible(style, rect)) continue;
+
+    const color = parseColor(style.color);
+    if (!color) continue;
+
+    const background = getEffectiveBackground(element);
+    const effectiveForeground = color.a < 1 ? blend(color, background) : color;
+
+    const ratio = contrastRatio(effectiveForeground, background);
+    const threshold = isLargeText(style) ? 3 : 4.5;
+
+    if (ratio >= threshold) continue;
+
+    const selector = buildSelector(element);
+    const text = textSnippet(element);
+    if (!text) continue;
+
+    const bounding = {
+      top: rect.top,
+      left: rect.left,
+      width: rect.width,
+      height: rect.height,
+    };
+
+    const foregroundHex = rgbaToHex(effectiveForeground);
+    const backgroundHex = rgbaToHex(background);
+    const tokenLink = tokenByValue.get(foregroundHex);
+    const suggestions = suggestTokens(background, threshold, tokenLink ? [tokenLink.token] : []);
+
+    reports.push({
+      selector,
+      text,
+      ratio,
+      threshold,
+      isLargeText: threshold === 3,
+      foreground: foregroundHex,
+      background: backgroundHex,
+      bounding,
+      tokenLink,
+      suggestions,
+    });
+  }
+
+  return reports.sort((a, b) => a.ratio - b.ratio);
+};


### PR DESCRIPTION
## Summary
- add a developer tools context for toggling shell debug utilities
- surface a developer menu entry in the shell status bar
- implement a DOM-driven contrast auditor overlay with design token suggestions and unit tests

## Testing
- yarn test colorAudit

------
https://chatgpt.com/codex/tasks/task_e_68cb465cff50832885f875252ba3f3fa