### PR TITLE
[reaver] Add handshake sequence diagram

### DIFF
--- a/__tests__/__snapshots__/reaverHandshake.test.tsx.snap
+++ b/__tests__/__snapshots__/reaverHandshake.test.tsx.snap
@@ -1,0 +1,326 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`HandshakeDiagram component renders the participants and all handshake steps 1`] = `
+<svg
+  class="max-w-full"
+  height="496"
+  role="img"
+  viewBox="0 0 316 496"
+  width="100%"
+>
+  <title
+    id="handshake-diagram-title"
+  >
+    WPA2 4-Way Handshake
+  </title>
+  <desc
+    id="handshake-diagram-description"
+  >
+    WPA2 four-way handshake sequence diagram showing message direction and capture timing.
+  </desc>
+  <g>
+    <text
+      class="fill-slate-100 text-sm font-semibold"
+      text-anchor="middle"
+      x="48"
+      y="20"
+    >
+      Access Point
+    </text>
+    <line
+      data-testid="handshake-lifeline"
+      stroke="#475569"
+      stroke-dasharray="6 6"
+      stroke-width="1.5"
+      x1="48"
+      x2="48"
+      y1="54"
+      y2="472"
+    />
+  </g>
+  <g>
+    <text
+      class="fill-slate-100 text-sm font-semibold"
+      text-anchor="middle"
+      x="268"
+      y="20"
+    >
+      Client Station
+    </text>
+    <line
+      data-testid="handshake-lifeline"
+      stroke="#475569"
+      stroke-dasharray="6 6"
+      stroke-width="1.5"
+      x1="268"
+      x2="268"
+      y1="54"
+      y2="472"
+    />
+  </g>
+  <g>
+    <line
+      data-testid="handshake-arrow"
+      stroke="#60a5fa"
+      stroke-width="2.5"
+      x1="48"
+      x2="268"
+      y1="112"
+      y2="112"
+    />
+    <polygon
+      fill="#60a5fa"
+      points="268,112 261,107.625 261,116.375"
+    />
+    <circle
+      cx="48"
+      cy="112"
+      fill="#60a5fa"
+      opacity="0.7"
+      r="4"
+    />
+    <foreignobject
+      height="82"
+      width="200"
+      x="58"
+      y="66"
+    >
+      <div
+        class="rounded-md border border-slate-700 bg-slate-900/90 px-3 py-2 text-xs text-slate-100 shadow-lg backdrop-blur"
+        xmlns="http://www.w3.org/1999/xhtml"
+      >
+        <div
+          class="flex items-center justify-between gap-2"
+        >
+          <span
+            class="font-mono text-sm text-slate-100"
+          >
+            M1
+          </span>
+          <button
+            aria-label="Copy M1 label"
+            class="rounded bg-slate-800 px-2 py-1 text-[11px] uppercase tracking-wide text-slate-200 transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-200"
+            data-step="M1"
+            type="button"
+          >
+            Copy
+          </button>
+        </div>
+        <p
+          class="mt-1 text-[11px] leading-snug text-slate-200"
+        >
+          ANonce + RSN parameters
+        </p>
+        <p
+          class="mt-1 text-[10px] font-mono text-slate-400"
+        >
+          Δ 
+          0.000
+           
+          milliseconds
+           · frame 
+          12
+        </p>
+      </div>
+    </foreignobject>
+  </g>
+  <g>
+    <line
+      data-testid="handshake-arrow"
+      stroke="#34d399"
+      stroke-width="2.5"
+      x1="268"
+      x2="48"
+      y1="208"
+      y2="208"
+    />
+    <polygon
+      fill="#34d399"
+      points="48,208 55,203.625 55,212.375"
+    />
+    <circle
+      cx="268"
+      cy="208"
+      fill="#34d399"
+      opacity="0.7"
+      r="4"
+    />
+    <foreignobject
+      height="82"
+      width="200"
+      x="58"
+      y="162"
+    >
+      <div
+        class="rounded-md border border-slate-700 bg-slate-900/90 px-3 py-2 text-xs text-slate-100 shadow-lg backdrop-blur"
+        xmlns="http://www.w3.org/1999/xhtml"
+      >
+        <div
+          class="flex items-center justify-between gap-2"
+        >
+          <span
+            class="font-mono text-sm text-slate-100"
+          >
+            M2
+          </span>
+          <button
+            aria-label="Copy M2 label"
+            class="rounded bg-slate-800 px-2 py-1 text-[11px] uppercase tracking-wide text-slate-200 transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-200"
+            data-step="M2"
+            type="button"
+          >
+            Copy
+          </button>
+        </div>
+        <p
+          class="mt-1 text-[11px] leading-snug text-slate-200"
+        >
+          SNonce + MIC
+        </p>
+        <p
+          class="mt-1 text-[10px] font-mono text-slate-400"
+        >
+          Δ 
+          0.512
+           
+          milliseconds
+           · frame 
+          13
+        </p>
+      </div>
+    </foreignobject>
+  </g>
+  <g>
+    <line
+      data-testid="handshake-arrow"
+      stroke="#60a5fa"
+      stroke-width="2.5"
+      x1="48"
+      x2="268"
+      y1="304"
+      y2="304"
+    />
+    <polygon
+      fill="#60a5fa"
+      points="268,304 261,299.625 261,308.375"
+    />
+    <circle
+      cx="48"
+      cy="304"
+      fill="#60a5fa"
+      opacity="0.7"
+      r="4"
+    />
+    <foreignobject
+      height="82"
+      width="200"
+      x="58"
+      y="258"
+    >
+      <div
+        class="rounded-md border border-slate-700 bg-slate-900/90 px-3 py-2 text-xs text-slate-100 shadow-lg backdrop-blur"
+        xmlns="http://www.w3.org/1999/xhtml"
+      >
+        <div
+          class="flex items-center justify-between gap-2"
+        >
+          <span
+            class="font-mono text-sm text-slate-100"
+          >
+            M3
+          </span>
+          <button
+            aria-label="Copy M3 label"
+            class="rounded bg-slate-800 px-2 py-1 text-[11px] uppercase tracking-wide text-slate-200 transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-200"
+            data-step="M3"
+            type="button"
+          >
+            Copy
+          </button>
+        </div>
+        <p
+          class="mt-1 text-[11px] leading-snug text-slate-200"
+        >
+          Install PTK + GTK
+        </p>
+        <p
+          class="mt-1 text-[10px] font-mono text-slate-400"
+        >
+          Δ 
+          1.024
+           
+          milliseconds
+           · frame 
+          14
+        </p>
+      </div>
+    </foreignobject>
+  </g>
+  <g>
+    <line
+      data-testid="handshake-arrow"
+      stroke="#34d399"
+      stroke-width="2.5"
+      x1="268"
+      x2="48"
+      y1="400"
+      y2="400"
+    />
+    <polygon
+      fill="#34d399"
+      points="48,400 55,395.625 55,404.375"
+    />
+    <circle
+      cx="268"
+      cy="400"
+      fill="#34d399"
+      opacity="0.7"
+      r="4"
+    />
+    <foreignobject
+      height="82"
+      width="200"
+      x="58"
+      y="354"
+    >
+      <div
+        class="rounded-md border border-slate-700 bg-slate-900/90 px-3 py-2 text-xs text-slate-100 shadow-lg backdrop-blur"
+        xmlns="http://www.w3.org/1999/xhtml"
+      >
+        <div
+          class="flex items-center justify-between gap-2"
+        >
+          <span
+            class="font-mono text-sm text-slate-100"
+          >
+            M4
+          </span>
+          <button
+            aria-label="Copy M4 label"
+            class="rounded bg-slate-800 px-2 py-1 text-[11px] uppercase tracking-wide text-slate-200 transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-200"
+            data-step="M4"
+            type="button"
+          >
+            Copy
+          </button>
+        </div>
+        <p
+          class="mt-1 text-[11px] leading-snug text-slate-200"
+        >
+          PTK install ack
+        </p>
+        <p
+          class="mt-1 text-[10px] font-mono text-slate-400"
+        >
+          Δ 
+          1.488
+           
+          milliseconds
+           · frame 
+          15
+        </p>
+      </div>
+    </foreignobject>
+  </g>
+</svg>
+`;

--- a/__tests__/reaverHandshake.test.tsx
+++ b/__tests__/reaverHandshake.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import HandshakeDiagram, {
+  createDiagramModel,
+  handshakeCaptureData,
+  type HandshakeCapture,
+} from '../apps/reaver/components/HandshakeDiagram';
+
+const capture: HandshakeCapture = handshakeCaptureData;
+
+describe('createDiagramModel', () => {
+  it('sorts messages by relative time and frame', () => {
+    const model = createDiagramModel(capture);
+    const relativeTimes = model.messages.map((message) => message.relativeTime);
+    const sorted = [...relativeTimes].sort((a, b) => a - b);
+    expect(relativeTimes).toEqual(sorted);
+    expect(model.messages).toHaveLength(capture.messages.length);
+  });
+
+  it('keeps labels within the diagram bounds', () => {
+    const model = createDiagramModel(capture);
+    model.messages.forEach((message) => {
+      expect(message.labelX).toBeGreaterThanOrEqual(8);
+      expect(message.labelX + message.labelWidth).toBeLessThanOrEqual(
+        model.width
+      );
+      expect(message.startX).toBeDefined();
+      expect(message.endX).toBeDefined();
+    });
+  });
+});
+
+describe('HandshakeDiagram component', () => {
+  it('renders the participants and all handshake steps', () => {
+    const { container } = render(<HandshakeDiagram />);
+
+    capture.participants.forEach((participant) => {
+      expect(screen.getByText(participant.label)).toBeInTheDocument();
+    });
+
+    capture.messages.forEach((message) => {
+      expect(screen.getAllByText(message.step).length).toBeGreaterThan(0);
+      expect(screen.getByText(message.summary)).toBeInTheDocument();
+    });
+
+    expect(
+      container.querySelectorAll('[data-testid="handshake-lifeline"]').length
+    ).toBe(capture.participants.length);
+    expect(
+      container.querySelectorAll('[data-testid="handshake-arrow"]').length
+    ).toBe(capture.messages.length);
+
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg).toMatchSnapshot();
+  });
+
+  it('copies step labels to the clipboard', async () => {
+    const user = userEvent.setup();
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    const nav: any = navigator;
+    const originalClipboard = nav.clipboard;
+    nav.clipboard = { writeText };
+
+    const { getByRole, findByTestId } = render(<HandshakeDiagram />);
+    const copyButton = getByRole('button', { name: /Copy M1 label/i });
+    await user.click(copyButton);
+
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('M1'));
+
+    const feedback = await findByTestId('copy-feedback');
+    expect(feedback.textContent).toMatch(/copied to clipboard/i);
+
+    nav.clipboard = originalClipboard;
+  });
+});

--- a/apps/reaver/components/HandshakeDiagram.tsx
+++ b/apps/reaver/components/HandshakeDiagram.tsx
@@ -1,0 +1,395 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import handshakeCapture from '../data/handshakeCapture.json';
+
+export interface SequenceParticipant {
+  id: string;
+  label: string;
+  accent: string;
+}
+
+export interface SequenceMessage {
+  step: string;
+  from: string;
+  to: string;
+  summary: string;
+  description: string;
+  relativeTime: number;
+  frame: number;
+}
+
+export interface HandshakeCapture {
+  id: string;
+  title: string;
+  capture: {
+    source: string;
+    tool: string;
+    notes: string;
+  };
+  timeUnit: string;
+  participants: SequenceParticipant[];
+  messages: SequenceMessage[];
+}
+
+export interface ParticipantNode extends SequenceParticipant {
+  x: number;
+}
+
+export interface MessageNode extends SequenceMessage {
+  startX: number;
+  endX: number;
+  midX: number;
+  y: number;
+  direction: 'left' | 'right';
+  labelX: number;
+  labelWidth: number;
+  color: string;
+  copyText: string;
+}
+
+export interface DiagramModel {
+  width: number;
+  height: number;
+  lifelineTop: number;
+  lifelineBottom: number;
+  participants: ParticipantNode[];
+  messages: MessageNode[];
+  minFrame: number;
+  maxFrame: number;
+  duration: number;
+}
+
+export const HEADER_HEIGHT = 64;
+export const ROW_HEIGHT = 96;
+export const LANE_SPACING = 220;
+export const LEFT_MARGIN = 48;
+export const RIGHT_MARGIN = 48;
+export const BOTTOM_MARGIN = 48;
+export const LABEL_WIDTH = 200;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+export const handshakeCaptureData = handshakeCapture as HandshakeCapture;
+
+export const createDiagramModel = (capture: HandshakeCapture): DiagramModel => {
+  const participants: ParticipantNode[] = capture.participants.map(
+    (participant, index) => ({
+      ...participant,
+      x: LEFT_MARGIN + LANE_SPACING * index,
+    })
+  );
+
+  const width =
+    (participants.length > 0
+      ? participants[participants.length - 1].x
+      : LEFT_MARGIN) + RIGHT_MARGIN;
+
+  const sortedMessages = [...capture.messages].sort((a, b) => {
+    if (a.relativeTime === b.relativeTime) {
+      return a.frame - b.frame;
+    }
+    return a.relativeTime - b.relativeTime;
+  });
+
+  const height = HEADER_HEIGHT + BOTTOM_MARGIN + ROW_HEIGHT * sortedMessages.length;
+  const lifelineTop = HEADER_HEIGHT - 10;
+  const lifelineBottom = height - BOTTOM_MARGIN / 2;
+
+  let minFrame = Number.POSITIVE_INFINITY;
+  let maxFrame = Number.NEGATIVE_INFINITY;
+  let duration = 0;
+
+  const messages: MessageNode[] = sortedMessages.map((message, index) => {
+    const from = participants.find((p) => p.id === message.from);
+    const to = participants.find((p) => p.id === message.to);
+
+    if (!from || !to) {
+      throw new Error(`Message references unknown participant: ${message.step}`);
+    }
+
+    const y = HEADER_HEIGHT + ROW_HEIGHT * index + ROW_HEIGHT / 2;
+    const direction: 'left' | 'right' = from.x <= to.x ? 'right' : 'left';
+    const startX = from.x;
+    const endX = to.x;
+    const midX = (startX + endX) / 2;
+    const labelWidth = LABEL_WIDTH;
+    const labelX = clamp(midX - labelWidth / 2, 8, width - labelWidth - 8);
+    const copyText = `${message.step} – ${message.summary}`;
+
+    minFrame = Math.min(minFrame, message.frame);
+    maxFrame = Math.max(maxFrame, message.frame);
+    duration = Math.max(duration, message.relativeTime);
+
+    return {
+      ...message,
+      startX,
+      endX,
+      midX,
+      y,
+      direction,
+      labelX,
+      labelWidth,
+      color: from.accent,
+      copyText,
+    };
+  });
+
+  if (!Number.isFinite(minFrame)) {
+    minFrame = 0;
+    maxFrame = 0;
+  }
+
+  return {
+    width,
+    height,
+    lifelineTop,
+    lifelineBottom,
+    participants,
+    messages,
+    minFrame,
+    maxFrame,
+    duration,
+  };
+};
+
+type CopyFeedback = {
+  step: string;
+  label: string;
+  error?: boolean;
+};
+
+const HandshakeDiagram: React.FC = () => {
+  const model = useMemo(
+    () => createDiagramModel(handshakeCaptureData),
+    []
+  );
+  const [copyFeedback, setCopyFeedback] = useState<CopyFeedback | null>(null);
+  const feedbackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const scheduleFeedback = useCallback((feedback: CopyFeedback | null) => {
+    if (feedbackTimer.current) {
+      clearTimeout(feedbackTimer.current);
+      feedbackTimer.current = null;
+    }
+
+    setCopyFeedback(feedback);
+
+    if (feedback) {
+      feedbackTimer.current = setTimeout(() => {
+        setCopyFeedback(null);
+        feedbackTimer.current = null;
+      }, 2000);
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (feedbackTimer.current) {
+        clearTimeout(feedbackTimer.current);
+      }
+    };
+  }, []);
+
+  const fallbackCopy = useCallback((text: string) => {
+    if (typeof document === 'undefined') return;
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'absolute';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+  }, []);
+
+  const copyStep = useCallback(
+    async (message: MessageNode) => {
+      const text = message.copyText;
+      try {
+        if (
+          typeof navigator !== 'undefined' &&
+          navigator.clipboard &&
+          'writeText' in navigator.clipboard
+        ) {
+          await navigator.clipboard.writeText(text);
+        } else {
+          fallbackCopy(text);
+        }
+        scheduleFeedback({ step: message.step, label: text });
+      } catch (error) {
+        scheduleFeedback({ step: message.step, label: text, error: true });
+      }
+    },
+    [fallbackCopy, scheduleFeedback]
+  );
+
+  const arrowHeadSize = 7;
+
+  return (
+    <section className="rounded-lg border border-slate-700 bg-slate-900/60 p-4 shadow-inner">
+      <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-100">
+            {handshakeCaptureData.title}
+          </h3>
+          <p className="text-xs text-slate-300">
+            Sequence reconstructed from {handshakeCaptureData.capture.tool} sample
+            capture <span className="font-mono">{handshakeCaptureData.capture.source}</span>.
+          </p>
+        </div>
+        <div className="text-right text-xs text-slate-400">
+          <div>
+            Frames {model.minFrame}–{model.maxFrame}
+          </div>
+          <div>
+            Duration {model.duration.toFixed(3)} {handshakeCaptureData.timeUnit}
+          </div>
+        </div>
+      </div>
+      <figure
+        className="w-full overflow-x-auto"
+        aria-labelledby="handshake-diagram-title"
+        aria-describedby="handshake-diagram-description"
+      >
+        <svg
+          viewBox={`0 0 ${model.width} ${model.height}`}
+          width="100%"
+          height={model.height}
+          role="img"
+          className="max-w-full"
+        >
+          <title id="handshake-diagram-title">{handshakeCaptureData.title}</title>
+          <desc id="handshake-diagram-description">
+            WPA2 four-way handshake sequence diagram showing message direction and
+            capture timing.
+          </desc>
+
+          {model.participants.map((participant) => (
+            <g key={participant.id}>
+              <text
+                x={participant.x}
+                y={20}
+                textAnchor="middle"
+                className="fill-slate-100 text-sm font-semibold"
+              >
+                {participant.label}
+              </text>
+              <line
+                x1={participant.x}
+                y1={model.lifelineTop}
+                x2={participant.x}
+                y2={model.lifelineBottom}
+                stroke="#475569"
+                strokeDasharray="6 6"
+                strokeWidth={1.5}
+                data-testid="handshake-lifeline"
+              />
+            </g>
+          ))}
+
+          {model.messages.map((message) => {
+            const arrowPoints =
+              message.direction === 'right'
+                ? `${message.endX},${message.y} ${message.endX - arrowHeadSize},${
+                    message.y - arrowHeadSize / 1.6
+                  } ${message.endX - arrowHeadSize},${message.y + arrowHeadSize / 1.6}`
+                : `${message.endX},${message.y} ${message.endX + arrowHeadSize},${
+                    message.y - arrowHeadSize / 1.6
+                  } ${message.endX + arrowHeadSize},${message.y + arrowHeadSize / 1.6}`;
+
+            return (
+              <g key={message.step}>
+                <line
+                  x1={message.startX}
+                  y1={message.y}
+                  x2={message.endX}
+                  y2={message.y}
+                  stroke={message.color}
+                  strokeWidth={2.5}
+                  data-testid="handshake-arrow"
+                />
+                <polygon points={arrowPoints} fill={message.color} />
+                <circle
+                  cx={message.startX}
+                  cy={message.y}
+                  r={4}
+                  fill={message.color}
+                  opacity={0.7}
+                />
+                <foreignObject
+                  x={message.labelX}
+                  y={message.y - 46}
+                  width={message.labelWidth}
+                  height={82}
+                >
+                  <div
+                    xmlns="http://www.w3.org/1999/xhtml"
+                    className="rounded-md border border-slate-700 bg-slate-900/90 px-3 py-2 text-xs text-slate-100 shadow-lg backdrop-blur"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-mono text-sm text-slate-100">
+                        {message.step}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => void copyStep(message)}
+                        className="rounded bg-slate-800 px-2 py-1 text-[11px] uppercase tracking-wide text-slate-200 transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-200"
+                        aria-label={`Copy ${message.step} label`}
+                        data-step={message.step}
+                      >
+                        Copy
+                      </button>
+                    </div>
+                    <p className="mt-1 text-[11px] leading-snug text-slate-200">
+                      {message.summary}
+                    </p>
+                    <p className="mt-1 text-[10px] font-mono text-slate-400">
+                      Δ {message.relativeTime.toFixed(3)} {handshakeCaptureData.timeUnit} · frame {message.frame}
+                    </p>
+                  </div>
+                </foreignObject>
+              </g>
+            );
+          })}
+        </svg>
+      </figure>
+      {copyFeedback && (
+        <div
+          className={`mt-3 inline-flex items-center rounded px-2 py-1 text-xs ${
+            copyFeedback.error
+              ? 'bg-red-900/70 text-red-200'
+              : 'bg-emerald-900/60 text-emerald-200'
+          }`}
+        >
+          {copyFeedback.error
+            ? `Unable to copy ${copyFeedback.label}`
+            : `${copyFeedback.label} copied to clipboard`}
+        </div>
+      )}
+      <p className="mt-3 text-xs text-slate-400">
+        {handshakeCaptureData.capture.notes}
+      </p>
+      <div
+        role="status"
+        aria-live="polite"
+        className="sr-only"
+        data-testid="copy-feedback"
+      >
+        {copyFeedback
+          ? copyFeedback.error
+            ? `Unable to copy ${copyFeedback.label}`
+            : `${copyFeedback.label} copied to clipboard`
+          : ''}
+      </div>
+    </section>
+  );
+};
+
+export default HandshakeDiagram;

--- a/apps/reaver/data/handshakeCapture.json
+++ b/apps/reaver/data/handshakeCapture.json
@@ -1,0 +1,52 @@
+{
+  "id": "wps-four-way",
+  "title": "WPA2 4-Way Handshake",
+  "capture": {
+    "source": "lab-capture-01.cap",
+    "tool": "airmon-ng replay",
+    "notes": "Synthetic capture that mirrors a clean WPA2 four-way handshake for teaching purposes."
+  },
+  "timeUnit": "milliseconds",
+  "participants": [
+    { "id": "ap", "label": "Access Point", "accent": "#60a5fa" },
+    { "id": "client", "label": "Client Station", "accent": "#34d399" }
+  ],
+  "messages": [
+    {
+      "step": "M1",
+      "from": "ap",
+      "to": "client",
+      "summary": "ANonce + RSN parameters",
+      "description": "Authenticator sends its ANonce and RSN information elements to kick off the handshake.",
+      "relativeTime": 0,
+      "frame": 12
+    },
+    {
+      "step": "M2",
+      "from": "client",
+      "to": "ap",
+      "summary": "SNonce + MIC",
+      "description": "Supplicant replies with its SNonce and a MIC computed from the PTK seed values.",
+      "relativeTime": 0.512,
+      "frame": 13
+    },
+    {
+      "step": "M3",
+      "from": "ap",
+      "to": "client",
+      "summary": "Install PTK + GTK",
+      "description": "Authenticator installs the PTK, sends the GTK encrypted under it, and instructs installation.",
+      "relativeTime": 1.024,
+      "frame": 14
+    },
+    {
+      "step": "M4",
+      "from": "client",
+      "to": "ap",
+      "summary": "PTK install ack",
+      "description": "Supplicant confirms the PTK installation and completes the four-way handshake.",
+      "relativeTime": 1.488,
+      "frame": 15
+    }
+  ]
+}

--- a/apps/reaver/index.tsx
+++ b/apps/reaver/index.tsx
@@ -8,6 +8,7 @@ import RouterProfiles, {
 } from './components/RouterProfiles';
 import APList from './components/APList';
 import ProgressDonut from './components/ProgressDonut';
+import HandshakeDiagram from './components/HandshakeDiagram';
 
 const PlayIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 20 20" fill="currentColor" {...props}>
@@ -211,6 +212,11 @@ const ReaverPanel: React.FC = () => {
       <div className="mb-6">
         <h2 className="text-lg mb-2">Access Points</h2>
         <APList />
+      </div>
+
+      <div className="mb-6">
+        <h2 className="text-lg mb-2">Captured Handshake</h2>
+        <HandshakeDiagram />
       </div>
 
       <div className="mb-6">


### PR DESCRIPTION
## Summary
- build a WPA2 handshake sequence diagram component that renders sample capture data, offers copy buttons, and lightweight rendering helpers
- ship the capture JSON alongside the Reaver simulator and surface it inside the app UI
- add unit and visual coverage for the diagram data, including a snapshot of the rendered SVG

## Testing
- yarn lint *(fails: repo has existing jsx-a11y/no-top-level-window issues)*
- yarn test *(fails: existing suites like window.test.tsx, nmapNse.test.tsx, aboutAccessibility.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1e441f9083289d6f445bedb65a8f