### PR TITLE
[apps] scope VSCode shortcuts to focused iframe

### DIFF
--- a/__tests__/vscode.shortcuts.test.tsx
+++ b/__tests__/vscode.shortcuts.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+jest.mock('next/dynamic', () => {
+  const ReactModule = require('react');
+  return (_importer) => {
+    const mod = require('../apps/vscode');
+    const Component = mod.default || mod;
+    return (props) => ReactModule.createElement(Component, props);
+  };
+});
+
+import VsCodeWrapper from '../components/apps/vscode';
+
+describe('VSCode shortcut focus management', () => {
+  it('allows browser shortcuts when the iframe is unfocused', () => {
+    render(<VsCodeWrapper />);
+    const iframe = screen.getByTitle('VsCode');
+
+    const listeners: Record<string, (event: any) => void> = {};
+    const contentWindow = {
+      addEventListener: jest.fn((type, cb) => {
+        listeners[type] = cb;
+      }),
+      removeEventListener: jest.fn((type, cb) => {
+        if (listeners[type] === cb) {
+          delete listeners[type];
+        }
+      }),
+      dispatchEvent: (event) => {
+        listeners[event.type]?.(event);
+      },
+    };
+
+    Object.defineProperty(iframe, 'contentWindow', {
+      configurable: true,
+      value: contentWindow,
+    });
+
+    fireEvent.load(iframe);
+    fireEvent.focus(iframe);
+
+    expect(contentWindow.addEventListener).toHaveBeenCalledWith('keydown', expect.any(Function));
+    const handler = contentWindow.addEventListener.mock.calls[0][1];
+
+    const activeEvent = {
+      type: 'keydown',
+      key: 'p',
+      ctrlKey: true,
+      metaKey: false,
+      preventDefault: jest.fn(),
+    };
+    act(() => {
+      handler(activeEvent);
+    });
+    expect(activeEvent.preventDefault).toHaveBeenCalled();
+
+    fireEvent.blur(iframe);
+    expect(contentWindow.removeEventListener).toHaveBeenCalledWith('keydown', handler);
+
+    const unfocusedEvent = {
+      type: 'keydown',
+      key: 'p',
+      ctrlKey: true,
+      metaKey: false,
+      preventDefault: jest.fn(),
+    };
+    contentWindow.dispatchEvent(unfocusedEvent);
+    expect(unfocusedEvent.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -1,12 +1,19 @@
 'use client';
 
 import Image from 'next/image';
+import type { FocusEventHandler, ReactEventHandler } from 'react';
 import ExternalFrame from '../../components/ExternalFrame';
 import { CloseIcon, MaximizeIcon, MinimizeIcon } from '../../components/ToolbarIcons';
 import { kaliTheme } from '../../styles/themes/kali';
 import { SIDEBAR_WIDTH, ICON_SIZE } from './utils';
 
-export default function VsCode() {
+type VsCodeProps = {
+  onFrameFocus?: FocusEventHandler<HTMLIFrameElement>;
+  onFrameBlur?: FocusEventHandler<HTMLIFrameElement>;
+  onFrameLoad?: ReactEventHandler<HTMLIFrameElement>;
+};
+
+export default function VsCode({ onFrameFocus, onFrameBlur, onFrameLoad }: VsCodeProps) {
   return (
     <div
       className="flex flex-col min-[1366px]:flex-row h-full w-full max-w-full"
@@ -53,7 +60,9 @@ export default function VsCode() {
             src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
             title="VsCode"
             className="w-full h-full"
-            onLoad={() => {}}
+            onFocus={onFrameFocus}
+            onBlur={onFrameBlur}
+            onLoad={onFrameLoad}
           />
           <div className="absolute top-4 left-4 flex items-center gap-4 bg-black/50 p-4 rounded">
             <Image


### PR DESCRIPTION
## Summary
- attach the VSCode quick-open shortcuts to the iframe's content window instead of the global window
- expose focus/blur/load hooks from the VSCode shell so shortcuts only bind while the frame is active
- add a unit test that verifies browser shortcuts remain available when the frame is unfocused

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window lint errors across unrelated files)*
- yarn test --watch=false __tests__/vscode.shortcuts.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc06722dcc832886b0e40965c03f23