### PR TITLE
[desktop] improve window minimize handling

### DIFF
--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,47 +1,70 @@
 import React from 'react';
 import Image from 'next/image';
 
-export default function Taskbar(props) {
-    const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+export default function Taskbar({
+    apps,
+    closed_windows,
+    minimized_windows,
+    focused_windows,
+    openApp,
+    requestMinimize,
+}) {
+    const runningApps = apps.filter(app => closed_windows[app.id] === false);
 
     const handleClick = (app) => {
         const id = app.id;
-        if (props.minimized_windows[id]) {
-            props.openApp(id);
-        } else if (props.focused_windows[id]) {
-            props.minimize(id);
+        if (minimized_windows[id]) {
+            openApp(id);
+        } else if (focused_windows[id]) {
+            requestMinimize(id);
         } else {
-            props.openApp(id);
+            openApp(id);
         }
     };
 
     return (
         <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => (
-                <button
-                    key={app.id}
-                    type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
-                    onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
-                    />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
-                </button>
-            ))}
+            {runningApps.map(app => {
+                const id = app.id;
+                const isMinimized = minimized_windows[id];
+                const isFocused = focused_windows[id] && !isMinimized;
+                const buttonClasses = [
+                    'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'
+                ];
+                if (isFocused) {
+                    buttonClasses.push('bg-white bg-opacity-20');
+                } else if (isMinimized) {
+                    buttonClasses.push('opacity-70');
+                }
+                const indicatorClass = isMinimized
+                    ? 'bg-white bg-opacity-40'
+                    : 'bg-white';
+
+                return (
+                    <button
+                        key={id}
+                        type="button"
+                        aria-label={app.title}
+                        aria-pressed={isFocused}
+                        data-context="taskbar"
+                        data-app-id={id}
+                        data-state={isFocused ? 'active' : isMinimized ? 'minimized' : 'background'}
+                        onClick={() => handleClick(app)}
+                        className={buttonClasses.join(' ')}
+                    >
+                        <Image
+                            width={24}
+                            height={24}
+                            className="w-5 h-5"
+                            src={app.icon.replace('./', '/')}
+                            alt=""
+                            sizes="24px"
+                        />
+                        <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                        <span className={`absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 rounded ${indicatorClass}`} />
+                    </button>
+                );
+            })}
         </div>
     );
 }

--- a/tests/window-minimize.spec.ts
+++ b/tests/window-minimize.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('window minimize and restore', () => {
+  test('restores geometry and focus via taskbar', async ({ page }) => {
+    test.setTimeout(120000);
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 60000 });
+
+    await page.waitForFunction(() => !!document.getElementById('desktop'), null, {
+      timeout: 120000,
+    });
+
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent('open-app', { detail: 'input-lab' }));
+    });
+
+    const windowLocator = page.locator('#input-lab');
+    await expect(windowLocator).toBeVisible({ timeout: 60000 });
+
+    const beforeBounds = await windowLocator.boundingBox();
+    expect(beforeBounds).not.toBeNull();
+
+    const input = windowLocator.locator('#input-lab-text');
+    await input.fill('Minimize Test');
+
+    await windowLocator.locator('button[aria-label="Window minimize"]').click();
+
+    await expect(windowLocator).not.toBeVisible();
+
+    const activeTaskbarButton = page.locator('button[data-state="active"]');
+    await expect(activeTaskbarButton).toHaveCount(1);
+    const activeAppId = await activeTaskbarButton.first().getAttribute('data-app-id');
+    expect(activeAppId).toBeTruthy();
+    expect(activeAppId).not.toBe('input-lab');
+    if (activeAppId) {
+      const activeWindow = page.locator(`#${activeAppId}`);
+      await expect(activeWindow).toHaveClass(/z-30/);
+    }
+
+    const taskbarButton = page.locator('button[data-app-id="input-lab"]');
+    await expect(taskbarButton).toHaveAttribute('data-state', 'minimized');
+
+    await taskbarButton.click();
+
+    await expect(windowLocator).toBeVisible();
+    await expect(windowLocator).toHaveClass(/z-30/);
+    await expect(taskbarButton).toHaveAttribute('data-state', 'active');
+    await expect(input).toHaveValue('Minimize Test');
+
+    const afterBounds = await windowLocator.boundingBox();
+    expect(afterBounds).not.toBeNull();
+    if (beforeBounds && afterBounds) {
+      expect(afterBounds.width).toBeCloseTo(beforeBounds.width, 1);
+      expect(afterBounds.height).toBeCloseTo(beforeBounds.height, 1);
+      expect(afterBounds.x).toBeCloseTo(beforeBounds.x, 1);
+      expect(afterBounds.y).toBeCloseTo(beforeBounds.y, 1);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- store minimized window geometry in the window component and hide the DOM node instead of animating to the dock
- keep minimized window state in the desktop manager so taskbar entries can toggle minimize and restore correctly
- render taskbar buttons with explicit minimized/active states and add a Playwright test that covers minimize and taskbar restore

## Testing
- yarn lint *(fails: repository has hundreds of pre-existing accessibility and window globals violations)*
- yarn test *(fails: multiple unrelated suites already failing in the repo)*
- npx playwright test tests/window-minimize.spec.ts --reporter=list *(fails: desktop bundle does not finish loading within the test timeout in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb542e18608328b1aeb56bc7314e35