### PR TITLE
refactor: add schema-based settings store

### DIFF
--- a/__tests__/settingsStore.test.ts
+++ b/__tests__/settingsStore.test.ts
@@ -1,0 +1,123 @@
+import { get, set, del } from 'idb-keyval';
+
+import {
+  SETTINGS_KEY,
+  defaults,
+  importSettings,
+  loadSettings,
+  migrateRecord,
+  migrations,
+} from '../utils/settingsStore';
+
+describe('settingsStore schema migrations', () => {
+  beforeEach(async () => {
+    await del(SETTINGS_KEY).catch(() => undefined);
+    if (typeof window !== 'undefined') {
+      window.localStorage.clear();
+    }
+  });
+
+  afterEach(async () => {
+    await del(SETTINGS_KEY).catch(() => undefined);
+    if (typeof window !== 'undefined') {
+      window.localStorage.clear();
+    }
+  });
+
+  it('loads defaults when no settings are stored', async () => {
+    const settings = await loadSettings();
+    expect(settings).toEqual(defaults);
+  });
+
+  it('upgrades version 1 records to the latest schema', async () => {
+    await set(SETTINGS_KEY, {
+      version: 1,
+      data: {
+        accent: '#ffffff',
+        wallpaper: 'wall-5',
+        density: 'compact',
+        reducedMotion: true,
+        fontScale: 1.25,
+        highContrast: true,
+        largeHitAreas: true,
+        pongSpin: false,
+        allowNetwork: true,
+      },
+    });
+
+    const settings = await loadSettings();
+    expect(settings.haptics).toBe(true);
+    expect(settings.density).toBe('compact');
+
+    const stored = await get(SETTINGS_KEY);
+    expect(stored.version).toBeGreaterThanOrEqual(2);
+  });
+
+  it('downgrades settings when migrating to an older schema', () => {
+    const record = {
+      version: 2,
+      data: {
+        ...defaults,
+        haptics: false,
+      },
+    };
+
+    const { record: downgraded, migrated } = migrateRecord(record, 1);
+    expect(migrated).toBe(true);
+    expect(downgraded.version).toBe(1);
+    expect(downgraded.data.haptics).toBeUndefined();
+  });
+
+  it('rolls back changes when a migration throws', async () => {
+    const originalMigration = migrations.up.get(1);
+    migrations.up.set(1, () => {
+      throw new Error('boom');
+    });
+
+    try {
+      await set(SETTINGS_KEY, {
+        version: 1,
+        data: {
+          accent: '#123456',
+          wallpaper: 'wall-3',
+          density: 'regular',
+          reducedMotion: false,
+          fontScale: 1,
+          highContrast: false,
+          largeHitAreas: false,
+          pongSpin: true,
+          allowNetwork: false,
+        },
+      });
+
+      const settings = await loadSettings();
+      expect(settings.haptics).toBeUndefined();
+
+      const stored = await get(SETTINGS_KEY);
+      expect(stored.version).toBe(1);
+    } finally {
+      if (originalMigration) {
+        migrations.up.set(1, originalMigration);
+      } else {
+        migrations.up.delete(1);
+      }
+    }
+  });
+
+  it('imports settings and upgrades them when required', async () => {
+    await importSettings(
+      JSON.stringify({
+        version: 1,
+        data: {
+          accent: '#ff0000',
+          wallpaper: 'wall-4',
+          density: 'compact',
+        },
+      }),
+    );
+
+    const settings = await loadSettings();
+    expect(settings.accent).toBe('#ff0000');
+    expect(settings.haptics).toBe(true);
+  });
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -71,15 +71,22 @@ export default function Settings() {
     await importSettingsData(text);
     try {
       const parsed = JSON.parse(text);
-      if (parsed.accent !== undefined) setAccent(parsed.accent);
-      if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
-      if (parsed.density !== undefined) setDensity(parsed.density);
-      if (parsed.reducedMotion !== undefined)
-        setReducedMotion(parsed.reducedMotion);
-      if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
-      if (parsed.highContrast !== undefined)
-        setHighContrast(parsed.highContrast);
+      const data =
+        parsed && typeof parsed === "object"
+          ? typeof parsed.data === "object" && parsed.data !== null
+            ? parsed.data
+            : parsed
+          : {};
+      if (data.accent !== undefined) setAccent(data.accent);
+      if (data.wallpaper !== undefined) setWallpaper(data.wallpaper);
+      if (data.density !== undefined) setDensity(data.density);
+      if (data.reducedMotion !== undefined)
+        setReducedMotion(data.reducedMotion);
+      if (data.fontScale !== undefined) setFontScale(data.fontScale);
+      if (data.highContrast !== undefined)
+        setHighContrast(data.highContrast);
       if (parsed.theme !== undefined) setTheme(parsed.theme);
+      else if (data.theme !== undefined) setTheme(data.theme);
     } catch (err) {
       console.error("Invalid settings", err);
     }

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -269,13 +269,17 @@ export function Settings() {
                     await importSettingsData(text);
                     try {
                         const parsed = JSON.parse(text);
-                        if (parsed.accent !== undefined) setAccent(parsed.accent);
-                        if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
-                        if (parsed.density !== undefined) setDensity(parsed.density);
-                        if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
-                        if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
-                        if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
+                        const data = (parsed && typeof parsed === 'object')
+                            ? (parsed.data && typeof parsed.data === 'object' ? parsed.data : parsed)
+                            : {};
+                        if (data.accent !== undefined) setAccent(data.accent);
+                        if (data.wallpaper !== undefined) setWallpaper(data.wallpaper);
+                        if (data.density !== undefined) setDensity(data.density);
+                        if (data.reducedMotion !== undefined) setReducedMotion(data.reducedMotion);
+                        if (data.largeHitAreas !== undefined) setLargeHitAreas(data.largeHitAreas);
+                        if (data.highContrast !== undefined) setHighContrast(data.highContrast);
                         if (parsed.theme !== undefined) { setTheme(parsed.theme); }
+                        else if (data.theme !== undefined) { setTheme(data.theme); }
                     } catch (err) {
                         console.error('Invalid settings', err);
                     }

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -1,26 +1,8 @@
 import { createContext, useContext, useEffect, useState, ReactNode, useRef } from 'react';
 import {
-  getAccent as loadAccent,
-  setAccent as saveAccent,
-  getWallpaper as loadWallpaper,
-  setWallpaper as saveWallpaper,
-  getDensity as loadDensity,
-  setDensity as saveDensity,
-  getReducedMotion as loadReducedMotion,
-  setReducedMotion as saveReducedMotion,
-  getFontScale as loadFontScale,
-  setFontScale as saveFontScale,
-  getHighContrast as loadHighContrast,
-  setHighContrast as saveHighContrast,
-  getLargeHitAreas as loadLargeHitAreas,
-  setLargeHitAreas as saveLargeHitAreas,
-  getPongSpin as loadPongSpin,
-  setPongSpin as savePongSpin,
-  getAllowNetwork as loadAllowNetwork,
-  setAllowNetwork as saveAllowNetwork,
-  getHaptics as loadHaptics,
-  setHaptics as saveHaptics,
   defaults,
+  loadSettings,
+  setSetting,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
 type Density = 'regular' | 'compact';
@@ -117,16 +99,17 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     (async () => {
-      setAccent(await loadAccent());
-      setWallpaper(await loadWallpaper());
-      setDensity((await loadDensity()) as Density);
-      setReducedMotion(await loadReducedMotion());
-      setFontScale(await loadFontScale());
-      setHighContrast(await loadHighContrast());
-      setLargeHitAreas(await loadLargeHitAreas());
-      setPongSpin(await loadPongSpin());
-      setAllowNetwork(await loadAllowNetwork());
-      setHaptics(await loadHaptics());
+      const settings = await loadSettings();
+      setAccent(settings.accent);
+      setWallpaper(settings.wallpaper);
+      setDensity(settings.density as Density);
+      setReducedMotion(settings.reducedMotion);
+      setFontScale(settings.fontScale);
+      setHighContrast(settings.highContrast);
+      setLargeHitAreas(settings.largeHitAreas);
+      setPongSpin(settings.pongSpin);
+      setAllowNetwork(settings.allowNetwork);
+      setHaptics(settings.haptics);
       setTheme(loadTheme());
     })();
   }, []);
@@ -149,11 +132,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     Object.entries(vars).forEach(([key, value]) => {
       document.documentElement.style.setProperty(key, value);
     });
-    saveAccent(accent);
+    void setSetting('accent', accent);
   }, [accent]);
 
   useEffect(() => {
-    saveWallpaper(wallpaper);
+    void setSetting('wallpaper', wallpaper);
   }, [wallpaper]);
 
   useEffect(() => {
@@ -179,35 +162,35 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     Object.entries(vars).forEach(([key, value]) => {
       document.documentElement.style.setProperty(key, value);
     });
-    saveDensity(density);
+    void setSetting('density', density);
   }, [density]);
 
   useEffect(() => {
     document.documentElement.classList.toggle('reduced-motion', reducedMotion);
-    saveReducedMotion(reducedMotion);
+    void setSetting('reducedMotion', reducedMotion);
   }, [reducedMotion]);
 
   useEffect(() => {
     document.documentElement.style.setProperty('--font-multiplier', fontScale.toString());
-    saveFontScale(fontScale);
+    void setSetting('fontScale', fontScale);
   }, [fontScale]);
 
   useEffect(() => {
     document.documentElement.classList.toggle('high-contrast', highContrast);
-    saveHighContrast(highContrast);
+    void setSetting('highContrast', highContrast);
   }, [highContrast]);
 
   useEffect(() => {
     document.documentElement.classList.toggle('large-hit-area', largeHitAreas);
-    saveLargeHitAreas(largeHitAreas);
+    void setSetting('largeHitAreas', largeHitAreas);
   }, [largeHitAreas]);
 
   useEffect(() => {
-    savePongSpin(pongSpin);
+    void setSetting('pongSpin', pongSpin);
   }, [pongSpin]);
 
   useEffect(() => {
-    saveAllowNetwork(allowNetwork);
+    void setSetting('allowNetwork', allowNetwork);
     if (typeof window === 'undefined') return;
     if (!fetchRef.current) fetchRef.current = window.fetch.bind(window);
     if (!allowNetwork) {
@@ -233,7 +216,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [allowNetwork]);
 
   useEffect(() => {
-    saveHaptics(haptics);
+    void setSetting('haptics', haptics);
   }, [haptics]);
 
   return (

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -3,215 +3,408 @@
 import { get, set, del } from 'idb-keyval';
 import { getTheme, setTheme } from './theme';
 
-const DEFAULT_SETTINGS = {
-  accent: '#1793d1',
-  wallpaper: 'wall-2',
-  density: 'regular',
-  reducedMotion: false,
-  fontScale: 1,
-  highContrast: false,
-  largeHitAreas: false,
-  pongSpin: true,
-  allowNetwork: false,
-  haptics: true,
+const SETTINGS_STORE_KEY = 'settings-store';
+const LEGACY_IDB_KEYS = ['accent', 'bg-image'];
+
+const clone = (value) =>
+  typeof structuredClone === 'function'
+    ? structuredClone(value)
+    : value === undefined
+      ? value
+      : JSON.parse(JSON.stringify(value));
+
+const SCHEMAS = new Map([
+  [
+    1,
+    {
+      version: 1,
+      defaults: {
+        accent: '#1793d1',
+        wallpaper: 'wall-2',
+        density: 'regular',
+        reducedMotion: false,
+        fontScale: 1,
+        highContrast: false,
+        largeHitAreas: false,
+        pongSpin: true,
+        allowNetwork: false,
+      },
+    },
+  ],
+  [
+    2,
+    {
+      version: 2,
+      defaults: {
+        accent: '#1793d1',
+        wallpaper: 'wall-2',
+        density: 'regular',
+        reducedMotion: false,
+        fontScale: 1,
+        highContrast: false,
+        largeHitAreas: false,
+        pongSpin: true,
+        allowNetwork: false,
+        haptics: true,
+      },
+    },
+  ],
+]);
+
+const LATEST_VERSION = Math.max(...SCHEMAS.keys());
+
+const MIGRATIONS = {
+  up: new Map([
+    [
+      1,
+      (data) => ({
+        ...data,
+        haptics: data.haptics ?? true,
+      }),
+    ],
+  ]),
+  down: new Map([
+    [
+      2,
+      (data) => {
+        const { haptics, ...rest } = data;
+        return rest;
+      },
+    ],
+  ]),
 };
 
-export async function getAccent() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
-  return (await get('accent')) || DEFAULT_SETTINGS.accent;
-}
+const DEFAULTS = Object.freeze({ ...SCHEMAS.get(LATEST_VERSION).defaults });
 
-export async function setAccent(accent) {
-  if (typeof window === 'undefined') return;
-  await set('accent', accent);
-}
+const isBrowser = () => typeof window !== 'undefined';
 
-export async function getWallpaper() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.wallpaper;
-  return (await get('bg-image')) || DEFAULT_SETTINGS.wallpaper;
-}
-
-export async function setWallpaper(wallpaper) {
-  if (typeof window === 'undefined') return;
-  await set('bg-image', wallpaper);
-}
-
-export async function getDensity() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
-  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
-}
-
-export async function setDensity(density) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('density', density);
-}
-
-export async function getReducedMotion() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
-  const stored = window.localStorage.getItem('reduced-motion');
-  if (stored !== null) {
-    return stored === 'true';
+const getSafeLocalStorage = () => {
+  if (!isBrowser()) return undefined;
+  try {
+    return window.localStorage;
+  } catch {
+    return undefined;
   }
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+};
+
+const getSchema = (version) => {
+  const schema = SCHEMAS.get(version);
+  if (!schema) {
+    throw new Error(`Unknown settings schema version: ${version}`);
+  }
+  return schema;
+};
+
+const normalizeForVersion = (data, version) => {
+  const schema = getSchema(version);
+  const normalized = {};
+  for (const [key, value] of Object.entries(schema.defaults)) {
+    normalized[key] = data && data[key] !== undefined ? data[key] : value;
+  }
+  return normalized;
+};
+
+const createRecord = (data, version, previousVersion = null, meta = {}) => ({
+  version,
+  data: normalizeForVersion(data, version),
+  meta: {
+    version,
+    previousVersion,
+    ...meta,
+  },
+});
+
+const isRecord = (value) =>
+  value &&
+  typeof value === 'object' &&
+  (typeof value.version === 'number' ||
+    (value.meta && typeof value.meta.version === 'number')) &&
+  value.data &&
+  typeof value.data === 'object';
+
+const migrateRecord = (record, targetVersion) => {
+  const sourceVersion = record.version ?? record.meta?.version ?? targetVersion;
+  const initialRecord = createRecord(record.data ?? {}, sourceVersion, null, record.meta);
+  if (sourceVersion === targetVersion) {
+    return { record: initialRecord, migrated: false };
+  }
+
+  const direction = targetVersion > sourceVersion ? 1 : -1;
+  let currentVersion = sourceVersion;
+  let currentData = clone(initialRecord.data);
+
+  try {
+    while (currentVersion !== targetVersion) {
+      if (direction > 0) {
+        const migrateUp = MIGRATIONS.up.get(currentVersion);
+        if (!migrateUp) {
+          throw new Error(`Missing upgrade path from v${currentVersion} to v${currentVersion + 1}`);
+        }
+        currentData = normalizeForVersion(migrateUp(clone(currentData)), currentVersion + 1);
+        currentVersion += 1;
+      } else {
+        const migrateDown = MIGRATIONS.down.get(currentVersion);
+        if (!migrateDown) {
+          throw new Error(`Missing downgrade path from v${currentVersion} to v${currentVersion - 1}`);
+        }
+        currentData = normalizeForVersion(migrateDown(clone(currentData)), currentVersion - 1);
+        currentVersion -= 1;
+      }
+    }
+    return {
+      record: createRecord(currentData, targetVersion, sourceVersion),
+      migrated: true,
+    };
+  } catch (error) {
+    return {
+      record: initialRecord,
+      migrated: false,
+      error,
+    };
+  }
+};
+
+const syncLegacySideEffects = (partial) => {
+  if (!isBrowser()) return;
+  const storage = getSafeLocalStorage();
+  if (!storage) return;
+
+  if (partial.wallpaper !== undefined) {
+    storage.setItem('bg-image', String(partial.wallpaper));
+  }
+  if (partial.density !== undefined) {
+    storage.setItem('density', String(partial.density));
+  }
+  if (partial.reducedMotion !== undefined) {
+    storage.setItem('reduced-motion', partial.reducedMotion ? 'true' : 'false');
+  }
+  if (partial.fontScale !== undefined) {
+    storage.setItem('font-scale', String(partial.fontScale));
+  }
+  if (partial.highContrast !== undefined) {
+    storage.setItem('high-contrast', partial.highContrast ? 'true' : 'false');
+  }
+  if (partial.largeHitAreas !== undefined) {
+    storage.setItem('large-hit-areas', partial.largeHitAreas ? 'true' : 'false');
+  }
+  if (partial.pongSpin !== undefined) {
+    storage.setItem('pong-spin', partial.pongSpin ? 'true' : 'false');
+  }
+  if (partial.allowNetwork !== undefined) {
+    storage.setItem('allow-network', partial.allowNetwork ? 'true' : 'false');
+  }
+  if (partial.haptics !== undefined) {
+    storage.setItem('haptics', partial.haptics ? 'true' : 'false');
+  }
+};
+
+const cleanupLegacyStorage = async () => {
+  await Promise.all(LEGACY_IDB_KEYS.map((key) => del(key).catch(() => undefined)));
+};
+
+const loadLegacyRecord = async () => {
+  if (!isBrowser()) return null;
+  const storage = getSafeLocalStorage();
+  const defaults = clone(DEFAULTS);
+  const [accent, idbWallpaper] = await Promise.all([
+    get('accent').catch(() => undefined),
+    get('bg-image').catch(() => undefined),
+  ]);
+
+  const data = { ...defaults };
+  if (typeof accent === 'string') {
+    data.accent = accent;
+  }
+
+  const wallpaper =
+    (typeof idbWallpaper === 'string' && idbWallpaper) || storage?.getItem('bg-image');
+  if (wallpaper) {
+    data.wallpaper = wallpaper;
+  }
+
+  if (storage) {
+    const density = storage.getItem('density');
+    if (density) data.density = density;
+    const reducedMotion = storage.getItem('reduced-motion');
+    if (reducedMotion !== null) data.reducedMotion = reducedMotion === 'true';
+    const fontScale = storage.getItem('font-scale');
+    if (fontScale) {
+      const parsed = parseFloat(fontScale);
+      if (!Number.isNaN(parsed)) data.fontScale = parsed;
+    }
+    const highContrast = storage.getItem('high-contrast');
+    if (highContrast !== null) data.highContrast = highContrast === 'true';
+    const largeHitAreas = storage.getItem('large-hit-areas');
+    if (largeHitAreas !== null) data.largeHitAreas = largeHitAreas === 'true';
+    const pongSpin = storage.getItem('pong-spin');
+    if (pongSpin !== null) data.pongSpin = pongSpin === 'true';
+    const allowNetwork = storage.getItem('allow-network');
+    if (allowNetwork !== null) data.allowNetwork = allowNetwork === 'true';
+    const haptics = storage.getItem('haptics');
+    if (haptics !== null) data.haptics = haptics === 'true';
+  }
+
+  return createRecord(data, LATEST_VERSION);
+};
+
+const readStoredRecord = async () => {
+  if (!isBrowser()) {
+    return { record: createRecord({}, LATEST_VERSION), fromLegacy: false };
+  }
+
+  const stored = await get(SETTINGS_STORE_KEY).catch(() => undefined);
+  if (isRecord(stored)) {
+    const version =
+      typeof stored.version === 'number'
+        ? stored.version
+        : typeof stored.meta?.version === 'number'
+          ? stored.meta.version
+          : LATEST_VERSION;
+    const meta = stored.meta ? { ...stored.meta, version } : { version };
+    return {
+      record: createRecord(stored.data ?? {}, version, meta.previousVersion ?? null, meta),
+      fromLegacy: false,
+    };
+  }
+
+  const legacy = await loadLegacyRecord();
+  if (legacy) {
+    return { record: legacy, fromLegacy: true };
+  }
+
+  return { record: createRecord({}, LATEST_VERSION), fromLegacy: false };
+};
+
+const writeRecord = async (record) => {
+  if (!isBrowser()) return;
+  await set(SETTINGS_STORE_KEY, record);
+};
+
+const ensureLatestRecord = async () => {
+  const { record, fromLegacy } = await readStoredRecord();
+  const { record: migrated, migrated: didMigrate, error } = migrateRecord(record, LATEST_VERSION);
+
+  if (error) {
+    console.error('Failed to migrate settings store', error);
+    return record;
+  }
+
+  if (fromLegacy || didMigrate) {
+    await writeRecord(migrated);
+    syncLegacySideEffects(migrated.data);
+    await cleanupLegacyStorage();
+    return migrated;
+  }
+
+  return migrated;
+};
+
+export const defaults = DEFAULTS;
+
+export const schemas = SCHEMAS;
+export const migrations = MIGRATIONS;
+export const SETTINGS_KEY = SETTINGS_STORE_KEY;
+
+export async function loadSettings() {
+  if (!isBrowser()) {
+    return clone(DEFAULTS);
+  }
+  const record = await ensureLatestRecord();
+  return clone(record.data);
 }
 
-export async function setReducedMotion(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
+export async function setSetting(key, value) {
+  if (!isBrowser()) return value;
+  const record = await ensureLatestRecord();
+  const nextData = { ...record.data, [key]: value };
+  const nextRecord = createRecord(nextData, LATEST_VERSION, record.version);
+  await writeRecord(nextRecord);
+  syncLegacySideEffects({ [key]: nextRecord.data[key] });
+  return nextRecord.data[key];
 }
 
-export async function getFontScale() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
-  const stored = window.localStorage.getItem('font-scale');
-  return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
-}
-
-export async function setFontScale(scale) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('font-scale', String(scale));
-}
-
-export async function getHighContrast() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
-  return window.localStorage.getItem('high-contrast') === 'true';
-}
-
-export async function setHighContrast(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
-}
-
-export async function getLargeHitAreas() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
-  return window.localStorage.getItem('large-hit-areas') === 'true';
-}
-
-export async function setLargeHitAreas(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
-}
-
-export async function getHaptics() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
-  const val = window.localStorage.getItem('haptics');
-  return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
-}
-
-export async function setHaptics(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('haptics', value ? 'true' : 'false');
-}
-
-export async function getPongSpin() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
-  const val = window.localStorage.getItem('pong-spin');
-  return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
-}
-
-export async function setPongSpin(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
-}
-
-export async function getAllowNetwork() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
-  return window.localStorage.getItem('allow-network') === 'true';
-}
-
-export async function setAllowNetwork(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('allow-network', value ? 'true' : 'false');
+export async function setSettings(partial) {
+  if (!isBrowser()) return clone(DEFAULTS);
+  const record = await ensureLatestRecord();
+  const nextData = { ...record.data, ...partial };
+  const nextRecord = createRecord(nextData, LATEST_VERSION, record.version);
+  await writeRecord(nextRecord);
+  syncLegacySideEffects(partial);
+  return clone(nextRecord.data);
 }
 
 export async function resetSettings() {
-  if (typeof window === 'undefined') return;
-  await Promise.all([
-    del('accent'),
-    del('bg-image'),
-  ]);
-  window.localStorage.removeItem('density');
-  window.localStorage.removeItem('reduced-motion');
-  window.localStorage.removeItem('font-scale');
-  window.localStorage.removeItem('high-contrast');
-  window.localStorage.removeItem('large-hit-areas');
-  window.localStorage.removeItem('pong-spin');
-  window.localStorage.removeItem('allow-network');
-  window.localStorage.removeItem('haptics');
+  if (!isBrowser()) return;
+  const record = createRecord({}, LATEST_VERSION);
+  await writeRecord(record);
+  syncLegacySideEffects(record.data);
+  await cleanupLegacyStorage();
 }
 
 export async function exportSettings() {
-  const [
-    accent,
-    wallpaper,
-    density,
-    reducedMotion,
-    fontScale,
-    highContrast,
-    largeHitAreas,
-    pongSpin,
-    allowNetwork,
-    haptics,
-  ] = await Promise.all([
-    getAccent(),
-    getWallpaper(),
-    getDensity(),
-    getReducedMotion(),
-    getFontScale(),
-    getHighContrast(),
-    getLargeHitAreas(),
-    getPongSpin(),
-    getAllowNetwork(),
-    getHaptics(),
-  ]);
+  const data = await loadSettings();
   const theme = getTheme();
+  const meta = {
+    version: LATEST_VERSION,
+  };
   return JSON.stringify({
-    accent,
-    wallpaper,
-    density,
-    reducedMotion,
-    fontScale,
-    highContrast,
-    largeHitAreas,
-    pongSpin,
-    allowNetwork,
-    haptics,
+    version: LATEST_VERSION,
+    meta,
+    data,
     theme,
+    ...data,
   });
 }
 
 export async function importSettings(json) {
-  if (typeof window === 'undefined') return;
-  let settings;
-  try {
-    settings = typeof json === 'string' ? JSON.parse(json) : json;
-  } catch (e) {
-    console.error('Invalid settings', e);
+  if (!isBrowser()) return;
+  let payload = json;
+  if (typeof payload === 'string') {
+    try {
+      payload = JSON.parse(payload);
+    } catch (error) {
+      console.error('Invalid settings', error);
+      return;
+    }
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    console.error('Invalid settings payload', payload);
     return;
   }
-  const {
-    accent,
-    wallpaper,
-    density,
-    reducedMotion,
-    fontScale,
-    highContrast,
-    largeHitAreas,
-    pongSpin,
-    allowNetwork,
-    haptics,
-    theme,
-  } = settings;
-  if (accent !== undefined) await setAccent(accent);
-  if (wallpaper !== undefined) await setWallpaper(wallpaper);
-  if (density !== undefined) await setDensity(density);
-  if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
-  if (fontScale !== undefined) await setFontScale(fontScale);
-  if (highContrast !== undefined) await setHighContrast(highContrast);
-  if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);
-  if (pongSpin !== undefined) await setPongSpin(pongSpin);
-  if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
-  if (haptics !== undefined) await setHaptics(haptics);
-  if (theme !== undefined) setTheme(theme);
+
+  const incomingVersion =
+    typeof payload.version === 'number'
+      ? payload.version
+      : typeof payload.meta?.version === 'number'
+        ? payload.meta.version
+        : LATEST_VERSION;
+  const incomingData =
+    payload.data && typeof payload.data === 'object'
+      ? payload.data
+      : payload;
+
+  const { record: migrated, error } = migrateRecord(
+    createRecord(incomingData, incomingVersion),
+    LATEST_VERSION,
+  );
+
+  if (error) {
+    console.error('Failed to migrate imported settings', error);
+    return;
+  }
+
+  const merged = await setSettings(migrated.data);
+  if (payload.theme !== undefined) {
+    setTheme(payload.theme);
+  } else if (payload.data && payload.data.theme !== undefined) {
+    setTheme(payload.data.theme);
+  }
+  return merged;
 }
 
-export const defaults = DEFAULT_SETTINGS;
+export async function getSettingsRecord() {
+  return ensureLatestRecord();
+}
+
+export { migrateRecord };


### PR DESCRIPTION
## Summary
- replace ad-hoc settings persistence with a schema-based store that tracks versions and migrations
- update the settings hook and UI importers to read/write through the new store
- add Jest coverage for settings upgrades, downgrades, and failed migrations

## Testing
- yarn lint
- yarn test settingsStore
- yarn test ReconNG

------
https://chatgpt.com/codex/tasks/task_e_68cc065d8c8c8328860a2e7f242c2089