### PR TITLE
[desktop] add density provider and touch toggle

### DIFF
--- a/components/apps/quick-settings/DensityToggle.tsx
+++ b/components/apps/quick-settings/DensityToggle.tsx
@@ -1,0 +1,36 @@
+import React, { useCallback } from 'react';
+import ToggleSwitch from '../../ToggleSwitch';
+import { useDesktop } from '../../core/DesktopProvider';
+
+const DensityToggle: React.FC = () => {
+  const { densityLock, setDensityLock, tokens, pointerType } = useDesktop();
+  const locked = densityLock === 'touch';
+
+  const onToggle = useCallback(
+    (checked: boolean) => {
+      setDensityLock(checked ? 'touch' : 'auto');
+    },
+    [setDensityLock],
+  );
+
+  return (
+    <div
+      className={`flex items-center justify-between rounded-md ${tokens.inlineGap} ${tokens.control}`.trim()}
+    >
+      <div className="flex flex-col">
+        <span className={`font-medium ${tokens.text}`.trim()}>Touch targets</span>
+        <span className={`text-ubt-grey ${tokens.subtleText}`.trim()}>
+          {locked ? 'Locked to touch-friendly layout' : `Auto (${pointerType})`}
+        </span>
+      </div>
+      <ToggleSwitch
+        checked={locked}
+        onChange={onToggle}
+        ariaLabel="Toggle touch target lock"
+        className="ml-4"
+      />
+    </div>
+  );
+};
+
+export default DensityToggle;

--- a/components/core/DesktopProvider.tsx
+++ b/components/core/DesktopProvider.tsx
@@ -1,0 +1,180 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import useInputMode, { InputMode, PointerType } from '../../hooks/useInputMode';
+import {
+  DensityLock,
+  DensityPreference,
+  displayDefaults,
+  getDensityLock,
+  getDensityPreference,
+  setDensityLock as persistDensityLock,
+  setDensityPreference as persistDensityPreference,
+} from '../../utils/settings/display';
+
+interface DensityTokens {
+  inlineGap: string;
+  stackGap: string;
+  control: string;
+  surface: string;
+  text: string;
+  subtleText: string;
+}
+
+interface DesktopContextValue {
+  density: DensityPreference;
+  preferredDensity: DensityPreference;
+  setPreferredDensity: (value: DensityPreference) => void;
+  densityLock: DensityLock;
+  setDensityLock: (lock: DensityLock) => void;
+  inputMode: InputMode;
+  pointerType: PointerType;
+  isTouch: boolean;
+  tokens: DensityTokens;
+}
+
+const DesktopContext = createContext<DesktopContextValue>({
+  density: displayDefaults.density,
+  preferredDensity: displayDefaults.density,
+  setPreferredDensity: () => {},
+  densityLock: displayDefaults.lock,
+  setDensityLock: () => {},
+  inputMode: 'pointer',
+  pointerType: 'mouse',
+  isTouch: false,
+  tokens: {
+    inlineGap: 'gap-2',
+    stackGap: 'space-y-2',
+    control: 'min-h-hit-target px-4 py-2',
+    surface: 'px-4 py-3',
+    text: 'text-base',
+    subtleText: 'text-sm',
+  },
+});
+
+export const useDesktop = () => useContext(DesktopContext);
+
+interface DesktopProviderProps {
+  children: React.ReactNode;
+}
+
+const compactTokens = {
+  inlineGap: 'gap-[var(--density-gap-inline)]',
+  stackGap: 'space-y-[var(--density-gap-block)]',
+  control: 'min-h-hit-target px-[var(--density-pad-x)] py-[var(--density-pad-y)]',
+  surface: 'px-[var(--density-surface-x)] py-[var(--density-surface-y)]',
+  text: 'text-sm',
+  subtleText: 'text-xs',
+};
+
+const regularTokens = {
+  inlineGap: 'gap-[var(--density-gap-inline)]',
+  stackGap: 'space-y-[var(--density-gap-block)]',
+  control: 'min-h-hit-target px-[var(--density-pad-x)] py-[var(--density-pad-y)]',
+  surface: 'px-[var(--density-surface-x)] py-[var(--density-surface-y)]',
+  text: 'text-base',
+  subtleText: 'text-sm',
+};
+
+const DesktopProvider: React.FC<DesktopProviderProps> = ({ children }) => {
+  const [preferredDensity, setPreferredDensityState] = useState<DensityPreference>(
+    displayDefaults.density,
+  );
+  const [densityLock, setDensityLockState] = useState<DensityLock>(displayDefaults.lock);
+  const hydratedRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const [storedDensity, storedLock] = await Promise.all([
+        getDensityPreference(),
+        getDensityLock(),
+      ]);
+      if (cancelled) return;
+      setPreferredDensityState(storedDensity);
+      setDensityLockState(storedLock);
+      hydratedRef.current = true;
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const pointerOverride: PointerType | null = densityLock === 'touch' ? 'touch' : null;
+  const { inputMode, pointerType } = useInputMode({ pointerOverride });
+  const isTouch = pointerOverride === 'touch' || pointerType === 'touch';
+  const density = densityLock === 'touch' ? 'regular' : preferredDensity;
+
+  useEffect(() => {
+    if (!hydratedRef.current) return;
+    persistDensityPreference(preferredDensity);
+  }, [preferredDensity]);
+
+  useEffect(() => {
+    if (!hydratedRef.current) return;
+    persistDensityLock(densityLock);
+  }, [densityLock]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    root.dataset.pointerType = pointerOverride ?? pointerType;
+    root.dataset.inputMode = inputMode;
+    root.dataset.density = density;
+    root.dataset.touch = isTouch ? 'true' : 'false';
+
+    const inlineGap = density === 'compact' ? '0.5rem' : '0.75rem';
+    const blockGap = density === 'compact' ? '0.5rem' : '0.75rem';
+    const padX = density === 'compact' ? '0.75rem' : '1rem';
+    const padY = density === 'compact' ? '0.25rem' : '0.5rem';
+    const surfaceX = density === 'compact' ? '0.75rem' : '1rem';
+    const surfaceY = density === 'compact' ? '0.75rem' : '1rem';
+    const hitTarget = isTouch ? '2.75rem' : density === 'compact' ? '2.25rem' : '2.5rem';
+
+    root.style.setProperty('--density-gap-inline', inlineGap);
+    root.style.setProperty('--density-gap-block', blockGap);
+    root.style.setProperty('--density-pad-x', padX);
+    root.style.setProperty('--density-pad-y', padY);
+    root.style.setProperty('--density-surface-x', surfaceX);
+    root.style.setProperty('--density-surface-y', surfaceY);
+    root.style.setProperty('--hit-target', hitTarget);
+
+    root.classList.remove('density-compact', 'density-regular');
+    root.classList.add(density === 'compact' ? 'density-compact' : 'density-regular');
+  }, [density, inputMode, isTouch, pointerOverride, pointerType]);
+
+  const handlePreferredDensity = useCallback((value: DensityPreference) => {
+    setPreferredDensityState(value);
+  }, []);
+
+  const handleDensityLock = useCallback((value: DensityLock) => {
+    setDensityLockState(value);
+  }, []);
+
+  const tokens = useMemo(() => (density === 'compact' ? compactTokens : regularTokens), [density]);
+
+  const contextValue = useMemo<DesktopContextValue>(
+    () => ({
+      density,
+      preferredDensity,
+      setPreferredDensity: handlePreferredDensity,
+      densityLock,
+      setDensityLock: handleDensityLock,
+      inputMode,
+      pointerType,
+      isTouch,
+      tokens,
+    }),
+    [density, preferredDensity, handlePreferredDensity, densityLock, handleDensityLock, inputMode, pointerType, isTouch, tokens],
+  );
+
+  return <DesktopContext.Provider value={contextValue}>{children}</DesktopContext.Provider>;
+};
+
+export default DesktopProvider;

--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from "react";
 import Tabs from "../Tabs";
 import ToggleSwitch from "../ToggleSwitch";
+import { useDesktop } from "../core/DesktopProvider";
 
 const PANEL_PREFIX = "xfce.panel.";
 
@@ -17,6 +18,7 @@ export default function Preferences() {
   ];
 
   const [active, setActive] = useState<TabId>("display");
+  const { tokens } = useDesktop();
 
   const [size, setSize] = useState(() => {
     if (typeof window === "undefined") return 24;
@@ -63,11 +65,11 @@ export default function Preferences() {
   return (
     <div>
       <Tabs tabs={TABS} active={active} onChange={setActive} />
-      <div className="p-4">
+      <div className={`p-4 ${tokens.stackGap}`.trim()}>
         {active === "display" && (
-          <div className="space-y-4">
+          <div className={`flex flex-col ${tokens.stackGap}`.trim()}>
             <div className="flex items-center justify-between">
-              <label htmlFor="orientation" className="text-ubt-grey">
+              <label htmlFor="orientation" className={`text-ubt-grey ${tokens.text}`.trim()}>
                 Orientation
               </label>
               <select
@@ -76,14 +78,14 @@ export default function Preferences() {
                 onChange={(e) =>
                   setOrientation(e.target.value as "horizontal" | "vertical")
                 }
-                className="bg-ub-cool-grey text-white px-2 py-1 rounded"
+                className={`bg-ub-cool-grey text-white rounded ${tokens.control}`.trim()}
               >
                 <option value="horizontal">Horizontal</option>
                 <option value="vertical">Vertical</option>
               </select>
             </div>
             <div className="flex items-center justify-between">
-              <span className="text-ubt-grey">Autohide</span>
+              <span className={`text-ubt-grey ${tokens.text}`.trim()}>Autohide</span>
               <ToggleSwitch
                 checked={autohide}
                 onChange={setAutohide}
@@ -93,9 +95,9 @@ export default function Preferences() {
           </div>
         )}
         {active === "measurements" && (
-          <div className="space-y-4">
+          <div className={`flex flex-col ${tokens.stackGap}`.trim()}>
             <div className="flex items-center justify-between">
-              <label htmlFor="panel-size" className="text-ubt-grey">
+              <label htmlFor="panel-size" className={`text-ubt-grey ${tokens.text}`.trim()}>
                 Size: {size}px
               </label>
               <input
@@ -110,7 +112,7 @@ export default function Preferences() {
               />
             </div>
             <div className="flex items-center justify-between">
-              <label htmlFor="panel-length" className="text-ubt-grey">
+              <label htmlFor="panel-length" className={`text-ubt-grey ${tokens.text}`.trim()}>
                 Length: {length}%
               </label>
               <input
@@ -127,13 +129,19 @@ export default function Preferences() {
           </div>
         )}
         {active === "appearance" && (
-          <p className="text-ubt-grey">Appearance settings are not available yet.</p>
+          <p className={`text-ubt-grey ${tokens.text}`.trim()}>
+            Appearance settings are not available yet.
+          </p>
         )}
         {active === "opacity" && (
-          <p className="text-ubt-grey">Opacity settings are not available yet.</p>
+          <p className={`text-ubt-grey ${tokens.text}`.trim()}>
+            Opacity settings are not available yet.
+          </p>
         )}
         {active === "items" && (
-          <p className="text-ubt-grey">Item settings are not available yet.</p>
+          <p className={`text-ubt-grey ${tokens.text}`.trim()}>
+            Item settings are not available yet.
+          </p>
         )}
       </div>
     </div>

--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useDesktop } from '../core/DesktopProvider';
 
 interface Segment {
   name: string;
@@ -10,8 +11,13 @@ interface Props {
 }
 
 const Breadcrumbs: React.FC<Props> = ({ path, onNavigate }) => {
+  const { tokens } = useDesktop();
+
   return (
-    <nav className="flex items-center space-x-1 text-white" aria-label="Breadcrumb">
+    <nav
+      className={`flex items-center text-white ${tokens.inlineGap} ${tokens.text}`.trim()}
+      aria-label="Breadcrumb"
+    >
       {path.map((seg, idx) => (
         <React.Fragment key={idx}>
           <button

--- a/components/ui/FormError.tsx
+++ b/components/ui/FormError.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useDesktop } from '../core/DesktopProvider';
 
 interface FormErrorProps {
   id?: string;
@@ -6,15 +7,18 @@ interface FormErrorProps {
   children: React.ReactNode;
 }
 
-const FormError = ({ id, className = '', children }: FormErrorProps) => (
-  <p
-    id={id}
-    role="status"
-    aria-live="polite"
-    className={`text-red-600 text-sm mt-2 ${className}`.trim()}
-  >
-    {children}
-  </p>
-);
+const FormError = ({ id, className = '', children }: FormErrorProps) => {
+  const { tokens } = useDesktop();
+  return (
+    <p
+      id={id}
+      role="status"
+      aria-live="polite"
+      className={`text-red-600 mt-2 ${tokens.subtleText} ${className}`.trim()}
+    >
+      {children}
+    </p>
+  );
+};
 
 export default FormError;

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import DensityToggle from '../apps/quick-settings/DensityToggle';
+import usePersistentState from '../../hooks/usePersistentState';
+import { useDesktop } from '../core/DesktopProvider';
 
 interface Props {
   open: boolean;
@@ -12,6 +14,7 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const { tokens } = useDesktop();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -21,36 +24,56 @@ const QuickSettings = ({ open }: Props) => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
 
+  const rowClass = `flex items-center justify-between rounded-md transition-colors ${tokens.inlineGap} ${tokens.control}`.trim();
+  const controlClass = `${tokens.control} w-full flex items-center justify-between rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-ub-orange/60`.trim();
+
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
-        open ? '' : 'hidden'
+      className={`absolute bg-ub-cool-grey rounded-md top-9 right-3 shadow border border-black border-opacity-20 transition transform origin-top-right ${
+        open ? 'opacity-100 scale-100' : 'pointer-events-none opacity-0 scale-95'
       }`}
+      aria-hidden={!open}
     >
-      <div className="px-4 pb-2">
+      <div className={`flex flex-col ${tokens.surface} ${tokens.stackGap}`.trim()}>
+        <DensityToggle />
         <button
-          className="w-full flex justify-between"
+          className={controlClass}
           onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+          type="button"
         >
-          <span>Theme</span>
-          <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
+          <span className={tokens.text}>Theme</span>
+          <span className={tokens.subtleText}>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
-        <input
-          type="checkbox"
-          checked={reduceMotion}
-          onChange={() => setReduceMotion(!reduceMotion)}
-        />
+        <div className={rowClass}>
+          <span className={tokens.text}>Sound</span>
+          <input
+            type="checkbox"
+            checked={sound}
+            onChange={() => setSound(!sound)}
+            className="form-checkbox"
+            aria-label="Toggle sound"
+          />
+        </div>
+        <div className={rowClass}>
+          <span className={tokens.text}>Network</span>
+          <input
+            type="checkbox"
+            checked={online}
+            onChange={() => setOnline(!online)}
+            className="form-checkbox"
+            aria-label="Toggle network"
+          />
+        </div>
+        <div className={rowClass}>
+          <span className={tokens.text}>Reduced motion</span>
+          <input
+            type="checkbox"
+            checked={reduceMotion}
+            onChange={() => setReduceMotion(!reduceMotion)}
+            className="form-checkbox"
+            aria-label="Toggle reduced motion"
+          />
+        </div>
       </div>
     </div>
   );

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState, createContext, useContext } from 'react';
+import { useDesktop } from '../core/DesktopProvider';
 
 function middleEllipsis(text: string, max = 30) {
   if (text.length <= max) return text;
@@ -38,6 +39,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
   onTabsChange,
   className = '',
 }) => {
+  const { tokens } = useDesktop();
   const [tabs, setTabs] = useState<TabDefinition[]>(initialTabs);
   const [activeId, setActiveId] = useState<string>(initialTabs[0]?.id || '');
   const prevActive = useRef<string>('');
@@ -164,17 +166,21 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
 
   return (
     <div
-      className={`flex flex-col w-full h-full ${className}`.trim()}
+      className={`flex flex-col w-full h-full ${tokens.text} ${className}`.trim()}
       tabIndex={0}
       onKeyDown={onKeyDown}
     >
-      <div className="flex flex-shrink-0 bg-gray-800 text-white text-sm overflow-x-auto">
+      <div
+        className={`flex flex-shrink-0 bg-gray-800 text-white overflow-x-auto ${tokens.inlineGap}`.trim()}
+      >
         {tabs.map((t, i) => (
           <div
             key={t.id}
-            className={`flex items-center gap-1.5 px-3 py-1 cursor-pointer select-none ${
+            className={`flex items-center select-none rounded-md transition-colors ${
+              tokens.inlineGap
+            } ${tokens.control} ${
               t.id === activeId ? 'bg-gray-700' : 'bg-gray-800'
-            }`}
+            } cursor-pointer`}
             draggable
             onDragStart={handleDragStart(i)}
             onDragOver={handleDragOver(i)}
@@ -184,7 +190,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
             <span className="max-w-[150px]">{middleEllipsis(t.title)}</span>
             {t.closable !== false && tabs.length > 1 && (
               <button
-                className="p-0.5"
+                className={`rounded px-1 ${tokens.subtleText}`.trim()}
                 onClick={(e) => {
                   e.stopPropagation();
                   closeTab(t.id);
@@ -198,7 +204,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
         ))}
         {onNewTab && (
           <button
-            className="px-2 py-1 bg-gray-800 hover:bg-gray-700"
+            className={`bg-gray-800 hover:bg-gray-700 rounded-md transition-colors ${tokens.control}`.trim()}
             onClick={addTab}
             aria-label="New Tab"
           >

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useDesktop } from '../core/DesktopProvider';
 
 interface ToastProps {
   message: string;
@@ -18,6 +19,8 @@ const Toast: React.FC<ToastProps> = ({
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [visible, setVisible] = useState(false);
 
+  const { tokens } = useDesktop();
+
   useEffect(() => {
     setVisible(true);
     timeoutRef.current = setTimeout(() => {
@@ -32,13 +35,15 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${
+        visible ? 'translate-y-0' : '-translate-y-full'
+      } ${tokens.control} ${tokens.inlineGap}`.trim()}
     >
-      <span>{message}</span>
+      <span className={tokens.text}>{message}</span>
       {onAction && actionLabel && (
         <button
           onClick={onAction}
-          className="ml-4 underline focus:outline-none"
+          className={`underline focus:outline-none ${tokens.subtleText}`.trim()}
         >
           {actionLabel}
         </button>

--- a/components/ui/VideoPlayer.tsx
+++ b/components/ui/VideoPlayer.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import PipPortalProvider, { usePipPortal } from "../common/PipPortal";
+import { useDesktop } from "../core/DesktopProvider";
 
 interface VideoPlayerProps {
   src: string;
@@ -16,6 +17,7 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
 }) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const { open, close } = usePipPortal();
+  const { tokens } = useDesktop();
   const [pipSupported, setPipSupported] = useState(false);
   const [docPipSupported, setDocPipSupported] = useState(false);
   const [isPip, setIsPip] = useState(false);
@@ -134,7 +136,7 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
         <button
           type="button"
           onClick={togglePiP}
-          className="absolute bottom-2 right-2 rounded bg-black bg-opacity-50 px-2 py-1 text-xs text-white"
+          className={`absolute bottom-2 right-2 rounded bg-black bg-opacity-50 text-white ${tokens.control} ${tokens.subtleText}`.trim()}
         >
           {isPip ? "Exit PiP" : "PiP"}
         </button>
@@ -143,7 +145,7 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
         <button
           type="button"
           onClick={openDocPip}
-          className="absolute bottom-2 right-16 rounded bg-black bg-opacity-50 px-2 py-1 text-xs text-white"
+          className={`absolute bottom-2 right-16 rounded bg-black bg-opacity-50 text-white ${tokens.control} ${tokens.subtleText}`.trim()}
         >
           Doc-PiP
         </button>

--- a/hooks/useInputMode.ts
+++ b/hooks/useInputMode.ts
@@ -1,0 +1,123 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+export type PointerType = 'mouse' | 'touch' | 'pen' | 'unknown';
+export type InputMode = 'keyboard' | 'pointer';
+
+interface UseInputModeOptions {
+  pointerOverride?: PointerType | null;
+}
+
+const getInitialPointerType = (): PointerType => {
+  if (typeof window === 'undefined') return 'mouse';
+  if (window.matchMedia('(pointer: coarse)').matches) return 'touch';
+  if (window.matchMedia('(hover: none)').matches) return 'touch';
+  if (navigator.maxTouchPoints && navigator.maxTouchPoints > 0) return 'touch';
+  return 'mouse';
+};
+
+const normalizePointer = (type?: string | null): PointerType => {
+  switch (type) {
+    case 'touch':
+      return 'touch';
+    case 'pen':
+      return 'pen';
+    case 'mouse':
+      return 'mouse';
+    default:
+      return 'unknown';
+  }
+};
+
+export default function useInputMode({ pointerOverride = null }: UseInputModeOptions = {}) {
+  const [pointerType, setPointerType] = useState<PointerType>(() => pointerOverride ?? getInitialPointerType());
+  const [inputMode, setInputMode] = useState<InputMode>('pointer');
+  const lastPointer = useRef<PointerType>(pointerType);
+
+  useEffect(() => {
+    if (pointerOverride) {
+      lastPointer.current = pointerOverride;
+      setPointerType(pointerOverride);
+      setInputMode('pointer');
+      return;
+    }
+
+    if (typeof window === 'undefined') return;
+
+    const updatePointer = (next: PointerType) => {
+      if (lastPointer.current === next) return;
+      lastPointer.current = next;
+      setPointerType(next);
+    };
+
+    const handlePointer = (event: PointerEvent) => {
+      const next = normalizePointer(event.pointerType);
+      setInputMode('pointer');
+      if (next === 'unknown') return;
+      updatePointer(next);
+    };
+
+    const handleTouch = () => {
+      setInputMode('pointer');
+      updatePointer('touch');
+    };
+
+    const handleMouse = () => {
+      setInputMode('pointer');
+      updatePointer('mouse');
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.metaKey || event.altKey || event.ctrlKey) return;
+      setInputMode('keyboard');
+    };
+
+    window.addEventListener('pointerdown', handlePointer, { passive: true });
+    window.addEventListener('pointermove', handlePointer, { passive: true });
+    window.addEventListener('touchstart', handleTouch, { passive: true });
+    window.addEventListener('mousemove', handleMouse, { passive: true });
+    window.addEventListener('keydown', handleKeyDown, true);
+
+    const coarseQuery = window.matchMedia('(pointer: coarse)');
+    const fineQuery = window.matchMedia('(pointer: fine)');
+
+    const handleCoarseChange = (event: MediaQueryListEvent) => {
+      if (pointerOverride) return;
+      if (event.matches) updatePointer('touch');
+    };
+
+    const handleFineChange = (event: MediaQueryListEvent) => {
+      if (pointerOverride) return;
+      if (event.matches && lastPointer.current !== 'mouse') updatePointer('mouse');
+    };
+
+    coarseQuery.addEventListener('change', handleCoarseChange);
+    fineQuery.addEventListener('change', handleFineChange);
+
+    return () => {
+      window.removeEventListener('pointerdown', handlePointer);
+      window.removeEventListener('pointermove', handlePointer);
+      window.removeEventListener('touchstart', handleTouch);
+      window.removeEventListener('mousemove', handleMouse);
+      window.removeEventListener('keydown', handleKeyDown, true);
+      coarseQuery.removeEventListener('change', handleCoarseChange);
+      fineQuery.removeEventListener('change', handleFineChange);
+    };
+  }, [pointerOverride]);
+
+  useEffect(() => {
+    if (!pointerOverride) return;
+    lastPointer.current = pointerOverride;
+    setPointerType(pointerOverride);
+    setInputMode('pointer');
+  }, [pointerOverride]);
+
+  return useMemo(
+    () => ({
+      inputMode,
+      pointerType,
+      isKeyboard: inputMode === 'keyboard',
+      isTouchPointer: pointerType === 'touch',
+    }),
+    [inputMode, pointerType],
+  );
+}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -4,8 +4,6 @@ import {
   setAccent as saveAccent,
   getWallpaper as loadWallpaper,
   setWallpaper as saveWallpaper,
-  getDensity as loadDensity,
-  setDensity as saveDensity,
   getReducedMotion as loadReducedMotion,
   setReducedMotion as saveReducedMotion,
   getFontScale as loadFontScale,
@@ -23,6 +21,7 @@ import {
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+import { useDesktop } from '../components/core/DesktopProvider';
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
@@ -104,7 +103,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [accent, setAccent] = useState<string>(defaults.accent);
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
-  const [density, setDensity] = useState<Density>(defaults.density as Density);
+  const { preferredDensity, setPreferredDensity } = useDesktop();
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
   const [highContrast, setHighContrast] = useState<boolean>(defaults.highContrast);
@@ -119,7 +118,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     (async () => {
       setAccent(await loadAccent());
       setWallpaper(await loadWallpaper());
-      setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
       setFontScale(await loadFontScale());
       setHighContrast(await loadHighContrast());
@@ -156,31 +154,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveWallpaper(wallpaper);
   }, [wallpaper]);
 
-  useEffect(() => {
-    const spacing: Record<Density, Record<string, string>> = {
-      regular: {
-        '--space-1': '0.25rem',
-        '--space-2': '0.5rem',
-        '--space-3': '0.75rem',
-        '--space-4': '1rem',
-        '--space-5': '1.5rem',
-        '--space-6': '2rem',
-      },
-      compact: {
-        '--space-1': '0.125rem',
-        '--space-2': '0.25rem',
-        '--space-3': '0.5rem',
-        '--space-4': '0.75rem',
-        '--space-5': '1rem',
-        '--space-6': '1.5rem',
-      },
-    };
-    const vars = spacing[density];
-    Object.entries(vars).forEach(([key, value]) => {
-      document.documentElement.style.setProperty(key, value);
-    });
-    saveDensity(density);
-  }, [density]);
 
   useEffect(() => {
     document.documentElement.classList.toggle('reduced-motion', reducedMotion);
@@ -241,7 +214,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       value={{
         accent,
         wallpaper,
-        density,
+        density: preferredDensity,
         reducedMotion,
         fontScale,
         highContrast,
@@ -252,7 +225,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         theme,
         setAccent,
         setWallpaper,
-        setDensity,
+        setDensity: setPreferredDensity,
         setReducedMotion,
         setFontScale,
         setHighContrast,

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import DesktopProvider from '../components/core/DesktopProvider';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -156,12 +157,13 @@ function MyApp(props) {
         >
           Skip to app grid
         </a>
-        <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
+        <DesktopProvider>
+          <SettingsProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
               beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;
                 const evt = e;
@@ -170,9 +172,10 @@ function MyApp(props) {
               }}
             />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
-        </SettingsProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </SettingsProvider>
+        </DesktopProvider>
       </div>
     </ErrorBoundary>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,6 +40,9 @@ module.exports = {
       fontFamily: {
         ubuntu: ['Ubuntu', 'sans-serif'],
       },
+      spacing: {
+        'hit-target': 'var(--hit-target)',
+      },
       minWidth: {
         '0': '0',
         '1/4': '25%',
@@ -53,6 +56,7 @@ module.exports = {
         '1/2': '50%',
         '3/4': '75%',
         'full': '100%',
+        'hit-target': 'var(--hit-target)',
       },
       zIndex: {
         '-10': '-10',
@@ -68,6 +72,7 @@ module.exports = {
         'app-icon-lg': '96px',
         'tray-icon': '16px',
         'tray-icon-lg': '32px',
+        'hit-target': 'var(--hit-target)',
       },
       keyframes: {
         glow: {

--- a/tests/manual/input-density.md
+++ b/tests/manual/input-density.md
@@ -1,0 +1,29 @@
+# Input density QA checklist
+
+Use this script after implementing input mode or density changes to ensure focus, hover, and touch targets adapt correctly.
+
+## Setup
+
+1. Start the development server (`yarn dev`) and load the desktop at http://localhost:3000.
+2. Open the Quick Settings tray from the top bar so the new *Touch targets* toggle is visible.
+3. Confirm `localStorage` has no stale overrides by clearing `display:density-lock` if present.
+
+## Pointer + keyboard parity
+
+- **Pointer hover**: With a mouse or trackpad, hover each Quick Settings row. Expect the row highlight to follow the pointer and controls to retain the compact density spacing.
+- **Keyboard focus**: Close the tray, press `Tab` until focus returns to the tray trigger, then reopen it with `Enter`. Use arrow keys to move through rows. Each focused control should expand to the touch target height and display a visible focus ring.
+- **Pointer transition**: Move the mouse again and ensure hover states resume without lingering keyboard focus styling.
+
+## Touch override behaviour
+
+1. Toggle *Touch targets* on. The panel rows should immediately grow to the 44px minimum height and the Quick Settings state should persist on reload.
+2. With the toggle enabled, open DevTools → Device Toolbar and emulate a touch device. Tap through the Quick Settings controls; the hit targets should remain large and the hover styling should not appear.
+3. Reload the page while the toggle remains on. Verify the density stays locked to the touch layout and `window.localStorage.getItem('display:density-lock') === 'touch'`.
+4. Disable the toggle and confirm the layout reverts to the preferred density while hover states return for pointer input.
+
+## Desktop shell integration
+
+- Open an app that uses tabbed navigation (for example, any terminal or browser simulation) and verify tab headers respect the new density tokens.
+- From the keyboard, cycle between tabs with `Ctrl+Tab` and ensure the active tab keeps the larger touch hit target when the lock is enabled.
+
+Record findings and file a bug if any control fails to meet the expected hit target or focus treatment.

--- a/utils/settings/display.ts
+++ b/utils/settings/display.ts
@@ -1,0 +1,48 @@
+const DENSITY_KEY = 'display:density';
+const DENSITY_LOCK_KEY = 'display:density-lock';
+
+export type DensityPreference = 'regular' | 'compact';
+export type DensityLock = 'auto' | 'touch';
+
+const isBrowser = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+const normalizeDensity = (value: string | null | undefined): DensityPreference => {
+  return value === 'compact' ? 'compact' : 'regular';
+};
+
+const normalizeLock = (value: string | null | undefined): DensityLock => {
+  return value === 'touch' ? 'touch' : 'auto';
+};
+
+export async function getDensityPreference(): Promise<DensityPreference> {
+  if (!isBrowser()) return 'regular';
+  const stored = window.localStorage.getItem(DENSITY_KEY) ?? window.localStorage.getItem('density');
+  return normalizeDensity(stored);
+}
+
+export async function setDensityPreference(value: DensityPreference) {
+  if (!isBrowser()) return;
+  window.localStorage.setItem(DENSITY_KEY, value);
+  // Maintain compatibility with older settings storage
+  window.localStorage.setItem('density', value);
+}
+
+export async function getDensityLock(): Promise<DensityLock> {
+  if (!isBrowser()) return 'auto';
+  const stored = window.localStorage.getItem(DENSITY_LOCK_KEY);
+  return normalizeLock(stored);
+}
+
+export async function setDensityLock(value: DensityLock) {
+  if (!isBrowser()) return;
+  if (value === 'auto') {
+    window.localStorage.removeItem(DENSITY_LOCK_KEY);
+  } else {
+    window.localStorage.setItem(DENSITY_LOCK_KEY, value);
+  }
+}
+
+export const displayDefaults: { density: DensityPreference; lock: DensityLock } = {
+  density: 'regular',
+  lock: 'auto',
+};

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -137,6 +137,8 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('display:density');
+  window.localStorage.removeItem('display:density-lock');
 }
 
 export async function exportSettings() {


### PR DESCRIPTION
## Summary
- add a reusable useInputMode hook that listens for pointer mode changes and optional overrides
- introduce DesktopProvider with shared density state, pointer metadata, and CSS token management persisted via utils/settings/display
- refresh Quick Settings, shared UI, and panel components to use density tokens and expose a touch-target toggle with updated manual QA docs

## Testing
- yarn lint *(fails: existing jsx-a11y and window usage violations in legacy apps)*
- yarn test *(fails: pre-existing modal and integration tests unrelated to new density provider)*

------
https://chatgpt.com/codex/tasks/task_e_68cb465a28b483288ad0f86e94b581c7