### PR TITLE
feat(autopsy): enhance keyword tester with exports

### DIFF
--- a/__tests__/keyword-tester.test.tsx
+++ b/__tests__/keyword-tester.test.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import KeywordTester from '../apps/autopsy/components/KeywordTester';
+
+describe('KeywordTester', () => {
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  const originalFileReader = (global as any).FileReader;
+  const OriginalBlob = window.Blob;
+
+  beforeEach(() => {
+    class FileReaderMock {
+      onload: ((event: ProgressEvent<FileReader>) => void) | null = null;
+      onerror: ((event: ProgressEvent<FileReader>) => void) | null = null;
+
+      readAsText(file: File | Blob) {
+        const read = () => {
+          if (typeof (file as any).text === 'function') {
+            return (file as any).text();
+          }
+          if (typeof (file as any).arrayBuffer === 'function') {
+            return (file as any)
+              .arrayBuffer()
+              .then((buffer: ArrayBuffer) => new TextDecoder().decode(buffer));
+          }
+          return Promise.resolve('');
+        };
+
+        read()
+          .then((text) => {
+            this.onload?.({ target: { result: text } } as ProgressEvent<FileReader>);
+          })
+          .catch((error) => {
+            this.onerror?.({ target: { error } } as ProgressEvent<FileReader>);
+          });
+      }
+    }
+
+    // @ts-ignore
+    global.FileReader = FileReaderMock;
+
+    class BlobWithText extends OriginalBlob {
+      private __text: string;
+
+      constructor(parts: BlobPart[], options?: BlobPropertyBag) {
+        super(parts, options);
+        this.__text = parts
+          .map((part) => (typeof part === 'string' ? part : ''))
+          .join('');
+      }
+
+      override text(): Promise<string> {
+        return Promise.resolve(this.__text);
+      }
+    }
+
+    Object.defineProperty(window, 'Blob', {
+      configurable: true,
+      writable: true,
+      value: BlobWithText,
+    });
+    Object.defineProperty(global, 'Blob', {
+      configurable: true,
+      writable: true,
+      value: BlobWithText,
+    });
+
+    Object.defineProperty(window.URL, 'createObjectURL', {
+      configurable: true,
+      writable: true,
+      value: jest.fn(() => 'blob:mock-url'),
+    });
+
+    Object.defineProperty(window.URL, 'revokeObjectURL', {
+      configurable: true,
+      writable: true,
+      value: jest.fn(),
+    });
+
+    jest
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window.URL, 'createObjectURL', {
+      configurable: true,
+      writable: true,
+      value: originalCreateObjectURL,
+    });
+    Object.defineProperty(window.URL, 'revokeObjectURL', {
+      configurable: true,
+      writable: true,
+      value: originalRevokeObjectURL,
+    });
+    if (originalFileReader) {
+      // @ts-ignore
+      global.FileReader = originalFileReader;
+    }
+    Object.defineProperty(window, 'Blob', {
+      configurable: true,
+      writable: true,
+      value: OriginalBlob,
+    });
+    Object.defineProperty(global, 'Blob', {
+      configurable: true,
+      writable: true,
+      value: OriginalBlob,
+    });
+  });
+
+  const uploadKeywords = (content: string) => {
+    const input = screen.getByLabelText(/keyword list/i) as HTMLInputElement;
+    const file = new File([content], 'keywords.txt', { type: 'text/plain' });
+    if (!(file as any).text) {
+      (file as any).text = () => Promise.resolve(content);
+    }
+    fireEvent.change(input, { target: { files: [file] } });
+  };
+
+  const blobToText = (blob: Blob) =>
+    new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        resolve((event?.target?.result as string) ?? '');
+      };
+      reader.onerror = () => reject(reader.error);
+      reader.readAsText(blob);
+    });
+
+  it('matches keywords in a case-insensitive way and tallies totals', async () => {
+    const { container } = render(<KeywordTester />);
+
+    uploadKeywords('ReSuMe');
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Found 2 hits across 1 file/i)
+      ).toBeInTheDocument()
+    );
+
+    expect(
+      screen.getAllByText((content, element) => element?.textContent === 'resume.docx').length
+    ).toBeGreaterThan(0);
+    expect(container.querySelectorAll('mark').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('exports matched snippets with highlighted context', async () => {
+    render(<KeywordTester />);
+
+    uploadKeywords('resume');
+
+    const exportTxtButton = await screen.findByRole('button', {
+      name: /export txt/i,
+    });
+
+    await waitFor(() => expect(exportTxtButton).not.toBeDisabled());
+
+    fireEvent.click(exportTxtButton);
+
+    const createObjectURLMock = window.URL.createObjectURL as jest.Mock;
+    expect(createObjectURLMock).toHaveBeenCalled();
+
+    const blob = createObjectURLMock.mock.calls[0][0] as Blob;
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBeGreaterThan(0);
+    const text = await blobToText(blob);
+
+    expect(text).toContain('Total hits: 2');
+    expect(text).toContain('resume.docx');
+    expect(text).toContain('**resume**');
+
+    const exportCsvButton = await screen.findByRole('button', {
+      name: /export csv/i,
+    });
+
+    fireEvent.click(exportCsvButton);
+
+    expect(createObjectURLMock).toHaveBeenCalledTimes(2);
+    const csvBlob = createObjectURLMock.mock.calls[1][0] as Blob;
+    expect(csvBlob).toBeInstanceOf(Blob);
+    expect(csvBlob.size).toBeGreaterThan(0);
+    const csv = await blobToText(csvBlob);
+
+    expect(csv).toContain('File,Field,Snippet,Hits');
+    expect(csv).toContain('**resume**.docx');
+    expect(csv).toContain('**Resume** found on user\'s desktop');
+  });
+});

--- a/apps/autopsy/components/KeywordTester.tsx
+++ b/apps/autopsy/components/KeywordTester.tsx
@@ -1,7 +1,35 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import events from '../events.json';
+
+type HighlightSnippet = {
+  html: string;
+  text: string;
+};
+
+type HighlightData = {
+  html: string;
+  text: string;
+  count: number;
+  snippets: HighlightSnippet[];
+};
+
+type ArtifactField = {
+  key: string;
+  label: string;
+  value: string;
+  highlight: HighlightData;
+};
+
+type ArtifactMatch = {
+  artifact: Record<string, any>;
+  nameField: ArtifactField;
+  otherFields: ArtifactField[];
+  totalHits: number;
+};
+
+const SNIPPET_CONTEXT = 40;
 
 const escapeHtml = (str: string = '') =>
   str
@@ -11,90 +39,441 @@ const escapeHtml = (str: string = '') =>
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
 
-function KeywordTester() {
+const escapeRegExp = (str: string) => str.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&');
+
+const buildHighlightedHtml = (
+  value: string,
+  positions: { index: number; length: number }[]
+) => {
+  if (positions.length === 0) return escapeHtml(value);
+  let result = '';
+  let lastIndex = 0;
+  positions.forEach((pos) => {
+    result += escapeHtml(value.slice(lastIndex, pos.index));
+    const matchText = value.slice(pos.index, pos.index + pos.length);
+    result += `<mark>${escapeHtml(matchText)}</mark>`;
+    lastIndex = pos.index + pos.length;
+  });
+  result += escapeHtml(value.slice(lastIndex));
+  return result;
+};
+
+const buildHighlightedText = (
+  value: string,
+  positions: { index: number; length: number }[]
+) => {
+  if (positions.length === 0) return value;
+  let result = '';
+  let lastIndex = 0;
+  positions.forEach((pos) => {
+    result += value.slice(lastIndex, pos.index);
+    const matchText = value.slice(pos.index, pos.index + pos.length);
+    result += `**${matchText}**`;
+    lastIndex = pos.index + pos.length;
+  });
+  result += value.slice(lastIndex);
+  return result;
+};
+
+const getHighlightData = (
+  value: string,
+  keywords: string[],
+  options: { skipSnippets?: boolean } = {}
+): HighlightData => {
+  const normalized = value ?? '';
+  const sanitizedKeywords = keywords.filter((k) => k.trim().length > 0);
+
+  if (normalized.length === 0) {
+    return { html: '', text: '', count: 0, snippets: [] };
+  }
+
+  if (sanitizedKeywords.length === 0) {
+    const escaped = escapeHtml(normalized);
+    return { html: escaped, text: normalized, count: 0, snippets: [] };
+  }
+
+  const positions: { index: number; length: number }[] = [];
+
+  sanitizedKeywords.forEach((keyword) => {
+    const regex = new RegExp(escapeRegExp(keyword), 'gi');
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(normalized)) !== null) {
+      positions.push({ index: match.index, length: match[0].length });
+      if (match[0].length === 0) {
+        regex.lastIndex += 1;
+      }
+    }
+  });
+
+  positions.sort((a, b) => a.index - b.index);
+
+  const highlightPositions: { index: number; length: number }[] = [];
+  let cursor = 0;
+  positions.forEach((pos) => {
+    if (pos.index >= cursor) {
+      highlightPositions.push(pos);
+      cursor = pos.index + pos.length;
+    }
+  });
+
+  const html = buildHighlightedHtml(normalized, highlightPositions);
+  const text = buildHighlightedText(normalized, highlightPositions);
+  const count = positions.length;
+
+  if (options.skipSnippets) {
+    return { html, text, count, snippets: [] };
+  }
+
+  const snippetMap = new Map<string, HighlightSnippet>();
+
+  positions.forEach((pos) => {
+    const start = Math.max(0, pos.index - SNIPPET_CONTEXT);
+    const end = Math.min(normalized.length, pos.index + pos.length + SNIPPET_CONTEXT);
+    const prefix = start > 0 ? '…' : '';
+    const suffix = end < normalized.length ? '…' : '';
+    const snippetRaw = `${prefix}${normalized.slice(start, end)}${suffix}`;
+
+    if (!snippetMap.has(snippetRaw)) {
+      const snippetHighlight = getHighlightData(snippetRaw, sanitizedKeywords, {
+        skipSnippets: true,
+      });
+      snippetMap.set(snippetRaw, {
+        html: snippetHighlight.html,
+        text: snippetHighlight.text,
+      });
+    }
+  });
+
+  return { html, text, count, snippets: Array.from(snippetMap.values()) };
+};
+
+const escapeCsvValue = (value: string | number) => {
+  const stringValue = `${value}`;
+  const escaped = stringValue.replace(/"/g, '""');
+  return /[",\n]/.test(stringValue) ? `"${escaped}"` : escaped;
+};
+
+const KeywordTester = () => {
   const [keywords, setKeywords] = useState<string[]>([]);
 
   const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+
     const reader = new FileReader();
     reader.onload = (ev) => {
       const text = (ev.target?.result as string) || '';
-      const list = text
-        .split(/\r?\n/)
-        .map((k) => k.trim())
-        .filter(Boolean);
+      const list = Array.from(
+        new Set(
+          text
+            .split(/\r?\n/)
+            .map((k) => k.trim())
+            .filter(Boolean)
+        )
+      );
       setKeywords(list);
     };
     reader.readAsText(file);
   };
 
-  const highlight = (text: string = '') => {
-    let safe = escapeHtml(text);
-    if (keywords.length === 0) return safe;
-    keywords.forEach((k) => {
-      const re = new RegExp(
-        `(${k.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')})`,
-        'gi'
-      );
-      safe = safe.replace(re, '<mark>$1</mark>');
+  const matches = useMemo<ArtifactMatch[]>(() => {
+    if (keywords.length === 0) return [];
+
+    return (events.artifacts as Record<string, any>[])
+      .map((artifact) => {
+        const nameField: ArtifactField = {
+          key: 'name',
+          label: 'Name',
+          value: artifact.name ?? '',
+          highlight: getHighlightData(artifact.name ?? '', keywords),
+        };
+
+        const fieldCandidates: ArtifactField[] = [
+          {
+            key: 'description',
+            label: 'Description',
+            value: artifact.description ?? '',
+            highlight: getHighlightData(artifact.description ?? '', keywords),
+          },
+        ];
+
+        if ('user' in artifact && artifact.user) {
+          fieldCandidates.push({
+            key: 'user',
+            label: 'User',
+            value: artifact.user,
+            highlight: getHighlightData(artifact.user, keywords),
+          });
+        }
+
+        const otherFields = fieldCandidates.filter(
+          (field) => field.highlight.count > 0
+        );
+
+        const totalHits =
+          nameField.highlight.count +
+          fieldCandidates.reduce((sum, field) => sum + field.highlight.count, 0);
+
+        if (totalHits === 0) return null;
+
+        return {
+          artifact,
+          nameField,
+          otherFields,
+          totalHits,
+        };
+      })
+      .filter(Boolean) as ArtifactMatch[];
+  }, [keywords]);
+
+  const totalHits = useMemo(
+    () => matches.reduce((sum, match) => sum + match.totalHits, 0),
+    [matches]
+  );
+
+  const hasKeywords = keywords.length > 0;
+  const hasMatches = matches.length > 0;
+
+  const buildTxtExport = () => {
+    const lines: string[] = [];
+    const timestamp = new Date().toISOString();
+    lines.push('Keyword hits export');
+    lines.push(`Generated: ${timestamp}`);
+    lines.push(`Total hits: ${totalHits}`);
+    lines.push(`Files with hits: ${matches.length}`);
+    lines.push('');
+
+    matches.forEach((match) => {
+      const fileName = match.artifact.name ?? 'Unknown artifact';
+      lines.push(`${fileName} — ${match.totalHits} hit${match.totalHits === 1 ? '' : 's'}`);
+
+      if (match.nameField.highlight.count > 0) {
+        const segments =
+          match.nameField.highlight.snippets.length > 0
+            ? match.nameField.highlight.snippets
+            : [
+                {
+                  html: match.nameField.highlight.html,
+                  text: match.nameField.highlight.text,
+                },
+              ];
+        segments.forEach((snippet) => {
+          lines.push(`  [Name] ${snippet.text}`);
+        });
+      }
+
+      match.otherFields.forEach((field) => {
+        const segments =
+          field.highlight.snippets.length > 0
+            ? field.highlight.snippets
+            : [
+                {
+                  html: field.highlight.html,
+                  text: field.highlight.text,
+                },
+              ];
+        segments.forEach((snippet) => {
+          lines.push(`  [${field.label}] ${snippet.text}`);
+        });
+      });
+
+      lines.push('');
     });
-    return safe;
+
+    return lines.join('\n');
   };
 
-  const matches = events.artifacts.filter((a) => {
-    const artifact = a as any;
-    const content = `${artifact.name} ${artifact.description} ${
-      'user' in artifact ? artifact.user : ''
-    }`.toLowerCase();
-    return keywords.some((k) => content.includes(k.toLowerCase()));
-  });
+  const buildCsvExport = () => {
+    const rows: string[] = [];
+    rows.push('File,Field,Snippet,Hits');
+
+    matches.forEach((match) => {
+      const fileName = match.artifact.name ?? 'Unknown artifact';
+
+      const pushRow = (label: string, snippetText: string, hits: number) => {
+        rows.push(
+          [
+            escapeCsvValue(fileName),
+            escapeCsvValue(label),
+            escapeCsvValue(snippetText),
+            escapeCsvValue(hits),
+          ].join(',')
+        );
+      };
+
+      if (match.nameField.highlight.count > 0) {
+        const segments =
+          match.nameField.highlight.snippets.length > 0
+            ? match.nameField.highlight.snippets
+            : [
+                {
+                  html: match.nameField.highlight.html,
+                  text: match.nameField.highlight.text,
+                },
+              ];
+        segments.forEach((snippet) => {
+          pushRow('Name', snippet.text, match.nameField.highlight.count);
+        });
+      }
+
+      match.otherFields.forEach((field) => {
+        const segments =
+          field.highlight.snippets.length > 0
+            ? field.highlight.snippets
+            : [
+                {
+                  html: field.highlight.html,
+                  text: field.highlight.text,
+                },
+              ];
+        segments.forEach((snippet) => {
+          pushRow(field.label, snippet.text, field.highlight.count);
+        });
+      });
+    });
+
+    return rows.join('\n');
+  };
+
+  const triggerDownload = (content: string, mime: string, extension: string) => {
+    const blob = new Blob([content], { type: `${mime};charset=utf-8` });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `keyword-hits-${new Date().toISOString().replace(/[:.]/g, '-')}.${extension}`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const exportMatches = (format: 'txt' | 'csv') => {
+    if (!hasMatches) return;
+    if (format === 'txt') {
+      triggerDownload(buildTxtExport(), 'text/plain', 'txt');
+    } else {
+      triggerDownload(buildCsvExport(), 'text/csv', 'csv');
+    }
+  };
 
   return (
     <div className="space-y-4">
       <div>
+        <label
+          htmlFor="keyword-upload"
+          className="mb-2 block text-sm font-medium text-gray-200"
+        >
+          Keyword list
+        </label>
         <input
+          id="keyword-upload"
           type="file"
           accept=".txt"
           onChange={handleUpload}
-          className="bg-ub-grey text-white p-2 rounded"
+          className="bg-ub-grey text-white file:mr-3 file:rounded file:border-0 file:bg-ub-cool file:px-3 file:py-2 file:text-sm file:font-semibold file:text-white"
         />
       </div>
-      {keywords.length > 0 && (
-        <div className="text-sm">Loaded {keywords.length} keywords</div>
-      )}
-      <div className="grid gap-2 md:grid-cols-2">
-        {matches.map((a, idx) => {
-          const artifact = a as any;
-          return (
-            <div
-              key={`${artifact.name}-${idx}`}
-              className="p-2 bg-ub-grey rounded text-sm"
+
+      {hasKeywords && (
+        <div className="space-y-2 rounded bg-ub-grey/60 p-3 text-sm text-gray-200">
+          <div>Loaded {keywords.length} keyword{keywords.length === 1 ? '' : 's'}</div>
+          <div className="flex flex-wrap gap-2 text-xs">
+            <button
+              type="button"
+              onClick={() => exportMatches('txt')}
+              className="rounded bg-ub-cool px-3 py-1 font-semibold text-white disabled:cursor-not-allowed disabled:opacity-40"
+              disabled={!hasMatches}
             >
-              <div
-                className="font-bold"
-                dangerouslySetInnerHTML={{ __html: highlight(artifact.name) }}
-              />
-              <div className="text-gray-400">{artifact.type}</div>
-              {'user' in artifact && (
-                <div
-                  className="text-xs"
-                  dangerouslySetInnerHTML={{
-                    __html: `User: ${highlight(artifact.user)}`,
-                  }}
-                />
-              )}
-              <div
-                className="text-xs"
-                dangerouslySetInnerHTML={{ __html: highlight(artifact.description) }}
-              />
-            </div>
-          );
-        })}
-      </div>
+              Export TXT
+            </button>
+            <button
+              type="button"
+              onClick={() => exportMatches('csv')}
+              className="rounded bg-ub-cool px-3 py-1 font-semibold text-white disabled:cursor-not-allowed disabled:opacity-40"
+              disabled={!hasMatches}
+            >
+              Export CSV
+            </button>
+          </div>
+          <div className="text-xs text-gray-300">
+            {hasMatches ? (
+              <>Found {totalHits} hit{totalHits === 1 ? '' : 's'} across {matches.length} file{matches.length === 1 ? '' : 's'}.</>
+            ) : (
+              <>No matches found in the available artifacts.</>
+            )}
+          </div>
+        </div>
+      )}
+
+      {hasMatches && (
+        <div className="grid gap-3 md:grid-cols-2">
+          {matches.map((match, idx) => {
+            const { artifact, nameField, otherFields, totalHits: hits } = match;
+            return (
+              <div key={`${artifact.name}-${idx}`} className="rounded bg-ub-grey p-3 text-sm">
+                <div className="flex items-start justify-between gap-2">
+                  <div
+                    className="font-bold"
+                    dangerouslySetInnerHTML={{
+                      __html:
+                        nameField.highlight.count > 0
+                          ? nameField.highlight.html
+                          : escapeHtml(nameField.value),
+                    }}
+                  />
+                  <span className="text-xs text-gray-300">
+                    {hits} hit{hits === 1 ? '' : 's'}
+                  </span>
+                </div>
+                {artifact.type && (
+                  <div className="text-xs text-gray-400">{artifact.type}</div>
+                )}
+                <div className="mt-3 space-y-3 text-xs text-gray-200">
+                  {nameField.highlight.count > 0 && nameField.highlight.snippets.length > 0 && (
+                    <div>
+                      <div className="mb-1 text-[11px] uppercase tracking-wide text-gray-400">
+                        Name snippet
+                      </div>
+                      <ul className="ml-4 list-disc space-y-1">
+                        {nameField.highlight.snippets.map((snippet, snippetIdx) => (
+                          <li
+                            key={`name-${snippetIdx}`}
+                            dangerouslySetInnerHTML={{ __html: snippet.html }}
+                          />
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                  {otherFields.map((field) => (
+                    <div key={`${artifact.name}-${field.key}`}>
+                      <div className="mb-1 text-[11px] uppercase tracking-wide text-gray-400">
+                        {field.label}
+                      </div>
+                      {field.highlight.snippets.length > 0 ? (
+                        <ul className="ml-4 list-disc space-y-1">
+                          {field.highlight.snippets.map((snippet, snippetIdx) => (
+                            <li
+                              key={`${field.key}-${snippetIdx}`}
+                              dangerouslySetInnerHTML={{ __html: snippet.html }}
+                            />
+                          ))}
+                        </ul>
+                      ) : (
+                        <div
+                          dangerouslySetInnerHTML={{ __html: field.highlight.html }}
+                        />
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
-}
+};
 
 export default KeywordTester;
-


### PR DESCRIPTION
## Summary
- add detailed keyword highlighting with per-file hit counts and match snippets in the Autopsy keyword tester
- provide TXT and CSV exports for matched snippets while showing overall totals and file summaries
- add tests covering case-insensitive matching and export payload generation

## Testing
- yarn lint *(fails: existing accessibility and window usage errors across unrelated apps)*
- yarn test __tests__/keyword-tester.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68cc1e46a62c8328a08109703ea0ef1b