### PR TITLE
[desktop] sanitize persisted window bounds

### DIFF
--- a/__tests__/desktopWindowBounds.test.ts
+++ b/__tests__/desktopWindowBounds.test.ts
@@ -1,0 +1,44 @@
+import { Desktop } from '../components/screen/desktop';
+
+describe('Desktop.validateWindowBounds', () => {
+  let desktop: Desktop;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 1200,
+      writable: true,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 800,
+      writable: true,
+    });
+    desktop = new Desktop();
+  });
+
+  it('returns a centered fallback rectangle for invalid input', () => {
+    const rect = desktop.validateWindowBounds(null);
+    expect(rect).toEqual({ x: 180, y: 120, width: 840, height: 560 });
+  });
+
+  it('parses numeric strings within viewport bounds', () => {
+    const rect = desktop.validateWindowBounds({
+      x: '100',
+      y: '200',
+      width: '300',
+      height: '250',
+    });
+    expect(rect).toEqual({ x: 100, y: 200, width: 300, height: 250 });
+  });
+
+  it('falls back when values exceed the viewport', () => {
+    const rect = desktop.validateWindowBounds({
+      x: 5000,
+      y: 4000,
+      width: 3000,
+      height: 2000,
+    });
+    expect(rect).toEqual({ x: 180, y: 120, width: 840, height: 560 });
+  });
+});

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -5,6 +5,8 @@ export interface SessionWindow {
   id: string;
   x: number;
   y: number;
+  width?: number;
+  height?: number;
 }
 
 export interface DesktopSession {


### PR DESCRIPTION
## Summary
- add a helper in Desktop to validate persisted window rectangles and fall back to a centered 70% default when values are invalid
- sanitize positions before saving session data so corrupted coordinates are not re-written
- cover the validator with unit tests and extend the session window type to support optional width/height values

## Testing
- yarn lint *(fails: repository has numerous pre-existing accessibility lint violations)*
- yarn test *(fails: existing suites continue to fail and the run was stopped after an extended duration; new validator tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68cb5438771c8328afcdb20a78dcffe7