### PR TITLE
[desktop] highlight focused window state

### DIFF
--- a/__tests__/__snapshots__/window.test.tsx.snap
+++ b/__tests__/__snapshots__/window.test.tsx.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Window focus affordance annotates focus state for styling hooks 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      aria-label="Focus Test"
+      class="cursor-default rounded-lg rounded-b-none z-30 window--focused opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"
+      data-focused="true"
+      id="focus-window"
+      role="dialog"
+      style="width: 60%; height: 85%;"
+      tabindex="0"
+    >
+      <div
+        class="windowYBorder cursor-[e-resize] border-transparent border-1 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
+      />
+      <div
+        class="windowXBorder cursor-[n-resize] border-transparent border-1 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
+      />
+      <div
+        aria-grabbed="false"
+        class=" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="flex justify-center w-full text-sm font-bold"
+        >
+          Focus Test
+        </div>
+      </div>
+      <div
+        class="absolute select-none right-0 top-0 mt-1 mr-1 flex justify-center items-center h-11 min-w-[8.25rem]"
+      >
+        <button
+          aria-label="Window minimize"
+          class="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+          type="button"
+        >
+          <img
+            alt="Kali window minimize"
+            class="h-4 w-4 inline"
+            data-nimg="1"
+            decoding="async"
+            height="16"
+            loading="lazy"
+            src="/themes/Yaru/window/window-minimize-symbolic.svg"
+            style="color: transparent;"
+            width="16"
+          />
+        </button>
+        <button
+          aria-label="Window maximize"
+          class="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+          type="button"
+        >
+          <img
+            alt="Kali window maximize"
+            class="h-4 w-4 inline"
+            data-nimg="1"
+            decoding="async"
+            height="16"
+            loading="lazy"
+            src="/themes/Yaru/window/window-maximize-symbolic.svg"
+            style="color: transparent;"
+            width="16"
+          />
+        </button>
+        <button
+          aria-label="Window close"
+          class="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
+          id="close-focus-window"
+          type="button"
+        >
+          <img
+            alt="Kali window close"
+            class="h-4 w-4 inline"
+            data-nimg="1"
+            decoding="async"
+            height="16"
+            loading="lazy"
+            src="/themes/Yaru/window/window-close-symbolic.svg"
+            style="color: transparent;"
+            width="16"
+          />
+        </button>
+      </div>
+      <div
+        class="w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen bg-ub-cool-grey"
+      >
+        <div>
+          content
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/__tests__/desktopFocus.test.tsx
+++ b/__tests__/desktopFocus.test.tsx
@@ -1,0 +1,35 @@
+import { Desktop } from '../components/screen/desktop';
+
+describe('Desktop focus orchestration', () => {
+  it('keeps only the requested window focused on focus swaps', () => {
+    const desktop = new Desktop();
+    desktop.state = {
+      ...desktop.state,
+      focused_windows: { app1: false, app2: true, app3: false },
+    };
+
+    const setStateSpy = jest.spyOn(desktop, 'setState').mockImplementation((update) => {
+      const nextState =
+        typeof update === 'function' ? update(desktop.state, desktop.props) : update;
+      desktop.state = {
+        ...desktop.state,
+        ...nextState,
+      };
+    });
+
+    desktop.focus('app1');
+    expect(desktop.state.focused_windows).toEqual({ app1: true, app2: false, app3: false });
+    expect(
+      Object.values(desktop.state.focused_windows).filter(Boolean)
+    ).toHaveLength(1);
+
+    desktop.focus('app2');
+    expect(desktop.state.focused_windows).toEqual({ app1: false, app2: true, app3: false });
+    expect(
+      Object.values(desktop.state.focused_windows).filter(Boolean)
+    ).toHaveLength(1);
+
+    expect(setStateSpy).toHaveBeenCalledTimes(2);
+    setStateSpy.mockRestore();
+  });
+});

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -42,6 +42,37 @@ describe('Window lifecycle', () => {
   });
 });
 
+describe('Window focus affordance', () => {
+  it('annotates focus state for styling hooks', () => {
+    const baseProps = {
+      id: 'focus-window',
+      title: 'Focus Test',
+      screen: () => <div>content</div>,
+      focus: () => {},
+      hasMinimised: () => {},
+      closed: () => {},
+      hideSideBar: () => {},
+      openApp: () => {},
+    };
+
+    const { asFragment, rerender, unmount } = render(
+      <Window {...baseProps} isFocused />
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+
+    rerender(
+      <Window {...baseProps} isFocused={false} />
+    );
+
+    expect(
+      screen.getByRole('dialog', { name: /focus test/i })
+    ).toHaveAttribute('data-focused', 'false');
+
+    unmount();
+  });
+});
+
 describe('Window snapping preview', () => {
   it('shows preview when dragged near left edge', () => {
     const ref = React.createRef<Window>();
@@ -199,7 +230,12 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({
+        key: 'ArrowDown',
+        altKey: true,
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+      } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -635,7 +635,17 @@ export class Window extends Component {
                 >
                     <div
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        className={[
+                            this.state.cursorType,
+                            this.state.closed ? "closed-window" : "",
+                            this.state.maximized ? "duration-300 rounded-none" : "rounded-lg rounded-b-none",
+                            this.props.minimized ? "opacity-0 invisible duration-200" : "",
+                            this.state.grabbed ? "opacity-70" : "",
+                            this.state.snapPreview ? "ring-2 ring-blue-400" : "",
+                            this.props.isFocused ? "z-30 window--focused" : "z-20",
+                            "opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col",
+                        ].filter(Boolean).join(" ")}
+                        data-focused={this.props.isFocused ? "true" : "false"}
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}

--- a/styles/index.css
+++ b/styles/index.css
@@ -93,10 +93,6 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     position: relative;
 }
 
-.notFocused {
-    filter: brightness(90%);
-}
-
 .root,
 #root,
 #docs-root {
@@ -105,9 +101,49 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .window-shadow {
-    box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -webkit-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -moz-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+    box-shadow: var(--window-shadow-elevation, 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%));
+    -webkit-box-shadow: var(--window-shadow-elevation, 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%));
+    -moz-box-shadow: var(--window-shadow-elevation, 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%));
+}
+
+.main-window {
+    --window-shadow-elevation: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+    --window-titlebar-bg: var(--color-ub-window-title);
+    --window-titlebar-shadow: inset 0 -1px 0 color-mix(in srgb, var(--color-inverse), transparent 85%);
+    transition:
+        filter var(--motion-medium, 300ms) ease,
+        box-shadow var(--motion-medium, 300ms) ease,
+        outline var(--motion-medium, 300ms) ease;
+    outline: 0 solid transparent;
+    will-change: filter, box-shadow;
+}
+
+.main-window .bg-ub-window-title {
+    background-color: var(--window-titlebar-bg);
+    box-shadow: var(--window-titlebar-shadow);
+    transition:
+        background-color var(--motion-fast, 150ms) ease,
+        box-shadow var(--motion-fast, 150ms) ease;
+}
+
+.main-window.window--focused,
+.main-window[data-focused="true"] {
+    --window-shadow-elevation:
+        0 0 0 1px color-mix(in srgb, var(--color-primary) 60%, transparent 40%),
+        0 0 0 6px color-mix(in srgb, var(--color-primary) 25%, transparent 75%),
+        0 18px 48px -16px color-mix(in srgb, var(--color-primary) 45%, transparent 82%);
+    --window-titlebar-bg: color-mix(in srgb, var(--color-primary) 65%, var(--color-ub-window-title) 35%);
+    --window-titlebar-shadow: inset 0 -1px 0 color-mix(in srgb, var(--color-primary) 45%, transparent 55%);
+    filter: brightness(1);
+}
+
+.main-window[data-focused="false"] {
+    --window-shadow-elevation:
+        0 6px 22px -16px color-mix(in srgb, var(--color-inverse) 55%, transparent 85%),
+        0 0 0 1px color-mix(in srgb, var(--color-inverse) 60%, transparent 92%);
+    --window-titlebar-bg: color-mix(in srgb, var(--color-ub-window-title) 85%, transparent 15%);
+    --window-titlebar-shadow: inset 0 -1px 0 color-mix(in srgb, var(--color-inverse), transparent 92%);
+    filter: brightness(0.82) saturate(0.92);
 }
 
 .closed-window {


### PR DESCRIPTION
## Summary
- expose a deterministic `window--focused` class and `data-focused` flag from the base window component for styling
- refresh global window styling to add an accent glow, elevated shadow, and muted unfocused treatment
- extend desktop/window unit tests with focus orchestration coverage and a snapshot for the focused affordance

## Testing
- yarn test --runTestsByPath __tests__/window.test.tsx __tests__/desktopFocus.test.tsx --runInBand
- yarn lint *(fails: repository has existing jsx-a11y and no-top-level-window violations outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb5439825c83289c51f4aaedc0fc17