### PR TITLE
[calculator] Add decimal memory with status toasts

### DIFF
--- a/__tests__/calculator.memory.test.ts
+++ b/__tests__/calculator.memory.test.ts
@@ -1,0 +1,54 @@
+jest.mock('../utils/statusToast', () => ({
+  dispatchStatusToast: jest.fn(),
+  subscribeStatusToast: jest.fn(() => () => {}),
+}));
+
+const { dispatchStatusToast } = require('../utils/statusToast');
+
+function loadCalculator() {
+  delete require.cache[require.resolve('../apps/calculator/main.js')];
+  return require('../apps/calculator/main.js');
+}
+
+describe('calculator memory helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.math = require('mathjs');
+  });
+
+  afterEach(() => {
+    delete global.math;
+  });
+
+  it('tracks memory using decimal arithmetic and emits toasts on updates', () => {
+    const calc = loadCalculator();
+    const { memoryAdd, memorySubtract, memoryRecall, memoryClear } = calc;
+
+    expect(memoryRecall()).toBe('0');
+
+    memoryAdd('0.1');
+    memoryAdd('0.2');
+    expect(memoryRecall()).toBe('0.3');
+
+    memorySubtract('0.05');
+    expect(memoryRecall()).toBe('0.25');
+
+    expect(dispatchStatusToast).toHaveBeenNthCalledWith(1, 'Memory updated: 0.1');
+    expect(dispatchStatusToast).toHaveBeenNthCalledWith(2, 'Memory updated: 0.3');
+    expect(dispatchStatusToast).toHaveBeenNthCalledWith(3, 'Memory updated: 0.25');
+
+    memoryClear();
+    expect(memoryRecall()).toBe('0');
+    expect(dispatchStatusToast).toHaveBeenNthCalledWith(4, 'Memory cleared');
+  });
+
+  it('ignores invalid expressions without mutating memory', () => {
+    const calc = loadCalculator();
+    const { memoryAdd, memoryRecall } = calc;
+
+    expect(memoryRecall()).toBe('0');
+    memoryAdd('not a number');
+    expect(memoryRecall()).toBe('0');
+    expect(dispatchStatusToast).not.toHaveBeenCalled();
+  });
+});

--- a/apps/calculator/index.tsx
+++ b/apps/calculator/index.tsx
@@ -30,6 +30,7 @@ export default function Calculator() {
     let memoryAdd: any;
     let memorySubtract: any;
     let memoryRecall: any;
+    let memoryClear: any;
     let formatBase: any;
     let getLastResult: any;
     let setBase: any;
@@ -49,6 +50,7 @@ export default function Calculator() {
       memoryAdd = mod.memoryAdd;
       memorySubtract = mod.memorySubtract;
       memoryRecall = mod.memoryRecall;
+      memoryClear = mod.memoryClear;
       formatBase = mod.formatBase;
       getLastResult = mod.getLastResult;
       setBase = mod.setBase;
@@ -121,6 +123,11 @@ export default function Calculator() {
 
           if (action === 'mr') {
             display.value = formatBase(memoryRecall());
+            return;
+          }
+
+          if (action === 'mc') {
+            memoryClear();
             return;
           }
 
@@ -197,10 +204,11 @@ export default function Calculator() {
       <button id="toggle-programmer" className="toggle h-12" aria-pressed="false" aria-label="toggle programmer mode">Programmer</button>
       <button id="toggle-history" className="toggle h-12" aria-pressed="false" aria-label="toggle history">History</button>
       <button id="toggle-formulas" className="toggle h-12" aria-pressed="false" aria-label="toggle formulas">Formulas</button>
-      <div className="memory-grid grid grid-cols-3" aria-label="memory functions">
+      <div className="memory-grid grid grid-cols-4" aria-label="memory functions">
         <button className={btnCls} data-action="mplus" aria-label="add to memory">M+</button>
         <button className={btnCls} data-action="mminus" aria-label="subtract from memory">M&minus;</button>
         <button className={btnCls} data-action="mr" aria-label="recall memory">MR</button>
+        <button className={btnCls} data-action="mc" aria-label="clear memory">MC</button>
       </div>
       <MemorySlots />
       <div className="button-grid grid grid-cols-4 font-mono" aria-label="calculator keypad">

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,13 +1,17 @@
 import React, { useEffect, useState } from "react";
 import Image from 'next/image';
+import Toast from '../ui/Toast';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
+
+const { subscribeStatusToast } = require('../../utils/statusToast');
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
 export default function Status() {
   const { allowNetwork } = useSettings();
   const [online, setOnline] = useState(true);
+  const [toast, setToast] = useState(null);
 
   useEffect(() => {
     const pingServer = async () => {
@@ -38,8 +42,26 @@ export default function Status() {
     };
   }, []);
 
+  useEffect(() => {
+    const unsubscribe = subscribeStatusToast((message) => {
+      if (!message) return;
+      setToast({ id: Date.now(), message });
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
   return (
-    <div className="flex justify-center items-center">
+    <>
+      {toast && (
+        <Toast
+          key={toast.id}
+          message={toast.message}
+          onClose={() => setToast(null)}
+        />
+      )}
+      <div className="flex justify-center items-center">
       <span
         className="mx-1.5 relative"
         title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}
@@ -79,6 +101,7 @@ export default function Status() {
       <span className="mx-1">
         <SmallArrow angle="down" className=" status-symbol" />
       </span>
-    </div>
+      </div>
+    </>
   );
 }

--- a/utils/statusToast.js
+++ b/utils/statusToast.js
@@ -1,0 +1,35 @@
+const STATUS_TOAST_EVENT = 'status-toast';
+
+function dispatchStatusToast(message) {
+  if (typeof window === 'undefined' || !message) return;
+  const detail = typeof message === 'string' ? { message } : message;
+  try {
+    window.dispatchEvent(new CustomEvent(STATUS_TOAST_EVENT, { detail }));
+  } catch {
+    // ignore environments without CustomEvent
+  }
+}
+
+function subscribeStatusToast(handler) {
+  if (typeof window === 'undefined' || typeof handler !== 'function') {
+    return () => {};
+  }
+  const listener = (event) => {
+    const detail = event?.detail;
+    const message =
+      typeof detail === 'string'
+        ? detail
+        : typeof detail?.message === 'string'
+          ? detail.message
+          : '';
+    if (message) handler(message);
+  };
+  window.addEventListener(STATUS_TOAST_EVENT, listener);
+  return () => window.removeEventListener(STATUS_TOAST_EVENT, listener);
+}
+
+module.exports = {
+  STATUS_TOAST_EVENT,
+  dispatchStatusToast,
+  subscribeStatusToast,
+};


### PR DESCRIPTION
## Summary
- refactor calculator memory helpers to use Decimal.js storage and expose memoryClear while dispatching status toasts
- add shared status toast event helpers and wire the status bar component to render toast notifications
- exercise calculator memory flows with a dedicated Jest suite covering toast interactions

## Testing
- yarn lint *(fails: existing accessibility violations across multiple apps)*
- yarn test *(fails: pre-existing suites including window, nmap NSE, reconng)*

------
https://chatgpt.com/codex/tasks/task_e_68cc066dcf188328897aaa2b71730aee