### PR TITLE
feat(weather): provider architecture with caching

### DIFF
--- a/__tests__/weatherApp.test.tsx
+++ b/__tests__/weatherApp.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import WeatherApp from '../apps/weather';
+import type { WeatherResponse } from '../apps/weather/providers/types';
+
+type CacheValue = Response;
+
+class CacheMock {
+  private store = new Map<string, CacheValue>();
+
+  async match(key: RequestInfo) {
+    return this.store.get(String(key)) ?? undefined;
+  }
+
+  async put(key: RequestInfo, value: CacheValue) {
+    this.store.set(String(key), value);
+  }
+}
+
+class CacheStorageMock {
+  private caches = new Map<string, CacheMock>();
+
+  async open(name: string) {
+    if (!this.caches.has(name)) {
+      this.caches.set(name, new CacheMock());
+    }
+    return this.caches.get(name)!;
+  }
+
+  clear() {
+    this.caches.clear();
+  }
+}
+
+const cachesMock = new CacheStorageMock();
+
+const createCacheEntry = (data: WeatherResponse): Response => ({
+  async json() {
+    return JSON.parse(JSON.stringify(data)) as WeatherResponse;
+  },
+  clone() {
+    return createCacheEntry(JSON.parse(JSON.stringify(data)) as WeatherResponse);
+  },
+}) as unknown as Response;
+
+const setNavigatorOnline = (value: boolean) => {
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    get: () => value,
+  });
+};
+
+beforeAll(() => {
+  Object.defineProperty(global, 'caches', {
+    configurable: true,
+    value: cachesMock,
+  });
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+  cachesMock.clear();
+  setNavigatorOnline(true);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const seedCityStorage = () => {
+  window.localStorage.setItem(
+    'weather-cities',
+    JSON.stringify([
+      { id: 'test-1', name: 'Test City', lat: 1, lon: 2 },
+    ]),
+  );
+  window.localStorage.setItem('weather-city-groups', JSON.stringify([]));
+  window.localStorage.setItem('weather-current-group', JSON.stringify(null));
+};
+
+test('switching providers refreshes readings from the new source', async () => {
+  seedCityStorage();
+
+  const payload = {
+    current_weather: { temperature: 10, weathercode: 2 },
+    daily: {
+      time: ['2024-01-01', '2024-01-02', '2024-01-03', '2024-01-04', '2024-01-05'],
+      temperature_2m_max: [10, 11, 12, 13, 14],
+      weathercode: [1, 2, 3, 4, 5],
+    },
+  };
+
+  const fetchMock = jest
+    .spyOn(global, 'fetch')
+    .mockResolvedValue({ ok: true, json: async () => payload } as Response);
+
+  const user = userEvent.setup();
+  render(<WeatherApp />);
+
+  await screen.findByText('10°C');
+
+  const select = screen.getByLabelText('Provider');
+  await user.selectOptions(select, 'demo');
+
+  await waitFor(() => {
+    expect(screen.getByText('13°C')).toBeInTheDocument();
+  });
+
+  expect(fetchMock).toHaveBeenCalled();
+});
+
+test('serves cached data when offline', async () => {
+  seedCityStorage();
+  window.localStorage.setItem('weather-provider', JSON.stringify('open-meteo'));
+
+  const cached: WeatherResponse = {
+    reading: { temp: 22, condition: 3, time: 123 },
+    forecast: [
+      { date: '2024-01-01', temp: 22, condition: 3 },
+      { date: '2024-01-02', temp: 23, condition: 5 },
+      { date: '2024-01-03', temp: 24, condition: 7 },
+      { date: '2024-01-04', temp: 25, condition: 9 },
+      { date: '2024-01-05', temp: 26, condition: 11 },
+    ],
+  };
+
+  const cache = await caches.open('weather');
+  await cache.put('open-meteo:1:2', createCacheEntry(cached));
+
+  const fetchMock = jest.spyOn(global, 'fetch').mockImplementation(() => {
+    throw new Error('should not fetch while offline');
+  });
+
+  setNavigatorOnline(false);
+
+  render(<WeatherApp />);
+
+  await waitFor(() => {
+    expect(screen.getByText('22°C')).toBeInTheDocument();
+  });
+
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(
+    screen.getByText(/Offline - showing cached data/i),
+  ).toBeInTheDocument();
+});

--- a/apps/weather/providers/demo.ts
+++ b/apps/weather/providers/demo.ts
@@ -1,0 +1,29 @@
+import type { WeatherProvider } from './types';
+import type { ForecastDay } from '../state';
+
+const buildDemoForecast = (base: number, start: number): ForecastDay[] =>
+  Array.from({ length: 5 }, (_, idx) => ({
+    date: new Date(start + idx * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+    temp: base + idx,
+    condition: (idx * 10) % 100,
+  }));
+
+const demo: WeatherProvider = {
+  id: 'demo',
+  label: 'Sample Data',
+  async fetch(city) {
+    const baseTemp = 10 + Math.round(Math.abs(city.lat) + Math.abs(city.lon));
+    const now = Date.now();
+
+    return {
+      reading: {
+        temp: baseTemp,
+        condition: 0,
+        time: now,
+      },
+      forecast: buildDemoForecast(baseTemp, now),
+    };
+  },
+};
+
+export default demo;

--- a/apps/weather/providers/index.ts
+++ b/apps/weather/providers/index.ts
@@ -1,0 +1,28 @@
+import demo from './demo';
+import openMeteo from './openMeteo';
+import type { WeatherProvider } from './types';
+
+const providerMap = {
+  [openMeteo.id]: openMeteo,
+  [demo.id]: demo,
+} as const;
+
+export type WeatherProviderId = keyof typeof providerMap;
+
+export const weatherProviders: Record<WeatherProviderId, WeatherProvider> = providerMap;
+
+export const defaultProviderId: WeatherProviderId = openMeteo.id;
+
+export const providerOptions: WeatherProvider[] = Object.values(providerMap);
+
+export const providerIds: WeatherProviderId[] = Object.keys(providerMap) as WeatherProviderId[];
+
+export const isProviderId = (value: unknown): value is WeatherProviderId =>
+  typeof value === 'string' && (value as string) in providerMap;
+
+export const getProvider = (id?: string | null): WeatherProvider => {
+  if (id && id in providerMap) {
+    return providerMap[id as WeatherProviderId];
+  }
+  return providerMap[defaultProviderId];
+};

--- a/apps/weather/providers/openMeteo.ts
+++ b/apps/weather/providers/openMeteo.ts
@@ -1,0 +1,61 @@
+import type { WeatherProvider } from './types';
+import type { ForecastDay } from '../state';
+
+const buildForecast = (data: any): ForecastDay[] => {
+  const times: unknown[] = data?.daily?.time ?? [];
+  const temps: unknown[] = data?.daily?.temperature_2m_max ?? [];
+  const codes: unknown[] = data?.daily?.weathercode ?? [];
+
+  if (!Array.isArray(times)) return [];
+
+  return times
+    .map((date, idx) => {
+      if (typeof date !== 'string') return null;
+      const temp = typeof temps[idx] === 'number' ? temps[idx] : null;
+      const condition = typeof codes[idx] === 'number' ? codes[idx] : null;
+      if (temp === null || condition === null) return null;
+      return {
+        date,
+        temp,
+        condition,
+      } satisfies ForecastDay;
+    })
+    .filter((value): value is ForecastDay => value !== null);
+};
+
+const openMeteo: WeatherProvider = {
+  id: 'open-meteo',
+  label: 'Open-Meteo',
+  async fetch(city) {
+    const params = new URLSearchParams({
+      latitude: String(city.lat),
+      longitude: String(city.lon),
+      current_weather: 'true',
+      daily: 'weathercode,temperature_2m_max',
+      forecast_days: '5',
+      timezone: 'auto',
+    });
+
+    const response = await fetch(`https://api.open-meteo.com/v1/forecast?${params}`);
+    if (!response.ok) {
+      throw new Error('Weather request failed');
+    }
+
+    const data = await response.json();
+    const current = data?.current_weather;
+    if (!current || typeof current.temperature !== 'number' || typeof current.weathercode !== 'number') {
+      throw new Error('Malformed weather data');
+    }
+
+    return {
+      reading: {
+        temp: current.temperature,
+        condition: current.weathercode,
+        time: Date.now(),
+      },
+      forecast: buildForecast(data),
+    };
+  },
+};
+
+export default openMeteo;

--- a/apps/weather/providers/types.ts
+++ b/apps/weather/providers/types.ts
@@ -1,0 +1,12 @@
+import type { City, ForecastDay, WeatherReading } from '../state';
+
+export interface WeatherResponse {
+  reading: WeatherReading;
+  forecast: ForecastDay[];
+}
+
+export interface WeatherProvider {
+  id: string;
+  label: string;
+  fetch(city: City): Promise<WeatherResponse>;
+}

--- a/apps/weather/state.ts
+++ b/apps/weather/state.ts
@@ -68,3 +68,9 @@ export function useCurrentGroup() {
   return usePersistentState<string | null>('weather-current-group', null, isStringOrNull);
 }
 
+const isProviderId = (value: unknown): value is string => typeof value === 'string';
+
+export function useWeatherProviderSetting() {
+  return usePersistentState<string>('weather-provider', 'open-meteo', isProviderId);
+}
+


### PR DESCRIPTION
## Summary
- extract weather providers into dedicated modules built around a WeatherResponse interface
- add provider selection plus stale-while-revalidate caching to the weather app UI
- cover provider switching and offline cache usage with new unit tests

## Testing
- yarn test weatherApp.test.tsx
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc065920c88328b760bcb23f706c02