### PR TITLE
[autopsy] add timeline type filters

### DIFF
--- a/__tests__/autopsy.test.tsx
+++ b/__tests__/autopsy.test.tsx
@@ -56,10 +56,10 @@ describe('Autopsy plugins and timeline', () => {
     });
     fireEvent.click(screen.getByText('Create Case'));
     await screen.findByText('Hash Analyzer');
-    const selects = screen.getAllByRole('combobox');
-    fireEvent.change(selects[0], { target: { value: 'hash' } });
+    const pluginSelect = await screen.findByLabelText('Select plugin');
+    fireEvent.change(pluginSelect, { target: { value: 'hash' } });
     await waitFor(() =>
-      expect((selects[0] as HTMLSelectElement).value).toBe('hash')
+      expect((pluginSelect as HTMLSelectElement).value).toBe('hash')
     );
   });
 
@@ -69,9 +69,9 @@ describe('Autopsy plugins and timeline', () => {
       target: { value: 'Demo' },
     });
     fireEvent.click(screen.getByText('Create Case'));
-    await screen.findByLabelText('Filter by type');
+    await screen.findByLabelText('Filter artifacts by type');
     expect(screen.getByText('resume.docx')).toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText('Filter by type'), {
+    fireEvent.change(screen.getByLabelText('Filter artifacts by type'), {
       target: { value: 'Log' },
     });
     expect(screen.queryByText('resume.docx')).toBeNull();

--- a/__tests__/autopsy.timeline.performance.test.ts
+++ b/__tests__/autopsy.timeline.performance.test.ts
@@ -1,0 +1,36 @@
+import { performance } from 'perf_hooks';
+import {
+  buildTimelineMetrics,
+  filterEventsByType,
+} from '../components/apps/autopsy/timelineUtils';
+
+describe('Autopsy timeline performance', () => {
+  const events = Array.from({ length: 20000 }, (_, index) => {
+    const typeIndex = index % 5;
+    return {
+      name: `event-${index}`,
+      timestamp: new Date(2023, 0, 1, 0, index % 1440, index % 60).toISOString(),
+      type: `type-${typeIndex}`,
+    };
+  });
+  const sorted = events
+    .slice()
+    .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+
+  it('filters events by type within 150ms', () => {
+    const start = performance.now();
+    const filtered = filterEventsByType(events, 'type-3');
+    const duration = performance.now() - start;
+    expect(filtered.length).toBeGreaterThan(0);
+    expect(duration).toBeLessThan(150);
+  });
+
+  it('builds zoom metrics within 150ms', () => {
+    const start = performance.now();
+    const metrics = buildTimelineMetrics(sorted);
+    const duration = performance.now() - start;
+    expect(metrics.times.length).toBe(sorted.length);
+    expect(metrics.rangeMinutes).toBeGreaterThan(0);
+    expect(duration).toBeLessThan(150);
+  });
+});

--- a/apps/autopsy/data/case.json
+++ b/apps/autopsy/data/case.json
@@ -3,27 +3,32 @@
     {
       "timestamp": "2023-08-01T10:00:00Z",
       "event": "resume.docx created on desktop",
-      "thumbnail": "/themes/Yaru/apps/gedit.png"
+      "thumbnail": "/themes/Yaru/apps/gedit.png",
+      "type": "Document"
     },
     {
       "timestamp": "2023-08-01T12:30:00Z",
       "event": "photo.jpg taken on phone",
-      "thumbnail": "/themes/Yaru/apps/autopsy.svg"
+      "thumbnail": "/themes/Yaru/apps/autopsy.svg",
+      "type": "Media"
     },
     {
       "timestamp": "2023-08-01T14:45:00Z",
       "event": "system.log updated",
-      "thumbnail": "/themes/Yaru/apps/autopsy.svg"
+      "thumbnail": "/themes/Yaru/apps/autopsy.svg",
+      "type": "Log"
     },
     {
       "timestamp": "2023-08-01T16:15:00Z",
       "event": "run.exe executed",
-      "thumbnail": "/themes/Yaru/apps/autopsy.svg"
+      "thumbnail": "/themes/Yaru/apps/autopsy.svg",
+      "type": "Executable"
     },
     {
       "timestamp": "2023-08-01T18:20:00Z",
       "event": "Registry key modified",
-      "thumbnail": "/themes/Yaru/apps/autopsy.svg"
+      "thumbnail": "/themes/Yaru/apps/autopsy.svg",
+      "type": "Registry"
     }
   ],
   "fileTree": {

--- a/components/apps/autopsy/timelineUtils.js
+++ b/components/apps/autopsy/timelineUtils.js
@@ -1,0 +1,50 @@
+export const filterEventsByType = (events = [], activeType = 'All') => {
+  if (activeType === 'All') {
+    return events;
+  }
+  return events.filter((event) => event?.type === activeType);
+};
+
+export const buildTimelineMetrics = (events = []) => {
+  const length = events.length;
+  if (!length) {
+    return {
+      min: 0,
+      max: 0,
+      rangeMinutes: 1,
+      times: new Float64Array(),
+    };
+  }
+  const times = new Float64Array(length);
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (let i = 0; i < length; i += 1) {
+    const ts = new Date(events[i].timestamp).getTime();
+    times[i] = ts;
+    if (ts < min) min = ts;
+    if (ts > max) max = ts;
+  }
+  if (!Number.isFinite(min)) {
+    min = 0;
+  }
+  if (!Number.isFinite(max)) {
+    max = min;
+  }
+  const spanMinutes = Math.max((max - min) / 60000, 1);
+  return {
+    min,
+    max,
+    rangeMinutes: spanMinutes,
+    times,
+  };
+};
+
+export const getTypeOptions = (events = []) => {
+  const types = new Set();
+  events.forEach((event) => {
+    if (event?.type) {
+      types.add(event.type);
+    }
+  });
+  return ['All', ...Array.from(types).sort()];
+};

--- a/components/apps/autopsy/timelineWorker.js
+++ b/components/apps/autopsy/timelineWorker.js
@@ -1,7 +1,22 @@
+import { buildTimelineMetrics } from './timelineUtils';
+
 self.onmessage = (e) => {
   const { events = [] } = e.data || {};
   const sorted = events.slice().sort(
     (a, b) => new Date(a.timestamp) - new Date(b.timestamp)
   );
-  self.postMessage(sorted);
+  const metrics = buildTimelineMetrics(sorted);
+  const { times, ...rest } = metrics;
+  const transferable = times.length ? [times.buffer] : [];
+  self.postMessage(
+    {
+      sorted,
+      metrics: {
+        ...rest,
+        length: times.length,
+        timesBuffer: times.buffer,
+      },
+    },
+    transferable
+  );
 };


### PR DESCRIPTION
## Summary
- add type metadata to the Autopsy demo case timeline and expose timeline helpers for filtering and metrics
- optimise the timeline worker/render path with typed arrays, a type selector, and accessibility tweaks to existing filters
- cover timeline filtering and zoom calculations with performance-focused Jest tests alongside updated artifact filter tests

## Testing
- yarn lint *(fails: pre-existing accessibility violations in unrelated apps)*
- yarn test --runTestsByPath __tests__/autopsy.test.tsx __tests__/autopsy.timeline.performance.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc1e48caa08328b22c0200660faef8