### PR TITLE
[apps] add stylus settings utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ through `gamepad.vibrationActuator` where available. Key bindings configured wit
 `components/apps/Games/common/input-remap` are persisted in the browser's Origin Private
 File System (OPFS) so players can store per-game profiles.
 
+### Stylus Calibration & Button Mapping
+
+The **Stylus Settings** utility exposes a live pressure canvas, curve editor, and per-app
+button overrides. Pointer events stream pressure values through a configurable Bezier
+curve managed by `hooks/useSettings.tsx`. Presets (linear, soft, and firm) offer quick
+starting points, while manual edits persist via `safeLocalStorage`. Focus changes from the
+desktop emit a `kali:window-focus` event so each window can automatically receive its
+stored mapping. Usage metrics such as sample counts and average pressure are surfaced in
+the UI and logged through the existing analytics wrapper.
+
 ---
 
 ## App Shell & Architecture

--- a/__tests__/components/apps/stylus-settings.test.tsx
+++ b/__tests__/components/apps/stylus-settings.test.tsx
@@ -1,0 +1,118 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import StylusSettingsApp from '../../../components/apps/stylus-settings';
+import { SettingsProvider, STYLUS_GLOBAL_MAPPING_ID } from '../../../hooks/useSettings';
+
+const createStorage = (): Storage => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  } as Storage;
+};
+
+describe('StylusSettingsApp', () => {
+  beforeEach(() => {
+    const storage = createStorage();
+    Object.defineProperty(window, 'localStorage', {
+      value: storage,
+      configurable: true,
+    });
+    localStorage.clear();
+  });
+
+  const renderApp = () =>
+    render(
+      <SettingsProvider>
+        <StylusSettingsApp />
+      </SettingsProvider>
+    );
+
+  it('records pressure metrics from the test canvas', async () => {
+    renderApp();
+    const canvas = screen.getByLabelText('Stylus pressure test area');
+    jest
+      .spyOn(canvas, 'getBoundingClientRect')
+      .mockReturnValue({
+        width: 360,
+        height: 200,
+        top: 0,
+        left: 0,
+        bottom: 200,
+        right: 360,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      } as DOMRect);
+
+    fireEvent.pointerDown(canvas, {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      pressure: 0.7,
+    });
+    fireEvent.pointerUp(canvas, { pointerId: 1 });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('0.50')).toHaveLength(2);
+    });
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('switches presets and restores defaults', () => {
+    renderApp();
+    const select = screen.getByLabelText('Curve preset');
+    expect(screen.getByText(/Linear pressure response/i)).toBeInTheDocument();
+
+    fireEvent.change(select, { target: { value: 'soft' } });
+    expect(
+      screen.getByText(/Requires firmer press near the start/i)
+    ).toBeInTheDocument();
+
+    const resetButton = screen.getByRole('button', { name: /reset curve/i });
+    fireEvent.click(resetButton);
+
+    expect(screen.getByText(/Linear pressure response/i)).toBeInTheDocument();
+  });
+
+  it('persists per-app button mappings and responds to focus events', async () => {
+    renderApp();
+    const appInput = screen.getByPlaceholderText('App ID');
+    fireEvent.change(appInput, { target: { value: 'paint-app' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    const primarySelect = screen.getByLabelText('Primary button');
+    fireEvent.change(primarySelect, { target: { value: 'pan' } });
+
+    await waitFor(() => {
+      expect((primarySelect as HTMLSelectElement).value).toBe('pan');
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('kali:window-focus', { detail: { appId: 'paint-app' } })
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Active mapping · Primary: pan · Secondary: eyedropper · Eraser: erase/i)
+      ).toBeInTheDocument();
+    });
+
+    const targetSelect = screen.getByLabelText('Target app');
+    fireEvent.change(targetSelect, { target: { value: STYLUS_GLOBAL_MAPPING_ID } });
+    expect((targetSelect as HTMLSelectElement).value).toBe(STYLUS_GLOBAL_MAPPING_ID);
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -72,6 +72,7 @@ const QuoteApp = createDynamicApp('quote', 'Quote');
 const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery');
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
+const StylusSettingsApp = createDynamicApp('stylus-settings', 'Stylus Settings');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
@@ -165,6 +166,7 @@ const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
+const displayStylusSettings = createDisplay(StylusSettingsApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 
@@ -266,6 +268,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayInputLab,
+  },
+  {
+    id: 'stylus-settings',
+    title: 'Stylus Settings',
+    icon: '/themes/Yaru/apps/input-lab.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayStylusSettings,
   },
 ];
 

--- a/components/apps/stylus-settings/index.tsx
+++ b/components/apps/stylus-settings/index.tsx
@@ -1,0 +1,469 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  STYLUS_GLOBAL_MAPPING_ID,
+  StylusAction,
+  StylusButtonMapping,
+  useSettings,
+} from '../../../hooks/useSettings';
+
+const CANVAS_WIDTH = 360;
+const CANVAS_HEIGHT = 200;
+const HANDLE_RADIUS = 4;
+
+type Point = { x: number; y: number };
+
+const formatPressure = (value: number) => value.toFixed(2);
+
+const StylusSettingsApp: React.FC = () => {
+  const {
+    accent,
+    stylusCurve,
+    stylusCurvePresetId,
+    stylusPresets,
+    updateStylusCurvePoint,
+    applyStylusPreset,
+    resetStylusCurve,
+    mapStylusPressure,
+    stylusActions,
+    stylusButtonMappings,
+    updateStylusButtonMapping,
+    resetStylusButtonMapping,
+    stylusActiveAppId,
+    activeStylusMapping,
+    stylusMetrics,
+    recordStylusSample,
+    getStylusMapping,
+  } = useSettings();
+
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const drawingRef = useRef(false);
+  const dragHandleRef = useRef<number | null>(null);
+  const [selectedPreset, setSelectedPreset] = useState<string>(stylusCurvePresetId);
+  const [manualAppSelection, setManualAppSelection] = useState(false);
+  const [selectedApp, setSelectedApp] = useState<string>(
+    stylusActiveAppId ?? STYLUS_GLOBAL_MAPPING_ID
+  );
+  const [newAppId, setNewAppId] = useState('');
+
+  useEffect(() => {
+    setSelectedPreset(stylusCurvePresetId);
+  }, [stylusCurvePresetId]);
+
+  useEffect(() => {
+    if (!manualAppSelection) {
+      setSelectedApp(stylusActiveAppId ?? STYLUS_GLOBAL_MAPPING_ID);
+    }
+  }, [manualAppSelection, stylusActiveAppId]);
+
+  const availableMappings = useMemo(() => {
+    const ids = new Set<string>();
+    ids.add(STYLUS_GLOBAL_MAPPING_ID);
+    Object.keys(stylusButtonMappings).forEach((id) => ids.add(id));
+    if (stylusActiveAppId) ids.add(stylusActiveAppId);
+    return Array.from(ids);
+  }, [stylusButtonMappings, stylusActiveAppId]);
+
+  const currentMapping = useMemo(
+    () =>
+      getStylusMapping(
+        selectedApp === STYLUS_GLOBAL_MAPPING_ID ? null : selectedApp
+      ),
+    [getStylusMapping, selectedApp]
+  );
+
+  const activePreset = useMemo(
+    () => stylusPresets.find((preset) => preset.id === stylusCurvePresetId),
+    [stylusPresets, stylusCurvePresetId]
+  );
+
+  const curvePath = useMemo(() => {
+    const [c1, c2] = stylusCurve.controlPoints;
+    const toSvg = (point: Point) => ({
+      x: point.x * 100,
+      y: 100 - point.y * 100,
+    });
+    const p1 = toSvg(c1);
+    const p2 = toSvg(c2);
+    return `M0,100 C ${p1.x},${p1.y} ${p2.x},${p2.y} 100,0`;
+  }, [stylusCurve.controlPoints]);
+
+  const handlePositions = useMemo(() => {
+    const toSvg = (point: Point) => ({
+      x: point.x * 100,
+      y: 100 - point.y * 100,
+    });
+    return stylusCurve.controlPoints.map(toSvg) as Point[];
+  }, [stylusCurve.controlPoints]);
+
+  const setManualSelection = useCallback((value: boolean) => {
+    setManualAppSelection(value);
+    if (!value) {
+      setSelectedApp(stylusActiveAppId ?? STYLUS_GLOBAL_MAPPING_ID);
+    }
+  }, [stylusActiveAppId]);
+
+  const handlePresetChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const presetId = event.target.value;
+    setSelectedPreset(presetId);
+    if (presetId !== 'custom') {
+      applyStylusPreset(presetId);
+    }
+  };
+
+  const ensureCanvasContext = () =>
+    canvasRef.current ? canvasRef.current.getContext('2d') : null;
+
+  const clearCanvas = () => {
+    const canvas = canvasRef.current;
+    const ctx = ensureCanvasContext();
+    if (!canvas || !ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+  };
+
+  const canvasCoordinates = (event: React.PointerEvent<HTMLCanvasElement>): Point => {
+    const canvas = canvasRef.current;
+    if (!canvas) return { x: 0, y: 0 };
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    };
+  };
+
+  const beginStroke = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = ensureCanvasContext();
+    const pressure = event.pressure ?? 0.5;
+    recordStylusSample(pressure);
+    drawingRef.current = true;
+    if (!ctx) return;
+    const { x, y } = canvasCoordinates(event);
+    ctx.strokeStyle = accent;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.lineWidth = 1 + mapStylusPressure(pressure) * 18;
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+    if (typeof canvas.setPointerCapture === 'function') {
+      canvas.setPointerCapture(event.pointerId);
+    }
+  };
+
+  const continueStroke = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    if (!drawingRef.current) return;
+    const ctx = ensureCanvasContext();
+    if (!ctx) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const { x, y } = canvasCoordinates(event);
+    const pressure = event.pressure ?? 0.5;
+    recordStylusSample(pressure);
+    ctx.lineWidth = 1 + mapStylusPressure(pressure) * 18;
+    ctx.lineTo(x, y);
+    ctx.stroke();
+  };
+
+  const finishStroke = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    drawingRef.current = false;
+    const canvas = canvasRef.current;
+    if (
+      canvas &&
+      typeof canvas.hasPointerCapture === 'function' &&
+      canvas.hasPointerCapture(event.pointerId)
+    ) {
+      canvas.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  const handleHandlePointerDown = (index: number) =>
+    (event: React.PointerEvent<SVGCircleElement>) => {
+      event.preventDefault();
+      dragHandleRef.current = index;
+      svgRef.current?.setPointerCapture(event.pointerId);
+    };
+
+  const handleSvgPointerMove = (event: React.PointerEvent<SVGSVGElement>) => {
+    if (dragHandleRef.current === null) return;
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    const x = Math.min(1, Math.max(0, (event.clientX - rect.left) / rect.width));
+    const y = Math.min(1, Math.max(0, 1 - (event.clientY - rect.top) / rect.height));
+    updateStylusCurvePoint(dragHandleRef.current as 0 | 1, { x, y });
+  };
+
+  const handleSvgPointerUp = (event: React.PointerEvent<SVGSVGElement>) => {
+    if (dragHandleRef.current === null) return;
+    svgRef.current?.releasePointerCapture(event.pointerId);
+    dragHandleRef.current = null;
+  };
+
+  const updateMapping = (button: keyof StylusButtonMapping, value: StylusAction) => {
+    const targetApp = selectedApp === STYLUS_GLOBAL_MAPPING_ID ? STYLUS_GLOBAL_MAPPING_ID : selectedApp;
+    updateStylusButtonMapping(targetApp, { [button]: value });
+  };
+
+  const handleAddMapping = () => {
+    const trimmed = newAppId.trim();
+    if (!trimmed) return;
+    updateStylusButtonMapping(trimmed, getStylusMapping(trimmed));
+    setSelectedApp(trimmed);
+    setManualAppSelection(true);
+    setNewAppId('');
+  };
+
+  const resetMappingForSelection = () => {
+    if (selectedApp === STYLUS_GLOBAL_MAPPING_ID) {
+      resetStylusButtonMapping();
+    } else {
+      resetStylusButtonMapping(selectedApp);
+    }
+  };
+
+  const mappingSummary = `Primary: ${activeStylusMapping.primary} · Secondary: ${activeStylusMapping.secondary} · Eraser: ${activeStylusMapping.eraser}`;
+
+  return (
+    <div className="flex h-full w-full flex-col gap-4 bg-black/60 p-4 text-white">
+      <div className="grid gap-4 lg:grid-cols-2">
+        <section className="flex flex-col gap-3 rounded border border-white/10 bg-black/30 p-4">
+          <header className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold">Pressure test</h2>
+              <p className="text-xs text-white/70">
+                Press, drag, and lift to visualise pressure after the curve is applied.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={clearCanvas}
+              className="rounded bg-white/10 px-3 py-1 text-xs hover:bg-white/20"
+            >
+              Clear canvas
+            </button>
+          </header>
+          <canvas
+            ref={canvasRef}
+            width={CANVAS_WIDTH}
+            height={CANVAS_HEIGHT}
+            aria-label="Stylus pressure test area"
+            className="h-48 w-full rounded border border-white/10 bg-black/40"
+            onPointerDown={beginStroke}
+            onPointerMove={continueStroke}
+            onPointerUp={finishStroke}
+            onPointerLeave={finishStroke}
+            onPointerCancel={finishStroke}
+          />
+          <dl className="grid grid-cols-2 gap-2 text-xs sm:grid-cols-4">
+            <div>
+              <dt className="font-medium text-white">Samples</dt>
+              <dd className="text-white/70">{stylusMetrics.totalSamples}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-white">Average</dt>
+              <dd className="text-white/70">{formatPressure(stylusMetrics.averagePressure)}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-white">Last pressure</dt>
+              <dd className="text-white/70">{formatPressure(stylusMetrics.lastPressure)}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-white">Focused app</dt>
+              <dd className="truncate text-white/70">
+                {stylusMetrics.lastFocusedApp ?? 'Default mapping'}
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        <section className="flex flex-col gap-3 rounded border border-white/10 bg-black/30 p-4">
+          <header className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold">Pressure curve</h2>
+              <p className="text-xs text-white/70">
+                Drag the handles or load a preset to shape how input pressure maps to output.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={resetStylusCurve}
+              className="rounded bg-white/10 px-3 py-1 text-xs hover:bg-white/20"
+            >
+              Reset curve
+            </button>
+          </header>
+          <div className="flex flex-col gap-2">
+            <label className="flex flex-col text-xs">
+              <span className="mb-1 font-semibold text-white">Curve preset</span>
+              <select
+                value={selectedPreset}
+                onChange={handlePresetChange}
+                className="rounded border border-white/10 bg-black/40 px-2 py-1 text-sm"
+              >
+                {stylusPresets.map((preset) => (
+                  <option value={preset.id} key={preset.id}>
+                    {preset.name}
+                  </option>
+                ))}
+                {stylusCurvePresetId === 'custom' && (
+                  <option value="custom">Custom</option>
+                )}
+              </select>
+            </label>
+            <p className="text-xs text-white/60">
+              {stylusCurvePresetId === 'custom'
+                ? 'Custom curve from manual edits.'
+                : activePreset?.description ?? 'Preset description unavailable.'}
+            </p>
+          </div>
+          <svg
+            ref={svgRef}
+            role="presentation"
+            viewBox="0 0 100 100"
+            className="h-48 w-full touch-none select-none"
+            onPointerMove={handleSvgPointerMove}
+            onPointerUp={handleSvgPointerUp}
+            onPointerLeave={handleSvgPointerUp}
+          >
+            <rect x={0} y={0} width={100} height={100} fill="rgba(255,255,255,0.04)" />
+            <path d="M0,0 L0,100" stroke="rgba(255,255,255,0.1)" strokeWidth={0.5} />
+            <path d="M0,100 L100,100" stroke="rgba(255,255,255,0.1)" strokeWidth={0.5} />
+            <path d={curvePath} stroke={accent} strokeWidth={2} fill="none" />
+            {handlePositions.map((pos, index) => (
+              <g key={index}>
+                <line
+                  x1={index === 0 ? 0 : 100}
+                  y1={index === 0 ? 100 : 0}
+                  x2={pos.x}
+                  y2={pos.y}
+                  stroke="rgba(255,255,255,0.2)"
+                  strokeWidth={0.75}
+                />
+                <circle
+                  role="slider"
+                  aria-label={`Curve control ${index + 1}`}
+                  cx={pos.x}
+                  cy={pos.y}
+                  r={HANDLE_RADIUS}
+                  fill={accent}
+                  stroke="white"
+                  strokeWidth={0.75}
+                  onPointerDown={handleHandlePointerDown(index)}
+                />
+              </g>
+            ))}
+          </svg>
+          <div className="grid grid-cols-2 gap-2 text-xs">
+            {stylusCurve.controlPoints.map((point, index) => (
+              <div key={index} className="flex flex-col rounded border border-white/10 bg-black/40 p-2">
+                <span className="font-semibold text-white">Handle {index + 1}</span>
+                <span className="text-white/60">X: {formatPressure(point.x)}</span>
+                <span className="text-white/60">Y: {formatPressure(point.y)}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+
+      <section className="flex flex-col gap-3 rounded border border-white/10 bg-black/30 p-4">
+        <header className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold">Button mapping</h2>
+            <p className="text-xs text-white/70">
+              Choose default actions or target a focused window to override them.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => setManualSelection(false)}
+              className="rounded bg-white/10 px-3 py-1 text-xs hover:bg-white/20"
+            >
+              Follow active window
+            </button>
+            <button
+              type="button"
+              onClick={resetMappingForSelection}
+              className="rounded bg-white/10 px-3 py-1 text-xs hover:bg-white/20"
+            >
+              Reset mapping
+            </button>
+          </div>
+        </header>
+        <div className="grid gap-3 md:grid-cols-[minmax(0,240px)_1fr]">
+          <div className="flex flex-col gap-3">
+            <label className="flex flex-col text-xs">
+              <span className="mb-1 font-semibold text-white">Target app</span>
+              <select
+                value={selectedApp}
+                onChange={(event) => {
+                  setSelectedApp(event.target.value);
+                  setManualAppSelection(true);
+                }}
+                className="rounded border border-white/10 bg-black/40 px-2 py-1 text-sm"
+              >
+                {availableMappings.map((id) => (
+                  <option value={id} key={id}>
+                    {id === STYLUS_GLOBAL_MAPPING_ID
+                      ? 'All apps (default)'
+                      : id === stylusActiveAppId
+                        ? `${id} (focused)`
+                        : id}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="flex items-end gap-2">
+              <label className="flex flex-1 flex-col text-xs">
+                <span className="mb-1 font-semibold text-white">Add app override</span>
+                <input
+                  value={newAppId}
+                  onChange={(event) => setNewAppId(event.target.value)}
+                  placeholder="App ID"
+                  className="rounded border border-white/10 bg-black/40 px-2 py-1 text-sm"
+                />
+              </label>
+              <button
+                type="button"
+                onClick={handleAddMapping}
+                className="rounded bg-white/10 px-3 py-1 text-xs hover:bg-white/20"
+              >
+                Add
+              </button>
+            </div>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            {(['primary', 'secondary', 'eraser'] as const).map((button) => (
+              <label key={button} className="flex flex-col text-xs">
+                <span className="mb-1 font-semibold text-white">
+                  {button === 'primary'
+                    ? 'Primary button'
+                    : button === 'secondary'
+                      ? 'Secondary button'
+                      : 'Eraser button'}
+                </span>
+                <select
+                  value={currentMapping[button]}
+                  onChange={(event) =>
+                    updateMapping(button, event.target.value as StylusAction)
+                  }
+                  className="rounded border border-white/10 bg-black/40 px-2 py-1 text-sm"
+                >
+                  {stylusActions.map((action) => (
+                    <option key={action} value={action}>
+                      {action}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ))}
+          </div>
+        </div>
+        <p className="text-xs text-white/60">Active mapping · {mappingSummary}</p>
+      </section>
+    </div>
+  );
+};
+
+export default StylusSettingsApp;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -733,7 +733,7 @@ export class Desktop extends Component {
     }
 
     focus = (objId) => {
-        // removes focus from all window and 
+        // removes focus from all window and
         // gives focus to window with 'id = objId'
         var focused_windows = this.state.focused_windows;
         focused_windows[objId] = true;
@@ -745,6 +745,9 @@ export class Desktop extends Component {
             }
         }
         this.setState({ focused_windows });
+        if (typeof window !== 'undefined') {
+            window.dispatchEvent(new CustomEvent('kali:window-focus', { detail: { appId: objId } }));
+        }
     }
 
     addNewFolder = () => {


### PR DESCRIPTION
## Summary
- add a Stylus Settings utility app with a live pressure canvas, curve editor, and mapping UI
- extend the settings provider with stylus curve presets, per-app button bindings, metrics, and focus listeners
- register the app in the utilities catalog and document stylus calibration capabilities

## Testing
- yarn lint *(fails: pre-existing accessibility and lint errors across legacy apps)*
- yarn test stylus-settings


------
https://chatgpt.com/codex/tasks/task_e_68cb19c8da748328b145843c4e8ca26d