### PR TITLE
feat(bluetooth): enhance pairing UX and tray status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Bluetooth sensor now shows guided pairing steps, battery reporting, and Quick Settings controls with reconnect caching.
 
 ## [2.1.0] - 2025-09-03
 ### Added

--- a/__tests__/components/apps/bluetooth.test.tsx
+++ b/__tests__/components/apps/bluetooth.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import BleSensor from '../../../components/apps/ble-sensor';
+import QuickSettings from '../../../components/ui/QuickSettings';
+import { installBluetoothMock, MockBluetoothDevice } from '../../../utils/bluetoothMock';
+import {
+  __resetBluetoothStateForTests,
+  getBluetoothState,
+  retryPairing,
+} from '../../../utils/bluetoothManager';
+
+describe('Bluetooth experience', () => {
+  let confirmSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    confirmSpy.mockRestore();
+    __resetBluetoothStateForTests();
+  });
+
+  const setupBluetooth = (
+    options?: Parameters<typeof installBluetoothMock>[0]
+  ): MockBluetoothDevice => {
+    const { device } = installBluetoothMock(options);
+    __resetBluetoothStateForTests();
+    return device;
+  };
+
+  it('progresses through pairing steps and surfaces battery level', async () => {
+    setupBluetooth({ batteryLevel: 78 });
+    render(<BleSensor />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /scan for devices/i }));
+    });
+
+    const battery = await screen.findByTestId('battery-level');
+    const readyStep = screen.getByTestId('pairing-step-complete');
+    expect(readyStep).toHaveTextContent(/Ready/i);
+    expect(battery).toHaveTextContent(/Battery 78%/i);
+
+    const services = await screen.findByTestId('service-list');
+    expect(services.querySelectorAll('li').length).toBeGreaterThan(0);
+    expect(getBluetoothState().status).toBe('connected');
+  });
+
+  it('allows retry after a failed connection attempt', async () => {
+    setupBluetooth({ failConnectAttempts: 3 });
+    render(<BleSensor />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /scan for devices/i }));
+    });
+
+    const alert = await screen.findByRole('alert', undefined, { timeout: 4000 });
+    expect(alert).toHaveTextContent(/retry/i);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /retry pairing/i }));
+    });
+
+    await screen.findByTestId('battery-level');
+    expect(getBluetoothState().status).toBe('connected');
+  });
+
+  it('reuses cached state when reconnecting after a disconnect', async () => {
+    const device = setupBluetooth({ batteryLevel: 64 });
+    render(
+      <>
+        <BleSensor />
+        <QuickSettings open />
+      </>
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /scan for devices/i }));
+    });
+    await screen.findByTestId('battery-level');
+
+    expect(window.localStorage.getItem('ble:lastDeviceId')).toBe(device.id);
+
+    await screen.findByText(/Connected and streaming cached data./i);
+
+    await act(async () => {
+      device.simulateDisconnect();
+    });
+
+    await act(async () => {
+      await retryPairing();
+    });
+    await waitFor(() => {
+      expect(getBluetoothState().status).toBe('connected');
+    });
+
+    const state = getBluetoothState();
+    expect(state.status).toBe('connected');
+    expect(state.services.length).toBeGreaterThan(0);
+  });
+});

--- a/docs/bluetooth-ux.md
+++ b/docs/bluetooth-ux.md
@@ -1,0 +1,16 @@
+# Bluetooth UX Guidelines
+
+The Bluetooth sensor app now guides users through explicit pairing stages and shares status with the desktop tray.
+
+## Pairing flow
+- The scanner shows four steps — request permission, secure pairing, service discovery, and ready state. Each step has an icon and highlights the active stage.
+- Errors surface retry messaging inside the app. Automatic retries reuse the cached device when possible.
+- Battery information is displayed when the sensor exposes the `battery_service` characteristic. Values are cached for reconnects.
+
+## Quick Settings integration
+- The system tray exposes current connection status, device name, and inline connect/disconnect actions.
+- Retry is available directly from the tray when the link drops. Buttons are disabled while pairing is in progress.
+- Battery percentage is shown inline whenever it is available from the cached profile.
+
+## Testing
+- `__tests__/components/apps/bluetooth.test.tsx` covers the happy path, retry flow, and reconnect handling. Run `yarn test` before submitting changes.

--- a/hooks/useBluetoothController.ts
+++ b/hooks/useBluetoothController.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import {
+  getBluetoothState,
+  subscribeToBluetooth,
+  startPairing,
+  retryPairing,
+  disconnectDevice,
+} from '../utils/bluetoothManager';
+
+type BluetoothControllerState = ReturnType<typeof getBluetoothState>;
+
+const useBluetoothController = () => {
+  const [state, setState] = useState<BluetoothControllerState>(() => getBluetoothState());
+
+  useEffect(() => {
+    const unsubscribe = subscribeToBluetooth((next) => {
+      setState(next);
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  return {
+    ...state,
+    startPairing,
+    retryPairing,
+    disconnectDevice,
+  };
+};
+
+export default useBluetoothController;

--- a/utils/bleProfiles.ts
+++ b/utils/bleProfiles.ts
@@ -12,6 +12,7 @@ export interface SavedProfile {
   deviceId: string;
   name: string;
   services: ServiceData[];
+  batteryLevel?: number | null;
 }
 
 const getDir = async (): Promise<any> => {
@@ -74,6 +75,7 @@ export const renameProfile = async (
     await saveProfile(deviceId, {
       name: newName,
       services: existing.services,
+      batteryLevel: existing.batteryLevel,
     });
   }
 };

--- a/utils/bluetoothManager.ts
+++ b/utils/bluetoothManager.ts
@@ -1,0 +1,531 @@
+import { publish, subscribe } from './pubsub';
+import {
+  saveProfile,
+  loadProfile,
+  ServiceData,
+} from './bleProfiles';
+
+type StepKey = 'request' | 'connect' | 'discover' | 'complete';
+type BluetoothStatus =
+  | 'idle'
+  | 'requesting'
+  | 'connecting'
+  | 'discovering'
+  | 'connected'
+  | 'disconnected'
+  | 'reconnecting'
+  | 'error';
+
+interface BluetoothCharacteristicLike {
+  uuid: string;
+  readValue: () => Promise<unknown> | unknown;
+}
+
+interface BluetoothServiceLike {
+  uuid: string;
+  getCharacteristics: () => Promise<BluetoothCharacteristicLike[]>;
+}
+
+interface BluetoothRemoteGATTServerLike {
+  connected: boolean;
+  connect: () => Promise<BluetoothRemoteGATTServerLike>;
+  disconnect: () => void;
+  getPrimaryServices: () => Promise<BluetoothServiceLike[]>;
+}
+
+interface BluetoothDeviceLike extends EventTarget {
+  id: string;
+  name?: string;
+  gatt?: BluetoothRemoteGATTServerLike | null;
+}
+
+interface BluetoothAdapterLike {
+  requestDevice: (options: BluetoothRequestDeviceOptions) => Promise<BluetoothDeviceLike>;
+  getDevices?: () => Promise<BluetoothDeviceLike[]>;
+}
+
+interface BluetoothRequestDeviceOptions {
+  acceptAllDevices?: boolean;
+  optionalServices?: string[];
+}
+
+interface BluetoothState {
+  supported: boolean;
+  status: BluetoothStatus;
+  step: StepKey;
+  busy: boolean;
+  deviceName?: string;
+  batteryLevel: number | null;
+  services: ServiceData[];
+  error?: string;
+  canRetry: boolean;
+  lastDeviceId: string | null;
+  fromCache: boolean;
+}
+
+const MAX_RETRIES = 3;
+const LAST_DEVICE_KEY = 'ble:lastDeviceId';
+const DEFAULT_PROMPT =
+  'This application will request access to nearby Bluetooth devices. Continue?';
+
+let currentState: BluetoothState = {
+  supported: typeof navigator !== 'undefined' && !!(navigator as any).bluetooth,
+  status: 'idle',
+  step: 'request',
+  busy: false,
+  deviceName: undefined,
+  batteryLevel: null,
+  services: [],
+  error: undefined,
+  canRetry: false,
+  lastDeviceId: null,
+  fromCache: false,
+};
+
+let hydrated = false;
+let currentDevice: BluetoothDeviceLike | null = null;
+let currentServer: BluetoothRemoteGATTServerLike | null = null;
+let manualDisconnect = false;
+let reconnecting = false;
+let broadcast: BroadcastChannel | null = null;
+
+function emit(partial?: Partial<BluetoothState>) {
+  if (partial) {
+    currentState = { ...currentState, ...partial };
+  }
+  publish('bluetooth/state', { ...currentState });
+}
+
+function getBluetooth(): BluetoothAdapterLike | null {
+  if (typeof navigator === 'undefined') return null;
+  return ((navigator as unknown as { bluetooth?: BluetoothAdapterLike }).bluetooth || null);
+}
+
+function ensureBroadcastChannel() {
+  if (broadcast || typeof window === 'undefined') return;
+  if ('BroadcastChannel' in window) {
+    broadcast = new BroadcastChannel('ble-profiles');
+  }
+}
+
+async function hydrateFromCache() {
+  if (hydrated) return;
+  hydrated = true;
+  ensureBroadcastChannel();
+  if (typeof window === 'undefined') return;
+  const lastId = window.localStorage.getItem(LAST_DEVICE_KEY);
+  if (!lastId) {
+    emit({ lastDeviceId: null });
+    return;
+  }
+  emit({ lastDeviceId: lastId, step: 'complete', status: 'disconnected', canRetry: true, fromCache: true });
+  try {
+    const profile = await loadProfile(lastId);
+    if (profile) {
+      emit({
+        deviceName: profile.name,
+        services: profile.services,
+        batteryLevel: profile.batteryLevel ?? null,
+      });
+    }
+  } catch (error) {
+    console.warn('Failed to hydrate Bluetooth profile', error);
+  }
+}
+
+function deriveStepFromStatus(status: BluetoothStatus): StepKey {
+  switch (status) {
+    case 'connecting':
+    case 'disconnected':
+    case 'reconnecting':
+      return 'connect';
+    case 'discovering':
+      return 'discover';
+    case 'connected':
+      return 'complete';
+    case 'requesting':
+    case 'idle':
+    case 'error':
+    default:
+      return currentState.step;
+  }
+}
+
+function friendlyError(error: unknown): string {
+  if (!error) return 'An unknown error occurred.';
+  if (error instanceof Error) {
+    const domName = (error as DOMException).name;
+    if (domName === 'NotAllowedError') {
+      return 'Permission to access Bluetooth was denied.';
+    }
+    if (domName === 'NotFoundError') {
+      return 'No Bluetooth devices were discovered.';
+    }
+    return error.message || 'An unknown Bluetooth error occurred.';
+  }
+  return 'An unknown Bluetooth error occurred.';
+}
+
+async function ensureDeviceHandle(reuse: boolean) {
+  if (!reuse) {
+    if (currentDevice) {
+      currentDevice.removeEventListener('gattserverdisconnected', handleDisconnect);
+    }
+    currentDevice = null;
+    return;
+  }
+  if (currentDevice || !currentState.lastDeviceId) return;
+  const adapter = getBluetooth();
+  if (!adapter?.getDevices) return;
+  try {
+    const devices = await adapter.getDevices();
+    const match = devices.find((device) => device.id === currentState.lastDeviceId);
+    if (match) {
+      attachDevice(match);
+    }
+  } catch (error) {
+    console.warn('Unable to recover Bluetooth device handle', error);
+  }
+}
+
+function attachDevice(device: BluetoothDeviceLike) {
+  if (currentDevice && currentDevice !== device) {
+    currentDevice.removeEventListener('gattserverdisconnected', handleDisconnect);
+  }
+  currentDevice = device;
+  currentDevice.addEventListener('gattserverdisconnected', handleDisconnect);
+}
+
+async function connectWithRetry(device: BluetoothDeviceLike) {
+  if (!device.gatt) {
+    throw new Error('The selected device does not expose a GATT server.');
+  }
+  let lastError: unknown = new Error('Unable to connect to device.');
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt += 1) {
+    try {
+      const server = await device.gatt.connect();
+      return server;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 400 * attempt));
+    }
+  }
+  throw lastError;
+}
+
+function extractBatteryLevel(value: unknown): number | null {
+  if (typeof value === 'number') return value;
+  if (value instanceof DataView) {
+    return value.byteLength > 0 ? value.getUint8(0) : null;
+  }
+  if (value instanceof Uint8Array) {
+    return value.length > 0 ? value[0] : null;
+  }
+  if (value && typeof value === 'object' && 'buffer' in (value as { buffer?: ArrayBuffer })) {
+    const buffer = (value as { buffer: ArrayBuffer }).buffer;
+    if (buffer instanceof ArrayBuffer && buffer.byteLength > 0) {
+      return new DataView(buffer).getUint8(0);
+    }
+  }
+  return null;
+}
+
+function formatCharacteristicValue(value: unknown): string {
+  if (value instanceof DataView) {
+    if (value.byteLength === 0) return '[empty]';
+    const text = new TextDecoder().decode(value.buffer);
+    if (text.trim()) return text;
+    return Array.from(new Uint8Array(value.buffer))
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join(' ');
+  }
+  if (value instanceof Uint8Array) {
+    if (value.length === 0) return '[empty]';
+    return Array.from(value)
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join(' ');
+  }
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') return value.toString();
+  if (value && typeof value === 'object' && 'buffer' in (value as { buffer?: ArrayBuffer })) {
+    const buffer = (value as { buffer: ArrayBuffer }).buffer;
+    if (buffer instanceof ArrayBuffer) {
+      return formatCharacteristicValue(new DataView(buffer));
+    }
+  }
+  return '[unreadable]';
+}
+
+async function readServices(server: BluetoothRemoteGATTServerLike) {
+  const services: ServiceData[] = [];
+  let batteryLevel: number | null = currentState.batteryLevel;
+  const primary = await server.getPrimaryServices();
+  for (const service of primary) {
+    const characteristics = await service.getCharacteristics();
+    const items = [];
+    for (const characteristic of characteristics) {
+      const raw = await characteristic.readValue();
+      const value = formatCharacteristicValue(raw);
+      if (
+        service.uuid === 'battery_service' ||
+        service.uuid === '0000180f-0000-1000-8000-00805f9b34fb' ||
+        characteristic.uuid === 'battery_level' ||
+        characteristic.uuid === '00002a19-0000-1000-8000-00805f9b34fb'
+      ) {
+        const maybeBattery = extractBatteryLevel(raw);
+        if (maybeBattery !== null) {
+          batteryLevel = maybeBattery;
+        }
+      }
+      items.push({ uuid: characteristic.uuid, value });
+    }
+    services.push({ uuid: service.uuid, characteristics: items });
+  }
+  return { services, batteryLevel };
+}
+
+async function persistProfile(
+  deviceId: string,
+  name: string,
+  services: ServiceData[],
+  batteryLevel: number | null
+) {
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(LAST_DEVICE_KEY, deviceId);
+    } catch (error) {
+      console.warn('Unable to persist Bluetooth cache key', error);
+    }
+  }
+  try {
+    await saveProfile(deviceId, {
+      name,
+      services,
+      batteryLevel,
+    });
+    ensureBroadcastChannel();
+    broadcast?.postMessage('update');
+  } catch (error) {
+    console.warn('Unable to persist Bluetooth profile', error);
+  }
+}
+
+interface PairingOptions {
+  bypassConfirm?: boolean;
+  reuseDevice?: boolean;
+  reason?: 'initial' | 'retry' | 'reconnect';
+  prompt?: string;
+}
+
+async function requestPairing(options: PairingOptions = {}): Promise<boolean> {
+  await hydrateFromCache();
+  if (!currentState.supported) {
+    emit({
+      status: 'error',
+      step: 'request',
+      error: 'Web Bluetooth is not supported in this browser.',
+      canRetry: false,
+      busy: false,
+    });
+    return false;
+  }
+  if (currentState.busy) return false;
+
+  if (!options.bypassConfirm && typeof window !== 'undefined') {
+    const allowed = window.confirm(options.prompt ?? DEFAULT_PROMPT);
+    if (!allowed) {
+      emit({ status: 'idle', step: 'request', busy: false });
+      return false;
+    }
+  }
+
+  if (options.reason === 'reconnect') {
+    emit({
+      status: 'reconnecting',
+      step: 'connect',
+      busy: true,
+      error: 'Connection lost. Trying to reconnect…',
+      canRetry: true,
+    });
+  } else {
+    emit({ status: 'requesting', step: 'request', busy: true, error: undefined, canRetry: false });
+  }
+
+  try {
+    await ensureDeviceHandle(options.reuseDevice ?? false);
+    const adapter = getBluetooth();
+    if (!currentDevice) {
+      if (!adapter) throw new Error('Bluetooth adapter unavailable.');
+      const device = await adapter.requestDevice({
+        acceptAllDevices: true,
+        optionalServices: ['battery_service', 'device_information'],
+      });
+      attachDevice(device);
+    }
+
+    if (!currentDevice) throw new Error('No Bluetooth device available.');
+
+    emit({
+      status: 'connecting',
+      step: 'connect',
+      deviceName: currentDevice.name || 'Unknown device',
+      lastDeviceId: currentDevice.id,
+      fromCache: options.reuseDevice ? currentState.fromCache : false,
+    });
+
+    currentServer = await connectWithRetry(currentDevice);
+    emit({ status: 'discovering', step: 'discover' });
+
+    const { services, batteryLevel } = await readServices(currentServer);
+
+    emit({
+      status: 'connected',
+      step: 'complete',
+      busy: false,
+      services,
+      batteryLevel,
+      deviceName: currentDevice.name || 'Unknown device',
+      error: undefined,
+      canRetry: false,
+      fromCache: false,
+    });
+
+    await persistProfile(
+      currentDevice.id,
+      currentDevice.name || 'Unknown device',
+      services,
+      batteryLevel
+    );
+    return true;
+  } catch (error) {
+    emit({
+      status: 'error',
+      step: deriveStepFromStatus('error'),
+      error: friendlyError(error),
+      busy: false,
+      canRetry: true,
+    });
+    return false;
+  }
+}
+
+function handleDisconnect() {
+  if (manualDisconnect) {
+    manualDisconnect = false;
+    emit({ status: 'disconnected', step: 'connect', busy: false, canRetry: true });
+    return;
+  }
+  if (reconnecting) return;
+  reconnecting = true;
+  requestPairing({ bypassConfirm: true, reuseDevice: true, reason: 'reconnect' })
+    .catch(() => {
+      emit({
+        status: 'error',
+        step: 'connect',
+        busy: false,
+        error: 'Unable to reconnect automatically. Please retry.',
+        canRetry: true,
+      });
+    })
+    .finally(() => {
+      reconnecting = false;
+    });
+}
+
+export function startPairing(options?: PairingOptions) {
+  return requestPairing({ ...options, reason: options?.reason ?? 'initial' });
+}
+
+export function retryPairing() {
+  return requestPairing({ bypassConfirm: true, reuseDevice: true, reason: 'retry' });
+}
+
+export function disconnectDevice() {
+  if (!currentDevice && !currentServer) {
+    emit({ status: 'idle', step: 'request', busy: false });
+    return;
+  }
+  manualDisconnect = true;
+  try {
+    currentServer?.disconnect();
+  } catch (error) {
+    console.warn('Bluetooth disconnect failed', error);
+  }
+  currentServer = null;
+  if (currentDevice) {
+    currentDevice.removeEventListener('gattserverdisconnected', handleDisconnect);
+    currentDevice = null;
+  }
+  emit({ status: 'disconnected', step: 'connect', busy: false, canRetry: true });
+}
+
+export function forgetDevice(deviceId: string) {
+  if (currentState.lastDeviceId !== deviceId) return;
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.removeItem(LAST_DEVICE_KEY);
+    } catch (error) {
+      console.warn('Failed to clear Bluetooth cache key', error);
+    }
+  }
+  if (currentDevice && currentDevice.id === deviceId) {
+    currentDevice.removeEventListener('gattserverdisconnected', handleDisconnect);
+    currentDevice = null;
+    currentServer = null;
+  }
+  emit({
+    lastDeviceId: null,
+    deviceName: undefined,
+    services: [],
+    batteryLevel: null,
+    status: 'idle',
+    step: 'request',
+    canRetry: false,
+    fromCache: false,
+  });
+}
+
+export function updateCachedDeviceName(deviceId: string, name: string) {
+  if (currentState.lastDeviceId === deviceId) {
+    emit({ deviceName: name });
+  }
+}
+
+export function getBluetoothState(): BluetoothState {
+  return { ...currentState };
+}
+
+export function subscribeToBluetooth(callback: (state: BluetoothState) => void) {
+  void hydrateFromCache();
+  return subscribe('bluetooth/state', (next) => {
+    callback(next as BluetoothState);
+  });
+}
+
+export function __resetBluetoothStateForTests() {
+  currentDevice?.removeEventListener('gattserverdisconnected', handleDisconnect);
+  currentDevice = null;
+  currentServer = null;
+  manualDisconnect = false;
+  reconnecting = false;
+  hydrated = false;
+  currentState = {
+    supported: typeof navigator !== 'undefined' && !!(navigator as any).bluetooth,
+    status: 'idle',
+    step: 'request',
+    busy: false,
+    deviceName: undefined,
+    batteryLevel: null,
+    services: [],
+    error: undefined,
+    canRetry: false,
+    lastDeviceId: null,
+    fromCache: false,
+  };
+  if (broadcast) {
+    broadcast.close();
+    broadcast = null;
+  }
+  emit();
+}
+

--- a/utils/bluetoothMock.ts
+++ b/utils/bluetoothMock.ts
@@ -1,0 +1,153 @@
+export interface MockBluetoothOptions {
+  batteryLevel?: number;
+  failRequest?: boolean;
+  failConnectAttempts?: number;
+  id?: string;
+  name?: string;
+}
+
+interface MockCharacteristicInit {
+  uuid: string;
+  read: () => Promise<unknown> | unknown;
+}
+
+class MockCharacteristic {
+  public readonly uuid: string;
+  private readonly reader: () => Promise<unknown> | unknown;
+
+  constructor(init: MockCharacteristicInit) {
+    this.uuid = init.uuid;
+    this.reader = init.read;
+  }
+
+  async readValue(): Promise<unknown> {
+    return await this.reader();
+  }
+}
+
+class MockService {
+  public readonly uuid: string;
+  private readonly characteristics: MockCharacteristic[];
+
+  constructor(uuid: string, characteristics: MockCharacteristic[]) {
+    this.uuid = uuid;
+    this.characteristics = characteristics;
+  }
+
+  async getCharacteristics(): Promise<MockCharacteristic[]> {
+    return this.characteristics;
+  }
+}
+
+class MockGATTServer {
+  public connected = false;
+  private attempts = 0;
+  private readonly device: MockBluetoothDevice;
+  private readonly options: Required<MockBluetoothOptions>;
+
+  constructor(device: MockBluetoothDevice, options: Required<MockBluetoothOptions>) {
+    this.device = device;
+    this.options = options;
+  }
+
+  async connect(): Promise<MockGATTServer> {
+    this.attempts += 1;
+    if (this.options.failConnectAttempts > 0 && this.attempts <= this.options.failConnectAttempts) {
+      throw new Error('GATT connection failed');
+    }
+    this.connected = true;
+    return this;
+  }
+
+  disconnect(): void {
+    if (!this.connected) return;
+    this.connected = false;
+    this.device.dispatchEvent(new Event('gattserverdisconnected'));
+  }
+
+  async getPrimaryServices(): Promise<MockService[]> {
+    return this.device.services;
+  }
+}
+
+export class MockBluetoothDevice extends EventTarget {
+  public readonly id: string;
+  public name: string;
+  public gatt: MockGATTServer;
+  public services: MockService[];
+
+  private batteryLevel: number;
+
+  constructor(options: Required<MockBluetoothOptions>) {
+    super();
+    this.id = options.id;
+    this.name = options.name;
+    this.batteryLevel = options.batteryLevel;
+    this.services = [
+      new MockService('battery_service', [
+        new MockCharacteristic({
+          uuid: 'battery_level',
+          read: () => {
+            const buffer = new ArrayBuffer(1);
+            new DataView(buffer).setUint8(0, this.batteryLevel);
+            return new DataView(buffer);
+          },
+        }),
+      ]),
+      new MockService('device_information', [
+        new MockCharacteristic({
+          uuid: 'serial_number',
+          read: () => 'SN-123456',
+        }),
+      ]),
+    ];
+    this.gatt = new MockGATTServer(this, options);
+  }
+
+  updateBatteryLevel(level: number) {
+    this.batteryLevel = Math.max(0, Math.min(100, Math.floor(level)));
+  }
+
+  simulateDisconnect() {
+    this.gatt.disconnect();
+  }
+}
+
+function withDefaults(options?: MockBluetoothOptions): Required<MockBluetoothOptions> {
+  return {
+    batteryLevel: options?.batteryLevel ?? 82,
+    failRequest: options?.failRequest ?? false,
+    failConnectAttempts: options?.failConnectAttempts ?? 0,
+    id: options?.id ?? 'mock-device',
+    name: options?.name ?? 'Mock Sensor',
+  };
+}
+
+export function createBluetoothMock(options?: MockBluetoothOptions) {
+  const config = withDefaults(options);
+  const device = new MockBluetoothDevice(config);
+
+  const bluetooth = {
+    async requestDevice() {
+      if (config.failRequest) {
+        throw new Error('No devices found');
+      }
+      return device;
+    },
+    async getDevices() {
+      return [device];
+    },
+  };
+
+  return { bluetooth, device };
+}
+
+export function installBluetoothMock(options?: MockBluetoothOptions) {
+  const { bluetooth, device } = createBluetoothMock(options);
+  const navigatorRef = (globalThis.navigator = globalThis.navigator || ({} as Navigator));
+  Object.defineProperty(navigatorRef, 'bluetooth', {
+    configurable: true,
+    value: bluetooth,
+  });
+  return { bluetooth, device };
+}


### PR DESCRIPTION
## Summary
- add a shared bluetooth manager, mock, and hook to cache device state and battery readings
- redesign the BLE sensor UI with progress steps, retry messaging, and richer saved profile controls
- surface bluetooth status and actions in Quick Settings, and document the new UX
- add component tests covering pairing success, retry, and reconnect flows

## Testing
- yarn lint *(fails: pre-existing accessibility and no-top-level-window violations across legacy apps)*
- yarn test *(fails: existing window and nmap suites unrelated to bluetooth changes)*
- yarn test __tests__/components/apps/bluetooth.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68cb19c405908328a4b1b55ed532c211