### PR TITLE
[desktop] Add edge collision feedback

### DIFF
--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -7,3 +7,29 @@
   height: calc(100% + 10px);
   width: calc(100% - 10px);
 }
+
+.edgeFeedback::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  border: 2px solid rgba(112, 202, 255, 0.55);
+  box-shadow: inset 0 0 12px rgba(112, 202, 255, 0.35);
+  opacity: 0;
+  animation: edgeFeedbackPulse 200ms ease-out;
+}
+
+@keyframes edgeFeedbackPulse {
+  0% {
+    opacity: 0;
+  }
+
+  35% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- add an edge feedback helper that decorates windows with a transient pulse class when drag or resize hits a boundary
- extend drag and resize handlers (including keyboard resizing) to invoke the feedback helper
- define the glow animation in the window stylesheet and cover the behaviour with new unit tests

## Testing
- not run (node/yarn binaries unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68cb54351e3483288e9aee4d96d70f94