### PR TITLE
[settings] add typography controls and live preview

### DIFF
--- a/__tests__/hooks/useSettings.fonts.test.tsx
+++ b/__tests__/hooks/useSettings.fonts.test.tsx
@@ -1,0 +1,107 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { SettingsProvider, useSettings } from '../../hooks/useSettings';
+import { defaults, getBodyFont, getCodeFont } from '../../utils/settingsStore';
+
+describe('useSettings typography preferences', () => {
+  beforeEach(() => {
+    const storage = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: (key: string) => (storage.has(key) ? storage.get(key)! : null),
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        clear: () => {
+          storage.clear();
+        },
+      },
+      configurable: true,
+    });
+    window.localStorage.clear();
+    document.documentElement.removeAttribute('style');
+    Object.keys(document.documentElement.dataset).forEach((key) => {
+      delete document.documentElement.dataset[key];
+    });
+    document.body.style.fontFamily = '';
+  });
+
+  test('persists font selections to storage and CSS variables', async () => {
+    const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+
+    await waitFor(() => {
+      expect(result.current.bodyFont).toBeDefined();
+    });
+
+    act(() => {
+      result.current.setBodyFont('system');
+      result.current.setCodeFont('system-mono');
+      result.current.setAntialiasing('grayscale');
+      result.current.setHinting('precision');
+    });
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem('font-body')).toBe('system');
+      expect(window.localStorage.getItem('font-code')).toBe('system-mono');
+      expect(window.localStorage.getItem('font-antialiasing')).toBe('grayscale');
+      expect(window.localStorage.getItem('font-hinting')).toBe('precision');
+    });
+
+    expect(result.current.bodyFont).toBe('system');
+    expect(result.current.codeFont).toBe('system-mono');
+    expect(document.documentElement.style.getPropertyValue('--font-family-body')).toContain('system-ui');
+    expect(document.documentElement.style.getPropertyValue('--font-family-code')).toContain('SFMono-Regular');
+    expect(document.body.style.fontFamily).toContain('system-ui');
+    expect(document.documentElement.style.getPropertyValue('--font-smoothing-webkit')).toBe('antialiased');
+    expect(document.documentElement.style.getPropertyValue('--font-text-rendering')).toBe('geometricPrecision');
+  });
+
+  test('restores persisted typography preferences on mount', async () => {
+    window.localStorage.setItem('font-body', 'inter');
+    window.localStorage.setItem('font-code', 'jetbrains-mono');
+    window.localStorage.setItem('font-antialiasing', 'grayscale');
+    window.localStorage.setItem('font-hinting', 'legibility');
+
+    await expect(getBodyFont()).resolves.toBe('inter');
+    await expect(getCodeFont()).resolves.toBe('jetbrains-mono');
+
+    const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(document.documentElement.dataset.bodyFont).toBe('inter');
+      expect(document.documentElement.dataset.codeFont).toBe('jetbrains-mono');
+    });
+
+    expect(result.current.bodyFont).toBe('inter');
+    expect(result.current.codeFont).toBe('jetbrains-mono');
+    expect(document.documentElement.style.getPropertyValue('--font-family-body')).toContain('Inter');
+    expect(document.documentElement.style.getPropertyValue('--font-family-code')).toContain('JetBrains Mono');
+    expect(document.documentElement.style.getPropertyValue('--font-smoothing-webkit')).toBe('antialiased');
+    expect(document.documentElement.style.getPropertyValue('--font-text-rendering')).toBe('optimizeLegibility');
+    expect(result.current.antialiasing).toBe('grayscale');
+    expect(result.current.hinting).toBe('legibility');
+  });
+
+  test('falls back to defaults when persisted values are invalid', async () => {
+    window.localStorage.setItem('font-body', 'unknown');
+    window.localStorage.setItem('font-code', 'weird');
+    window.localStorage.setItem('font-antialiasing', 'other');
+    window.localStorage.setItem('font-hinting', 'mystery');
+
+    const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+
+    await waitFor(() => {
+      expect(result.current.bodyFont).toBe(defaults.bodyFont);
+      expect(result.current.codeFont).toBe(defaults.codeFont);
+    });
+
+    expect(result.current.antialiasing).toBe(defaults.antialiasing);
+    expect(result.current.hinting).toBe(defaults.hinting);
+  });
+});

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,14 +1,117 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
-import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
+import {
+    useSettings,
+    ACCENT_OPTIONS,
+    BODY_FONT_OPTIONS,
+    CODE_FONT_OPTIONS,
+    ANTIALIASING_OPTIONS,
+    HINTING_OPTIONS,
+} from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
+const findOption = (options, id) => options.find((option) => option.id === id) || options[0];
+
+const TypographyPreview = ({
+    accent,
+    accentTextColor,
+    contrast,
+    liveRegionRef,
+    bodyFont,
+    codeFont,
+    antialiasing,
+    hinting,
+}) => {
+    const bodyOption = findOption(BODY_FONT_OPTIONS, bodyFont);
+    const codeOption = findOption(CODE_FONT_OPTIONS, codeFont);
+    const antialiasingOption = findOption(ANTIALIASING_OPTIONS, antialiasing);
+    const hintingOption = findOption(HINTING_OPTIONS, hinting);
+
+    return (
+        <section
+            aria-label="Typography preview"
+            className="w-full max-w-3xl mx-auto my-6 p-4 rounded border border-gray-900 bg-ub-dark text-ubt-grey space-y-3 shadow-inner"
+        >
+            <h3 className="text-lg font-semibold text-ubt-grey">Live typography preview</h3>
+            <p
+                className="leading-relaxed text-base"
+                style={{ fontFamily: bodyOption.stack }}
+            >
+                {bodyOption.sample}
+            </p>
+            <pre
+                className="p-3 rounded border border-gray-900 overflow-x-auto text-sm"
+                style={{
+                    fontFamily: codeOption.stack,
+                    lineHeight: '1.4',
+                    backgroundColor: 'rgba(0, 0, 0, 0.35)',
+                }}
+            >
+                <code>{codeOption.sample}</code>
+            </pre>
+            <div className="flex items-center justify-between flex-wrap gap-3">
+                <button
+                    className="px-3 py-1 rounded font-semibold"
+                    style={{ backgroundColor: accent, color: accentTextColor }}
+                >
+                    Accent button
+                </button>
+                <p className={`text-sm ${contrast >= 4.5 ? 'text-green-400' : 'text-red-400'}`}>
+                    {`Contrast ${contrast.toFixed(2)}:1 ${contrast >= 4.5 ? 'Pass' : 'Fail'}`}
+                </p>
+            </div>
+            <p className="text-xs text-ubt-grey" style={{ opacity: 0.8 }}>
+                {`${bodyOption.label} body · ${codeOption.label} code`}
+                <br />
+                {`Antialiasing: ${antialiasingOption.label} • Hinting: ${hintingOption.label}`}
+            </p>
+            <span ref={liveRegionRef} role="status" aria-live="polite" className="sr-only"></span>
+        </section>
+    );
+};
+
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const {
+        accent,
+        setAccent,
+        wallpaper,
+        setWallpaper,
+        density,
+        setDensity,
+        reducedMotion,
+        setReducedMotion,
+        largeHitAreas,
+        setLargeHitAreas,
+        fontScale,
+        setFontScale,
+        highContrast,
+        setHighContrast,
+        pongSpin,
+        setPongSpin,
+        allowNetwork,
+        setAllowNetwork,
+        haptics,
+        setHaptics,
+        bodyFont,
+        setBodyFont,
+        codeFont,
+        setCodeFont,
+        antialiasing,
+        setAntialiasing,
+        hinting,
+        setHinting,
+        theme,
+        setTheme,
+    } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
 
     const wallpapers = ['wall-1', 'wall-2', 'wall-3', 'wall-4', 'wall-5', 'wall-6', 'wall-7', 'wall-8'];
+
+    const bodyFontOption = findOption(BODY_FONT_OPTIONS, bodyFont);
+    const codeFontOption = findOption(CODE_FONT_OPTIONS, codeFont);
+    const antialiasingOption = findOption(ANTIALIASING_OPTIONS, antialiasing);
+    const hintingOption = findOption(HINTING_OPTIONS, hinting);
 
     const changeBackgroundImage = (e) => {
         const name = e.currentTarget.dataset.path;
@@ -54,6 +157,8 @@ export function Settings() {
         });
         return () => cancelAnimationFrame(raf);
     }, [accent, accentText, contrastRatio]);
+
+    const accentTextColor = accentText();
 
     return (
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
@@ -110,6 +215,82 @@ export function Settings() {
                     onChange={(e) => setFontScale(parseFloat(e.target.value))}
                     className="ubuntu-slider"
                 />
+            </div>
+            <div className="flex flex-col items-center my-4 space-y-2">
+                <div className="flex justify-center items-center">
+                    <label className="mr-2 text-ubt-grey">Body Font:</label>
+                    <select
+                        value={bodyFont}
+                        onChange={(e) => setBodyFont(e.target.value)}
+                        className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                    >
+                        {BODY_FONT_OPTIONS.map((option) => (
+                            <option key={option.id} value={option.id}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <p className="text-xs text-center text-ubt-grey" style={{ opacity: 0.75 }}>
+                    {bodyFontOption.sample}
+                </p>
+            </div>
+            <div className="flex flex-col items-center my-4 space-y-2">
+                <div className="flex justify-center items-center">
+                    <label className="mr-2 text-ubt-grey">Code Font:</label>
+                    <select
+                        value={codeFont}
+                        onChange={(e) => setCodeFont(e.target.value)}
+                        className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                    >
+                        {CODE_FONT_OPTIONS.map((option) => (
+                            <option key={option.id} value={option.id}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <p className="text-xs text-center text-ubt-grey" style={{ opacity: 0.75 }}>
+                    {codeFontOption.sample}
+                </p>
+            </div>
+            <div className="flex flex-col items-center my-4 space-y-2">
+                <div className="flex justify-center items-center">
+                    <label className="mr-2 text-ubt-grey">Antialiasing:</label>
+                    <select
+                        value={antialiasing}
+                        onChange={(e) => setAntialiasing(e.target.value)}
+                        className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                    >
+                        {ANTIALIASING_OPTIONS.map((option) => (
+                            <option key={option.id} value={option.id}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <p className="text-xs text-center text-ubt-grey" style={{ opacity: 0.75 }}>
+                    {antialiasingOption.description}
+                </p>
+            </div>
+            <div className="flex flex-col items-center my-4 space-y-2">
+                <div className="flex justify-center items-center">
+                    <label className="mr-2 text-ubt-grey">Hinting:</label>
+                    <select
+                        value={hinting}
+                        onChange={(e) => setHinting(e.target.value)}
+                        className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                    >
+                        {HINTING_OPTIONS.map((option) => (
+                            <option key={option.id} value={option.id}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <p className="text-xs text-center text-ubt-grey" style={{ opacity: 0.75 }}>
+                    {hintingOption.description}
+                </p>
             </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey flex items-center">
@@ -177,24 +358,16 @@ export function Settings() {
                     Pong Spin
                 </label>
             </div>
-            <div className="flex justify-center my-4">
-                <div
-                    className="p-4 rounded transition-colors duration-300 motion-reduce:transition-none"
-                    style={{ backgroundColor: '#0f1317', color: '#ffffff' }}
-                >
-                    <p className="mb-2 text-center">Preview</p>
-                    <button
-                        className="px-2 py-1 rounded"
-                        style={{ backgroundColor: accent, color: accentText() }}
-                    >
-                        Accent
-                    </button>
-                    <p className={`mt-2 text-sm text-center ${contrast >= 4.5 ? 'text-green-400' : 'text-red-400'}`}>
-                        {`Contrast ${contrast.toFixed(2)}:1 ${contrast >= 4.5 ? 'Pass' : 'Fail'}`}
-                    </p>
-                    <span ref={liveRegion} role="status" aria-live="polite" className="sr-only"></span>
-                </div>
-            </div>
+            <TypographyPreview
+                accent={accent}
+                accentTextColor={accentTextColor}
+                contrast={contrast}
+                liveRegionRef={liveRegion}
+                bodyFont={bodyFont}
+                codeFont={codeFont}
+                antialiasing={antialiasing}
+                hinting={hinting}
+            />
             <div className="flex flex-wrap justify-center items-center border-t border-gray-900">
                 {
                     wallpapers.map((name, index) => (
@@ -251,6 +424,13 @@ export function Settings() {
                         setLargeHitAreas(defaults.largeHitAreas);
                         setFontScale(defaults.fontScale);
                         setHighContrast(defaults.highContrast);
+                        setAllowNetwork(defaults.allowNetwork);
+                        setHaptics(defaults.haptics);
+                        setPongSpin(defaults.pongSpin);
+                        setBodyFont(defaults.bodyFont);
+                        setCodeFont(defaults.codeFont);
+                        setAntialiasing(defaults.antialiasing);
+                        setHinting(defaults.hinting);
                         setTheme('default');
                     }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
@@ -273,8 +453,16 @@ export function Settings() {
                         if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
                         if (parsed.density !== undefined) setDensity(parsed.density);
                         if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
+                        if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
                         if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
                         if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
+                        if (parsed.allowNetwork !== undefined) setAllowNetwork(parsed.allowNetwork);
+                        if (parsed.haptics !== undefined) setHaptics(parsed.haptics);
+                        if (parsed.pongSpin !== undefined) setPongSpin(parsed.pongSpin);
+                        if (parsed.bodyFont !== undefined) setBodyFont(parsed.bodyFont);
+                        if (parsed.codeFont !== undefined) setCodeFont(parsed.codeFont);
+                        if (parsed.antialiasing !== undefined) setAntialiasing(parsed.antialiasing);
+                        if (parsed.hinting !== undefined) setHinting(parsed.hinting);
                         if (parsed.theme !== undefined) { setTheme(parsed.theme); }
                     } catch (err) {
                         console.error('Invalid settings', err);

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,3 +22,7 @@ yarn dev
 See the [Architecture](./architecture.md) document for an overview of how the project is organized.
 
 For app contributions, see the [New App Checklist](./new-app-checklist.md).
+
+## Typography preferences
+
+The desktop `Settings` app lets you adjust body and code fonts, as well as text antialiasing and hinting. Changes update instantly across the workspace via CSS custom properties (`--font-family-body`, `--font-family-code`, and the smoothing variables defined in `styles/globals.css`). If you add new typography options, register them in `hooks/useSettings.tsx` and surface them through the settings preview so users can verify the effect before leaving the panel.

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -149,7 +149,10 @@ function MyApp(props) {
   return (
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />
-      <div className={ubuntu.className}>
+      <div
+        className={ubuntu.className}
+        style={{ fontFamily: 'var(--font-family-base, var(--font-family-body))' }}
+      >
         <a
           href="#app-grid"
           className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,6 +20,12 @@
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   accent-color: var(--color-control-accent);
+  --font-family-body: 'Ubuntu', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  --font-family-code: 'Fira Code', 'Source Code Pro', 'Ubuntu Mono', 'Courier New', monospace;
+  --font-smoothing-webkit: auto;
+  --font-smoothing-moz: auto;
+  --font-smoothing-standard: auto;
+  --font-text-rendering: auto;
 }
 
 /* Dark theme */

--- a/styles/index.css
+++ b/styles/index.css
@@ -5,10 +5,14 @@ html {
 }
 
 body{
-    font-family: var(--font-family-base);
+    font-family: var(--font-family-base, var(--font-family-body));
     font-display: swap;
     background-color: var(--color-bg);
     color: var(--color-text);
+    -webkit-font-smoothing: var(--font-smoothing-webkit);
+    -moz-osx-font-smoothing: var(--font-smoothing-moz);
+    font-smooth: var(--font-smoothing-standard);
+    text-rendering: var(--font-text-rendering);
 }
 
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
@@ -504,8 +508,11 @@ dialog {
 
 /* Ensure monospace layout for app outputs */
 textarea,
-pre {
-    font-family: monospace;
+pre,
+code,
+kbd,
+samp {
+    font-family: var(--font-family-code);
     line-height: 1.2;
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -53,7 +53,7 @@
   --motion-slow: 500ms;
 
   /* Fonts */
-  --font-family-base: 'Ubuntu', sans-serif;
+  --font-family-base: var(--font-family-body, 'Ubuntu', sans-serif);
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,10 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  bodyFont: 'ubuntu',
+  codeFont: 'fira-code',
+  antialiasing: 'system',
+  hinting: 'auto',
 };
 
 export async function getAccent() {
@@ -81,6 +85,46 @@ export async function setHighContrast(value) {
   window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
 }
 
+export async function getBodyFont() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.bodyFont;
+  return window.localStorage.getItem('font-body') || DEFAULT_SETTINGS.bodyFont;
+}
+
+export async function setBodyFont(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('font-body', value);
+}
+
+export async function getCodeFont() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.codeFont;
+  return window.localStorage.getItem('font-code') || DEFAULT_SETTINGS.codeFont;
+}
+
+export async function setCodeFont(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('font-code', value);
+}
+
+export async function getAntialiasing() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.antialiasing;
+  return window.localStorage.getItem('font-antialiasing') || DEFAULT_SETTINGS.antialiasing;
+}
+
+export async function setAntialiasing(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('font-antialiasing', value);
+}
+
+export async function getHinting() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.hinting;
+  return window.localStorage.getItem('font-hinting') || DEFAULT_SETTINGS.hinting;
+}
+
+export async function setHinting(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('font-hinting', value);
+}
+
 export async function getLargeHitAreas() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
   return window.localStorage.getItem('large-hit-areas') === 'true';
@@ -137,6 +181,10 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('font-body');
+  window.localStorage.removeItem('font-code');
+  window.localStorage.removeItem('font-antialiasing');
+  window.localStorage.removeItem('font-hinting');
 }
 
 export async function exportSettings() {
@@ -151,6 +199,10 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    bodyFont,
+    codeFont,
+    antialiasing,
+    hinting,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +214,10 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getBodyFont(),
+    getCodeFont(),
+    getAntialiasing(),
+    getHinting(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +231,10 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    bodyFont,
+    codeFont,
+    antialiasing,
+    hinting,
     theme,
   });
 }
@@ -199,6 +259,10 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    bodyFont,
+    codeFont,
+    antialiasing,
+    hinting,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +275,10 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (bodyFont !== undefined) await setBodyFont(bodyFont);
+  if (codeFont !== undefined) await setCodeFont(codeFont);
+  if (antialiasing !== undefined) await setAntialiasing(antialiasing);
+  if (hinting !== undefined) await setHinting(hinting);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- extend the settings store and context with body/code font, antialiasing, and hinting preferences that update CSS variables in place
- refresh the Settings app UI with typography selectors, a live preview, and reset/import flows that cover the new options
- propagate font variables through global styles, the app wrapper, and docs while adding coverage for font persistence

## Testing
- yarn lint *(fails: existing accessibility lint violations in unrelated app components)*
- yarn test __tests__/hooks/useSettings.fonts.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb19c6a7708328935f92779403a372