### PR TITLE
[power] add saver telemetry and analytics

### DIFF
--- a/__tests__/components/ui/QuickSettings.saver.test.tsx
+++ b/__tests__/components/ui/QuickSettings.saver.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import QuickSettings from '../../../components/ui/QuickSettings';
+import {
+  estimateLifeGainMinutes,
+  setPowerSaverEnabled,
+} from '../../../utils/powerManager';
+import { logPowerSaverChange } from '../../../utils/analytics';
+
+jest.mock('../../../utils/powerManager', () => ({
+  estimateLifeGainMinutes: jest.fn(() => 95),
+  setPowerSaverEnabled: jest.fn(),
+}));
+
+jest.mock('../../../utils/analytics', () => ({
+  logPowerSaverChange: jest.fn(),
+}));
+
+describe('QuickSettings power saver toggle', () => {
+  const estimateLifeGainMinutesMock = estimateLifeGainMinutes as jest.Mock;
+  const setPowerSaverEnabledMock = setPowerSaverEnabled as jest.Mock;
+  const logPowerSaverChangeMock = logPowerSaverChange as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.localStorage.clear();
+    document.documentElement.style.removeProperty('--power-saver-brightness');
+  });
+
+  it('dims the display and logs analytics when toggled', async () => {
+    const user = userEvent.setup();
+    render(<QuickSettings open />);
+
+    const toggle = screen.getByRole('checkbox', { name: /power saver/i });
+
+    expect(toggle).not.toBeChecked();
+    expect(setPowerSaverEnabledMock).toHaveBeenLastCalledWith(false);
+    expect(estimateLifeGainMinutesMock).toHaveBeenCalledTimes(1);
+
+    await user.click(toggle);
+
+    await waitFor(() => expect(toggle).toBeChecked());
+    await waitFor(() => expect(setPowerSaverEnabledMock).toHaveBeenLastCalledWith(true));
+    await waitFor(() =>
+      expect(logPowerSaverChangeMock).toHaveBeenLastCalledWith(true, 95),
+    );
+    expect(
+      document.documentElement.style.getPropertyValue('--power-saver-brightness'),
+    ).toBe('0.7');
+
+    await user.click(toggle);
+
+    await waitFor(() => expect(setPowerSaverEnabledMock).toHaveBeenLastCalledWith(false));
+    await waitFor(() => expect(logPowerSaverChangeMock).toHaveBeenLastCalledWith(false));
+    expect(
+      document.documentElement.style.getPropertyValue('--power-saver-brightness'),
+    ).toBe('1');
+  });
+});

--- a/components/apps/power-dashboard/HealthPanel.tsx
+++ b/components/apps/power-dashboard/HealthPanel.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+import { getBatterySnapshot, type BatterySnapshot } from '../../../utils/powerManager';
+
+const clampPercent = (value: number): number => Math.min(100, Math.max(0, Math.round(value)));
+
+const HealthPanel = () => {
+  const [snapshot, setSnapshot] = useState<BatterySnapshot>(() => getBatterySnapshot());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const id = window.setInterval(() => {
+      setSnapshot(getBatterySnapshot());
+    }, 60000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const { cycleCount, healthPercent, designCapacityWh, fullChargeCapacityWh, levelPercent } = snapshot;
+  const cappedHealth = clampPercent(healthPercent);
+  const wearPercent = clampPercent(100 - cappedHealth);
+  const capacityDelta = Math.max(0, designCapacityWh - fullChargeCapacityWh);
+
+  return (
+    <section
+      className="rounded-md bg-ub-dark-grey text-white p-4 space-y-4"
+      aria-label="Battery health overview"
+    >
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold">Battery health</h2>
+        <p className="text-xs text-gray-300">
+          Mock telemetry derived from the portfolio power manager.
+        </p>
+      </header>
+      <dl className="space-y-4 text-sm">
+        <div>
+          <dt className="uppercase tracking-wide text-gray-300 text-xs">Cycle count</dt>
+          <dd className="text-2xl font-bold" aria-live="polite">
+            {cycleCount}
+          </dd>
+        </div>
+        <div className="space-y-2">
+          <dt className="uppercase tracking-wide text-gray-300 text-xs">Health remaining</dt>
+          <dd className="flex items-center gap-3">
+            <div
+              className="flex-1 h-2 rounded bg-ub-cool-grey overflow-hidden"
+              role="presentation"
+              aria-hidden="true"
+            >
+              <div
+                className="h-full bg-green-400"
+                style={{ width: `${cappedHealth}%` }}
+              />
+            </div>
+            <span className="text-base font-semibold" aria-live="polite">
+              {cappedHealth}%
+            </span>
+          </dd>
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <dt className="uppercase tracking-wide text-gray-300 text-xs">Design capacity</dt>
+            <dd className="font-semibold">{designCapacityWh.toFixed(1)} Wh</dd>
+          </div>
+          <div>
+            <dt className="uppercase tracking-wide text-gray-300 text-xs">Full charge</dt>
+            <dd className="font-semibold">{fullChargeCapacityWh.toFixed(1)} Wh</dd>
+          </div>
+        </div>
+        <div className="text-xs text-gray-300">
+          <p>
+            Estimated wear: <span className="font-semibold">{wearPercent}%</span>
+          </p>
+          <p>
+            Capacity delta: <span className="font-semibold">{capacityDelta.toFixed(1)} Wh</span>
+          </p>
+          <p>
+            Remaining charge: <span className="font-semibold">{levelPercent}%</span>
+          </p>
+        </div>
+      </dl>
+    </section>
+  );
+};
+
+export default HealthPanel;

--- a/docs/power-dashboard.md
+++ b/docs/power-dashboard.md
@@ -1,0 +1,66 @@
+# Power dashboard and saver integration
+
+This portfolio now ships a lightweight power dashboard stack that keeps the UI in sync
+with the simulated battery telemetry and saver controls.
+
+## Mock power manager
+
+`utils/powerManager.ts` centralises mock telemetry for the desktop.
+
+- `getBatterySnapshot()` returns the cycle count, health percentage, remaining charge and
+  nominal capacity figures derived from a simulated pack.
+- `estimateLifeGainMinutes()` provides a rough runtime gain when power saver mode is active.
+- `setPowerSaverEnabled()`, `isPowerSaverEnabled()` and `onPowerSaverChange()` expose a
+  minimal pub/sub layer so background tasks can adjust their workload.
+- `getResourceSamplingConfig()` maps the current saver state to sampling intervals used by
+  the resource monitor and other background jobs.
+
+## Health panel
+
+`components/apps/power-dashboard/HealthPanel.tsx` renders the mock telemetry. The panel
+surfaces:
+
+- Cycle count with live updates every minute.
+- Health percentage visualised with a progress bar.
+- Design versus full charge capacity along with derived wear metrics and remaining charge.
+
+Drop the component into any window body to embed the dashboard section.
+
+## Quick Settings saver toggle
+
+Quick Settings (`components/ui/QuickSettings.tsx`) now includes a **Power saver** toggle that:
+
+- Persists the state locally and emits analytics events (`logPowerSaverChange`) whenever the
+  mode changes.
+- Dims the desktop by adjusting the new `--power-saver-brightness` CSS variable which is read
+  by the global `body` rule.
+- Notifies `powerManager` so background utilities can react.
+
+The helper text shows the estimated runtime gain reported by `estimateLifeGainMinutes()`.
+
+## Resource monitor throttling
+
+`components/apps/resource_monitor.js` subscribes to the power manager and swaps sampling
+intervals when saver mode is active. Charts and network worker updates now slow down to
+halve the workload while the saver toggle is on.
+
+## Analytics
+
+`utils/analytics.ts` tracks saver usage with:
+
+- `logPowerSaverChange()` – dispatches GA events and tallies activations plus estimated life
+  gained.
+- `getPowerSaverMetrics()` – exposes the counters for dashboards or tests.
+
+A private `__resetPowerSaverMetrics()` helper keeps the Jest suite deterministic.
+
+## Styling hook
+
+`styles/globals.css` defines `--power-saver-brightness` (default `1`). `styles/index.css`
+consumes the variable and animates brightness transitions, so other components can rely on
+the shared variable without duplicating filters.
+
+## Tests
+
+`__tests__/components/ui/QuickSettings.saver.test.tsx` verifies the new toggle, DOM updates,
+and analytics hooks. Existing analytics tests now cover the saver metrics as well.

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,6 +20,7 @@
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   accent-color: var(--color-control-accent);
+  --power-saver-brightness: 1;
 }
 
 /* Dark theme */

--- a/styles/index.css
+++ b/styles/index.css
@@ -9,6 +9,8 @@ body{
     font-display: swap;
     background-color: var(--color-bg);
     color: var(--color-text);
+    filter: brightness(var(--power-saver-brightness, 1));
+    transition: filter 200ms ease-in-out;
 }
 
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -2,6 +2,12 @@ import ReactGA from 'react-ga4';
 
 type EventInput = Parameters<typeof ReactGA.event>[0];
 
+export interface PowerSaverMetrics {
+  activationCount: number;
+  totalEstimatedMinutesGained: number;
+  lastGainEstimate: number;
+}
+
 const safeEvent = (...args: Parameters<typeof ReactGA.event>): void => {
   try {
     const eventFn = ReactGA.event;
@@ -12,6 +18,10 @@ const safeEvent = (...args: Parameters<typeof ReactGA.event>): void => {
     // Ignore analytics errors
   }
 };
+
+let powerSaverActivationCount = 0;
+let totalPowerSaverGainMinutes = 0;
+let lastPowerSaverGain = 0;
 
 export const logEvent = (event: EventInput): void => {
   safeEvent(event);
@@ -27,4 +37,47 @@ export const logGameEnd = (game: string, label?: string): void => {
 
 export const logGameError = (game: string, message?: string): void => {
   logEvent({ category: game, action: 'error', label: message });
+};
+
+export const logPowerSaverChange = (
+  enabled: boolean,
+  estimatedGainMinutes?: number,
+): void => {
+  if (enabled) {
+    powerSaverActivationCount += 1;
+    if (typeof estimatedGainMinutes === 'number') {
+      totalPowerSaverGainMinutes += estimatedGainMinutes;
+      lastPowerSaverGain = estimatedGainMinutes;
+    }
+  } else {
+    lastPowerSaverGain = 0;
+  }
+
+  const label =
+    typeof estimatedGainMinutes === 'number'
+      ? `Estimated gain ${estimatedGainMinutes} minutes`
+      : undefined;
+  const value =
+    typeof estimatedGainMinutes === 'number'
+      ? Math.round(estimatedGainMinutes)
+      : undefined;
+
+  logEvent({
+    category: 'power-saver',
+    action: enabled ? 'enabled' : 'disabled',
+    label,
+    value,
+  });
+};
+
+export const getPowerSaverMetrics = (): PowerSaverMetrics => ({
+  activationCount: powerSaverActivationCount,
+  totalEstimatedMinutesGained: totalPowerSaverGainMinutes,
+  lastGainEstimate: lastPowerSaverGain,
+});
+
+export const __resetPowerSaverMetrics = (): void => {
+  powerSaverActivationCount = 0;
+  totalPowerSaverGainMinutes = 0;
+  lastPowerSaverGain = 0;
 };

--- a/utils/powerManager.ts
+++ b/utils/powerManager.ts
@@ -1,0 +1,77 @@
+export interface BatterySnapshot {
+  cycleCount: number;
+  healthPercent: number;
+  levelPercent: number;
+  designCapacityWh: number;
+  fullChargeCapacityWh: number;
+}
+
+export interface ResourceSamplingConfig {
+  sampleInterval: number;
+  drawThrottle: number;
+}
+
+const BATTERY_BASELINE: BatterySnapshot = {
+  cycleCount: 327,
+  designCapacityWh: 58.2,
+  fullChargeCapacityWh: 47.6,
+  healthPercent: 0, // computed lazily
+  levelPercent: 64,
+};
+
+const BASELINE_DRAIN_PER_HOUR = 14.2;
+const SAVER_DRAIN_PER_HOUR = 9.6;
+
+const DEFAULT_SAMPLING: ResourceSamplingConfig = {
+  sampleInterval: 1000,
+  drawThrottle: 1000,
+};
+
+const SAVER_SAMPLING: ResourceSamplingConfig = {
+  sampleInterval: 2000,
+  drawThrottle: 2000,
+};
+
+let powerSaverEnabled = false;
+const listeners = new Set<(enabled: boolean) => void>();
+
+const computeHealthPercent = (snapshot: BatterySnapshot): number =>
+  Math.round((snapshot.fullChargeCapacityWh / snapshot.designCapacityWh) * 100);
+
+export const getBatterySnapshot = (): BatterySnapshot => ({
+  ...BATTERY_BASELINE,
+  healthPercent: computeHealthPercent(BATTERY_BASELINE),
+});
+
+export const estimateLifeGainMinutes = (level = getBatterySnapshot().levelPercent): number => {
+  const baselineHours = level / BASELINE_DRAIN_PER_HOUR;
+  const saverHours = level / SAVER_DRAIN_PER_HOUR;
+  return Math.max(0, Math.round((saverHours - baselineHours) * 60));
+};
+
+export const setPowerSaverEnabled = (enabled: boolean): void => {
+  if (powerSaverEnabled === enabled) return;
+  powerSaverEnabled = enabled;
+  listeners.forEach((listener) => {
+    try {
+      listener(powerSaverEnabled);
+    } catch {
+      // Ignore subscriber errors
+    }
+  });
+};
+
+export const isPowerSaverEnabled = (): boolean => powerSaverEnabled;
+
+export const onPowerSaverChange = (
+  listener: (enabled: boolean) => void,
+): (() => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+export const getResourceSamplingConfig = (
+  enabled: boolean,
+): ResourceSamplingConfig => ({
+  ...(enabled ? SAVER_SAMPLING : DEFAULT_SAMPLING),
+});


### PR DESCRIPTION
## Summary
- add a `powerManager` utility that exposes mock battery health, life gain estimates, and resource sampling configs
- surface a new HealthPanel plus a Quick Settings power saver toggle that dims the UI and logs analytics
- capture saver metrics in analytics, document the flow, and add Jest coverage for the toggle

## Testing
- yarn lint *(fails: repo-wide jsx-a11y/control-has-associated-label & legacy public scripts lint errors)*
- yarn test QuickSettings.saver
- yarn test *(fails: existing suites such as window.test.tsx and nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cb19c2ed5c8328a58c9b3aa518ca56