### PR TITLE
[desktop] maintain window stacking order

### DIFF
--- a/__tests__/desktopFocus.test.tsx
+++ b/__tests__/desktopFocus.test.tsx
@@ -1,0 +1,99 @@
+import { Desktop } from '../components/screen/desktop';
+
+type WindowId = string;
+
+function createDesktop(windowIds: WindowId[]) {
+  const desktop = new Desktop({ snapEnabled: false });
+  const focused_windows: Record<WindowId, boolean> = {};
+  const closed_windows: Record<WindowId, boolean> = {};
+  const minimized_windows: Record<WindowId, boolean> = {};
+  const overlapped_windows: Record<WindowId, boolean> = {};
+  const window_z_indexes: Record<WindowId, number> = {};
+
+  windowIds.forEach((id) => {
+    focused_windows[id] = false;
+    closed_windows[id] = false;
+    minimized_windows[id] = false;
+    overlapped_windows[id] = false;
+    window_z_indexes[id] = 0;
+  });
+
+  desktop.state = {
+    ...desktop.state,
+    focused_windows,
+    closed_windows,
+    minimized_windows,
+    overlapped_windows,
+    window_z_indexes,
+  };
+
+  desktop.setState = (update: any, callback?: () => void) => {
+    const nextState =
+      typeof update === 'function' ? update(desktop.state) : update;
+    desktop.state = { ...desktop.state, ...nextState };
+    if (typeof callback === 'function') {
+      callback();
+    }
+  };
+
+  desktop.app_stack = [...windowIds];
+  return desktop;
+}
+
+describe('Desktop window z-index management', () => {
+  test('mouse focus raises the active window', () => {
+    const desktop = createDesktop(['app1', 'app2']);
+
+    desktop.focus('app1');
+    const firstZ = desktop.state.window_z_indexes.app1;
+    expect(firstZ).toBeGreaterThan(0);
+
+    desktop.focus('app2');
+    expect(desktop.state.window_z_indexes.app2).toBeGreaterThan(firstZ);
+    expect(desktop.state.focused_windows.app2).toBe(true);
+    expect(desktop.state.focused_windows.app1).toBe(false);
+  });
+
+  test('keyboard cycling promotes the next non-minimized window', () => {
+    const desktop = createDesktop(['app1', 'app2', 'app3']);
+
+    desktop.focus('app1');
+    const zBeforeCycle = desktop.state.window_z_indexes.app1;
+    expect(zBeforeCycle).toBeGreaterThan(0);
+
+    desktop.state.minimized_windows.app2 = true;
+
+    desktop.cycleApps(1);
+
+    expect(desktop.state.focused_windows.app3).toBe(true);
+    expect(desktop.state.window_z_indexes.app3).toBeGreaterThan(
+      desktop.state.window_z_indexes.app1
+    );
+  });
+
+  test('minimize and restore keeps stacking order consistent', () => {
+    const desktop = createDesktop(['app1', 'app2']);
+
+    desktop.focus('app1');
+    desktop.focus('app2');
+    const zBeforeMinimize = desktop.state.window_z_indexes.app2;
+    expect(zBeforeMinimize).toBeGreaterThan(
+      desktop.state.window_z_indexes.app1
+    );
+
+    desktop.hasMinimised('app2');
+
+    expect(desktop.state.minimized_windows.app2).toBe(true);
+    expect(desktop.state.window_z_indexes.app2).toBe(0);
+    expect(desktop.state.focused_windows.app1).toBe(true);
+    expect(desktop.state.window_z_indexes.app1).toBeGreaterThan(zBeforeMinimize);
+
+    desktop.state.minimized_windows.app2 = false;
+    desktop.focus('app2');
+
+    expect(desktop.state.focused_windows.app2).toBe(true);
+    expect(desktop.state.window_z_indexes.app2).toBeGreaterThan(
+      desktop.state.window_z_indexes.app1
+    );
+  });
+});

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -525,40 +525,40 @@ export class Window extends Component {
             this.focusWindow();
         } else if (e.altKey) {
             if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.unsnapWindow();
             } else if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('left');
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('right');
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('top');
             }
             this.focusWindow();
         } else if (e.shiftKey) {
             const step = 1;
             if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ width: Math.max(prev.width - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ width: Math.min(prev.width + step, 100) }), this.resizeBoundries);
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ height: Math.max(prev.height - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ height: Math.min(prev.height + step, 100) }), this.resizeBoundries);
             }
             this.focusWindow();
@@ -634,8 +634,8 @@ export class Window extends Component {
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
                 >
                     <div
-                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%`, zIndex: this.props.zIndex }}
+                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? "" : " notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}


### PR DESCRIPTION
## Summary
- track per-window z-indices in the desktop manager so focused windows float to the top and minimized windows release their slot
- pass zIndex into the window component and guard keyboard handlers when events omit preventDefault/stopPropagation
- add regression coverage for focus cycling to verify minimize/restore keeps stacking order

## Testing
- yarn test --runTestsByPath __tests__/desktopFocus.test.tsx
- yarn test --runTestsByPath __tests__/window.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb542d41b08328b0d5af755bfb4cd2