### PR TITLE
[accessibility] Sync high-contrast theme detection

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -1,13 +1,54 @@
 import { renderHook, act } from '@testing-library/react';
 import { SettingsProvider, useSettings } from '../hooks/useSettings';
-import { getTheme, getUnlockedThemes, setTheme } from '../utils/theme';
+import {
+  applyHighContrastPreference,
+  getTheme,
+  getUnlockedThemes,
+  setTheme,
+} from '../utils/theme';
 
 
 describe('theme persistence and unlocking', () => {
   beforeEach(() => {
+    const store: Record<string, string> = {};
+    const localStorageMock: Storage = {
+      getItem: (key: string) => (key in store ? store[key] : null),
+      setItem: (key: string, value: string) => {
+        store[key] = String(value);
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        Object.keys(store).forEach((key) => delete store[key]);
+      },
+      key: (index: number) => Object.keys(store)[index] ?? null,
+      get length() {
+        return Object.keys(store).length;
+      },
+    };
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      configurable: true,
+      writable: true,
+    });
     window.localStorage.clear();
+    // @ts-ignore provide default stub
+    window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
     document.documentElement.dataset.theme = '';
     document.documentElement.className = '';
+    document.documentElement.dataset.colorScheme = '';
+    document.documentElement.dataset.contrast = '';
+    document.documentElement.style.colorScheme = '';
   });
 
   test('theme persists across sessions', () => {
@@ -59,6 +100,16 @@ describe('theme persistence and unlocking', () => {
     ).toBe('red');
   });
 
+  test('setTheme maps to color-scheme tokens', () => {
+    setTheme('dark');
+    expect(document.documentElement.style.colorScheme).toBe('dark');
+    expect(document.documentElement.dataset.colorScheme).toBe('dark');
+
+    setTheme('default');
+    expect(document.documentElement.style.colorScheme).toBe('light');
+    expect(document.documentElement.dataset.colorScheme).toBe('light');
+  });
+
   test('defaults to system preference when no stored theme', () => {
     // simulate dark mode preference
     // @ts-ignore
@@ -68,5 +119,61 @@ describe('theme persistence and unlocking', () => {
     // @ts-ignore
     window.matchMedia = jest.fn().mockReturnValue({ matches: false });
     expect(getTheme()).toBe('default');
+  });
+
+  test('high contrast tokens respond to prefers-contrast media query', () => {
+    const originalMatchMedia = window.matchMedia;
+    // @ts-ignore
+    window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+      matches: query.includes('prefers-contrast: more'),
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+
+    const style = document.createElement('style');
+    style.innerHTML = `
+      :root { --color-bg: white; --color-text: black; }
+      .high-contrast { --color-bg: black; --color-text: white; }
+    `;
+    document.head.appendChild(style);
+
+    window.localStorage.removeItem('high-contrast');
+    const enabled = applyHighContrastPreference();
+    expect(enabled).toBe(true);
+    expect(document.documentElement.classList.contains('high-contrast')).toBe(true);
+    const computed = getComputedStyle(document.documentElement);
+    expect(computed.getPropertyValue('--color-bg').trim()).toBe('black');
+    expect(computed.getPropertyValue('--color-text').trim()).toBe('white');
+
+    document.head.removeChild(style);
+    window.matchMedia = originalMatchMedia;
+  });
+
+  test('manual contrast override beats system preference', () => {
+    const originalMatchMedia = window.matchMedia;
+    window.localStorage.setItem('high-contrast', 'false');
+    // @ts-ignore
+    window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+      matches: query.includes('prefers-contrast: more'),
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+
+    const enabled = applyHighContrastPreference();
+    expect(enabled).toBe(false);
+    expect(document.documentElement.classList.contains('high-contrast')).toBe(false);
+    expect(document.documentElement.dataset.contrast).toBe('standard');
+
+    window.matchMedia = originalMatchMedia;
   });
 });

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -73,7 +73,15 @@ export async function setFontScale(scale) {
 
 export async function getHighContrast() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
-  return window.localStorage.getItem('high-contrast') === 'true';
+  const stored = window.localStorage.getItem('high-contrast');
+  if (stored !== null) {
+    return stored === 'true';
+  }
+  try {
+    return window.matchMedia?.('(prefers-contrast: more)').matches ?? false;
+  } catch (e) {
+    return DEFAULT_SETTINGS.highContrast;
+  }
 }
 
 export async function setHighContrast(value) {

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -1,4 +1,6 @@
 export const THEME_KEY = 'app:theme';
+const HIGH_CONTRAST_KEY = 'high-contrast';
+const DEFAULT_THEME = 'default';
 
 // Score required to unlock each theme
 export const THEME_UNLOCKS: Record<string, number> = {
@@ -10,20 +12,68 @@ export const THEME_UNLOCKS: Record<string, number> = {
 
 const DARK_THEMES = ['dark', 'neon', 'matrix'] as const;
 
+const getStoredContrastPreference = (): boolean | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const storage = window.localStorage;
+    if (!storage) return null;
+    const stored = storage.getItem(HIGH_CONTRAST_KEY);
+    if (stored === null) return null;
+    return stored === 'true';
+  } catch {
+    return null;
+  }
+};
+
+const prefers = (query: string): boolean => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  try {
+    return window.matchMedia(query).matches;
+  } catch {
+    return false;
+  }
+};
+
+const applyDocumentTheme = (theme: string): void => {
+  if (typeof document === 'undefined') return;
+  const isDark = isDarkTheme(theme);
+  const colorScheme = isDark ? 'dark' : 'light';
+  document.documentElement.dataset.theme = theme;
+  document.documentElement.classList.toggle('dark', isDark);
+  document.documentElement.style.colorScheme = colorScheme;
+  document.documentElement.dataset.colorScheme = colorScheme;
+};
+
 export const isDarkTheme = (theme: string): boolean =>
   DARK_THEMES.includes(theme as (typeof DARK_THEMES)[number]);
 
+export const resolveHighContrastPreference = (): boolean => {
+  const stored = getStoredContrastPreference();
+  if (stored !== null) return stored;
+  return prefers('(prefers-contrast: more)');
+};
+
+export const applyHighContrastPreference = (override?: boolean): boolean => {
+  const shouldEnable =
+    typeof override === 'boolean' ? override : resolveHighContrastPreference();
+  if (typeof document !== 'undefined') {
+    document.documentElement.classList.toggle('high-contrast', shouldEnable);
+    document.documentElement.dataset.contrast = shouldEnable ? 'high' : 'standard';
+  }
+  return shouldEnable;
+};
+
 export const getTheme = (): string => {
-  if (typeof window === 'undefined') return 'default';
+  if (typeof window === 'undefined') return DEFAULT_THEME;
   try {
     const stored = window.localStorage.getItem(THEME_KEY);
     if (stored) return stored;
-    const prefersDark = window.matchMedia?.(
-      '(prefers-color-scheme: dark)'
-    ).matches;
-    return prefersDark ? 'dark' : 'default';
+    const prefersDark = prefers('(prefers-color-scheme: dark)');
+    return prefersDark ? 'dark' : DEFAULT_THEME;
   } catch {
-    return 'default';
+    return DEFAULT_THEME;
   }
 };
 
@@ -31,11 +81,11 @@ export const setTheme = (theme: string): void => {
   if (typeof window === 'undefined') return;
   try {
     window.localStorage.setItem(THEME_KEY, theme);
-    document.documentElement.dataset.theme = theme;
-    document.documentElement.classList.toggle('dark', isDarkTheme(theme));
   } catch {
     /* ignore storage errors */
   }
+  applyDocumentTheme(theme);
+  applyHighContrastPreference();
 };
 
 export const getUnlockedThemes = (highScore: number): string[] =>


### PR DESCRIPTION
## Summary
- detect prefers-contrast during the pre-paint theme bootstrap and map themes onto data attributes and color-scheme
- centralize high-contrast resolution logic in theme utilities and fall back to system preferences when no manual override exists
- extend the theme persistence test suite with high-contrast coverage and localStorage/matchMedia stubs

## Testing
- yarn test --runTestsByPath __tests__/themePersistence.test.ts
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb543062d483288d387cd56386d319