### PR TITLE
[resource-monitor] offload charts to worker and add perf spec

### DIFF
--- a/components/apps/resource_monitor.js
+++ b/components/apps/resource_monitor.js
@@ -1,85 +1,200 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { hasOffscreenCanvas } from '../../utils/feature';
 
-// Number of samples to keep in the timeline
-const MAX_POINTS = 60;
+const createEmptyStats = () => ({
+  latest: 0,
+  average: 0,
+  min: 0,
+  max: 0,
+  windowAverage: 0,
+  windowMin: 0,
+  windowMax: 0,
+  trend: 0,
+  count: 0,
+});
+
+const METRIC_CONFIG = [
+  { key: 'cpu', label: 'CPU', suffix: '%', precision: 1, color: '#00ff00' },
+  { key: 'memory', label: 'Memory', suffix: '%', precision: 1, color: '#ffd700' },
+  { key: 'down', label: 'Download', suffix: 'Mbps', precision: 2, color: '#00ffff' },
+  { key: 'up', label: 'Upload', suffix: 'Mbps', precision: 2, color: '#ff00ff' },
+];
+
+const toNumber = (value, fallback = 0) =>
+  typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+
+const isSameLatest = (a, b) =>
+  a.cpu === b.cpu && a.memory === b.memory && a.down === b.down && a.up === b.up;
+
+const formatMetric = (value, precision, suffix) => {
+  const numeric = Number.isFinite(value) ? value : 0;
+  const formatted = numeric.toFixed(precision);
+  if (!suffix) return formatted;
+  if (suffix === '%') return `${formatted}${suffix}`;
+  return `${formatted} ${suffix}`;
+};
 
 const ResourceMonitor = () => {
   const cpuCanvas = useRef(null);
   const memCanvas = useRef(null);
-  const fpsCanvas = useRef(null);
   const netCanvas = useRef(null);
-  const workerRef = useRef(null);
-
-  const dataRef = useRef({ cpu: [], mem: [], fps: [], net: [] });
-  const displayRef = useRef({ cpu: [], mem: [], fps: [], net: [] });
-  const animRef = useRef();
-  const lastDrawRef = useRef(0);
-  const THROTTLE_MS = 1000;
+  const containerRef = useRef(null);
+  const monitorWorkerRef = useRef(null);
+  const stressWindows = useRef([]);
+  const stressEls = useRef([]);
+  const latestRef = useRef({ cpu: 0, memory: 0, down: 0, up: 0 });
+  const supportsOffscreenRef = useRef(false);
 
   const [paused, setPaused] = useState(false);
   const [stress, setStress] = useState(false);
   const [fps, setFps] = useState(0);
+  const [summary, setSummary] = useState({
+    cpu: createEmptyStats(),
+    memory: createEmptyStats(),
+    down: createEmptyStats(),
+    up: createEmptyStats(),
+  });
 
-  const stressWindows = useRef([]);
-  const stressEls = useRef([]);
-  const containerRef = useRef(null);
-
-  useEffect(() => () => cancelAnimationFrame(animRef.current), []);
-
-  // Spawn worker for network speed tests
   useEffect(() => {
-    if (typeof window === 'undefined' || typeof Worker !== 'function') return;
-    workerRef.current = new Worker(
-      new URL('./speedtest.worker.js', import.meta.url),
-    );
-    workerRef.current.onmessage = (e) => {
-      const { speed } = e.data || {};
-      pushSample('net', speed);
-      scheduleDraw();
+    if (typeof window === 'undefined') return undefined;
+    window.__playwright_mainThreadWork = [];
+    return () => {
+      window.__playwright_mainThreadWork = [];
     };
-    workerRef.current.postMessage({ type: 'start' });
-    return () => workerRef.current?.terminate();
-  }, [scheduleDraw]);
+  }, []);
 
   useEffect(() => {
-    if (workerRef.current) {
-      workerRef.current.postMessage({ type: paused ? 'stop' : 'start' });
+    if (typeof window === 'undefined' || typeof Worker !== 'function') return undefined;
+
+    const offscreenSupported = hasOffscreenCanvas();
+    supportsOffscreenRef.current = offscreenSupported;
+    const worker = new Worker(new URL('./resource_monitor.worker.js', import.meta.url));
+    monitorWorkerRef.current = worker;
+
+    const reduceMotionQuery =
+      typeof window.matchMedia === 'function'
+        ? window.matchMedia('(prefers-reduced-motion: reduce)')
+        : null;
+    const reduceMotion = !!reduceMotionQuery?.matches;
+
+    const canvases = {};
+    const transfers = [];
+    if (offscreenSupported && cpuCanvas.current && 'transferControlToOffscreen' in cpuCanvas.current) {
+      const canvas = cpuCanvas.current.transferControlToOffscreen();
+      canvases.cpu = canvas;
+      transfers.push(canvas);
     }
+    if (offscreenSupported && memCanvas.current && 'transferControlToOffscreen' in memCanvas.current) {
+      const canvas = memCanvas.current.transferControlToOffscreen();
+      canvases.memory = canvas;
+      transfers.push(canvas);
+    }
+    if (offscreenSupported && netCanvas.current && 'transferControlToOffscreen' in netCanvas.current) {
+      const canvas = netCanvas.current.transferControlToOffscreen();
+      canvases.network = canvas;
+      transfers.push(canvas);
+    }
+
+    const initPayload = { type: 'init', canvases, reduceMotion };
+    if (transfers.length > 0) worker.postMessage(initPayload, transfers);
+    else worker.postMessage(initPayload);
+    worker.postMessage({ type: 'decimate', value: reduceMotion ? 2 : 1 });
+    worker.postMessage({ type: 'visibility', hidden: document.visibilityState === 'hidden' });
+
+    worker.onmessage = (event) => {
+      const { type, summary: summaryData, latest: latestSample } = event.data || {};
+      if (type !== 'summary' || !summaryData) return;
+      const start = typeof performance !== 'undefined' ? performance.now() : Date.now();
+      setSummary(summaryData);
+      let nextLatest = latestRef.current;
+      if (latestSample && typeof latestSample === 'object') {
+        nextLatest = {
+          cpu: toNumber(latestSample.cpu, latestRef.current.cpu),
+          memory: toNumber(latestSample.memory, latestRef.current.memory),
+          down: toNumber(latestSample.down, latestRef.current.down),
+          up: toNumber(latestSample.up, latestRef.current.up),
+        };
+        if (!isSameLatest(latestRef.current, nextLatest)) {
+          latestRef.current = nextLatest;
+        }
+      }
+      if (!supportsOffscreenRef.current) {
+        drawFallbackCharts(
+          {
+            cpu: cpuCanvas.current,
+            memory: memCanvas.current,
+            network: netCanvas.current,
+          },
+          summaryData,
+          nextLatest,
+        );
+      }
+      if (typeof window !== 'undefined') {
+        const store = (window.__playwright_mainThreadWork = window.__playwright_mainThreadWork || []);
+        const end = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        store.push(end - start);
+        if (store.length > 120) store.shift();
+      }
+    };
+
+    const handleVisibility = () => {
+      worker.postMessage({ type: 'visibility', hidden: document.visibilityState === 'hidden' });
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    const handleMotionChange = (event) => {
+      worker.postMessage({ type: 'decimate', value: event.matches ? 2 : 1 });
+    };
+    if (reduceMotionQuery) {
+      if (typeof reduceMotionQuery.addEventListener === 'function') {
+        reduceMotionQuery.addEventListener('change', handleMotionChange);
+      } else if (typeof reduceMotionQuery.addListener === 'function') {
+        reduceMotionQuery.addListener(handleMotionChange);
+      }
+    }
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibility);
+      if (reduceMotionQuery) {
+        if (typeof reduceMotionQuery.removeEventListener === 'function') {
+          reduceMotionQuery.removeEventListener('change', handleMotionChange);
+        } else if (typeof reduceMotionQuery.removeListener === 'function') {
+          reduceMotionQuery.removeListener(handleMotionChange);
+        }
+      }
+      worker.terminate();
+      monitorWorkerRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!monitorWorkerRef.current) return;
+    monitorWorkerRef.current.postMessage({ type: 'pause', value: paused });
   }, [paused]);
 
-  // Sampling loop using requestAnimationFrame
   useEffect(() => {
+    if (!monitorWorkerRef.current) return;
+    monitorWorkerRef.current.postMessage({ type: 'stress', value: stress });
+  }, [stress]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
     let raf;
-    let lastFrame = performance.now();
-    let lastSample = performance.now();
-
-    const sample = (now) => {
-      const dt = now - lastFrame;
-      lastFrame = now;
-      const currentFps = 1000 / dt;
-      if (!paused) setFps(currentFps);
-
-      if (!paused && now - lastSample >= 1000) {
-        const target = 1000 / 60; // 60 FPS ideal frame time
-        const cpu = Math.min(100, Math.max(0, ((dt - target) / target) * 100));
-        let mem = 0;
-        if (performance && performance.memory) {
-          const { usedJSHeapSize, totalJSHeapSize } = performance.memory;
-          mem = (usedJSHeapSize / totalJSHeapSize) * 100;
-        }
-        pushSample('cpu', cpu);
-        pushSample('mem', mem);
-        pushSample('fps', currentFps);
-        scheduleDraw();
-        lastSample = now;
+    let last = performance.now();
+    let lastUpdate = last;
+    const measure = (now) => {
+      const dt = now - last;
+      last = now;
+      if (!paused && dt > 0 && now - lastUpdate >= 500) {
+        setFps(1000 / dt);
+        lastUpdate = now;
       }
-      raf = requestAnimationFrame(sample);
+      raf = requestAnimationFrame(measure);
     };
-    raf = requestAnimationFrame(sample);
+    raf = requestAnimationFrame(measure);
     return () => cancelAnimationFrame(raf);
-  }, [paused, scheduleDraw]);
+  }, [paused]);
 
-  // Stress test animation – many moving windows
   useEffect(() => {
     let raf;
     const animate = () => {
@@ -102,7 +217,6 @@ const ResourceMonitor = () => {
     return () => cancelAnimationFrame(raf);
   }, [stress, paused]);
 
-  // Create or clear stress windows when toggled
   useEffect(() => {
     if (stress) {
       const rect = containerRef.current?.getBoundingClientRect();
@@ -119,56 +233,6 @@ const ResourceMonitor = () => {
       stressEls.current = [];
     }
   }, [stress]);
-
-  const pushSample = (key, value) => {
-    const arr = dataRef.current[key];
-    arr.push(value);
-    if (arr.length > MAX_POINTS) arr.shift();
-  };
-
-  const drawCharts = (dataset = dataRef.current) => {
-    drawChart(cpuCanvas.current, dataset.cpu, '#00ff00', 'CPU %', 100);
-    drawChart(memCanvas.current, dataset.mem, '#ffd700', 'Memory %', 100);
-    drawChart(fpsCanvas.current, dataset.fps, '#00ffff', 'FPS', 120);
-    drawChart(netCanvas.current, dataset.net, '#ff00ff', 'Mbps', 100);
-  };
-
-  const animateCharts = useCallback(() => {
-    const from = { ...displayRef.current };
-    const to = { ...dataRef.current };
-    const start = performance.now();
-    const duration = 300;
-
-    const step = (now) => {
-      const t = Math.min(1, (now - start) / duration);
-      const interpolated = {};
-      ['cpu', 'mem', 'fps', 'net'].forEach((key) => {
-        const fromArr = from[key];
-        const toArr = to[key];
-        interpolated[key] = toArr.map((v, i) => {
-          const a = fromArr[i] ?? fromArr[fromArr.length - 1] ?? 0;
-          return a + (v - a) * t;
-        });
-      });
-      drawCharts(interpolated);
-      if (t < 1) {
-        animRef.current = requestAnimationFrame(step);
-      } else {
-        displayRef.current = to;
-      }
-    };
-
-    cancelAnimationFrame(animRef.current);
-    animRef.current = requestAnimationFrame(step);
-  }, []);
-
-  const scheduleDraw = useCallback(() => {
-    const now = performance.now();
-    if (now - lastDrawRef.current >= THROTTLE_MS) {
-      lastDrawRef.current = now;
-      animateCharts();
-    }
-  }, [animateCharts]);
 
   const togglePause = () => setPaused((p) => !p);
   const toggleStress = () => setStress((s) => !s);
@@ -187,7 +251,7 @@ const ResourceMonitor = () => {
         </button>
         <span className="ml-auto text-sm">FPS: {fps.toFixed(1)}</span>
       </div>
-      <div className="flex flex-1 items-center justify-evenly gap-4 p-4">
+      <div className="flex flex-1 flex-wrap items-center justify-evenly gap-4 p-4">
         <canvas
           ref={cpuCanvas}
           width={300}
@@ -205,14 +269,6 @@ const ResourceMonitor = () => {
           className="bg-ub-dark-grey"
         />
         <canvas
-          ref={fpsCanvas}
-          width={300}
-          height={100}
-          role="img"
-          aria-label="FPS chart"
-          className="bg-ub-dark-grey"
-        />
-        <canvas
           ref={netCanvas}
           width={300}
           height={100}
@@ -220,6 +276,37 @@ const ResourceMonitor = () => {
           aria-label="Network speed chart"
           className="bg-ub-dark-grey"
         />
+      </div>
+      <div className="px-4 pb-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3 text-xs">
+        {METRIC_CONFIG.map((metric) => {
+          const stats = summary[metric.key] || createEmptyStats();
+          return (
+            <div
+              key={metric.key}
+              className="rounded border border-gray-700 bg-ub-dark-grey px-3 py-2 shadow-inner"
+            >
+              <div className="flex items-baseline justify-between">
+                <span className="uppercase tracking-wide text-[10px] text-gray-400">
+                  {metric.label}
+                </span>
+                <span className="font-semibold text-sm">
+                  {formatMetric(stats.latest, metric.precision, metric.suffix)}
+                </span>
+              </div>
+              <div className="mt-1 text-[10px] leading-relaxed text-gray-400">
+                <div>
+                  Avg: {formatMetric(stats.average, metric.precision, metric.suffix)}
+                </div>
+                <div>
+                  Window: {formatMetric(stats.windowAverage, metric.precision, metric.suffix)}
+                </div>
+                <div>
+                  Max: {formatMetric(stats.max, metric.precision, metric.suffix)}
+                </div>
+              </div>
+            </div>
+          );
+        })}
       </div>
       {stressWindows.current.map((_, i) => (
         <div
@@ -234,27 +321,63 @@ const ResourceMonitor = () => {
   );
 };
 
-function drawChart(canvas, values, color, label, maxVal) {
+function drawFallbackCharts(canvases, summary, latest) {
+  if (!latest) return;
+  drawFallbackBar(canvases.cpu, latest.cpu, 'CPU', '#00ff00', 100);
+  drawFallbackBar(canvases.memory, latest.memory, 'Memory', '#ffd700', 100);
+  drawFallbackNetwork(
+    canvases.network,
+    latest.down,
+    latest.up,
+    summary?.down?.max ?? 0,
+    summary?.up?.max ?? 0,
+  );
+}
+
+function drawFallbackBar(canvas, value, label, color, maxValue) {
   if (!canvas) return;
   const ctx = canvas.getContext('2d');
   if (!ctx) return;
   const w = canvas.width;
   const h = canvas.height;
   ctx.clearRect(0, 0, w, h);
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  values.forEach((v, i) => {
-    const x = (i / (values.length - 1 || 1)) * w;
-    const y = h - (v / maxVal) * h;
-    if (i === 0) ctx.moveTo(x, y);
-    else ctx.lineTo(x, y);
-  });
-  ctx.stroke();
-  const latest = values[values.length - 1] || 0;
+  ctx.fillStyle = '#0f172a';
+  ctx.fillRect(0, 0, w, h);
+  const safeValue = Number.isFinite(value) ? value : 0;
+  const safeMax = maxValue > 0 ? maxValue : 100;
+  const ratio = Math.max(0, Math.min(1, safeValue / safeMax));
+  const barWidth = ratio * w;
+  ctx.fillStyle = color;
+  ctx.fillRect(0, h - 18, barWidth, 16);
   ctx.fillStyle = '#ffffff';
   ctx.font = '12px sans-serif';
-  ctx.fillText(`${label}: ${latest.toFixed(1)}`, 4, 12);
+  ctx.fillText(`${label}: ${safeValue.toFixed(1)}`, 4, 14);
+}
+
+function drawFallbackNetwork(canvas, down, up, downMax, upMax) {
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  const w = canvas.width;
+  const h = canvas.height;
+  ctx.clearRect(0, 0, w, h);
+  ctx.fillStyle = '#0f172a';
+  ctx.fillRect(0, 0, w, h);
+  const safeDown = Number.isFinite(down) ? down : 0;
+  const safeUp = Number.isFinite(up) ? up : 0;
+  const safeDownMax = Number.isFinite(downMax) && downMax > 0 ? downMax : 0;
+  const safeUpMax = Number.isFinite(upMax) && upMax > 0 ? upMax : 0;
+  const maxVal = Math.max(safeDownMax, safeUpMax, safeDown, safeUp, 1);
+  const downRatio = Math.max(0, Math.min(1, safeDown / maxVal));
+  const upRatio = Math.max(0, Math.min(1, safeUp / maxVal));
+  ctx.fillStyle = '#00ffff';
+  ctx.fillRect(0, h / 2 - 18, downRatio * w, 16);
+  ctx.fillStyle = '#ff00ff';
+  ctx.fillRect(0, h / 2 + 2, upRatio * w, 16);
+  ctx.fillStyle = '#ffffff';
+  ctx.font = '12px sans-serif';
+  ctx.fillText(`Down: ${safeDown.toFixed(1)} Mbps`, 4, 14);
+  ctx.fillText(`Up: ${safeUp.toFixed(1)} Mbps`, 4, h - 6);
 }
 
 export default ResourceMonitor;

--- a/tests/resource-monitor.perf.spec.ts
+++ b/tests/resource-monitor.perf.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const APP_ID = 'resource-monitor';
+
+const waitForMainThreadMetrics = async (page: Page) => {
+  await page.waitForFunction(() => {
+    const store = (window as any).__playwright_mainThreadWork;
+    if (!Array.isArray(store)) return false;
+    const numeric = store.filter((value) => typeof value === 'number' && !Number.isNaN(value));
+    return numeric.length >= 5;
+  });
+};
+
+test.describe('Resource monitor performance', () => {
+  test('main thread work stays under 8ms', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('#desktop');
+    await page.waitForFunction(() => {
+      const bootLogo = document.querySelector('img[alt="Ubuntu Logo"]');
+      if (!bootLogo) return true;
+      const bootContainer = bootLogo.closest('div');
+      if (!bootContainer) return true;
+      return bootContainer.classList.contains('invisible');
+    });
+
+    await page.evaluate((id) => {
+      window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
+    }, APP_ID);
+
+    await page.waitForSelector(`#${APP_ID}`);
+    await waitForMainThreadMetrics(page);
+
+    const maxDuration = await page.evaluate(() => {
+      const store = ((window as any).__playwright_mainThreadWork || []) as number[];
+      return store.reduce((max, value) => {
+        if (typeof value !== 'number' || Number.isNaN(value)) return max;
+        return value > max ? value : max;
+      }, 0);
+    });
+
+    expect(maxDuration).toBeLessThan(8);
+  });
+});


### PR DESCRIPTION
## Summary
- refactor the resource monitor to rely on worker summaries and expose metric cards
- extend the resource monitor web worker with moving-average aggregation and structured messages
- add a Playwright performance spec that opens the resource monitor and asserts main-thread work stays below 8 ms

## Testing
- yarn lint *(fails: existing jsx-a11y issues in unrelated apps)*
- yarn test *(fails: pre-existing jest failures in window and nmap specs)*
- npx playwright test tests/resource-monitor.perf.spec.ts *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc066dc39c8328a2f3eaeed2a2ba9c