### PR TITLE
[reaver] simulate staggered AP discovery controls

### DIFF
--- a/__tests__/reaverAPList.test.tsx
+++ b/__tests__/reaverAPList.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import APList from '../apps/reaver/components/APList';
+
+const sampleAps = [
+  { ssid: 'CafeWiFi', bssid: '00:11:22:33:44:55', wps: 'enabled' as const },
+  { ssid: 'HomeSecure', bssid: '66:77:88:99:AA:BB', wps: 'locked' as const },
+  { ssid: 'Guest', bssid: 'CC:DD:EE:FF:00:11', wps: 'disabled' as const },
+];
+
+describe('APList scanning simulation', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      json: jest.fn().mockResolvedValue(sampleAps),
+    } as unknown as Response);
+    jest.spyOn(global.Math, 'random').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('reveals access points gradually based on staggered timers', async () => {
+    render(<APList />);
+
+    const startButton = await screen.findByRole('button', { name: /start scan/i });
+
+    await waitFor(() => expect(startButton).not.toBeDisabled());
+
+    const stopButton = screen.getByRole('button', { name: /stop scan/i });
+
+    await act(async () => {
+      startButton.click();
+    });
+
+    await waitFor(() => expect(stopButton).not.toBeDisabled());
+
+    const cycleIndicator = await screen.findByTestId('scan-cycle');
+    await waitFor(() =>
+      expect(cycleIndicator).toHaveTextContent(/Scan cycle:\s*1/i),
+    );
+
+    const list = screen.getByRole('list', { name: /simulated access points/i });
+
+    expect(within(list).queryAllByRole('listitem')).toHaveLength(0);
+
+    await act(async () => {
+      jest.advanceTimersByTime(290);
+    });
+    expect(within(list).queryAllByRole('listitem')).toHaveLength(0);
+
+    await act(async () => {
+      jest.advanceTimersByTime(20);
+    });
+    expect(within(list).getAllByRole('listitem')).toHaveLength(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(within(list).getAllByRole('listitem')).toHaveLength(2);
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(within(list).getAllByRole('listitem')).toHaveLength(3);
+  });
+
+  it('respects updated refresh interval values for subsequent scans', async () => {
+    render(<APList />);
+
+    const startButton = await screen.findByRole('button', { name: /start scan/i });
+
+    await waitFor(() => expect(startButton).not.toBeDisabled());
+
+    const stopButton = screen.getByRole('button', { name: /stop scan/i });
+
+    await act(async () => {
+      startButton.click();
+    });
+
+    await waitFor(() => expect(stopButton).not.toBeDisabled());
+
+    const cycleIndicator = await screen.findByTestId('scan-cycle');
+    await waitFor(() =>
+      expect(cycleIndicator).toHaveTextContent(/Scan cycle:\s*1/i),
+    );
+
+    const intervalInput = screen.getByLabelText(/refresh interval/i) as HTMLInputElement;
+
+    fireEvent.change(intervalInput, { target: { value: '2' } });
+
+    await waitFor(() =>
+      expect(cycleIndicator).toHaveTextContent(/Scan cycle:\s*2/i),
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1990);
+    });
+
+    expect(cycleIndicator).toHaveTextContent(/Scan cycle:\s*2/i);
+
+    await act(async () => {
+      jest.advanceTimersByTime(20);
+    });
+
+    await waitFor(() =>
+      expect(cycleIndicator).toHaveTextContent(/Scan cycle:\s*3/i),
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    await waitFor(() =>
+      expect(cycleIndicator).toHaveTextContent(/Scan cycle:\s*4/i),
+    );
+  });
+});

--- a/apps/reaver/components/APList.tsx
+++ b/apps/reaver/components/APList.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 export interface AccessPoint {
   ssid: string;
@@ -44,30 +50,241 @@ const statusIcon = (status: AccessPoint['wps']) => {
   }
 };
 
-const APList: React.FC = () => {
-  const [aps, setAps] = useState<AccessPoint[]>([]);
+const MIN_DELAY_MS = 300;
+const MAX_DELAY_MS = 1200;
+const DEFAULT_REFRESH_SECONDS = 8;
 
-  useEffect(() => {
-    fetch('/demo-data/reaver/aps.json')
-      .then((r) => r.json())
-      .then(setAps)
-      .catch(() => setAps([]));
+const APList: React.FC = () => {
+  const [allAps, setAllAps] = useState<AccessPoint[]>([]);
+  const [displayedAps, setDisplayedAps] = useState<AccessPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isScanning, setIsScanning] = useState(false);
+  const [refreshSeconds, setRefreshSeconds] = useState(DEFAULT_REFRESH_SECONDS);
+  const [scanCycle, setScanCycle] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const scheduledAddsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const refreshTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const refreshIntervalMs = useMemo(
+    () => Math.max(2, refreshSeconds) * 1000,
+    [refreshSeconds],
+  );
+
+  const clearScheduledAdds = useCallback(() => {
+    scheduledAddsRef.current.forEach((timeoutId) => clearTimeout(timeoutId));
+    scheduledAddsRef.current = [];
   }, []);
 
+  const clearRefreshTimer = useCallback(() => {
+    if (refreshTimerRef.current) {
+      clearInterval(refreshTimerRef.current);
+      refreshTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleScan = useCallback(() => {
+    clearScheduledAdds();
+    if (allAps.length === 0) {
+      setDisplayedAps([]);
+      return;
+    }
+
+    setScanCycle((cycle) => cycle + 1);
+    setDisplayedAps([]);
+
+    let accumulatedDelay = 0;
+    const span = MAX_DELAY_MS - MIN_DELAY_MS;
+
+    allAps.forEach((ap) => {
+      const randomDelta = MIN_DELAY_MS + Math.random() * span;
+      accumulatedDelay += randomDelta;
+      const timeoutId = setTimeout(() => {
+        setDisplayedAps((current) => {
+          if (current.find((existing) => existing.bssid === ap.bssid)) {
+            return current;
+          }
+          return [...current, ap];
+        });
+      }, accumulatedDelay);
+
+      scheduledAddsRef.current.push(timeoutId);
+    });
+  }, [allAps, clearScheduledAdds]);
+
+  const stopTimers = useCallback(() => {
+    clearRefreshTimer();
+    clearScheduledAdds();
+  }, [clearRefreshTimer, clearScheduledAdds]);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+    fetch('/demo-data/reaver/aps.json')
+      .then((response) => response.json())
+      .then((data: AccessPoint[]) => {
+        if (!active) return;
+        setAllAps(data);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!active) return;
+        setAllAps([]);
+        setError('Unable to load sample access points.');
+        setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isScanning || allAps.length === 0) {
+      return;
+    }
+
+    scheduleScan();
+    clearRefreshTimer();
+    refreshTimerRef.current = setInterval(() => {
+      scheduleScan();
+    }, refreshIntervalMs);
+
+    return () => {
+      clearRefreshTimer();
+      clearScheduledAdds();
+    };
+  }, [
+    isScanning,
+    allAps,
+    refreshIntervalMs,
+    scheduleScan,
+    clearRefreshTimer,
+    clearScheduledAdds,
+  ]);
+
+  useEffect(() => () => stopTimers(), [stopTimers]);
+
+  const startScan = () => {
+    setScanCycle(0);
+    setDisplayedAps([]);
+    setIsScanning(true);
+  };
+
+  const stopScan = () => {
+    setIsScanning(false);
+    stopTimers();
+  };
+
+  const handleRefreshChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const value = Number(event.target.value);
+    if (Number.isNaN(value)) return;
+    setRefreshSeconds(Math.min(30, Math.max(2, Math.round(value))));
+  };
+
+  const statusMessage = useMemo(() => {
+    if (loading) {
+      return 'Loading sample APs…';
+    }
+    if (error) {
+      return error;
+    }
+    return isScanning ? 'Scanning for WPS-enabled access points…' : 'Scan paused';
+  }, [loading, error, isScanning]);
+
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-4">
-      {aps.map((ap) => (
-        <div
-          key={ap.bssid}
-          className="flex items-center justify-between bg-gray-800 rounded p-3"
-        >
-          <div>
-            <div className="font-semibold">{ap.ssid}</div>
-            <div className="text-xs font-mono text-gray-400">{ap.bssid}</div>
-          </div>
-          {statusIcon(ap.wps)}
+    <div>
+      <div className="flex flex-wrap items-end gap-4 mb-4">
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={startScan}
+            className="px-3 py-1.5 rounded bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-400 text-sm font-semibold"
+            disabled={isScanning || loading || !!error || allAps.length === 0}
+          >
+            Start scan
+          </button>
+          <button
+            type="button"
+            onClick={stopScan}
+            className="px-3 py-1.5 rounded bg-red-600 hover:bg-red-500 disabled:bg-gray-700 disabled:text-gray-400 text-sm font-semibold"
+            disabled={!isScanning}
+          >
+            Stop scan
+          </button>
         </div>
-      ))}
+        <label className="text-sm text-gray-300">
+          <span className="block text-xs uppercase tracking-wide text-gray-400 mb-1">
+            Refresh interval (seconds)
+          </span>
+          <input
+            type="number"
+            min={2}
+            max={30}
+            step={1}
+            value={refreshSeconds}
+            onChange={handleRefreshChange}
+            className="w-24 bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+        </label>
+        <p className="text-xs text-gray-400" aria-live="polite">
+          <span className="font-semibold text-gray-300">Status:</span> {statusMessage}{' '}
+          <span className="ml-2" data-testid="scan-cycle">
+            Scan cycle: {scanCycle}
+          </span>
+        </p>
+      </div>
+
+      {!loading && !error && !isScanning && displayedAps.length === 0 ? (
+        <p className="text-sm text-gray-400 mb-3">
+          Press "Start scan" to simulate access point discovery.
+        </p>
+      ) : null}
+
+      {isScanning && displayedAps.length === 0 ? (
+        <p className="text-sm text-gray-400 mb-3" aria-live="polite">
+          Listening for beacon frames…
+        </p>
+      ) : null}
+
+      <ul
+        className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-4"
+        aria-label="Simulated access points"
+      >
+        {displayedAps.map((ap) => (
+          <li
+            key={ap.bssid}
+            className="ap-list-item flex items-center justify-between bg-gray-800 rounded p-3 shadow-sm"
+          >
+            <div>
+              <div className="font-semibold">{ap.ssid}</div>
+              <div className="text-xs font-mono text-gray-400">{ap.bssid}</div>
+            </div>
+            {statusIcon(ap.wps)}
+          </li>
+        ))}
+      </ul>
+
+      <style jsx>{`
+        .ap-list-item {
+          opacity: 0;
+          transform: translateY(8px);
+          animation: ap-list-fade 0.45s ease-out forwards;
+        }
+
+        @keyframes ap-list-fade {
+          from {
+            opacity: 0;
+            transform: translateY(12px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+      `}</style>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add timer-driven scan scheduling to the AP list with start/stop controls and fade-in presentation
- make the refresh cadence user-configurable with status messaging and cycle tracking
- cover staggered population timing and refresh interval adjustments with new unit tests

## Testing
- yarn lint *(fails: existing accessibility rules in unrelated apps)*
- yarn test reaverAPList.test.tsx --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68cc1e4534208328b61f046d2b5f518d