### PR TITLE
[apps] add sandbox runner utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Browse all apps, games, and security tool demos at `/apps`, which presents a sea
 | Settings | /apps/settings | Utility / Media |
 | Trash | /apps/trash | Utility / Media |
 | Project Gallery | /apps/project-gallery | Utility / Media |
+| Sandbox Runner | /apps/sandbox-runner | Utility / Security |
 | Quote | /apps/quote | Utility / Media |
 
 > The VS Code app now embeds a StackBlitz IDE via iframe instead of the local Monaco editor.

--- a/__tests__/components/apps/sandbox-runner.test.tsx
+++ b/__tests__/components/apps/sandbox-runner.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import * as sandboxManager from '@/utils/sandboxManager';
+import SandboxRunner from '@/components/apps/sandbox-runner';
+
+jest.mock('@/utils/sandboxManager', () => ({
+  NETWORK_POLICIES: [
+    { id: 'allow-all', label: 'Allow all traffic', description: 'Allow' },
+    { id: 'block-external', label: 'Block external network', description: 'Block' },
+    { id: 'isolate', label: 'Isolate (offline)', description: 'Offline' },
+  ],
+  startSandbox: jest.fn(),
+  cleanupSandbox: jest.fn(),
+  markWindowAsSandboxed: jest.fn(),
+  unmarkWindowAsSandboxed: jest.fn(),
+  describeNetworkPolicy: jest.fn(() => 'mock-policy'),
+}));
+
+const startSandboxMock = sandboxManager.startSandbox as jest.Mock;
+const cleanupSandboxMock = sandboxManager.cleanupSandbox as jest.Mock;
+const markWindowMock = sandboxManager.markWindowAsSandboxed as jest.Mock;
+const unmarkWindowMock = sandboxManager.unmarkWindowAsSandboxed as jest.Mock;
+
+describe('SandboxRunner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cleanupSandboxMock.mockResolvedValue({
+      sessionId: null,
+      removedHomes: [],
+      errors: [],
+      hadStorage: false,
+    });
+  });
+
+  test('allows adding custom home paths', () => {
+    render(<SandboxRunner />);
+    markWindowMock.mockClear();
+    unmarkWindowMock.mockClear();
+
+    const input = screen.getByLabelText(/Temporary home paths/i);
+    fireEvent.change(input, { target: { value: 'lab/session-a' } });
+    fireEvent.click(screen.getByRole('button', { name: /Add home/i }));
+
+    expect(screen.getByText('lab/session-a')).toBeInTheDocument();
+  });
+
+  test('starts sandbox and displays active status', async () => {
+    startSandboxMock.mockResolvedValue({
+      id: 'sandbox-123',
+      label: 'Research sandbox',
+      homes: ['home/sandbox', 'tmp/sandbox-cache'],
+      networkPolicy: 'block-external',
+      createdAt: Date.now(),
+      status: 'running',
+    });
+
+    render(<SandboxRunner />);
+    markWindowMock.mockClear();
+    unmarkWindowMock.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: /Start sandbox/i }));
+
+    expect(startSandboxMock).toHaveBeenCalledWith({
+      label: 'Research sandbox',
+      homes: ['home/sandbox', 'tmp/sandbox-cache'],
+      networkPolicy: 'block-external',
+    });
+
+    expect(await screen.findByText(/Active sandbox:/i)).toBeInTheDocument();
+    expect(markWindowMock).toHaveBeenCalledWith('sandbox-runner');
+  });
+
+  test('cleans up sandbox storage and reports summary', async () => {
+    startSandboxMock.mockResolvedValue({
+      id: 'sandbox-321',
+      label: 'Research sandbox',
+      homes: ['home/sandbox', 'tmp/sandbox-cache'],
+      networkPolicy: 'block-external',
+      createdAt: Date.now(),
+      status: 'running',
+    });
+    cleanupSandboxMock.mockResolvedValue({
+      sessionId: 'sandbox-321',
+      removedHomes: ['home/sandbox'],
+      errors: [],
+      hadStorage: true,
+    });
+
+    render(<SandboxRunner />);
+    markWindowMock.mockClear();
+    unmarkWindowMock.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: /Start sandbox/i }));
+    await screen.findByText(/Active sandbox:/i);
+
+    markWindowMock.mockClear();
+    unmarkWindowMock.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: /Cleanup/i }));
+
+    expect(await screen.findByText(/Removed homes: 1/)).toBeInTheDocument();
+    expect(cleanupSandboxMock).toHaveBeenCalled();
+    expect(unmarkWindowMock).toHaveBeenCalledWith('sandbox-runner');
+  });
+
+  test('shows error when sandbox start fails', async () => {
+    startSandboxMock.mockRejectedValue(new Error('fail'));
+
+    render(<SandboxRunner />);
+    markWindowMock.mockClear();
+    unmarkWindowMock.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: /Start sandbox/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Failed to start sandbox');
+  });
+});
+

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -8,6 +8,9 @@ jest.mock('react-draggable', () => ({
   default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 jest.mock('../components/apps/terminal', () => ({ displayTerminal: jest.fn() }));
+jest.mock('../utils/sandboxManager', () => ({
+  isWindowSandboxed: jest.fn(() => false),
+}));
 
 describe('Window lifecycle', () => {
   it('invokes callbacks on close', () => {

--- a/apps.config.js
+++ b/apps.config.js
@@ -87,6 +87,7 @@ const MetasploitApp = createDynamicApp('metasploit', 'Metasploit');
 
 const AutopsyApp = createDynamicApp('autopsy', 'Autopsy');
 const PluginManagerApp = createDynamicApp('plugin-manager', 'Plugin Manager');
+const SandboxRunnerApp = createDynamicApp('sandbox-runner', 'Sandbox Runner');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
@@ -170,6 +171,7 @@ const displayGhidra = createDisplay(GhidraApp);
 
 const displayAutopsy = createDisplay(AutopsyApp);
 const displayPluginManager = createDisplay(PluginManagerApp);
+const displaySandboxRunner = createDisplay(SandboxRunnerApp);
 
 const displayWireshark = createDisplay(WiresharkApp);
 const displayBleSensor = createDisplay(BleSensorApp);
@@ -257,6 +259,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayProjectGallery,
+  },
+  {
+    id: 'sandbox-runner',
+    title: 'Sandbox Runner',
+    icon: '/themes/Yaru/apps/terminal.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displaySandboxRunner,
   },
   {
     id: 'input-lab',

--- a/components/apps/sandbox-runner/index.tsx
+++ b/components/apps/sandbox-runner/index.tsx
@@ -1,0 +1,335 @@
+'use client';
+
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import {
+  NETWORK_POLICIES,
+  NetworkPolicy,
+  SandboxCleanupResult,
+  SandboxSession,
+  cleanupSandbox,
+  describeNetworkPolicy,
+  markWindowAsSandboxed,
+  startSandbox,
+  unmarkWindowAsSandboxed,
+} from '@/utils/sandboxManager';
+
+const SANDBOX_APP_ID = 'sandbox-runner';
+
+interface HomeEntry {
+  value: string;
+  persisted: boolean;
+}
+
+const DEFAULT_HOMES: HomeEntry[] = [
+  { value: 'home/sandbox', persisted: true },
+  { value: 'tmp/sandbox-cache', persisted: false },
+];
+
+const inputSanitize = (value: string) => {
+  const trimmed = value.replace(/\\/g, '/').trim();
+  return trimmed.replace(/^\/+/, '');
+};
+
+export default function SandboxRunner() {
+  const [label, setLabel] = useState('Research sandbox');
+  const [homeInput, setHomeInput] = useState('workspace/session');
+  const [homes, setHomes] = useState<HomeEntry[]>(DEFAULT_HOMES);
+  const [networkPolicy, setNetworkPolicy] = useState<NetworkPolicy>('block-external');
+  const [session, setSession] = useState<SandboxSession | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [logs, setLogs] = useState<string[]>([
+    'Sandbox control plane ready. Define a sandbox, then start it.',
+  ]);
+  const [lastCleanup, setLastCleanup] = useState<SandboxCleanupResult | null>(null);
+
+  const cleanHomes = useMemo(
+    () => homes.map((home) => home.value),
+    [homes],
+  );
+
+  const appendLog = (message: string) => {
+    setLogs((prev) => [...prev, `${new Date().toLocaleTimeString()} · ${message}`]);
+  };
+
+  useEffect(() => {
+    if (session) {
+      markWindowAsSandboxed(SANDBOX_APP_ID);
+    } else {
+      unmarkWindowAsSandboxed(SANDBOX_APP_ID);
+    }
+  }, [session]);
+
+  useEffect(() => {
+    return () => {
+      unmarkWindowAsSandboxed(SANDBOX_APP_ID);
+      cleanupSandbox().catch(() => {
+        // ignore cleanup errors during unmount; UI already gone
+      });
+    };
+  }, []);
+
+  const addHome = (event: FormEvent) => {
+    event.preventDefault();
+    const sanitized = inputSanitize(homeInput);
+    if (!sanitized) return;
+    if (cleanHomes.includes(sanitized)) {
+      setHomeInput('');
+      return;
+    }
+    setHomes((prev) => [...prev, { value: sanitized, persisted: false }]);
+    setHomeInput('');
+  };
+
+  const removeHome = (value: string) => {
+    setHomes((prev) => prev.filter((entry) => entry.value !== value));
+  };
+
+  const handleStart = async () => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    setLastCleanup(null);
+    appendLog('Starting sandbox environment...');
+    try {
+      const response = await startSandbox({
+        label,
+        homes: cleanHomes,
+        networkPolicy,
+      });
+      setSession(response);
+      appendLog(
+        `Sandbox "${response.label}" online with ${response.homes.length} home paths and ` +
+          `${networkPolicy.replace('-', ' ')} network controls.`,
+      );
+    } catch (err) {
+      setError('Failed to start sandbox. Check configuration and try again.');
+      appendLog('Sandbox launch failed. No environment was started.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleCleanup = async () => {
+    if (busy) return;
+    setBusy(true);
+    appendLog('Stopping sandbox and purging storage...');
+    try {
+      const result = await cleanupSandbox();
+      setLastCleanup(result);
+      if (result.sessionId) {
+        appendLog(
+          `Sandbox session ${result.sessionId} cleaned. Removed ${result.removedHomes.length} home ` +
+            `paths${result.errors.length ? ' with warnings.' : '.'}`,
+        );
+      } else {
+        appendLog('No active sandbox session detected during cleanup.');
+      }
+      setSession(null);
+      if (result.errors.length > 0) {
+        setError('Cleanup completed with warnings. Storage may require manual review.');
+      } else {
+        setError(null);
+      }
+    } catch (err) {
+      setError('Sandbox cleanup failed. Retry to ensure the environment is reset.');
+      appendLog('Cleanup encountered an unexpected error.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full overflow-y-auto bg-ub-cool-grey text-white p-4 text-sm space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">Sandbox Runner</h1>
+        <p className="text-white/70">
+          Configure a temporary workspace with mock container boundaries. Homes are stored in the
+          browser&apos;s Origin Private File System and purged on cleanup.
+        </p>
+      </header>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <form
+          onSubmit={addHome}
+          className="bg-black/40 border border-white/10 rounded-lg p-4 space-y-3"
+          aria-label="Sandbox configuration"
+        >
+          <div className="space-y-1">
+            <label className="block text-xs uppercase tracking-wide text-white/60" htmlFor="sandbox-label">
+              Sandbox label
+            </label>
+            <input
+              id="sandbox-label"
+              value={label}
+              onChange={(event) => setLabel(event.target.value)}
+              className="w-full rounded bg-black/60 border border-white/20 px-2 py-1 focus:outline-none focus:ring-2 focus:ring-ub-orange"
+              placeholder="Research sandbox"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label
+              className="block text-xs uppercase tracking-wide text-white/60"
+              htmlFor="sandbox-home-input"
+            >
+              Temporary home paths
+            </label>
+            <div className="flex gap-2">
+              <input
+                id="sandbox-home-input"
+                value={homeInput}
+                onChange={(event) => setHomeInput(event.target.value)}
+                className="flex-1 rounded bg-black/60 border border-white/20 px-2 py-1 focus:outline-none focus:ring-2 focus:ring-ub-orange"
+                placeholder="workspace/session"
+              />
+              <button
+                type="submit"
+                className="bg-ub-orange text-black font-semibold px-3 py-1 rounded disabled:opacity-50"
+                disabled={!homeInput.trim()}
+              >
+                Add home
+              </button>
+            </div>
+            <ul className="space-y-1" aria-live="polite">
+              {homes.map((home) => (
+                <li
+                  key={home.value}
+                  className="flex items-center justify-between rounded bg-white/5 px-2 py-1"
+                >
+                  <span className="truncate" title={home.value}>
+                    {home.value}
+                    {home.persisted && <span className="ml-2 text-xs text-ubt-grey">(default)</span>}
+                  </span>
+                  <button
+                    type="button"
+                    className="text-xs text-white/70 hover:text-white"
+                    onClick={() => removeHome(home.value)}
+                    aria-label={`Remove ${home.value}`}
+                  >
+                    Remove
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <fieldset className="space-y-2">
+            <legend className="text-xs uppercase tracking-wide text-white/60">
+              Network controls
+            </legend>
+            <div className="space-y-2">
+              {NETWORK_POLICIES.map((policy) => (
+                <label
+                  key={policy.id}
+                  className="flex items-start gap-2 rounded border border-white/10 bg-white/5 p-3"
+                >
+                  <input
+                    type="radio"
+                    name="network-policy"
+                    value={policy.id}
+                    checked={networkPolicy === policy.id}
+                    onChange={() => setNetworkPolicy(policy.id)}
+                    className="mt-1"
+                  />
+                  <span>
+                    <span className="block font-semibold">{policy.label}</span>
+                    <span className="block text-white/70 text-xs">{policy.description}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <div className="flex flex-wrap gap-2 pt-2">
+            <button
+              type="button"
+              onClick={handleStart}
+              className="bg-ub-green text-black font-semibold px-4 py-2 rounded disabled:opacity-50"
+              disabled={busy || !!session}
+            >
+              Start sandbox
+            </button>
+            <button
+              type="button"
+              onClick={handleCleanup}
+              className="bg-white/10 border border-white/20 px-4 py-2 rounded disabled:opacity-50"
+              disabled={busy || (!session && !lastCleanup)}
+            >
+              Cleanup
+            </button>
+          </div>
+          {error && <p className="text-ub-orange text-xs" role="alert">{error}</p>}
+        </form>
+
+        <aside className="bg-black/30 border border-white/5 rounded-lg p-4 space-y-4">
+          <div className="space-y-2">
+            <h2 className="text-lg font-semibold">Status</h2>
+            <div className="rounded bg-black/40 p-3 text-sm" aria-live="polite">
+              {session ? (
+                <div className="space-y-1">
+                  <p>
+                    <span className="font-semibold">Active sandbox:</span> {session.label}
+                  </p>
+                  <p>
+                    <span className="font-semibold">Network policy:</span>{' '}
+                    {NETWORK_POLICIES.find((item) => item.id === session.networkPolicy)?.label}
+                  </p>
+                  <p>
+                    <span className="font-semibold">Homes:</span> {session.homes.join(', ')}
+                  </p>
+                  <p className="text-white/60 text-xs">
+                    {describeNetworkPolicy(session.networkPolicy)}
+                  </p>
+                </div>
+              ) : (
+                <p>No sandbox running. Configure options and press “Start sandbox”.</p>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <h3 className="font-semibold">Cleanup summary</h3>
+            <div className="rounded bg-black/40 p-3 text-xs space-y-1" aria-live="polite">
+              {lastCleanup ? (
+                <>
+                  <p>
+                    Removed homes: {lastCleanup.removedHomes.length}
+                    {lastCleanup.removedHomes.length > 0 && (
+                      <span className="block text-white/60">{lastCleanup.removedHomes.join(', ')}</span>
+                    )}
+                  </p>
+                  <p>Storage touched: {lastCleanup.hadStorage ? 'Yes' : 'No'}</p>
+                  <p>
+                    Errors:{' '}
+                    {lastCleanup.errors.length > 0
+                      ? lastCleanup.errors.join(', ')
+                      : 'None'}
+                  </p>
+                </>
+              ) : (
+                <p>No cleanup performed yet.</p>
+              )}
+            </div>
+          </div>
+        </aside>
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="text-lg font-semibold">Event log</h2>
+        <div
+          className="h-40 overflow-auto rounded bg-black/60 border border-white/10 p-3 text-xs leading-5"
+          role="log"
+          aria-live="polite"
+        >
+          {logs.map((line, index) => (
+            <div key={`${line}-${index}`} className="whitespace-pre-wrap">
+              {line}
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/lib/analytics-client.ts
+++ b/lib/analytics-client.ts
@@ -4,7 +4,10 @@ export type EventName =
   | 'contact_submit'
   | 'contact_submit_error'
   | 'outbound_link_click'
-  | 'download_click';
+  | 'download_click'
+  | 'sandbox_start'
+  | 'sandbox_cleanup'
+  | 'sandbox_cleanup_error';
 
 export function trackEvent(
   name: EventName,

--- a/utils/sandboxManager.ts
+++ b/utils/sandboxManager.ts
@@ -1,0 +1,315 @@
+import { trackEvent } from '@/lib/analytics-client';
+
+export type NetworkPolicy = 'allow-all' | 'block-external' | 'isolate';
+
+export interface SandboxConfig {
+  label?: string;
+  homes: string[];
+  networkPolicy: NetworkPolicy;
+}
+
+export interface SandboxSession {
+  id: string;
+  label: string;
+  homes: string[];
+  networkPolicy: NetworkPolicy;
+  createdAt: number;
+  status: 'running';
+}
+
+export interface SandboxCleanupResult {
+  sessionId: string | null;
+  removedHomes: string[];
+  errors: string[];
+  hadStorage: boolean;
+}
+
+export interface NetworkPolicyDefinition {
+  id: NetworkPolicy;
+  label: string;
+  description: string;
+}
+
+export const NETWORK_POLICIES: readonly NetworkPolicyDefinition[] = [
+  {
+    id: 'allow-all',
+    label: 'Allow all traffic',
+    description:
+      'Standard mode. Apps keep normal connectivity with auditing hooks enabled for visibility.',
+  },
+  {
+    id: 'block-external',
+    label: 'Block external network',
+    description:
+      'Outbound requests are restricted to loopback and RFC1918 ranges to mimic an internal lab.',
+  },
+  {
+    id: 'isolate',
+    label: 'Isolate (offline)',
+    description:
+      'Fully offline sandbox. No network access is granted; only filesystem operations are permitted.',
+  },
+];
+
+const SANDBOX_ROOT_DIR = 'sandboxes';
+const DEFAULT_HOME = 'home/sandbox';
+
+let activeSession: SandboxSession | null = null;
+let appliedPolicy: NetworkPolicy = 'allow-all';
+const sandboxWindows = new Set<string>();
+
+function emitSandboxUpdate() {
+  if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+    window.dispatchEvent(new CustomEvent('sandbox-windows-changed'));
+  }
+}
+
+function sanitizeLabel(raw?: string): string {
+  const trimmed = raw?.trim() ?? '';
+  if (!trimmed) return 'Sandbox';
+  const collapsed = trimmed.replace(/\s+/g, ' ');
+  return collapsed.slice(0, 80);
+}
+
+function slugifyLabel(label: string): string {
+  const slug = label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || 'sandbox';
+}
+
+function normalizeHomes(homes: string[]): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  homes.forEach((entry) => {
+    const normalized = normalizeHome(entry);
+    if (normalized && !seen.has(normalized)) {
+      seen.add(normalized);
+      result.push(normalized);
+    }
+  });
+  if (result.length === 0) {
+    result.push(DEFAULT_HOME);
+  }
+  return result;
+}
+
+function normalizeHome(input: string): string {
+  const cleaned = input.replace(/\\/g, '/').trim();
+  const stripped = cleaned.replace(/^\/+/, '');
+  if (!stripped) return '';
+  const segments = stripped
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .map((segment) => segment.replace(/[^a-zA-Z0-9._-]/g, '-'));
+  const safe = segments.join('/');
+  if (safe.includes('..')) return '';
+  return safe;
+}
+
+async function getSandboxRoot(create: boolean): Promise<FileSystemDirectoryHandle | null> {
+  if (typeof navigator === 'undefined') return null;
+  const storage = (navigator as any).storage;
+  if (!storage?.getDirectory) return null;
+  try {
+    const root: FileSystemDirectoryHandle = await storage.getDirectory();
+    if (create) {
+      return root.getDirectoryHandle(SANDBOX_ROOT_DIR, { create: true });
+    }
+    try {
+      return root.getDirectoryHandle(SANDBOX_ROOT_DIR);
+    } catch {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+async function ensureSandboxHomes(session: SandboxSession) {
+  const base = await getSandboxRoot(true);
+  if (!base) return;
+  let sandboxDir = await base.getDirectoryHandle(session.id, { create: true });
+  for (const home of session.homes) {
+    const segments = home.split('/');
+    let pointer = sandboxDir;
+    for (const segment of segments) {
+      pointer = await pointer.getDirectoryHandle(segment, { create: true });
+    }
+  }
+}
+
+async function deleteSandboxDir(session: SandboxSession): Promise<{ removed: boolean; errors: string[] }> {
+  const base = await getSandboxRoot(false);
+  if (!base) {
+    return { removed: false, errors: [] };
+  }
+  const errors: string[] = [];
+  try {
+    await (base as any).removeEntry(session.id, { recursive: true });
+    return { removed: true, errors };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'sandbox_remove_failed';
+    errors.push(message);
+  }
+
+  try {
+    const sandboxDir = await base.getDirectoryHandle(session.id);
+    for (const home of session.homes) {
+      const segments = home.split('/').filter(Boolean);
+      await removeNestedDirectory(sandboxDir, segments);
+    }
+    await (base as any).removeEntry(session.id);
+    return { removed: true, errors };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'sandbox_remove_failed';
+    if (!errors.includes(message)) errors.push(message);
+  }
+
+  return { removed: false, errors };
+}
+
+async function removeNestedDirectory(
+  dir: FileSystemDirectoryHandle,
+  segments: string[],
+): Promise<void> {
+  if (segments.length === 0) return;
+  const [head, ...tail] = segments;
+  try {
+    if (tail.length === 0) {
+      await dir.removeEntry(head, { recursive: true } as any);
+      return;
+    }
+    const next = await dir.getDirectoryHandle(head);
+    await removeNestedDirectory(next, tail);
+    try {
+      await dir.removeEntry(head, { recursive: true } as any);
+    } catch {
+      // ignore cleanup failure for parent directories
+    }
+  } catch {
+    // ignore if the directory cannot be removed
+  }
+}
+
+function applyNetworkPolicy(policy: NetworkPolicy) {
+  appliedPolicy = policy;
+}
+
+function resetNetworkPolicy() {
+  appliedPolicy = 'allow-all';
+}
+
+export function isWindowSandboxed(id: string): boolean {
+  return sandboxWindows.has(id);
+}
+
+export function markWindowAsSandboxed(id: string) {
+  if (!sandboxWindows.has(id)) {
+    sandboxWindows.add(id);
+    emitSandboxUpdate();
+  }
+}
+
+export function unmarkWindowAsSandboxed(id: string) {
+  if (sandboxWindows.delete(id)) {
+    emitSandboxUpdate();
+  }
+}
+
+export function clearSandboxedWindows() {
+  if (sandboxWindows.size > 0) {
+    sandboxWindows.clear();
+    emitSandboxUpdate();
+  }
+}
+
+export function getActiveSession(): SandboxSession | null {
+  return activeSession;
+}
+
+export async function startSandbox(config: SandboxConfig): Promise<SandboxSession> {
+  const homes = normalizeHomes(config.homes);
+  const policy = NETWORK_POLICIES.find((item) => item.id === config.networkPolicy)?.id ?? 'block-external';
+  const label = sanitizeLabel(config.label);
+  const id = `${slugifyLabel(label)}-${Math.random().toString(36).slice(2, 8)}`;
+
+  if (activeSession) {
+    await cleanupSandbox();
+  }
+
+  const session: SandboxSession = {
+    id,
+    label,
+    homes,
+    networkPolicy: policy,
+    createdAt: Date.now(),
+    status: 'running',
+  };
+
+  activeSession = session;
+  clearSandboxedWindows();
+  applyNetworkPolicy(policy);
+  await ensureSandboxHomes(session);
+
+  trackEvent('sandbox_start', {
+    networkPolicy: policy,
+    homeCount: homes.length,
+  });
+
+  return session;
+}
+
+export async function cleanupSandbox(): Promise<SandboxCleanupResult> {
+  const session = activeSession;
+  if (!session) {
+    return { sessionId: null, removedHomes: [], errors: [], hadStorage: false };
+  }
+
+  activeSession = null;
+  clearSandboxedWindows();
+  resetNetworkPolicy();
+
+  const result: SandboxCleanupResult = {
+    sessionId: session.id,
+    removedHomes: [...session.homes],
+    errors: [],
+    hadStorage: false,
+  };
+
+  const base = await getSandboxRoot(false);
+  if (base) {
+    result.hadStorage = true;
+    const deletion = await deleteSandboxDir(session);
+    if (!deletion.removed) {
+      result.errors.push(...deletion.errors);
+    } else if (deletion.errors.length) {
+      result.errors.push(...deletion.errors);
+    }
+  }
+
+  trackEvent('sandbox_cleanup', {
+    homeCount: result.removedHomes.length,
+    hadErrors: result.errors.length > 0,
+  });
+
+  if (result.errors.length > 0) {
+    trackEvent('sandbox_cleanup_error', { count: result.errors.length });
+  }
+
+  return result;
+}
+
+export function describeNetworkPolicy(policy: NetworkPolicy): string {
+  return (
+    NETWORK_POLICIES.find((item) => item.id === policy)?.description ??
+    'Applies sandbox network defaults.'
+  );
+}
+
+export function getCurrentPolicy(): NetworkPolicy {
+  return appliedPolicy;
+}
+


### PR DESCRIPTION
## Summary
- add a sandbox manager utility that provisions temporary OPFS directories, applies mock network policies, and records analytics for sandbox lifecycles
- build a Sandbox Runner app UI so users can define temporary homes, choose network isolation modes, and review logs/cleanup results
- surface a sandbox badge in window headers, harden keyboard handlers, extend analytics events, and cover the new flow with tests and docs

## Testing
- yarn lint *(fails: repository already has many jsx-a11y/control-has-associated-label and no-top-level-window errors)*
- yarn test *(fails: existing suites such as __tests__/nmapNse.test.tsx and __tests__/Modal.test.tsx hit known issues)*
- yarn test sandbox-runner window --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68cb19d1f2a0832880b18005b43c658b