### PR TITLE
[test] add vscode regression playwright spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,22 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
+  playwright-vscode:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: npx playwright install --with-deps chromium
+      - run: |
+          yarn dev &
+          npx wait-on http://localhost:3000
+      - run: npx playwright test playwright/vscode.regression.spec.ts
+
   vercel-preview:
     runs-on: ubuntu-latest
     needs: install

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,14 @@
+# Testing
+
+## Playwright regression coverage
+
+### VS Code embed cleanup (`playwright/vscode.regression.spec.ts`)
+
+* Navigates directly to `/apps/vscode` and waits for the StackBlitz VS Code embed to boot.
+* Opens the `public/wallpapers/wall-7.webp` asset (≈246 KB) via Quick Open to exercise large-file rendering inside the iframe.
+* Runs a workspace search for the term `"portfolio"` to ensure the search service remains responsive.
+* Clicks the host window close button to remove the VS Code iframe.
+* Verifies Chromium event listener counts from `getEventListeners(window)` do **not** grow once the iframe is torn down.
+* Uses `requestIdleCallback` and `performance.now()` to require that the page returns to an idle state within **2 seconds** of closing.
+
+> The spec relies on Chromium because `getEventListeners` is a Chrome DevTools protocol API. CI runs it in the `playwright-vscode` job.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testDir: '.',
+  testMatch: ['tests/**/*.spec.ts', 'playwright/**/*.spec.ts'],
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/playwright/vscode.regression.spec.ts
+++ b/playwright/vscode.regression.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from '@playwright/test';
+import type { CDPSession } from 'playwright-core';
+
+const LARGE_FILE_PATH = 'public/wallpapers/wall-7.webp';
+const SEARCH_TERM = 'portfolio';
+
+const quickOpenShortcut = process.platform === 'darwin' ? 'Meta+P' : 'Control+P';
+const searchShortcut = process.platform === 'darwin' ? 'Meta+Shift+F' : 'Control+Shift+F';
+
+async function getListenerSummary(client: CDPSession) {
+  const { result } = await client.send('Runtime.evaluate', {
+    expression: `(() => {
+      const entries = Object.entries(getEventListeners(window));
+      return entries.map(([type, listeners]) => [type, listeners.length]);
+    })()` ,
+    includeCommandLineAPI: true,
+    returnByValue: true,
+  });
+  return result.value as [string, number][];
+}
+
+function toListenerMap(entries: [string, number][]) {
+  return Object.fromEntries(entries) as Record<string, number>;
+}
+
+test.describe('VS Code regression', () => {
+  test('loads large file, runs search, and idles cleanly after close', async ({ page, context, browserName }) => {
+    test.skip(browserName !== 'chromium', 'CDP getEventListeners is only supported in Chromium');
+    await page.goto('/apps/vscode');
+
+    const client = await context.newCDPSession(page);
+    await client.send('Runtime.enable');
+    const beforeEntries = await getListenerSummary(client);
+    const beforeMap = toListenerMap(beforeEntries);
+    const beforeTotal = Object.values(beforeMap).reduce((acc, count) => acc + count, 0);
+
+    await expect(page.locator('iframe[title="VsCode"]')).toBeAttached({ timeout: 120_000 });
+    const frame = page.frameLocator('iframe[title="VsCode"]');
+    await expect(frame.locator('.monaco-workbench')).toBeVisible({ timeout: 120_000 });
+
+    await frame.locator('.monaco-workbench').click({ position: { x: 200, y: 200 } });
+    await page.keyboard.press(quickOpenShortcut);
+
+    const quickOpenInput = frame.locator('input[aria-label*="file to open" i]');
+    await expect(quickOpenInput).toBeVisible({ timeout: 20_000 });
+    await quickOpenInput.fill(LARGE_FILE_PATH);
+    await page.keyboard.press('Enter');
+
+    await expect(frame.getByRole('tab', { name: /wall-7\.webp/i })).toBeVisible({ timeout: 20_000 });
+    await expect(frame.getByRole('img', { name: /wall-7\.webp/i })).toBeVisible({ timeout: 20_000 });
+
+    await page.keyboard.press(searchShortcut);
+    const searchInput = frame.locator('textarea[aria-label="Search"], textarea[aria-label^="Search"], input[aria-label="Search"]');
+    await expect(searchInput.first()).toBeVisible({ timeout: 10_000 });
+    await searchInput.first().fill(SEARCH_TERM);
+    await page.keyboard.press('Enter');
+    await expect(frame.locator('[role="treeitem"]').filter({ hasText: new RegExp(SEARCH_TERM, 'i') })).toBeVisible({ timeout: 20_000 });
+
+    await page.getByRole('button', { name: 'Close' }).click();
+    await expect(page.locator('iframe[title="VsCode"]')).toHaveCount(0, { timeout: 20_000 });
+
+    const afterEntries = await getListenerSummary(client);
+    const afterMap = toListenerMap(afterEntries);
+    const afterTotal = Object.values(afterMap).reduce((acc, count) => acc + count, 0);
+
+    for (const type of new Set([...Object.keys(beforeMap), ...Object.keys(afterMap)])) {
+      expect(afterMap[type] ?? 0).toBeLessThanOrEqual(beforeMap[type] ?? 0);
+    }
+    expect(afterTotal).toBeLessThanOrEqual(beforeTotal);
+
+    const idleWithinTwoSeconds = await page.evaluate(async () => {
+      if (typeof requestIdleCallback !== 'function') {
+        return false;
+      }
+      const start = performance.now();
+      return new Promise<boolean>((resolve) => {
+        const idleCheck = () => {
+          requestIdleCallback(
+            () => {
+              resolve(performance.now() - start <= 2000);
+            },
+            { timeout: 2000 },
+          );
+        };
+        idleCheck();
+        setTimeout(() => resolve(false), 2200);
+      });
+    });
+
+    expect(idleWithinTwoSeconds).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add a VS Code regression Playwright spec that opens a large file, runs search, checks listener cleanup and verifies the page returns idle after close
- expose the spec in Playwright config and CI so it runs under a dedicated GitHub Actions job
- document the CPU idle threshold and listener expectations in `docs/testing.md`

## Testing
- `npx playwright test playwright/vscode.regression.spec.ts` *(fails: host is missing Playwright browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cc06707c3c8328a0a5bdc451c6dda6