### PR TITLE
[networking] add simulated networking console

### DIFF
--- a/__tests__/components/apps/networking.test.tsx
+++ b/__tests__/components/apps/networking.test.tsx
@@ -1,0 +1,125 @@
+import { networkingReducer, initialNetworkingState } from '../../../components/apps/networking';
+import { loadNetworkAdapters, resetNetworkConfig } from '../../../utils/networkState';
+
+describe('networkingReducer', () => {
+  beforeEach(() => {
+    resetNetworkConfig();
+  });
+
+  it('initializes adapters and tracks selection', () => {
+    const adapters = loadNetworkAdapters();
+    const state = networkingReducer(initialNetworkingState, {
+      type: 'setAdapters',
+      adapters,
+    });
+
+    expect(state.adapters).toHaveLength(adapters.length);
+    expect(state.selectedAdapterId).toBe(adapters[0].id);
+
+    const nextState = networkingReducer(state, {
+      type: 'selectAdapter',
+      adapterId: adapters[1].id,
+    });
+
+    expect(nextState.selectedAdapterId).toBe(adapters[1].id);
+
+    const reloaded = networkingReducer(nextState, {
+      type: 'setAdapters',
+      adapters,
+    });
+
+    expect(reloaded.selectedAdapterId).toBe(adapters[1].id);
+  });
+
+  it('updates routes when editing, adding, and removing entries', () => {
+    const adapters = loadNetworkAdapters();
+    let state = networkingReducer(initialNetworkingState, {
+      type: 'setAdapters',
+      adapters,
+    });
+    const adapterId = adapters[0].id;
+    const originalRoute = adapters[0].routes[0];
+
+    state = networkingReducer(state, {
+      type: 'updateRoute',
+      adapterId,
+      routeId: originalRoute.id,
+      field: 'destination',
+      value: '172.16.0.0',
+    });
+
+    expect(state.adapters[0].routes[0].destination).toBe('172.16.0.0');
+
+    state = networkingReducer(state, {
+      type: 'addRoute',
+      adapterId,
+    });
+
+    expect(state.adapters[0].routes).toHaveLength(adapters[0].routes.length + 1);
+    const addedRoute = state.adapters[0].routes[state.adapters[0].routes.length - 1];
+    expect(addedRoute.id).not.toBe(originalRoute.id);
+    expect(addedRoute.destination).toBe('');
+
+    state = networkingReducer(state, {
+      type: 'removeRoute',
+      adapterId,
+      routeId: addedRoute.id,
+    });
+
+    expect(state.adapters[0].routes).toHaveLength(adapters[0].routes.length);
+  });
+
+  it('manages search domains, pending state, and adapter replacement', () => {
+    const adapters = loadNetworkAdapters();
+    let state = networkingReducer(initialNetworkingState, {
+      type: 'setAdapters',
+      adapters,
+    });
+    const adapterId = adapters[0].id;
+
+    state = networkingReducer(state, {
+      type: 'setSearchDomain',
+      adapterId,
+      index: 0,
+      value: 'corp.local',
+    });
+
+    expect(state.adapters[0].searchDomains[0]).toBe('corp.local');
+
+    state = networkingReducer(state, {
+      type: 'addSearchDomain',
+      adapterId,
+    });
+
+    expect(state.adapters[0].searchDomains[state.adapters[0].searchDomains.length - 1]).toBe('');
+
+    const removalIndex = state.adapters[0].searchDomains.length - 1;
+    state = networkingReducer(state, {
+      type: 'removeSearchDomain',
+      adapterId,
+      index: removalIndex,
+    });
+
+    expect(state.adapters[0].searchDomains).toHaveLength(adapters[0].searchDomains.length);
+
+    state = networkingReducer(state, {
+      type: 'setPending',
+      adapterId,
+    });
+
+    expect(state.pendingAdapter).toBe(adapterId);
+
+    const replacement = {
+      ...state.adapters[0],
+      name: 'Updated Adapter',
+    };
+
+    state = networkingReducer(state, {
+      type: 'replaceAdapter',
+      adapter: replacement,
+    });
+
+    expect(state.adapters[0].name).toBe('Updated Adapter');
+    expect(state.pendingAdapter).toBe(adapterId);
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -77,6 +77,7 @@ const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
 const TrashApp = createDynamicApp('trash', 'Trash');
 const SerialTerminalApp = createDynamicApp('serial-terminal', 'Serial Terminal');
+const NetworkingApp = createDynamicApp('networking', 'Networking');
 
 
 const WiresharkApp = createDynamicApp('wireshark', 'Wireshark');
@@ -163,6 +164,7 @@ const displayProjectGallery = createDisplay(ProjectGalleryApp);
 const displayTrash = createDisplay(TrashApp);
 const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
+const displayNetworking = createDisplay(NetworkingApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
 
@@ -266,6 +268,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayInputLab,
+  },
+  {
+    id: 'networking',
+    title: 'Networking',
+    icon: '/themes/Yaru/apps/radar-symbolic.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayNetworking,
   },
 ];
 
@@ -709,6 +720,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayResourceMonitor,
+  },
+  {
+    id: 'networking',
+    title: 'Networking',
+    icon: '/themes/Yaru/apps/radar-symbolic.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayNetworking,
   },
   {
     id: 'screen-recorder',

--- a/components/apps/networking/index.tsx
+++ b/components/apps/networking/index.tsx
@@ -1,0 +1,417 @@
+import React, { useEffect, useMemo, useReducer, useState } from 'react';
+import Toast from '../../ui/Toast';
+import {
+  applyAdapterConfig,
+  createEmptyRoute,
+  loadNetworkAdapters,
+  type NetworkAdapter,
+  type RouteEntry,
+} from '../../../utils/networkState';
+
+export type NetworkingState = {
+  adapters: NetworkAdapter[];
+  selectedAdapterId: string;
+  pendingAdapter?: string;
+};
+
+export type NetworkingAction =
+  | { type: 'setAdapters'; adapters: NetworkAdapter[] }
+  | { type: 'selectAdapter'; adapterId: string }
+  | { type: 'updateRoute'; adapterId: string; routeId: string; field: keyof Omit<RouteEntry, 'id'>; value: string }
+  | { type: 'addRoute'; adapterId: string }
+  | { type: 'removeRoute'; adapterId: string; routeId: string }
+  | { type: 'setSearchDomain'; adapterId: string; index: number; value: string }
+  | { type: 'addSearchDomain'; adapterId: string }
+  | { type: 'removeSearchDomain'; adapterId: string; index: number }
+  | { type: 'setPending'; adapterId?: string }
+  | { type: 'replaceAdapter'; adapter: NetworkAdapter };
+
+export const initialNetworkingState: NetworkingState = {
+  adapters: [],
+  selectedAdapterId: '',
+  pendingAdapter: undefined,
+};
+
+const updateAdapters = (
+  adapters: NetworkAdapter[],
+  adapterId: string,
+  updater: (adapter: NetworkAdapter) => NetworkAdapter
+) => adapters.map((adapter) => (adapter.id === adapterId ? updater(adapter) : adapter));
+
+export const networkingReducer = (
+  state: NetworkingState,
+  action: NetworkingAction
+): NetworkingState => {
+  switch (action.type) {
+    case 'setAdapters': {
+      const selectedAdapterId = action.adapters.length
+        ? action.adapters.find((adapter) => adapter.id === state.selectedAdapterId)?.id ?? action.adapters[0].id
+        : '';
+      return {
+        ...state,
+        adapters: action.adapters,
+        selectedAdapterId,
+      };
+    }
+    case 'selectAdapter':
+      return {
+        ...state,
+        selectedAdapterId: action.adapterId,
+      };
+    case 'updateRoute':
+      return {
+        ...state,
+        adapters: updateAdapters(state.adapters, action.adapterId, (adapter) => ({
+          ...adapter,
+          routes: adapter.routes.map((route) =>
+            route.id === action.routeId ? { ...route, [action.field]: action.value } : route
+          ),
+        })),
+      };
+    case 'addRoute':
+      return {
+        ...state,
+        adapters: updateAdapters(state.adapters, action.adapterId, (adapter) => ({
+          ...adapter,
+          routes: [...adapter.routes, createEmptyRoute()],
+        })),
+      };
+    case 'removeRoute':
+      return {
+        ...state,
+        adapters: updateAdapters(state.adapters, action.adapterId, (adapter) => ({
+          ...adapter,
+          routes: adapter.routes.filter((route) => route.id !== action.routeId),
+        })),
+      };
+    case 'setSearchDomain':
+      return {
+        ...state,
+        adapters: updateAdapters(state.adapters, action.adapterId, (adapter) => ({
+          ...adapter,
+          searchDomains: adapter.searchDomains.map((domain, index) =>
+            index === action.index ? action.value : domain
+          ),
+        })),
+      };
+    case 'addSearchDomain':
+      return {
+        ...state,
+        adapters: updateAdapters(state.adapters, action.adapterId, (adapter) => ({
+          ...adapter,
+          searchDomains: [...adapter.searchDomains, ''],
+        })),
+      };
+    case 'removeSearchDomain':
+      return {
+        ...state,
+        adapters: updateAdapters(state.adapters, action.adapterId, (adapter) => ({
+          ...adapter,
+          searchDomains: adapter.searchDomains.filter((_, index) => index !== action.index),
+        })),
+      };
+    case 'setPending':
+      return {
+        ...state,
+        pendingAdapter: action.adapterId,
+      };
+    case 'replaceAdapter':
+      return {
+        ...state,
+        adapters: state.adapters.map((adapter) =>
+          adapter.id === action.adapter.id ? action.adapter : adapter
+        ),
+      };
+    default:
+      return state;
+  }
+};
+
+const connectionStatusClasses: Record<NetworkAdapter['status'], string> = {
+  connected: 'text-green-400',
+  disconnected: 'text-red-400',
+};
+
+const NetworkingApp: React.FC = () => {
+  const [state, dispatch] = useReducer(networkingReducer, initialNetworkingState);
+  const [toastMessage, setToastMessage] = useState('');
+
+  useEffect(() => {
+    dispatch({ type: 'setAdapters', adapters: loadNetworkAdapters() });
+  }, []);
+
+  const selectedAdapter = useMemo(
+    () => state.adapters.find((adapter) => adapter.id === state.selectedAdapterId),
+    [state.adapters, state.selectedAdapterId]
+  );
+
+  const handleAdapterChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    dispatch({ type: 'selectAdapter', adapterId: event.target.value });
+  };
+
+  const handleRouteChange = (
+    adapterId: string,
+    routeId: string,
+    field: keyof Omit<RouteEntry, 'id'>,
+    value: string
+  ) => {
+    dispatch({ type: 'updateRoute', adapterId, routeId, field, value });
+  };
+
+  const handleApply = async () => {
+    if (!selectedAdapter) {
+      return;
+    }
+    dispatch({ type: 'setPending', adapterId: selectedAdapter.id });
+    const result = await applyAdapterConfig(selectedAdapter.id, {
+      routes: selectedAdapter.routes,
+      searchDomains: selectedAdapter.searchDomains,
+    });
+    if (result.success) {
+      dispatch({ type: 'replaceAdapter', adapter: result.adapter });
+      setToastMessage(`Applied network changes to ${result.adapter.name}.`);
+    } else {
+      setToastMessage(result.message);
+    }
+    dispatch({ type: 'setPending', adapterId: undefined });
+  };
+
+  const isPending = selectedAdapter && state.pendingAdapter === selectedAdapter.id;
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-ub-cool-grey text-white">
+      <header className="border-b border-gray-800 p-4">
+        <h1 className="text-xl font-semibold">Networking</h1>
+        <p className="text-sm text-ubt-grey">
+          Review simulated adapters, inspect connection details, and tune routing without touching the host OS.
+        </p>
+      </header>
+      <div className="flex-1 overflow-y-auto p-4 space-y-6">
+        <section>
+          <h2 className="mb-3 text-lg font-semibold">Connections</h2>
+          {state.adapters.length === 0 ? (
+            <p className="text-sm text-ubt-grey">No adapters detected in the lab environment.</p>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2">
+              {state.adapters.map((adapter) => (
+                <article key={adapter.id} className="rounded-md border border-gray-800 bg-[#0f1419] p-4 shadow-inner">
+                  <div className="mb-2 flex items-center justify-between">
+                    <div>
+                      <h3 className="text-base font-semibold">{adapter.name}</h3>
+                      <p className="text-xs uppercase tracking-wide text-ubt-grey">{adapter.type.toUpperCase()}</p>
+                    </div>
+                    <span className={`text-sm font-medium ${connectionStatusClasses[adapter.status]}`}>
+                      {adapter.status === 'connected' ? 'Connected' : 'Disconnected'}
+                    </span>
+                  </div>
+                  <dl className="grid grid-cols-2 gap-y-2 text-sm">
+                    <div>
+                      <dt className="text-ubt-grey">IPv4</dt>
+                      <dd className="font-mono text-sm">{adapter.ipv4}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-ubt-grey">Gateway</dt>
+                      <dd className="font-mono text-sm">{adapter.gateway}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-ubt-grey">DNS</dt>
+                      <dd className="font-mono text-sm">{adapter.dns.join(', ')}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-ubt-grey">MAC</dt>
+                      <dd className="font-mono text-sm">{adapter.mac}</dd>
+                    </div>
+                  </dl>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+        <section>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold">Advanced configuration</h2>
+              <p className="text-sm text-ubt-grey">
+                Edit routing tables and DNS search domains for the active adapter. Changes persist to local storage only.
+              </p>
+            </div>
+            {state.adapters.length > 0 && (
+              <label className="text-sm">
+                <span className="mr-2 text-ubt-grey">Adapter:</span>
+                <select
+                  value={state.selectedAdapterId}
+                  onChange={handleAdapterChange}
+                  className="rounded border border-gray-700 bg-gray-900 px-2 py-1 text-sm focus:border-ubt-gedit-blue focus:outline-none"
+                >
+                  {state.adapters.map((adapter) => (
+                    <option key={adapter.id} value={adapter.id}>
+                      {adapter.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+          </div>
+          {selectedAdapter ? (
+            <div className="mt-4 space-y-6">
+              <div>
+                <div className="mb-2 flex items-center justify-between">
+                  <h3 className="text-base font-semibold">Routes</h3>
+                  <button
+                    type="button"
+                    onClick={() => dispatch({ type: 'addRoute', adapterId: selectedAdapter.id })}
+                    className="rounded border border-ubt-gedit-blue px-3 py-1 text-sm text-ubt-gedit-blue transition hover:bg-ubt-gedit-blue hover:text-black"
+                  >
+                    Add route
+                  </button>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="min-w-full divide-y divide-gray-800 text-sm">
+                    <thead className="bg-gray-900 text-left text-xs uppercase tracking-wide text-ubt-grey">
+                      <tr>
+                        <th className="px-3 py-2">Destination</th>
+                        <th className="px-3 py-2">Netmask</th>
+                        <th className="px-3 py-2">Gateway</th>
+                        <th className="px-3 py-2">Metric</th>
+                        <th className="px-3 py-2"></th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-800">
+                      {selectedAdapter.routes.map((route) => (
+                        <tr key={route.id} className="bg-[#111822]">
+                          <td className="px-3 py-2">
+                            <input
+                              type="text"
+                              value={route.destination}
+                              onChange={(event) =>
+                                handleRouteChange(selectedAdapter.id, route.id, 'destination', event.target.value)
+                              }
+                              className="w-full rounded border border-gray-700 bg-[#0d131a] px-2 py-1 font-mono text-sm focus:border-ubt-gedit-blue focus:outline-none"
+                              placeholder="0.0.0.0"
+                            />
+                          </td>
+                          <td className="px-3 py-2">
+                            <input
+                              type="text"
+                              value={route.netmask}
+                              onChange={(event) =>
+                                handleRouteChange(selectedAdapter.id, route.id, 'netmask', event.target.value)
+                              }
+                              className="w-full rounded border border-gray-700 bg-[#0d131a] px-2 py-1 font-mono text-sm focus:border-ubt-gedit-blue focus:outline-none"
+                              placeholder="255.255.255.0"
+                            />
+                          </td>
+                          <td className="px-3 py-2">
+                            <input
+                              type="text"
+                              value={route.gateway}
+                              onChange={(event) =>
+                                handleRouteChange(selectedAdapter.id, route.id, 'gateway', event.target.value)
+                              }
+                              className="w-full rounded border border-gray-700 bg-[#0d131a] px-2 py-1 font-mono text-sm focus:border-ubt-gedit-blue focus:outline-none"
+                              placeholder="192.168.0.1"
+                            />
+                          </td>
+                          <td className="px-3 py-2">
+                            <input
+                              type="number"
+                              value={route.metric}
+                              onChange={(event) =>
+                                handleRouteChange(selectedAdapter.id, route.id, 'metric', event.target.value)
+                              }
+                              className="w-24 rounded border border-gray-700 bg-[#0d131a] px-2 py-1 font-mono text-sm focus:border-ubt-gedit-blue focus:outline-none"
+                              min={0}
+                            />
+                          </td>
+                          <td className="px-3 py-2 text-right">
+                            <button
+                              type="button"
+                              onClick={() => dispatch({ type: 'removeRoute', adapterId: selectedAdapter.id, routeId: route.id })}
+                              className="rounded border border-red-500 px-2 py-1 text-xs text-red-400 transition hover:bg-red-500 hover:text-black"
+                            >
+                              Remove
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+              <div>
+                <div className="mb-2 flex items-center justify-between">
+                  <h3 className="text-base font-semibold">DNS search domains</h3>
+                  <button
+                    type="button"
+                    onClick={() => dispatch({ type: 'addSearchDomain', adapterId: selectedAdapter.id })}
+                    className="rounded border border-ubt-gedit-blue px-3 py-1 text-sm text-ubt-gedit-blue transition hover:bg-ubt-gedit-blue hover:text-black"
+                  >
+                    Add domain
+                  </button>
+                </div>
+                {selectedAdapter.searchDomains.length === 0 ? (
+                  <p className="text-sm text-ubt-grey">No search domains configured.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {selectedAdapter.searchDomains.map((domain, index) => (
+                      <div key={`${domain}-${index}`} className="flex items-center gap-2">
+                        <input
+                          type="text"
+                          value={domain}
+                          onChange={(event) =>
+                            dispatch({
+                              type: 'setSearchDomain',
+                              adapterId: selectedAdapter.id,
+                              index,
+                              value: event.target.value,
+                            })
+                          }
+                          className="flex-1 rounded border border-gray-700 bg-[#0d131a] px-2 py-1 font-mono text-sm focus:border-ubt-gedit-blue focus:outline-none"
+                          placeholder="corp.example"
+                        />
+                        <button
+                          type="button"
+                          onClick={() =>
+                            dispatch({
+                              type: 'removeSearchDomain',
+                              adapterId: selectedAdapter.id,
+                              index,
+                            })
+                          }
+                          className="rounded border border-red-500 px-2 py-1 text-xs text-red-400 transition hover:bg-red-500 hover:text-black"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={handleApply}
+                  disabled={Boolean(isPending)}
+                  className={`rounded px-4 py-2 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-ubt-gedit-blue ${
+                    isPending
+                      ? 'cursor-not-allowed bg-gray-700 text-gray-400'
+                      : 'bg-ubt-gedit-blue text-black hover:bg-ubt-gedit-blue/90'
+                  }`}
+                >
+                  {isPending ? 'Applying…' : 'Apply changes'}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <p className="mt-4 text-sm text-ubt-grey">Select an adapter to manage its configuration.</p>
+          )}
+        </section>
+      </div>
+      {toastMessage && (
+        <Toast message={toastMessage} onClose={() => setToastMessage('')} />
+      )}
+    </div>
+  );
+};
+
+export default NetworkingApp;

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -61,6 +61,11 @@ Tools to cover: **BeEF, Ettercap, Metasploit, Wireshark, Kismet, Nikto, Autopsy,
 - Display `performance.memory` data and FPS from `performance.now()` deltas.
 - Show CPU synthetic load graph using `requestAnimationFrame` buckets.
 
+### Networking
+- Surface simulated adapters with connection details sourced from `utils/networkState.ts`.
+- Provide editable routing table and DNS search domain controls that persist via `safeLocalStorage`.
+- Trigger in-app apply flow that reconfigures the simulation and shows success or failure toasts without reloading.
+
 ### Project Gallery
 - Load projects from `projects.json`; add filters and buttons for repo and live demo.
 

--- a/utils/networkState.ts
+++ b/utils/networkState.ts
@@ -1,0 +1,239 @@
+import { safeLocalStorage } from './safeStorage';
+
+export type RouteEntry = {
+  id: string;
+  destination: string;
+  netmask: string;
+  gateway: string;
+  metric: string;
+};
+
+export type NetworkAdapter = {
+  id: string;
+  name: string;
+  type: 'ethernet' | 'wifi' | 'vpn';
+  status: 'connected' | 'disconnected';
+  ipv4: string;
+  gateway: string;
+  dns: string[];
+  mac: string;
+  routes: RouteEntry[];
+  searchDomains: string[];
+};
+
+type PersistedConfig = Record<string, { routes: RouteEntry[]; searchDomains: string[] }>;
+
+const STORAGE_KEY = 'networking.adapters';
+
+const baseAdapters: NetworkAdapter[] = [
+  {
+    id: 'eth0',
+    name: 'Wired Connection (eth0)',
+    type: 'ethernet',
+    status: 'connected',
+    ipv4: '192.168.56.101',
+    gateway: '192.168.56.1',
+    dns: ['1.1.1.1', '8.8.8.8'],
+    mac: '00:1A:2B:3C:4D:5E',
+    routes: [
+      {
+        id: 'eth0-default',
+        destination: '0.0.0.0',
+        netmask: '0.0.0.0',
+        gateway: '192.168.56.1',
+        metric: '100',
+      },
+      {
+        id: 'eth0-lab',
+        destination: '10.10.0.0',
+        netmask: '255.255.0.0',
+        gateway: '192.168.56.5',
+        metric: '50',
+      },
+    ],
+    searchDomains: ['corp.example', 'lab.local'],
+  },
+  {
+    id: 'wlan0',
+    name: 'Wireless (wlan0)',
+    type: 'wifi',
+    status: 'connected',
+    ipv4: '10.0.0.42',
+    gateway: '10.0.0.1',
+    dns: ['9.9.9.9', '149.112.112.112'],
+    mac: '00:5E:60:AF:12:34',
+    routes: [
+      {
+        id: 'wlan0-default',
+        destination: '0.0.0.0',
+        netmask: '0.0.0.0',
+        gateway: '10.0.0.1',
+        metric: '100',
+      },
+    ],
+    searchDomains: ['home.lab'],
+  },
+];
+
+let memoryOverrides: PersistedConfig | null = null;
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const cloneRoute = (route: RouteEntry): RouteEntry => ({ ...route });
+
+const readPersistedConfig = (): PersistedConfig => {
+  if (memoryOverrides) {
+    return { ...memoryOverrides };
+  }
+  if (!safeLocalStorage) {
+    memoryOverrides = {};
+    return {};
+  }
+  try {
+    const raw = safeLocalStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      memoryOverrides = {};
+      return {};
+    }
+    const parsed = JSON.parse(raw) as PersistedConfig;
+    memoryOverrides = parsed;
+    return { ...parsed };
+  } catch (err) {
+    console.warn('Unable to parse networking state from storage', err);
+    memoryOverrides = {};
+    return {};
+  }
+};
+
+const writePersistedConfig = (config: PersistedConfig) => {
+  memoryOverrides = { ...config };
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+  } catch (err) {
+    console.warn('Unable to persist networking state', err);
+  }
+};
+
+const mergeAdapter = (adapter: NetworkAdapter, override?: { routes: RouteEntry[]; searchDomains: string[] }): NetworkAdapter => ({
+  ...adapter,
+  routes: override?.routes ? override.routes.map(cloneRoute) : adapter.routes.map(cloneRoute),
+  searchDomains: override?.searchDomains ? [...override.searchDomains] : [...adapter.searchDomains],
+  dns: [...adapter.dns],
+});
+
+const ipv4Pattern =
+  /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)$/;
+
+const domainPattern = /^(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$/;
+
+const createRouteId = () => `route-${Math.random().toString(36).slice(2, 9)}`;
+
+export const createEmptyRoute = (): RouteEntry => ({
+  id: createRouteId(),
+  destination: '',
+  netmask: '',
+  gateway: '',
+  metric: '100',
+});
+
+export const loadNetworkAdapters = (): NetworkAdapter[] => {
+  const overrides = readPersistedConfig();
+  return baseAdapters.map((adapter) => mergeAdapter(adapter, overrides[adapter.id]));
+};
+
+type AdapterConfig = {
+  routes: RouteEntry[];
+  searchDomains: string[];
+};
+
+const normalizeRoutes = (routes: RouteEntry[]): RouteEntry[] =>
+  routes.map((route) => ({
+    id: route.id || createRouteId(),
+    destination: route.destination.trim(),
+    netmask: route.netmask.trim(),
+    gateway: route.gateway.trim(),
+    metric: route.metric.trim(),
+  }));
+
+const normalizeDomains = (domains: string[]): string[] =>
+  domains.map((domain) => domain.trim()).filter((domain) => domain.length > 0);
+
+const validateConfig = (config: AdapterConfig): string | null => {
+  if (config.routes.length === 0) {
+    return 'Add at least one route before applying changes.';
+  }
+  for (const route of config.routes) {
+    if (!route.destination || !route.netmask || !route.gateway) {
+      return 'Routes must include destination, netmask, and gateway.';
+    }
+    if (!ipv4Pattern.test(route.destination)) {
+      return `Destination ${route.destination} is not a valid IPv4 address.`;
+    }
+    if (!ipv4Pattern.test(route.netmask)) {
+      return `Netmask ${route.netmask} is not a valid IPv4 address.`;
+    }
+    if (!ipv4Pattern.test(route.gateway)) {
+      return `Gateway ${route.gateway} is not a valid IPv4 address.`;
+    }
+    const metricValue = Number(route.metric);
+    if (!Number.isFinite(metricValue) || metricValue < 0) {
+      return `Metric for route ${route.destination} must be a positive number.`;
+    }
+  }
+  for (const domain of config.searchDomains) {
+    if (!domainPattern.test(domain)) {
+      return `Search domain ${domain} is not valid.`;
+    }
+  }
+  return null;
+};
+
+export const applyAdapterConfig = async (
+  adapterId: string,
+  config: AdapterConfig
+): Promise<
+  | { success: true; adapter: NetworkAdapter }
+  | { success: false; message: string }
+> => {
+  const base = baseAdapters.find((adapter) => adapter.id === adapterId);
+  if (!base) {
+    await wait(150);
+    return { success: false, message: 'Adapter not found.' };
+  }
+
+  const normalizedRoutes = normalizeRoutes(config.routes);
+  const normalizedDomains = normalizeDomains(config.searchDomains);
+
+  const error = validateConfig({ routes: normalizedRoutes, searchDomains: normalizedDomains });
+  if (error) {
+    await wait(200);
+    return { success: false, message: error };
+  }
+
+  const overrides = readPersistedConfig();
+  overrides[adapterId] = {
+    routes: normalizedRoutes.map(cloneRoute),
+    searchDomains: [...normalizedDomains],
+  };
+  writePersistedConfig(overrides);
+
+  await wait(300);
+
+  return {
+    success: true,
+    adapter: mergeAdapter(base, overrides[adapterId]),
+  };
+};
+
+export const resetNetworkConfig = () => {
+  memoryOverrides = {};
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.removeItem(STORAGE_KEY);
+  } catch (err) {
+    console.warn('Unable to clear networking state', err);
+  }
+};
+
+export type { AdapterConfig };


### PR DESCRIPTION
## Summary
- add a networking app that surfaces adapter cards and route/search-domain editing backed by safeLocalStorage
- provide a networkState utility for simulated apply validation and persistence
- cover the networking reducer with unit tests and document the new task requirements

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations across legacy apps)*
- yarn test *(fails: pre-existing window, nmap NSE, and settings suite issues)*

------
https://chatgpt.com/codex/tasks/task_e_68cb19c34a148328a7d4df2e990f8201