### PR TITLE
feat(kismet): add vendor lookup cache

### DIFF
--- a/__tests__/ouiLookup.test.ts
+++ b/__tests__/ouiLookup.test.ts
@@ -1,0 +1,51 @@
+import { batchLookupVendors, getCacheStats, lookupVendor, resetOuiCache } from '../utils/ouiLookup';
+
+describe('ouiLookup', () => {
+  beforeEach(() => {
+    resetOuiCache();
+  });
+
+  it('caches resolved vendors for repeated lookups', () => {
+    expect(getCacheStats()).toEqual({ cacheSize: 0, mapSize: 0 });
+    const vendor = lookupVendor('00:11:22:33:44:55');
+    expect(vendor).toBe('Acme Corp');
+    const afterFirstLookup = getCacheStats();
+    expect(afterFirstLookup.cacheSize).toBe(1);
+    expect(afterFirstLookup.mapSize).toBeGreaterThan(0);
+
+    const repeatedVendor = lookupVendor('00:11:22:33:44:55');
+    expect(repeatedVendor).toBe('Acme Corp');
+    expect(getCacheStats().cacheSize).toBe(1);
+
+    const otherVendor = lookupVendor('66:77:88:00:00:01');
+    expect(otherVendor).toBe('Globex');
+    expect(getCacheStats().cacheSize).toBe(2);
+  });
+
+  it('handles invalid addresses gracefully', () => {
+    expect(lookupVendor('not-a-mac')).toBe('Unknown');
+    expect(lookupVendor(undefined)).toBe('Unknown');
+    expect(lookupVendor(null)).toBe('Unknown');
+  });
+
+  it('performs batch lookups under 80ms for 100 addresses', () => {
+    // Warm the map to isolate batch performance.
+    lookupVendor('00:11:22:00:00:00');
+
+    const macs = Array.from({ length: 100 }, (_, index) => {
+      const base = index % 2 === 0 ? '00:11:22' : '66:77:88';
+      const suffix = index.toString(16).padStart(6, '0');
+      const pairs = [suffix.slice(0, 2), suffix.slice(2, 4), suffix.slice(4, 6)];
+      return `${base}:${pairs.join(':')}`;
+    });
+
+    const start = performance.now();
+    const vendors = batchLookupVendors(macs);
+    const duration = performance.now() - start;
+
+    expect(vendors).toHaveLength(100);
+    expect(vendors.filter((v) => v === 'Acme Corp').length).toBeGreaterThan(0);
+    expect(vendors.filter((v) => v === 'Globex').length).toBeGreaterThan(0);
+    expect(duration).toBeLessThan(80);
+  });
+});

--- a/components/apps/ettercap/index.js
+++ b/components/apps/ettercap/index.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import data from './data.json';
 import ArpLab from './components/ArpLab';
-import vendors from '../kismet/oui.json';
+import { lookupVendor } from '../../../utils/ouiLookup';
 
 const { arpTable, flows } = data;
 const attackerMac = 'aa:aa:aa:aa:aa:aa';
@@ -49,7 +49,7 @@ const EttercapApp = () => {
       arpTable.map(({ ip, mac }) => ({
         ip,
         mac,
-        vendor: vendors[mac.slice(0, 8).toUpperCase()] || 'Unknown',
+        vendor: lookupVendor(mac),
       })),
     []
   );

--- a/utils/ouiLookup.ts
+++ b/utils/ouiLookup.ts
@@ -1,0 +1,98 @@
+import ouiData from '../components/apps/kismet/oui.json';
+
+const UNKNOWN_VENDOR = 'Unknown';
+
+type OuiDataset = Record<string, string>;
+
+type CacheStats = {
+  cacheSize: number;
+  mapSize: number;
+};
+
+let ouiMap: Map<string, string> | null = null;
+const vendorCache = new Map<string, string>();
+
+const normalizeOuiPrefix = (value?: string | null): string | null => {
+  if (!value) return null;
+  const cleaned = String(value).toUpperCase().replace(/[^0-9A-F]/g, '');
+  if (cleaned.length !== 6) return null;
+  return `${cleaned.slice(0, 2)}:${cleaned.slice(2, 4)}:${cleaned.slice(4, 6)}`;
+};
+
+const normalizeMacAddress = (value?: string | null): string | null => {
+  if (!value) return null;
+  const cleaned = String(value).toUpperCase().replace(/[^0-9A-F]/g, '');
+  if (cleaned.length < 6) return null;
+  const truncated = cleaned.slice(0, 12);
+  const segments: string[] = [];
+  for (let i = 0; i < truncated.length; i += 2) {
+    const pair = truncated.slice(i, i + 2);
+    if (pair.length === 2) {
+      segments.push(pair);
+    }
+  }
+  if (segments.length < 3) return null;
+  return segments.join(':');
+};
+
+const ensureOuiMap = (): Map<string, string> => {
+  if (!ouiMap) {
+    ouiMap = new Map<string, string>();
+    const dataset = ouiData as OuiDataset;
+    for (const [prefix, vendor] of Object.entries(dataset)) {
+      const normalizedPrefix = normalizeOuiPrefix(prefix);
+      if (!normalizedPrefix) continue;
+      const trimmedVendor = vendor.trim();
+      if (!trimmedVendor) continue;
+      ouiMap.set(normalizedPrefix, trimmedVendor);
+    }
+  }
+  return ouiMap;
+};
+
+const cacheVendor = (mac: string, vendor: string): string => {
+  vendorCache.set(mac, vendor);
+  return vendor;
+};
+
+export const lookupVendor = (mac?: string | null): string => {
+  const normalizedMac = normalizeMacAddress(mac);
+  if (!normalizedMac) return UNKNOWN_VENDOR;
+  const cached = vendorCache.get(normalizedMac);
+  if (cached !== undefined) return cached;
+  const ouiKey = normalizedMac.split(':').slice(0, 3).join(':');
+  if (!ouiKey) return cacheVendor(normalizedMac, UNKNOWN_VENDOR);
+  const map = ensureOuiMap();
+  const vendor = map.get(ouiKey) ?? UNKNOWN_VENDOR;
+  return cacheVendor(normalizedMac, vendor);
+};
+
+export const batchLookupVendors = (
+  macs: Array<string | null | undefined>,
+): string[] => {
+  if (!Array.isArray(macs) || macs.length === 0) {
+    return [];
+  }
+  const map = ensureOuiMap();
+  return macs.map((mac) => {
+    const normalizedMac = normalizeMacAddress(mac);
+    if (!normalizedMac) return UNKNOWN_VENDOR;
+    const cached = vendorCache.get(normalizedMac);
+    if (cached !== undefined) return cached;
+    const ouiKey = normalizedMac.split(':').slice(0, 3).join(':');
+    const vendor = (ouiKey && map.get(ouiKey)) ?? UNKNOWN_VENDOR;
+    return cacheVendor(normalizedMac, vendor);
+  });
+};
+
+export const resetOuiCache = (): void => {
+  vendorCache.clear();
+  ouiMap = null;
+};
+
+export const getCacheStats = (): CacheStats => ({
+  cacheSize: vendorCache.size,
+  mapSize: ouiMap?.size ?? 0,
+});
+
+export { UNKNOWN_VENDOR };


### PR DESCRIPTION
## Summary
- add a shared OUI lookup utility with in-memory caching and batch resolution helpers
- surface vendor names in the Kismet network table and reuse the lookup inside Ettercap
- cover the new lookup logic with caching and performance focused unit tests

## Testing
- yarn test __tests__/ouiLookup.test.ts __tests__/kismet.test.tsx __tests__/ettercap.test.tsx
- yarn lint *(fails: existing repository-wide accessibility and window/document lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1e3f47c08328b361ac7fac87a01f