### PR TITLE
[apps] add AppArmor learning lab simulator

### DIFF
--- a/__tests__/components/apps/apparmor.test.tsx
+++ b/__tests__/components/apps/apparmor.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import AppArmorLab from '../../../components/apps/apparmor';
+
+describe('AppArmor learning lab', () => {
+  test('updates profile mode when toggles change', () => {
+    render(<AppArmorLab />);
+
+    const statusBadge = screen.getByTestId('profile-status-demo-browser');
+    expect(statusBadge).toHaveTextContent('enforce');
+
+    fireEvent.click(screen.getByLabelText(/Demo Browser complain mode/i));
+
+    expect(statusBadge).toHaveTextContent('complain');
+  });
+
+  test('walks through learning flow and shows generated diff', () => {
+    render(<AppArmorLab />);
+
+    expect(screen.getByText(/profile demo-browser/i)).toBeInTheDocument();
+
+    let nextButton = screen.getByRole('button', { name: /next/i });
+    fireEvent.click(nextButton);
+
+    expect(
+      screen.getByText(/Permit desktop notifications over D-Bus/i)
+    ).toBeInTheDocument();
+
+    nextButton = screen.getByRole('button', { name: /next/i });
+    fireEvent.click(nextButton);
+
+    expect(
+      screen.getByLabelText('Include suggestion: Allow reading user configuration files')
+    ).toBeChecked();
+
+    nextButton = screen.getByRole('button', { name: /next/i });
+    fireEvent.click(nextButton);
+
+    const diff = screen.getByTestId('apparmor-profile-diff');
+    expect(diff.textContent).toContain('+++ demo-browser.learned');
+    expect(diff.textContent).toContain('owner @{HOME}/.config/demo-browser/** rw,');
+
+    const preview = screen.getByTestId('apparmor-profile-preview');
+    expect(preview.textContent).toContain('capability net_bind_service');
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -79,6 +79,7 @@ const TrashApp = createDynamicApp('trash', 'Trash');
 const SerialTerminalApp = createDynamicApp('serial-terminal', 'Serial Terminal');
 
 
+const AppArmorLabApp = createDynamicApp('apparmor', 'AppArmor Lab');
 const WiresharkApp = createDynamicApp('wireshark', 'Wireshark');
 const BleSensorApp = createDynamicApp('ble-sensor', 'BLE Sensor');
 const DsniffApp = createDynamicApp('dsniff', 'dsniff');
@@ -171,6 +172,7 @@ const displayGhidra = createDisplay(GhidraApp);
 const displayAutopsy = createDisplay(AutopsyApp);
 const displayPluginManager = createDisplay(PluginManagerApp);
 
+const displayAppArmorLab = createDisplay(AppArmorLabApp);
 const displayWireshark = createDisplay(WiresharkApp);
 const displayBleSensor = createDisplay(BleSensorApp);
 const displayBeef = createDisplay(BeefApp);
@@ -745,6 +747,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayMetasploit,
+  },
+  {
+    id: 'apparmor',
+    title: 'AppArmor Lab',
+    icon: '/themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayAppArmorLab,
   },
   {
     id: 'wireshark',

--- a/apps/apparmor/index.tsx
+++ b/apps/apparmor/index.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import React from 'react';
+
+import AppArmorLab from '../../components/apps/apparmor';
+
+const AppArmorPage: React.FC = () => (
+  <div className="h-full w-full">
+    <AppArmorLab />
+  </div>
+);
+
+export default AppArmorPage;

--- a/components/apps/apparmor/index.tsx
+++ b/components/apps/apparmor/index.tsx
@@ -1,0 +1,377 @@
+import React, { useMemo, useState } from 'react';
+
+import {
+  AppArmorProfile,
+  ProfileStatus,
+  computeLearningResult,
+  getDefaultSelectedSuggestionIds,
+  profileStatusOptions,
+  sampleLearningSession,
+  sampleProfiles,
+} from '../../../utils/apparmorLearner';
+
+const steps = [
+  {
+    title: 'Baseline profile',
+    description:
+      'Review the existing policy for the Demo Browser before training begins.',
+  },
+  {
+    title: 'Ingest sample logs',
+    description:
+      'Process canned AppArmor audit entries to understand what the application attempted.',
+  },
+  {
+    title: 'Select learning suggestions',
+    description:
+      'Decide which generated rules should be applied to the profile.',
+  },
+  {
+    title: 'Preview generated profile',
+    description:
+      'Compare the learned profile and diff before rolling out the changes.',
+  },
+] as const;
+
+const statusColours: Record<ProfileStatus, string> = {
+  disabled: 'bg-gray-700 text-gray-200',
+  enabled: 'bg-sky-700 text-white',
+  complain: 'bg-amber-600 text-black',
+  enforce: 'bg-green-600 text-white',
+};
+
+const AppArmorLab: React.FC = () => {
+  const [profiles, setProfiles] = useState<AppArmorProfile[]>(() =>
+    sampleProfiles.map((profile) => ({ ...profile }))
+  );
+  const [activeStep, setActiveStep] = useState(0);
+  const [selectedSuggestionIds, setSelectedSuggestionIds] = useState<string[]>(
+    () => getDefaultSelectedSuggestionIds(sampleLearningSession)
+  );
+
+  const session = sampleLearningSession;
+  const orderedSuggestionIds = useMemo(
+    () => session.suggestions.map((suggestion) => suggestion.id),
+    [session]
+  );
+
+  const result = useMemo(
+    () => computeLearningResult(session, selectedSuggestionIds),
+    [selectedSuggestionIds, session]
+  );
+
+  const selectedProfile = profiles.find(
+    (profile) => profile.id === session.profileId
+  );
+
+  const setProfileStatus = (profileId: string, status: ProfileStatus) => {
+    setProfiles((prev) =>
+      prev.map((profile) =>
+        profile.id === profileId ? { ...profile, status } : profile
+      )
+    );
+  };
+
+  const toggleSuggestion = (suggestionId: string) => {
+    setSelectedSuggestionIds((prev) => {
+      const next = prev.includes(suggestionId)
+        ? prev.filter((id) => id !== suggestionId)
+        : [...prev, suggestionId];
+      return orderedSuggestionIds.filter((id) => next.includes(id));
+    });
+  };
+
+  const goToNextStep = () =>
+    setActiveStep((current) => Math.min(current + 1, steps.length - 1));
+  const goToPreviousStep = () =>
+    setActiveStep((current) => Math.max(current - 1, 0));
+
+  const renderStepContent = () => {
+    if (activeStep === 0) {
+      return (
+        <div className="space-y-3 text-sm text-gray-200">
+          <p>
+            {`The current profile for ${session.profileName} limits the demo browser to shared libraries and outbound HTTPS.`}
+          </p>
+          <pre className="max-h-64 overflow-auto rounded border border-gray-700 bg-gray-950 p-3 text-xs text-green-200">
+            <code>{session.baseProfile}</code>
+          </pre>
+          <p>
+            {`Learning mode will propose new rules without applying them automatically. Continue through the flow to inspect the generated policy.`}
+          </p>
+        </div>
+      );
+    }
+
+    if (activeStep === 1) {
+      return (
+        <div className="space-y-4">
+          {session.suggestions.map((suggestion) => (
+            <article
+              key={suggestion.id}
+              className="rounded border border-slate-700 bg-slate-900 p-3 text-sm text-slate-200"
+            >
+              <header className="mb-2 flex items-center justify-between">
+                <h3 className="font-semibold text-slate-100">
+                  {suggestion.title}
+                </h3>
+                <span className="rounded bg-slate-700 px-2 py-0.5 text-xs uppercase tracking-wide text-slate-200">
+                  {suggestion.category}
+                </span>
+              </header>
+              <p className="mb-2 text-xs text-slate-300">
+                {suggestion.rationale}
+              </p>
+              <p className="rounded bg-black/40 p-2 font-mono text-[11px] leading-relaxed text-amber-200">
+                {suggestion.rawLog}
+              </p>
+            </article>
+          ))}
+        </div>
+      );
+    }
+
+    if (activeStep === 2) {
+      const selectedSet = new Set(selectedSuggestionIds);
+      return (
+        <div className="space-y-3">
+          {session.suggestions.map((suggestion) => (
+            <label
+              key={suggestion.id}
+              className="block cursor-pointer rounded border border-gray-700 bg-gray-900 p-3 text-sm text-gray-200 transition hover:border-blue-500"
+            >
+              <div className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  className="mt-1 h-4 w-4 cursor-pointer accent-blue-500"
+                  checked={selectedSet.has(suggestion.id)}
+                  onChange={() => toggleSuggestion(suggestion.id)}
+                  aria-label={`Include suggestion: ${suggestion.title}`}
+                />
+                <div className="flex-1 space-y-2">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <h3 className="font-semibold text-gray-100">
+                      {suggestion.title}
+                    </h3>
+                    <span className="rounded bg-slate-700 px-2 py-0.5 text-xs uppercase tracking-wide text-slate-200">
+                      {suggestion.category}
+                    </span>
+                  </div>
+                  <p className="text-xs text-gray-300">{suggestion.rationale}</p>
+                  <pre className="overflow-auto rounded bg-black/30 p-2 text-[11px] text-green-200">
+                    <code>{suggestion.ruleLines.join('\n')}</code>
+                  </pre>
+                  <details className="text-xs text-gray-400">
+                    <summary className="cursor-pointer text-gray-300">
+                      View log excerpt
+                    </summary>
+                    <p className="mt-1 rounded bg-black/30 p-2 font-mono text-[11px] leading-relaxed text-amber-200">
+                      {suggestion.rawLog}
+                    </p>
+                  </details>
+                </div>
+              </div>
+            </label>
+          ))}
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-4 text-sm text-gray-200">
+        <p>
+          {result.appliedSuggestions.length === 0
+            ? 'No rules selected. Go back a step to include at least one suggestion before exporting.'
+            : 'Learning mode generated the following additions. Review them before committing the profile.'}
+        </p>
+        {result.appliedSuggestions.length > 0 && (
+          <ul className="space-y-2">
+            {result.appliedSuggestions.map((suggestion) => (
+              <li
+                key={suggestion.id}
+                className="rounded border border-slate-700 bg-slate-900 p-3"
+              >
+                <p className="font-semibold text-gray-100">
+                  {suggestion.title}
+                </p>
+                <pre className="mt-2 overflow-auto rounded bg-black/30 p-2 text-[11px] text-green-200">
+                  <code>{suggestion.ruleLines.join('\n')}</code>
+                </pre>
+              </li>
+            ))}
+          </ul>
+        )}
+        <section aria-labelledby="apparmor-preview-heading" className="space-y-2">
+          <h3
+            id="apparmor-preview-heading"
+            className="text-base font-semibold text-gray-100"
+          >
+            Generated profile
+          </h3>
+          <pre
+            data-testid="apparmor-profile-preview"
+            className="max-h-64 overflow-auto rounded border border-gray-700 bg-gray-950 p-3 text-xs text-green-200"
+          >
+            <code>{result.previewProfile}</code>
+          </pre>
+        </section>
+        <section aria-labelledby="apparmor-diff-heading" className="space-y-2">
+          <h3
+            id="apparmor-diff-heading"
+            className="text-base font-semibold text-gray-100"
+          >
+            Unified diff
+          </h3>
+          <pre
+            data-testid="apparmor-profile-diff"
+            className="max-h-64 overflow-auto rounded border border-gray-700 bg-gray-950 p-3 text-xs text-blue-200"
+          >
+            <code>{result.diff}</code>
+          </pre>
+        </section>
+      </div>
+    );
+  };
+
+  return (
+    <div className="h-full w-full overflow-y-auto bg-slate-950 p-4 text-slate-100">
+      <header className="mb-5 space-y-1">
+        <h1 className="text-xl font-semibold">AppArmor Profile Lab</h1>
+        <p className="text-sm text-slate-300">
+          Experiment with a safe AppArmor learning workflow. All data is simulated and never touches your host policies.
+        </p>
+      </header>
+
+      <section className="mb-6 space-y-4" aria-labelledby="apparmor-profiles-heading">
+        <div className="flex items-center justify-between">
+          <h2 id="apparmor-profiles-heading" className="text-lg font-semibold">
+            Profile catalogue
+          </h2>
+          <span className="text-xs text-slate-400">
+            Toggle enforcement modes to understand how AppArmor manages services.
+          </span>
+        </div>
+        <div className="space-y-3">
+          {profiles.map((profile) => (
+            <article
+              key={profile.id}
+              className="rounded border border-slate-800 bg-slate-900 p-4"
+            >
+              <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <h3 className="text-base font-semibold text-slate-100">
+                    {profile.name}
+                  </h3>
+                  <p className="text-xs text-slate-300">{profile.description}</p>
+                  <p className="text-xs text-slate-400">Executable: {profile.path}</p>
+                </div>
+                <span
+                  data-testid={`profile-status-${profile.id}`}
+                  className={`rounded px-2 py-1 text-xs font-semibold ${statusColours[profile.status]}`}
+                >
+                  {profile.status}
+                </span>
+              </div>
+              <fieldset className="space-y-2">
+                <legend className="text-xs uppercase tracking-wide text-slate-400">
+                  Mode
+                </legend>
+                <div className="flex flex-wrap gap-3">
+                  {profileStatusOptions.map((option) => (
+                    <label
+                      key={option.key}
+                      className={`flex cursor-pointer items-center gap-2 rounded border border-slate-800 px-2 py-1 text-xs hover:border-blue-500 ${
+                        profile.status === option.key ? 'bg-blue-900/40' : 'bg-transparent'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name={`status-${profile.id}`}
+                        value={option.key}
+                        className="h-3 w-3 cursor-pointer accent-blue-500"
+                        checked={profile.status === option.key}
+                        onChange={() => setProfileStatus(profile.id, option.key)}
+                        aria-label={`${profile.name} ${option.label.toLowerCase()} mode`}
+                      />
+                      <div>
+                        <p className="font-medium text-slate-100">{option.label}</p>
+                        <p className="text-[11px] text-slate-400">{option.helper}</p>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="apparmor-learning-heading" className="space-y-4">
+        <div>
+          <h2
+            id="apparmor-learning-heading"
+            className="text-lg font-semibold text-slate-100"
+          >
+            Guided learning mode
+          </h2>
+          <p className="text-xs text-slate-300">
+            Follow the steps below to generate a hardened profile for the Demo Browser. You can move back and forth at any time.
+          </p>
+        </div>
+        <ol className="flex flex-wrap gap-2 text-xs">
+          {steps.map((step, index) => (
+            <li
+              key={step.title}
+              className={`rounded px-2 py-1 ${
+                index === activeStep
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-slate-800 text-slate-300'
+              }`}
+            >
+              Step {index + 1}: {step.title}
+            </li>
+          ))}
+        </ol>
+        <div className="rounded border border-slate-800 bg-slate-900 p-4" aria-live="polite">
+          <header className="mb-4">
+            <h3 className="text-base font-semibold text-slate-100">
+              Step {activeStep + 1}: {steps[activeStep].title}
+            </h3>
+            <p className="text-xs text-slate-300">{steps[activeStep].description}</p>
+            {selectedProfile && (
+              <p className="mt-1 text-xs text-slate-400">
+                Focus profile: {selectedProfile.name} ({selectedProfile.status})
+              </p>
+            )}
+          </header>
+          {renderStepContent()}
+          <footer className="mt-4 flex flex-wrap items-center justify-between gap-2">
+            <div className="text-xs text-slate-400">
+              {result.appliedSuggestions.length} suggestion(s) selected
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={goToPreviousStep}
+                disabled={activeStep === 0}
+                className="rounded border border-slate-700 px-3 py-1 text-xs text-slate-200 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Previous
+              </button>
+              <button
+                type="button"
+                onClick={goToNextStep}
+                disabled={activeStep === steps.length - 1}
+                className="rounded bg-blue-600 px-3 py-1 text-xs font-semibold text-white disabled:cursor-not-allowed disabled:bg-blue-600/40"
+              >
+                Next
+              </button>
+            </div>
+          </footer>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default AppArmorLab;

--- a/docs/apparmor-lab.md
+++ b/docs/apparmor-lab.md
@@ -1,0 +1,19 @@
+# AppArmor Profile Lab
+
+The AppArmor Profile Lab provides an educational walkthrough of how profile learning works in AppArmor without touching a host system. It lives at `components/apps/apparmor/index.tsx` and is registered as an app under `apps/apparmor`.
+
+## Feature Highlights
+
+- **Profile catalogue** – three demo services showcase how AppArmor modes (`disabled`, `enabled`, `complain`, `enforce`) affect confinement. Radio groups let users toggle the simulated state and see status badges update instantly.
+- **Guided learning flow** – a four-step wizard walks through the baseline profile, sample audit logs, rule selection, and final preview. Navigation buttons support back/next so learners can experiment freely.
+- **Learning engine** – canned audit logs feed into `utils/apparmorLearner.ts`, which returns suggestions, generated rules, and a unified diff. The UI surfaces rule snippets, rationale, and raw logs while ensuring no real policy changes occur.
+- **Diff and preview** – the last step renders the generated profile alongside a diff (headers use `<profile>.base`/`<profile>.learned`). Deselecting suggestions updates both views so the user understands the impact of each rule.
+
+## Files of Interest
+
+- `components/apps/apparmor/index.tsx` – React component powering the lab UI.
+- `utils/apparmorLearner.ts` – deterministic learning helper that transforms simulated logs into rule insertions and diff output.
+- `apps/apparmor/index.tsx` – Next.js route that embeds the component inside the desktop shell.
+- `__tests__/components/apps/apparmor.test.tsx` – Jest tests covering profile mode toggles and the guided flow.
+
+All data is static and scoped to the browser to ensure the simulator remains safe for public demos.

--- a/utils/apparmorLearner.ts
+++ b/utils/apparmorLearner.ts
@@ -1,0 +1,248 @@
+export type ProfileStatus = 'disabled' | 'enabled' | 'complain' | 'enforce';
+
+export interface AppArmorProfile {
+  id: string;
+  name: string;
+  description: string;
+  path: string;
+  status: ProfileStatus;
+}
+
+export interface LearningSuggestion {
+  id: string;
+  title: string;
+  category: 'filesystem' | 'capability' | 'ipc';
+  rawLog: string;
+  rationale: string;
+  ruleLines: string[];
+}
+
+export interface LearningSession {
+  profileId: string;
+  profileName: string;
+  executable: string;
+  baseProfile: string;
+  suggestions: LearningSuggestion[];
+}
+
+export interface LearningResult {
+  previewProfile: string;
+  diff: string;
+  appliedSuggestions: LearningSuggestion[];
+}
+
+export const profileStatusOptions: ReadonlyArray<{
+  key: ProfileStatus;
+  label: string;
+  helper: string;
+}> = [
+  {
+    key: 'disabled',
+    label: 'Disabled',
+    helper: 'Profile is unloaded and not enforced.',
+  },
+  {
+    key: 'enabled',
+    label: 'Enabled',
+    helper: 'Profile is loaded but follows its current mode.',
+  },
+  {
+    key: 'complain',
+    label: 'Complain',
+    helper: 'Logs violations instead of blocking access.',
+  },
+  {
+    key: 'enforce',
+    label: 'Enforce',
+    helper: 'Blocks access that is not explicitly allowed.',
+  },
+];
+
+export const sampleProfiles: ReadonlyArray<AppArmorProfile> = [
+  {
+    id: 'demo-browser',
+    name: 'Demo Browser',
+    description: 'Sandboxed web browser that loads user preferences and sends desktop notifications.',
+    path: '/usr/bin/demo-browser',
+    status: 'enforce',
+  },
+  {
+    id: 'research-notes',
+    name: 'Research Notes',
+    description: 'Markdown editor storing files in the documents workspace.',
+    path: '/opt/tools/research-notes',
+    status: 'complain',
+  },
+  {
+    id: 'log-forwarder',
+    name: 'Log Forwarder',
+    description: 'Service that tails journal entries and forwards summaries to a collector.',
+    path: '/usr/local/bin/log-forwarder',
+    status: 'enabled',
+  },
+];
+
+const baseProfile = `# AppArmor profile generated for demonstration purposes\nprofile demo-browser /usr/bin/demo-browser {\n  # Allow essential runtime dependencies\n  /usr/lib/** mr,\n  /etc/ld.so.cache r,\n  /etc/ssl/certs/** r,\n\n  # Basic networking to reach HTTPS endpoints\n  network inet stream,\n}\n`;
+
+const simulatedSuggestions: ReadonlyArray<LearningSuggestion> = [
+  {
+    id: 'config-read',
+    title: 'Allow reading user configuration files',
+    category: 'filesystem',
+    rawLog:
+      'Sep 13 09:14:22 workstation kernel: audit: type=1400 apparmor="DENIED" profile="demo-browser" name="/home/alex/.config/demo-browser/settings.json" requested_mask="r" denied_mask="r"',
+    rationale:
+      'The browser loads its per-user configuration when booting. Restricting the rule to the user-owned directory keeps confinement tight.',
+    ruleLines: ['owner @{HOME}/.config/demo-browser/** rw,'],
+  },
+  {
+    id: 'notifications',
+    title: 'Permit desktop notifications over D-Bus',
+    category: 'ipc',
+    rawLog:
+      'Sep 13 09:14:24 workstation dbus-daemon[2213]: apparmor="DENIED" operation="dbus_method_call" bus="session" path="/org/freedesktop/Notifications" interface="org.freedesktop.Notifications" member="Notify" mask="send" name="org.freedesktop.Notifications"',
+    rationale:
+      'Desktop notifications are part of the browsing experience. Limiting the D-Bus rule to the Notifications interface avoids broad bus access.',
+    ruleLines: [
+      'dbus send bus=session path=/org/freedesktop/Notifications \\',
+      'interface=org.freedesktop.Notifications member=Notify',
+    ],
+  },
+  {
+    id: 'download-cache',
+    title: 'Write to download cache',
+    category: 'filesystem',
+    rawLog:
+      'Sep 13 09:14:31 workstation kernel: audit: type=1400 apparmor="DENIED" profile="demo-browser" name="/home/alex/Downloads/demo.tmp" requested_mask="w" denied_mask="w"',
+    rationale:
+      'Temporary downloads should land in the user download directory. Using the @{HOME} variable keeps the rule generic for all users.',
+    ruleLines: ['owner @{HOME}/Downloads/** rw,'],
+  },
+  {
+    id: 'certificate-refresh',
+    title: 'Allow refreshing certificate store metadata',
+    category: 'filesystem',
+    rawLog:
+      'Sep 13 09:14:37 workstation kernel: audit: type=1400 apparmor="DENIED" profile="demo-browser" name="/var/lib/demo-browser/cert-cache.json" requested_mask="w" denied_mask="w"',
+    rationale:
+      'The browser maintains its own cached trust store. Restricting writes to the application directory prevents wider filesystem access.',
+    ruleLines: ['/var/lib/demo-browser/** rw,'],
+  },
+  {
+    id: 'loopback-capability',
+    title: 'Grant bind access to loopback ports',
+    category: 'capability',
+    rawLog:
+      'Sep 13 09:14:40 workstation kernel: audit: type=1400 apparmor="DENIED" profile="demo-browser" pid=4221 comm="demo-browser" capability=36 capname="net_bind_service"',
+    rationale:
+      'The embedded testing server binds to high loopback ports for WebDriver automation. The capability rule is scoped to the service.',
+    ruleLines: ['capability net_bind_service,'],
+  },
+];
+
+export const sampleLearningSession: LearningSession = {
+  profileId: 'demo-browser',
+  profileName: 'demo-browser',
+  executable: '/usr/bin/demo-browser',
+  baseProfile,
+  suggestions: simulatedSuggestions,
+};
+
+export const getDefaultSelectedSuggestionIds = (
+  session: LearningSession = sampleLearningSession
+): string[] => session.suggestions.map((suggestion) => suggestion.id);
+
+const buildInsertedLines = (suggestions: LearningSuggestion[]): string[] => {
+  const lines: string[] = [];
+  suggestions.forEach((suggestion) => {
+    lines.push(`  # ${suggestion.title}`);
+    suggestion.ruleLines.forEach((rule) => {
+      const formatted = rule.startsWith('  ')
+        ? rule
+        : `  ${rule}`;
+      lines.push(formatted);
+    });
+  });
+  return lines;
+};
+
+const insertBeforeClosingBrace = (
+  base: string,
+  insertLines: string[]
+): string => {
+  if (insertLines.length === 0) {
+    return base;
+  }
+  const lines = base.split('\n');
+  const closingIndex = findClosingBraceIndex(lines);
+  const before = closingIndex === -1 ? lines : lines.slice(0, closingIndex);
+  const after = closingIndex === -1 ? [] : lines.slice(closingIndex);
+  const merged = [...before, ...insertLines, ...after];
+  return merged.join('\n');
+};
+
+const findClosingBraceIndex = (lines: string[]): number => {
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    if (lines[i].trim() === '}') {
+      return i;
+    }
+  }
+  return -1;
+};
+
+const buildDiff = (
+  base: string,
+  inserted: string[],
+  profileName: string
+): string => {
+  if (inserted.length === 0) {
+    return 'No changes proposed. Select at least one suggestion to build a diff.';
+  }
+
+  const baseLines = base.split('\n');
+  const closingIndex = findClosingBraceIndex(baseLines);
+  const contextStart = closingIndex === -1 ? Math.max(0, baseLines.length - 3) : Math.max(0, closingIndex - 2);
+  const context = closingIndex === -1
+    ? baseLines.slice(contextStart)
+    : baseLines.slice(contextStart, closingIndex);
+  const closingLine = closingIndex === -1 ? '}' : baseLines[closingIndex];
+
+  const diffLines: string[] = [
+    `--- ${profileName}.base`,
+    `+++ ${profileName}.learned`,
+    '@@',
+    ...context.map((line) => ` ${line}`),
+    ...inserted.map((line) => `+${line}`),
+    ` ${closingLine}`,
+  ];
+
+  return diffLines.join('\n');
+};
+
+export const computeLearningResult = (
+  session: LearningSession,
+  selectedSuggestionIds: string[]
+): LearningResult => {
+  const selectedSet = new Set(selectedSuggestionIds);
+  const appliedSuggestions = session.suggestions.filter((suggestion) =>
+    selectedSet.has(suggestion.id)
+  );
+
+  if (appliedSuggestions.length === 0) {
+    return {
+      previewProfile: session.baseProfile,
+      diff: 'No changes proposed. Select at least one suggestion to build a diff.',
+      appliedSuggestions: [],
+    };
+  }
+
+  const inserted = buildInsertedLines(appliedSuggestions);
+  const previewProfile = insertBeforeClosingBrace(session.baseProfile, inserted);
+  const diff = buildDiff(session.baseProfile, inserted, session.profileName);
+
+  return {
+    previewProfile,
+    diff,
+    appliedSuggestions,
+  };
+};


### PR DESCRIPTION
## Summary
- build the AppArmor Profile Lab component with per-profile mode toggles, guided learning flow, and generated diff preview
- add a deterministic learning helper, register the new simulator route, and expose it through the desktop catalog
- document the simulator and cover the core workflow with component tests

## Testing
- yarn lint *(fails: repository has pre-existing accessibility and browser global lint errors)*
- yarn test *(fails: repository has pre-existing failing suites such as window and nmap NSE)*

------
https://chatgpt.com/codex/tasks/task_e_68cb19d9b57c8328b662c1cb613a02e7