### PR TITLE
feat(wifi): add Wi-Fi insights simulation

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -93,6 +93,7 @@ const PinballApp = createDynamicApp('pinball', 'Pinball');
 const VolatilityApp = createDynamicApp('volatility', 'Volatility');
 
 const KismetApp = createDynamicApp('kismet.jsx', 'Kismet');
+const WifiInsightsApp = createDynamicApp('wifi-insights', 'Wi-Fi Insights');
 
 const HashcatApp = createDynamicApp('hashcat', 'Hashcat');
 const MsfPostApp = createDynamicApp('msf-post', 'Metasploit Post');
@@ -201,6 +202,7 @@ const displayContact = createDisplay(ContactApp);
 const displayHashcat = createDisplay(HashcatApp);
 
 const displayKismet = createDisplay(KismetApp);
+const displayWifiInsights = createDisplay(WifiInsightsApp);
 
 // Utilities list used for the "Utilities" folder on the desktop
 const utilityList = [
@@ -808,6 +810,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayKismet,
+  },
+  {
+    id: 'wifi-insights',
+    title: 'Wi-Fi Insights',
+    icon: '/themes/Yaru/status/network-wireless-signal-good-symbolic.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayWifiInsights,
   },
   {
     id: 'nikto',

--- a/apps/wifi-insights/index.tsx
+++ b/apps/wifi-insights/index.tsx
@@ -1,0 +1,1 @@
+export { WifiInsightsApp as default } from '../../pages/apps/wifi-insights';

--- a/components/apps/wifi/ChannelChart.tsx
+++ b/components/apps/wifi/ChannelChart.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import StatsChart from '../../StatsChart';
+import type { WifiBand, WifiNetwork } from '../../../types/wifi';
+
+export interface WifiChannelSummary {
+  channel: number;
+  band: WifiBand;
+  signalDbm: number;
+  noiseDbm: number;
+  normalizedSignal: number;
+  normalizedNoise: number;
+  utilization: number; // 0..1
+  networks: WifiNetwork[];
+}
+
+interface ChannelChartProps {
+  summary: WifiChannelSummary;
+}
+
+const describeUtilisation = (utilisation: number) => {
+  if (utilisation >= 0.75) return 'heavy';
+  if (utilisation >= 0.45) return 'moderate';
+  return 'light';
+};
+
+const ChannelChart: React.FC<ChannelChartProps> = ({ summary }) => {
+  const { channel, band, signalDbm, noiseDbm, normalizedSignal, normalizedNoise, networks, utilization } = summary;
+  const captionId = `wifi-channel-${channel}`;
+  const utilizationPercent = Math.round(utilization * 100);
+  const networkNames = networks.map((network) => network.ssid).join(', ');
+
+  return (
+    <figure
+      className="rounded-md border border-ubt-cool-grey/60 bg-black/40 p-3 shadow-inner"
+      aria-labelledby={captionId}
+    >
+      <div aria-hidden="true">
+        <StatsChart count={normalizedSignal} time={normalizedNoise} />
+      </div>
+      <figcaption id={captionId} className="mt-2 text-sm text-ubt-grey">
+        <span className="font-semibold text-white">Channel {channel}</span> on the {band} band averages
+        {` ${signalDbm.toFixed(0)} dBm`} signal with a noise floor near {noiseDbm.toFixed(0)} dBm.
+      </figcaption>
+      <p className="sr-only">
+        Channel {channel} hosts {networks.length} network{networks.length === 1 ? '' : 's'} with {describeUtilisation(utilization)}
+        utilisation at approximately {utilizationPercent}% airtime.
+      </p>
+      <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-xs text-ubt-grey">
+        <div>
+          <dt className="uppercase tracking-wide text-[0.65rem]">Signal</dt>
+          <dd className="text-white">{signalDbm.toFixed(1)} dBm</dd>
+        </div>
+        <div>
+          <dt className="uppercase tracking-wide text-[0.65rem]">Noise</dt>
+          <dd className="text-white">{noiseDbm.toFixed(1)} dBm</dd>
+        </div>
+        <div>
+          <dt className="uppercase tracking-wide text-[0.65rem]">Utilisation</dt>
+          <dd className="text-white">{utilizationPercent}% airtime</dd>
+        </div>
+        <div>
+          <dt className="uppercase tracking-wide text-[0.65rem]">Networks</dt>
+          <dd className="text-white">{networkNames || '—'}</dd>
+        </div>
+      </dl>
+    </figure>
+  );
+};
+
+export default ChannelChart;

--- a/components/apps/wifi/NetworkList.tsx
+++ b/components/apps/wifi/NetworkList.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import type { WifiNetwork } from '../../../types/wifi';
+
+interface NetworkListProps {
+  networks: WifiNetwork[];
+}
+
+const formatLastSeen = (iso: string) => {
+  const timestamp = new Date(iso).getTime();
+  const diffSeconds = Math.max(0, Math.round((Date.now() - timestamp) / 1000));
+  if (diffSeconds < 60) return `${diffSeconds}s ago`;
+  if (diffSeconds < 3600) return `${Math.floor(diffSeconds / 60)}m ago`;
+  return `${Math.floor(diffSeconds / 3600)}h ago`;
+};
+
+const formatQuality = (signal: number) => {
+  const normalized = Math.min(100, Math.max(0, 100 + signal));
+  if (normalized >= 70) return 'Excellent';
+  if (normalized >= 50) return 'Good';
+  if (normalized >= 30) return 'Fair';
+  return 'Weak';
+};
+
+const NetworkList: React.FC<NetworkListProps> = ({ networks }) => (
+  <section aria-label="Discovered Wi-Fi networks" className="space-y-2">
+    <h2 className="text-lg font-semibold text-white">Scan results</h2>
+    <ul className="space-y-2" role="list">
+      {networks.map((network) => (
+        <li
+          key={network.bssid}
+          className="rounded-md border border-ubt-cool-grey/60 bg-black/30 p-3 text-sm text-ubt-grey"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <p className="text-base font-semibold text-white">{network.ssid}</p>
+              <p className="text-xs uppercase tracking-wide">{network.band} • Channel {network.channel}</p>
+            </div>
+            <div className="text-right text-xs">
+              <p className="text-white">{formatQuality(network.signal)}</p>
+              <p>{network.signal.toFixed(0)} dBm</p>
+            </div>
+          </div>
+          <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+            <div>
+              <dt className="uppercase tracking-wide text-[0.65rem]">Security</dt>
+              <dd className="text-white">{network.security}</dd>
+            </div>
+            <div>
+              <dt className="uppercase tracking-wide text-[0.65rem]">Channel width</dt>
+              <dd className="text-white">{network.widthMHz} MHz</dd>
+            </div>
+            <div>
+              <dt className="uppercase tracking-wide text-[0.65rem]">Utilisation</dt>
+              <dd className="text-white">{Math.round(network.utilization * 100)}%</dd>
+            </div>
+            <div>
+              <dt className="uppercase tracking-wide text-[0.65rem]">Last seen</dt>
+              <dd className="text-white">{formatLastSeen(network.lastSeen)}</dd>
+            </div>
+          </dl>
+        </li>
+      ))}
+    </ul>
+  </section>
+);
+
+export default NetworkList;

--- a/components/apps/wifi/SecurityBadgeList.tsx
+++ b/components/apps/wifi/SecurityBadgeList.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+export interface SecurityBadgeSummary {
+  label: string;
+  count: number;
+  variant: 'strong' | 'legacy' | 'open';
+}
+
+interface SecurityBadgeListProps {
+  badges: SecurityBadgeSummary[];
+}
+
+const variantClass: Record<SecurityBadgeSummary['variant'], string> = {
+  strong: 'bg-emerald-600/30 text-emerald-200 border-emerald-500/60',
+  legacy: 'bg-amber-600/30 text-amber-200 border-amber-500/60',
+  open: 'bg-rose-600/30 text-rose-200 border-rose-500/60',
+};
+
+const SecurityBadgeList: React.FC<SecurityBadgeListProps> = ({ badges }) => (
+  <section aria-label="Security posture" className="space-y-2">
+    <h2 className="text-lg font-semibold text-white">Security breakdown</h2>
+    <ul className="flex flex-wrap gap-2" role="list">
+      {badges.map((badge) => (
+        <li key={badge.label}>
+          <span
+            className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold ${variantClass[badge.variant]}`}
+            aria-label={`${badge.count} networks use ${badge.label}`}
+          >
+            <span aria-hidden="true">{badge.label}</span>
+            <span className="rounded bg-black/40 px-1.5 py-0.5 text-[0.7rem] text-white" aria-hidden="true">
+              {badge.count}
+            </span>
+          </span>
+        </li>
+      ))}
+    </ul>
+  </section>
+);
+
+export default SecurityBadgeList;

--- a/docs/design-portal/networking.md
+++ b/docs/design-portal/networking.md
@@ -1,0 +1,12 @@
+# Networking
+
+## Wi-Fi Insights module
+
+- **Location:** `apps/wifi-insights` and `/apps/wifi-insights` desktop entry.
+- **Purpose:** Visualises simulated Wi-Fi scan data for quick channel health checks.
+- **Shell:** Renders inside `WindowMainScreen` with responsive two-column channel grid.
+- **Data:** Populated through `workers/wifiScan.ts` (≤3 s turnaround). The worker automatically falls back to offline/demo mode and only emits the bundled fixtures.
+- **Visuals:** `components/apps/wifi/ChannelChart` wraps the existing `StatsChart` bars with accessible captions. `SecurityBadgeList` surfaces security posture badges, while `NetworkList` shows per-network metadata.
+- **Exports:** Uses `utils/export.ts` helpers for JSON/CSV clipboard copy and file download. Buttons live in the window header actions.
+- **Accessibility:** Charts include `<figcaption>` descriptions and sr-only summaries so the simulation is screen reader friendly.
+- **Notes:** Keep new data additions under the 3 second worker SLA and update badge variants if new security types are introduced.

--- a/pages/apps/wifi-insights.tsx
+++ b/pages/apps/wifi-insights.tsx
@@ -1,0 +1,277 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { WindowMainScreen } from '../../components/base/window';
+import ChannelChart, {
+  WifiChannelSummary,
+} from '../../components/apps/wifi/ChannelChart';
+import SecurityBadgeList, {
+  SecurityBadgeSummary,
+} from '../../components/apps/wifi/SecurityBadgeList';
+import NetworkList from '../../components/apps/wifi/NetworkList';
+import type {
+  WifiNetwork,
+  WifiScanRequest,
+  WifiScanResult,
+  WifiScanWorkerMessage,
+} from '../../types/wifi';
+import { exportToClipboard, exportToFile, type ExportFormat } from '../../utils/export';
+
+type ScanState = 'idle' | 'scanning' | 'ready' | 'error';
+
+const normaliseDbm = (value: number) => Math.min(100, Math.max(0, 100 + value));
+
+const toChannelSummaries = (networks: WifiNetwork[]): WifiChannelSummary[] => {
+  const grouped = new Map<number, WifiChannelSummary>();
+
+  networks.forEach((network) => {
+    const current = grouped.get(network.channel);
+    if (!current) {
+      grouped.set(network.channel, {
+        channel: network.channel,
+        band: network.band,
+        signalDbm: network.signal,
+        noiseDbm: network.noise,
+        normalizedSignal: normaliseDbm(network.signal),
+        normalizedNoise: normaliseDbm(network.noise),
+        utilization: network.utilization,
+        networks: [network],
+      });
+      return;
+    }
+    current.networks.push(network);
+    const count = current.networks.length;
+    current.signalDbm = (current.signalDbm * (count - 1) + network.signal) / count;
+    current.noiseDbm = (current.noiseDbm * (count - 1) + network.noise) / count;
+    current.normalizedSignal = normaliseDbm(current.signalDbm);
+    current.normalizedNoise = normaliseDbm(current.noiseDbm);
+    current.utilization =
+      (current.utilization * (count - 1) + network.utilization) / count;
+  });
+
+  return Array.from(grouped.values()).sort((a, b) => a.channel - b.channel);
+};
+
+const toSecurityBadges = (networks: WifiNetwork[]): SecurityBadgeSummary[] => {
+  const counts = new Map<string, number>();
+  networks.forEach((network) => {
+    counts.set(network.security, (counts.get(network.security) ?? 0) + 1);
+  });
+
+  const variantFor = (label: string): SecurityBadgeSummary['variant'] => {
+    if (label === 'Open') return 'open';
+    if (label === 'WEP' || label === 'WPA') return 'legacy';
+    return 'strong';
+  };
+
+  return Array.from(counts.entries())
+    .map(([label, count]) => ({ label, count, variant: variantFor(label) }))
+    .sort((a, b) => b.count - a.count);
+};
+
+const formatMode = (result?: WifiScanResult) => {
+  if (!result) return null;
+  switch (result.mode) {
+    case 'offline':
+      return 'Offline fixtures';
+    case 'demo':
+      return 'Demo data';
+    default:
+      return 'Simulated live data';
+  }
+};
+
+const WifiInsightsApp: React.FC = () => {
+  const [status, setStatus] = useState<ScanState>('idle');
+  const [result, setResult] = useState<WifiScanResult | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const workerRef = useRef<Worker | null>(null);
+
+  const runScan = useCallback(() => {
+    if (typeof window === 'undefined' || typeof Worker === 'undefined') {
+      setStatus('error');
+      return;
+    }
+
+    if (workerRef.current) {
+      workerRef.current.terminate();
+      workerRef.current = null;
+    }
+
+    try {
+      const worker = new Worker(new URL('../../workers/wifiScan.ts', import.meta.url));
+      workerRef.current = worker;
+      setStatus('scanning');
+
+      worker.onmessage = (event: MessageEvent<WifiScanWorkerMessage>) => {
+        const message = event.data;
+        if (message?.type === 'result') {
+          setResult(message.result);
+          setStatus('ready');
+        }
+      };
+
+      worker.onerror = (error) => {
+        console.error('Wi-Fi scan worker error', error);
+        setStatus('error');
+      };
+
+      const request: WifiScanRequest = {
+        type: 'scan',
+        offline: typeof navigator !== 'undefined' ? !navigator.onLine : true,
+        demoMode: true,
+      };
+      worker.postMessage(request);
+    } catch (error) {
+      console.error('Unable to start Wi-Fi scan', error);
+      setStatus('error');
+    }
+  }, []);
+
+  useEffect(() => {
+    runScan();
+    return () => {
+      if (workerRef.current) {
+        workerRef.current.terminate();
+        workerRef.current = null;
+      }
+    };
+  }, [runScan]);
+
+  useEffect(() => {
+    if (!feedback) return;
+    const timer = window.setTimeout(() => setFeedback(null), 2400);
+    return () => window.clearTimeout(timer);
+  }, [feedback]);
+
+  const channelSummaries = useMemo(
+    () => (result ? toChannelSummaries(result.networks) : []),
+    [result],
+  );
+
+  const securityBadges = useMemo(
+    () => (result ? toSecurityBadges(result.networks) : []),
+    [result],
+  );
+
+  const handleClipboard = useCallback(
+    async (format: ExportFormat) => {
+      if (!result) return;
+      const success = await exportToClipboard(result.networks, format);
+      setFeedback(
+        success
+          ? `${format.toUpperCase()} copied to clipboard`
+          : 'Clipboard export failed',
+      );
+    },
+    [result],
+  );
+
+  const handleDownload = useCallback(
+    (format: ExportFormat) => {
+      if (!result) return;
+      const success = exportToFile(
+        result.networks,
+        format,
+        `wifi-insights-${format === 'json' ? 'scan.json' : 'scan.csv'}`,
+      );
+      setFeedback(
+        success
+          ? `${format.toUpperCase()} download started`
+          : 'Download failed',
+      );
+    },
+    [result],
+  );
+
+  const modeLabel = formatMode(result ?? undefined);
+
+  return (
+    <WindowMainScreen
+      screen={() => (
+        <div className="flex h-full flex-col gap-4 bg-ub-cool-grey/80 p-4 text-white">
+          <header className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h1 className="text-2xl font-semibold">Wi-Fi Insights</h1>
+              <p className="text-sm text-ubt-grey">
+                {status === 'scanning' && 'Scanning nearby channels…'}
+                {status === 'ready' && result && (
+                  <>
+                    Last run {new Date(result.generatedAt).toLocaleTimeString()}
+                    {modeLabel ? ` • ${modeLabel}` : ''}
+                  </>
+                )}
+                {status === 'error' &&
+                  'Simulation unavailable. Check offline/demo mode and retry.'}
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={runScan}
+                className="rounded-md bg-ubt-blue px-3 py-2 text-sm font-semibold text-black shadow focus:outline-none focus:ring"
+              >
+                {status === 'scanning' ? 'Scanning…' : 'Rescan networks'}
+              </button>
+              <div className="flex flex-wrap gap-2">
+                {(['json', 'csv'] as ExportFormat[]).map((format) => (
+                  <React.Fragment key={`copy-${format}`}>
+                    <button
+                      type="button"
+                      disabled={!result}
+                      onClick={() => handleClipboard(format)}
+                      className="rounded-md border border-ubt-cool-grey px-3 py-2 text-xs font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Copy {format.toUpperCase()}
+                    </button>
+                    <button
+                      type="button"
+                      disabled={!result}
+                      onClick={() => handleDownload(format)}
+                      className="rounded-md border border-ubt-cool-grey px-3 py-2 text-xs font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Save {format.toUpperCase()}
+                    </button>
+                  </React.Fragment>
+                ))}
+              </div>
+            </div>
+          </header>
+
+          {feedback && (
+            <p className="text-xs text-emerald-300" role="status">
+              {feedback}
+            </p>
+          )}
+
+          {channelSummaries.length ? (
+            <div className="grid gap-4 md:grid-cols-2">
+              {channelSummaries.map((summary) => (
+                <ChannelChart key={summary.channel} summary={summary} />
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-md border border-dashed border-ubt-cool-grey/70 p-6 text-center text-sm text-ubt-grey">
+              {status === 'scanning'
+                ? 'Collecting channel statistics…'
+                : 'No wireless networks detected in the latest scan.'}
+            </div>
+          )}
+
+          {securityBadges.length ? (
+            <SecurityBadgeList badges={securityBadges} />
+          ) : (
+            <p className="text-sm text-ubt-grey">Security breakdown will appear after a successful scan.</p>
+          )}
+
+          {result && result.networks.length ? (
+            <NetworkList networks={result.networks} />
+          ) : null}
+        </div>
+      )}
+    />
+  );
+};
+
+const WifiInsightsPage = () => <WifiInsightsApp />;
+
+export { WifiInsightsApp };
+export default WifiInsightsPage;

--- a/types/wifi.ts
+++ b/types/wifi.ts
@@ -1,0 +1,43 @@
+export type WifiSecurity =
+  | 'WPA3'
+  | 'WPA2/WPA3'
+  | 'WPA2'
+  | 'WPA'
+  | 'WEP'
+  | 'Open';
+
+export type WifiBand = '2.4 GHz' | '5 GHz' | '6 GHz';
+
+export interface WifiNetwork {
+  ssid: string;
+  bssid: string;
+  channel: number;
+  band: WifiBand;
+  security: WifiSecurity;
+  signal: number; // in dBm (negative values typical)
+  noise: number; // in dBm (negative values)
+  utilization: number; // range 0..1 representing airtime utilisation
+  lastSeen: string; // ISO timestamp
+  widthMHz: number;
+}
+
+export type WifiScanMode = 'simulated' | 'demo' | 'offline';
+
+export interface WifiScanRequest {
+  type: 'scan';
+  offline?: boolean;
+  demoMode?: boolean;
+}
+
+export interface WifiScanResult {
+  mode: WifiScanMode;
+  generatedAt: string;
+  networks: WifiNetwork[];
+}
+
+export interface WifiScanResponseMessage {
+  type: 'result';
+  result: WifiScanResult;
+}
+
+export type WifiScanWorkerMessage = WifiScanResponseMessage;

--- a/utils/export.ts
+++ b/utils/export.ts
@@ -1,0 +1,82 @@
+export type ExportFormat = 'json' | 'csv';
+
+type SerializableRecord = Record<string, unknown>;
+
+const toCSV = (rows: SerializableRecord[]): string => {
+  if (!rows.length) return '';
+  const headers = Array.from(new Set(rows.flatMap((row) => Object.keys(row))));
+
+  const escape = (value: unknown) => {
+    if (value === null || value === undefined) return '';
+    const str = String(value);
+    if (/[",\n]/.test(str)) {
+      return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+  };
+
+  const lines = rows.map((row) => headers.map((header) => escape(row[header])).join(','));
+  return [headers.join(','), ...lines].join('\n');
+};
+
+const normaliseRows = (data: unknown): SerializableRecord[] => {
+  if (!Array.isArray(data)) return [];
+  return data.map((item) => {
+    if (item && typeof item === 'object') {
+      return item as SerializableRecord;
+    }
+    return { value: item };
+  });
+};
+
+const serialise = (data: unknown, format: ExportFormat): string => {
+  if (format === 'json') {
+    return JSON.stringify(data, null, 2);
+  }
+  return toCSV(normaliseRows(data));
+};
+
+export const exportToClipboard = async (
+  data: unknown,
+  format: ExportFormat,
+): Promise<boolean> => {
+  if (typeof navigator === 'undefined' || !navigator.clipboard) {
+    return false;
+  }
+  const content = serialise(data, format);
+  if (!content) return false;
+  try {
+    await navigator.clipboard.writeText(content);
+    return true;
+  } catch (error) {
+    console.warn('Clipboard export failed', error);
+    return false;
+  }
+};
+
+export const exportToFile = (
+  data: unknown,
+  format: ExportFormat,
+  filename: string,
+): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  const content = serialise(data, format);
+  if (!content) return false;
+
+  const blob = new Blob([content], {
+    type: format === 'json' ? 'application/json' : 'text/csv',
+  });
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+  return true;
+};
+

--- a/workers/wifiScan.ts
+++ b/workers/wifiScan.ts
@@ -1,0 +1,109 @@
+import type {
+  WifiNetwork,
+  WifiScanMode,
+  WifiScanRequest,
+  WifiScanResponseMessage,
+} from '../types/wifi';
+
+const baseNetworks: WifiNetwork[] = [
+  {
+    ssid: 'Campus-5G',
+    bssid: '00:11:22:33:44:55',
+    channel: 36,
+    band: '5 GHz',
+    security: 'WPA3',
+    signal: -48,
+    noise: -92,
+    utilization: 0.58,
+    lastSeen: new Date().toISOString(),
+    widthMHz: 80,
+  },
+  {
+    ssid: 'Research-Lab',
+    bssid: '00:11:22:33:44:66',
+    channel: 149,
+    band: '5 GHz',
+    security: 'WPA2/WPA3',
+    signal: -55,
+    noise: -95,
+    utilization: 0.46,
+    lastSeen: new Date().toISOString(),
+    widthMHz: 80,
+  },
+  {
+    ssid: 'IoT-Sensors',
+    bssid: '00:11:22:33:44:77',
+    channel: 1,
+    band: '2.4 GHz',
+    security: 'WPA2',
+    signal: -63,
+    noise: -93,
+    utilization: 0.39,
+    lastSeen: new Date().toISOString(),
+    widthMHz: 20,
+  },
+  {
+    ssid: 'Guest-Wifi',
+    bssid: '00:11:22:33:44:88',
+    channel: 6,
+    band: '2.4 GHz',
+    security: 'Open',
+    signal: -68,
+    noise: -90,
+    utilization: 0.71,
+    lastSeen: new Date().toISOString(),
+    widthMHz: 20,
+  },
+  {
+    ssid: 'Engineering',
+    bssid: '00:11:22:33:44:99',
+    channel: 11,
+    band: '2.4 GHz',
+    security: 'WPA2',
+    signal: -52,
+    noise: -94,
+    utilization: 0.33,
+    lastSeen: new Date().toISOString(),
+    widthMHz: 40,
+  },
+];
+
+const jitter = (value: number, spread: number) => value + (Math.random() - 0.5) * spread;
+
+const cloneWithJitter = (network: WifiNetwork): WifiNetwork => ({
+  ...network,
+  signal: Math.round(jitter(network.signal, 6)),
+  noise: Math.round(jitter(network.noise, 4)),
+  utilization: Math.max(0, Math.min(1, Number((network.utilization + (Math.random() - 0.5) * 0.1).toFixed(2)))),
+  lastSeen: new Date(Date.now() - Math.floor(Math.random() * 60000)).toISOString(),
+});
+
+const detectMode = (offline?: boolean, demoMode?: boolean): WifiScanMode => {
+  if (offline) return 'offline';
+  if (demoMode) return 'demo';
+  return 'simulated';
+};
+
+self.onmessage = (event: MessageEvent<WifiScanRequest>) => {
+  const { data } = event;
+  if (!data || data.type !== 'scan') return;
+
+  const offlineFlag = data.offline ?? (typeof navigator !== 'undefined' && navigator.onLine === false);
+  const mode = detectMode(offlineFlag, data.demoMode);
+  const delay = mode === 'simulated' ? 600 + Math.random() * 900 : 250 + Math.random() * 200; // always < 3s
+
+  const result: WifiScanResponseMessage = {
+    type: 'result',
+    result: {
+      mode,
+      generatedAt: new Date().toISOString(),
+      networks: baseNetworks.map(cloneWithJitter),
+    },
+  };
+
+  setTimeout(() => {
+    self.postMessage(result);
+  }, delay);
+};
+
+export {};


### PR DESCRIPTION
## Summary
- add a Wi-Fi Insights desktop app with channel charts, security badges, and export controls
- introduce shared Wi-Fi visualization components and a simulated wifiScan worker
- provide JSON/CSV export helpers and document the feature in the design portal

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations across legacy apps)*
- yarn test *(fails: known failing suites such as window and nmapNse tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cb465be5c883288ca012d43aad97f7