### PR TITLE
Add micro interaction hooks and design portal previews

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -70,6 +70,7 @@ const QrApp = createDynamicApp('qr', 'QR Tool');
 const AsciiArtApp = createDynamicApp('ascii_art', 'ASCII Art');
 const QuoteApp = createDynamicApp('quote', 'Quote');
 const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery');
+const DesignPortalApp = createDynamicApp('design-portal', 'Design Portal');
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
@@ -160,6 +161,7 @@ const displayQr = createDisplay(QrApp);
 const displayAsciiArt = createDisplay(AsciiArtApp);
 const displayQuote = createDisplay(QuoteApp);
 const displayProjectGallery = createDisplay(ProjectGalleryApp);
+const displayDesignPortal = createDisplay(DesignPortalApp);
 const displayTrash = createDisplay(TrashApp);
 const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
@@ -257,6 +259,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayProjectGallery,
+  },
+  {
+    id: 'design-portal',
+    title: 'Design Portal',
+    icon: '/themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayDesignPortal,
   },
   {
     id: 'input-lab',

--- a/apps/design-portal/index.tsx
+++ b/apps/design-portal/index.tsx
@@ -1,0 +1,394 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import {
+  useDesignToken,
+  useHoldInteraction,
+  usePressInteraction,
+  usePulseInteraction,
+  useReducedMotion,
+  useShakeInteraction,
+  useShimmerInteraction,
+  useSnapInteraction,
+} from '../../components/ui/micro-interactions';
+
+interface InteractionConfig {
+  amplitude: number;
+  duration: number;
+}
+
+type InteractionId = 'press' | 'hold' | 'shimmer' | 'shake' | 'pulse' | 'snap';
+
+const defaultConfigs: Record<InteractionId, InteractionConfig> = {
+  press: { amplitude: 0.08, duration: 150 },
+  hold: { amplitude: 0.25, duration: 360 },
+  shimmer: { amplitude: 0.35, duration: 1400 },
+  shake: { amplitude: 0.55, duration: 380 },
+  pulse: { amplitude: 0.32, duration: 420 },
+  snap: { amplitude: 0.42, duration: 240 },
+};
+
+interface InteractionSectionProps {
+  id: InteractionId;
+  title: string;
+  description: string;
+  config: InteractionConfig;
+  onAmplitudeChange: (value: number) => void;
+  onDurationChange: (value: number) => void;
+  children: ReactNode;
+}
+
+const InteractionSection = ({
+  id,
+  title,
+  description,
+  config,
+  onAmplitudeChange,
+  onDurationChange,
+  children,
+}: InteractionSectionProps) => (
+  <section
+    aria-labelledby={`${id}-heading`}
+    className="rounded-xl border border-white/10 bg-black/30 p-4 shadow-lg backdrop-blur"
+  >
+    <header className="space-y-1">
+      <h2 id={`${id}-heading`} className="text-lg font-semibold text-white">
+        {title}
+      </h2>
+      <p className="text-sm text-ubt-grey/80">{description}</p>
+    </header>
+    <div className="mt-4 flex flex-col gap-4 lg:flex-row">
+      <div className="flex flex-1 items-center justify-center rounded-lg bg-white/5 p-4" data-testid={`${id}-preview`}>
+        {children}
+      </div>
+      <div className="w-full max-w-xs space-y-4 rounded-lg bg-white/5 p-4" aria-label={`${title} configuration`}>
+        <Knob
+          id={`${id}-amplitude`}
+          label="Amplitude"
+          min={0}
+          max={1}
+          step={0.01}
+          value={config.amplitude}
+          onChange={onAmplitudeChange}
+          formatter={(value) => value.toFixed(2)}
+        />
+        <Knob
+          id={`${id}-duration`}
+          label="Duration"
+          min={0}
+          max={2000}
+          step={10}
+          value={config.duration}
+          onChange={onDurationChange}
+          suffix="ms"
+        />
+      </div>
+    </div>
+  </section>
+);
+
+interface KnobProps {
+  id: string;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  onChange: (value: number) => void;
+  suffix?: string;
+  formatter?: (value: number) => string;
+}
+
+const Knob = ({ id, label, min, max, step, value, onChange, suffix = '', formatter }: KnobProps) => {
+  const display = formatter ? formatter(value) : value.toString();
+  const sliderId = `${id}-slider`;
+  const numberId = `${id}-number`;
+  const labelId = `${id}-label`;
+  const valueId = `${id}-value`;
+  return (
+    <div className="flex flex-col gap-2 text-sm text-ubt-grey/80">
+      <div className="flex items-center justify-between text-xs uppercase tracking-wider text-ubt-grey/60">
+        <label id={labelId} htmlFor={sliderId} className="cursor-pointer">
+          {label}
+        </label>
+        <span id={valueId} className="font-semibold text-ubt-grey">
+          {display}
+          {suffix}
+        </span>
+      </div>
+      <input
+        id={sliderId}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+        aria-labelledby={labelId}
+        aria-describedby={valueId}
+        className="h-2 w-full rounded-full bg-white/20"
+      />
+      <label htmlFor={numberId} className="sr-only">
+        {`${label} value`}
+      </label>
+      <input
+        id={numberId}
+        type="number"
+        inputMode="decimal"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+        aria-labelledby={`${labelId} ${valueId}`}
+        className="rounded border border-white/10 bg-black/40 px-2 py-1 text-right text-sm text-white"
+      />
+    </div>
+  );
+};
+
+const TokenBadge = ({ name, value }: { name: string; value: string }) => (
+  <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-ubt-grey/80">
+    <span className="font-mono text-white">{name}</span>
+    <span>{value}</span>
+  </span>
+);
+
+const PressPreview = ({ config }: { config: InteractionConfig }) => {
+  const press = usePressInteraction({
+    amplitude: config.amplitude,
+    duration: config.duration,
+  });
+  const pressProps = press.getPressProps<HTMLButtonElement>({
+    className:
+      'rounded-lg bg-ub-orange px-6 py-3 font-semibold text-black shadow focus:outline-none focus:ring-2 focus:ring-ub-orange focus:ring-offset-2 focus:ring-offset-black',
+  });
+  return (
+    <button type="button" {...pressProps}>
+      Press to confirm
+    </button>
+  );
+};
+
+const HoldPreview = ({ config }: { config: InteractionConfig }) => {
+  const hold = useHoldInteraction({
+    amplitude: config.amplitude,
+    duration: config.duration,
+  });
+  const holdProps = hold.getHoldProps<HTMLButtonElement>({
+    className:
+      'rounded-lg bg-ubt-blue px-6 py-3 font-semibold text-black shadow focus:outline-none focus:ring-2 focus:ring-ubt-blue focus:ring-offset-2 focus:ring-offset-black',
+  });
+  const progressPercent = Math.round(hold.progress * 100);
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <button type="button" {...holdProps}>
+        Hold to unlock
+      </button>
+      <div className="h-2 w-full rounded-full bg-white/10" aria-hidden="true">
+        <div
+          className="h-full rounded-full bg-ubt-blue transition-[width] duration-75 ease-out"
+          style={{ width: `${progressPercent}%` }}
+        />
+      </div>
+      <span className="text-xs text-ubt-grey/70">Progress: {progressPercent}%</span>
+    </div>
+  );
+};
+
+const ShimmerPreview = ({ config }: { config: InteractionConfig }) => {
+  const shimmer = useShimmerInteraction({
+    amplitude: config.amplitude,
+    duration: config.duration,
+    baseColor: 'rgba(15, 19, 23, 0.92)',
+  });
+  const shimmerProps = shimmer.getShimmerProps<HTMLDivElement>({
+    className:
+      'relative w-full overflow-hidden rounded-md border border-white/10 bg-ub-grey/40 text-left text-sm text-white shadow-inner',
+  });
+  return (
+    <div data-testid="shimmer-preview" {...shimmerProps}>
+      <div className="space-y-2 p-4">
+        <p className="text-xs uppercase tracking-widest text-ubt-grey/70">Micro animation</p>
+        <p className="text-lg font-semibold">Shimmer loading card</p>
+        <p className="text-sm text-ubt-grey/80">
+          Driven by live design tokens with configurable highlight strength.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+const ShakePreview = ({ config }: { config: InteractionConfig }) => {
+  const shake = useShakeInteraction({
+    amplitude: config.amplitude,
+    duration: config.duration,
+  });
+  const shakeProps = shake.getShakeProps<HTMLButtonElement>({
+    className:
+      'rounded-lg bg-red-500 px-6 py-3 font-semibold text-white shadow focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-offset-2 focus:ring-offset-black',
+    onClick: () => shake.trigger(),
+  });
+  return (
+    <button type="button" {...shakeProps}>
+      Shake to alert
+    </button>
+  );
+};
+
+const PulsePreview = ({ config }: { config: InteractionConfig }) => {
+  const pulse = usePulseInteraction({
+    amplitude: config.amplitude,
+    duration: config.duration,
+  });
+  const pulseProps = pulse.getPulseProps<HTMLButtonElement>({
+    className:
+      'rounded-full bg-ubt-green px-6 py-3 font-semibold text-black shadow focus:outline-none focus:ring-2 focus:ring-ubt-green focus:ring-offset-2 focus:ring-offset-black',
+    onClick: () => pulse.trigger(),
+  });
+  return (
+    <button type="button" {...pulseProps}>
+      Pulse beacon
+    </button>
+  );
+};
+
+const SnapPreview = ({ config }: { config: InteractionConfig }) => {
+  const snap = useSnapInteraction({
+    amplitude: config.amplitude,
+    duration: config.duration,
+  });
+  const snapProps = snap.getSnapProps<HTMLButtonElement>({
+    className:
+      'rounded-lg bg-white/80 px-6 py-3 font-semibold text-black shadow focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-black',
+    onClick: () => snap.trigger(),
+  });
+  return (
+    <button type="button" {...snapProps}>
+      Snap into place
+    </button>
+  );
+};
+
+const DesignPortalApp = () => {
+  const [configs, setConfigs] = useState(defaultConfigs);
+
+  const updateConfig = (id: InteractionId, patch: Partial<InteractionConfig>) => {
+    setConfigs((prev) => ({ ...prev, [id]: { ...prev[id], ...patch } }));
+  };
+
+  const clampAmplitude = (value: number) => {
+    if (!Number.isFinite(value)) return 0;
+    return Math.min(Math.max(value, 0), 1);
+  };
+
+  const clampDuration = (value: number) => {
+    if (!Number.isFinite(value)) return 0;
+    return Math.max(value, 0);
+  };
+
+  const motionFast = useDesignToken('--motion-fast', '150ms');
+  const motionMedium = useDesignToken('--motion-medium', '300ms');
+  const motionSlow = useDesignToken('--motion-slow', '500ms');
+  const prefersReduced = useReducedMotion();
+
+  const tokenBadges = useMemo(
+    () => [
+      { name: '--motion-fast', value: motionFast },
+      { name: '--motion-medium', value: motionMedium },
+      { name: '--motion-slow', value: motionSlow },
+    ],
+    [motionFast, motionMedium, motionSlow],
+  );
+
+  return (
+    <div className="h-full w-full overflow-y-auto bg-ub-cool-grey p-6 text-white">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6">
+        <header className="space-y-4">
+          <div>
+            <h1 className="text-2xl font-semibold">Design portal · Micro-interactions</h1>
+            <p className="mt-2 max-w-3xl text-sm text-ubt-grey/80">
+              Explore reusable interaction hooks that map to the Kali desktop design tokens. Adjust amplitude
+              and duration to preview press, hold, shimmer, shake, pulse, and snap behaviors while validating
+              accessibility constraints.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2" aria-label="Motion tokens">
+            {tokenBadges.map((token) => (
+              <TokenBadge key={token.name} name={token.name} value={token.value} />
+            ))}
+            <span className="ml-auto inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-ubt-grey/70">
+              <span className="font-semibold uppercase tracking-widest">Reduced motion</span>
+              <span className="font-mono text-white">{prefersReduced ? 'enabled' : 'off'}</span>
+            </span>
+          </div>
+        </header>
+        <div className="grid gap-6 xl:grid-cols-2">
+          <InteractionSection
+            id="press"
+            title="Press"
+            description="Scale and depth feedback triggered on pointer or keyboard press."
+            config={configs.press}
+            onAmplitudeChange={(value) => updateConfig('press', { amplitude: clampAmplitude(value) })}
+            onDurationChange={(value) => updateConfig('press', { duration: clampDuration(value) })}
+          >
+            <PressPreview config={configs.press} />
+          </InteractionSection>
+          <InteractionSection
+            id="hold"
+            title="Hold"
+            description="Long-press affordance with progress feedback before commit."
+            config={configs.hold}
+            onAmplitudeChange={(value) => updateConfig('hold', { amplitude: clampAmplitude(value) })}
+            onDurationChange={(value) => updateConfig('hold', { duration: clampDuration(value) })}
+          >
+            <HoldPreview config={configs.hold} />
+          </InteractionSection>
+          <InteractionSection
+            id="shimmer"
+            title="Shimmer"
+            description="Ambient loading shimmer that respects system motion preferences."
+            config={configs.shimmer}
+            onAmplitudeChange={(value) => updateConfig('shimmer', { amplitude: clampAmplitude(value) })}
+            onDurationChange={(value) => updateConfig('shimmer', { duration: clampDuration(value) })}
+          >
+            <ShimmerPreview config={configs.shimmer} />
+          </InteractionSection>
+          <InteractionSection
+            id="shake"
+            title="Shake"
+            description="Directional nudge for validation and attention cues."
+            config={configs.shake}
+            onAmplitudeChange={(value) => updateConfig('shake', { amplitude: clampAmplitude(value) })}
+            onDurationChange={(value) => updateConfig('shake', { duration: clampDuration(value) })}
+          >
+            <ShakePreview config={configs.shake} />
+          </InteractionSection>
+          <InteractionSection
+            id="pulse"
+            title="Pulse"
+            description="One-shot pulse animation for status and beacon elements."
+            config={configs.pulse}
+            onAmplitudeChange={(value) => updateConfig('pulse', { amplitude: clampAmplitude(value) })}
+            onDurationChange={(value) => updateConfig('pulse', { duration: clampDuration(value) })}
+          >
+            <PulsePreview config={configs.pulse} />
+          </InteractionSection>
+          <InteractionSection
+            id="snap"
+            title="Snap"
+            description="Snaps content into place with a subtle overshoot easing curve."
+            config={configs.snap}
+            onAmplitudeChange={(value) => updateConfig('snap', { amplitude: clampAmplitude(value) })}
+            onDurationChange={(value) => updateConfig('snap', { duration: clampDuration(value) })}
+          >
+            <SnapPreview config={configs.snap} />
+          </InteractionSection>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DesignPortalApp;

--- a/components/ui/micro-interactions/index.ts
+++ b/components/ui/micro-interactions/index.ts
@@ -1,0 +1,19 @@
+export { usePressInteraction } from './usePress';
+export type { PressInteractionReturn } from './usePress';
+export { useHoldInteraction } from './useHold';
+export type { HoldInteractionReturn } from './useHold';
+export { useShimmerInteraction } from './useShimmer';
+export type { ShimmerInteractionReturn } from './useShimmer';
+export { useShakeInteraction } from './useShake';
+export type { ShakeInteractionReturn } from './useShake';
+export { usePulseInteraction } from './usePulse';
+export type { PulseInteractionReturn } from './usePulse';
+export { useSnapInteraction } from './useSnap';
+export type { SnapInteractionReturn } from './useSnap';
+export {
+  useDesignToken,
+  useDuration,
+  useReducedMotion,
+  clamp,
+  parseDuration,
+} from './utils';

--- a/components/ui/micro-interactions/useHold.ts
+++ b/components/ui/micro-interactions/useHold.ts
@@ -1,0 +1,130 @@
+'use client';
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type { HTMLAttributes, KeyboardEvent } from 'react';
+import {
+  MicroInteractionOptions,
+  clamp,
+  useDuration,
+  useReducedMotion,
+  useRafLoop,
+  useTimeout,
+  withInteractionProps,
+} from './utils';
+
+interface HoldOptions extends MicroInteractionOptions {
+  delay?: number;
+}
+
+export const useHoldInteraction = (options: HoldOptions = {}) => {
+  const { amplitude = 0.2, duration, delay } = options;
+  const reducedMotion = useReducedMotion();
+  const durationMs = useDuration(duration, '--motion-medium', 320);
+  const holdDelay = delay ?? durationMs;
+
+  const [isPressed, setIsPressed] = useState(false);
+  const [isHeld, setIsHeld] = useState(false);
+  const [progress, setProgress] = useState(0);
+
+  const startTime = useRef<number | null>(null);
+  const { start: startTimeout, clear: clearTimeout } = useTimeout();
+
+  const rafLoop = useRafLoop(() => {
+    if (startTime.current === null) return false;
+    const elapsed = performance.now() - startTime.current;
+    const ratio = Math.min(elapsed / holdDelay, 1);
+    setProgress(ratio);
+    return ratio < 1 && !reducedMotion;
+  });
+
+  const reset = useCallback(() => {
+    startTime.current = null;
+    setIsPressed(false);
+    setIsHeld(false);
+    setProgress(0);
+    clearTimeout();
+    rafLoop.stop();
+  }, [clearTimeout, rafLoop]);
+
+  const commitHold = useCallback(() => {
+    if (reducedMotion) return;
+    setIsHeld(true);
+  }, [reducedMotion]);
+
+  const begin = useCallback(() => {
+    if (isPressed || reducedMotion) return;
+    startTime.current = performance.now();
+    setIsPressed(true);
+    setProgress(0);
+    rafLoop.start();
+    startTimeout(commitHold, holdDelay);
+  }, [commitHold, holdDelay, isPressed, rafLoop, reducedMotion, startTimeout]);
+
+  const style = useMemo(() => {
+    if (reducedMotion)
+      return {
+        transition: 'transform 0ms',
+      };
+    const clamped = clamp(amplitude, 0, 1);
+    const eased = Math.pow(progress, 1.5);
+    const scale = isHeld ? 1 + clamped * 0.6 : 1 + eased * clamped * 0.5;
+    return {
+      transform: `scale(${scale.toFixed(3)})`,
+      transition: isHeld ? `transform ${durationMs / 1.5}ms ease-out` : undefined,
+      boxShadow: isHeld
+        ? `0 ${Math.round(clamped * 10)}px ${Math.round(clamped * 30)}px rgba(0,0,0,0.35)`
+        : `0 3px 8px rgba(0,0,0,${0.15 + eased * 0.2})`,
+    };
+  }, [amplitude, durationMs, isHeld, progress, reducedMotion]);
+
+  const handlePointerDown = useCallback(() => {
+    begin();
+  }, [begin]);
+
+  const handleEnd = useCallback(() => {
+    reset();
+  }, [reset]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        begin();
+      }
+    },
+    [begin],
+  );
+
+  const handleKeyUp = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        reset();
+      }
+    },
+    [reset],
+  );
+
+  const getHoldProps = useCallback(
+    <T extends HTMLElement>(userProps?: HTMLAttributes<T>) =>
+      withInteractionProps<T>(userProps, style, {
+        onPointerDown: handlePointerDown,
+        onPointerUp: handleEnd,
+        onPointerLeave: handleEnd,
+        onPointerCancel: handleEnd,
+        onKeyDown: handleKeyDown,
+        onKeyUp: handleKeyUp,
+        onBlur: handleEnd,
+      }),
+    [handleEnd, handleKeyDown, handleKeyUp, handlePointerDown, style],
+  );
+
+  return {
+    isHeld,
+    isPressing: isPressed,
+    progress,
+    getHoldProps,
+  };
+};
+
+export type HoldInteractionReturn = ReturnType<typeof useHoldInteraction>;

--- a/components/ui/micro-interactions/usePress.ts
+++ b/components/ui/micro-interactions/usePress.ts
@@ -1,0 +1,96 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import type { HTMLAttributes, KeyboardEvent } from 'react';
+import {
+  MicroInteractionOptions,
+  clamp,
+  useDuration,
+  useReducedMotion,
+  withInteractionProps,
+} from './utils';
+
+interface PressOptions extends MicroInteractionOptions {
+  restoreDelay?: number;
+}
+
+export const usePressInteraction = (options: PressOptions = {}) => {
+  const { amplitude = 0.08, duration, restoreDelay = 80 } = options;
+  const [pressed, setPressed] = useState(false);
+  const reducedMotion = useReducedMotion();
+  const durationMs = useDuration(duration, '--motion-fast', 150);
+
+  const clamped = clamp(amplitude, 0, 0.6);
+
+  const style = useMemo(() => {
+    if (reducedMotion)
+      return {
+        transition: `transform 0ms`,
+      };
+    const scale = pressed ? 1 - clamped : 1;
+    const shadowY = Math.round(clamped * 12);
+    const shadowBlur = Math.round(clamped * 24);
+    return {
+      transform: `scale(${scale.toFixed(3)})`,
+      transition: `transform ${durationMs}ms ease, box-shadow ${durationMs}ms ease`,
+      boxShadow: pressed
+        ? `0 ${shadowY}px ${shadowBlur}px rgba(0, 0, 0, 0.35)`
+        : '0 2px 4px rgba(0, 0, 0, 0.2)',
+    };
+  }, [clamped, durationMs, pressed, reducedMotion]);
+
+  const endPress = useCallback(() => {
+    window.setTimeout(() => setPressed(false), restoreDelay);
+  }, [restoreDelay]);
+
+  const handlePointerDown = useCallback(() => {
+    if (reducedMotion) return;
+    setPressed(true);
+  }, [reducedMotion]);
+
+  const handlePointerUp = useCallback(() => {
+    if (reducedMotion) return;
+    endPress();
+  }, [endPress, reducedMotion]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        if (!reducedMotion) setPressed(true);
+      }
+    },
+    [reducedMotion],
+  );
+
+  const handleKeyUp = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        endPress();
+      }
+    },
+    [endPress],
+  );
+
+  const getPressProps = useCallback(
+    <T extends HTMLElement>(userProps?: HTMLAttributes<T>) =>
+      withInteractionProps<T>(userProps, style, {
+        onPointerDown: handlePointerDown,
+        onPointerUp: handlePointerUp,
+        onPointerLeave: handlePointerUp,
+        onPointerCancel: handlePointerUp,
+        onKeyDown: handleKeyDown,
+        onKeyUp: handleKeyUp,
+        onBlur: handlePointerUp,
+      }),
+    [handleKeyDown, handleKeyUp, handlePointerDown, handlePointerUp, style],
+  );
+
+  return {
+    isPressed: pressed,
+    getPressProps,
+  };
+};
+
+export type PressInteractionReturn = ReturnType<typeof usePressInteraction>;

--- a/components/ui/micro-interactions/usePulse.ts
+++ b/components/ui/micro-interactions/usePulse.ts
@@ -1,0 +1,62 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import type { HTMLAttributes } from 'react';
+import {
+  MicroInteractionOptions,
+  clamp,
+  useDuration,
+  useKeyframes,
+  useReducedMotion,
+  withInteractionProps,
+} from './utils';
+
+interface PulseOptions extends MicroInteractionOptions {
+  iterations?: number | 'infinite';
+  easing?: string;
+}
+
+export const usePulseInteraction = (options: PulseOptions = {}) => {
+  const { amplitude = 0.25, duration, iterations = 1, easing = 'ease-in-out' } = options;
+  const reduced = useReducedMotion();
+  const durationMs = useDuration(duration, '--motion-medium', 420);
+  const scaleMax = 1 + clamp(amplitude, 0, 1) * 0.4;
+
+  const keyframes = useKeyframes(`
+    0% { transform: scale(1); opacity: 1; }
+    40% { transform: scale(${scaleMax}); opacity: 0.65; }
+    100% { transform: scale(1); opacity: 1; }
+  `);
+
+  const [active, setActive] = useState(false);
+
+  const trigger = useCallback(() => {
+    if (reduced) return;
+    setActive(false);
+    window.requestAnimationFrame(() => setActive(true));
+  }, [reduced]);
+
+  const style = useMemo(() => {
+    if (!active || reduced) return {};
+    return {
+      animation: `${keyframes} ${durationMs}ms ${easing} ${iterations}`,
+      transformOrigin: 'center',
+    };
+  }, [active, durationMs, easing, iterations, keyframes, reduced]);
+
+  const getPulseProps = useCallback(
+    <T extends HTMLElement>(userProps?: HTMLAttributes<T>) =>
+      withInteractionProps<T>(userProps, style, {
+        onAnimationEnd: () => setActive(false),
+      }),
+    [style],
+  );
+
+  return {
+    isActive: active,
+    trigger,
+    getPulseProps,
+  };
+};
+
+export type PulseInteractionReturn = ReturnType<typeof usePulseInteraction>;

--- a/components/ui/micro-interactions/useShake.ts
+++ b/components/ui/micro-interactions/useShake.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import type { HTMLAttributes } from 'react';
+import {
+  MicroInteractionOptions,
+  clamp,
+  useDuration,
+  useKeyframes,
+  useReducedMotion,
+  withInteractionProps,
+} from './utils';
+
+interface ShakeOptions extends MicroInteractionOptions {
+  axis?: 'x' | 'y';
+}
+
+export const useShakeInteraction = (options: ShakeOptions = {}) => {
+  const { amplitude = 0.4, duration, axis = 'x' } = options;
+  const reduced = useReducedMotion();
+  const durationMs = useDuration(duration, '--motion-medium', 360);
+  const offset = useMemo(() => 4 + clamp(amplitude, 0, 1) * 12, [amplitude]);
+
+  const frames = axis === 'x'
+    ? `
+      0% { transform: translateX(0); }
+      20% { transform: translateX(${offset}px); }
+      40% { transform: translateX(-${offset}px); }
+      60% { transform: translateX(${offset}px); }
+      80% { transform: translateX(-${Math.round(offset / 2)}px); }
+      100% { transform: translateX(0); }
+    `
+    : `
+      0% { transform: translateY(0); }
+      20% { transform: translateY(${offset}px); }
+      40% { transform: translateY(-${offset}px); }
+      60% { transform: translateY(${offset}px); }
+      80% { transform: translateY(-${Math.round(offset / 2)}px); }
+      100% { transform: translateY(0); }
+    `;
+
+  const keyframes = useKeyframes(frames);
+  const [active, setActive] = useState(false);
+
+  const trigger = useCallback(() => {
+    if (reduced) return;
+    setActive(false);
+    window.requestAnimationFrame(() => setActive(true));
+  }, [reduced]);
+
+  const style = useMemo(() => {
+    if (!active || reduced) return {};
+    return {
+      animation: `${keyframes} ${durationMs}ms cubic-bezier(0.36, 0.07, 0.19, 0.97)`,
+      willChange: 'transform',
+    };
+  }, [active, durationMs, keyframes, reduced]);
+
+  const getShakeProps = useCallback(
+    <T extends HTMLElement>(userProps?: HTMLAttributes<T>) =>
+      withInteractionProps<T>(userProps, style, {
+        onAnimationEnd: () => setActive(false),
+      }),
+    [style],
+  );
+
+  return {
+    isActive: active,
+    trigger,
+    getShakeProps,
+  };
+};
+
+export type ShakeInteractionReturn = ReturnType<typeof useShakeInteraction>;

--- a/components/ui/micro-interactions/useShimmer.ts
+++ b/components/ui/micro-interactions/useShimmer.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useMemo } from 'react';
+import type { HTMLAttributes } from 'react';
+import {
+  MicroInteractionOptions,
+  clamp,
+  useDuration,
+  useKeyframes,
+  useReducedMotion,
+  withInteractionProps,
+} from './utils';
+
+interface ShimmerOptions extends MicroInteractionOptions {
+  angle?: number;
+  baseColor?: string;
+  highlightColor?: string;
+}
+
+export const useShimmerInteraction = (options: ShimmerOptions = {}) => {
+  const { amplitude = 0.35, duration, angle = 90, baseColor, highlightColor } = options;
+  const reduced = useReducedMotion();
+  const durationMs = useDuration(duration, '--motion-slow', 1400);
+  const shimmerKeyframes = useKeyframes(`
+    0% { background-position: -150% 0; }
+    100% { background-position: 150% 0; }
+  `);
+
+  const style = useMemo(() => {
+    const alpha = clamp(amplitude, 0, 1);
+    const highlight = highlightColor ?? `rgba(255, 255, 255, ${alpha.toFixed(2)})`;
+    const bg = baseColor ?? 'rgba(255,255,255,0.1)';
+    const gradient = `linear-gradient(${angle}deg, transparent 0%, ${highlight} 45%, ${highlight} 55%, transparent 100%)`;
+    if (reduced) {
+      return {
+        backgroundImage: gradient,
+        backgroundColor: bg,
+      };
+    }
+    return {
+      position: 'relative' as const,
+      backgroundImage: gradient,
+      backgroundColor: bg,
+      backgroundSize: '200% 100%',
+      animation: `${shimmerKeyframes} ${durationMs}ms linear infinite`,
+    };
+  }, [angle, amplitude, baseColor, durationMs, highlightColor, reduced, shimmerKeyframes]);
+
+  const getShimmerProps = <T extends HTMLElement>(userProps?: HTMLAttributes<T>) =>
+    withInteractionProps<T>(userProps, style, {});
+
+  return {
+    isAnimating: !reduced,
+    getShimmerProps,
+  };
+};
+
+export type ShimmerInteractionReturn = ReturnType<typeof useShimmerInteraction>;

--- a/components/ui/micro-interactions/useSnap.ts
+++ b/components/ui/micro-interactions/useSnap.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import type { HTMLAttributes } from 'react';
+import {
+  MicroInteractionOptions,
+  clamp,
+  useDuration,
+  useKeyframes,
+  useReducedMotion,
+  withInteractionProps,
+} from './utils';
+
+interface SnapOptions extends MicroInteractionOptions {
+  direction?: 'up' | 'down';
+  damping?: number;
+}
+
+export const useSnapInteraction = (options: SnapOptions = {}) => {
+  const { amplitude = 0.35, duration, direction = 'down', damping = 0.6 } = options;
+  const reduced = useReducedMotion();
+  const durationMs = useDuration(duration, '--motion-fast', 220);
+  const offset = clamp(amplitude, 0, 1) * 12;
+  const overshoot = offset * damping;
+
+  const translateAxis = direction === 'down' ? 1 : -1;
+
+  const keyframes = useKeyframes(`
+    0% { transform: translateY(${translateAxis * -offset}px) scale(${1 + amplitude * 0.2}); }
+    60% { transform: translateY(${translateAxis * overshoot}px) scale(${1 - amplitude * 0.1}); }
+    100% { transform: translateY(0) scale(1); }
+  `);
+
+  const [active, setActive] = useState(false);
+
+  const trigger = useCallback(() => {
+    if (reduced) return;
+    setActive(false);
+    window.requestAnimationFrame(() => setActive(true));
+  }, [reduced]);
+
+  const style = useMemo(() => {
+    if (!active || reduced) return {};
+    const animationValue = `${keyframes} ${durationMs}ms cubic-bezier(0.2, 0.8, 0.3, 1)`;
+    return {
+      animation: animationValue,
+      transformOrigin: 'center',
+      willChange: 'transform',
+    };
+  }, [active, durationMs, keyframes, reduced]);
+
+  const getSnapProps = useCallback(
+    <T extends HTMLElement>(userProps?: HTMLAttributes<T>) =>
+      withInteractionProps<T>(userProps, style, {
+        onAnimationEnd: () => setActive(false),
+      }),
+    [style],
+  );
+
+  return {
+    isActive: active,
+    trigger,
+    getSnapProps,
+  };
+};
+
+export type SnapInteractionReturn = ReturnType<typeof useSnapInteraction>;

--- a/components/ui/micro-interactions/utils.ts
+++ b/components/ui/micro-interactions/utils.ts
@@ -1,0 +1,182 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { CSSProperties, HTMLAttributes, SyntheticEvent } from 'react';
+import usePrefersReducedMotion from '../../../hooks/usePrefersReducedMotion';
+
+export interface MicroInteractionOptions {
+  amplitude?: number;
+  duration?: number;
+}
+
+export const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+export const parseDuration = (input: number | string | undefined, fallback: number) => {
+  if (typeof input === 'number' && Number.isFinite(input)) return input;
+  if (typeof input === 'string') {
+    const trimmed = input.trim();
+    if (!trimmed) return fallback;
+    if (trimmed.endsWith('ms')) return Number.parseFloat(trimmed.replace('ms', ''));
+    if (trimmed.endsWith('s')) return Number.parseFloat(trimmed.replace('s', '')) * 1000;
+    const numeric = Number.parseFloat(trimmed);
+    if (Number.isFinite(numeric)) return numeric;
+  }
+  return fallback;
+};
+
+export const useReducedMotion = () => usePrefersReducedMotion();
+
+export const useDesignToken = (token: string, fallback: string) => {
+  const [value, setValue] = useState<string>(fallback);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const root = document.documentElement;
+
+    const read = () => {
+      const style = getComputedStyle(root);
+      const raw = style.getPropertyValue(token);
+      if (raw) setValue(raw.trim());
+    };
+
+    read();
+
+    const observer = new MutationObserver((mutations) => {
+      if (mutations.some((m) => m.type === 'attributes')) read();
+    });
+    observer.observe(root, { attributes: true, attributeFilter: ['class', 'style'] });
+
+    const handleTheme = () => read();
+    window.addEventListener('storage', handleTheme);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('storage', handleTheme);
+    };
+  }, [token]);
+
+  return value;
+};
+
+export const useDuration = (duration: number | undefined, token: string, fallback: number) => {
+  const tokenValue = useDesignToken(token, `${fallback}ms`);
+  return useMemo(() => parseDuration(duration ?? tokenValue, fallback), [duration, fallback, tokenValue]);
+};
+
+export type EventHandler<T extends SyntheticEvent> = (event: T) => void;
+
+export const composeEventHandlers = <T extends SyntheticEvent>(
+  theirs: EventHandler<T> | undefined,
+  ours: EventHandler<T>,
+): EventHandler<T> => (event) => {
+  theirs?.(event);
+  if (!event.defaultPrevented) ours(event);
+};
+
+let keyframeCount = 0;
+
+export const useKeyframes = (frames: string) => {
+  const name = useMemo(() => {
+    keyframeCount += 1;
+    return `micro-${keyframeCount}`;
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const styleEl = document.createElement('style');
+    styleEl.setAttribute('data-micro-interaction', name);
+    styleEl.appendChild(document.createTextNode(`@keyframes ${name} {${frames}}`));
+    document.head.appendChild(styleEl);
+    return () => {
+      document.head.removeChild(styleEl);
+    };
+  }, [frames, name]);
+
+  return name;
+};
+
+export const mergeStyles = (
+  base: CSSProperties | undefined,
+  addition: CSSProperties,
+): CSSProperties => ({ ...(base ?? {}), ...addition });
+
+export const withInteractionProps = <T extends HTMLElement>(
+  userProps: HTMLAttributes<T> | undefined,
+  interactionStyle: CSSProperties,
+  handlers: Partial<Record<keyof HTMLAttributes<T>, EventHandler<any>>>,
+): HTMLAttributes<T> => {
+  const props = userProps ?? {};
+  const { style: userStyle, ...rest } = props;
+
+  const composed: HTMLAttributes<T> = {
+    ...rest,
+    style: mergeStyles(userStyle, interactionStyle),
+  };
+
+  (Object.entries(handlers) as Array<[keyof HTMLAttributes<T>, EventHandler<any> | undefined]>).forEach(
+    ([key, handler]) => {
+      if (!handler) return;
+      const existing = composed[key];
+      composed[key] = existing
+        ? (composeEventHandlers(existing as EventHandler<any>, handler) as HTMLAttributes<T>[keyof HTMLAttributes<T>])
+        : (handler as HTMLAttributes<T>[keyof HTMLAttributes<T>]);
+    },
+  );
+
+  return composed;
+};
+
+export const useTimeout = () => {
+  const timeoutRef = useRef<number | null>(null);
+
+  const clear = useCallback(() => {
+    if (timeoutRef.current) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const start = useCallback((callback: () => void, delay: number) => {
+    clear();
+    timeoutRef.current = window.setTimeout(() => {
+      timeoutRef.current = null;
+      callback();
+    }, delay);
+  }, [clear]);
+
+  useEffect(() => clear, [clear]);
+
+  return { start, clear };
+};
+
+export const useRafLoop = (callback: () => boolean) => {
+  const raf = useRef<number | null>(null);
+
+  const loop = useCallback(() => {
+    if (callback()) {
+      raf.current = window.requestAnimationFrame(loop);
+    } else if (raf.current) {
+      window.cancelAnimationFrame(raf.current);
+      raf.current = null;
+    }
+  }, [callback]);
+
+  useEffect(() => () => {
+    if (raf.current) window.cancelAnimationFrame(raf.current);
+  }, []);
+
+  return {
+    start: () => {
+      if (raf.current === null) {
+        raf.current = window.requestAnimationFrame(loop);
+      }
+    },
+    stop: () => {
+      if (raf.current !== null) {
+        window.cancelAnimationFrame(raf.current);
+        raf.current = null;
+      }
+    },
+  };
+};

--- a/docs/motion.md
+++ b/docs/motion.md
@@ -1,0 +1,55 @@
+# Motion system and micro-interactions
+
+The portfolio UI exposes a set of reusable micro-interaction hooks under
+`components/ui/micro-interactions/`. These hooks centralise motion behaviour so that
+press, hold, shimmer, shake, pulse and snap effects stay consistent with the
+Ubuntu/Kali themed design tokens and accessibility rules.
+
+## Available hooks
+
+| Hook | Purpose | Default amplitude | Default duration |
+| ---- | ------- | ----------------- | ---------------- |
+| `usePressInteraction` | Provides press feedback by scaling and shadowing a control while it is pressed. | `0.08` | token `--motion-fast` |
+| `useHoldInteraction` | Shows progressive feedback for long presses with a configurable commit threshold. | `0.25` | token `--motion-medium` |
+| `useShimmerInteraction` | Creates a loading shimmer driven by tokenised highlight intensity. | `0.35` | token `--motion-slow` |
+| `useShakeInteraction` | Adds a one-shot shake animation for attention or error cues. | `0.55` | token `--motion-medium` |
+| `usePulseInteraction` | Emits a pulse beacon animation suitable for status chips and toasts. | `0.32` | token `--motion-medium` |
+| `useSnapInteraction` | Snaps content into place with a short overshoot easing curve. | `0.42` | token `--motion-fast` |
+
+All hooks accept `amplitude` and `duration` overrides so you can fine-tune the
+magnitude and timing per use-case.【F:components/ui/micro-interactions/index.ts†L1-L18】
+
+### Reduced motion
+
+Each hook delegates to `useReducedMotion`, which in turn uses the global
+settings toggle and the `prefers-reduced-motion` media query. When reduced
+motion is enabled, animations either remove transforms entirely or collapse to
+instant transitions. Consumers do not need to guard this manually—spreading the
+returned props is sufficient.【F:components/ui/micro-interactions/utils.ts†L25-L50】【F:components/ui/micro-interactions/usePress.ts†L9-L56】
+
+### Token access
+
+Utility helpers expose `useDesignToken` and `useDuration` to read live values
+from the token CSS. Hooks and previews re-evaluate automatically when the root
+`class` or `style` attributes change (for example when switching to high
+contrast mode).【F:components/ui/micro-interactions/utils.ts†L32-L64】
+
+## Design portal previews
+
+The Design Portal app (`/apps/design-portal`) acts as a Storybook-like
+playground. It displays each pattern, shows current motion token values and
+exposes knobs for amplitude and duration. The previews share the same hooks as
+production components, so any design-system updates propagate automatically.【F:apps/design-portal/index.tsx†L1-L208】
+
+Key accessibility behaviours covered by the previews include:
+
+- Live indication of the `prefers-reduced-motion` state.
+- Visual progress feedback for the long-press pattern.
+- Test hooks that confirm background/text contrast remains ≥ 4.5:1.
+
+## Testing
+
+Playwright accessibility tests exercise the design portal to verify colour
+contrast and reduced-motion behaviour. The tests live under
+`tests/accessibility/` and can be run via `npx playwright test` or `yarn test`
+(if configured to proxy to Playwright).【F:tests/accessibility/micro-interactions.spec.ts†L1-L36】

--- a/pages/apps/design-portal.jsx
+++ b/pages/apps/design-portal.jsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const DesignPortal = dynamic(() => import('../../apps/design-portal'), {
+  ssr: false,
+  loading: () => <p>Loading design portal…</p>,
+});
+
+export default DesignPortal;

--- a/tests/accessibility/micro-interactions.spec.ts
+++ b/tests/accessibility/micro-interactions.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+import { contrastRatio } from './utils';
+
+test.describe('Design portal micro-interactions', () => {
+  test('shimmer preview maintains accessible contrast', async ({ page }) => {
+    await page.goto('/apps/design-portal');
+    await page.waitForSelector('[data-testid="shimmer-preview"]');
+    const colors = await page.$eval('[data-testid="shimmer-preview"] p:last-of-type', (element) => {
+      const textStyles = window.getComputedStyle(element as HTMLElement);
+      const container = (element.closest('[data-testid="shimmer-preview"]') ?? element.parentElement) as HTMLElement;
+      const containerStyles = window.getComputedStyle(container);
+      return {
+        fg: textStyles.color,
+        bg: containerStyles.backgroundColor || 'rgb(0, 0, 0)',
+      };
+    });
+
+    const ratio = contrastRatio(colors.fg, colors.bg);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  test('reduced motion disables animated shimmer and press transforms', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.goto('/apps/design-portal');
+
+    await page.waitForSelector('[data-testid="shimmer-preview"]');
+    const shimmerAnimation = await page.$eval('[data-testid="shimmer-preview"]', (element) => {
+      const styles = window.getComputedStyle(element as HTMLElement);
+      return {
+        name: styles.animationName,
+        duration: styles.animationDuration,
+      };
+    });
+    expect(shimmerAnimation.name === 'none' || Number.parseFloat(shimmerAnimation.duration) === 0).toBeTruthy();
+
+    const pressButton = page.getByRole('button', { name: 'Press to confirm' });
+    const before = await pressButton.evaluate((el) => window.getComputedStyle(el).transform);
+    await pressButton.dispatchEvent('pointerdown');
+    await page.waitForTimeout(50);
+    const after = await pressButton.evaluate((el) => window.getComputedStyle(el).transform);
+    await pressButton.dispatchEvent('pointerup');
+    const acceptable = new Set(['none', 'matrix(1, 0, 0, 1, 0, 0)']);
+    expect(acceptable.has(after)).toBeTruthy();
+  });
+});

--- a/tests/accessibility/utils.ts
+++ b/tests/accessibility/utils.ts
@@ -1,0 +1,48 @@
+export interface RGBColor {
+  r: number;
+  g: number;
+  b: number;
+}
+
+export const parseColor = (value: string): RGBColor => {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('#')) {
+    const hex = trimmed.slice(1);
+    const normalized = hex.length === 3
+      ? hex.split('').map((c) => c + c).join('')
+      : hex.padEnd(6, '0');
+    const int = Number.parseInt(normalized.slice(0, 6), 16);
+    return {
+      r: (int >> 16) & 0xff,
+      g: (int >> 8) & 0xff,
+      b: int & 0xff,
+    };
+  }
+  const match = trimmed.match(/rgba?\(([^)]+)\)/i);
+  if (!match) throw new Error(`Unsupported color format: ${value}`);
+  const parts = match[1]
+    .split(',')
+    .slice(0, 3)
+    .map((component) => Number.parseFloat(component.trim()));
+  if (parts.length < 3 || parts.some((n) => Number.isNaN(n))) {
+    throw new Error(`Unable to parse color: ${value}`);
+  }
+  return { r: parts[0], g: parts[1], b: parts[2] };
+};
+
+const toLinear = (channel: number) => {
+  const normalized = channel / 255;
+  return normalized <= 0.03928
+    ? normalized / 12.92
+    : Math.pow((normalized + 0.055) / 1.055, 2.4);
+};
+
+export const relativeLuminance = ({ r, g, b }: RGBColor) =>
+  0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+
+export const contrastRatio = (foreground: string, background: string) => {
+  const fgLum = relativeLuminance(parseColor(foreground));
+  const bgLum = relativeLuminance(parseColor(background));
+  const [light, dark] = fgLum > bgLum ? [fgLum, bgLum] : [bgLum, fgLum];
+  return (light + 0.05) / (dark + 0.05);
+};


### PR DESCRIPTION
## Summary
- add reusable micro interaction hooks for press, hold, shimmer, shake, pulse, and snap behaviours
- expose a design portal preview app that surfaces live motion tokens with adjustable knobs for each pattern
- document motion guidance and add Playwright accessibility checks for contrast and reduced motion

## Testing
- npx playwright test tests/accessibility/micro-interactions.spec.ts
- yarn lint *(fails: repository has existing accessibility lint errors across numerous modules)*
- yarn test *(fails: repository has existing failing Jest suites such as nmapNse and modal)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4658d5008328a9aa5c34f695aad7