### PR TITLE
[apps] add VPN manager simulation with secure storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ play/pause and track controls include keyboard hotkeys.
 | Reaver | /apps/reaver | Security Tool (simulated) |
 | Recon-ng | /apps/reconng | Security Tool (simulated) |
 | Volatility | /apps/volatility | Security Tool (simulated) |
+| VPN Manager | /apps/vpn-manager | Security Tool (simulated) |
 | Wireshark | /apps/wireshark | Security Tool (simulated, lab use only) |
 
 > All security apps are **non-operational simulations** intended for education/demos. They **do not** execute exploits and should not be used for any unauthorized activity.

--- a/__tests__/components/apps/vpn-manager.test.tsx
+++ b/__tests__/components/apps/vpn-manager.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import VpnManager from '../../../components/apps/vpn-manager';
+import { resetNetworkState } from '../../../utils/networkState';
+import { logEvent } from '../../../utils/analytics';
+
+jest.mock('../../../utils/vpnStorage', () => {
+  let storedProfiles = [
+    {
+      id: 'profile-1',
+      name: 'Lab VPN',
+      type: 'openvpn',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      leakTests: [],
+      openVpn: {
+        type: 'openvpn',
+        remote: 'vpn.example.com',
+        port: 1194,
+        protocol: 'udp',
+        auth: 'username/password',
+        cipher: 'AES-256',
+        options: { remote: 'vpn.example.com 1194' },
+        blocks: {},
+      },
+    },
+  ];
+
+  return {
+    __esModule: true,
+    loadProfiles: jest.fn(async () => storedProfiles),
+    saveProfiles: jest.fn(async (next) => {
+      storedProfiles = next;
+    }),
+    clearProfiles: jest.fn(async () => {
+      storedProfiles = [];
+    }),
+    __setProfiles: (profiles: typeof storedProfiles) => {
+      storedProfiles = profiles;
+    },
+  };
+});
+
+jest.mock('../../../utils/analytics', () => ({
+  __esModule: true,
+  logEvent: jest.fn(),
+}));
+
+describe('VPN Manager component', () => {
+const storageMock = jest.requireMock(
+  '../../../utils/vpnStorage',
+) as {
+  __setProfiles: (profiles: any[]) => void;
+};
+
+  beforeEach(() => {
+    resetNetworkState();
+    storageMock.__setProfiles([
+      {
+        id: 'profile-1',
+        name: 'Lab VPN',
+        type: 'openvpn',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        leakTests: [],
+        openVpn: {
+          type: 'openvpn',
+          remote: 'vpn.example.com',
+          port: 1194,
+          protocol: 'udp',
+          auth: 'username/password',
+          cipher: 'AES-256',
+          options: { remote: 'vpn.example.com 1194' },
+          blocks: {},
+        },
+      },
+    ]);
+    (logEvent as jest.Mock).mockClear();
+    window.localStorage.clear();
+  });
+
+  it('toggles the kill switch and updates the displayed IP when disconnected', async () => {
+    const user = userEvent.setup();
+    render(<VpnManager />);
+
+    await screen.findByText('Lab VPN');
+    expect(screen.getByText(/Kill switch: Disabled/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Enable kill switch/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Kill switch: Enabled/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Current IP: 0\.0\.0\.0/)).toBeInTheDocument();
+  });
+
+  it('logs a metric when a leak test passes after connecting', async () => {
+    const user = userEvent.setup();
+    render(<VpnManager />);
+
+    await screen.findByText('Lab VPN');
+
+    await user.click(screen.getByRole('button', { name: /Connect/i }));
+
+    await user.click(screen.getByRole('button', { name: /Run leak test/i }));
+
+    await screen.findByText(/No leaks detected/i);
+    expect(logEvent).toHaveBeenCalledWith({
+      category: 'VPN Manager',
+      action: 'leak-test-pass',
+      label: 'Lab VPN',
+    });
+  });
+});

--- a/__tests__/utils/vpnParser.test.ts
+++ b/__tests__/utils/vpnParser.test.ts
@@ -1,0 +1,78 @@
+import {
+  parseOpenVpnConfig,
+  parseWireGuardConfig,
+  parseVpnProfile,
+  detectProfileType,
+} from '../../utils/vpnParser';
+
+describe('vpnParser', () => {
+  it('parses OpenVPN configuration metadata and inline blocks', () => {
+    const configText = `# sample profile
+client
+remote vpn.example.com 1194
+proto udp
+port 1194
+auth-user-pass
+<ca>
+-----BEGIN CERTIFICATE-----
+CA DATA
+-----END CERTIFICATE-----
+</ca>
+`;
+
+    const parsed = parseOpenVpnConfig(configText);
+
+    expect(parsed.type).toBe('openvpn');
+    expect(parsed.remote).toBe('vpn.example.com');
+    expect(parsed.port).toBe(1194);
+    expect(parsed.protocol).toBe('udp');
+    expect(parsed.auth).toBe('username/password');
+    expect(parsed.blocks.ca).toContain('BEGIN CERTIFICATE');
+    expect(parsed.options.remote).toEqual('vpn.example.com 1194');
+  });
+
+  it('parses WireGuard configuration sections and peers', () => {
+    const configText = `[Interface]
+Address = 10.0.0.2/32
+DNS = 1.1.1.1
+
+[Peer]
+PublicKey = abcdef
+Endpoint = vpn.example.com:51820
+AllowedIPs = 0.0.0.0/0, ::/0
+PersistentKeepalive = 25
+`;
+
+    const parsed = parseWireGuardConfig(configText);
+
+    expect(parsed.type).toBe('wireguard');
+    expect(parsed.interface['Address']).toEqual(['10.0.0.2/32']);
+    expect(parsed.interface['DNS']).toEqual(['1.1.1.1']);
+    expect(parsed.peers).toHaveLength(1);
+    expect(parsed.peers[0]).toMatchObject({
+      publicKey: 'abcdef',
+      endpoint: 'vpn.example.com:51820',
+      allowedIps: ['0.0.0.0/0', '::/0'],
+      persistentKeepalive: 25,
+    });
+  });
+
+  it('detects configuration type from filename and content', () => {
+    expect(detectProfileType('profile.ovpn', '')).toBe('openvpn');
+    expect(detectProfileType('wg.conf', '')).toBe('wireguard');
+    expect(
+      detectProfileType(
+        'no-extension',
+        '[Interface]\nAddress = 10.0.0.1/24\n[Peer]\nPublicKey = key',
+      ),
+    ).toBe('wireguard');
+  });
+
+  it('parses VPN profile based on detection', () => {
+    const wgConfig = `[Interface]\nAddress = 10.0.0.2/32`; // minimal
+    expect(parseVpnProfile('wg.conf', wgConfig).type).toBe('wireguard');
+
+    const ovpnConfig = 'remote vpn.example.com 1194';
+    expect(parseVpnProfile('profile.ovpn', ovpnConfig).type).toBe('openvpn');
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -77,6 +77,7 @@ const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
 const TrashApp = createDynamicApp('trash', 'Trash');
 const SerialTerminalApp = createDynamicApp('serial-terminal', 'Serial Terminal');
+const VpnManagerApp = createDynamicApp('vpn-manager', 'VPN Manager');
 
 
 const WiresharkApp = createDynamicApp('wireshark', 'Wireshark');
@@ -163,6 +164,7 @@ const displayProjectGallery = createDisplay(ProjectGalleryApp);
 const displayTrash = createDisplay(TrashApp);
 const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
+const displayVpnManager = createDisplay(VpnManagerApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
 
@@ -266,6 +268,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayInputLab,
+  },
+  {
+    id: 'vpn-manager',
+    title: 'VPN Manager',
+    icon: '/themes/Yaru/apps/resource-monitor.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayVpnManager,
   },
 ];
 

--- a/components/apps/vpn-manager/index.tsx
+++ b/components/apps/vpn-manager/index.tsx
@@ -1,0 +1,579 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  parseVpnProfile,
+  detectProfileType,
+} from '../../../utils/vpnParser';
+import type {
+  OpenVpnConfig,
+  WireGuardConfig,
+} from '../../../utils/vpnParser';
+import {
+  connect,
+  disconnect,
+  getExternalIp,
+  isConnected,
+  isKillSwitchEnabled,
+  runLeakTest,
+  setKillSwitchEnabled,
+} from '../../../utils/networkState';
+import type { LeakTestResult } from '../../../utils/networkState';
+import {
+  loadProfiles,
+  saveProfiles,
+  type StoredVpnProfile,
+  type LeakTestEntry,
+} from '../../../utils/vpnStorage';
+import { logEvent } from '../../../utils/analytics';
+
+const KILL_SWITCH_PREF_KEY = 'vpn-manager:kill-switch';
+
+const createId = () =>
+  (globalThis.crypto?.randomUUID?.() ??
+    `vpn-${Date.now().toString(36)}-${Math.random()
+      .toString(16)
+      .slice(2, 8)}`);
+
+const formatTimestamp = (iso: string): string => {
+  try {
+    const date = new Date(iso);
+    return date.toLocaleString();
+  } catch {
+    return iso;
+  }
+};
+
+const summarizeOpenVpn = (config: OpenVpnConfig | undefined) => {
+  if (!config) return 'No remote specified';
+  const remote = config.remote ?? 'Unknown remote';
+  const proto = config.protocol ?? 'udp';
+  const rawPort = config.port ?? (() => {
+    const value = config.options['port'];
+    if (Array.isArray(value)) return Number.parseInt(value[0] ?? '', 10);
+    if (typeof value === 'string') return Number.parseInt(value, 10);
+    return undefined;
+  })();
+  const port = !rawPort || Number.isNaN(rawPort) ? '1194' : String(rawPort);
+  return `${remote} • ${proto.toUpperCase()} • ${port}`;
+};
+
+const summarizeWireGuard = (config: WireGuardConfig | undefined) => {
+  if (!config) return 'No peers configured';
+  const endpoint = config.peers[0]?.endpoint ?? 'Endpoint unknown';
+  const address =
+    config.interface['Address']?.[0] ??
+    config.interface['Address6']?.[0] ??
+    config.interface['address']?.[0];
+  return address ? `${endpoint} • ${address}` : endpoint;
+};
+
+const initialStatus = 'Import an OpenVPN (.ovpn) or WireGuard (.conf) profile to begin.';
+
+const VpnManager: React.FC = () => {
+  const [profiles, setProfiles] = useState<StoredVpnProfile[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [sessionIps, setSessionIps] = useState<Record<string, string>>({});
+  const [currentIp, setCurrentIp] = useState<string>(getExternalIp());
+  const [killSwitch, setKillSwitch] = useState<boolean>(isKillSwitchEnabled());
+  const [status, setStatus] = useState<string>(initialStatus);
+  const [isBusy, setBusy] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const persistProfiles = useCallback(async (next: StoredVpnProfile[]) => {
+    setProfiles(next);
+    try {
+      await saveProfiles(next);
+    } catch {
+      setError('Unable to persist profiles to secure storage.');
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const stored = await loadProfiles();
+        if (cancelled) return;
+        setProfiles(stored);
+        if (stored.length > 0) {
+          setSelectedId(stored[0].id);
+          setStatus('Select a profile to connect or run leak tests.');
+        }
+      } catch {
+        if (!cancelled) {
+          setError('Unable to load VPN profiles.');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = window.localStorage.getItem(KILL_SWITCH_PREF_KEY);
+      const enabled = stored === 'true';
+      const ip = setKillSwitchEnabled(enabled);
+      setKillSwitch(enabled);
+      if (!isConnected()) {
+        setCurrentIp(ip);
+      }
+    } catch {
+      // ignore preference errors
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(KILL_SWITCH_PREF_KEY, killSwitch ? 'true' : 'false');
+    } catch {
+      // ignore persistence errors
+    }
+  }, [killSwitch]);
+
+  const selectedProfile = useMemo(
+    () => profiles.find((profile) => profile.id === selectedId) ?? null,
+    [profiles, selectedId],
+  );
+
+  const updateProfile = useCallback(
+    async (id: string, updates: Partial<StoredVpnProfile>) => {
+      const next = profiles.map((profile) =>
+        profile.id === id
+          ? {
+              ...profile,
+              ...updates,
+              updatedAt: new Date().toISOString(),
+            }
+          : profile,
+      );
+      await persistProfiles(next);
+    },
+    [persistProfiles, profiles],
+  );
+
+  const appendLeakTest = useCallback(
+    async (id: string, entry: LeakTestEntry) => {
+      const next = profiles.map((profile) =>
+        profile.id === id
+          ? {
+              ...profile,
+              leakTests: [entry, ...profile.leakTests].slice(0, 5),
+              updatedAt: new Date().toISOString(),
+            }
+          : profile,
+      );
+      await persistProfiles(next);
+    },
+    [persistProfiles, profiles],
+  );
+
+  const handleToggleKillSwitch = useCallback(() => {
+    const next = !killSwitch;
+    const ip = setKillSwitchEnabled(next);
+    setKillSwitch(next);
+    if (!activeId) {
+      setCurrentIp(ip);
+      setStatus(
+        next
+          ? 'Kill switch engaged. Traffic blocked while disconnected.'
+          : 'Kill switch disabled. Default connection restored while disconnected.',
+      );
+    }
+  }, [activeId, killSwitch]);
+
+  const handleConnect = useCallback(
+    async (profile: StoredVpnProfile) => {
+      setBusy(true);
+      setError(null);
+      try {
+        const { ip, latencyMs } = connect();
+        setCurrentIp(ip);
+        setSessionIps((prev) => ({ ...prev, [profile.id]: ip }));
+        setActiveId(profile.id);
+        await updateProfile(profile.id, { lastConnectedAt: new Date().toISOString() });
+        setStatus(
+          `Connected to ${profile.name}. Exit IP ${ip}, simulated latency ${latencyMs} ms.`,
+        );
+      } finally {
+        setBusy(false);
+      }
+    },
+    [updateProfile],
+  );
+
+  const handleDisconnect = useCallback(
+    (profile: StoredVpnProfile) => {
+      setBusy(true);
+      try {
+        const ip = disconnect();
+        setCurrentIp(ip);
+        setActiveId(null);
+        setSessionIps((prev) => {
+          const next = { ...prev };
+          delete next[profile.id];
+          return next;
+        });
+        setStatus(
+          killSwitch
+            ? 'Disconnected. Kill switch is blocking outbound traffic.'
+            : `Disconnected. External IP reverted to ${ip}.`,
+        );
+      } finally {
+        setBusy(false);
+      }
+    },
+    [killSwitch],
+  );
+
+  const handleLeakTest = useCallback(
+    async (profile: StoredVpnProfile) => {
+      const expectedIp = sessionIps[profile.id] ?? null;
+      const result: LeakTestResult = runLeakTest(expectedIp);
+      const entry: LeakTestEntry = {
+        id: createId(),
+        timestamp: result.timestamp,
+        ip: result.ip,
+        targetIp: result.targetIp,
+        leaking: result.leaking,
+        dnsLeaking: result.dnsLeaking,
+        webRtcLeaking: result.webRtcLeaking,
+      };
+      await appendLeakTest(profile.id, entry);
+      setStatus(
+        result.leaking
+          ? 'Potential leak detected. Review your profile configuration.'
+          : 'Leak test passed. No leaks detected.',
+      );
+      if (!result.leaking) {
+        logEvent({ category: 'VPN Manager', action: 'leak-test-pass', label: profile.name });
+      }
+    },
+    [appendLeakTest, sessionIps],
+  );
+
+  const handleDeleteProfile = useCallback(
+    async (id: string) => {
+      const next = profiles.filter((profile) => profile.id !== id);
+      await persistProfiles(next);
+      setSessionIps((prev) => {
+        const copy = { ...prev };
+        delete copy[id];
+        return copy;
+      });
+      if (activeId === id) {
+        disconnect();
+        setActiveId(null);
+      }
+      if (selectedId === id) {
+        setSelectedId(next[0]?.id ?? null);
+      }
+    },
+    [activeId, persistProfiles, profiles, selectedId],
+  );
+
+  const handleImport = useCallback(
+    async (file: File) => {
+      setBusy(true);
+      setError(null);
+      try {
+        const text = await file.text();
+        const type = detectProfileType(file.name, text);
+        const parsed = parseVpnProfile(file.name, text);
+        const name = file.name.replace(/\.(ovpn|conf)$/i, '');
+        const now = new Date().toISOString();
+        const newProfile: StoredVpnProfile = {
+          id: createId(),
+          name: name || 'Imported Profile',
+          type,
+          createdAt: now,
+          updatedAt: now,
+          autoConnect: false,
+          favourite: false,
+          notes:
+            type === 'openvpn'
+              ? summarizeOpenVpn(parsed as OpenVpnConfig)
+              : summarizeWireGuard(parsed as WireGuardConfig),
+          leakTests: [],
+          openVpn: type === 'openvpn' ? (parsed as OpenVpnConfig) : undefined,
+          wireGuard: type === 'wireguard' ? (parsed as WireGuardConfig) : undefined,
+        };
+        const next = [...profiles, newProfile];
+        await persistProfiles(next);
+        setSelectedId(newProfile.id);
+        setStatus(`Profile "${newProfile.name}" imported successfully.`);
+      } catch (err) {
+        setError((err as Error).message || 'Unable to import VPN profile.');
+      } finally {
+        setBusy(false);
+        if (fileInputRef.current) {
+          fileInputRef.current.value = '';
+        }
+      }
+    },
+    [persistProfiles, profiles],
+  );
+
+  const handleFileChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(
+    async (event) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+      await handleImport(file);
+    },
+    [handleImport],
+  );
+
+  return (
+    <div
+      className="h-full w-full bg-ub-cool-grey text-white"
+      data-testid="vpn-manager"
+    >
+      <div className="flex h-full flex-col gap-4 p-4">
+        <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-xl font-semibold">VPN Manager</h1>
+            <p className="text-sm text-gray-300">Current IP: {currentIp}</p>
+            <p className="text-sm text-gray-400">Kill switch: {killSwitch ? 'Enabled' : 'Disabled'}</p>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <button
+              type="button"
+              onClick={handleToggleKillSwitch}
+              className="rounded bg-blue-600 px-3 py-1 text-sm hover:bg-blue-500"
+            >
+              {killSwitch ? 'Disable kill switch' : 'Enable kill switch'}
+            </button>
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="rounded border border-blue-400 px-3 py-1 text-sm hover:bg-blue-500 hover:text-black"
+              disabled={isBusy}
+            >
+              Import profile
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".ovpn,.conf"
+              className="hidden"
+              onChange={handleFileChange}
+            />
+          </div>
+        </header>
+
+        <section className="rounded border border-gray-700 bg-black/30 p-3">
+          <p className="text-sm" aria-live="polite">
+            {status}
+          </p>
+          {error && (
+            <p className="mt-2 text-sm text-red-300" role="alert">
+              {error}
+            </p>
+          )}
+        </section>
+
+        <div className="grid flex-1 gap-4 md:grid-cols-[260px,1fr]">
+          <aside className="rounded border border-gray-700 bg-black/30 p-3">
+            <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-300">
+              Profiles
+            </h2>
+            {profiles.length === 0 ? (
+              <p className="text-sm text-gray-400">No profiles stored yet.</p>
+            ) : (
+              <ul className="flex flex-col gap-2">
+                {profiles.map((profile) => {
+                  const isSelected = profile.id === selectedId;
+                  const isActive = profile.id === activeId;
+                  return (
+                    <li key={profile.id}>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedId(profile.id)}
+                        className={`w-full rounded border px-3 py-2 text-left text-sm transition-colors ${
+                          isSelected
+                            ? 'border-blue-400 bg-blue-900/60'
+                            : 'border-transparent bg-black/20 hover:border-blue-400'
+                        }`}
+                      >
+                        <div className="flex items-center justify-between">
+                          <span className="font-medium">{profile.name}</span>
+                          <span
+                            className={`rounded px-2 py-0.5 text-xs ${
+                              isActive ? 'bg-green-500 text-black' : 'bg-gray-700'
+                            }`}
+                          >
+                            {isActive ? 'Connected' : 'Stored'}
+                          </span>
+                        </div>
+                        <p className="mt-1 text-xs text-gray-300">
+                          {profile.type === 'openvpn'
+                            ? summarizeOpenVpn(profile.openVpn)
+                            : summarizeWireGuard(profile.wireGuard)}
+                        </p>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </aside>
+
+          <section className="flex flex-col gap-4 rounded border border-gray-700 bg-black/30 p-4">
+            {selectedProfile ? (
+              <div className="flex flex-col gap-4">
+                <header>
+                  <h2 className="text-lg font-semibold">{selectedProfile.name}</h2>
+                  <p className="text-sm text-gray-300">
+                    {selectedProfile.type === 'openvpn'
+                      ? summarizeOpenVpn(selectedProfile.openVpn)
+                      : summarizeWireGuard(selectedProfile.wireGuard)}
+                  </p>
+                  {selectedProfile.notes && (
+                    <p className="mt-1 text-xs text-gray-400">{selectedProfile.notes}</p>
+                  )}
+                </header>
+
+                <div className="flex flex-wrap gap-2">
+                  {activeId === selectedProfile.id ? (
+                    <button
+                      type="button"
+                      onClick={() => handleDisconnect(selectedProfile)}
+                      className="rounded bg-red-600 px-3 py-1 text-sm hover:bg-red-500"
+                      disabled={isBusy}
+                    >
+                      Disconnect
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => handleConnect(selectedProfile)}
+                      className="rounded bg-green-600 px-3 py-1 text-sm hover:bg-green-500"
+                      disabled={isBusy}
+                    >
+                      Connect
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => handleLeakTest(selectedProfile)}
+                    className="rounded border border-blue-400 px-3 py-1 text-sm hover:bg-blue-500 hover:text-black"
+                    disabled={isBusy}
+                  >
+                    Run leak test
+                  </button>
+                  <details className="rounded border border-gray-700 bg-black/30 p-3 text-sm">
+                    <summary className="cursor-pointer font-semibold">Profile settings</summary>
+                    <div className="mt-2 flex flex-col gap-2 text-xs">
+                      <label className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          checked={Boolean(selectedProfile.autoConnect)}
+                          onChange={(event) =>
+                            updateProfile(selectedProfile.id, {
+                              autoConnect: event.target.checked,
+                            })
+                          }
+                        />
+                        Auto-connect on launch
+                      </label>
+                      <label className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          checked={Boolean(selectedProfile.favourite)}
+                          onChange={(event) =>
+                            updateProfile(selectedProfile.id, {
+                              favourite: event.target.checked,
+                            })
+                          }
+                        />
+                        Mark as favourite
+                      </label>
+                      <label className="flex flex-col gap-1">
+                        <span>Notes</span>
+                        <textarea
+                          className="min-h-[60px] rounded border border-gray-700 bg-black/40 p-2"
+                          defaultValue={selectedProfile.notes ?? ''}
+                          onBlur={(event) =>
+                            updateProfile(selectedProfile.id, {
+                              notes: event.target.value,
+                            })
+                          }
+                        />
+                      </label>
+                      <button
+                        type="button"
+                        onClick={() => handleDeleteProfile(selectedProfile.id)}
+                        className="self-start rounded bg-red-700 px-3 py-1 text-white hover:bg-red-600"
+                        disabled={isBusy}
+                      >
+                        Delete profile
+                      </button>
+                    </div>
+                  </details>
+                </div>
+
+                <div>
+                  <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300">
+                    Leak tests
+                  </h3>
+                  {selectedProfile.leakTests.length === 0 ? (
+                    <p className="mt-2 text-sm text-gray-400">No leak tests run yet.</p>
+                  ) : (
+                    <ul className="mt-2 space-y-2 text-sm">
+                      {selectedProfile.leakTests.map((entry) => (
+                        <li
+                          key={entry.id}
+                          className={`rounded border px-3 py-2 ${
+                            entry.leaking
+                              ? 'border-red-500 bg-red-900/40'
+                              : 'border-green-500 bg-green-900/30'
+                          }`}
+                        >
+                          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
+                            <span className="font-medium">
+                              {entry.leaking ? 'Leak detected' : 'No leaks detected'}
+                            </span>
+                            <span className="text-xs text-gray-200">
+                              {formatTimestamp(entry.timestamp)}
+                            </span>
+                          </div>
+                          <p className="text-xs text-gray-200">
+                            Exit IP: {entry.ip} • Expected: {entry.targetIp}
+                          </p>
+                          {entry.leaking && (
+                            <p className="text-xs text-red-200">
+                              DNS leak: {entry.dnsLeaking ? 'Yes' : 'No'} • WebRTC leak:{' '}
+                              {entry.webRtcLeaking ? 'Yes' : 'No'}
+                            </p>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-gray-400">
+                Select a stored profile to view details and run actions.
+              </p>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const displayVpnManager = () => <VpnManager />;
+
+export default VpnManager;

--- a/utils/encryptedStore.ts
+++ b/utils/encryptedStore.ts
@@ -1,0 +1,205 @@
+import { isBrowser } from './isBrowser';
+
+const DEFAULT_KEY_SEED = 'kali-portfolio::vpn-manager::task70';
+const FALLBACK_KEY = 'vpn-manager-fallback';
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+const encodeBase64 = (data: Uint8Array): string => {
+  if (typeof globalThis.btoa === 'function') {
+    let binary = '';
+    data.forEach((byte) => {
+      binary += String.fromCharCode(byte);
+    });
+    return globalThis.btoa(binary);
+  }
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(data).toString('base64');
+  }
+  let binary = '';
+  data.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return globalThis.btoa ? globalThis.btoa(binary) : binary;
+};
+
+const decodeBase64 = (value: string): Uint8Array => {
+  if (typeof globalThis.atob === 'function') {
+    const binary = globalThis.atob(value);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+  if (typeof Buffer !== 'undefined') {
+    return new Uint8Array(Buffer.from(value, 'base64'));
+  }
+  const bytes = new Uint8Array(value.length);
+  for (let i = 0; i < value.length; i += 1) {
+    bytes[i] = value.charCodeAt(i);
+  }
+  return bytes;
+};
+
+const xorWithFallbackKey = (data: Uint8Array): Uint8Array => {
+  const keyBytes = textEncoder.encode(FALLBACK_KEY);
+  const output = new Uint8Array(data.length);
+  for (let i = 0; i < data.length; i += 1) {
+    output[i] = data[i] ^ keyBytes[i % keyBytes.length];
+  }
+  return output;
+};
+
+const fallbackEncrypt = (plainText: string): string => {
+  const bytes = textEncoder.encode(plainText);
+  const cipher = xorWithFallbackKey(bytes);
+  return encodeBase64(cipher);
+};
+
+const fallbackDecrypt = (payload: string): string => {
+  const cipherBytes = decodeBase64(payload);
+  const plainBytes = xorWithFallbackKey(cipherBytes);
+  return textDecoder.decode(plainBytes);
+};
+
+const getLocationSalt = (): string => {
+  if (!isBrowser) return 'server';
+  try {
+    return globalThis.location?.host || 'client';
+  } catch {
+    return 'client';
+  }
+};
+
+const deriveKey = async (): Promise<CryptoKey | null> => {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) return null;
+
+  const material = await subtle.importKey(
+    'raw',
+    textEncoder.encode(DEFAULT_KEY_SEED),
+    { name: 'PBKDF2' },
+    false,
+    ['deriveBits', 'deriveKey'],
+  );
+
+  return subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: textEncoder.encode(`vpn-manager:${getLocationSalt()}`),
+      iterations: 150_000,
+      hash: 'SHA-256',
+    },
+    material,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+};
+
+const encryptValue = async (plainText: string): Promise<string> => {
+  try {
+    const key = await deriveKey();
+    if (!key) {
+      return fallbackEncrypt(plainText);
+    }
+    const subtle = globalThis.crypto!.subtle;
+    const iv = globalThis.crypto!.getRandomValues(new Uint8Array(12));
+    const cipherBuffer = await subtle.encrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      textEncoder.encode(plainText),
+    );
+    const payload = `${encodeBase64(iv)}.${encodeBase64(new Uint8Array(cipherBuffer))}`;
+    return payload;
+  } catch {
+    return fallbackEncrypt(plainText);
+  }
+};
+
+const decryptValue = async (payload: string): Promise<string> => {
+  try {
+    const key = await deriveKey();
+    if (!key) {
+      return fallbackDecrypt(payload);
+    }
+    const subtle = globalThis.crypto!.subtle;
+    const [ivB64, cipherB64] = payload.split('.');
+    if (!ivB64 || !cipherB64) {
+      return fallbackDecrypt(payload);
+    }
+    const iv = decodeBase64(ivB64);
+    const cipherBytes = decodeBase64(cipherB64);
+    const plainBuffer = await subtle.decrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      cipherBytes,
+    );
+    return textDecoder.decode(plainBuffer);
+  } catch {
+    return fallbackDecrypt(payload);
+  }
+};
+
+const memoryStore = new Map<string, string>();
+
+const getStorage = () => {
+  if (isBrowser && globalThis.localStorage) {
+    return {
+      getItem: (key: string) => globalThis.localStorage.getItem(key),
+      setItem: (key: string, value: string) => globalThis.localStorage.setItem(key, value),
+      removeItem: (key: string) => globalThis.localStorage.removeItem(key),
+    };
+  }
+  return {
+    getItem: (key: string) => memoryStore.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      memoryStore.set(key, value);
+    },
+    removeItem: (key: string) => {
+      memoryStore.delete(key);
+    },
+  };
+};
+
+export interface EncryptedStore<T> {
+  load: () => Promise<T>;
+  save: (value: T) => Promise<void>;
+  clear: () => Promise<void>;
+}
+
+export function createEncryptedStore<T>(
+  key: string,
+  defaultValue: T,
+): EncryptedStore<T> {
+  const storageKey = `encrypted:${key}`;
+  const storage = getStorage();
+
+  return {
+    load: async () => {
+      const stored = storage.getItem(storageKey);
+      if (!stored) return defaultValue;
+      try {
+        const decrypted = await decryptValue(stored);
+        return JSON.parse(decrypted) as T;
+      } catch {
+        return defaultValue;
+      }
+    },
+    save: async (value: T) => {
+      try {
+        const payload = await encryptValue(JSON.stringify(value));
+        storage.setItem(storageKey, payload);
+      } catch {
+        storage.setItem(storageKey, fallbackEncrypt(JSON.stringify(value)));
+      }
+    },
+    clear: async () => {
+      storage.removeItem(storageKey);
+    },
+  };
+}
+
+export default createEncryptedStore;

--- a/utils/networkState.ts
+++ b/utils/networkState.ts
@@ -1,0 +1,99 @@
+export interface ConnectionResult {
+  ip: string;
+  latencyMs: number;
+}
+
+export interface LeakTestResult {
+  ip: string;
+  targetIp: string;
+  leaking: boolean;
+  dnsLeaking: boolean;
+  webRtcLeaking: boolean;
+  timestamp: string;
+}
+
+const DEFAULT_EXIT_IP = '198.51.100.42';
+const VPN_EXIT_POOL = [
+  '203.0.113.8',
+  '198.51.100.77',
+  '192.0.2.24',
+  '198.51.100.163',
+  '203.0.113.99',
+];
+
+let poolIndex = 0;
+let currentIp = DEFAULT_EXIT_IP;
+let connected = false;
+let killSwitchEnabled = false;
+
+const cyclePool = (): string => {
+  const ip = VPN_EXIT_POOL[poolIndex % VPN_EXIT_POOL.length];
+  poolIndex += 1;
+  return ip;
+};
+
+export const getExternalIp = (): string => currentIp;
+
+export const isKillSwitchEnabled = (): boolean => killSwitchEnabled;
+
+export const isConnected = (): boolean => connected;
+
+export const connect = (): ConnectionResult => {
+  connected = true;
+  const ip = cyclePool();
+  currentIp = ip;
+  const latencyMs = 35 + ((poolIndex * 7) % 40);
+  return { ip, latencyMs };
+};
+
+export const disconnect = (): string => {
+  connected = false;
+  if (killSwitchEnabled) {
+    currentIp = '0.0.0.0';
+  } else {
+    currentIp = DEFAULT_EXIT_IP;
+  }
+  return currentIp;
+};
+
+export const setKillSwitchEnabled = (value: boolean): string => {
+  killSwitchEnabled = value;
+  if (!connected) {
+    currentIp = killSwitchEnabled ? '0.0.0.0' : DEFAULT_EXIT_IP;
+  }
+  return currentIp;
+};
+
+export const runLeakTest = (expectedIp: string | null): LeakTestResult => {
+  const targetIp = expectedIp ?? (connected ? currentIp : DEFAULT_EXIT_IP);
+  const leaking = currentIp !== targetIp && currentIp !== '0.0.0.0';
+  const timestamp = new Date().toISOString();
+  return {
+    ip: currentIp,
+    targetIp,
+    leaking,
+    dnsLeaking: leaking,
+    webRtcLeaking: leaking && !killSwitchEnabled,
+    timestamp,
+  };
+};
+
+export const resetNetworkState = (): void => {
+  poolIndex = 0;
+  currentIp = DEFAULT_EXIT_IP;
+  connected = false;
+  killSwitchEnabled = false;
+};
+
+const networkState = {
+  connect,
+  disconnect,
+  getExternalIp,
+  isConnected,
+  isKillSwitchEnabled,
+  runLeakTest,
+  setKillSwitchEnabled,
+  resetNetworkState,
+};
+
+export default networkState;

--- a/utils/vpnParser.ts
+++ b/utils/vpnParser.ts
@@ -1,0 +1,258 @@
+export type VpnProfileType = 'openvpn' | 'wireguard';
+
+export interface OpenVpnConfig {
+  type: 'openvpn';
+  remote?: string;
+  port?: number;
+  protocol?: string;
+  auth?: string;
+  cipher?: string;
+  options: Record<string, string | string[]>;
+  blocks: Record<string, string>;
+}
+
+export interface WireGuardPeer {
+  publicKey?: string;
+  presharedKey?: string;
+  endpoint?: string;
+  allowedIps: string[];
+  persistentKeepalive?: number | null;
+  notes?: string;
+  settings: Record<string, string[]>;
+}
+
+export interface WireGuardConfig {
+  type: 'wireguard';
+  interface: Record<string, string[]>;
+  peers: WireGuardPeer[];
+}
+
+export type ParsedVpnProfile = OpenVpnConfig | WireGuardConfig;
+
+const trimQuotes = (value: string): string => {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith('\'') && trimmed.endsWith('\''))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+};
+
+const mergeOption = (
+  map: Record<string, string | string[]>,
+  key: string,
+  value: string,
+): void => {
+  const existing = map[key];
+  if (typeof existing === 'undefined') {
+    map[key] = value;
+  } else if (Array.isArray(existing)) {
+    existing.push(value);
+    map[key] = existing;
+  } else {
+    map[key] = [existing, value];
+  }
+};
+
+export const parseOpenVpnConfig = (content: string): OpenVpnConfig => {
+  const options: Record<string, string | string[]> = {};
+  const blocks: Record<string, string> = {};
+  let remote: string | undefined;
+  let port: number | undefined;
+  let protocol: string | undefined;
+  let auth: string | undefined;
+  let cipher: string | undefined;
+
+  const lines = content.replace(/\r/g, '').split('\n');
+  let activeBlock: string | null = null;
+  let blockBuffer: string[] = [];
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#') || line.startsWith(';')) continue;
+
+    const blockStart = line.match(/^<(\w+)>$/);
+    const blockEnd = line.match(/^<\/(\w+)>$/);
+
+    if (blockStart) {
+      activeBlock = blockStart[1];
+      blockBuffer = [];
+      continue;
+    }
+    if (blockEnd && activeBlock === blockEnd[1]) {
+      blocks[activeBlock] = blockBuffer.join('\n').trim();
+      activeBlock = null;
+      blockBuffer = [];
+      continue;
+    }
+
+    if (activeBlock) {
+      blockBuffer.push(rawLine);
+      continue;
+    }
+
+    const parts = line.split(/\s+/);
+    const key = parts[0];
+    const value = parts.slice(1).join(' ').trim();
+
+    if (!key) continue;
+
+    switch (key.toLowerCase()) {
+      case 'remote': {
+        if (parts.length >= 2) {
+          remote = parts[1];
+        }
+        if (parts.length >= 3) {
+          const parsedPort = Number.parseInt(parts[2], 10);
+          if (!Number.isNaN(parsedPort)) {
+            port = parsedPort;
+          }
+        }
+        break;
+      }
+      case 'port': {
+        const parsedPort = Number.parseInt(value, 10);
+        if (!Number.isNaN(parsedPort)) {
+          port = parsedPort;
+        }
+        break;
+      }
+      case 'proto':
+      case 'protocol':
+        protocol = value.toLowerCase();
+        break;
+      case 'auth-user-pass':
+        auth = value || 'username/password';
+        break;
+      case 'cipher':
+        cipher = value;
+        break;
+      default:
+        break;
+    }
+
+    if (value) {
+      mergeOption(options, key, value);
+    } else {
+      mergeOption(options, key, '');
+    }
+  }
+
+  return {
+    type: 'openvpn',
+    remote,
+    port,
+    protocol,
+    auth,
+    cipher,
+    options,
+    blocks,
+  };
+};
+
+const parseValueList = (value: string): string[] =>
+  value
+    .split(',')
+    .map((item) => trimQuotes(item))
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+
+export const parseWireGuardConfig = (content: string): WireGuardConfig => {
+  const interfaceSection: Record<string, string[]> = {};
+  const peers: WireGuardPeer[] = [];
+
+  let currentSection: 'interface' | 'peer' | null = null;
+  let activePeer: WireGuardPeer | null = null;
+
+  const lines = content.replace(/\r/g, '').split('\n');
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#') || line.startsWith(';')) continue;
+
+    const sectionMatch = line.match(/^\[(.+)]$/);
+    if (sectionMatch) {
+      const sectionName = sectionMatch[1].toLowerCase();
+      if (sectionName === 'interface') {
+        currentSection = 'interface';
+        activePeer = null;
+      } else if (sectionName === 'peer') {
+        currentSection = 'peer';
+        activePeer = {
+          allowedIps: [],
+          settings: {},
+        };
+        peers.push(activePeer);
+      } else {
+        currentSection = null;
+        activePeer = null;
+      }
+      continue;
+    }
+
+    const [rawKey, ...rawValueParts] = line.split('=');
+    if (!rawKey) continue;
+    const key = rawKey.trim();
+    const rawValue = rawValueParts.join('=').trim();
+    const values = parseValueList(rawValue);
+
+    if (currentSection === 'interface') {
+      interfaceSection[key] = values;
+      continue;
+    }
+
+    if (currentSection === 'peer' && activePeer) {
+      activePeer.settings[key] = values;
+      const lowerKey = key.toLowerCase();
+      switch (lowerKey) {
+        case 'publickey':
+          [activePeer.publicKey] = values;
+          break;
+        case 'presharedkey':
+          [activePeer.presharedKey] = values;
+          break;
+        case 'endpoint':
+          [activePeer.endpoint] = values;
+          break;
+        case 'allowedips':
+          activePeer.allowedIps = values;
+          break;
+        case 'persistentkeepalive': {
+          const parsed = Number.parseInt(values[0] ?? '', 10);
+          activePeer.persistentKeepalive = Number.isNaN(parsed) ? null : parsed;
+          break;
+        }
+        case 'description':
+        case 'remark':
+        case 'comment':
+          activePeer.notes = values.join(', ');
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  return {
+    type: 'wireguard',
+    interface: interfaceSection,
+    peers,
+  };
+};
+
+export const detectProfileType = (fileName: string, content: string): VpnProfileType => {
+  if (/\.ovpn$/i.test(fileName)) return 'openvpn';
+  if (/\.conf$/i.test(fileName)) return 'wireguard';
+
+  if (content.includes('[Interface]') || content.includes('[Peer]')) {
+    return 'wireguard';
+  }
+  return 'openvpn';
+};
+
+export const parseVpnProfile = (fileName: string, content: string): ParsedVpnProfile => {
+  const type = detectProfileType(fileName, content);
+  if (type === 'wireguard') {
+    return parseWireGuardConfig(content);
+  }
+  return parseOpenVpnConfig(content);
+};

--- a/utils/vpnStorage.ts
+++ b/utils/vpnStorage.ts
@@ -1,0 +1,47 @@
+import { createEncryptedStore } from './encryptedStore';
+import type { OpenVpnConfig, WireGuardConfig, VpnProfileType } from './vpnParser';
+
+export interface LeakTestEntry {
+  id: string;
+  timestamp: string;
+  ip: string;
+  targetIp: string;
+  leaking: boolean;
+  dnsLeaking: boolean;
+  webRtcLeaking: boolean;
+}
+
+export interface StoredVpnProfile {
+  id: string;
+  name: string;
+  type: VpnProfileType;
+  createdAt: string;
+  updatedAt: string;
+  lastConnectedAt?: string;
+  autoConnect?: boolean;
+  favourite?: boolean;
+  notes?: string;
+  leakTests: LeakTestEntry[];
+  openVpn?: OpenVpnConfig;
+  wireGuard?: WireGuardConfig;
+}
+
+const store = createEncryptedStore<StoredVpnProfile[]>(
+  'vpn-manager/profiles',
+  [],
+);
+
+export const loadProfiles = (): Promise<StoredVpnProfile[]> => store.load();
+
+export const saveProfiles = (profiles: StoredVpnProfile[]): Promise<void> =>
+  store.save(profiles);
+
+export const clearProfiles = (): Promise<void> => store.clear();
+
+const vpnStorage = {
+  loadProfiles,
+  saveProfiles,
+  clearProfiles,
+};
+
+export default vpnStorage;


### PR DESCRIPTION
## Summary
- add a VPN Manager desktop utility with profile import, connection simulation, leak testing, and kill switch controls
- introduce reusable encrypted storage, VPN profile parsing, and mock network state helpers wired into the new app
- register the app in the launcher, document it in the README, and cover the parser and UI logic with targeted unit tests

## Testing
- `yarn lint` *(fails: repository currently has pre-existing accessibility lint errors across legacy apps)*
- `yarn test` *(fails: existing suites rely on unavailable browser storage APIs under jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68cb19c3ca888328b96c4e4a3ce5c551