### PR TITLE
[terminal] persist appearance settings

### DIFF
--- a/__tests__/settingsStore.terminal.test.ts
+++ b/__tests__/settingsStore.terminal.test.ts
@@ -1,0 +1,67 @@
+import {
+  defaults,
+  getTerminalFontScale,
+  setTerminalFontScale,
+  getTerminalTheme,
+  setTerminalTheme,
+  getTerminalSize,
+  setTerminalSize,
+} from '../utils/settingsStore';
+
+const TERMINAL_FONT_KEY = 'terminal-font';
+const TERMINAL_THEME_KEY = 'terminal-theme';
+const TERMINAL_SIZE_KEY = 'terminal-size';
+const NEW_FONT_KEY = 'terminalFontScale';
+const NEW_THEME_KEY = 'terminalTheme';
+const NEW_SIZE_KEY = 'terminalSize';
+
+describe('terminal settings storage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns defaults when nothing stored', async () => {
+    await expect(getTerminalFontScale()).resolves.toBe(defaults.terminalFontScale);
+    await expect(getTerminalTheme()).resolves.toBe(defaults.terminalTheme);
+    await expect(getTerminalSize()).resolves.toEqual(defaults.terminalSize);
+  });
+
+  it('migrates legacy keys to the new schema', async () => {
+    window.localStorage.setItem(TERMINAL_FONT_KEY, '1.25');
+    window.localStorage.setItem(TERMINAL_THEME_KEY, 'matrix');
+    window.localStorage.setItem(
+      TERMINAL_SIZE_KEY,
+      JSON.stringify({ width: 720, height: 480 }),
+    );
+
+    expect(await getTerminalFontScale()).toBeCloseTo(1.25);
+    expect(window.localStorage.getItem(TERMINAL_FONT_KEY)).toBeNull();
+    expect(window.localStorage.getItem(NEW_FONT_KEY)).toBe('1.25');
+
+    expect(await getTerminalTheme()).toBe('matrix');
+    expect(window.localStorage.getItem(TERMINAL_THEME_KEY)).toBeNull();
+    expect(window.localStorage.getItem(NEW_THEME_KEY)).toBe('matrix');
+
+    expect(await getTerminalSize()).toEqual({ width: 720, height: 480 });
+    expect(window.localStorage.getItem(TERMINAL_SIZE_KEY)).toBeNull();
+    expect(window.localStorage.getItem(NEW_SIZE_KEY)).toBe(
+      JSON.stringify({ width: 720, height: 480 }),
+    );
+  });
+
+  it('persists new keys without data loss', async () => {
+    await setTerminalFontScale(1.5);
+    await setTerminalTheme('paper');
+    await setTerminalSize({ width: 800, height: 600 });
+
+    expect(await getTerminalFontScale()).toBeCloseTo(1.5);
+    expect(await getTerminalTheme()).toBe('paper');
+    expect(await getTerminalSize()).toEqual({ width: 800, height: 600 });
+
+    expect(window.localStorage.getItem(NEW_FONT_KEY)).toBe('1.5');
+    expect(window.localStorage.getItem(NEW_THEME_KEY)).toBe('paper');
+    expect(window.localStorage.getItem(NEW_SIZE_KEY)).toBe(
+      JSON.stringify({ width: 800, height: 600 }),
+    );
+  });
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -31,6 +31,9 @@ export default function Settings() {
     setHaptics,
     theme,
     setTheme,
+    setTerminalFontScale,
+    setTerminalTheme,
+    setTerminalSize,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -80,6 +83,16 @@ export default function Settings() {
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
       if (parsed.theme !== undefined) setTheme(parsed.theme);
+      if (parsed.terminalFontScale !== undefined)
+        setTerminalFontScale(parsed.terminalFontScale);
+      if (parsed.terminalTheme !== undefined) setTerminalTheme(parsed.terminalTheme);
+      if (
+        parsed.terminalSize &&
+        typeof parsed.terminalSize.width === 'number' &&
+        typeof parsed.terminalSize.height === 'number'
+      ) {
+        setTerminalSize({ ...parsed.terminalSize });
+      }
     } catch (err) {
       console.error("Invalid settings", err);
     }
@@ -101,6 +114,9 @@ export default function Settings() {
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
     setTheme("default");
+    setTerminalFontScale(defaults.terminalFontScale);
+    setTerminalTheme(defaults.terminalTheme);
+    setTerminalSize({ ...defaults.terminalSize });
   };
 
   const [showKeymap, setShowKeymap] = useState(false);

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,7 @@ import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme, setTerminalFontScale, setTerminalTheme, setTerminalSize } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -252,6 +252,9 @@ export function Settings() {
                         setFontScale(defaults.fontScale);
                         setHighContrast(defaults.highContrast);
                         setTheme('default');
+                        setTerminalFontScale(defaults.terminalFontScale);
+                        setTerminalTheme(defaults.terminalTheme);
+                        setTerminalSize({ ...defaults.terminalSize });
                     }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
                 >
@@ -276,6 +279,11 @@ export function Settings() {
                         if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
                         if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
                         if (parsed.theme !== undefined) { setTheme(parsed.theme); }
+                        if (parsed.terminalFontScale !== undefined) setTerminalFontScale(parsed.terminalFontScale);
+                        if (parsed.terminalTheme !== undefined) setTerminalTheme(parsed.terminalTheme);
+                        if (parsed.terminalSize && typeof parsed.terminalSize.width === 'number' && typeof parsed.terminalSize.height === 'number') {
+                            setTerminalSize({ ...parsed.terminalSize });
+                        }
                     } catch (err) {
                         console.error('Invalid settings', err);
                     }

--- a/docs/apps/terminal.md
+++ b/docs/apps/terminal.md
@@ -1,0 +1,19 @@
+# Terminal app
+
+The Kali-inspired terminal emulation provides a resizable xterm.js surface that now reads and writes its appearance settings through the global settings store.
+
+## Persistent preferences
+
+- **Font scale (`terminalFontScale`)** – multiplies the base 14px xterm font. Stored values are migrated automatically from the legacy `terminal-font` key.
+- **Theme (`terminalTheme`)** – maps to predefined palettes (`kali`, `matrix`, `paper`) and is migrated from the legacy `terminal-theme` key.
+- **Window size (`terminalSize`)** – captures the pixel width and height produced by the draggable window and replaces the old `terminal-size` localStorage entry.
+
+Values are synchronised through the `SettingsProvider`, so changing them from the desktop settings panel or within the terminal overlay updates every mounted instance without a reload.
+
+When history files are restored from the Origin Private File System (OPFS), the saved font scale and theme are applied before the banner text renders to avoid flashes.
+
+## User experience notes
+
+- The settings overlay now indicates that changes persist between sessions, matching the behaviour of the new store entries.
+- The toolbar’s settings button advertises “Terminal settings (auto-save)” for screen readers and tooltips.
+- Import/export of desktop preferences now carries the terminal appearance settings alongside other options, and “Reset Desktop” restores the defaults defined in `utils/settingsStore`.

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,10 +20,17 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getTerminalFontScale as loadTerminalFontScale,
+  setTerminalFontScale as saveTerminalFontScale,
+  getTerminalTheme as loadTerminalTheme,
+  setTerminalTheme as saveTerminalTheme,
+  getTerminalSize as loadTerminalSize,
+  setTerminalSize as saveTerminalSize,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
 type Density = 'regular' | 'compact';
+export type TerminalSize = { width: number; height: number };
 
 // Predefined accent palette exposed to settings UI
 export const ACCENT_OPTIONS = [
@@ -63,6 +70,9 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  terminalFontScale: number;
+  terminalTheme: string;
+  terminalSize: TerminalSize;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +84,9 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setTerminalFontScale: (value: number) => void;
+  setTerminalTheme: (value: string) => void;
+  setTerminalSize: (value: TerminalSize) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +101,9 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  terminalFontScale: defaults.terminalFontScale,
+  terminalTheme: defaults.terminalTheme,
+  terminalSize: defaults.terminalSize,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +115,9 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setTerminalFontScale: () => {},
+  setTerminalTheme: () => {},
+  setTerminalSize: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -113,6 +132,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [terminalFontScale, setTerminalFontScale] = useState<number>(
+    defaults.terminalFontScale,
+  );
+  const [terminalTheme, setTerminalTheme] = useState<string>(defaults.terminalTheme);
+  const [terminalSize, setTerminalSize] = useState<TerminalSize>({
+    ...defaults.terminalSize,
+  });
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -128,6 +154,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
       setTheme(loadTheme());
+      setTerminalFontScale(await loadTerminalFontScale());
+      setTerminalTheme(await loadTerminalTheme());
+      const size = await loadTerminalSize();
+      setTerminalSize({ ...size });
     })();
   }, []);
 
@@ -236,6 +266,22 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveTerminalFontScale(terminalFontScale);
+  }, [terminalFontScale]);
+
+  useEffect(() => {
+    saveTerminalTheme(terminalTheme);
+  }, [terminalTheme]);
+
+  useEffect(() => {
+    saveTerminalSize(terminalSize);
+  }, [terminalSize]);
+
+  const updateTerminalSize = (value: TerminalSize) => {
+    setTerminalSize({ ...value });
+  };
+
   return (
     <SettingsContext.Provider
       value={{
@@ -250,6 +296,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        terminalFontScale,
+        terminalTheme,
+        terminalSize,
         setAccent,
         setWallpaper,
         setDensity,
@@ -261,6 +310,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setTerminalFontScale,
+        setTerminalTheme,
+        setTerminalSize: updateTerminalSize,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- add terminal-specific font, theme, and window size entries to the shared settings store with legacy migrations and import/export support
- expose the new settings through the SettingsProvider and apply them to the terminal app, including ResizeObserver persistence and OPFS restore tweaks
- document the persistent options, update terminal UI copy, and cover migrations with focused Jest tests

## Testing
- yarn lint *(fails: pre-existing accessibility violations across unrelated apps)*
- yarn test settingsStore.terminal

------
https://chatgpt.com/codex/tasks/task_e_68cc0675972083288714719e31837660