### PR TITLE
feat(apps): add services manager

### DIFF
--- a/__tests__/components/apps/services.test.tsx
+++ b/__tests__/components/apps/services.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import ServicesApp from '../../../components/apps/services';
+
+describe('ServicesApp', () => {
+
+  it('lists services and filters by search query', () => {
+    render(<ServicesApp />);
+
+    expect(screen.getByText('Network Scanner')).toBeInTheDocument();
+    expect(screen.getByText('Patch Daemon')).toBeInTheDocument();
+
+    const search = screen.getByPlaceholderText('Search by name or description');
+    fireEvent.change(search, { target: { value: 'patch' } });
+
+    expect(screen.getByText('Patch Daemon')).toBeInTheDocument();
+    expect(screen.queryByText('Network Scanner')).not.toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: 'nope' } });
+    expect(
+      screen.getByText('No services match "nope".'),
+    ).toBeInTheDocument();
+  });
+
+  it('starts and stops a manual service while surfacing logs', async () => {
+    render(<ServicesApp />);
+
+    const rowButton = screen.getByRole('button', { name: /^Patch Daemon/ });
+    const row = rowButton.closest('tr') as HTMLTableRowElement | null;
+    expect(row).not.toBeNull();
+
+    const startButton = within(row as HTMLTableRowElement).getByRole('button', {
+      name: /Start Patch Daemon/i,
+    });
+    fireEvent.click(startButton);
+
+    expect(screen.getByTestId('status-patch-daemon')).toHaveTextContent('Running');
+
+    fireEvent.click(rowButton);
+    const logPanel = screen.getByText('Recent Logs').closest('td');
+    expect(logPanel).not.toBeNull();
+    if (logPanel) {
+      expect(within(logPanel).getAllByRole('listitem')[0]).toHaveTextContent(
+        'Patch Daemon started.',
+      );
+    }
+
+    const stopButton = within(row as HTMLTableRowElement).getByRole('button', {
+      name: /Stop Patch Daemon/i,
+    });
+    fireEvent.click(stopButton);
+
+    expect(screen.getByTestId('status-patch-daemon')).toHaveTextContent('Stopped');
+    if (logPanel) {
+      expect(within(logPanel).getAllByRole('listitem')[0]).toHaveTextContent(
+        'Patch Daemon stopped.',
+      );
+    }
+  });
+
+  it('enables and disables a service updating startup type and logs', async () => {
+    render(<ServicesApp />);
+
+    const rowButton = screen.getByRole('button', { name: /^Reporting Agent/ });
+    fireEvent.click(rowButton);
+
+    const row = rowButton.closest('tr');
+    expect(row).not.toBeNull();
+
+    const enableButton = screen.getByRole('button', { name: /Enable Reporting Agent/i });
+    fireEvent.click(enableButton);
+
+    if (row) {
+      expect(within(row).getByText('Stopped')).toBeInTheDocument();
+      expect(within(row).getByText('Automatic')).toBeInTheDocument();
+    }
+
+    const logPanel = screen.getByText('Recent Logs').closest('td');
+    expect(logPanel).not.toBeNull();
+    if (logPanel) {
+      expect(within(logPanel).getAllByRole('listitem')[0]).toHaveTextContent(
+        'Reporting Agent set to Automatic startup.',
+      );
+    }
+
+    if (row) {
+      const disableButton = within(row).getByRole('button', {
+        name: /Disable Reporting Agent/i,
+      });
+      fireEvent.click(disableButton);
+    }
+
+    if (row) {
+      expect(within(row).getByText('Disabled')).toBeInTheDocument();
+    }
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -70,6 +70,7 @@ const QrApp = createDynamicApp('qr', 'QR Tool');
 const AsciiArtApp = createDynamicApp('ascii_art', 'ASCII Art');
 const QuoteApp = createDynamicApp('quote', 'Quote');
 const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery');
+const ServicesApp = createDynamicApp('services', 'Services');
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
@@ -160,6 +161,7 @@ const displayQr = createDisplay(QrApp);
 const displayAsciiArt = createDisplay(AsciiArtApp);
 const displayQuote = createDisplay(QuoteApp);
 const displayProjectGallery = createDisplay(ProjectGalleryApp);
+const displayServices = createDisplay(ServicesApp);
 const displayTrash = createDisplay(TrashApp);
 const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
@@ -709,6 +711,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayResourceMonitor,
+  },
+  {
+    id: 'services',
+    title: 'Services',
+    icon: '/themes/Yaru/apps/services.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayServices,
   },
   {
     id: 'screen-recorder',

--- a/components/apps/services/index.tsx
+++ b/components/apps/services/index.tsx
@@ -1,0 +1,348 @@
+import React, { useMemo, useState } from 'react';
+import Toast from '../../ui/Toast';
+import {
+  ServiceDefinition,
+  ServiceLogEntry,
+  ServiceLogLevel,
+  ServiceStatus,
+  StartupType,
+  getServiceRegistry,
+} from '../../../utils/serviceRegistry';
+
+const STATUS_LABELS: Record<ServiceStatus, { label: string; className: string }> = {
+  running: { label: 'Running', className: 'bg-green-500/20 text-green-300' },
+  stopped: { label: 'Stopped', className: 'bg-gray-500/20 text-gray-200' },
+  paused: { label: 'Paused', className: 'bg-yellow-500/20 text-yellow-200' },
+};
+
+const LEVEL_STYLES: Record<ServiceLogLevel, string> = {
+  info: 'border-blue-400/40 bg-blue-500/10 text-blue-200',
+  warning: 'border-yellow-400/40 bg-yellow-500/10 text-yellow-100',
+  error: 'border-red-500/40 bg-red-500/10 text-red-200',
+};
+
+const MAX_LOGS = 8;
+
+type UpdateResult = {
+  next: ServiceDefinition;
+  toast?: string;
+};
+
+const addLogEntry = (
+  service: ServiceDefinition,
+  message: string,
+  level: ServiceLogLevel = 'info',
+): ServiceLogEntry[] => [
+  {
+    timestamp: new Date().toISOString(),
+    message,
+    level,
+  },
+  ...service.recentLogs,
+].slice(0, MAX_LOGS);
+
+const ServicesApp: React.FC = () => {
+  const [services, setServices] = useState<ServiceDefinition[]>(() =>
+    getServiceRegistry(),
+  );
+  const [expanded, setExpanded] = useState<string[]>([]);
+  const [query, setQuery] = useState('');
+  const [toast, setToast] = useState('');
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const visibleServices = useMemo(() => {
+    if (!normalizedQuery) return services;
+    return services.filter((service) => {
+      const haystack = `${service.name} ${service.description}`.toLowerCase();
+      return haystack.includes(normalizedQuery);
+    });
+  }, [services, normalizedQuery]);
+
+  const toggleExpanded = (id: string) => {
+    setExpanded((prev) =>
+      prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id],
+    );
+  };
+
+  const updateService = (
+    id: string,
+    mutate: (service: ServiceDefinition) => UpdateResult,
+  ) => {
+    let message = '';
+    setServices((prev) =>
+      prev.map((service) => {
+        if (service.id !== id) return service;
+        const result = mutate(service);
+        if (result.toast) {
+          message = result.toast;
+        }
+        return result.next;
+      }),
+    );
+    if (message) setToast(message);
+  };
+
+  const handleStart = (id: string) => {
+    updateService(id, (service) => {
+      if (service.status === 'running') {
+        return {
+          next: service,
+          toast: `${service.name} is already running`,
+        };
+      }
+      return {
+        next: {
+          ...service,
+          status: 'running',
+          recentLogs: addLogEntry(service, `${service.name} started.`),
+        },
+        toast: `${service.name} started`,
+      };
+    });
+  };
+
+  const handleStop = (id: string) => {
+    updateService(id, (service) => {
+      if (service.status === 'stopped') {
+        return {
+          next: service,
+          toast: `${service.name} is already stopped`,
+        };
+      }
+      return {
+        next: {
+          ...service,
+          status: 'stopped',
+          recentLogs: addLogEntry(service, `${service.name} stopped.`),
+        },
+        toast: `${service.name} stopped`,
+      };
+    });
+  };
+
+  const handleEnable = (id: string) => {
+    updateService(id, (service) => {
+      const wasDisabled = service.startupType === 'Disabled';
+      const newStartup: StartupType = 'Automatic';
+      return {
+        next: {
+          ...service,
+          status: wasDisabled ? 'stopped' : service.status,
+          startupType: newStartup,
+          recentLogs: addLogEntry(
+            service,
+            `${service.name} set to ${newStartup} startup.`,
+          ),
+        },
+        toast: `${service.name} enabled (${newStartup})`,
+      };
+    });
+  };
+
+  const handleDisable = (id: string) => {
+    updateService(id, (service) => {
+      if (service.startupType === 'Disabled' && service.status === 'stopped') {
+        return {
+          next: service,
+          toast: `${service.name} is already disabled`,
+        };
+      }
+      return {
+        next: {
+          ...service,
+          status: 'stopped',
+          startupType: 'Disabled',
+          recentLogs: addLogEntry(
+            service,
+            `${service.name} disabled and stopped.`,
+            'warning',
+          ),
+        },
+        toast: `${service.name} disabled`,
+      };
+    });
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-ub-cool-grey text-white">
+      <div className="border-b border-black/40 bg-black/30 px-4 py-3">
+        <h1 className="text-lg font-semibold">Service Manager</h1>
+        <p className="text-xs text-gray-300">
+          Manage simulated Kali services, startup behaviour, and review logs.
+        </p>
+      </div>
+      <div className="px-4 py-3">
+        <label className="block text-xs font-semibold uppercase tracking-wide text-gray-300">
+          Search services
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search by name or description"
+            className="mt-2 w-full rounded border border-black/50 bg-black/40 p-2 text-sm text-white placeholder-gray-400 focus:border-ubt-grey focus:outline-none"
+          />
+        </label>
+      </div>
+      <div className="flex-1 overflow-auto px-4 pb-6">
+        <div className="overflow-hidden rounded border border-black/40 bg-black/20">
+          <table className="min-w-full divide-y divide-black/40 text-sm">
+            <thead className="bg-black/40 text-left text-xs uppercase tracking-wide text-gray-300">
+              <tr>
+                <th scope="col" className="px-4 py-2">
+                  Service
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  Status
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  Startup
+                </th>
+                <th scope="col" className="px-4 py-2 text-right">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibleServices.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="px-4 py-6 text-center text-sm text-gray-300"
+                  >
+                    No services match "{query}".
+                  </td>
+                </tr>
+              )}
+              {visibleServices.map((service) => {
+                const statusMeta = STATUS_LABELS[service.status];
+                const isExpanded = expanded.includes(service.id);
+                return (
+                  <React.Fragment key={service.id}>
+                    <tr className="border-b border-black/20">
+                      <td className="px-4 py-3 align-top">
+                        <button
+                          type="button"
+                          onClick={() => toggleExpanded(service.id)}
+                          aria-expanded={isExpanded}
+                          aria-controls={`${service.id}-logs`}
+                          className="w-full text-left focus:outline-none focus:ring-2 focus:ring-ubt-grey"
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div>
+                              <p className="text-base font-semibold">
+                                {service.name}
+                              </p>
+                              <p className="mt-1 text-xs text-gray-300">
+                                {service.description}
+                              </p>
+                            </div>
+                            <span className="text-lg" aria-hidden="true">
+                              {isExpanded ? '▾' : '▸'}
+                            </span>
+                          </div>
+                        </button>
+                      </td>
+                      <td className="px-4 py-3 align-top">
+                        <span
+                          data-testid={`status-${service.id}`}
+                          className={`inline-flex rounded px-2 py-1 text-xs font-semibold ${statusMeta.className}`}
+                        >
+                          {statusMeta.label}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 align-top text-sm text-gray-200">
+                        {service.startupType}
+                      </td>
+                      <td className="px-4 py-3 align-top">
+                        <div className="flex flex-wrap justify-end gap-2 text-xs">
+                          <button
+                            type="button"
+                            onClick={() => handleStart(service.id)}
+                            className="rounded bg-ub-green px-3 py-1 font-semibold text-black disabled:opacity-40"
+                            disabled={service.status === 'running'}
+                            aria-label={`Start ${service.name}`}
+                          >
+                            Start
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleStop(service.id)}
+                            className="rounded bg-ub-red px-3 py-1 font-semibold text-white disabled:opacity-40"
+                            disabled={service.status === 'stopped'}
+                            aria-label={`Stop ${service.name}`}
+                          >
+                            Stop
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleEnable(service.id)}
+                            className="rounded bg-ub-yellow px-3 py-1 font-semibold text-black"
+                            aria-label={`Enable ${service.name}`}
+                          >
+                            Enable
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleDisable(service.id)}
+                            className="rounded bg-gray-600 px-3 py-1 font-semibold text-white"
+                            aria-label={`Disable ${service.name}`}
+                          >
+                            Disable
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                    {isExpanded && (
+                      <tr>
+                        <td
+                          id={`${service.id}-logs`}
+                          colSpan={4}
+                          className="bg-black/30 px-6 py-4"
+                        >
+                          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-300">
+                            Recent Logs
+                          </h2>
+                          <ul className="mt-3 space-y-2 text-xs">
+                            {service.recentLogs.map((log) => (
+                              <li
+                                key={`${log.timestamp}-${log.message}`}
+                                className={`rounded border px-3 py-2 ${LEVEL_STYLES[log.level]}`}
+                              >
+                                <p className="font-semibold">
+                                  <span className="mr-2 text-[10px] uppercase tracking-wide">
+                                    {log.level}
+                                  </span>
+                                  <time
+                                    className="text-[10px] uppercase tracking-wide text-gray-300"
+                                    dateTime={log.timestamp}
+                                  >
+                                    {new Date(log.timestamp).toLocaleString()}
+                                  </time>
+                                </p>
+                                <p className="mt-1 text-gray-100">{log.message}</p>
+                              </li>
+                            ))}
+                            {service.recentLogs.length === 0 && (
+                              <li className="rounded border border-dashed border-gray-600 px-3 py-2 text-gray-300">
+                                No log entries yet.
+                              </li>
+                            )}
+                          </ul>
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      {toast && <Toast message={toast} onClose={() => setToast('')} />}
+    </div>
+  );
+};
+
+export default ServicesApp;
+
+export const displayServices = () => <ServicesApp />;

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -61,6 +61,9 @@ Tools to cover: **BeEF, Ettercap, Metasploit, Wireshark, Kismet, Nikto, Autopsy,
 - Display `performance.memory` data and FPS from `performance.now()` deltas.
 - Show CPU synthetic load graph using `requestAnimationFrame` buckets.
 
+### Services
+- Surface mock systemd-style services from `utils/serviceRegistry.ts` with search, status badges, start/stop controls, and expandable log history.
+
 ### Project Gallery
 - Load projects from `projects.json`; add filters and buttons for repo and live demo.
 

--- a/public/themes/Yaru/apps/services.svg
+++ b/public/themes/Yaru/apps/services.svg
@@ -1,0 +1,23 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="12" fill="#1F2230"/>
+  <path d="M16 22C16 19.7909 17.7909 18 20 18H44C46.2091 18 48 19.7909 48 22V42C48 44.2091 46.2091 46 44 46H20C17.7909 46 16 44.2091 16 42V22Z" fill="#2F3650"/>
+  <rect x="20" y="24" width="24" height="4" rx="2" fill="#4ADE80"/>
+  <rect x="20" y="32" width="18" height="4" rx="2" fill="#60A5FA"/>
+  <rect x="20" y="40" width="12" height="4" rx="2" fill="#FBBF24"/>
+  <g filter="url(#shadow)">
+    <circle cx="44" cy="40" r="8" fill="#111827"/>
+    <path d="M44 34L45.8 37.2L49.4 37.8L46.9 40.3L47.5 44L44 42.2L40.5 44L41.1 40.3L38.6 37.8L42.2 37.2L44 34Z" fill="#F472B6"/>
+  </g>
+  <defs>
+    <filter id="shadow" x="34" y="30" width="20" height="20" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="1"/>
+      <feGaussianBlur stdDeviation="1"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.35 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+  </defs>
+</svg>

--- a/utils/serviceRegistry.ts
+++ b/utils/serviceRegistry.ts
@@ -1,0 +1,127 @@
+export type ServiceStatus = 'running' | 'stopped' | 'paused';
+
+export type StartupType = 'Automatic' | 'Manual' | 'Disabled';
+
+export type ServiceLogLevel = 'info' | 'warning' | 'error';
+
+export interface ServiceLogEntry {
+  timestamp: string;
+  message: string;
+  level: ServiceLogLevel;
+}
+
+export interface ServiceDefinition {
+  id: string;
+  name: string;
+  description: string;
+  status: ServiceStatus;
+  startupType: StartupType;
+  recentLogs: ServiceLogEntry[];
+}
+
+const registry: ServiceDefinition[] = [
+  {
+    id: 'network-scanner',
+    name: 'Network Scanner',
+    description: 'Schedules nightly discovery sweeps across lab segments.',
+    status: 'running',
+    startupType: 'Automatic',
+    recentLogs: [
+      {
+        timestamp: '2024-05-12T08:30:00Z',
+        message: 'Completed nightly discovery job (24 hosts reachable).',
+        level: 'info',
+      },
+      {
+        timestamp: '2024-05-11T21:04:00Z',
+        message: 'Partial scan due to DNS timeout on segment DMZ-02.',
+        level: 'warning',
+      },
+      {
+        timestamp: '2024-05-11T08:30:00Z',
+        message: 'Scheduled sweep finished in 3m41s.',
+        level: 'info',
+      },
+    ],
+  },
+  {
+    id: 'log-shipper',
+    name: 'Log Shipper',
+    description: 'Publishes transformed audit logs to the central ELK index.',
+    status: 'running',
+    startupType: 'Automatic',
+    recentLogs: [
+      {
+        timestamp: '2024-05-12T09:05:00Z',
+        message: 'Forwarded 5.4k events from auth pipeline.',
+        level: 'info',
+      },
+      {
+        timestamp: '2024-05-12T09:02:00Z',
+        message: 'Recovered from transient queue back-pressure.',
+        level: 'warning',
+      },
+      {
+        timestamp: '2024-05-12T08:55:00Z',
+        message: 'Rotated log buffers for project devnet.',
+        level: 'info',
+      },
+    ],
+  },
+  {
+    id: 'patch-daemon',
+    name: 'Patch Daemon',
+    description: 'Applies offline package updates in maintenance windows.',
+    status: 'stopped',
+    startupType: 'Manual',
+    recentLogs: [
+      {
+        timestamp: '2024-05-10T01:00:00Z',
+        message: 'Manual run completed for 12 pending security fixes.',
+        level: 'info',
+      },
+      {
+        timestamp: '2024-05-09T23:58:00Z',
+        message: 'Detected reboot requirement on host kali-lab-03.',
+        level: 'warning',
+      },
+      {
+        timestamp: '2024-05-05T00:45:00Z',
+        message: 'Last scheduled window deferred by maintainer.',
+        level: 'info',
+      },
+    ],
+  },
+  {
+    id: 'reporting-agent',
+    name: 'Reporting Agent',
+    description: 'Generates compliance deltas and emails weekly digests.',
+    status: 'paused',
+    startupType: 'Disabled',
+    recentLogs: [
+      {
+        timestamp: '2024-05-08T12:15:00Z',
+        message: 'Paused after workspace maintenance request.',
+        level: 'warning',
+      },
+      {
+        timestamp: '2024-05-08T11:58:00Z',
+        message: 'Queued 4 draft compliance reports.',
+        level: 'info',
+      },
+      {
+        timestamp: '2024-05-01T12:00:00Z',
+        message: 'Generated baseline metrics snapshot.',
+        level: 'info',
+      },
+    ],
+  },
+];
+
+export const getServiceRegistry = (): ServiceDefinition[] =>
+  registry.map((service) => ({
+    ...service,
+    recentLogs: [...service.recentLogs],
+  }));
+
+export default registry;


### PR DESCRIPTION
## Summary
- add a Services manager window that lists mock registry data with search, controls, toast feedback, and expandable logs
- introduce a typed service registry helper and wire the new Services app into the launcher configuration with a themed icon
- cover the new UI with component tests and note the feature in the desktop tasks doc

## Testing
- yarn lint *(fails: existing repo lint violations unrelated to Services changes)*
- yarn test *(fails: existing suite issues such as nmapNse, Modal, window focus tests)*
- npx jest __tests__/components/apps/services.test.tsx --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68cb19dab1bc8328b55bc861d9022ad9