### PR TITLE
[components] Add firewall simulator UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ See Vercel's [Speed Insights Quickstart](https://vercel.com/docs/speed-insights/
 - Client-side only **simulations** of security tools (no real exploitation)
 - A large set of games rendered in-browser (Canvas/DOM), with a shared `GameLayout`
 
+## Firewall Simulator
+
+The simulated firewall utility mirrors how desktop security suites separate trusted and untrusted networks.
+
+- Profiles for **Home**, **Work**, and **Public** are persisted in [`utils/firewallStore.ts`](./utils/firewallStore.ts) with per-profile rule sets.
+- The UI in [`components/apps/firewall`](./components/apps/firewall) exposes rule lists and an inline editor for protocol, port, and application combinations.
+- Profile switches emit analytics events via `utils/analytics.ts` and swap the active rule set atomically so other windows never see partial state.
+
 ### Gamepad Input & Remapping
 
 Games can listen for normalized gamepad events via `utils/gamepad.ts`. The manager polls

--- a/__tests__/components/apps/firewall.test.tsx
+++ b/__tests__/components/apps/firewall.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import FirewallApp from '../../../components/apps/firewall';
+import { logEvent } from '../../../utils/analytics';
+import { getFirewallState, resetFirewallState } from '../../../utils/firewallStore';
+
+jest.mock('../../../utils/analytics', () => ({
+  logEvent: jest.fn(),
+}));
+
+const mockedLogEvent = logEvent as jest.MockedFunction<typeof logEvent>;
+
+describe('FirewallApp', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetFirewallState();
+    mockedLogEvent.mockReset();
+  });
+
+  it('renders the Home profile by default with seeded rules', () => {
+    render(<FirewallApp />);
+    expect(screen.getByRole('button', { name: 'Home' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('profile-description')).toHaveTextContent('Balanced defaults');
+    expect(screen.getAllByText('Web Browser')).toHaveLength(2);
+    expect(screen.getByText('Unknown Inbound')).toBeInTheDocument();
+  });
+
+  it('switches profiles and logs an analytics event', () => {
+    render(<FirewallApp />);
+    fireEvent.click(screen.getByRole('button', { name: 'Work' }));
+    expect(mockedLogEvent).toHaveBeenCalledWith({
+      category: 'firewall',
+      action: 'profile_change',
+      label: 'Work',
+    });
+    expect(screen.getByText('VPN Client')).toBeInTheDocument();
+    expect(screen.queryByText('Unknown Inbound')).not.toBeInTheDocument();
+  });
+
+  it('adds a custom rule to the active profile', () => {
+    render(<FirewallApp />);
+    fireEvent.change(screen.getByLabelText('Application'), { target: { value: 'Dev Server' } });
+    fireEvent.change(screen.getByLabelText('Port'), { target: { value: '8080' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add Rule' }));
+    expect(screen.getByText('Dev Server')).toBeInTheDocument();
+    expect(screen.getByText('8080')).toBeInTheDocument();
+    const state = getFirewallState();
+    const hasRule = state.profiles[state.activeProfile].some(
+      (rule) => rule.app === 'Dev Server' && rule.port === '8080'
+    );
+    expect(hasRule).toBe(true);
+  });
+
+  it('edits an existing rule inline', () => {
+    render(<FirewallApp />);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit' })[0]);
+    const portInput = screen.getByLabelText('Port');
+    fireEvent.change(portInput, { target: { value: '8081' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Update Rule' }));
+    expect(screen.getByText('8081')).toBeInTheDocument();
+    const state = getFirewallState();
+    expect(state.profiles.home.some((rule) => rule.port === '8081')).toBe(true);
+    expect(state.profiles.home.some((rule) => rule.port === '80')).toBe(false);
+  });
+
+  it('removes a rule and exits edit mode when deleting the selected rule', () => {
+    render(<FirewallApp />);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit' })[0]);
+    fireEvent.click(screen.getByLabelText('Delete rule for Web Browser on port 80'));
+    expect(screen.queryByText('80')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add Rule' })).toBeInTheDocument();
+    const state = getFirewallState();
+    expect(state.profiles.home.some((rule) => rule.port === '80')).toBe(false);
+  });
+});

--- a/components/apps/firewall/index.tsx
+++ b/components/apps/firewall/index.tsx
@@ -1,0 +1,319 @@
+import { ChangeEvent, FormEvent, useCallback, useMemo, useState } from 'react';
+import { logEvent } from '../../../utils/analytics';
+import {
+  FIREWALL_ACTIONS,
+  FIREWALL_PROFILES,
+  FIREWALL_PROTOCOLS,
+  addRule,
+  getFirewallState,
+  removeRule,
+  setActiveProfile,
+  updateRule,
+  type FirewallAction,
+  type FirewallProfile,
+  type FirewallRule,
+  type FirewallRuleInput,
+  type FirewallState,
+} from '../../../utils/firewallStore';
+
+const PROFILE_LABELS: Record<FirewallProfile, string> = {
+  home: 'Home',
+  work: 'Work',
+  public: 'Public',
+};
+
+const PROFILE_DESCRIPTIONS: Record<FirewallProfile, string> = {
+  home: 'Balanced defaults for trusted home networks with outbound web access enabled.',
+  work: 'Adds allowances for VPN and remote desktop tools used on corporate networks.',
+  public: 'Locks down most inbound traffic when connected to cafés, airports, or other public Wi-Fi.',
+};
+
+const ACTION_LABELS: Record<FirewallAction, string> = {
+  allow: 'Allow',
+  block: 'Block',
+};
+
+const createEmptyDraft = (): FirewallRuleInput => ({
+  app: '',
+  port: '',
+  protocol: 'TCP',
+  action: 'allow',
+});
+
+export default function FirewallApp() {
+  const [state, setState] = useState<FirewallState>(() => getFirewallState());
+  const [draft, setDraft] = useState<FirewallRuleInput>(() => createEmptyDraft());
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const activeRules = state.profiles[state.activeProfile];
+  const isEditing = editingId !== null;
+  const submitLabel = isEditing ? 'Update Rule' : 'Add Rule';
+
+  const resetForm = useCallback(() => {
+    setDraft(createEmptyDraft());
+    setEditingId(null);
+    setError(null);
+  }, []);
+
+  const handleProfileChange = useCallback(
+    (profile: FirewallProfile) => {
+      if (profile === state.activeProfile) {
+        return;
+      }
+      const nextState = setActiveProfile(profile);
+      setState(nextState);
+      resetForm();
+      logEvent({
+        category: 'firewall',
+        action: 'profile_change',
+        label: PROFILE_LABELS[profile],
+      });
+    },
+    [resetForm, state.activeProfile]
+  );
+
+  const handleInputChange = useCallback(
+    (field: keyof FirewallRuleInput) =>
+      (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+        const { value } = event.target;
+        setDraft((prev) => ({
+          ...prev,
+          [field]: value,
+        }));
+        if (error) {
+          setError(null);
+        }
+      },
+    [error]
+  );
+
+  const handleEdit = useCallback((rule: FirewallRule) => {
+    setEditingId(rule.id);
+    setDraft({
+      app: rule.app,
+      port: rule.port,
+      protocol: rule.protocol,
+      action: rule.action,
+    });
+    setError(null);
+  }, []);
+
+  const handleDelete = useCallback(
+    (rule: FirewallRule) => {
+      const nextState = removeRule(state.activeProfile, rule.id);
+      setState(nextState);
+      if (editingId === rule.id) {
+        resetForm();
+      }
+    },
+    [editingId, resetForm, state.activeProfile]
+  );
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const trimmedPort = draft.port.trim();
+      if (trimmedPort.length === 0) {
+        setError('Port is required.');
+        return;
+      }
+      const ruleInput: FirewallRuleInput = {
+        app: draft.app,
+        port: trimmedPort,
+        protocol: draft.protocol,
+        action: draft.action,
+      };
+      const nextState = isEditing && editingId
+        ? updateRule(state.activeProfile, editingId, ruleInput)
+        : addRule(state.activeProfile, ruleInput);
+      setState(nextState);
+      resetForm();
+    },
+    [draft, editingId, isEditing, resetForm, state.activeProfile]
+  );
+
+  const actionOptions = useMemo(
+    () => FIREWALL_ACTIONS.map((action) => (
+      <option key={action} value={action}>
+        {ACTION_LABELS[action]}
+      </option>
+    )),
+    []
+  );
+
+  const protocolOptions = useMemo(
+    () => FIREWALL_PROTOCOLS.map((protocol) => (
+      <option key={protocol} value={protocol}>
+        {protocol}
+      </option>
+    )),
+    []
+  );
+
+  return (
+    <div className="flex h-full flex-col bg-ub-cool-grey text-white">
+      <header className="border-b border-ubt-grey px-4 py-3">
+        <h1 className="text-lg font-semibold">Firewall Profiles</h1>
+        <p className="text-xs text-ubt-grey">
+          Simulate how Kali would manage inbound and outbound rules across common network scenarios.
+        </p>
+      </header>
+      <main className="flex flex-1 flex-col gap-6 overflow-y-auto p-4">
+        <section>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-ubt-grey">Profile</h2>
+          <div className="mt-2 flex flex-wrap gap-2" role="group" aria-label="Firewall profiles">
+            {FIREWALL_PROFILES.map((profile) => {
+              const isActive = state.activeProfile === profile;
+              return (
+                <button
+                  key={profile}
+                  type="button"
+                  onClick={() => handleProfileChange(profile)}
+                  aria-pressed={isActive}
+                  className={`rounded px-3 py-1 text-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-ubt-blue ${
+                    isActive
+                      ? 'bg-ubt-blue text-white shadow'
+                      : 'bg-black/40 text-ubt-grey hover:bg-black/60'
+                  }`}
+                >
+                  {PROFILE_LABELS[profile]}
+                </button>
+              );
+            })}
+          </div>
+          <p className="mt-3 text-sm text-ubt-grey" data-testid="profile-description">
+            {PROFILE_DESCRIPTIONS[state.activeProfile]}
+          </p>
+        </section>
+        <section className="flex-1">
+          <div className="mb-2 flex items-center justify-between">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-ubt-grey">Rules</h2>
+            <span className="text-xs text-ubt-grey">{activeRules.length} rule{activeRules.length === 1 ? '' : 's'}</span>
+          </div>
+          <div className="overflow-x-auto rounded border border-ubt-grey bg-black/30">
+            {activeRules.length === 0 ? (
+              <p className="p-4 text-sm text-ubt-grey">No rules defined for this profile.</p>
+            ) : (
+              <table className="min-w-full text-left text-sm">
+                <thead className="bg-black/40 text-ubt-grey">
+                  <tr>
+                    <th className="px-4 py-2 font-medium">Application</th>
+                    <th className="px-4 py-2 font-medium">Protocol</th>
+                    <th className="px-4 py-2 font-medium">Port</th>
+                    <th className="px-4 py-2 font-medium">Action</th>
+                    <th className="px-4 py-2 text-right font-medium">Controls</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {activeRules.map((rule) => (
+                    <tr key={rule.id} className="border-t border-ubt-grey/40">
+                      <td className="px-4 py-2">{rule.app}</td>
+                      <td className="px-4 py-2">{rule.protocol}</td>
+                      <td className="px-4 py-2">{rule.port}</td>
+                      <td className="px-4 py-2">{ACTION_LABELS[rule.action]}</td>
+                      <td className="px-4 py-2 text-right">
+                        <div className="flex justify-end gap-2">
+                          <button
+                            type="button"
+                            onClick={() => handleEdit(rule)}
+                            className="rounded bg-black/40 px-2 py-1 text-xs text-ubt-grey transition hover:bg-black/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-ubt-blue"
+                          >
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleDelete(rule)}
+                            className="rounded bg-black/40 px-2 py-1 text-xs text-red-300 transition hover:bg-black/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+                            aria-label={`Delete rule for ${rule.app} on port ${rule.port}`}
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </section>
+        <section>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-ubt-grey">Rule Editor</h2>
+          <form className="mt-3 space-y-3 rounded border border-ubt-grey bg-black/30 p-4" onSubmit={handleSubmit}>
+            <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
+              <label className="flex flex-col text-xs uppercase tracking-wide" htmlFor="firewall-application">
+                Application
+                <input
+                  id="firewall-application"
+                  type="text"
+                  value={draft.app}
+                  onChange={handleInputChange('app')}
+                  aria-label="Application"
+                  placeholder="e.g. Web Browser"
+                  className="mt-1 rounded bg-ub-cool-grey px-2 py-1 text-sm text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-ubt-blue"
+                />
+              </label>
+              <label className="flex flex-col text-xs uppercase tracking-wide" htmlFor="firewall-protocol">
+                Protocol
+                <select
+                  id="firewall-protocol"
+                  value={draft.protocol}
+                  onChange={handleInputChange('protocol')}
+                  className="mt-1 rounded bg-ub-cool-grey px-2 py-1 text-sm text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-ubt-blue"
+                >
+                  {protocolOptions}
+                </select>
+              </label>
+              <label className="flex flex-col text-xs uppercase tracking-wide" htmlFor="firewall-port">
+                Port
+                <input
+                  id="firewall-port"
+                  type="text"
+                  value={draft.port}
+                  onChange={handleInputChange('port')}
+                  aria-label="Port"
+                  placeholder="e.g. 443 or Any"
+                  className="mt-1 rounded bg-ub-cool-grey px-2 py-1 text-sm text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-ubt-blue"
+                />
+              </label>
+              <label className="flex flex-col text-xs uppercase tracking-wide" htmlFor="firewall-action">
+                Action
+                <select
+                  id="firewall-action"
+                  value={draft.action}
+                  onChange={handleInputChange('action')}
+                  className="mt-1 rounded bg-ub-cool-grey px-2 py-1 text-sm text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-ubt-blue"
+                >
+                  {actionOptions}
+                </select>
+              </label>
+            </div>
+            {error ? (
+              <p role="alert" className="text-sm text-red-300">
+                {error}
+              </p>
+            ) : null}
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="submit"
+                className="rounded bg-ubt-blue px-4 py-2 text-sm font-semibold text-white transition hover:bg-ubt-blue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-ubt-blue"
+              >
+                {submitLabel}
+              </button>
+              {isEditing ? (
+                <button
+                  type="button"
+                  onClick={resetForm}
+                  className="rounded bg-black/40 px-3 py-2 text-sm text-ubt-grey transition hover:bg-black/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-ubt-blue"
+                >
+                  Cancel Edit
+                </button>
+              ) : null}
+            </div>
+          </form>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/utils/firewallStore.ts
+++ b/utils/firewallStore.ts
@@ -1,0 +1,321 @@
+import { safeLocalStorage } from './safeStorage';
+
+export type FirewallProfile = 'home' | 'work' | 'public';
+export type FirewallProtocol = 'TCP' | 'UDP' | 'Any';
+export type FirewallAction = 'allow' | 'block';
+
+export interface FirewallRule {
+  id: string;
+  app: string;
+  port: string;
+  protocol: FirewallProtocol;
+  action: FirewallAction;
+}
+
+export type FirewallRuleInput = Omit<FirewallRule, 'id'>;
+
+export interface FirewallState {
+  activeProfile: FirewallProfile;
+  profiles: Record<FirewallProfile, FirewallRule[]>;
+}
+
+export const FIREWALL_PROFILES: readonly FirewallProfile[] = [
+  'home',
+  'work',
+  'public',
+] as const;
+
+export const FIREWALL_PROTOCOLS: readonly FirewallProtocol[] = [
+  'TCP',
+  'UDP',
+  'Any',
+] as const;
+
+export const FIREWALL_ACTIONS: readonly FirewallAction[] = [
+  'allow',
+  'block',
+] as const;
+
+const STORAGE_KEY = 'firewall-state-v1';
+
+const DEFAULT_STATE: FirewallState = {
+  activeProfile: 'home',
+  profiles: {
+    home: [
+      {
+        id: 'home-allow-http',
+        app: 'Web Browser',
+        port: '80',
+        protocol: 'TCP',
+        action: 'allow',
+      },
+      {
+        id: 'home-allow-https',
+        app: 'Web Browser',
+        port: '443',
+        protocol: 'TCP',
+        action: 'allow',
+      },
+      {
+        id: 'home-block-inbound',
+        app: 'Unknown Inbound',
+        port: 'Any',
+        protocol: 'Any',
+        action: 'block',
+      },
+    ],
+    work: [
+      {
+        id: 'work-allow-vpn',
+        app: 'VPN Client',
+        port: '1194',
+        protocol: 'UDP',
+        action: 'allow',
+      },
+      {
+        id: 'work-allow-rdp',
+        app: 'Remote Desktop',
+        port: '3389',
+        protocol: 'TCP',
+        action: 'allow',
+      },
+      {
+        id: 'work-block-filesharing',
+        app: 'Unauthorized File Sharing',
+        port: 'Any',
+        protocol: 'Any',
+        action: 'block',
+      },
+    ],
+    public: [
+      {
+        id: 'public-allow-https',
+        app: 'Web Browser',
+        port: '443',
+        protocol: 'TCP',
+        action: 'allow',
+      },
+      {
+        id: 'public-block-filesharing',
+        app: 'File Sharing Tools',
+        port: 'Any',
+        protocol: 'Any',
+        action: 'block',
+      },
+      {
+        id: 'public-block-remote',
+        app: 'Remote Management',
+        port: '3389',
+        protocol: 'TCP',
+        action: 'block',
+      },
+    ],
+  },
+};
+
+let state: FirewallState = loadInitialState();
+
+function loadInitialState(): FirewallState {
+  const fallback = cloneState(DEFAULT_STATE);
+  if (!safeLocalStorage) {
+    return fallback;
+  }
+  try {
+    const raw = safeLocalStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return fallback;
+    }
+    const parsed = JSON.parse(raw) as Partial<FirewallState> | undefined;
+    const activeProfile = isValidProfile(parsed?.activeProfile)
+      ? parsed!.activeProfile
+      : fallback.activeProfile;
+    const profiles = ensureProfiles(parsed?.profiles);
+    return {
+      activeProfile,
+      profiles,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+function isValidProfile(profile: unknown): profile is FirewallProfile {
+  return typeof profile === 'string' && FIREWALL_PROFILES.includes(profile as FirewallProfile);
+}
+
+function cloneRules(rules: FirewallRule[]): FirewallRule[] {
+  return rules.map((rule) => ({ ...rule }));
+}
+
+function cloneState(input: FirewallState): FirewallState {
+  return {
+    activeProfile: input.activeProfile,
+    profiles: {
+      home: cloneRules(input.profiles.home),
+      work: cloneRules(input.profiles.work),
+      public: cloneRules(input.profiles.public),
+    },
+  };
+}
+
+function ensureProfiles(
+  profiles: Partial<Record<string, unknown>> | undefined
+): Record<FirewallProfile, FirewallRule[]> {
+  const record: Partial<Record<string, unknown>> = profiles && typeof profiles === 'object' ? profiles : {};
+  const result: Record<FirewallProfile, FirewallRule[]> = {
+    home: [],
+    work: [],
+    public: [],
+  };
+  for (const profile of FIREWALL_PROFILES) {
+    const maybeRules = record[profile];
+    if (Array.isArray(maybeRules)) {
+      const normalised = maybeRules
+        .map((rule) => normaliseRule(rule))
+        .filter((rule): rule is FirewallRule => Boolean(rule));
+      result[profile] = normalised.length > 0 ? normalised : cloneRules(DEFAULT_STATE.profiles[profile]);
+    } else {
+      result[profile] = cloneRules(DEFAULT_STATE.profiles[profile]);
+    }
+  }
+  return result;
+}
+
+function normaliseRule(rule: unknown): FirewallRule | null {
+  if (!rule || typeof rule !== 'object') {
+    return null;
+  }
+  const data = rule as Partial<Record<keyof FirewallRule, unknown>>;
+  const id = typeof data.id === 'string' && data.id.trim() ? data.id.trim() : createRuleId();
+  const app = typeof data.app === 'string' ? data.app : '';
+  const port = typeof data.port === 'string' ? data.port : '';
+  const protocol = FIREWALL_PROTOCOLS.includes(data.protocol as FirewallProtocol)
+    ? (data.protocol as FirewallProtocol)
+    : 'Any';
+  const action = FIREWALL_ACTIONS.includes(data.action as FirewallAction)
+    ? (data.action as FirewallAction)
+    : 'allow';
+  return {
+    id,
+    app: sanitiseText(app, 'Any Application'),
+    port: sanitiseText(port, 'Any'),
+    protocol,
+    action,
+  };
+}
+
+function createRuleId(): string {
+  if (typeof globalThis !== 'undefined') {
+    const { crypto } = globalThis as typeof globalThis & { crypto?: Crypto };
+    if (crypto && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  }
+  return `rule-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function sanitiseText(value: string, fallback: string): string {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+function createRuleFromInput(input: FirewallRuleInput, id?: string): FirewallRule {
+  return {
+    id: id ?? createRuleId(),
+    app: sanitiseText(input.app, 'Any Application'),
+    port: sanitiseText(input.port, 'Any'),
+    protocol: FIREWALL_PROTOCOLS.includes(input.protocol) ? input.protocol : 'Any',
+    action: FIREWALL_ACTIONS.includes(input.action) ? input.action : 'allow',
+  };
+}
+
+function persistState(): void {
+  if (!safeLocalStorage) {
+    return;
+  }
+  try {
+    safeLocalStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Ignore persistence errors (storage full, disabled, etc.)
+  }
+}
+
+function applyState(next: FirewallState): FirewallState {
+  state = cloneState(next);
+  persistState();
+  return getFirewallState();
+}
+
+export function getFirewallState(): FirewallState {
+  return cloneState(state);
+}
+
+export function setActiveProfile(profile: FirewallProfile): FirewallState {
+  if (state.activeProfile === profile) {
+    return getFirewallState();
+  }
+  return applyState({
+    activeProfile: profile,
+    profiles: state.profiles,
+  });
+}
+
+export function addRule(profile: FirewallProfile, input: FirewallRuleInput): FirewallState {
+  const rule = createRuleFromInput(input);
+  const nextProfiles: FirewallState['profiles'] = {
+    ...state.profiles,
+    [profile]: [...state.profiles[profile], rule],
+  } as FirewallState['profiles'];
+  return applyState({
+    activeProfile: state.activeProfile,
+    profiles: nextProfiles,
+  });
+}
+
+export function updateRule(
+  profile: FirewallProfile,
+  id: string,
+  input: FirewallRuleInput
+): FirewallState {
+  const currentRules = state.profiles[profile];
+  const index = currentRules.findIndex((rule) => rule.id === id);
+  if (index === -1) {
+    return getFirewallState();
+  }
+  const updatedRule = createRuleFromInput(input, currentRules[index].id);
+  const nextRules = [...currentRules];
+  nextRules[index] = updatedRule;
+  const nextProfiles: FirewallState['profiles'] = {
+    ...state.profiles,
+    [profile]: nextRules,
+  } as FirewallState['profiles'];
+  return applyState({
+    activeProfile: state.activeProfile,
+    profiles: nextProfiles,
+  });
+}
+
+export function removeRule(profile: FirewallProfile, id: string): FirewallState {
+  const currentRules = state.profiles[profile];
+  const nextRules = currentRules.filter((rule) => rule.id !== id);
+  const finalRules = nextRules.length > 0 ? nextRules : cloneRules(DEFAULT_STATE.profiles[profile]);
+  const nextProfiles: FirewallState['profiles'] = {
+    ...state.profiles,
+    [profile]: finalRules,
+  } as FirewallState['profiles'];
+  return applyState({
+    activeProfile: state.activeProfile,
+    profiles: nextProfiles,
+  });
+}
+
+export function resetFirewallState(): FirewallState {
+  if (safeLocalStorage) {
+    try {
+      safeLocalStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // ignore
+    }
+  }
+  return applyState(DEFAULT_STATE);
+}


### PR DESCRIPTION
## Summary
- build a firewall app that lets users flip between Home, Work, and Public profiles with rule lists and an inline editor
- persist profile rules and analytics events through a new `firewallStore` utility with seeded defaults
- cover the workflow with focused Jest tests and extend the README with a firewall simulator overview

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window errors across legacy apps)*
- yarn test firewall.test.tsx
- yarn test *(fails: existing window snapping, nmap NSE clipboard, and install button suites)*

------
https://chatgpt.com/codex/tasks/task_e_68cb19da13048328b3a99d40b64cecf4