### PR TITLE
[desktop] add tiling helper and API

### DIFF
--- a/__tests__/windowLayout.test.ts
+++ b/__tests__/windowLayout.test.ts
@@ -1,0 +1,69 @@
+import { computeWindowLayout } from '../utils/windowLayout';
+
+describe('computeWindowLayout', () => {
+  it('returns an empty map when no windows are provided', () => {
+    expect(computeWindowLayout([], 'horizontal')).toEqual({});
+  });
+
+  it('tiles windows horizontally with even spacing', () => {
+    const ids = ['one', 'two', 'three', 'four'];
+    const layout = computeWindowLayout(ids, 'horizontal');
+
+    const firstWidth = layout[ids[0]].width;
+    ids.forEach((id) => {
+      expect(layout[id].width).toBeCloseTo(firstWidth, 5);
+      expect(layout[id].height).toBeCloseTo(1, 5);
+      expect(layout[id].y).toBeCloseTo(0, 5);
+    });
+
+    for (let i = 0; i < ids.length - 1; i += 1) {
+      const current = layout[ids[i]];
+      const next = layout[ids[i + 1]];
+      expect(next.x - current.x).toBeCloseTo(firstWidth, 5);
+    }
+  });
+
+  it('tiles windows vertically with even spacing', () => {
+    const ids = ['alpha', 'beta', 'gamma'];
+    const layout = computeWindowLayout(ids, 'vertical');
+
+    const firstHeight = layout[ids[0]].height;
+    ids.forEach((id) => {
+      expect(layout[id].height).toBeCloseTo(firstHeight, 5);
+      expect(layout[id].width).toBeCloseTo(1, 5);
+      expect(layout[id].x).toBeCloseTo(0, 5);
+    });
+
+    for (let i = 0; i < ids.length - 1; i += 1) {
+      const current = layout[ids[i]];
+      const next = layout[ids[i + 1]];
+      expect(next.y - current.y).toBeCloseTo(firstHeight, 5);
+    }
+  });
+
+  it('respects uniform margins in the layout', () => {
+    const ids = ['left', 'right'];
+    const margin = 0.05;
+    const layout = computeWindowLayout(ids, 'horizontal', { margin });
+
+    const expectedWidth = (1 - margin * 2) / ids.length;
+    expect(layout[ids[0]].x).toBeCloseTo(margin, 5);
+    expect(layout[ids[0]].width).toBeCloseTo(expectedWidth, 5);
+    expect(layout[ids[0]].height).toBeCloseTo(1 - margin * 2, 5);
+    expect(layout[ids[1]].x + layout[ids[1]].width).toBeCloseTo(1 - margin, 5);
+  });
+
+  it('supports directional margins', () => {
+    const ids = ['top', 'bottom'];
+    const layout = computeWindowLayout(ids, 'vertical', {
+      margin: { top: 0.1, bottom: 0.05, left: 0.02, right: 0.03 },
+    });
+
+    const expectedHeight = (1 - 0.1 - 0.05) / ids.length;
+    expect(layout[ids[0]].y).toBeCloseTo(0.1, 5);
+    expect(layout[ids[0]].height).toBeCloseTo(expectedHeight, 5);
+    expect(layout[ids[0]].x).toBeCloseTo(0.02, 5);
+    expect(layout[ids[0]].width).toBeCloseTo(1 - 0.02 - 0.03, 5);
+    expect(layout[ids[1]].y + layout[ids[1]].height).toBeCloseTo(1 - 0.05, 5);
+  });
+});

--- a/utils/windowLayout.ts
+++ b/utils/windowLayout.ts
@@ -1,0 +1,101 @@
+export type LayoutDirection = 'horizontal' | 'vertical';
+
+export type LayoutMargins = {
+  top?: number;
+  right?: number;
+  bottom?: number;
+  left?: number;
+};
+
+export interface LayoutOptions {
+  margin?: number | LayoutMargins;
+  gap?: number;
+}
+
+export interface NormalizedRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+};
+
+const sanitize = (value: number | undefined): number => {
+  if (value === undefined || !Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, value);
+};
+
+const resolveMargins = (margin?: number | LayoutMargins): Required<LayoutMargins> => {
+  if (typeof margin === 'number') {
+    const sanitized = sanitize(margin);
+    return { top: sanitized, right: sanitized, bottom: sanitized, left: sanitized };
+  }
+  return {
+    top: sanitize(margin?.top),
+    right: sanitize(margin?.right),
+    bottom: sanitize(margin?.bottom),
+    left: sanitize(margin?.left),
+  };
+};
+
+export const computeWindowLayout = (
+  ids: string[],
+  direction: LayoutDirection,
+  options: LayoutOptions = {}
+): Record<string, NormalizedRect> => {
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return {};
+  }
+  if (direction !== 'horizontal' && direction !== 'vertical') {
+    throw new Error(`Unsupported layout direction: ${direction}`);
+  }
+
+  const margins = resolveMargins(options.margin);
+  const gap = sanitize(options.gap);
+  const count = ids.length;
+  const result: Record<string, NormalizedRect> = {};
+
+  if (direction === 'horizontal') {
+    const availableWidth = Math.max(0, 1 - margins.left - margins.right - gap * (count - 1));
+    const width = count > 0 ? availableWidth / count : 0;
+    const height = Math.max(0, 1 - margins.top - margins.bottom);
+    const maxXStart = Math.max(0, 1 - width);
+
+    ids.forEach((id, index) => {
+      const xStart = margins.left + index * (width + gap);
+      result[id] = {
+        x: clamp(xStart, 0, maxXStart),
+        y: clamp(margins.top, 0, Math.max(0, 1 - height)),
+        width: clamp(width, 0, Math.max(0, 1 - margins.left - margins.right)),
+        height,
+      };
+    });
+  } else {
+    const availableHeight = Math.max(0, 1 - margins.top - margins.bottom - gap * (count - 1));
+    const height = count > 0 ? availableHeight / count : 0;
+    const width = Math.max(0, 1 - margins.left - margins.right);
+    const maxYStart = Math.max(0, 1 - height);
+
+    ids.forEach((id, index) => {
+      const yStart = margins.top + index * (height + gap);
+      result[id] = {
+        x: clamp(margins.left, 0, Math.max(0, 1 - width)),
+        y: clamp(yStart, 0, maxYStart),
+        width,
+        height: clamp(height, 0, Math.max(0, 1 - margins.top - margins.bottom)),
+      };
+    });
+  }
+
+  return result;
+};


### PR DESCRIPTION
## Summary
- add a windowLayout utility that returns normalized rectangles for horizontal and vertical tiling
- track window refs inside Desktop and expose a tileWindows method that applies the computed geometry while clamping to the viewport
- cover the helper with unit tests to validate even spacing and margin handling

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window rules across legacy apps)*
- yarn test --runTestsByPath __tests__/windowLayout.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cb54365cbc8328851effc826fd7df0