### PR TITLE
[apps] Add startup manager preferences UI

### DIFF
--- a/__tests__/analytics.test.ts
+++ b/__tests__/analytics.test.ts
@@ -1,5 +1,13 @@
 import ReactGA from 'react-ga4';
-import { logEvent, logGameStart, logGameEnd, logGameError } from '../utils/analytics';
+import {
+  logEvent,
+  logGameStart,
+  logGameEnd,
+  logGameError,
+  logStartupDelayChange,
+  logStartupImpactSnapshot,
+  logStartupToggle,
+} from '../utils/analytics';
 
 jest.mock('react-ga4', () => ({
   event: jest.fn(),
@@ -36,6 +44,43 @@ describe('analytics utilities', () => {
   it('handles errors from ReactGA.event without throwing', () => {
     mockEvent.mockImplementationOnce(() => { throw new Error('fail'); });
     expect(() => logEvent({ category: 't', action: 'a' } as any)).not.toThrow();
+  });
+
+  it('logs startup toggle actions with rounded impact', () => {
+    logStartupToggle('entry-1', true, 7.4);
+    expect(mockEvent).toHaveBeenCalledWith({
+      category: 'Startup Manager',
+      action: 'enable-entry',
+      label: 'entry-1',
+      value: 7,
+    });
+    logStartupToggle('entry-2', false, -3);
+    expect(mockEvent).toHaveBeenCalledWith({
+      category: 'Startup Manager',
+      action: 'disable-entry',
+      label: 'entry-2',
+      value: 0,
+    });
+  });
+
+  it('logs startup delay changes with clamped seconds', () => {
+    logStartupDelayChange('entry-3', 42.8);
+    expect(mockEvent).toHaveBeenCalledWith({
+      category: 'Startup Manager',
+      action: 'set-delay',
+      label: 'entry-3',
+      value: 43,
+    });
+  });
+
+  it('logs startup impact snapshots', () => {
+    logStartupImpactSnapshot(18.2, 1);
+    expect(mockEvent).toHaveBeenCalledWith({
+      category: 'Startup Manager',
+      action: 'impact-snapshot',
+      label: 'heavy-disabled:1',
+      value: 18,
+    });
   });
 });
 

--- a/__tests__/components/apps/startup-manager.test.tsx
+++ b/__tests__/components/apps/startup-manager.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import StartupManager from '../../../components/apps/startup-manager';
+import { startupEntries } from '../../../utils/startupEntries';
+import {
+  logStartupDelayChange,
+  logStartupImpactSnapshot,
+  logStartupToggle,
+} from '../../../utils/analytics';
+
+jest.mock('../../../utils/analytics', () => ({
+  __esModule: true,
+  logStartupDelayChange: jest.fn(),
+  logStartupImpactSnapshot: jest.fn(),
+  logStartupToggle: jest.fn(),
+}));
+
+describe('StartupManager app', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    (logStartupDelayChange as jest.Mock).mockReset();
+    (logStartupImpactSnapshot as jest.Mock).mockReset();
+    (logStartupToggle as jest.Mock).mockReset();
+  });
+
+  it('renders startup entries with summary and persists defaults', async () => {
+    render(<StartupManager />);
+
+    await waitFor(() => expect(logStartupImpactSnapshot).toHaveBeenCalled());
+
+    expect(screen.getByText('Startup Manager')).toBeInTheDocument();
+    const firstEntry = startupEntries[0];
+    expect(screen.getByText(firstEntry.name)).toBeInTheDocument();
+
+    const toggle = screen.getByLabelText(
+      `Toggle ${firstEntry.name}`
+    ) as HTMLInputElement;
+    expect(toggle.checked).toBe(firstEntry.defaultEnabled);
+
+    const summary = screen.getByText(/Aggregate impact score/);
+    const totalImpact = startupEntries.reduce(
+      (sum, entry) => (entry.defaultEnabled ? sum + entry.impactScore : sum),
+      0
+    );
+    expect(summary).toHaveTextContent(String(totalImpact));
+
+    await waitFor(() =>
+      expect(localStorage.getItem('startup-manager-preferences')).toBeTruthy()
+    );
+  });
+
+  it('stores preference changes and warns when disabling heavy entries', async () => {
+    const heavyEntry = startupEntries.find((entry) => entry.heavy);
+    expect(heavyEntry).toBeDefined();
+
+    render(<StartupManager />);
+    await waitFor(() => expect(logStartupImpactSnapshot).toHaveBeenCalled());
+
+    const toggle = screen.getByLabelText(
+      `Toggle ${heavyEntry!.name}`
+    ) as HTMLInputElement;
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(toggle.checked).toBe(false));
+    await waitFor(() =>
+      expect(logStartupToggle).toHaveBeenCalledWith(
+        heavyEntry!.id,
+        false,
+        heavyEntry!.impactScore
+      )
+    );
+    await waitFor(() =>
+      expect(logStartupImpactSnapshot).toHaveBeenCalledTimes(2)
+    );
+
+    const raw = localStorage.getItem('startup-manager-preferences');
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw || '{}');
+    expect(parsed.enabled[heavyEntry!.id]).toBe(false);
+    expect(screen.getByText(heavyEntry!.warning!)).toBeInTheDocument();
+  });
+
+  it('updates delays, logs analytics, and persists changes', async () => {
+    const adjustable = startupEntries.find((entry) => !entry.heavy);
+    expect(adjustable).toBeDefined();
+
+    render(<StartupManager />);
+    await waitFor(() => expect(logStartupImpactSnapshot).toHaveBeenCalled());
+    (logStartupImpactSnapshot as jest.Mock).mockClear();
+
+    const delayInput = screen.getByLabelText(
+      `Delay ${adjustable!.name}`
+    ) as HTMLInputElement;
+    fireEvent.change(delayInput, { target: { value: '12' } });
+
+    await waitFor(() => expect(delayInput.value).toBe('12'));
+    await waitFor(() =>
+      expect(logStartupDelayChange).toHaveBeenCalledWith(adjustable!.id, 12)
+    );
+    await waitFor(() => expect(logStartupImpactSnapshot).toHaveBeenCalled());
+
+    const stored = JSON.parse(
+      localStorage.getItem('startup-manager-preferences') || '{}'
+    );
+    expect(stored.delays[adjustable!.id]).toBe(12);
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -86,6 +86,7 @@ const BeefApp = createDynamicApp('beef', 'BeEF');
 const MetasploitApp = createDynamicApp('metasploit', 'Metasploit');
 
 const AutopsyApp = createDynamicApp('autopsy', 'Autopsy');
+const StartupManagerApp = createDynamicApp('startup-manager', 'Startup Manager');
 const PluginManagerApp = createDynamicApp('plugin-manager', 'Plugin Manager');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
@@ -169,6 +170,7 @@ const displayInputLab = createDisplay(InputLabApp);
 const displayGhidra = createDisplay(GhidraApp);
 
 const displayAutopsy = createDisplay(AutopsyApp);
+const displayStartupManager = createDisplay(StartupManagerApp);
 const displayPluginManager = createDisplay(PluginManagerApp);
 
 const displayWireshark = createDisplay(WiresharkApp);
@@ -826,6 +828,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayAutopsy,
+  },
+  {
+    id: 'startup-manager',
+    title: 'Startup Manager',
+    icon: '/themes/Yaru/apps/resource-monitor.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayStartupManager,
   },
   {
     id: 'plugin-manager',

--- a/components/apps/startup-manager/index.tsx
+++ b/components/apps/startup-manager/index.tsx
@@ -1,0 +1,247 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { startupEntries, StartupEntry } from '../../../utils/startupEntries';
+import { safeLocalStorage } from '../../../utils/safeStorage';
+import {
+  logStartupDelayChange,
+  logStartupImpactSnapshot,
+  logStartupToggle,
+} from '../../../utils/analytics';
+
+const STORAGE_KEY = 'startup-manager-preferences';
+
+interface StartupPreferences {
+  enabled: Record<string, boolean>;
+  delays: Record<string, number>;
+}
+
+const clampDelay = (value: number): number => {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(120, Math.max(0, Math.round(value)));
+};
+
+const createDefaultPreferences = (): StartupPreferences => ({
+  enabled: startupEntries.reduce<Record<string, boolean>>((acc, entry) => {
+    acc[entry.id] = entry.defaultEnabled;
+    return acc;
+  }, {}),
+  delays: startupEntries.reduce<Record<string, number>>((acc, entry) => {
+    acc[entry.id] = entry.defaultDelay;
+    return acc;
+  }, {}),
+});
+
+const readStoredPreferences = (): StartupPreferences => {
+  const defaults = createDefaultPreferences();
+  if (!safeLocalStorage) return defaults;
+  try {
+    const raw = safeLocalStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaults;
+    const parsed = JSON.parse(raw) as Partial<StartupPreferences>;
+    const enabled = { ...defaults.enabled };
+    const delays = { ...defaults.delays };
+
+    if (parsed.enabled && typeof parsed.enabled === 'object') {
+      Object.entries(parsed.enabled).forEach(([key, value]) => {
+        if (typeof value === 'boolean') {
+          enabled[key] = value;
+        }
+      });
+    }
+
+    if (parsed.delays && typeof parsed.delays === 'object') {
+      Object.entries(parsed.delays).forEach(([key, value]) => {
+        if (typeof value === 'number') {
+          delays[key] = clampDelay(value);
+        }
+      });
+    }
+
+    return { enabled, delays };
+  } catch {
+    return defaults;
+  }
+};
+
+const StartupManager: React.FC = () => {
+  const [preferences, setPreferences] = useState<StartupPreferences>(() =>
+    readStoredPreferences()
+  );
+  const previousPreferences = useRef<StartupPreferences | null>(null);
+
+  useEffect(() => {
+    if (!safeLocalStorage) return;
+    try {
+      safeLocalStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+    } catch {
+      /* ignore storage errors */
+    }
+  }, [preferences]);
+
+  const totalImpact = useMemo(
+    () =>
+      startupEntries.reduce(
+        (total, entry) =>
+          preferences.enabled[entry.id] ? total + entry.impactScore : total,
+        0
+      ),
+    [preferences.enabled]
+  );
+
+  const enabledCount = useMemo(
+    () =>
+      startupEntries.reduce(
+        (count, entry) => (preferences.enabled[entry.id] ? count + 1 : count),
+        0
+      ),
+    [preferences.enabled]
+  );
+
+  const heavyDisabled = useMemo(
+    () =>
+      startupEntries.filter(
+        (entry) => entry.heavy && !preferences.enabled[entry.id]
+      ).length,
+    [preferences.enabled]
+  );
+
+  useEffect(() => {
+    const prev = previousPreferences.current;
+    if (!prev) {
+      previousPreferences.current = preferences;
+      logStartupImpactSnapshot(totalImpact, heavyDisabled);
+      return;
+    }
+
+    startupEntries.forEach((entry) => {
+      const prevEnabled = prev.enabled[entry.id];
+      const nextEnabled = preferences.enabled[entry.id];
+      if (prevEnabled !== nextEnabled) {
+        logStartupToggle(entry.id, nextEnabled, entry.impactScore);
+      }
+
+      const prevDelay = prev.delays[entry.id];
+      const nextDelay = preferences.delays[entry.id];
+      if (prevDelay !== nextDelay) {
+        logStartupDelayChange(entry.id, nextDelay);
+      }
+    });
+
+    previousPreferences.current = preferences;
+    logStartupImpactSnapshot(totalImpact, heavyDisabled);
+  }, [preferences, totalImpact, heavyDisabled]);
+
+  const toggleEntry = (entry: StartupEntry) => {
+    setPreferences((prev) => ({
+      enabled: { ...prev.enabled, [entry.id]: !prev.enabled[entry.id] },
+      delays: { ...prev.delays },
+    }));
+  };
+
+  const updateDelay = (entry: StartupEntry, value: number) => {
+    const nextDelay = clampDelay(value);
+    setPreferences((prev) => {
+      const currentDelay = prev.delays[entry.id];
+      if (currentDelay === nextDelay) {
+        return prev;
+      }
+      return {
+        enabled: { ...prev.enabled },
+        delays: { ...prev.delays, [entry.id]: nextDelay },
+      };
+    });
+  };
+
+  return (
+    <div className="h-full w-full overflow-auto bg-ub-cool-grey text-white p-4">
+      <header className="mb-4">
+        <h1 className="text-2xl font-semibold">Startup Manager</h1>
+        <p className="text-sm text-ubt-grey">
+          Choose which simulated services run at sign-in, delay lightweight items,
+          and monitor how changes affect boot impact.
+        </p>
+      </header>
+
+      <section className="mb-4 rounded border border-white/10 bg-black/30 p-4">
+        <h2 className="text-lg font-semibold">Impact Summary</h2>
+        <p className="text-sm text-white/80">
+          Enabled entries: {enabledCount} / {startupEntries.length}
+        </p>
+        <p className="text-sm text-white/80">
+          Aggregate impact score: <span className="font-semibold">{totalImpact}</span>
+        </p>
+        {heavyDisabled > 0 && (
+          <p className="mt-2 rounded border border-ub-orange bg-black/30 p-2 text-sm text-ub-orange" role="alert">
+            {heavyDisabled} critical service{heavyDisabled > 1 ? 's are' : ' is'} disabled. Boot insights may be delayed.
+          </p>
+        )}
+      </section>
+
+      <div className="space-y-4">
+        {startupEntries.map((entry) => {
+          const enabled = preferences.enabled[entry.id];
+          const delay = preferences.delays[entry.id] ?? entry.defaultDelay;
+          return (
+            <article
+              key={entry.id}
+              className="rounded border border-white/10 bg-black/30 p-4 shadow-inner"
+            >
+              <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                <div>
+                  <h3 className="text-xl font-semibold">{entry.name}</h3>
+                  <p className="text-sm text-white/80">{entry.description}</p>
+                  <p className="mt-1 text-xs text-ubt-grey">Source: {entry.source}</p>
+                </div>
+                <label className="flex items-center gap-2 text-sm">
+                  <span className="font-semibold">
+                    {enabled ? 'Enabled at boot' : 'Disabled'}
+                  </span>
+                  <input
+                    aria-label={`Toggle ${entry.name}`}
+                    checked={enabled}
+                    className="h-5 w-5 accent-ub-orange"
+                    onChange={() => toggleEntry(entry)}
+                    type="checkbox"
+                  />
+                </label>
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-4 text-sm text-white/80">
+                <div>
+                  Impact score:{' '}
+                  <span className="font-semibold text-white">{entry.impactScore}</span>
+                </div>
+                <label className="flex items-center gap-2">
+                  <span className="text-white/80">Delay (seconds)</span>
+                  <input
+                    aria-label={`Delay ${entry.name}`}
+                    className="w-20 rounded border border-white/10 bg-ub-dark text-white px-2 py-1"
+                    inputMode="numeric"
+                    min={0}
+                    max={120}
+                    onChange={(event) =>
+                      updateDelay(entry, Number(event.target.value))
+                    }
+                    type="number"
+                    value={delay}
+                  />
+                </label>
+              </div>
+
+              {entry.heavy && !enabled && (
+                <p
+                  className="mt-3 rounded border border-ub-orange bg-black/30 p-3 text-sm text-ub-orange"
+                  role="alert"
+                >
+                  {entry.warning ||
+                    `${entry.name} is marked as a heavy service. Disable it only if you understand the trade-offs.`}
+                </p>
+              )}
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default StartupManager;

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -51,6 +51,9 @@ Implement safe, non-executing simulators for each tool. Features:
 Tools to cover: **BeEF, Ettercap, Metasploit, Wireshark, Kismet, Nikto, Autopsy, Nessus, Hydra, Nmap NSE, Radare2, Volatility, Hashcat, Metasploit Post, dsniff, John the Ripper, OpenVAS, Recon-ng, Ghidra, Mimikatz, Reaver**.
 
 ## Other Apps
+### Startup Manager
+- Surface mock startup services with impact scores, allow enabling/disabling and per-entry delays, and persist preferences with safe storage.
+
 ### About Alex
 - Replace static content with resume widget loaded from JSON; show skills as chips and project links.
 

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -28,3 +28,40 @@ export const logGameEnd = (game: string, label?: string): void => {
 export const logGameError = (game: string, message?: string): void => {
   logEvent({ category: game, action: 'error', label: message });
 };
+
+export const logStartupToggle = (
+  entryId: string,
+  enabled: boolean,
+  impactScore: number
+): void => {
+  logEvent({
+    category: 'Startup Manager',
+    action: enabled ? 'enable-entry' : 'disable-entry',
+    label: entryId,
+    value: Math.max(0, Math.round(impactScore)),
+  });
+};
+
+export const logStartupDelayChange = (
+  entryId: string,
+  delaySeconds: number
+): void => {
+  logEvent({
+    category: 'Startup Manager',
+    action: 'set-delay',
+    label: entryId,
+    value: Math.max(0, Math.round(delaySeconds)),
+  });
+};
+
+export const logStartupImpactSnapshot = (
+  totalImpact: number,
+  heavyDisabled: number
+): void => {
+  logEvent({
+    category: 'Startup Manager',
+    action: 'impact-snapshot',
+    label: `heavy-disabled:${heavyDisabled}`,
+    value: Math.max(0, Math.round(totalImpact)),
+  });
+};

--- a/utils/startupEntries.ts
+++ b/utils/startupEntries.ts
@@ -1,0 +1,58 @@
+export interface StartupEntry {
+  id: string;
+  name: string;
+  description: string;
+  source: string;
+  impactScore: number;
+  defaultEnabled: boolean;
+  defaultDelay: number;
+  heavy?: boolean;
+  warning?: string;
+}
+
+export const startupEntries: StartupEntry[] = [
+  {
+    id: 'threat-monitor',
+    name: 'Threat Monitor',
+    description:
+      'Collects telemetry from the simulated SOC sensors so the desktop feeds dashboards immediately after sign-in.',
+    source: 'systemd — /etc/systemd/system/threat-monitor.service',
+    impactScore: 9,
+    defaultEnabled: true,
+    defaultDelay: 0,
+    heavy: true,
+    warning: 'Threat Monitor primes forensic baselines. Disabling it delays incident response triage.',
+  },
+  {
+    id: 'widget-sync',
+    name: 'Widget Sync',
+    description:
+      'Restores pinned desktop widgets and layout tweaks from the last session.',
+    source: 'autostart — ~/.config/autostart/widget-sync.desktop',
+    impactScore: 3,
+    defaultEnabled: true,
+    defaultDelay: 5,
+  },
+  {
+    id: 'update-check',
+    name: 'Security Update Check',
+    description:
+      'Polls the package mirrors for simulator updates and surfaces changelog notifications.',
+    source: 'cron @reboot — /opt/portfolio/bin/update-check.sh',
+    impactScore: 5,
+    defaultEnabled: false,
+    defaultDelay: 30,
+  },
+  {
+    id: 'forensic-handoff',
+    name: 'Forensic Handoff Prep',
+    description:
+      'Preloads offline evidence vaults and copies runbooks into RAM for faster lab turnover.',
+    source: 'systemd — /etc/systemd/system/forensic-handoff.service',
+    impactScore: 8,
+    defaultEnabled: true,
+    defaultDelay: 0,
+    heavy: true,
+    warning: 'Forensic Handoff Prep keeps lab exports warm. Disable only if you do not need immediate capture kits.',
+  },
+];


### PR DESCRIPTION
## Summary
- add a Startup Manager desktop app that lists mock startup services, persists toggle/delay state, and raises warnings for heavy services
- extend analytics with startup impact tracking utilities, register the app in the launcher config, and document the task in docs/tasks.md
- add Jest coverage for the new component and provide the startupEntries dataset

## Testing
- yarn lint *(fails: repository has numerous existing accessibility and no-top-level-window violations)*
- CI=1 yarn test *(fails: legacy suites such as window snapping and nmap NSE are currently red)*
- CI=1 yarn test startup-manager


------
https://chatgpt.com/codex/tasks/task_e_68cb19cc56a8832880cb9207cc69ea9e