### PR TITLE
[design] add design system route and runtime tokens

### DIFF
--- a/components/util-components/CopyButton.tsx
+++ b/components/util-components/CopyButton.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useState } from 'react';
+import copyToClipboard from '../../utils/clipboard';
+
+interface CopyButtonProps {
+  value: string;
+  label?: string;
+  className?: string;
+}
+
+const resetAfter = 1600;
+
+export default function CopyButton({ value, label = 'Copy', className = '' }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!value) return;
+    try {
+      await copyToClipboard(value);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), resetAfter);
+    } catch (err) {
+      console.error('Copy failed', err);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={`design-copy-trigger ${className}`.trim()}
+      data-copied={copied}
+      aria-label={copied ? 'Copied to clipboard' : label}
+    >
+      <span>{copied ? 'Copied' : label}</span>
+      <span aria-hidden="true">{copied ? '✅' : '📋'}</span>
+    </button>
+  );
+}

--- a/data/design-system/DesignTokenContext.tsx
+++ b/data/design-system/DesignTokenContext.tsx
@@ -1,0 +1,56 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { snapshotTokens, type TokenValue } from './tokens';
+import { useTheme } from '../../hooks/useTheme';
+import { useSettings } from '../../hooks/useSettings';
+
+interface DesignTokenContextValue {
+  colors: TokenValue[];
+  spacing: TokenValue[];
+  typography: TokenValue[];
+  radius: TokenValue[];
+  motion: TokenValue[];
+  refresh: () => void;
+}
+
+const initialState = snapshotTokens();
+
+const DesignTokenContext = createContext<DesignTokenContextValue>({
+  ...initialState,
+  refresh: () => {},
+});
+
+export const DesignTokenProvider = ({ children }: { children: ReactNode }) => {
+  const { theme } = useTheme();
+  const { accent, density, fontScale, highContrast, largeHitAreas, reducedMotion } = useSettings();
+  const [tokens, setTokens] = useState(initialState);
+
+  const refresh = useCallback(() => {
+    setTokens(snapshotTokens());
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh, theme, accent, density, fontScale, highContrast, largeHitAreas, reducedMotion]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const observer = new MutationObserver(() => refresh());
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'style', 'data-theme'],
+    });
+    return () => observer.disconnect();
+  }, [refresh]);
+
+  const value = useMemo(
+    () => ({
+      ...tokens,
+      refresh,
+    }),
+    [tokens, refresh],
+  );
+
+  return <DesignTokenContext.Provider value={value}>{children}</DesignTokenContext.Provider>;
+};
+
+export const useDesignTokens = () => useContext(DesignTokenContext);

--- a/data/design-system/tokens.ts
+++ b/data/design-system/tokens.ts
@@ -1,0 +1,157 @@
+import { useMemo } from 'react';
+
+export interface TokenDefinition {
+  name: string;
+  label: string;
+  fallback: string;
+  description?: string;
+}
+
+export interface TokenValue {
+  name: string;
+  label: string;
+  cssVar: string;
+  value: string;
+  description?: string;
+  valuePx?: number;
+}
+
+const COLOR_TOKENS: TokenDefinition[] = [
+  { name: 'color-bg', label: 'Background', fallback: '#0f1317' },
+  { name: 'color-text', label: 'Foreground text', fallback: '#F5F5F5' },
+  { name: 'color-ub-grey', label: 'Shell grey', fallback: '#0f1317' },
+  { name: 'color-ub-warm-grey', label: 'Warm grey', fallback: '#7d7f83' },
+  { name: 'color-ub-cool-grey', label: 'Cool grey', fallback: '#1a1f26' },
+  { name: 'color-ub-orange', label: 'Accent blue', fallback: '#1793d1' },
+  { name: 'color-ub-lite-abrgn', label: 'Window chrome light', fallback: '#22262c' },
+  { name: 'color-ub-med-abrgn', label: 'Window chrome', fallback: '#1b1f24' },
+  { name: 'color-ub-drk-abrgn', label: 'Window chrome dark', fallback: '#13171b' },
+  { name: 'color-ub-window-title', label: 'Window title', fallback: '#0c0f12' },
+  { name: 'color-ub-gedit-dark', label: 'Terminal dark', fallback: '#021B33' },
+  { name: 'color-ub-gedit-light', label: 'Terminal light', fallback: '#003B70' },
+  { name: 'color-ub-gedit-darker', label: 'Terminal darkest', fallback: '#010D1A' },
+  { name: 'color-ubt-grey', label: 'Surface grey', fallback: '#F6F6F5' },
+  { name: 'color-ubt-warm-grey', label: 'Warm surface', fallback: '#AEA79F' },
+  { name: 'color-ubt-cool-grey', label: 'Cool surface', fallback: '#333333' },
+  { name: 'color-ubt-blue', label: 'Info blue', fallback: '#62A0EA' },
+  { name: 'color-ubt-green', label: 'Success green', fallback: '#73D216' },
+  { name: 'color-ubt-gedit-orange', label: 'Warning orange', fallback: '#F39A21' },
+  { name: 'color-ubt-gedit-blue', label: 'Secondary blue', fallback: '#50B6C6' },
+  { name: 'color-ubt-gedit-dark', label: 'Secondary dark', fallback: '#003B70' },
+  { name: 'color-ub-border-orange', label: 'Accent border', fallback: '#1793d1' },
+  { name: 'color-ub-dark-grey', label: 'Backdrop dark', fallback: '#2a2e36' },
+  { name: 'game-color-secondary', label: 'Game secondary', fallback: '#1d4ed8' },
+  { name: 'game-color-success', label: 'Game success', fallback: '#15803d' },
+  { name: 'game-color-warning', label: 'Game warning', fallback: '#d97706' },
+  { name: 'game-color-danger', label: 'Game danger', fallback: '#b91c1c' },
+];
+
+const SPACING_TOKENS: TokenDefinition[] = [
+  { name: 'space-1', label: 'Spacing 1', fallback: '0.25rem', description: 'Tight padding and dividers' },
+  { name: 'space-2', label: 'Spacing 2', fallback: '0.5rem', description: 'Compact gaps and padding' },
+  { name: 'space-3', label: 'Spacing 3', fallback: '0.75rem', description: 'Form controls and inline spacing' },
+  { name: 'space-4', label: 'Spacing 4', fallback: '1rem', description: 'Default stack spacing' },
+  { name: 'space-5', label: 'Spacing 5', fallback: '1.5rem', description: 'Section padding' },
+  { name: 'space-6', label: 'Spacing 6', fallback: '2rem', description: 'Hero and card padding' },
+];
+
+const TYPOGRAPHY_TOKENS: TokenDefinition[] = [
+  { name: 'font-family-base', label: 'Base family', fallback: "'Ubuntu', sans-serif" },
+  { name: 'font-multiplier', label: 'Font multiplier', fallback: '1' },
+  { name: 'hit-area', label: 'Hit area', fallback: '32px', description: 'Minimum interactive target size' },
+  { name: 'focus-outline-width', label: 'Focus outline width', fallback: '2px' },
+  { name: 'focus-outline-color', label: 'Focus outline color', fallback: '#62A0EA' },
+];
+
+const RADIUS_TOKENS: TokenDefinition[] = [
+  { name: 'radius-sm', label: 'Radius small', fallback: '2px' },
+  { name: 'radius-md', label: 'Radius medium', fallback: '4px' },
+  { name: 'radius-lg', label: 'Radius large', fallback: '8px' },
+  { name: 'radius-round', label: 'Radius round', fallback: '9999px' },
+];
+
+const MOTION_TOKENS: TokenDefinition[] = [
+  { name: 'motion-fast', label: 'Motion fast', fallback: '150ms' },
+  { name: 'motion-medium', label: 'Motion medium', fallback: '300ms' },
+  { name: 'motion-slow', label: 'Motion slow', fallback: '500ms' },
+];
+
+const getStyles = (): CSSStyleDeclaration | null => {
+  if (typeof window === 'undefined') return null;
+  return getComputedStyle(document.documentElement);
+};
+
+const readTokens = (defs: TokenDefinition[], styles: CSSStyleDeclaration | null): TokenValue[] =>
+  defs.map((def) => {
+    const cssVar = `--${def.name}`;
+    const raw = styles?.getPropertyValue(cssVar).trim();
+    const value = raw && raw.length > 0 ? raw : def.fallback;
+    const token: TokenValue = {
+      name: def.name,
+      label: def.label,
+      cssVar,
+      value,
+      description: def.description,
+    };
+    if (styles) {
+      const px = resolvePx(value, styles);
+      if (!Number.isNaN(px)) token.valuePx = px;
+    }
+    return token;
+  });
+
+const LENGTH_RE = /(-?\d*\.?\d+)(px|rem|em)?/;
+
+const resolvePx = (value: string, styles: CSSStyleDeclaration): number => {
+  const match = value.match(LENGTH_RE);
+  if (!match) return Number.NaN;
+  const magnitude = parseFloat(match[1]);
+  const unit = match[2] ?? '';
+  if (!Number.isFinite(magnitude)) return Number.NaN;
+  switch (unit) {
+    case '':
+    case 'px':
+      return magnitude;
+    case 'rem':
+    case 'em': {
+      const base = parseFloat(styles.fontSize);
+      if (!Number.isFinite(base)) return Number.NaN;
+      return magnitude * base;
+    }
+    default:
+      return Number.NaN;
+  }
+};
+
+export const useTokenSnapshot = () => {
+  const styles = getStyles();
+  return useMemo(
+    () => ({
+      colors: readTokens(COLOR_TOKENS, styles),
+      spacing: readTokens(SPACING_TOKENS, styles),
+      typography: readTokens(TYPOGRAPHY_TOKENS, styles),
+      radius: readTokens(RADIUS_TOKENS, styles),
+      motion: readTokens(MOTION_TOKENS, styles),
+    }),
+    // styles is not stable, so we rely on primitives using stringified theme markers
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [styles?.cssText],
+  );
+};
+
+export const snapshotTokens = () => {
+  const styles = getStyles();
+  return {
+    colors: readTokens(COLOR_TOKENS, styles),
+    spacing: readTokens(SPACING_TOKENS, styles),
+    typography: readTokens(TYPOGRAPHY_TOKENS, styles),
+    radius: readTokens(RADIUS_TOKENS, styles),
+    motion: readTokens(MOTION_TOKENS, styles),
+  };
+};
+
+export const colorTokenDefs = COLOR_TOKENS;
+export const spacingTokenDefs = SPACING_TOKENS;
+export const typographyTokenDefs = TYPOGRAPHY_TOKENS;
+export const radiusTokenDefs = RADIUS_TOKENS;
+export const motionTokenDefs = MOTION_TOKENS;

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing
+
+Welcome! This document collects the onboarding steps that internal contributors follow when working on the Kali Linux portfolio.
+It mirrors the automation running in CI so you can reproduce the same checks locally.
+
+## 1. Environment setup
+
+1. Install the Node version defined in `.nvmrc`. We recommend using `nvm`:
+   ```bash
+   nvm install
+   nvm use
+   ```
+2. Install dependencies with Yarn 4 (the repo is configured for Plug'n'Play via `corepack`):
+   ```bash
+   yarn install
+   ```
+3. Create a local environment file if you need to exercise features that require keys:
+   ```bash
+   cp .env.local.example .env.local
+   ```
+   Populate only the variables you plan to use. Most routes—including the new design system (`/design`)—work without network
+   access or secrets.
+
+## 2. Daily workflow
+
+- Start the development server:
+  ```bash
+  yarn dev
+  ```
+  The desktop shell boots at <http://localhost:3000>. Use the settings menu to toggle themes, density, and accessibility modes
+  while developing; the design system mirrors these controls.
+- Keep an eye on the terminal for ESLint or TypeScript diagnostics emitted during compilation.
+- When you add UI that mimics the Ubuntu/Kali chrome, import the shared components from `components/ubuntu.js` (e.g.
+  `components/screen/navbar`, `components/util-components/background-image`) instead of duplicating markup.
+
+## 3. Required checks
+
+Before opening a pull request make sure the following scripts succeed:
+
+```bash
+yarn lint
+yarn test
+```
+
+If you touched code that affects smoke flows, also run:
+
+```bash
+yarn smoke
+```
+
+Playwright end-to-end tests are optional locally but run in CI:
+
+```bash
+npx playwright test
+```
+
+## 4. Design system notes
+
+- `/design` is a static-first route—avoid adding API calls or remote fetches.
+- Theme tokens are loaded at runtime. If you introduce new variables add them to `styles/tokens.css` and the loaders in
+  `data/design-system/tokens.ts`.
+- Use the shared `CopyButton` component (`components/util-components/CopyButton`) for clipboard affordances.
+- Update `docs/CHANGELOG.md` or feature-specific docs when you ship something user-facing.
+
+## 5. Pull request checklist
+
+- [ ] Tests and lint pass locally.
+- [ ] No secrets or personal data in the diff.
+- [ ] UI follows accessibility expectations (keyboard, focus, reduced motion).
+- [ ] Screenshots or clips attached for visible changes.
+- [ ] PR description lists flags toggled and relevant routes.
+
+Thanks for contributing! If you get stuck, open an issue or tag the maintainers in the Discord workspace.

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "jspdf": "^3.0.2",
     "kaitai-struct": "^0.10.0",
     "leaflet": "^1.9.4",
+    "lunr": "^2.3.9",
     "marked": "^16.2.1",
     "mathjs": "^14.6.0",
     "matter-js": "0.20.0",

--- a/pages/design/index.tsx
+++ b/pages/design/index.tsx
@@ -1,0 +1,599 @@
+import Head from 'next/head';
+import React, { useEffect, useMemo, useState } from 'react';
+import Navbar from '../../components/screen/navbar';
+import BackgroundImage from '../../components/util-components/background-image';
+import CopyButton from '../../components/util-components/CopyButton';
+import { DesignTokenProvider, useDesignTokens } from '../../data/design-system/DesignTokenContext';
+import {
+  buildDesignIndex,
+  clearDesignIndex,
+  searchDesign,
+  type DesignSearchDocument,
+} from '../../utils/search/designIndex';
+import { useTheme } from '../../hooks/useTheme';
+import { useSettings } from '../../hooks/useSettings';
+import { THEME_UNLOCKS } from '../../utils/theme';
+import type { TokenValue } from '../../data/design-system/tokens';
+import '../../styles/design-system.css';
+
+const shellSnippet = `import Navbar from '@/components/screen/navbar';
+import BackgroundImage from '@/components/util-components/background-image';
+
+export function DesignShell({ children }) {
+  return (
+    <div className="relative min-h-screen bg-ub-grey text-ubt-grey">
+      <BackgroundImage />
+      <Navbar />
+      <main className="relative z-10 pt-14 pb-10">{children}</main>
+    </div>
+  );
+}`;
+
+const layoutSnippet = `export const Panel = ({ title, children }) => (
+  <section className="rounded-xl border border-ub-border-orange/40 bg-ub-lite-abrgn/70 p-6">
+    <header className="mb-4 flex items-center justify-between">
+      <h2 className="text-lg font-semibold text-ubt-grey">{title}</h2>
+    </header>
+    <div className="space-y-4 text-ubt-grey/90">{children}</div>
+  </section>
+);`;
+
+const motionSnippet = `button {
+  transition: transform var(--motion-fast) ease, box-shadow var(--motion-medium) ease;
+}
+
+button:focus-visible {
+  transition-duration: var(--motion-fast);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  button {
+    transition-duration: 0ms;
+  }
+}`;
+
+const toneSnippet = `// Voice checklist
+- Lead with actions users can take.
+- Prefer security education over fear.
+- Explain acronyms on first use.
+- Highlight keyboard support with the key name wrapped in <kbd> tags.`;
+
+type SectionConfig = {
+  id: string;
+  title: string;
+  description: string;
+  render: React.ReactNode;
+  doc: DesignSearchDocument;
+};
+
+type TokenGroup = {
+  heading: string;
+  tokens: TokenValue[];
+};
+
+const themeOptions = Object.keys(THEME_UNLOCKS);
+
+const toSearchableText = (groups: TokenGroup[]): string =>
+  groups
+    .map((group) =>
+      `${group.heading} ${group.tokens
+        .map((token) => `${token.label} ${token.name} ${token.value}`)
+        .join(' ')}`,
+    )
+    .join(' ');
+
+const getContrastColor = (value: string): string => {
+  const rgbMatch = value.match(/rgba?\(([^)]+)\)/i);
+  let r: number;
+  let g: number;
+  let b: number;
+  if (rgbMatch) {
+    const parts = rgbMatch[1]
+      .split(',')
+      .map((part) => part.trim())
+      .map(Number);
+    [r, g, b] = [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+  } else if (value.startsWith('#')) {
+    const hex = value.replace('#', '');
+    const normalized = hex.length === 3 ? hex.split('').map((c) => c + c).join('') : hex;
+    const int = Number.parseInt(normalized.padEnd(6, '0').slice(0, 6), 16);
+    r = (int >> 16) & 255;
+    g = (int >> 8) & 255;
+    b = int & 255;
+  } else {
+    return '#ffffff';
+  }
+  const [nr, ng, nb] = [r, g, b].map((channel) => {
+    const c = channel / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  });
+  const luminance = 0.2126 * nr + 0.7152 * ng + 0.0722 * nb;
+  return luminance > 0.55 ? '#0f1317' : '#ffffff';
+};
+
+const formatPx = (valuePx?: number): string | undefined => {
+  if (!valuePx || Number.isNaN(valuePx)) return undefined;
+  return `${Math.round(valuePx)}px`;
+};
+
+const TokensSection = () => {
+  const { colors, spacing, typography, radius } = useDesignTokens();
+
+  return (
+    <section id="tokens" className="design-card">
+      <h2 className="design-section-title">
+        <span className="text-3xl">🎨</span>
+        Tokens
+      </h2>
+      <div className="design-section-body">
+        <p>
+          Tokens are read live from the active theme so previews stay in sync with runtime values. Use the copy
+          controls to grab CSS variables without leaving the page.
+        </p>
+        <div className="space-y-8">
+          <div>
+            <h3 className="text-lg font-semibold text-ubt-grey">Color</h3>
+            <div className="design-token-grid">
+              {colors.map((token) => {
+                const textColor = getContrastColor(token.value);
+                return (
+                  <div key={token.name} className="design-token-swatch" style={{ backgroundColor: token.value, color: textColor }}>
+                    <CopyButton value={`var(${token.cssVar})`} className="design-token-copy" />
+                    <div className="design-token-meta">
+                      <p className="text-base font-semibold normal-case">{token.label}</p>
+                      <p className="font-mono text-xs lowercase">{token.value}</p>
+                      <p className="font-mono text-xs lowercase text-ubt-grey/70">{token.cssVar}</p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-ubt-grey">Spacing scale</h3>
+            <div className="design-spacing-grid">
+              {spacing.map((token) => {
+                const px = formatPx(token.valuePx);
+                const width = Math.max(12, Math.min(240, (token.valuePx ?? 16) * 3));
+                return (
+                  <div key={token.name} className="design-spacing-row">
+                    <div>
+                      <p className="font-semibold text-ubt-grey">{token.label}</p>
+                      <p className="text-xs text-ubt-grey/70">{token.description}</p>
+                      <div className="mt-2 flex items-center gap-2 font-mono text-xs text-ubt-grey/80">
+                        <span>{token.value}</span>
+                        {px && <span>({px})</span>}
+                        <CopyButton value={`var(${token.cssVar})`} className="design-inline-copy" />
+                      </div>
+                    </div>
+                    <div className="design-spacing-visual">
+                      <div className="design-spacing-bar" style={{ width }} />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-ubt-grey">Typography & focus</h3>
+            <div className="design-typography-list">
+              {typography.map((token) => (
+                <div key={token.name} className="design-typography-item">
+                  <p className="font-semibold text-ubt-grey">{token.label}</p>
+                  <p className="font-mono text-sm text-ubt-grey/80">{token.value}</p>
+                  <CopyButton value={`var(${token.cssVar})`} className="design-inline-copy" />
+                  {token.description && <p className="text-xs text-ubt-grey/70">{token.description}</p>}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-ubt-grey">Radii</h3>
+            <div className="design-typography-list">
+              {radius.map((token) => (
+                <div key={token.name} className="design-typography-item">
+                  <p className="font-semibold text-ubt-grey">{token.label}</p>
+                  <p className="font-mono text-sm text-ubt-grey/80">{token.value}</p>
+                  <CopyButton value={`var(${token.cssVar})`} className="design-inline-copy" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const ComponentsSection = () => (
+  <section id="components" className="design-card">
+    <h2 className="design-section-title">
+      <span className="text-3xl">🧩</span>
+      Components
+    </h2>
+    <div className="design-section-body">
+      <p>
+        Reuse the Ubuntu shell pieces instead of duplicating chrome. The design system page itself mounts the shared{' '}
+        <code className="design-badge">Navbar</code> and <code className="design-badge">BackgroundImage</code> from the
+        desktop experience so new surfaces feel native.
+      </p>
+      <div className="design-code-block">
+        <CopyButton value={shellSnippet} className="design-token-copy" />
+        <pre>
+          <code>{shellSnippet}</code>
+        </pre>
+      </div>
+      <ul className="design-list">
+        <li>
+          Use the <code className="design-badge">SettingsProvider</code> and <code className="design-badge">useTheme</code>{' '}
+          hooks to stay in sync with personalization controls.
+        </li>
+        <li>
+          Windows, menus, and the dock ship from <code className="design-badge">components/screen</code>; wire new views as
+          focused content areas within that frame.
+        </li>
+        <li>
+          Keep utility widgets under <code className="design-badge">components/util-components</code> so icons and copy
+          buttons remain consistent.
+        </li>
+      </ul>
+    </div>
+  </section>
+);
+
+const LayoutSection = () => (
+  <section id="layout" className="design-card">
+    <h2 className="design-section-title">
+      <span className="text-3xl">📐</span>
+      Layout
+    </h2>
+    <div className="design-section-body">
+      <p>
+        Align experiences with the responsive desktop grid: 12-column on wide screens, stacked on mobile. The shared spacing
+        tokens guarantee comfortable density that still respects compact mode.
+      </p>
+      <div className="design-code-block">
+        <CopyButton value={layoutSnippet} className="design-token-copy" />
+        <pre>
+          <code>{layoutSnippet}</code>
+        </pre>
+      </div>
+      <ul className="design-list">
+        <li>Use <code className="design-badge">max-w-6xl</code> containers to keep lines readable on ultrawide monitors.</li>
+        <li>
+          Apply <code className="design-badge">gap-[var(--space-X)]</code> utilities instead of hard-coded pixels so density
+          toggles propagate everywhere.
+        </li>
+        <li>
+          Leverage the radius tokens for cards, panels, and chips; <code className="design-badge">radius-lg</code> pairs with
+          the window aesthetic.
+        </li>
+      </ul>
+    </div>
+  </section>
+);
+
+const MotionSection = () => {
+  const { motion } = useDesignTokens();
+  return (
+    <section id="motion" className="design-card">
+      <h2 className="design-section-title">
+        <span className="text-3xl">🎞️</span>
+        Motion
+      </h2>
+      <div className="design-section-body">
+        <p>
+          Motion tokens bias toward subtlety. Respect reduced-motion preferences automatically by reading values from the
+          token provider.
+        </p>
+        <div className="design-typography-list">
+          {motion.map((token) => (
+            <div key={token.name} className="design-typography-item">
+              <p className="font-semibold text-ubt-grey">{token.label}</p>
+              <p className="font-mono text-sm text-ubt-grey/80">{token.value}</p>
+              <CopyButton value={`var(${token.cssVar})`} className="design-inline-copy" />
+            </div>
+          ))}
+        </div>
+        <div className="design-code-block">
+          <CopyButton value={motionSnippet} className="design-token-copy" />
+          <pre>
+            <code>{motionSnippet}</code>
+          </pre>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const AccessibilitySection = () => (
+  <section id="accessibility" className="design-card">
+    <h2 className="design-section-title">
+      <span className="text-3xl">♿</span>
+      Accessibility
+    </h2>
+    <div className="design-section-body">
+      <ul className="design-list">
+        <li>
+          Honor <code className="design-badge">reduced-motion</code>, <code className="design-badge">high-contrast</code>,
+          and <code className="design-badge">large-hit-area</code> modes exposed in user settings.
+        </li>
+        <li>Focus indicators should use <code className="design-badge">var(--focus-outline-color)</code>.</li>
+        <li>
+          Every window, menu, and app tile must remain reachable via keyboard and announce state changes with the live region in
+          <code className="design-badge">_app.jsx</code>.
+        </li>
+        <li>
+          Prefer semantic HTML and ARIA labels that match the Ubuntu desktop vocabulary—"dock", "workspace switcher", and so on.
+        </li>
+      </ul>
+      <CopyButton value="var(--focus-outline-color)" label="Copy focus color" />
+    </div>
+  </section>
+);
+
+const ContentSection = () => (
+  <section id="content" className="design-card">
+    <h2 className="design-section-title">
+      <span className="text-3xl">📝</span>
+      Content
+    </h2>
+    <div className="design-section-body">
+      <p>
+        Voice balances Kali&apos;s security roots with Ubuntu&apos;s friendliness. Keep copy actionable, welcoming, and free from fear
+        marketing.
+      </p>
+      <div className="design-code-block">
+        <CopyButton value={toneSnippet} className="design-token-copy" />
+        <pre>
+          <code>{toneSnippet}</code>
+        </pre>
+      </div>
+      <ul className="design-list">
+        <li>Lead with verbs that describe what the user can do next.</li>
+        <li>Frame security warnings as guidance, not alarms.</li>
+        <li>Pair hacker terminology with short explanations for newcomers.</li>
+        <li>Highlight accessibility affordances such as keyboard shortcuts or caption toggles.</li>
+      </ul>
+    </div>
+  </section>
+);
+
+const ControlsPanel = () => {
+  const { theme, setTheme } = useTheme();
+  const { density, setDensity, reducedMotion, setReducedMotion, highContrast, setHighContrast } = useSettings();
+
+  return (
+    <section className="design-card">
+      <h2 className="design-section-title">
+        <span className="text-3xl">🧭</span>
+        Preview controls
+      </h2>
+      <div className="design-section-body">
+        <div className="grid gap-6 md:grid-cols-2">
+          <label className="flex flex-col gap-2">
+            <span className="text-sm font-semibold text-ubt-grey">Theme</span>
+            <select
+              value={theme}
+              onChange={(event) => setTheme(event.target.value)}
+              className="rounded-lg border border-ub-border-orange/40 bg-ub-drk-abrgn/60 px-3 py-2 text-ubt-grey focus:outline-none focus:ring-2 focus:ring-ub-border-orange"
+            >
+              {themeOptions.map((option) => (
+                <option key={option} value={option} className="bg-ub-drk-abrgn text-ubt-grey">
+                  {option}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="flex flex-col gap-2">
+            <span className="text-sm font-semibold text-ubt-grey">Density</span>
+            <div className="flex gap-3">
+              {(['regular', 'compact'] as const).map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() => setDensity(option)}
+                  className={`design-copy-trigger ${density === option ? 'bg-ub-border-orange/60 text-black' : ''}`.trim()}
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setReducedMotion(!reducedMotion)}
+            className={`design-copy-trigger ${reducedMotion ? 'bg-ub-border-orange/60 text-black' : ''}`.trim()}
+          >
+            {reducedMotion ? 'Reduced motion: on' : 'Reduced motion: off'}
+          </button>
+          <button
+            type="button"
+            onClick={() => setHighContrast(!highContrast)}
+            className={`design-copy-trigger ${highContrast ? 'bg-ub-border-orange/60 text-black' : ''}`.trim()}
+          >
+            {highContrast ? 'High contrast: on' : 'High contrast: off'}
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const DesignSystemContent = () => {
+  const tokens = useDesignTokens();
+  const [query, setQuery] = useState('');
+
+  const groups: TokenGroup[] = useMemo(
+    () => [
+      { heading: 'Color', tokens: tokens.colors },
+      { heading: 'Spacing', tokens: tokens.spacing },
+      { heading: 'Typography', tokens: tokens.typography },
+      { heading: 'Radius', tokens: tokens.radius },
+      { heading: 'Motion', tokens: tokens.motion },
+    ],
+    [tokens],
+  );
+
+  const docs = useMemo<SectionConfig[]>(() => {
+    const tokensDoc: SectionConfig = {
+      id: 'tokens',
+      title: 'Tokens',
+      description: 'Live color, spacing, and typography tokens pulled from the theme runtime.',
+      render: <TokensSection />, // tokens read from context internally
+      doc: {
+        id: 'tokens',
+        title: 'Tokens',
+        section: 'Tokens',
+        body: toSearchableText(groups),
+        keywords: ['color', 'spacing', 'typography', 'radius', 'token'],
+      },
+    };
+
+    const other: SectionConfig[] = [
+      {
+        id: 'components',
+        title: 'Components',
+        description: 'Shell components shared with the desktop environment.',
+        render: <ComponentsSection />,
+        doc: {
+          id: 'components',
+          title: 'Components',
+          section: 'Components',
+          body: 'Ubuntu shell reuse background image navbar settings provider util components copy button',
+          keywords: ['navbar', 'background', 'shell', 'window', 'provider'],
+        },
+      },
+      {
+        id: 'layout',
+        title: 'Layout',
+        description: 'Grid, spacing, and responsive guidance.',
+        render: <LayoutSection />,
+        doc: {
+          id: 'layout',
+          title: 'Layout',
+          section: 'Layout',
+          body: 'responsive grid max width spacing tokens radius utilities cards panels',
+          keywords: ['grid', 'panel', 'spacing', 'radius'],
+        },
+      },
+      {
+        id: 'motion',
+        title: 'Motion',
+        description: 'Timing tokens and reduced motion fallbacks.',
+        render: <MotionSection />,
+        doc: {
+          id: 'motion',
+          title: 'Motion',
+          section: 'Motion',
+          body: `${tokens.motion.map((token) => `${token.name} ${token.value}`).join(' ')} animations transitions reduced motion`,
+          keywords: ['motion', 'animation', 'transition'],
+        },
+      },
+      {
+        id: 'accessibility',
+        title: 'Accessibility',
+        description: 'Keyboard, focus, and personalization guidelines.',
+        render: <AccessibilitySection />,
+        doc: {
+          id: 'accessibility',
+          title: 'Accessibility',
+          section: 'Accessibility',
+          body: 'focus outline color live region keyboard reduced motion high contrast large hit areas',
+          keywords: ['focus', 'keyboard', 'a11y'],
+        },
+      },
+      {
+        id: 'content',
+        title: 'Content',
+        description: 'Voice and tone reminders.',
+        render: <ContentSection />,
+        doc: {
+          id: 'content',
+          title: 'Content',
+          section: 'Content',
+          body: 'voice tone actionable guidance explain acronyms accessibility copywriting',
+          keywords: ['tone', 'voice', 'copy'],
+        },
+      },
+    ];
+
+    return [tokensDoc, ...other];
+  }, [groups, tokens.motion]);
+
+  const documents = useMemo(() => docs.map((section) => section.doc), [docs]);
+
+  useEffect(() => {
+    clearDesignIndex();
+    buildDesignIndex(documents);
+    return () => clearDesignIndex();
+  }, [documents]);
+
+  const sections = useMemo(() => {
+    if (!query.trim()) return docs;
+    const results = searchDesign(query.trim());
+    const ids = new Set(results.map((result) => result.id));
+    return docs.filter((section) => ids.has(section.id));
+  }, [docs, query]);
+
+  return (
+    <>
+      <section className="design-card">
+        <h2 className="design-section-title">
+          <span className="text-3xl">🔍</span>
+          Search the system
+        </h2>
+        <div className="design-section-body">
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search tokens, motion, accessibility, and more"
+            className="design-search"
+          />
+        </div>
+      </section>
+      <ControlsPanel />
+      {sections.length ? (
+        sections.map((section) => <React.Fragment key={section.id}>{section.render}</React.Fragment>)
+      ) : (
+        <div className="design-no-results">No sections matched your search. Try a different keyword.</div>
+      )}
+    </>
+  );
+};
+
+const DesignSystemPage = () => (
+  <DesignTokenProvider>
+    <div className="design-page">
+      <Head>
+        <title>Kali Linux Portfolio — Design System</title>
+        <meta
+          name="description"
+          content="Design tokens, layout primitives, and accessibility guidelines for the Kali Linux portfolio shell."
+        />
+      </Head>
+      <div className="design-shell-background">
+        <BackgroundImage />
+      </div>
+      <div className="design-shell-navbar">
+        <Navbar />
+      </div>
+      <main className="design-container">
+        <header className="design-card">
+          <h1 className="design-section-title">
+            <span className="text-3xl">🛠️</span>
+            Kali Design System
+          </h1>
+          <p className="design-section-body">
+            A reference workstation for contributors. Preview live tokens, copy shell scaffolds, and ship features that inherit
+            personalization settings without any network calls.
+          </p>
+        </header>
+        <DesignSystemContent />
+      </main>
+    </div>
+  </DesignTokenProvider>
+);
+
+export default DesignSystemPage;

--- a/styles/design-system.css
+++ b/styles/design-system.css
@@ -1,0 +1,103 @@
+@tailwind components;
+
+@layer components {
+  .design-page {
+    @apply relative min-h-screen bg-ub-grey text-ubt-grey overflow-x-hidden;
+  }
+
+  .design-shell-background {
+    @apply absolute inset-0 -z-10;
+  }
+
+  .design-shell-navbar {
+    @apply sticky top-0 z-40 h-12;
+  }
+
+  .design-container {
+    @apply relative mx-auto flex max-w-6xl flex-col gap-10 px-6 pb-24 pt-24 md:px-10;
+  }
+
+  .design-card {
+    @apply rounded-xl border border-ub-border-orange/30 bg-ub-lite-abrgn/70 p-6 shadow-xl shadow-black/30 backdrop-blur;
+  }
+
+  .design-section-title {
+    @apply mb-4 flex items-center gap-3 text-2xl font-semibold text-ubt-grey;
+  }
+
+  .design-section-body {
+    @apply space-y-4 text-base leading-relaxed text-ubt-grey/90;
+  }
+
+  .design-token-grid {
+    @apply grid gap-4 sm:grid-cols-2 lg:grid-cols-3;
+  }
+
+  .design-token-swatch {
+    @apply relative overflow-hidden rounded-xl border border-ub-border-orange/40 bg-ub-drk-abrgn/40 shadow-lg;
+  }
+
+  .design-token-meta {
+    @apply space-y-1 p-4 text-xs uppercase tracking-wide text-ubt-grey/90;
+  }
+
+  .design-token-copy {
+    @apply absolute right-3 top-3;
+  }
+
+  .design-spacing-grid {
+    @apply grid gap-4 md:grid-cols-2;
+  }
+
+  .design-spacing-row {
+    @apply flex items-center justify-between gap-6 rounded-lg border border-ub-border-orange/40 bg-ub-drk-abrgn/40 p-4;
+  }
+
+  .design-spacing-visual {
+    @apply relative h-8 flex-1 rounded-full bg-ub-lite-abrgn/70;
+  }
+
+  .design-spacing-bar {
+    @apply absolute inset-y-2 left-2 rounded-full bg-ub-border-orange/60;
+  }
+
+  .design-typography-list {
+    @apply grid gap-4 md:grid-cols-2;
+  }
+
+  .design-typography-item {
+    @apply space-y-1 rounded-lg border border-ub-border-orange/30 bg-ub-drk-abrgn/40 p-4;
+  }
+
+  .design-search {
+    @apply w-full rounded-lg border border-ub-border-orange/40 bg-ub-lite-abrgn/70 px-4 py-3 text-base text-ubt-grey placeholder:text-ubt-grey/50 focus:outline-none focus:ring-2 focus:ring-ub-border-orange;
+  }
+
+  .design-inline-copy {
+    @apply ml-auto flex-shrink-0;
+  }
+
+  .design-copy-trigger {
+    @apply relative flex items-center gap-2 rounded-full border border-ub-border-orange/40 bg-ub-lite-abrgn/80 px-3 py-1 text-xs font-medium uppercase tracking-wide text-ubt-grey transition hover:bg-ub-border-orange/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-border-orange;
+  }
+
+  .design-copy-trigger[data-copied='true'] {
+    @apply bg-ub-border-orange/60 text-black;
+  }
+
+  .design-code-block {
+    @apply relative overflow-auto rounded-lg border border-ub-border-orange/30 bg-black/60 p-4 font-mono text-sm text-ubt-grey shadow-inner;
+  }
+
+  .design-list {
+    @apply list-disc space-y-2 pl-5 text-ubt-grey/90;
+  }
+
+  .design-badge {
+    @apply inline-flex items-center gap-1 rounded-full border border-ub-border-orange/30 bg-ub-drk-abrgn/60 px-3 py-1 text-xs uppercase tracking-wide text-ubt-grey/80;
+  }
+
+  .design-no-results {
+    @apply rounded-lg border border-dashed border-ub-border-orange/40 bg-ub-drk-abrgn/40 p-6 text-center text-ubt-grey/70;
+  }
+}

--- a/utils/search/designIndex.ts
+++ b/utils/search/designIndex.ts
@@ -1,0 +1,69 @@
+import lunr from 'lunr';
+
+export interface DesignSearchDocument {
+  id: string;
+  title: string;
+  section: string;
+  body: string;
+  keywords?: string[];
+}
+
+interface CachedIndex {
+  index: lunr.Index;
+  documents: Record<string, DesignSearchDocument>;
+}
+
+let cache: CachedIndex | null = null;
+
+const normaliseDocuments = (docs: DesignSearchDocument[]): Record<string, DesignSearchDocument> => {
+  const dictionary: Record<string, DesignSearchDocument> = {};
+  docs.forEach((doc) => {
+    dictionary[doc.id] = doc;
+  });
+  return dictionary;
+};
+
+export const buildDesignIndex = (docs: DesignSearchDocument[]): lunr.Index => {
+  const documents = normaliseDocuments(docs);
+  const idx = lunr(function () {
+    this.ref('id');
+    this.field('title', { boost: 5 });
+    this.field('section', { boost: 3 });
+    this.field('body');
+    this.field('keywords', { boost: 4 });
+
+    docs.forEach((doc) => {
+      this.add({ ...doc, keywords: doc.keywords?.join(' ') ?? '' });
+    });
+  });
+
+  cache = {
+    index: idx,
+    documents,
+  };
+
+  return idx;
+};
+
+export const ensureDesignIndex = (docs: DesignSearchDocument[]): CachedIndex => {
+  if (!cache) {
+    buildDesignIndex(docs);
+  }
+  return cache!;
+};
+
+export const searchDesign = (query: string): DesignSearchDocument[] => {
+  if (!cache || !query.trim()) return cache?.documents ? Object.values(cache.documents) : [];
+  try {
+    const hits = cache.index.search(query);
+    return hits
+      .map((hit) => cache!.documents[hit.ref])
+      .filter((doc): doc is DesignSearchDocument => Boolean(doc));
+  } catch {
+    return [];
+  }
+};
+
+export const clearDesignIndex = () => {
+  cache = null;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9657,6 +9657,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lunr@npm:^2.3.9":
+  version: 2.3.9
+  resolution: "lunr@npm:2.3.9"
+  checksum: 10c0/77d7dbb4fbd602aac161e2b50887d8eda28c0fa3b799159cee380fbb311f1e614219126ecbbd2c3a9c685f1720a8109b3c1ca85cc893c39b6c9cc6a62a1d8a8b
+  languageName: node
+  linkType: hard
+
 "luxon@npm:^3.7.1":
   version: 3.7.1
   resolution: "luxon@npm:3.7.1"
@@ -13922,6 +13929,7 @@ __metadata:
     jspdf: "npm:^3.0.2"
     kaitai-struct: "npm:^0.10.0"
     leaflet: "npm:^1.9.4"
+    lunr: "npm:^2.3.9"
     magic-string: "npm:0.30.18"
     marked: "npm:^16.2.1"
     mathjs: "npm:^14.6.0"


### PR DESCRIPTION
## Summary
- add a `/design` route that reuses the Ubuntu shell chrome and renders live design system sections with search
- load color, spacing, typography, radius, and motion tokens from the active theme through a shared design token context
- add reusable copy button styling, local search helpers, and contributor onboarding docs for the design system workflow

## Testing
- yarn lint *(fails: existing accessibility and window globals issues across legacy apps)*
- yarn test *(fails: existing window/localStorage and act() warnings in legacy suites)*

------
https://chatgpt.com/codex/tasks/task_e_68cb45d84b7883288e3c4b74086ca30a