### PR TITLE
[tests] add settings performance sweep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,20 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
+  playwright:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: npx playwright install --with-deps
+      - run: yarn build
+      - run: npx playwright test
+
   vercel-preview:
     runs-on: ubuntu-latest
     needs: install

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,24 @@
 import { defineConfig } from '@playwright/test';
 
+const isCI = !!process.env.CI;
+const baseURL = process.env.BASE_URL || 'http://localhost:3000';
+const startCommand = 'yarn start --hostname 0.0.0.0 --port 3000';
+const launchCommand = isCI ? startCommand : `yarn build && ${startCommand}`;
+
 export default defineConfig({
   testDir: './tests',
   testMatch: /.*\.spec\.ts/,
+  fullyParallel: true,
+  timeout: 120 * 1000,
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    baseURL,
+    actionTimeout: 120 * 1000,
+    navigationTimeout: 120 * 1000,
+  },
+  webServer: {
+    command: launchCommand,
+    url: baseURL,
+    reuseExistingServer: !isCI,
+    timeout: isCI ? 5 * 60 * 1000 : 10 * 60 * 1000,
   },
 });

--- a/tests/settings.performance.spec.ts
+++ b/tests/settings.performance.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '@playwright/test';
+
+type FrameMetrics = {
+  frames: number;
+  duration: number;
+  fps: number;
+};
+
+const THEME_OPTIONS = ['default', 'dark', 'neon', 'matrix'] as const;
+const ACCENT_OPTIONS = [
+  '#1793d1',
+  '#e53e3e',
+  '#d97706',
+  '#38a169',
+  '#805ad5',
+  '#ed64a6',
+] as const;
+const DENSITY_OPTIONS = ['regular', 'compact'] as const;
+const ITERATIONS = 200;
+
+const FIVE_MB = 5 * 1024 * 1024;
+
+test.describe('settings performance', () => {
+  test('toggling theme, accent, and density stays within memory budget', async ({ page }) => {
+    await page.goto('/apps/settings');
+    await page.waitForLoadState('networkidle');
+
+    const appearanceTab = page.getByRole('tab', { name: 'Appearance' });
+    const accessibilityTab = page.getByRole('tab', { name: 'Accessibility' });
+
+    await appearanceTab.click();
+
+    const themeSelect = page
+      .locator('select')
+      .filter({ has: page.locator('option[value="matrix"]') });
+    await themeSelect.waitFor();
+
+    const accentRadios = page.locator('button[role="radio"][aria-label^="select-accent-"]');
+    await expect(accentRadios).toHaveCount(ACCENT_OPTIONS.length);
+
+    const initialMemory = await page.evaluate(() => {
+      const memory = (performance as any).memory as
+        | { usedJSHeapSize: number }
+        | undefined;
+      return memory ? memory.usedJSHeapSize : null;
+    });
+    test.skip(initialMemory === null, 'performance.memory not available in this browser');
+
+    await page.evaluate(() => {
+      if (!(window as any).__frameMeter) {
+        (window as any).__frameMeter = (() => {
+          let frames = 0;
+          let start = 0;
+          let running = false;
+          const step = () => {
+            if (!running) return;
+            frames += 1;
+            requestAnimationFrame(step);
+          };
+          return {
+            start() {
+              frames = 0;
+              start = performance.now();
+              running = true;
+              requestAnimationFrame(step);
+            },
+            stop() {
+              running = false;
+              const duration = performance.now() - start;
+              const fps = duration > 0 ? (frames * 1000) / duration : 0;
+              return { frames, duration, fps };
+            },
+          };
+        })();
+      }
+      (window as any).__frameMeter.start();
+    });
+
+    for (let i = 0; i < ITERATIONS; i += 1) {
+      const themeValue = THEME_OPTIONS[(i + 1) % THEME_OPTIONS.length];
+      await themeSelect.selectOption(themeValue);
+
+      const accentIndex = (i + 1) % ACCENT_OPTIONS.length;
+      await accentRadios.nth(accentIndex).click({ force: true });
+      await page.waitForTimeout(0);
+    }
+
+    await accessibilityTab.click();
+
+    const densitySelect = page
+      .locator('select')
+      .filter({ has: page.locator('option[value="compact"]') });
+    await densitySelect.waitFor();
+
+    for (let i = 0; i < ITERATIONS; i += 1) {
+      const densityValue = DENSITY_OPTIONS[(i + 1) % DENSITY_OPTIONS.length];
+      await densitySelect.selectOption(densityValue);
+      await page.waitForTimeout(0);
+    }
+
+    const frameStats = await page.evaluate<FrameMetrics>(() => (window as any).__frameMeter.stop());
+    expect(frameStats.frames).toBeGreaterThan(0);
+    expect(frameStats.duration).toBeGreaterThan(0);
+
+    test.info().annotations.push({
+      type: 'frame-rate',
+      description: `Frames: ${frameStats.frames}, Duration: ${frameStats.duration.toFixed(1)}ms, FPS: ${frameStats.fps.toFixed(1)}`,
+    });
+
+    const finalMemory = await page.evaluate(() => {
+      const memory = (performance as any).memory as
+        | { usedJSHeapSize: number }
+        | undefined;
+      return memory ? memory.usedJSHeapSize : null;
+    });
+
+    expect(finalMemory).not.toBeNull();
+
+    const memoryDelta = (finalMemory as number) - (initialMemory as number);
+    test.info().annotations.push({
+      type: 'memory-delta',
+      description: `Heap delta ${(memoryDelta / (1024 * 1024)).toFixed(2)} MB`,
+    });
+
+    expect(memoryDelta).toBeLessThan(FIVE_MB);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Playwright regression spec that cycles appearance settings 200 times, records frame metrics, and ensures heap growth stays under 5 MB
- update Playwright configuration to launch a production server with longer timeouts so the new performance test has reliable headroom
- extend the CI workflow with a Playwright job that installs browsers, builds the app, and runs the E2E suite

## Testing
- yarn lint *(fails: longstanding accessibility violations in existing apps)*
- yarn test *(fails: existing Jest suites such as window/nmap NSE/timeouts)*
- npx playwright test *(fails: existing apps smoke specs waiting for `<main>` on dynamic routes)*
- npx playwright test tests/settings.performance.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68cc065a8f14832898185baf739dcfbf