### PR TITLE
feat(dnd): add quiet hours settings and overrides

### DIFF
--- a/__tests__/hooks/useSettings.dnd.test.tsx
+++ b/__tests__/hooks/useSettings.dnd.test.tsx
@@ -1,0 +1,49 @@
+import { isWithinQuietHours, DndSchedule } from '../../hooks/useSettings';
+
+const createSchedule = (overrides: Partial<DndSchedule> = {}): DndSchedule => ({
+  id: overrides.id || 'test-schedule',
+  label: overrides.label,
+  start: overrides.start || '22:00',
+  end: overrides.end || '06:00',
+  days: overrides.days || [1, 2, 3, 4, 5],
+  enabled: overrides.enabled !== undefined ? overrides.enabled : true,
+});
+
+describe('isWithinQuietHours', () => {
+  it('returns inactive when no schedules are configured', () => {
+    const result = isWithinQuietHours([], new Date('2024-01-01T10:00:00'));
+    expect(result.active).toBe(false);
+  });
+
+  it('activates for a simple same-day schedule window', () => {
+    const schedule = createSchedule({ start: '09:00', end: '17:00', days: [3] });
+    const result = isWithinQuietHours([schedule], new Date('2024-01-03T12:30:00'));
+    expect(result.active).toBe(true);
+    expect(result.schedule).toEqual(schedule);
+  });
+
+  it('handles windows that span midnight into the next day', () => {
+    const schedule = createSchedule({ start: '22:00', end: '06:00', days: [1] });
+    expect(isWithinQuietHours([schedule], new Date('2024-01-01T23:30:00')).active).toBe(true);
+    // Tuesday early morning should still be inside Monday night window
+    expect(isWithinQuietHours([schedule], new Date('2024-01-02T04:30:00')).active).toBe(true);
+    expect(isWithinQuietHours([schedule], new Date('2024-01-02T07:30:00')).active).toBe(false);
+  });
+
+  it('covers the correct day when an overnight window starts on Saturday', () => {
+    const schedule = createSchedule({ start: '23:00', end: '03:00', days: [6] });
+    expect(isWithinQuietHours([schedule], new Date('2024-01-07T01:30:00')).active).toBe(true);
+    expect(isWithinQuietHours([schedule], new Date('2024-01-07T04:00:00')).active).toBe(false);
+  });
+
+  it('treats schedules with matching start and end times as full-day quiet hours', () => {
+    const schedule = createSchedule({ start: '00:00', end: '00:00', days: [4] });
+    expect(isWithinQuietHours([schedule], new Date('2024-01-04T12:00:00')).active).toBe(true);
+    expect(isWithinQuietHours([schedule], new Date('2024-01-05T12:00:00')).active).toBe(false);
+  });
+
+  it('ignores disabled schedules', () => {
+    const schedule = createSchedule({ enabled: false });
+    expect(isWithinQuietHours([schedule], new Date('2024-01-02T00:30:00')).active).toBe(false);
+  });
+});

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,19 +1,151 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
-import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
+import {
+    resetSettings,
+    defaults,
+    exportSettings as exportSettingsData,
+    importSettings as importSettingsData,
+    getDndEnabled as loadDndEnabled,
+    getDndSchedules as loadDndSchedules,
+    getDndOverrides as loadDndOverrides,
+    getUrgentAllowList as loadUrgentAllowList,
+} from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const {
+        accent,
+        setAccent,
+        wallpaper,
+        setWallpaper,
+        density,
+        setDensity,
+        reducedMotion,
+        setReducedMotion,
+        largeHitAreas,
+        setLargeHitAreas,
+        fontScale,
+        setFontScale,
+        highContrast,
+        setHighContrast,
+        pongSpin,
+        setPongSpin,
+        allowNetwork,
+        setAllowNetwork,
+        haptics,
+        setHaptics,
+        theme,
+        setTheme,
+        dndEnabled,
+        setDndEnabled,
+        dndSchedules,
+        setDndSchedules,
+        dndOverrides,
+        setDndOverrides,
+        urgentAllowList,
+        setUrgentAllowList,
+    } = useSettings();
     const [contrast, setContrast] = useState(0);
+    const [newScheduleLabel, setNewScheduleLabel] = useState('');
+    const [newScheduleStart, setNewScheduleStart] = useState('22:00');
+    const [newScheduleEnd, setNewScheduleEnd] = useState('07:00');
+    const [newScheduleDays, setNewScheduleDays] = useState([1, 2, 3, 4, 5]);
+    const [newOverrideApp, setNewOverrideApp] = useState('');
+    const [newOverrideMode, setNewOverrideMode] = useState('allow');
+    const [urgentEntry, setUrgentEntry] = useState('');
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
 
     const wallpapers = ['wall-1', 'wall-2', 'wall-3', 'wall-4', 'wall-5', 'wall-6', 'wall-7', 'wall-8'];
+    const dayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
     const changeBackgroundImage = (e) => {
         const name = e.currentTarget.dataset.path;
         setWallpaper(name);
     };
+
+    const toggleNewScheduleDay = useCallback((day) => {
+        setNewScheduleDays(prev => {
+            const exists = prev.includes(day);
+            const next = exists ? prev.filter(d => d !== day) : [...prev, day];
+            return next.sort((a, b) => a - b);
+        });
+    }, []);
+
+    const addSchedule = useCallback(() => {
+        if (!newScheduleStart || !newScheduleEnd || newScheduleDays.length === 0) {
+            return;
+        }
+        const label = newScheduleLabel.trim();
+        const newEntry = {
+            id: `schedule-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            label: label || undefined,
+            start: newScheduleStart,
+            end: newScheduleEnd,
+            days: [...newScheduleDays].sort((a, b) => a - b),
+            enabled: true,
+        };
+        setDndSchedules(prev => [...prev, newEntry]);
+        setNewScheduleLabel('');
+        setNewScheduleStart('22:00');
+        setNewScheduleEnd('07:00');
+        setNewScheduleDays([1, 2, 3, 4, 5]);
+    }, [newScheduleLabel, newScheduleStart, newScheduleEnd, newScheduleDays, setDndSchedules]);
+
+    const updateScheduleLabel = useCallback((id, value) => {
+        setDndSchedules(prev => prev.map(schedule => schedule.id === id ? { ...schedule, label: value } : schedule));
+    }, [setDndSchedules]);
+
+    const updateScheduleTime = useCallback((id, field, value) => {
+        setDndSchedules(prev => prev.map(schedule => schedule.id === id ? { ...schedule, [field]: value } : schedule));
+    }, [setDndSchedules]);
+
+    const toggleScheduleDay = useCallback((id, day) => {
+        setDndSchedules(prev => prev.map(schedule => {
+            if (schedule.id !== id) return schedule;
+            const exists = schedule.days.includes(day);
+            const nextDays = exists ? schedule.days.filter(d => d !== day) : [...schedule.days, day];
+            return { ...schedule, days: nextDays.sort((a, b) => a - b) };
+        }));
+    }, [setDndSchedules]);
+
+    const toggleScheduleEnabled = useCallback((id) => {
+        setDndSchedules(prev => prev.map(schedule => schedule.id === id ? { ...schedule, enabled: !schedule.enabled } : schedule));
+    }, [setDndSchedules]);
+
+    const removeSchedule = useCallback((id) => {
+        setDndSchedules(prev => prev.filter(schedule => schedule.id !== id));
+    }, [setDndSchedules]);
+
+    const addOverride = useCallback(() => {
+        const trimmed = newOverrideApp.trim();
+        if (!trimmed) return;
+        setDndOverrides(prev => ({ ...prev, [trimmed]: newOverrideMode }));
+        setNewOverrideApp('');
+        setNewOverrideMode('allow');
+    }, [newOverrideApp, newOverrideMode, setDndOverrides]);
+
+    const updateOverride = useCallback((appId, mode) => {
+        setDndOverrides(prev => ({ ...prev, [appId]: mode }));
+    }, [setDndOverrides]);
+
+    const removeOverride = useCallback((appId) => {
+        setDndOverrides(prev => {
+            const next = { ...prev };
+            delete next[appId];
+            return next;
+        });
+    }, [setDndOverrides]);
+
+    const addUrgentEntry = useCallback(() => {
+        const trimmed = urgentEntry.trim();
+        if (!trimmed || urgentAllowList.includes(trimmed)) return;
+        setUrgentAllowList(prev => [...prev, trimmed]);
+        setUrgentEntry('');
+    }, [urgentEntry, urgentAllowList, setUrgentAllowList]);
+
+    const removeUrgentEntry = useCallback((entry) => {
+        setUrgentAllowList(prev => prev.filter(item => item !== entry));
+    }, [setUrgentAllowList]);
 
     let hexToRgb = (hex) => {
         hex = hex.replace('#', '');
@@ -177,6 +309,252 @@ export function Settings() {
                     Pong Spin
                 </label>
             </div>
+            <div className="mx-auto my-6 w-11/12 max-w-4xl bg-ub-dark-400 border border-gray-900 rounded p-4 text-ubt-grey">
+                <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                    <div>
+                        <h2 className="text-lg font-semibold text-white">Do Not Disturb</h2>
+                        <p className="text-xs text-ubt-grey">Define quiet hours and control which alerts break through.</p>
+                    </div>
+                    <label className="flex items-center text-sm text-ubt-grey">
+                        <input
+                            type="checkbox"
+                            checked={dndEnabled}
+                            onChange={(e) => setDndEnabled(e.target.checked)}
+                            className="mr-2"
+                        />
+                        Enabled
+                    </label>
+                </div>
+                <div className="mt-4 space-y-4">
+                    {dndSchedules.length === 0 ? (
+                        <p className="text-sm text-ubt-grey">No schedules yet. Add one below to silence notifications during quiet hours.</p>
+                    ) : (
+                        dndSchedules.map((schedule) => (
+                            <div key={schedule.id} className="border border-ubt-cool-grey rounded p-3 bg-ub-cool-grey bg-opacity-20">
+                                <div className="flex flex-col md:flex-row md:items-center md:gap-4 gap-3">
+                                    <div className="flex-1">
+                                        <label className="block text-xs uppercase tracking-wide mb-1 text-ubt-grey">Label</label>
+                                        <input
+                                            type="text"
+                                            value={schedule.label || ''}
+                                            onChange={(e) => updateScheduleLabel(schedule.id, e.target.value)}
+                                            className="w-full bg-ub-cool-grey text-white px-2 py-1 rounded border border-ubt-cool-grey"
+                                            placeholder="Weeknights, Weekend..."
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className="block text-xs uppercase tracking-wide mb-1 text-ubt-grey">Start</label>
+                                        <input
+                                            type="time"
+                                            value={schedule.start}
+                                            onChange={(e) => updateScheduleTime(schedule.id, 'start', e.target.value)}
+                                            className="bg-ub-cool-grey text-white px-2 py-1 rounded border border-ubt-cool-grey"
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className="block text-xs uppercase tracking-wide mb-1 text-ubt-grey">End</label>
+                                        <input
+                                            type="time"
+                                            value={schedule.end}
+                                            onChange={(e) => updateScheduleTime(schedule.id, 'end', e.target.value)}
+                                            className="bg-ub-cool-grey text-white px-2 py-1 rounded border border-ubt-cool-grey"
+                                        />
+                                    </div>
+                                    <label className="flex items-center text-sm text-ubt-grey whitespace-nowrap">
+                                        <input
+                                            type="checkbox"
+                                            checked={schedule.enabled}
+                                            onChange={() => toggleScheduleEnabled(schedule.id)}
+                                            className="mr-2"
+                                            disabled={!dndEnabled}
+                                        />
+                                        Active
+                                    </label>
+                                </div>
+                                <div className="mt-3 flex flex-wrap gap-2">
+                                    {dayLabels.map((label, index) => {
+                                        const selected = schedule.days.includes(index);
+                                        return (
+                                            <button
+                                                key={`${schedule.id}-${label}`}
+                                                type="button"
+                                                onClick={() => toggleScheduleDay(schedule.id, index)}
+                                                className={`px-2 py-1 rounded border text-xs ${selected ? 'bg-ub-orange text-white border-ub-orange' : 'bg-ub-cool-grey text-ubt-grey border-ubt-cool-grey'}`}
+                                                aria-pressed={selected}
+                                            >
+                                                {label}
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                                <div className="mt-3 flex justify-end">
+                                    <button
+                                        type="button"
+                                        onClick={() => removeSchedule(schedule.id)}
+                                        className="text-xs text-red-300 hover:text-red-200"
+                                    >
+                                        Remove schedule
+                                    </button>
+                                </div>
+                            </div>
+                        ))
+                    )}
+                </div>
+                <div className="mt-4 border-t border-gray-800 pt-4">
+                    <h3 className="text-sm font-semibold text-white">Add quiet hours</h3>
+                    <div className="grid gap-2 md:grid-cols-4 sm:grid-cols-2 grid-cols-1 mt-2">
+                        <label className="flex flex-col text-xs text-ubt-grey">
+                            Name
+                            <input
+                                type="text"
+                                value={newScheduleLabel}
+                                onChange={(e) => setNewScheduleLabel(e.target.value)}
+                                className="mt-1 bg-ub-cool-grey text-white px-2 py-1 rounded border border-ubt-cool-grey"
+                                placeholder="Weeknights"
+                            />
+                        </label>
+                        <label className="flex flex-col text-xs text-ubt-grey">
+                            Start
+                            <input
+                                type="time"
+                                value={newScheduleStart}
+                                onChange={(e) => setNewScheduleStart(e.target.value)}
+                                className="mt-1 bg-ub-cool-grey text-white px-2 py-1 rounded border border-ubt-cool-grey"
+                            />
+                        </label>
+                        <label className="flex flex-col text-xs text-ubt-grey">
+                            End
+                            <input
+                                type="time"
+                                value={newScheduleEnd}
+                                onChange={(e) => setNewScheduleEnd(e.target.value)}
+                                className="mt-1 bg-ub-cool-grey text-white px-2 py-1 rounded border border-ubt-cool-grey"
+                            />
+                        </label>
+                        <div className="flex flex-col text-xs text-ubt-grey">
+                            Days
+                            <div className="mt-1 flex flex-wrap gap-2">
+                                {dayLabels.map((label, index) => {
+                                    const selected = newScheduleDays.includes(index);
+                                    return (
+                                        <button
+                                            key={`new-${label}`}
+                                            type="button"
+                                            onClick={() => toggleNewScheduleDay(index)}
+                                            className={`px-2 py-1 rounded border ${selected ? 'bg-ub-orange text-white border-ub-orange' : 'bg-ub-cool-grey text-ubt-grey border-ubt-cool-grey'}`}
+                                            aria-pressed={selected}
+                                        >
+                                            {label}
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={addSchedule}
+                        className="mt-3 px-3 py-1 rounded bg-ub-orange text-white text-sm"
+                    >
+                        Add Schedule
+                    </button>
+                </div>
+                <div className="mt-6 border-t border-gray-800 pt-4">
+                    <h3 className="text-sm font-semibold text-white">App overrides</h3>
+                    <p className="text-xs text-ubt-grey mb-2">Choose apps that bypass or always follow quiet hours.</p>
+                    {Object.keys(dndOverrides).length === 0 ? (
+                        <p className="text-xs text-ubt-grey">No overrides configured.</p>
+                    ) : (
+                        <ul className="space-y-2">
+                            {Object.entries(dndOverrides).map(([appId, mode]) => (
+                                <li key={appId} className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 border border-ubt-cool-grey rounded px-3 py-2">
+                                    <span className="font-mono text-sm text-white break-all">{appId}</span>
+                                    <div className="flex items-center gap-2">
+                                        <select
+                                            value={mode}
+                                            onChange={(e) => updateOverride(appId, e.target.value)}
+                                            className="bg-ub-cool-grey text-white px-2 py-1 rounded border border-ubt-cool-grey text-sm"
+                                        >
+                                            <option value="allow">Bypass DND</option>
+                                            <option value="block">Always mute</option>
+                                        </select>
+                                        <button
+                                            type="button"
+                                            onClick={() => removeOverride(appId)}
+                                            className="text-xs text-red-300 hover:text-red-200"
+                                        >
+                                            Remove
+                                        </button>
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                    <div className="mt-3 grid gap-2 sm:grid-cols-[2fr_1fr_auto] grid-cols-1">
+                        <input
+                            type="text"
+                            value={newOverrideApp}
+                            onChange={(e) => setNewOverrideApp(e.target.value)}
+                            placeholder="App id (e.g. mail)"
+                            className="bg-ub-cool-grey text-white px-2 py-1 rounded border border-ubt-cool-grey"
+                        />
+                        <select
+                            value={newOverrideMode}
+                            onChange={(e) => setNewOverrideMode(e.target.value)}
+                            className="bg-ub-cool-grey text-white px-2 py-1 rounded border border-ubt-cool-grey text-sm"
+                        >
+                            <option value="allow">Bypass DND</option>
+                            <option value="block">Always mute</option>
+                        </select>
+                        <button
+                            type="button"
+                            onClick={addOverride}
+                            className="px-3 py-1 rounded bg-ub-orange text-white text-sm"
+                        >
+                            Add override
+                        </button>
+                    </div>
+                </div>
+                <div className="mt-6 border-t border-gray-800 pt-4">
+                    <h3 className="text-sm font-semibold text-white">Urgent allow list</h3>
+                    <p className="text-xs text-ubt-grey mb-2">Urgent alerts from these senders can bypass quiet hours.</p>
+                    {urgentAllowList.length === 0 ? (
+                        <p className="text-xs text-ubt-grey">No urgent senders configured.</p>
+                    ) : (
+                        <ul className="flex flex-wrap gap-2">
+                            {urgentAllowList.map((entry) => (
+                                <li key={entry} className="flex items-center bg-ub-cool-grey text-white px-2 py-1 rounded text-xs gap-2 border border-ubt-cool-grey">
+                                    <span>{entry}</span>
+                                    <button
+                                        type="button"
+                                        onClick={() => removeUrgentEntry(entry)}
+                                        className="text-red-300 hover:text-red-200"
+                                        aria-label={`Remove ${entry} from urgent allow list`}
+                                    >
+                                        ×
+                                    </button>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                    <div className="mt-3 flex flex-col sm:flex-row gap-2">
+                        <input
+                            type="text"
+                            value={urgentEntry}
+                            onChange={(e) => setUrgentEntry(e.target.value)}
+                            placeholder="Contact or source id"
+                            className="flex-1 bg-ub-cool-grey text-white px-2 py-1 rounded border border-ubt-cool-grey"
+                        />
+                        <button
+                            type="button"
+                            onClick={addUrgentEntry}
+                            className="px-3 py-1 rounded bg-ub-orange text-white text-sm self-start sm:self-auto"
+                        >
+                            Add sender
+                        </button>
+                    </div>
+                </div>
+            </div>
             <div className="flex justify-center my-4">
                 <div
                     className="p-4 rounded transition-colors duration-300 motion-reduce:transition-none"
@@ -252,6 +630,10 @@ export function Settings() {
                         setFontScale(defaults.fontScale);
                         setHighContrast(defaults.highContrast);
                         setTheme('default');
+                        setDndEnabled(defaults.dndEnabled);
+                        setDndSchedules((defaults.dndSchedules || []).map(schedule => ({ ...schedule, days: [...(schedule.days || [])] })));
+                        setDndOverrides({ ...(defaults.dndOverrides || {}) });
+                        setUrgentAllowList([...(defaults.urgentAllowList || [])]);
                     }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
                 >
@@ -279,6 +661,16 @@ export function Settings() {
                     } catch (err) {
                         console.error('Invalid settings', err);
                     }
+                    const [loadedEnabled, loadedSchedules, loadedOverrides, loadedUrgent] = await Promise.all([
+                        loadDndEnabled(),
+                        loadDndSchedules(),
+                        loadDndOverrides(),
+                        loadUrgentAllowList(),
+                    ]);
+                    setDndEnabled(loadedEnabled);
+                    setDndSchedules(loadedSchedules);
+                    setDndOverrides(loadedOverrides);
+                    setUrgentAllowList(loadedUrgent);
                     e.target.value = '';
                 }}
                 className="hidden"

--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -1,39 +1,114 @@
 import React, { createContext, useCallback, useEffect, useState } from 'react';
+import { useSettings, isWithinQuietHours, DndOverrides } from '../../hooks/useSettings';
 
 export interface AppNotification {
   id: string;
   message: string;
   date: number;
+  urgency: 'normal' | 'urgent';
+  overrideReason?: string;
+  source?: string;
+  scheduleId?: string;
 }
 
 interface NotificationsContextValue {
   notifications: Record<string, AppNotification[]>;
-  pushNotification: (appId: string, message: string) => void;
+  pushNotification: (appId: string, payload: NotificationPayload) => void;
   clearNotifications: (appId?: string) => void;
 }
 
 export const NotificationsContext = createContext<NotificationsContextValue | null>(null);
 
+export interface NotificationOptions {
+  message: string;
+  urgency?: 'normal' | 'urgent';
+  source?: string;
+  timestamp?: number;
+}
+
+export type NotificationPayload = string | NotificationOptions;
+
+const formatScheduleDescriptor = (scheduleLabel?: string, start?: string, end?: string) => {
+  if (scheduleLabel) return scheduleLabel;
+  if (start && end) return `${start}–${end}`;
+  return undefined;
+};
+
 export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   const [notifications, setNotifications] = useState<Record<string, AppNotification[]>>({});
+  const { dndEnabled, dndSchedules, dndOverrides, urgentAllowList } = useSettings();
 
-  const pushNotification = useCallback((appId: string, message: string) => {
-    setNotifications(prev => {
-      const list = prev[appId] ?? [];
-      const next = {
-        ...prev,
-        [appId]: [
-          ...list,
-          {
-            id: `${Date.now()}-${Math.random()}`,
-            message,
-            date: Date.now(),
-          },
-        ],
-      };
-      return next;
-    });
-  }, []);
+  const pushNotification = useCallback(
+    (appId: string, payload: NotificationPayload) => {
+      const normalized: NotificationOptions =
+        typeof payload === 'string' ? { message: payload } : payload;
+      const { message, urgency = 'normal', source, timestamp } = normalized;
+      const createdAt = timestamp ?? Date.now();
+
+      const evaluation = isWithinQuietHours(dndSchedules, new Date(createdAt));
+      const schedule = evaluation.schedule;
+      const scheduleDescriptor = formatScheduleDescriptor(
+        schedule?.label,
+        schedule?.start,
+        schedule?.end
+      );
+      const overrideMode: DndOverrides[string] | undefined = dndOverrides[appId];
+
+      let shouldBlock = false;
+      let overrideReason: string | undefined;
+
+      if (overrideMode === 'block') {
+        shouldBlock = true;
+      } else if (dndEnabled && evaluation.active) {
+        if (overrideMode === 'allow') {
+          overrideReason = scheduleDescriptor
+            ? `Bypassed quiet hours via app override (${scheduleDescriptor})`
+            : 'Bypassed quiet hours via app override';
+        } else if (urgency === 'urgent') {
+          const allowedBySource =
+            (source && urgentAllowList.includes(source)) || urgentAllowList.includes(appId);
+          if (allowedBySource) {
+            const base = source
+              ? `Urgent alert allowed for ${source}`
+              : 'Urgent alert allowed';
+            overrideReason = scheduleDescriptor ? `${base} (${scheduleDescriptor})` : base;
+          } else {
+            shouldBlock = true;
+          }
+        } else {
+          shouldBlock = true;
+        }
+      }
+
+      if (shouldBlock) {
+        setNotifications(prev => {
+          if (!prev[appId]) return prev;
+          const next = { ...prev };
+          delete next[appId];
+          return next;
+        });
+        return;
+      }
+
+      setNotifications(prev => {
+        const list = prev[appId] ?? [];
+        const nextEntry: AppNotification = {
+          id: `${createdAt}-${Math.random()}`,
+          message,
+          date: createdAt,
+          urgency,
+          overrideReason,
+          source,
+          scheduleId: schedule?.id,
+        };
+        return {
+          ...prev,
+          [appId]: [...list, nextEntry],
+        };
+      });
+    },
+    [dndEnabled, dndSchedules, dndOverrides, urgentAllowList]
+  );
 
   const clearNotifications = useCallback((appId?: string) => {
     setNotifications(prev => {
@@ -68,7 +143,12 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
             <h3>{appId}</h3>
             <ul>
               {list.map(n => (
-                <li key={n.id}>{n.message}</li>
+                <li key={n.id} className={n.urgency === 'urgent' ? 'urgent-notification' : ''}>
+                  <div>{n.message}</div>
+                  {n.overrideReason && (
+                    <p className="text-xs text-ubt-grey italic">{n.overrideReason}</p>
+                  )}
+                </li>
               ))}
             </ul>
           </section>

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,16 +2,32 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import { useSettings, DndSchedule } from '../../hooks/useSettings';
 
 interface Props {
   open: boolean;
 }
+
+const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+const describeSchedule = (schedule: DndSchedule) => {
+  if (schedule.label && schedule.label.trim()) return schedule.label;
+  const sortedDays = [...schedule.days].sort((a, b) => a - b);
+  const daySummary =
+    sortedDays.length === 7
+      ? 'Daily'
+      : sortedDays.length
+        ? sortedDays.map(day => DAY_LABELS[day] ?? '').filter(Boolean).join(', ')
+        : 'Custom';
+  return `${daySummary} ${schedule.start}–${schedule.end}`;
+};
 
 const QuickSettings = ({ open }: Props) => {
   const [theme, setTheme] = usePersistentState('qs-theme', 'light');
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const { dndEnabled, setDndEnabled, dndSchedules, setDndSchedules } = useSettings();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -51,6 +67,46 @@ const QuickSettings = ({ open }: Props) => {
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
         />
+      </div>
+      <div className="mt-4 border-t border-black border-opacity-20 pt-3 px-4 space-y-2">
+        <div className="flex justify-between items-center">
+          <span>Do Not Disturb</span>
+          <input
+            type="checkbox"
+            checked={dndEnabled}
+            onChange={() => setDndEnabled(!dndEnabled)}
+            aria-label="Toggle do not disturb"
+          />
+        </div>
+        <div className="space-y-1">
+          {dndSchedules.length === 0 ? (
+            <p className="text-xs text-ubt-grey">No quiet hours configured.</p>
+          ) : (
+            dndSchedules.map(schedule => (
+              <label
+                key={schedule.id}
+                className="flex justify-between items-center text-xs gap-2"
+              >
+                <span>{describeSchedule(schedule)}</span>
+                <input
+                  type="checkbox"
+                  checked={schedule.enabled}
+                  disabled={!dndEnabled}
+                  onChange={() =>
+                    setDndSchedules(prev =>
+                      prev.map(entry =>
+                        entry.id === schedule.id
+                          ? { ...entry, enabled: !entry.enabled }
+                          : entry
+                      )
+                    )
+                  }
+                  aria-label={`Toggle schedule ${describeSchedule(schedule)}`}
+                />
+              </label>
+            ))
+          )}
+        </div>
       </div>
     </div>
   );

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -129,4 +129,5 @@ For each game below, build a canvas-based component with `requestAnimationFrame`
 ## Housekeeping
 - Keep `apps.config.js` organized with utilities and games grouped and exported consistently.
 - Monitor `fast-glob` updates and explore hash optimizations for the custom service worker.
+- Accessibility: ensure new notification and DND controls expose clear labels, focus states, and screen reader hints when quiet hours suppress alerts.
 

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,70 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  dndEnabled: false,
+  dndSchedules: [],
+  dndOverrides: {},
+  urgentAllowList: [],
+};
+
+const DND_ENABLED_KEY = 'dnd-enabled';
+const DND_SCHEDULES_KEY = 'dnd-schedules';
+const DND_OVERRIDES_KEY = 'dnd-overrides';
+const DND_URGENT_ALLOW_KEY = 'dnd-urgent-allow';
+
+const getSafeLocalStorage = () => {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch (err) {
+    return null;
+  }
+};
+
+const cloneSchedule = schedule => ({
+  ...schedule,
+  days: Array.isArray(schedule.days) ? [...schedule.days] : [],
+});
+
+const parseSchedules = raw => {
+  if (!Array.isArray(raw)) return DEFAULT_SETTINGS.dndSchedules.slice();
+  return raw
+    .map(schedule => {
+      if (!schedule || typeof schedule !== 'object') return null;
+      const { id, label, start, end, days, enabled } = schedule;
+      if (typeof id !== 'string' || typeof start !== 'string' || typeof end !== 'string') {
+        return null;
+      }
+      const normalizedDays = Array.isArray(days)
+        ? days.filter(day => Number.isInteger(day) && day >= 0 && day <= 6)
+        : [];
+      return {
+        id,
+        label: typeof label === 'string' && label.trim() ? label : undefined,
+        start,
+        end,
+        days: normalizedDays,
+        enabled: typeof enabled === 'boolean' ? enabled : true,
+      };
+    })
+    .filter(Boolean)
+    .map(cloneSchedule);
+};
+
+const parseOverrides = raw => {
+  if (!raw || typeof raw !== 'object') return { ...DEFAULT_SETTINGS.dndOverrides };
+  return Object.entries(raw).reduce((acc, [key, value]) => {
+    if (typeof key !== 'string') return acc;
+    if (value === 'allow' || value === 'block') {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+};
+
+const parseUrgentAllowList = raw => {
+  if (!Array.isArray(raw)) return DEFAULT_SETTINGS.urgentAllowList.slice();
+  return raw.filter(entry => typeof entry === 'string' && entry.trim().length > 0);
 };
 
 export async function getAccent() {
@@ -123,6 +187,83 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getDndEnabled() {
+  const storage = getSafeLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.dndEnabled;
+  const stored = storage.getItem(DND_ENABLED_KEY);
+  if (stored === null) return DEFAULT_SETTINGS.dndEnabled;
+  return stored === 'true';
+}
+
+export async function setDndEnabled(value) {
+  const storage = getSafeLocalStorage();
+  if (!storage) return;
+  storage.setItem(DND_ENABLED_KEY, value ? 'true' : 'false');
+}
+
+export async function getDndSchedules() {
+  const storage = getSafeLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.dndSchedules.slice();
+  try {
+    const raw = storage.getItem(DND_SCHEDULES_KEY);
+    if (!raw) return DEFAULT_SETTINGS.dndSchedules.slice();
+    const parsed = JSON.parse(raw);
+    return parseSchedules(parsed);
+  } catch (err) {
+    console.warn('Failed to parse stored DND schedules', err);
+    return DEFAULT_SETTINGS.dndSchedules.slice();
+  }
+}
+
+export async function setDndSchedules(value) {
+  const storage = getSafeLocalStorage();
+  if (!storage) return;
+  const payload = Array.isArray(value) ? value.map(cloneSchedule) : [];
+  storage.setItem(DND_SCHEDULES_KEY, JSON.stringify(payload));
+}
+
+export async function getDndOverrides() {
+  const storage = getSafeLocalStorage();
+  if (!storage) return { ...DEFAULT_SETTINGS.dndOverrides };
+  try {
+    const raw = storage.getItem(DND_OVERRIDES_KEY);
+    if (!raw) return { ...DEFAULT_SETTINGS.dndOverrides };
+    const parsed = JSON.parse(raw);
+    return parseOverrides(parsed);
+  } catch (err) {
+    console.warn('Failed to parse stored DND overrides', err);
+    return { ...DEFAULT_SETTINGS.dndOverrides };
+  }
+}
+
+export async function setDndOverrides(value) {
+  const storage = getSafeLocalStorage();
+  if (!storage) return;
+  const normalized = value && typeof value === 'object' ? value : {};
+  storage.setItem(DND_OVERRIDES_KEY, JSON.stringify(normalized));
+}
+
+export async function getUrgentAllowList() {
+  const storage = getSafeLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.urgentAllowList.slice();
+  try {
+    const raw = storage.getItem(DND_URGENT_ALLOW_KEY);
+    if (!raw) return DEFAULT_SETTINGS.urgentAllowList.slice();
+    const parsed = JSON.parse(raw);
+    return parseUrgentAllowList(parsed);
+  } catch (err) {
+    console.warn('Failed to parse stored urgent allow list', err);
+    return DEFAULT_SETTINGS.urgentAllowList.slice();
+  }
+}
+
+export async function setUrgentAllowList(value) {
+  const storage = getSafeLocalStorage();
+  if (!storage) return;
+  const normalized = Array.isArray(value) ? value.filter(entry => typeof entry === 'string') : [];
+  storage.setItem(DND_URGENT_ALLOW_KEY, JSON.stringify(normalized));
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +278,10 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem(DND_ENABLED_KEY);
+  window.localStorage.removeItem(DND_SCHEDULES_KEY);
+  window.localStorage.removeItem(DND_OVERRIDES_KEY);
+  window.localStorage.removeItem(DND_URGENT_ALLOW_KEY);
 }
 
 export async function exportSettings() {
@@ -151,6 +296,10 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    dndEnabled,
+    dndSchedules,
+    dndOverrides,
+    urgentAllowList,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +311,10 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getDndEnabled(),
+    getDndSchedules(),
+    getDndOverrides(),
+    getUrgentAllowList(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -176,6 +329,10 @@ export async function exportSettings() {
     allowNetwork,
     haptics,
     theme,
+    dndEnabled,
+    dndSchedules,
+    dndOverrides,
+    urgentAllowList,
   });
 }
 
@@ -200,6 +357,10 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    dndEnabled,
+    dndSchedules,
+    dndOverrides,
+    urgentAllowList,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -212,6 +373,10 @@ export async function importSettings(json) {
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
+  if (dndEnabled !== undefined) await setDndEnabled(dndEnabled);
+  if (dndSchedules !== undefined) await setDndSchedules(parseSchedules(dndSchedules));
+  if (dndOverrides !== undefined) await setDndOverrides(parseOverrides(dndOverrides));
+  if (urgentAllowList !== undefined) await setUrgentAllowList(parseUrgentAllowList(urgentAllowList));
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- add do-not-disturb scheduling, overrides, and urgent allow-list persistence to the settings context
- update the notification center and quick settings panel to honor quiet hours and surface urgent override reasons
- expand the settings app with schedule management UI, app overrides, urgent sender configuration, and new scheduling tests plus documentation update

## Testing
- yarn lint *(fails: repository already contains numerous jsx-a11y and top-level window lint violations)*
- yarn test *(fails: existing suites unrelated to this change fail in the monorepo)*
- yarn test __tests__/hooks/useSettings.dnd.test.tsx --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68cb19bf0e348328be1443c1261f7ff3