### PR TITLE
[wordle] add shareable result canvas

### DIFF
--- a/__tests__/share.test.ts
+++ b/__tests__/share.test.ts
@@ -3,6 +3,7 @@ import share, { canShare } from '../utils/share';
 describe('share utility', () => {
   afterEach(() => {
     delete (navigator as any).share;
+    delete (navigator as any).canShare;
   });
 
   it('returns false when Web Share API unsupported', async () => {
@@ -21,6 +22,25 @@ describe('share utility', () => {
       text: 'hello',
       title: 'title',
       url: 'http://example.com',
+    });
+  });
+
+  it('shares files when supported by the browser', async () => {
+    const shareMock = jest.fn().mockResolvedValue(undefined);
+    const canShareMock = jest.fn().mockReturnValue(true);
+    (navigator as any).share = shareMock;
+    (navigator as any).canShare = canShareMock;
+
+    const file = new File(['hello'], 'note.txt', { type: 'text/plain' });
+    const payload = { text: 'File share', files: [file] } as const;
+
+    const result = await share(payload);
+    expect(result).toBe(true);
+    expect(canShareMock).toHaveBeenCalledWith({ files: [file] });
+    expect(shareMock).toHaveBeenCalledWith({
+      text: 'File share',
+      files: [file],
+      url: window.location.href,
     });
   });
 });

--- a/__tests__/wordle-share-image.test.ts
+++ b/__tests__/wordle-share-image.test.ts
@@ -1,0 +1,69 @@
+import { generateWordleShareImageData, WORDLE_SHARE_LAYOUT } from '../games/wordle/shareImage';
+import type { GuessEntry } from '../games/wordle/logic';
+
+const sampleGuesses: GuessEntry[] = [
+  {
+    guess: 'CRANE',
+    result: ['present', 'absent', 'absent', 'absent', 'absent'],
+  },
+  {
+    guess: 'LIGHT',
+    result: ['absent', 'correct', 'absent', 'absent', 'present'],
+  },
+  {
+    guess: 'MOUSE',
+    result: ['correct', 'correct', 'correct', 'correct', 'correct'],
+  },
+];
+
+const pixelAt = (
+  data: Uint8ClampedArray,
+  width: number,
+  x: number,
+  y: number,
+): [number, number, number, number] => {
+  const idx = (y * width + x) * 4;
+  return [data[idx], data[idx + 1], data[idx + 2], data[idx + 3]];
+};
+
+describe('Wordle share image generation', () => {
+  it('produces the configured canvas dimensions', () => {
+    const image = generateWordleShareImageData(sampleGuesses);
+    expect(image.width).toBe(WORDLE_SHARE_LAYOUT.width);
+    expect(image.height).toBe(WORDLE_SHARE_LAYOUT.height);
+  });
+
+  it('encodes board colors for each result state', () => {
+    const image = generateWordleShareImageData(sampleGuesses);
+    const { board } = WORDLE_SHARE_LAYOUT;
+
+    const centerOf = (row: number, col: number) => ({
+      x: Math.floor(
+        board.x + col * (board.cellSize + board.gap) + board.cellSize / 2,
+      ),
+      y: Math.floor(
+        board.y + row * (board.cellSize + board.gap) + board.cellSize / 2,
+      ),
+    });
+
+    const { x: correctX, y: correctY } = centerOf(2, 0);
+    const correctPixel = pixelAt(image.data, image.width, correctX, correctY);
+    expect(correctPixel).toEqual([22, 163, 74, 255]);
+
+    const { x: presentX, y: presentY } = centerOf(1, 4);
+    const presentPixel = pixelAt(image.data, image.width, presentX, presentY);
+    expect(presentPixel).toEqual([234, 179, 8, 255]);
+
+    const { x: absentX, y: absentY } = centerOf(0, 1);
+    const absentPixel = pixelAt(image.data, image.width, absentX, absentY);
+    expect(absentPixel).toEqual([75, 85, 99, 255]);
+
+    const { x: emptyX, y: emptyY } = centerOf(5, 0);
+    const emptyPixel = pixelAt(image.data, image.width, emptyX, emptyY);
+    expect(emptyPixel).toEqual([17, 24, 39, 255]);
+
+    const backgroundPixel = pixelAt(image.data, image.width, 2, 2);
+    expect(backgroundPixel).toEqual([15, 19, 23, 255]);
+  });
+});
+

--- a/games/wordle/shareImage.ts
+++ b/games/wordle/shareImage.ts
@@ -1,0 +1,372 @@
+import type { GuessEntry, LetterResult } from './logic';
+
+type RGBA = [number, number, number, number];
+
+interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface BoardLayout extends Rect {
+  cellSize: number;
+  gap: number;
+}
+
+export interface WordleShareLayout {
+  width: number;
+  height: number;
+  card: Rect;
+  header: Rect;
+  board: BoardLayout;
+  footer: Rect;
+}
+
+const CONFIG = {
+  rows: 6,
+  cols: 5,
+  cellSize: 64,
+  gap: 12,
+  cardMargin: 24,
+  contentPadding: 32,
+  headerHeight: 96,
+  boardSpacing: 32,
+  footerHeight: 88,
+} as const;
+
+const gridWidth =
+  CONFIG.cols * CONFIG.cellSize + (CONFIG.cols - 1) * CONFIG.gap;
+const gridHeight =
+  CONFIG.rows * CONFIG.cellSize + (CONFIG.rows - 1) * CONFIG.gap;
+
+const cardWidth = gridWidth + CONFIG.contentPadding * 2;
+const cardHeight =
+  CONFIG.headerHeight + CONFIG.boardSpacing + gridHeight + CONFIG.footerHeight;
+
+const width = cardWidth + CONFIG.cardMargin * 2;
+const height = cardHeight + CONFIG.cardMargin * 2;
+
+export const WORDLE_SHARE_LAYOUT: WordleShareLayout = {
+  width,
+  height,
+  card: {
+    x: CONFIG.cardMargin,
+    y: CONFIG.cardMargin,
+    width: cardWidth,
+    height: cardHeight,
+  },
+  header: {
+    x: CONFIG.cardMargin,
+    y: CONFIG.cardMargin,
+    width: cardWidth,
+    height: CONFIG.headerHeight,
+  },
+  board: {
+    x: CONFIG.cardMargin + CONFIG.contentPadding,
+    y: CONFIG.cardMargin + CONFIG.headerHeight + CONFIG.boardSpacing,
+    width: gridWidth,
+    height: gridHeight,
+    cellSize: CONFIG.cellSize,
+    gap: CONFIG.gap,
+  },
+  footer: {
+    x: CONFIG.cardMargin,
+    y:
+      CONFIG.cardMargin +
+      CONFIG.headerHeight +
+      CONFIG.boardSpacing +
+      gridHeight,
+    width: cardWidth,
+    height: CONFIG.footerHeight,
+  },
+};
+
+const palette = {
+  outer: hexToRgba('#0f1317'),
+  card: hexToRgba('#111827'),
+  header: hexToRgba('#1f2937'),
+  boardBackground: hexToRgba('#1f2937'),
+  border: hexToRgba('#374151'),
+  empty: hexToRgba('#111827'),
+  correct: hexToRgba('#16a34a'),
+  present: hexToRgba('#eab308'),
+  absent: hexToRgba('#4b5563'),
+  textPrimary: '#f9fafb',
+  textAccent: '#62a0ea',
+  textMuted: '#d1d5db',
+} as const;
+
+const CELL_INSET = 6;
+
+function hexToRgba(hex: string, alpha = 1): RGBA {
+  const normalized = hex.replace('#', '');
+  const value =
+    normalized.length === 3
+      ? normalized
+          .split('')
+          .map((ch) => ch + ch)
+          .join('')
+      : normalized;
+  const bigint = parseInt(value, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  const a = Math.round(alpha * 255);
+  return [r, g, b, a];
+}
+
+function fillRect(
+  data: Uint8ClampedArray,
+  canvasWidth: number,
+  canvasHeight: number,
+  x: number,
+  y: number,
+  rectWidth: number,
+  rectHeight: number,
+  color: RGBA,
+) {
+  const [r, g, b, a] = color;
+  const startX = Math.max(0, Math.floor(x));
+  const startY = Math.max(0, Math.floor(y));
+  const endX = Math.min(canvasWidth, Math.ceil(x + rectWidth));
+  const endY = Math.min(canvasHeight, Math.ceil(y + rectHeight));
+
+  for (let yy = startY; yy < endY; yy += 1) {
+    let offset = (yy * canvasWidth + startX) * 4;
+    for (let xx = startX; xx < endX; xx += 1) {
+      data[offset] = r;
+      data[offset + 1] = g;
+      data[offset + 2] = b;
+      data[offset + 3] = a;
+      offset += 4;
+    }
+  }
+}
+
+function colorForResult(result?: LetterResult): RGBA {
+  if (result === 'correct') return palette.correct;
+  if (result === 'present') return palette.present;
+  if (result === 'absent') return palette.absent;
+  return palette.empty;
+}
+
+export interface WordleShareImageData {
+  width: number;
+  height: number;
+  data: Uint8ClampedArray;
+}
+
+export const generateWordleShareImageData = (
+  guesses: GuessEntry[],
+): WordleShareImageData => {
+  const { width: canvasWidth, height: canvasHeight, card, header, board } =
+    WORDLE_SHARE_LAYOUT;
+  const data = new Uint8ClampedArray(canvasWidth * canvasHeight * 4);
+
+  fillRect(data, canvasWidth, canvasHeight, 0, 0, canvasWidth, canvasHeight, palette.outer);
+  fillRect(
+    data,
+    canvasWidth,
+    canvasHeight,
+    card.x,
+    card.y,
+    card.width,
+    card.height,
+    palette.card,
+  );
+  fillRect(
+    data,
+    canvasWidth,
+    canvasHeight,
+    header.x,
+    header.y,
+    header.width,
+    header.height,
+    palette.header,
+  );
+  fillRect(
+    data,
+    canvasWidth,
+    canvasHeight,
+    board.x,
+    board.y,
+    board.width,
+    board.height,
+    palette.boardBackground,
+  );
+
+  for (let row = 0; row < CONFIG.rows; row += 1) {
+    const entry = guesses[row];
+    const rowResults = entry?.result ?? [];
+    for (let col = 0; col < CONFIG.cols; col += 1) {
+      const cellX = board.x + col * (board.cellSize + board.gap);
+      const cellY = board.y + row * (board.cellSize + board.gap);
+      fillRect(
+        data,
+        canvasWidth,
+        canvasHeight,
+        cellX,
+        cellY,
+        board.cellSize,
+        board.cellSize,
+        palette.border,
+      );
+      fillRect(
+        data,
+        canvasWidth,
+        canvasHeight,
+        cellX + CELL_INSET,
+        cellY + CELL_INSET,
+        board.cellSize - CELL_INSET * 2,
+        board.cellSize - CELL_INSET * 2,
+        colorForResult(rowResults[col]),
+      );
+    }
+  }
+
+  return {
+    width: canvasWidth,
+    height: canvasHeight,
+    data,
+  };
+};
+
+export interface WordleShareScore {
+  attempts: number;
+  solved: boolean;
+  scoreText: string;
+  statusText: string;
+}
+
+export const computeWordleShareScore = (
+  guesses: GuessEntry[],
+  solution: string,
+): WordleShareScore => {
+  const solvedIndex = guesses.findIndex((g) => g.guess === solution);
+  const solved = solvedIndex !== -1;
+  const attempts = solved ? solvedIndex + 1 : guesses.length;
+  const scoreText = `${solved ? attempts : 'X'}/${CONFIG.rows}`;
+  const statusText = solved
+    ? `Solved in ${attempts} ${attempts === 1 ? 'try' : 'tries'}`
+    : `Missed • ${solution}`;
+
+  return { attempts, solved, scoreText, statusText };
+};
+
+const createImageData = (
+  width: number,
+  height: number,
+  data: Uint8ClampedArray,
+): ImageData => {
+  if (typeof ImageData !== 'undefined') {
+    return new ImageData(data, width, height);
+  }
+  // Fallback for environments missing ImageData constructor (should be rare on browsers)
+  const context = document.createElement('canvas').getContext('2d');
+  if (!context) {
+    throw new Error('Unable to create canvas context for ImageData fallback.');
+  }
+  const imageData = context.createImageData(width, height);
+  imageData.data.set(data);
+  return imageData;
+};
+
+const applyShareTypography = (
+  ctx: CanvasRenderingContext2D,
+  score: WordleShareScore,
+  solution: string,
+) => {
+  const { header, footer, width: canvasWidth } = WORDLE_SHARE_LAYOUT;
+
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+
+  ctx.fillStyle = palette.textPrimary;
+  ctx.font = `700 ${Math.round(header.height * 0.38)}px Ubuntu, 'Segoe UI', sans-serif`;
+  ctx.fillText('Wordle', canvasWidth / 2, header.y + header.height * 0.38);
+
+  ctx.fillStyle = palette.textAccent;
+  ctx.font = `600 ${Math.round(header.height * 0.32)}px Ubuntu, 'Segoe UI', sans-serif`;
+  ctx.fillText(score.scoreText, canvasWidth / 2, header.y + header.height * 0.72);
+
+  ctx.fillStyle = palette.textMuted;
+  ctx.font = `400 ${Math.round(footer.height * 0.38)}px Ubuntu, 'Segoe UI', sans-serif`;
+  ctx.fillText(score.statusText, canvasWidth / 2, footer.y + footer.height * 0.35);
+
+  if (!score.solved) {
+    ctx.font = `500 ${Math.round(footer.height * 0.3)}px Ubuntu, 'Segoe UI', sans-serif`;
+    ctx.fillText(`Answer: ${solution}`, canvasWidth / 2, footer.y + footer.height * 0.7);
+  }
+};
+
+export const paintWordleShareCanvas = (
+  canvas: HTMLCanvasElement,
+  guesses: GuessEntry[],
+  solution: string,
+): WordleShareScore => {
+  const { width: canvasWidth, height: canvasHeight } = WORDLE_SHARE_LAYOUT;
+  const image = generateWordleShareImageData(guesses);
+  canvas.width = canvasWidth;
+  canvas.height = canvasHeight;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('2D canvas context not available.');
+  }
+  const imageData = createImageData(image.width, image.height, image.data);
+  ctx.putImageData(imageData, 0, 0);
+
+  const score = computeWordleShareScore(guesses, solution);
+  applyShareTypography(ctx, score, solution);
+  return score;
+};
+
+const canvasToBlob = (canvas: HTMLCanvasElement): Promise<Blob> =>
+  new Promise((resolve, reject) => {
+    if (canvas.toBlob) {
+      canvas.toBlob((blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error('Failed to export canvas.'));
+        }
+      }, 'image/png');
+      return;
+    }
+
+    try {
+      const dataUrl = canvas.toDataURL('image/png');
+      const base64 = dataUrl.split(',')[1];
+      const binary = atob(base64);
+      const array = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i += 1) {
+        array[i] = binary.charCodeAt(i);
+      }
+      resolve(new Blob([array], { type: 'image/png' }));
+    } catch (error) {
+      reject(error instanceof Error ? error : new Error('Failed to export canvas.'));
+    }
+  });
+
+export const renderWordleShareCanvas = async (
+  guesses: GuessEntry[],
+  solution: string,
+): Promise<{ blob: Blob; score: WordleShareScore }> => {
+  if (typeof document === 'undefined') {
+    throw new Error('Canvas rendering is only available in the browser.');
+  }
+
+  const canvas = document.createElement('canvas');
+  const score = paintWordleShareCanvas(canvas, guesses, solution);
+  const blob = await canvasToBlob(canvas);
+  return { blob, score };
+};
+
+export default {
+  WORDLE_SHARE_LAYOUT,
+  generateWordleShareImageData,
+  computeWordleShareScore,
+  paintWordleShareCanvas,
+  renderWordleShareCanvas,
+};
+

--- a/utils/share.ts
+++ b/utils/share.ts
@@ -1,16 +1,65 @@
-// Simple helper around the Web Share API
-export const canShare = () =>
-  typeof navigator !== 'undefined' && typeof navigator.share === 'function';
+export interface ShareOptions {
+  text?: string;
+  title?: string;
+  url?: string;
+  files?: File[];
+}
 
-// Shares the provided text along with optional title and url
-export const share = async (
-  text: string,
+// Simple helper around the Web Share API
+export const canShare = (options?: ShareOptions): boolean => {
+  if (typeof navigator === 'undefined' || typeof navigator.share !== 'function') {
+    return false;
+  }
+
+  if (options?.files && options.files.length > 0) {
+    const canShareFn = (navigator as Navigator & { canShare?: (data: ShareData) => boolean }).canShare;
+    if (typeof canShareFn !== 'function') {
+      return false;
+    }
+
+    try {
+      return canShareFn({ files: options.files });
+    } catch {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const normalizeOptions = (
+  dataOrText: string | ShareOptions,
   title?: string,
-  url?: string
+  url?: string,
+): ShareOptions => {
+  if (typeof dataOrText === 'string') {
+    return { text: dataOrText, title, url };
+  }
+  return dataOrText;
+};
+
+// Shares the provided payload (text, files, etc.) via the Web Share API
+export const share = async (
+  dataOrText: string | ShareOptions,
+  title?: string,
+  url?: string,
 ): Promise<boolean> => {
-  if (!canShare()) return false;
+  const options = normalizeOptions(dataOrText, title, url);
+  if (!canShare(options)) return false;
+
+  const shareData: ShareData = {};
+  if (options.text) shareData.text = options.text;
+  if (options.title) shareData.title = options.title;
+  if (options.files && options.files.length > 0) shareData.files = options.files;
+
+  if (options.url !== undefined) {
+    shareData.url = options.url;
+  } else if (typeof window !== 'undefined') {
+    shareData.url = window.location.href;
+  }
+
   try {
-    await navigator.share({ text, title, url: url ?? window.location.href });
+    await navigator.share(shareData);
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- add a share image generator that renders the final Wordle board and score to a styled canvas
- update the Wordle UI to show the canvas preview and export a PNG via Web Share, download, or clipboard fallbacks
- extend the share helper to support file payloads and cover the new functionality with Jest tests

## Testing
- yarn lint *(fails: existing accessibility and static asset lint errors in unrelated areas)*
- yarn test *(fails: existing suites such as nmap-nse, contact.api, niktoPage; new tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1e224a7c8328a731e293df7f0b01