### PR TITLE
feat: add keyboard move and resize shortcuts

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -160,7 +160,7 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.height).toBe(96.3);
   });
 
-  it('releases snap with Alt+ArrowDown restoring size', () => {
+  it('releases snap with super-arrow ArrowDown restoring size', () => {
     const ref = React.createRef<Window>();
     render(
       <Window
@@ -199,7 +199,8 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      const event = new CustomEvent('super-arrow', { detail: 'ArrowDown' });
+      document.getElementById('test-window')!.dispatchEvent(event);
     });
 
     expect(ref.current!.state.snapped).toBeNull();
@@ -281,6 +282,99 @@ describe('Window keyboard dragging', () => {
 
     fireEvent.keyDown(handle, { key: ' ', code: 'Space' });
     expect(handle).toHaveAttribute('aria-grabbed', 'false');
+  });
+});
+
+describe('Window keyboard transforms', () => {
+  it('moves window 10px with Alt+ArrowRight and keeps focus', () => {
+    const focus = jest.fn();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={focus}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.style.transform = 'translate(0px, 0px)';
+    winEl.focus();
+
+    act(() => {
+      fireEvent.keyDown(winEl, { key: 'ArrowRight', altKey: true });
+    });
+
+    expect(winEl.style.transform).toBe('translate(10px, 0px)');
+    expect(focus).toHaveBeenLastCalledWith('test-window');
+    expect(document.activeElement).toBe(winEl);
+  });
+
+  it('resizes window height by 10px with Alt+Shift+ArrowDown', () => {
+    const focus = jest.fn();
+    const ref = React.createRef<Window>();
+
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={focus}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.focus();
+    const startHeight = ref.current!.state.height;
+
+    act(() => {
+      fireEvent.keyDown(winEl, { key: 'ArrowDown', altKey: true, shiftKey: true });
+    });
+
+    const expectedHeight = startHeight + (10 / window.innerHeight) * 100;
+    expect(ref.current!.state.height).toBeCloseTo(expectedHeight, 2);
+    expect(focus).toHaveBeenLastCalledWith('test-window');
+    expect(document.activeElement).toBe(winEl);
+  });
+
+  it('handles window-transform custom events for moves', () => {
+    const focus = jest.fn();
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={focus}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.style.transform = 'translate(0px, 0px)';
+
+    act(() => {
+      ref.current!.handleWindowTransform({
+        detail: { intent: 'move', dx: -10, dy: 10 },
+      } as any);
+    });
+
+    expect(winEl.style.transform).toBe('translate(-10px, 10px)');
+    expect(focus).toHaveBeenLastCalledWith('test-window');
+    expect(document.activeElement).toBe(winEl);
   });
 });
 

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -147,24 +147,51 @@ export class Desktop extends Component {
     }
 
     handleGlobalShortcut = (e) => {
+        const arrowKeys = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'];
+
+        if (e.altKey && !e.metaKey && !e.ctrlKey && arrowKeys.includes(e.key)) {
+            const id = this.getFocusedWindowId();
+            if (id) {
+                e.preventDefault();
+                const delta = {
+                    ArrowLeft: { dx: -10, dy: 0 },
+                    ArrowRight: { dx: 10, dy: 0 },
+                    ArrowUp: { dx: 0, dy: -10 },
+                    ArrowDown: { dx: 0, dy: 10 },
+                }[e.key] || { dx: 0, dy: 0 };
+                const event = new CustomEvent('window-transform', {
+                    detail: {
+                        intent: e.shiftKey ? 'resize' : 'move',
+                        ...delta,
+                    },
+                });
+                document.getElementById(id)?.dispatchEvent(event);
+            }
+            return;
+        }
+
         if (e.altKey && e.key === 'Tab') {
             e.preventDefault();
             if (!this.state.showWindowSwitcher) {
                 this.openWindowSwitcher();
             }
-        } else if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'v') {
+            this.cycleApps(e.shiftKey ? -1 : 1);
+            return;
+        }
+
+        if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'v') {
             e.preventDefault();
             this.openApp('clipboard-manager');
+            return;
         }
-        else if (e.altKey && e.key === 'Tab') {
-            e.preventDefault();
-            this.cycleApps(e.shiftKey ? -1 : 1);
-        }
-        else if (e.altKey && (e.key === '`' || e.key === '~')) {
+
+        if (e.altKey && (e.key === '`' || e.key === '~')) {
             e.preventDefault();
             this.cycleAppWindows(e.shiftKey ? -1 : 1);
+            return;
         }
-        else if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
+
+        if (e.metaKey && arrowKeys.includes(e.key)) {
             e.preventDefault();
             const id = this.getFocusedWindowId();
             if (id) {


### PR DESCRIPTION
## Summary
- dispatch 10px move and resize intents from global Alt shortcuts so focused windows can be nudged without snapping
- teach the Window component to focus itself, respond to window-transform events, and translate or resize by 10px when Alt or Alt+Shift is pressed
- cover the new keyboard paths with unit tests for moving, resizing, and custom transform events while updating the snap release test

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label violations in unrelated files)*
- yarn test *(fails: existing suite failures that require Supabase/localStorage test fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68cb542cddfc8328b6ba8c1de4731a8a