### PR TITLE
Add screen recorder overlay with evidence export

### DIFF
--- a/__tests__/components/apps/screen-recorder.annotations.test.tsx
+++ b/__tests__/components/apps/screen-recorder.annotations.test.tsx
@@ -1,0 +1,117 @@
+import {
+  annotationReducer,
+  clampRect,
+  createInitialAnnotationState,
+  isPointWithinRect,
+  normalizeRect,
+} from '../../../components/apps/screen-recorder/annotations';
+
+describe('annotationReducer', () => {
+  it('adds and selects a new annotation', () => {
+    const initial = createInitialAnnotationState();
+    const rectAnnotation = {
+      id: 'rect-1',
+      type: 'rect' as const,
+      color: '#fff',
+      x: 12,
+      y: 8,
+      width: 40,
+      height: 24,
+    };
+    const next = annotationReducer(initial, {
+      type: 'ADD',
+      annotation: rectAnnotation,
+    });
+    expect(next.annotations).toHaveLength(1);
+    expect(next.annotations[0]).toEqual(rectAnnotation);
+    expect(next.selectedId).toBe('rect-1');
+  });
+
+  it('updates annotation geometry', () => {
+    const initial = createInitialAnnotationState();
+    const rectAnnotation = {
+      id: 'rect-1',
+      type: 'rect' as const,
+      color: '#fff',
+      x: 10,
+      y: 10,
+      width: 30,
+      height: 30,
+    };
+    const withAnnotation = annotationReducer(initial, {
+      type: 'ADD',
+      annotation: rectAnnotation,
+    });
+    const updated = annotationReducer(withAnnotation, {
+      type: 'UPDATE',
+      id: 'rect-1',
+      changes: { width: 50, height: 45 } as Partial<typeof rectAnnotation>,
+    });
+    expect(updated.annotations[0]).toMatchObject({ width: 50, height: 45 });
+  });
+
+  it('removes annotations and clears selection', () => {
+    const initial = createInitialAnnotationState();
+    const rectAnnotation = {
+      id: 'rect-1',
+      type: 'rect' as const,
+      color: '#fff',
+      x: 10,
+      y: 10,
+      width: 30,
+      height: 30,
+    };
+    const withAnnotation = annotationReducer(initial, {
+      type: 'ADD',
+      annotation: rectAnnotation,
+    });
+    const selected = annotationReducer(withAnnotation, {
+      type: 'SELECT',
+      id: 'rect-1',
+    });
+    const removed = annotationReducer(selected, {
+      type: 'REMOVE',
+      id: 'rect-1',
+    });
+    expect(removed.annotations).toHaveLength(0);
+    expect(removed.selectedId).toBeNull();
+  });
+
+  it('resets to the initial state', () => {
+    const initial = createInitialAnnotationState();
+    const state = annotationReducer(initial, {
+      type: 'ADD',
+      annotation: {
+        id: 'arrow-1',
+        type: 'arrow' as const,
+        color: '#fff',
+        start: { x: 0, y: 0 },
+        end: { x: 10, y: 10 },
+      },
+    });
+    expect(state.annotations).toHaveLength(1);
+    const reset = annotationReducer(state, { type: 'RESET' });
+    expect(reset).toEqual(createInitialAnnotationState());
+  });
+});
+
+describe('annotation geometry helpers', () => {
+  it('normalizes negative rectangle dimensions', () => {
+    const rect = normalizeRect({ x: 20, y: 30, width: -10, height: -5 });
+    expect(rect).toEqual({ x: 10, y: 25, width: 10, height: 5 });
+  });
+
+  it('clamps rectangle to canvas bounds', () => {
+    const rect = clampRect(
+      { x: -5, y: 10, width: 50, height: 60 },
+      { width: 100, height: 80 },
+    );
+    expect(rect).toEqual({ x: 0, y: 10, width: 50, height: 60 });
+  });
+
+  it('detects whether a point is inside a rectangle', () => {
+    const rect = { x: 10, y: 10, width: 30, height: 30 };
+    expect(isPointWithinRect({ x: 25, y: 25 }, rect)).toBe(true);
+    expect(isPointWithinRect({ x: 5, y: 25 }, rect)).toBe(false);
+  });
+});

--- a/components/apps/evidence-vault/helpers.ts
+++ b/components/apps/evidence-vault/helpers.ts
@@ -1,0 +1,61 @@
+import type { Annotation } from '../screen-recorder/annotations';
+
+export interface EvidenceAsset {
+  name: string;
+  mimeType?: string;
+  size?: number;
+  path?: string;
+  blob?: Blob;
+}
+
+export interface EvidenceRecord {
+  id: string;
+  label: string;
+  tags: string[];
+  createdAt: number;
+  description?: string;
+  assets: EvidenceAsset[];
+  metadata?: Record<string, unknown>;
+  annotations?: Annotation[];
+}
+
+type Listener = (items: EvidenceRecord[]) => void;
+
+let store: EvidenceRecord[] = [];
+const listeners = new Set<Listener>();
+
+const emit = () => {
+  const snapshot = [...store];
+  listeners.forEach((listener) => listener(snapshot));
+};
+
+export const getEvidenceStore = (): EvidenceRecord[] => [...store];
+
+export const ingestEvidenceRecord = (
+  record: EvidenceRecord,
+): EvidenceRecord[] => {
+  store = [...store.filter((item) => item.id !== record.id), record];
+  emit();
+  return [...store];
+};
+
+export const removeEvidenceRecord = (id: string): EvidenceRecord[] => {
+  store = store.filter((item) => item.id !== id);
+  emit();
+  return [...store];
+};
+
+export const subscribeToEvidenceStore = (
+  listener: Listener,
+): (() => void) => {
+  listeners.add(listener);
+  listener([...store]);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const resetEvidenceStore = () => {
+  store = [];
+  emit();
+};

--- a/components/apps/evidence-vault/index.js
+++ b/components/apps/evidence-vault/index.js
@@ -1,9 +1,16 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  getEvidenceStore,
+  ingestEvidenceRecord,
+  subscribeToEvidenceStore,
+} from './helpers';
 
-// Build hierarchical tree from slash-delimited tags
 const buildTagTree = (items) => {
   const root = {};
   items.forEach((item) => {
+    if (!item.tags || item.tags.length === 0) {
+      return;
+    }
     item.tags.forEach((tag) => {
       const parts = tag.split('/').filter(Boolean);
       let node = root;
@@ -29,12 +36,13 @@ const TagTree = ({ data, onSelect }) => (
 
 const TagTreeNode = ({ name, node, onSelect }) => {
   const hasChildren = Object.keys(node.children).length > 0;
+  const showItemsButton = node.items && node.items.length > 0;
   return (
     <li className="mb-1">
       {hasChildren ? (
         <details>
           <summary className="cursor-pointer">{name}</summary>
-          {node.items.length > 0 && (
+          {showItemsButton && (
             <button
               onClick={() => onSelect(node)}
               className="ml-2 text-xs text-blue-400 hover:underline"
@@ -57,13 +65,40 @@ const TagTreeNode = ({ name, node, onSelect }) => {
 };
 
 const EvidenceVaultApp = () => {
-  const [items, setItems] = useState([]);
+  const [items, setItems] = useState(getEvidenceStore());
   const [selectedNode, setSelectedNode] = useState(null);
+  const [objectUrls, setObjectUrls] = useState({});
   const fileInputRef = useRef(null);
 
   useEffect(() => {
-    // reset selection when items change
+    const unsubscribe = subscribeToEvidenceStore(setItems);
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
     setSelectedNode(null);
+  }, [items]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const next = {};
+    items.forEach((item) => {
+      item.assets.forEach((asset, index) => {
+        if (asset.blob instanceof Blob) {
+          const key = `${item.id}-${index}`;
+          next[key] = URL.createObjectURL(asset.blob);
+        }
+      });
+    });
+    setObjectUrls((prev) => {
+      Object.entries(prev).forEach(([key, url]) => {
+        if (!next[key]) URL.revokeObjectURL(url);
+      });
+      return next;
+    });
+    return () => {
+      Object.values(next).forEach((url) => URL.revokeObjectURL(url));
+    };
   }, [items]);
 
   const addNote = () => {
@@ -75,10 +110,15 @@ const EvidenceVaultApp = () => {
       .split(',')
       .map((t) => t.trim())
       .filter(Boolean);
-    setItems((prev) => [
-      ...prev,
-      { id: Date.now(), type: 'note', title, content, tags },
-    ]);
+    ingestEvidenceRecord({
+      id: `note-${Date.now()}`,
+      label: title,
+      description: content,
+      tags,
+      createdAt: Date.now(),
+      assets: [],
+      metadata: { type: 'note', content },
+    });
   };
 
   const handleFileChange = (e) => {
@@ -89,15 +129,27 @@ const EvidenceVaultApp = () => {
       .split(',')
       .map((t) => t.trim())
       .filter(Boolean);
-    const url = URL.createObjectURL(file);
-    setItems((prev) => [
-      ...prev,
-      { id: Date.now(), type: 'file', name: file.name, url, tags },
-    ]);
-    e.target.value = '';
+    ingestEvidenceRecord({
+      id: `file-${Date.now()}`,
+      label: file.name,
+      tags,
+      createdAt: Date.now(),
+      assets: [
+        {
+          name: file.name,
+          mimeType: file.type,
+          size: file.size,
+          blob: file,
+        },
+      ],
+      metadata: { type: 'file' },
+    });
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
   };
 
-  const treeData = buildTagTree(items);
+  const treeData = useMemo(() => buildTagTree(items), [items]);
   const displayItems = selectedNode ? selectedNode.items : items;
 
   return (
@@ -109,7 +161,11 @@ const EvidenceVaultApp = () => {
         >
           All Items
         </button>
-        <TagTree data={treeData} onSelect={setSelectedNode} />
+        {Object.keys(treeData).length > 0 ? (
+          <TagTree data={treeData} onSelect={setSelectedNode} />
+        ) : (
+          <p className="text-xs text-gray-400">No tags assigned yet.</p>
+        )}
       </div>
       <div className="flex-1 pl-4 flex flex-col">
         <div className="mb-2 space-x-2">
@@ -133,28 +189,74 @@ const EvidenceVaultApp = () => {
           />
         </div>
         <ul className="flex-1 overflow-auto space-y-2">
+          {displayItems.length === 0 && (
+            <li className="text-sm text-gray-400">No evidence captured yet.</li>
+          )}
           {displayItems.map((item) => (
-            <li key={item.id} className="p-2 bg-gray-800 rounded">
-              {item.type === 'note' ? (
-                <div>
-                  <h4 className="font-semibold">{item.title}</h4>
-                  <p className="text-sm whitespace-pre-wrap">{item.content}</p>
-                </div>
-              ) : (
-                <div>
-                  <h4 className="font-semibold">{item.name}</h4>
-                  <a
-                    href={item.url}
-                    download
-                    className="text-blue-400 underline text-sm"
-                  >
-                    Download
-                  </a>
+            <li key={item.id} className="p-3 bg-gray-800/80 rounded border border-gray-700/60">
+              <div className="flex items-baseline justify-between">
+                <h4 className="font-semibold text-sm">{item.label}</h4>
+                <span className="text-xs text-gray-400">
+                  {new Date(item.createdAt).toLocaleString()}
+                </span>
+              </div>
+              {item.description && (
+                <p className="mt-1 text-sm whitespace-pre-wrap text-gray-200">
+                  {item.description}
+                </p>
+              )}
+              {item.assets.length > 0 && (
+                <div className="mt-2">
+                  <h5 className="text-xs uppercase tracking-wide text-gray-400">
+                    Assets
+                  </h5>
+                  <ul className="mt-1 space-y-1 text-sm">
+                    {item.assets.map((asset, index) => {
+                      const key = `${item.id}-${index}`;
+                      const url = objectUrls[key];
+                      return (
+                        <li
+                          key={key}
+                          className="flex items-center justify-between gap-2 rounded bg-gray-900/60 px-2 py-1"
+                        >
+                          <span className="truncate" title={asset.name}>
+                            {asset.name}
+                          </span>
+                          {url ? (
+                            <a
+                              href={url}
+                              download={asset.name}
+                              className="text-xs text-blue-400 hover:underline"
+                            >
+                              Download
+                            </a>
+                          ) : asset.path ? (
+                            <span className="text-xs text-gray-400">{asset.path}</span>
+                          ) : null}
+                        </li>
+                      );
+                    })}
+                  </ul>
                 </div>
               )}
               {item.tags.length > 0 && (
-                <p className="text-xs mt-1 text-gray-400">
+                <p className="mt-2 text-xs text-gray-400">
                   Tags: {item.tags.join(', ')}
+                </p>
+              )}
+              {item.metadata && Object.keys(item.metadata).length > 0 && (
+                <details className="mt-2 text-xs">
+                  <summary className="cursor-pointer text-blue-300">
+                    Metadata
+                  </summary>
+                  <pre className="mt-1 whitespace-pre-wrap break-words bg-gray-900/70 p-2 rounded">
+                    {JSON.stringify(item.metadata, null, 2)}
+                  </pre>
+                </details>
+              )}
+              {item.annotations && item.annotations.length > 0 && (
+                <p className="mt-2 text-xs text-gray-400">
+                  {item.annotations.length} annotation(s) saved
                 </p>
               )}
             </li>

--- a/components/apps/screen-recorder.tsx
+++ b/components/apps/screen-recorder.tsx
@@ -1,119 +1,620 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react';
+import SelectionOverlay from './screen-recorder/SelectionOverlay';
+import {
+  Annotation,
+  CaptureMode,
+  SelectionRect,
+  annotationReducer,
+  createInitialAnnotationState,
+} from './screen-recorder/annotations';
+import useOPFS from '../../hooks/useOPFS';
+import { ingestEvidenceRecord } from './evidence-vault/helpers';
 
-function ScreenRecorder() {
-    const [recording, setRecording] = useState(false);
-    const [videoUrl, setVideoUrl] = useState<string | null>(null);
-    const recorderRef = useRef<MediaRecorder | null>(null);
-    const chunksRef = useRef<Blob[]>([]);
-    const streamRef = useRef<MediaStream | null>(null);
+const quickTagPresets = [
+  'capture/screen',
+  'status/triage',
+  'severity/medium',
+  'component/ui',
+];
 
-    const startRecording = async () => {
-        try {
-            const stream = await navigator.mediaDevices.getDisplayMedia({
-                video: true,
-                audio: true,
-            });
-            streamRef.current = stream;
-            const recorder = new MediaRecorder(stream);
-            chunksRef.current = [];
-            recorder.ondataavailable = (e: BlobEvent) => {
-                if (e.data.size > 0) chunksRef.current.push(e.data);
-            };
-            recorder.onstop = () => {
-                const blob = new Blob(chunksRef.current, { type: 'video/webm' });
-                const url = URL.createObjectURL(blob);
-                setVideoUrl(url);
-                stream.getTracks().forEach((t) => t.stop());
-            };
-            recorder.start();
-            recorderRef.current = recorder;
-            setRecording(true);
-        } catch {
-            // ignore
+const createSessionId = () =>
+  typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+const isTypingTarget = (target: EventTarget | null) =>
+  target instanceof HTMLInputElement ||
+  target instanceof HTMLTextAreaElement ||
+  (target as HTMLElement | null)?.isContentEditable === true;
+
+const triggerDownload = (name: string, blob: Blob) => {
+  if (typeof window === 'undefined') return;
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = name;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+};
+
+const dataUrlToBlob = async (dataUrl: string): Promise<Blob> => {
+  const response = await fetch(dataUrl);
+  return await response.blob();
+};
+
+const captureFrameFromStream = (stream: MediaStream): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const video = document.createElement('video');
+    video.muted = true;
+    video.srcObject = stream;
+    const cleanup = () => {
+      video.pause();
+      video.srcObject = null;
+    };
+    video.onloadedmetadata = () => {
+      video.play().catch(() => {});
+      requestAnimationFrame(() => {
+        const canvas = document.createElement('canvas');
+        canvas.width = video.videoWidth;
+        canvas.height = video.videoHeight;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          cleanup();
+          reject(new Error('Canvas context unavailable'));
+          return;
         }
+        ctx.drawImage(video, 0, 0);
+        const dataUrl = canvas.toDataURL('image/png');
+        cleanup();
+        resolve(dataUrl);
+      });
     };
-
-    const stopRecording = () => {
-        recorderRef.current?.stop();
-        setRecording(false);
+    video.onerror = () => {
+      cleanup();
+      reject(new Error('Failed to capture frame'));
     };
+  });
+};
 
-    const saveRecording = async () => {
-        if (!videoUrl) return;
-        const blob = new Blob(chunksRef.current, { type: 'video/webm' });
-        if ('showSaveFilePicker' in window) {
-            try {
-                const handle = await (window as any).showSaveFilePicker({
-                    suggestedName: 'recording.webm',
-                    types: [
-                        {
-                            description: 'WebM video',
-                            accept: { 'video/webm': ['.webm'] },
-                        },
-                    ],
-                });
-                const writable = await handle.createWritable();
-                await writable.write(blob);
-                await writable.close();
-            } catch {
-                // ignore
-            }
-        } else {
-            const a = document.createElement('a');
-            a.href = videoUrl;
-            a.download = 'recording.webm';
-            document.body.appendChild(a);
-            a.click();
-            a.remove();
-        }
-    };
-
-    useEffect(() => {
-        return () => {
-            streamRef.current?.getTracks().forEach((t) => t.stop());
-            recorderRef.current?.stop();
-        };
-    }, []);
-
-    return (
-        <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white space-y-4 p-4">
-            {!recording && (
-                <button
-                    type="button"
-                    onClick={startRecording}
-                    className="px-4 py-2 rounded bg-ub-dracula hover:bg-ub-dracula-dark"
-                >
-                    Start Recording
-                </button>
-            )}
-            {recording && (
-                <button
-                    type="button"
-                    onClick={stopRecording}
-                    className="px-4 py-2 rounded bg-red-600 hover:bg-red-700"
-                >
-                    Stop Recording
-                </button>
-            )}
-            {videoUrl && !recording && (
-                <>
-                    <video src={videoUrl} controls className="max-w-full" />
-                    <button
-                        type="button"
-                        onClick={saveRecording}
-                        className="px-4 py-2 rounded bg-ub-dracula hover:bg-ub-dracula-dark"
-                    >
-                        Save Recording
-                    </button>
-                </>
-            )}
-        </div>
-    );
+interface CaptureSession {
+  id: string;
+  mode: CaptureMode;
+  startedAt: number;
+  videoBlob?: Blob;
+  annotations?: Annotation[];
+  selection?: SelectionRect | null;
+  frame?: string | null;
+  regionImage?: string | null;
 }
+
+const ScreenRecorder: React.FC = () => {
+  const [captureMode, setCaptureMode] = useState<CaptureMode>('screen');
+  const [recording, setRecording] = useState(false);
+  const [videoUrl, setVideoUrl] = useState<string | null>(null);
+  const [regionPreview, setRegionPreview] = useState<string | null>(null);
+  const [overlayImage, setOverlayImage] = useState<string | null>(null);
+  const [showOverlay, setShowOverlay] = useState(false);
+  const [selection, setSelection] = useState<SelectionRect | null>(null);
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState('');
+  const [status, setStatus] = useState<string | null>(null);
+  const [session, setSession] = useState<CaptureSession | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const opfs = useOPFS();
+  const [annotationState, dispatchAnnotation] = useReducer(
+    annotationReducer,
+    createInitialAnnotationState(),
+  );
+
+  useEffect(() => {
+    return () => {
+      streamRef.current?.getTracks().forEach((track) => track.stop());
+      recorderRef.current?.stop();
+      if (videoUrl) URL.revokeObjectURL(videoUrl);
+    };
+  }, [videoUrl]);
+
+  const handleVideoCapture = useCallback(
+    async (mode: CaptureMode) => {
+      if (recording) {
+        setStatus('Stop the current recording before starting a new one.');
+        return;
+      }
+      setCaptureMode(mode);
+      setRegionPreview(null);
+      setSelection(null);
+      dispatchAnnotation({ type: 'RESET' });
+      setStatus('Requesting display capture…');
+      try {
+        const stream = await navigator.mediaDevices.getDisplayMedia({
+          video: true,
+          audio: mode !== 'window',
+        });
+        streamRef.current = stream;
+        const recorder = new MediaRecorder(stream, { mimeType: 'video/webm' });
+        recorderRef.current = recorder;
+        chunksRef.current = [];
+        const sessionId = createSessionId();
+        setSession({ id: sessionId, mode, startedAt: Date.now() });
+        setVideoUrl((prev) => {
+          if (prev) URL.revokeObjectURL(prev);
+          return null;
+        });
+        recorder.ondataavailable = (event) => {
+          if (event.data.size > 0) {
+            chunksRef.current.push(event.data);
+          }
+        };
+        recorder.onstop = () => {
+          const blob = new Blob(chunksRef.current, { type: 'video/webm' });
+          setVideoUrl((prev) => {
+            if (prev) URL.revokeObjectURL(prev);
+            return URL.createObjectURL(blob);
+          });
+          setSession((prev) =>
+            prev && prev.id === sessionId ? { ...prev, videoBlob: blob } : prev,
+          );
+          setRecording(false);
+          stream.getTracks().forEach((track) => track.stop());
+          streamRef.current = null;
+          setStatus('Recording complete. Review and export when ready.');
+        };
+        recorder.onerror = () => {
+          setRecording(false);
+          setStatus('Recording error. Please try again.');
+        };
+        recorder.start();
+        setRecording(true);
+        setStatus('Recording in progress. Use the stop control when finished.');
+      } catch (error) {
+        setStatus('Screen capture request was cancelled.');
+      }
+    },
+    [dispatchAnnotation, recording],
+  );
+
+  const handleStopRecording = useCallback(() => {
+    if (!recording || !recorderRef.current) return;
+    setStatus('Stopping recording…');
+    recorderRef.current.stop();
+  }, [recording]);
+
+  const handleRegionCapture = useCallback(async () => {
+    setCaptureMode('region');
+    setRegionPreview(null);
+    setSelection(null);
+    dispatchAnnotation({ type: 'RESET' });
+    setStatus('Preparing region capture…');
+    try {
+      const stream = await navigator.mediaDevices.getDisplayMedia({
+        video: true,
+      });
+      const frame = await captureFrameFromStream(stream);
+      stream.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+      const sessionId = createSessionId();
+      setSession({
+        id: sessionId,
+        mode: 'region',
+        startedAt: Date.now(),
+        frame,
+      });
+      setOverlayImage(frame);
+      setShowOverlay(true);
+      setStatus('Drag to mark the capture region, then press Enter to confirm.');
+    } catch (error) {
+      setStatus('Region capture cancelled.');
+    }
+  }, [dispatchAnnotation]);
+
+  const handleStartCapture = useCallback(
+    (mode: CaptureMode) => {
+      if (mode === 'region') {
+        handleRegionCapture();
+      } else {
+        handleVideoCapture(mode);
+      }
+    },
+    [handleRegionCapture, handleVideoCapture],
+  );
+
+  const handleOverlayConfirm = useCallback(
+    (result: {
+      dataUrl: string;
+      selection: SelectionRect | null;
+      annotations: Annotation[];
+    }) => {
+      setShowOverlay(false);
+      setRegionPreview(result.dataUrl);
+      setSelection(result.selection);
+      setStatus('Region captured. Export when ready.');
+      setSession((prev) => {
+        const base =
+          prev && prev.mode === 'region'
+            ? prev
+            : {
+                id: createSessionId(),
+                mode: 'region' as CaptureMode,
+                startedAt: Date.now(),
+                frame: overlayImage,
+              };
+        return {
+          ...base,
+          annotations: result.annotations,
+          selection: result.selection,
+          regionImage: result.dataUrl,
+          frame: base.frame ?? overlayImage,
+        };
+      });
+    },
+    [overlayImage],
+  );
+
+  const handleOverlayCancel = useCallback(() => {
+    setShowOverlay(false);
+    setStatus((prev) => prev ?? 'Region capture cancelled.');
+  }, []);
+
+  const handleOverlayModeHotkey = useCallback(
+    (mode: CaptureMode) => {
+      setShowOverlay(false);
+      if (mode === 'region') {
+        handleRegionCapture();
+      } else {
+        handleVideoCapture(mode);
+      }
+    },
+    [handleRegionCapture, handleVideoCapture],
+  );
+
+  const toggleTag = useCallback((tag: string) => {
+    setTags((prev) =>
+      prev.includes(tag)
+        ? prev.filter((value) => value !== tag)
+        : [...prev, tag],
+    );
+  }, []);
+
+  const removeTag = useCallback((tag: string) => {
+    setTags((prev) => prev.filter((value) => value !== tag));
+  }, []);
+
+  const handleAddTag = useCallback(() => {
+    const trimmed = tagInput.trim();
+    if (!trimmed) return;
+    setTags((prev) => (prev.includes(trimmed) ? prev : [...prev, trimmed]));
+    setTagInput('');
+  }, [tagInput]);
+
+  const readyToExport = useMemo(() => {
+    if (!session) return false;
+    return Boolean(session.videoBlob || session.regionImage);
+  }, [session]);
+
+  const handleExport = useCallback(async () => {
+    if (!session) {
+      setStatus('No capture session available yet.');
+      return;
+    }
+    if (!session.videoBlob && !session.regionImage) {
+      setStatus('Capture content before exporting.');
+      return;
+    }
+    const timestamp = session.startedAt || Date.now();
+    const folderName = new Date(timestamp).toISOString().replace(/:/g, '-');
+    const folderPath = `evidence/screen-recorder/${folderName}`;
+    const assets: {
+      name: string;
+      mimeType?: string;
+      size?: number;
+      path?: string;
+      blob?: Blob;
+    }[] = [];
+    let dir: FileSystemDirectoryHandle | null = null;
+    if (opfs.supported) {
+      dir = await opfs.getDir(folderPath);
+    }
+    const persistFile = async (name: string, blob: Blob) => {
+      if (dir) {
+        const success = await opfs.writeFile(name, blob, dir);
+        if (success) {
+          assets.push({
+            name,
+            path: `${folderPath}/${name}`,
+            mimeType: blob.type,
+            size: blob.size,
+            blob,
+          });
+          return;
+        }
+      }
+      triggerDownload(name, blob);
+      assets.push({ name, mimeType: blob.type, size: blob.size, blob });
+    };
+    try {
+      if (session.videoBlob) {
+        await persistFile('capture.webm', session.videoBlob);
+      }
+      if (session.regionImage) {
+        const regionBlob = await dataUrlToBlob(session.regionImage);
+        await persistFile('region.png', regionBlob);
+      }
+      const metadata = {
+        mode: session.mode,
+        tags,
+        selection: session.selection,
+        annotations: session.annotations,
+        folderPath,
+        startedAt: session.startedAt,
+        exportedAt: Date.now(),
+      };
+      const metadataBlob = new Blob([JSON.stringify(metadata, null, 2)], {
+        type: 'application/json',
+      });
+      await persistFile('metadata.json', metadataBlob);
+      ingestEvidenceRecord({
+        id: session.id,
+        label: `Screen capture (${session.mode})`,
+        tags,
+        createdAt: Date.now(),
+        assets,
+        annotations: session.annotations,
+        metadata,
+        description:
+          session.mode === 'region'
+            ? 'Annotated region capture'
+            : 'Display media recording',
+      });
+      setStatus(
+        opfs.supported
+          ? `Exported to ${folderPath}.`
+          : 'Exported using browser downloads.',
+      );
+    } catch (error) {
+      setStatus('Export failed. Please retry.');
+    }
+  }, [opfs, session, tags]);
+
+  const reopenOverlay = useCallback(() => {
+    if (!session?.frame) return;
+    dispatchAnnotation({ type: 'SET', annotations: session.annotations || [] });
+    setSelection(session.selection || null);
+    setOverlayImage(session.frame);
+    setShowOverlay(true);
+    setCaptureMode('region');
+    setStatus('Adjust annotations, then press Enter to save.');
+  }, [session]);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (!event.shiftKey || isTypingTarget(event.target)) return;
+      const key = event.key.toLowerCase();
+      const mapping: Record<string, CaptureMode> = {
+        s: 'screen',
+        w: 'window',
+        r: 'region',
+      };
+      const mode = mapping[key];
+      if (mode) {
+        event.preventDefault();
+        handleStartCapture(mode);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [handleStartCapture]);
+
+  return (
+    <div className="flex h-full w-full flex-col space-y-4 overflow-auto bg-ub-cool-grey p-4 text-white">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Screen Recorder</h2>
+          <p className="text-xs text-ubt-lblue">
+            Hotkeys: Shift+S screen, Shift+W window, Shift+R region, Enter to
+            confirm, Esc to cancel overlay.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => handleStartCapture('screen')}
+            disabled={recording}
+            className={`rounded px-3 py-2 text-sm font-semibold transition ${
+              recording
+                ? 'cursor-not-allowed bg-gray-600 text-gray-300'
+                : 'bg-ub-dracula hover:bg-ub-dracula-dark'
+            }`}
+          >
+            Capture Screen
+          </button>
+          <button
+            type="button"
+            onClick={() => handleStartCapture('window')}
+            disabled={recording}
+            className={`rounded px-3 py-2 text-sm font-semibold transition ${
+              recording
+                ? 'cursor-not-allowed bg-gray-600 text-gray-300'
+                : 'bg-ub-dracula hover:bg-ub-dracula-dark'
+            }`}
+          >
+            Capture Window
+          </button>
+          <button
+            type="button"
+            onClick={() => handleStartCapture('region')}
+            className="rounded bg-sky-500 px-3 py-2 text-sm font-semibold text-slate-900 transition hover:bg-sky-400"
+          >
+            Capture Region
+          </button>
+          {recording && (
+            <button
+              type="button"
+              onClick={handleStopRecording}
+              className="rounded bg-red-600 px-3 py-2 text-sm font-semibold hover:bg-red-500"
+            >
+              Stop
+            </button>
+          )}
+        </div>
+      </div>
+      {status && (
+        <div className="rounded border border-ubt-lblue/40 bg-ub-dracula/30 px-3 py-2 text-sm text-ubt-lblue">
+          {status}
+        </div>
+      )}
+      <section className="rounded border border-white/10 bg-black/30 p-3">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-200">
+          Evidence tags
+        </h3>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {quickTagPresets.map((tag) => {
+            const active = tags.includes(tag);
+            return (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => toggleTag(tag)}
+                className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
+                  active
+                    ? 'bg-sky-500 text-slate-900 shadow'
+                    : 'bg-slate-800/80 text-slate-200 hover:bg-slate-700'
+                }`}
+              >
+                {tag}
+              </button>
+            );
+          })}
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <input
+            type="text"
+            value={tagInput}
+            onChange={(event) => setTagInput(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                handleAddTag();
+              }
+            }}
+            placeholder="Add custom tag"
+            className="w-48 rounded border border-slate-600 bg-slate-900 px-2 py-1 text-xs focus:border-sky-500 focus:outline-none"
+          />
+          <button
+            type="button"
+            onClick={handleAddTag}
+            className="rounded bg-ub-dracula px-3 py-1 text-xs font-semibold hover:bg-ub-dracula-dark"
+          >
+            Add
+          </button>
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="flex items-center gap-1 rounded-full bg-slate-800/80 px-3 py-1 text-xs text-slate-100"
+                >
+                  {tag}
+                  <button
+                    type="button"
+                    onClick={() => removeTag(tag)}
+                    className="text-slate-400 hover:text-slate-200"
+                    aria-label={`Remove tag ${tag}`}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+      <section className="grid gap-4 md:grid-cols-2">
+        {videoUrl && (
+          <div className="rounded border border-white/10 bg-black/30 p-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold">Recording preview</h3>
+              <span className="text-xs text-gray-400">{captureMode}</span>
+            </div>
+            <video
+              src={videoUrl}
+              controls
+              className="mt-2 w-full rounded border border-slate-700"
+            />
+          </div>
+        )}
+        {regionPreview && (
+          <div className="rounded border border-white/10 bg-black/30 p-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold">Annotated region</h3>
+              <button
+                type="button"
+                onClick={reopenOverlay}
+                className="text-xs text-sky-400 hover:underline"
+              >
+                Edit annotations
+              </button>
+            </div>
+            <img
+              src={regionPreview}
+              alt="Annotated region preview"
+              className="mt-2 max-h-80 w-full rounded border border-slate-700 object-contain"
+            />
+            {annotationState.annotations.length > 0 && (
+              <p className="mt-2 text-xs text-gray-400">
+                {annotationState.annotations.length} annotation(s) included.
+              </p>
+            )}
+          </div>
+        )}
+      </section>
+      <div className="mt-auto flex items-center justify-between rounded border border-white/10 bg-black/30 px-4 py-3">
+        <div className="text-xs text-gray-300">
+          Export bundles media, annotations, and metadata to the Evidence Vault.
+        </div>
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={!readyToExport}
+          className={`rounded px-4 py-2 text-sm font-semibold transition ${
+            readyToExport
+              ? 'bg-sky-500 text-slate-900 hover:bg-sky-400'
+              : 'cursor-not-allowed bg-gray-600 text-gray-300'
+          }`}
+        >
+          Export to Evidence Vault
+        </button>
+      </div>
+      {showOverlay && overlayImage && (
+        <SelectionOverlay
+          open={showOverlay}
+          imageSrc={overlayImage}
+          mode={captureMode}
+          annotationState={annotationState}
+          dispatch={dispatchAnnotation}
+          selection={selection}
+          onSelectionChange={setSelection}
+          onClose={handleOverlayCancel}
+          onConfirm={handleOverlayConfirm}
+          onModeHotkey={handleOverlayModeHotkey}
+        />
+      )}
+    </div>
+  );
+};
 
 export default ScreenRecorder;
 
 export const displayScreenRecorder = () => {
-    return <ScreenRecorder />;
+  return <ScreenRecorder />;
 };
-

--- a/components/apps/screen-recorder/SelectionOverlay.tsx
+++ b/components/apps/screen-recorder/SelectionOverlay.tsx
@@ -1,0 +1,764 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  Annotation,
+  AnnotationAction,
+  AnnotationState,
+  CaptureMode,
+  Point,
+  SelectionRect,
+  clampRect,
+  normalizeRect,
+} from './annotations';
+
+const TOOLBAR_HEIGHT = 48;
+const MAGNIFIER_SIZE = 140;
+const MAGNIFIER_ZOOM = 4;
+const DEFAULT_COLOR = '#38bdf8';
+const TEXT_BACKGROUND = 'rgba(15, 23, 42, 0.8)';
+const TEXT_COLOR = '#e2e8f0';
+
+const createId = () =>
+  typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+type OverlayTool = 'select' | 'arrow' | 'rect' | 'text' | 'blur';
+
+interface SelectionOverlayProps {
+  open: boolean;
+  imageSrc: string | null;
+  mode: CaptureMode;
+  annotationState: AnnotationState;
+  dispatch: React.Dispatch<AnnotationAction>;
+  selection: SelectionRect | null;
+  onSelectionChange: (rect: SelectionRect | null) => void;
+  onClose: () => void;
+  onConfirm: (result: {
+    dataUrl: string;
+    selection: SelectionRect | null;
+    annotations: Annotation[];
+  }) => void;
+  onModeHotkey: (mode: CaptureMode) => void;
+}
+
+const toolLabels: Record<OverlayTool, string> = {
+  select: 'Region',
+  arrow: 'Arrow',
+  rect: 'Box',
+  text: 'Text',
+  blur: 'Blur',
+};
+
+const isInputElement = (target: EventTarget | null): boolean => {
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    (target as HTMLElement | null)?.isContentEditable === true
+  );
+};
+
+const getPointerPosition = (
+  event: React.PointerEvent<HTMLCanvasElement> | PointerEvent,
+  canvas: HTMLCanvasElement,
+): Point => {
+  const rect = canvas.getBoundingClientRect();
+  const scaleX = canvas.width / rect.width;
+  const scaleY = canvas.height / rect.height;
+  return {
+    x: (event.clientX - rect.left) * scaleX,
+    y: (event.clientY - rect.top) * scaleY,
+  };
+};
+
+const drawArrow = (
+  ctx: CanvasRenderingContext2D,
+  annotation: Extract<Annotation, { type: 'arrow' }>,
+  origin: Point,
+) => {
+  const startX = annotation.start.x - origin.x;
+  const startY = annotation.start.y - origin.y;
+  const endX = annotation.end.x - origin.x;
+  const endY = annotation.end.y - origin.y;
+  const headLength = 12;
+  const angle = Math.atan2(endY - startY, endX - startX);
+
+  ctx.save();
+  ctx.strokeStyle = annotation.color;
+  ctx.fillStyle = annotation.color;
+  ctx.lineWidth = 3;
+  ctx.lineJoin = 'round';
+  ctx.beginPath();
+  ctx.moveTo(startX, startY);
+  ctx.lineTo(endX, endY);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo(endX, endY);
+  ctx.lineTo(
+    endX - headLength * Math.cos(angle - Math.PI / 6),
+    endY - headLength * Math.sin(angle - Math.PI / 6),
+  );
+  ctx.lineTo(
+    endX - headLength * Math.cos(angle + Math.PI / 6),
+    endY - headLength * Math.sin(angle + Math.PI / 6),
+  );
+  ctx.lineTo(endX, endY);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+};
+
+const drawRect = (
+  ctx: CanvasRenderingContext2D,
+  annotation: Extract<Annotation, { type: 'rect' }>,
+  origin: Point,
+  highlighted: boolean,
+) => {
+  const x = annotation.x - origin.x;
+  const y = annotation.y - origin.y;
+  ctx.save();
+  ctx.strokeStyle = highlighted ? '#f97316' : annotation.color;
+  ctx.lineWidth = highlighted ? 3 : 2;
+  ctx.strokeRect(x, y, annotation.width, annotation.height);
+  ctx.restore();
+};
+
+const drawText = (
+  ctx: CanvasRenderingContext2D,
+  annotation: Extract<Annotation, { type: 'text' }>,
+  origin: Point,
+) => {
+  const x = annotation.x - origin.x;
+  const y = annotation.y - origin.y;
+  ctx.save();
+  ctx.font = '16px Inter, system-ui, sans-serif';
+  ctx.textBaseline = 'top';
+  const metrics = ctx.measureText(annotation.text);
+  const paddingX = 8;
+  const paddingY = 4;
+  const boxWidth = metrics.width + paddingX * 2;
+  const boxHeight = 20 + paddingY * 2;
+  ctx.fillStyle = annotation.background;
+  ctx.fillRect(x, y, boxWidth, boxHeight);
+  ctx.fillStyle = annotation.color;
+  ctx.fillText(annotation.text, x + paddingX, y + paddingY);
+  ctx.restore();
+};
+
+const drawBlur = (
+  ctx: CanvasRenderingContext2D,
+  annotation: Extract<Annotation, { type: 'blur' }>,
+  origin: Point,
+  image: HTMLImageElement | null,
+  highlighted: boolean,
+) => {
+  if (!image || annotation.width <= 0 || annotation.height <= 0) return;
+  const x = annotation.x - origin.x;
+  const y = annotation.y - origin.y;
+  const temp = document.createElement('canvas');
+  temp.width = annotation.width;
+  temp.height = annotation.height;
+  const tempCtx = temp.getContext('2d');
+  if (!tempCtx) return;
+  tempCtx.filter = `blur(${annotation.intensity}px)`;
+  tempCtx.drawImage(
+    image,
+    annotation.x,
+    annotation.y,
+    annotation.width,
+    annotation.height,
+    0,
+    0,
+    annotation.width,
+    annotation.height,
+  );
+  ctx.drawImage(temp, x, y);
+  if (highlighted) {
+    ctx.save();
+    ctx.strokeStyle = '#f97316';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(x, y, annotation.width, annotation.height);
+    ctx.restore();
+  }
+};
+
+const drawAnnotations = (
+  ctx: CanvasRenderingContext2D,
+  annotations: Annotation[],
+  image: HTMLImageElement | null,
+  origin: Point,
+  selectedId: string | null,
+) => {
+  annotations.forEach((annotation) => {
+    if (annotation.type === 'arrow') {
+      drawArrow(ctx, annotation, origin);
+      return;
+    }
+    if (annotation.type === 'rect') {
+      drawRect(ctx, annotation, origin, annotation.id === selectedId);
+      return;
+    }
+    if (annotation.type === 'text') {
+      drawText(ctx, annotation, origin);
+      return;
+    }
+    if (annotation.type === 'blur') {
+      drawBlur(ctx, annotation, origin, image, annotation.id === selectedId);
+    }
+  });
+};
+
+const SelectionOverlay: React.FC<SelectionOverlayProps> = ({
+  open,
+  imageSrc,
+  mode,
+  annotationState,
+  dispatch,
+  selection,
+  onSelectionChange,
+  onClose,
+  onConfirm,
+  onModeHotkey,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const magnifierRef = useRef<HTMLCanvasElement | null>(null);
+  const [image, setImage] = useState<HTMLImageElement | null>(null);
+  const [activeTool, setActiveTool] = useState<OverlayTool>('select');
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStartRef = useRef<Point | null>(null);
+  const activeAnnotationIdRef = useRef<string | null>(null);
+  const [magnifierPosition, setMagnifierPosition] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setActiveTool('select');
+      dragStartRef.current = null;
+      activeAnnotationIdRef.current = null;
+      setMagnifierPosition(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (!imageSrc) {
+      setImage(null);
+      return;
+    }
+    const img = new Image();
+    img.onload = () => setImage(img);
+    img.src = imageSrc;
+    return () => {
+      setImage(null);
+    };
+  }, [imageSrc, open]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !image) return;
+    canvas.width = image.width;
+    canvas.height = image.height;
+  }, [image]);
+
+  const bounds = useMemo(() => {
+    if (!image) return { width: 0, height: 0 };
+    return { width: image.width, height: image.height };
+  }, [image]);
+
+  const renderCanvas = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    if (image) {
+      ctx.drawImage(image, 0, 0);
+    }
+    if (selection && selection.width > 0 && selection.height > 0) {
+      ctx.save();
+      ctx.fillStyle = 'rgba(15, 23, 42, 0.45)';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.globalCompositeOperation = 'destination-out';
+      ctx.fillRect(selection.x, selection.y, selection.width, selection.height);
+      ctx.restore();
+      ctx.save();
+      ctx.setLineDash([6, 4]);
+      ctx.lineWidth = 2;
+      ctx.strokeStyle = '#38bdf8';
+      ctx.strokeRect(selection.x, selection.y, selection.width, selection.height);
+      ctx.restore();
+    }
+    drawAnnotations(
+      ctx,
+      annotationState.annotations,
+      image,
+      { x: 0, y: 0 },
+      annotationState.selectedId,
+    );
+  }, [annotationState.annotations, annotationState.selectedId, image, selection]);
+
+  useEffect(() => {
+    if (!open) return;
+    renderCanvas();
+  }, [open, renderCanvas]);
+
+  const updateMagnifier = useCallback(
+    (point: Point, event: PointerEvent | React.PointerEvent<HTMLCanvasElement>) => {
+      const canvas = magnifierRef.current;
+      if (!canvas || !image) return;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      const sourceSize = MAGNIFIER_SIZE / MAGNIFIER_ZOOM;
+      const sx = Math.max(
+        0,
+        Math.min(image.width - sourceSize, point.x - sourceSize / 2),
+      );
+      const sy = Math.max(
+        0,
+        Math.min(image.height - sourceSize, point.y - sourceSize / 2),
+      );
+      canvas.width = MAGNIFIER_SIZE;
+      canvas.height = MAGNIFIER_SIZE;
+      ctx.imageSmoothingEnabled = false;
+      ctx.clearRect(0, 0, MAGNIFIER_SIZE, MAGNIFIER_SIZE);
+      ctx.drawImage(
+        image,
+        sx,
+        sy,
+        sourceSize,
+        sourceSize,
+        0,
+        0,
+        MAGNIFIER_SIZE,
+        MAGNIFIER_SIZE,
+      );
+      ctx.strokeStyle = '#f8fafc';
+      ctx.lineWidth = 1;
+      ctx.strokeRect(0, 0, MAGNIFIER_SIZE, MAGNIFIER_SIZE);
+      setMagnifierPosition({
+        x: Math.min(event.clientX + 24, window.innerWidth - MAGNIFIER_SIZE - 16),
+        y: Math.min(event.clientY + 24, window.innerHeight - MAGNIFIER_SIZE - 16),
+      });
+    },
+    [image],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLCanvasElement>) => {
+      if (!open) return;
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      canvas.setPointerCapture(event.pointerId);
+      setIsDragging(true);
+      const point = getPointerPosition(event, canvas);
+      dragStartRef.current = point;
+
+      if (activeTool === 'select') {
+        onSelectionChange({ x: point.x, y: point.y, width: 0, height: 0 });
+        return;
+      }
+
+      if (activeTool === 'text') {
+        const text = window.prompt('Annotation text');
+        canvas.releasePointerCapture(event.pointerId);
+        if (!text) {
+          setIsDragging(false);
+          return;
+        }
+        const annotation: Annotation = {
+          id: createId(),
+          type: 'text',
+          color: TEXT_COLOR,
+          x: point.x,
+          y: point.y,
+          text,
+          background: TEXT_BACKGROUND,
+        };
+        dispatch({ type: 'ADD', annotation });
+        renderCanvas();
+        setIsDragging(false);
+        return;
+      }
+
+      const id = createId();
+      if (activeTool === 'arrow') {
+        const annotation: Annotation = {
+          id,
+          type: 'arrow',
+          color: DEFAULT_COLOR,
+          start: point,
+          end: point,
+        };
+        dispatch({ type: 'ADD', annotation });
+        activeAnnotationIdRef.current = id;
+        return;
+      }
+      if (activeTool === 'rect') {
+        const annotation: Annotation = {
+          id,
+          type: 'rect',
+          color: DEFAULT_COLOR,
+          x: point.x,
+          y: point.y,
+          width: 0,
+          height: 0,
+        };
+        dispatch({ type: 'ADD', annotation });
+        activeAnnotationIdRef.current = id;
+        return;
+      }
+      if (activeTool === 'blur') {
+        const annotation: Annotation = {
+          id,
+          type: 'blur',
+          x: point.x,
+          y: point.y,
+          width: 0,
+          height: 0,
+          intensity: 6,
+        };
+        dispatch({ type: 'ADD', annotation });
+        activeAnnotationIdRef.current = id;
+      }
+    },
+    [activeTool, dispatch, onSelectionChange, open, renderCanvas],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLCanvasElement>) => {
+      if (!open) return;
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const point = getPointerPosition(event, canvas);
+      updateMagnifier(point, event.nativeEvent);
+      if (!isDragging || !dragStartRef.current) {
+        return;
+      }
+      if (activeTool === 'select') {
+        const draft = normalizeRect({
+          x: dragStartRef.current.x,
+          y: dragStartRef.current.y,
+          width: point.x - dragStartRef.current.x,
+          height: point.y - dragStartRef.current.y,
+        });
+        const constrained = clampRect(draft, bounds);
+        onSelectionChange(constrained);
+        renderCanvas();
+        return;
+      }
+      const activeId = activeAnnotationIdRef.current;
+      if (!activeId) return;
+      if (activeTool === 'arrow') {
+        dispatch({
+          type: 'UPDATE',
+          id: activeId,
+          changes: {
+            end: {
+              x: Math.max(0, Math.min(point.x, bounds.width)),
+              y: Math.max(0, Math.min(point.y, bounds.height)),
+            },
+          } as Partial<Annotation>,
+        });
+        renderCanvas();
+        return;
+      }
+      const width = Math.max(0, Math.min(point.x, bounds.width)) - dragStartRef.current.x;
+      const height =
+        Math.max(0, Math.min(point.y, bounds.height)) - dragStartRef.current.y;
+      const rect = normalizeRect({
+        x: dragStartRef.current.x,
+        y: dragStartRef.current.y,
+        width,
+        height,
+      });
+      dispatch({
+        type: 'UPDATE',
+        id: activeId,
+        changes: {
+          x: rect.x,
+          y: rect.y,
+          width: rect.width,
+          height: rect.height,
+        } as Partial<Annotation>,
+      });
+      renderCanvas();
+    },
+    [activeTool, bounds, dispatch, isDragging, onSelectionChange, open, renderCanvas, updateMagnifier],
+  );
+
+  const handlePointerUp = useCallback(
+    (event: React.PointerEvent<HTMLCanvasElement>) => {
+      if (!open) return;
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      canvas.releasePointerCapture(event.pointerId);
+      setIsDragging(false);
+      dragStartRef.current = null;
+      if (activeTool === 'select') {
+        if (!selection || selection.width < 4 || selection.height < 4) {
+          onSelectionChange(null);
+        } else {
+          const constrained = clampRect(selection, bounds);
+          onSelectionChange(constrained);
+        }
+        renderCanvas();
+        return;
+      }
+      const activeId = activeAnnotationIdRef.current;
+      activeAnnotationIdRef.current = null;
+      if (!activeId) return;
+      const annotation = annotationState.annotations.find(
+        (item) => item.id === activeId,
+      );
+      if (!annotation) return;
+      if (annotation.type === 'arrow') {
+        if (
+          Math.hypot(
+            annotation.end.x - annotation.start.x,
+            annotation.end.y - annotation.start.y,
+          ) < 8
+        ) {
+          dispatch({ type: 'REMOVE', id: annotation.id });
+        }
+        renderCanvas();
+        return;
+      }
+      if (annotation.type === 'rect' || annotation.type === 'blur') {
+        if (annotation.width < 8 || annotation.height < 8) {
+          dispatch({ type: 'REMOVE', id: annotation.id });
+        }
+        renderCanvas();
+      }
+    },
+    [activeTool, annotationState.annotations, bounds, dispatch, onSelectionChange, open, renderCanvas, selection],
+  );
+
+  const handlePointerLeave = useCallback(() => {
+    setMagnifierPosition(null);
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    if (!canvasRef.current || !image) return;
+    const hasSelection =
+      selection && selection.width > 0 && selection.height > 0;
+    const region = hasSelection
+      ? clampRect(selection, bounds)
+      : { x: 0, y: 0, width: bounds.width, height: bounds.height };
+    const exportWidth = Math.max(1, Math.round(region.width));
+    const exportHeight = Math.max(1, Math.round(region.height));
+    const exportCanvas = document.createElement('canvas');
+    exportCanvas.width = exportWidth;
+    exportCanvas.height = exportHeight;
+    const exportCtx = exportCanvas.getContext('2d');
+    if (!exportCtx) return;
+    exportCtx.drawImage(
+      image,
+      region.x,
+      region.y,
+      region.width,
+      region.height,
+      0,
+      0,
+      exportWidth,
+      exportHeight,
+    );
+    drawAnnotations(
+      exportCtx,
+      annotationState.annotations,
+      image,
+      { x: region.x, y: region.y },
+      null,
+    );
+    const dataUrl = exportCanvas.toDataURL('image/png');
+    onConfirm({
+      dataUrl,
+      selection: hasSelection ? region : null,
+      annotations: annotationState.annotations,
+    });
+  }, [annotationState.annotations, annotationState.selectedId, bounds, image, onConfirm, selection]);
+
+  useEffect(() => {
+    if (!open) return;
+    const keyListener = (event: KeyboardEvent) => {
+      if (isInputElement(event.target)) return;
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        handleConfirm();
+        return;
+      }
+      if (event.key === 'Delete' || event.key === 'Backspace') {
+        if (annotationState.selectedId) {
+          event.preventDefault();
+          dispatch({ type: 'REMOVE', id: annotationState.selectedId });
+          renderCanvas();
+        }
+      }
+      if (event.shiftKey) {
+        const key = event.key.toLowerCase();
+        const mapping: Record<string, CaptureMode> = {
+          s: 'screen',
+          w: 'window',
+          r: 'region',
+        };
+        const modeKey = mapping[key];
+        if (modeKey) {
+          event.preventDefault();
+          onModeHotkey(modeKey);
+        }
+      }
+    };
+    window.addEventListener('keydown', keyListener);
+    return () => window.removeEventListener('keydown', keyListener);
+  }, [annotationState.selectedId, dispatch, handleConfirm, onClose, onModeHotkey, open, renderCanvas]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const handleClick = (event: MouseEvent) => {
+      if (!canvas || !open) return;
+      const point = getPointerPosition(event as unknown as PointerEvent, canvas);
+      const hit = annotationState.annotations.find((annotation) => {
+        if (annotation.type === 'arrow') {
+          const distance = Math.hypot(
+            annotation.end.x - annotation.start.x,
+            annotation.end.y - annotation.start.y,
+          );
+          if (distance < 6) return false;
+          const t =
+            ((point.x - annotation.start.x) *
+              (annotation.end.x - annotation.start.x) +
+              (point.y - annotation.start.y) *
+                (annotation.end.y - annotation.start.y)) /
+            Math.max(distance ** 2, 1);
+          if (t < 0 || t > 1) return false;
+          const projX = annotation.start.x +
+            t * (annotation.end.x - annotation.start.x);
+          const projY = annotation.start.y +
+            t * (annotation.end.y - annotation.start.y);
+          return Math.hypot(point.x - projX, point.y - projY) <= 8;
+        }
+        if (annotation.type === 'text') {
+          const ctx = canvas.getContext('2d');
+          if (!ctx) return false;
+          ctx.font = '16px Inter, system-ui, sans-serif';
+          const metrics = ctx.measureText(annotation.text);
+          const width = metrics.width + 16;
+          const height = 28;
+          return (
+            point.x >= annotation.x &&
+            point.x <= annotation.x + width &&
+            point.y >= annotation.y &&
+            point.y <= annotation.y + height
+          );
+        }
+        const rect = {
+          x: annotation.x,
+          y: annotation.y,
+          width: annotation.width,
+          height: annotation.height,
+        };
+        return (
+          point.x >= rect.x &&
+          point.x <= rect.x + rect.width &&
+          point.y >= rect.y &&
+          point.y <= rect.y + rect.height
+        );
+      });
+      if (hit) {
+        dispatch({ type: 'SELECT', id: hit.id });
+      } else {
+        dispatch({ type: 'SELECT', id: null });
+      }
+      renderCanvas();
+    };
+    canvas.addEventListener('click', handleClick);
+    return () => canvas.removeEventListener('click', handleClick);
+  }, [annotationState.annotations, dispatch, open, renderCanvas]);
+
+  if (!open || !image) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="absolute top-8 left-1/2 -translate-x-1/2 rounded bg-slate-900/90 px-4 py-2 text-xs text-slate-200 shadow-lg">
+        <p className="font-semibold text-slate-100">
+          Region capture ({mode.toUpperCase()})
+        </p>
+        <p>
+          Hotkeys: Shift+S screen, Shift+W window, Shift+R region, Enter confirm,
+          Esc cancel
+        </p>
+      </div>
+      <div className="relative max-h-[88vh] max-w-[92vw] overflow-hidden rounded-lg border border-slate-700 bg-slate-950/40 shadow-2xl">
+        <canvas
+          ref={canvasRef}
+          className="h-full w-full cursor-crosshair"
+          style={{ maxWidth: '92vw', maxHeight: `calc(88vh - ${TOOLBAR_HEIGHT}px)` }}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerLeave={handlePointerLeave}
+        />
+        {magnifierPosition && (
+          <canvas
+            ref={magnifierRef}
+            className="pointer-events-none absolute rounded border border-slate-600 shadow-lg"
+            style={{
+              width: MAGNIFIER_SIZE,
+              height: MAGNIFIER_SIZE,
+              left: magnifierPosition.x,
+              top: magnifierPosition.y,
+            }}
+          />
+        )}
+        <div className="absolute bottom-4 right-4 flex gap-2">
+          <button
+            type="button"
+            onClick={handleConfirm}
+            className="rounded bg-sky-500 px-4 py-2 text-sm font-semibold text-slate-900 shadow hover:bg-sky-400"
+          >
+            Use selection
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded bg-slate-700/80 px-4 py-2 text-sm text-slate-200 hover:bg-slate-600"
+          >
+            Cancel
+          </button>
+        </div>
+        <div className="absolute top-4 left-4 flex h-10 items-center gap-2 rounded-full bg-slate-900/90 px-4 text-xs text-slate-200 shadow-lg">
+          {(Object.keys(toolLabels) as OverlayTool[]).map((tool) => (
+            <button
+              key={tool}
+              type="button"
+              onClick={() => setActiveTool(tool)}
+              className={`rounded-full px-3 py-1 font-medium transition ${
+                activeTool === tool
+                  ? 'bg-sky-500 text-slate-900 shadow'
+                  : 'bg-transparent text-slate-200 hover:bg-slate-800'
+              }`}
+            >
+              {toolLabels[tool]}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SelectionOverlay;

--- a/components/apps/screen-recorder/annotations.ts
+++ b/components/apps/screen-recorder/annotations.ts
@@ -1,0 +1,157 @@
+export type CaptureMode = 'screen' | 'window' | 'region';
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface SelectionRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type Annotation =
+  | {
+      id: string;
+      type: 'arrow';
+      color: string;
+      start: Point;
+      end: Point;
+    }
+  | {
+      id: string;
+      type: 'rect';
+      color: string;
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+    }
+  | {
+      id: string;
+      type: 'text';
+      color: string;
+      x: number;
+      y: number;
+      text: string;
+      background: string;
+    }
+  | {
+      id: string;
+      type: 'blur';
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+      intensity: number;
+    };
+
+export interface AnnotationState {
+  annotations: Annotation[];
+  selectedId: string | null;
+}
+
+export const createInitialAnnotationState = (): AnnotationState => ({
+  annotations: [],
+  selectedId: null,
+});
+
+export type AnnotationAction =
+  | { type: 'ADD'; annotation: Annotation }
+  | { type: 'UPDATE'; id: string; changes: Partial<Annotation> }
+  | { type: 'REMOVE'; id: string }
+  | { type: 'SELECT'; id: string | null }
+  | { type: 'SET'; annotations: Annotation[] }
+  | { type: 'RESET' };
+
+const updateAnnotation = (
+  annotations: Annotation[],
+  id: string,
+  changes: Partial<Annotation>,
+): Annotation[] =>
+  annotations.map((annotation) =>
+    annotation.id === id ? { ...annotation, ...changes } : annotation,
+  );
+
+export const annotationReducer = (
+  state: AnnotationState,
+  action: AnnotationAction,
+): AnnotationState => {
+  switch (action.type) {
+    case 'ADD':
+      return {
+        annotations: [...state.annotations, action.annotation],
+        selectedId: action.annotation.id,
+      };
+    case 'UPDATE':
+      return {
+        ...state,
+        annotations: updateAnnotation(
+          state.annotations,
+          action.id,
+          action.changes,
+        ),
+      };
+    case 'REMOVE':
+      return {
+        annotations: state.annotations.filter(
+          (annotation) => annotation.id !== action.id,
+        ),
+        selectedId:
+          state.selectedId === action.id ? null : state.selectedId,
+      };
+    case 'SELECT':
+      return { ...state, selectedId: action.id };
+    case 'SET':
+      return { annotations: [...action.annotations], selectedId: null };
+    case 'RESET':
+      return createInitialAnnotationState();
+    default:
+      return state;
+  }
+};
+
+export const isPointWithinRect = (
+  point: Point,
+  rect: SelectionRect,
+): boolean => {
+  return (
+    point.x >= rect.x &&
+    point.y >= rect.y &&
+    point.x <= rect.x + rect.width &&
+    point.y <= rect.y + rect.height
+  );
+};
+
+export const normalizeRect = (rect: SelectionRect): SelectionRect => {
+  const normalized: SelectionRect = { ...rect };
+  if (rect.width < 0) {
+    normalized.x = rect.x + rect.width;
+    normalized.width = Math.abs(rect.width);
+  }
+  if (rect.height < 0) {
+    normalized.y = rect.y + rect.height;
+    normalized.height = Math.abs(rect.height);
+  }
+  return normalized;
+};
+
+export const clampRect = (
+  rect: SelectionRect,
+  bounds: { width: number; height: number },
+): SelectionRect => {
+  const normalized = normalizeRect(rect);
+  const x = Math.max(0, Math.min(normalized.x, bounds.width));
+  const y = Math.max(0, Math.min(normalized.y, bounds.height));
+  const width = Math.max(
+    0,
+    Math.min(normalized.width, bounds.width - x),
+  );
+  const height = Math.max(
+    0,
+    Math.min(normalized.height, bounds.height - y),
+  );
+  return { x, y, width, height };
+};

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -80,6 +80,9 @@ Tools to cover: **BeEF, Ettercap, Metasploit, Wireshark, Kismet, Nikto, Autopsy,
 ### QR Tool
 - Add camera select drop-down and "download QR" button after generation.
 
+### Screen Recorder
+- Document hotkeys (Shift+S for full screen, Shift+W for window, Shift+R for region, Enter to confirm, Esc to cancel) and keep annotation tools discoverable in overlay.
+
 ### ASCII Art
 - Support text-to-ASCII and image-to-ASCII via hidden canvas sampling.
 


### PR DESCRIPTION
## Summary
- add reusable annotation reducer utilities and a region-selection overlay with magnifier, tool palette, and capture hotkeys for the screen recorder
- extend the screen recorder to drive the overlay, manage tagging, persist assets via OPFS/download fallback, and ingest metadata into the evidence vault
- factor evidence vault ingestion helpers and refresh the vault UI while documenting capture hotkeys and covering reducers with new unit tests

## Testing
- yarn lint *(fails: repository has existing accessibility and window/global lint violations)*
- yarn test *(fails: existing suites such as nmap NSE and pdf viewer crash under jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68cb19c125ec83289bff1a2977da746b