### PR TITLE
[apps] add spotify library loader

### DIFF
--- a/__tests__/spotify-library.test.ts
+++ b/__tests__/spotify-library.test.ts
@@ -1,0 +1,114 @@
+import {
+  createLibraryIndex,
+  filterLibrary,
+  toQueueTracks,
+  type RawSpotifyLibrary,
+} from "../apps/spotify/library";
+
+const SAMPLE_LIBRARY: RawSpotifyLibrary = {
+  tracks: [
+    {
+      id: "track-night-drive",
+      title: "Night Drive",
+      artist: "Synth Fox",
+      album: "City Signals",
+      url: "https://example.com/night-drive.mp3",
+      cover: "/themes/Yaru/apps/spotify.svg",
+    },
+    {
+      id: "track-terminal-code",
+      title: "Terminal Code",
+      artist: "Synth Fox",
+      album: "City Signals",
+      url: "https://example.com/terminal-code.mp3",
+      cover: "/themes/Yaru/apps/spotify.svg",
+    },
+    {
+      id: "track-laser-focus",
+      title: "Laser Focus",
+      artist: "Circuit Dream",
+      album: "Focus Tape",
+      url: "https://example.com/laser-focus.mp3",
+      cover: "/themes/Yaru/apps/spotify.svg",
+    },
+  ],
+  albums: [
+    {
+      id: "album-city-signals",
+      title: "City Signals",
+      artist: "Synth Fox",
+      cover: "/themes/Yaru/apps/spotify.svg",
+      tracks: ["track-night-drive", "track-terminal-code"],
+    },
+    {
+      id: "album-focus-tape",
+      title: "Focus Tape",
+      artist: "Circuit Dream",
+      cover: "/themes/Yaru/apps/spotify.svg",
+      tracks: ["track-laser-focus"],
+    },
+  ],
+  playlists: [
+    {
+      id: "playlist-night-focus",
+      title: "Night Focus",
+      description: "Late-night synthwave coding.",
+      tracks: ["track-night-drive", "track-laser-focus"],
+    },
+  ],
+};
+
+describe("spotify library loader", () => {
+  it("resolves track references for albums and playlists", () => {
+    const library = createLibraryIndex(SAMPLE_LIBRARY);
+    expect(library.tracks.map((track) => track.id)).toEqual([
+      "track-night-drive",
+      "track-terminal-code",
+      "track-laser-focus",
+    ]);
+    expect(library.albums[0].tracks.map((track) => track.id)).toEqual([
+      "track-night-drive",
+      "track-terminal-code",
+    ]);
+    expect(library.playlists[0].tracks.map((track) => track.id)).toEqual([
+      "track-night-drive",
+      "track-laser-focus",
+    ]);
+  });
+
+  it("filters tracks, albums, and playlists using shared tokens", () => {
+    const library = createLibraryIndex(SAMPLE_LIBRARY);
+    const filtered = filterLibrary(library, "night synth");
+    expect(filtered.tracks.map((track) => track.id)).toEqual([
+      "track-night-drive",
+    ]);
+    expect(filtered.albums.map((album) => album.id)).toEqual([
+      "album-city-signals",
+    ]);
+    expect(filtered.playlists.map((playlist) => playlist.id)).toEqual([
+      "playlist-night-focus",
+    ]);
+
+    const focusFiltered = filterLibrary(library, "laser focus");
+    expect(focusFiltered.tracks.map((track) => track.id)).toEqual([
+      "track-laser-focus",
+    ]);
+    expect(focusFiltered.albums.map((album) => album.id)).toEqual([
+      "album-focus-tape",
+    ]);
+  });
+
+  it("strips search metadata when converting to queue tracks", () => {
+    const library = createLibraryIndex(SAMPLE_LIBRARY);
+    const queue = toQueueTracks(library.tracks);
+    expect(queue).toHaveLength(3);
+    expect(queue.every((track) => !("searchText" in track))).toBe(true);
+    expect(queue[0]).toEqual(
+      expect.objectContaining({
+        id: "track-night-drive",
+        title: "Night Drive",
+        url: "https://example.com/night-drive.mp3",
+      }),
+    );
+  });
+});

--- a/apps/spotify/library.ts
+++ b/apps/spotify/library.ts
@@ -1,0 +1,194 @@
+import rawLibrary from "../../data/spotify/library.json";
+
+export interface QueueTrack {
+  id: string;
+  title: string;
+  url: string;
+  cover?: string;
+  artist?: string;
+  album?: string;
+}
+
+export interface LibraryTrack extends QueueTrack {
+  searchText: string;
+}
+
+export interface LibraryAlbum {
+  id: string;
+  title: string;
+  artist: string;
+  cover?: string;
+  tracks: LibraryTrack[];
+  searchText: string;
+}
+
+export interface LibraryPlaylist {
+  id: string;
+  title: string;
+  description?: string;
+  tracks: LibraryTrack[];
+  searchText: string;
+}
+
+export interface SpotifyLibrary {
+  tracks: LibraryTrack[];
+  trackMap: Record<string, LibraryTrack>;
+  albums: LibraryAlbum[];
+  playlists: LibraryPlaylist[];
+}
+
+export interface RawLibraryTrack extends QueueTrack {}
+
+export interface RawLibraryAlbum {
+  id: string;
+  title: string;
+  artist: string;
+  cover?: string;
+  tracks: string[];
+}
+
+export interface RawLibraryPlaylist {
+  id: string;
+  title: string;
+  description?: string;
+  tracks: string[];
+}
+
+export interface RawSpotifyLibrary {
+  tracks: RawLibraryTrack[];
+  albums: RawLibraryAlbum[];
+  playlists: RawLibraryPlaylist[];
+}
+
+const normalizeForSearch = (value: string) =>
+  value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+
+const toSearchText = (...values: Array<string | undefined>) =>
+  normalizeForSearch(values.filter(Boolean).join(" "));
+
+const tokenize = (query: string) =>
+  query
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((token) => normalizeForSearch(token));
+
+const mapToObject = (map: Map<string, LibraryTrack>): Record<string, LibraryTrack> => {
+  const entries: Record<string, LibraryTrack> = {};
+  map.forEach((value, key) => {
+    entries[key] = value;
+  });
+  return entries;
+};
+
+export const createLibraryIndex = (raw: RawSpotifyLibrary): SpotifyLibrary => {
+  const trackMap = new Map<string, LibraryTrack>();
+
+  raw.tracks.forEach((track) => {
+    if (!track.id || !track.url) {
+      return;
+    }
+    const searchText = toSearchText(track.title, track.artist, track.album);
+    const libraryTrack: LibraryTrack = {
+      ...track,
+      searchText,
+    };
+    trackMap.set(track.id, libraryTrack);
+  });
+
+  const resolveTracks = (ids: string[]) =>
+    ids
+      .map((id) => trackMap.get(id))
+      .filter((track): track is LibraryTrack => Boolean(track));
+
+  const albums: LibraryAlbum[] = raw.albums.map((album) => {
+    const tracks = resolveTracks(album.tracks);
+    const searchText = toSearchText(
+      album.title,
+      album.artist,
+      ...tracks.map((track) => track.title),
+    );
+    return {
+      id: album.id,
+      title: album.title,
+      artist: album.artist,
+      cover: album.cover,
+      tracks,
+      searchText,
+    };
+  });
+
+  const playlists: LibraryPlaylist[] = raw.playlists.map((playlist) => {
+    const tracks = resolveTracks(playlist.tracks);
+    const searchText = toSearchText(
+      playlist.title,
+      playlist.description,
+      ...tracks.map((track) => track.title),
+      ...tracks.map((track) => track.artist),
+    );
+    return {
+      id: playlist.id,
+      title: playlist.title,
+      description: playlist.description,
+      tracks,
+      searchText,
+    };
+  });
+
+  return {
+    tracks: raw.tracks
+      .map((track) => trackMap.get(track.id))
+      .filter((track): track is LibraryTrack => Boolean(track)),
+    trackMap: mapToObject(trackMap),
+    albums,
+    playlists,
+  };
+};
+
+export type QueueTrackList = QueueTrack[];
+
+export const toQueueTrack = (track: LibraryTrack): QueueTrack => {
+  const { searchText: _searchText, ...rest } = track;
+  return rest;
+};
+
+export const toQueueTracks = (tracks: LibraryTrack[]): QueueTrackList =>
+  tracks.map((track) => toQueueTrack(track));
+
+export interface FilteredLibrary {
+  tracks: LibraryTrack[];
+  albums: LibraryAlbum[];
+  playlists: LibraryPlaylist[];
+}
+
+const matchesTokens = (searchText: string, tokens: string[]) =>
+  tokens.every((token) => searchText.includes(token));
+
+const filterCollection = <T extends { searchText: string }>(
+  items: T[],
+  tokens: string[],
+) => {
+  if (!tokens.length) {
+    return items;
+  }
+  return items.filter((item) => matchesTokens(item.searchText, tokens));
+};
+
+export const filterLibrary = (
+  library: SpotifyLibrary,
+  query: string,
+): FilteredLibrary => {
+  const tokens = tokenize(query);
+  return {
+    tracks: filterCollection(library.tracks, tokens),
+    albums: filterCollection(library.albums, tokens),
+    playlists: filterCollection(library.playlists, tokens),
+  };
+};
+
+const defaultLibrary = rawLibrary as RawSpotifyLibrary;
+
+export const spotifyLibrary = createLibraryIndex(defaultLibrary);

--- a/data/spotify/library.json
+++ b/data/spotify/library.json
@@ -1,0 +1,106 @@
+{
+  "tracks": [
+    {
+      "id": "helix-neon-drive",
+      "title": "Neon Drive",
+      "artist": "SoundHelix Ensemble",
+      "album": "Kali Nights",
+      "url": "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3",
+      "cover": "/themes/Yaru/apps/spotify.svg"
+    },
+    {
+      "id": "helix-midnight-terminal",
+      "title": "Midnight Terminal",
+      "artist": "SoundHelix Ensemble",
+      "album": "Kali Nights",
+      "url": "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3",
+      "cover": "/themes/Yaru/apps/spotify.svg"
+    },
+    {
+      "id": "helix-cyan-aurora",
+      "title": "Cyan Aurora",
+      "artist": "Echo Sector",
+      "album": "Polar Wave",
+      "url": "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3",
+      "cover": "/themes/Yaru/apps/spotify.svg"
+    },
+    {
+      "id": "helix-terminal-dawn",
+      "title": "Terminal Dawn",
+      "artist": "Echo Sector",
+      "album": "Polar Wave",
+      "url": "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-4.mp3",
+      "cover": "/themes/Yaru/apps/spotify.svg"
+    },
+    {
+      "id": "helix-overclocked-lullaby",
+      "title": "Overclocked Lullaby",
+      "artist": "Bitshift Dreams",
+      "album": "Kernel Reveries",
+      "url": "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-5.mp3",
+      "cover": "/themes/Yaru/apps/spotify.svg"
+    },
+    {
+      "id": "helix-sandstorm-protocol",
+      "title": "Sandstorm Protocol",
+      "artist": "Bitshift Dreams",
+      "album": "Kernel Reveries",
+      "url": "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-6.mp3",
+      "cover": "/themes/Yaru/apps/spotify.svg"
+    }
+  ],
+  "albums": [
+    {
+      "id": "album-kali-nights",
+      "title": "Kali Nights",
+      "artist": "SoundHelix Ensemble",
+      "cover": "/themes/Yaru/apps/spotify.svg",
+      "tracks": [
+        "helix-neon-drive",
+        "helix-midnight-terminal"
+      ]
+    },
+    {
+      "id": "album-polar-wave",
+      "title": "Polar Wave",
+      "artist": "Echo Sector",
+      "cover": "/themes/Yaru/apps/spotify.svg",
+      "tracks": [
+        "helix-cyan-aurora",
+        "helix-terminal-dawn"
+      ]
+    },
+    {
+      "id": "album-kernel-reveries",
+      "title": "Kernel Reveries",
+      "artist": "Bitshift Dreams",
+      "cover": "/themes/Yaru/apps/spotify.svg",
+      "tracks": [
+        "helix-overclocked-lullaby",
+        "helix-sandstorm-protocol"
+      ]
+    }
+  ],
+  "playlists": [
+    {
+      "id": "playlist-deep-focus",
+      "title": "Deep Focus",
+      "description": "Slow-burn instrumentals for writing exploits.",
+      "tracks": [
+        "helix-neon-drive",
+        "helix-overclocked-lullaby",
+        "helix-terminal-dawn"
+      ]
+    },
+    {
+      "id": "playlist-sprint-mode",
+      "title": "Sprint Mode",
+      "description": "High-tempo outrun tracks for late-night patching.",
+      "tracks": [
+        "helix-sandstorm-protocol",
+        "helix-midnight-terminal",
+        "helix-cyan-aurora"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- replace the manual playlist textarea with a library browser that loads local JSON
- add search and filtering controls for tracks, albums, and playlists with quick queue actions
- add unit tests covering library parsing and filtering helpers

## Testing
- yarn lint *(fails: repo has hundreds of pre-existing accessibility lint errors and static public JS violations)*
- yarn test *(fails: existing window and nmap suites fail; new spotify-library tests pass)*
- yarn test spotify-library *(fails overall due to existing suites; spotify-library test itself passes)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1e3490e083289ac0544edf7b0237