### PR TITLE
playwright: add terminal regression test

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "export": "NEXT_PUBLIC_STATIC_EXPORT=true next build",
     "test": "jest",
     "test:watch": "jest --watch",
+    "test:playwright": "playwright test",
     "lint": "eslint . --max-warnings=0",
     "tsc": "tsc",
     "typecheck": "tsc --noEmit",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testDir: '.',
+  testMatch: /(?:^|[\\/])(?:tests|playwright)[\\/].*\.spec\.ts$/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/playwright/terminal.regression.spec.ts
+++ b/playwright/terminal.regression.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '@playwright/test';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const CPU_THROTTLE_RATE = 2;
+const SCRIPT_LINE_TARGET = 1200;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const logPath = path.resolve(repoRoot, 'test-log.md');
+
+function formatBytes(bytes: number): string {
+  if (!bytes) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const power = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / Math.pow(1024, power);
+  return `${value.toFixed(2)} ${units[power]}`;
+}
+
+test.describe('terminal regression', () => {
+  test('measures terminal responsiveness and cleanup', async ({ page, browserName }, testInfo) => {
+    test.slow();
+    test.skip(browserName !== 'chromium', 'Terminal metrics rely on Chromium-only APIs');
+
+    const client = await page.context().newCDPSession(page);
+    await client.send('Network.enable');
+    await client.send('Network.clearBrowserCache');
+    await client.send('Network.clearBrowserCookies');
+    await client.send('Emulation.setCPUThrottlingRate', { rate: CPU_THROTTLE_RATE });
+
+    const metrics = {
+      cpuThrottleRate: CPU_THROTTLE_RATE,
+      navigationTtiMs: 0,
+      helpCommandMs: 0,
+      baselineHeapBytes: 0,
+      postCloseHeapBytes: 0,
+      heapDeltaRatio: 0,
+      emittedLines: SCRIPT_LINE_TARGET,
+    };
+
+    try {
+      await page.goto('/apps/terminal', { waitUntil: 'networkidle' });
+      const terminal = page.locator('[data-testid="xterm-container"]');
+      await expect(terminal).toBeVisible();
+
+      await page.waitForFunction(() => {
+        const rows = document.querySelector('[data-testid="xterm-container"] .xterm-rows');
+        if (!rows) return false;
+        const text = rows.textContent || '';
+        return text.includes('Welcome to the web terminal!') && text.includes('└─$ ');
+      });
+
+      const navigationTti = await page.evaluate(() => {
+        const entry = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
+        const start = entry?.startTime ?? 0;
+        return performance.now() - start;
+      });
+      metrics.navigationTtiMs = navigationTti;
+      expect(navigationTti).toBeLessThanOrEqual(1000);
+
+      const baselineMemory = await page.evaluate(() => performance.memory?.usedJSHeapSize ?? 0);
+      metrics.baselineHeapBytes = baselineMemory;
+      expect(baselineMemory).toBeGreaterThan(0);
+
+      await terminal.click();
+
+      const helpStart = await page.evaluate(() => performance.now());
+      await page.keyboard.type('help', { delay: 1 });
+      await page.keyboard.press('Enter');
+      await page.waitForFunction(() => {
+        const rows = document.querySelector('[data-testid="xterm-container"] .xterm-rows');
+        const text = rows?.textContent || '';
+        return text.includes('Available commands:') && text.includes('Example scripts:');
+      });
+      const helpDuration = await page.evaluate((start) => performance.now() - start, helpStart);
+      metrics.helpCommandMs = helpDuration;
+
+      for (let i = 0; i < SCRIPT_LINE_TARGET; i += 1) {
+        const lineLabel = `playwright-line-${i}`;
+        await page.keyboard.insertText(`echo ${lineLabel}`);
+        await page.keyboard.press('Enter');
+        await page.waitForFunction(
+          (expected) => {
+            const rows = document.querySelector('[data-testid="xterm-container"] .xterm-rows');
+            return rows?.textContent?.includes(expected) ?? false;
+          },
+          lineLabel,
+        );
+      }
+
+      const closeButton = page.locator('button[aria-label="Window close"]');
+      await expect(closeButton).toBeVisible();
+      await closeButton.click();
+      await expect(terminal).toHaveCount(0);
+
+      await page.waitForTimeout(500);
+
+      const postCloseMemory = await page.evaluate(() => performance.memory?.usedJSHeapSize ?? 0);
+      metrics.postCloseHeapBytes = postCloseMemory;
+      expect(postCloseMemory).toBeGreaterThan(0);
+
+      if (baselineMemory > 0) {
+        const delta = Math.abs(postCloseMemory - baselineMemory) / baselineMemory;
+        metrics.heapDeltaRatio = delta;
+        expect(delta).toBeLessThanOrEqual(0.05);
+      }
+
+      const timestamp = new Date().toISOString();
+      const logEntry = `\n## Terminal regression run — ${timestamp}\n\n` +
+        `- CPU throttle: ${CPU_THROTTLE_RATE}×\n` +
+        `- Navigation TTI: ${metrics.navigationTtiMs.toFixed(2)} ms\n` +
+        `- Help command latency: ${metrics.helpCommandMs.toFixed(2)} ms\n` +
+        `- Baseline heap: ${formatBytes(metrics.baselineHeapBytes)}\n` +
+        `- Post-close heap: ${formatBytes(metrics.postCloseHeapBytes)}\n` +
+        `- Heap delta: ${(metrics.heapDeltaRatio * 100).toFixed(2)}%\n` +
+        `- Script lines emitted: ${SCRIPT_LINE_TARGET}\n`;
+
+      await fs.appendFile(logPath, logEntry, 'utf8');
+      await testInfo.attach('terminal-regression-metrics', {
+        body: JSON.stringify({ ...metrics, timestamp }, null, 2),
+        contentType: 'application/json',
+      });
+    } finally {
+      await client.send('Emulation.setCPUThrottlingRate', { rate: 1 });
+    }
+  });
+});

--- a/test-log.md
+++ b/test-log.md
@@ -32,3 +32,7 @@ Attempted to load each route under `/apps` in Chromium, Firefox, and WebKit. All
 - `yarn why bare-fs` shows the module is required by `tar-fs@3.1.0` via `@puppeteer/browsers@2.10.7`.
 - Latest versions (`@puppeteer/browsers@2.10.8`, `tar-fs@3.1.0`) still depend on `bare-fs@4.2.1`, so the warning remains.
 - `puppeteer` and `puppeteer-core` require this chain; removing them would break existing tooling, so the warning is ignored.
+
+## Terminal regression metrics
+
+Entries appended automatically by `playwright/terminal.regression.spec.ts` after each run capture the latest `/apps/terminal` navigation, command latency, and heap usage data points.


### PR DESCRIPTION
## Summary
- add a regression test that measures the terminal app’s TTI, command latency, heap usage, and writes metrics to test-log.md
- update the Playwright configuration so specs in playwright/ run with the existing suite and add a package.json script entry
- document the new metrics log section in test-log.md for manual reviews

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations across the repo)*
- yarn test *(fails: pre-existing issues in window, nmap-nse, contact, and pdf viewer test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0674894c8328beff6fd52e67ce40