### PR TITLE
[desktop] add window context menu

### DIFF
--- a/__tests__/windowContextMenu.test.tsx
+++ b/__tests__/windowContextMenu.test.tsx
@@ -1,0 +1,159 @@
+import { Desktop } from '../components/screen/desktop'
+
+jest.mock('react-ga4', () => ({ event: jest.fn(), send: jest.fn() }))
+
+function syncSetState(instance: any) {
+    instance.setState = (update: any, callback?: () => void) => {
+        const nextState = typeof update === 'function' ? update(instance.state, instance.props) : update
+        instance.state = { ...instance.state, ...nextState }
+        if (callback) callback()
+    }
+}
+
+function createDesktop(): any {
+    const desktop = new Desktop()
+    syncSetState(desktop)
+    desktop.props = { snapEnabled: true, clearSession: jest.fn() } as any
+    return desktop
+}
+
+describe('Desktop window context menu', () => {
+    afterEach(() => {
+        document.body.innerHTML = ''
+        jest.clearAllMocks()
+    })
+
+    it('opens window context menu on right click', () => {
+        const desktop = createDesktop()
+        desktop.showContextMenu = jest.fn()
+
+        const target = document.createElement('div')
+        target.dataset.context = 'window'
+        target.dataset.appId = 'demo-app'
+        document.body.appendChild(target)
+
+        const event = {
+            preventDefault: jest.fn(),
+            target,
+            pageX: 10,
+            pageY: 20,
+        } as any
+
+        desktop.checkContextMenu(event)
+
+        expect(event.preventDefault).toHaveBeenCalled()
+        expect(desktop.state.context_app).toBe('demo-app')
+        expect(desktop.showContextMenu).toHaveBeenCalledWith(event, 'window')
+    })
+
+    it('opens window context menu via Shift+F10', () => {
+        const desktop = createDesktop()
+        desktop.showContextMenu = jest.fn()
+
+        const target = document.createElement('div')
+        target.dataset.context = 'window'
+        target.dataset.appId = 'demo-app'
+        target.getBoundingClientRect = () => ({ left: 15, top: 25, height: 30, width: 40, right: 55, bottom: 65 }) as any
+        document.body.appendChild(target)
+
+        const event = {
+            shiftKey: true,
+            key: 'F10',
+            preventDefault: jest.fn(),
+            target,
+        } as any
+
+        desktop.handleContextKey(event)
+
+        expect(event.preventDefault).toHaveBeenCalled()
+        expect(desktop.state.context_app).toBe('demo-app')
+        const showMenuMock = desktop.showContextMenu as jest.Mock
+        expect(showMenuMock).toHaveBeenCalled()
+        const [, menuName] = showMenuMock.mock.calls[0]
+        expect(menuName).toBe('window')
+    })
+
+    it('invokes window helpers for context actions', () => {
+        const desktop = createDesktop()
+        const windowInstance = {
+            changeCursorToMove: jest.fn(),
+            focusWindow: jest.fn(),
+            minimizeWindow: jest.fn(),
+            maximizeWindow: jest.fn(),
+            snapWindow: jest.fn(),
+            unsnapWindow: jest.fn(),
+            closeWindow: jest.fn(),
+            state: { maximized: false, snapped: null },
+            props: { allowMaximize: true, resizable: true },
+        } as any
+
+        desktop.windowRefs['about-alex'] = windowInstance
+        desktop.state.context_app = 'about-alex'
+        desktop.state.minimized_windows['about-alex'] = false
+        desktop.openApp = jest.fn()
+
+        const root = document.createElement('div')
+        root.id = 'about-alex'
+        root.tabIndex = 0
+        root.focus = jest.fn()
+        const title = document.createElement('div')
+        title.className = 'bg-ub-window-title'
+        title.tabIndex = 0
+        title.focus = jest.fn()
+        root.appendChild(title)
+        document.body.appendChild(root)
+
+        desktop.handleWindowMenuAction('move')
+        expect(windowInstance.changeCursorToMove).toHaveBeenCalled()
+        expect(windowInstance.focusWindow).toHaveBeenCalled()
+        expect(title.focus).toHaveBeenCalled()
+
+        windowInstance.focusWindow.mockClear()
+        windowInstance.unsnapWindow.mockClear()
+        root.focus.mockClear()
+        windowInstance.state.snapped = 'left'
+        desktop.handleWindowMenuAction('resize')
+        expect(windowInstance.unsnapWindow).toHaveBeenCalled()
+        expect(windowInstance.focusWindow).toHaveBeenCalled()
+        expect(root.focus).toHaveBeenCalled()
+
+        windowInstance.minimizeWindow.mockClear()
+        desktop.state.minimized_windows['about-alex'] = false
+        desktop.handleWindowMenuAction('minimize')
+        expect(windowInstance.minimizeWindow).toHaveBeenCalled()
+
+        windowInstance.minimizeWindow.mockClear()
+        desktop.state.minimized_windows['about-alex'] = true
+        desktop.handleWindowMenuAction('minimize')
+        expect(desktop.openApp).toHaveBeenCalledWith('about-alex')
+
+        desktop.handleWindowMenuAction('maximize')
+        expect(windowInstance.maximizeWindow).toHaveBeenCalled()
+
+        windowInstance.snapWindow.mockClear()
+        windowInstance.state.snapped = null
+        desktop.handleWindowMenuAction('snap-left')
+        expect(windowInstance.snapWindow).toHaveBeenCalledWith('left')
+
+        windowInstance.snapWindow.mockClear()
+        windowInstance.unsnapWindow.mockClear()
+        windowInstance.state.snapped = 'left'
+        desktop.handleWindowMenuAction('snap-left')
+        expect(windowInstance.unsnapWindow).toHaveBeenCalled()
+
+        windowInstance.unsnapWindow.mockClear()
+        windowInstance.snapWindow.mockClear()
+        windowInstance.state.snapped = 'right'
+        desktop.handleWindowMenuAction('snap-right')
+        expect(windowInstance.unsnapWindow).toHaveBeenCalled()
+
+        windowInstance.unsnapWindow.mockClear()
+        windowInstance.snapWindow.mockClear()
+        windowInstance.state.snapped = null
+        desktop.handleWindowMenuAction('snap-right')
+        expect(windowInstance.snapWindow).toHaveBeenCalledWith('right')
+
+        desktop.handleWindowMenuAction('close')
+        expect(windowInstance.closeWindow).toHaveBeenCalled()
+    })
+})

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -641,10 +641,13 @@ export class Window extends Component {
                         aria-label={this.props.title}
                         tabIndex={0}
                         onKeyDown={this.handleKeyDown}
+                        data-context="window"
+                        data-app-id={this.id}
                     >
                         {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} />}
                         {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}
                         <WindowTopBar
+                            id={this.id}
                             title={this.props.title}
                             onKeyDown={this.handleTitleBarKeyDown}
                             onBlur={this.releaseGrab}
@@ -674,7 +677,7 @@ export class Window extends Component {
 export default Window
 
 // Window's title bar
-export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
+export function WindowTopBar({ id, title, onKeyDown, onBlur, grabbed }) {
     return (
         <div
             className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
@@ -683,6 +686,8 @@ export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
             aria-grabbed={grabbed}
             onKeyDown={onKeyDown}
             onBlur={onBlur}
+            data-context="window"
+            data-app-id={id}
         >
             <div className="flex justify-center w-full text-sm font-bold">{title}</div>
         </div>

--- a/components/context-menus/window-menu.js
+++ b/components/context-menus/window-menu.js
@@ -1,0 +1,88 @@
+import React, { useRef } from 'react'
+import useFocusTrap from '../../hooks/useFocusTrap'
+import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+
+function WindowMenu(props) {
+    const menuRef = useRef(null)
+    useFocusTrap(menuRef, props.active)
+    useRovingTabIndex(menuRef, props.active, 'vertical')
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            props.onCloseMenu && props.onCloseMenu()
+        }
+    }
+
+    const handleAction = (callback) => () => {
+        if (typeof callback === 'function') {
+            callback()
+        }
+        props.onCloseMenu && props.onCloseMenu()
+    }
+
+    const renderItem = (label, ariaLabel, onClick, disabled = false) => {
+        const keyValue = `${ariaLabel}-${label}`
+        if (disabled) {
+            return (
+                <div
+                    key={keyValue}
+                    role="menuitem"
+                    aria-disabled="true"
+                    className="w-full py-0.5 hover:bg-gray-700 mb-1.5 text-gray-400"
+                >
+                    <span className="ml-5">{label}</span>
+                </div>
+            )
+        }
+
+        return (
+            <button
+                key={keyValue}
+                type="button"
+                onClick={handleAction(onClick)}
+                role="menuitem"
+                aria-label={ariaLabel}
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">{label}</span>
+            </button>
+        )
+    }
+
+    return (
+        <div
+            id="window-menu"
+            role="menu"
+            aria-label="Window context menu"
+            aria-hidden={!props.active}
+            ref={menuRef}
+            onKeyDown={handleKeyDown}
+            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+        >
+            {renderItem('Move', 'Move Window', props.onMove, !props.canMove)}
+            {renderItem('Resize', 'Resize Window', props.onResize, !props.canResize)}
+            <Divider />
+            {renderItem(props.isMinimized ? 'Restore' : 'Minimize', props.isMinimized ? 'Restore Window' : 'Minimize Window', props.onMinimize)}
+            {props.allowMaximize !== false && renderItem(props.isMaximized ? 'Restore' : 'Maximize', props.isMaximized ? 'Restore Window' : 'Maximize Window', props.onMaximize)}
+            {props.snapEnabled && (
+                <>
+                    <Divider />
+                    {renderItem(props.snapped === 'left' ? 'Unsnap from Left' : 'Snap Left', props.snapped === 'left' ? 'Unsnap Window from Left' : 'Snap Window Left', props.onSnapLeft, !props.canSnapLeft)}
+                    {renderItem(props.snapped === 'right' ? 'Unsnap from Right' : 'Snap Right', props.snapped === 'right' ? 'Unsnap Window from Right' : 'Snap Window Right', props.onSnapRight, !props.canSnapRight)}
+                </>
+            )}
+            <Divider />
+            {renderItem('Close', 'Close Window', props.onClose)}
+        </div>
+    )
+}
+
+function Divider() {
+    return (
+        <div className="flex justify-center w-full">
+            <div className=" border-t border-gray-900 py-1 w-2/5"></div>
+        </div>
+    )
+}
+
+export default WindowMenu


### PR DESCRIPTION
## Summary
- add window data attributes so Desktop can recognize window/titlebar context targets
- teach Desktop to track window instances, surface a window context menu, and wire actions to the existing helpers
- introduce a dedicated window context menu component plus tests covering right-click, Shift+F10, and action routing

## Testing
- yarn test windowContextMenu.test.tsx
- yarn lint *(fails: existing jsx-a11y/no-top-level-window violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb543424d483289e82f084fd968625