### PR TITLE
[resource-monitor] configure alert thresholds

### DIFF
--- a/__tests__/resourceMonitorAlerts.test.ts
+++ b/__tests__/resourceMonitorAlerts.test.ts
@@ -1,0 +1,55 @@
+import { createAlertManager, pushRingBuffer } from '../components/apps/resource_monitor';
+
+describe('resource monitor alerts', () => {
+  it('throttles alerts within the configured window', () => {
+    const events: Array<{ metric: string; timestamp: number }> = [];
+    let now = 0;
+    const manager = createAlertManager(
+      {
+        cpu: { limit: 80, debounceMs: 5000 },
+        mem: { limit: 70, debounceMs: 4000 },
+      },
+      (event) => {
+        events.push({ metric: event.metric, timestamp: event.timestamp });
+      },
+      () => now,
+    );
+
+    now = 1000;
+    manager.evaluate({ cpu: 90, mem: 0 });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ metric: 'cpu', timestamp: 1000 });
+
+    now = 1500;
+    manager.evaluate({ cpu: 95, mem: 0 });
+    expect(events).toHaveLength(1);
+
+    now = 2500;
+    manager.evaluate({ cpu: 20, mem: 0 });
+    expect(events).toHaveLength(1);
+
+    now = 4000;
+    manager.evaluate({ cpu: 85, mem: 0 });
+    expect(events).toHaveLength(1);
+
+    now = 7000;
+    manager.evaluate({ cpu: 88, mem: 0 });
+    expect(events).toHaveLength(2);
+    expect(events[1]).toMatchObject({ metric: 'cpu', timestamp: 7000 });
+  });
+
+  it('maintains a bounded alert log buffer', () => {
+    const limit = 3;
+    const makeEntry = (n: number) => ({ id: String(n), message: `entry-${n}`, timestamp: n });
+    let buffer: Array<{ id: string; message: string; timestamp: number }> = [];
+
+    buffer = pushRingBuffer(buffer, makeEntry(1), limit);
+    buffer = pushRingBuffer(buffer, makeEntry(2), limit);
+    buffer = pushRingBuffer(buffer, makeEntry(3), limit);
+    buffer = pushRingBuffer(buffer, makeEntry(4), limit);
+
+    expect(buffer).toHaveLength(limit);
+    expect(buffer[0]).toMatchObject({ message: 'entry-2' });
+    expect(buffer[buffer.length - 1]).toMatchObject({ message: 'entry-4' });
+  });
+});

--- a/components/apps/resource_monitor.js
+++ b/components/apps/resource_monitor.js
@@ -1,7 +1,105 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+import { NotificationsContext } from '../common/NotificationCenter';
+import Modal from '../base/Modal';
 
 // Number of samples to keep in the timeline
 const MAX_POINTS = 60;
+const LOG_SIZE = 40;
+const METRICS = ['cpu', 'mem'];
+
+export const DEFAULT_THRESHOLDS = Object.freeze({
+  cpu: { limit: 85, debounceMs: 5000 },
+  mem: { limit: 80, debounceMs: 5000 },
+});
+
+export const validateThresholds = (value) => {
+  if (!value || typeof value !== 'object') return false;
+  return METRICS.every((metric) => {
+    const entry = value[metric];
+    return (
+      entry &&
+      typeof entry === 'object' &&
+      typeof entry.limit === 'number' &&
+      Number.isFinite(entry.limit) &&
+      typeof entry.debounceMs === 'number' &&
+      Number.isFinite(entry.debounceMs)
+    );
+  });
+};
+
+export const pushRingBuffer = (buffer, entry, limit) => {
+  const next = [...buffer, entry];
+  if (limit <= 0) return next.slice(-1);
+  if (next.length > limit) {
+    return next.slice(next.length - limit);
+  }
+  return next;
+};
+
+export const createAlertManager = (thresholds, onAlert, now = () => Date.now()) => {
+  const state = {};
+  METRICS.forEach((metric) => {
+    state[metric] = { active: false, cooldownUntil: 0 };
+  });
+
+  const evaluate = (values) => {
+    METRICS.forEach((metric) => {
+      const config = thresholds[metric];
+      if (!config) return;
+      const value = values[metric];
+      if (typeof value !== 'number' || Number.isNaN(value)) return;
+      const slot = state[metric];
+      const time = now();
+      if (value >= config.limit) {
+        if (!slot.active && time >= slot.cooldownUntil) {
+          slot.active = true;
+          slot.cooldownUntil = time + config.debounceMs;
+          onAlert?.({ metric, value, limit: config.limit, timestamp: time });
+        }
+      } else {
+        slot.active = false;
+      }
+    });
+  };
+
+  const reset = () => {
+    METRICS.forEach((metric) => {
+      state[metric].active = false;
+      state[metric].cooldownUntil = 0;
+    });
+  };
+
+  return { evaluate, reset };
+};
+
+const createDefaultThresholds = () => ({
+  cpu: { ...DEFAULT_THRESHOLDS.cpu },
+  mem: { ...DEFAULT_THRESHOLDS.mem },
+});
+
+const formatTime = (ts) =>
+  new Date(ts).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+
+const createDraft = (config) => ({
+  cpu: {
+    limit: String(config.cpu?.limit ?? DEFAULT_THRESHOLDS.cpu.limit),
+    debounceMs: String(config.cpu?.debounceMs ?? DEFAULT_THRESHOLDS.cpu.debounceMs),
+  },
+  mem: {
+    limit: String(config.mem?.limit ?? DEFAULT_THRESHOLDS.mem.limit),
+    debounceMs: String(config.mem?.debounceMs ?? DEFAULT_THRESHOLDS.mem.debounceMs),
+  },
+});
+
+const metricLabel = {
+  cpu: 'CPU',
+  mem: 'Memory',
+};
 
 const ResourceMonitor = () => {
   const cpuCanvas = useRef(null);
@@ -19,10 +117,58 @@ const ResourceMonitor = () => {
   const [paused, setPaused] = useState(false);
   const [stress, setStress] = useState(false);
   const [fps, setFps] = useState(0);
+  const [thresholds, setThresholds] = usePersistentState(
+    'resource-thresholds',
+    createDefaultThresholds,
+    validateThresholds,
+  );
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [draft, setDraft] = useState(() => createDraft(thresholds));
+  const [logEntries, setLogEntries] = useState([]);
 
   const stressWindows = useRef([]);
   const stressEls = useRef([]);
   const containerRef = useRef(null);
+  const logRef = useRef([]);
+  const notifications = useContext(NotificationsContext);
+
+  useEffect(() => {
+    if (settingsOpen) {
+      setDraft(createDraft(thresholds));
+    }
+  }, [settingsOpen, thresholds]);
+
+  const appendLog = useCallback((message, timestamp = Date.now()) => {
+    const entry = {
+      id: `${timestamp}-${Math.random()}`,
+      message,
+      timestamp,
+    };
+    const next = pushRingBuffer(logRef.current, entry, LOG_SIZE);
+    logRef.current = next;
+    setLogEntries(next);
+  }, []);
+
+  const clearLog = useCallback(() => {
+    logRef.current = [];
+    setLogEntries([]);
+  }, []);
+
+  const handleAlert = useCallback(
+    ({ metric, value, limit, timestamp }) => {
+      const label = metricLabel[metric] || metric.toUpperCase();
+      const message = `${label} usage high: ${value.toFixed(1)}% (limit ${limit}%)`;
+      notifications?.pushNotification?.('resource-monitor', message);
+      appendLog(message, timestamp);
+    },
+    [notifications, appendLog],
+  );
+
+  const alertManagerRef = useRef(createAlertManager(thresholds, handleAlert));
+
+  useEffect(() => {
+    alertManagerRef.current = createAlertManager(thresholds, handleAlert);
+  }, [thresholds, handleAlert]);
 
   useEffect(() => () => cancelAnimationFrame(animRef.current), []);
 
@@ -67,6 +213,7 @@ const ResourceMonitor = () => {
           const { usedJSHeapSize, totalJSHeapSize } = performance.memory;
           mem = (usedJSHeapSize / totalJSHeapSize) * 100;
         }
+        alertManagerRef.current?.evaluate({ cpu, mem });
         pushSample('cpu', cpu);
         pushSample('mem', mem);
         pushSample('fps', currentFps);
@@ -172,6 +319,48 @@ const ResourceMonitor = () => {
 
   const togglePause = () => setPaused((p) => !p);
   const toggleStress = () => setStress((s) => !s);
+  const openSettings = () => setSettingsOpen(true);
+
+  const updateDraft = (metric, field, value) => {
+    setDraft((prev) => ({
+      ...prev,
+      [metric]: {
+        ...prev[metric],
+        [field]: value,
+      },
+    }));
+  };
+
+  const clampPercent = (value, fallback) => {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return fallback;
+    return Math.min(100, Math.max(0, parsed));
+  };
+
+  const clampWindow = (value, fallback) => {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return fallback;
+    return Math.max(500, parsed);
+  };
+
+  const saveSettings = (event) => {
+    event.preventDefault();
+    const next = {
+      cpu: {
+        limit: clampPercent(draft.cpu.limit, thresholds.cpu.limit),
+        debounceMs: clampWindow(draft.cpu.debounceMs, thresholds.cpu.debounceMs),
+      },
+      mem: {
+        limit: clampPercent(draft.mem.limit, thresholds.mem.limit),
+        debounceMs: clampWindow(draft.mem.debounceMs, thresholds.mem.debounceMs),
+      },
+    };
+    setThresholds(next);
+    setSettingsOpen(false);
+  };
+
+  const closeSettings = () => setSettingsOpen(false);
+  const displayedLog = [...logEntries].slice().reverse();
 
   return (
     <div
@@ -185,41 +374,76 @@ const ResourceMonitor = () => {
         <button onClick={toggleStress} className="px-2 py-1 bg-ub-dark-grey rounded">
           {stress ? 'Stop Stress' : 'Stress Test'}
         </button>
-        <span className="ml-auto text-sm">FPS: {fps.toFixed(1)}</span>
+        <button onClick={openSettings} className="px-2 py-1 bg-ub-dark-grey rounded">
+          Settings
+        </button>
+        <div className="ml-auto text-right text-xs leading-tight text-gray-300">
+          <div>
+            CPU ≥ {thresholds.cpu.limit}% · window {Math.round(thresholds.cpu.debounceMs / 1000)}s
+          </div>
+          <div>
+            Memory ≥ {thresholds.mem.limit}% · window {Math.round(thresholds.mem.debounceMs / 1000)}s
+          </div>
+        </div>
+        <span className="text-sm">FPS: {fps.toFixed(1)}</span>
       </div>
-      <div className="flex flex-1 items-center justify-evenly gap-4 p-4">
-        <canvas
-          ref={cpuCanvas}
-          width={300}
-          height={100}
-          role="img"
-          aria-label="CPU usage chart"
-          className="bg-ub-dark-grey"
-        />
-        <canvas
-          ref={memCanvas}
-          width={300}
-          height={100}
-          role="img"
-          aria-label="Memory usage chart"
-          className="bg-ub-dark-grey"
-        />
-        <canvas
-          ref={fpsCanvas}
-          width={300}
-          height={100}
-          role="img"
-          aria-label="FPS chart"
-          className="bg-ub-dark-grey"
-        />
-        <canvas
-          ref={netCanvas}
-          width={300}
-          height={100}
-          role="img"
-          aria-label="Network speed chart"
-          className="bg-ub-dark-grey"
-        />
+      <div className="flex flex-1 overflow-hidden">
+        <div className="flex flex-1 items-center justify-evenly gap-4 p-4">
+          <canvas
+            ref={cpuCanvas}
+            width={300}
+            height={100}
+            role="img"
+            aria-label="CPU usage chart"
+            className="bg-ub-dark-grey"
+          />
+          <canvas
+            ref={memCanvas}
+            width={300}
+            height={100}
+            role="img"
+            aria-label="Memory usage chart"
+            className="bg-ub-dark-grey"
+          />
+          <canvas
+            ref={fpsCanvas}
+            width={300}
+            height={100}
+            role="img"
+            aria-label="FPS chart"
+            className="bg-ub-dark-grey"
+          />
+          <canvas
+            ref={netCanvas}
+            width={300}
+            height={100}
+            role="img"
+            aria-label="Network speed chart"
+            className="bg-ub-dark-grey"
+          />
+        </div>
+        <aside className="w-64 border-l border-gray-700 bg-ub-dark-grey/70 text-xs flex flex-col">
+          <div className="flex items-center px-3 py-2 border-b border-gray-700">
+            <h2 className="font-semibold">Alert Log</h2>
+            <button
+              onClick={clearLog}
+              className="ml-auto text-[10px] uppercase tracking-wide text-gray-300 hover:text-white"
+            >
+              Clear
+            </button>
+          </div>
+          <ul className="flex-1 overflow-y-auto divide-y divide-gray-700">
+            {displayedLog.length === 0 && (
+              <li className="px-3 py-2 text-gray-400">No alerts yet</li>
+            )}
+            {displayedLog.map((entry) => (
+              <li key={entry.id} className="px-3 py-2">
+                <div className="text-[10px] text-gray-400">{formatTime(entry.timestamp)}</div>
+                <div>{entry.message}</div>
+              </li>
+            ))}
+          </ul>
+        </aside>
       </div>
       {stressWindows.current.map((_, i) => (
         <div
@@ -230,6 +454,64 @@ const ResourceMonitor = () => {
           className="absolute w-8 h-6 bg-white bg-opacity-20 border border-gray-500 pointer-events-none"
         />
       ))}
+      <Modal isOpen={settingsOpen} onClose={closeSettings}>
+        <div
+          className="fixed inset-0 flex items-center justify-center bg-black/60"
+          onClick={closeSettings}
+        >
+          <div
+            role="document"
+            className="w-full max-w-md rounded-lg border border-gray-700 bg-ub-cool-grey p-4 text-sm"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-lg font-semibold mb-2">Alert Settings</h2>
+            <form className="space-y-4" onSubmit={saveSettings}>
+              {METRICS.map((metric) => (
+                <fieldset key={metric} className="border border-gray-700 rounded p-3">
+                  <legend className="px-1 text-xs uppercase tracking-wide text-gray-300">
+                    {metricLabel[metric] || metric.toUpperCase()}
+                  </legend>
+                  <label className="flex flex-col gap-1 mb-2">
+                    <span>Threshold (%)</span>
+                    <input
+                      type="number"
+                      min="0"
+                      max="100"
+                      step="1"
+                      value={draft[metric].limit}
+                      onChange={(e) => updateDraft(metric, 'limit', e.target.value)}
+                      className="rounded bg-ub-dark-grey p-1 text-white"
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span>Debounce window (ms)</span>
+                    <input
+                      type="number"
+                      min="500"
+                      step="100"
+                      value={draft[metric].debounceMs}
+                      onChange={(e) => updateDraft(metric, 'debounceMs', e.target.value)}
+                      className="rounded bg-ub-dark-grey p-1 text-white"
+                    />
+                  </label>
+                </fieldset>
+              ))}
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={closeSettings}
+                  className="px-3 py-1 rounded bg-ub-dark-grey"
+                >
+                  Cancel
+                </button>
+                <button type="submit" className="px-3 py-1 rounded bg-green-600">
+                  Save
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </Modal>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a settings modal to Resource Monitor to configure CPU/memory alert thresholds and debounce windows
- persist threshold selections, trigger shared notifications, and append to a ring-buffered alert log
- cover alert throttling and logging helpers with unit tests

## Testing
- yarn lint *(fails: repository has existing jsx-a11y and no-top-level-window lint errors outside the change scope)*
- yarn test resourceMonitorAlerts

------
https://chatgpt.com/codex/tasks/task_e_68cc0665a7ac8328bf432e351e1efb6f