### PR TITLE
[logger] add buffered log monitor

### DIFF
--- a/__tests__/chatManager.test.ts
+++ b/__tests__/chatManager.test.ts
@@ -1,9 +1,13 @@
 import { getChatId } from '../src/chat/chatManager';
-import { createLogger } from '../lib/logger';
+import { clearAppLogBuffer, createLogger } from '../lib/logger';
 
 describe('getChatId', () => {
+  afterEach(() => {
+    clearAppLogBuffer('chat-test');
+  });
+
   it('throws and logs when chat is undefined', () => {
-    const logger = createLogger('test');
+    const logger = createLogger({ correlationId: 'test', appId: 'chat-test' });
     const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
     expect(() => getChatId(undefined as any, logger)).toThrow('chat is required');
     expect(spy).toHaveBeenCalled();

--- a/__tests__/logger.test.ts
+++ b/__tests__/logger.test.ts
@@ -1,0 +1,65 @@
+import {
+  LOG_BUFFER_LIMIT,
+  clearAppLogBuffer,
+  createLogger,
+  formatLogsForExport,
+  getAppLogBuffer,
+} from '../lib/logger';
+
+describe('logger buffers', () => {
+  const appId = 'test-app';
+
+  beforeEach(() => {
+    clearAppLogBuffer(appId);
+  });
+
+  afterEach(() => {
+    clearAppLogBuffer(appId);
+  });
+
+  it('enforces per-app buffer limits', () => {
+    const logger = createLogger({ appId, correlationId: 'limit-test' });
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      for (let i = 0; i < LOG_BUFFER_LIMIT + 5; i += 1) {
+        logger.info(`event-${i}`);
+      }
+    } finally {
+      spy.mockRestore();
+    }
+
+    const logs = getAppLogBuffer(appId);
+    expect(logs).toHaveLength(LOG_BUFFER_LIMIT);
+    expect(logs[0].message).toBe('event-5');
+    expect(logs[logs.length - 1].message).toBe(`event-${LOG_BUFFER_LIMIT + 4}`);
+    expect(logs.every((entry) => entry.appId === appId)).toBe(true);
+  });
+
+  it('serializes logs for export without sensitive metadata', () => {
+    const logger = createLogger({ appId, correlationId: 'export-test' });
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      logger.warn('user action', { user: 'alice', password: 'super-secret' });
+    } finally {
+      spy.mockRestore();
+    }
+
+    const raw = formatLogsForExport(appId);
+    const parsed = JSON.parse(raw);
+
+    expect(parsed.appId).toBe(appId);
+    expect(parsed.count).toBe(1);
+    expect(typeof parsed.exportedAt).toBe('string');
+    expect(parsed.logs).toHaveLength(1);
+
+    const [entry] = parsed.logs;
+    expect(entry).toMatchObject({
+      appId,
+      level: 'warn',
+      message: 'user action',
+      correlationId: 'export-test',
+    });
+    expect(typeof entry.timestamp).toBe('string');
+    expect(entry.meta).toEqual({ user: 'alice' });
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -77,6 +77,7 @@ const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
 const TrashApp = createDynamicApp('trash', 'Trash');
 const SerialTerminalApp = createDynamicApp('serial-terminal', 'Serial Terminal');
+const LogMonitorApp = createDynamicApp('log-monitor', 'Log Monitor');
 
 
 const WiresharkApp = createDynamicApp('wireshark', 'Wireshark');
@@ -163,6 +164,7 @@ const displayProjectGallery = createDisplay(ProjectGalleryApp);
 const displayTrash = createDisplay(TrashApp);
 const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
+const displayLogMonitor = createDisplay(LogMonitorApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
 
@@ -257,6 +259,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayProjectGallery,
+  },
+  {
+    id: 'log-monitor',
+    title: 'Log Monitor',
+    icon: '/themes/Yaru/apps/gedit.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayLogMonitor,
   },
   {
     id: 'input-lab',

--- a/apps/kismet/index.tsx
+++ b/apps/kismet/index.tsx
@@ -9,7 +9,7 @@ const KismetPage: React.FC = () => {
   const handleNetworkDiscovered = useCallback(
     (net?: { ssid: string; bssid: string; discoveredAt: number }) => {
       if (!net) return;
-      const logger = createLogger();
+      const logger = createLogger({ appId: 'kismet' });
       logger.info('network discovered', {
         ssid: net.ssid || net.bssid,
         time: new Date(net.discoveredAt).toISOString(),

--- a/components/apps/log-monitor/index.tsx
+++ b/components/apps/log-monitor/index.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  LOG_BUFFER_LIMIT,
+  LogEvent,
+  formatLogsForExport,
+  getAppLogBuffer,
+  getBufferedAppIds,
+  subscribeToLogUpdates,
+} from '../../../lib/logger';
+
+const levelColors: Record<LogEvent['level'], string> = {
+  info: 'text-green-300',
+  warn: 'text-yellow-300',
+  error: 'text-red-300',
+  debug: 'text-slate-200',
+};
+
+function LogMonitor() {
+  const [appIds, setAppIds] = useState<string[]>(() => getBufferedAppIds());
+  const [selectedApp, setSelectedApp] = useState<string>(() => {
+    const ids = getBufferedAppIds();
+    return ids[0] ?? '';
+  });
+  const [logs, setLogs] = useState<LogEvent[]>(() => {
+    const ids = getBufferedAppIds();
+    return ids[0] ? getAppLogBuffer(ids[0]) : [];
+  });
+
+  useEffect(() => {
+    const update = () => {
+      const ids = getBufferedAppIds();
+      setAppIds(ids);
+      let nextSelected = '';
+      setSelectedApp((current) => {
+        if (ids.length === 0) {
+          nextSelected = '';
+          return '';
+        }
+        if (current && ids.includes(current)) {
+          nextSelected = current;
+          return current;
+        }
+        nextSelected = ids[0];
+        return ids[0];
+      });
+      setLogs(nextSelected ? getAppLogBuffer(nextSelected) : []);
+    };
+    const unsubscribe = subscribeToLogUpdates(update);
+    update();
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    if (!selectedApp) {
+      setLogs([]);
+      return;
+    }
+    setLogs(getAppLogBuffer(selectedApp));
+  }, [selectedApp]);
+
+  const handleExport = useCallback(() => {
+    if (!selectedApp || logs.length === 0) return;
+    const payload = formatLogsForExport(selectedApp);
+    const blob = new Blob([payload], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const safeName = selectedApp.replace(/[^a-z0-9-_]+/gi, '-').replace(/^-+|-+$/g, '') || 'logs';
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${safeName}-logs.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [logs.length, selectedApp]);
+
+  const hasLogs = logs.length > 0;
+
+  return (
+    <div className="flex h-full flex-col bg-ub-cool-grey text-white">
+      <div className="flex flex-wrap items-center gap-3 border-b border-black/40 px-4 py-3">
+        <label className="text-sm font-semibold" htmlFor="log-monitor-app">
+          Application
+        </label>
+        <select
+          id="log-monitor-app"
+          value={selectedApp}
+          onChange={(event) => setSelectedApp(event.target.value)}
+          className="rounded bg-black/30 px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ubt-blue"
+        >
+          {appIds.length === 0 && <option value="">No logs yet</option>}
+          {appIds.map((id) => (
+            <option key={id} value={id}>
+              {id}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={!selectedApp || !hasLogs}
+          className="rounded bg-ubt-blue px-3 py-1 text-sm font-semibold text-black transition hover:bg-blue-300 disabled:cursor-not-allowed disabled:bg-black/30 disabled:text-white/40"
+        >
+          Export JSON
+        </button>
+      </div>
+      <p className="px-4 pt-3 text-xs text-white/70">
+        Monitoring the last {LOG_BUFFER_LIMIT} events emitted per application.
+      </p>
+      <div className="flex-1 overflow-auto px-4 pb-4 pt-2">
+        {!selectedApp ? (
+          <p className="text-sm text-white/70">
+            Logs will appear here once an application emits events through the logger.
+          </p>
+        ) : !hasLogs ? (
+          <p className="text-sm text-white/70">No log entries recorded yet for {selectedApp}.</p>
+        ) : (
+          <table className="w-full border-collapse text-left text-sm">
+            <thead className="sticky top-0 bg-ub-cool-grey">
+              <tr className="border-b border-black/40 text-xs uppercase tracking-wide text-white/60">
+                <th className="px-2 py-2">Time</th>
+                <th className="px-2 py-2">Level</th>
+                <th className="px-2 py-2">Message</th>
+                <th className="px-2 py-2">Meta</th>
+                <th className="px-2 py-2">Correlation</th>
+              </tr>
+            </thead>
+            <tbody>
+              {logs.map((entry) => (
+                <tr
+                  key={`${entry.timestamp}-${entry.message}-${entry.correlationId}`}
+                  className="border-b border-black/30 last:border-b-0"
+                >
+                  <td className="px-2 py-2 align-top text-xs text-white/70">
+                    {new Date(entry.timestamp).toLocaleString()}
+                  </td>
+                  <td
+                    className={`px-2 py-2 align-top font-semibold ${
+                      levelColors[entry.level] ?? 'text-white'
+                    }`}
+                  >
+                    {entry.level.toUpperCase()}
+                  </td>
+                  <td className="px-2 py-2 align-top">{entry.message}</td>
+                  <td className="px-2 py-2 align-top text-xs text-white/80">
+                    {entry.meta ? (
+                      <code className="whitespace-pre-wrap break-words">
+                        {JSON.stringify(entry.meta, null, 2)}
+                      </code>
+                    ) : (
+                      <span className="text-white/50">—</span>
+                    )}
+                  </td>
+                  <td className="px-2 py-2 align-top text-xs text-white/60 break-all">
+                    {entry.correlationId}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default LogMonitor;

--- a/components/core/ErrorBoundary.tsx
+++ b/components/core/ErrorBoundary.tsx
@@ -9,7 +9,7 @@ interface State {
   hasError: boolean;
 }
 
-const log = createLogger();
+const log = createLogger({ appId: 'error-boundary' });
 
 class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,5 +1,16 @@
 const SENSITIVE_KEYS = new Set(['password', 'secret', 'token', 'key']);
 
+export type LogLevel = 'info' | 'warn' | 'error' | 'debug';
+
+export interface LogEvent {
+  appId: string;
+  correlationId: string;
+  level: LogLevel;
+  message: string;
+  timestamp: string;
+  meta?: Record<string, any>;
+}
+
 export interface Logger {
   info(message: string, meta?: Record<string, any>): void;
   warn(message: string, meta?: Record<string, any>): void;
@@ -7,22 +18,66 @@ export interface Logger {
   debug(message: string, meta?: Record<string, any>): void;
 }
 
-class ConsoleLogger implements Logger {
-  constructor(private correlationId: string) {}
+export const LOG_BUFFER_LIMIT = 200;
 
-  private log(level: string, message: string, meta: Record<string, any> = {}) {
-    const safeMeta: Record<string, any> = {};
-    for (const [key, value] of Object.entries(meta)) {
-      if (!SENSITIVE_KEYS.has(key.toLowerCase())) {
-        safeMeta[key] = value;
-      }
+type LogListener = () => void;
+
+const logBuffers = new Map<string, LogEvent[]>();
+const listeners = new Set<LogListener>();
+
+function notifyListeners() {
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch {
+      // Ignore listener errors to avoid breaking logging.
     }
-    const entry = {
+  }
+}
+
+function getOrCreateBuffer(appId: string) {
+  if (!logBuffers.has(appId)) {
+    logBuffers.set(appId, []);
+  }
+  return logBuffers.get(appId)!;
+}
+
+function sanitizeMeta(meta?: Record<string, any>) {
+  if (!meta) {
+    return undefined;
+  }
+  const safeMeta: Record<string, any> = {};
+  for (const [key, value] of Object.entries(meta)) {
+    if (!SENSITIVE_KEYS.has(key.toLowerCase())) {
+      safeMeta[key] = value;
+    }
+  }
+  return Object.keys(safeMeta).length > 0 ? safeMeta : undefined;
+}
+
+function appendToBuffer(appId: string, entry: LogEvent) {
+  const buffer = getOrCreateBuffer(appId);
+  buffer.push(entry);
+  if (buffer.length > LOG_BUFFER_LIMIT) {
+    buffer.splice(0, buffer.length - LOG_BUFFER_LIMIT);
+  }
+  notifyListeners();
+}
+
+class BufferedConsoleLogger implements Logger {
+  constructor(private correlationId: string, private appId: string) {}
+
+  private log(level: LogLevel, message: string, meta?: Record<string, any>) {
+    const safeMeta = sanitizeMeta(meta);
+    const entry: LogEvent = {
       level,
       message,
       correlationId: this.correlationId,
-      ...safeMeta,
+      timestamp: new Date().toISOString(),
+      appId: this.appId,
+      ...(safeMeta ? { meta: safeMeta } : {}),
     };
+    appendToBuffer(this.appId, entry);
     console.log(JSON.stringify(entry));
   }
 
@@ -60,6 +115,50 @@ function generateCorrelationId(): string {
   }
 }
 
-export function createLogger(correlationId: string = generateCorrelationId()): Logger {
-  return new ConsoleLogger(correlationId);
+export interface LoggerOptions {
+  correlationId?: string;
+  appId?: string;
+}
+
+export function subscribeToLogUpdates(listener: LogListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getBufferedAppIds(): string[] {
+  return Array.from(logBuffers.keys()).sort();
+}
+
+export function getAppLogBuffer(appId: string): LogEvent[] {
+  const buffer = logBuffers.get(appId);
+  return buffer ? buffer.map((entry) => ({ ...entry, meta: entry.meta ? { ...entry.meta } : undefined })) : [];
+}
+
+export function clearAppLogBuffer(appId: string) {
+  if (logBuffers.delete(appId)) {
+    notifyListeners();
+  }
+}
+
+export function formatLogsForExport(appId: string) {
+  const logs = getAppLogBuffer(appId);
+  return JSON.stringify(
+    {
+      appId,
+      exportedAt: new Date().toISOString(),
+      count: logs.length,
+      logs,
+    },
+    null,
+    2,
+  );
+}
+
+export function createLogger(options?: string | LoggerOptions): Logger {
+  const opts: LoggerOptions = typeof options === 'string' ? { correlationId: options } : options ?? {};
+  const correlationId = opts.correlationId ?? generateCorrelationId();
+  const appId = opts.appId ?? 'global';
+  return new BufferedConsoleLogger(correlationId, appId);
 }

--- a/pages/api/admin/messages.js
+++ b/pages/api/admin/messages.js
@@ -5,7 +5,13 @@ export default async function handler(
   req,
   res
 ) {
-  const logger = createLogger(req.headers['x-correlation-id']);
+  const correlationIdHeader = req.headers['x-correlation-id'];
+  const logger = createLogger({
+    correlationId: Array.isArray(correlationIdHeader)
+      ? correlationIdHeader[0]
+      : correlationIdHeader,
+    appId: 'api/admin/messages',
+  });
   if (req.method !== 'GET') {
     logger.warn('method not allowed', { method: req.method });
     res.status(405).json({ error: 'Method not allowed' });

--- a/src/chat/chatManager.ts
+++ b/src/chat/chatManager.ts
@@ -4,7 +4,7 @@ export interface Chat {
   id: string;
 }
 
-export function getChatId(chat?: Chat, logger: Logger = createLogger()) {
+export function getChatId(chat?: Chat, logger: Logger = createLogger({ appId: 'chat' })) {
   if (!chat) {
     logger.error('chat is required');
     throw new Error('chat is required');


### PR DESCRIPTION
## Summary
- capture logger output into per-app ring buffers with helpers to read and export them
- surface a Log Monitor utility to browse buffered events and trigger JSON exports
- tag existing logger callers with app IDs and cover buffer behaviour with unit tests

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window violations across unrelated apps)*
- yarn test *(fails: pre-existing window focus and PopularModules act warnings in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68cc06418ae0832886ade52a29ca36ec