### PR TITLE
[video-player] add theater mode toggle and stats overlay

### DIFF
--- a/__tests__/VideoPlayer.test.tsx
+++ b/__tests__/VideoPlayer.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import VideoPlayer from '../components/ui/VideoPlayer';
+
+describe('VideoPlayer UI', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('toggles theater mode and persists preference', async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<VideoPlayer src="/video.mp4" />);
+    const frame = screen.getByTestId('video-player-frame');
+    const toggle = screen.getByRole('button', { name: /toggle theater mode/i });
+
+    expect(frame).toHaveAttribute('data-theater-mode', 'off');
+
+    await user.click(toggle);
+    await waitFor(() => {
+      expect(frame).toHaveAttribute('data-theater-mode', 'on');
+    });
+    await waitFor(() => {
+      expect(window.localStorage.getItem('video-player:theater-mode')).toBe('true');
+    });
+
+    unmount();
+    render(<VideoPlayer src="/video.mp4" />);
+    const persistedFrame = screen.getByTestId('video-player-frame');
+    expect(persistedFrame).toHaveAttribute('data-theater-mode', 'on');
+  });
+
+  it('updates stats overlay with resolution and dropped frames', async () => {
+    jest.useFakeTimers();
+    render(<VideoPlayer src="/video.mp4" />);
+
+    const frame = screen.getByTestId('video-player-frame');
+    const video = frame.querySelector('video') as HTMLVideoElement;
+    expect(video).toBeTruthy();
+
+    Object.defineProperty(video, 'videoWidth', {
+      configurable: true,
+      get: () => 1920,
+    });
+    Object.defineProperty(video, 'videoHeight', {
+      configurable: true,
+      get: () => 1080,
+    });
+
+    const qualityMock = jest.fn();
+    qualityMock.mockReturnValueOnce({ droppedVideoFrames: 1 });
+    qualityMock.mockReturnValue({ droppedVideoFrames: 5 });
+    (video as any).getVideoPlaybackQuality = qualityMock;
+
+    await act(async () => {
+      video.dispatchEvent(new Event('loadedmetadata'));
+    });
+
+    await screen.findByText('Resolution: 1920×1080');
+    await screen.findByText('Dropped frames: 1');
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText('Dropped frames: 5')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a theater mode toggle to the shared video player that persists user preference
- surface a live stats overlay for resolution and dropped frames without re-render jank
- cover the new behaviors with unit tests for layout persistence and stat polling

## Testing
- `yarn lint` *(fails: existing accessibility violations across unrelated apps)*
- `CI=1 yarn test --runTestsByPath __tests__/VideoPlayer.test.tsx __tests__/youtube.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68cc1e28f0308328bc54f28014b0bc3a