### PR TITLE
[file-explorer] improve selection interactions

### DIFF
--- a/__tests__/file-explorer.selection.test.tsx
+++ b/__tests__/file-explorer.selection.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import FileExplorer from '../components/apps/file-explorer';
+
+const mockUseOPFS = jest.fn();
+
+jest.mock('../hooks/useOPFS', () => ({
+  __esModule: true,
+  default: () => mockUseOPFS(),
+}));
+
+const createFileHandle = (name: string) => ({
+  kind: 'file',
+  name,
+  move: jest.fn(),
+  getFile: jest.fn().mockResolvedValue({
+    name,
+    text: jest.fn().mockResolvedValue(''),
+  }),
+});
+
+const createDirHandle = (name: string, children: any[] = []) => {
+  const handle = {
+    kind: 'directory' as const,
+    name,
+    move: jest.fn(),
+    entries() {
+      const pairs = children.map((child) => [child.name, child]);
+      return {
+        async *[Symbol.asyncIterator]() {
+          for (const pair of pairs) {
+            yield pair;
+          }
+        },
+      };
+    },
+  };
+  (handle as any).children = children;
+  return handle;
+};
+
+const structure = {
+  directories: ['alpha', 'beta'],
+  files: ['notes.txt', 'omega.md', 'zeta.log'],
+};
+
+const originalShowDirectoryPicker = (window as any).showDirectoryPicker;
+
+const setShowDirectoryPicker = (value: any) => {
+  Object.defineProperty(window, 'showDirectoryPicker', {
+    configurable: true,
+    writable: true,
+    value,
+  });
+};
+
+const setupExplorerMock = () => {
+  const dirHandles = structure.directories.map((name) => createDirHandle(name));
+  const fileHandles = structure.files.map((name) => createFileHandle(name));
+  const rootHandle = createDirHandle('root', [...dirHandles, ...fileHandles]);
+  const unsavedHandle = createDirHandle('unsaved');
+  mockUseOPFS.mockReturnValue({
+    supported: true,
+    root: rootHandle,
+    getDir: jest.fn().mockResolvedValue(unsavedHandle),
+    readFile: jest.fn(),
+    writeFile: jest.fn(),
+    deleteFile: jest.fn(),
+  });
+};
+
+beforeEach(() => {
+  mockUseOPFS.mockReset();
+  setupExplorerMock();
+  setShowDirectoryPicker(jest.fn());
+});
+
+afterEach(() => {
+  if (originalShowDirectoryPicker === undefined) {
+    delete (window as any).showDirectoryPicker;
+  } else {
+    setShowDirectoryPicker(originalShowDirectoryPicker);
+  }
+});
+
+describe('FileExplorer selection mechanics', () => {
+  it('selects a range with shift-click', async () => {
+    render(<FileExplorer />);
+
+    const firstItem = await screen.findByRole('treeitem', { name: 'alpha' });
+    fireEvent.click(firstItem);
+
+    const rangeTarget = screen.getByRole('treeitem', { name: 'omega.md' });
+    fireEvent.click(rangeTarget, { shiftKey: true });
+
+    const selected = screen
+      .getAllByRole('treeitem', { selected: true })
+      .map((el) => el.textContent?.trim());
+
+    expect(selected).toEqual(['alpha', 'beta', 'notes.txt', 'omega.md']);
+  });
+
+  it('navigates selection with arrow keys', async () => {
+    render(<FileExplorer />);
+
+    const firstItem = await screen.findByRole('treeitem', { name: 'alpha' });
+    fireEvent.click(firstItem);
+
+    const tree = screen.getByTestId('file-explorer-tree');
+
+    fireEvent.keyDown(tree, { key: 'ArrowDown' });
+    expect(screen.getByRole('treeitem', { name: 'beta', selected: true })).toBeInTheDocument();
+
+    fireEvent.keyDown(tree, { key: 'ArrowDown' });
+    expect(screen.getByRole('treeitem', { name: 'notes.txt', selected: true })).toBeInTheDocument();
+
+    fireEvent.keyDown(tree, { key: 'ArrowUp' });
+    expect(screen.getByRole('treeitem', { name: 'beta', selected: true })).toBeInTheDocument();
+  });
+});

--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import useOPFS from '../../hooks/useOPFS';
 import { getDb } from '../../utils/safeIDB';
 import Breadcrumbs from '../ui/Breadcrumbs';
@@ -61,6 +61,7 @@ export async function saveFileDialog(options = {}) {
 
 const DB_NAME = 'file-explorer';
 const STORE_NAME = 'recent';
+const DRAG_MIME = 'application/x-file-explorer-entry';
 
 function openDB() {
   return getDb(DB_NAME, 1, {
@@ -104,6 +105,9 @@ export default function FileExplorer() {
   const [results, setResults] = useState([]);
   const workerRef = useRef(null);
   const fallbackInputRef = useRef(null);
+  const treeRef = useRef(null);
+  const [selectedEntries, setSelectedEntries] = useState(() => new Set());
+  const [anchorIndex, setAnchorIndex] = useState(null);
 
   const hasWorker = typeof Worker !== 'undefined';
   const {
@@ -122,6 +126,18 @@ export default function FileExplorer() {
     if (ok) getRecentDirs().then(setRecent);
   }, []);
 
+  const readDir = useCallback(async (handle) => {
+    if (!handle) return;
+    const ds = [];
+    const fs = [];
+    for await (const [name, h] of handle.entries()) {
+      if (h.kind === 'file') fs.push({ name, handle: h });
+      else if (h.kind === 'directory') ds.push({ name, handle: h });
+    }
+    setDirs(ds);
+    setFiles(fs);
+  }, []);
+
   useEffect(() => {
     if (!opfsSupported || !root) return;
     (async () => {
@@ -129,21 +145,140 @@ export default function FileExplorer() {
       setDirHandle(root);
       setPath([{ name: root.name || '/', handle: root }]);
       await readDir(root);
+      setSelectedEntries(new Set());
+      setAnchorIndex(null);
     })();
-  }, [opfsSupported, root, getDir]);
+  }, [opfsSupported, root, getDir, readDir]);
 
-  const saveBuffer = async (name, data) => {
-    if (unsavedDir) await opfsWrite(name, data, unsavedDir);
+  const allEntries = useMemo(() => [...dirs, ...files], [dirs, files]);
+
+  const entryMap = useMemo(() => {
+    const map = new Map();
+    allEntries.forEach((entry, index) => {
+      const key = entry?.handle?.name || entry?.name;
+      if (key) map.set(key, { entry, index });
+    });
+    return map;
+  }, [allEntries]);
+
+  useEffect(() => {
+    setSelectedEntries((prev) => {
+      if (!prev.size) return prev;
+      const next = new Set();
+      allEntries.forEach((entry) => {
+        const key = entry?.handle?.name;
+        if (key && prev.has(key)) next.add(key);
+      });
+      if (next.size === prev.size) return prev;
+      return next;
+    });
+  }, [allEntries]);
+
+  useEffect(() => {
+    if (anchorIndex === null) return;
+    if (anchorIndex < allEntries.length) return;
+    if (!allEntries.length) {
+      setAnchorIndex(null);
+    } else {
+      setAnchorIndex(allEntries.length - 1);
+    }
+  }, [anchorIndex, allEntries]);
+
+  const transferHasType = (dt, type) => {
+    if (!dt?.types) return false;
+    if (typeof dt.types.includes === 'function') return dt.types.includes(type);
+    for (let i = 0; i < dt.types.length; i += 1) {
+      if (dt.types[i] === type) return true;
+    }
+    return false;
   };
 
-  const loadBuffer = async (name) => {
-    if (!unsavedDir) return null;
-    return await opfsRead(name, unsavedDir);
+  const getTransferNames = (dt) => {
+    if (!dt) return [];
+    const raw = dt.getData(DRAG_MIME);
+    if (!raw) return [];
+    try {
+      const payload = JSON.parse(raw);
+      if (Array.isArray(payload?.names)) {
+        return payload.names.filter((name) => typeof name === 'string');
+      }
+    } catch {}
+    return [];
   };
 
-  const removeBuffer = async (name) => {
-    if (unsavedDir) await opfsDelete(name, unsavedDir);
+  const getEntryName = (entry) => {
+    if (!entry) return '';
+    if (typeof entry === 'string') return entry;
+    if (entry?.handle?.name) return entry.handle.name;
+    return entry?.name || '';
   };
+
+  const saveBuffer = useCallback(
+    async (entry, data, options = {}) => {
+      if (!entry) return;
+      if (options?.moveTarget && entry?.handle?.move) {
+        try {
+          await entry.handle.move(options.moveTarget);
+        } catch {}
+      }
+      const name = getEntryName(entry);
+      if (!unsavedDir || data === undefined || !name) return;
+      await opfsWrite(name, data, unsavedDir);
+    },
+    [unsavedDir, opfsWrite],
+  );
+
+  const loadBuffer = useCallback(
+    async (entry) => {
+      if (!unsavedDir) return null;
+      const name = getEntryName(entry);
+      if (!name) return null;
+      return await opfsRead(name, unsavedDir);
+    },
+    [unsavedDir, opfsRead],
+  );
+
+  const removeBuffer = useCallback(
+    async (entry) => {
+      if (!unsavedDir) return;
+      const name = getEntryName(entry);
+      if (!name) return;
+      await opfsDelete(name, unsavedDir);
+    },
+    [unsavedDir, opfsDelete],
+  );
+
+  const moveEntries = useCallback(
+    async (names, destinationHandle) => {
+      if (!destinationHandle || !names?.length) return;
+      const unique = Array.from(new Set(names));
+      const entriesToMove = unique
+        .map((name) => entryMap.get(name))
+        .filter(Boolean)
+        .map((info) => info.entry)
+        .filter((entry) => entry?.handle && entry.handle !== destinationHandle);
+      if (!entriesToMove.length) return;
+      await Promise.all(
+        entriesToMove.map(async (entry) => {
+          try {
+            await saveBuffer(entry, undefined, { moveTarget: destinationHandle });
+          } catch {}
+        }),
+      );
+      setSelectedEntries((prev) => {
+        if (!prev.size) return prev;
+        const next = new Set(prev);
+        let changed = false;
+        unique.forEach((name) => {
+          if (next.delete(name)) changed = true;
+        });
+        return changed ? next : prev;
+      });
+      setAnchorIndex(null);
+      if (dirHandle) await readDir(dirHandle);
+    },
+    [entryMap, saveBuffer, dirHandle, readDir],
+  );
 
   const openFallback = async (e) => {
     const file = e.target.files[0];
@@ -161,6 +296,8 @@ export default function FileExplorer() {
       setRecent(await getRecentDirs());
       setPath([{ name: handle.name || '/', handle }]);
       await readDir(handle);
+      setSelectedEntries(new Set());
+      setAnchorIndex(null);
     } catch {}
   };
 
@@ -171,39 +308,193 @@ export default function FileExplorer() {
       setDirHandle(entry.handle);
       setPath([{ name: entry.name, handle: entry.handle }]);
       await readDir(entry.handle);
+      setSelectedEntries(new Set());
+      setAnchorIndex(null);
     } catch {}
   };
 
-  const openFile = async (file) => {
-    setCurrentFile(file);
-    let text = '';
-    if (opfsSupported) {
-      const unsaved = await loadBuffer(file.name);
-      if (unsaved !== null) text = unsaved;
-    }
-    if (!text) {
-      const f = await file.handle.getFile();
-      text = await f.text();
-    }
-    setContent(text);
-  };
+  const openFile = useCallback(
+    async (file) => {
+      if (!file) return;
+      setCurrentFile(file);
+      let text = '';
+      if (opfsSupported) {
+        const unsaved = await loadBuffer(file);
+        if (unsaved !== null) text = unsaved;
+      }
+      if (!text && file.handle?.getFile) {
+        const f = await file.handle.getFile();
+        text = await f.text();
+      }
+      setContent(text);
+      const key = file?.handle?.name || file?.name;
+      const info = key ? entryMap.get(key) : null;
+      if (info) {
+        setSelectedEntries(new Set([info.entry.handle.name]));
+        setAnchorIndex(info.index);
+      }
+    },
+    [entryMap, loadBuffer, opfsSupported],
+  );
 
-  const readDir = async (handle) => {
-    const ds = [];
-    const fs = [];
-    for await (const [name, h] of handle.entries()) {
-      if (h.kind === 'file') fs.push({ name, handle: h });
-      else if (h.kind === 'directory') ds.push({ name, handle: h });
-    }
-    setDirs(ds);
-    setFiles(fs);
-  };
+  const openDir = useCallback(
+    async (dir, options = {}) => {
+      if (!dir?.handle) return;
+      if (options?.moveEntries?.length) {
+        await moveEntries(options.moveEntries, dir.handle);
+        return;
+      }
+      setDirHandle(dir.handle);
+      setPath((p) => [...p, { name: dir.name, handle: dir.handle }]);
+      await readDir(dir.handle);
+      setSelectedEntries(new Set());
+      setAnchorIndex(null);
+    },
+    [moveEntries, readDir],
+  );
 
-  const openDir = async (dir) => {
-    setDirHandle(dir.handle);
-    setPath((p) => [...p, { name: dir.name, handle: dir.handle }]);
-    await readDir(dir.handle);
-  };
+  const handleEntryClick = useCallback(
+    (event, entry) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const key = entry?.handle?.name || entry?.name;
+      if (!key) return;
+      const info = entryMap.get(key);
+      const index = info?.index ?? -1;
+      const isToggle = event.metaKey || event.ctrlKey;
+      const isRange = event.shiftKey && anchorIndex !== null && anchorIndex >= 0 && index >= 0;
+
+      if (isRange) {
+        const start = Math.min(anchorIndex, index);
+        const end = Math.max(anchorIndex, index);
+        const rangeSet = new Set();
+        for (let i = start; i <= end; i += 1) {
+          const rangeEntry = allEntries[i];
+          const rangeKey = rangeEntry?.handle?.name;
+          if (rangeKey) rangeSet.add(rangeKey);
+        }
+        setSelectedEntries(rangeSet);
+      } else if (isToggle && index >= 0) {
+        const wasSelected = selectedEntries.has(key);
+        const next = new Set(selectedEntries);
+        if (wasSelected) {
+          next.delete(key);
+        } else {
+          next.add(key);
+        }
+        setSelectedEntries(next);
+        if (wasSelected && selectedEntries.size === 1) {
+          setAnchorIndex(null);
+        } else if (!wasSelected) {
+          setAnchorIndex(index);
+        }
+      } else {
+        setSelectedEntries(new Set([key]));
+        setAnchorIndex(index >= 0 ? index : null);
+      }
+      treeRef.current?.focus();
+    },
+    [allEntries, anchorIndex, entryMap, selectedEntries],
+  );
+
+  const handleKeyDown = useCallback(
+    (event) => {
+      if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return;
+      if (!allEntries.length) return;
+      event.preventDefault();
+      event.stopPropagation();
+      let currentIndex = anchorIndex;
+      if (currentIndex === null) {
+        const firstSelected = selectedEntries.values().next();
+        if (!firstSelected.done) {
+          const info = entryMap.get(firstSelected.value);
+          currentIndex = info ? info.index : 0;
+        } else {
+          currentIndex = 0;
+        }
+      }
+      if (currentIndex < 0) currentIndex = 0;
+      if (currentIndex >= allEntries.length) currentIndex = allEntries.length - 1;
+
+      let nextIndex = currentIndex;
+      if (event.key === 'ArrowDown') nextIndex = Math.min(allEntries.length - 1, currentIndex + 1);
+      else if (event.key === 'ArrowUp') nextIndex = Math.max(0, currentIndex - 1);
+      else if (event.key === 'Home') nextIndex = 0;
+      else if (event.key === 'End') nextIndex = allEntries.length - 1;
+
+      if (nextIndex === currentIndex || nextIndex < 0 || nextIndex >= allEntries.length) return;
+      const nextEntry = allEntries[nextIndex];
+      const key = nextEntry?.handle?.name;
+      if (!key) return;
+      setSelectedEntries(new Set([key]));
+      setAnchorIndex(nextIndex);
+    },
+    [allEntries, anchorIndex, entryMap, selectedEntries],
+  );
+
+  const handleDragStart = useCallback(
+    (event, entry) => {
+      const key = entry?.handle?.name;
+      const dt = event.dataTransfer;
+      if (!dt || !key) return;
+      let names;
+      if (selectedEntries.has(key)) {
+        names = Array.from(selectedEntries);
+      } else {
+        names = [key];
+        setSelectedEntries(new Set(names));
+        const info = entryMap.get(key);
+        if (info) setAnchorIndex(info.index);
+      }
+      try {
+        dt.effectAllowed = 'move';
+        dt.setData(DRAG_MIME, JSON.stringify({ names }));
+        dt.setData('text/plain', names.join(', '));
+      } catch {}
+    },
+    [selectedEntries, entryMap],
+  );
+
+  const handleDirDragOver = useCallback((event) => {
+    if (!transferHasType(event.dataTransfer, DRAG_MIME)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = 'move';
+  }, []);
+
+  const handleDropOnDir = useCallback(
+    async (event, dir) => {
+      if (!transferHasType(event.dataTransfer, DRAG_MIME)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const names = getTransferNames(event.dataTransfer);
+      if (!names.length) return;
+      await openDir(dir, { moveEntries: names });
+    },
+    [openDir],
+  );
+
+  const handleRootDragOver = useCallback(
+    (event) => {
+      if (!transferHasType(event.dataTransfer, DRAG_MIME)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      event.dataTransfer.dropEffect = 'move';
+    },
+    [],
+  );
+
+  const handleRootDrop = useCallback(
+    async (event) => {
+      if (!transferHasType(event.dataTransfer, DRAG_MIME)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const names = getTransferNames(event.dataTransfer);
+      if (!names.length || !dirHandle) return;
+      await moveEntries(names, dirHandle);
+    },
+    [dirHandle, moveEntries],
+  );
 
   const navigateTo = async (index) => {
     const target = path[index];
@@ -211,6 +502,8 @@ export default function FileExplorer() {
     setDirHandle(target.handle);
     setPath(path.slice(0, index + 1));
     await readDir(target.handle);
+    setSelectedEntries(new Set());
+    setAnchorIndex(null);
   };
 
   const goBack = async () => {
@@ -220,6 +513,8 @@ export default function FileExplorer() {
     setPath(newPath);
     setDirHandle(prev.handle);
     await readDir(prev.handle);
+    setSelectedEntries(new Set());
+    setAnchorIndex(null);
   };
 
   const saveFile = async () => {
@@ -228,14 +523,14 @@ export default function FileExplorer() {
       const writable = await currentFile.handle.createWritable();
       await writable.write(content);
       await writable.close();
-      if (opfsSupported) await removeBuffer(currentFile.name);
+      if (opfsSupported) await removeBuffer(currentFile);
     } catch {}
   };
 
   const onChange = (e) => {
     const text = e.target.value;
     setContent(text);
-    if (opfsSupported && currentFile) saveBuffer(currentFile.name, text);
+    if (opfsSupported && currentFile) saveBuffer(currentFile, text);
   };
 
   const runSearch = () => {
@@ -314,7 +609,18 @@ export default function FileExplorer() {
         )}
       </div>
       <div className="flex flex-1 overflow-hidden">
-        <div className="w-40 overflow-auto border-r border-gray-600">
+        <div
+          className="w-40 overflow-auto border-r border-gray-600"
+          role="tree"
+          aria-label="Directory tree"
+          aria-multiselectable="true"
+          tabIndex={0}
+          ref={treeRef}
+          onKeyDown={handleKeyDown}
+          data-testid="file-explorer-tree"
+          onDragOver={handleRootDragOver}
+          onDrop={handleRootDrop}
+        >
           <div className="p-2 font-bold">Recent</div>
           {recent.map((r, i) => (
             <div
@@ -326,25 +632,51 @@ export default function FileExplorer() {
             </div>
           ))}
           <div className="p-2 font-bold">Directories</div>
-          {dirs.map((d, i) => (
-            <div
-              key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openDir(d)}
-            >
-              {d.name}
-            </div>
-          ))}
+          {dirs.map((d) => {
+            const key = d?.handle?.name || d?.name;
+            const selected = key ? selectedEntries.has(key) : false;
+            return (
+              <div
+                key={key || d.name}
+                role="treeitem"
+                aria-selected={selected}
+                tabIndex={-1}
+                className={`px-2 cursor-pointer hover:bg-black hover:bg-opacity-30 select-none${
+                  selected ? ' bg-black bg-opacity-60' : ''
+                }`}
+                draggable={!!d?.handle}
+                onClick={(event) => handleEntryClick(event, d)}
+                onDoubleClick={() => openDir(d)}
+                onDragStart={(event) => handleDragStart(event, d)}
+                onDragOver={handleDirDragOver}
+                onDrop={(event) => handleDropOnDir(event, d)}
+              >
+                {d.name}
+              </div>
+            );
+          })}
           <div className="p-2 font-bold">Files</div>
-          {files.map((f, i) => (
-            <div
-              key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openFile(f)}
-            >
-              {f.name}
-            </div>
-          ))}
+          {files.map((f) => {
+            const key = f?.handle?.name || f?.name;
+            const selected = key ? selectedEntries.has(key) : false;
+            return (
+              <div
+                key={key || f.name}
+                role="treeitem"
+                aria-selected={selected}
+                tabIndex={-1}
+                className={`px-2 cursor-pointer hover:bg-black hover:bg-opacity-30 select-none${
+                  selected ? ' bg-black bg-opacity-60' : ''
+                }`}
+                draggable={!!f?.handle}
+                onClick={(event) => handleEntryClick(event, f)}
+                onDoubleClick={() => openFile(f)}
+                onDragStart={(event) => handleDragStart(event, f)}
+              >
+                {f.name}
+              </div>
+            );
+          })}
         </div>
         <div className="flex-1 flex flex-col">
           {currentFile && (

--- a/tests/file-explorer-selection.spec.ts
+++ b/tests/file-explorer-selection.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+
+test('file explorer supports repeated keyboard selection', async ({ page }) => {
+  await page.addInitScript(() => {
+    const createFile = (name: string) => ({
+      kind: 'file',
+      name,
+      move: async () => {},
+      getFile: async () => ({
+        name,
+        text: async () => '',
+      }),
+    });
+
+    const createDir = (name: string, children: any[] = []) => ({
+      kind: 'directory',
+      name,
+      move: async () => {},
+      entries() {
+        const items = children.map((child) => [child.name, child]);
+        return {
+          async *[Symbol.asyncIterator]() {
+            for (const item of items) {
+              yield item;
+            }
+          },
+        };
+      },
+    });
+
+    const directories = [createDir('alpha'), createDir('beta'), createDir('gamma')];
+    const files = [
+      createFile('notes.txt'),
+      createFile('omega.md'),
+      createFile('zeta.log'),
+      createFile('tasks.json'),
+    ];
+    const rootHandle = createDir('root', [...directories, ...files]);
+
+    (window as any).showDirectoryPicker = async () => rootHandle;
+  });
+
+  await page.goto('/apps/file-explorer');
+  await page.getByRole('button', { name: 'Open Folder' }).click();
+
+  const tree = page.getByTestId('file-explorer-tree');
+  await expect(tree.getByRole('treeitem', { name: 'alpha' })).toBeVisible();
+
+  await tree.getByRole('treeitem', { name: 'alpha' }).click();
+  await tree.focus();
+
+  const operations = 50;
+  for (let i = 0; i < operations; i += 1) {
+    await tree.press('ArrowDown');
+  }
+
+  const itemNames = await tree.getByRole('treeitem').allTextContents();
+  expect(itemNames.length).toBeGreaterThan(0);
+  const finalExpected = itemNames[itemNames.length - 1]?.trim() ?? '';
+
+  await expect.poll(async () => {
+    const selected = await tree
+      .locator('[role="treeitem"][aria-selected="true"]')
+      .allTextContents();
+    return selected.map((text) => text.trim()).join(',');
+  }).toBe(finalExpected);
+});


### PR DESCRIPTION
## Summary
- overhaul the file explorer tree selection state to support shift ranges, multi-select toggles, keyboard navigation, and drag-and-drop moves via DataTransfer
- extend OPFS helpers so save/move operations can call handle.move and keep temporary buffers in sync
- add unit coverage for range selection and keyboard moves plus a Playwright stress spec for repeated arrow navigation

## Testing
- yarn lint *(fails: repository has 500+ pre-existing jsx-a11y and no-top-level-window violations)*
- yarn test *(fails: existing suites such as window.test, nmapNse.test, useSettings hook, and other act() warnings already failing in main branch)*
- npx playwright test *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc066b22608328bc6de9374e85a8a9