### PR TITLE
Add power dashboard app with simulated power controls

### DIFF
--- a/__tests__/components/apps/power-dashboard.test.tsx
+++ b/__tests__/components/apps/power-dashboard.test.tsx
@@ -1,0 +1,63 @@
+import { groupSamplesByHour } from '../../../components/apps/power-dashboard/data';
+import type { PowerSample } from '../../../utils/powerManager';
+
+describe('power dashboard data grouping', () => {
+  const baseTimestamp = Date.UTC(2024, 0, 1, 12, 45, 0, 0);
+
+  const sample = (overrides: Partial<PowerSample>): PowerSample => ({
+    timestamp: baseTimestamp,
+    deviceId: 'deck',
+    appId: 'desktop',
+    batteryLevel: 80,
+    temperatureC: 40,
+    dischargeRateMw: 600,
+    ...overrides,
+  });
+
+  it('groups samples into hourly buckets and averages values', () => {
+    const samples: PowerSample[] = [
+      sample({ timestamp: baseTimestamp - 15 * 60 * 1000, batteryLevel: 80, temperatureC: 42 }),
+      sample({ timestamp: baseTimestamp - 40 * 60 * 1000, batteryLevel: 60, temperatureC: 38 }),
+      sample({ timestamp: baseTimestamp - 90 * 60 * 1000, batteryLevel: 90, temperatureC: 35 }),
+    ];
+
+    const groups = groupSamplesByHour(samples, 2, baseTimestamp);
+
+    expect(groups).toHaveLength(2);
+    const currentHour = groups[groups.length - 1];
+    expect(currentHour.sampleCount).toBe(2);
+    expect(currentHour.averageLevel).toBeCloseTo(70);
+    expect(currentHour.averageTemperature).toBeCloseTo(40);
+
+    const previousHour = groups[0];
+    expect(previousHour.sampleCount).toBe(1);
+    expect(previousHour.averageLevel).toBeCloseTo(90);
+  });
+
+  it('clamps values and handles empty buckets', () => {
+    const samples: PowerSample[] = [
+      sample({ timestamp: baseTimestamp - 30 * 60 * 1000, batteryLevel: 120, temperatureC: 80 }),
+      sample({ timestamp: baseTimestamp - 30 * 60 * 1000, batteryLevel: -10, temperatureC: 20 }),
+    ];
+
+    const groups = groupSamplesByHour(samples, 1, baseTimestamp);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].averageLevel).toBeGreaterThanOrEqual(0);
+    expect(groups[0].averageLevel).toBeLessThanOrEqual(100);
+    expect(groups[0].minLevel).toBeGreaterThanOrEqual(0);
+    expect(groups[0].maxLevel).toBeLessThanOrEqual(100);
+  });
+
+  it('ignores samples outside of the requested window', () => {
+    const samples: PowerSample[] = [
+      sample({ timestamp: baseTimestamp - 26 * 60 * 60 * 1000, batteryLevel: 50 }),
+      sample({ timestamp: baseTimestamp - 10 * 60 * 1000, batteryLevel: 75 }),
+    ];
+
+    const groups = groupSamplesByHour(samples, 1, baseTimestamp);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].sampleCount).toBe(1);
+    expect(groups[0].averageLevel).toBeCloseTo(75);
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -10,6 +10,7 @@ import { displayWeather } from './components/apps/weather';
 import { displayClipboardManager } from './components/apps/ClipboardManager';
 import { displayFiglet } from './components/apps/figlet';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
+import { displayPowerDashboard } from './components/apps/power-dashboard';
 import { displayScreenRecorder } from './components/apps/screen-recorder';
 import { displayNikto } from './components/apps/nikto';
 
@@ -266,6 +267,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayInputLab,
+  },
+  {
+    id: 'power-dashboard',
+    title: 'Power Dashboard',
+    icon: '/themes/Yaru/apps/resource-monitor.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayPowerDashboard,
   },
 ];
 

--- a/components/apps/power-dashboard/data.ts
+++ b/components/apps/power-dashboard/data.ts
@@ -1,0 +1,100 @@
+import type { PowerSample } from '../../../utils/powerManager';
+
+export const HOURS_IN_DAY = 24;
+const HOUR_MS = 60 * 60 * 1000;
+
+export interface HourlyGroup {
+  /** Timestamp at the start of the hour bucket */
+  hour: number;
+  /** Average battery level across all samples in the bucket */
+  averageLevel: number;
+  /** Minimum battery level encountered within the bucket */
+  minLevel: number;
+  /** Maximum battery level encountered within the bucket */
+  maxLevel: number;
+  /** Average temperature in Celsius */
+  averageTemperature: number;
+  /** Number of samples aggregated */
+  sampleCount: number;
+}
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (Number.isNaN(value)) return min;
+  return Math.min(max, Math.max(min, value));
+};
+
+const alignToHour = (timestamp: number): number => {
+  const date = new Date(timestamp);
+  date.setMinutes(0, 0, 0);
+  return date.getTime();
+};
+
+export const groupSamplesByHour = (
+  samples: PowerSample[],
+  hours: number = HOURS_IN_DAY,
+  now: number = Date.now(),
+): HourlyGroup[] => {
+  const safeHours = Math.max(1, Math.round(hours));
+  const endHour = alignToHour(now);
+  const startHour = endHour - (safeHours - 1) * HOUR_MS;
+  const buckets: HourlyGroup[] = Array.from({ length: safeHours }, (_, index) => ({
+    hour: startHour + index * HOUR_MS,
+    averageLevel: 0,
+    minLevel: 100,
+    maxLevel: 0,
+    averageTemperature: 0,
+    sampleCount: 0,
+  }));
+
+  if (!samples.length) {
+    return buckets.map((bucket) => ({
+      ...bucket,
+      minLevel: 0,
+    }));
+  }
+
+  const bucketAccumulator = buckets.map(() => ({
+    levelSum: 0,
+    tempSum: 0,
+  }));
+
+  samples.forEach((sample) => {
+    const { timestamp, batteryLevel, temperatureC } = sample;
+    if (timestamp < startHour || timestamp >= endHour + HOUR_MS) {
+      return;
+    }
+    const bucketIndex = Math.floor((timestamp - startHour) / HOUR_MS);
+    if (bucketIndex < 0 || bucketIndex >= buckets.length) {
+      return;
+    }
+    const accumulator = bucketAccumulator[bucketIndex];
+    accumulator.levelSum += batteryLevel;
+    accumulator.tempSum += temperatureC;
+    const bucket = buckets[bucketIndex];
+    bucket.sampleCount += 1;
+    bucket.minLevel = Math.min(bucket.minLevel, batteryLevel);
+    bucket.maxLevel = Math.max(bucket.maxLevel, batteryLevel);
+  });
+
+  return buckets.map((bucket, index) => {
+    const { levelSum, tempSum } = bucketAccumulator[index];
+    const count = bucket.sampleCount || 0;
+    const averageLevel = count ? clamp(levelSum / count, 0, 100) : 0;
+    const averageTemperature = count ? tempSum / count : 0;
+    return {
+      ...bucket,
+      averageLevel,
+      minLevel: count ? clamp(bucket.minLevel, 0, 100) : 0,
+      maxLevel: count ? clamp(bucket.maxLevel, 0, 100) : 0,
+      averageTemperature,
+    };
+  });
+};
+
+export const toDisplayHour = (timestamp: number): string => {
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};

--- a/components/apps/power-dashboard/index.tsx
+++ b/components/apps/power-dashboard/index.tsx
@@ -1,0 +1,677 @@
+import React, {
+  FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useSettings } from '../../../hooks/useSettings';
+import {
+  applyCpuGovernor,
+  applyDisplaySleep,
+  applyPowerPlan,
+  calibrateBattery,
+  fetchPowerHistory,
+  fetchThermalSummary,
+  getBatterySnapshot,
+  listApps,
+  listDevices,
+  subscribeToPowerStream,
+  type BatterySnapshot,
+  type CalibrationResult,
+  type CpuGovernor,
+  type DisplaySleep,
+  type PowerPlan,
+  type PowerSample,
+  type ThermalSummary,
+} from '../../../utils/powerManager';
+import { groupSamplesByHour, toDisplayHour } from './data';
+import { logEvent } from '../../../utils/analytics';
+
+interface SummaryItem {
+  label: string;
+  value: string;
+  subLabel?: string;
+}
+
+const PLAN_OPTIONS: PowerPlan[] = ['performance', 'balanced', 'battery-saver'];
+const GOVERNOR_OPTIONS: CpuGovernor[] = ['performance', 'balanced', 'powersave'];
+const DISPLAY_SLEEP_OPTIONS: DisplaySleep[] = [1, 5, 10, 30, 'never'];
+
+const formatPlanLabel = (plan: PowerPlan) => {
+  if (plan === 'battery-saver') return 'Battery Saver';
+  if (plan === 'balanced') return 'Balanced';
+  return 'Performance';
+};
+
+const formatGovernorLabel = (governor: CpuGovernor) => {
+  if (governor === 'powersave') return 'Power Save';
+  if (governor === 'performance') return 'Performance';
+  return 'Balanced';
+};
+
+const formatDisplaySleepLabel = (sleep: DisplaySleep) => {
+  if (sleep === 'never') return 'Never';
+  if (sleep === 0) return 'Never';
+  if (sleep === 1) return '1 minute';
+  return `${sleep} minutes`;
+};
+
+const formatRuntime = (minutes: number | undefined): string => {
+  if (!minutes || !Number.isFinite(minutes)) {
+    return 'n/a';
+  }
+  if (minutes < 60) {
+    return `${Math.round(minutes)}m`;
+  }
+  const hrs = Math.floor(minutes / 60);
+  const mins = Math.round(minutes % 60);
+  return mins ? `${hrs}h ${mins}m` : `${hrs}h`;
+};
+
+const drawLineChart = (
+  canvas: HTMLCanvasElement | null,
+  values: number[],
+  options: { color: string; label: string; max?: number; min?: number },
+) => {
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  const { width, height } = canvas;
+  ctx.clearRect(0, 0, width, height);
+
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.35)';
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.08)';
+  ctx.lineWidth = 1;
+  const gridLines = 4;
+  for (let i = 0; i <= gridLines; i += 1) {
+    const y = (i / gridLines) * height;
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(width, y);
+    ctx.stroke();
+  }
+
+  const filteredValues = values.filter((value) => Number.isFinite(value));
+  const maxValue = options.max ?? Math.max(100, Math.max(...filteredValues, 0) + 5);
+  const minValue = options.min ?? Math.min(0, Math.min(...filteredValues, 0) - 5);
+  const range = maxValue - minValue || 1;
+
+  if (filteredValues.length) {
+    ctx.strokeStyle = options.color;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    values.forEach((value, index) => {
+      const x = (index / Math.max(values.length - 1, 1)) * width;
+      const percent = (value - minValue) / range;
+      const y = height - percent * height;
+      if (index === 0) {
+        ctx.moveTo(x, y);
+      } else {
+        ctx.lineTo(x, y);
+      }
+    });
+    ctx.stroke();
+
+    const latestValue = values[values.length - 1];
+    const percent = (latestValue - minValue) / range;
+    const y = height - percent * height;
+    const x = width;
+    ctx.fillStyle = options.color;
+    ctx.beginPath();
+    ctx.arc(x - 6, y, 4, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  ctx.fillStyle = '#ffffff';
+  ctx.font = '12px sans-serif';
+  const latest = values[values.length - 1];
+  const suffix = Number.isFinite(latest) ? latest.toFixed(1) : '--';
+  ctx.fillText(`${options.label}: ${suffix}`, 8, 16);
+};
+
+const PowerDashboard: React.FC = () => {
+  const {
+    powerPlan,
+    setPowerPlan: updatePowerPlan,
+    cpuGovernor,
+    setCpuGovernor: updateCpuGovernor,
+    displaySleep,
+    setDisplaySleep: updateDisplaySleep,
+  } = useSettings();
+  const [samples, setSamples] = useState<PowerSample[]>([]);
+  const [batterySnapshot, setBatterySnapshot] = useState<BatterySnapshot | null>(null);
+  const [thermalSummary, setThermalSummary] = useState<ThermalSummary | null>(null);
+  const [controlFeedback, setControlFeedback] = useState<string | null>(null);
+  const [calibrationMode, setCalibrationMode] = useState(false);
+  const [calibrationInput, setCalibrationInput] = useState('');
+  const [calibrationResult, setCalibrationResult] = useState<CalibrationResult | null>(null);
+  const [calibrationError, setCalibrationError] = useState<string | null>(null);
+
+  const deviceOptions = useMemo(() => listDevices(), []);
+  const appOptions = useMemo(() => listApps(), []);
+
+  const deviceLabel = useMemo(() => {
+    const map = new Map<string, string>();
+    deviceOptions.forEach((device) => {
+      map.set(device.id, device.label);
+    });
+    return map;
+  }, [deviceOptions]);
+
+  const [selectedDevices, setSelectedDevices] = useState<string[]>(() =>
+    deviceOptions.map((device) => device.id),
+  );
+  const [selectedApps, setSelectedApps] = useState<string[]>(() => appOptions.map((app) => app.id));
+
+  const batteryCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const thermalCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const statusRegion = useRef<HTMLParagraphElement | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      const [history, snapshot] = await Promise.all([
+        fetchPowerHistory(),
+        getBatterySnapshot(),
+      ]);
+      if (!active) return;
+      setSamples(history);
+      setBatterySnapshot(snapshot);
+    })();
+    const unsubscribe = subscribeToPowerStream((sample) => {
+      setSamples((prev) => {
+        const next = [...prev, sample];
+        const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+        return next.filter((item) => item.timestamp >= cutoff);
+      });
+    });
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const summary = await fetchThermalSummary(samples);
+      if (!cancelled) {
+        setThermalSummary(summary);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [samples]);
+
+  const toggleDevice = useCallback((id: string) => {
+    setSelectedDevices((current) => {
+      if (current.includes(id)) {
+        if (current.length === 1) return current;
+        return current.filter((device) => device !== id);
+      }
+      return [...current, id];
+    });
+  }, []);
+
+  const toggleApp = useCallback((id: string) => {
+    setSelectedApps((current) => {
+      if (current.includes(id)) {
+        if (current.length === 1) return current;
+        return current.filter((app) => app !== id);
+      }
+      return [...current, id];
+    });
+  }, []);
+
+  const resetFilters = useCallback(() => {
+    setSelectedDevices(deviceOptions.map((device) => device.id));
+    setSelectedApps(appOptions.map((app) => app.id));
+  }, [deviceOptions, appOptions]);
+
+  const selectedDeviceSet = useMemo(() => new Set(selectedDevices), [selectedDevices]);
+  const selectedAppSet = useMemo(() => new Set(selectedApps), [selectedApps]);
+
+  const filteredSamples = useMemo(
+    () =>
+      samples.filter(
+        (sample) =>
+          selectedDeviceSet.has(sample.deviceId) &&
+          (selectedAppSet.size === 0 || selectedAppSet.has(sample.appId)),
+      ),
+    [samples, selectedDeviceSet, selectedAppSet],
+  );
+
+  const hourlyGroups = useMemo(() => groupSamplesByHour(filteredSamples), [filteredSamples]);
+
+  const batterySeries = useMemo(() => hourlyGroups.map((group) => group.averageLevel), [hourlyGroups]);
+  const thermalSeries = useMemo(
+    () => hourlyGroups.map((group) => group.averageTemperature),
+    [hourlyGroups],
+  );
+
+  useEffect(() => {
+    drawLineChart(batteryCanvasRef.current, batterySeries, {
+      color: '#4ade80',
+      label: 'Battery',
+      max: 100,
+      min: 0,
+    });
+  }, [batterySeries]);
+
+  useEffect(() => {
+    const maxTemp = Math.max(50, Math.max(...thermalSeries, 0) + 5);
+    drawLineChart(thermalCanvasRef.current, thermalSeries, {
+      color: '#60a5fa',
+      label: 'Temperature °C',
+      max: maxTemp,
+      min: 20,
+    });
+  }, [thermalSeries]);
+
+  const stats = useMemo(() => {
+    const lastSample = filteredSamples[filteredSamples.length - 1];
+    const currentBattery = lastSample?.batteryLevel ?? batterySnapshot?.level ?? 0;
+    const lowestBattery = hourlyGroups.reduce(
+      (min, group) => Math.min(min, group.minLevel || min),
+      Number.isFinite(currentBattery) ? currentBattery : 0,
+    );
+    const averageBattery = hourlyGroups.length
+      ? hourlyGroups.reduce((sum, group) => sum + group.averageLevel, 0) / hourlyGroups.length
+      : currentBattery;
+    const maxTemp = hourlyGroups.reduce(
+      (max, group) => Math.max(max, group.averageTemperature),
+      thermalSummary?.max ?? 0,
+    );
+    const uniqueDevices = new Set(filteredSamples.map((sample) => sample.deviceId)).size;
+    const uniqueApps = new Set(filteredSamples.map((sample) => sample.appId)).size;
+    const lastUpdated = lastSample?.timestamp ?? batterySnapshot?.timestamp ?? Date.now();
+    return {
+      currentBattery,
+      lowestBattery,
+      averageBattery,
+      maxTemp,
+      uniqueDevices,
+      uniqueApps,
+      sampleCount: filteredSamples.length,
+      lastUpdated,
+    };
+  }, [
+    filteredSamples,
+    hourlyGroups,
+    batterySnapshot?.level,
+    batterySnapshot?.timestamp,
+    thermalSummary?.max,
+  ]);
+
+  const summaryItems: SummaryItem[] = [
+    {
+      label: 'Current Battery',
+      value: `${Math.round(stats.currentBattery * 10) / 10}%`,
+      subLabel: `Updated ${new Date(stats.lastUpdated).toLocaleTimeString()}`,
+    },
+    {
+      label: 'Average 24h Level',
+      value: `${Math.round(stats.averageBattery)}%`,
+      subLabel: `${stats.sampleCount} samples`,
+    },
+    {
+      label: 'Peak Temperature',
+      value: `${Math.round(stats.maxTemp)}°C`,
+      subLabel: thermalSummary?.hottestDevice
+        ? `Hottest: ${deviceLabel.get(thermalSummary.hottestDevice) ?? thermalSummary.hottestDevice}`
+        : undefined,
+    },
+    {
+      label: 'Fleet Coverage',
+      value: `${stats.uniqueDevices} devices / ${stats.uniqueApps} apps`,
+      subLabel: stats.uniqueDevices === deviceOptions.length ? 'All devices' : 'Filtered view',
+    },
+  ];
+
+  const announceStatus = useCallback((message: string) => {
+    if (statusRegion.current) {
+      statusRegion.current.textContent = message;
+    }
+    setControlFeedback(message);
+  }, []);
+
+  const handlePlanChange = useCallback(
+    async (plan: PowerPlan) => {
+      try {
+        updatePowerPlan(plan);
+        await applyPowerPlan(plan);
+        announceStatus(`Power plan set to ${formatPlanLabel(plan)}`);
+      } catch (error) {
+        announceStatus('Failed to update power plan');
+        console.error(error);
+      }
+    },
+    [announceStatus, updatePowerPlan],
+  );
+
+  const handleGovernorChange = useCallback(
+    async (governor: CpuGovernor) => {
+      try {
+        updateCpuGovernor(governor);
+        await applyCpuGovernor(governor);
+        announceStatus(`CPU governor switched to ${formatGovernorLabel(governor)}`);
+      } catch (error) {
+        announceStatus('Failed to update CPU governor');
+        console.error(error);
+      }
+    },
+    [announceStatus, updateCpuGovernor],
+  );
+
+  const handleDisplaySleepChange = useCallback(
+    async (value: DisplaySleep) => {
+      try {
+        updateDisplaySleep(value);
+        await applyDisplaySleep(value);
+        announceStatus(`Display sleep set to ${formatDisplaySleepLabel(value)}`);
+      } catch (error) {
+        announceStatus('Failed to apply display sleep preference');
+        console.error(error);
+      }
+    },
+    [announceStatus, updateDisplaySleep],
+  );
+
+  const handleCalibration = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const observed = Number(calibrationInput);
+      if (Number.isNaN(observed) || observed < 0 || observed > 100) {
+        setCalibrationError('Enter a value between 0 and 100.');
+        return;
+      }
+      const result = calibrateBattery(filteredSamples, observed);
+      const map = new Map<string, PowerSample>();
+      result.adjustedHistory.forEach((sample) => {
+        map.set(`${sample.timestamp}:${sample.deviceId}:${sample.appId}`, sample);
+      });
+      setSamples((prev) =>
+        prev.map((sample) => {
+          const key = `${sample.timestamp}:${sample.deviceId}:${sample.appId}`;
+          return map.get(key) ?? sample;
+        }),
+      );
+      setCalibrationResult(result);
+      setCalibrationError(null);
+      setCalibrationInput('');
+      announceStatus(
+        `Calibration applied. Offset ${result.offset.toFixed(1)}%. Runtime ${formatRuntime(
+          result.projectedRuntimeMinutes,
+        )}.`,
+      );
+      setBatterySnapshot((snapshot) => ({
+        timestamp: Date.now(),
+        level: Math.round(result.adjustedHistory[result.adjustedHistory.length - 1]?.batteryLevel ?? observed),
+        charging: snapshot?.charging ?? false,
+        temperatureC:
+          result.adjustedHistory[result.adjustedHistory.length - 1]?.temperatureC ??
+          snapshot?.temperatureC ??
+          0,
+      }));
+      logEvent({
+        category: 'power-dashboard',
+        action: 'calibration',
+        label: `offset=${result.offset.toFixed(2)},runtime=${Math.round(
+          result.projectedRuntimeMinutes || 0,
+        )}`,
+        value: Math.round(result.projectedRuntimeMinutes || 0),
+      });
+    },
+    [announceStatus, calibrationInput, filteredSamples],
+  );
+
+  const displayedHours = useMemo(
+    () =>
+      hourlyGroups.filter((_, index) => index === 0 || index === hourlyGroups.length - 1 || index % 6 === 0),
+    [hourlyGroups],
+  );
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-ub-cool-grey text-white">
+      <header className="p-4">
+        <h1 className="text-xl font-semibold">Power Dashboard</h1>
+        <p className="text-xs text-ubt-grey">
+          Monitor device battery usage and thermal trends across the last 24 hours.
+        </p>
+      </header>
+      <main className="flex-1 space-y-4 overflow-y-auto p-4">
+        <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          {summaryItems.map((item) => (
+            <div key={item.label} className="rounded-md border border-gray-700 bg-ub-dark-grey p-3 shadow-inner">
+              <p className="text-xs uppercase tracking-wide text-ubt-grey">{item.label}</p>
+              <p className="text-2xl font-semibold">{item.value}</p>
+              {item.subLabel ? <p className="text-xs text-ubt-grey">{item.subLabel}</p> : null}
+            </div>
+          ))}
+          {calibrationResult ? (
+            <div className="rounded-md border border-gray-700 bg-ub-dark-grey p-3 shadow-inner">
+              <p className="text-xs uppercase tracking-wide text-ubt-grey">Calibration</p>
+              <p className="text-2xl font-semibold">
+                Offset {calibrationResult.offset.toFixed(1)}%
+              </p>
+              <p className="text-xs text-ubt-grey">
+                Projected runtime {formatRuntime(calibrationResult.projectedRuntimeMinutes)}
+              </p>
+            </div>
+          ) : null}
+        </section>
+
+        <section className="rounded-md border border-gray-800 bg-ub-dark-grey p-4 shadow-inner">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold">Filters</h2>
+              <p className="text-xs text-ubt-grey">Choose which devices and apps to visualise.</p>
+            </div>
+            <button
+              onClick={resetFilters}
+              className="self-start rounded bg-ub-cool-grey px-3 py-1 text-xs hover:bg-ub-cool-grey/80"
+            >
+              Reset filters
+            </button>
+          </div>
+          <div className="mt-3 grid gap-3 md:grid-cols-2">
+            <fieldset>
+              <legend className="text-sm font-semibold">Devices</legend>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {deviceOptions.map((device) => (
+                  <label key={device.id} className="flex items-center gap-2 text-xs">
+                    <input
+                      type="checkbox"
+                      className="accent-ub-orange"
+                      checked={selectedDevices.includes(device.id)}
+                      onChange={() => toggleDevice(device.id)}
+                    />
+                    <span>{device.label}</span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+            <fieldset>
+              <legend className="text-sm font-semibold">Apps</legend>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {appOptions.map((app) => (
+                  <label key={app.id} className="flex items-center gap-2 text-xs">
+                    <input
+                      type="checkbox"
+                      className="accent-ub-orange"
+                      checked={selectedApps.includes(app.id)}
+                      onChange={() => toggleApp(app.id)}
+                    />
+                    <span>{app.label}</span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+          </div>
+        </section>
+
+        <section className="rounded-md border border-gray-800 bg-ub-dark-grey p-4 shadow-inner">
+          <h2 className="text-lg font-semibold">24 hour telemetry</h2>
+          <div className="mt-3 grid gap-4 lg:grid-cols-2">
+            <div>
+              <canvas
+                ref={batteryCanvasRef}
+                width={420}
+                height={180}
+                role="img"
+                aria-label="Battery level over time"
+                className="w-full"
+              />
+            </div>
+            <div>
+              <canvas
+                ref={thermalCanvasRef}
+                width={420}
+                height={180}
+                role="img"
+                aria-label="Temperature over time"
+                className="w-full"
+              />
+            </div>
+          </div>
+          <div className="mt-2 flex flex-wrap justify-between gap-2 text-[0.65rem] uppercase tracking-wide text-ubt-grey">
+            {displayedHours.map((group) => (
+              <span key={group.hour}>{toDisplayHour(group.hour)}</span>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-md border border-gray-800 bg-ub-dark-grey p-4 shadow-inner">
+          <h2 className="text-lg font-semibold">Power controls</h2>
+          <p className="text-xs text-ubt-grey">
+            Tune performance and standby behaviour. Settings persist via desktop preferences.
+          </p>
+          <div className="mt-4 grid gap-4 lg:grid-cols-3">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-ubt-grey">Plan</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {PLAN_OPTIONS.map((plan) => {
+                  const active = powerPlan === plan;
+                  return (
+                    <button
+                      key={plan}
+                      onClick={() => handlePlanChange(plan)}
+                      className={`rounded px-3 py-1 text-xs transition ${
+                        active
+                          ? 'bg-ub-orange text-black'
+                          : 'bg-ub-cool-grey hover:bg-ub-cool-grey/80'
+                      }`}
+                      aria-pressed={active}
+                    >
+                      {formatPlanLabel(plan)}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+            <div>
+              <label className="text-xs uppercase tracking-wide text-ubt-grey" htmlFor="governor-select">
+                CPU Governor
+              </label>
+              <select
+                id="governor-select"
+                value={cpuGovernor}
+                onChange={(event) => handleGovernorChange(event.target.value as CpuGovernor)}
+                className="mt-2 w-full rounded bg-ub-cool-grey p-2 text-sm"
+              >
+                {GOVERNOR_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {formatGovernorLabel(option)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="text-xs uppercase tracking-wide text-ubt-grey" htmlFor="display-sleep">
+                Display Sleep
+              </label>
+              <select
+                id="display-sleep"
+                value={displaySleep === 'never' ? 'never' : String(displaySleep)}
+                onChange={(event) => {
+                  const value = event.target.value === 'never' ? 'never' : Number(event.target.value);
+                  handleDisplaySleepChange(value as DisplaySleep);
+                }}
+                className="mt-2 w-full rounded bg-ub-cool-grey p-2 text-sm"
+              >
+                {DISPLAY_SLEEP_OPTIONS.map((option) => (
+                  <option key={option.toString()} value={option.toString()}>
+                    {formatDisplaySleepLabel(option)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <p ref={statusRegion} role="status" className="mt-3 text-xs text-ubt-grey">
+            {controlFeedback}
+          </p>
+        </section>
+
+        <section className="rounded-md border border-gray-800 bg-ub-dark-grey p-4 shadow-inner">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold">Battery calibration</h2>
+              <p className="text-xs text-ubt-grey">
+                Enter the observed state-of-charge to realign simulated estimates.
+              </p>
+            </div>
+            <button
+              onClick={() => setCalibrationMode((value) => !value)}
+              className="rounded bg-ub-cool-grey px-3 py-1 text-xs hover:bg-ub-cool-grey/80"
+            >
+              {calibrationMode ? 'Close' : 'Start calibration'}
+            </button>
+          </div>
+          {calibrationMode ? (
+            <form className="mt-3 grid gap-3 md:grid-cols-3" onSubmit={handleCalibration}>
+              <label className="text-sm">
+                Observed battery %
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step={0.5}
+                  value={calibrationInput}
+                  onChange={(event) => setCalibrationInput(event.target.value)}
+                  className="mt-1 w-full rounded bg-ub-cool-grey p-2 text-sm"
+                  required
+                />
+              </label>
+              <div className="md:col-span-2">
+                <p className="text-xs text-ubt-grey">
+                  Calibration adjusts historical samples to better match real usage. Runtime is estimated
+                  from the adjusted discharge slope.
+                </p>
+                {calibrationError ? (
+                  <p className="mt-1 text-xs text-red-400">{calibrationError}</p>
+                ) : null}
+              </div>
+              <div className="md:col-span-3 flex justify-end">
+                <button
+                  type="submit"
+                  className="rounded bg-ub-orange px-4 py-1 text-xs font-semibold text-black"
+                >
+                  Apply calibration
+                </button>
+              </div>
+            </form>
+          ) : null}
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export const displayPowerDashboard = () => <PowerDashboard />;
+
+export default PowerDashboard;

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -57,6 +57,11 @@ Tools to cover: **BeEF, Ettercap, Metasploit, Wireshark, Kismet, Nikto, Autopsy,
 ### Settings
 - Add theme picker, wallpaper selector, and "reset desktop" clearing `localStorage` in `settingsStore.js`.
 
+### Power Dashboard
+- Visualize simulated battery and thermal data with 24-hour charts that mirror `resource_monitor` drawing helpers.
+- Provide per-device and per-app filters, power plan toggles, and CPU/display controls wired through `useSettings`.
+- Offer a calibration flow that adjusts estimates and logs analytics via `utils/analytics.ts`.
+
 ### Resource Monitor
 - Display `performance.memory` data and FPS from `performance.now()` deltas.
 - Show CPU synthetic load graph using `requestAnimationFrame` buckets.

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,8 +20,15 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getPowerPlan as loadPowerPlan,
+  setPowerPlan as savePowerPlan,
+  getCpuGovernor as loadCpuGovernor,
+  setCpuGovernor as saveCpuGovernor,
+  getDisplaySleep as loadDisplaySleep,
+  setDisplaySleep as saveDisplaySleep,
   defaults,
 } from '../utils/settingsStore';
+import type { CpuGovernor, DisplaySleep, PowerPlan } from '../utils/powerManager';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
 type Density = 'regular' | 'compact';
 
@@ -63,6 +70,9 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  powerPlan: PowerPlan;
+  cpuGovernor: CpuGovernor;
+  displaySleep: DisplaySleep;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +84,9 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setPowerPlan: (value: PowerPlan) => void;
+  setCpuGovernor: (value: CpuGovernor) => void;
+  setDisplaySleep: (value: DisplaySleep) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +101,9 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  powerPlan: defaults.powerPlan as PowerPlan,
+  cpuGovernor: defaults.cpuGovernor as CpuGovernor,
+  displaySleep: defaults.displaySleep as DisplaySleep,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +115,9 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setPowerPlan: () => {},
+  setCpuGovernor: () => {},
+  setDisplaySleep: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -113,6 +132,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [powerPlan, setPowerPlan] = useState<PowerPlan>(defaults.powerPlan as PowerPlan);
+  const [cpuGovernor, setCpuGovernor] = useState<CpuGovernor>(defaults.cpuGovernor as CpuGovernor);
+  const [displaySleep, setDisplaySleep] = useState<DisplaySleep>(defaults.displaySleep as DisplaySleep);
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -128,6 +150,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
       setTheme(loadTheme());
+      setPowerPlan((await loadPowerPlan()) as PowerPlan);
+      setCpuGovernor((await loadCpuGovernor()) as CpuGovernor);
+      setDisplaySleep((await loadDisplaySleep()) as DisplaySleep);
     })();
   }, []);
 
@@ -155,6 +180,18 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     saveWallpaper(wallpaper);
   }, [wallpaper]);
+
+  useEffect(() => {
+    savePowerPlan(powerPlan);
+  }, [powerPlan]);
+
+  useEffect(() => {
+    saveCpuGovernor(cpuGovernor);
+  }, [cpuGovernor]);
+
+  useEffect(() => {
+    saveDisplaySleep(displaySleep);
+  }, [displaySleep]);
 
   useEffect(() => {
     const spacing: Record<Density, Record<string, string>> = {
@@ -250,6 +287,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        powerPlan,
+        cpuGovernor,
+        displaySleep,
         setAccent,
         setWallpaper,
         setDensity,
@@ -261,6 +301,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setPowerPlan,
+        setCpuGovernor,
+        setDisplaySleep,
       }}
     >
       {children}

--- a/utils/powerManager.ts
+++ b/utils/powerManager.ts
@@ -1,0 +1,337 @@
+export type PowerPlan = 'performance' | 'balanced' | 'battery-saver';
+export type CpuGovernor = 'performance' | 'balanced' | 'powersave';
+export type DisplaySleep = number | 'never';
+
+export interface PowerDevice {
+  id: string;
+  label: string;
+  type: 'laptop' | 'tablet' | 'phone' | 'accessory';
+}
+
+export interface PowerApp {
+  id: string;
+  label: string;
+  category: 'security' | 'productivity' | 'system';
+}
+
+export interface PowerSample {
+  timestamp: number;
+  deviceId: string;
+  appId: string;
+  batteryLevel: number;
+  temperatureC: number;
+  dischargeRateMw: number;
+}
+
+export interface BatterySnapshot {
+  timestamp: number;
+  level: number;
+  charging: boolean;
+  temperatureC: number;
+}
+
+export interface ThermalSummary {
+  average: number;
+  max: number;
+  hottestDevice?: string;
+}
+
+export interface CalibrationResult {
+  adjustedHistory: PowerSample[];
+  offset: number;
+  projectedRuntimeMinutes: number;
+}
+
+const DEVICES: PowerDevice[] = [
+  { id: 'deck', label: 'Offensive Laptop', type: 'laptop' },
+  { id: 'rig', label: 'Lab Workstation', type: 'laptop' },
+  { id: 'field-tablet', label: 'Field Tablet', type: 'tablet' },
+];
+
+const APPS: PowerApp[] = [
+  { id: 'metasploit', label: 'Metasploit Lab', category: 'security' },
+  { id: 'wireshark', label: 'Wireshark Capture', category: 'security' },
+  { id: 'reports', label: 'Report Writer', category: 'productivity' },
+  { id: 'desktop', label: 'Desktop Idle', category: 'system' },
+];
+
+const SAMPLE_INTERVAL_MINUTES = 30;
+const STREAM_INTERVAL_MS = 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+
+let lastSamples: PowerSample[] = [];
+const listeners = new Set<(sample: PowerSample) => void>();
+let streamTimer: ReturnType<typeof setInterval> | null = null;
+let currentPlan: PowerPlan = 'balanced';
+let currentGovernor: CpuGovernor = 'balanced';
+let currentDisplaySleep: DisplaySleep = 10;
+
+const keyForSample = (sample: PowerSample): string => `${sample.deviceId}:${sample.appId}`;
+const latestSampleByKey = new Map<string, PowerSample>();
+
+const randomInRange = (min: number, max: number): number => Math.random() * (max - min) + min;
+
+const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
+
+const planMultiplier = (plan: PowerPlan): number => {
+  switch (plan) {
+    case 'performance':
+      return 1.2;
+    case 'battery-saver':
+      return 0.75;
+    default:
+      return 1;
+  }
+};
+
+const governorMultiplier = (governor: CpuGovernor): number => {
+  switch (governor) {
+    case 'performance':
+      return 1.15;
+    case 'powersave':
+      return 0.85;
+    default:
+      return 1;
+  }
+};
+
+const displaySleepMultiplier = (sleep: DisplaySleep): number => {
+  if (sleep === 'never') return 1.2;
+  if (sleep === 0) return 1;
+  if (sleep <= 5) return 0.95;
+  if (sleep <= 15) return 0.9;
+  return 0.85;
+};
+
+const initializeHistory = (now: number = Date.now()): PowerSample[] => {
+  const history: PowerSample[] = [];
+  const totalPoints = Math.ceil((24 * 60) / SAMPLE_INTERVAL_MINUTES);
+  for (let point = totalPoints; point >= 0; point -= 1) {
+    const timestamp = now - point * SAMPLE_INTERVAL_MINUTES * 60 * 1000;
+    DEVICES.forEach((device, deviceIndex) => {
+      APPS.forEach((app, appIndex) => {
+        const baseDrain = 1.1 + deviceIndex * 0.4 + appIndex * 0.25;
+        const drift = randomInRange(-2, 2);
+        const baseLevel = clamp(100 - point * baseDrain + drift, 8, 100);
+        const temperature = clamp(32 + baseDrain * 4 + randomInRange(-1.5, 2.5), 28, 80);
+        const sample: PowerSample = {
+          timestamp,
+          deviceId: device.id,
+          appId: app.id,
+          batteryLevel: baseLevel,
+          temperatureC: temperature,
+          dischargeRateMw: 700 + baseDrain * 50 + randomInRange(-40, 40),
+        };
+        history.push(sample);
+        latestSampleByKey.set(keyForSample(sample), sample);
+      });
+    });
+  }
+  lastSamples = history.slice(-DEVICES.length * APPS.length * totalPoints);
+  return history;
+};
+
+const ensureHistory = (): PowerSample[] => {
+  if (!lastSamples.length) {
+    initializeHistory();
+  }
+  return lastSamples;
+};
+
+const ensureStream = (): void => {
+  if (streamTimer || typeof window === 'undefined') {
+    return;
+  }
+  streamTimer = setInterval(() => {
+    const now = Date.now();
+    const planFactor = planMultiplier(currentPlan);
+    const governorFactor = governorMultiplier(currentGovernor);
+    const sleepFactor = displaySleepMultiplier(currentDisplaySleep);
+    const combined = planFactor * governorFactor * sleepFactor;
+    DEVICES.forEach((device) => {
+      APPS.forEach((app) => {
+        const key = `${device.id}:${app.id}`;
+        const previous = latestSampleByKey.get(key);
+        const drain = 0.9 + (previous ? previous.dischargeRateMw / 1000 : 1);
+        const variability = randomInRange(-0.4, 0.4);
+        const batteryDelta = (drain + variability) * combined * 0.6;
+        const baseTemperature = previous ? previous.temperatureC : 38;
+        const newSample: PowerSample = {
+          timestamp: now,
+          deviceId: device.id,
+          appId: app.id,
+          batteryLevel: previous
+            ? clamp(previous.batteryLevel - batteryDelta, 5, 100)
+            : clamp(100 - randomInRange(0, 10), 5, 100),
+          temperatureC: clamp(baseTemperature + combined * 0.35 + randomInRange(-0.8, 0.8), 28, 85),
+          dischargeRateMw: clamp((previous?.dischargeRateMw ?? 750) * (0.9 + randomInRange(-0.05, 0.05)), 450, 1400),
+        };
+        lastSamples.push(newSample);
+        latestSampleByKey.set(key, newSample);
+        listeners.forEach((listener) => listener(newSample));
+      });
+    });
+    const cutoff = now - 24 * HOUR_MS;
+    lastSamples = lastSamples.filter((sample) => sample.timestamp >= cutoff);
+  }, STREAM_INTERVAL_MS);
+};
+
+const stopStreamIfIdle = (): void => {
+  if (!listeners.size && streamTimer) {
+    clearInterval(streamTimer);
+    streamTimer = null;
+  }
+};
+
+export const listDevices = (): PowerDevice[] => DEVICES.slice();
+
+export const listApps = (): PowerApp[] => APPS.slice();
+
+export const fetchPowerHistory = async (
+  options: {
+    deviceIds?: string[];
+    appIds?: string[];
+    hours?: number;
+    now?: number;
+  } = {},
+): Promise<PowerSample[]> => {
+  const history = ensureHistory();
+  const { deviceIds, appIds, hours = 24, now = Date.now() } = options;
+  const cutoff = now - hours * HOUR_MS;
+  return history
+    .filter((sample) => {
+      if (sample.timestamp < cutoff) return false;
+      if (deviceIds?.length && !deviceIds.includes(sample.deviceId)) return false;
+      if (appIds?.length && !appIds.includes(sample.appId)) return false;
+      return true;
+    })
+    .sort((a, b) => a.timestamp - b.timestamp);
+};
+
+export const subscribeToPowerStream = (
+  listener: (sample: PowerSample) => void,
+): (() => void) => {
+  ensureHistory();
+  if (typeof window !== 'undefined') {
+    ensureStream();
+  }
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+    stopStreamIfIdle();
+  };
+};
+
+export const getBatterySnapshot = async (): Promise<BatterySnapshot> => {
+  try {
+    if (typeof navigator !== 'undefined' && 'getBattery' in navigator) {
+      const battery = await (navigator as any).getBattery();
+      return {
+        timestamp: Date.now(),
+        level: Math.round((battery.level ?? 1) * 100),
+        charging: Boolean(battery.charging),
+        temperatureC: clamp(36 + randomInRange(-2, 2), 28, 45),
+      };
+    }
+  } catch (error) {
+    // Ignore real battery API errors and fall back to simulation
+    console.warn('Battery API unavailable, using simulated data', error);
+  }
+  const history = ensureHistory();
+  const latest = history[history.length - 1];
+  return {
+    timestamp: Date.now(),
+    level: Math.round(latest?.batteryLevel ?? 100),
+    charging: false,
+    temperatureC: clamp(latest?.temperatureC ?? 36, 28, 45),
+  };
+};
+
+export const fetchThermalSummary = async (
+  samples?: PowerSample[],
+): Promise<ThermalSummary> => {
+  const source = samples?.length ? samples : ensureHistory();
+  if (!source.length) {
+    return { average: 0, max: 0 };
+  }
+  const total = source.reduce((acc, sample) => acc + sample.temperatureC, 0);
+  const hottest = source.reduce((max, sample) => {
+    if (!max || sample.temperatureC > max.temperatureC) {
+      return sample;
+    }
+    return max;
+  });
+  return {
+    average: total / source.length,
+    max: hottest.temperatureC,
+    hottestDevice: hottest.deviceId,
+  };
+};
+
+export const applyPowerPlan = async (plan: PowerPlan): Promise<void> => {
+  currentPlan = plan;
+};
+
+export const applyCpuGovernor = async (governor: CpuGovernor): Promise<void> => {
+  currentGovernor = governor;
+};
+
+export const applyDisplaySleep = async (value: DisplaySleep): Promise<void> => {
+  currentDisplaySleep = value;
+};
+
+export const calibrateBattery = (
+  samples: PowerSample[],
+  observedLevel: number,
+): CalibrationResult => {
+  if (!samples.length) {
+    return {
+      adjustedHistory: samples,
+      offset: 0,
+      projectedRuntimeMinutes: 0,
+    };
+  }
+  const latest = samples[samples.length - 1];
+  const offset = clamp(observedLevel, 0, 100) - latest.batteryLevel;
+  const updatedHistory = samples.map((sample) => {
+    const adjusted = {
+      ...sample,
+      batteryLevel: clamp(sample.batteryLevel + offset, 0, 100),
+    };
+    const key = keyForSample(adjusted);
+    latestSampleByKey.set(key, adjusted);
+    return adjusted;
+  });
+  // Persist calibration into the main history set
+  const targets = new Set(updatedHistory.map((sample) => `${sample.timestamp}:${keyForSample(sample)}`));
+  lastSamples = lastSamples.map((sample) => {
+    const key = `${sample.timestamp}:${keyForSample(sample)}`;
+    if (targets.has(key)) {
+      const adjusted = updatedHistory.find(
+        (candidate) =>
+          candidate.timestamp === sample.timestamp &&
+          candidate.deviceId === sample.deviceId &&
+          candidate.appId === sample.appId,
+      );
+      return adjusted ?? sample;
+    }
+    return sample;
+  });
+
+  const sorted = [...updatedHistory].sort((a, b) => a.timestamp - b.timestamp);
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+  const minutes = (last.timestamp - first.timestamp) / (60 * 1000);
+  const delta = first.batteryLevel - last.batteryLevel;
+  const ratePerMinute = minutes > 0 ? delta / minutes : 0;
+  const runtime = ratePerMinute > 0 ? last.batteryLevel / ratePerMinute : 0;
+
+  return {
+    adjustedHistory: updatedHistory,
+    offset,
+    projectedRuntimeMinutes: runtime,
+  };
+};
+
+// Initialize on module load so SSR builds have deterministic data
+initializeHistory();

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,18 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  powerPlan: 'balanced',
+  cpuGovernor: 'balanced',
+  displaySleep: 10,
+};
+
+const getLocalStorage = () => {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
 };
 
 export async function getAccent() {
@@ -37,18 +49,21 @@ export async function setWallpaper(wallpaper) {
 }
 
 export async function getDensity() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
-  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.density;
+  return storage.getItem('density') || DEFAULT_SETTINGS.density;
 }
 
 export async function setDensity(density) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('density', density);
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('density', density);
 }
 
 export async function getReducedMotion() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
-  const stored = window.localStorage.getItem('reduced-motion');
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.reducedMotion;
+  const stored = storage.getItem('reduced-motion');
   if (stored !== null) {
     return stored === 'true';
   }
@@ -56,87 +71,145 @@ export async function getReducedMotion() {
 }
 
 export async function setReducedMotion(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('reduced-motion', value ? 'true' : 'false');
 }
 
 export async function getFontScale() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
-  const stored = window.localStorage.getItem('font-scale');
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.fontScale;
+  const stored = storage.getItem('font-scale');
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
 export async function setFontScale(scale) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('font-scale', String(scale));
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('font-scale', String(scale));
 }
 
 export async function getHighContrast() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
-  return window.localStorage.getItem('high-contrast') === 'true';
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.highContrast;
+  return storage.getItem('high-contrast') === 'true';
 }
 
 export async function setHighContrast(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('high-contrast', value ? 'true' : 'false');
 }
 
 export async function getLargeHitAreas() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
-  return window.localStorage.getItem('large-hit-areas') === 'true';
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.largeHitAreas;
+  return storage.getItem('large-hit-areas') === 'true';
 }
 
 export async function setLargeHitAreas(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('large-hit-areas', value ? 'true' : 'false');
 }
 
 export async function getHaptics() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
-  const val = window.localStorage.getItem('haptics');
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.haptics;
+  const val = storage.getItem('haptics');
   return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
 }
 
 export async function setHaptics(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('haptics', value ? 'true' : 'false');
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('haptics', value ? 'true' : 'false');
 }
 
 export async function getPongSpin() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
-  const val = window.localStorage.getItem('pong-spin');
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.pongSpin;
+  const val = storage.getItem('pong-spin');
   return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
 }
 
 export async function setPongSpin(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('pong-spin', value ? 'true' : 'false');
 }
 
 export async function getAllowNetwork() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
-  return window.localStorage.getItem('allow-network') === 'true';
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.allowNetwork;
+  return storage.getItem('allow-network') === 'true';
 }
 
 export async function setAllowNetwork(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('allow-network', value ? 'true' : 'false');
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('allow-network', value ? 'true' : 'false');
+}
+
+export async function getPowerPlan() {
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.powerPlan;
+  return storage.getItem('power-plan') || DEFAULT_SETTINGS.powerPlan;
+}
+
+export async function setPowerPlan(value) {
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('power-plan', value);
+}
+
+export async function getCpuGovernor() {
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.cpuGovernor;
+  return storage.getItem('cpu-governor') || DEFAULT_SETTINGS.cpuGovernor;
+}
+
+export async function setCpuGovernor(value) {
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('cpu-governor', value);
+}
+
+export async function getDisplaySleep() {
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.displaySleep;
+  const stored = storage.getItem('display-sleep');
+  if (stored === null) return DEFAULT_SETTINGS.displaySleep;
+  if (stored === 'never') return 'never';
+  const parsed = parseInt(stored, 10);
+  return Number.isNaN(parsed) ? DEFAULT_SETTINGS.displaySleep : parsed;
+}
+
+export async function setDisplaySleep(value) {
+  const storage = getLocalStorage();
+  if (!storage) return;
+  const serialised = value === 'never' ? 'never' : String(value);
+  storage.setItem('display-sleep', serialised);
 }
 
 export async function resetSettings() {
-  if (typeof window === 'undefined') return;
+  const storage = getLocalStorage();
+  if (!storage) return;
   await Promise.all([
     del('accent'),
     del('bg-image'),
   ]);
-  window.localStorage.removeItem('density');
-  window.localStorage.removeItem('reduced-motion');
-  window.localStorage.removeItem('font-scale');
-  window.localStorage.removeItem('high-contrast');
-  window.localStorage.removeItem('large-hit-areas');
-  window.localStorage.removeItem('pong-spin');
-  window.localStorage.removeItem('allow-network');
-  window.localStorage.removeItem('haptics');
+  storage.removeItem('density');
+  storage.removeItem('reduced-motion');
+  storage.removeItem('font-scale');
+  storage.removeItem('high-contrast');
+  storage.removeItem('large-hit-areas');
+  storage.removeItem('pong-spin');
+  storage.removeItem('allow-network');
+  storage.removeItem('haptics');
+  storage.removeItem('power-plan');
+  storage.removeItem('cpu-governor');
+  storage.removeItem('display-sleep');
 }
 
 export async function exportSettings() {
@@ -151,6 +224,9 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    powerPlan,
+    cpuGovernor,
+    displaySleep,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +238,9 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getPowerPlan(),
+    getCpuGovernor(),
+    getDisplaySleep(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -176,6 +255,9 @@ export async function exportSettings() {
     allowNetwork,
     haptics,
     theme,
+    powerPlan,
+    cpuGovernor,
+    displaySleep,
   });
 }
 
@@ -200,6 +282,9 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    powerPlan,
+    cpuGovernor,
+    displaySleep,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -212,6 +297,9 @@ export async function importSettings(json) {
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
+  if (powerPlan !== undefined) await setPowerPlan(powerPlan);
+  if (cpuGovernor !== undefined) await setCpuGovernor(cpuGovernor);
+  if (displaySleep !== undefined) await setDisplaySleep(displaySleep);
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- add a Power Dashboard utility app that streams simulated battery and thermal data with filtering, charts, power-plan controls, and calibration logging
- expose new power plan, CPU governor, and display sleep settings persisted through the settings store and context
- provide a simulated power management layer plus hourly aggregation helpers and targeted unit tests

## Testing
- yarn lint *(fails: existing repository lint violations)*
- yarn test --watch=false *(fails: existing repository test regressions)*
- yarn test --runTestsByPath __tests__/components/apps/power-dashboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb19c2aeb88328aa6b5b2c8f7d08fa