### PR TITLE
terminal: improve accessibility and keyboard flow

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -76,4 +76,33 @@ describe('Terminal component', () => {
     fireEvent.keyDown(root, { ctrlKey: true, key: 'w' });
     expect(container.querySelectorAll('.flex.items-center.cursor-pointer').length).toBe(1);
   });
+
+  it('cycles focus within the terminal toolbar', async () => {
+    const ref = createRef<any>();
+    const { getByLabelText } = render(<Terminal ref={ref} openApp={openApp} />);
+    await act(async () => {});
+
+    const copyButton = getByLabelText('Copy') as HTMLButtonElement;
+    const settingsButton = getByLabelText('Settings') as HTMLButtonElement;
+
+    await act(async () => {
+      settingsButton.focus();
+    });
+    expect(document.activeElement).toBe(settingsButton);
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'Tab' });
+    });
+    expect(document.activeElement).toBe(copyButton);
+
+    await act(async () => {
+      copyButton.focus();
+    });
+    expect(document.activeElement).toBe(copyButton);
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    });
+    expect(document.activeElement).toBe(settingsButton);
+  });
 });

--- a/playwright/a11y-terminal.spec.ts
+++ b/playwright/a11y-terminal.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+const accessibilityThreshold = 95;
+
+const penaltyByImpact: Record<string, number> = {
+  critical: 60,
+  serious: 40,
+  moderate: 10,
+  minor: 5,
+};
+
+test.describe('Terminal accessibility regression', () => {
+  test('meets Lighthouse-inspired score on /apps/terminal', async ({ page }) => {
+    await page.goto('http://localhost:3000/apps/terminal');
+
+    const snapshot = await page.accessibility.snapshot();
+    expect(snapshot).toBeTruthy();
+
+    const axeResults = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa'])
+      .analyze();
+
+    const penalty = axeResults.violations.reduce((total, violation) => {
+      const impact = violation.impact || 'minor';
+      return total + (penaltyByImpact[impact] ?? penaltyByImpact.minor);
+    }, 0);
+
+    const score = Math.max(0, 100 - penalty);
+    expect(score).toBeGreaterThanOrEqual(accessibilityThreshold);
+  });
+});


### PR DESCRIPTION
## Summary
- trap focus across the terminal chrome and modals, restore the buffer on Escape, and wire up platform-aware shortcuts
- expose terminal output to assistive tech with live region metadata and aria-pressed state for toolbar toggles
- add regression coverage for terminal focus handling in Jest and Lighthouse-style accessibility auditing in Playwright

## Testing
- yarn lint *(fails: existing repository accessibility lint violations)*
- yarn test *(fails: pre-existing suites such as window, nmap NSE, and reconNG)*

------
https://chatgpt.com/codex/tasks/task_e_68cc06764bd48328ae180e4fb6c4114b