### PR TITLE
[about] optimize media loading and timeline assets

### DIFF
--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -4,6 +4,7 @@ import React, {
   useRef,
   useEffect,
 } from 'react';
+import Image from 'next/image';
 import rawMilestones from '../data/milestones.json';
 
 interface Milestone {
@@ -126,11 +127,16 @@ const ScrollableTimeline: React.FC = () => {
                       className="text-left w-full focus:outline-none"
                     >
                       <div className="text-ubt-blue font-bold text-lg mb-2">{year}</div>
-                      <img
-                        src={first.image}
-                        alt={first.title}
-                        className="w-full h-32 object-cover mb-2 rounded"
-                      />
+                      <div className="relative w-full h-32 mb-2">
+                        <Image
+                          src={first.image}
+                          alt={first.title}
+                          fill
+                          className="object-cover rounded"
+                          sizes="(max-width: 640px) 80vw, 16rem"
+                          loading="lazy"
+                        />
+                      </div>
                       <p className="text-sm md:text-base mb-2">{first.title}</p>
                       {renderTags(first.tags)}
                     </button>
@@ -155,11 +161,16 @@ const ScrollableTimeline: React.FC = () => {
                     rel="noopener noreferrer"
                     className="block mb-2"
                   >
-                    <img
-                      src={m.image}
-                      alt={m.title}
-                      className="w-full h-32 object-cover mb-2 rounded"
-                    />
+                    <div className="relative w-full h-32 mb-2">
+                      <Image
+                        src={m.image}
+                        alt={m.title}
+                        fill
+                        className="object-cover rounded"
+                        sizes="(max-width: 640px) 80vw, 16rem"
+                        loading="lazy"
+                      />
+                    </div>
                     <p className="text-sm md:text-base">{m.title}</p>
                   </a>
                   {renderTags(m.tags)}

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -74,7 +74,8 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
             src={section.icon}
             width={16}
             height={16}
-            sizes="16px"
+            sizes="(max-width: 768px) 24px, 16px"
+            loading="lazy"
           />
           <span className=" ml-1 md:ml-2 text-gray-50 ">{section.label}</span>
         </div>
@@ -113,6 +114,8 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
       <main className="w-full h-full flex bg-ub-cool-grey text-white select-none relative">
         <Head>
           <title>About</title>
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
           <script
             type="application/ld+json"
             nonce={nonce}
@@ -358,12 +361,16 @@ const SkillSection = ({ title, badges }: { title: string; badges: { src: string;
       />
       <div className="flex flex-wrap justify-center items-start w-full mt-2">
         {filteredBadges.map((badge) => (
-          <img
+          <Image
             key={badge.alt}
-            className="m-1 cursor-pointer"
+            className="m-1 cursor-pointer h-10 w-auto"
             src={badge.src}
             alt={badge.alt}
             title={badge.description}
+            width={200}
+            height={60}
+            sizes="(max-width: 768px) 45vw, 200px"
+            loading="lazy"
             onClick={() => setSelected(badge)}
           />
         ))}

--- a/next.config.js
+++ b/next.config.js
@@ -139,6 +139,8 @@ module.exports = withBundleAnalyzer(
         'yt3.ggpht.com',
         'i.scdn.co',
         'www.google.com',
+        'img.shields.io',
+        'via.placeholder.com',
         'example.com',
         'developer.mozilla.org',
         'en.wikipedia.org',


### PR DESCRIPTION
## Summary
- swap badge and navigation icons in the About app to Next.js `<Image>` with responsive sizing and lazy loading, and preconnect to Google font domains
- refactor the scrollable timeline cards to use Next.js `<Image>` with `fill` layout for responsive cover art
- allow Next.js to serve additional remote assets by adding `img.shields.io` and `via.placeholder.com` to the image domain allow-list

## Testing
- `yarn lint` *(fails: longstanding accessibility errors in other apps)*
- `yarn test` *(fails: pre-existing suite failures and act()/localStorage issues)*
- `npx lighthouse 'http://localhost:3001/apps?app=about' --output=json --output-path=./lighthouse-about.json --port=9222 --form-factor=mobile --throttling-method=simulate` *(fails: NO_FCP because the single-page desktop shell never paints content under headless audit)*

------
https://chatgpt.com/codex/tasks/task_e_68cc066056d48328b3f3619a31b4a3de