### PR TITLE
[permissions] add mock permission manager

### DIFF
--- a/__tests__/components/apps/permissions.test.tsx
+++ b/__tests__/components/apps/permissions.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PermissionsApp from '../../../components/apps/permissions';
+import { resetMockFileSystem } from '../../../utils/fileSystemMock';
+
+describe('PermissionsApp', () => {
+  beforeEach(() => {
+    resetMockFileSystem();
+  });
+
+  it('updates the octal preview when toggling permissions', async () => {
+    const user = userEvent.setup();
+    render(<PermissionsApp />);
+
+    expect(screen.getByText(/Octal preview: 750/)).toBeInTheDocument();
+
+    const otherWrite = screen.getByRole('checkbox', {
+      name: /Other Write/i,
+    });
+
+    await user.click(otherWrite);
+
+    expect(screen.getByText(/Octal preview: 752/)).toBeInTheDocument();
+  });
+
+  it('shows dry-run warnings for system files', async () => {
+    const user = userEvent.setup();
+    render(<PermissionsApp />);
+
+    await user.selectOptions(screen.getByLabelText('Target path'), ['/etc/passwd']);
+
+    await user.click(
+      screen.getByRole('checkbox', {
+        name: /Other Read/i,
+      })
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /Preview \(dry run\)/i,
+      })
+    );
+
+    expect(screen.getByText('Dry run simulation')).toBeInTheDocument();
+    expect(
+      screen.getByText('/etc/passwd is marked as a system file.')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/644 -> 640/)).toBeInTheDocument();
+  });
+
+  it('requires typing the path before applying destructive changes', async () => {
+    const user = userEvent.setup();
+    render(<PermissionsApp />);
+
+    await user.selectOptions(screen.getByLabelText('Target path'), ['/etc/passwd']);
+
+    await user.click(
+      screen.getByRole('checkbox', {
+        name: /Other Read/i,
+      })
+    );
+
+    const applyButton = screen.getByRole('button', { name: /Apply changes/i });
+    expect(applyButton).toBeDisabled();
+
+    const confirmationField = screen.getByLabelText(/Type the path to confirm/i);
+
+    await user.type(confirmationField, '/wrong');
+    expect(applyButton).toBeDisabled();
+
+    await user.clear(confirmationField);
+    await user.type(confirmationField, '/etc/passwd');
+    expect(applyButton).toBeEnabled();
+
+    await user.click(applyButton);
+
+    expect(screen.getByText('Changes applied')).toBeInTheDocument();
+    expect(
+      screen.getByText('/etc/passwd is marked as a system file.')
+    ).toBeInTheDocument();
+  });
+});

--- a/components/apps/permissions/index.tsx
+++ b/components/apps/permissions/index.tsx
@@ -1,0 +1,406 @@
+import React, { useMemo, useState } from 'react';
+import {
+  applyMockPermissions,
+  getMockFileEntries,
+  getMockFileEntry,
+  MockFileEntry,
+  PermissionChange,
+  toOctalString,
+} from '../../../utils/fileSystemMock';
+
+type Role = 'user' | 'group' | 'other';
+type PermissionKey = 'read' | 'write' | 'execute';
+
+type PermissionMatrix = Record<Role, Record<PermissionKey, boolean>>;
+
+type OperationType = 'dry-run' | 'applied';
+
+interface OperationSummary {
+  type: OperationType;
+  path: string;
+  mode: string;
+  recursive: boolean;
+  changes: PermissionChange[];
+  warnings: string[];
+}
+
+const ROLE_LABELS: Record<Role, string> = {
+  user: 'User',
+  group: 'Group',
+  other: 'Other',
+};
+
+const PERMISSION_LABELS: Record<PermissionKey, string> = {
+  read: 'Read',
+  write: 'Write',
+  execute: 'Execute',
+};
+
+const ROLE_ORDER: Role[] = ['user', 'group', 'other'];
+const PERMISSION_ORDER: PermissionKey[] = ['read', 'write', 'execute'];
+
+const BIT_MAP: Record<Role, Record<PermissionKey, number>> = {
+  user: {
+    read: 0o400,
+    write: 0o200,
+    execute: 0o100,
+  },
+  group: {
+    read: 0o40,
+    write: 0o20,
+    execute: 0o10,
+  },
+  other: {
+    read: 0o4,
+    write: 0o2,
+    execute: 0o1,
+  },
+};
+
+const modeToMatrix = (mode: number): PermissionMatrix => ({
+  user: {
+    read: Boolean(mode & BIT_MAP.user.read),
+    write: Boolean(mode & BIT_MAP.user.write),
+    execute: Boolean(mode & BIT_MAP.user.execute),
+  },
+  group: {
+    read: Boolean(mode & BIT_MAP.group.read),
+    write: Boolean(mode & BIT_MAP.group.write),
+    execute: Boolean(mode & BIT_MAP.group.execute),
+  },
+  other: {
+    read: Boolean(mode & BIT_MAP.other.read),
+    write: Boolean(mode & BIT_MAP.other.write),
+    execute: Boolean(mode & BIT_MAP.other.execute),
+  },
+});
+
+const matrixToMode = (matrix: PermissionMatrix): number =>
+  ROLE_ORDER.reduce((total, role) => {
+    const permissions = PERMISSION_ORDER.reduce((sum, permission) => {
+      if (matrix[role][permission]) {
+        return sum + BIT_MAP[role][permission];
+      }
+      return sum;
+    }, 0);
+
+    return total + permissions;
+  }, 0);
+
+const matrixToSymbolic = (matrix: PermissionMatrix): string =>
+  ROLE_ORDER.map((role) =>
+    PERMISSION_ORDER.map((permission) =>
+      matrix[role][permission]
+        ? permission === 'read'
+          ? 'r'
+          : permission === 'write'
+            ? 'w'
+            : 'x'
+        : '-'
+    ).join('')
+  ).join('');
+
+const isDestructiveChange = (
+  entry: MockFileEntry | undefined,
+  newMode: number
+): boolean => {
+  if (!entry) {
+    return false;
+  }
+
+  const ownerReadRemoved = Boolean(entry.mode & 0o400) && !(newMode & 0o400);
+  const otherWriteAdded = !Boolean(entry.mode & 0o2) && Boolean(newMode & 0o2);
+
+  return Boolean(entry.isSystem) || ownerReadRemoved || otherWriteAdded;
+};
+
+const PermissionsApp: React.FC = () => {
+  const [version, setVersion] = useState(0);
+  const files = useMemo(() => getMockFileEntries(), [version]);
+  const [selectedPath, setSelectedPath] = useState(() => files[0]?.path ?? '');
+  const [matrix, setMatrix] = useState<PermissionMatrix>(() =>
+    modeToMatrix(files[0]?.mode ?? 0o644)
+  );
+  const [recursive, setRecursive] = useState(false);
+  const [confirmationInput, setConfirmationInput] = useState('');
+  const [result, setResult] = useState<OperationSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedEntry = files.find((entry) => entry.path === selectedPath);
+
+  const targetMode = useMemo(() => matrixToMode(matrix), [matrix]);
+  const octalPreview = useMemo(() => toOctalString(targetMode), [targetMode]);
+  const symbolicPreview = useMemo(() => matrixToSymbolic(matrix), [matrix]);
+  const destructive = isDestructiveChange(selectedEntry, targetMode);
+  const canApply = Boolean(selectedEntry) && (!destructive || confirmationInput === selectedEntry?.path);
+  const canRecursive = selectedEntry?.type === 'directory';
+
+  const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextPath = event.target.value;
+    const entry = getMockFileEntry(nextPath);
+
+    setSelectedPath(nextPath);
+    setMatrix(modeToMatrix(entry?.mode ?? 0o644));
+    setRecursive(false);
+    setConfirmationInput('');
+    setResult(null);
+    setError(null);
+  };
+
+  const handleToggle = (role: Role, permission: PermissionKey) => {
+    setMatrix((prev) => ({
+      ...prev,
+      [role]: {
+        ...prev[role],
+        [permission]: !prev[role][permission],
+      },
+    }));
+    setResult(null);
+    setError(null);
+  };
+
+  const handleRecursiveChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setRecursive(event.target.checked);
+  };
+
+  const handleOperation = (dryRun: boolean) => {
+    if (!selectedEntry) {
+      setError('Select a file or directory to continue.');
+      return;
+    }
+
+    if (!dryRun && destructive && confirmationInput !== selectedEntry.path) {
+      setError('Type the full path to confirm this change.');
+      return;
+    }
+
+    try {
+      const response = applyMockPermissions(selectedEntry.path, targetMode, {
+        recursive,
+        dryRun,
+      });
+
+      const summary: OperationSummary = {
+        type: dryRun ? 'dry-run' : 'applied',
+        path: selectedEntry.path,
+        mode: octalPreview,
+        recursive,
+        changes: response.changes,
+        warnings: response.warnings,
+      };
+
+      setResult(summary);
+      setError(null);
+
+      if (!dryRun) {
+        setConfirmationInput('');
+        setMatrix(modeToMatrix(targetMode));
+        setVersion((value) => value + 1);
+      }
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('Unable to change permissions.');
+      }
+    }
+  };
+
+  if (!files.length) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-ub-cool-grey text-white">
+        No files available.
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full w-full overflow-y-auto bg-ub-cool-grey p-6 text-white">
+      <h1 className="text-2xl font-semibold">Permissions Manager</h1>
+      <p className="mt-1 text-sm text-ubt-grey">
+        Adjust simulated permissions for demo files. Changes never touch the real
+        file system.
+      </p>
+
+      <div className="mt-6 space-y-6">
+        <section>
+          <label
+            htmlFor="permission-path"
+            className="block text-sm font-medium text-ubt-grey"
+          >
+            Target path
+          </label>
+          <select
+            id="permission-path"
+            value={selectedPath}
+            onChange={handleSelectChange}
+            className="mt-2 w-full rounded border border-ubt-grey bg-black bg-opacity-30 px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            {files.map((entry) => (
+              <option key={entry.path} value={entry.path}>
+                {entry.path} {entry.type === 'directory' ? '(dir)' : '(file)'}
+              </option>
+            ))}
+          </select>
+          {selectedEntry?.isSystem && (
+            <p className="mt-2 text-sm text-yellow-300">
+              This path is marked as a system file. Proceed carefully.
+            </p>
+          )}
+        </section>
+
+        <section className="rounded border border-ubt-grey bg-black bg-opacity-30 p-4">
+          <h2 className="text-lg font-semibold">Permission matrix</h2>
+          <div className="mt-4 grid gap-4 md:grid-cols-3">
+            {ROLE_ORDER.map((role) => (
+              <fieldset key={role} className="rounded border border-ubt-grey p-3">
+                <legend className="px-1 text-sm font-semibold uppercase tracking-wide text-ubt-grey">
+                  {ROLE_LABELS[role]}
+                </legend>
+                <div className="mt-2 space-y-2">
+                  {PERMISSION_ORDER.map((permission) => (
+                    <label
+                      key={permission}
+                      className="flex items-center gap-2 text-sm"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={matrix[role][permission]}
+                        onChange={() => handleToggle(role, permission)}
+                        className="h-4 w-4 rounded border border-ubt-grey bg-black"
+                        aria-label={`${ROLE_LABELS[role]} ${PERMISSION_LABELS[permission]}`}
+                      />
+                      <span>{PERMISSION_LABELS[permission]}</span>
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
+            ))}
+          </div>
+          <div className="mt-4 flex flex-wrap gap-4 text-sm text-ubt-grey">
+            <span>
+              Current: {selectedEntry ? toOctalString(selectedEntry.mode) : '---'}
+            </span>
+            <span>Octal preview: {octalPreview}</span>
+            <span>Symbolic: {symbolicPreview}</span>
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={recursive && canRecursive}
+              onChange={handleRecursiveChange}
+              disabled={!canRecursive}
+              className="h-4 w-4 rounded border border-ubt-grey bg-black"
+            />
+            <span>Apply recursively to nested files</span>
+          </label>
+          {!canRecursive && (
+            <p className="text-xs text-ubt-grey">
+              Recursive apply is only available for directories.
+            </p>
+          )}
+        </section>
+
+        {destructive && selectedEntry && (
+          <section className="rounded border border-red-500 bg-red-500 bg-opacity-10 p-4 text-sm text-red-100">
+            <p>
+              This change could be destructive. Type
+              <span className="mx-1 font-mono text-red-200">
+                {selectedEntry.path}
+              </span>
+              to confirm.
+            </p>
+            <label
+              htmlFor="permission-confirmation"
+              className="mt-3 block text-xs uppercase tracking-wide text-red-200"
+            >
+              Type the path to confirm
+            </label>
+            <input
+              id="permission-confirmation"
+              type="text"
+              value={confirmationInput}
+              onChange={(event) => setConfirmationInput(event.target.value)}
+              className="mt-1 w-full rounded border border-red-500 bg-black bg-opacity-40 px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-red-500"
+            />
+          </section>
+        )}
+
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={() => handleOperation(true)}
+            className="rounded bg-slate-600 px-4 py-2 text-sm font-semibold transition hover:bg-slate-500 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={!selectedEntry}
+          >
+            Preview (dry run)
+          </button>
+          <button
+            type="button"
+            onClick={() => handleOperation(false)}
+            className="rounded bg-blue-600 px-4 py-2 text-sm font-semibold transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={!canApply}
+          >
+            Apply changes
+          </button>
+        </div>
+
+        {error && (
+          <div
+            className="rounded border border-red-500 bg-red-500 bg-opacity-10 p-3 text-sm text-red-100"
+            role="alert"
+          >
+            {error}
+          </div>
+        )}
+
+        {result && (
+          <div
+            className="space-y-3 rounded border border-ubt-grey bg-black bg-opacity-30 p-4"
+            aria-live="polite"
+          >
+            <h2 className="text-lg font-semibold">
+              {result.type === 'dry-run' ? 'Dry run simulation' : 'Changes applied'}
+            </h2>
+            <p className="text-sm text-ubt-grey">
+              {result.type === 'dry-run'
+                ? `Simulated applying ${result.mode} to ${result.path}${result.recursive ? ' recursively' : ''}.`
+                : `Applied ${result.mode} to ${result.path}${result.recursive ? ' recursively' : ''}.`}
+            </p>
+            {result.changes.length > 0 ? (
+              <ul className="space-y-1 text-sm">
+                {result.changes.map((change) => (
+                  <li key={change.path}>
+                    {change.path}: {change.from} -&gt; {change.to}
+                    {change.isSystem ? ' (system file)' : ''}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-ubt-grey">
+                {result.type === 'dry-run'
+                  ? 'No changes would be made.'
+                  : 'No changes were necessary.'}
+              </p>
+            )}
+            {result.warnings.length > 0 && (
+              <div className="rounded border border-yellow-500 bg-yellow-500 bg-opacity-10 p-3">
+                <h3 className="text-sm font-semibold text-yellow-200">Warnings</h3>
+                <ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-yellow-100">
+                  {result.warnings.map((warning) => (
+                    <li key={warning}>{warning}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PermissionsApp;

--- a/docs/permissions-app.md
+++ b/docs/permissions-app.md
@@ -1,0 +1,19 @@
+# Permissions App
+
+The Permissions Manager simulates adjusting Unix-style file modes inside the Kali Linux portfolio without touching the real file system.
+
+## Features
+
+- Presents a three-by-three matrix for **user**, **group**, and **other** roles so visitors can toggle read, write, and execute bits with immediate octal and symbolic previews.
+- Supports recursive application for directories. The UI automatically disables the option for files to avoid confusion.
+- Provides a **dry-run preview** that surfaces all affected paths and any warnings before committing a change.
+- Requires a typed confirmation that matches the selected path whenever a potentially destructive change (system file or risky bit flip) is detected.
+- Highlights system paths in the results and warning panels so readers understand the simulated impact.
+
+## Implementation notes
+
+- Mock data and the dry-run simulator live in `utils/fileSystemMock.ts`. The helper returns affected paths, warnings, and supports recursive changes so the UI can render accurate previews.
+- Component code is located at `components/apps/permissions/index.tsx`. It derives octal and symbolic values from the matrix, renders the confirmation prompt, and routes all operations through the mock simulator.
+- Tests reside in `__tests__/components/apps/permissions.test.tsx` and cover the preview math, warning display, and destructive-change confirmation flow.
+
+This app is intentionally self-contained and ships with mock data so it remains safe to showcase in demos and static exports.

--- a/utils/fileSystemMock.ts
+++ b/utils/fileSystemMock.ts
@@ -1,0 +1,118 @@
+export type MockFileType = 'file' | 'directory';
+
+export interface MockFileEntry {
+  path: string;
+  mode: number;
+  type: MockFileType;
+  isSystem?: boolean;
+}
+
+export interface PermissionChange {
+  path: string;
+  from: string;
+  to: string;
+  isSystem: boolean;
+}
+
+export interface PermissionResult {
+  changes: PermissionChange[];
+  warnings: string[];
+}
+
+export interface ApplyPermissionOptions {
+  recursive?: boolean;
+  dryRun?: boolean;
+}
+
+const cloneEntry = (entry: MockFileEntry): MockFileEntry => ({
+  path: entry.path,
+  mode: entry.mode,
+  type: entry.type,
+  isSystem: entry.isSystem ?? false,
+});
+
+const initialFileSystem: MockFileEntry[] = [
+  { path: '/home/demo', mode: 0o750, type: 'directory' },
+  { path: '/home/demo/scripts', mode: 0o755, type: 'directory' },
+  { path: '/home/demo/scripts/deploy.sh', mode: 0o744, type: 'file' },
+  { path: '/var/log/app.log', mode: 0o640, type: 'file' },
+  { path: '/etc/passwd', mode: 0o644, type: 'file', isSystem: true },
+  { path: '/usr/bin/nmap', mode: 0o755, type: 'file', isSystem: true },
+];
+
+let fileSystemState: MockFileEntry[] = initialFileSystem.map(cloneEntry);
+
+const withTrailingSlash = (path: string): string =>
+  path.endsWith('/') ? path : `${path}/`;
+
+const findEntry = (path: string): MockFileEntry | undefined =>
+  fileSystemState.find((entry) => entry.path === path);
+
+const getDescendants = (path: string): MockFileEntry[] => {
+  const prefix = withTrailingSlash(path);
+  return fileSystemState.filter(
+    (entry) => entry.path !== path && entry.path.startsWith(prefix)
+  );
+};
+
+export const toOctalString = (mode: number): string =>
+  mode.toString(8).padStart(3, '0');
+
+export const resetMockFileSystem = (): void => {
+  fileSystemState = initialFileSystem.map(cloneEntry);
+};
+
+export const getMockFileEntries = (): MockFileEntry[] =>
+  fileSystemState.map(cloneEntry);
+
+export const getMockFileEntry = (path: string): MockFileEntry | undefined => {
+  const entry = findEntry(path);
+  return entry ? cloneEntry(entry) : undefined;
+};
+
+export const applyMockPermissions = (
+  path: string,
+  mode: number,
+  options: ApplyPermissionOptions = {}
+): PermissionResult => {
+  const entry = findEntry(path);
+  if (!entry) {
+    throw new Error(`Path not found: ${path}`);
+  }
+
+  const affected: MockFileEntry[] = [entry];
+
+  if (options.recursive && entry.type === 'directory') {
+    affected.push(...getDescendants(path));
+  }
+
+  const modeString = toOctalString(mode);
+  const changes: PermissionChange[] = [];
+  const warnings = new Set<string>();
+
+  affected.forEach((item) => {
+    if (item.mode !== mode) {
+      changes.push({
+        path: item.path,
+        from: toOctalString(item.mode),
+        to: modeString,
+        isSystem: Boolean(item.isSystem),
+      });
+    }
+
+    if (item.isSystem) {
+      warnings.add(`${item.path} is marked as a system file.`);
+    }
+  });
+
+  if (!options.dryRun) {
+    affected.forEach((item) => {
+      item.mode = mode;
+    });
+  }
+
+  return {
+    changes,
+    warnings: Array.from(warnings),
+  };
+};


### PR DESCRIPTION
## Summary
- add a permissions manager app with matrix controls, dry-run previewing, and destructive-change confirmations
- provide a mock filesystem simulator that tracks warnings and recursive application for dry runs
- document the new app and add regression tests for the matrix, dry-run warnings, and confirmation workflow

## Testing
- yarn lint *(fails: repository has numerous pre-existing accessibility and no-top-level-window violations)*
- yarn test *(partially ran; multiple legacy suites fail, permissions suite passes)*

------
https://chatgpt.com/codex/tasks/task_e_68cb19d2c1508328b75c0a1620cec965