### PR TITLE
[youtube] Persist queue and align list controls

### DIFF
--- a/apps/youtube/state/queue.ts
+++ b/apps/youtube/state/queue.ts
@@ -1,0 +1,9 @@
+import usePersistentState from '../../../hooks/usePersistentState';
+import { Video, validateVideoList } from './watchLater';
+
+const QUEUE_KEY = 'youtube:queue';
+
+export default function usePlaybackQueue() {
+  return usePersistentState<Video[]>(QUEUE_KEY, [], validateVideoList);
+}
+

--- a/apps/youtube/state/watchLater.ts
+++ b/apps/youtube/state/watchLater.ts
@@ -13,7 +13,7 @@ export interface Video {
 
 const WATCH_LATER_KEY = 'youtube:watch-later';
 
-function isVideo(v: any): v is Video {
+export function isVideo(v: any): v is Video {
   return (
     v &&
     typeof v.id === 'string' &&
@@ -27,11 +27,11 @@ function isVideo(v: any): v is Video {
   );
 }
 
-function validate(list: unknown): list is Video[] {
+export function validateVideoList(list: unknown): list is Video[] {
   return Array.isArray(list) && list.every(isVideo);
 }
 
 export default function useWatchLater() {
-  return usePersistentState<Video[]>(WATCH_LATER_KEY, [], validate);
+  return usePersistentState<Video[]>(WATCH_LATER_KEY, [], validateVideoList);
 }
 


### PR DESCRIPTION
## Summary
- persist the YouTube playback queue alongside the existing watch later list
- unify sidebar list interactions with shared drag, keyboard reordering, and remove controls
- add regression tests covering queue/watch-later persistence, reordering, and removal

## Testing
- yarn lint *(fails: pre-existing accessibility and no-top-level-window lint errors across unrelated apps)*
- yarn test --watch=false *(fails: pre-existing suites such as window and nmap NSE tests)*
- yarn test __tests__/youtube.test.tsx --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cc1e28158c8328ba16ebb6bbfbb491