### PR TITLE
[certificates] add certificate management workspace

### DIFF
--- a/__tests__/components/apps/certificates.test.tsx
+++ b/__tests__/components/apps/certificates.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import CertificatesApp from '../../../components/apps/certificates';
+import {
+  resetCertStore,
+  getState,
+} from '../../../utils/certStore';
+import { publish } from '../../../utils/pubsub';
+
+describe('CertificatesApp', () => {
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(
+      new Date('2025-01-01T00:00:00.000Z').valueOf()
+    );
+    resetCertStore();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders default certificates and metadata', () => {
+    render(<CertificatesApp />);
+    expect(screen.getByText('Certificate Store')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Kali Root CA/i })).toBeInTheDocument();
+    const metadata = screen.getByLabelText(/Certificate metadata/i);
+    expect(within(metadata).getByRole('heading', { name: /Metadata/i })).toBeInTheDocument();
+    expect(within(metadata).getByText(/2035-12-31/)).toBeInTheDocument();
+  });
+
+  it('filters by scope and updates selection', () => {
+    render(<CertificatesApp />);
+    fireEvent.change(screen.getByLabelText(/Scope/i), { target: { value: 'user' } });
+    expect(screen.getByRole('button', { name: /Developer Signing Cert/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Kali Root CA/i })).not.toBeInTheDocument();
+  });
+
+  it('shows expiry warnings for expiring and expired certificates', () => {
+    render(<CertificatesApp />);
+    expect(screen.getByText(/Expires in/)).toBeInTheDocument();
+    expect(screen.getByText(/Expired/)).toBeInTheDocument();
+  });
+
+  it('links TLS issues to the selected certificate and reacts to pubsub events', async () => {
+    render(<CertificatesApp />);
+    fireEvent.click(screen.getByRole('button', { name: /Lab VPN Gateway/i }));
+    expect(
+      screen.getByText(/TLS handshake failed: certificate about to expire/i)
+    ).toBeInTheDocument();
+
+    const devFingerprint = getState().certificates.find(
+      (cert) => cert.label === 'Developer Signing Cert'
+    )?.fingerprint;
+    expect(devFingerprint).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: /Developer Signing Cert/i }));
+    expect(
+      screen.getByText(/No TLS issues linked to this certificate/i)
+    ).toBeInTheDocument();
+
+    act(() => {
+      publish('tls:issue', {
+        summary: 'Client handshake error',
+        severity: 'critical',
+        source: 'Wireshark',
+        fingerprints: [devFingerprint!],
+        detectedAt: '2025-01-01T02:00:00.000Z',
+        remediation: 'Renew client certificate',
+      });
+    });
+
+    expect(
+      await screen.findByText(/Client handshake error/i)
+    ).toBeInTheDocument();
+  });
+
+  it('supports trust and revoke actions', () => {
+    render(<CertificatesApp />);
+    fireEvent.click(screen.getByRole('button', { name: /Developer Signing Cert/i }));
+    const metadata = screen.getByLabelText(/Certificate metadata/i);
+    expect(within(metadata).getByText(/Untrusted/i)).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Trust' }));
+    });
+    expect(within(metadata).getByText(/Trusted/i)).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Revoke' }));
+    });
+    expect(within(metadata).getByText(/Revoked/i)).toBeInTheDocument();
+  });
+
+  it('imports a certificate and exposes export preview', () => {
+    render(<CertificatesApp />);
+    const payload = JSON.stringify({
+      label: 'QA Service Cert',
+      subject: 'CN=qa.lab.internal',
+      issuer: 'CN=Kali Issuing CA',
+      validFrom: '2025-01-01T00:00:00.000Z',
+      validTo: '2025-12-31T00:00:00.000Z',
+      type: 'Server',
+      usage: ['Server Authentication'],
+    });
+
+    act(() => {
+      fireEvent.change(screen.getByLabelText(/Import certificate payload/i), {
+        target: { value: payload },
+      });
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('Imported QA Service Cert');
+    expect(
+      screen.getByRole('button', { name: /QA Service Cert/i })
+    ).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /QA Service Cert/i }));
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+    });
+
+    const exportPreview = screen.getByLabelText(/Export preview content/i) as HTMLTextAreaElement;
+    expect(exportPreview.value).toContain('"label": "QA Service Cert"');
+  });
+});

--- a/components/apps/certificates/index.tsx
+++ b/components/apps/certificates/index.tsx
@@ -1,0 +1,525 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  useCertStore,
+  trustCertificate,
+  revokeCertificate,
+  importCertificate,
+  exportCertificate,
+  dismissTlsIssue,
+  getStatus,
+  type Certificate,
+  type CertificateStatus,
+  type TlsIssue,
+} from '../../../utils/certStore';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const EXPIRY_WARNING_DAYS = 30;
+
+type ScopeFilter = 'all' | 'system' | 'user';
+type IssueFilter = 'all' | 'with' | 'without';
+
+type Message = { type: 'success' | 'error'; text: string } | null;
+
+const statusLabels: Record<CertificateStatus, string> = {
+  trusted: 'Trusted',
+  untrusted: 'Untrusted',
+  revoked: 'Revoked',
+};
+
+const statusColors: Record<CertificateStatus, string> = {
+  trusted: 'bg-green-700 text-green-100',
+  untrusted: 'bg-gray-700 text-gray-200',
+  revoked: 'bg-red-800 text-red-100',
+};
+
+const issueSeverityStyles: Record<string, string> = {
+  info: 'bg-blue-900 text-blue-100',
+  warning: 'bg-yellow-800 text-yellow-100',
+  critical: 'bg-red-900 text-red-100',
+};
+
+function formatDate(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return 'Unknown';
+  return parsed.toISOString().slice(0, 10);
+}
+
+function pluralize(count: number, word: string): string {
+  return `${count} ${word}${count === 1 ? '' : 's'}`;
+}
+
+function computeExpiry(cert: Certificate) {
+  const target = new Date(cert.validTo);
+  if (Number.isNaN(target.getTime())) {
+    return { status: 'unknown', label: 'Unknown expiry' };
+  }
+  const now = Date.now();
+  const diff = target.getTime() - now;
+  if (diff < 0) {
+    const daysAgo = Math.max(0, Math.ceil(Math.abs(diff) / ONE_DAY_MS));
+    return {
+      status: 'expired',
+      label: daysAgo === 0 ? 'Expired today' : `Expired ${pluralize(daysAgo, 'day')} ago`,
+    };
+  }
+  const daysLeft = Math.ceil(diff / ONE_DAY_MS);
+  if (daysLeft <= EXPIRY_WARNING_DAYS) {
+    return {
+      status: 'expiring',
+      label: `Expires in ${pluralize(daysLeft, 'day')}`,
+    };
+  }
+  return {
+    status: 'valid',
+    label: `Valid until ${formatDate(cert.validTo)}`,
+  };
+}
+
+function issueMatchesFilter(issueFilter: IssueFilter, issueCount: number): boolean {
+  if (issueFilter === 'all') return true;
+  if (issueFilter === 'with') return issueCount > 0;
+  return issueCount === 0;
+}
+
+const CertificatesApp: React.FC = () => {
+  const { certificates, tlsIssues } = useCertStore();
+  const [scopeFilter, setScopeFilter] = useState<ScopeFilter>('all');
+  const [statusFilter, setStatusFilter] = useState<'all' | CertificateStatus>('all');
+  const [issueFilter, setIssueFilter] = useState<IssueFilter>('all');
+  const [search, setSearch] = useState('');
+  const [selectedFingerprint, setSelectedFingerprint] = useState<string | null>(null);
+  const [importText, setImportText] = useState('');
+  const [message, setMessage] = useState<Message>(null);
+  const [exportPreview, setExportPreview] = useState('');
+
+  const filteredCertificates = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return certificates.filter((cert) => {
+      if (scopeFilter !== 'all' && cert.scope !== scopeFilter) return false;
+      const status = getStatus(cert);
+      if (statusFilter !== 'all' && status !== statusFilter) return false;
+      const issueCount = tlsIssues.filter((issue) =>
+        issue.fingerprints.includes(cert.fingerprint)
+      ).length;
+      if (!issueMatchesFilter(issueFilter, issueCount)) return false;
+      if (!query) return true;
+      const haystack = `${cert.label} ${cert.subject} ${cert.issuer}`.toLowerCase();
+      return haystack.includes(query);
+    });
+  }, [certificates, scopeFilter, statusFilter, issueFilter, search, tlsIssues]);
+
+  useEffect(() => {
+    if (!filteredCertificates.length) {
+      setSelectedFingerprint(null);
+      return;
+    }
+    if (!selectedFingerprint) {
+      setSelectedFingerprint(filteredCertificates[0].fingerprint);
+      return;
+    }
+    const stillVisible = filteredCertificates.some(
+      (cert) => cert.fingerprint === selectedFingerprint
+    );
+    if (!stillVisible) {
+      setSelectedFingerprint(filteredCertificates[0].fingerprint);
+    }
+  }, [filteredCertificates, selectedFingerprint]);
+
+  const selectedCertificate = useMemo(
+    () =>
+      certificates.find((cert) => cert.fingerprint === selectedFingerprint) || null,
+    [certificates, selectedFingerprint]
+  );
+
+  const selectedIssues = useMemo(() => {
+    if (!selectedCertificate) return [] as TlsIssue[];
+    return tlsIssues.filter((issue) =>
+      issue.fingerprints.includes(selectedCertificate.fingerprint)
+    );
+  }, [selectedCertificate, tlsIssues]);
+
+  const setSuccess = (text: string) => setMessage({ type: 'success', text });
+  const setError = (text: string) => setMessage({ type: 'error', text });
+
+  const handleTrust = () => {
+    if (!selectedCertificate) return;
+    trustCertificate(selectedCertificate.fingerprint);
+    setSuccess(`Trusted ${selectedCertificate.label}`);
+  };
+
+  const handleRevoke = () => {
+    if (!selectedCertificate) return;
+    revokeCertificate(selectedCertificate.fingerprint);
+    setSuccess(`Revoked ${selectedCertificate.label}`);
+  };
+
+  const handleExport = () => {
+    if (!selectedCertificate) return;
+    const exported = exportCertificate(selectedCertificate.fingerprint);
+    if (!exported) {
+      setError('Unable to export certificate');
+      return;
+    }
+    setExportPreview(exported);
+    setSuccess(`Prepared export for ${selectedCertificate.label}`);
+  };
+
+  const handleImport = () => {
+    try {
+      const cert = importCertificate(importText.trim());
+      setSuccess(`Imported ${cert.label}`);
+      setImportText('');
+      setSelectedFingerprint(cert.fingerprint);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to import certificate');
+    }
+  };
+
+  const handleDismissIssue = (issueId: string) => {
+    dismissTlsIssue(issueId);
+    setSuccess('Dismissed TLS issue');
+  };
+
+  return (
+    <div className="flex h-full bg-ub-cool-grey text-white">
+      <div className="w-2/5 border-r border-gray-700 flex flex-col">
+        <div className="p-3 space-y-2 bg-gray-900">
+          <h1 className="text-lg font-semibold">Certificate Store</h1>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <label className="flex flex-col text-xs uppercase tracking-wide text-gray-300">
+              Scope
+              <select
+                className="mt-1 rounded bg-gray-800 p-1 text-sm text-white"
+                value={scopeFilter}
+                onChange={(event) =>
+                  setScopeFilter(event.target.value as ScopeFilter)
+                }
+              >
+                <option value="all">All</option>
+                <option value="system">System</option>
+                <option value="user">User</option>
+              </select>
+            </label>
+            <label className="flex flex-col text-xs uppercase tracking-wide text-gray-300">
+              Trust state
+              <select
+                className="mt-1 rounded bg-gray-800 p-1 text-sm text-white"
+                value={statusFilter}
+                onChange={(event) =>
+                  setStatusFilter(event.target.value as 'all' | CertificateStatus)
+                }
+              >
+                <option value="all">All</option>
+                <option value="trusted">Trusted</option>
+                <option value="untrusted">Untrusted</option>
+                <option value="revoked">Revoked</option>
+              </select>
+            </label>
+            <label className="flex flex-col text-xs uppercase tracking-wide text-gray-300">
+              TLS issues
+              <select
+                className="mt-1 rounded bg-gray-800 p-1 text-sm text-white"
+                value={issueFilter}
+                onChange={(event) =>
+                  setIssueFilter(event.target.value as IssueFilter)
+                }
+              >
+                <option value="all">All</option>
+                <option value="with">With TLS issues</option>
+                <option value="without">Without TLS issues</option>
+              </select>
+            </label>
+            <label className="flex flex-col text-xs uppercase tracking-wide text-gray-300">
+              Search
+              <input
+                className="mt-1 rounded bg-gray-800 p-1 text-sm text-white"
+                type="search"
+                placeholder="Search certificates"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                aria-label="Search certificates"
+              />
+            </label>
+          </div>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          <ul className="divide-y divide-gray-800" aria-label="Certificate list">
+            {filteredCertificates.map((cert) => {
+              const status = getStatus(cert);
+              const expiry = computeExpiry(cert);
+              const issueCount = tlsIssues.filter((issue) =>
+                issue.fingerprints.includes(cert.fingerprint)
+              ).length;
+              const isSelected = selectedFingerprint === cert.fingerprint;
+              return (
+                <li key={cert.fingerprint}>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedFingerprint(cert.fingerprint)}
+                    className={`flex w-full flex-col items-start gap-1 p-3 text-left transition hover:bg-gray-800 ${
+                      isSelected ? 'bg-gray-800' : ''
+                    }`}
+                    aria-pressed={isSelected}
+                  >
+                    <div className="flex w-full items-center justify-between">
+                      <span className="font-semibold">{cert.label}</span>
+                      <span
+                        className={`rounded px-2 py-0.5 text-xs font-semibold ${statusColors[status]}`}
+                      >
+                        {statusLabels[status]}
+                      </span>
+                    </div>
+                    <div className="text-xs text-gray-300">
+                      {cert.scope === 'system' ? 'System' : 'User'} · {cert.type}
+                    </div>
+                    <div className="text-xs text-gray-400">{cert.issuer}</div>
+                    <div
+                      className={`text-xs ${
+                        expiry.status === 'expired'
+                          ? 'text-red-400'
+                          : expiry.status === 'expiring'
+                            ? 'text-yellow-300'
+                            : 'text-gray-300'
+                      }`}
+                    >
+                      {expiry.label}
+                    </div>
+                    {issueCount > 0 && (
+                      <div className="text-xs text-red-300">
+                        {pluralize(issueCount, 'TLS issue')} linked
+                      </div>
+                    )}
+                  </button>
+                </li>
+              );
+            })}
+            {filteredCertificates.length === 0 && (
+              <li className="p-3 text-sm text-gray-300">
+                No certificates match the selected filters.
+              </li>
+            )}
+          </ul>
+        </div>
+        <div className="border-t border-gray-800 p-3 space-y-2 bg-gray-900">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-200">
+            Import certificate
+          </h2>
+          <textarea
+            className="w-full rounded bg-gray-800 p-2 text-xs text-white"
+            rows={4}
+            placeholder='Paste certificate JSON (e.g. {"label":"New cert",...})'
+            value={importText}
+            onChange={(event) => setImportText(event.target.value)}
+            aria-label="Import certificate payload"
+          />
+          <button
+            type="button"
+            className="w-full rounded bg-blue-700 px-3 py-2 text-sm font-semibold hover:bg-blue-600 disabled:opacity-50"
+            onClick={handleImport}
+            disabled={!importText.trim()}
+          >
+            Import
+          </button>
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {message && (
+          <div
+            role="status"
+            className={`rounded border px-3 py-2 text-sm ${
+              message.type === 'success'
+                ? 'border-green-600 bg-green-900 text-green-100'
+                : 'border-red-700 bg-red-900 text-red-100'
+            }`}
+          >
+            {message.text}
+          </div>
+        )}
+        {selectedCertificate ? (
+          <div className="space-y-4">
+            <header className="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <h2 className="text-xl font-semibold">{selectedCertificate.label}</h2>
+                <p className="text-sm text-gray-300">{selectedCertificate.subject}</p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={handleTrust}
+                  className="rounded bg-green-700 px-3 py-1 text-sm font-semibold hover:bg-green-600"
+                >
+                  Trust
+                </button>
+                <button
+                  type="button"
+                  onClick={handleRevoke}
+                  className="rounded bg-red-800 px-3 py-1 text-sm font-semibold hover:bg-red-700"
+                >
+                  Revoke
+                </button>
+                <button
+                  type="button"
+                  onClick={handleExport}
+                  className="rounded bg-blue-700 px-3 py-1 text-sm font-semibold hover:bg-blue-600"
+                >
+                  Export
+                </button>
+              </div>
+            </header>
+            <section className="space-y-2" aria-label="Certificate metadata">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300">
+                Metadata
+              </h3>
+              <dl className="grid gap-2 text-sm">
+                <div className="flex justify-between gap-4">
+                  <dt className="text-gray-300">Issuer</dt>
+                  <dd className="flex-1 text-right text-gray-100 break-all">
+                    {selectedCertificate.issuer}
+                  </dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-gray-300">Serial</dt>
+                  <dd className="text-gray-100">{selectedCertificate.serialNumber}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-gray-300">Fingerprint</dt>
+                  <dd className="flex-1 text-right text-gray-100 break-all">
+                    {selectedCertificate.fingerprint}
+                  </dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-gray-300">Valid from</dt>
+                  <dd className="text-gray-100">{formatDate(selectedCertificate.validFrom)}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-gray-300">Valid to</dt>
+                  <dd className="text-gray-100">{formatDate(selectedCertificate.validTo)}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-gray-300">Usage</dt>
+                  <dd className="text-gray-100">{selectedCertificate.usage.join(', ')}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-gray-300">Algorithm</dt>
+                  <dd className="text-gray-100">{selectedCertificate.algorithm}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-gray-300">Scope</dt>
+                  <dd className="text-gray-100">
+                    {selectedCertificate.scope === 'system' ? 'System' : 'User'}
+                  </dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-gray-300">Status</dt>
+                  <dd>
+                    <span
+                      className={`rounded px-2 py-0.5 text-xs font-semibold ${
+                        statusColors[getStatus(selectedCertificate)]
+                      }`}
+                    >
+                      {statusLabels[getStatus(selectedCertificate)]}
+                    </span>
+                  </dd>
+                </div>
+                {selectedCertificate.notes && (
+                  <div className="flex justify-between gap-4">
+                    <dt className="text-gray-300">Notes</dt>
+                    <dd className="flex-1 text-right text-gray-100">
+                      {selectedCertificate.notes}
+                    </dd>
+                  </div>
+                )}
+                {Object.entries(selectedCertificate.metadata).map(([key, value]) => (
+                  <div className="flex justify-between gap-4" key={key}>
+                    <dt className="text-gray-300">{key}</dt>
+                    <dd className="flex-1 text-right text-gray-100 break-all">{value}</dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
+            <section className="space-y-2" aria-label="TLS issues">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300">
+                TLS Issues ({selectedIssues.length})
+              </h3>
+              {selectedIssues.length > 0 ? (
+                <ul className="space-y-3">
+                  {selectedIssues.map((issue) => (
+                    <li
+                      key={issue.id}
+                      className="rounded border border-gray-700 bg-gray-900 p-3"
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-2">
+                            <span
+                              className={`rounded px-2 py-0.5 text-xs font-semibold ${
+                                issueSeverityStyles[issue.severity] ||
+                                issueSeverityStyles.info
+                              }`}
+                            >
+                              {issue.severity.toUpperCase()}
+                            </span>
+                            <span className="text-xs text-gray-300">
+                              {issue.source}
+                            </span>
+                          </div>
+                          <p className="font-semibold">{issue.summary}</p>
+                          {issue.details && (
+                            <p className="text-sm text-gray-300">{issue.details}</p>
+                          )}
+                          <p className="text-xs text-gray-400">
+                            Detected {formatDate(issue.detectedAt)}
+                          </p>
+                          {issue.remediation && (
+                            <p className="text-xs text-gray-300">
+                              Remediation: {issue.remediation}
+                            </p>
+                          )}
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => handleDismissIssue(issue.id)}
+                          className="rounded bg-gray-800 px-2 py-1 text-xs font-semibold hover:bg-gray-700"
+                        >
+                          Dismiss
+                        </button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-gray-300">
+                  No TLS issues linked to this certificate.
+                </p>
+              )}
+            </section>
+            {exportPreview && (
+              <section className="space-y-2" aria-label="Export preview">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300">
+                  Export Preview
+                </h3>
+                <textarea
+                  className="w-full rounded bg-black p-3 font-mono text-xs text-green-200"
+                  rows={8}
+                  readOnly
+                  value={exportPreview}
+                  aria-label="Export preview content"
+                />
+              </section>
+            )}
+          </div>
+        ) : (
+          <div className="text-sm text-gray-300">
+            Select a certificate from the list to view metadata and TLS issues.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const displayCertificates = () => <CertificatesApp />;
+
+export default CertificatesApp;

--- a/docs/certificates-app.md
+++ b/docs/certificates-app.md
@@ -1,0 +1,62 @@
+# Certificates App
+
+The **Certificates** utility provides a desktop-style view of the mock trust store that powers certificate-centric demos. It
+is built entirely on top of the client-side `utils/certStore.ts` store and exposes the following behaviours:
+
+- Lists **system** and **user** certificates with quick filters for scope, trust state, TLS issue status, and a search box.
+- Highlights approaching expirations (30 day warning window) and past expirations with prominent badges.
+- Links TLS diagnostics from scanners (Nmap NSE, Nessus, Wireshark simulators, etc.) to the matching certificate fingerprint.
+  Any tool can publish to the shared `tls:issue` pubsub channel to surface an incident inside the manager.
+- Presents a metadata viewer with issuer, fingerprint, key usage, and any supplemental metadata from the store.
+- Supports mock **trust**, **revoke**, **import**, and **export** actions to mirror an OS certificate manager.
+
+## Import / Export format
+
+The `importCertificate` helper expects JSON payloads with the following minimal shape:
+
+```json
+{
+  "label": "QA Service Cert",
+  "subject": "CN=qa.lab.internal",
+  "issuer": "CN=Kali Issuing CA",
+  "validFrom": "2025-01-01T00:00:00.000Z",
+  "validTo": "2025-12-31T00:00:00.000Z",
+  "type": "Server",
+  "usage": ["Server Authentication"]
+}
+```
+
+Optional properties include `fingerprint`, `serialNumber`, `scope`, `metadata`, `algorithm`, and `trusted`. When a payload
+omits the fingerprint, the store generates a mock SHA-1 style fingerprint to keep identifiers unique.
+
+The export button returns the same structure, formatted as pretty-printed JSON so it can be pasted back into the import box or
+into other demos.
+
+## TLS issue bridge
+
+Apps that simulate TLS findings can publish incidents via the global pubsub helper:
+
+```ts
+import { publish } from '../utils/pubsub';
+
+publish('tls:issue', {
+  summary: 'Deprecated cipher suite negotiated',
+  severity: 'warning',
+  source: 'Wireshark',
+  fingerprints: ['DD:44:33:DD:44:33:DD:44:33:DD:44:33:DD:44:33:DD:44:33:DD:44:33:DD:44:33'],
+  detectedAt: new Date().toISOString(),
+  remediation: 'Rotate service certificate and disable TLS 1.0',
+});
+```
+
+The certificates app automatically subscribes to this channel and rebroadcasts the issue in the UI if it matches any known
+fingerprints. Multiple fingerprints may be supplied to cover leaf and intermediate certificates.
+
+## Store reset helpers
+
+`utils/certStore.ts` also exposes `resetCertStore()` for test suites and storybook scenarios. This repopulates the store with
+fixture certificates and TLS issues so tests remain deterministic. The React hook `useCertStore()` is used inside the
+component to subscribe to changes.
+
+Refer to `__tests__/components/apps/certificates.test.tsx` for examples that validate filtering, trust toggles, pubsub-driven
+TLS issues, and import/export flows.

--- a/utils/certStore.ts
+++ b/utils/certStore.ts
@@ -1,0 +1,446 @@
+import { useSyncExternalStore } from 'react';
+import { subscribe as subscribeToPubsub } from './pubsub';
+
+export type CertificateScope = 'system' | 'user';
+export type CertificateType = 'CA' | 'Server' | 'Client' | 'Code Signing';
+export type CertificateStatus = 'trusted' | 'untrusted' | 'revoked';
+export type TlsSeverity = 'info' | 'warning' | 'critical';
+
+export interface Certificate {
+  id: string;
+  label: string;
+  scope: CertificateScope;
+  type: CertificateType;
+  issuer: string;
+  subject: string;
+  serialNumber: string;
+  fingerprint: string;
+  validFrom: string;
+  validTo: string;
+  usage: string[];
+  algorithm: string;
+  trusted: boolean;
+  revoked: boolean;
+  metadata: Record<string, string>;
+  notes?: string;
+}
+
+export interface TlsIssue {
+  id: string;
+  source: string;
+  summary: string;
+  details?: string;
+  severity: TlsSeverity;
+  detectedAt: string;
+  fingerprints: string[];
+  remediation?: string;
+}
+
+export interface ImportCertificatePayload {
+  label: string;
+  subject: string;
+  issuer: string;
+  validFrom: string;
+  validTo: string;
+  type: CertificateType;
+  usage: string[];
+  algorithm?: string;
+  fingerprint?: string;
+  serialNumber?: string;
+  scope?: CertificateScope;
+  metadata?: Record<string, string>;
+  trusted?: boolean;
+}
+
+export interface CertStoreState {
+  certificates: Certificate[];
+  tlsIssues: TlsIssue[];
+}
+
+type Listener = () => void;
+
+type TlsIssuePayload = Partial<Omit<TlsIssue, 'id' | 'detectedAt' | 'fingerprints'>> & {
+  id?: string;
+  detectedAt?: string | number | Date;
+  fingerprints: string[];
+};
+
+const TLS_TOPIC = 'tls:issue';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+const initialCertificates: Certificate[] = [
+  {
+    id: 'root-ca',
+    label: 'Kali Root CA',
+    scope: 'system',
+    type: 'CA',
+    issuer: 'CN=Kali Root Authority, O=Kali Lab, C=CA',
+    subject: 'CN=Kali Root Authority, O=Kali Lab, C=CA',
+    serialNumber: '01',
+    fingerprint: 'AA:11:00:AA:11:00:AA:11:00:AA:11:00:AA:11:00:AA:11:00:AA:11:00:AA:11:00',
+    validFrom: '2020-01-01T00:00:00.000Z',
+    validTo: '2035-12-31T23:59:59.000Z',
+    usage: ['Certificate Signing', 'CRL Signing'],
+    algorithm: 'RSA-4096',
+    trusted: true,
+    revoked: false,
+    metadata: {
+      subjectAltName: 'DNS:root-ca.kali.lan',
+      keyUsage: 'Digital Signature, Certificate Sign, CRL Sign',
+      extendedKeyUsage: 'N/A',
+    },
+  },
+  {
+    id: 'vpn-gateway',
+    label: 'Lab VPN Gateway',
+    scope: 'system',
+    type: 'Server',
+    issuer: 'CN=Kali Root Authority, O=Kali Lab, C=CA',
+    subject: 'CN=vpn.lab.internal, O=Kali Lab',
+    serialNumber: '02',
+    fingerprint: 'BB:22:11:BB:22:11:BB:22:11:BB:22:11:BB:22:11:BB:22:11:BB:22:11:BB:22:11',
+    validFrom: '2024-01-01T00:00:00.000Z',
+    validTo: '2025-01-20T00:00:00.000Z',
+    usage: ['Server Authentication', 'Key Encipherment'],
+    algorithm: 'ECDSA-P256',
+    trusted: true,
+    revoked: false,
+    metadata: {
+      subjectAltName: 'DNS:vpn.lab.internal, DNS:vpn.lab',
+      keyUsage: 'Digital Signature, Key Encipherment',
+      extendedKeyUsage: 'TLS Web Server Authentication',
+    },
+  },
+  {
+    id: 'legacy-proxy',
+    label: 'Legacy Proxy Certificate',
+    scope: 'system',
+    type: 'Server',
+    issuer: 'CN=Legacy Signing Authority, O=Retired Systems, C=US',
+    subject: 'CN=proxy.legacy.local, O=Retired Systems',
+    serialNumber: '0F',
+    fingerprint: 'CC:33:22:CC:33:22:CC:33:22:CC:33:22:CC:33:22:CC:33:22:CC:33:22:CC:33:22',
+    validFrom: '2018-03-01T00:00:00.000Z',
+    validTo: '2024-04-01T00:00:00.000Z',
+    usage: ['Server Authentication'],
+    algorithm: 'RSA-2048',
+    trusted: false,
+    revoked: true,
+    metadata: {
+      subjectAltName: 'DNS:proxy.legacy.local',
+      keyUsage: 'Digital Signature, Key Encipherment',
+      extendedKeyUsage: 'TLS Web Server Authentication',
+    },
+    notes: 'Legacy proxy decommissioned; certificate revoked.',
+  },
+  {
+    id: 'dev-signing',
+    label: 'Developer Signing Cert',
+    scope: 'user',
+    type: 'Code Signing',
+    issuer: 'CN=Kali Issuing CA, O=Kali Lab, C=CA',
+    subject: 'CN=Alex Dev, OU=Engineering, O=Kali Lab',
+    serialNumber: 'AC1D3V',
+    fingerprint: 'DD:44:33:DD:44:33:DD:44:33:DD:44:33:DD:44:33:DD:44:33:DD:44:33:DD:44:33',
+    validFrom: '2024-06-15T00:00:00.000Z',
+    validTo: '2026-06-15T00:00:00.000Z',
+    usage: ['Code Signing', 'Digital Signature'],
+    algorithm: 'RSA-3072',
+    trusted: false,
+    revoked: false,
+    metadata: {
+      subjectAltName: 'email:alex@lab.internal',
+      keyUsage: 'Digital Signature, Non Repudiation',
+      extendedKeyUsage: 'Code Signing',
+    },
+  },
+];
+
+const initialIssues: TlsIssue[] = [
+  {
+    id: 'issue-vpn-handshake',
+    source: 'Nmap NSE',
+    summary: 'TLS handshake failed: certificate about to expire',
+    details:
+      'TLS enumeration scripts flagged vpn.lab.internal due to a certificate expiring soon. Renew before users are locked out.',
+    severity: 'warning',
+    detectedAt: '2024-12-30T12:00:00.000Z',
+    fingerprints: [initialCertificates[1].fingerprint],
+    remediation: 'Generate new server certificate from Kali Root Authority and redeploy.',
+  },
+  {
+    id: 'issue-legacy-expired',
+    source: 'Nessus',
+    summary: 'Expired TLS certificate served by proxy.legacy.local',
+    details:
+      'Historical scans show the legacy proxy serving an expired certificate. Confirm service is offline.',
+    severity: 'critical',
+    detectedAt: '2024-05-02T09:30:00.000Z',
+    fingerprints: [initialCertificates[2].fingerprint],
+    remediation: 'Remove legacy proxy entries from load balancer and revoke certificate.',
+  },
+];
+
+let state: CertStoreState = {
+  certificates: initialCertificates.map(cloneCertificate),
+  tlsIssues: initialIssues.map(cloneIssue),
+};
+
+const listeners = new Set<Listener>();
+
+function cloneCertificate(cert: Certificate): Certificate {
+  return {
+    ...cert,
+    usage: [...cert.usage],
+    metadata: { ...cert.metadata },
+  };
+}
+
+function cloneIssue(issue: TlsIssue): TlsIssue {
+  return {
+    ...issue,
+    fingerprints: [...issue.fingerprints],
+  };
+}
+
+function createSnapshot(): CertStoreState {
+  return {
+    certificates: state.certificates.map(cloneCertificate),
+    tlsIssues: state.tlsIssues.map(cloneIssue),
+  };
+}
+
+let snapshotCache: CertStoreState = createSnapshot();
+
+function recomputeSnapshot(): void {
+  snapshotCache = createSnapshot();
+}
+
+function emit(): void {
+  recomputeSnapshot();
+  listeners.forEach((listener) => listener());
+}
+
+function snapshot(): CertStoreState {
+  return snapshotCache;
+}
+
+function ensureFingerprintUnique(fingerprint: string): string {
+  let candidate = fingerprint.toUpperCase();
+  const existing = new Set(state.certificates.map((c) => c.fingerprint));
+  while (existing.has(candidate)) {
+    candidate = generateFingerprint();
+  }
+  return candidate;
+}
+
+function generateFingerprint(): string {
+  const parts = Array.from({ length: 20 }, () =>
+    Math.floor(Math.random() * 256)
+      .toString(16)
+      .padStart(2, '0')
+      .toUpperCase()
+  );
+  return parts.join(':');
+}
+
+function generateSerialNumber(): string {
+  return Math.floor(Date.now() + Math.random() * ONE_DAY_MS)
+    .toString(16)
+    .toUpperCase();
+}
+
+function normalizeIssuePayload(payload: TlsIssuePayload): TlsIssue {
+  const detectedAt =
+    payload.detectedAt instanceof Date
+      ? payload.detectedAt.toISOString()
+      : typeof payload.detectedAt === 'number'
+        ? new Date(payload.detectedAt).toISOString()
+        : payload.detectedAt || new Date().toISOString();
+
+  return {
+    id: payload.id || `tls-issue-${Date.now()}`,
+    source: payload.source || 'Unknown',
+    summary: payload.summary || 'Unspecified TLS issue',
+    details: payload.details,
+    severity: payload.severity || 'warning',
+    detectedAt,
+    fingerprints: payload.fingerprints.length ? payload.fingerprints : [],
+    remediation: payload.remediation,
+  };
+}
+
+function updateIssueLinks(issue: TlsIssue): void {
+  if (!issue.fingerprints.length) return;
+  const knownFingerprints = new Set(state.certificates.map((c) => c.fingerprint));
+  issue.fingerprints = issue.fingerprints.filter((fp) => knownFingerprints.has(fp));
+}
+
+export function getState(): CertStoreState {
+  return createSnapshot();
+}
+
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function useCertStore(): CertStoreState {
+  return useSyncExternalStore(subscribe, snapshot, snapshot);
+}
+
+export function getStatus(cert: Certificate): CertificateStatus {
+  if (cert.revoked) return 'revoked';
+  if (cert.trusted) return 'trusted';
+  return 'untrusted';
+}
+
+export function trustCertificate(fingerprint: string): void {
+  const cert = state.certificates.find((c) => c.fingerprint === fingerprint);
+  if (!cert) return;
+  cert.trusted = true;
+  cert.revoked = false;
+  emit();
+}
+
+export function revokeCertificate(fingerprint: string): void {
+  const cert = state.certificates.find((c) => c.fingerprint === fingerprint);
+  if (!cert) return;
+  cert.revoked = true;
+  cert.trusted = false;
+  emit();
+}
+
+export function removeCertificate(fingerprint: string): void {
+  const index = state.certificates.findIndex((c) => c.fingerprint === fingerprint);
+  if (index === -1) return;
+  state.certificates.splice(index, 1);
+  state.tlsIssues = state.tlsIssues.map((issue) => ({
+    ...issue,
+    fingerprints: issue.fingerprints.filter((fp) => fp !== fingerprint),
+  }));
+  emit();
+}
+
+export function importCertificate(
+  payload: string | ImportCertificatePayload
+): Certificate {
+  let parsed: ImportCertificatePayload;
+  if (typeof payload === 'string') {
+    try {
+      parsed = JSON.parse(payload) as ImportCertificatePayload;
+    } catch (err) {
+      throw new Error('Certificate import expects JSON payload.');
+    }
+  } else {
+    parsed = payload;
+  }
+
+  if (!parsed || !parsed.label || !parsed.subject || !parsed.issuer) {
+    throw new Error('Certificate payload missing required fields.');
+  }
+
+  const fingerprint = ensureFingerprintUnique(
+    parsed.fingerprint || generateFingerprint()
+  );
+
+  const cert: Certificate = {
+    id: parsed.serialNumber || fingerprint,
+    label: parsed.label,
+    scope: parsed.scope || 'user',
+    type: parsed.type,
+    issuer: parsed.issuer,
+    subject: parsed.subject,
+    serialNumber: parsed.serialNumber || generateSerialNumber(),
+    fingerprint,
+    validFrom: parsed.validFrom,
+    validTo: parsed.validTo,
+    usage: [...parsed.usage],
+    algorithm: parsed.algorithm || 'RSA-2048',
+    trusted: parsed.trusted ?? false,
+    revoked: false,
+    metadata: {
+      ...(parsed.metadata || {}),
+    },
+  };
+
+  state.certificates.push(cert);
+  emit();
+  return cloneCertificate(cert);
+}
+
+export function exportCertificate(fingerprint: string): string | null {
+  const cert = state.certificates.find((c) => c.fingerprint === fingerprint);
+  if (!cert) return null;
+  const payload = {
+    label: cert.label,
+    issuer: cert.issuer,
+    subject: cert.subject,
+    serialNumber: cert.serialNumber,
+    fingerprint: cert.fingerprint,
+    validFrom: cert.validFrom,
+    validTo: cert.validTo,
+    usage: cert.usage,
+    algorithm: cert.algorithm,
+    scope: cert.scope,
+    trusted: cert.trusted,
+    revoked: cert.revoked,
+    metadata: cert.metadata,
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+export function recordTlsIssue(payload: TlsIssuePayload): TlsIssue {
+  const issue = normalizeIssuePayload(payload);
+  updateIssueLinks(issue);
+
+  const existingIndex = state.tlsIssues.findIndex((i) => i.id === issue.id);
+  if (existingIndex >= 0) {
+    state.tlsIssues[existingIndex] = issue;
+  } else {
+    state.tlsIssues = [issue, ...state.tlsIssues];
+  }
+  emit();
+  return cloneIssue(issue);
+}
+
+export function dismissTlsIssue(issueId: string): void {
+  const before = state.tlsIssues.length;
+  state.tlsIssues = state.tlsIssues.filter((issue) => issue.id !== issueId);
+  if (state.tlsIssues.length !== before) {
+    emit();
+  }
+}
+
+export function resetCertStore(): void {
+  state = {
+    certificates: initialCertificates.map(cloneCertificate),
+    tlsIssues: initialIssues.map(cloneIssue),
+  };
+  emit();
+}
+
+subscribeToPubsub(TLS_TOPIC, (data) => {
+  if (!data || typeof data !== 'object') return;
+  const payload = data as TlsIssuePayload;
+  if (!Array.isArray(payload.fingerprints)) return;
+  recordTlsIssue(payload);
+});
+
+const certStore = {
+  getState,
+  useCertStore,
+  trustCertificate,
+  revokeCertificate,
+  removeCertificate,
+  importCertificate,
+  exportCertificate,
+  recordTlsIssue,
+  dismissTlsIssue,
+  resetCertStore,
+};
+
+export default certStore;


### PR DESCRIPTION
## Summary
- add a certificates desktop app with filter controls, expiry warnings, metadata viewer, and TLS issue linking
- provide a mock certStore with import/export, trust/revoke actions, and pubsub-backed TLS incident ingestion
- document the workflow and exercise the main UI flows in a dedicated Jest suite

## Testing
- yarn exec eslint components/apps/certificates/index.tsx utils/certStore.ts __tests__/components/apps/certificates.test.tsx docs/certificates-app.md
- yarn test __tests__/components/apps/certificates.test.tsx --runInBand --noStackTrace
- yarn lint *(fails: repo has hundreds of pre-existing accessibility and window/document warnings)*
- yarn test *(fails: repo has existing failures such as __tests__/window.test.tsx and __tests__/nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1694c0f48328a41ed78c29cf9eea