### PR TITLE
[build] share TypeScript base config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,19 +24,8 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: npm run lint
-
-  typecheck:
-    runs-on: ubuntu-latest
-    needs: install
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: yarn
-      - run: yarn install --immutable --immutable-cache
-      - run: npm run tsc -- --noEmit
+      - run: yarn lint
+      - run: yarn tsc --noEmit
 
   test:
     runs-on: ubuntu-latest

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable",
+      "WebWorker",
+      "WebWorker.ImportScripts"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/tsconfig.gamepad.json
+++ b/tsconfig.gamepad.json
@@ -1,12 +1,11 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
     "outDir": "./dist",
     "rootDir": ".",
     "allowJs": false,
     "tsBuildInfoFile": "./dist/tsconfig.gamepad.tsbuildinfo"
-
   },
   "include": ["utils/gamepad.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "es2020",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "noImplicitAny": true,
-    "forceConsistentCasingInFileNames": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
-    "types": [],
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./*"]
-
-    }
-  },
+  "extends": "./tsconfig.base.json",
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types/**/*.d.ts"],
   "exclude": ["node_modules", "__tests__", "components/apps/archive", "components/apps/kismet"]
 }


### PR DESCRIPTION
## Summary
- add a repository-level tsconfig.base.json with shared compiler options and worker-aware libs
- point the Next.js and gamepad configs at the base file
- run yarn tsc --noEmit during CI linting to surface type issues consistently

## Testing
- [x] yarn tsc --noEmit

## Flags
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68cb52e2ff908328a771c5ea153e0554