### PR TITLE
[post-exploitation] Add module README viewer

### DIFF
--- a/__tests__/metadata.test.ts
+++ b/__tests__/metadata.test.ts
@@ -14,6 +14,7 @@ describe('modules metadata', () => {
             description: 'The session to run this module on.',
           },
         ],
+        docPath: '/docs/modules/getsystem.md',
       },
       {
         name: 'keyscan_start',
@@ -26,6 +27,7 @@ describe('modules metadata', () => {
             description: 'The session to run this module on.',
           },
         ],
+        docPath: '/docs/modules/keyscan_start.md',
       },
       {
         name: 'persistence_service',
@@ -43,6 +45,7 @@ describe('modules metadata', () => {
             description: 'Remote port used for callback.',
           },
         ],
+        docPath: '/docs/modules/persistence_service.md',
       },
       {
         name: 'hashdump',
@@ -55,6 +58,7 @@ describe('modules metadata', () => {
             description: 'The session to run this module on.',
           },
         ],
+        docPath: '/docs/modules/hashdump.md',
       },
     ]);
   });

--- a/__tests__/postExploitation.test.tsx
+++ b/__tests__/postExploitation.test.tsx
@@ -1,8 +1,100 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import PostExploitation from '../pages/post_exploitation';
+import { useRouter } from 'next/router';
+import { loadMarked } from '../lib/loadMarked';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('../lib/loadMarked', () => ({
+  loadMarked: jest.fn(),
+}));
+
+const mockedLoadMarked = loadMarked as jest.MockedFunction<typeof loadMarked>;
+
+const fakeMarked = {
+  Renderer: class {
+    heading(text: string, level: number) {
+      return `<h${level}>${text}</h${level}>`;
+    }
+  },
+  parse: (
+    markdown: string,
+    options?: { renderer?: { heading?: (text: string, level: number, raw: string) => string } }
+  ) => {
+    const renderer = options?.renderer;
+    return markdown
+      .split(/\n+/)
+      .filter((line) => line.length > 0)
+      .map((line) => {
+        const headingMatch = line.match(/^(#{1,6})\s*(.*)$/);
+        if (headingMatch && renderer?.heading) {
+          const level = headingMatch[1].length;
+          const text = headingMatch[2];
+          return renderer.heading(text, level, text);
+        }
+        return `<p>${line}</p>`;
+      })
+      .join('');
+  },
+};
+
+const createRouter = (overrides: Partial<ReturnType<typeof useRouter>> = {}) => {
+  const router = {
+    pathname: '/post_exploitation',
+    query: {},
+    asPath: '/post_exploitation',
+    isReady: true,
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    events: {
+      on: jest.fn(),
+      off: jest.fn(),
+      emit: jest.fn(),
+    },
+  } as unknown as ReturnType<typeof useRouter> & {
+    push: jest.Mock;
+    query: Record<string, any>;
+    asPath: string;
+  };
+
+  Object.assign(router, overrides);
+
+  router.push.mockImplementation(
+    (url: { pathname?: string; query?: Record<string, any>; hash?: string }) => {
+      if (url.query) {
+        router.query = { ...url.query };
+      }
+      const queryString = url.query
+        ? `?${new URLSearchParams(url.query as Record<string, string>).toString()}`
+        : '';
+      const hash = url.hash ? `#${url.hash}` : '';
+      router.asPath = `${url.pathname ?? router.pathname}${queryString}${hash}`;
+      return Promise.resolve(true);
+    }
+  );
+
+  return router;
+};
+
+const useRouterMock = useRouter as jest.Mock;
 
 describe('PostExploitation', () => {
+  beforeEach(() => {
+    mockedLoadMarked.mockResolvedValue({ marked: fakeMarked });
+    const router = createRouter();
+    useRouterMock.mockReturnValue(router);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    mockedLoadMarked.mockReset();
+  });
+
   it('filters modules by selected tags', () => {
     render(<PostExploitation />);
     fireEvent.click(screen.getByLabelText('persistence'));
@@ -12,5 +104,72 @@ describe('PostExploitation', () => {
     expect(
       screen.queryByRole('button', { name: /getsystem/i })
     ).not.toBeInTheDocument();
+  });
+
+  it('sanitizes README content and exposes anchor navigation', async () => {
+    const router = createRouter();
+    useRouterMock.mockReturnValue(router);
+
+    const maliciousMarkdown = `# Demo\n\n## Options\n<script>alert('xss')</script>`;
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(maliciousMarkdown),
+      } as unknown as Response);
+
+    render(<PostExploitation />);
+
+    fireEvent.click(screen.getByRole('button', { name: /getsystem/i }));
+
+    const optionsNav = await screen.findByRole('link', { name: /Options/i });
+    expect(optionsNav).toBeInTheDocument();
+    expect(document.querySelector('script')).toBeNull();
+
+    fireEvent.click(optionsNav);
+    await waitFor(() => {
+      expect(router.push).toHaveBeenCalledWith(
+        expect.objectContaining({ hash: 'options' }),
+        undefined,
+        expect.objectContaining({ shallow: true, scroll: false })
+      );
+    });
+
+    fetchSpy.mockRestore();
+  });
+
+  it('scrolls to deep-linked sections when provided via the URL hash', async () => {
+    const scrollSpy = jest.fn();
+    const originalGetElementById = document.getElementById;
+    const getElementSpy = jest
+      .spyOn(document, 'getElementById')
+      .mockImplementation((id: string): HTMLElement | null => {
+        if (id === 'options') {
+          return { scrollIntoView: scrollSpy } as unknown as HTMLElement;
+        }
+        return originalGetElementById.call(document, id);
+      });
+
+    const router = createRouter({
+      query: { module: 'hashdump' },
+      asPath: '/post_exploitation?module=hashdump#options',
+    });
+    useRouterMock.mockReturnValue(router);
+
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('# hashdump\n\n## Options\n- item'),
+      } as unknown as Response);
+
+    render(<PostExploitation />);
+
+    await waitFor(() => {
+      expect(scrollSpy).toHaveBeenCalled();
+    });
+
+    getElementSpy.mockRestore();
+    fetchSpy.mockRestore();
   });
 });

--- a/components/ModuleReadme.tsx
+++ b/components/ModuleReadme.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import DOMPurify from 'dompurify';
+import { useRouter } from 'next/router';
+import type { ModuleMetadata } from '../modules/metadata';
+import { loadMarked } from '../lib/loadMarked';
+
+interface HeadingLink {
+  id: string;
+  text: string;
+  level: number;
+}
+
+interface ModuleReadmeProps {
+  module: ModuleMetadata;
+}
+
+const sanitizeText = (value: string) =>
+  DOMPurify.sanitize(value, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
+
+export default function ModuleReadme({ module }: ModuleReadmeProps) {
+  const router = useRouter();
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const [rendered, setRendered] = useState<{
+    html: string;
+    headings: HeadingLink[];
+  }>({ html: '', headings: [] });
+  const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>(
+    'idle'
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus('loading');
+    setError(null);
+    setRendered({ html: '', headings: [] });
+
+    const load = async () => {
+      try {
+        const response = await fetch(module.docPath);
+        if (!response.ok) {
+          throw new Error('Failed to load documentation');
+        }
+        const markdown = await response.text();
+        if (cancelled) return;
+        if (!markdown.trim()) {
+          throw new Error('Empty documentation');
+        }
+
+        const { marked } = await loadMarked();
+        if (cancelled) return;
+
+        const collected: HeadingLink[] = [];
+        const slugCounts = new Map<string, number>();
+        const renderer = new marked.Renderer();
+        const createSlug = (value: string) => {
+          const base = sanitizeText(value)
+            .toLowerCase()
+            .replace(/[^a-z0-9\s-]/g, '')
+            .trim()
+            .replace(/\s+/g, '-');
+          const candidate = base || `section-${collected.length}`;
+          const count = slugCounts.get(candidate) ?? 0;
+          slugCounts.set(candidate, count + 1);
+          return count > 0 ? `${candidate}-${count}` : candidate;
+        };
+
+        renderer.heading = (text, level, raw) => {
+          const slug = createSlug(raw);
+          collected.push({
+            id: slug,
+            text: sanitizeText(text),
+            level,
+          });
+          return `<h${level} id="${slug}">${text}</h${level}>`;
+        };
+
+        const renderedHtml = marked.parse(markdown, { renderer }) as string;
+        const safeHtml = DOMPurify.sanitize(renderedHtml, {
+          USE_PROFILES: { html: true },
+        });
+
+        if (cancelled) return;
+        setRendered({ html: safeHtml, headings: collected });
+        setStatus('ready');
+      } catch (err) {
+        if (cancelled) return;
+        setError('Unable to load documentation for this module.');
+        setStatus('error');
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [module.docPath]);
+
+  const html = rendered.html;
+  const headings = rendered.headings;
+
+  const currentHash = useMemo(() => {
+    const [, hash] = router.asPath.split('#');
+    return hash || '';
+  }, [router.asPath]);
+
+  useEffect(() => {
+    if (!html) return;
+    const [, hash] = router.asPath.split('#');
+    if (!hash) {
+      if (scrollContainerRef.current) {
+        scrollContainerRef.current.scrollTop = 0;
+      }
+      return;
+    }
+    const target = document.getElementById(hash);
+    target?.scrollIntoView({ block: 'start' });
+  }, [html, router.asPath]);
+
+  const handleAnchorClick = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>, id: string) => {
+      event.preventDefault();
+      const nextQuery = { ...router.query, module: module.name };
+      router.push(
+        {
+          pathname: router.pathname,
+          query: nextQuery,
+          hash: id,
+        },
+        undefined,
+        { shallow: true, scroll: false }
+      );
+    },
+    [module.name, router]
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      {headings.length > 0 && (
+        <nav
+          aria-label={`${module.name} README sections`}
+          className="flex flex-wrap gap-2"
+        >
+          {headings
+            .filter((heading) => heading.level <= 3)
+            .map((heading) => (
+              <a
+                key={heading.id}
+                href={`#${heading.id}`}
+                onClick={(event) => handleAnchorClick(event, heading.id)}
+                className={`rounded border px-2 py-1 text-sm transition-colors hover:bg-gray-100 focus:outline-none focus:ring ${
+                  currentHash === heading.id ? 'bg-gray-200 font-semibold' : ''
+                }`}
+              >
+                {heading.text}
+              </a>
+            ))}
+        </nav>
+      )}
+
+      <div
+        ref={scrollContainerRef}
+        className="prose max-w-none overflow-y-auto rounded border p-3"
+      >
+        {status === 'loading' && <p>Loading documentation…</p>}
+        {status === 'error' && (
+          <p role="alert">{error ?? 'Documentation unavailable.'}</p>
+        )}
+        {status === 'ready' && (
+          <div dangerouslySetInnerHTML={{ __html: html }} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/loadMarked.ts
+++ b/lib/loadMarked.ts
@@ -1,0 +1,8 @@
+let loader: Promise<typeof import('marked')> | null = null;
+
+export const loadMarked = () => {
+  if (!loader) {
+    loader = import('marked');
+  }
+  return loader;
+};

--- a/modules/metadata.ts
+++ b/modules/metadata.ts
@@ -9,6 +9,8 @@ export interface ModuleMetadata {
   description: string;
   tags: string[];
   options: ModuleOption[];
+  /** Relative path to the module documentation Markdown file. */
+  docPath: string;
 }
 
 const MODULES: Record<string, ModuleMetadata> = {
@@ -23,6 +25,7 @@ const MODULES: Record<string, ModuleMetadata> = {
         description: 'The session to run this module on.',
       },
     ],
+    docPath: '/docs/modules/getsystem.md',
   },
   keyscan_start: {
     name: 'keyscan_start',
@@ -35,6 +38,7 @@ const MODULES: Record<string, ModuleMetadata> = {
         description: 'The session to run this module on.',
       },
     ],
+    docPath: '/docs/modules/keyscan_start.md',
   },
   persistence_service: {
     name: 'persistence_service',
@@ -52,6 +56,7 @@ const MODULES: Record<string, ModuleMetadata> = {
         description: 'Remote port used for callback.',
       },
     ],
+    docPath: '/docs/modules/persistence_service.md',
   },
   hashdump: {
     name: 'hashdump',
@@ -64,6 +69,7 @@ const MODULES: Record<string, ModuleMetadata> = {
         description: 'The session to run this module on.',
       },
     ],
+    docPath: '/docs/modules/hashdump.md',
   },
 };
 

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
 import Meta from '../components/SEO/Meta';
 import modules, { ModuleMetadata } from '../modules/metadata';
 import ModuleCard from '../components/ModuleCard';
+import ModuleReadme from '../components/ModuleReadme';
 import VirtualList from 'rc-virtual-list';
 
 export default function PostExploitation() {
+  const router = useRouter();
+  const pendingModuleRef = useRef<string | null>(null);
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState<ModuleMetadata | null>(null);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
@@ -25,12 +29,44 @@ export default function PostExploitation() {
     );
   };
 
+  useEffect(() => {
+    if (!router.isReady || pendingModuleRef.current) {
+      return;
+    }
+    const moduleParam = router.query.module;
+    if (typeof moduleParam !== 'string') {
+      if (selected) {
+        setSelected(null);
+      }
+      return;
+    }
+    const match = modules.find((m) => m.name === moduleParam) ?? null;
+    if (!match || selected?.name === match.name) {
+      return;
+    }
+    setSelected(match);
+  }, [router.isReady, router.query.module, selected]);
+
   const filtered = modules.filter(
     (m) =>
       m.name.toLowerCase().includes(query.toLowerCase()) &&
       (selectedTags.length === 0 ||
         m.tags.some((t) => selectedTags.includes(t)))
   );
+
+  const handleSelect = (module: ModuleMetadata) => {
+    setSelected(module);
+    pendingModuleRef.current = module.name;
+    const nextQuery = { ...router.query, module: module.name };
+    router
+      .push({ pathname: router.pathname, query: nextQuery }, undefined, {
+        shallow: true,
+        scroll: false,
+      })
+      .finally(() => {
+        pendingModuleRef.current = null;
+      });
+  };
 
   return (
     <>
@@ -85,7 +121,7 @@ export default function PostExploitation() {
                 <li key={m.name}>
                   <ModuleCard
                     module={m}
-                    onSelect={setSelected}
+                    onSelect={handleSelect}
                     selected={selected?.name === m.name}
                     query={query}
                   />
@@ -94,20 +130,14 @@ export default function PostExploitation() {
             </VirtualList>
           )}
         </section>
-        <aside className="prose">
+        <aside className="prose flex flex-col gap-4">
           {selected ? (
             <>
-              <h2>{selected.name}</h2>
-              <p>{selected.description}</p>
-              <h3>Options</h3>
-              <ul>
-                {selected.options.map((opt) => (
-                  <li key={opt.name}>
-                    <strong>{opt.name}</strong>{' '}
-                    {opt.required ? '(required)' : '(optional)'} - {opt.description}
-                  </li>
-                ))}
-              </ul>
+              <div>
+                <h2>{selected.name}</h2>
+                <p>{selected.description}</p>
+              </div>
+              <ModuleReadme module={selected} />
             </>
           ) : (
             <p>Select a module to view details.</p>

--- a/public/docs/modules/getsystem.md
+++ b/public/docs/modules/getsystem.md
@@ -1,0 +1,22 @@
+# getsystem
+
+Gain SYSTEM privileges on a compromised Windows host.
+
+## Overview
+- Elevates the current Meterpreter session to `NT AUTHORITY\\SYSTEM`.
+- Attempts multiple techniques, falling back when a method fails.
+
+## Options
+
+| Name | Required | Description |
+| ---- | -------- | ----------- |
+| SESSION | Yes | ID of the session to elevate. |
+
+## Usage
+1. Ensure you have an active Windows Meterpreter session.
+2. Run `run post/windows/escalate/getsystem`.
+3. Verify the session now runs as SYSTEM.
+
+## Notes
+- This simulation never executes real privilege escalation.
+- Review the official Metasploit module README for production usage.

--- a/public/docs/modules/hashdump.md
+++ b/public/docs/modules/hashdump.md
@@ -1,0 +1,22 @@
+# hashdump
+
+Extract password hashes from the Windows SAM database.
+
+## Overview
+- Reads the SAM and SYSTEM hives from the compromised host.
+- Decrypts cached credentials for offline password analysis.
+
+## Options
+
+| Name | Required | Description |
+| ---- | -------- | ----------- |
+| SESSION | Yes | ID of the session to target. |
+
+## Usage
+1. Run the module once SYSTEM privileges are obtained.
+2. Export hashes for offline cracking tools like `john` or `hashcat`.
+3. Rotate credentials after testing to maintain good hygiene.
+
+## Notes
+- This simulation returns sample hashes only.
+- Never process real credentials outside an approved lab.

--- a/public/docs/modules/keyscan_start.md
+++ b/public/docs/modules/keyscan_start.md
@@ -1,0 +1,22 @@
+# keyscan_start
+
+Begin recording keystrokes from the compromised machine.
+
+## Overview
+- Hooks into the active Meterpreter session keyboard buffer.
+- Streams keystrokes back to the operator console.
+
+## Options
+
+| Name | Required | Description |
+| ---- | -------- | ----------- |
+| SESSION | Yes | ID of the session to monitor. |
+
+## Usage
+1. Launch `keyscan_start` against a live session.
+2. Use `keyscan_dump` periodically to review captured input.
+3. Stop collection with `keyscan_stop` when complete.
+
+## Notes
+- Captured keystrokes stay within this educational sandbox.
+- Use real tooling only with explicit authorization.

--- a/public/docs/modules/persistence_service.md
+++ b/public/docs/modules/persistence_service.md
@@ -1,0 +1,23 @@
+# persistence_service
+
+Install a Windows service to maintain Meterpreter access.
+
+## Overview
+- Creates a resilient service that reconnects to the handler.
+- Useful for regaining access after a reboot.
+
+## Options
+
+| Name | Required | Description |
+| ---- | -------- | ----------- |
+| SESSION | Yes | ID of the session to persist. |
+| RPORT | No | Callback port for the service payload. |
+
+## Usage
+1. Confirm the target permits service creation.
+2. Configure callback parameters and run the module.
+3. Verify the service appears in the Windows Service Manager.
+
+## Notes
+- This environment simulates success without touching real hosts.
+- Always obtain authorization before deploying persistence mechanisms.


### PR DESCRIPTION
## Summary
- add a ModuleReadme client component that fetches module documentation, sanitizes it, and renders anchor navigation
- store docPath metadata for post-exploitation modules and add markdown docs under public/docs/modules
- wire the new component into the post exploitation page and extend tests for metadata, navigation, and sanitization

## Testing
- [ ] yarn lint *(fails because of pre-existing accessibility violations across legacy apps)*
- [x] yarn test __tests__/postExploitation.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc1e40d6508328962f92c2543b2a58