### PR TITLE
[beef] add module gallery demos

### DIFF
--- a/__tests__/beef.test.tsx
+++ b/__tests__/beef.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act, within } from '@testing-library/react';
 import Beef from '../components/apps/beef';
 
 describe('BeEF app', () => {
@@ -22,5 +22,64 @@ describe('BeEF app', () => {
     }
     fireEvent.click(screen.getByRole('button', { name: /reset lab/i }));
     expect(screen.getByText(/Disclaimer/i)).toBeInTheDocument();
+  });
+
+  test('module gallery groups modules and surfaces output types', () => {
+    render(<Beef />);
+    fireEvent.click(screen.getByRole('button', { name: /begin/i }));
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    expect(screen.getByRole('heading', { name: /social engineering/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /data harvesting/i })).toBeInTheDocument();
+    expect(screen.getAllByText(/Alert Dialog/)[0]).toBeInTheDocument();
+    expect(screen.getByText(/Output: Modal dialog/)).toBeInTheDocument();
+    expect(screen.getByText(/Run a module to stream its simulation output./i)).toBeInTheDocument();
+  });
+
+  test('running a module demo streams sequential output', () => {
+    jest.useFakeTimers();
+
+    try {
+      render(<Beef />);
+      fireEvent.click(screen.getByRole('button', { name: /begin/i }));
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+      const alertHeading = screen.getAllByText('Alert Dialog')[0];
+      const alertCard = alertHeading.closest('article');
+      expect(alertCard).not.toBeNull();
+      const runButton = within(alertCard as HTMLElement).getByRole('button', { name: /run demo/i });
+
+      fireEvent.click(runButton);
+
+      const timelinePanel = screen
+        .getByText(/demo timeline/i)
+        .closest('div')
+        ?.parentElement?.parentElement;
+      expect(timelinePanel).not.toBeNull();
+
+      act(() => {
+        jest.advanceTimersByTime(450);
+      });
+      expect(within(timelinePanel as HTMLElement).getAllByText(/Deploying payload: alert dialog stub/i)[0]).toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(450);
+      });
+      expect(within(timelinePanel as HTMLElement).getAllByText(/Browser executed window\.alert/i)[0]).toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(450);
+      });
+      expect(within(timelinePanel as HTMLElement).getAllByText(/Operator saw acknowledgement/i)[0]).toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(400);
+      });
+      expect(within(alertCard as HTMLElement).getByText(/Done/i)).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/components/apps/beef/ModuleGallery.js
+++ b/components/apps/beef/ModuleGallery.js
@@ -1,0 +1,287 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import modulesData from './modules.json';
+
+const demoSequences = {
+  alert: [
+    '📡 Deploying payload: alert dialog stub',
+    '🖥️ Browser executed window.alert("BeEF demo alert!")',
+    '✅ Operator saw acknowledgement in the sandboxed iframe',
+  ],
+  prompt: [
+    '📨 Shipping prompt dialog payload',
+    '⌨️ Target prompted for demo text input',
+    '✅ Input captured locally for review only',
+  ],
+  confirm: [
+    '🔁 Sending confirmation request',
+    '🖱️ Target clicked "OK" within the simulated dialog',
+    '✅ Confirmation state: accepted (demo)',
+  ],
+  'get-cookie': [
+    '🍪 Enumerating document.cookie …',
+    '📄 Captured sample: session=demo-token; secure',
+    '✅ Stored locally; nothing transmitted outward',
+  ],
+  'get-local-storage': [
+    '📦 Inspecting localStorage keys',
+    '🗂️ Keys discovered: ["theme", "remember_me"]',
+    '✅ Values persisted inside demo vault',
+  ],
+  'get-session-storage': [
+    '📦 Inspecting sessionStorage footprint',
+    '🗂️ Keys discovered: ["csrf", "analytics"]',
+    '✅ Session entries cleared after review',
+  ],
+  'browser-info': [
+    '🔍 Fingerprinting user agent details',
+    '🧠 UA string parsed into JSON profile',
+    '✅ Profile cached in offline report',
+  ],
+  'detect-plugins': [
+    '🔌 Querying navigator.plugins collection',
+    '📊 Plugin count simulated: 3 (PDF, DRM, WebRTC)',
+    '✅ Recon result logged locally',
+  ],
+  geolocation: [
+    '📍 Requesting geolocation permission',
+    '🗺️ Demo coordinates resolved: 37.7749, -122.4194',
+    '✅ Coordinates masked before storage',
+  ],
+  'play-sound': [
+    '🔊 Preparing audio buffer',
+    '🎵 Playback started: 440Hz sine wave (simulated)',
+    '✅ Audio channel stopped after preview',
+  ],
+  'change-background': [
+    '🎨 Sending style mutation command',
+    '🌈 Background toggled to lime accent',
+    '✅ DOM style reset queued',
+  ],
+  'open-tab': [
+    '🌐 Crafting window.open payload',
+    "🪟 Simulated tab launch to https://example.com",
+    '✅ Operator log updated with virtual visit',
+  ],
+  redirect: [
+    '🚦 Injecting location redirect',
+    '➡️ Target navigated to https://example.com (simulated)',
+    '✅ Original page restored in sandbox',
+  ],
+  'fetch-url': [
+    '🌐 Dispatching fetch request to https://example.com',
+    '🧾 Retrieved demo HTML snippet (length: 245 chars)',
+    '✅ Response cached in offline log',
+  ],
+  'port-scan': [
+    '🛰️ Initiating virtual port sweep',
+    '📡 Ports 22, 80, 443 marked as "open" (demo)',
+    '✅ Report saved with simulated latency chart',
+  ],
+  'network-scan': [
+    '🌐 Launching internal network discovery',
+    '🖥️ Detected demo hosts: 192.168.0.10, 192.168.0.42',
+    '✅ Recon map updated in sandbox',
+  ],
+  keylogger: [
+    '⌨️ Injecting keylogger hook',
+    '📝 Capturing demo keystrokes: hunter2',
+    '✅ Log encrypted and stored locally only',
+  ],
+  clipboard: [
+    '📋 Requesting clipboard read permission',
+    '🧾 Sample clipboard text: "demo payload"',
+    '✅ Clipboard buffer cleared after inspection',
+  ],
+  screenshot: [
+    '📷 Preparing canvas renderer',
+    '🖼️ Captured 1280x720 frame (simulated)',
+    '✅ Image cached inside sandboxed store',
+  ],
+  'webcam-snapshot': [
+    '🎥 Requesting webcam stream',
+    '🖼️ Snapshot captured at 640x480 (placeholder)',
+    '✅ Media stream stopped and discarded',
+  ],
+};
+
+const defaultSequence = (moduleName) => [
+  `▶️ Running ${moduleName} demo sequence`,
+  'ℹ️ Awaiting simulated output …',
+  '✅ Demo finished; no data left the browser',
+];
+
+export default function ModuleGallery() {
+  const modules = modulesData.modules;
+
+  const moduleMap = useMemo(() => {
+    return modules.reduce((acc, module) => {
+      acc[module.id] = module;
+      return acc;
+    }, {});
+  }, [modules]);
+
+  const groupedByTag = useMemo(() => {
+    return modules.reduce((acc, module) => {
+      const primaryTag = module.tags?.[0] ?? 'Other';
+      if (!acc[primaryTag]) {
+        acc[primaryTag] = [];
+      }
+      acc[primaryTag].push(module);
+      return acc;
+    }, {});
+  }, [modules]);
+
+  const sortedTags = useMemo(
+    () => Object.keys(groupedByTag).sort((a, b) => a.localeCompare(b)),
+    [groupedByTag],
+  );
+
+  const [activeModuleId, setActiveModuleId] = useState(modules[0]?.id ?? null);
+  const [displayedLines, setDisplayedLines] = useState([]);
+  const [isRunning, setIsRunning] = useState(false);
+  const [completedModules, setCompletedModules] = useState({});
+
+  const activeSequence = useMemo(() => {
+    if (!activeModuleId) {
+      return [];
+    }
+    const name = moduleMap[activeModuleId]?.name ?? 'Module';
+    return demoSequences[activeModuleId] ?? defaultSequence(name);
+  }, [activeModuleId, moduleMap]);
+
+  useEffect(() => {
+    if (!isRunning || !activeModuleId) {
+      return undefined;
+    }
+
+    if (displayedLines.length >= activeSequence.length) {
+      const completionTimer = setTimeout(() => {
+        setIsRunning(false);
+      }, 400);
+      return () => clearTimeout(completionTimer);
+    }
+
+    const timer = setTimeout(() => {
+      setDisplayedLines((prev) => {
+        if (prev.length >= activeSequence.length) {
+          return prev;
+        }
+        return [...prev, activeSequence[prev.length]];
+      });
+    }, 450);
+
+    return () => clearTimeout(timer);
+  }, [activeSequence, activeModuleId, displayedLines.length, isRunning]);
+
+  useEffect(() => {
+    if (!isRunning && activeModuleId && displayedLines.length === activeSequence.length && activeSequence.length > 0) {
+      setCompletedModules((prev) => ({ ...prev, [activeModuleId]: true }));
+    }
+  }, [activeModuleId, activeSequence.length, displayedLines.length, isRunning]);
+
+  const handleRunDemo = (moduleId) => {
+    setActiveModuleId(moduleId);
+    setDisplayedLines([]);
+    setIsRunning(true);
+  };
+
+  const activeModule = activeModuleId ? moduleMap[activeModuleId] : null;
+  const progress = activeSequence.length
+    ? Math.min(100, Math.round((displayedLines.length / activeSequence.length) * 100))
+    : 0;
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-ubt-grey">
+        Explore BeEF module simulations grouped by focus area. Each tile lists the intended output type and links to the real
+        documentation. Launch a demo to watch a short, deterministic animation of the simulated result.
+      </p>
+      <div className="space-y-6">
+        {sortedTags.map((tag) => (
+          <section key={tag} aria-label={`${tag} modules`} className="space-y-3">
+            <header className="flex items-center gap-3">
+              <h3 className="text-lg font-semibold text-white">{tag}</h3>
+              <span className="text-xs uppercase tracking-wide text-ubt-grey">
+                {groupedByTag[tag].length} module{groupedByTag[tag].length > 1 ? 's' : ''}
+              </span>
+            </header>
+            <div className="grid gap-3 lg:grid-cols-2 xl:grid-cols-3">
+              {groupedByTag[tag]
+                .slice()
+                .sort((a, b) => a.name.localeCompare(b.name))
+                .map((module) => {
+                  const isActive = module.id === activeModuleId;
+                  const isComplete = completedModules[module.id];
+
+                  return (
+                    <article
+                      key={module.id}
+                      className="border border-white/10 rounded-md bg-black/40 p-4 shadow-inner backdrop-blur"
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <div>
+                          <h4 className="font-semibold text-white">{module.name}</h4>
+                          <p className="text-xs text-ubt-grey">Output: {module.outputType}</p>
+                        </div>
+                        {isComplete && <span className="text-ub-primary text-xs font-semibold">Done</span>}
+                      </div>
+                      <p className="mt-2 text-xs text-ubt-grey leading-relaxed">{module.description}</p>
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {module.tags.slice(1).map((moduleTag) => (
+                          <span key={moduleTag} className="bg-white/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-white/70 rounded">
+                            {moduleTag}
+                          </span>
+                        ))}
+                      </div>
+                      <pre className="mt-3 overflow-auto rounded bg-black/60 p-2 text-[11px] text-emerald-200">
+                        {module.demo}
+                      </pre>
+                      <div className="mt-3 flex items-center justify-between gap-2">
+                        <button
+                          type="button"
+                          onClick={() => handleRunDemo(module.id)}
+                          className="px-3 py-1 text-xs rounded bg-ub-primary text-white hover:bg-ub-primary/90 disabled:opacity-60"
+                          disabled={isRunning && isActive}
+                        >
+                          {isActive && isRunning ? 'Running…' : 'Run demo'}
+                        </button>
+                        <a
+                          href={module.link}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-xs text-sky-300 hover:text-sky-200"
+                        >
+                          Docs
+                        </a>
+                      </div>
+                    </article>
+                  );
+                })}
+            </div>
+          </section>
+        ))}
+      </div>
+      {activeModule && (
+        <div className="rounded-md border border-white/10 bg-black/60 p-4">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <h4 className="text-sm font-semibold text-white">{activeModule.name} demo timeline</h4>
+              <p className="text-xs text-ubt-grey">{activeModule.outputType} • primary tag: {activeModule.tags[0]}</p>
+            </div>
+            <span className="text-[10px] uppercase tracking-wide text-ubt-grey">{progress}%</span>
+          </div>
+          <div className="mt-2 h-2 rounded bg-white/10">
+            <div className="h-full rounded bg-ub-primary transition-all" style={{ width: `${progress}%` }} />
+          </div>
+          <div className="mt-3 grid gap-1 text-xs font-mono text-emerald-200">
+            {displayedLines.length > 0 ? (
+              displayedLines.map((line, index) => <span key={`${line}-${index.toString()}`}>{line}</span>)
+            ) : (
+              <span className="text-ubt-grey">Run a module to stream its simulation output.</span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/apps/beef/index.js
+++ b/components/apps/beef/index.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import PayloadBuilder from '../../../apps/beef/components/PayloadBuilder';
+import ModuleGallery from './ModuleGallery';
 
 export default function Beef() {
   const targetPage = `\n<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="utf-8"/>\n  <title>Sandboxed Target</title>\n</head>\n<body>\n  <h1>Sandboxed Target Page</h1>\n  <p>This page is isolated and cannot make network requests.</p>\n  <script>document.body.append(' - loaded');<\/script>\n</body>\n</html>`;
@@ -30,11 +31,10 @@ export default function Beef() {
       action: 'Next',
     },
     {
-      title: 'Run Demo Module',
-      body: 'A deterministic module runs and prints output below.',
-      render: (
-        <pre className="bg-black text-white p-2 text-xs rounded">{`Demo module executed\nResult: success`}</pre>
-      ),
+      title: 'Module Gallery',
+      body:
+        'Browse grouped BeEF modules and trigger sandboxed demos. The animations below stream deterministic output representing each module’s effect.',
+      render: <ModuleGallery />,
       action: 'Next',
     },
     {

--- a/components/apps/beef/modules.json
+++ b/components/apps/beef/modules.json
@@ -1,24 +1,184 @@
 {
   "modules": [
-    {"id": "alert", "name": "Alert Dialog", "description": "Display a simple alert dialog in the hooked browser.", "demo": "window.alert('BeEF demo alert!');", "link": "https://github.com/beefproject/beef/wiki/Alert-Dialog"},
-    {"id": "prompt", "name": "Prompt Dialog", "description": "Ask the user for input using the browser's prompt dialog.", "demo": "window.prompt('Enter demo text');", "link": "https://github.com/beefproject/beef/wiki/Prompt-Dialog"},
-    {"id": "confirm", "name": "Confirm Dialog", "description": "Show a confirmation dialog with OK and Cancel options.", "demo": "window.confirm('Do you accept?');", "link": "https://github.com/beefproject/beef/wiki/Confirm-Dialog"},
-    {"id": "get-cookie", "name": "Get Cookies", "description": "Retrieve document cookies from the hooked browser.", "demo": "document.cookie", "link": "https://github.com/beefproject/beef/wiki/Get-Cookies"},
-    {"id": "get-local-storage", "name": "List Local Storage", "description": "Enumerate items in localStorage.", "demo": "Object.keys(localStorage)", "link": "https://github.com/beefproject/beef/wiki/Get-Local-Storage"},
-    {"id": "get-session-storage", "name": "List Session Storage", "description": "Enumerate items in sessionStorage.", "demo": "Object.keys(sessionStorage)", "link": "https://github.com/beefproject/beef/wiki/Get-Session-Storage"},
-    {"id": "browser-info", "name": "Browser Details", "description": "Gather user agent and browser details.", "demo": "navigator.userAgent", "link": "https://github.com/beefproject/beef/wiki/Browser-Details"},
-    {"id": "detect-plugins", "name": "Detect Plugins", "description": "List plugins exposed by the browser.", "demo": "navigator.plugins.length", "link": "https://github.com/beefproject/beef/wiki/Detect-Plugins"},
-    {"id": "geolocation", "name": "Get Geolocation", "description": "Request the browser's current geolocation.", "demo": "navigator.geolocation.getCurrentPosition(()=>{})", "link": "https://github.com/beefproject/beef/wiki/Get-Geolocation"},
-    {"id": "play-sound", "name": "Play Sound", "description": "Play an audio clip in the hooked browser.", "demo": "new Audio('data:audio/wav;base64,...').play();", "link": "https://github.com/beefproject/beef/wiki/Play-Sound"},
-    {"id": "change-background", "name": "Change Background", "description": "Change the page background color.", "demo": "document.body.style.background='lime';", "link": "https://github.com/beefproject/beef/wiki/Change-Background"},
-    {"id": "open-tab", "name": "Open New Tab", "description": "Open a new tab to a given URL.", "demo": "window.open('https://example.com','_blank');", "link": "https://github.com/beefproject/beef/wiki/Open-New-Tab"},
-    {"id": "redirect", "name": "Redirect Browser", "description": "Redirect the current page to another URL.", "demo": "window.location='https://example.com';", "link": "https://github.com/beefproject/beef/wiki/Redirect-Browser"},
-    {"id": "fetch-url", "name": "Fetch URL", "description": "Perform a fetch request to a chosen URL.", "demo": "fetch('https://example.com').then(r=>r.text());", "link": "https://github.com/beefproject/beef/wiki/Fetch-URL"},
-    {"id": "port-scan", "name": "Port Scanner", "description": "Scan a set of ports on the client network.", "demo": "// Demo only: no real scanning performed", "link": "https://github.com/beefproject/beef/wiki/Port-Scanner"},
-    {"id": "network-scan", "name": "Network Scanner", "description": "Attempt to discover internal network hosts.", "demo": "// Demo only: network scan placeholder", "link": "https://github.com/beefproject/beef/wiki/Network-Scanner"},
-    {"id": "keylogger", "name": "Keylogger", "description": "Log keystrokes typed by the user.", "demo": "// Demo only: keylogger placeholder", "link": "https://github.com/beefproject/beef/wiki/Keylogger"},
-    {"id": "clipboard", "name": "Clipboard Theft", "description": "Read text from the clipboard with permission.", "demo": "navigator.clipboard.readText()", "link": "https://github.com/beefproject/beef/wiki/Clipboard-Theft"},
-    {"id": "screenshot", "name": "Screenshot", "description": "Capture a screenshot of the current page.", "demo": "html2canvas(document.body)", "link": "https://github.com/beefproject/beef/wiki/Screenshot"},
-    {"id": "webcam-snapshot", "name": "Webcam Snapshot", "description": "Take a snapshot from the user's webcam.", "demo": "navigator.mediaDevices.getUserMedia({video:true})", "link": "https://github.com/beefproject/beef/wiki/Webcam-Snapshot"}
+    {
+      "id": "alert",
+      "name": "Alert Dialog",
+      "description": "Display a simple alert dialog in the hooked browser.",
+      "demo": "window.alert('BeEF demo alert!');",
+      "link": "https://github.com/beefproject/beef/wiki/Alert-Dialog",
+      "outputType": "Modal dialog",
+      "tags": ["Social Engineering", "Dialog", "User Interaction"]
+    },
+    {
+      "id": "prompt",
+      "name": "Prompt Dialog",
+      "description": "Ask the user for input using the browser's prompt dialog.",
+      "demo": "window.prompt('Enter demo text');",
+      "link": "https://github.com/beefproject/beef/wiki/Prompt-Dialog",
+      "outputType": "Modal prompt",
+      "tags": ["Social Engineering", "Dialog", "User Interaction"]
+    },
+    {
+      "id": "confirm",
+      "name": "Confirm Dialog",
+      "description": "Show a confirmation dialog with OK and Cancel options.",
+      "demo": "window.confirm('Do you accept?');",
+      "link": "https://github.com/beefproject/beef/wiki/Confirm-Dialog",
+      "outputType": "Modal confirm",
+      "tags": ["Social Engineering", "Dialog", "User Interaction"]
+    },
+    {
+      "id": "get-cookie",
+      "name": "Get Cookies",
+      "description": "Retrieve document cookies from the hooked browser.",
+      "demo": "document.cookie",
+      "link": "https://github.com/beefproject/beef/wiki/Get-Cookies",
+      "outputType": "Key/value text",
+      "tags": ["Data Harvesting", "Reconnaissance", "Storage"]
+    },
+    {
+      "id": "get-local-storage",
+      "name": "List Local Storage",
+      "description": "Enumerate items in localStorage.",
+      "demo": "Object.keys(localStorage)",
+      "link": "https://github.com/beefproject/beef/wiki/Get-Local-Storage",
+      "outputType": "Key list",
+      "tags": ["Data Harvesting", "Reconnaissance", "Storage"]
+    },
+    {
+      "id": "get-session-storage",
+      "name": "List Session Storage",
+      "description": "Enumerate items in sessionStorage.",
+      "demo": "Object.keys(sessionStorage)",
+      "link": "https://github.com/beefproject/beef/wiki/Get-Session-Storage",
+      "outputType": "Key list",
+      "tags": ["Data Harvesting", "Reconnaissance", "Storage"]
+    },
+    {
+      "id": "browser-info",
+      "name": "Browser Details",
+      "description": "Gather user agent and browser details.",
+      "demo": "navigator.userAgent",
+      "link": "https://github.com/beefproject/beef/wiki/Browser-Details",
+      "outputType": "JSON blob",
+      "tags": ["Reconnaissance", "Fingerprinting", "Client Insights"]
+    },
+    {
+      "id": "detect-plugins",
+      "name": "Detect Plugins",
+      "description": "List plugins exposed by the browser.",
+      "demo": "navigator.plugins.length",
+      "link": "https://github.com/beefproject/beef/wiki/Detect-Plugins",
+      "outputType": "Count summary",
+      "tags": ["Reconnaissance", "Fingerprinting", "Client Insights"]
+    },
+    {
+      "id": "geolocation",
+      "name": "Get Geolocation",
+      "description": "Request the browser's current geolocation.",
+      "demo": "navigator.geolocation.getCurrentPosition(()=>{})",
+      "link": "https://github.com/beefproject/beef/wiki/Get-Geolocation",
+      "outputType": "Coordinate pair",
+      "tags": ["Field Intelligence", "User Interaction", "Location"]
+    },
+    {
+      "id": "play-sound",
+      "name": "Play Sound",
+      "description": "Play an audio clip in the hooked browser.",
+      "demo": "new Audio('data:audio/wav;base64,...').play();",
+      "link": "https://github.com/beefproject/beef/wiki/Play-Sound",
+      "outputType": "Audio feedback",
+      "tags": ["Environment Control", "Sensory", "Experience"]
+    },
+    {
+      "id": "change-background",
+      "name": "Change Background",
+      "description": "Change the page background color.",
+      "demo": "document.body.style.background='lime';",
+      "link": "https://github.com/beefproject/beef/wiki/Change-Background",
+      "outputType": "DOM mutation",
+      "tags": ["Environment Control", "Visual", "Experience"]
+    },
+    {
+      "id": "open-tab",
+      "name": "Open New Tab",
+      "description": "Open a new tab to a given URL.",
+      "demo": "window.open('https://example.com','_blank');",
+      "link": "https://github.com/beefproject/beef/wiki/Open-New-Tab",
+      "outputType": "Tab launch",
+      "tags": ["Environment Control", "Navigation", "Experience"]
+    },
+    {
+      "id": "redirect",
+      "name": "Redirect Browser",
+      "description": "Redirect the current page to another URL.",
+      "demo": "window.location='https://example.com';",
+      "link": "https://github.com/beefproject/beef/wiki/Redirect-Browser",
+      "outputType": "URL change",
+      "tags": ["Environment Control", "Navigation", "Experience"]
+    },
+    {
+      "id": "fetch-url",
+      "name": "Fetch URL",
+      "description": "Perform a fetch request to a chosen URL.",
+      "demo": "fetch('https://example.com').then(r=>r.text());",
+      "link": "https://github.com/beefproject/beef/wiki/Fetch-URL",
+      "outputType": "HTML snippet",
+      "tags": ["Reconnaissance", "Network", "Data Harvesting"]
+    },
+    {
+      "id": "port-scan",
+      "name": "Port Scanner",
+      "description": "Scan a set of ports on the client network.",
+      "demo": "// Demo only: no real scanning performed",
+      "link": "https://github.com/beefproject/beef/wiki/Port-Scanner",
+      "outputType": "Port map",
+      "tags": ["Reconnaissance", "Network", "Simulation"]
+    },
+    {
+      "id": "network-scan",
+      "name": "Network Scanner",
+      "description": "Attempt to discover internal network hosts.",
+      "demo": "// Demo only: network scan placeholder",
+      "link": "https://github.com/beefproject/beef/wiki/Network-Scanner",
+      "outputType": "Host list",
+      "tags": ["Reconnaissance", "Network", "Simulation"]
+    },
+    {
+      "id": "keylogger",
+      "name": "Keylogger",
+      "description": "Log keystrokes typed by the user.",
+      "demo": "// Demo only: keylogger placeholder",
+      "link": "https://github.com/beefproject/beef/wiki/Keylogger",
+      "outputType": "Keystroke log",
+      "tags": ["Data Harvesting", "Persistence", "Simulation"]
+    },
+    {
+      "id": "clipboard",
+      "name": "Clipboard Theft",
+      "description": "Read text from the clipboard with permission.",
+      "demo": "navigator.clipboard.readText()",
+      "link": "https://github.com/beefproject/beef/wiki/Clipboard-Theft",
+      "outputType": "Clipboard text",
+      "tags": ["Data Harvesting", "Social Engineering", "User Interaction"]
+    },
+    {
+      "id": "screenshot",
+      "name": "Screenshot",
+      "description": "Capture a screenshot of the current page.",
+      "demo": "html2canvas(document.body)",
+      "link": "https://github.com/beefproject/beef/wiki/Screenshot",
+      "outputType": "Image capture",
+      "tags": ["Field Intelligence", "Visual", "Data Harvesting"]
+    },
+    {
+      "id": "webcam-snapshot",
+      "name": "Webcam Snapshot",
+      "description": "Take a snapshot from the user's webcam.",
+      "demo": "navigator.mediaDevices.getUserMedia({video:true})",
+      "link": "https://github.com/beefproject/beef/wiki/Webcam-Snapshot",
+      "outputType": "Image capture",
+      "tags": ["Field Intelligence", "Visual", "Data Harvesting"]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- add a module gallery component for BeEF with grouped tags and animated demo timelines
- expand modules.json with tags, output types, and deterministic sequences for demo playback
- wire the gallery into the BeEF lab flow and extend Jest coverage for module rendering and demo playback

## Testing
- yarn lint *(fails: repository already has widespread jsx-a11y and no-top-level-window violations)*
- yarn test *(fails: existing suites such as window.test.tsx and nmapNse.test.tsx unrelated to this change)*
- yarn test __tests__/beef.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68cc1e38db348328bc13ee7f0a07c314