### PR TITLE
[quick-settings] redesign quick settings panel

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/router";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
@@ -12,6 +13,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import { getSettingsSectionFromQuery } from "../../utils/navigation";
 
 export default function Settings() {
   const {
@@ -41,6 +43,27 @@ export default function Settings() {
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    const section = getSettingsSectionFromQuery(router.query);
+    if (section && section !== activeTab) {
+      setActiveTab(section as TabId);
+    }
+  }, [router.isReady, router.query, activeTab]);
+
+  const handleTabChange = (id: TabId) => {
+    setActiveTab(id);
+    if (!router.isReady) return;
+    const current = router.query.tab;
+    const currentId = Array.isArray(current) ? current[0] : current;
+    if (currentId === id) return;
+    const nextQuery = { ...router.query, tab: id };
+    router.replace({ pathname: router.pathname, query: nextQuery }, undefined, {
+      shallow: true,
+    });
+  };
 
   const wallpapers = [
     "wall-1",
@@ -108,7 +131,7 @@ export default function Settings() {
   return (
     <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
       <div className="flex justify-center border-b border-gray-900">
-        <Tabs tabs={tabs} active={activeTab} onChange={setActiveTab} />
+        <Tabs tabs={tabs} active={activeTab} onChange={handleTabChange} />
       </div>
       {activeTab === "appearance" && (
         <>

--- a/components/apps/quick-settings/Panel.tsx
+++ b/components/apps/quick-settings/Panel.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/router";
+import usePersistentState from "../../../hooks/usePersistentState";
+import AccessibleToggle from "../../base/AccessibleToggle";
+import { useSettings } from "../../../hooks/useSettings";
+import { isDarkTheme } from "../../../utils/theme";
+import {
+  getSettingsHref,
+  navigateToSettings,
+  type SettingsSection,
+} from "../../../utils/navigation";
+
+interface PanelProps {
+  open: boolean;
+}
+
+const clampPercentage = (value: number) => {
+  if (Number.isNaN(value)) return 0;
+  return Math.min(100, Math.max(0, Math.round(value)));
+};
+
+const percentValidator = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+const booleanValidator = (value: unknown): value is boolean =>
+  typeof value === "boolean";
+
+const TRANSITION_DURATION = 135;
+
+const SliderControl = ({
+  id,
+  label,
+  icon,
+  value,
+  onChange,
+  disabled,
+}: {
+  id: string;
+  label: string;
+  icon: string;
+  value: number;
+  onChange: (next: number) => void;
+  disabled: boolean;
+}) => {
+  const clamped = clampPercentage(value);
+  const describedBy = `${id}-value`;
+  return (
+    <div className="rounded-xl border border-black border-opacity-20 bg-ub-cool-grey/80 p-4 shadow-sm">
+      <div className="flex items-center justify-between text-sm font-semibold text-ubt-grey">
+        <span className="flex items-center gap-2 text-ubt-grey">
+          <span aria-hidden className="text-lg leading-none">
+            {icon}
+          </span>
+          {label}
+        </span>
+        <output
+          id={describedBy}
+          className="text-xs uppercase tracking-wide text-ubt-grey text-opacity-80"
+          aria-live="off"
+        >
+          {clamped}%
+        </output>
+      </div>
+      <input
+        id={id}
+        type="range"
+        min={0}
+        max={100}
+        value={clamped}
+        aria-label={label}
+        aria-describedby={describedBy}
+        aria-valuetext={`${clamped}%`}
+        className="mt-3 w-full accent-ub-orange"
+        disabled={disabled}
+        onChange={(event) => onChange(Number(event.target.value))}
+      />
+    </div>
+  );
+};
+
+const getBrightnessFactor = (value: number) => {
+  const clamped = clampPercentage(value);
+  return (0.5 + clamped / 200).toFixed(3);
+};
+
+const getVolumeLevel = (value: number) => {
+  const clamped = clampPercentage(value);
+  return (clamped / 100).toFixed(3);
+};
+
+const SETTINGS_LINKS: Record<string, SettingsSection> = {
+  network: "privacy",
+  dark: "appearance",
+  contrast: "accessibility",
+  motion: "accessibility",
+};
+
+const Panel = ({ open }: PanelProps) => {
+  const router = useRouter();
+  const {
+    allowNetwork,
+    setAllowNetwork,
+    reducedMotion,
+    setReducedMotion,
+    highContrast,
+    setHighContrast,
+    theme,
+    setTheme,
+  } = useSettings();
+  const [soundEnabled, setSoundEnabled] = usePersistentState(
+    "qs-sound",
+    true,
+    booleanValidator,
+  );
+  const [brightness, setBrightness] = usePersistentState(
+    "qs-brightness",
+    100,
+    percentValidator,
+  );
+  const [volume, setVolume] = usePersistentState(
+    "qs-volume",
+    70,
+    percentValidator,
+  );
+  const previousVolume = useRef(volume);
+
+  const [rendered, setRendered] = useState(open);
+  useEffect(() => {
+    if (open) {
+      setRendered(true);
+    } else {
+      const timeout = window.setTimeout(
+        () => setRendered(false),
+        TRANSITION_DURATION,
+      );
+      return () => window.clearTimeout(timeout);
+    }
+    return undefined;
+  }, [open]);
+
+  useEffect(() => {
+    const factor = getBrightnessFactor(brightness);
+    document.documentElement.style.setProperty(
+      "--quick-settings-brightness",
+      factor,
+    );
+    document.documentElement.dataset.brightness = factor;
+  }, [brightness]);
+
+  useEffect(() => {
+    const level = getVolumeLevel(volume);
+    document.documentElement.style.setProperty(
+      "--quick-settings-volume",
+      level,
+    );
+    document.documentElement.dataset.volume = level;
+  }, [volume]);
+
+  useEffect(() => {
+    if (volume > 0) {
+      previousVolume.current = volume;
+    }
+  }, [volume]);
+
+  const previousLightTheme = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isDarkTheme(theme)) {
+      previousLightTheme.current = theme;
+    }
+  }, [theme]);
+
+  useEffect(() => {
+    document.documentElement.dataset.sound = soundEnabled ? "on" : "muted";
+  }, [soundEnabled]);
+
+  const toggleSound = () => {
+    setSoundEnabled((prev) => {
+      const next = !prev;
+      if (next) {
+        if (volume === 0) {
+          const fallback = previousVolume.current > 0 ? previousVolume.current : 70;
+          setVolume(fallback);
+        }
+      } else {
+        if (volume > 0) {
+          previousVolume.current = volume;
+        }
+        setVolume(0);
+      }
+      return next;
+    });
+  };
+
+  const handleDarkModeToggle = (next: boolean) => {
+    if (next) {
+      if (!isDarkTheme(theme)) {
+        previousLightTheme.current = theme;
+      }
+      setTheme("dark");
+    } else {
+      const fallback = previousLightTheme.current ?? "default";
+      setTheme(fallback);
+    }
+  };
+
+  const navigate = (section: SettingsSection) => {
+    navigateToSettings(router, section);
+  };
+
+  const panelHidden = !open && !rendered;
+
+  if (panelHidden) {
+    return null;
+  }
+
+  const darkActive = isDarkTheme(theme);
+
+  return (
+    <section
+      id="quick-settings-panel"
+      role="dialog"
+      aria-label="Quick settings"
+      aria-hidden={!open}
+      data-state={open ? "open" : "closed"}
+      className={`pointer-events-none absolute right-3 top-9 z-50 w-80 max-w-[calc(100vw-1.5rem)] transition-all will-change-transform ${
+        open ? "pointer-events-auto" : ""
+      }`}
+      style={{
+        transitionDuration: "calc(var(--motion-fast, 150ms) * 0.9)",
+        transitionTimingFunction: "cubic-bezier(0.2, 0, 0, 1)",
+      }}
+    >
+      <div
+        className={`rounded-2xl border border-black border-opacity-20 bg-ub-cool-grey/95 p-4 shadow-2xl backdrop-blur-sm transition-all ${
+          open
+            ? "translate-y-0 opacity-100"
+            : "-translate-y-2 opacity-0"
+        }`}
+        style={{
+          transitionDuration: "calc(var(--motion-fast, 150ms) * 0.9)",
+          transitionTimingFunction: "cubic-bezier(0.2, 0, 0, 1)",
+        }}
+      >
+        <div className="mb-4 text-xs uppercase tracking-wide text-ubt-grey text-opacity-80">
+          {open ? "Quick Controls" : ""}
+        </div>
+        <div
+          className="grid grid-cols-2 gap-3"
+          role="group"
+          aria-label="System toggles"
+        >
+          <AccessibleToggle
+            id="quick-toggle-network"
+            label="Network Access"
+            description="Allow apps to reach the internet"
+            icon="📶"
+            checked={allowNetwork}
+            onToggle={setAllowNetwork}
+            onLongPress={() => navigate(SETTINGS_LINKS.network)}
+            statusLabel={allowNetwork ? "Allowed" : "Blocked"}
+            disabled={!open}
+          />
+          <AccessibleToggle
+            id="quick-toggle-dark"
+            label="Dark Theme"
+            description="Switch between light and dark UI"
+            icon="🌙"
+            checked={darkActive}
+            onToggle={handleDarkModeToggle}
+            onLongPress={() => navigate(SETTINGS_LINKS.dark)}
+            statusLabel={darkActive ? "Dark" : "Default"}
+            disabled={!open}
+          />
+          <AccessibleToggle
+            id="quick-toggle-contrast"
+            label="High Contrast"
+            description="Boost text and control contrast"
+            icon="🌓"
+            checked={highContrast}
+            onToggle={setHighContrast}
+            onLongPress={() => navigate(SETTINGS_LINKS.contrast)}
+            statusLabel={highContrast ? "High" : "Standard"}
+            disabled={!open}
+          />
+          <AccessibleToggle
+            id="quick-toggle-motion"
+            label="Reduce Motion"
+            description="Simplify animations across the desktop"
+            icon="🎞️"
+            checked={reducedMotion}
+            onToggle={setReducedMotion}
+            onLongPress={() => navigate(SETTINGS_LINKS.motion)}
+            statusLabel={reducedMotion ? "Reduced" : "Full"}
+            disabled={!open}
+          />
+        </div>
+        <div
+          className="mt-4 flex flex-col gap-3"
+          role="group"
+          aria-label="Display and audio controls"
+        >
+          <SliderControl
+            id="quick-slider-brightness"
+            label="Brightness"
+            icon="💡"
+            value={brightness}
+            onChange={setBrightness}
+            disabled={!open}
+          />
+          <SliderControl
+            id="quick-slider-volume"
+            label="Volume"
+            icon={soundEnabled ? "🔊" : "🔇"}
+            value={volume}
+            onChange={(next) => {
+              setVolume(next);
+              if (next === 0) {
+                setSoundEnabled(false);
+              } else if (!soundEnabled) {
+                setSoundEnabled(true);
+              }
+            }}
+            disabled={!open}
+          />
+          <div className="flex items-center justify-between text-xs text-ubt-grey text-opacity-80">
+            <span>Sound</span>
+            <button
+              type="button"
+              className="rounded-md border border-black border-opacity-10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-ubt-grey transition-colors hover:border-opacity-30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ub-orange"
+              onClick={toggleSound}
+              onKeyDown={(event) => {
+                if (event.key === " " || event.key === "Enter") {
+                  event.preventDefault();
+                }
+              }}
+              onKeyUp={(event) => {
+                if (event.key === " " || event.key === "Enter") {
+                  event.preventDefault();
+                  toggleSound();
+                }
+              }}
+              aria-pressed={soundEnabled}
+              aria-label={soundEnabled ? "Mute sound" : "Unmute sound"}
+              disabled={!open}
+            >
+              {soundEnabled ? "Mute" : "Unmute"}
+            </button>
+          </div>
+        </div>
+        <div className="mt-4 border-t border-black border-opacity-10 pt-3 text-right">
+          <a
+            href={getSettingsHref("appearance")}
+            className="text-xs font-semibold uppercase tracking-wide text-ub-orange transition-colors hover:text-ubb-orange focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ub-orange"
+          >
+            Open Settings
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Panel;

--- a/components/base/AccessibleToggle.tsx
+++ b/components/base/AccessibleToggle.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type ButtonHTMLAttributes,
+  type ReactNode,
+} from "react";
+
+export interface AccessibleToggleProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onClick"> {
+  /**
+   * Current checked state of the toggle.
+   */
+  checked: boolean;
+  /**
+   * Visible label rendered inside the button. Forms the accessible name.
+   */
+  label: string;
+  /**
+   * Optional supporting description announced via `aria-describedby`.
+   */
+  description?: string;
+  /**
+   * Optional status indicator rendered on the trailing edge.
+   */
+  statusLabel?: string;
+  /**
+   * Optional icon displayed at the leading edge of the control.
+   */
+  icon?: ReactNode;
+  /**
+   * Called with the next checked state when the control is toggled.
+   */
+  onToggle: (next: boolean) => void;
+  /**
+   * Optional long-press handler triggered after the interaction threshold.
+   */
+  onLongPress?: () => void;
+}
+
+const LONG_PRESS_DURATION = 550;
+
+const baseClassName =
+  "group relative flex flex-col justify-between gap-2 rounded-xl border border-black border-opacity-20 p-4 text-left transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ub-orange";
+
+export default function AccessibleToggle({
+  checked,
+  label,
+  description,
+  statusLabel,
+  icon,
+  onToggle,
+  onLongPress,
+  className = "",
+  disabled,
+  id,
+  ...rest
+}: AccessibleToggleProps) {
+  const timerRef = useRef<number | null>(null);
+  const longPressTriggered = useRef(false);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const startTimer = useCallback(() => {
+    if (!onLongPress) return;
+    clearTimer();
+    longPressTriggered.current = false;
+    timerRef.current = window.setTimeout(() => {
+      longPressTriggered.current = true;
+      onLongPress();
+    }, LONG_PRESS_DURATION);
+  }, [clearTimer, onLongPress]);
+
+  useEffect(() => () => clearTimer(), [clearTimer]);
+
+  const handlePointerDown = useCallback<
+    NonNullable<AccessibleToggleProps["onPointerDown"]>
+  >(
+    (event) => {
+      if (disabled) return;
+      if (event.button !== undefined && event.button !== 0) return;
+      if (onLongPress) {
+        startTimer();
+      }
+    },
+    [disabled, onLongPress, startTimer],
+  );
+
+  const handlePointerUp = useCallback<
+    NonNullable<AccessibleToggleProps["onPointerUp"]>
+  >(() => {
+    clearTimer();
+  }, [clearTimer]);
+
+  const handlePointerLeave = useCallback<
+    NonNullable<AccessibleToggleProps["onPointerLeave"]>
+  >(() => {
+    clearTimer();
+  }, [clearTimer]);
+
+  const handleKeyDown = useCallback<
+    NonNullable<AccessibleToggleProps["onKeyDown"]>
+  >(
+    (event) => {
+      if (disabled) return;
+      if (event.key !== " " && event.key !== "Enter") return;
+      if (event.repeat) return;
+      event.preventDefault();
+      if (onLongPress) {
+        startTimer();
+      }
+    },
+    [disabled, onLongPress, startTimer],
+  );
+
+  const handleKeyUp = useCallback<
+    NonNullable<AccessibleToggleProps["onKeyUp"]>
+  >(
+    (event) => {
+      if (event.key !== " " && event.key !== "Enter") return;
+      event.preventDefault();
+      clearTimer();
+    },
+    [clearTimer],
+  );
+
+  const handleClick = useCallback<
+    NonNullable<ButtonHTMLAttributes<HTMLButtonElement>["onClick"]>
+  >(
+    (event) => {
+      if (disabled) {
+        event.preventDefault();
+        return;
+      }
+      if (longPressTriggered.current) {
+        event.preventDefault();
+        event.stopPropagation();
+        longPressTriggered.current = false;
+        return;
+      }
+      onToggle(!checked);
+    },
+    [checked, disabled, onToggle],
+  );
+
+  const descriptionId = useMemo(() => {
+    if (!description && !statusLabel) return undefined;
+    return `${id ?? label.replace(/\s+/g, "-").toLowerCase()}-description`;
+  }, [description, id, label, statusLabel]);
+
+  const statusId = useMemo(() => {
+    if (!statusLabel) return undefined;
+    return `${id ?? label.replace(/\s+/g, "-").toLowerCase()}-status`;
+  }, [id, label, statusLabel]);
+
+  const ariaDescribedBy = useMemo(() => {
+    if (descriptionId && statusId && description && statusLabel)
+      return `${descriptionId} ${statusId}`;
+    if (descriptionId && description) return descriptionId;
+    if (statusId && statusLabel) return statusId;
+    return undefined;
+  }, [description, descriptionId, statusId, statusLabel]);
+
+  const stateClasses = checked
+    ? "bg-ub-orange text-white"
+    : "bg-ub-cool-grey/80 text-ubt-grey hover:bg-ub-cool-grey";
+
+  return (
+    <button
+      {...rest}
+      id={id}
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-describedby={ariaDescribedBy}
+      disabled={disabled}
+      onClick={handleClick}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerLeave={handlePointerLeave}
+      onKeyDown={handleKeyDown}
+      onKeyUp={handleKeyUp}
+      className={`${baseClassName} ${stateClasses} ${className}`.trim()}
+    >
+      <span className="flex items-start justify-between gap-3">
+        {icon ? (
+          <span aria-hidden className="text-xl leading-none">
+            {icon}
+          </span>
+        ) : null}
+        <span className="flex-1 space-y-1">
+          <span className="block text-sm font-semibold tracking-wide">
+            {label}
+          </span>
+          {description ? (
+            <span
+              id={descriptionId}
+              className="block text-xs text-ubt-grey text-opacity-80"
+            >
+              {description}
+            </span>
+          ) : null}
+        </span>
+        <span
+          id={statusId}
+          className="text-xs font-medium uppercase tracking-wide text-ubt-grey text-opacity-80"
+        >
+          {statusLabel ?? (checked ? "On" : "Off")}
+        </span>
+      </span>
+    </button>
+  );
+}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -31,6 +31,9 @@ export default class Navbar extends Component {
                                         type="button"
                                         id="status-bar"
                                         aria-label="System status"
+                                        aria-haspopup="dialog"
+                                        aria-controls="quick-settings-panel"
+                                        aria-expanded={this.state.status_card}
                                         onClick={() => {
                                                 this.setState({ status_card: !this.state.status_card });
                                         }}
@@ -39,8 +42,8 @@ export default class Navbar extends Component {
                                         }
                                 >
                                         <Status />
-                                        <QuickSettings open={this.state.status_card} />
                                 </button>
+                                <QuickSettings open={this.state.status_card} />
 			</div>
 		);
 	}

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,59 +1,11 @@
 "use client";
 
-import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
+import Panel from "../apps/quick-settings/Panel";
 
 interface Props {
   open: boolean;
 }
 
-const QuickSettings = ({ open }: Props) => {
-  const [theme, setTheme] = usePersistentState('qs-theme', 'light');
-  const [sound, setSound] = usePersistentState('qs-sound', true);
-  const [online, setOnline] = usePersistentState('qs-online', true);
-  const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
-
-  useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark');
-  }, [theme]);
-
-  useEffect(() => {
-    document.documentElement.classList.toggle('reduce-motion', reduceMotion);
-  }, [reduceMotion]);
-
-  return (
-    <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
-        open ? '' : 'hidden'
-      }`}
-    >
-      <div className="px-4 pb-2">
-        <button
-          className="w-full flex justify-between"
-          onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-        >
-          <span>Theme</span>
-          <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
-        </button>
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
-        <input
-          type="checkbox"
-          checked={reduceMotion}
-          onChange={() => setReduceMotion(!reduceMotion)}
-        />
-      </div>
-    </div>
-  );
-};
+const QuickSettings = ({ open }: Props) => <Panel open={open} />;
 
 export default QuickSettings;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testDir: '.',
+  testMatch: ['tests/**/*.spec.ts', 'playwright/tests/**/*.spec.ts'],
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/playwright/tests/quick-settings.spec.ts
+++ b/playwright/tests/quick-settings.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Quick settings panel', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'System status' }).click();
+    await expect(page.locator('#quick-settings-panel')).toBeVisible();
+  });
+
+  test('toggles network access', async ({ page }) => {
+    const toggle = page.getByRole('switch', { name: 'Network Access' });
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+  });
+
+  test('long pressing dark theme opens the appearance settings tab', async ({ page }) => {
+    const darkToggle = page.getByRole('switch', { name: 'Dark Theme' });
+    await darkToggle.hover();
+    await darkToggle.dispatchEvent('pointerdown', {
+      button: 0,
+      pointerType: 'mouse',
+      isPrimary: true,
+    });
+    await page.waitForTimeout(600);
+    await darkToggle.dispatchEvent('pointerup', {
+      button: 0,
+      pointerType: 'mouse',
+      isPrimary: true,
+    });
+    await page.waitForURL('**/apps/settings?tab=appearance');
+    const appearanceTab = page.getByRole('tab', { name: 'Appearance' });
+    await expect(appearanceTab).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,5 +1,10 @@
 @import './globals.css';
 
+:root {
+    --quick-settings-brightness: 1;
+    --quick-settings-volume: 0.7;
+}
+
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
 }
@@ -9,6 +14,8 @@ body{
     font-display: swap;
     background-color: var(--color-bg);
     color: var(--color-text);
+    filter: brightness(var(--quick-settings-brightness, 1));
+    transition: filter calc(var(--motion-fast, 150ms) * 0.9) ease;
 }
 
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -1,0 +1,34 @@
+import type { ParsedUrlQuery } from "querystring";
+import type { NextRouter } from "next/router";
+
+export const SETTINGS_SECTIONS = [
+  "appearance",
+  "accessibility",
+  "privacy",
+] as const;
+
+export type SettingsSection = (typeof SETTINGS_SECTIONS)[number];
+
+export const isSettingsSection = (value: unknown): value is SettingsSection =>
+  typeof value === "string" && SETTINGS_SECTIONS.includes(value as SettingsSection);
+
+export const getSettingsHref = (section: SettingsSection = "appearance") =>
+  `/apps/settings?tab=${section}`;
+
+export const navigateToSettings = (
+  router: NextRouter,
+  section: SettingsSection = "appearance",
+) => {
+  router.push(getSettingsHref(section));
+};
+
+export const getSettingsSectionFromQuery = (
+  query: ParsedUrlQuery,
+): SettingsSection | null => {
+  const value = query.tab ?? query.section;
+  const candidate = Array.isArray(value) ? value[0] : value;
+  if (isSettingsSection(candidate)) {
+    return candidate;
+  }
+  return null;
+};


### PR DESCRIPTION
## Summary
- rebuild the quick settings panel with accessible toggles, two-row layout, and faster motion-token animations
- add an accessible toggle primitive, wire long-press deep links, and expose navigation helpers for settings tabs
- sync the navbar, settings tab routing, and Playwright coverage to exercise the new quick settings behaviours

## Testing
- yarn lint *(fails: repository has 500+ pre-existing accessibility lint errors)*
- yarn test *(fails: existing jest suites fail with unwrapped act/localStorage errors)*
- npx playwright test *(fails: Playwright browsers not installed in runner environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb465ab7b88328ab134e0d36743501