### PR TITLE
[nessus] Add category filters and tests

### DIFF
--- a/__tests__/nessusApp.test.tsx
+++ b/__tests__/nessusApp.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import NessusApp from '../apps/nessus';
+
+describe('Nessus category filters', () => {
+  const plugins = [
+    {
+      id: 1,
+      name: 'Plugin A',
+      severity: 'High',
+      cwe: [],
+      cve: [],
+      tags: ['network'],
+      category: 'Network',
+    },
+    {
+      id: 2,
+      name: 'Plugin B',
+      severity: 'Low',
+      cwe: [],
+      cve: [],
+      tags: ['config'],
+      category: 'Configuration',
+    },
+  ];
+
+  const emptyScan = { findings: [] };
+
+  beforeEach(() => {
+    global.fetch = jest.fn((url: string) => {
+      if (url.includes('plugins.json')) {
+        return Promise.resolve({
+          json: () => Promise.resolve(plugins),
+        }) as any;
+      }
+      if (url.includes('scanA.json') || url.includes('scanB.json')) {
+        return Promise.resolve({
+          json: () => Promise.resolve(emptyScan),
+        }) as any;
+      }
+      return Promise.resolve({
+        json: () => Promise.resolve([]),
+      }) as any;
+    }) as any;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('updates pending checks when category toggles change', async () => {
+    render(<NessusApp />);
+
+    await waitFor(() => expect(screen.getByText('Plugin A')).toBeInTheDocument());
+    expect(screen.getByText(/Pending checks: 2/)).toBeInTheDocument();
+
+    const [networkToggle] = screen.getAllByRole('button', { name: 'Network' });
+    fireEvent.click(networkToggle);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Pending checks: 1/)).toBeInTheDocument()
+    );
+    expect(screen.queryByText('Plugin A')).not.toBeInTheDocument();
+    expect(screen.getByText('Plugin B')).toBeInTheDocument();
+
+    fireEvent.click(networkToggle);
+    await waitFor(() =>
+      expect(screen.getByText(/Pending checks: 2/)).toBeInTheDocument()
+    );
+    expect(screen.getByText('Plugin A')).toBeInTheDocument();
+  });
+});

--- a/apps/nessus/components/FiltersDrawer.tsx
+++ b/apps/nessus/components/FiltersDrawer.tsx
@@ -11,6 +11,9 @@ interface Props {
   tags: string[];
   tagFilters: string[];
   toggleTag: (tag: string) => void;
+  categories: string[];
+  categoryFilters: Record<string, boolean>;
+  toggleCategory: (category: string) => void;
 }
 
 export default function FiltersDrawer({
@@ -21,6 +24,9 @@ export default function FiltersDrawer({
   tags,
   tagFilters,
   toggleTag,
+  categories,
+  categoryFilters,
+  toggleCategory,
 }: Props) {
   return (
     <div
@@ -60,6 +66,31 @@ export default function FiltersDrawer({
             ))}
           </div>
         </div>
+        {categories.length > 0 && (
+          <div className="mt-6">
+            <h4 className="font-semibold mb-2">Categories</h4>
+            <div className="flex flex-wrap gap-2">
+              {categories.map((cat) => {
+                const active = categoryFilters[cat] ?? true;
+                return (
+                  <button
+                    key={cat}
+                    type="button"
+                    onClick={() => toggleCategory(cat)}
+                    aria-pressed={active}
+                    className={`px-2 py-1 rounded-full border text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
+                      active
+                        ? 'bg-blue-600 border-blue-600'
+                        : 'bg-gray-800 border-gray-700'
+                    }`}
+                  >
+                    {cat}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/nessus/components/FindingCard.tsx
+++ b/apps/nessus/components/FindingCard.tsx
@@ -24,6 +24,7 @@ export default function FindingCard({ plugin }: Props) {
       </div>
       <div className="font-semibold">{plugin.name}</div>
       <div className="flex gap-2 mt-2 flex-wrap text-xs">
+        <span className="px-2 py-1 bg-blue-700 rounded">{plugin.category}</span>
         {plugin.cwe?.map((cwe) => (
           <span key={cwe} className="px-2 py-1 bg-gray-700 rounded">
             CWE-{cwe}

--- a/apps/nessus/types.ts
+++ b/apps/nessus/types.ts
@@ -8,6 +8,7 @@ export interface Plugin {
   cwe?: string[];
   cve?: string[];
   tags?: string[];
+  category: string;
 }
 
 export interface Finding {

--- a/public/demo-data/nessus/plugins.json
+++ b/public/demo-data/nessus/plugins.json
@@ -1,7 +1,7 @@
 [
-  {"id": 1001, "name": "SSL Certificate Expiry", "severity": "High", "cwe": ["295"], "cve": ["2024-0001"], "tags": ["ssl", "certificate"]},
-  {"id": 1002, "name": "Weak SSH Ciphers", "severity": "Medium", "cwe": ["327"], "cve": ["2023-0002"], "tags": ["ssh", "crypto"]},
-  {"id": 1003, "name": "Default Credentials", "severity": "Critical", "cwe": ["1392"], "tags": ["auth"]},
-  {"id": 1004, "name": "Outdated Web Server", "severity": "Low", "cwe": ["200"], "cve": ["2022-0004"], "tags": ["web", "server"]},
-  {"id": 1005, "name": "Informational Banner", "severity": "Info", "tags": ["info"]}
+  {"id": 1001, "name": "SSL Certificate Expiry", "severity": "High", "cwe": ["295"], "cve": ["2024-0001"], "tags": ["ssl", "certificate"], "category": "Encryption"},
+  {"id": 1002, "name": "Weak SSH Ciphers", "severity": "Medium", "cwe": ["327"], "cve": ["2023-0002"], "tags": ["ssh", "crypto"], "category": "Encryption"},
+  {"id": 1003, "name": "Default Credentials", "severity": "Critical", "cwe": ["1392"], "tags": ["auth"], "category": "Authentication"},
+  {"id": 1004, "name": "Outdated Web Server", "severity": "Low", "cwe": ["200"], "cve": ["2022-0004"], "tags": ["web", "server"], "category": "Patching"},
+  {"id": 1005, "name": "Informational Banner", "severity": "Info", "tags": ["info"], "category": "Informational"}
 ]


### PR DESCRIPTION
## Summary
- surface plugin category metadata throughout the Nessus UI and plugin fixtures
- add inline and drawer-based category toggles that immediately update the pending count and filtered results
- cover the category filtering and pending counter updates with a focused Jest test

## Testing
- yarn lint *(fails: repository already has numerous jsx-a11y and no-top-level-window errors unrelated to this change)*
- yarn test __tests__/nessusApp.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc1e3c00e08328ad70d29624dde2e8