### PR TITLE
[http] add DNS validation and tests

### DIFF
--- a/__tests__/httpBuilder.test.tsx
+++ b/__tests__/httpBuilder.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { HTTPBuilder } from '../apps/http';
+
+describe('HTTPBuilder validation', () => {
+  const originalGlobalWorker = (global as any).Worker;
+  const originalWindowWorker =
+    typeof window !== 'undefined' ? (window as any).Worker : undefined;
+
+  beforeEach(() => {
+    (global as any).Worker = undefined;
+    if (typeof window !== 'undefined') {
+      (window as any).Worker = undefined;
+    }
+  });
+
+  afterEach(() => {
+    (global as any).Worker = originalGlobalWorker;
+    if (typeof window !== 'undefined') {
+      (window as any).Worker = originalWindowWorker;
+    }
+  });
+
+  it('rejects non-http protocols', async () => {
+    const user = userEvent.setup();
+    render(<HTTPBuilder />);
+
+    const input = screen.getByLabelText(/url/i);
+    await user.type(input, 'ftp://example.com');
+
+    expect(
+      screen.getByText('Only HTTP and HTTPS URLs are supported.')
+    ).toBeInTheDocument();
+  });
+
+  it('blocks file scheme URLs explicitly', async () => {
+    const user = userEvent.setup();
+    render(<HTTPBuilder />);
+
+    const input = screen.getByLabelText(/url/i);
+    await user.type(input, 'file://etc/passwd');
+
+    expect(
+      screen.getByText('file:// URLs are blocked for security reasons.')
+    ).toBeInTheDocument();
+  });
+
+  it('resolves a valid HTTP URL', async () => {
+    const user = userEvent.setup();
+    render(<HTTPBuilder />);
+
+    const input = screen.getByLabelText(/url/i);
+    await user.type(input, 'https://example.com');
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Resolved example\.com to 192\.0\.2\./i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('returns actionable DNS errors for invalid hostnames', async () => {
+    const user = userEvent.setup();
+    render(<HTTPBuilder />);
+
+    const input = screen.getByLabelText(/url/i);
+    await user.type(input, 'https://bad_host.example');
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'DNS lookup failed: Invalid hostname label: "bad_host".'
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('requires a domain suffix when not using localhost', async () => {
+    const user = userEvent.setup();
+    render(<HTTPBuilder />);
+
+    const input = screen.getByLabelText(/url/i);
+    await user.type(input, 'https://example');
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'DNS lookup failed: Hostname must include a domain suffix (e.g., example.com).'
+        )
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/http/dnsResolver.worker.ts
+++ b/apps/http/dnsResolver.worker.ts
@@ -1,0 +1,21 @@
+import { simulateDnsLookup, type DnsLookupRequest } from './dnsUtils';
+
+export type { DnsLookupResponse } from './dnsUtils';
+
+const ctx: DedicatedWorkerGlobalScope = self as unknown as DedicatedWorkerGlobalScope;
+
+ctx.addEventListener('message', async (event: MessageEvent<DnsLookupRequest>) => {
+  const { id, host } = event.data;
+
+  try {
+    const address = await simulateDnsLookup(host);
+    ctx.postMessage({ id, type: 'success', host, address });
+  } catch (error) {
+    ctx.postMessage({
+      id,
+      type: 'error',
+      host,
+      error: error instanceof Error ? error.message : 'Unknown error.',
+    });
+  }
+});

--- a/apps/http/dnsUtils.ts
+++ b/apps/http/dnsUtils.ts
@@ -1,0 +1,103 @@
+export type DnsLookupRequest = {
+  id: number;
+  host: string;
+};
+
+export type DnsLookupSuccess = {
+  id: number;
+  type: 'success';
+  host: string;
+  address: string;
+};
+
+export type DnsLookupFailure = {
+  id: number;
+  type: 'error';
+  host: string;
+  error: string;
+};
+
+export type DnsLookupResponse = DnsLookupSuccess | DnsLookupFailure;
+
+const IPV4_REGEX = /^(?:\d{1,3}\.){3}\d{1,3}$/;
+
+const HOST_LABEL_REGEX = /^(?!-)[A-Za-z0-9-]{1,63}(?<!-)$/;
+
+export function validateHostname(host: string): string | null {
+  const trimmed = host.trim();
+
+  if (!trimmed) {
+    return 'Hostname is required.';
+  }
+
+  if (trimmed.length > 253) {
+    return 'Hostname is too long (253 characters maximum).';
+  }
+
+  if (trimmed === 'localhost') {
+    return null;
+  }
+
+  if (IPV4_REGEX.test(trimmed)) {
+    const parts = trimmed.split('.').map(Number);
+    if (parts.some((part) => Number.isNaN(part) || part < 0 || part > 255)) {
+      return 'Invalid IPv4 address: octets must be between 0 and 255.';
+    }
+
+    return null;
+  }
+
+  if (trimmed.includes(':')) {
+    return 'IPv6 lookup is not supported in this demo.';
+  }
+
+  const labels = trimmed.split('.');
+  if (labels.length < 2) {
+    return 'Hostname must include a domain suffix (e.g., example.com).';
+  }
+
+  for (const label of labels) {
+    if (!label) {
+      return 'Hostname contains empty labels (consecutive dots are not allowed).';
+    }
+
+    if (!HOST_LABEL_REGEX.test(label)) {
+      return `Invalid hostname label: "${label}".`;
+    }
+  }
+
+  return null;
+}
+
+function hashHostname(host: string): number {
+  let hash = 0;
+  for (let i = 0; i < host.length; i += 1) {
+    hash = (hash * 31 + host.charCodeAt(i)) % 2048;
+  }
+  return hash;
+}
+
+export async function simulateDnsLookup(host: string): Promise<string> {
+  const normalized = host.trim().toLowerCase();
+  const validationError = validateHostname(normalized);
+
+  if (validationError) {
+    throw new Error(validationError);
+  }
+
+  if (normalized === 'localhost') {
+    return '127.0.0.1';
+  }
+
+  if (IPV4_REGEX.test(normalized)) {
+    return normalized;
+  }
+
+  const hash = hashHostname(normalized);
+  const lastOctet = (hash % 254) + 1;
+
+  // Use TEST-NET-1 range (192.0.2.0/24) reserved for documentation and examples.
+  const address = `192.0.2.${lastOctet}`;
+
+  return address;
+}


### PR DESCRIPTION
## Summary
- add client-side validation to the HTTP Request Builder including protocol checks and DNS feedback
- introduce a shared DNS lookup stub/worker used for async hostname validation
- cover the new validation logic with focused Jest tests for edge cases

## Testing
- yarn lint *(fails: repository contains existing accessibility lint errors unrelated to this change)*
- yarn test httpBuilder

------
https://chatgpt.com/codex/tasks/task_e_68cc1e3d00708328bab428bdb656cfa3