### PR TITLE
[utilities] add credentials vault app

### DIFF
--- a/__tests__/components/apps/credentials-vault.test.tsx
+++ b/__tests__/components/apps/credentials-vault.test.tsx
@@ -1,0 +1,171 @@
+import React, { useEffect } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { webcrypto } from 'crypto';
+import {
+  SecretVaultProvider,
+  useSecretVault,
+} from '../../../hooks/useSecretVault';
+import {
+  SECRET_VAULT_DB_NAME,
+  SECRET_VAULT_STORE,
+  cancelClipboardWipe,
+  createVaultSession,
+  readVaultSecrets,
+  scheduleClipboardWipe,
+  writeVaultSecret,
+} from '../../../utils/secretVault';
+
+declare const indexedDB: IDBFactory;
+
+describe('Credentials Vault', () => {
+  beforeAll(() => {
+    Object.defineProperty(global, 'crypto', {
+      value: webcrypto,
+      configurable: true,
+    });
+  });
+
+  const resetVaultDb = async () =>
+    new Promise<void>((resolve, reject) => {
+      const request = indexedDB.deleteDatabase(SECRET_VAULT_DB_NAME);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+      request.onblocked = () => resolve();
+    });
+
+  beforeEach(async () => {
+    await resetVaultDb();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('encrypts secrets and decrypts them with the passphrase', async () => {
+    const session = await createVaultSession('passphrase');
+    const saved = await writeVaultSecret(session, {
+      label: 'Email',
+      username: 'alice',
+      password: 'SuperSecret!',
+      notes: 'Primary inbox account',
+      metadata: {
+        scopes: ['personal'],
+        tags: ['accounts/email'],
+        restrictCopy: false,
+        expiresAt: null,
+      },
+    });
+    const stored = await session.db.get(SECRET_VAULT_STORE, saved.id);
+    expect(stored).toBeDefined();
+    expect(stored?.payload).not.toContain('SuperSecret!');
+
+    const roundTrip = await readVaultSecrets(session);
+    expect(roundTrip).toHaveLength(1);
+    expect(roundTrip[0]).toMatchObject({
+      label: 'Email',
+      username: 'alice',
+      password: 'SuperSecret!',
+    });
+    session.db.close();
+  });
+
+  it('segregates expired items via the unlock context', async () => {
+    const session = await createVaultSession('vault-pass');
+    const now = Date.now();
+    await writeVaultSecret(session, {
+      label: 'VPN',
+      username: 'corp-user',
+      password: 'vpn',
+      notes: '',
+      metadata: {
+        scopes: ['work'],
+        tags: ['remote/access'],
+        restrictCopy: false,
+        expiresAt: now + 60_000,
+      },
+    });
+    await writeVaultSecret(session, {
+      label: 'Temp access',
+      username: 'contractor',
+      password: 'temp',
+      notes: '',
+      metadata: {
+        scopes: ['work'],
+        tags: ['remote/access'],
+        restrictCopy: false,
+        expiresAt: now - 60_000,
+      },
+    });
+    session.db.close();
+
+    const originalPrompt = window.prompt;
+    Object.defineProperty(window, 'prompt', {
+      configurable: true,
+      writable: true,
+      value: jest.fn().mockReturnValue('vault-pass'),
+    });
+
+    const Harness: React.FC = () => {
+      const { unlock, activeItems, expiredItems } = useSecretVault();
+      useEffect(() => {
+        unlock();
+      }, [unlock]);
+      return (
+        <>
+          <span data-testid="active-count">{activeItems.length}</span>
+          <span data-testid="expired-count">{expiredItems.length}</span>
+        </>
+      );
+    };
+
+    render(
+      <SecretVaultProvider>
+        <Harness />
+      </SecretVaultProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active-count').textContent).toBe('1');
+    });
+    expect(screen.getByTestId('expired-count').textContent).toBe('1');
+
+    if (originalPrompt) {
+      Object.defineProperty(window, 'prompt', {
+        configurable: true,
+        writable: true,
+        value: originalPrompt,
+      });
+    } else {
+      delete (window as any).prompt;
+    }
+  });
+
+  it('clears the clipboard after the scheduled timeout and on teardown', async () => {
+    jest.useFakeTimers();
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    const originalClipboard = navigator.clipboard;
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    scheduleClipboardWipe(20000);
+    jest.advanceTimersByTime(20000);
+    await Promise.resolve();
+    expect(writeText).toHaveBeenCalledWith('');
+
+    writeText.mockClear();
+    scheduleClipboardWipe(20000);
+    await cancelClipboardWipe({ wipe: true });
+    expect(writeText).toHaveBeenCalledWith('');
+
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: originalClipboard,
+        configurable: true,
+      });
+    } else {
+      delete (navigator as any).clipboard;
+    }
+    jest.useRealTimers();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -97,6 +97,7 @@ const KismetApp = createDynamicApp('kismet.jsx', 'Kismet');
 const HashcatApp = createDynamicApp('hashcat', 'Hashcat');
 const MsfPostApp = createDynamicApp('msf-post', 'Metasploit Post');
 const EvidenceVaultApp = createDynamicApp('evidence-vault', 'Evidence Vault');
+const CredentialsVaultApp = createDynamicApp('credentials-vault', 'Credentials Vault');
 const MimikatzApp = createDynamicApp('mimikatz', 'Mimikatz');
 const MimikatzOfflineApp = createDynamicApp('mimikatz/offline', 'Mimikatz Offline');
 const EttercapApp = createDynamicApp('ettercap', 'Ettercap');
@@ -182,6 +183,7 @@ const displayVolatility = createDisplay(VolatilityApp);
 
 const displayMsfPost = createDisplay(MsfPostApp);
 const displayEvidenceVault = createDisplay(EvidenceVaultApp);
+const displayCredentialsVault = createDisplay(CredentialsVaultApp);
 const displayMimikatz = createDisplay(MimikatzApp);
 const displayMimikatzOffline = createDisplay(MimikatzOfflineApp);
 const displayEttercap = createDisplay(EttercapApp);
@@ -230,6 +232,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayClipboardManager,
+  },
+  {
+    id: 'credentials-vault',
+    title: 'Credentials Vault',
+    icon: '/themes/Yaru/apps/credentials-vault.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayCredentialsVault,
   },
   {
     id: 'figlet',

--- a/components/apps/credentials-vault/index.tsx
+++ b/components/apps/credentials-vault/index.tsx
@@ -1,0 +1,615 @@
+"use client";
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  SecretVaultProvider,
+  useSecretVault,
+} from '../../../hooks/useSecretVault';
+import {
+  cancelClipboardWipe,
+  scheduleClipboardWipe,
+  type SecretVaultDecryptedItem,
+} from '../../../utils/secretVault';
+import { logVaultCopy } from '../../../utils/analytics';
+
+type FormState = {
+  id?: string;
+  label: string;
+  username: string;
+  password: string;
+  notes: string;
+  scopes: string;
+  tags: string;
+  expiresAt: string;
+  restrictCopy: boolean;
+};
+
+const emptyForm: FormState = {
+  label: '',
+  username: '',
+  password: '',
+  notes: '',
+  scopes: '',
+  tags: '',
+  expiresAt: '',
+  restrictCopy: false,
+};
+
+interface TagNode {
+  path: string;
+  children: Record<string, TagNode>;
+}
+
+const buildTagTree = (items: SecretVaultDecryptedItem[]): Record<string, TagNode> => {
+  const root: Record<string, TagNode> = {};
+  items.forEach((item) => {
+    item.metadata.tags.forEach((tag) => {
+      const segments = tag
+        .split('/')
+        .map((segment) => segment.trim())
+        .filter(Boolean);
+      let cursor = root;
+      let currentPath = '';
+      segments.forEach((segment) => {
+        currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+        if (!cursor[segment]) {
+          cursor[segment] = { path: currentPath, children: {} };
+        }
+        cursor = cursor[segment].children;
+      });
+    });
+  });
+  return root;
+};
+
+const TagTree: React.FC<{
+  data: Record<string, TagNode>;
+  selected: string | null;
+  onSelect: (tag: string) => void;
+}> = ({ data, selected, onSelect }) => {
+  if (!data || Object.keys(data).length === 0) {
+    return <p className="text-xs text-gray-500">No tags defined.</p>;
+  }
+  return (
+    <ul className="pl-3 space-y-1 text-sm">
+      {Object.entries(data).map(([name, node]) => (
+        <TagTreeNode
+          key={node.path}
+          name={name}
+          node={node}
+          selected={selected}
+          onSelect={onSelect}
+        />
+      ))}
+    </ul>
+  );
+};
+
+const TagTreeNode: React.FC<{
+  name: string;
+  node: TagNode;
+  selected: string | null;
+  onSelect: (tag: string) => void;
+}> = ({ name, node, selected, onSelect }) => {
+  const hasChildren = Object.keys(node.children).length > 0;
+  const isSelected = selected === node.path;
+  return (
+    <li className="mb-1">
+      <button
+        type="button"
+        onClick={() => onSelect(node.path)}
+        className={`text-left hover:underline focus:outline-none ${
+          isSelected ? 'text-blue-300' : ''
+        }`}
+      >
+        {name}
+      </button>
+      {hasChildren && (
+        <TagTree data={node.children} selected={selected} onSelect={onSelect} />
+      )}
+    </li>
+  );
+};
+
+const parseListInput = (value: string): string[] =>
+  value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+const formatDateForInput = (timestamp: number | null): string => {
+  if (!timestamp) return '';
+  const iso = new Date(timestamp).toISOString();
+  return iso.slice(0, 10);
+};
+
+const formatExpiryDisplay = (timestamp: number | null): string => {
+  if (!timestamp) return 'No expiry';
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? 'No expiry' : date.toLocaleString();
+};
+
+const maskPassword = (password: string): string => {
+  if (!password) return '';
+  return '•'.repeat(Math.min(password.length, 8));
+};
+
+const CredentialsVaultPanel: React.FC = () => {
+  const {
+    locked,
+    unlock,
+    loading,
+    error,
+    items,
+    activeItems,
+    expiredItems,
+    expiryWarnings,
+    saveSecret,
+    deleteSecret,
+  } = useSecretVault();
+  const [selectedScope, setSelectedScope] = useState<string | null>(null);
+  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [formState, setFormState] = useState<FormState>({ ...emptyForm });
+
+  useEffect(() => {
+    return () => {
+      void cancelClipboardWipe({ wipe: true });
+    };
+  }, []);
+
+  const scopes = useMemo(() => {
+    const set = new Set<string>();
+    items.forEach((item) => {
+      item.metadata.scopes.forEach((scope) => set.add(scope));
+    });
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [items]);
+
+  const tagTree = useMemo(() => buildTagTree(items), [items]);
+
+  const handleTagSelect = useCallback((tag: string) => {
+    setSelectedTag((prev) => (prev === tag ? null : tag));
+  }, []);
+
+  const matchesFilters = useCallback(
+    (item: SecretVaultDecryptedItem) => {
+      const scopeMatch = !selectedScope || item.metadata.scopes.includes(selectedScope);
+      const tagMatch = !selectedTag || item.metadata.tags.includes(selectedTag);
+      return scopeMatch && tagMatch;
+    },
+    [selectedScope, selectedTag]
+  );
+
+  const filteredActive = useMemo(
+    () => activeItems.filter(matchesFilters),
+    [activeItems, matchesFilters]
+  );
+  const filteredExpired = useMemo(
+    () => expiredItems.filter(matchesFilters),
+    [expiredItems, matchesFilters]
+  );
+
+  const handleCopy = useCallback(
+    async (item: SecretVaultDecryptedItem, value: string, label: string) => {
+      if (item.metadata.restrictCopy) {
+        setStatus('Copy is disabled for this credential.');
+        return;
+      }
+      if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+        setStatus('Clipboard access is unavailable.');
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(value);
+        scheduleClipboardWipe();
+        logVaultCopy(label);
+        setStatus(`${label} copied. Clipboard will clear in 20 seconds.`);
+      } catch {
+        setStatus('Failed to copy to clipboard.');
+      }
+    },
+    []
+  );
+
+  const handleEdit = useCallback((item: SecretVaultDecryptedItem) => {
+    setFormState({
+      id: item.id,
+      label: item.label,
+      username: item.username,
+      password: item.password,
+      notes: item.notes ?? '',
+      scopes: item.metadata.scopes.join(', '),
+      tags: item.metadata.tags.join(', '),
+      expiresAt: formatDateForInput(item.metadata.expiresAt),
+      restrictCopy: item.metadata.restrictCopy,
+    });
+    setFormError(null);
+    setStatus(null);
+  }, []);
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      const confirmed =
+        typeof window === 'undefined' ? true : window.confirm('Delete this credential?');
+      if (!confirmed) return;
+      await deleteSecret(id);
+      setStatus('Credential removed.');
+      if (formState.id === id) {
+        setFormState({ ...emptyForm });
+      }
+    },
+    [deleteSecret, formState.id]
+  );
+
+  const handleFieldChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const { name, value, type, checked } = event.target;
+      setFormState((prev) => ({
+        ...prev,
+        [name]: type === 'checkbox' ? checked : value,
+      }));
+    },
+    []
+  );
+
+  const handleFormReset = useCallback(() => {
+    setFormState({ ...emptyForm });
+    setFormError(null);
+    setStatus(null);
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setFormError(null);
+      setStatus(null);
+
+      if (!formState.label.trim() || !formState.username.trim() || !formState.password) {
+        setFormError('Label, username, and password are required.');
+        return;
+      }
+
+      const expiryValue = formState.expiresAt
+        ? Date.parse(formState.expiresAt)
+        : null;
+      if (formState.expiresAt && Number.isNaN(expiryValue)) {
+        setFormError('Enter a valid expiration date.');
+        return;
+      }
+
+      const saved = await saveSecret({
+        id: formState.id,
+        label: formState.label.trim(),
+        username: formState.username,
+        password: formState.password,
+        notes: formState.notes,
+        metadata: {
+          scopes: parseListInput(formState.scopes),
+          tags: parseListInput(formState.tags),
+          restrictCopy: formState.restrictCopy,
+          expiresAt: expiryValue,
+        },
+      });
+
+      if (saved) {
+        setStatus('Credential saved.');
+        setFormState({ ...emptyForm });
+      }
+    },
+    [formState, saveSecret]
+  );
+
+  if (locked) {
+    return (
+      <div className="h-full w-full bg-gray-900 text-white p-6 flex flex-col items-center justify-center text-center space-y-3">
+        <h2 className="text-xl font-semibold">Credentials Vault</h2>
+        <p className="text-sm text-gray-300">
+          Unlock the vault to access encrypted credentials stored in IndexedDB.
+        </p>
+        {error && <p className="text-sm text-red-400">{error}</p>}
+        <button
+          type="button"
+          onClick={unlock}
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded"
+        >
+          Unlock Vault
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col">
+      {status && <div className="mb-2 text-xs text-green-400">{status}</div>}
+      {error && <div className="mb-2 text-xs text-red-400">{error}</div>}
+      {loading && <div className="mb-2 text-xs text-gray-300">Loading vault data…</div>}
+      {expiryWarnings.length > 0 && (
+        <div className="mb-3 text-xs text-yellow-300">
+          {expiryWarnings.length} credential{expiryWarnings.length === 1 ? '' : 's'} expiring soon.
+        </div>
+      )}
+      <div className="flex flex-1 gap-4 overflow-hidden">
+        <aside className="w-1/3 border-r border-gray-700 pr-4 overflow-auto space-y-4">
+          <section>
+            <h3 className="text-sm font-semibold mb-2">Scopes</h3>
+            <ul className="space-y-1 text-sm">
+              <li>
+                <button
+                  type="button"
+                  onClick={() => setSelectedScope(null)}
+                  className={`hover:underline ${selectedScope === null ? 'text-blue-300' : ''}`}
+                >
+                  All scopes
+                </button>
+              </li>
+              {scopes.map((scope) => (
+                <li key={scope}>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setSelectedScope((prev) => (prev === scope ? null : scope))
+                    }
+                    className={`hover:underline ${selectedScope === scope ? 'text-blue-300' : ''}`}
+                  >
+                    {scope}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
+          <section>
+            <h3 className="text-sm font-semibold mb-2">Tags</h3>
+            {selectedTag && (
+              <button
+                type="button"
+                onClick={() => setSelectedTag(null)}
+                className="mb-2 text-xs text-blue-300 hover:underline"
+              >
+                Clear tag filter
+              </button>
+            )}
+            <TagTree data={tagTree} selected={selectedTag} onSelect={handleTagSelect} />
+          </section>
+        </aside>
+        <section className="flex-1 overflow-hidden flex flex-col gap-4">
+          <form
+            onSubmit={handleSubmit}
+            onReset={handleFormReset}
+            className="bg-gray-800 rounded p-4 space-y-3"
+          >
+            <h3 className="text-sm font-semibold">Add or edit credential</h3>
+            {formError && <p className="text-xs text-red-300">{formError}</p>}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs">
+              <label className="flex flex-col space-y-1">
+                <span>Label</span>
+                <input
+                  className="bg-gray-900 border border-gray-700 rounded px-2 py-1"
+                  name="label"
+                  value={formState.label}
+                  onChange={handleFieldChange}
+                  required
+                />
+              </label>
+              <label className="flex flex-col space-y-1">
+                <span>Username</span>
+                <input
+                  className="bg-gray-900 border border-gray-700 rounded px-2 py-1"
+                  name="username"
+                  value={formState.username}
+                  onChange={handleFieldChange}
+                  required
+                />
+              </label>
+              <label className="flex flex-col space-y-1">
+                <span>Password</span>
+                <input
+                  className="bg-gray-900 border border-gray-700 rounded px-2 py-1"
+                  name="password"
+                  type="password"
+                  value={formState.password}
+                  onChange={handleFieldChange}
+                  required
+                />
+              </label>
+              <label className="flex flex-col space-y-1">
+                <span>Expiry</span>
+                <input
+                  className="bg-gray-900 border border-gray-700 rounded px-2 py-1"
+                  name="expiresAt"
+                  type="date"
+                  value={formState.expiresAt}
+                  onChange={handleFieldChange}
+                />
+              </label>
+              <label className="flex flex-col space-y-1 md:col-span-2">
+                <span>Scopes (comma separated)</span>
+                <input
+                  className="bg-gray-900 border border-gray-700 rounded px-2 py-1"
+                  name="scopes"
+                  value={formState.scopes}
+                  onChange={handleFieldChange}
+                  placeholder="e.g. work, personal"
+                />
+              </label>
+              <label className="flex flex-col space-y-1 md:col-span-2">
+                <span>Tags (comma separated, use / for hierarchy)</span>
+                <input
+                  className="bg-gray-900 border border-gray-700 rounded px-2 py-1"
+                  name="tags"
+                  value={formState.tags}
+                  onChange={handleFieldChange}
+                  placeholder="finance/banking, identity"
+                />
+              </label>
+              <label className="flex flex-col space-y-1 md:col-span-2">
+                <span>Notes</span>
+                <textarea
+                  className="bg-gray-900 border border-gray-700 rounded px-2 py-1"
+                  name="notes"
+                  rows={2}
+                  value={formState.notes}
+                  onChange={handleFieldChange}
+                />
+              </label>
+            </div>
+            <label className="flex items-center space-x-2 text-xs">
+              <input
+                type="checkbox"
+                name="restrictCopy"
+                checked={formState.restrictCopy}
+                onChange={handleFieldChange}
+              />
+              <span>Disable clipboard copy for this credential</span>
+            </label>
+            <div className="flex gap-2 text-xs">
+              <button
+                type="submit"
+                className="px-3 py-1 bg-blue-600 hover:bg-blue-500 rounded"
+                disabled={loading}
+              >
+                Save Credential
+              </button>
+              <button
+                type="reset"
+                className="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+              >
+                Reset
+              </button>
+            </div>
+          </form>
+          <div className="flex-1 overflow-auto space-y-4 pb-2">
+            <section>
+              <header className="flex items-center justify-between mb-2">
+                <h3 className="text-sm font-semibold">Active credentials</h3>
+                <span className="text-xs text-gray-400">{filteredActive.length}</span>
+              </header>
+              {filteredActive.length === 0 ? (
+                <p className="text-xs text-gray-500">No active credentials match the current filters.</p>
+              ) : (
+                <ul className="space-y-3">
+                  {filteredActive.map((item) => (
+                    <li key={item.id} className="bg-gray-800 rounded p-3 space-y-2">
+                      <div className="flex items-baseline justify-between gap-2">
+                        <h4 className="font-semibold text-sm">{item.label}</h4>
+                        <span className="text-xs text-gray-400">
+                          Expires: {formatExpiryDisplay(item.metadata.expiresAt)}
+                        </span>
+                      </div>
+                      <p className="text-xs text-gray-400">
+                        Scopes: {item.metadata.scopes.length ? item.metadata.scopes.join(', ') : 'None'}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        Tags: {item.metadata.tags.length ? item.metadata.tags.join(', ') : 'None'}
+                      </p>
+                      <p className="text-xs text-gray-300">Username: {item.username}</p>
+                      <p className="text-xs text-gray-300">Password: {maskPassword(item.password)}</p>
+                      {item.notes && (
+                        <p className="text-xs text-gray-300 whitespace-pre-wrap">{item.notes}</p>
+                      )}
+                      <div className="flex flex-wrap gap-2 text-xs pt-1">
+                        <button
+                          type="button"
+                          onClick={() => handleCopy(item, item.username, `${item.label} username`)}
+                          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+                          disabled={item.metadata.restrictCopy}
+                        >
+                          Copy username
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleCopy(item, item.password, `${item.label} password`)}
+                          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+                          disabled={item.metadata.restrictCopy}
+                        >
+                          Copy password
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleEdit(item)}
+                          className="px-2 py-1 bg-blue-700 hover:bg-blue-600 rounded"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(item.id)}
+                          className="px-2 py-1 bg-red-700 hover:bg-red-600 rounded"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                      {item.metadata.restrictCopy && (
+                        <p className="text-[0.65rem] text-yellow-300">
+                          Copying is disabled. Update the credential to allow clipboard export.
+                        </p>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+            <section>
+              <header className="flex items-center justify-between mb-2">
+                <h3 className="text-sm font-semibold">Expired credentials</h3>
+                <span className="text-xs text-gray-400">{filteredExpired.length}</span>
+              </header>
+              {filteredExpired.length === 0 ? (
+                <p className="text-xs text-gray-500">No expired credentials.</p>
+              ) : (
+                <ul className="space-y-3">
+                  {filteredExpired.map((item) => (
+                    <li key={item.id} className="bg-gray-800 rounded p-3 space-y-2 border border-red-800">
+                      <div className="flex items-baseline justify-between gap-2">
+                        <h4 className="font-semibold text-sm">{item.label}</h4>
+                        <span className="text-xs text-red-300">
+                          Expired: {formatExpiryDisplay(item.metadata.expiresAt)}
+                        </span>
+                      </div>
+                      <p className="text-xs text-gray-300">Username: {item.username}</p>
+                      {item.notes && (
+                        <p className="text-xs text-gray-300 whitespace-pre-wrap">{item.notes}</p>
+                      )}
+                      <div className="flex flex-wrap gap-2 text-xs pt-1">
+                        <button
+                          type="button"
+                          onClick={() => handleEdit(item)}
+                          className="px-2 py-1 bg-blue-700 hover:bg-blue-600 rounded"
+                        >
+                          Renew
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(item.id)}
+                          className="px-2 py-1 bg-red-700 hover:bg-red-600 rounded"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+const CredentialsVaultApp: React.FC = () => (
+  <SecretVaultProvider>
+    <CredentialsVaultPanel />
+  </SecretVaultProvider>
+);
+
+export const displayCredentialsVault = () => <CredentialsVaultApp />;
+
+export default CredentialsVaultApp;

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -54,6 +54,9 @@ Tools to cover: **BeEF, Ettercap, Metasploit, Wireshark, Kismet, Nikto, Autopsy,
 ### About Alex
 - Replace static content with resume widget loaded from JSON; show skills as chips and project links.
 
+### Credentials Vault
+- Maintain encrypted IndexedDB credential store with passphrase unlock workflow, expiry warnings, and clipboard auto-wipe instrumentation.
+
 ### Settings
 - Add theme picker, wallpaper selector, and "reset desktop" clearing `localStorage` in `settingsStore.js`.
 

--- a/hooks/useSecretVault.tsx
+++ b/hooks/useSecretVault.tsx
@@ -1,0 +1,195 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  createVaultSession,
+  readVaultSecrets,
+  writeVaultSecret,
+  deleteVaultSecret,
+  deriveExpiryCollections,
+  isExpired,
+  type SecretVaultDecryptedItem,
+  type SecretVaultDraft,
+  type SecretVaultSession,
+} from '../utils/secretVault';
+import { logVaultUnlockFailure } from '../utils/analytics';
+
+interface SecretVaultContextValue {
+  locked: boolean;
+  loading: boolean;
+  error: string | null;
+  items: SecretVaultDecryptedItem[];
+  activeItems: SecretVaultDecryptedItem[];
+  expiredItems: SecretVaultDecryptedItem[];
+  expiryWarnings: SecretVaultDecryptedItem[];
+  unlock: () => Promise<boolean>;
+  refresh: () => Promise<void>;
+  saveSecret: (draft: SecretVaultDraft) => Promise<SecretVaultDecryptedItem | null>;
+  deleteSecret: (id: string) => Promise<void>;
+}
+
+const SecretVaultContext = createContext<SecretVaultContextValue | undefined>(undefined);
+
+const getErrorLabel = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return typeof error === 'string' ? error : 'unknown';
+};
+
+export const SecretVaultProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const sessionRef = useRef<SecretVaultSession | null>(null);
+  const [items, setItems] = useState<SecretVaultDecryptedItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [locked, setLocked] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadItems = useCallback(
+    async (activeSession?: SecretVaultSession) => {
+      const session = activeSession ?? sessionRef.current;
+      if (!session) return;
+      setLoading(true);
+      try {
+        const secrets = await readVaultSecrets(session);
+        setItems(secrets);
+        setError(null);
+      } catch (err) {
+        setError('Unable to read stored credentials.');
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  const unlock = useCallback(async () => {
+    if (sessionRef.current) {
+      return true;
+    }
+    if (typeof window === 'undefined') {
+      const label = 'no-window';
+      logVaultUnlockFailure(label);
+      setError('The credentials vault is available only in the browser.');
+      return false;
+    }
+    const passphrase = window.prompt('Enter vault passphrase');
+    if (!passphrase) {
+      logVaultUnlockFailure('cancelled');
+      setError('Vault unlock cancelled.');
+      return false;
+    }
+    setLoading(true);
+    try {
+      const session = await createVaultSession(passphrase);
+      sessionRef.current = session;
+      setLocked(false);
+      setError(null);
+      await loadItems(session);
+      return true;
+    } catch (err) {
+      const label = getErrorLabel(err);
+      logVaultUnlockFailure(label);
+      sessionRef.current = null;
+      setLocked(true);
+      setError('Unable to unlock vault. Check your passphrase.');
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, [loadItems]);
+
+  const ensureSession = useCallback(async () => {
+    if (sessionRef.current) {
+      return sessionRef.current;
+    }
+    const unlocked = await unlock();
+    if (!unlocked || !sessionRef.current) {
+      throw new Error('UNLOCK_FAILED');
+    }
+    return sessionRef.current;
+  }, [unlock]);
+
+  const saveSecret = useCallback(
+    async (draft: SecretVaultDraft) => {
+      try {
+        const session = await ensureSession();
+        const saved = await writeVaultSecret(session, draft);
+        await loadItems(session);
+        return saved;
+      } catch (err) {
+        setError('Unable to save credential.');
+        return null;
+      }
+    },
+    [ensureSession, loadItems]
+  );
+
+  const removeSecret = useCallback(
+    async (id: string) => {
+      try {
+        const session = await ensureSession();
+        await deleteVaultSecret(session, id);
+        await loadItems(session);
+      } catch {
+        setError('Unable to delete credential.');
+      }
+    },
+    [ensureSession, loadItems]
+  );
+
+  const refresh = useCallback(async () => {
+    await loadItems();
+  }, [loadItems]);
+
+  const expiryCollections = useMemo(() => deriveExpiryCollections(items), [items]);
+  const expiredItems = expiryCollections.expired;
+  const expiryWarnings = expiryCollections.warnings;
+  const activeItems = useMemo(
+    () => items.filter((item) => !isExpired(item)),
+    [items]
+  );
+
+  const value = useMemo<SecretVaultContextValue>(
+    () => ({
+      locked,
+      loading,
+      error,
+      items,
+      activeItems,
+      expiredItems,
+      expiryWarnings,
+      unlock,
+      refresh,
+      saveSecret,
+      deleteSecret: removeSecret,
+    }),
+    [
+      locked,
+      loading,
+      error,
+      items,
+      activeItems,
+      expiredItems,
+      expiryWarnings,
+      unlock,
+      refresh,
+      saveSecret,
+      removeSecret,
+    ]
+  );
+
+  return <SecretVaultContext.Provider value={value}>{children}</SecretVaultContext.Provider>;
+};
+
+export const useSecretVault = (): SecretVaultContextValue => {
+  const context = useContext(SecretVaultContext);
+  if (!context) {
+    throw new Error('useSecretVault must be used within a SecretVaultProvider');
+  }
+  return context;
+};

--- a/public/themes/Yaru/apps/credentials-vault.svg
+++ b/public/themes/Yaru/apps/credentials-vault.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect x="6" y="20" width="52" height="38" rx="6" fill="#1f2937" stroke="#4b5563" stroke-width="2"/>
+  <path d="M22 24v-6a10 10 0 1 1 20 0v6" stroke="#9ca3af" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <rect x="26" y="34" width="12" height="16" rx="6" fill="#2563eb"/>
+  <circle cx="32" cy="42" r="4" fill="#dbeafe"/>
+  <path d="M32 44v5" stroke="#1d4ed8" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -28,3 +28,17 @@ export const logGameEnd = (game: string, label?: string): void => {
 export const logGameError = (game: string, message?: string): void => {
   logEvent({ category: game, action: 'error', label: message });
 };
+
+const VAULT_CATEGORY = 'credentials-vault';
+
+export const logVaultCopy = (label: string): void => {
+  logEvent({ category: VAULT_CATEGORY, action: 'copy', label });
+};
+
+export const logVaultAutoClear = (): void => {
+  logEvent({ category: VAULT_CATEGORY, action: 'auto-clear' });
+};
+
+export const logVaultUnlockFailure = (label?: string): void => {
+  logEvent({ category: VAULT_CATEGORY, action: 'unlock-failure', label });
+};

--- a/utils/secretVault.ts
+++ b/utils/secretVault.ts
@@ -1,0 +1,407 @@
+import { getDb } from './safeIDB';
+import { logVaultAutoClear } from './analytics';
+import type { IDBPDatabase } from 'idb';
+
+export interface SecretVaultMetadata {
+  scopes: string[];
+  tags: string[];
+  expiresAt: number | null;
+  restrictCopy: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface SecretVaultContent {
+  username: string;
+  password: string;
+  notes?: string;
+}
+
+export interface SecretVaultDecryptedItem extends SecretVaultContent {
+  id: string;
+  label: string;
+  metadata: SecretVaultMetadata;
+}
+
+export interface SecretVaultDraft extends SecretVaultContent {
+  id?: string;
+  label: string;
+  metadata: Partial<Pick<
+    SecretVaultMetadata,
+    'scopes' | 'tags' | 'expiresAt' | 'restrictCopy'
+  >>;
+}
+
+interface SecretVaultStoredItem {
+  id: string;
+  label: string;
+  payload: string;
+  iv: string;
+  metadata: SecretVaultMetadata;
+}
+
+interface SecretVaultMetaRecord {
+  salt: string;
+  verification: string;
+  verificationIv: string;
+  createdAt: number;
+}
+
+export interface SecretVaultSession {
+  key: CryptoKey;
+  db: IDBPDatabase;
+}
+
+export interface ClipboardCancelOptions {
+  wipe?: boolean;
+}
+
+const DB_NAME = 'credentials-vault';
+const STORE_NAME = 'credentials';
+const META_STORE = 'meta';
+const META_KEY = 'vault-meta';
+const CHECK_VALUE = 'vault-check';
+const EXPIRY_WARNING_WINDOW = 1000 * 60 * 60 * 24 * 2; // 48 hours
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+let dbPromise: ReturnType<typeof getDb> | null = null;
+let clipboardTimeout: ReturnType<typeof setTimeout> | null = null;
+
+export const SECRET_VAULT_DB_NAME = DB_NAME;
+export const SECRET_VAULT_STORE = STORE_NAME;
+
+const getCrypto = (): Crypto => {
+  const cryptoObj =
+    (typeof globalThis !== 'undefined' && (globalThis.crypto as Crypto | undefined)) ||
+    (typeof window !== 'undefined' ? (window.crypto as Crypto | undefined) : undefined);
+  if (!cryptoObj || !cryptoObj.subtle) {
+    throw new Error('WEB_CRYPTO_UNAVAILABLE');
+  }
+  return cryptoObj;
+};
+
+const bufferToBase64 = (buffer: ArrayBuffer): string => {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(buffer).toString('base64');
+  }
+  let binary = '';
+  const bytes = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.byteLength; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+};
+
+const base64ToUint8Array = (value: string): Uint8Array => {
+  if (typeof Buffer !== 'undefined') {
+    return Uint8Array.from(Buffer.from(value, 'base64'));
+  }
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+};
+
+const ensureDb = () => {
+  dbPromise = getDb(DB_NAME, 1, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+      }
+      if (!db.objectStoreNames.contains(META_STORE)) {
+        db.createObjectStore(META_STORE);
+      }
+    },
+  });
+  return dbPromise;
+};
+
+const deriveKey = async (passphrase: string, salt: Uint8Array): Promise<CryptoKey> => {
+  const crypto = getCrypto();
+  const baseKey = await crypto.subtle.importKey(
+    'raw',
+    textEncoder.encode(passphrase),
+    { name: 'PBKDF2' },
+    false,
+    ['deriveKey']
+  );
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt,
+      iterations: 250000,
+      hash: 'SHA-256',
+    },
+    baseKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+};
+
+const encryptText = async (
+  key: CryptoKey,
+  value: string
+): Promise<{ cipher: string; iv: string }> => {
+  const crypto = getCrypto();
+  const ivBytes = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: ivBytes },
+    key,
+    textEncoder.encode(value)
+  );
+  return {
+    cipher: bufferToBase64(ciphertext),
+    iv: bufferToBase64(ivBytes.buffer),
+  };
+};
+
+const decryptText = async (key: CryptoKey, cipher: string, iv: string): Promise<string> => {
+  const crypto = getCrypto();
+  const data = base64ToUint8Array(cipher);
+  const ivBytes = base64ToUint8Array(iv);
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: ivBytes },
+    key,
+    data
+  );
+  return textDecoder.decode(plaintext);
+};
+
+const normalizeList = (values?: string[]): string[] => {
+  if (!values) return [];
+  const deduped = new Set<string>();
+  values
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .forEach((value) => deduped.add(value));
+  return Array.from(deduped);
+};
+
+export const createVaultSession = async (passphrase: string): Promise<SecretVaultSession> => {
+  if (!passphrase) {
+    throw new Error('EMPTY_PASSPHRASE');
+  }
+  const dbp = ensureDb();
+  if (!dbp) {
+    throw new Error('INDEXEDDB_UNAVAILABLE');
+  }
+  const db = await dbp;
+  const crypto = getCrypto();
+
+  const meta = (await db.get(META_STORE, META_KEY)) as SecretVaultMetaRecord | undefined;
+  if (!meta) {
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const key = await deriveKey(passphrase, salt);
+    const verification = await encryptText(key, CHECK_VALUE);
+    const record: SecretVaultMetaRecord = {
+      salt: bufferToBase64(salt.buffer),
+      verification: verification.cipher,
+      verificationIv: verification.iv,
+      createdAt: Date.now(),
+    };
+    await db.put(META_STORE, record, META_KEY);
+    return { key, db };
+  }
+
+  const salt = base64ToUint8Array(meta.salt);
+  const key = await deriveKey(passphrase, salt);
+  try {
+    await decryptText(key, meta.verification, meta.verificationIv);
+  } catch (error) {
+    throw new Error('INVALID_PASSPHRASE');
+  }
+
+  return { key, db };
+};
+
+const parseContent = (serialized: string): SecretVaultContent => {
+  try {
+    const parsed = JSON.parse(serialized) as SecretVaultContent;
+    return {
+      username: parsed.username || '',
+      password: parsed.password || '',
+      notes: parsed.notes || '',
+    };
+  } catch {
+    return { username: '', password: '', notes: '' };
+  }
+};
+
+export const readVaultSecrets = async (
+  session: SecretVaultSession
+): Promise<SecretVaultDecryptedItem[]> => {
+  const records = (await session.db.getAll(STORE_NAME)) as SecretVaultStoredItem[];
+  const results: SecretVaultDecryptedItem[] = [];
+  for (const record of records) {
+    try {
+      const plaintext = await decryptText(session.key, record.payload, record.iv);
+      const content = parseContent(plaintext);
+      const metadata: SecretVaultMetadata = {
+        scopes: normalizeList(record.metadata.scopes),
+        tags: normalizeList(record.metadata.tags),
+        restrictCopy: Boolean(record.metadata.restrictCopy),
+        expiresAt:
+          typeof record.metadata.expiresAt === 'number'
+            ? record.metadata.expiresAt
+            : record.metadata.expiresAt === null
+            ? null
+            : null,
+        createdAt: record.metadata.createdAt || record.metadata.updatedAt || Date.now(),
+        updatedAt: record.metadata.updatedAt || record.metadata.createdAt || Date.now(),
+      };
+      results.push({
+        id: record.id,
+        label: record.label,
+        metadata,
+        ...content,
+      });
+    } catch {
+      // Skip unreadable records
+    }
+  }
+  return results.sort((a, b) => b.metadata.updatedAt - a.metadata.updatedAt);
+};
+
+const resolveDraftMetadata = (
+  draft: SecretVaultDraft,
+  existing?: SecretVaultStoredItem
+): SecretVaultMetadata => {
+  const now = Date.now();
+  const baseMetadata = existing?.metadata;
+  const expiresAtValue =
+    draft.metadata.expiresAt !== undefined
+      ? draft.metadata.expiresAt ?? null
+      : baseMetadata?.expiresAt ?? null;
+
+  return {
+    scopes: normalizeList(
+      draft.metadata.scopes ?? baseMetadata?.scopes ?? []
+    ),
+    tags: normalizeList(draft.metadata.tags ?? baseMetadata?.tags ?? []),
+    restrictCopy: Boolean(
+      draft.metadata.restrictCopy ?? baseMetadata?.restrictCopy ?? false
+    ),
+    expiresAt: expiresAtValue,
+    createdAt: baseMetadata?.createdAt ?? now,
+    updatedAt: now,
+  };
+};
+
+export const writeVaultSecret = async (
+  session: SecretVaultSession,
+  draft: SecretVaultDraft
+): Promise<SecretVaultDecryptedItem> => {
+  const cryptoObj = getCrypto();
+  const id =
+    draft.id ??
+    (typeof cryptoObj.randomUUID === 'function'
+      ? cryptoObj.randomUUID()
+      : `vault-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const existing = draft.id
+    ? ((await session.db.get(STORE_NAME, draft.id)) as SecretVaultStoredItem | undefined)
+    : undefined;
+  const metadata = resolveDraftMetadata(draft, existing);
+  const serialized = JSON.stringify({
+    username: draft.username,
+    password: draft.password,
+    notes: draft.notes ?? '',
+  });
+  const encrypted = await encryptText(session.key, serialized);
+  const record: SecretVaultStoredItem = {
+    id,
+    label: draft.label,
+    payload: encrypted.cipher,
+    iv: encrypted.iv,
+    metadata,
+  };
+  await session.db.put(STORE_NAME, record);
+  return {
+    id,
+    label: draft.label,
+    metadata,
+    username: draft.username,
+    password: draft.password,
+    notes: draft.notes ?? '',
+  };
+};
+
+export const deleteVaultSecret = async (
+  session: SecretVaultSession,
+  id: string
+): Promise<void> => {
+  await session.db.delete(STORE_NAME, id);
+};
+
+export const isExpired = (item: SecretVaultDecryptedItem, now = Date.now()): boolean => {
+  return typeof item.metadata.expiresAt === 'number' && item.metadata.expiresAt <= now;
+};
+
+export const willExpireSoon = (
+  item: SecretVaultDecryptedItem,
+  now = Date.now()
+): boolean => {
+  if (!item.metadata.expiresAt) return false;
+  return item.metadata.expiresAt > now && item.metadata.expiresAt - now <= EXPIRY_WARNING_WINDOW;
+};
+
+const clipboardAvailable = (): boolean =>
+  typeof navigator !== 'undefined' &&
+  !!navigator.clipboard &&
+  typeof navigator.clipboard.writeText === 'function';
+
+export const scheduleClipboardWipe = (delay = 20000): void => {
+  if (!clipboardAvailable()) return;
+  if (clipboardTimeout) {
+    clearTimeout(clipboardTimeout);
+  }
+  clipboardTimeout = setTimeout(async () => {
+    clipboardTimeout = null;
+    try {
+      await navigator.clipboard.writeText('');
+      logVaultAutoClear();
+    } catch {
+      // ignore clipboard errors
+    }
+  }, delay);
+};
+
+export const cancelClipboardWipe = async (
+  options: ClipboardCancelOptions = {}
+): Promise<void> => {
+  if (clipboardTimeout) {
+    clearTimeout(clipboardTimeout);
+    clipboardTimeout = null;
+  }
+  if (options.wipe && clipboardAvailable()) {
+    try {
+      await navigator.clipboard.writeText('');
+    } catch {
+      // ignore clipboard errors
+    }
+  }
+};
+
+export const getActiveClipboardTimeout = (): ReturnType<typeof setTimeout> | null =>
+  clipboardTimeout;
+
+export const deriveExpiryCollections = (
+  items: SecretVaultDecryptedItem[],
+  now = Date.now()
+) => {
+  const expired: SecretVaultDecryptedItem[] = [];
+  const warnings: SecretVaultDecryptedItem[] = [];
+  for (const item of items) {
+    if (isExpired(item, now)) {
+      expired.push(item);
+    } else if (willExpireSoon(item, now)) {
+      warnings.push(item);
+    }
+  }
+  return { expired, warnings };
+};


### PR DESCRIPTION
## Summary
- add a credentials vault utility with encrypted IndexedDB storage, tag tree filters, expiry views, and clipboard auto-wipe UX
- implement a shared secret vault hook and AES-GCM helpers plus analytics events for copy, auto-clear, and unlock failures
- register the app in the utilities catalog, add documentation and icon, and cover encryption/expiry/clipboard flows with tests

## Testing
- yarn lint *(fails: existing repo lint issues for unrelated apps)*
- yarn test *(fails: pre-existing suite failures such as nmapNse.test.tsx and Modal.test.tsx)*
- yarn test __tests__/components/apps/credentials-vault.test.tsx __tests__/window.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb19be68a08328a3e40bdc5b391456