### PR TITLE
[vscode] Harden iframe messaging and add heartbeat

### DIFF
--- a/__tests__/vscode.messaging.test.tsx
+++ b/__tests__/vscode.messaging.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import VsCode, { type ExternalFrameHandle } from '../apps/vscode';
+import { VsCodeMessagingWrapper, HEARTBEAT_TIMEOUT_MS } from '../components/apps/vscode';
+
+describe('VS Code messaging manager', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  const setup = async () => {
+    const frameRef = React.createRef<ExternalFrameHandle | null>();
+    const postMessageSpy = jest.spyOn(window, 'postMessage');
+
+    render(<VsCodeMessagingWrapper openApp={jest.fn()} frameRef={frameRef} VsCodeComponent={VsCode} />);
+
+    const iframe = await screen.findByTitle('VsCode');
+    const contentWindow = { postMessage: jest.fn() } as unknown as Window;
+
+    Object.defineProperty(iframe, 'contentWindow', {
+      value: contentWindow,
+      configurable: true,
+    });
+
+    await waitFor(() => expect(frameRef.current).not.toBeNull());
+
+    await act(async () => {
+      fireEvent.load(iframe);
+    });
+
+    const handshakeCalls = (contentWindow.postMessage as jest.Mock).mock.calls;
+    const firstCall = handshakeCalls[0];
+    if (!firstCall) {
+      throw new Error('expected handshake postMessage call');
+    }
+    const nonce = firstCall[0]?.nonce;
+
+    return { frameRef, iframe, contentWindow, nonce, postMessageSpy };
+  };
+
+  it('performs a guarded handshake with allowed origins', async () => {
+    const { contentWindow, nonce, postMessageSpy } = await setup();
+
+    expect(nonce).toBeDefined();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: 'https://stackblitz.com',
+          data: { type: 'vscode:init', nonce },
+          source: contentWindow,
+        }),
+      );
+    });
+
+    const postMessageMock = contentWindow.postMessage as jest.Mock;
+    const ackCall = postMessageMock.mock.calls.find(
+      ([payload, origin]) => origin === 'https://stackblitz.com' && payload?.type === 'vscode:ack',
+    );
+    expect(ackCall?.[0]).toEqual(expect.objectContaining({ type: 'vscode:ack', nonce }));
+
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        __externalFrameForwarded: true,
+        origin: 'https://stackblitz.com',
+        payload: expect.objectContaining({ type: 'vscode:init', nonce }),
+      }),
+      expect.any(String),
+    );
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: 'https://stackblitz.com',
+          data: { type: 'vscode:ping', nonce },
+          source: contentWindow,
+        }),
+      );
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(HEARTBEAT_TIMEOUT_MS - 1);
+    });
+
+    expect(screen.queryByTestId('vscode-crash-overlay')).toBeNull();
+  });
+
+  it('rejects messages from unexpected origins', async () => {
+    const { contentWindow, nonce } = await setup();
+
+    const initialCalls = (contentWindow.postMessage as jest.Mock).mock.calls.length;
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: 'https://evil.example',
+          data: { type: 'vscode:init', nonce },
+          source: contentWindow,
+        }),
+      );
+    });
+
+    expect((contentWindow.postMessage as jest.Mock).mock.calls.length).toBe(initialCalls);
+    expect(screen.queryByTestId('vscode-crash-overlay')).toBeNull();
+  });
+
+  it('reloads the iframe when heartbeat pings stop', async () => {
+    const { contentWindow, nonce, frameRef } = await setup();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: 'https://stackblitz.com',
+          data: { type: 'vscode:init', nonce },
+          source: contentWindow,
+        }),
+      );
+    });
+
+    const controller = frameRef.current;
+    expect(controller).not.toBeNull();
+    const reloadSpy = jest.spyOn(controller!, 'reload');
+
+    await act(async () => {
+      jest.advanceTimersByTime(HEARTBEAT_TIMEOUT_MS + 1);
+    });
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('vscode-crash-overlay')).toBeInTheDocument();
+  });
+});

--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -1,12 +1,33 @@
 'use client';
 
+import type { ComponentPropsWithoutRef, Ref } from 'react';
 import Image from 'next/image';
 import ExternalFrame from '../../components/ExternalFrame';
 import { CloseIcon, MaximizeIcon, MinimizeIcon } from '../../components/ToolbarIcons';
 import { kaliTheme } from '../../styles/themes/kali';
 import { SIDEBAR_WIDTH, ICON_SIZE } from './utils';
 
-export default function VsCode() {
+type MessagingConfig = {
+  allowedOrigins: string[];
+  nonce: string;
+  onMessage?: (payload: Record<string, unknown>, rawEvent: MessageEvent) => void;
+};
+
+export type ExternalFrameHandle = {
+  postMessage: (message: Record<string, unknown>, targetOrigin: string) => void;
+  reload: () => void;
+  getIframe: () => HTMLIFrameElement | null;
+};
+
+type FrameLoadHandler = ComponentPropsWithoutRef<'iframe'>['onLoad'];
+
+export type VsCodeProps = {
+  frameRef?: Ref<ExternalFrameHandle>;
+  messaging?: MessagingConfig;
+  onFrameLoad?: FrameLoadHandler;
+};
+
+export default function VsCode({ frameRef, messaging, onFrameLoad }: VsCodeProps = {}) {
   return (
     <div
       className="flex flex-col min-[1366px]:flex-row h-full w-full max-w-full"
@@ -50,10 +71,12 @@ export default function VsCode() {
         </div>
         <div className="relative flex-1" style={{ backgroundColor: kaliTheme.background }}>
           <ExternalFrame
+            ref={frameRef}
             src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
             title="VsCode"
             className="w-full h-full"
-            onLoad={() => {}}
+            onLoad={onFrameLoad}
+            messaging={messaging}
           />
           <div className="absolute top-4 left-4 flex items-center gap-4 bg-black/50 p-4 rounded">
             <Image

--- a/components/apps/vscode.jsx
+++ b/components/apps/vscode.jsx
@@ -1,11 +1,14 @@
 'use client';
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import apps from '../../apps.config';
 
+const ALLOWED_ORIGINS = ['https://stackblitz.com', 'https://vscode.dev'];
+export const HEARTBEAT_TIMEOUT_MS = 10000;
+
 // Load the actual VSCode app lazily so no editor dependencies are required
-const VsCode = dynamic(() => import('../../apps/vscode'), { ssr: false });
+const LazyVsCode = dynamic(() => import('../../apps/vscode'), { ssr: false });
 
 // Simple fuzzy match: returns true if query characters appear in order
 function fuzzyMatch(text, query) {
@@ -20,12 +23,32 @@ function fuzzyMatch(text, query) {
   return qi === q.length;
 }
 
-// Static files that can be opened directly in a new tab
 const files = ['README.md', 'CHANGELOG.md', 'package.json'];
 
-export default function VsCodeWrapper({ openApp }) {
+const createNonce = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+export function VsCodeMessagingWrapper({ openApp, frameRef: externalFrameRef, VsCodeComponent = LazyVsCode }) {
   const [visible, setVisible] = useState(false);
   const [query, setQuery] = useState('');
+  const [crashed, setCrashed] = useState(false);
+
+  const internalFrameRef = useRef(null);
+  const frameControllerRef = useMemo(() => externalFrameRef ?? internalFrameRef, [externalFrameRef]);
+  const nonceRef = useRef('');
+  const heartbeatRef = useRef(null);
+  const handshakeOriginRef = useRef(null);
+  const handshakeCompleteRef = useRef(false);
+
+  if (!nonceRef.current) {
+    nonceRef.current = createNonce();
+  }
+
+  const nonce = nonceRef.current;
 
   const items = useMemo(() => {
     const list = [
@@ -49,25 +72,118 @@ export default function VsCodeWrapper({ openApp }) {
     return () => window.removeEventListener('keydown', handler);
   }, []);
 
-  const selectItem = (item) => {
-    setVisible(false);
-    setQuery('');
-    if (item.type === 'app' && openApp) {
-      openApp(item.id);
-    } else if (item.type === 'file') {
-      window.open(item.id, '_blank');
+  const clearHeartbeat = useCallback(() => {
+    if (heartbeatRef.current) {
+      clearTimeout(heartbeatRef.current);
+      heartbeatRef.current = null;
     }
-  };
+  }, []);
+
+  useEffect(() => () => clearHeartbeat(), [clearHeartbeat]);
+
+  const handleCrash = useCallback(() => {
+    clearHeartbeat();
+    handshakeCompleteRef.current = false;
+    handshakeOriginRef.current = null;
+    setCrashed(true);
+    const controller = frameControllerRef.current;
+    controller?.reload?.();
+  }, [clearHeartbeat, frameControllerRef]);
+
+  const scheduleHeartbeat = useCallback(() => {
+    if (!handshakeCompleteRef.current || typeof window === 'undefined') return;
+    clearHeartbeat();
+    heartbeatRef.current = window.setTimeout(() => {
+      handleCrash();
+    }, HEARTBEAT_TIMEOUT_MS);
+  }, [clearHeartbeat, handleCrash]);
+
+  const sendAck = useCallback(
+    (origin) => {
+      const controller = frameControllerRef.current;
+      if (!controller?.postMessage) return;
+      if (!ALLOWED_ORIGINS.includes(origin)) return;
+      controller.postMessage({ type: 'vscode:ack' }, origin);
+    },
+    [frameControllerRef],
+  );
+
+  const sendHandshake = useCallback(() => {
+    const controller = frameControllerRef.current;
+    if (!controller?.postMessage) return;
+    ALLOWED_ORIGINS.forEach((origin) => {
+      controller.postMessage({ type: 'vscode:init-request' }, origin);
+    });
+  }, [frameControllerRef]);
+
+  const handleFrameLoad = useCallback(() => {
+    setCrashed(false);
+    handshakeCompleteRef.current = false;
+    handshakeOriginRef.current = null;
+    clearHeartbeat();
+    sendHandshake();
+  }, [clearHeartbeat, sendHandshake]);
+
+  const handleFrameMessage = useCallback(
+    (payload, event) => {
+      if (!payload || typeof payload !== 'object') return;
+      if (payload.nonce !== nonce) return;
+      if (!ALLOWED_ORIGINS.includes(event.origin)) return;
+      if (handshakeOriginRef.current && handshakeOriginRef.current !== event.origin) return;
+
+      if (payload.type === 'vscode:init') {
+        handshakeCompleteRef.current = true;
+        handshakeOriginRef.current = event.origin;
+        setCrashed(false);
+        scheduleHeartbeat();
+        sendAck(event.origin);
+      } else if (payload.type === 'vscode:ping') {
+        if (!handshakeCompleteRef.current) return;
+        scheduleHeartbeat();
+      }
+    },
+    [nonce, scheduleHeartbeat, sendAck],
+  );
+
+  const messagingConfig = useMemo(
+    () => ({
+      allowedOrigins: ALLOWED_ORIGINS,
+      nonce,
+      onMessage: handleFrameMessage,
+    }),
+    [nonce, handleFrameMessage],
+  );
+
+  const selectItem = useCallback(
+    (item) => {
+      setVisible(false);
+      setQuery('');
+      if (item.type === 'app' && openApp) {
+        openApp(item.id);
+      } else if (item.type === 'file') {
+        window.open(item.id, '_blank');
+      }
+    },
+    [openApp],
+  );
 
   return (
     <div className="relative h-full w-full">
-      <VsCode />
+      <VsCodeComponent frameRef={frameControllerRef} messaging={messagingConfig} onFrameLoad={handleFrameLoad} />
+      {crashed && (
+        <div
+          data-testid="vscode-crash-overlay"
+          className="absolute inset-0 z-40 flex flex-col items-center justify-center bg-black/70 px-4 text-center text-white"
+        >
+          <p className="text-sm font-medium md:text-base">VS Code preview disconnected. Reloading…</p>
+        </div>
+      )}
       {visible && (
-        <div className="absolute inset-0 flex items-start justify-center pt-24 bg-black/50">
-          <div className="bg-gray-800 text-white w-11/12 max-w-md rounded shadow-lg p-2">
+        <div className="absolute inset-0 z-30 flex items-start justify-center bg-black/50 pt-24">
+          <div className="w-11/12 max-w-md rounded bg-gray-800 p-2 text-white shadow-lg">
             <input
               autoFocus
-              className="w-full p-2 mb-2 bg-gray-700 rounded outline-none"
+              className="mb-2 w-full rounded bg-gray-700 p-2 outline-none"
               placeholder="Search apps or files"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
@@ -77,15 +193,13 @@ export default function VsCodeWrapper({ openApp }) {
                 <li key={`${item.type}-${item.id}`}>
                   <button
                     onClick={() => selectItem(item)}
-                    className="w-full text-left px-2 py-1 rounded hover:bg-gray-700"
+                    className="w-full rounded px-2 py-1 text-left hover:bg-gray-700"
                   >
                     {item.title}
                   </button>
                 </li>
               ))}
-              {items.length === 0 && (
-                <li className="px-2 py-1 text-sm text-gray-400">No results</li>
-              )}
+              {items.length === 0 && <li className="px-2 py-1 text-sm text-gray-400">No results</li>}
             </ul>
           </div>
         </div>
@@ -94,5 +208,8 @@ export default function VsCodeWrapper({ openApp }) {
   );
 }
 
-export const displayVsCode = (openApp) => <VsCodeWrapper openApp={openApp} />;
+export default function VsCodeWrapper(props) {
+  return <VsCodeMessagingWrapper {...props} />;
+}
 
+export const displayVsCode = (openApp) => <VsCodeWrapper openApp={openApp} />;


### PR DESCRIPTION
## Summary
- wrap the VS Code iframe with a message manager that enforces allowed origins, nonce handshake, and heartbeat-driven reload overlay
- extend `ExternalFrame` with guarded postMessage forwarding plus an imperative API for reload/posting
- add targeted messaging tests that cover handshake success, malicious origin rejection, and heartbeat timeouts

## Testing
- yarn lint *(fails: repository currently reports 580 pre-existing accessibility and window globals violations)*
- yarn test --runTestsByPath __tests__/vscode.messaging.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc0673f1088328a31e30967dc81278