### PR TITLE
[test] add resource monitor stability spec

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testDir: '.',
+  testMatch: ['tests/**/*.spec.ts', 'playwright/**/*.spec.ts'],
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/playwright/resource-monitor.stability.spec.ts
+++ b/playwright/resource-monitor.stability.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '@playwright/test';
+
+const TEST_DURATION_MS = 2 * 60 * 1000;
+const TARGET_FRAME_TIME_MS = 1000 / 60;
+const DROP_THRESHOLD_PERCENT = 20;
+
+declare global {
+  interface Window {
+    __frameTimes?: number[];
+  }
+}
+
+interface FrameStats {
+  dropPercentage: number;
+  droppedFrames: number;
+  expectedFrames: number;
+  averageFps: number;
+  durationMs: number;
+}
+
+function computeFrameStats(frameTimes: number[]): FrameStats {
+  if (frameTimes.length < 2) {
+    return {
+      dropPercentage: 0,
+      droppedFrames: 0,
+      expectedFrames: frameTimes.length,
+      averageFps: 0,
+      durationMs: 0,
+    };
+  }
+
+  let droppedFrames = 0;
+  let expectedFrames = 0;
+
+  for (let i = 1; i < frameTimes.length; i += 1) {
+    const delta = frameTimes[i] - frameTimes[i - 1];
+    const framesExpected = Math.max(1, Math.round(delta / TARGET_FRAME_TIME_MS));
+    expectedFrames += framesExpected;
+    droppedFrames += Math.max(0, framesExpected - 1);
+  }
+
+  const durationMs = frameTimes[frameTimes.length - 1] - frameTimes[0];
+  const averageFps = durationMs > 0 ? frameTimes.length / (durationMs / 1000) : 0;
+  const dropPercentage = expectedFrames > 0 ? (droppedFrames / expectedFrames) * 100 : 0;
+
+  return {
+    dropPercentage,
+    droppedFrames,
+    expectedFrames,
+    averageFps,
+    durationMs,
+  };
+}
+
+test.describe('Resource monitor stability', () => {
+  test('maintains acceptable frame drop percentage', async ({ page }) => {
+    test.slow();
+
+    const response = await page.goto('/apps/resource-monitor');
+
+    expect(response, 'Expected a response when loading the resource monitor').not.toBeNull();
+    expect(
+      response?.ok(),
+      `Failed to load resource monitor page: status ${response?.status()}`,
+    ).toBeTruthy();
+
+    await page.waitForFunction(() => Array.isArray(window.__frameTimes), {
+      timeout: 30_000,
+    });
+
+    await page.evaluate(() => {
+      if (!Array.isArray(window.__frameTimes)) {
+        throw new Error('Resource monitor did not expose window.__frameTimes');
+      }
+      window.__frameTimes.length = 0;
+    });
+
+    await page.waitForTimeout(TEST_DURATION_MS);
+
+    const frameTimes = await page.evaluate(() => {
+      if (!Array.isArray(window.__frameTimes)) {
+        return null;
+      }
+      return [...window.__frameTimes];
+    });
+
+    expect(frameTimes).not.toBeNull();
+
+    const stats = computeFrameStats(frameTimes ?? []);
+
+    test.info().annotations.push({
+      type: 'resource-monitor',
+      description: [
+        `frames=${frameTimes?.length ?? 0}`,
+        `expected=${stats.expectedFrames.toFixed(0)}`,
+        `dropped=${stats.droppedFrames.toFixed(0)}`,
+        `dropPct=${stats.dropPercentage.toFixed(2)}%`,
+        `avgFps=${stats.averageFps.toFixed(2)}`,
+      ].join(' | '),
+    });
+
+    expect(frameTimes?.length ?? 0).toBeGreaterThan(0);
+    expect(stats.dropPercentage).toBeLessThanOrEqual(DROP_THRESHOLD_PERCENT);
+  });
+});
+

--- a/test-log.md
+++ b/test-log.md
@@ -32,3 +32,9 @@ Attempted to load each route under `/apps` in Chromium, Firefox, and WebKit. All
 - `yarn why bare-fs` shows the module is required by `tar-fs@3.1.0` via `@puppeteer/browsers@2.10.7`.
 - Latest versions (`@puppeteer/browsers@2.10.8`, `tar-fs@3.1.0`) still depend on `bare-fs@4.2.1`, so the warning remains.
 - `puppeteer` and `puppeteer-core` require this chain; removing them would break existing tooling, so the warning is ignored.
+
+## Resource monitor stability (2025-09-18)
+
+- Added `playwright/resource-monitor.stability.spec.ts` to hold the Resource Monitor open for 2 minutes and compute frame drop percentage from `window.__frameTimes`.
+- The spec annotates total samples, expected frames, dropped frames, drop percentage, and average FPS, failing the run when drops exceed 20%.
+- Running `npx playwright test playwright/resource-monitor.stability.spec.ts --config=playwright.config.ts` against `yarn dev` currently returns HTTP 404 for `/apps/resource-monitor`, so the instrumentation array never initializes and metrics are not yet recorded.


### PR DESCRIPTION
## Summary
- add a resource monitor stability Playwright spec that samples frame times for two minutes and fails when drop rate exceeds 20%
- update the Playwright config to include specs that live under both `tests/` and `playwright/`
- document the new long-run stability check and current 404 blocker in `test-log.md`

## Testing
- ❌ `npx playwright test playwright/resource-monitor.stability.spec.ts --config=playwright.config.ts` *(fails because `/apps/resource-monitor` returns HTTP 404, so `window.__frameTimes` never initializes)*

------
https://chatgpt.com/codex/tasks/task_e_68cc06652e108328859432c02c88d09e