### PR TITLE
[notifications] add grouped summary center

### DIFF
--- a/__tests__/notifications.store.test.ts
+++ b/__tests__/notifications.store.test.ts
@@ -1,0 +1,91 @@
+import { buildNotificationGroups, computeSummaryStats } from '../hooks/useNotifications';
+import type { AppNotification } from '../types/notifications';
+
+describe('notification grouping', () => {
+  const now = 1_700_000_000_000;
+
+  const makeNotification = (overrides: Partial<AppNotification>): AppNotification => ({
+    id: overrides.id ?? Math.random().toString(36).slice(2),
+    appId: overrides.appId ?? 'terminal',
+    subject: overrides.subject ?? 'Status',
+    body: overrides.body ?? 'Ping received',
+    date: overrides.date ?? now,
+    isCritical: overrides.isCritical ?? false,
+  });
+
+  it('collapses repeats within five seconds', () => {
+    const notifications: Record<string, AppNotification[]> = {
+      terminal: [
+        makeNotification({ id: 'a', date: now }),
+        makeNotification({ id: 'b', date: now + 3_000 }),
+      ],
+    };
+
+    const groups = buildNotificationGroups(notifications);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].occurrences).toHaveLength(1);
+    expect(groups[0].occurrences[0].repeatCount).toBe(2);
+    expect(groups[0].totalCount).toBe(2);
+  });
+
+  it('creates new bursts after the repeat window', () => {
+    const notifications: Record<string, AppNotification[]> = {
+      mail: [
+        makeNotification({ id: 'a', subject: 'Inbox', date: now }),
+        makeNotification({ id: 'b', subject: 'Inbox', date: now + 6_000 }),
+      ],
+    };
+
+    const groups = buildNotificationGroups(notifications);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].occurrences).toHaveLength(2);
+    expect(groups[0].occurrences[0].repeatCount).toBe(1);
+    expect(groups[0].occurrences[1].repeatCount).toBe(1);
+  });
+
+  it('groups by application and subject', () => {
+    const notifications: Record<string, AppNotification[]> = {
+      mail: [
+        makeNotification({ id: 'a', appId: 'mail', subject: 'Inbox', body: 'One' }),
+        makeNotification({ id: 'b', appId: 'mail', subject: 'Updates', body: 'Two' }),
+      ],
+      alerts: [
+        makeNotification({ id: 'c', appId: 'alerts', subject: 'System', body: 'Critical', isCritical: true }),
+      ],
+    };
+
+    const groups = buildNotificationGroups(notifications);
+    expect(groups).toHaveLength(3);
+    const critical = groups.find(group => group.appId === 'alerts');
+    expect(critical?.isCritical).toBe(true);
+  });
+
+  it('filters by summary window start', () => {
+    const notifications: Record<string, AppNotification[]> = {
+      terminal: [
+        makeNotification({ id: 'a', date: now - 10_000 }),
+        makeNotification({ id: 'b', date: now + 2_000 }),
+      ],
+    };
+
+    const groups = buildNotificationGroups(notifications, { windowStart: now });
+    expect(groups).toHaveLength(1);
+    expect(groups[0].totalCount).toBe(1);
+  });
+
+  it('computes summary statistics', () => {
+    const notifications: Record<string, AppNotification[]> = {
+      ops: [
+        makeNotification({ id: 'a', subject: 'Queue', date: now }),
+        makeNotification({ id: 'b', subject: 'Queue', date: now + 1_000 }),
+        makeNotification({ id: 'c', subject: 'Queue', date: now + 6_200 }),
+      ],
+    };
+
+    const groups = buildNotificationGroups(notifications);
+    const stats = computeSummaryStats(groups);
+    expect(stats.rawCount).toBe(3);
+    expect(stats.cardCount).toBe(1);
+    expect(stats.clusterCount).toBe(2);
+  });
+});

--- a/apps/notifications/index.tsx
+++ b/apps/notifications/index.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import NotificationCenter from '../../components/common/NotificationCenter';
+import SummaryPanel from '../../components/apps/notifications/SummaryPanel';
+import useNotifications, {
+  type NotificationGroup,
+} from '../../hooks/useNotifications';
+
+const formatRelativeTime = (timestamp: number) => {
+  const now = Date.now();
+  const diff = Math.max(0, now - timestamp);
+  const minutes = Math.floor(diff / (60 * 1000));
+  if (minutes <= 0) return 'just now';
+  if (minutes === 1) return '1 minute ago';
+  if (minutes < 60) return `${minutes} minutes ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours === 1) return '1 hour ago';
+  if (hours < 24) return `${hours} hours ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return '1 day ago';
+  return `${days} days ago`;
+};
+
+const NotificationsDashboard: React.FC = () => {
+  const {
+    summaryGroups,
+    hiddenGroupCount,
+    doNotDisturb,
+    setDoNotDisturb,
+    summaryInterval,
+    setSummaryInterval,
+    triggerSummary,
+    nextSummaryAt,
+    summaryStats,
+    totalSummaryGroups,
+    groupedNotifications,
+  } = useNotifications();
+
+  const groupsByApp = useMemo(() => {
+    return groupedNotifications.reduce<Record<string, NotificationGroup[]>>(
+      (acc, group) => {
+        if (!acc[group.appId]) acc[group.appId] = [];
+        acc[group.appId].push(group);
+        return acc;
+      },
+      {},
+    );
+  }, [groupedNotifications]);
+
+  const appEntries = useMemo(() => Object.entries(groupsByApp), [groupsByApp]);
+
+  return (
+    <main
+      role="main"
+      className="flex h-full flex-col gap-4 overflow-y-auto bg-ub-dark/80 p-4 text-ubt-grey"
+      aria-label="Notification center"
+    >
+      <SummaryPanel
+        groups={summaryGroups}
+        hiddenGroupCount={hiddenGroupCount}
+        doNotDisturb={doNotDisturb}
+        onToggleDoNotDisturb={setDoNotDisturb}
+        summaryInterval={summaryInterval}
+        onChangeSummaryInterval={setSummaryInterval}
+        triggerSummary={triggerSummary}
+        nextSummaryAt={nextSummaryAt}
+        summaryStats={summaryStats}
+        totalGroups={totalSummaryGroups}
+      />
+
+      <section
+        aria-labelledby="notification-by-app"
+        className="rounded-lg border border-ubt-cool-grey bg-ub-cool-grey/40"
+      >
+        <header className="border-b border-ubt-cool-grey/60 px-4 py-3">
+          <h2
+            id="notification-by-app"
+            className="text-lg font-semibold text-white"
+          >
+            By application
+          </h2>
+          <p className="text-sm text-ubt-grey/80">
+            Detailed grouped alerts for each application. Use arrow keys to
+            explore cards and press Enter to focus a summary.
+          </p>
+        </header>
+        {appEntries.length > 0 ? (
+          <div className="divide-y divide-ubt-cool-grey/40" role="list">
+            {appEntries.map(([appId, groups]) => {
+              const total = groups.reduce((sum, group) => sum + group.totalCount, 0);
+              return (
+                <article
+                  key={appId}
+                  role="region"
+                  aria-labelledby={`app-section-${appId}`}
+                  className="focus-within:ring-2 focus-within:ring-sky-400 focus-within:ring-offset-2"
+                >
+                  <header className="flex items-center justify-between gap-2 px-4 py-3">
+                    <h3
+                      id={`app-section-${appId}`}
+                      className="text-base font-semibold text-white"
+                    >
+                      {appId}
+                    </h3>
+                    <span className="text-xs uppercase tracking-wide text-ubt-grey/70">
+                      {total} {total === 1 ? 'alert' : 'alerts'}
+                    </span>
+                  </header>
+                  <ul
+                    role="list"
+                    className="grid gap-3 px-4 pb-4 sm:grid-cols-2 xl:grid-cols-3"
+                  >
+                    {groups.map(group => (
+                      <li
+                        key={`${group.appId}-${group.subject}`}
+                        role="listitem"
+                        tabIndex={0}
+                        className={`rounded-lg border px-3 py-3 text-sm shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-sky-400 ${
+                          group.isCritical
+                            ? 'border-red-500/70 bg-red-900/20 text-red-100'
+                            : 'border-ubt-cool-grey/70 bg-ub-dark/70 text-ubt-grey'
+                        }`}
+                        aria-label={`${group.subject} in ${group.appId}, ${group.totalCount} total notifications. Last seen ${formatRelativeTime(group.lastDate)}.`}
+                      >
+                        <p className="text-sm font-semibold text-white">
+                          {group.subject}
+                        </p>
+                        <p className="mt-1 text-xs text-ubt-grey/80">
+                          {group.lastBody}
+                        </p>
+                        <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-ubt-grey/70">
+                          <span>
+                            {group.totalCount}{' '}
+                            {group.totalCount === 1 ? 'alert' : 'alerts'}
+                          </span>
+                          <span aria-hidden="true">•</span>
+                          <span>
+                            {group.occurrences.length}{' '}
+                            {group.occurrences.length === 1 ? 'burst' : 'bursts'}
+                          </span>
+                          <span aria-hidden="true">•</span>
+                          <span>{formatRelativeTime(group.lastDate)}</span>
+                          {group.isCritical && (
+                            <span className="rounded-full bg-red-700 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white">
+                              Critical
+                            </span>
+                          )}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </article>
+              );
+            })}
+          </div>
+        ) : (
+          <p
+            role="status"
+            className="px-4 py-6 text-center text-sm text-ubt-grey"
+          >
+            No notifications have been received yet. When apps emit alerts they
+            will appear here grouped by subject.
+          </p>
+        )}
+      </section>
+    </main>
+  );
+};
+
+const NotificationsApp: React.FC = () => (
+  <NotificationCenter>
+    <NotificationsDashboard />
+  </NotificationCenter>
+);
+
+export default NotificationsApp;

--- a/components/apps/notifications/SummaryPanel.tsx
+++ b/components/apps/notifications/SummaryPanel.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import type {
+  NotificationGroup,
+  NotificationSummaryStats,
+} from '../../../hooks/useNotifications';
+import {
+  minutesFromMs,
+  SUMMARY_INTERVAL_OPTIONS_MINUTES,
+  msFromMinutes,
+} from '../../../utils/settings/notificationPreferences';
+
+interface SummaryPanelProps {
+  groups: NotificationGroup[];
+  hiddenGroupCount: number;
+  doNotDisturb: boolean;
+  onToggleDoNotDisturb: (value: boolean) => void;
+  summaryInterval: number;
+  onChangeSummaryInterval: (value: number) => void;
+  triggerSummary: () => void;
+  nextSummaryAt: number | null;
+  summaryStats: NotificationSummaryStats;
+  totalGroups: number;
+}
+
+const formatTime = (timestamp: number) => {
+  const date = new Date(timestamp);
+  return new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: 'numeric',
+  }).format(date);
+};
+
+const formatRelativeTime = (timestamp: number) => {
+  const now = Date.now();
+  const diff = Math.max(0, now - timestamp);
+  const minutes = Math.floor(diff / (60 * 1000));
+  if (minutes <= 0) return 'just now';
+  if (minutes === 1) return '1 minute ago';
+  if (minutes < 60) return `${minutes} minutes ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours === 1) return '1 hour ago';
+  if (hours < 24) return `${hours} hours ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return '1 day ago';
+  return `${days} days ago`;
+};
+
+const formatIntervalLabel = (minutes: number) => {
+  if (minutes === 60) return '60 minutes (1 hour)';
+  if (minutes > 60 && minutes % 60 === 0) {
+    const hours = minutes / 60;
+    return `${minutes} minutes (${hours} hours)`;
+  }
+  return `${minutes} minutes`;
+};
+
+const SummaryPanel: React.FC<SummaryPanelProps> = ({
+  groups,
+  hiddenGroupCount,
+  doNotDisturb,
+  onToggleDoNotDisturb,
+  summaryInterval,
+  onChangeSummaryInterval,
+  triggerSummary,
+  nextSummaryAt,
+  summaryStats,
+  totalGroups,
+}) => {
+  const intervalMinutes = minutesFromMs(summaryInterval);
+
+  const availableIntervals = useMemo(() => {
+    const base = [...SUMMARY_INTERVAL_OPTIONS_MINUTES];
+    if (!base.includes(intervalMinutes)) {
+      base.push(intervalMinutes);
+    }
+    return base.sort((a, b) => a - b);
+  }, [intervalMinutes]);
+
+  const reductionLabel = useMemo(() => {
+    if (!summaryStats.rawCount) return 'No notifications yet in this window.';
+    const saved = Math.max(0, summaryStats.rawCount - summaryStats.cardCount);
+    const percent = summaryStats.rawCount
+      ? Math.round((saved / summaryStats.rawCount) * 100)
+      : 0;
+    return `Condensed ${summaryStats.rawCount} notifications into ${summaryStats.cardCount} cards (${percent}% reduction).`;
+  }, [summaryStats]);
+
+  const hiddenMessage = hiddenGroupCount
+    ? `${hiddenGroupCount} notification ${
+        hiddenGroupCount === 1 ? 'group is' : 'groups are'
+      } muted by Do Not Disturb.`
+    : '';
+
+  return (
+    <section
+      aria-labelledby="notification-summary-title"
+      className="rounded-lg border border-ubt-cool-grey bg-ub-cool-grey/60 p-4 text-ubt-grey shadow-lg"
+    >
+      <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2
+            id="notification-summary-title"
+            className="text-lg font-semibold text-white"
+          >
+            Notification summary
+          </h2>
+          <p className="text-sm" aria-live="polite">
+            {reductionLabel}
+          </p>
+          {nextSummaryAt && (
+            <p className="text-xs text-ubt-grey/80" role="status">
+              Next summary at {formatTime(nextSummaryAt)}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-col gap-3 md:flex-row md:items-center">
+          <button
+            type="button"
+            role="switch"
+            aria-checked={doNotDisturb}
+            onClick={() => onToggleDoNotDisturb(!doNotDisturb)}
+            className={`rounded-full px-4 py-2 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${
+              doNotDisturb
+                ? 'bg-yellow-600 text-black focus-visible:ring-yellow-400'
+                : 'bg-ub-dark text-white focus-visible:ring-sky-500'
+            }`}
+          >
+            {doNotDisturb ? 'Do Not Disturb: On' : 'Do Not Disturb: Off'}
+          </button>
+          <label className="flex flex-col text-xs uppercase tracking-wide">
+            Summary interval
+            <select
+              value={intervalMinutes}
+              onChange={event => {
+                const minutes = Number.parseInt(event.target.value, 10);
+                const ms = msFromMinutes(minutes);
+                onChangeSummaryInterval(ms);
+              }}
+              className="mt-1 rounded border border-ubt-cool-grey bg-ub-dark px-3 py-1 text-sm text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+              aria-label="Summary interval"
+            >
+              {availableIntervals.map(option => (
+                <option key={option} value={option}>
+                  {formatIntervalLabel(option)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={triggerSummary}
+            className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
+          >
+            Summarize now
+          </button>
+        </div>
+      </header>
+
+      {hiddenMessage && (
+        <p className="mt-3 text-sm text-amber-300" aria-live="polite">
+          {hiddenMessage}
+        </p>
+      )}
+
+      <div className="mt-4">
+        {groups.length > 0 ? (
+          <ul role="list" className="flex flex-col gap-3">
+            {groups.map(group => (
+              <li
+                key={`${group.appId}-${group.subject}`}
+                role="listitem"
+                tabIndex={0}
+                className={`rounded-lg border px-4 py-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-sky-400 ${
+                  group.isCritical
+                    ? 'border-red-500/80 bg-red-900/20 text-red-100'
+                    : 'border-ubt-cool-grey bg-ub-dark/70 text-ubt-grey'
+                }`}
+                aria-label={`${group.subject} from ${group.appId}. ${group.totalCount} notifications in this window.`}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex flex-col">
+                    <span className="text-xs uppercase tracking-wide text-ubt-grey/70">
+                      {group.appId}
+                    </span>
+                    <span className="text-base font-semibold text-white">
+                      {group.subject}
+                    </span>
+                  </div>
+                  <div className="text-right text-sm">
+                    <span className="font-semibold text-white">{group.totalCount}</span>
+                    <span className="ml-1 text-ubt-grey/70">
+                      {group.totalCount === 1 ? 'alert' : 'alerts'}
+                    </span>
+                  </div>
+                </div>
+                <p className="mt-2 text-sm text-ubt-grey/90">
+                  {group.lastBody}
+                </p>
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-ubt-grey/70">
+                  <span>{`Last activity ${formatRelativeTime(group.lastDate)}`}</span>
+                  <span aria-hidden="true">•</span>
+                  <span>{`${group.occurrences.length} unique ${
+                    group.occurrences.length === 1 ? 'burst' : 'bursts'
+                  }`}</span>
+                  {group.isCritical && (
+                    <span className="rounded-full bg-red-700 px-2 py-0.5 text-xs font-semibold text-white">
+                      Critical
+                    </span>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p
+            role="status"
+            className="rounded border border-dashed border-ubt-cool-grey bg-ub-dark/60 p-4 text-center text-sm text-ubt-grey"
+          >
+            You're all caught up. No notifications in this summary window.
+          </p>
+        )}
+      </div>
+
+      <footer className="mt-4 text-xs text-ubt-grey/60">
+        Tracking {totalGroups} grouped subjects across all apps.
+      </footer>
+    </section>
+  );
+};
+
+export default SummaryPanel;

--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -1,52 +1,175 @@
-import React, { createContext, useCallback, useEffect, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  NotificationsContext,
+  type NotificationsContextValue,
+} from '../../hooks/notificationsContext';
+import type {
+  AppNotification,
+  NotificationInput,
+  NotificationSummarySnapshot,
+} from '../../types/notifications';
+import {
+  DEFAULT_SUMMARY_INTERVAL_MS,
+  getDoNotDisturbPreference,
+  getSummaryIntervalPreference,
+  setDoNotDisturbPreference,
+  setSummaryIntervalPreference,
+} from '../../utils/settings/notificationPreferences';
+import { logEvent } from '../../utils/analytics';
+import {
+  buildNotificationGroups,
+  computeSummaryStats,
+} from '../../hooks/useNotifications';
 
-export interface AppNotification {
-  id: string;
-  message: string;
-  date: number;
-}
+const createNotification = (input: NotificationInput): AppNotification => {
+  const timestamp = input.date ?? Date.now();
+  return {
+    id: `${timestamp}-${Math.random().toString(36).slice(2, 10)}`,
+    appId: input.appId,
+    subject: input.subject,
+    body: input.body,
+    date: timestamp,
+    isCritical: Boolean(input.isCritical),
+  };
+};
 
-interface NotificationsContextValue {
-  notifications: Record<string, AppNotification[]>;
-  pushNotification: (appId: string, message: string) => void;
-  clearNotifications: (appId?: string) => void;
-}
+export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({
+  children,
+}) => {
+  const [notifications, setNotifications] = useState<
+    NotificationsContextValue['notifications']
+  >({});
+  const notificationsRef = useRef(notifications);
+  const [doNotDisturb, setDoNotDisturbState] = useState(false);
+  const [summaryInterval, setSummaryIntervalState] = useState(
+    DEFAULT_SUMMARY_INTERVAL_MS,
+  );
+  const [summaryWindowStart, setSummaryWindowStart] = useState(() => Date.now());
+  const summaryWindowStartRef = useRef(summaryWindowStart);
+  const [lastSummarySnapshot, setLastSummarySnapshot] =
+    useState<NotificationSummarySnapshot | null>(null);
 
-export const NotificationsContext = createContext<NotificationsContextValue | null>(null);
+  useEffect(() => {
+    notificationsRef.current = notifications;
+  }, [notifications]);
 
-export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
-  const [notifications, setNotifications] = useState<Record<string, AppNotification[]>>({});
+  useEffect(() => {
+    summaryWindowStartRef.current = summaryWindowStart;
+  }, [summaryWindowStart]);
 
-  const pushNotification = useCallback((appId: string, message: string) => {
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const [storedDnd, storedInterval] = await Promise.all([
+        getDoNotDisturbPreference(),
+        getSummaryIntervalPreference(),
+      ]);
+      if (!mounted) return;
+      setDoNotDisturbState(storedDnd);
+      setSummaryIntervalState(storedInterval);
+      const now = Date.now();
+      summaryWindowStartRef.current = now;
+      setSummaryWindowStart(now);
+    })().catch(() => {
+      // ignore preference load errors
+    });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const pushNotification = useCallback((input: NotificationInput) => {
     setNotifications(prev => {
-      const list = prev[appId] ?? [];
-      const next = {
+      const list = prev[input.appId] ?? [];
+      const nextList = [...list, createNotification(input)];
+      return {
         ...prev,
-        [appId]: [
-          ...list,
-          {
-            id: `${Date.now()}-${Math.random()}`,
-            message,
-            date: Date.now(),
-          },
-        ],
+        [input.appId]: nextList,
       };
-      return next;
     });
   }, []);
 
   const clearNotifications = useCallback((appId?: string) => {
     setNotifications(prev => {
       if (!appId) return {};
+      if (!(appId in prev)) return prev;
       const next = { ...prev };
       delete next[appId];
       return next;
     });
   }, []);
 
-  const totalCount = Object.values(notifications).reduce(
-    (sum, list) => sum + list.length,
-    0
+  const updateDoNotDisturb = useCallback((value: boolean) => {
+    setDoNotDisturbState(value);
+    setDoNotDisturbPreference(value).catch(() => {
+      // ignore persistence errors
+    });
+  }, []);
+
+  const updateSummaryInterval = useCallback((value: number) => {
+    setSummaryIntervalState(value);
+    const now = Date.now();
+    summaryWindowStartRef.current = now;
+    setSummaryWindowStart(now);
+    setSummaryIntervalPreference(value).catch(() => {
+      // ignore persistence errors
+    });
+  }, []);
+
+  const runSummary = useCallback(() => {
+    const windowEnd = Date.now();
+    const windowStart = summaryWindowStartRef.current;
+    const groups = buildNotificationGroups(notificationsRef.current, {
+      windowStart,
+      windowEnd,
+    });
+    const stats = computeSummaryStats(groups);
+    const snapshot: NotificationSummarySnapshot = {
+      windowStart,
+      windowEnd,
+      stats,
+    };
+    setLastSummarySnapshot(snapshot);
+    if (stats.rawCount > 0) {
+      logEvent({
+        category: 'notification-center',
+        action: 'summary-run',
+        label: `interval:${summaryInterval}|raw:${stats.rawCount}|cards:${stats.cardCount}`,
+        value: Math.max(0, stats.rawCount - stats.cardCount),
+      });
+    }
+    summaryWindowStartRef.current = windowEnd;
+    setSummaryWindowStart(windowEnd);
+  }, [summaryInterval]);
+
+  const triggerSummary = useCallback(() => {
+    runSummary();
+  }, [runSummary]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    if (!summaryInterval || summaryInterval <= 0) return undefined;
+    const id = window.setInterval(() => {
+      runSummary();
+    }, summaryInterval);
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [runSummary, summaryInterval]);
+
+  const totalCount = useMemo(
+    () =>
+      Object.values(notifications).reduce(
+        (sum, list) => sum + list.length,
+        0,
+      ),
+    [notifications],
   );
 
   useEffect(() => {
@@ -57,25 +180,36 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
     }
   }, [totalCount]);
 
+  const contextValue = useMemo<NotificationsContextValue>(() => ({
+    notifications,
+    pushNotification,
+    clearNotifications,
+    doNotDisturb,
+    setDoNotDisturb: updateDoNotDisturb,
+    summaryInterval,
+    setSummaryInterval: updateSummaryInterval,
+    summaryWindowStart,
+    triggerSummary,
+    lastSummarySnapshot,
+  }), [
+    notifications,
+    pushNotification,
+    clearNotifications,
+    doNotDisturb,
+    updateDoNotDisturb,
+    summaryInterval,
+    updateSummaryInterval,
+    summaryWindowStart,
+    triggerSummary,
+    lastSummarySnapshot,
+  ]);
+
   return (
-    <NotificationsContext.Provider
-      value={{ notifications, pushNotification, clearNotifications }}
-    >
+    <NotificationsContext.Provider value={contextValue}>
       {children}
-      <div className="notification-center">
-        {Object.entries(notifications).map(([appId, list]) => (
-          <section key={appId} className="notification-group">
-            <h3>{appId}</h3>
-            <ul>
-              {list.map(n => (
-                <li key={n.id}>{n.message}</li>
-              ))}
-            </ul>
-          </section>
-        ))}
-      </div>
     </NotificationsContext.Provider>
   );
 };
 
 export default NotificationCenter;
+export type { NotificationInput } from '../../types/notifications';

--- a/hooks/notificationsContext.ts
+++ b/hooks/notificationsContext.ts
@@ -1,0 +1,22 @@
+import { createContext } from 'react';
+import type {
+  AppNotification,
+  NotificationInput,
+  NotificationSummarySnapshot,
+} from '../types/notifications';
+
+export interface NotificationsContextValue {
+  notifications: Record<string, AppNotification[]>;
+  pushNotification: (input: NotificationInput) => void;
+  clearNotifications: (appId?: string) => void;
+  doNotDisturb: boolean;
+  setDoNotDisturb: (value: boolean) => void;
+  summaryInterval: number;
+  setSummaryInterval: (value: number) => void;
+  summaryWindowStart: number;
+  triggerSummary: () => void;
+  lastSummarySnapshot: NotificationSummarySnapshot | null;
+}
+
+export const NotificationsContext =
+  createContext<NotificationsContextValue | null>(null);

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -1,12 +1,171 @@
-import { useContext } from 'react';
-import { NotificationsContext } from '../components/common/NotificationCenter';
+import { useContext, useMemo } from 'react';
+import {
+  NotificationsContext,
+  type NotificationsContextValue,
+} from './notificationsContext';
+import type {
+  AppNotification,
+  NotificationGroup,
+  NotificationOccurrence,
+  NotificationSummaryStats,
+} from '../types/notifications';
+import { NOTIFICATION_REPEAT_WINDOW_MS } from '../types/notifications';
 
-export const useNotifications = () => {
+export type {
+  NotificationGroup,
+  NotificationOccurrence,
+  NotificationSummarySnapshot,
+  NotificationSummaryStats,
+} from '../types/notifications';
+
+export interface GroupNotificationsOptions {
+  windowStart?: number;
+  windowEnd?: number;
+}
+
+const filterByWindow = (
+  notification: AppNotification,
+  options: GroupNotificationsOptions,
+): boolean => {
+  const { windowStart, windowEnd } = options;
+  if (windowStart !== undefined && notification.date < windowStart) return false;
+  if (windowEnd !== undefined && notification.date > windowEnd) return false;
+  return true;
+};
+
+const appendToGroup = (
+  group: NotificationGroup,
+  notification: AppNotification,
+) => {
+  const occurrences = group.occurrences;
+  const lastOccurrence = occurrences[occurrences.length - 1];
+  if (
+    lastOccurrence &&
+    notification.date - lastOccurrence.date <= NOTIFICATION_REPEAT_WINDOW_MS
+  ) {
+    lastOccurrence.repeatCount += 1;
+    lastOccurrence.date = notification.date;
+    lastOccurrence.body = notification.body;
+    lastOccurrence.isCritical =
+      lastOccurrence.isCritical || notification.isCritical;
+  } else {
+    occurrences.push({
+      id: notification.id,
+      body: notification.body,
+      date: notification.date,
+      repeatCount: 1,
+      isCritical: notification.isCritical,
+    });
+  }
+  group.totalCount += 1;
+  group.lastDate = notification.date;
+  group.lastBody = notification.body;
+  group.isCritical = group.isCritical || notification.isCritical;
+};
+
+export const buildNotificationGroups = (
+  notifications: NotificationsContextValue['notifications'],
+  options: GroupNotificationsOptions = {},
+): NotificationGroup[] => {
+  const entries: AppNotification[] = [];
+  Object.values(notifications).forEach(list => {
+    list.forEach(notification => {
+      if (filterByWindow(notification, options)) {
+        entries.push(notification);
+      }
+    });
+  });
+  entries.sort((a, b) => a.date - b.date);
+
+  const groups = new Map<string, NotificationGroup>();
+  entries.forEach(notification => {
+    const key = `${notification.appId}::${notification.subject}`;
+    let group = groups.get(key);
+    if (!group) {
+      group = {
+        appId: notification.appId,
+        subject: notification.subject,
+        totalCount: 0,
+        lastDate: notification.date,
+        lastBody: notification.body,
+        occurrences: [],
+        isCritical: notification.isCritical,
+      };
+      groups.set(key, group);
+    }
+    appendToGroup(group, notification);
+  });
+
+  return Array.from(groups.values()).sort((a, b) => b.lastDate - a.lastDate);
+};
+
+export const computeSummaryStats = (
+  groups: NotificationGroup[],
+): NotificationSummaryStats => {
+  return groups.reduce(
+    (acc, group) => {
+      acc.rawCount += group.totalCount;
+      acc.cardCount += 1;
+      acc.clusterCount += group.occurrences.length;
+      return acc;
+    },
+    { rawCount: 0, cardCount: 0, clusterCount: 0 } as NotificationSummaryStats,
+  );
+};
+
+export interface UseNotificationsResult extends NotificationsContextValue {
+  groupedNotifications: NotificationGroup[];
+  summaryGroups: NotificationGroup[];
+  totalSummaryGroups: number;
+  hiddenGroupCount: number;
+  summaryStats: NotificationSummaryStats;
+  nextSummaryAt: number | null;
+}
+
+export const useNotifications = (): UseNotificationsResult => {
   const ctx = useContext(NotificationsContext);
   if (!ctx) {
     throw new Error('useNotifications must be used within NotificationCenter');
   }
-  return ctx;
+
+  const groupedNotifications = useMemo(
+    () => buildNotificationGroups(ctx.notifications),
+    [ctx.notifications],
+  );
+
+  const windowedGroups = useMemo(
+    () =>
+      buildNotificationGroups(ctx.notifications, {
+        windowStart: ctx.summaryWindowStart,
+      }),
+    [ctx.notifications, ctx.summaryWindowStart],
+  );
+
+  const summaryStats = useMemo(
+    () => computeSummaryStats(windowedGroups),
+    [windowedGroups],
+  );
+
+  const summaryGroups = useMemo(() => {
+    if (!ctx.doNotDisturb) return windowedGroups;
+    return windowedGroups.filter(group => group.isCritical);
+  }, [ctx.doNotDisturb, windowedGroups]);
+
+  const hiddenGroupCount = windowedGroups.length - summaryGroups.length;
+  const nextSummaryAt =
+    ctx.summaryInterval > 0
+      ? ctx.summaryWindowStart + ctx.summaryInterval
+      : null;
+
+  return {
+    ...ctx,
+    groupedNotifications,
+    summaryGroups,
+    totalSummaryGroups: windowedGroups.length,
+    hiddenGroupCount,
+    summaryStats,
+    nextSummaryAt,
+  };
 };
 
 export default useNotifications;

--- a/pages/apps/notifications.tsx
+++ b/pages/apps/notifications.tsx
@@ -1,0 +1,17 @@
+import dynamic from 'next/dynamic';
+import React from 'react';
+
+const NotificationsApp = dynamic(() => import('../../apps/notifications'), {
+  ssr: false,
+  loading: () => (
+    <p className="p-6 text-center text-sm text-ubt-grey" role="status">
+      Loading notification center…
+    </p>
+  ),
+});
+
+const NotificationsPage: React.FC = () => {
+  return <NotificationsApp />;
+};
+
+export default NotificationsPage;

--- a/types/notifications.ts
+++ b/types/notifications.ts
@@ -1,0 +1,48 @@
+export const NOTIFICATION_REPEAT_WINDOW_MS = 5000;
+
+export interface NotificationInput {
+  appId: string;
+  subject: string;
+  body: string;
+  isCritical?: boolean;
+  date?: number;
+}
+
+export interface AppNotification {
+  id: string;
+  appId: string;
+  subject: string;
+  body: string;
+  date: number;
+  isCritical: boolean;
+}
+
+export interface NotificationOccurrence {
+  id: string;
+  body: string;
+  date: number;
+  repeatCount: number;
+  isCritical: boolean;
+}
+
+export interface NotificationGroup {
+  appId: string;
+  subject: string;
+  totalCount: number;
+  lastDate: number;
+  lastBody: string;
+  occurrences: NotificationOccurrence[];
+  isCritical: boolean;
+}
+
+export interface NotificationSummaryStats {
+  rawCount: number;
+  cardCount: number;
+  clusterCount: number;
+}
+
+export interface NotificationSummarySnapshot {
+  windowStart: number;
+  windowEnd: number;
+  stats: NotificationSummaryStats;
+}

--- a/utils/settings/notificationPreferences.ts
+++ b/utils/settings/notificationPreferences.ts
@@ -1,0 +1,55 @@
+const DO_NOT_DISTURB_KEY = 'notifications:dnd';
+const SUMMARY_INTERVAL_KEY = 'notifications:summary-interval-ms';
+
+export const MINUTE_IN_MS = 60 * 1000;
+export const SUMMARY_INTERVAL_OPTIONS_MINUTES = [5, 15, 30, 60] as const;
+export const SUMMARY_INTERVAL_OPTIONS_MS = SUMMARY_INTERVAL_OPTIONS_MINUTES.map(
+  minutes => minutes * MINUTE_IN_MS,
+);
+
+export const DEFAULT_DO_NOT_DISTURB = false;
+export const DEFAULT_SUMMARY_INTERVAL_MS = 15 * MINUTE_IN_MS;
+
+export const DEFAULT_NOTIFICATION_PREFERENCES = {
+  doNotDisturb: DEFAULT_DO_NOT_DISTURB,
+  summaryIntervalMs: DEFAULT_SUMMARY_INTERVAL_MS,
+} as const;
+
+export async function getDoNotDisturbPreference(): Promise<boolean> {
+  if (typeof window === 'undefined') return DEFAULT_DO_NOT_DISTURB;
+  const stored = window.localStorage.getItem(DO_NOT_DISTURB_KEY);
+  if (stored === null) return DEFAULT_DO_NOT_DISTURB;
+  return stored === 'true';
+}
+
+export async function setDoNotDisturbPreference(value: boolean): Promise<void> {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(DO_NOT_DISTURB_KEY, value ? 'true' : 'false');
+}
+
+export async function getSummaryIntervalPreference(): Promise<number> {
+  if (typeof window === 'undefined') return DEFAULT_SUMMARY_INTERVAL_MS;
+  const stored = window.localStorage.getItem(SUMMARY_INTERVAL_KEY);
+  if (!stored) return DEFAULT_SUMMARY_INTERVAL_MS;
+  const parsed = Number.parseInt(stored, 10);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+  return DEFAULT_SUMMARY_INTERVAL_MS;
+}
+
+export async function setSummaryIntervalPreference(value: number): Promise<void> {
+  if (typeof window === 'undefined') return;
+  const sanitized = Number.isFinite(value) && value > 0
+    ? Math.round(value)
+    : DEFAULT_SUMMARY_INTERVAL_MS;
+  window.localStorage.setItem(SUMMARY_INTERVAL_KEY, String(sanitized));
+}
+
+export function minutesFromMs(value: number): number {
+  return Math.round(value / MINUTE_IN_MS);
+}
+
+export function msFromMinutes(value: number): number {
+  return Math.max(1, Math.round(value)) * MINUTE_IN_MS;
+}


### PR DESCRIPTION
## Summary
- refactor the notification provider to group events, respect preferences, and emit telemetry for summary windows
- add a notification summary dashboard with accessible cards and controls tied to Do Not Disturb and interval settings
- persist notification preferences and cover the grouping behaviour with targeted unit tests

## Testing
- yarn lint *(fails: pre-existing accessibility lint errors across legacy apps)*
- yarn test notifications.store.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cb4658b0d48328bde6c924ae3428d0