### PR TITLE
[desktop] clamp window bounds to container

### DIFF
--- a/__tests__/windowBounds.test.js
+++ b/__tests__/windowBounds.test.js
@@ -1,0 +1,17 @@
+import { clampPosition, computeMovementBounds } from '../utils/windowBounds';
+
+describe('windowBounds helper', () => {
+    it('clamps positions within the available desktop area', () => {
+        const bounds = computeMovementBounds({ width: 500, height: 400 }, { width: 200, height: 150 });
+        const result = clampPosition({ x: 420, y: -25 }, bounds);
+        expect(result).toEqual({ x: 300, y: 0 });
+    });
+
+    it('handles containers smaller than the window gracefully', () => {
+        const bounds = computeMovementBounds({ width: 100, height: 90 }, { width: 250, height: 200 });
+        const result = clampPosition({ x: 10, y: 40 }, bounds);
+        expect(bounds.right).toBe(0);
+        expect(bounds.bottom).toBe(0);
+        expect(result).toEqual({ x: 0, y: 0 });
+    });
+});

--- a/utils/windowBounds.js
+++ b/utils/windowBounds.js
@@ -1,0 +1,54 @@
+const getDesktopRoot = () => {
+    if (typeof document === 'undefined') {
+        return null;
+    }
+    return document.getElementById('window-area') || document.getElementById('desktop');
+};
+
+export const measureDesktopRect = () => {
+    const container = getDesktopRoot();
+    return container ? container.getBoundingClientRect() : null;
+};
+
+export const computeMovementBounds = (containerRect, windowSize = {}) => {
+    const containerWidth = containerRect?.width ?? 0;
+    const containerHeight = containerRect?.height ?? 0;
+    const windowWidth = windowSize?.width ?? 0;
+    const windowHeight = windowSize?.height ?? 0;
+
+    return {
+        left: 0,
+        top: 0,
+        right: Math.max(containerWidth - windowWidth, 0),
+        bottom: Math.max(containerHeight - windowHeight, 0),
+    };
+};
+
+const clampValue = (value, min, max) => {
+    const safeValue = Number.isFinite(value) ? value : 0;
+    const safeMin = Number.isFinite(min) ? min : 0;
+    const safeMax = Number.isFinite(max) ? max : safeMin;
+    return Math.min(Math.max(safeValue, safeMin), safeMax);
+};
+
+export const clampPosition = (position = {}, bounds = {}) => {
+    const left = bounds.left ?? 0;
+    const top = bounds.top ?? 0;
+    const right = bounds.right ?? left;
+    const bottom = bounds.bottom ?? top;
+
+    return {
+        x: clampValue(position.x, left, right),
+        y: clampValue(position.y, top, bottom),
+    };
+};
+
+export const getRelativePosition = (windowRect, containerRect) => {
+    if (!windowRect || !containerRect) {
+        return { x: 0, y: 0 };
+    }
+    return {
+        x: windowRect.left - containerRect.left,
+        y: windowRect.top - containerRect.top,
+    };
+};


### PR DESCRIPTION
## Summary
- measure desktop bounds inside the window component so transforms stay inside the desktop container
- clamp persisted window positions and resync them whenever the desktop size changes
- share a reusable windowBounds helper and cover it with a regression test

## Testing
- [ ] yarn lint (fails: existing accessibility and no-top-level-window violations across unrelated modules)
- [x] yarn test --runTestsByPath __tests__/windowBounds.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cb542b445c83288e86fe34bbfbd8ad