### PR TITLE
[desktop] force quit button with runtime cleanup

### DIFF
--- a/__tests__/appRuntime.test.ts
+++ b/__tests__/appRuntime.test.ts
@@ -1,0 +1,34 @@
+import {
+  cleanupAppRuntime,
+  getHeapMetrics,
+  registerAppTimer,
+  resetAppRuntime,
+  setHeapBaseline,
+  updateHeapUsage,
+} from '../utils/appRuntime';
+
+describe('app runtime registry', () => {
+  afterEach(() => {
+    resetAppRuntime();
+  });
+
+  it('resets heap metrics to baseline on cleanup', () => {
+    setHeapBaseline('demo-app', 42);
+    updateHeapUsage('demo-app', 84);
+
+    cleanupAppRuntime('demo-app');
+
+    expect(getHeapMetrics('demo-app')).toEqual({ baseline: 42, current: 42 });
+  });
+
+  it('clears registered timers during cleanup', () => {
+    const clearFn = jest.fn();
+    const handle = 123;
+
+    registerAppTimer('demo-app', handle, clearFn);
+
+    cleanupAppRuntime('demo-app');
+
+    expect(clearFn).toHaveBeenCalledWith(handle);
+  });
+});

--- a/__tests__/desktopForceQuit.test.ts
+++ b/__tests__/desktopForceQuit.test.ts
@@ -1,0 +1,36 @@
+import { Desktop } from '../components/screen/desktop';
+import { cleanupAppRuntime } from '../utils/appRuntime';
+
+jest.mock('../utils/appRuntime', () => ({
+  cleanupAppRuntime: jest.fn(),
+  ensureHeapBaseline: jest.fn(),
+}));
+
+describe('Desktop forceQuitApp', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('cleans runtime state and restarts when requested', async () => {
+    jest.useFakeTimers();
+    const desktop = new Desktop({});
+    desktop.state.closed_windows = { 'test-app': false };
+    desktop.closeApp = jest.fn(() => Promise.resolve());
+    desktop.openApp = jest.fn();
+
+    const listener = jest.fn();
+    window.addEventListener('force-quit', listener);
+
+    await desktop.forceQuitApp('test-app', { restart: true });
+
+    expect(cleanupAppRuntime).toHaveBeenCalledWith('test-app');
+    expect(desktop.closeApp).toHaveBeenCalledWith('test-app', { skipSnapshot: true });
+    expect(listener).toHaveBeenCalled();
+
+    jest.runAllTimers();
+    expect(desktop.openApp).toHaveBeenCalledWith('test-app');
+
+    window.removeEventListener('force-quit', listener);
+    jest.useRealTimers();
+  });
+});

--- a/utils/appRuntime.ts
+++ b/utils/appRuntime.ts
@@ -1,0 +1,113 @@
+type TimerHandle = number | NodeJS.Timeout;
+
+type TimerEntry = {
+  handle: TimerHandle;
+  clear: () => void;
+};
+
+type HeapMetrics = {
+  baseline: number;
+  current: number;
+};
+
+const timers = new Map<string, Set<TimerEntry>>();
+const heapMetrics = new Map<string, HeapMetrics>();
+
+const defaultClear = (handle: TimerHandle) => {
+  if (typeof handle === 'number') {
+    clearTimeout(handle);
+  } else {
+    clearTimeout(handle);
+  }
+};
+
+const ensureTimerSet = (appId: string) => {
+  if (!timers.has(appId)) {
+    timers.set(appId, new Set());
+  }
+  return timers.get(appId)!;
+};
+
+const ensureHeapEntry = (appId: string, fallback = 0): HeapMetrics => {
+  if (!heapMetrics.has(appId)) {
+    heapMetrics.set(appId, { baseline: fallback, current: fallback });
+  }
+  return heapMetrics.get(appId)!;
+};
+
+export const registerAppTimer = (
+  appId: string,
+  handle: TimerHandle,
+  clearFn: (handle: TimerHandle) => void = defaultClear
+) => {
+  if (!appId || handle === null || typeof handle === 'undefined') {
+    return () => {};
+  }
+
+  const entry: TimerEntry = {
+    handle,
+    clear: () => {
+      try {
+        clearFn(handle);
+      } catch (err) {
+        // ignore timer cleanup errors so force quit never crashes
+      }
+    },
+  };
+
+  const set = ensureTimerSet(appId);
+  set.add(entry);
+
+  return () => {
+    const current = timers.get(appId);
+    if (!current) return;
+    current.delete(entry);
+    if (current.size === 0) {
+      timers.delete(appId);
+    }
+  };
+};
+
+export const clearAppTimers = (appId: string) => {
+  const set = timers.get(appId);
+  if (!set) return;
+  timers.delete(appId);
+  set.forEach((entry) => {
+    entry.clear();
+  });
+};
+
+export const setHeapBaseline = (appId: string, baseline: number) => {
+  heapMetrics.set(appId, { baseline, current: baseline });
+};
+
+export const ensureHeapBaseline = (appId: string, baseline = 0) => {
+  return ensureHeapEntry(appId, baseline);
+};
+
+export const updateHeapUsage = (appId: string, value: number) => {
+  const entry = ensureHeapEntry(appId, value);
+  entry.current = value;
+};
+
+export const resetHeapUsage = (appId: string) => {
+  const entry = heapMetrics.get(appId);
+  if (!entry) return;
+  entry.current = entry.baseline;
+};
+
+export const getHeapMetrics = (appId: string) => {
+  return heapMetrics.get(appId) ?? null;
+};
+
+export const cleanupAppRuntime = (appId: string) => {
+  clearAppTimers(appId);
+  resetHeapUsage(appId);
+};
+
+export const resetAppRuntime = () => {
+  timers.clear();
+  heapMetrics.clear();
+};
+
+export type { HeapMetrics };


### PR DESCRIPTION
## Summary
- add a runtime registry to track app timers and mock heap metrics
- expose a force quit control on each window that invokes desktop cleanup and optional restart
- cover the new lifecycle with unit tests for the window component, runtime registry, and desktop handler

## Testing
- yarn test --runTestsByPath __tests__/window.test.tsx __tests__/appRuntime.test.ts __tests__/desktopForceQuit.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc064333688328a909fe205c08e131