### PR TITLE
[about] add print-friendly layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ See `.env.local.example` for the full list.
 - Run `yarn lint` and `yarn test` before committing changes.
 - For manual smoke tests, start `yarn dev` and in another terminal run `yarn smoke` to visit every `/apps/*` route.
 
+## Print Support
+
+- The About Alex desktop app ships with a dedicated print stylesheet (`styles/about/print.css`).
+- When a print job is triggered, the layout collapses to a single column, navigation chrome is hidden, and wider page margins keep the resume-style copy readable.
+
 ---
 
 ## Speed Insights

--- a/__tests__/aboutPrintLayout.test.tsx
+++ b/__tests__/aboutPrintLayout.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import AboutApp from '../components/apps/About';
+
+describe('AboutApp print layout', () => {
+  const originalMatchMedia = window.matchMedia;
+  const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(window, 'localStorage', originalLocalStorageDescriptor);
+    }
+  });
+
+  it('updates the print data attribute when the print media query changes', () => {
+    const listeners = new Set<(event: MediaQueryListEvent) => void>();
+
+    const addListener = (listener: MediaQueryListListener | EventListenerOrEventListenerObject) => {
+      if (typeof listener === 'function') {
+        listeners.add(listener as (event: MediaQueryListEvent) => void);
+      } else if (listener && typeof (listener as EventListenerObject).handleEvent === 'function') {
+        listeners.add(
+          ((listener as EventListenerObject).handleEvent as unknown as (event: MediaQueryListEvent) => void)
+        );
+      }
+    };
+
+    const removeListener = (listener: MediaQueryListListener | EventListenerOrEventListenerObject) => {
+      if (typeof listener === 'function') {
+        listeners.delete(listener as (event: MediaQueryListEvent) => void);
+      } else if (listener && typeof (listener as EventListenerObject).handleEvent === 'function') {
+        listeners.delete(
+          ((listener as EventListenerObject).handleEvent as unknown as (event: MediaQueryListEvent) => void)
+        );
+      }
+    };
+
+    const mockMediaQuery = {
+      matches: false,
+      media: 'print',
+      onchange: null,
+      addEventListener: jest.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type === 'change') {
+          addListener(listener);
+        }
+      }),
+      removeEventListener: jest.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type === 'change') {
+          removeListener(listener);
+        }
+      }),
+      addListener: jest.fn((listener: MediaQueryListListener) => addListener(listener)),
+      removeListener: jest.fn((listener: MediaQueryListListener) => removeListener(listener)),
+      dispatchEvent: jest.fn().mockReturnValue(true),
+    } as unknown as MediaQueryList;
+
+    const emit = (matches: boolean) => {
+      (mockMediaQuery as unknown as { matches: boolean }).matches = matches;
+      listeners.forEach((listener) => {
+        listener({ matches } as MediaQueryListEvent);
+      });
+    };
+
+    window.matchMedia = jest.fn().mockReturnValue(mockMediaQuery);
+
+    const storage: Record<string, string> = {};
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: jest.fn((key: string) => (key in storage ? storage[key] : null)),
+        setItem: jest.fn((key: string, value: string) => {
+          storage[key] = String(value);
+        }),
+        removeItem: jest.fn((key: string) => {
+          delete storage[key];
+        }),
+        clear: jest.fn(() => {
+          for (const key in storage) {
+            delete storage[key];
+          }
+        }),
+      },
+      configurable: true,
+    });
+
+    render(<AboutApp />);
+
+    const root = screen.getByTestId('about-app-root');
+    expect(root).toHaveAttribute('data-print-active', 'false');
+
+    act(() => {
+      emit(true);
+    });
+
+    expect(root).toHaveAttribute('data-print-active', 'true');
+
+    act(() => {
+      emit(false);
+    });
+
+    expect(root).toHaveAttribute('data-print-active', 'false');
+  });
+});

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -8,6 +8,7 @@ import '../styles/globals.css';
 import '../styles/index.css';
 import '../styles/resume-print.css';
 import '../styles/print.css';
+import '../styles/about/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';

--- a/styles/about/print.css
+++ b/styles/about/print.css
@@ -1,0 +1,34 @@
+@media print {
+  .about-app {
+    flex-direction: column !important;
+    align-items: stretch !important;
+    background: #fff !important;
+    color: #000 !important;
+  }
+
+  .about-app--print {
+    padding: 0.75in;
+  }
+
+  .about-app__nav,
+  .about-app__toggle {
+    display: none !important;
+  }
+
+  .about-app__content {
+    width: 100% !important;
+    max-width: none !important;
+    background: transparent !important;
+    box-shadow: none !important;
+  }
+
+  .about-app__content > * {
+    max-width: 720px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .about-app__content.windowMainScreen {
+    background: transparent !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a print media listener to the About desktop app so it can flag when print styling should apply
- add a scoped print stylesheet that collapses the layout to a single column, hides navigation controls, and lightens the background
- cover the print toggle with a new @testing-library/react unit test and document the print support in the README

## Testing
- yarn lint *(fails: repository currently has existing jsx-a11y control label and no-top-level-window violations unrelated to this change)*
- yarn test __tests__/aboutPrintLayout.test.tsx __tests__/aboutAccessibility.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc065f41e48328b0625f138f7ab2f3