### PR TITLE
[chrome] Persist pinned tabs and context actions

### DIFF
--- a/__tests__/chrome.test.tsx
+++ b/__tests__/chrome.test.tsx
@@ -1,0 +1,198 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Chrome from '../components/apps/chrome';
+
+jest.mock('html-to-image', () => ({
+  toPng: jest.fn(() => Promise.resolve('data:image/png;base64,')),
+}));
+
+jest.mock('@mozilla/readability', () => ({
+  Readability: jest.fn().mockImplementation(() => ({
+    parse: () => ({ content: '<p>Mock content</p>' }),
+  })),
+}));
+
+jest.mock('../components/apps/chrome/bookmarks', () => ({
+  getCachedFavicon: jest.fn(() => Promise.resolve(null)),
+  cacheFavicon: jest.fn(),
+  getBookmarks: jest.fn(() => Promise.resolve([])),
+  saveBookmarks: jest.fn(() => Promise.resolve()),
+}));
+
+const mockFetch = jest.fn(async () => ({
+  headers: new Map(),
+  blob: async () => new Blob(),
+  text: async () => '<html><body></body></html>',
+}));
+
+describe('Chrome tab management', () => {
+  const originalFetch = global.fetch;
+  const OriginalFileReader = global.FileReader;
+  const originalWindowOpen = window.open;
+  const originalLocalStorage = window.localStorage;
+  const originalSessionStorage = window.sessionStorage;
+
+  beforeAll(() => {
+    // @ts-expect-error - override for tests
+    global.fetch = mockFetch;
+    // Minimal FileReader stub for favicon caching
+    class MockFileReader {
+      public result: string | ArrayBuffer | null = null;
+      public onload: null | (() => void) = null;
+      readAsDataURL() {
+        this.result = 'data:image/png;base64,';
+        if (this.onload) {
+          this.onload();
+        }
+      }
+    }
+    // @ts-expect-error - override for tests
+    global.FileReader = MockFileReader;
+    window.open = jest.fn();
+    const createStorage = () => {
+      let store: Record<string, string> = {};
+      return {
+        getItem: (key: string) => (key in store ? store[key] : null),
+        setItem: (key: string, value: string) => {
+          store[key] = String(value);
+        },
+        removeItem: (key: string) => {
+          delete store[key];
+        },
+        clear: () => {
+          store = {};
+        },
+      } as Storage;
+    };
+    Object.defineProperty(window, 'localStorage', {
+      value: createStorage(),
+      configurable: true,
+    });
+    Object.defineProperty(window, 'sessionStorage', {
+      value: createStorage(),
+      configurable: true,
+    });
+  });
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+    if (OriginalFileReader) {
+      // @ts-expect-error - restore original implementation
+      global.FileReader = OriginalFileReader;
+    } else {
+      // @ts-expect-error - cleanup mock when no original existed
+      delete global.FileReader;
+    }
+    window.open = originalWindowOpen;
+    Object.defineProperty(window, 'localStorage', {
+      value: originalLocalStorage,
+      configurable: true,
+    });
+    Object.defineProperty(window, 'sessionStorage', {
+      value: originalSessionStorage,
+      configurable: true,
+    });
+  });
+
+  it('persists pinned tabs even if primary storage is cleared', async () => {
+    const { unmount } = render(<Chrome />);
+
+    const [homeTab] = await screen.findAllByRole('tab');
+    fireEvent.contextMenu(homeTab);
+
+    const pinOption = await screen.findByRole('menuitem', { name: /pin tab/i });
+    fireEvent.click(pinOption);
+
+    await screen.findByRole('button', { name: /unpin tab/i });
+
+    await waitFor(() => {
+      const stored = window.localStorage.getItem('chrome-tabs-pinned');
+      expect(stored).not.toBeNull();
+      const parsed = JSON.parse(stored || '[]');
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBeGreaterThan(0);
+    });
+
+    window.localStorage.removeItem('chrome-tabs');
+
+    unmount();
+
+    render(<Chrome />);
+
+    await screen.findByRole('button', { name: /unpin tab/i });
+  });
+
+  it('supports closing others and reopening the most recent closed tab from the context menu', async () => {
+    const tabs = [
+      {
+        id: 1,
+        url: 'https://example.com/one',
+        history: ['https://example.com/one'],
+        historyIndex: 0,
+        scroll: 0,
+        blocked: false,
+        muted: false,
+        pinned: false,
+        crashed: false,
+      },
+      {
+        id: 2,
+        url: 'https://example.com/two',
+        history: ['https://example.com/two'],
+        historyIndex: 0,
+        scroll: 0,
+        blocked: false,
+        muted: false,
+        pinned: false,
+        crashed: false,
+      },
+      {
+        id: 3,
+        url: 'https://example.com/three',
+        history: ['https://example.com/three'],
+        historyIndex: 0,
+        scroll: 0,
+        blocked: false,
+        muted: false,
+        pinned: false,
+        crashed: false,
+      },
+    ];
+
+    window.localStorage.setItem('chrome-tabs', JSON.stringify({ tabs, active: 2 }));
+    window.localStorage.setItem('chrome-tabs-pinned', JSON.stringify([]));
+
+    render(<Chrome />);
+
+    const targetTab = await screen.findByRole('tab', { name: /example.com\/two/i });
+    fireEvent.contextMenu(targetTab);
+
+    const closeOthers = await screen.findByRole('menuitem', { name: /close other tabs/i });
+    expect(closeOthers).not.toBeDisabled();
+    fireEvent.click(closeOthers);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('tab')).toHaveLength(1);
+    });
+
+    const remainingTab = screen.getByRole('tab', { name: /example.com\/two/i });
+    fireEvent.contextMenu(remainingTab);
+
+    const reopen = await screen.findByRole('menuitem', { name: /reopen closed tab/i });
+    expect(reopen).not.toBeDisabled();
+    fireEvent.click(reopen);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('tab')).toHaveLength(2);
+    });
+
+    const reopened = await screen.findByRole('tab', { name: /example.com\/three/i });
+    expect(reopened).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/components/apps/chrome/index.tsx
+++ b/components/apps/chrome/index.tsx
@@ -24,9 +24,18 @@ interface TabData {
   scroll: number;
   blocked?: boolean;
   muted?: boolean;
+  pinned?: boolean;
+  crashed?: boolean;
+}
+
+interface ContextMenuState {
+  tabId: number;
+  x: number;
+  y: number;
 }
 
 const STORAGE_KEY = 'chrome-tabs';
+const PINNED_STORAGE_KEY = 'chrome-tabs-pinned';
 const HOME_URL = 'home://start';
 const SANDBOX_FLAGS = ['allow-scripts', 'allow-forms', 'allow-popups'] as const;
 const CSP = "default-src 'self'; script-src 'none'; connect-src 'none';";
@@ -49,41 +58,107 @@ const formatUrl = (value: string) => {
   return encodeURI(url);
 };
 
-const readTabs = (): { tabs: TabData[]; active: number } => {
-  if (typeof window === 'undefined') return { tabs: [], active: 0 };
+const sortTabs = (list: TabData[]): TabData[] => {
+  const pinned = list.filter((tab) => tab.pinned);
+  const regular = list.filter((tab) => !tab.pinned);
+  return [...pinned, ...regular];
+};
+
+const cloneTab = (tab: TabData): TabData => ({
+  ...tab,
+  history: [...tab.history],
+});
+
+const safeParse = <T,>(value: string | null): T | null => {
+  if (!value) return null;
   try {
-    const data = JSON.parse(localStorage.getItem(STORAGE_KEY) || '');
-    return data || { tabs: [], active: 0 };
+    return JSON.parse(value) as T;
   } catch {
-    return { tabs: [], active: 0 };
+    return null;
   }
 };
 
+const readTabs = (): { tabs: TabData[]; active: number } => {
+  if (typeof window === 'undefined') return { tabs: [], active: 0 };
+
+  const stored = safeParse<{ tabs?: TabData[]; active?: number } | TabData[]>(
+    localStorage.getItem(STORAGE_KEY),
+  );
+  const pinnedStored = safeParse<TabData[]>(localStorage.getItem(PINNED_STORAGE_KEY)) || [];
+
+  const legacyTabs = Array.isArray(stored) ? stored : [];
+  const savedTabs = Array.isArray(stored?.tabs) ? stored.tabs : legacyTabs;
+  const activeFromStore = typeof (stored as { active?: number } | null)?.active === 'number'
+    ? (stored as { active?: number }).active!
+    : 0;
+
+  const combined = sortTabs([
+    ...pinnedStored.map((tab) => ({ ...tab, pinned: true })),
+    ...savedTabs,
+  ]).map((tab) => ({
+    ...tab,
+    blocked: tab.blocked ?? false,
+    muted: tab.muted ?? false,
+    pinned: tab.pinned ?? false,
+    crashed: tab.crashed ?? false,
+  }));
+
+  const deduped: TabData[] = [];
+  const seen = new Set<number>();
+  combined.forEach((tab) => {
+    if (typeof tab.id !== 'number' || seen.has(tab.id)) return;
+    seen.add(tab.id);
+    deduped.push(tab);
+  });
+
+  const active = seen.has(activeFromStore) ? activeFromStore : deduped[0]?.id ?? 0;
+  return { tabs: deduped, active };
+};
+
 const saveTabs = (tabs: TabData[], active: number) => {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify({ tabs, active }));
+  if (typeof window === 'undefined') return;
+  const ordered = sortTabs(tabs);
+  const pinned = ordered.filter((tab) => tab.pinned);
+  const regular = ordered.filter((tab) => !tab.pinned);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify({ tabs: regular, active }));
+  localStorage.setItem(PINNED_STORAGE_KEY, JSON.stringify(pinned));
 };
 
 const Chrome: React.FC = () => {
   const { tabs: storedTabs, active: storedActive } = readTabs();
   const sessionUrl =
     typeof window !== 'undefined' ? sessionStorage.getItem('chrome-last-url') : null;
-  const [tabs, setTabs] = useState<TabData[]>(
-    storedTabs.length
-      ? storedTabs.map((t) => ({ blocked: false, muted: false, ...t }))
-      : [
-          {
-            id: Date.now(),
-            url: sessionUrl || HOME_URL,
-            history: [sessionUrl || HOME_URL],
-            historyIndex: 0,
-            scroll: 0,
-            blocked: false,
-            muted: false,
-          },
-        ]
+  const defaultTab: TabData = {
+    id: Date.now(),
+    url: sessionUrl || HOME_URL,
+    history: [sessionUrl || HOME_URL],
+    historyIndex: 0,
+    scroll: 0,
+    blocked: false,
+    muted: false,
+    pinned: false,
+    crashed: false,
+  };
+  const normalizedStoredTabs = storedTabs.length
+    ? storedTabs.map((t) => ({
+        ...t,
+        blocked: t.blocked ?? false,
+        muted: t.muted ?? false,
+        pinned: t.pinned ?? false,
+        crashed: t.crashed ?? false,
+      }))
+    : [];
+  const initialTabs = normalizedStoredTabs.length ? sortTabs(normalizedStoredTabs) : [defaultTab];
+  const hasStoredActive = normalizedStoredTabs.some((tab) => tab.id === storedActive);
+  const initialActiveId = hasStoredActive ? storedActive : initialTabs[0].id;
+
+  const [tabs, setTabs] = useState<TabData[]>(initialTabs);
+  const [activeId, setActiveId] = useState<number>(initialActiveId);
+  const [address, setAddress] = useState<string>(
+    initialTabs.find((t) => t.id === initialActiveId)?.url || HOME_URL,
   );
-  const [activeId, setActiveId] = useState<number>(storedActive || tabs[0].id);
-  const [address, setAddress] = useState<string>(tabs.find((t) => t.id === activeId)?.url || HOME_URL);
+  const [closedTabs, setClosedTabs] = useState<TabData[]>([]);
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const [showFlags, setShowFlags] = useState(false);
@@ -128,10 +203,23 @@ const Chrome: React.FC = () => {
         const file = await root.getFileHandle('chrome-tiles.json', { create: true });
         const writable = await file.createWritable();
         await writable.write(JSON.stringify(tiles));
-        await writable.close();
-      } catch {}
-    })();
+      await writable.close();
+    } catch {}
+  })();
   }, [tiles]);
+
+  useEffect(() => {
+    const closeMenu = () => setContextMenu(null);
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setContextMenu(null);
+    };
+    window.addEventListener('click', closeMenu);
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('click', closeMenu);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
   const isAllowed = useCallback((url: string) => {
     if (url === HOME_URL) return true;
     try {
@@ -160,6 +248,19 @@ const Chrome: React.FC = () => {
       articles[activeId] ? DOMPurify.sanitize(articles[activeId]) : '',
     [articles, activeId],
   );
+
+  const removeArticles = useCallback((ids: number[]) => {
+    if (!ids.length) return;
+    setArticles((prev) => {
+      const next = { ...prev };
+      ids.forEach((tabId) => {
+        if (tabId in next) {
+          delete next[tabId];
+        }
+      });
+      return next;
+    });
+  }, []);
 
   const updateFavicon = useCallback(
     async (url: string) => {
@@ -203,17 +304,45 @@ const Chrome: React.FC = () => {
 
   const filteredTabs = useMemo(
     () =>
-      tabs.filter((t) =>
+      sortTabs(tabs).filter((t) =>
         t.url.toLowerCase().includes(tabQuery.toLowerCase()),
       ),
     [tabs, tabQuery],
   );
 
-  const activeTab = tabs.find((t) => t.id === activeId)!;
+  const activeTab = useMemo(
+    () => (tabs.find((t) => t.id === activeId) ?? tabs[0])!,
+    [tabs, activeId],
+  );
+
+  const pinnedFilteredTabs = useMemo(
+    () => filteredTabs.filter((t) => t.pinned),
+    [filteredTabs],
+  );
+
+  const regularFilteredTabs = useMemo(
+    () => filteredTabs.filter((t) => !t.pinned),
+    [filteredTabs],
+  );
+
+  const hasClosedTabs = closedTabs.length > 0;
+  const contextTarget = useMemo(
+    () => (contextMenu ? tabs.find((t) => t.id === contextMenu.tabId) ?? null : null),
+    [contextMenu, tabs],
+  );
+  const canCloseOthers = useMemo(
+    () =>
+      contextTarget
+        ? tabs.some((t) => t.id !== contextTarget.id && !t.pinned)
+        : false,
+    [contextTarget, tabs],
+  );
 
   useEffect(() => {
     setTabs((prev) =>
-      prev.map((t) => ({ ...t, blocked: t.blocked || !isAllowed(t.url) })),
+      sortTabs(
+        prev.map((t) => ({ ...t, blocked: t.blocked || !isAllowed(t.url) })),
+      ),
     );
   }, [isAllowed]);
 
@@ -249,16 +378,19 @@ const Chrome: React.FC = () => {
         }
       }
       setTabs((prev) =>
-        prev.map((t) =>
-          t.id === activeId
-            ? {
-                ...t,
-                url,
-                blocked,
-                history: [...t.history.slice(0, t.historyIndex + 1), url],
-                historyIndex: t.historyIndex + 1,
-              }
-            : t,
+        sortTabs(
+          prev.map((t) =>
+            t.id === activeId
+              ? {
+                  ...t,
+                  url,
+                  blocked,
+                  crashed: false,
+                  history: [...t.history.slice(0, t.historyIndex + 1), url],
+                  historyIndex: t.historyIndex + 1,
+                }
+              : t,
+          ),
         ),
       );
       setAddress(url);
@@ -274,18 +406,22 @@ const Chrome: React.FC = () => {
   const addTab = useCallback(
     (url: string = HOME_URL) => {
       const id = Date.now();
-      setTabs((prev) => [
-        ...prev,
-        {
-          id,
-          url,
-          history: [url],
-          historyIndex: 0,
-          scroll: 0,
-          blocked: false,
-          muted: false,
-        },
-      ]);
+      setTabs((prev) =>
+        sortTabs([
+          ...prev,
+          {
+            id,
+            url,
+            history: [url],
+            historyIndex: 0,
+            scroll: 0,
+            blocked: false,
+            muted: false,
+            pinned: false,
+            crashed: false,
+          },
+        ]),
+      );
       setActiveId(id);
       setAddress(url);
       updateFavicon(url);
@@ -294,22 +430,80 @@ const Chrome: React.FC = () => {
     [updateFavicon, fetchArticle],
   );
 
+  const togglePin = useCallback((id: number) => {
+    setTabs((prev) => {
+      if (!prev.some((t) => t.id === id)) return prev;
+      const next = prev.map((t) =>
+        t.id === id
+          ? {
+              ...t,
+              pinned: !t.pinned,
+            }
+          : t,
+      );
+      return sortTabs(next);
+    });
+    setContextMenu(null);
+  }, []);
+
   const closeTab = useCallback(
     (id: number) => {
-      setTabs((prev) => prev.filter((t) => t.id !== id));
-      setArticles((prev) => {
-        const { [id]: _omit, ...rest } = prev;
-        return rest;
-      });
-      if (id === activeId && tabs.length > 1) {
+      if (tabs.length <= 1) return;
+      const closing = tabs.find((t) => t.id === id);
+      if (!closing) return;
+      setClosedTabs((prev) => [cloneTab(closing), ...prev]);
+      removeArticles([id]);
+      const remaining = tabs.filter((t) => t.id !== id);
+      setTabs(sortTabs(remaining));
+      if (id === activeId) {
         const idx = tabs.findIndex((t) => t.id === id);
-        const next = tabs[idx - 1] || tabs[idx + 1];
-        setActiveId(next.id);
-        setAddress(next.url);
+        const fallback = tabs[idx - 1] || tabs[idx + 1] || remaining[0];
+        if (fallback) {
+          setActiveId(fallback.id);
+          setAddress(fallback.url);
+        }
       }
-  },
-  [activeId, tabs],
-);
+      setContextMenu(null);
+    },
+    [tabs, activeId, removeArticles],
+  );
+
+  const closeOthers = useCallback(
+    (id: number) => {
+      const target = tabs.find((t) => t.id === id);
+      if (!target) return;
+      const toClose = tabs.filter((t) => t.id !== id && !t.pinned);
+      if (toClose.length) {
+        const closedSnapshots = toClose.map(cloneTab).reverse();
+        setClosedTabs((prev) => [...closedSnapshots, ...prev]);
+        removeArticles(toClose.map((t) => t.id));
+      }
+      const remaining = tabs.filter((t) => t.id === id || t.pinned);
+      setTabs(sortTabs(remaining));
+      setActiveId(id);
+      setAddress(target.url);
+      setContextMenu(null);
+    },
+    [tabs, removeArticles],
+  );
+
+  const reopenClosedTab = useCallback(() => {
+    if (!closedTabs.length) return;
+    const [latest, ...rest] = closedTabs;
+    const reopened = { ...cloneTab(latest), crashed: false };
+    setClosedTabs(rest);
+    setTabs((prev) => {
+      if (prev.some((tab) => tab.id === reopened.id)) return prev;
+      return sortTabs([...prev, reopened]);
+    });
+    setActiveId(reopened.id);
+    setAddress(reopened.url);
+    updateFavicon(reopened.url);
+    if (!reopened.blocked) {
+      fetchArticle(reopened.id, reopened.url);
+    }
+    setContextMenu(null);
+  }, [closedTabs, fetchArticle, updateFavicon]);
 
   const handleDragStart = useCallback(
     (id: number) => () => {
@@ -331,7 +525,7 @@ const Chrome: React.FC = () => {
         if (fromIdx === -1 || toIdx === -1) return prev;
         const [moved] = next.splice(fromIdx, 1);
         next.splice(toIdx, 0, moved);
-        return next;
+        return sortTabs(next);
       });
     },
     [],
@@ -342,29 +536,58 @@ const Chrome: React.FC = () => {
   }, []);
 
   const reload = useCallback(() => {
+    setTabs((prev) =>
+      sortTabs(prev.map((t) => (t.id === activeId ? { ...t, crashed: false } : t))),
+    );
     iframeRef.current?.contentWindow?.location.reload();
-  }, []);
+  }, [activeId]);
 
   const stop = useCallback(() => {
     iframeRef.current?.contentWindow?.stop();
   }, []);
 
+  const handleIframeLoad = useCallback(() => {
+    setTabs((prev) =>
+      sortTabs(prev.map((t) => (t.id === activeId ? { ...t, crashed: false } : t))),
+    );
+  }, [activeId]);
+
+  const handleIframeError = useCallback(() => {
+    setTabs((prev) =>
+      sortTabs(prev.map((t) => (t.id === activeId ? { ...t, crashed: true } : t))),
+    );
+  }, [activeId]);
+
   const goBack = useCallback(() => {
     setTabs((prev) =>
-      prev.map((t) =>
-        t.id === activeId && t.historyIndex > 0
-          ? { ...t, historyIndex: t.historyIndex - 1, url: t.history[t.historyIndex - 1] }
-          : t,
+      sortTabs(
+        prev.map((t) =>
+          t.id === activeId && t.historyIndex > 0
+            ? {
+                ...t,
+                historyIndex: t.historyIndex - 1,
+                url: t.history[t.historyIndex - 1],
+                crashed: false,
+              }
+            : t,
+        ),
       ),
     );
   }, [activeId]);
 
   const goForward = useCallback(() => {
     setTabs((prev) =>
-      prev.map((t) =>
-        t.id === activeId && t.historyIndex < t.history.length - 1
-          ? { ...t, historyIndex: t.historyIndex + 1, url: t.history[t.historyIndex + 1] }
-          : t,
+      sortTabs(
+        prev.map((t) =>
+          t.id === activeId && t.historyIndex < t.history.length - 1
+            ? {
+                ...t,
+                historyIndex: t.historyIndex + 1,
+                url: t.history[t.historyIndex + 1],
+                crashed: false,
+              }
+            : t,
+        ),
       ),
     );
   }, [activeId]);
@@ -379,25 +602,42 @@ const Chrome: React.FC = () => {
   }, [activeTab.url, updateFavicon]);
 
   useEffect(() => {
-    if (!activeTab.blocked && isAllowed(activeTab.url) && !articles[activeId]) {
+    if (
+      !activeTab.blocked &&
+      !activeTab.crashed &&
+      isAllowed(activeTab.url) &&
+      !articles[activeId]
+    ) {
       fetchArticle(activeId, activeTab.url);
     }
     if (!setIframeMuted(!!activeTab.muted) && activeTab.muted) {
       setTabs((prev) =>
-        prev.map((t) => (t.id === activeId ? { ...t, muted: false } : t)),
+        sortTabs(prev.map((t) => (t.id === activeId ? { ...t, muted: false } : t))),
       );
 
     }
-  }, [activeId, activeTab.url, activeTab.muted, articles, fetchArticle, setIframeMuted, isAllowed, activeTab.blocked]);
+  }, [
+    activeId,
+    activeTab.url,
+    activeTab.muted,
+    activeTab.blocked,
+    activeTab.crashed,
+    articles,
+    fetchArticle,
+    setIframeMuted,
+    isAllowed,
+  ]);
 
   useEffect(() => {
     const handleScroll = () => {
       try {
         setTabs((prev) =>
-          prev.map((t) =>
-            t.id === activeId
-              ? { ...t, scroll: iframeRef.current?.contentWindow?.scrollY || 0 }
-              : t
+          sortTabs(
+            prev.map((t) =>
+              t.id === activeId
+                ? { ...t, scroll: iframeRef.current?.contentWindow?.scrollY || 0 }
+                : t
+            )
           )
         );
       } catch {
@@ -411,7 +651,14 @@ const Chrome: React.FC = () => {
 
   useEffect(() => {
     try {
-      iframeRef.current?.contentWindow?.scrollTo(0, activeTab.scroll);
+      const frameWindow = iframeRef.current?.contentWindow;
+      const { scrollTo } = frameWindow || {};
+      if (
+        typeof scrollTo === 'function' &&
+        !String(scrollTo).includes('notImplemented')
+      ) {
+        scrollTo.call(frameWindow, 0, activeTab.scroll);
+      }
     } catch {
       /* ignore cross-origin */
     }
@@ -429,7 +676,7 @@ const Chrome: React.FC = () => {
     const next = !activeTab.muted;
     if (setIframeMuted(next)) {
       setTabs((prev) =>
-        prev.map((t) => (t.id === activeId ? { ...t, muted: next } : t)),
+        sortTabs(prev.map((t) => (t.id === activeId ? { ...t, muted: next } : t))),
       );
     } else {
       console.warn('Unable to control audio for this site.');
@@ -641,7 +888,7 @@ const Chrome: React.FC = () => {
         const newTabs = [...prev];
         const [moved] = newTabs.splice(fromIdx, 1);
         newTabs.splice(toIdx, 0, moved);
-        return newTabs;
+        return sortTabs(newTabs);
       });
       draggingId.current = null;
     },
@@ -651,6 +898,99 @@ const Chrome: React.FC = () => {
   const onDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
   }, []);
+
+  const renderTab = (t: TabData) => {
+    const isActive = t.id === activeId;
+    const label = t.url.replace(/^https?:\/\/(www\.)?/, '');
+    const canClose = !t.pinned && tabs.length > 1;
+    const faviconNode = (() => {
+      try {
+        const origin = new URL(t.url).origin;
+        const src = favicons[origin];
+        return src ? (
+          <img src={src} alt="" className="w-4 h-4 flex-shrink-0" />
+        ) : null;
+      } catch {
+        return null;
+      }
+    })();
+
+    return (
+      <div
+        key={t.id}
+        id={`tab-${t.id}`}
+        role="tab"
+        aria-selected={isActive}
+        data-pinned={t.pinned ? 'true' : 'false'}
+        className={`group flex items-center px-2 py-1 cursor-pointer rounded-sm space-x-1 ${
+          isActive ? 'bg-gray-600' : 'bg-gray-700 hover:bg-gray-600'
+        } ${t.pinned ? 'min-w-[60px]' : ''}`}
+        onClick={() => {
+          setActiveId(t.id);
+          setAddress(t.url);
+          setContextMenu(null);
+        }}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setContextMenu({ tabId: t.id, x: e.clientX, y: e.clientY });
+        }}
+        draggable
+        onDragStart={onDragStart(t.id)}
+        onDragOver={onDragOver}
+        onDrop={onDrop(t.id)}
+        title={t.url}
+      >
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            togglePin(t.id);
+          }}
+          aria-label={t.pinned ? 'Unpin tab' : 'Pin tab'}
+          className="text-xs"
+        >
+          {t.pinned ? '📌' : '📍'}
+        </button>
+        {faviconNode}
+        <span className="truncate" style={{ maxWidth: t.pinned ? 72 : 120 }}>
+          {label}
+        </span>
+        {t.muted && <span className="ml-1">🔇</span>}
+        {t.crashed && (
+          <span className="ml-1" role="img" aria-label="Tab crashed">
+            💥
+          </span>
+        )}
+        {canClose && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              closeTab(t.id);
+            }}
+            aria-label="Close Tab"
+            className="ml-1 text-lg leading-none"
+          >
+            ×
+          </button>
+        )}
+      </div>
+    );
+  };
+
+  const crashedView = (
+    <div className="flex flex-col items-center justify-center w-full h-full text-center p-4">
+      <p className="mb-2">This tab has crashed.</p>
+      <p className="mb-4 text-sm">Reload to try the page again.</p>
+      <button
+        type="button"
+        onClick={reload}
+        className="px-3 py-1 bg-gray-800 text-white rounded"
+      >
+        Reload tab
+      </button>
+    </div>
+  );
 
   const blockedView = (
     <div className="flex flex-col items-center justify-center w-full h-full text-center p-4">
@@ -713,52 +1053,65 @@ const Chrome: React.FC = () => {
         ref={tabStripRef}
         tabIndex={0}
         onKeyDown={onTabStripKeyDown}
+        role="tablist"
+        aria-label="Tabs"
       >
-        {filteredTabs.map((t) => (
-          <div
-            key={t.id}
-            id={`tab-${t.id}`}
-            className={`flex items-center px-2 py-1 cursor-pointer ${t.id === activeId ? 'bg-gray-600' : 'bg-gray-700'} `}
-            onClick={() => setActiveId(t.id)}
-            draggable
-            onDragStart={onDragStart(t.id)}
-            onDragOver={onDragOver}
-            onDrop={onDrop(t.id)}
-
-          >
-            {(() => {
-              try {
-                const origin = new URL(t.url).origin;
-                const src = favicons[origin];
-                return src ? (
-                  <img
-                    src={src}
-                    alt=""
-                    className="w-4 h-4 mr-1 flex-shrink-0"
-                  />
-                ) : null;
-              } catch {
-                return null;
-              }
-            })()}
-            <span className="mr-2 truncate" style={{ maxWidth: 100 }}>
-              {t.url.replace(/^https?:\/\/(www\.)?/, '')}
-            </span>
-            {t.muted && <span className="mr-1">🔇</span>}
-            {tabs.length > 1 && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  closeTab(t.id);
-                }}
-                aria-label="Close Tab"
-              >
-                ×
-              </button>
-            )}
-          </div>
-        ))}
+        {pinnedFilteredTabs.map((t) => renderTab(t))}
+        {pinnedFilteredTabs.length > 0 && regularFilteredTabs.length > 0 && (
+          <div className="w-px bg-gray-600 my-1" aria-hidden="true" />
+        )}
+        {regularFilteredTabs.map((t) => renderTab(t))}
       </div>
+      {contextMenu && contextTarget && (
+        <div
+          role="menu"
+          className="fixed z-50 bg-gray-800 text-white text-sm rounded border border-gray-600 shadow-lg"
+          style={{ top: contextMenu.y, left: contextMenu.x }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <button
+            type="button"
+            role="menuitem"
+            className="block w-full text-left px-3 py-1 hover:bg-gray-700"
+            onClick={() => togglePin(contextMenu.tabId)}
+          >
+            {contextTarget.pinned ? 'Unpin tab' : 'Pin tab'}
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className={`block w-full text-left px-3 py-1 hover:bg-gray-700 ${
+              tabs.length <= 1 ? 'opacity-60 cursor-not-allowed hover:bg-gray-800' : ''
+            }`}
+            onClick={() => closeTab(contextMenu.tabId)}
+            disabled={tabs.length <= 1}
+          >
+            Close tab
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className={`block w-full text-left px-3 py-1 hover:bg-gray-700 ${
+              !canCloseOthers ? 'opacity-60 cursor-not-allowed hover:bg-gray-800' : ''
+            }`}
+            onClick={() => closeOthers(contextMenu.tabId)}
+            disabled={!canCloseOthers}
+          >
+            Close other tabs
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className={`block w-full text-left px-3 py-1 hover:bg-gray-700 ${
+              !hasClosedTabs ? 'opacity-60 cursor-not-allowed hover:bg-gray-800' : ''
+            }`}
+            onClick={reopenClosedTab}
+            disabled={!hasClosedTabs}
+          >
+            Reopen closed tab
+          </button>
+        </div>
+      )}
       {overflowing && (
         <div className="bg-gray-700 p-1">
           <input
@@ -773,6 +1126,8 @@ const Chrome: React.FC = () => {
         <div className="flex-grow bg-white relative overflow-auto">
           {activeTab.url === HOME_URL ? (
             homeGrid
+          ) : activeTab.crashed ? (
+            crashedView
           ) : articles[activeId] ? (
             <main
               style={{ maxInlineSize: '60ch', margin: 'auto' }}
@@ -792,6 +1147,8 @@ const Chrome: React.FC = () => {
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; geolocation; gyroscope; picture-in-picture; microphone; camera"
               referrerPolicy="no-referrer"
               allowFullScreen
+              onLoad={handleIframeLoad}
+              onError={handleIframeError}
             />
           )}
           {showFlags && (


### PR DESCRIPTION
## Summary
- extend the Chrome tab model with pinned/crashed state, dedicated persistence, and ordering helpers
- add UI affordances for pinning, context menus, and crash recovery plus iframe scroll guards
- create Jest coverage that exercises pinned tab restoration and context menu actions

## Testing
- `yarn lint` *(fails: existing accessibility/no-top-level-window violations in unrelated apps)*
- `yarn test` *(fails: existing nmapNse and ReconNG suites plus window keyboard handling)*

------
https://chatgpt.com/codex/tasks/task_e_68cc066454208328b2abf533afce4c7d