### PR TITLE
[calculator] enhance tape history controls

### DIFF
--- a/__tests__/calculator.tape.test.tsx
+++ b/__tests__/calculator.tape.test.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
-import Tape from '../apps/calculator/components/Tape';
+import Tape, { TapeEntry } from '../apps/calculator/components/Tape';
 
 describe('Calculator Tape', () => {
   beforeEach(() => {
     document.body.innerHTML = '<input id="display" />';
     const writeText = jest.fn().mockResolvedValue(undefined);
     Object.assign(navigator, { clipboard: { writeText } });
+    window.localStorage.clear();
   });
 
   it('recalls result to display', () => {
+    const entry: TapeEntry = { id: 'entry-1', expr: '1+1', result: '2' };
     const { getByLabelText } = render(
-      <Tape entries={[{ expr: '1+1', result: '2' }]} />,
+      <Tape entries={[entry]} />,
     );
     fireEvent.click(getByLabelText('recall result'));
     const display = document.getElementById('display') as HTMLInputElement;
@@ -19,12 +21,61 @@ describe('Calculator Tape', () => {
   });
 
   it('copies result to clipboard', async () => {
+    const entry: TapeEntry = { id: 'entry-1', expr: '1+1', result: '2' };
     const { getByLabelText } = render(
-      <Tape entries={[{ expr: '1+1', result: '2' }]} />,
+      <Tape entries={[entry]} />,
     );
     fireEvent.click(getByLabelText('copy result'));
     await waitFor(() =>
       expect((navigator.clipboard as any).writeText).toHaveBeenCalledWith('2'),
+    );
+  });
+
+  it('persists pinned entries across renders', async () => {
+    const entry: TapeEntry = { id: 'entry-1', expr: '4*4', result: '16' };
+    const { getByLabelText, rerender } = render(<Tape entries={[entry]} />);
+
+    const pinButton = getByLabelText('pin entry');
+    fireEvent.click(pinButton);
+
+    await waitFor(() =>
+      expect(window.localStorage.getItem('calc-pins')).toContain('entry-1'),
+    );
+    expect(pinButton).toHaveAttribute('aria-pressed', 'true');
+
+    rerender(<Tape entries={[entry]} />);
+
+    const persistedButton = getByLabelText('unpin entry');
+    expect(persistedButton).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('clears history and pinned state', async () => {
+    const entry: TapeEntry = { id: 'entry-1', expr: '5+7', result: '12' };
+    const onClear = jest.fn();
+
+    function Wrapper() {
+      const [entries, setEntries] = React.useState([entry]);
+      const handleClear = () => {
+        onClear();
+        setEntries([]);
+      };
+      return <Tape entries={entries} onClearHistory={handleClear} />;
+    }
+
+    const { getByLabelText } = render(<Wrapper />);
+
+    const pinButton = getByLabelText('pin entry');
+    fireEvent.click(pinButton);
+
+    await waitFor(() =>
+      expect(window.localStorage.getItem('calc-pins')).toContain('entry-1'),
+    );
+
+    fireEvent.click(getByLabelText('clear history'));
+
+    await waitFor(() => expect(onClear).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(window.localStorage.getItem('calc-pins')).toBe('[]'),
     );
   });
 });

--- a/apps/calculator/components/Tape.tsx
+++ b/apps/calculator/components/Tape.tsx
@@ -1,18 +1,58 @@
 'use client';
 
-import { useCallback, useEffect, useRef } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
 
-interface TapeProps {
-  entries: { expr: string; result: string }[];
+export interface TapeEntry {
+  id: string;
+  expr: string;
+  result: string;
 }
 
-export default function Tape({ entries }: TapeProps) {
+interface TapeProps {
+  entries: TapeEntry[];
+  onClearHistory?: () => void;
+}
+
+export default function Tape({ entries, onClearHistory }: TapeProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const [pinnedIds, setPinnedIds, , clearPinned] = usePersistentState<string[]>(
+    'calc-pins',
+    () => [],
+    (value): value is string[] =>
+      Array.isArray(value) && value.every((id) => typeof id === 'string'),
+  );
 
   useEffect(() => {
     const el = containerRef.current;
     if (el) el.scrollTop = 0;
   }, [entries]);
+
+  useEffect(() => {
+    const entryIds = new Set(entries.map((entry) => entry.id));
+    setPinnedIds((current) => {
+      const filtered = current.filter((id) => entryIds.has(id));
+      return filtered.length === current.length ? current : filtered;
+    });
+  }, [entries, setPinnedIds]);
+
+  const orderedEntries = useMemo(() => {
+    if (!entries.length) return [];
+    const pinnedSet = new Set(pinnedIds);
+    const pinned: TapeEntry[] = [];
+    const regular: TapeEntry[] = [];
+    entries.forEach((entry) => {
+      if (pinnedSet.has(entry.id)) pinned.push(entry);
+      else regular.push(entry);
+    });
+    return [...pinned, ...regular];
+  }, [entries, pinnedIds]);
 
   const handleRecall = useCallback((result: string) => {
     const display = document.getElementById('display') as HTMLInputElement | null;
@@ -21,38 +61,126 @@ export default function Tape({ entries }: TapeProps) {
 
   const handleCopy = useCallback(async (text: string) => {
     try {
-      await navigator.clipboard.writeText(text);
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      }
     } catch {
       // ignore clipboard errors
     }
   }, []);
 
+  const togglePin = useCallback(
+    (id: string) => {
+      if (!id) return;
+      setPinnedIds((current) => {
+        if (current.includes(id)) {
+          return current.filter((pinnedId) => pinnedId !== id);
+        }
+        return [...current, id];
+      });
+    },
+    [setPinnedIds],
+  );
+
+  const handleClearHistory = useCallback(() => {
+    onClearHistory?.();
+    clearPinned();
+    const el = containerRef.current;
+    if (el) el.scrollTop = 0;
+  }, [clearPinned, onClearHistory]);
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (!containerRef.current) return;
+      if (event.key === 'Home') {
+        event.preventDefault();
+        containerRef.current.scrollTop = 0;
+      } else if (event.key === 'End') {
+        event.preventDefault();
+        containerRef.current.scrollTop = containerRef.current.scrollHeight;
+      }
+    },
+    [],
+  );
+
   return (
-    <div ref={containerRef} className="tape font-mono max-h-40 overflow-y-auto">
-      {entries.map(({ expr, result }, i) => (
-        <div
-          key={i}
-          className="p-1 odd:bg-black/20 even:bg-black/10 flex items-center gap-2"
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs uppercase tracking-wide text-white/70">Tape</span>
+        <button
+          type="button"
+          onClick={handleClearHistory}
+          className="text-xs px-2 py-1 bg-black/40 hover:bg-black/50 transition rounded"
+          aria-label="clear history"
         >
-          <div className="flex-1">
-            {expr} = {result}
-          </div>
-          <button
-            className="text-xs px-1 py-0.5 bg-black/20 rounded"
-            onClick={() => handleRecall(result)}
-            aria-label="recall result"
-          >
-            Ans
-          </button>
-          <button
-            className="text-xs px-1 py-0.5 bg-black/20 rounded"
-            onClick={() => handleCopy(result)}
-            aria-label="copy result"
-          >
-            Copy
-          </button>
-        </div>
-      ))}
+          Clear history
+        </button>
+      </div>
+      <div
+        ref={containerRef}
+        className="tape font-mono max-h-40 overflow-y-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:ring-white"
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        role="list"
+        aria-label="calculation history"
+      >
+        {orderedEntries.length === 0 ? (
+          <div className="p-2 text-xs text-white/60">No history yet.</div>
+        ) : (
+          orderedEntries.map(({ id, expr, result }) => {
+            const isPinned = pinnedIds.includes(id);
+            return (
+              <div
+                key={id}
+                role="listitem"
+                data-pinned={isPinned || undefined}
+                className={`p-2 flex items-center gap-2 odd:bg-black/20 even:bg-black/10 ${
+                  isPinned ? 'border-l-2 border-yellow-400 bg-yellow-500/10' : ''
+                }`}
+              >
+                <div className="flex-1">
+                  {expr} = {result}
+                </div>
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    className="text-xs px-1 py-0.5 bg-black/30 rounded"
+                    onClick={() => togglePin(id)}
+                    aria-label={isPinned ? 'unpin entry' : 'pin entry'}
+                    aria-pressed={isPinned}
+                  >
+                    📌
+                  </button>
+                  <button
+                    type="button"
+                    className="text-xs px-1 py-0.5 bg-black/30 rounded"
+                    onClick={() => handleRecall(result)}
+                    aria-label="recall result"
+                  >
+                    Ans
+                  </button>
+                  <button
+                    type="button"
+                    className="text-xs px-1 py-0.5 bg-black/30 rounded"
+                    onClick={() => handleCopy(expr)}
+                    aria-label="copy expression"
+                  >
+                    Copy expr
+                  </button>
+                  <button
+                    type="button"
+                    className="text-xs px-1 py-0.5 bg-black/30 rounded"
+                    onClick={() => handleCopy(result)}
+                    aria-label="copy result"
+                  >
+                    Copy
+                  </button>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add persistent pin toggles, copy controls, and keyboard-aware scroll wrapper to the calculator tape
- hydrate stored calculator history with stable IDs so pinned entries survive reloads and clearing
- extend tape tests to cover pin persistence and the clear-history workflow

## Testing
- yarn test calculator.tape.test.tsx
- yarn lint *(fails: repository has numerous pre-existing jsx-a11y and no-top-level-window warnings)*
- yarn test *(fails: existing suites such as window and nmapNse plus watch-mode interaction)*

------
https://chatgpt.com/codex/tasks/task_e_68cc066f34648328926c3518dd6ab426