### PR TITLE
[settings] Preview imported settings before applying

### DIFF
--- a/__tests__/settingsImport.test.tsx
+++ b/__tests__/settingsImport.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import Settings from '../components/apps/settings';
+
+const mockSetters = {
+  setAccent: jest.fn(),
+  setWallpaper: jest.fn(),
+  setDensity: jest.fn(),
+  setReducedMotion: jest.fn(),
+  setFontScale: jest.fn(),
+  setHighContrast: jest.fn(),
+  setLargeHitAreas: jest.fn(),
+  setPongSpin: jest.fn(),
+  setAllowNetwork: jest.fn(),
+  setHaptics: jest.fn(),
+  setTheme: jest.fn(),
+};
+
+const mockState = {
+  accent: '#1793d1',
+  wallpaper: 'wall-2',
+  density: 'regular',
+  reducedMotion: false,
+  fontScale: 1,
+  highContrast: false,
+  largeHitAreas: false,
+  pongSpin: true,
+  allowNetwork: false,
+  haptics: true,
+  theme: 'default',
+};
+
+const mockImportSettings = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../hooks/useSettings', () => ({
+  ACCENT_OPTIONS: ['#1793d1', '#ff0000'],
+  useSettings: () => ({
+    ...mockState,
+    ...mockSetters,
+  }),
+}));
+
+jest.mock('../utils/settingsStore', () => ({
+  resetSettings: jest.fn(),
+  defaults: {
+    accent: '#1793d1',
+    wallpaper: 'wall-2',
+    density: 'regular',
+    reducedMotion: false,
+    largeHitAreas: false,
+    fontScale: 1,
+    highContrast: false,
+    pongSpin: true,
+    allowNetwork: false,
+    haptics: true,
+  },
+  exportSettings: jest.fn(),
+  importSettings: (...args: unknown[]) => mockImportSettings(...args),
+}));
+
+jest.mock('react-diff-viewer', () => {
+  const React = require('react');
+  return function MockDiffViewer(props: { oldValue: string; newValue: string }) {
+    return React.createElement(
+      'div',
+      { 'data-testid': 'diff-viewer' },
+      React.createElement('pre', { 'data-testid': 'diff-old' }, props.oldValue),
+      React.createElement('pre', { 'data-testid': 'diff-new' }, props.newValue),
+    );
+  };
+});
+
+const createMockFile = (contents: string): File =>
+  ({
+    text: () => Promise.resolve(contents),
+    name: 'settings.json',
+    lastModified: Date.now(),
+    size: contents.length,
+    type: 'application/json',
+  } as unknown as File);
+
+describe('Settings import flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(mockState, {
+      accent: '#1793d1',
+      wallpaper: 'wall-2',
+      density: 'regular',
+      reducedMotion: false,
+      fontScale: 1,
+      highContrast: false,
+      largeHitAreas: false,
+      pongSpin: true,
+      allowNetwork: false,
+      haptics: true,
+      theme: 'default',
+    });
+  });
+
+  it('shows a helpful error when the import file contains invalid JSON', async () => {
+    render(<Settings />);
+
+    const input = screen.getByLabelText(/import settings file/i) as HTMLInputElement;
+    const file = createMockFile('{not-json');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Import failed: File is not valid JSON.');
+    expect(mockImportSettings).not.toHaveBeenCalled();
+  });
+
+  it('opens a diff preview before applying valid imported settings', async () => {
+    render(<Settings />);
+
+    const input = screen.getByLabelText(/import settings file/i) as HTMLInputElement;
+    const imported = { accent: '#222222', allowNetwork: true };
+    const file = createMockFile(JSON.stringify(imported));
+
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+
+    await screen.findByRole('dialog');
+    const diffOld = await screen.findByTestId('diff-old');
+    const diffNew = await screen.findByTestId('diff-new');
+
+    expect(diffOld.textContent).toContain('"accent": "#1793d1"');
+    expect(diffNew.textContent).toContain('"accent": "#222222"');
+    expect(diffNew.textContent).toContain('"allowNetwork": true');
+    expect(screen.getByRole('button', { name: /apply import/i })).toBeInTheDocument();
+    expect(mockImportSettings).not.toHaveBeenCalled();
+  });
+});

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,12 +1,136 @@
-import React, { useEffect, useRef, useState, useCallback } from 'react';
+import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
+import ReactDiffViewer from 'react-diff-viewer';
+import { z } from 'zod';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
+import Modal from '../base/Modal';
+
+const BASE_SETTINGS_SCHEMA = z.object({
+    accent: z.string({ invalid_type_error: 'Accent must be a string.' }).regex(/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/, {
+        message: 'Accent must be a hex color (example: #1793d1).',
+    }),
+    wallpaper: z.string({ invalid_type_error: 'Wallpaper must be a string.' }).min(1, { message: 'Wallpaper cannot be empty.' }),
+    density: z.enum(['regular', 'compact'], { message: 'Density must be either "regular" or "compact".' }),
+    reducedMotion: z.boolean({ invalid_type_error: 'Reduced motion must be a boolean.' }),
+    fontScale: z.number({ invalid_type_error: 'Font scale must be a number.' }).min(0.5, { message: 'Font scale must be at least 0.5.' }).max(2, { message: 'Font scale must be 2.0 or less.' }),
+    highContrast: z.boolean({ invalid_type_error: 'High contrast must be a boolean.' }),
+    largeHitAreas: z.boolean({ invalid_type_error: 'Large hit areas must be a boolean.' }),
+    pongSpin: z.boolean({ invalid_type_error: 'Pong spin must be a boolean.' }),
+    allowNetwork: z.boolean({ invalid_type_error: 'Allow network requests must be a boolean.' }),
+    haptics: z.boolean({ invalid_type_error: 'Haptics must be a boolean.' }),
+    theme: z.enum(['default', 'dark', 'neon', 'matrix'], { message: 'Theme must be one of default, dark, neon, or matrix.' }),
+});
+
+const IMPORT_SETTINGS_SCHEMA = BASE_SETTINGS_SCHEMA.partial().strict();
+
+const SETTINGS_KEY_ORDER = [
+    'accent',
+    'wallpaper',
+    'density',
+    'reducedMotion',
+    'fontScale',
+    'highContrast',
+    'largeHitAreas',
+    'pongSpin',
+    'allowNetwork',
+    'haptics',
+    'theme',
+];
+
+const sortSettingsKeys = (settings) => {
+    const ordered = {};
+    SETTINGS_KEY_ORDER.forEach((key) => {
+        if (Object.prototype.hasOwnProperty.call(settings, key)) {
+            ordered[key] = settings[key];
+        }
+    });
+    Object.keys(settings).forEach((key) => {
+        if (!Object.prototype.hasOwnProperty.call(ordered, key)) {
+            ordered[key] = settings[key];
+        }
+    });
+    return ordered;
+};
+
+const formatSettings = (settings) => JSON.stringify(sortSettingsKeys(settings), null, 2);
+
+const formatSchemaIssues = (issues) => issues.map((issue) => {
+    const path = issue.path.length ? issue.path.join('.') : 'root';
+    return `${path}: ${issue.message}`;
+}).join('\n');
 
 export function Settings() {
     const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
+    const [importError, setImportError] = useState('');
+    const [applyError, setApplyError] = useState('');
+    const [pendingSettings, setPendingSettings] = useState(null);
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [isApplying, setIsApplying] = useState(false);
+
+    const currentSettings = useMemo(() => ({
+        accent,
+        wallpaper,
+        density,
+        reducedMotion,
+        fontScale,
+        highContrast,
+        largeHitAreas,
+        pongSpin,
+        allowNetwork,
+        haptics,
+        theme,
+    }), [accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, pongSpin, allowNetwork, haptics, theme]);
+
+    const diffValues = useMemo(() => {
+        if (!pendingSettings) return null;
+        const merged = { ...currentSettings, ...pendingSettings };
+        const oldValue = formatSettings(currentSettings);
+        const newValue = formatSettings(merged);
+        return {
+            oldValue,
+            newValue,
+            hasChanges: oldValue !== newValue,
+        };
+    }, [currentSettings, pendingSettings]);
+
+    const closeModal = useCallback(() => {
+        setIsModalOpen(false);
+        setPendingSettings(null);
+        setApplyError('');
+    }, [setIsModalOpen, setPendingSettings, setApplyError]);
+
+    const applyLocalSettings = useCallback((settings) => {
+        if (settings.accent !== undefined) setAccent(settings.accent);
+        if (settings.wallpaper !== undefined) setWallpaper(settings.wallpaper);
+        if (settings.density !== undefined) setDensity(settings.density);
+        if (settings.reducedMotion !== undefined) setReducedMotion(settings.reducedMotion);
+        if (settings.fontScale !== undefined) setFontScale(settings.fontScale);
+        if (settings.highContrast !== undefined) setHighContrast(settings.highContrast);
+        if (settings.largeHitAreas !== undefined) setLargeHitAreas(settings.largeHitAreas);
+        if (settings.pongSpin !== undefined) setPongSpin(settings.pongSpin);
+        if (settings.allowNetwork !== undefined) setAllowNetwork(settings.allowNetwork);
+        if (settings.haptics !== undefined) setHaptics(settings.haptics);
+        if (settings.theme !== undefined) setTheme(settings.theme);
+    }, [setAccent, setWallpaper, setDensity, setReducedMotion, setFontScale, setHighContrast, setLargeHitAreas, setPongSpin, setAllowNetwork, setHaptics, setTheme]);
+
+    const handleApplyPending = useCallback(async () => {
+        if (!pendingSettings) return;
+        setIsApplying(true);
+        setApplyError('');
+        try {
+            await importSettingsData(pendingSettings);
+            applyLocalSettings(pendingSettings);
+            closeModal();
+        } catch (err) {
+            console.error('Failed to apply imported settings', err);
+            setApplyError('Unable to apply settings. Please try again.');
+        } finally {
+            setIsApplying(false);
+        }
+    }, [pendingSettings, applyLocalSettings, closeModal]);
 
     const wallpapers = ['wall-1', 'wall-2', 'wall-3', 'wall-4', 'wall-5', 'wall-6', 'wall-7', 'wall-8'];
 
@@ -43,6 +167,39 @@ export function Settings() {
         return contrastRatio(accent, '#000000') > contrastRatio(accent, '#ffffff') ? '#000000' : '#ffffff';
     }, [accent, contrastRatio]);
 
+    const handleImportChange = useCallback(async (event) => {
+        const { files } = event.target;
+        const file = files && files[0];
+        if (!file) return;
+        setImportError('');
+        setApplyError('');
+        try {
+            const text = await file.text();
+            let parsed;
+            try {
+                parsed = JSON.parse(text);
+            } catch (jsonErr) {
+                throw new Error('File is not valid JSON.');
+            }
+            const result = IMPORT_SETTINGS_SCHEMA.safeParse(parsed);
+            if (!result.success) {
+                throw new Error(formatSchemaIssues(result.error.issues));
+            }
+            if (Object.keys(result.data).length === 0) {
+                throw new Error('The file does not contain any supported settings.');
+            }
+            setPendingSettings(result.data);
+            setIsModalOpen(true);
+        } catch (error) {
+            const message = error instanceof Error && error.message ? error.message : 'Unexpected error while reading settings.';
+            setPendingSettings(null);
+            setIsModalOpen(false);
+            setImportError(`Import failed: ${message}`);
+        } finally {
+            event.target.value = '';
+        }
+    }, [setImportError, setApplyError, setPendingSettings, setIsModalOpen]);
+
     useEffect(() => {
         let raf = requestAnimationFrame(() => {
             let ratio = contrastRatio(accent, accentText());
@@ -56,234 +213,299 @@ export function Settings() {
     }, [accent, accentText, contrastRatio]);
 
     return (
-        <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
-            <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
-            </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Theme:</label>
-                <select
-                    value={theme}
-                    onChange={(e) => setTheme(e.target.value)}
-                    className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-                >
-                    <option value="default">Default</option>
-                    <option value="dark">Dark</option>
-                    <option value="neon">Neon</option>
-                    <option value="matrix">Matrix</option>
-                </select>
-            </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Accent:</label>
-                <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
-                    {ACCENT_OPTIONS.map((c) => (
-                        <button
-                            key={c}
-                            aria-label={`select-accent-${c}`}
-                            role="radio"
-                            aria-checked={accent === c}
-                            onClick={() => setAccent(c)}
-                            className={`w-8 h-8 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
-                            style={{ backgroundColor: c }}
-                        />
-                    ))}
+        <>
+            <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
+                <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
                 </div>
-            </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Density:</label>
-                <select
-                    value={density}
-                    onChange={(e) => setDensity(e.target.value)}
-                    className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-                >
-                    <option value="regular">Regular</option>
-                    <option value="compact">Compact</option>
-                </select>
-            </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Font Size:</label>
+                <div className="flex justify-center my-4">
+                    <label className="mr-2 text-ubt-grey">Theme:</label>
+                    <select
+                        value={theme}
+                        onChange={(e) => setTheme(e.target.value)}
+                        className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                    >
+                        <option value="default">Default</option>
+                        <option value="dark">Dark</option>
+                        <option value="neon">Neon</option>
+                        <option value="matrix">Matrix</option>
+                    </select>
+                </div>
+                <div className="flex justify-center my-4">
+                    <label className="mr-2 text-ubt-grey">Accent:</label>
+                    <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
+                        {ACCENT_OPTIONS.map((c) => (
+                            <button
+                                key={c}
+                                aria-label={`select-accent-${c}`}
+                                role="radio"
+                                aria-checked={accent === c}
+                                onClick={() => setAccent(c)}
+                                className={`w-8 h-8 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
+                                style={{ backgroundColor: c }}
+                            />
+                        ))}
+                    </div>
+                </div>
+                <div className="flex justify-center my-4">
+                    <label className="mr-2 text-ubt-grey">Density:</label>
+                    <select
+                        value={density}
+                        onChange={(e) => setDensity(e.target.value)}
+                        className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                    >
+                        <option value="regular">Regular</option>
+                        <option value="compact">Compact</option>
+                    </select>
+                </div>
+                <div className="flex justify-center my-4">
+                    <label className="mr-2 text-ubt-grey">Font Size:</label>
+                    <input
+                        type="range"
+                        min="0.75"
+                        max="1.5"
+                        step="0.05"
+                        value={fontScale}
+                        onChange={(e) => setFontScale(parseFloat(e.target.value))}
+                        className="ubuntu-slider"
+                    />
+                </div>
+                <div className="flex justify-center my-4">
+                    <label className="mr-2 text-ubt-grey flex items-center">
+                        <input
+                            type="checkbox"
+                            checked={reducedMotion}
+                            onChange={(e) => setReducedMotion(e.target.checked)}
+                            className="mr-2"
+                        />
+                        Reduced Motion
+                    </label>
+                </div>
+                <div className="flex justify-center my-4">
+                    <label className="mr-2 text-ubt-grey flex items-center">
+                        <input
+                            type="checkbox"
+                            checked={largeHitAreas}
+                            onChange={(e) => setLargeHitAreas(e.target.checked)}
+                            className="mr-2"
+                        />
+                        Large Hit Areas
+                    </label>
+                </div>
+                <div className="flex justify-center my-4">
+                    <label className="mr-2 text-ubt-grey flex items-center">
+                        <input
+                            type="checkbox"
+                            checked={highContrast}
+                            onChange={(e) => setHighContrast(e.target.checked)}
+                            className="mr-2"
+                        />
+                        High Contrast
+                    </label>
+                </div>
+                <div className="flex justify-center my-4">
+                    <label className="mr-2 text-ubt-grey flex items-center">
+                        <input
+                            type="checkbox"
+                            checked={allowNetwork}
+                            onChange={(e) => setAllowNetwork(e.target.checked)}
+                            className="mr-2"
+                        />
+                        Allow Network Requests
+                    </label>
+                </div>
+                <div className="flex justify-center my-4">
+                    <label className="mr-2 text-ubt-grey flex items-center">
+                        <input
+                            type="checkbox"
+                            checked={haptics}
+                            onChange={(e) => setHaptics(e.target.checked)}
+                            className="mr-2"
+                        />
+                        Haptics
+                    </label>
+                </div>
+                <div className="flex justify-center my-4">
+                    <label className="mr-2 text-ubt-grey flex items-center">
+                        <input
+                            type="checkbox"
+                            checked={pongSpin}
+                            onChange={(e) => setPongSpin(e.target.checked)}
+                            className="mr-2"
+                        />
+                        Pong Spin
+                    </label>
+                </div>
+                <div className="flex justify-center my-4">
+                    <div
+                        className="p-4 rounded transition-colors duration-300 motion-reduce:transition-none"
+                        style={{ backgroundColor: '#0f1317', color: '#ffffff' }}
+                    >
+                        <p className="mb-2 text-center">Preview</p>
+                        <button
+                            className="px-2 py-1 rounded"
+                            style={{ backgroundColor: accent, color: accentText() }}
+                        >
+                            Accent
+                        </button>
+                        <p className={`mt-2 text-sm text-center ${contrast >= 4.5 ? 'text-green-400' : 'text-red-400'}`}>
+                            {`Contrast ${contrast.toFixed(2)}:1 ${contrast >= 4.5 ? 'Pass' : 'Fail'}`}
+                        </p>
+                        <span ref={liveRegion} role="status" aria-live="polite" className="sr-only"></span>
+                    </div>
+                </div>
+                <div className="flex flex-wrap justify-center items-center border-t border-gray-900">
+                    {
+                        wallpapers.map((name) => (
+                            <div
+                                key={name}
+                                role="button"
+                                aria-label={`Select ${name.replace('wall-', 'wallpaper ')}`}
+                                aria-pressed={name === wallpaper}
+                                tabIndex="0"
+                                onClick={changeBackgroundImage}
+                                onFocus={changeBackgroundImage}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.preventDefault();
+                                        changeBackgroundImage(e);
+                                    }
+                                }}
+                                data-path={name}
+                                className={((name === wallpaper) ? " border-yellow-700 " : " border-transparent ") + " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"}
+                                style={{ backgroundImage: `url(/wallpapers/${name}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}
+                            ></div>
+                        ))
+                    }
+                </div>
+                <div className="flex flex-col items-center justify-center gap-2 border-t border-gray-900 pt-4 sm:flex-row sm:space-x-4">
+                    <button
+                        onClick={async () => {
+                            const data = await exportSettingsData();
+                            const blob = new Blob([data], { type: 'application/json' });
+                            const url = URL.createObjectURL(blob);
+                            const a = document.createElement('a');
+                            a.href = url;
+                            a.download = 'settings.json';
+                            a.click();
+                            URL.revokeObjectURL(url);
+                        }}
+                        className="px-4 py-2 rounded bg-ub-orange text-white font-semibold"
+                    >
+                        Export Settings
+                    </button>
+                    <button
+                        onClick={() => {
+                            setImportError('');
+                            setApplyError('');
+                            if (fileInput.current) {
+                                fileInput.current.click();
+                            }
+                        }}
+                        className="px-4 py-2 rounded bg-ub-orange text-white font-semibold"
+                    >
+                        Import Settings
+                    </button>
+                    <button
+                        onClick={async () => {
+                            await resetSettings();
+                            setAccent(defaults.accent);
+                            setWallpaper(defaults.wallpaper);
+                            setDensity(defaults.density);
+                            setReducedMotion(defaults.reducedMotion);
+                            setLargeHitAreas(defaults.largeHitAreas);
+                            setFontScale(defaults.fontScale);
+                            setHighContrast(defaults.highContrast);
+                            setAllowNetwork(defaults.allowNetwork);
+                            setHaptics(defaults.haptics);
+                            setPongSpin(defaults.pongSpin);
+                            setTheme('default');
+                        }}
+                        className="px-4 py-2 rounded bg-ub-orange text-white font-semibold"
+                    >
+                        Reset Desktop
+                    </button>
+                </div>
+                {importError && (
+                    <div role="alert" className="mx-auto mt-3 w-11/12 max-w-3xl rounded border border-red-500/40 bg-red-900/40 px-3 py-2 text-center text-sm text-red-200 whitespace-pre-line">
+                        {importError}
+                    </div>
+                )}
                 <input
-                    type="range"
-                    min="0.75"
-                    max="1.5"
-                    step="0.05"
-                    value={fontScale}
-                    onChange={(e) => setFontScale(parseFloat(e.target.value))}
-                    className="ubuntu-slider"
+                    type="file"
+                    accept="application/json"
+                    ref={fileInput}
+                    onChange={handleImportChange}
+                    aria-label="Import settings file"
+                    className="hidden"
                 />
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={reducedMotion}
-                        onChange={(e) => setReducedMotion(e.target.checked)}
-                        className="mr-2"
-                    />
-                    Reduced Motion
-                </label>
-            </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={largeHitAreas}
-                        onChange={(e) => setLargeHitAreas(e.target.checked)}
-                        className="mr-2"
-                    />
-                    Large Hit Areas
-                </label>
-            </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={highContrast}
-                        onChange={(e) => setHighContrast(e.target.checked)}
-                        className="mr-2"
-                    />
-                    High Contrast
-                </label>
-            </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={allowNetwork}
-                        onChange={(e) => setAllowNetwork(e.target.checked)}
-                        className="mr-2"
-                    />
-                    Allow Network Requests
-                </label>
-            </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={haptics}
-                        onChange={(e) => setHaptics(e.target.checked)}
-                        className="mr-2"
-                    />
-                    Haptics
-                </label>
-            </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={pongSpin}
-                        onChange={(e) => setPongSpin(e.target.checked)}
-                        className="mr-2"
-                    />
-                    Pong Spin
-                </label>
-            </div>
-            <div className="flex justify-center my-4">
-                <div
-                    className="p-4 rounded transition-colors duration-300 motion-reduce:transition-none"
-                    style={{ backgroundColor: '#0f1317', color: '#ffffff' }}
-                >
-                    <p className="mb-2 text-center">Preview</p>
-                    <button
-                        className="px-2 py-1 rounded"
-                        style={{ backgroundColor: accent, color: accentText() }}
+            <Modal isOpen={isModalOpen} onClose={closeModal}>
+                <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/70 p-4">
+                    <div
+                        className="max-h-full w-full max-w-5xl overflow-hidden rounded-lg border border-gray-800 bg-ub-cool-grey text-white shadow-2xl"
+                        role="document"
+                        aria-labelledby="settings-import-title"
                     >
-                        Accent
-                    </button>
-                    <p className={`mt-2 text-sm text-center ${contrast >= 4.5 ? 'text-green-400' : 'text-red-400'}`}>
-                        {`Contrast ${contrast.toFixed(2)}:1 ${contrast >= 4.5 ? 'Pass' : 'Fail'}`}
-                    </p>
-                    <span ref={liveRegion} role="status" aria-live="polite" className="sr-only"></span>
+                        <div className="flex flex-col gap-4 p-4">
+                            <div className="flex flex-col gap-2 border-b border-gray-800 pb-3 sm:flex-row sm:items-center sm:justify-between">
+                                <h2 id="settings-import-title" className="text-lg font-semibold">Review imported settings</h2>
+                                <button
+                                    type="button"
+                                    onClick={closeModal}
+                                    className="self-start rounded bg-transparent px-3 py-1 text-sm text-ubt-grey transition hover:bg-ub-dark-400 focus:outline-none focus:ring-2 focus:ring-ub-orange"
+                                >
+                                    Close
+                                </button>
+                            </div>
+                            {diffValues ? (
+                                diffValues.hasChanges ? (
+                                    <ReactDiffViewer
+                                        oldValue={diffValues.oldValue}
+                                        newValue={diffValues.newValue}
+                                        splitView
+                                        useDarkTheme
+                                        showDiffOnly={false}
+                                        hideLineNumbers={false}
+                                        leftTitle="Current settings"
+                                        rightTitle="Imported settings"
+                                    />
+                                ) : (
+                                    <div className="rounded border border-ubt-cool-grey bg-ub-dark-400/70 p-4 text-center text-ubt-grey">
+                                        No differences detected; applying will keep your current configuration.
+                                    </div>
+                                )
+                            ) : (
+                                <div className="rounded border border-ubt-cool-grey bg-ub-dark-400/70 p-4 text-center text-ubt-grey">
+                                    Unable to generate a preview for this file.
+                                </div>
+                            )}
+                            {applyError && (
+                                <div role="alert" className="rounded border border-red-500/40 bg-red-900/40 px-3 py-2 text-sm text-red-200 whitespace-pre-line">
+                                    {applyError}
+                                </div>
+                            )}
+                            <div className="flex flex-col gap-2 sm:flex-row sm:justify-end sm:space-x-2">
+                                <button
+                                    type="button"
+                                    onClick={closeModal}
+                                    className="rounded bg-transparent px-4 py-2 text-ubt-grey transition hover:bg-ub-dark-400 focus:outline-none focus:ring-2 focus:ring-ub-orange"
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={handleApplyPending}
+                                    disabled={isApplying}
+                                    className="rounded bg-ub-orange px-4 py-2 font-semibold text-white transition disabled:opacity-60"
+                                >
+                                    {isApplying ? 'Applying…' : 'Apply import'}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
-            </div>
-            <div className="flex flex-wrap justify-center items-center border-t border-gray-900">
-                {
-                    wallpapers.map((name, index) => (
-                        <div
-                            key={name}
-                            role="button"
-                            aria-label={`Select ${name.replace('wall-', 'wallpaper ')}`}
-                            aria-pressed={name === wallpaper}
-                            tabIndex="0"
-                            onClick={changeBackgroundImage}
-                            onFocus={changeBackgroundImage}
-                            onKeyDown={(e) => {
-                                if (e.key === 'Enter' || e.key === ' ') {
-                                    e.preventDefault();
-                                    changeBackgroundImage(e);
-                                }
-                            }}
-                            data-path={name}
-                            className={((name === wallpaper) ? " border-yellow-700 " : " border-transparent ") + " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"}
-                            style={{ backgroundImage: `url(/wallpapers/${name}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}
-                        ></div>
-                    ))
-                }
-            </div>
-            <div className="flex justify-center my-4 border-t border-gray-900 pt-4 space-x-4">
-                <button
-                    onClick={async () => {
-                        const data = await exportSettingsData();
-                        const blob = new Blob([data], { type: 'application/json' });
-                        const url = URL.createObjectURL(blob);
-                        const a = document.createElement('a');
-                        a.href = url;
-                        a.download = 'settings.json';
-                        a.click();
-                        URL.revokeObjectURL(url);
-                    }}
-                    className="px-4 py-2 rounded bg-ub-orange text-white"
-                >
-                    Export Settings
-                </button>
-                <button
-                    onClick={() => fileInput.current && fileInput.current.click()}
-                    className="px-4 py-2 rounded bg-ub-orange text-white"
-                >
-                    Import Settings
-                </button>
-                <button
-                    onClick={async () => {
-                        await resetSettings();
-                        setAccent(defaults.accent);
-                        setWallpaper(defaults.wallpaper);
-                        setDensity(defaults.density);
-                        setReducedMotion(defaults.reducedMotion);
-                        setLargeHitAreas(defaults.largeHitAreas);
-                        setFontScale(defaults.fontScale);
-                        setHighContrast(defaults.highContrast);
-                        setTheme('default');
-                    }}
-                    className="px-4 py-2 rounded bg-ub-orange text-white"
-                >
-                    Reset Desktop
-                </button>
-            </div>
-            <input
-                type="file"
-                accept="application/json"
-                ref={fileInput}
-                onChange={async (e) => {
-                    const file = e.target.files && e.target.files[0];
-                    if (!file) return;
-                    const text = await file.text();
-                    await importSettingsData(text);
-                    try {
-                        const parsed = JSON.parse(text);
-                        if (parsed.accent !== undefined) setAccent(parsed.accent);
-                        if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
-                        if (parsed.density !== undefined) setDensity(parsed.density);
-                        if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
-                        if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
-                        if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
-                        if (parsed.theme !== undefined) { setTheme(parsed.theme); }
-                    } catch (err) {
-                        console.error('Invalid settings', err);
-                    }
-                    e.target.value = '';
-                }}
-                className="hidden"
-            />
-        </div>
+            </Modal>
+        </>
     )
 }
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "react-activity-calendar": "^2.7.13",
     "react-bootstrap": "^2.10.4",
     "react-cytoscapejs": "^2.0.0",
+    "react-diff-viewer": "^3.1.1",
     "react-dom": "19.1.1",
     "react-draggable": "^4.4.5",
     "react-force-graph": "^1.45.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -330,7 +330,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.10.4, @babel/helper-module-imports@npm:^7.27.1":
+"@babel/helper-module-imports@npm:^7.0.0, @babel/helper-module-imports@npm:^7.10.4, @babel/helper-module-imports@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-module-imports@npm:7.27.1"
   dependencies:
@@ -1437,6 +1437,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.7.2":
+  version: 7.28.4
+  resolution: "@babel/runtime@npm:7.28.4"
+  checksum: 10c0/792ce7af9750fb9b93879cc9d1db175701c4689da890e6ced242ea0207c9da411ccf16dc04e689cc01158b28d7898c40d75598f4559109f761c12ce01e959bf7
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.27.1, @babel/template@npm:^7.27.2":
   version: 7.27.2
   resolution: "@babel/template@npm:7.27.2"
@@ -1592,17 +1599,77 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/hash@npm:^0.8.0":
+"@emotion/cache@npm:^10.0.27":
+  version: 10.0.29
+  resolution: "@emotion/cache@npm:10.0.29"
+  dependencies:
+    "@emotion/sheet": "npm:0.9.4"
+    "@emotion/stylis": "npm:0.8.5"
+    "@emotion/utils": "npm:0.11.3"
+    "@emotion/weak-memoize": "npm:0.2.5"
+  checksum: 10c0/df109408fd463f243d6df48b4a28b410502f4506290875d0b9e07dc654638f71167d2b418b26f7e1c3d165cc44d507f476f4ff88652e7390c6ccb33aa04f8799
+  languageName: node
+  linkType: hard
+
+"@emotion/hash@npm:0.8.0, @emotion/hash@npm:^0.8.0":
   version: 0.8.0
   resolution: "@emotion/hash@npm:0.8.0"
   checksum: 10c0/706303d35d416217cd7eb0d36dbda4627bb8bdf4a32ea387e8dd99be11b8e0a998e10af21216e8a5fade518ad955ff06aa8890f20e694ce3a038ae7fc1000556
   languageName: node
   linkType: hard
 
-"@emotion/unitless@npm:^0.7.5":
+"@emotion/memoize@npm:0.7.4":
+  version: 0.7.4
+  resolution: "@emotion/memoize@npm:0.7.4"
+  checksum: 10c0/b2376548fc147b43afd1ff005a80a1a025bd7eb4fb759fdb23e96e5ff290ee8ba16628a332848d600fb91c3cdc319eee5395fa33d8875e5d5a8c4ce18cddc18e
+  languageName: node
+  linkType: hard
+
+"@emotion/serialize@npm:^0.11.15, @emotion/serialize@npm:^0.11.16":
+  version: 0.11.16
+  resolution: "@emotion/serialize@npm:0.11.16"
+  dependencies:
+    "@emotion/hash": "npm:0.8.0"
+    "@emotion/memoize": "npm:0.7.4"
+    "@emotion/unitless": "npm:0.7.5"
+    "@emotion/utils": "npm:0.11.3"
+    csstype: "npm:^2.5.7"
+  checksum: 10c0/70b49a4261a79c2f5675a872cafc41dd102d6f04df76228b5ab6fd8b0b775a90f34b3d2c1c317c1a5e8fb8f3deebd9a5e764518e1968f616348982471e19a411
+  languageName: node
+  linkType: hard
+
+"@emotion/sheet@npm:0.9.4":
+  version: 0.9.4
+  resolution: "@emotion/sheet@npm:0.9.4"
+  checksum: 10c0/a37b3f619096d2576bee6b2cb0104dbe8cd008809000cb5d77482691e9539211902ef420e29b5ee6aa039d3e77468facd595bd60624c5a0af5f29a0889cd9eab
+  languageName: node
+  linkType: hard
+
+"@emotion/stylis@npm:0.8.5":
+  version: 0.8.5
+  resolution: "@emotion/stylis@npm:0.8.5"
+  checksum: 10c0/f109e3f11cb0d48e8658aaa23578c5bcfe35e297819cfb089a3de6ba8dc0f89b0960474922690c6028df5d2e1895b4967f2fb280642c030054c312f1e137ce26
+  languageName: node
+  linkType: hard
+
+"@emotion/unitless@npm:0.7.5, @emotion/unitless@npm:^0.7.5":
   version: 0.7.5
   resolution: "@emotion/unitless@npm:0.7.5"
   checksum: 10c0/4d0d94f53cb97b4481bbfa394953e1899a0b877644642ba9dd7247c27eb8c48e14e22aeb11411d7d9874685ad85dd5fb5b50eb78c6d8840eb56a84b92dcef2f4
+  languageName: node
+  linkType: hard
+
+"@emotion/utils@npm:0.11.3":
+  version: 0.11.3
+  resolution: "@emotion/utils@npm:0.11.3"
+  checksum: 10c0/bac34c74fc5d4c2aec52f2e739436b9631866822a05d1807fcfb856e7320d24804b8ce912a7fa8e447d937fd839f4bde0231a4f71bc6fa0f7e73289d6313f64f
+  languageName: node
+  linkType: hard
+
+"@emotion/weak-memoize@npm:0.2.5":
+  version: 0.2.5
+  resolution: "@emotion/weak-memoize@npm:0.2.5"
+  checksum: 10c0/cabfaaecabbb407d323098afc0bb2dd2ec9aaea0672f8f2c54b84b99d5f8cc680356cf166583fd5593330ceef29f2c26554c2c65dff06c0a8f5f8c7da69d89f1
   languageName: node
   linkType: hard
 
@@ -3610,6 +3677,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/parse-json@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "@types/parse-json@npm:4.0.2"
+  checksum: 10c0/b1b863ac34a2c2172fbe0807a1ec4d5cb684e48d422d15ec95980b81475fac4fdb3768a8b13eef39130203a7c04340fc167bae057c7ebcafd7dec9fe6c36aeb1
+  languageName: node
+  linkType: hard
+
 "@types/phoenix@npm:^1.6.6":
   version: 1.6.6
   resolution: "@types/phoenix@npm:1.6.6"
@@ -5008,6 +5082,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-emotion@npm:^10.0.27":
+  version: 10.2.2
+  resolution: "babel-plugin-emotion@npm:10.2.2"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.0.0"
+    "@emotion/hash": "npm:0.8.0"
+    "@emotion/memoize": "npm:0.7.4"
+    "@emotion/serialize": "npm:^0.11.16"
+    babel-plugin-macros: "npm:^2.0.0"
+    babel-plugin-syntax-jsx: "npm:^6.18.0"
+    convert-source-map: "npm:^1.5.0"
+    escape-string-regexp: "npm:^1.0.5"
+    find-root: "npm:^1.1.0"
+    source-map: "npm:^0.5.7"
+  checksum: 10c0/324edc532819610522b9877189bb0072f745feefd38bb02b986bf7f9fe09e847535356b7aaa01b64f0cd5a9b508ccadc93afc61acc06a593271cc77beb1f8164
+  languageName: node
+  linkType: hard
+
 "babel-plugin-istanbul@npm:^7.0.0":
   version: 7.0.0
   resolution: "babel-plugin-istanbul@npm:7.0.0"
@@ -5029,6 +5121,17 @@ __metadata:
     "@babel/types": "npm:^7.27.3"
     "@types/babel__core": "npm:^7.20.5"
   checksum: 10c0/49087f45c8ac359d68c622f4bd471300376b0ca2b6bd6ecaa1bd254ea87eda8fa3ce6144848e3bbabad337d276474a47e2ac3f6272f82e1f2337924ff49a02bd
+  languageName: node
+  linkType: hard
+
+"babel-plugin-macros@npm:^2.0.0":
+  version: 2.8.0
+  resolution: "babel-plugin-macros@npm:2.8.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.7.2"
+    cosmiconfig: "npm:^6.0.0"
+    resolve: "npm:^1.12.0"
+  checksum: 10c0/9a101e2844a800e65662b2a8d0758bdbbe500ae02d68ef6f3466ead7eaa1350e3872b97014b20bf6f3a1a46b3c9613dfac7578af6f6ae6d4eccbd68ad7b6f228
   languageName: node
   linkType: hard
 
@@ -5065,6 +5168,13 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
   checksum: 10c0/63aa8ed716df6a9277c6ab42b887858fa9f57a70cc1d0ae2b91bdf081e45d4502848cba306fb60b02f59f99b32fd02ff4753b373cac48ccdac9b7d19dd56f06d
+  languageName: node
+  linkType: hard
+
+"babel-plugin-syntax-jsx@npm:^6.18.0":
+  version: 6.18.0
+  resolution: "babel-plugin-syntax-jsx@npm:6.18.0"
+  checksum: 10c0/d5954e9c2a3dd519f23e78674ecfba61394a8fae63499afdeca4214fad68997556ebd15ce012bbc4d527ae0e3cecc98d3e8f78004a68707122642d0df4ab7213
   languageName: node
   linkType: hard
 
@@ -5745,6 +5855,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"convert-source-map@npm:^1.5.0":
+  version: 1.9.0
+  resolution: "convert-source-map@npm:1.9.0"
+  checksum: 10c0/281da55454bf8126cbc6625385928c43479f2060984180c42f3a86c8b8c12720a24eac260624a7d1e090004028d2dee78602330578ceec1a08e27cb8bb0a8a5b
+  languageName: node
+  linkType: hard
+
 "convert-source-map@npm:^2.0.0":
   version: 2.0.0
   resolution: "convert-source-map@npm:2.0.0"
@@ -5800,6 +5917,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cosmiconfig@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "cosmiconfig@npm:6.0.0"
+  dependencies:
+    "@types/parse-json": "npm:^4.0.0"
+    import-fresh: "npm:^3.1.0"
+    parse-json: "npm:^5.0.0"
+    path-type: "npm:^4.0.0"
+    yaml: "npm:^1.7.2"
+  checksum: 10c0/666ed8732d0bf7d7fe6f8516c8ee6041e0622032e8fa26201577b883d2767ad105d03f38b34b93d1f02f26b22a89e7bab4443b9d2e7f931f48d0e944ffa038b5
+  languageName: node
+  linkType: hard
+
 "cosmiconfig@npm:^9.0.0":
   version: 9.0.0
   resolution: "cosmiconfig@npm:9.0.0"
@@ -5814,6 +5944,18 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/1c1703be4f02a250b1d6ca3267e408ce16abfe8364193891afc94c2d5c060b69611fdc8d97af74b7e6d5d1aac0ab2fb94d6b079573146bc2d756c2484ce5f0ee
+  languageName: node
+  linkType: hard
+
+"create-emotion@npm:^10.0.14, create-emotion@npm:^10.0.27":
+  version: 10.0.27
+  resolution: "create-emotion@npm:10.0.27"
+  dependencies:
+    "@emotion/cache": "npm:^10.0.27"
+    "@emotion/serialize": "npm:^0.11.15"
+    "@emotion/sheet": "npm:0.9.4"
+    "@emotion/utils": "npm:0.11.3"
+  checksum: 10c0/9857e3dfbf162e321a40c30e5237fc5b25bb3843ff4451be85c1ad73e92252b24e8383eb506bf42b200d0098569257a084109e73bd3284184edd26d1917a539a
   languageName: node
   linkType: hard
 
@@ -5876,6 +6018,13 @@ __metadata:
     "@asamuzakjp/css-color": "npm:^3.2.0"
     rrweb-cssom: "npm:^0.8.0"
   checksum: 10c0/71add1b0ffafa1bedbef6855db6189b9523d3320e015a0bf3fbd504760efb9a81e1f1a225228d5fa892ee58e56d06994ca372e7f4e461cda7c4c9985fe075f65
+  languageName: node
+  linkType: hard
+
+"csstype@npm:^2.5.7":
+  version: 2.6.21
+  resolution: "csstype@npm:2.6.21"
+  checksum: 10c0/e07f27f2100bce9890bb4c3cb9263af97388f0d99b50073b663f1e363fa51b68ac7e2c8a612cd911d2b33c52d83afd1b0b8bc4de1d3ca76ee019a230295daffb
   languageName: node
   linkType: hard
 
@@ -6332,6 +6481,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"diff@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "diff@npm:4.0.2"
+  checksum: 10c0/81b91f9d39c4eaca068eb0c1eb0e4afbdc5bb2941d197f513dd596b820b956fef43485876226d65d497bebc15666aa2aa82c679e84f65d5f2bfbf14ee46e32c1
+  languageName: node
+  linkType: hard
+
 "diff@npm:^8":
   version: 8.0.2
   resolution: "diff@npm:8.0.2"
@@ -6480,6 +6636,16 @@ __metadata:
   version: 9.2.2
   resolution: "emoji-regex@npm:9.2.2"
   checksum: 10c0/af014e759a72064cf66e6e694a7fc6b0ed3d8db680427b021a89727689671cefe9d04151b2cad51dbaf85d5ba790d061cd167f1cf32eb7b281f6368b3c181639
+  languageName: node
+  linkType: hard
+
+"emotion@npm:^10.0.14":
+  version: 10.0.27
+  resolution: "emotion@npm:10.0.27"
+  dependencies:
+    babel-plugin-emotion: "npm:^10.0.27"
+    create-emotion: "npm:^10.0.27"
+  checksum: 10c0/a4c6963ef148cadbd5d72dbf9724d3685ed0d87330ceefcacfe9ae225ad7d8c6a08df232c291dc1ee0523c049c194a1b7dc6959ef98757464186b2d3c6de4592
   languageName: node
   linkType: hard
 
@@ -6746,6 +6912,13 @@ __metadata:
   version: 1.2.0
   resolution: "escape-latex@npm:1.2.0"
   checksum: 10c0/b77ea1594a38625295793a61105222c283c1792d1b2511bbfd6338cf02cc427dcabce7e7c1e22ec2f5c40baf3eaf2eeaf229a62dbbb74c6e69bb4a4209f2544f
+  languageName: node
+  linkType: hard
+
+"escape-string-regexp@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "escape-string-regexp@npm:1.0.5"
+  checksum: 10c0/a968ad453dd0c2724e14a4f20e177aaf32bb384ab41b674a8454afe9a41c5e6fe8903323e0a1052f56289d04bd600f81278edf140b0fcc02f5cac98d0f5b5371
   languageName: node
   linkType: hard
 
@@ -7409,6 +7582,13 @@ __metadata:
   dependencies:
     to-regex-range: "npm:^5.0.1"
   checksum: 10c0/b75b691bbe065472f38824f694c2f7449d7f5004aa950426a2c28f0306c60db9b880c0b0e4ed819997ffb882d1da02cfcfc819bddc94d71627f5269682edf018
+  languageName: node
+  linkType: hard
+
+"find-root@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "find-root@npm:1.1.0"
+  checksum: 10c0/1abc7f3bf2f8d78ff26d9e00ce9d0f7b32e5ff6d1da2857bcdf4746134c422282b091c672cde0572cac3840713487e0a7a636af9aa1b74cb11894b447a521efa
   languageName: node
   linkType: hard
 
@@ -8095,7 +8275,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
+"import-fresh@npm:^3.1.0, import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
   version: 3.3.1
   resolution: "import-fresh@npm:3.3.1"
   dependencies:
@@ -9786,6 +9966,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"memoize-one@npm:^5.0.4":
+  version: 5.2.1
+  resolution: "memoize-one@npm:5.2.1"
+  checksum: 10c0/fd22dbe9a978a2b4f30d6a491fc02fb90792432ad0dab840dc96c1734d2bd7c9cdeb6a26130ec60507eb43230559523615873168bcbe8fafab221c30b11d54c1
+  languageName: node
+  linkType: hard
+
 "merge-descriptors@npm:^1.0.1":
   version: 1.0.3
   resolution: "merge-descriptors@npm:1.0.3"
@@ -10703,7 +10890,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-json@npm:^5.2.0":
+"parse-json@npm:^5.0.0, parse-json@npm:^5.2.0":
   version: 5.2.0
   resolution: "parse-json@npm:5.2.0"
   dependencies:
@@ -10766,6 +10953,13 @@ __metadata:
   version: 6.2.1
   resolution: "path-to-regexp@npm:6.2.1"
   checksum: 10c0/7a73811ca703e5c199e5b50b9649ab8f6f7b458a37f7dff9ea338815203f5b1f95fe8cb24d4fdfe2eab5d67ce43562d92534330babca35cdf3231f966adb9360
+  languageName: node
+  linkType: hard
+
+"path-type@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "path-type@npm:4.0.0"
+  checksum: 10c0/666f6973f332f27581371efaf303fd6c272cc43c2057b37aa99e3643158c7e4b2626549555d88626e99ea9e046f82f32e41bbde5f1508547e9a11b149b52387c
   languageName: node
   linkType: hard
 
@@ -11848,6 +12042,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-diff-viewer@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "react-diff-viewer@npm:3.1.1"
+  dependencies:
+    classnames: "npm:^2.2.6"
+    create-emotion: "npm:^10.0.14"
+    diff: "npm:^4.0.1"
+    emotion: "npm:^10.0.14"
+    memoize-one: "npm:^5.0.4"
+    prop-types: "npm:^15.6.2"
+  peerDependencies:
+    react: ^15.3.0 || ^16.0.0
+    react-dom: ^15.3.0 || ^16.0.0
+  checksum: 10c0/83f95a19a2c206ca12c74ad8d90bb006fd31d5010b32d7822dfd33108eda72148733f69a3434c3cf8f8f80c4b8ac5696773c4ea820e9b5b837783b017ac57389
+  languageName: node
+  linkType: hard
+
 "react-dom@npm:19.1.1":
   version: 19.1.1
   resolution: "react-dom@npm:19.1.1"
@@ -12185,7 +12396,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.7, resolve@npm:^1.22.1, resolve@npm:^1.22.10, resolve@npm:^1.22.4, resolve@npm:^1.22.8":
+"resolve@npm:^1.1.7, resolve@npm:^1.12.0, resolve@npm:^1.22.1, resolve@npm:^1.22.10, resolve@npm:^1.22.4, resolve@npm:^1.22.8":
   version: 1.22.10
   resolution: "resolve@npm:1.22.10"
   dependencies:
@@ -12211,7 +12422,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.10#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.12.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.10#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
   version: 1.22.10
   resolution: "resolve@patch:resolve@npm%3A1.22.10#optional!builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
   dependencies:
@@ -13944,6 +14155,7 @@ __metadata:
     react-activity-calendar: "npm:^2.7.13"
     react-bootstrap: "npm:^2.10.4"
     react-cytoscapejs: "npm:^2.0.0"
+    react-diff-viewer: "npm:^3.1.1"
     react-dom: "npm:19.1.1"
     react-draggable: "npm:^4.4.5"
     react-force-graph: "npm:^1.45.0"
@@ -14771,6 +14983,13 @@ __metadata:
   version: 5.0.0
   resolution: "yallist@npm:5.0.0"
   checksum: 10c0/a499c81ce6d4a1d260d4ea0f6d49ab4da09681e32c3f0472dee16667ed69d01dae63a3b81745a24bd78476ec4fcf856114cb4896ace738e01da34b2c42235416
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^1.7.2":
+  version: 1.10.2
+  resolution: "yaml@npm:1.10.2"
+  checksum: 10c0/5c28b9eb7adc46544f28d9a8d20c5b3cb1215a886609a2fd41f51628d8aaa5878ccd628b755dbcd29f6bb4921bd04ffbc6dcc370689bb96e594e2f9813d2605f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- validate imported desktop settings against a strict schema and hold them for review instead of applying immediately
- add a modal with a side-by-side ReactDiffViewer preview plus clear error messaging before saving changes
- cover invalid JSON and successful preview flows with focused unit tests

## Testing
- yarn test settingsImport
- yarn lint *(fails: repository has numerous existing jsx-a11y/no-top-level-window violations)*

------
https://chatgpt.com/codex/tasks/task_e_68cc065b9fb4832884850c7d1efe1131