### PR TITLE
apps: add gesture customizer configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Browse all apps, games, and security tool demos at `/apps`, which presents a sea
 | Settings | /apps/settings | Utility / Media |
 | Trash | /apps/trash | Utility / Media |
 | Project Gallery | /apps/project-gallery | Utility / Media |
+| Gesture Customizer | /apps/gesture-customizer | Input & Automation |
 | Quote | /apps/quote | Utility / Media |
 
 > The VS Code app now embeds a StackBlitz IDE via iframe instead of the local Monaco editor.
@@ -383,6 +384,11 @@ The Spotify app lets you customize a mood-to-playlist mapping. Use the in-app fo
 add, reorder, or delete moods; selections persist in the browser's Origin Private File
 System so your choices restore on load. The last mood played is remembered, and
 play/pause and track controls include keyboard hotkeys.
+
+The Gesture Customizer app exposes the desktop manager's window operations for
+three and four-finger gestures. Conflicts with existing keyboard shortcuts are
+highlighted, and presets are stored in the browser's Origin Private File System
+for quick reuse across sessions.
 
 ### Terminal Commands
 - `clear` – clears the terminal display.

--- a/__tests__/components/apps/gesture-customizer.test.tsx
+++ b/__tests__/components/apps/gesture-customizer.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GestureCustomizer from '../../../components/apps/gesture-customizer';
+import useOPFS from '../../../hooks/useOPFS';
+
+jest.mock('../../../hooks/useOPFS', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('GestureCustomizer app', () => {
+  const mockGetDir = jest.fn();
+  const mockWriteFile = jest.fn();
+  const mockReadFile = jest.fn();
+  const mockListFiles = jest.fn();
+  const mockedUseOPFS = useOPFS as jest.MockedFunction<typeof useOPFS>;
+
+  beforeEach(() => {
+    mockGetDir.mockResolvedValue({} as FileSystemDirectoryHandle);
+    mockWriteFile.mockResolvedValue(true);
+    mockReadFile.mockResolvedValue(null);
+    mockListFiles.mockResolvedValue([]);
+
+    mockedUseOPFS.mockReturnValue({
+      supported: true,
+      root: {} as FileSystemDirectoryHandle,
+      getDir: mockGetDir,
+      readFile: mockReadFile,
+      writeFile: mockWriteFile,
+      deleteFile: jest.fn(),
+      listFiles: mockListFiles,
+    });
+  });
+
+  afterEach(() => {
+    mockGetDir.mockReset();
+    mockWriteFile.mockReset();
+    mockReadFile.mockReset();
+    mockListFiles.mockReset();
+    mockedUseOPFS.mockReset();
+  });
+
+  it('renders gestures with assignable actions', () => {
+    render(<GestureCustomizer />);
+    expect(screen.getByText(/three-finger swipe up/i)).toBeInTheDocument();
+    expect(screen.getAllByRole('combobox').length).toBeGreaterThan(0);
+  });
+
+  it('shows a conflict prompt for actions that have keyboard shortcuts', async () => {
+    const user = userEvent.setup();
+    render(<GestureCustomizer />);
+
+    const [firstSelect] = screen.getAllByRole('combobox');
+    await user.selectOptions(firstSelect, 'open-clipboard-manager');
+
+    const prompt = await screen.findByRole('alertdialog');
+    expect(prompt).toHaveTextContent(/Ctrl\+Shift\+V/i);
+
+    await user.click(screen.getByRole('button', { name: /keep action/i }));
+    await waitFor(() => {
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText(/Ctrl\+Shift\+V/i)).toBeInTheDocument();
+  });
+
+  it('saves presets to OPFS with a slugified file name', async () => {
+    const user = userEvent.setup();
+    const presetDir = { name: 'gestures' } as unknown as FileSystemDirectoryHandle;
+    mockGetDir.mockResolvedValue(presetDir);
+
+    render(<GestureCustomizer />);
+    await user.type(
+      screen.getByPlaceholderText(/window-management/i),
+      'Team Flow',
+    );
+    await user.click(screen.getByRole('button', { name: /save preset/i }));
+
+    await waitFor(() => expect(mockWriteFile).toHaveBeenCalled());
+    const [fileName, payload, dirArg] = mockWriteFile.mock.calls[0];
+    expect(fileName).toBe('team-flow.json');
+    expect(typeof payload).toBe('string');
+    expect(JSON.parse(payload).assignments).toBeDefined();
+    expect(dirArg).toBe(presetDir);
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -72,6 +72,7 @@ const QuoteApp = createDynamicApp('quote', 'Quote');
 const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery');
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
+const GestureCustomizerApp = createDynamicApp('gesture-customizer', 'Gesture Customizer');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
@@ -165,6 +166,7 @@ const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
+const displayGestureCustomizer = createDisplay(GestureCustomizerApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 
@@ -266,6 +268,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayInputLab,
+  },
+  {
+    id: 'gesture-customizer',
+    title: 'Gesture Customizer',
+    icon: '/themes/Yaru/apps/gesture-customizer.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayGestureCustomizer,
   },
 ];
 

--- a/components/apps/gesture-customizer/index.tsx
+++ b/components/apps/gesture-customizer/index.tsx
@@ -1,0 +1,615 @@
+"use client";
+
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from 'react';
+import useOPFS from '../../../hooks/useOPFS';
+import { DESKTOP_ACTIONS, DESKTOP_SHORTCUTS } from '../../screen/desktop';
+
+type DesktopAction = {
+  id: string;
+  label: string;
+  description: string;
+  operation: string;
+  args?: string[];
+};
+
+type DesktopShortcut = {
+  id: string;
+  combo: string;
+  actionId: string;
+  description: string;
+};
+
+type GestureConfig = {
+  id: string;
+  label: string;
+  description: string;
+  fingers: 3 | 4;
+  category: 'swipe' | 'tap';
+};
+
+type ConflictPrompt = {
+  gestureId: string;
+  actionId: string;
+  combos: string[];
+  previousActionId: string;
+};
+
+type StatusMessage = {
+  tone: 'info' | 'success' | 'error';
+  message: string;
+};
+
+const ACTIONS = DESKTOP_ACTIONS as DesktopAction[];
+const SHORTCUTS = DESKTOP_SHORTCUTS as DesktopShortcut[];
+
+const GESTURES: GestureConfig[] = [
+  {
+    id: 'three-swipe-up',
+    label: 'Three-finger swipe up',
+    description: 'Reveal multitasking overlays such as the window switcher.',
+    fingers: 3,
+    category: 'swipe',
+  },
+  {
+    id: 'three-swipe-down',
+    label: 'Three-finger swipe down',
+    description: 'Return to the last active window or the desktop.',
+    fingers: 3,
+    category: 'swipe',
+  },
+  {
+    id: 'three-swipe-left',
+    label: 'Three-finger swipe left',
+    description: 'Great for assigning "previous" style navigation gestures.',
+    fingers: 3,
+    category: 'swipe',
+  },
+  {
+    id: 'three-swipe-right',
+    label: 'Three-finger swipe right',
+    description: 'Ideal for next-app or forward navigation shortcuts.',
+    fingers: 3,
+    category: 'swipe',
+  },
+  {
+    id: 'four-swipe-up',
+    label: 'Four-finger swipe up',
+    description: 'Use this for power actions like showing the applications view.',
+    fingers: 4,
+    category: 'swipe',
+  },
+  {
+    id: 'four-swipe-down',
+    label: 'Four-finger swipe down',
+    description: 'Handy for quickly minimising or revealing windows.',
+    fingers: 4,
+    category: 'swipe',
+  },
+  {
+    id: 'four-tap',
+    label: 'Four-finger tap',
+    description: 'Reserve for quick-launch actions such as opening settings.',
+    fingers: 4,
+    category: 'tap',
+  },
+];
+
+const defaultAssignments: Record<string, string> = {
+  'three-swipe-up': 'open-window-switcher',
+  'three-swipe-down': 'focus-last-app',
+  'three-swipe-left': 'cycle-apps',
+  'three-swipe-right': 'cycle-apps',
+  'four-swipe-up': 'toggle-all-apps',
+  'four-swipe-down': 'minimize-focused',
+  'four-tap': 'open-settings',
+};
+
+const PRESET_DIR = 'gestures/presets';
+const EXPORT_DIR = 'gestures/exports';
+
+const GestureCustomizer: React.FC = () => {
+  const [assignments, setAssignments] = useState<Record<string, string>>(
+    () => ({ ...defaultAssignments })
+  );
+  const [acknowledged, setAcknowledged] = useState<Record<string, boolean>>({});
+  const [conflictPrompt, setConflictPrompt] = useState<ConflictPrompt | null>(
+    null,
+  );
+  const [presetName, setPresetName] = useState('');
+  const [status, setStatus] = useState<StatusMessage | null>(null);
+  const [presets, setPresets] = useState<string[]>([]);
+  const [selectedPreset, setSelectedPreset] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [loadingPreset, setLoadingPreset] = useState(false);
+
+  const { supported, getDir, writeFile, readFile, listFiles } = useOPFS();
+
+  const combosByAction = useMemo(() => {
+    const map: Record<string, string[]> = {};
+    SHORTCUTS.forEach((shortcut) => {
+      if (!map[shortcut.actionId]) {
+        map[shortcut.actionId] = [];
+      }
+      if (!map[shortcut.actionId].includes(shortcut.combo)) {
+        map[shortcut.actionId].push(shortcut.combo);
+      }
+    });
+    return map;
+  }, []);
+
+  const actionMap = useMemo(() => {
+    const map: Record<string, DesktopAction> = {};
+    ACTIONS.forEach((action) => {
+      map[action.id] = action;
+    });
+    return map;
+  }, []);
+
+  const conflictTitleId = useId();
+  const conflictDescId = useId();
+
+  const slugify = useCallback((value: string) => {
+    const slug = value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9-_]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '');
+    return slug;
+  }, []);
+
+  const refreshPresets = useCallback(async () => {
+    if (!supported) return;
+    try {
+      const dir = await getDir(PRESET_DIR);
+      if (!dir) return;
+      const files = await listFiles(dir);
+      const names = files
+        .map((file) => file?.name)
+        .filter((name): name is string => typeof name === 'string')
+        .map((name) => name.replace(/\.json$/i, ''));
+      names.sort((a, b) => a.localeCompare(b));
+      setPresets(names);
+    } catch (error) {
+      console.error('Failed to list gesture presets', error);
+    }
+  }, [supported, getDir, listFiles]);
+
+  useEffect(() => {
+    refreshPresets();
+  }, [refreshPresets]);
+
+  useEffect(() => {
+    if (selectedPreset && !presets.includes(selectedPreset)) {
+      setSelectedPreset('');
+    }
+  }, [presets, selectedPreset]);
+
+  const handleActionChange = useCallback(
+    (gestureId: string, actionId: string) => {
+      setAssignments((prev) => {
+        const previousActionId = prev[gestureId] ?? '';
+        if (previousActionId === actionId) {
+          return prev;
+        }
+
+        const next = { ...prev, [gestureId]: actionId };
+        const key = `${gestureId}:${actionId}`;
+        const combos = combosByAction[actionId] ?? [];
+        const wasAcknowledged = acknowledged[key];
+
+        if (combos.length && !wasAcknowledged) {
+          setConflictPrompt({
+            gestureId,
+            actionId,
+            combos,
+            previousActionId,
+          });
+        } else {
+          setConflictPrompt(null);
+        }
+
+        return next;
+      });
+    },
+    [acknowledged, combosByAction],
+  );
+
+  const handleKeepConflict = useCallback(() => {
+    if (!conflictPrompt) return;
+    const key = `${conflictPrompt.gestureId}:${conflictPrompt.actionId}`;
+    setAcknowledged((prev) => ({ ...prev, [key]: true }));
+    setConflictPrompt(null);
+  }, [conflictPrompt]);
+
+  const handleRevertConflict = useCallback(() => {
+    if (!conflictPrompt) return;
+    const { gestureId, actionId, previousActionId } = conflictPrompt;
+    setAssignments((prev) => {
+      const next = { ...prev };
+      const fallback =
+        previousActionId || defaultAssignments[gestureId] || '';
+      next[gestureId] = fallback;
+      return next;
+    });
+    setConflictPrompt(null);
+  }, [conflictPrompt]);
+
+  const handleSavePreset = useCallback(
+    async (event?: React.FormEvent) => {
+      event?.preventDefault();
+      if (!supported) {
+        setStatus({
+          tone: 'error',
+          message: 'OPFS is not supported in this browser. Saving is disabled.',
+        });
+        return;
+      }
+      const slug = slugify(presetName);
+      if (!slug) {
+        setStatus({
+          tone: 'error',
+          message: 'Enter a preset name before saving.',
+        });
+        return;
+      }
+      setSaving(true);
+      setStatus(null);
+      try {
+        const dir = await getDir(PRESET_DIR);
+        if (!dir) {
+          throw new Error('preset directory unavailable');
+        }
+        const payload = JSON.stringify(
+          {
+            version: 1,
+            savedAt: new Date().toISOString(),
+            assignments,
+            acknowledged,
+          },
+          null,
+          2,
+        );
+        const ok = await writeFile(`${slug}.json`, payload, dir);
+        if (!ok) {
+          throw new Error('write failed');
+        }
+        setStatus({
+          tone: 'success',
+          message: `Saved preset "${slug}" to ${PRESET_DIR}.`,
+        });
+        setPresetName(slug);
+        await refreshPresets();
+      } catch (error) {
+        console.error('Failed to save gesture preset', error);
+        setStatus({
+          tone: 'error',
+          message:
+            'Failed to save preset. Confirm storage permissions and try again.',
+        });
+      } finally {
+        setSaving(false);
+      }
+    },
+    [supported, slugify, presetName, getDir, assignments, acknowledged, writeFile, refreshPresets],
+  );
+
+  const handleExportPreset = useCallback(async () => {
+    if (!supported) {
+      setStatus({
+        tone: 'error',
+        message: 'OPFS is not supported in this browser. Export is disabled.',
+      });
+      return;
+    }
+    setExporting(true);
+    setStatus(null);
+    try {
+      const dir = await getDir(EXPORT_DIR);
+      if (!dir) {
+        throw new Error('export directory unavailable');
+      }
+      const timestamp = new Date()
+        .toISOString()
+        .replace(/[:.]/g, '-')
+        .toLowerCase();
+      const fileName = `gesture-layout-${timestamp}.json`;
+      const payload = JSON.stringify(
+        {
+          version: 1,
+          exportedAt: new Date().toISOString(),
+          assignments,
+          acknowledged,
+        },
+        null,
+        2,
+      );
+      const ok = await writeFile(fileName, payload, dir);
+      if (!ok) {
+        throw new Error('export write failed');
+      }
+      setStatus({
+        tone: 'success',
+        message: `Exported current layout to ${EXPORT_DIR}/${fileName}.`,
+      });
+    } catch (error) {
+      console.error('Failed to export gesture preset', error);
+      setStatus({
+        tone: 'error',
+        message: 'Failed to export preset to OPFS.',
+      });
+    } finally {
+      setExporting(false);
+    }
+  }, [supported, getDir, assignments, acknowledged, writeFile]);
+
+  const handleLoadPreset = useCallback(async () => {
+    if (!selectedPreset) return;
+    if (!supported) {
+      setStatus({
+        tone: 'error',
+        message: 'OPFS is not supported in this browser. Loading is disabled.',
+      });
+      return;
+    }
+    setLoadingPreset(true);
+    setStatus(null);
+    try {
+      const dir = await getDir(PRESET_DIR);
+      if (!dir) {
+        throw new Error('preset directory unavailable');
+      }
+      const contents = await readFile(`${selectedPreset}.json`, dir);
+      if (!contents) {
+        throw new Error('preset not found');
+      }
+      const parsed = JSON.parse(contents);
+      if (parsed && typeof parsed === 'object') {
+        const parsedAssignments =
+          typeof parsed.assignments === 'object' && parsed.assignments
+            ? parsed.assignments
+            : {};
+        setAssignments({ ...defaultAssignments, ...parsedAssignments });
+        const parsedAcknowledged =
+          typeof parsed.acknowledged === 'object' && parsed.acknowledged
+            ? parsed.acknowledged
+            : {};
+        const cleaned: Record<string, boolean> = {};
+        Object.keys(parsedAcknowledged).forEach((key) => {
+          if (parsedAcknowledged[key]) cleaned[key] = true;
+        });
+        setAcknowledged(cleaned);
+      }
+      setConflictPrompt(null);
+      setStatus({
+        tone: 'success',
+        message: `Loaded preset "${selectedPreset}".`,
+      });
+    } catch (error) {
+      console.error('Failed to load gesture preset', error);
+      setStatus({
+        tone: 'error',
+        message: `Failed to load preset "${selectedPreset}".`,
+      });
+    } finally {
+      setLoadingPreset(false);
+    }
+  }, [selectedPreset, supported, getDir, readFile]);
+
+  return (
+    <div
+      data-testid="gesture-customizer"
+      className="h-full w-full overflow-y-auto bg-ub-cool-grey p-4 text-white"
+    >
+      <div className="mx-auto flex max-w-5xl flex-col gap-6">
+        <header className="space-y-2">
+          <h1 className="text-2xl font-semibold">Gesture Customizer</h1>
+          <p className="text-sm text-ubt-warm-grey">
+            Map three and four-finger gestures to desktop operations managed by
+            the window system. Conflicts with existing keyboard shortcuts are
+            detected automatically so you can decide whether to keep or adjust
+            an assignment.
+          </p>
+          {!supported && (
+            <p className="rounded bg-yellow-900/60 px-3 py-2 text-sm text-yellow-200">
+              Preset storage requires a browser with Origin Private File System
+              support. Gesture mappings can still be explored, but saving and
+              exporting are disabled.
+            </p>
+          )}
+        </header>
+
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">Gesture assignments</h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            {GESTURES.map((gesture) => {
+              const actionId = assignments[gesture.id] ?? '';
+              const action = actionMap[actionId];
+              const combos = combosByAction[actionId] ?? [];
+              return (
+                <div
+                  key={gesture.id}
+                  className="flex flex-col justify-between gap-3 rounded border border-gray-700 bg-ub-dark-grey p-4"
+                >
+                  <div className="space-y-1">
+                    <h3 className="text-lg font-medium">{gesture.label}</h3>
+                    <p className="text-xs text-ubt-warm-grey">
+                      {gesture.description}
+                    </p>
+                  </div>
+                  <label className="space-y-2 text-sm">
+                    <span className="block font-medium">Assigned action</span>
+                    <select
+                      className="w-full rounded border border-gray-700 bg-ub-dark px-2 py-1 text-white"
+                      value={actionId}
+                      onChange={(event) =>
+                        handleActionChange(gesture.id, event.target.value)
+                      }
+                    >
+                      <option value="">No action</option>
+                      {ACTIONS.map((option) => (
+                        <option key={option.id} value={option.id}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                    {action && (
+                      <p className="text-xs text-ubt-warm-grey">
+                        {action.description}
+                      </p>
+                    )}
+                    {combos.length > 0 && (
+                      <div className="space-y-1 text-xs text-orange-300">
+                        <p className="font-semibold">Existing shortcuts</p>
+                        <ul className="space-y-0.5">
+                          {combos.map((combo) => (
+                            <li key={combo}>
+                              <code className="rounded bg-black/40 px-1 py-0.5">
+                                {combo}
+                              </code>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </label>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="space-y-4 rounded border border-gray-700 bg-ub-dark-grey p-4">
+          <h2 className="text-xl font-semibold">Presets</h2>
+          <form className="space-y-3" onSubmit={handleSavePreset}>
+            <label className="flex flex-col gap-1 text-sm">
+              <span className="font-medium">Preset name</span>
+              <input
+                type="text"
+                value={presetName}
+                onChange={(event) => setPresetName(event.target.value)}
+                className="rounded border border-gray-700 bg-ub-dark px-2 py-1 text-white"
+                placeholder="e.g. window-management"
+              />
+            </label>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="submit"
+                className="rounded bg-ub-warm-grey px-3 py-1 text-sm font-medium text-white hover:bg-opacity-80 disabled:opacity-60"
+                disabled={saving || !supported}
+              >
+                {saving ? 'Saving…' : 'Save preset'}
+              </button>
+              <button
+                type="button"
+                className="rounded bg-ub-warm-grey px-3 py-1 text-sm font-medium text-white hover:bg-opacity-80 disabled:opacity-60"
+                onClick={handleExportPreset}
+                disabled={exporting || !supported}
+              >
+                {exporting ? 'Exporting…' : 'Export JSON'}
+              </button>
+            </div>
+          </form>
+
+          <div className="space-y-2 text-sm">
+            <span className="font-medium">Load saved preset</span>
+            {presets.length === 0 ? (
+              <p className="text-xs text-ubt-warm-grey">
+                No presets saved yet. Create one above to populate this list.
+              </p>
+            ) : (
+              <div className="flex flex-wrap items-center gap-2">
+                <select
+                  className="rounded border border-gray-700 bg-ub-dark px-2 py-1 text-white"
+                  value={selectedPreset}
+                  onChange={(event) => setSelectedPreset(event.target.value)}
+                >
+                  <option value="">Choose preset…</option>
+                  {presets.map((name) => (
+                    <option key={name} value={name}>
+                      {name}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  className="rounded bg-ub-warm-grey px-3 py-1 text-sm font-medium text-white hover:bg-opacity-80 disabled:opacity-60"
+                  onClick={handleLoadPreset}
+                  disabled={loadingPreset || !selectedPreset || !supported}
+                >
+                  {loadingPreset ? 'Loading…' : 'Load preset'}
+                </button>
+              </div>
+            )}
+          </div>
+        </section>
+
+        {conflictPrompt && (
+          <div
+            role="alertdialog"
+            aria-labelledby={conflictTitleId}
+            aria-describedby={conflictDescId}
+            className="space-y-3 rounded border border-orange-500 bg-orange-900/40 p-4 text-sm text-orange-100"
+          >
+            <h3 id={conflictTitleId} className="text-base font-semibold">
+              Shortcut conflict detected
+            </h3>
+            <p id={conflictDescId}>
+              The action “
+              {actionMap[conflictPrompt.actionId]?.label ?? conflictPrompt.actionId}
+              ” already listens to the following keyboard shortcuts:{' '}
+              {conflictPrompt.combos.join(', ')}. Keep the gesture assignment or
+              choose another action.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                className="rounded bg-ub-warm-grey px-3 py-1 font-medium text-white hover:bg-opacity-80"
+                onClick={handleKeepConflict}
+              >
+                Keep action
+              </button>
+              <button
+                type="button"
+                className="rounded border border-orange-200 px-3 py-1 font-medium text-orange-100 hover:bg-orange-800/60"
+                onClick={handleRevertConflict}
+              >
+                Choose different action
+              </button>
+            </div>
+          </div>
+        )}
+
+        <div
+          aria-live="polite"
+          role="status"
+          className="min-h-[1.5rem] text-sm"
+        >
+          {status && (
+            <span
+              className={
+                status.tone === 'error'
+                  ? 'text-red-300'
+                  : status.tone === 'success'
+                  ? 'text-green-300'
+                  : 'text-ubt-warm-grey'
+              }
+            >
+              {status.message}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GestureCustomizer;
+

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -24,6 +24,128 @@ import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { useSnapSetting } from '../../hooks/usePersistentState';
 
+export const DESKTOP_ACTIONS = Object.freeze([
+    {
+        id: 'open-window-switcher',
+        label: 'Open Window Switcher',
+        description: 'Show the overview of open windows managed by the desktop switcher.',
+        operation: 'openWindowSwitcher',
+    },
+    {
+        id: 'cycle-apps',
+        label: 'Cycle Through Apps',
+        description: 'Focus the next or previous application window in the stack.',
+        operation: 'cycleApps',
+    },
+    {
+        id: 'cycle-app-windows',
+        label: 'Cycle Windows of Focused App',
+        description: 'Rotate focus across the open windows that belong to the same application.',
+        operation: 'cycleAppWindows',
+    },
+    {
+        id: 'open-clipboard-manager',
+        label: 'Open Clipboard Manager',
+        description: 'Launch the clipboard manager utility window.',
+        operation: 'openApp',
+        args: ['clipboard-manager'],
+    },
+    {
+        id: 'snap-focused-window',
+        label: 'Snap Focused Window',
+        description: 'Dispatch the Super+Arrow command to the active window for snapping.',
+        operation: 'dispatchSuperArrow',
+    },
+    {
+        id: 'toggle-all-apps',
+        label: 'Toggle Application Overview',
+        description: 'Open or close the all applications launcher grid.',
+        operation: 'showAllApps',
+    },
+    {
+        id: 'show-shortcut-selector',
+        label: 'Open Shortcut Selector',
+        description: 'Launch the desktop shortcut selector dialog.',
+        operation: 'openShortcutSelector',
+    },
+    {
+        id: 'focus-last-app',
+        label: 'Focus Last Active App',
+        description: 'Return focus to the most recently used non-minimized window.',
+        operation: 'giveFocusToLastApp',
+    },
+    {
+        id: 'minimize-focused',
+        label: 'Minimize Focused Window',
+        description: 'Minimize the currently focused window and advance focus.',
+        operation: 'hasMinimised',
+    },
+    {
+        id: 'open-settings',
+        label: 'Open Settings',
+        description: 'Launch the desktop settings panel.',
+        operation: 'openApp',
+        args: ['settings'],
+    },
+]);
+
+export const DESKTOP_SHORTCUTS = Object.freeze([
+    {
+        id: 'alt-tab',
+        combo: 'Alt+Tab',
+        actionId: 'open-window-switcher',
+        description: 'Open the window switcher overlay.',
+    },
+    {
+        id: 'alt-shift-tab',
+        combo: 'Alt+Shift+Tab',
+        actionId: 'cycle-apps',
+        description: 'Cycle backwards through open applications.',
+    },
+    {
+        id: 'ctrl-shift-v',
+        combo: 'Ctrl+Shift+V',
+        actionId: 'open-clipboard-manager',
+        description: 'Launch the Clipboard Manager app.',
+    },
+    {
+        id: 'alt-backtick',
+        combo: 'Alt+`',
+        actionId: 'cycle-app-windows',
+        description: 'Cycle windows for the focused application.',
+    },
+    {
+        id: 'alt-tilde',
+        combo: 'Alt+~',
+        actionId: 'cycle-app-windows',
+        description: 'Cycle windows for the focused application.',
+    },
+    {
+        id: 'super-arrow-left',
+        combo: 'Super+ArrowLeft',
+        actionId: 'snap-focused-window',
+        description: 'Snap the focused window to the left half of the screen.',
+    },
+    {
+        id: 'super-arrow-right',
+        combo: 'Super+ArrowRight',
+        actionId: 'snap-focused-window',
+        description: 'Snap the focused window to the right half of the screen.',
+    },
+    {
+        id: 'super-arrow-up',
+        combo: 'Super+ArrowUp',
+        actionId: 'snap-focused-window',
+        description: 'Snap the focused window to the top.',
+    },
+    {
+        id: 'super-arrow-down',
+        combo: 'Super+ArrowDown',
+        actionId: 'snap-focused-window',
+        description: 'Snap the focused window to the bottom.',
+    },
+]);
+
 export class Desktop extends Component {
     constructor() {
         super();
@@ -166,12 +288,15 @@ export class Desktop extends Component {
         }
         else if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
             e.preventDefault();
-            const id = this.getFocusedWindowId();
-            if (id) {
-                const event = new CustomEvent('super-arrow', { detail: e.key });
-                document.getElementById(id)?.dispatchEvent(event);
-            }
+            this.dispatchSuperArrow(e.key);
         }
+    }
+
+    dispatchSuperArrow = (direction) => {
+        const id = this.getFocusedWindowId();
+        if (!id) return;
+        const event = new CustomEvent('super-arrow', { detail: direction });
+        document.getElementById(id)?.dispatchEvent(event);
     }
 
     getFocusedWindowId = () => {

--- a/public/themes/Yaru/apps/gesture-customizer.svg
+++ b/public/themes/Yaru/apps/gesture-customizer.svg
@@ -1,0 +1,8 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="12" fill="#1F2937"/>
+  <path d="M16 24H48" stroke="#60A5FA" stroke-width="4" stroke-linecap="round" stroke-opacity="0.8"/>
+  <path d="M16 32H44" stroke="#60A5FA" stroke-width="4" stroke-linecap="round" stroke-opacity="0.6"/>
+  <path d="M16 40H40" stroke="#60A5FA" stroke-width="4" stroke-linecap="round" stroke-opacity="0.4"/>
+  <path d="M33 18C28.5817 18 25 21.5817 25 26V44C25 45.6569 26.3431 47 28 47C29.1046 47 30 46.1046 30 45V34C30 32.8954 30.8954 32 32 32C33.1046 32 34 32.8954 34 34V45C34 46.1046 34.8954 47 36 47C37.1046 47 38 46.1046 38 45V36C38 34.8954 38.8954 34 40 34C41.1046 34 42 34.8954 42 36V42C42 43.1046 42.8954 44 44 44C45.1046 44 46 43.1046 46 42V31C46 24.3726 40.6274 19 34 19H33Z" fill="#FBBF24"/>
+  <circle cx="20" cy="20" r="6" fill="#F9FAFB" fill-opacity="0.9"/>
+</svg>


### PR DESCRIPTION
## Summary
- expose desktop shortcut metadata from the desktop manager and register a Gesture Customizer utility
- build the Gesture Customizer UI for assigning three- and four-finger gestures and persisting presets with OPFS
- add coverage for the new app and document the feature alongside a dedicated icon

## Testing
- yarn lint *(fails: existing accessibility and lint issues across legacy apps)*
- yarn test *(fails: pre-existing nmap NSE clipboard test and related act warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68cb19c9dedc832890ab4cad8b97ad0c