### PR TITLE
[reaver] add pixie dust guided demo

### DIFF
--- a/__tests__/reaverPixieDust.test.tsx
+++ b/__tests__/reaverPixieDust.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import PixieDustDemo, {
+  PIXIE_STEP_DELAY,
+  PIXIE_STEPS,
+} from '@/apps/reaver/components/PixieDustDemo';
+import { ReaverPanel } from '@/apps/reaver';
+
+jest.mock('@/apps/reaver/components/APList', () => ({
+  __esModule: true,
+  default: () => <div data-testid="reaver-ap-list">Mocked AP list</div>,
+}));
+
+describe('PixieDustDemo', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('advances steps sequentially and completes the demo', () => {
+    render(<PixieDustDemo onCancel={jest.fn()} />);
+
+    const secondProgress = screen.getByLabelText('Derive nonces and keys progress');
+
+    act(() => {
+      jest.advanceTimersByTime(PIXIE_STEPS[0].duration - PIXIE_STEP_DELAY);
+    });
+
+    expect(secondProgress).toHaveTextContent('0%');
+
+    act(() => {
+      jest.advanceTimersByTime(PIXIE_STEP_DELAY + PIXIE_STEPS[0].duration);
+    });
+
+    expect(Number(secondProgress.textContent?.replace('%', '') || 0)).toBeGreaterThan(0);
+
+    const totalDuration = PIXIE_STEPS.reduce((sum, step) => sum + step.duration, 0);
+    act(() => {
+      jest.advanceTimersByTime(totalDuration + PIXIE_STEP_DELAY * PIXIE_STEPS.length);
+    });
+
+    expect(screen.getByText(/offline key recovered/i)).toBeInTheDocument();
+  });
+});
+
+describe('ReaverPanel Pixie Dust integration', () => {
+  const originalFetch = global.fetch;
+  const mockFetch = jest.fn();
+
+  beforeEach(() => {
+    mockFetch.mockImplementation((url: RequestInfo | URL) => {
+      const href = typeof url === 'string' ? url : url.toString();
+      if (href.includes('routers')) {
+        return Promise.resolve({
+          json: () => Promise.resolve([{ model: 'Test Router', notes: 'Demo router' }]),
+        }) as unknown as Promise<Response>;
+      }
+      if (href.includes('aps')) {
+        return Promise.resolve({
+          json: () => Promise.resolve([{ ssid: 'Demo', bssid: '00:00:00:00', wps: 'enabled' }]),
+        }) as unknown as Promise<Response>;
+      }
+      return Promise.reject(new Error('Unknown resource'));
+    });
+    // @ts-ignore
+    global.fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    global.fetch = originalFetch;
+  });
+
+  it('returns to the AP list when cancelling the guided demo', async () => {
+    await act(async () => {
+      render(<ReaverPanel />);
+    });
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    const pending = mockFetch.mock.results
+      .map((result) => result.value)
+      .filter((value): value is Promise<unknown> => value instanceof Promise);
+
+    await act(async () => {
+      await Promise.all(pending);
+    });
+
+    const openButton = screen.getByRole('button', { name: /pixie dust guided demo/i });
+    fireEvent.click(openButton);
+
+    expect(screen.getByTestId('pixie-dust-demo')).toBeInTheDocument();
+
+    const cancelButton = screen.getByRole('button', { name: /cancel demo/i });
+    fireEvent.click(cancelButton);
+
+    expect(screen.queryByTestId('pixie-dust-demo')).not.toBeInTheDocument();
+    expect(screen.getByTestId('reaver-ap-list')).toBeInTheDocument();
+  });
+});

--- a/apps/reaver/components/APList.tsx
+++ b/apps/reaver/components/APList.tsx
@@ -55,7 +55,10 @@ const APList: React.FC = () => {
   }, []);
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-4">
+    <div
+      className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-4"
+      data-testid="reaver-ap-list"
+    >
       {aps.map((ap) => (
         <div
           key={ap.bssid}

--- a/apps/reaver/components/PixieDustDemo.tsx
+++ b/apps/reaver/components/PixieDustDemo.tsx
@@ -1,0 +1,242 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+export type PixieStepStatus = 'pending' | 'running' | 'done';
+
+export interface PixieStepDefinition {
+  title: string;
+  description: string;
+  duration: number;
+}
+
+export const PIXIE_STEPS: PixieStepDefinition[] = [
+  {
+    title: 'Capture handshake material',
+    description:
+      'Monitor the target channel and cache WPS M1/M2 exchanges for offline work.',
+    duration: 2200,
+  },
+  {
+    title: 'Derive nonces and keys',
+    description:
+      'Extract the enrollee nonce, public key, and hashes needed for Pixie Dust analysis.',
+    duration: 2600,
+  },
+  {
+    title: 'Recover PIN offline',
+    description:
+      'Brute-force the weak PRNG seeded PIN space without touching the access point.',
+    duration: 2400,
+  },
+];
+
+const PROGRESS_TICK = 50;
+export const PIXIE_STEP_DELAY = 400;
+
+interface PixieDustDemoProps {
+  onCancel: () => void;
+  onComplete?: () => void;
+}
+
+interface StepState {
+  progress: number;
+  status: PixieStepStatus;
+}
+
+const createInitialState = (): StepState[] =>
+  PIXIE_STEPS.map(() => ({ progress: 0, status: 'pending' as PixieStepStatus }));
+
+const PixieDustDemo: React.FC<PixieDustDemoProps> = ({ onCancel, onComplete }) => {
+  const [steps, setSteps] = useState<StepState[]>(createInitialState);
+  const [status, setStatus] = useState<'running' | 'complete'>('running');
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const delayRef = useRef<NodeJS.Timeout | null>(null);
+  const cancelledRef = useRef(false);
+
+  const cleanup = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    if (delayRef.current) {
+      clearTimeout(delayRef.current);
+      delayRef.current = null;
+    }
+  }, []);
+
+  const startStep = useCallback(
+    (index: number) => {
+      if (cancelledRef.current) return;
+      if (index >= PIXIE_STEPS.length) {
+        setStatus('complete');
+        return;
+      }
+
+      setSteps((prev) => {
+        const next = [...prev];
+        next[index] = { ...next[index], status: 'running' };
+        return next;
+      });
+
+      const duration = PIXIE_STEPS[index].duration;
+      let elapsed = 0;
+
+      cleanup();
+      intervalRef.current = setInterval(() => {
+        if (cancelledRef.current) {
+          cleanup();
+          return;
+        }
+
+        elapsed += PROGRESS_TICK;
+        const progress = Math.min(100, Math.round((elapsed / duration) * 100));
+
+        setSteps((prev) => {
+          const next = [...prev];
+          next[index] = { ...next[index], progress };
+          return next;
+        });
+
+        if (progress >= 100) {
+          cleanup();
+          setSteps((prev) => {
+            const next = [...prev];
+            next[index] = { ...next[index], progress: 100, status: 'done' };
+            return next;
+          });
+
+          if (index + 1 >= PIXIE_STEPS.length) {
+            setStatus('complete');
+            return;
+          }
+
+          delayRef.current = setTimeout(() => {
+            delayRef.current = null;
+            startStep(index + 1);
+          }, PIXIE_STEP_DELAY);
+        }
+      }, PROGRESS_TICK);
+    },
+    [cleanup]
+  );
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    setSteps(createInitialState());
+    setStatus('running');
+    startStep(0);
+
+    return () => {
+      cancelledRef.current = true;
+      cleanup();
+    };
+  }, [cleanup, startStep]);
+
+  useEffect(() => {
+    if (status === 'complete') {
+      cleanup();
+      onComplete?.();
+    }
+  }, [cleanup, onComplete, status]);
+
+  const handleCancel = () => {
+    cancelledRef.current = true;
+    cleanup();
+    onCancel();
+  };
+
+  const statusBadge = (stepStatus: PixieStepStatus) => {
+    switch (stepStatus) {
+      case 'done':
+        return 'bg-green-500 text-black';
+      case 'running':
+        return 'bg-blue-500 text-white animate-pulse';
+      default:
+        return 'bg-gray-700 text-gray-300';
+    }
+  };
+
+  return (
+    <div
+      data-testid="pixie-dust-demo"
+      className="p-4 bg-gray-800 rounded border border-blue-500 text-sm"
+    >
+      <div className="flex items-start justify-between mb-3">
+        <div>
+          <h3 className="text-lg font-semibold">Pixie Dust Guided Demo</h3>
+          <p className="text-xs text-gray-300">
+            Offline WPS attack walkthrough. Animations show each stage completing in order.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleCancel}
+          className="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded text-xs"
+        >
+          Cancel demo
+        </button>
+      </div>
+      <ol className="space-y-3" aria-live="polite">
+        {PIXIE_STEPS.map((step, index) => {
+          const state = steps[index];
+          return (
+            <li key={step.title} className="p-3 bg-gray-900 rounded">
+              <div className="flex items-center justify-between mb-2">
+                <span className="font-medium">{step.title}</span>
+                <span
+                  className={`px-2 py-0.5 rounded text-[0.65rem] ${statusBadge(state.status)}`}
+                  data-testid={`pixie-status-${index}`}
+                >
+                  {state.status === 'pending'
+                    ? 'Waiting'
+                    : state.status === 'running'
+                    ? 'Running'
+                    : 'Complete'}
+                </span>
+              </div>
+              <p className="text-xs text-gray-400 mb-2">{step.description}</p>
+              <div className="flex items-center gap-3">
+                <div className="flex-1 h-2 bg-gray-700 rounded overflow-hidden">
+                  <div
+                    className={`h-2 ${
+                      state.status === 'done'
+                        ? 'bg-green-500'
+                        : state.status === 'running'
+                        ? 'bg-blue-400'
+                        : 'bg-gray-600'
+                    } transition-all duration-75`}
+                    style={{ width: `${state.progress}%` }}
+                    data-testid={`pixie-progress-${index}`}
+                  />
+                </div>
+                <span
+                  className="w-12 text-right font-mono text-xs"
+                  aria-label={`${step.title} progress`}
+                >
+                  {state.progress}%
+                </span>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+      {status === 'complete' && (
+        <div className="mt-4 p-3 bg-gray-900 rounded border border-green-500" role="status">
+          <h4 className="text-sm font-semibold mb-1">Offline key recovered</h4>
+          <p className="text-xs text-gray-300 mb-3">
+            The Pixie Dust demo completed using captured handshake data. In the real attack,
+            no further interaction with the access point would be needed.
+          </p>
+          <button
+            type="button"
+            onClick={handleCancel}
+            className="px-3 py-1 bg-green-600 hover:bg-green-500 rounded text-xs text-black"
+          >
+            Back to AP list
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PixieDustDemo;

--- a/apps/reaver/index.tsx
+++ b/apps/reaver/index.tsx
@@ -8,6 +8,7 @@ import RouterProfiles, {
 } from './components/RouterProfiles';
 import APList from './components/APList';
 import ProgressDonut from './components/ProgressDonut';
+import PixieDustDemo from './components/PixieDustDemo';
 
 const PlayIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 20 20" fill="currentColor" {...props}>
@@ -66,7 +67,7 @@ const formatTime = (seconds: number) => {
     .join(':');
 };
 
-const ReaverPanel: React.FC = () => {
+export const ReaverPanel: React.FC = () => {
   const [routers, setRouters] = useState<RouterMeta[]>([]);
   const [routerIdx, setRouterIdx] = useState(0);
   const [rate, setRate] = useState(1);
@@ -80,6 +81,7 @@ const ReaverPanel: React.FC = () => {
   const lockRef = useRef(0); // lockout seconds remaining
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const logRef = useRef<HTMLDivElement>(null);
+  const [showPixieDust, setShowPixieDust] = useState(false);
 
   useEffect(() => {
     fetch('/demo-data/reaver/routers.json')
@@ -176,7 +178,9 @@ const ReaverPanel: React.FC = () => {
     }, [stageIdx]);
 
   useEffect(() => {
-    logRef.current?.scrollTo({ top: logRef.current.scrollHeight });
+    if (logRef.current && typeof logRef.current.scrollTo === 'function') {
+      logRef.current.scrollTo({ top: logRef.current.scrollHeight });
+    }
   }, [logs]);
 
   const stageStatus = (i: number) => {
@@ -209,8 +213,23 @@ const ReaverPanel: React.FC = () => {
       </p>
 
       <div className="mb-6">
-        <h2 className="text-lg mb-2">Access Points</h2>
-        <APList />
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-lg">Access Points</h2>
+          {!showPixieDust && (
+            <button
+              type="button"
+              onClick={() => setShowPixieDust(true)}
+              className="px-3 py-1 bg-blue-600 hover:bg-blue-500 rounded text-sm"
+            >
+              Launch Pixie Dust Guided Demo
+            </button>
+          )}
+        </div>
+        {showPixieDust ? (
+          <PixieDustDemo onCancel={() => setShowPixieDust(false)} />
+        ) : (
+          <APList />
+        )}
       </div>
 
       <div className="mb-6">


### PR DESCRIPTION
## Summary
- add a sequential Pixie Dust walkthrough component with cancellable animations for the Reaver simulator
- integrate the guided demo into the access point panel and export the panel for testing
- cover the new flow with interaction-focused tests and provide a stable AP list test surface

## Testing
- `yarn lint` *(fails: repository contains existing accessibility and lint violations unrelated to this change)*
- `yarn test __tests__/reaverPixieDust.test.tsx`
- `yarn test` *(fails: suite has pre-existing window/about accessibility regressions)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1e44749c8328b695bea678dc2cfd