### PR TITLE
[reports] refactor nikto report to use server data

### DIFF
--- a/__tests__/niktoReport.test.tsx
+++ b/__tests__/niktoReport.test.tsx
@@ -1,46 +1,94 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import NiktoReport from '../pages/nikto-report';
+import NiktoReportClient from '../components/nikto/NiktoReportClient';
+import type { NiktoFinding } from '../lib/reports/nikto';
 
-describe('NiktoReport', () => {
+describe('NiktoReportClient', () => {
+  const baseData: NiktoFinding[] = [
+    {
+      path: '/admin',
+      finding: 'admin portal',
+      references: ['OSVDB-1'],
+      severity: 'High',
+      details: 'details',
+    },
+    {
+      path: '/cgi-bin',
+      finding: 'cgi script',
+      references: ['CVE-1'],
+      severity: 'Medium',
+      details: 'details',
+    },
+  ];
+
   beforeEach(() => {
-    global.fetch = jest.fn(() =>
-      Promise.resolve({
+    jest.useFakeTimers();
+    global.fetch = jest.fn((input: RequestInfo) => {
+      const url = typeof input === 'string' ? input : input.url;
+      const parsed = new URL(url, 'http://localhost');
+      const path = parsed.searchParams.get('path')?.toLowerCase() ?? '';
+      const severity = parsed.searchParams.get('severity');
+      let findings = [...baseData];
+      if (path) {
+        findings = findings.filter((item) => item.path.toLowerCase().startsWith(path));
+      }
+      if (severity && severity !== 'All') {
+        findings = findings.filter((item) => item.severity === severity);
+      }
+      return Promise.resolve({
+        ok: true,
         json: () =>
-          Promise.resolve([
-            {
-              path: '/admin',
-              finding: 'admin portal',
-              references: ['OSVDB-1'],
-              severity: 'High',
-              details: 'details',
-            },
-            {
-              path: '/cgi-bin',
-              finding: 'cgi script',
-              references: ['CVE-1'],
-              severity: 'Medium',
-              details: 'details',
-            },
-          ]),
-      })
-    ) as any;
+          Promise.resolve({
+            findings,
+            matchCount: findings.length,
+            availableSeverities: ['All', 'High', 'Medium'],
+            timings: { serverMs: 5 },
+          }),
+      }) as unknown as Promise<Response>;
+    }) as jest.Mock;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('filters by path and severity and shows details', async () => {
-    const user = userEvent.setup();
-    render(<NiktoReport />);
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(
+      <NiktoReportClient
+        initialData={{
+          findings: baseData,
+          summaryCounts: { High: 1, Medium: 1 },
+          filters: { severity: 'All', path: '' },
+          matchCount: baseData.length,
+          availableSeverities: ['All', 'High', 'Medium'],
+          timings: { serverMs: 0 },
+        }}
+      />,
+    );
 
     await screen.findByText('/admin');
     expect(screen.getAllByRole('row')).toHaveLength(3);
 
     await user.type(screen.getByPlaceholderText(/filter by path/i), '/cgi');
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('path=%2Fcgi'));
+    expect(await screen.findByText('/cgi-bin')).toBeInTheDocument();
     expect(screen.queryByText('/admin')).not.toBeInTheDocument();
 
     await user.clear(screen.getByPlaceholderText(/filter by path/i));
-    await user.selectOptions(screen.getByDisplayValue('All'), 'High');
-    expect(screen.getByText('/admin')).toBeInTheDocument();
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    await user.selectOptions(screen.getByLabelText(/severity/i), 'High');
+    await screen.findByText('/admin');
     expect(screen.queryByText('/cgi-bin')).not.toBeInTheDocument();
 
     await user.click(screen.getByText('/admin'));

--- a/components/nikto/NiktoReportClient.tsx
+++ b/components/nikto/NiktoReportClient.tsx
@@ -1,0 +1,328 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { NiktoFinding, NiktoReportPayload } from '../../lib/reports/nikto';
+import { NIKTO_SEVERITY_COLORS } from './constants';
+
+interface NiktoReportClientProps {
+  initialData: NiktoReportPayload & {
+    availableSeverities: string[];
+    timings?: { serverMs?: number };
+  };
+}
+
+interface FiltersState {
+  severity: string;
+  path: string;
+}
+
+interface TimingsState {
+  serverMs?: number;
+}
+
+const FETCH_DEBOUNCE = 250;
+
+const EXPORT_HEADERS = ['Path', 'Finding', 'Severity', 'References', 'Details'] as const;
+
+const serializeCsv = (rows: NiktoFinding[]) => {
+  const header = EXPORT_HEADERS.join(',');
+  const body = rows
+    .map((row) => {
+      const values = [
+        row.path,
+        row.finding,
+        row.severity,
+        row.references.join('; '),
+        row.details,
+      ];
+      return values
+        .map((value) => `"${String(value).replace(/"/g, '""')}"`)
+        .join(',');
+    })
+    .join('\n');
+  return `${header}\n${body}`;
+};
+
+const createParams = (filters: FiltersState) => {
+  const params = new URLSearchParams();
+  if (filters.severity && filters.severity !== 'All') {
+    params.set('severity', filters.severity);
+  }
+  if (filters.path.trim()) {
+    params.set('path', filters.path.trim());
+  }
+  return params.toString();
+};
+
+const matchKey = (finding: NiktoFinding) => `${finding.path}::${finding.finding}`;
+
+const NiktoReportClient = ({ initialData }: NiktoReportClientProps) => {
+  const [filters, setFilters] = useState<FiltersState>({
+    severity: initialData.filters.severity ?? 'All',
+    path: initialData.filters.path ?? '',
+  });
+  const [pathInput, setPathInput] = useState(initialData.filters.path ?? '');
+  const [findings, setFindings] = useState<NiktoFinding[]>(initialData.findings);
+  const [selected, setSelected] = useState<NiktoFinding | null>(null);
+  const [severities, setSeverities] = useState<string[]>(initialData.availableSeverities);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [timings, setTimings] = useState<TimingsState>(initialData.timings ?? {});
+  const [lastFetchMs, setLastFetchMs] = useState<number | null>(null);
+  const [hydrationMs, setHydrationMs] = useState<number | null>(null);
+  const [matchCount, setMatchCount] = useState<number>(initialData.matchCount);
+
+  const firstUpdateRef = useRef(true);
+
+  useEffect(() => {
+    const perf = typeof performance !== 'undefined' ? performance : undefined;
+    if (!perf || typeof perf.now !== 'function') return;
+
+    const entries =
+      typeof perf.getEntriesByType === 'function'
+        ? perf.getEntriesByType('navigation')
+        : [];
+    const navEntry = entries[0] as
+      | PerformanceNavigationTiming
+      | undefined;
+    const baseline = navEntry?.startTime ?? 0;
+    const hydrated = perf.now() - baseline;
+    setHydrationMs(hydrated);
+    console.info(`[NiktoReport] hydrated in ${hydrated.toFixed(1)}ms`);
+  }, []);
+
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      setFilters((prev) => {
+        if (prev.path === pathInput) return prev;
+        return { ...prev, path: pathInput };
+      });
+    }, FETCH_DEBOUNCE);
+    return () => window.clearTimeout(handle);
+  }, [pathInput]);
+
+  useEffect(() => {
+    if (firstUpdateRef.current) {
+      firstUpdateRef.current = false;
+      return;
+    }
+
+    const controller = new AbortController();
+    const supportsPerfNow =
+      typeof performance !== 'undefined' && typeof performance.now === 'function';
+    const startedAt = supportsPerfNow ? performance.now() : 0;
+    setLoading(true);
+    setError(null);
+
+    const query = createParams(filters);
+    const url = query ? `/api/reports/nikto?${query}` : '/api/reports/nikto';
+
+    fetch(url, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed to load report');
+        return res.json();
+      })
+      .then((payload) => {
+        setFindings(payload.findings ?? []);
+        setMatchCount(payload.matchCount ?? (payload.findings?.length ?? 0));
+        if (payload.availableSeverities) {
+          setSeverities(payload.availableSeverities);
+        }
+        setTimings(payload.timings ?? {});
+        setSelected((prev) => {
+          if (!prev) return null;
+          const next = (payload.findings ?? []).find(
+            (finding: NiktoFinding) => matchKey(finding) === matchKey(prev),
+          );
+          return next ?? null;
+        });
+        if (supportsPerfNow) {
+          setLastFetchMs(performance.now() - startedAt);
+        } else {
+          setLastFetchMs(null);
+        }
+      })
+      .catch((err) => {
+        if (err.name === 'AbortError') return;
+        setError('Unable to load filtered results.');
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [filters]);
+
+  useEffect(() => {
+    if (!selected) return;
+    const exists = findings.some((finding) => matchKey(finding) === matchKey(selected));
+    if (!exists) setSelected(null);
+  }, [findings, selected]);
+
+  const exportJson = () => {
+    if (!findings.length) return;
+    const blob = new Blob([JSON.stringify(findings, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'nikto-findings.json';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const exportCsv = () => {
+    if (!findings.length) return;
+    const csv = serializeCsv(findings);
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'nikto-findings.csv';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const severityOptions = useMemo(() => severities ?? ['All', 'High', 'Medium', 'Low', 'Info'], [
+    severities,
+  ]);
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap items-end gap-2">
+        <label className="flex flex-col text-xs" htmlFor="nikto-path-filter">
+          Path prefix
+          <input
+            id="nikto-path-filter"
+            className="mt-1 rounded border border-gray-600 bg-gray-800 p-2 text-sm text-white"
+            placeholder="Filter by path"
+            value={pathInput}
+            onChange={(event) => setPathInput(event.target.value)}
+          />
+        </label>
+        <label className="flex flex-col text-xs" htmlFor="nikto-severity-filter">
+          Severity
+          <select
+            id="nikto-severity-filter"
+            className="mt-1 rounded border border-gray-600 bg-gray-800 p-2 text-sm text-white"
+            value={filters.severity}
+            onChange={(event) =>
+              setFilters((prev) => ({ ...prev, severity: event.target.value }))
+            }
+          >
+            {severityOptions.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="ml-auto flex gap-2">
+          <button
+            type="button"
+            className="rounded bg-blue-600 px-3 py-2 text-sm"
+            onClick={exportJson}
+            disabled={!findings.length}
+          >
+            Export JSON
+          </button>
+          <button
+            type="button"
+            className="rounded bg-blue-600 px-3 py-2 text-sm"
+            onClick={exportCsv}
+            disabled={!findings.length}
+          >
+            Export CSV
+          </button>
+        </div>
+      </div>
+      <div className="text-xs text-gray-400">
+        <span>Matches: {matchCount}</span>
+        {hydrationMs !== null && (
+          <span className="ml-2">Hydration: {hydrationMs.toFixed(1)}ms</span>
+        )}
+        {lastFetchMs !== null && (
+          <span className="ml-2">
+            Last fetch: {lastFetchMs.toFixed(1)}ms
+            {timings.serverMs !== undefined
+              ? ` (server ${timings.serverMs.toFixed(1)}ms)`
+              : ''}
+          </span>
+        )}
+      </div>
+      {error && <p className="text-sm text-red-400">{error}</p>}
+      <div className="overflow-hidden rounded border border-gray-700">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-gray-800 text-xs uppercase tracking-wide text-gray-300">
+            <tr>
+              <th className="px-3 py-2">Path</th>
+              <th className="px-3 py-2">Finding</th>
+              <th className="px-3 py-2">Severity</th>
+              <th className="px-3 py-2">References</th>
+            </tr>
+          </thead>
+          <tbody>
+            {findings.map((finding) => {
+              const isSelected = selected ? matchKey(selected) === matchKey(finding) : false;
+              return (
+                <tr
+                  key={matchKey(finding)}
+                  className={`cursor-pointer border-l-4 transition hover:bg-gray-800 ${
+                    isSelected ? 'bg-gray-800/60' : ''
+                  }`}
+                  style={{
+                    borderColor:
+                      NIKTO_SEVERITY_COLORS[finding.severity] ?? NIKTO_SEVERITY_COLORS.Info,
+                  }}
+                  onClick={() => setSelected(finding)}
+                >
+                  <td className="px-3 py-2 font-mono text-xs">{finding.path}</td>
+                  <td className="px-3 py-2">{finding.finding}</td>
+                  <td className="px-3 py-2">{finding.severity}</td>
+                  <td className="px-3 py-2 text-xs">
+                    {finding.references.length ? finding.references.join(', ') : '—'}
+                  </td>
+                </tr>
+              );
+            })}
+            {!findings.length && !loading && (
+              <tr>
+                <td className="px-3 py-4 text-center text-sm text-gray-400" colSpan={4}>
+                  No findings match the current filters.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+        {loading && (
+          <div className="bg-gray-900/80 p-3 text-sm text-gray-300" role="status">
+            Loading filtered results…
+          </div>
+        )}
+      </div>
+      {selected && (
+        <div className="rounded border border-gray-700 bg-gray-800 p-3 text-sm">
+          <h2 className="text-lg font-semibold">{selected.finding}</h2>
+          <dl className="mt-2 space-y-1 text-xs">
+            <div className="flex gap-2">
+              <dt className="font-semibold">Path:</dt>
+              <dd className="font-mono">{selected.path}</dd>
+            </div>
+            <div className="flex gap-2">
+              <dt className="font-semibold">Severity:</dt>
+              <dd>{selected.severity}</dd>
+            </div>
+            <div className="flex gap-2">
+              <dt className="font-semibold">References:</dt>
+              <dd>{selected.references.length ? selected.references.join(', ') : 'None'}</dd>
+            </div>
+          </dl>
+          <p className="mt-3 whitespace-pre-wrap text-sm text-gray-200">{selected.details}</p>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default NiktoReportClient;

--- a/components/nikto/constants.ts
+++ b/components/nikto/constants.ts
@@ -1,0 +1,7 @@
+export const NIKTO_SEVERITY_COLORS: Record<string, string> = {
+  Critical: '#991b1b',
+  High: '#b45309',
+  Medium: '#a16207',
+  Low: '#1e40af',
+  Info: '#4b5563',
+};

--- a/lib/reports/nikto.ts
+++ b/lib/reports/nikto.ts
@@ -1,0 +1,98 @@
+import data from '../../public/demo-data/nikto/report.json';
+
+export type NiktoSeverity = 'Critical' | 'High' | 'Medium' | 'Low' | 'Info';
+
+export interface NiktoFinding {
+  path: string;
+  finding: string;
+  references: string[];
+  severity: string;
+  details: string;
+}
+
+export interface NiktoFilters {
+  severity?: string;
+  pathPrefix?: string;
+}
+
+export interface NiktoReportPayload {
+  findings: NiktoFinding[];
+  summaryCounts: Record<string, number>;
+  filters: { severity: string; path: string };
+  matchCount: number;
+}
+
+const SEVERITY_ORDER: NiktoSeverity[] = ['Critical', 'High', 'Medium', 'Low', 'Info'];
+
+const findingsData: NiktoFinding[] = (data as NiktoFinding[]).map((item) => ({
+  ...item,
+  severity: item.severity || 'Info',
+  references: Array.isArray(item.references) ? item.references : [],
+}));
+
+const summaryCounts = countBySeverity(findingsData);
+
+function countBySeverity(list: NiktoFinding[]): Record<string, number> {
+  return list.reduce<Record<string, number>>((acc, finding) => {
+    const key = finding.severity || 'Info';
+    acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, {});
+}
+
+function normalizeSeverity(value?: string): string {
+  if (!value) return '';
+  return value.trim().toLowerCase();
+}
+
+function matchesSeverity(finding: NiktoFinding, severity: string): boolean {
+  if (!severity || severity === 'all') return true;
+  return finding.severity.toLowerCase() === severity;
+}
+
+function matchesPathPrefix(finding: NiktoFinding, prefix: string): boolean {
+  if (!prefix) return true;
+  return finding.path.toLowerCase().startsWith(prefix);
+}
+
+export function getNiktoSeverities(): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const level of SEVERITY_ORDER) {
+    if (findingsData.some((item) => item.severity === level)) {
+      seen.add(level);
+      ordered.push(level);
+    }
+  }
+  for (const finding of findingsData) {
+    if (!seen.has(finding.severity)) {
+      seen.add(finding.severity);
+      ordered.push(finding.severity);
+    }
+  }
+  return ordered;
+}
+
+export function getNiktoReport(filters: NiktoFilters = {}): NiktoReportPayload {
+  const severity = normalizeSeverity(filters.severity) || 'all';
+  const pathPrefix = (filters.pathPrefix || '').trim().toLowerCase();
+
+  const filtered = findingsData.filter(
+    (finding) =>
+      matchesSeverity(finding, severity) && matchesPathPrefix(finding, pathPrefix),
+  );
+
+  return {
+    findings: filtered,
+    summaryCounts,
+    filters: {
+      severity: filters.severity ?? 'All',
+      path: filters.pathPrefix ?? '',
+    },
+    matchCount: filtered.length,
+  };
+}
+
+export function getNiktoDataset() {
+  return findingsData;
+}

--- a/pages/api/reports/nikto.ts
+++ b/pages/api/reports/nikto.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { performance } from 'perf_hooks';
+import { getNiktoReport, getNiktoSeverities } from '../../../lib/reports/nikto';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const start = performance.now();
+  const severity = Array.isArray(req.query.severity)
+    ? req.query.severity[0]
+    : req.query.severity;
+  const path = Array.isArray(req.query.path) ? req.query.path[0] : req.query.path;
+
+  const report = getNiktoReport({ severity: severity ?? undefined, pathPrefix: path ?? undefined });
+  const duration = performance.now() - start;
+
+  res.status(200).json({
+    ...report,
+    availableSeverities: ['All', ...getNiktoSeverities()],
+    timings: { serverMs: duration },
+  });
+}

--- a/pages/nikto-report.tsx
+++ b/pages/nikto-report.tsx
@@ -1,231 +1,59 @@
-"use client";
+import type { GetStaticProps, InferGetStaticPropsType } from 'next';
+import NiktoReportClient from '../components/nikto/NiktoReportClient';
+import { NIKTO_SEVERITY_COLORS } from '../components/nikto/constants';
+import { getNiktoReport, getNiktoSeverities } from '../lib/reports/nikto';
 
-import React, { useEffect, useMemo, useState } from 'react';
+const buildSeverityList = (available: string[]) =>
+  available.filter((severity) => severity !== 'All');
 
-interface NiktoFinding {
-  path: string;
-  finding: string;
-  references: string[];
-  severity: string;
-  details: string;
-}
-
-const severityColors: Record<string, string> = {
-  High: '#b45309',
-  Medium: '#a16207',
-  Low: '#1e40af',
-  Info: '#4b5563',
+export const getStaticProps: GetStaticProps<{
+  initialData: ReturnType<typeof getNiktoReport> & {
+    availableSeverities: string[];
+    timings: { serverMs: number };
+  };
+}> = async () => {
+  const report = getNiktoReport();
+  const severities = ['All', ...getNiktoSeverities()];
+  return {
+    props: {
+      initialData: {
+        ...report,
+        availableSeverities: severities,
+        timings: { serverMs: 0 },
+      },
+    },
+  };
 };
 
-const NiktoReport: React.FC = () => {
-  const [findings, setFindings] = useState<NiktoFinding[]>([]);
-  const [severity, setSeverity] = useState('All');
-  const [pathFilter, setPathFilter] = useState('');
-  const [selected, setSelected] = useState<NiktoFinding | null>(null);
+type NiktoReportPageProps = InferGetStaticPropsType<typeof getStaticProps>;
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const res = await fetch('/demo-data/nikto/report.json');
-        const data = await res.json();
-        setFindings(data);
-      } catch {
-        // ignore errors
-      }
-    };
-    load();
-  }, []);
-
-  const counts = useMemo(() => {
-    return findings.reduce<Record<string, number>>((acc, f) => {
-      const sev = f.severity || 'Info';
-      acc[sev] = (acc[sev] || 0) + 1;
-      return acc;
-    }, {});
-  }, [findings]);
-
-  const filtered = useMemo(
-    () =>
-      findings.filter(
-        (f) =>
-          (severity === 'All' || f.severity.toLowerCase() === severity.toLowerCase()) &&
-          f.path.toLowerCase().startsWith(pathFilter.toLowerCase())
-      ),
-    [findings, severity, pathFilter]
-  );
-
-  const exportJSON = () => {
-    const blob = new Blob([JSON.stringify(filtered, null, 2)], {
-      type: 'application/json',
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'nikto-findings.json';
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-  };
-
-  const exportCSV = () => {
-    const rows = [
-      ['Path', 'Finding', 'Severity', 'References', 'Details'],
-      ...filtered.map((f) => [
-        f.path,
-        f.finding,
-        f.severity,
-        f.references.join('; '),
-        f.details,
-      ]),
-    ];
-    const csv = rows
-      .map((r) =>
-        r.map((c) => `"${String(c).replace(/"/g, '""')}"`).join(',')
-      )
-      .join('\n');
-    const blob = new Blob([csv], { type: 'text/csv' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'nikto-findings.csv';
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-  };
+const NiktoReportPage = ({ initialData }: NiktoReportPageProps) => {
+  const severityOrder = buildSeverityList(initialData.availableSeverities);
 
   return (
-    <div className="p-4 bg-gray-900 text-white min-h-screen">
-      <h1 className="text-xl mb-4">Nikto Report</h1>
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
-        {['High', 'Medium', 'Low', 'Info'].map((sev) => (
+    <div className="min-h-screen space-y-4 bg-gray-900 p-4 text-white">
+      <h1 className="text-2xl">Nikto Report</h1>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {severityOrder.map((sev) => (
           <div
             key={sev}
-            className="bg-gray-800 p-2 rounded flex items-center justify-between"
+            className="flex items-center justify-between rounded bg-gray-800 p-2"
           >
             <span
-              className="px-2 py-0.5 rounded-full text-xs text-white"
-              style={{ backgroundColor: severityColors[sev] }}
+              className="rounded px-2 py-0.5 text-xs text-white"
+              style={{ backgroundColor: NIKTO_SEVERITY_COLORS[sev] ?? '#4b5563' }}
             >
               {sev}
             </span>
-            <span className="font-mono">{counts[sev] || 0}</span>
+            <span className="font-mono">
+              {initialData.summaryCounts[sev] ?? 0}
+            </span>
           </div>
         ))}
       </div>
-      <div className="flex space-x-2 mb-4">
-        <input
-          placeholder="Filter by path"
-          className="p-2 rounded text-black"
-          value={pathFilter}
-          onChange={(e) => setPathFilter(e.target.value)}
-        />
-        <select
-          className="p-2 rounded text-black"
-          value={severity}
-          onChange={(e) => setSeverity(e.target.value)}
-        >
-          {['All', 'Info', 'Low', 'Medium', 'High'].map((s) => (
-            <option key={s} value={s}>
-              {s}
-            </option>
-          ))}
-        </select>
-        <button
-          type="button"
-          onClick={exportJSON}
-          className="p-2 bg-blue-600 rounded"
-          aria-label="Export JSON"
-        >
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            width={24}
-            height={24}
-          >
-            <path d="M12 3v12m0 0l4-4m-4 4-4-4" />
-            <path d="M4.5 15.75v3.75A2.25 2.25 0 006.75 21h10.5A2.25 2.25 0 0019.5 19.5v-3.75" />
-          </svg>
-        </button>
-        <button
-          type="button"
-          onClick={exportCSV}
-          className="p-2 bg-blue-600 rounded"
-          aria-label="Export CSV"
-        >
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            width={24}
-            height={24}
-          >
-            <path d="M12 3v12m0 0l4-4m-4 4-4-4" />
-            <path d="M4.5 15.75v3.75A2.25 2.25 0 006.75 21h10.5A2.25 2.25 0 0019.5 19.5v-3.75" />
-          </svg>
-        </button>
-      </div>
-      <table className="w-full text-left text-sm">
-        <thead>
-          <tr className="bg-gray-700">
-            <th className="p-2">Path</th>
-            <th className="p-2">Finding</th>
-            <th className="p-2">References</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filtered.map((f) => (
-            <tr
-              key={f.path}
-              className="odd:bg-gray-800 cursor-pointer hover:bg-gray-700 border-l-4"
-              style={{ borderLeftColor: severityColors[f.severity] || '#4b5563' }}
-              onClick={() => setSelected(f)}
-            >
-              <td className="p-2">{f.path}</td>
-              <td className="p-2">{f.finding}</td>
-              <td className="p-2">{f.references.join(', ')}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      {selected && (
-        <div
-          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center"
-          onClick={() => setSelected(null)}
-        >
-          <div
-            className="bg-gray-800 p-4 rounded max-w-lg w-full"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h2 className="text-lg mb-2">{selected.path}</h2>
-            <p className="mb-2">
-              <span className="font-bold">Severity:</span> {selected.severity}
-            </p>
-            <p className="mb-2">{selected.finding}</p>
-            <p className="mb-2">
-              <span className="font-bold">References:</span>{' '}
-              {selected.references.join(', ')}
-            </p>
-            <p>{selected.details}</p>
-            <button
-              className="mt-4 px-4 py-2 bg-blue-600 rounded"
-              onClick={() => setSelected(null)}
-            >
-              Close
-            </button>
-          </div>
-        </div>
-      )}
+      <NiktoReportClient initialData={initialData} />
     </div>
   );
 };
 
-export default NiktoReport;
+export default NiktoReportPage;


### PR DESCRIPTION
## Summary
- move nikto report filtering logic into lib helpers and an API route
- update the page to render a server summary with a dedicated client island for interactive controls
- add a new NiktoReportClient component with performance instrumentation and refresh the associated test

## Testing
- yarn lint *(fails: repository has pre-existing jsx-a11y/no-top-level-window violations across multiple apps)*
- yarn test --watch=false *(fails: suite already contains failing window and API tests in main branch)*

------
https://chatgpt.com/codex/tasks/task_e_68cb52ed24c08328958ea44b3d6af2ed