### PR TITLE
[theme] add system and high contrast variants

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -1,36 +1,205 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { SettingsProvider, useSettings } from '../hooks/useSettings';
-import { getTheme, getUnlockedThemes, setTheme } from '../utils/theme';
+import { getTheme, getUnlockedThemes, setTheme, THEME_KEY } from '../utils/theme';
+import * as settingsStore from '../utils/settingsStore';
 
+jest.mock('../utils/settingsStore', () => {
+  const actual = jest.requireActual('../utils/settingsStore');
+  return {
+    ...actual,
+    getAccent: jest.fn().mockResolvedValue(actual.defaults.accent),
+    setAccent: jest.fn().mockResolvedValue(undefined),
+    getWallpaper: jest.fn().mockResolvedValue(actual.defaults.wallpaper),
+    setWallpaper: jest.fn().mockResolvedValue(undefined),
+    getDensity: jest.fn().mockResolvedValue(actual.defaults.density),
+    setDensity: jest.fn().mockResolvedValue(undefined),
+    getReducedMotion: jest.fn().mockResolvedValue(actual.defaults.reducedMotion),
+    setReducedMotion: jest.fn().mockResolvedValue(undefined),
+    getFontScale: jest.fn().mockResolvedValue(actual.defaults.fontScale),
+    setFontScale: jest.fn().mockResolvedValue(undefined),
+    getHighContrast: jest.fn().mockResolvedValue(actual.defaults.highContrast),
+    setHighContrast: jest.fn().mockResolvedValue(undefined),
+    getLargeHitAreas: jest.fn().mockResolvedValue(actual.defaults.largeHitAreas),
+    setLargeHitAreas: jest.fn().mockResolvedValue(undefined),
+    getPongSpin: jest.fn().mockResolvedValue(actual.defaults.pongSpin),
+    setPongSpin: jest.fn().mockResolvedValue(undefined),
+    getAllowNetwork: jest.fn().mockResolvedValue(actual.defaults.allowNetwork),
+    setAllowNetwork: jest.fn().mockResolvedValue(undefined),
+    getHaptics: jest.fn().mockResolvedValue(actual.defaults.haptics),
+    setHaptics: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+const originalMatchMedia = window.matchMedia;
+
+const setupBroadcastChannelMock = () => {
+  type BroadcastPayload = { type?: string; theme?: string; source?: string };
+  type Listener = (event: MessageEvent<BroadcastPayload>) => void;
+
+  const channels = new Map<string, Set<MockBroadcastChannel>>();
+
+  class MockBroadcastChannel {
+    public name: string;
+    private listeners: Set<Listener> = new Set();
+
+    constructor(name: string) {
+      this.name = name;
+      if (!channels.has(name)) {
+        channels.set(name, new Set());
+      }
+      channels.get(name)!.add(this);
+    }
+
+    postMessage(message: BroadcastPayload) {
+      const targets = channels.get(this.name);
+      if (!targets) return;
+      targets.forEach((channel) => {
+        channel.listeners.forEach((listener) => {
+          listener({ data: message } as MessageEvent<BroadcastPayload>);
+        });
+      });
+    }
+
+    addEventListener(type: string, listener: Listener) {
+      if (type !== 'message') return;
+      this.listeners.add(listener);
+    }
+
+    removeEventListener(type: string, listener: Listener) {
+      if (type !== 'message') return;
+      this.listeners.delete(listener);
+    }
+
+    close() {
+      const targets = channels.get(this.name);
+      if (!targets) return;
+      targets.delete(this);
+      this.listeners.clear();
+    }
+  }
+
+  const previous = (window as any).BroadcastChannel;
+  (window as any).BroadcastChannel = MockBroadcastChannel;
+
+  return () => {
+    if (previous) {
+      (window as any).BroadcastChannel = previous;
+    } else {
+      delete (window as any).BroadcastChannel;
+    }
+    channels.clear();
+  };
+};
+
+const asMock = <T extends (...args: any[]) => any>(fn: T) =>
+  fn as unknown as jest.MockedFunction<T>;
+
+const setupMatchMediaMock = (initial = false) => {
+  let matches = initial;
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  const mock = jest.fn().mockImplementation(() => ({
+    media: '(prefers-color-scheme: dark)',
+    get matches() {
+      return matches;
+    },
+    addEventListener: (event: string, callback: (event: MediaQueryListEvent) => void) => {
+      if (event === 'change') listeners.add(callback);
+    },
+    removeEventListener: (event: string, callback: (event: MediaQueryListEvent) => void) => {
+      if (event === 'change') listeners.delete(callback);
+    },
+    addListener: (callback: (event: MediaQueryListEvent) => void) => {
+      listeners.add(callback);
+    },
+    removeListener: (callback: (event: MediaQueryListEvent) => void) => {
+      listeners.delete(callback);
+    },
+    dispatchEvent: () => true,
+  }));
+
+  // @ts-ignore
+  window.matchMedia = mock;
+
+  return {
+    setMatches(value: boolean) {
+      matches = value;
+      listeners.forEach((listener) =>
+        listener({
+          matches: value,
+          media: '(prefers-color-scheme: dark)',
+        } as MediaQueryListEvent),
+      );
+    },
+  };
+};
+
+const renderSettingsHook = async () => {
+  const hook = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return hook;
+};
 
 describe('theme persistence and unlocking', () => {
   beforeEach(() => {
     window.localStorage.clear();
     document.documentElement.dataset.theme = '';
+    delete document.documentElement.dataset.themePreference;
     document.documentElement.className = '';
+    jest.clearAllMocks();
+    const defaults = settingsStore.defaults;
+    asMock(settingsStore.getAccent).mockResolvedValue(defaults.accent);
+    asMock(settingsStore.getWallpaper).mockResolvedValue(defaults.wallpaper);
+    asMock(settingsStore.getDensity).mockResolvedValue(defaults.density);
+    asMock(settingsStore.getReducedMotion).mockResolvedValue(defaults.reducedMotion);
+    asMock(settingsStore.getFontScale).mockResolvedValue(defaults.fontScale);
+    asMock(settingsStore.getHighContrast).mockResolvedValue(defaults.highContrast);
+    asMock(settingsStore.getLargeHitAreas).mockResolvedValue(defaults.largeHitAreas);
+    asMock(settingsStore.getPongSpin).mockResolvedValue(defaults.pongSpin);
+    asMock(settingsStore.getAllowNetwork).mockResolvedValue(defaults.allowNetwork);
+    asMock(settingsStore.getHaptics).mockResolvedValue(defaults.haptics);
+    asMock(settingsStore.setAccent).mockResolvedValue(undefined);
+    asMock(settingsStore.setWallpaper).mockResolvedValue(undefined);
+    asMock(settingsStore.setDensity).mockResolvedValue(undefined);
+    asMock(settingsStore.setReducedMotion).mockResolvedValue(undefined);
+    asMock(settingsStore.setFontScale).mockResolvedValue(undefined);
+    asMock(settingsStore.setHighContrast).mockResolvedValue(undefined);
+    asMock(settingsStore.setLargeHitAreas).mockResolvedValue(undefined);
+    asMock(settingsStore.setPongSpin).mockResolvedValue(undefined);
+    asMock(settingsStore.setAllowNetwork).mockResolvedValue(undefined);
+    asMock(settingsStore.setHaptics).mockResolvedValue(undefined);
   });
 
-  test('theme persists across sessions', () => {
-    const { result } = renderHook(() => useSettings(), {
-      wrapper: SettingsProvider,
-    });
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    jest.clearAllMocks();
+  });
+
+  test('theme persists across sessions', async () => {
+    const { result } = await renderSettingsHook();
     act(() => result.current.setTheme('dark'));
     expect(result.current.theme).toBe('dark');
     expect(getTheme()).toBe('dark');
     expect(window.localStorage.getItem('app:theme')).toBe('dark');
+    expect(document.documentElement.dataset.themePreference).toBe('dark');
 
   });
 
   test('themes unlock at score milestones', () => {
     const unlocked = getUnlockedThemes(600);
-    expect(unlocked).toEqual(expect.arrayContaining(['default', 'neon', 'dark']));
+    expect(unlocked).toEqual(
+      expect.arrayContaining(['default', 'high-contrast', 'system', 'neon', 'dark']),
+    );
     expect(unlocked).not.toContain('matrix');
   });
 
-  test('dark class applied for neon and matrix themes', () => {
+  test('dark class applied for neon, matrix, and high contrast themes', () => {
     setTheme('neon');
     expect(document.documentElement.classList.contains('dark')).toBe(true);
     setTheme('matrix');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    setTheme('high-contrast');
     expect(document.documentElement.classList.contains('dark')).toBe(true);
   });
 
@@ -40,6 +209,7 @@ describe('theme persistence and unlocking', () => {
       :root { --color-bg: white; }
       html[data-theme='dark'] { --color-bg: black; }
       html[data-theme='neon'] { --color-bg: red; }
+      html[data-theme='high-contrast'] { --color-bg: rgb(255, 255, 0); }
     `;
     document.head.appendChild(style);
 
@@ -57,16 +227,85 @@ describe('theme persistence and unlocking', () => {
     expect(
       getComputedStyle(document.documentElement).getPropertyValue('--color-bg')
     ).toBe('red');
+
+    setTheme('high-contrast');
+    expect(
+      getComputedStyle(document.documentElement).getPropertyValue('--color-bg').trim(),
+    ).toBe('rgb(255, 255, 0)');
   });
 
   test('defaults to system preference when no stored theme', () => {
-    // simulate dark mode preference
-    // @ts-ignore
-    window.matchMedia = jest.fn().mockReturnValue({ matches: true });
+    setupMatchMediaMock(true);
     expect(getTheme()).toBe('dark');
-    // simulate light mode preference
-    // @ts-ignore
-    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+    setupMatchMediaMock(false);
     expect(getTheme()).toBe('default');
+  });
+
+  test('system theme follows OS preference changes', async () => {
+    const controller = setupMatchMediaMock(false);
+    const { result } = await renderSettingsHook();
+
+    act(() => result.current.setTheme('system'));
+    expect(result.current.theme).toBe('system');
+    expect(window.localStorage.getItem('app:theme')).toBe('system');
+    expect(document.documentElement.dataset.theme).toBe('default');
+    expect(document.documentElement.dataset.themePreference).toBe('system');
+
+    act(() => {
+      controller.setMatches(true);
+    });
+    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(window.localStorage.getItem('app:theme')).toBe('system');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.dataset.themePreference).toBe('system');
+
+    act(() => {
+      controller.setMatches(false);
+    });
+    expect(document.documentElement.dataset.theme).toBe('default');
+    expect(window.localStorage.getItem('app:theme')).toBe('system');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(document.documentElement.dataset.themePreference).toBe('system');
+  });
+
+  test('responds to storage theme changes from other contexts', async () => {
+    const { result, unmount } = await renderSettingsHook();
+
+    await act(async () => {
+      window.localStorage.setItem(THEME_KEY, 'dark');
+      const event = new StorageEvent('storage', {
+        key: THEME_KEY,
+        newValue: 'dark',
+      });
+      window.dispatchEvent(event);
+    });
+
+    await waitFor(() => {
+      expect(result.current.theme).toBe('dark');
+    });
+
+    unmount();
+  });
+
+  test('broadcast channel syncs theme updates across instances', async () => {
+    const restoreBroadcast = setupBroadcastChannelMock();
+
+    try {
+      const first = await renderSettingsHook();
+      const second = await renderSettingsHook();
+
+      act(() => {
+        first.result.current.setTheme('dark');
+      });
+
+      await waitFor(() => {
+        expect(second.result.current.theme).toBe('dark');
+      });
+
+      first.unmount();
+      second.unmount();
+    } finally {
+      restoreBroadcast();
+    }
   });
 });

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -6,6 +6,15 @@ interface Props {
   highScore?: number;
 }
 
+const THEME_LABELS: Record<string, string> = {
+  default: 'Light',
+  dark: 'Dark',
+  'high-contrast': 'High Contrast',
+  system: 'System',
+  neon: 'Neon',
+  matrix: 'Matrix',
+};
+
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const unlocked = getUnlockedThemes(highScore);
@@ -27,7 +36,7 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
             >
               {unlocked.map((t) => (
                 <option key={t} value={t}>
-                  {t}
+                  {THEME_LABELS[t] ?? t}
                 </option>
               ))}
             </select>

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -66,8 +66,10 @@ export function Settings() {
                     onChange={(e) => setTheme(e.target.value)}
                     className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
                 >
-                    <option value="default">Default</option>
+                    <option value="default">Light</option>
                     <option value="dark">Dark</option>
+                    <option value="high-contrast">High Contrast</option>
+                    <option value="system">System</option>
                     <option value="neon">Neon</option>
                     <option value="matrix">Matrix</option>
                 </select>

--- a/public/theme.js
+++ b/public/theme.js
@@ -12,9 +12,11 @@
     }
 
     var theme = stored || (prefersDark ? 'dark' : 'default');
-    document.documentElement.dataset.theme = theme;
-    var darkThemes = ['dark', 'neon', 'matrix'];
-    document.documentElement.classList.toggle('dark', darkThemes.includes(theme));
+    var resolved = theme === 'system' ? (prefersDark ? 'dark' : 'default') : theme;
+    document.documentElement.dataset.theme = resolved;
+    document.documentElement.dataset.themePreference = theme;
+    var darkThemes = ['dark', 'neon', 'matrix', 'high-contrast'];
+    document.documentElement.classList.toggle('dark', darkThemes.includes(resolved));
   } catch (e) {
     console.error('Failed to apply theme', e);
     document.documentElement.dataset.theme = 'default';

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -68,6 +68,24 @@ html[data-theme='matrix'] {
 
 }
 
+/* High contrast theme */
+html[data-theme='high-contrast'] {
+  --color-bg: #000000;
+  --color-text: #ffffff;
+  --color-primary: #ffd400;
+  --color-secondary: #000000;
+  --color-accent: #ffd400;
+  --color-muted: #111111;
+  --color-surface: #000000;
+  --color-inverse: #000000;
+  --color-border: #ffffff;
+  --color-terminal: #00ff00;
+  --color-dark: #000000;
+  --color-focus-ring: #ffffff;
+  --color-selection: #ffffff;
+  --color-control-accent: #ffd400;
+}
+
 ::selection {
   background: var(--color-selection);
   color: var(--color-inverse);

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -3,15 +3,36 @@ export const THEME_KEY = 'app:theme';
 // Score required to unlock each theme
 export const THEME_UNLOCKS: Record<string, number> = {
   default: 0,
-  neon: 100,
+  'high-contrast': 0,
   dark: 500,
+  neon: 100,
   matrix: 1000,
 };
 
-const DARK_THEMES = ['dark', 'neon', 'matrix'] as const;
+const DARK_THEMES = ['dark', 'neon', 'matrix', 'high-contrast'] as const;
+const ALWAYS_AVAILABLE_THEMES = ['default', 'high-contrast', 'system'] as const;
 
-export const isDarkTheme = (theme: string): boolean =>
-  DARK_THEMES.includes(theme as (typeof DARK_THEMES)[number]);
+const resolveThemePreference = (theme: string): string => {
+  if (theme === 'system') {
+    if (
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia
+    ) {
+      const prefersDark = window.matchMedia(
+        '(prefers-color-scheme: dark)'
+      ).matches;
+      return prefersDark ? 'dark' : 'default';
+    }
+    return 'default';
+  }
+  return theme;
+};
+
+export const isDarkTheme = (theme: string): boolean => {
+  const resolved = resolveThemePreference(theme);
+  return DARK_THEMES.includes(resolved as (typeof DARK_THEMES)[number]);
+};
 
 export const getTheme = (): string => {
   if (typeof window === 'undefined') return 'default';
@@ -30,18 +51,34 @@ export const getTheme = (): string => {
 export const setTheme = (theme: string): void => {
   if (typeof window === 'undefined') return;
   try {
-    window.localStorage.setItem(THEME_KEY, theme);
-    document.documentElement.dataset.theme = theme;
-    document.documentElement.classList.toggle('dark', isDarkTheme(theme));
+    const resolved = resolveThemePreference(theme);
+    const stored = window.localStorage.getItem(THEME_KEY);
+    if (stored !== theme) {
+      window.localStorage.setItem(THEME_KEY, theme);
+    }
+    document.documentElement.dataset.theme = resolved;
+    document.documentElement.dataset.themePreference = theme;
+    document.documentElement.classList.toggle('dark', isDarkTheme(resolved));
   } catch {
     /* ignore storage errors */
   }
 };
 
-export const getUnlockedThemes = (highScore: number): string[] =>
+export const getUnlockedThemes = (highScore: number): string[] => {
+  const unlocked: string[] = [];
+  const addUnique = (theme: string) => {
+    if (!unlocked.includes(theme)) unlocked.push(theme);
+  };
+
+  ALWAYS_AVAILABLE_THEMES.forEach(addUnique);
+
   Object.entries(THEME_UNLOCKS)
     .filter(([, score]) => highScore >= score)
-    .map(([theme]) => theme);
+    .forEach(([theme]) => addUnique(theme));
+
+  return unlocked;
+};
 
 export const isThemeUnlocked = (theme: string, highScore: number): boolean =>
+  ALWAYS_AVAILABLE_THEMES.includes(theme as (typeof ALWAYS_AVAILABLE_THEMES)[number]) ||
   highScore >= (THEME_UNLOCKS[theme] ?? Infinity);


### PR DESCRIPTION
## Summary
- add system preference resolution and broadcast/storage sync to the settings provider
- surface light, dark, system, and high-contrast options across the settings UIs and preload script
- extend the theme persistence tests to cover system detection, broadcast channel sync, and storage events

## Testing
- yarn test __tests__/themePersistence.test.ts
- yarn lint *(fails with existing accessibility violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc065d64f88328bff0bf6f8d76beba