### PR TITLE
[contact] Guard contact CTA behind site key

### DIFF
--- a/__tests__/aboutContactCta.test.tsx
+++ b/__tests__/aboutContactCta.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ContactCTA } from '../components/apps/alex';
+
+jest.mock('react-ga4', () => ({
+  send: jest.fn(),
+  event: jest.fn(),
+}));
+
+describe('ContactCTA', () => {
+  const originalSiteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
+
+  afterEach(() => {
+    if (originalSiteKey === undefined) {
+      delete process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
+    } else {
+      process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY = originalSiteKey;
+    }
+    jest.clearAllMocks();
+  });
+
+  it('renders the contact CTA when the site key is configured', () => {
+    process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY = 'test-key';
+
+    render(<ContactCTA />);
+
+    expect(
+      screen.getByRole('button', { name: /open contact window/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/set next_public_recaptcha_site_key to enable contact/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows a configuration hint when the site key is missing', () => {
+    delete process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
+
+    render(<ContactCTA />);
+
+    expect(
+      screen.getByText(/set next_public_recaptcha_site_key to enable contact/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /open contact window/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -13,6 +13,8 @@ import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayScreenRecorder } from './components/apps/screen-recorder';
 import { displayNikto } from './components/apps/nikto';
 
+const contactEnabled = Boolean(process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY);
+
 export const chromeDefaultTiles = [
   { title: 'MDN', url: 'https://developer.mozilla.org/' },
   { title: 'Wikipedia', url: 'https://en.wikipedia.org' },
@@ -911,7 +913,7 @@ const apps = [
     id: 'contact',
     title: 'Contact',
     icon: '/themes/Yaru/apps/project-gallery.svg',
-    disabled: false,
+    disabled: !contactEnabled,
     favourite: false,
     desktop_shortcut: false,
     screen: displayContact,

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -185,10 +185,40 @@ function About() {
                     I also have interests in deep learning, software development, and animation.
                 </li>
             </ul>
+            <ContactCTA />
             <Timeline />
         </>
     )
 }
+
+export const ContactCTA = () => {
+    const contactEnabled = Boolean(process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY);
+
+    const handleLaunch = React.useCallback(() => {
+        if (typeof window !== 'undefined') {
+            window.dispatchEvent(new CustomEvent('open-app', { detail: 'contact' }));
+            ReactGA.event({ category: 'contact', action: 'open_contact_app' });
+        }
+    }, []);
+
+    return (
+        <div className="no-print mt-6 flex flex-col items-center">
+            {contactEnabled ? (
+                <button
+                    type="button"
+                    onClick={handleLaunch}
+                    className="px-4 py-2 rounded bg-ubt-blue text-white text-sm md:text-base focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ubt-blue"
+                >
+                    Open contact window
+                </button>
+            ) : (
+                <p className="text-xs md:text-sm text-center text-yellow-300" role="status">
+                    Contact window disabled. Set NEXT_PUBLIC_RECAPTCHA_SITE_KEY to enable contact.
+                </p>
+            )}
+        </div>
+    );
+};
 
 function Timeline() {
     const events = [


### PR DESCRIPTION
## Summary
- hide the About app contact CTA when NEXT_PUBLIC_RECAPTCHA_SITE_KEY is missing and show a configuration hint instead
- disable the Contact launcher entry whenever the reCAPTCHA site key is absent so it respects the same guard
- add unit coverage that exercises the CTA behaviour with and without the environment variable

## Testing
- yarn test aboutContactCta
- yarn lint *(fails: existing jsx-a11y/no-top-level-window violations across unrelated apps)*

------
https://chatgpt.com/codex/tasks/task_e_68cc065ee2388328b3f08a7ca2acbf94