### PR TITLE
runtime: tune api runtimes for node and edge

### DIFF
--- a/app/api/log-client-error/route.ts
+++ b/app/api/log-client-error/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+export const runtime = 'edge';
+
 export async function POST(req: NextRequest) {
   const body = await req.json();
   console.error('Client error:', body);

--- a/pages/api/admin/messages.js
+++ b/pages/api/admin/messages.js
@@ -1,6 +1,8 @@
 import { getServiceClient } from '../../../lib/service-client';
 import { createLogger } from '../../../lib/logger';
 
+export const runtime = 'nodejs';
+
 export default async function handler(
   req,
   res

--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -4,6 +4,7 @@ import { validateServerEnv } from '../../lib/validate';
 import { getServiceSupabase } from '../../lib/supabase';
 
 // Simple in-memory rate limiter. Not suitable for distributed environments.
+export const runtime = 'nodejs';
 export const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 5;
 

--- a/pages/api/dummy.js
+++ b/pages/api/dummy.js
@@ -1,7 +1,18 @@
-export default function handler(req, res) {
+export const runtime = 'edge';
+
+export default async function handler(req) {
   if (req.method === 'POST') {
-    res.status(200).json({ message: 'Received' });
-  } else {
-    res.status(405).json({ message: 'Method not allowed' });
+    return new Response(JSON.stringify({ message: 'Received' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
+
+  return new Response(JSON.stringify({ message: 'Method not allowed' }), {
+    status: 405,
+    headers: {
+      'Content-Type': 'application/json',
+      Allow: 'POST',
+    },
+  });
 }

--- a/pages/api/figlet/fonts.js
+++ b/pages/api/figlet/fonts.js
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+export const runtime = 'nodejs';
+
 export default function handler(req, res) {
   const fontsDir = path.join(process.cwd(), 'figlet', 'fonts');
   let fonts = [];

--- a/pages/api/hydra.js
+++ b/pages/api/hydra.js
@@ -7,6 +7,8 @@ import path from 'path';
 const execFileAsync = promisify(execFile);
 const allowed = new Set(['http', 'https', 'ssh', 'ftp', 'smtp']);
 
+export const runtime = 'nodejs';
+
 export default async function handler(req, res) {
   if (
     process.env.FEATURE_TOOL_APIS !== 'enabled' ||

--- a/pages/api/john.js
+++ b/pages/api/john.js
@@ -6,6 +6,8 @@ import { promisify } from 'util';
 
 const execAsync = promisify(exec);
 
+export const runtime = 'nodejs';
+
 export default async function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
     res.status(501).json({ error: 'Not implemented' });

--- a/pages/api/leaderboard/submit.js
+++ b/pages/api/leaderboard/submit.js
@@ -1,5 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
+export const runtime = 'nodejs';
+
 export default async function handler(
   req,
   res,

--- a/pages/api/leaderboard/top.js
+++ b/pages/api/leaderboard/top.js
@@ -1,5 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
+export const runtime = 'nodejs';
+
 export default async function handler(
   req,
   res,

--- a/pages/api/modules/update.js
+++ b/pages/api/modules/update.js
@@ -13,14 +13,11 @@ function compareSemver(a, b) {
   return 0;
 }
 
-export default async function handler(
-  req,
-  res,
-) {
-  const currentParam = req.query.version;
-  const current = Array.isArray(currentParam)
-    ? currentParam[0]
-    : currentParam || '0.0.0';
+export const runtime = 'edge';
+
+export default async function handler(req) {
+  const requestUrl = new URL(req.url);
+  const current = requestUrl.searchParams.get('version') || '0.0.0';
 
   let latest = versionData.version;
   try {
@@ -38,5 +35,11 @@ export default async function handler(
   }
 
   const needsUpdate = compareSemver(current, latest) < 0;
-  res.status(200).json({ current, latest, needsUpdate });
+  return new Response(
+    JSON.stringify({ current, latest, needsUpdate }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    },
+  );
 }

--- a/pages/api/nse/update.js
+++ b/pages/api/nse/update.js
@@ -1,6 +1,8 @@
 import { readFile } from 'fs/promises';
 import path from 'path';
 
+export const runtime = 'nodejs';
+
 export default async function handler(_req, res) {
   try {
     const versionPath = path.join(process.cwd(), 'public', 'demo-data', 'nmap', 'script-db-version.json');

--- a/pages/api/pacman/leaderboard.js
+++ b/pages/api/pacman/leaderboard.js
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+export const runtime = 'nodejs';
+
 const filePath = path.join(process.cwd(), 'data', 'pacman-leaderboard.json');
 const MAX_ENTRIES = 10;
 

--- a/pages/api/plugins/[name].js
+++ b/pages/api/plugins/[name].js
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+export const runtime = 'nodejs';
+
 export default function handler(req, res) {
   const { name } = req.query;
   const filename = Array.isArray(name) ? name.join('/') : name;

--- a/pages/api/plugins/index.js
+++ b/pages/api/plugins/index.js
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+export const runtime = 'nodejs';
+
 export default function handler(_req, res) {
   const catalogDir = path.join(process.cwd(), 'plugins', 'catalog');
   try {

--- a/pages/api/quote.ts
+++ b/pages/api/quote.ts
@@ -1,4 +1,3 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
 import quotesData from '../../public/quotes/quotes.json';
 
 interface Quote {
@@ -9,14 +8,20 @@ interface Quote {
 
 const quotes = quotesData as Quote[];
 
-export default function handler(
-  req: NextApiRequest,
-  res: NextApiResponse,
-) {
-  const tag = Array.isArray(req.query.tag) ? req.query.tag[0] : req.query.tag;
+export const runtime = 'edge';
+
+export default function handler(req: Request): Response {
+  const url = new URL(req.url);
+  const tag = url.searchParams.get('tag');
   const pool = tag ? quotes.filter((q) => q.tags?.includes(tag)) : quotes;
   const quote = pool[Math.floor(Math.random() * pool.length)];
-  res.setHeader('Cache-Control', 'public, s-maxage=86400, stale-while-revalidate=3600');
-  res.status(200).json(quote);
+
+  return new Response(JSON.stringify(quote), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=3600',
+    },
+  });
 }
 

--- a/pages/api/radare2.js
+++ b/pages/api/radare2.js
@@ -6,6 +6,8 @@ import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
 
+export const runtime = 'nodejs';
+
 export default async function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
     res.status(501).json({ error: 'Not implemented' });

--- a/pages/api/share.js
+++ b/pages/api/share.js
@@ -1,14 +1,28 @@
-export default function handler(req, res) {
+export const runtime = 'edge';
+
+export default async function handler(req) {
   if (req.method !== 'POST') {
-    res.status(405).end();
-    return;
+    return new Response(null, {
+      status: 405,
+      headers: { Allow: 'POST' },
+    });
   }
 
-  const { text, url, title } = req.body || {};
+  let payload = null;
+  try {
+    payload = await req.json();
+  } catch {
+    payload = null;
+  }
+
+  const { text, url, title } = payload || {};
   const content = text || url || title || '';
   const params = new URLSearchParams();
   if (content) {
     params.set('text', content);
   }
-  res.redirect(307, `/apps/sticky_notes/?${params.toString()}`);
+
+  const requestUrl = new URL(req.url);
+  const redirectUrl = new URL(`/apps/sticky_notes/?${params.toString()}`, requestUrl.origin);
+  return Response.redirect(redirectUrl.toString(), 307);
 }

--- a/pages/api/track.js
+++ b/pages/api/track.js
@@ -1,5 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
 
+export const runtime = "nodejs";
+
 export default async function handler(
   req,
   res,

--- a/pages/api/wallpapers.js
+++ b/pages/api/wallpapers.js
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+export const runtime = 'nodejs';
+
 export default function handler(req, res) {
   const dir = path.join(process.cwd(), 'public', 'images', 'wallpapers');
   try {

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,75 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
-    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
+    "pages/api/figlet/fonts.js": {
+      "runtime": "@vercel/node@5.3.20",
+      "memory": 1024,
+      "maxDuration": 60
+    },
+    "pages/api/radare2.js": {
+      "runtime": "@vercel/node@5.3.20",
+      "memory": 1024,
+      "maxDuration": 60
+    },
+    "pages/api/john.js": {
+      "runtime": "@vercel/node@5.3.20",
+      "memory": 1024,
+      "maxDuration": 60
+    },
+    "pages/api/track.js": {
+      "runtime": "@vercel/node@5.3.20",
+      "memory": 1024,
+      "maxDuration": 60
+    },
+    "pages/api/pacman/leaderboard.js": {
+      "runtime": "@vercel/node@5.3.20",
+      "memory": 1024,
+      "maxDuration": 60
+    },
+    "pages/api/plugins/index.js": {
+      "runtime": "@vercel/node@5.3.20",
+      "memory": 1024,
+      "maxDuration": 60
+    },
+    "pages/api/plugins/[name].js": {
+      "runtime": "@vercel/node@5.3.20",
+      "memory": 1024,
+      "maxDuration": 60
+    },
+    "pages/api/wallpapers.js": {
+      "runtime": "@vercel/node@5.3.20",
+      "memory": 1024,
+      "maxDuration": 60
+    },
+    "pages/api/admin/messages.js": {
+      "runtime": "@vercel/node@5.3.20",
+      "memory": 1024,
+      "maxDuration": 60
+    },
+    "pages/api/hydra.js": {
+      "runtime": "@vercel/node@5.3.20",
+      "memory": 1024,
+      "maxDuration": 60
+    },
+    "pages/api/nse/update.js": {
+      "runtime": "@vercel/node@5.3.20",
+      "memory": 1024,
+      "maxDuration": 60
+    },
+    "pages/api/contact.js": {
+      "runtime": "@vercel/node@5.3.20",
+      "memory": 1024,
+      "maxDuration": 60
+    },
+    "pages/api/leaderboard/top.js": {
+      "runtime": "@vercel/node@5.3.20",
+      "memory": 1024,
+      "maxDuration": 60
+    },
+    "pages/api/leaderboard/submit.js": {
+      "runtime": "@vercel/node@5.3.20",
+      "memory": 1024,
+      "maxDuration": 60
+    }
   }
 }


### PR DESCRIPTION
## Summary
- convert lightweight API routes to the Edge runtime and use the Web Response API
- mark Node-dependent handlers with `runtime = "nodejs"` so heavy tooling stays on Node
- scope Vercel function settings to the Node routes with higher memory and duration limits

## Testing
- yarn lint *(fails: repository has existing accessibility and browser-global lint violations)*
- yarn test *(fails: repository has existing unwrapped React act warnings and jsdom localStorage errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cb52e160508328a9b60c376ed8c942