### PR TITLE
feat: enhance clipboard manager history

### DIFF
--- a/__tests__/components/apps/ClipboardManager.test.tsx
+++ b/__tests__/components/apps/ClipboardManager.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import ClipboardManager, {
+  CLIPBOARD_DB_NAME,
+  CLIPBOARD_STORE_NAME,
+  CLIPBOARD_RETENTION_MS,
+  MAX_CLIPBOARD_ITEMS,
+  closeClipboardDb,
+  getClipboardDb,
+  resetClipboardDbCache,
+} from '../../../components/apps/ClipboardManager';
+
+describe('ClipboardManager', () => {
+  const originalClipboard = navigator.clipboard;
+  const originalPermissions = (navigator as any).permissions;
+
+  const resetDatabase = async () => {
+    await closeClipboardDb();
+    await new Promise<void>((resolve) => {
+      const request = indexedDB.deleteDatabase(CLIPBOARD_DB_NAME);
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+      request.onblocked = () => resolve();
+    });
+    resetClipboardDbCache();
+  };
+
+  beforeEach(async () => {
+    await resetDatabase();
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        readText: jest.fn().mockResolvedValue(''),
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+    });
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: {
+        query: jest.fn().mockResolvedValue({ state: 'granted' }),
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: originalClipboard,
+      });
+    } else {
+      delete (navigator as any).clipboard;
+    }
+    if (originalPermissions) {
+      Object.defineProperty(navigator, 'permissions', {
+        configurable: true,
+        value: originalPermissions,
+      });
+    } else {
+      delete (navigator as any).permissions;
+    }
+  });
+
+  it('enforces retention limits and keeps pinned items', async () => {
+    const db = await getClipboardDb();
+    expect(db).toBeTruthy();
+    if (!db) throw new Error('Failed to open clipboard DB');
+
+    const tx = db.transaction(CLIPBOARD_STORE_NAME, 'readwrite');
+    const now = Date.now();
+    for (let i = 0; i < MAX_CLIPBOARD_ITEMS + 5; i += 1) {
+      await tx.store.add({
+        text: `item-${i}`,
+        created: now - i * 1000,
+        pinned: false,
+      });
+    }
+    await tx.store.add({
+      text: 'pinned-old',
+      created: now - CLIPBOARD_RETENTION_MS - 5000,
+      pinned: true,
+    });
+    await tx.store.add({
+      text: 'expired',
+      created: now - CLIPBOARD_RETENTION_MS - 5000,
+      pinned: false,
+    });
+    await tx.done;
+
+    render(<ClipboardManager />);
+
+    await screen.findByText('pinned-old');
+
+    const pinnedSection = await screen.findByLabelText('Pinned clipboard entries');
+    expect(within(pinnedSection).getByText('pinned-old')).toBeInTheDocument();
+
+    const recentSection = await screen.findByLabelText('Recent clipboard entries');
+    await waitFor(() => {
+      expect(within(recentSection).getAllByRole('listitem')).toHaveLength(MAX_CLIPBOARD_ITEMS);
+    });
+    expect(screen.queryByText('expired')).not.toBeInTheDocument();
+    expect(screen.queryByText(`item-${MAX_CLIPBOARD_ITEMS + 4}`)).not.toBeInTheDocument();
+  });
+
+  it('allows pinning and unpinning entries', async () => {
+    const db = await getClipboardDb();
+    expect(db).toBeTruthy();
+    if (!db) throw new Error('Failed to open clipboard DB');
+
+    const tx = db.transaction(CLIPBOARD_STORE_NAME, 'readwrite');
+    await tx.store.add({ text: 'pin me', created: Date.now(), pinned: false });
+    await tx.done;
+
+    render(<ClipboardManager />);
+
+    await screen.findByText('pin me');
+
+    const row = screen.getByText('pin me').closest('div[data-active]');
+    expect(row).toBeTruthy();
+    const pinButton = within(row as HTMLElement).getByRole('button', { name: 'Pin' });
+    fireEvent.click(pinButton);
+
+    const pinnedSection = await screen.findByLabelText('Pinned clipboard entries');
+    expect(within(pinnedSection).getByText('pin me')).toBeInTheDocument();
+
+    const pinnedRow = within(pinnedSection).getByText('pin me').closest('div[data-active]');
+    expect(pinnedRow).toBeTruthy();
+    const unpinButton = within(pinnedRow as HTMLElement).getByRole('button', { name: 'Unpin' });
+    fireEvent.click(unpinButton);
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Pinned clipboard entries')).not.toBeInTheDocument();
+    });
+  });
+
+  it('filters sensitive clipboard entries and shows a warning badge', async () => {
+    const clipboard = navigator.clipboard as unknown as {
+      readText: jest.Mock;
+      writeText: jest.Mock;
+    };
+    clipboard.readText.mockResolvedValueOnce('api_key=ABCDEFGHIJKLMNOP1234567890');
+
+    render(<ClipboardManager />);
+
+    await act(async () => {
+      fireEvent.copy(document);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText('Filtered potential secret: generic secret')).toBeInTheDocument(),
+    );
+
+    expect(screen.queryByText(/api_key=ABCDEFGHIJKLMNOP1234567890/)).not.toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Filtered potential secret');
+  });
+});

--- a/components/apps/ClipboardManager.tsx
+++ b/components/apps/ClipboardManager.tsx
@@ -1,142 +1,274 @@
 "use client";
 
-import React, { useEffect, useState, useCallback } from 'react';
-import { getDb } from '../../utils/safeIDB';
+import React, { useCallback, useEffect, useState } from 'react';
+import HistoryOverlay from './ClipboardManager/HistoryOverlay';
+import { detectSensitiveContent } from '../../utils/redaction';
+import { ensureObjectStore, getDb } from '../../utils/safeIDB';
 
-interface ClipItem {
+export interface ClipItem {
   id?: number;
   text: string;
   created: number;
+  pinned?: boolean;
 }
 
-const DB_NAME = 'clipboard-manager';
-const STORE_NAME = 'items';
+export const CLIPBOARD_DB_NAME = 'clipboard-manager';
+export const CLIPBOARD_STORE_NAME = 'items';
+export const CLIPBOARD_DB_VERSION = 2;
+export const CLIPBOARD_CREATED_INDEX = 'by-created';
+export const CLIPBOARD_PINNED_INDEX = 'by-pinned';
+export const MAX_CLIPBOARD_ITEMS = 25;
+export const CLIPBOARD_RETENTION_MS = 24 * 60 * 60 * 1000;
 
 let dbPromise: ReturnType<typeof getDb> | null = null;
-function getDB() {
+
+export function getClipboardDb() {
   if (!dbPromise) {
-    dbPromise = getDb(DB_NAME, 1, {
-      upgrade(db) {
-        if (!db.objectStoreNames.contains(STORE_NAME)) {
-          db.createObjectStore(STORE_NAME, {
-            keyPath: 'id',
-            autoIncrement: true,
-          });
-        }
+    dbPromise = getDb(CLIPBOARD_DB_NAME, CLIPBOARD_DB_VERSION, {
+      upgrade(db, _oldVersion, _newVersion, transaction) {
+        ensureObjectStore(
+          db as any,
+          transaction as any,
+          CLIPBOARD_STORE_NAME,
+          { keyPath: 'id', autoIncrement: true },
+          [
+            { name: CLIPBOARD_CREATED_INDEX, keyPath: 'created' },
+            { name: CLIPBOARD_PINNED_INDEX, keyPath: 'pinned' },
+          ],
+        );
       },
     });
   }
+
   return dbPromise;
+}
+
+export function resetClipboardDbCache() {
+  dbPromise = null;
+}
+
+export async function closeClipboardDb() {
+  if (!dbPromise) return;
+  try {
+    const db = await dbPromise;
+    db?.close?.();
+  } catch {
+    // ignore close failures in tests
+  } finally {
+    dbPromise = null;
+  }
+}
+
+function normalizeItem(item: ClipItem): ClipItem {
+  return {
+    id: item.id,
+    text: item.text,
+    created: item.created,
+    pinned: Boolean(item.pinned),
+  };
 }
 
 const ClipboardManager: React.FC = () => {
   const [items, setItems] = useState<ClipItem[]>([]);
+  const [warnings, setWarnings] = useState<string[]>([]);
 
   const loadItems = useCallback(async () => {
     try {
-      const dbp = getDB();
-      if (!dbp) return;
-      const db = await dbp;
+      const dbp = getClipboardDb();
+      if (!dbp) {
+        setItems([]);
+        return;
+      }
 
-      const all = await db.getAll(STORE_NAME);
-      setItems(all.sort((a, b) => (b.id ?? 0) - (a.id ?? 0)));
-    } catch {
-      // ignore errors
+      const db = await dbp;
+      const tx = db.transaction(CLIPBOARD_STORE_NAME, 'readwrite');
+      const store = tx.store;
+      const index = store.index(CLIPBOARD_CREATED_INDEX);
+      const records = await index.getAll();
+      const now = Date.now();
+      const preserved: ClipItem[] = [];
+      const toDelete: number[] = [];
+      let unpinnedCount = 0;
+
+      for (let i = records.length - 1; i >= 0; i -= 1) {
+        const record = records[i];
+        const created = typeof record.created === 'number' ? record.created : 0;
+        const pinned = Boolean(record.pinned);
+        const id = record.id;
+
+        if (!pinned && now - created > CLIPBOARD_RETENTION_MS) {
+          if (typeof id === 'number') {
+            toDelete.push(id);
+          }
+          continue;
+        }
+
+        if (!pinned && unpinnedCount >= MAX_CLIPBOARD_ITEMS) {
+          if (typeof id === 'number') {
+            toDelete.push(id);
+          }
+          continue;
+        }
+
+        preserved.push(
+          normalizeItem({
+            id,
+            text: record.text,
+            created,
+            pinned,
+          }),
+        );
+
+        if (!pinned) {
+          unpinnedCount += 1;
+        }
+      }
+
+      for (const id of toDelete) {
+        await store.delete(id);
+      }
+
+      await tx.done;
+
+      preserved.sort((a, b) => b.created - a.created);
+      setItems(preserved);
+    } catch (error) {
+      console.error('Failed to load clipboard history', error);
     }
   }, []);
 
   const addItem = useCallback(
     async (text: string) => {
       if (!text) return;
+      const detection = detectSensitiveContent(text);
+      if (detection.hasMatch) {
+        const messages = detection.matches.length
+          ? detection.matches.map((match) => `Filtered potential secret: ${match}`)
+          : ['Filtered potential secret'];
+        setWarnings((prev) => {
+          const next = [...prev, ...messages];
+          return next.slice(-5);
+        });
+        return;
+      }
+
       try {
-        const dbp = getDB();
+        const dbp = getClipboardDb();
         if (!dbp) return;
         const db = await dbp;
-
-        const tx = db.transaction(STORE_NAME, 'readwrite');
-        await tx.store.add({ text, created: Date.now() });
+        const tx = db.transaction(CLIPBOARD_STORE_NAME, 'readwrite');
+        await tx.store.add({ text, created: Date.now(), pinned: false });
         await tx.done;
         await loadItems();
-      } catch {
-        // ignore errors
+      } catch (error) {
+        console.error('Clipboard add failed:', error);
       }
     },
-    [loadItems]
+    [loadItems],
   );
+
+  const captureClipboard = useCallback(async () => {
+    try {
+      const permissions = (navigator.permissions as any)?.query?.({
+        name: 'clipboard-read' as PermissionName,
+      });
+      if (permissions) {
+        const status = await permissions;
+        if (status?.state === 'denied') {
+          return;
+        }
+      }
+
+      const text = await navigator.clipboard?.readText?.();
+      if (!text) return;
+      if (items[0]?.text === text) return;
+      await addItem(text);
+    } catch (error) {
+      console.error('Clipboard read failed:', error);
+    }
+  }, [addItem, items]);
 
   useEffect(() => {
     loadItems();
   }, [loadItems]);
 
-  const handleCopy = useCallback(async () => {
-    try {
-      const perm = await (navigator.permissions as any)?.query?.({
-        name: 'clipboard-read' as any,
-      });
-      if (perm && perm.state === 'denied') return;
-      const text = await navigator.clipboard.readText();
-      if (text && (!items[0] || items[0].text !== text)) {
-        await addItem(text);
-      }
-    } catch (err) {
-      console.error('Clipboard read failed:', err);
-    }
-  }, [items, addItem]);
-
   useEffect(() => {
-    document.addEventListener('copy', handleCopy);
-    return () => document.removeEventListener('copy', handleCopy);
-  }, [handleCopy]);
+    document.addEventListener('copy', captureClipboard);
+    return () => document.removeEventListener('copy', captureClipboard);
+  }, [captureClipboard]);
 
-  const writeToClipboard = async (text: string) => {
+  const writeToClipboard = useCallback(async (text: string) => {
     try {
-      const perm = await (navigator.permissions as any)?.query?.({
-        name: 'clipboard-write' as any,
+      const permissions = (navigator.permissions as any)?.query?.({
+        name: 'clipboard-write' as PermissionName,
       });
-      if (perm && perm.state === 'denied') return;
-      await navigator.clipboard.writeText(text);
-    } catch (err) {
-      console.error('Clipboard write failed:', err);
+      if (permissions) {
+        const status = await permissions;
+        if (status?.state === 'denied') {
+          return;
+        }
+      }
+      await navigator.clipboard?.writeText?.(text);
+    } catch (error) {
+      console.error('Clipboard write failed:', error);
     }
-  };
+  }, []);
 
-  const clearHistory = async () => {
+  const handleCopyItem = useCallback(
+    (item: ClipItem) => {
+      if (!item.text) return;
+      void writeToClipboard(item.text);
+    },
+    [writeToClipboard],
+  );
+
+  const togglePin = useCallback(
+    async (item: ClipItem) => {
+      if (typeof item.id !== 'number') return;
+      try {
+        const dbp = getClipboardDb();
+        if (!dbp) return;
+        const db = await dbp;
+        const tx = db.transaction(CLIPBOARD_STORE_NAME, 'readwrite');
+        const current = await tx.store.get(item.id);
+        if (current) {
+          await tx.store.put({ ...current, pinned: !current.pinned });
+        }
+        await tx.done;
+        await loadItems();
+      } catch (error) {
+        console.error('Failed to toggle pin state', error);
+      }
+    },
+    [loadItems],
+  );
+
+  const clearHistory = useCallback(async () => {
     try {
-      const dbp = getDB();
-      if (!dbp) return;
+      const dbp = getClipboardDb();
+      if (!dbp) {
+        setItems([]);
+        return;
+      }
       const db = await dbp;
-
-      await db.clear(STORE_NAME);
+      await db.clear(CLIPBOARD_STORE_NAME);
       setItems([]);
-    } catch {
-      // ignore errors
+    } catch (error) {
+      console.error('Failed to clear clipboard history', error);
     }
-  };
+  }, []);
 
   return (
-    <div className="p-4 space-y-2 text-white bg-ub-cool-grey h-full overflow-auto">
-      <button
-        className="px-2 py-1 bg-gray-700 hover:bg-gray-600"
-        onClick={clearHistory}
-      >
-        Clear History
-      </button>
-      <ul className="space-y-1">
-        {items.map((item) => (
-          <li
-            key={item.id}
-            className="cursor-pointer hover:underline"
-            onClick={() => writeToClipboard(item.text)}
-          >
-            {item.text}
-          </li>
-        ))}
-      </ul>
-    </div>
+    <HistoryOverlay
+      items={items}
+      warnings={warnings}
+      onClear={clearHistory}
+      onCopy={handleCopyItem}
+      onTogglePin={togglePin}
+    />
   );
 };
 
 export const displayClipboardManager = () => <ClipboardManager />;
 
 export default ClipboardManager;
-

--- a/components/apps/ClipboardManager/HistoryOverlay.tsx
+++ b/components/apps/ClipboardManager/HistoryOverlay.tsx
@@ -1,0 +1,283 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import type { ClipItem } from '../ClipboardManager';
+
+interface HistoryOverlayProps {
+  items: ClipItem[];
+  warnings: string[];
+  onClear: () => void;
+  onCopy: (item: ClipItem) => void;
+  onTogglePin: (item: ClipItem) => void;
+}
+
+const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: '2-digit',
+  minute: '2-digit',
+});
+
+const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+});
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function highlightMatches(text: string, query: string) {
+  if (!query) return text;
+  const regex = new RegExp(`(${escapeRegExp(query)})`, 'gi');
+  const segments = text.split(regex);
+  return segments.map((segment, index) =>
+    index % 2 === 1 ? (
+      <mark key={`${segment}-${index}`} className="rounded bg-ubt-blue/30 px-0.5">
+        {segment}
+      </mark>
+    ) : (
+      <React.Fragment key={`${segment}-${index}`}>{segment}</React.Fragment>
+    ),
+  );
+}
+
+function formatTimestamp(value: number) {
+  const created = new Date(value);
+  const now = new Date();
+  const isSameDay =
+    created.getFullYear() === now.getFullYear() &&
+    created.getMonth() === now.getMonth() &&
+    created.getDate() === now.getDate();
+
+  return isSameDay ? timeFormatter.format(created) : dateTimeFormatter.format(created);
+}
+
+const HistoryOverlay: React.FC<HistoryOverlayProps> = ({
+  items,
+  warnings,
+  onClear,
+  onCopy,
+  onTogglePin,
+}) => {
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const searchRef = useRef<HTMLInputElement | null>(null);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    searchRef.current?.focus();
+  }, []);
+
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const { pinned, history } = useMemo(() => {
+    const pinnedItems = items.filter((item) => item.pinned);
+    const historyItems = items.filter((item) => !item.pinned);
+
+    if (!normalizedQuery) {
+      return { pinned: pinnedItems, history: historyItems };
+    }
+
+    const filter = (item: ClipItem) =>
+      item.text.toLowerCase().includes(normalizedQuery);
+
+    return {
+      pinned: pinnedItems.filter(filter),
+      history: historyItems.filter(filter),
+    };
+  }, [items, normalizedQuery]);
+
+  const flatList = useMemo(() => [...pinned, ...history], [pinned, history]);
+
+  useEffect(() => {
+    if (!flatList.length) {
+      setActiveIndex(-1);
+    } else if (activeIndex < 0 || activeIndex >= flatList.length) {
+      setActiveIndex(0);
+    }
+  }, [flatList, activeIndex]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (!overlayRef.current || !overlayRef.current.contains(target)) {
+        return;
+      }
+
+      if (!flatList.length) return;
+
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault();
+        setActiveIndex((prev) => {
+          const next = prev < 0 ? 0 : prev;
+          const offset = event.key === 'ArrowDown' ? 1 : -1;
+          const total = flatList.length;
+          return (total + next + offset) % total;
+        });
+      } else if (event.key === 'Enter' && activeIndex >= 0 && activeIndex < flatList.length) {
+        event.preventDefault();
+        onCopy(flatList[activeIndex]);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [activeIndex, flatList, onCopy]);
+
+  const hasQuery = normalizedQuery.length > 0;
+  const hasResults = flatList.length > 0;
+
+  return (
+    <div
+      ref={overlayRef}
+      className="flex h-full flex-col bg-ub-cool-grey/95 text-white"
+      role="dialog"
+      aria-label="Clipboard history"
+    >
+      <div className="flex items-center justify-between gap-4 border-b border-white/10 px-4 py-3">
+        <div>
+          <h2 className="text-lg font-semibold">Clipboard history</h2>
+          <p className="text-xs text-white/70">Use Enter to paste the highlighted entry.</p>
+        </div>
+        <button
+          type="button"
+          className="rounded border border-white/20 px-3 py-1 text-sm text-white/80 transition hover:border-ubt-blue hover:text-ubt-blue disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={onClear}
+          disabled={!items.length}
+        >
+          Clear history
+        </button>
+      </div>
+
+      {warnings.length > 0 && (
+        <div className="flex flex-wrap gap-2 px-4 py-2 text-xs" role="status">
+          {warnings.map((warning, index) => (
+            <span
+              key={`${warning}-${index}`}
+              className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-1 text-amber-200"
+            >
+              <span aria-hidden="true">⚠️</span>
+              {warning}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="px-4 py-3">
+        <label className="flex items-center gap-2 rounded-md bg-black/40 px-3 py-2 focus-within:ring-2 focus-within:ring-ubt-blue">
+          <span className="text-xs uppercase tracking-wide text-white/60">Search</span>
+          <input
+            ref={searchRef}
+            type="text"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Find text"
+            className="flex-1 bg-transparent text-sm text-white outline-none placeholder:text-white/40"
+            aria-label="Search clipboard history"
+          />
+        </label>
+      </div>
+
+      <div className="flex-1 space-y-6 overflow-y-auto px-4 pb-4">
+        {pinned.length > 0 && (
+          <section aria-label="Pinned clipboard entries" className="space-y-2">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-white/60">Pinned</h3>
+            <ul className="space-y-2">
+              {pinned.map((item, index) => (
+                <HistoryRow
+                  key={item.id ?? `${item.created}-pinned`}
+                  item={item}
+                  isActive={index === activeIndex}
+                  query={normalizedQuery}
+                  onCopy={onCopy}
+                  onTogglePin={onTogglePin}
+                />
+              ))}
+            </ul>
+          </section>
+        )}
+
+        <section aria-label="Recent clipboard entries" className="space-y-2">
+          {history.length > 0 && (
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-white/60">
+              {pinned.length ? 'Recent' : 'History'}
+            </h3>
+          )}
+          <ul className="space-y-2">
+            {history.map((item, index) => (
+              <HistoryRow
+                key={item.id ?? `${item.created}-history`}
+                item={item}
+                isActive={index + pinned.length === activeIndex}
+                query={normalizedQuery}
+                onCopy={onCopy}
+                onTogglePin={onTogglePin}
+              />
+            ))}
+          </ul>
+
+          {!items.length && !hasQuery && (
+            <p className="text-sm text-white/60">Copy something to build your clipboard history.</p>
+          )}
+
+          {hasQuery && !hasResults && (
+            <p className="text-sm text-white/60">No results for “{query}”.</p>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+interface HistoryRowProps {
+  item: ClipItem;
+  isActive: boolean;
+  query: string;
+  onCopy: (item: ClipItem) => void;
+  onTogglePin: (item: ClipItem) => void;
+}
+
+const HistoryRow: React.FC<HistoryRowProps> = ({ item, isActive, query, onCopy, onTogglePin }) => {
+  const handleCopy = () => onCopy(item);
+  const handleToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onTogglePin(item);
+  };
+
+  return (
+    <li>
+      <div
+        className={
+          'group relative flex items-start gap-3 rounded-md border border-transparent bg-white/5 px-3 py-2 transition hover:border-ubt-blue hover:bg-black/60' +
+          (isActive ? ' border-ubt-blue bg-black/60' : '')
+        }
+        data-active={isActive}
+      >
+        <button
+          type="button"
+          className="flex-1 text-left text-sm leading-snug text-white"
+          onClick={handleCopy}
+        >
+          <div className="break-words">{highlightMatches(item.text, query)}</div>
+          <time
+            dateTime={new Date(item.created).toISOString()}
+            className="mt-1 block text-xs text-white/50"
+          >
+            {formatTimestamp(item.created)}
+          </time>
+        </button>
+        <div className="flex flex-col items-end gap-2">
+          <button
+            type="button"
+            onClick={handleToggle}
+            className="rounded border border-white/20 px-2 py-1 text-xs text-white/70 transition hover:border-ubt-blue hover:text-ubt-blue"
+            aria-pressed={Boolean(item.pinned)}
+          >
+            {item.pinned ? 'Unpin' : 'Pin'}
+          </button>
+        </div>
+      </div>
+    </li>
+  );
+};
+
+export default HistoryOverlay;

--- a/docs/clipboard-manager.md
+++ b/docs/clipboard-manager.md
@@ -1,0 +1,11 @@
+# Clipboard Manager Overlay
+
+The Clipboard Manager captures clipboard entries locally using IndexedDB so the history persists between sessions. Key behaviors:
+
+- Stores up to **25 unpinned entries** from the last 24 hours. Older unpinned clips are pruned automatically while pinned clips remain regardless of age.
+- Saves timestamps and pin state for each entry so the UI can show sections for pinned and recent history.
+- Filters copied text through `utils/redaction.ts`; potential secrets are skipped and surfaced as warning badges instead of being stored.
+- Provides instant search with highlighted matches, plus arrow key navigation and <kbd>Enter</kbd> to copy the selected entry.
+- `Ctrl` + `Shift` + `V` opens the overlay window, mirroring the OS shortcut for clipboard history.
+
+Use the **Pin** button to keep critical entries at the top and **Clear history** to remove all stored items. The manager falls back gracefully if the browser disables clipboard APIs or IndexedDB.

--- a/utils/redaction.ts
+++ b/utils/redaction.ts
@@ -1,0 +1,64 @@
+const SECRET_RULES = [
+  {
+    label: 'private key',
+    pattern: /-----BEGIN [^-]+ PRIVATE KEY-----[\s\S]*?-----END [^-]+ PRIVATE KEY-----/gi,
+    replacement: '[REDACTED PRIVATE KEY]',
+  },
+  {
+    label: 'AWS access key',
+    pattern: /\bAKIA[0-9A-Z]{16}\b/g,
+    replacement: 'AKIA****************',
+  },
+  {
+    label: 'AWS secret key',
+    pattern: /aws_secret_access_key\s*[:=]\s*["']?[A-Za-z0-9\/+=]{40}["']?/gi,
+    replacement: 'aws_secret_access_key=[REDACTED]',
+  },
+  {
+    label: 'JWT token',
+    pattern: /\beyJ[0-9A-Za-z_-]+\.[0-9A-Za-z_-]+\.[0-9A-Za-z_-]+\b/g,
+    replacement: '[REDACTED JWT]',
+  },
+  {
+    label: 'generic secret',
+    pattern:
+      /\b((?:api(?:_?key)?|token|secret|password|passphrase|auth))\b\s*[:=]\s*["']?[A-Za-z0-9\-_.]{16,}["']?/gi,
+    replacement: '$1=[REDACTED]',
+  },
+];
+
+export interface RedactionResult {
+  hasMatch: boolean;
+  matches: string[];
+  redacted: string;
+}
+
+function clonePattern(pattern: RegExp) {
+  return new RegExp(pattern.source, pattern.flags);
+}
+
+export function detectSensitiveContent(text: string): RedactionResult {
+  const matches: string[] = [];
+  let redacted = text;
+
+  for (const rule of SECRET_RULES) {
+    const testPattern = clonePattern(rule.pattern);
+    if (!testPattern.test(redacted)) {
+      continue;
+    }
+
+    matches.push(rule.label);
+    const replacePattern = clonePattern(rule.pattern);
+    redacted = redacted.replace(replacePattern, rule.replacement);
+  }
+
+  return {
+    hasMatch: matches.length > 0,
+    matches,
+    redacted,
+  };
+}
+
+export function redactSensitiveContent(text: string): string {
+  return detectSensitiveContent(text).redacted;
+}

--- a/utils/safeIDB.ts
+++ b/utils/safeIDB.ts
@@ -1,7 +1,45 @@
-import { openDB } from 'idb';
+import { openDB, type IDBPDatabase, type IDBPObjectStore, type IDBPTransaction } from 'idb';
 import { hasIndexedDB } from './isBrowser';
 
-export function getDb(name: string, version = 1, upgrade?: Parameters<typeof openDB>[2]) {
+export interface StoreIndexDefinition {
+  name: string;
+  keyPath: string | string[];
+  options?: IDBIndexParameters;
+}
+
+export function ensureObjectStore(
+  db: IDBPDatabase<unknown>,
+  transaction: IDBPTransaction<unknown, string[], 'versionchange'> | null | undefined,
+  storeName: string,
+  options: IDBObjectStoreParameters,
+  indexes: StoreIndexDefinition[] = [],
+) {
+  let store: IDBPObjectStore<unknown, string[], unknown>;
+
+  if (!db.objectStoreNames.contains(storeName)) {
+    store = db.createObjectStore(storeName, options);
+  } else if (transaction) {
+    store = transaction.objectStore(storeName);
+  } else {
+    throw new Error(
+      `Transaction required to upgrade existing store "${storeName}"`,
+    );
+  }
+
+  for (const index of indexes) {
+    if (!store.indexNames.contains(index.name)) {
+      store.createIndex(index.name, index.keyPath, index.options);
+    }
+  }
+
+  return store;
+}
+
+export function getDb(
+  name: string,
+  version = 1,
+  upgrade?: Parameters<typeof openDB>[2],
+) {
   if (!hasIndexedDB) return null;
   return openDB(name, version, upgrade);
 }


### PR DESCRIPTION
## Summary
- refactor the clipboard manager to persist timestamps, limit unpinned history to 25 fresh entries, support pinning, and skip secret-like clips before storage
- add a keyboard-driven overlay UI with search highlighting, pinned and recent sections, and warning badges for filtered items
- extend IndexedDB helpers and redaction utilities while documenting the workflow and adding targeted clipboard manager tests

## Testing
- yarn lint *(fails: repository has pre-existing accessibility and no-top-level-window lint errors)*
- yarn test __tests__/components/apps/ClipboardManager.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68cb19c0a0f0832897e94fcaa4b84e77