### PR TITLE
[camera] add preflight diagnostics

### DIFF
--- a/__tests__/camera.preflight.test.tsx
+++ b/__tests__/camera.preflight.test.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CameraApp from '../components/apps/camera';
+
+const originalMediaDevicesDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis.navigator,
+  'mediaDevices',
+);
+const originalPermissionsDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis.navigator,
+  'permissions',
+);
+const originalGetContextDescriptor = Object.getOwnPropertyDescriptor(
+  HTMLCanvasElement.prototype,
+  'getContext',
+);
+
+const restoreNavigatorProperty = (
+  key: 'mediaDevices' | 'permissions',
+  descriptor: PropertyDescriptor | undefined,
+) => {
+  if (descriptor) {
+    Object.defineProperty(globalThis.navigator, key, descriptor);
+  } else {
+    delete (globalThis.navigator as Record<string, unknown>)[key];
+  }
+};
+
+const mockNavigatorProperty = (
+  key: 'mediaDevices' | 'permissions',
+  value: unknown,
+) => {
+  Object.defineProperty(globalThis.navigator, key, {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value,
+  });
+};
+
+describe('CameraApp preflight', () => {
+  let consoleWarn: jest.SpyInstance;
+  let consoleInfo: jest.SpyInstance;
+
+  beforeAll(() => {
+    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+      configurable: true,
+      value: jest.fn(() => ({
+        beginPath: jest.fn(),
+        moveTo: jest.fn(),
+        lineTo: jest.fn(),
+        stroke: jest.fn(),
+        clearRect: jest.fn(),
+        drawImage: jest.fn(),
+      })),
+    });
+  });
+
+  afterAll(() => {
+    if (originalGetContextDescriptor) {
+      Object.defineProperty(
+        HTMLCanvasElement.prototype,
+        'getContext',
+        originalGetContextDescriptor,
+      );
+    } else {
+      delete (HTMLCanvasElement.prototype as Record<string, unknown>).getContext;
+    }
+  });
+
+  beforeEach(() => {
+    restoreNavigatorProperty('mediaDevices', originalMediaDevicesDescriptor);
+    restoreNavigatorProperty('permissions', originalPermissionsDescriptor);
+    consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    consoleInfo = jest.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarn.mockRestore();
+    consoleInfo.mockRestore();
+    restoreNavigatorProperty('mediaDevices', originalMediaDevicesDescriptor);
+    restoreNavigatorProperty('permissions', originalPermissionsDescriptor);
+  });
+
+  it('blocks start when media devices API is missing', async () => {
+    mockNavigatorProperty('mediaDevices', undefined);
+    mockNavigatorProperty('permissions', undefined);
+
+    render(<CameraApp />);
+
+    await screen.findByText('Camera APIs are not available in this browser.');
+    const startButton = screen.getByRole('button', { name: /start camera/i });
+    expect(startButton).toBeDisabled();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[Camera App] Preflight diagnostics',
+      expect.objectContaining({ hasMediaDevices: false, ready: false }),
+    );
+  });
+
+  it('reports when no camera devices are found', async () => {
+    const enumerateDevices = jest.fn().mockResolvedValue([
+      { kind: 'audioinput', deviceId: 'mic-1', label: 'Microphone' } as MediaDeviceInfo,
+    ]);
+    const getUserMedia = jest.fn();
+
+    mockNavigatorProperty('mediaDevices', {
+      enumerateDevices,
+      getUserMedia,
+    });
+
+    const permissionStatus = {
+      state: 'granted' as PermissionState,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    } as unknown as PermissionStatus;
+
+    mockNavigatorProperty('permissions', {
+      query: jest.fn().mockResolvedValue(permissionStatus),
+    });
+
+    render(<CameraApp />);
+
+    await screen.findByText('No camera detected.');
+    expect(screen.getByRole('button', { name: /start camera/i })).toBeDisabled();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[Camera App] Preflight diagnostics',
+      expect.objectContaining({ videoDeviceCount: 0, ready: false }),
+    );
+  });
+
+  it('blocks start when camera permission is denied', async () => {
+    const enumerateDevices = jest.fn().mockResolvedValue([
+      { kind: 'videoinput', deviceId: 'cam-1', label: 'Camera' } as MediaDeviceInfo,
+    ]);
+    const getUserMedia = jest.fn();
+
+    mockNavigatorProperty('mediaDevices', {
+      enumerateDevices,
+      getUserMedia,
+    });
+
+    const permissionStatus = {
+      state: 'denied' as PermissionState,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    } as unknown as PermissionStatus;
+
+    mockNavigatorProperty('permissions', {
+      query: jest.fn().mockResolvedValue(permissionStatus),
+    });
+
+    render(<CameraApp />);
+
+    await screen.findByText('Camera access has been denied.');
+    const startButton = screen.getByRole('button', { name: /start camera/i });
+    expect(startButton).toBeDisabled();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[Camera App] Preflight diagnostics',
+      expect.objectContaining({ permissionState: 'denied', ready: false }),
+    );
+  });
+});

--- a/__tests__/qr_scanner.preflight.test.tsx
+++ b/__tests__/qr_scanner.preflight.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import QRScanner from '../components/apps/qr';
+
+jest.mock('qrcode', () => ({
+  toDataURL: jest.fn().mockResolvedValue(''),
+  toString: jest.fn(),
+}));
+
+const originalMediaDevicesDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis.navigator,
+  'mediaDevices',
+);
+const originalPermissionsDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis.navigator,
+  'permissions',
+);
+
+const restoreNavigatorProperty = (
+  key: 'mediaDevices' | 'permissions',
+  descriptor: PropertyDescriptor | undefined,
+) => {
+  if (descriptor) {
+    Object.defineProperty(globalThis.navigator, key, descriptor);
+  } else {
+    delete (globalThis.navigator as Record<string, unknown>)[key];
+  }
+};
+
+const mockNavigatorProperty = (key: 'mediaDevices' | 'permissions', value: unknown) => {
+  Object.defineProperty(globalThis.navigator, key, {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value,
+  });
+};
+
+describe('QRScanner preflight', () => {
+  let consoleWarn: jest.SpyInstance;
+  let consoleInfo: jest.SpyInstance;
+
+  beforeEach(() => {
+    restoreNavigatorProperty('mediaDevices', originalMediaDevicesDescriptor);
+    restoreNavigatorProperty('permissions', originalPermissionsDescriptor);
+    consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    consoleInfo = jest.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarn.mockRestore();
+    consoleInfo.mockRestore();
+    restoreNavigatorProperty('mediaDevices', originalMediaDevicesDescriptor);
+    restoreNavigatorProperty('permissions', originalPermissionsDescriptor);
+  });
+
+  it('blocks start when media devices API is missing', async () => {
+    mockNavigatorProperty('mediaDevices', undefined);
+    mockNavigatorProperty('permissions', undefined);
+
+    render(<QRScanner />);
+
+    await screen.findByText('Camera APIs are not available in this browser.');
+    const startButton = screen.getByRole('button', { name: /start scanner/i });
+    expect(startButton).toBeDisabled();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[QR Scanner] Preflight diagnostics',
+      expect.objectContaining({ hasMediaDevices: false, ready: false }),
+    );
+  });
+
+  it('reports when no camera devices are found', async () => {
+    const enumerateDevices = jest
+      .fn()
+      .mockResolvedValue([
+        { kind: 'audioinput', deviceId: 'mic-1', label: 'Microphone' } as MediaDeviceInfo,
+      ]);
+    const getUserMedia = jest.fn();
+
+    mockNavigatorProperty('mediaDevices', {
+      enumerateDevices,
+      getUserMedia,
+    });
+
+    const permissionStatus = {
+      state: 'granted' as PermissionState,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    } as unknown as PermissionStatus;
+
+    mockNavigatorProperty('permissions', {
+      query: jest.fn().mockResolvedValue(permissionStatus),
+    });
+
+    render(<QRScanner />);
+
+    await screen.findByText('No camera detected.');
+    expect(screen.getByRole('button', { name: /start scanner/i })).toBeDisabled();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[QR Scanner] Preflight diagnostics',
+      expect.objectContaining({ videoDeviceCount: 0, ready: false }),
+    );
+  });
+
+  it('blocks start when camera permission is denied', async () => {
+    const enumerateDevices = jest
+      .fn()
+      .mockResolvedValue([
+        { kind: 'videoinput', deviceId: 'cam-1', label: 'Camera' } as MediaDeviceInfo,
+      ]);
+    const getUserMedia = jest.fn();
+
+    mockNavigatorProperty('mediaDevices', {
+      enumerateDevices,
+      getUserMedia,
+    });
+
+    const permissionStatus = {
+      state: 'denied' as PermissionState,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    } as unknown as PermissionStatus;
+
+    mockNavigatorProperty('permissions', {
+      query: jest.fn().mockResolvedValue(permissionStatus),
+    });
+
+    render(<QRScanner />);
+
+    await screen.findByText('Camera access has been denied.');
+    const startButton = screen.getByRole('button', { name: /start scanner/i });
+    expect(startButton).toBeDisabled();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[QR Scanner] Preflight diagnostics',
+      expect.objectContaining({ permissionState: 'denied', ready: false }),
+    );
+  });
+});

--- a/components/apps/camera.tsx
+++ b/components/apps/camera.tsx
@@ -1,33 +1,314 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+type CheckStatus = 'pass' | 'warn' | 'fail';
+
+interface PreflightCheck {
+  id: string;
+  label: string;
+  status: CheckStatus;
+  message: string;
+  suggestion?: string;
+}
+
+interface PreflightDiagnostics {
+  hasMediaDevices: boolean;
+  enumerateSupported: boolean;
+  getUserMediaSupported: boolean;
+  ready: boolean;
+  videoDeviceCount?: number;
+  permissionState: PermissionState | 'unsupported' | 'error';
+  enumerateError?: string;
+  permissionError?: string;
+  devices?: Array<{ kind: string; label: string }>;
+  checks: Array<{ id: string; status: CheckStatus }>;
+}
 
 const CameraApp: React.FC = () => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const overlayRef = useRef<HTMLCanvasElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const permissionStatusRef = useRef<PermissionStatus | null>(null);
+  const isMountedRef = useRef(true);
   const [snapshot, setSnapshot] = useState<string>('');
   const [drawing, setDrawing] = useState(false);
+  const [error, setError] = useState('');
+  const [isRunning, setIsRunning] = useState(false);
+  const [preflightChecks, setPreflightChecks] = useState<PreflightCheck[]>([]);
+  const [preflightStatus, setPreflightStatus] = useState<
+    'pending' | 'ready' | 'blocked'
+  >('pending');
+  const [preflightLoading, setPreflightLoading] = useState(true);
+
+  const runPreflight = useCallback(async (): Promise<boolean> => {
+    if (!isMountedRef.current) return false;
+    setPreflightLoading(true);
+    setPreflightStatus('pending');
+
+    const hasMediaDevices = Boolean(navigator.mediaDevices);
+    const getUserMediaSupported = Boolean(
+      navigator.mediaDevices?.getUserMedia,
+    );
+    const enumerateSupported =
+      typeof navigator.mediaDevices?.enumerateDevices === 'function';
+
+    const checks: PreflightCheck[] = [];
+    const diagnostics: PreflightDiagnostics = {
+      hasMediaDevices,
+      enumerateSupported,
+      getUserMediaSupported,
+      ready: false,
+      permissionState: 'unsupported',
+      checks: [],
+    };
+
+    if (!hasMediaDevices) {
+      checks.push({
+        id: 'media-devices',
+        label: 'Media Devices API',
+        status: 'fail',
+        message: 'Camera APIs are not available in this browser.',
+        suggestion: 'Use a modern browser that supports MediaDevices.',
+      });
+    } else {
+      checks.push({
+        id: 'media-devices',
+        label: 'Media Devices API',
+        status: 'pass',
+        message: 'Media devices API detected.',
+      });
+
+      if (!getUserMediaSupported) {
+        checks.push({
+          id: 'get-user-media',
+          label: 'Camera stream support',
+          status: 'fail',
+          message: 'Camera streaming is not supported.',
+          suggestion:
+            'Use a browser that supports navigator.mediaDevices.getUserMedia.',
+        });
+      } else {
+        checks.push({
+          id: 'get-user-media',
+          label: 'Camera stream support',
+          status: 'pass',
+          message: 'Browser can start camera streams.',
+        });
+      }
+
+      if (!enumerateSupported) {
+        checks.push({
+          id: 'enumerate-devices',
+          label: 'Device enumeration',
+          status: 'fail',
+          message: 'Cannot list connected cameras.',
+          suggestion: 'Allow camera permissions or try reconnecting your webcam.',
+        });
+      } else {
+        try {
+          const devices = await navigator.mediaDevices!.enumerateDevices();
+          diagnostics.devices = devices.map((device) => ({
+            kind: device.kind,
+            label: device.label || device.deviceId,
+          }));
+          const videoDevices = devices.filter(
+            (device) => device.kind === 'videoinput',
+          );
+          diagnostics.videoDeviceCount = videoDevices.length;
+          if (videoDevices.length === 0) {
+            checks.push({
+              id: 'camera-availability',
+              label: 'Connected cameras',
+              status: 'fail',
+              message: 'No camera detected.',
+              suggestion:
+                'Connect a webcam and ensure no other app is using it.',
+            });
+          } else {
+            const cameraLabel =
+              videoDevices.length === 1 ? 'camera' : 'cameras';
+            checks.push({
+              id: 'camera-availability',
+              label: 'Connected cameras',
+              status: 'pass',
+              message: `Found ${videoDevices.length} ${cameraLabel} ready to use.`,
+            });
+          }
+        } catch (err) {
+          diagnostics.enumerateError =
+            err instanceof Error ? err.message : String(err);
+          checks.push({
+            id: 'camera-availability',
+            label: 'Connected cameras',
+            status: 'fail',
+            message: 'Could not list cameras.',
+            suggestion:
+              'Ensure the browser has permission to access media devices.',
+          });
+        }
+      }
+    }
+
+    let permissionState: PermissionState | 'unsupported' | 'error' =
+      'unsupported';
+    if (
+      'permissions' in navigator &&
+      typeof navigator.permissions?.query === 'function'
+    ) {
+      try {
+        const status = await navigator.permissions.query({
+          name: 'camera' as PermissionName,
+        });
+        if (permissionStatusRef.current?.onchange) {
+          permissionStatusRef.current.onchange = null;
+        }
+        permissionStatusRef.current = status;
+        status.onchange = () => {
+          void runPreflight();
+        };
+        permissionState = status.state;
+        if (status.state === 'denied') {
+          checks.push({
+            id: 'camera-permission',
+            label: 'Camera permission',
+            status: 'fail',
+            message: 'Camera access has been denied.',
+            suggestion:
+              'Update your browser settings to allow camera access for this site.',
+          });
+        } else if (status.state === 'prompt') {
+          checks.push({
+            id: 'camera-permission',
+            label: 'Camera permission',
+            status: 'warn',
+            message: 'Camera access will be requested when starting.',
+            suggestion: 'Be ready to approve the permission prompt when it appears.',
+          });
+        } else {
+          checks.push({
+            id: 'camera-permission',
+            label: 'Camera permission',
+            status: 'pass',
+            message: 'Camera permission already granted.',
+          });
+        }
+      } catch (err) {
+        diagnostics.permissionError =
+          err instanceof Error ? err.message : String(err);
+        permissionState = 'error';
+        checks.push({
+          id: 'camera-permission',
+          label: 'Camera permission',
+          status: 'warn',
+          message: 'Unable to read camera permission status.',
+          suggestion: 'Start the camera to trigger the permission prompt.',
+        });
+      }
+    } else {
+      checks.push({
+        id: 'camera-permission',
+        label: 'Camera permission',
+        status: 'warn',
+        message: 'Browser does not expose permission status.',
+        suggestion: 'Starting the camera may show a permission prompt.',
+      });
+    }
+
+    const ready = checks.every((check) => check.status !== 'fail');
+    diagnostics.permissionState = permissionState;
+    diagnostics.ready = ready;
+    diagnostics.checks = checks.map((check) => ({
+      id: check.id,
+      status: check.status,
+    }));
+
+    if (isMountedRef.current) {
+      setPreflightChecks(checks);
+      setPreflightStatus(ready ? 'ready' : 'blocked');
+      setPreflightLoading(false);
+    }
+
+    if (ready) {
+      console.info('[Camera App] Preflight diagnostics', diagnostics);
+    } else {
+      console.warn('[Camera App] Preflight diagnostics', diagnostics);
+    }
+
+    return ready;
+  }, []);
 
   useEffect(() => {
-    let stream: MediaStream;
+    if (!isRunning) return;
+
+    let active = true;
+
     const start = async () => {
+      if (!navigator.mediaDevices?.getUserMedia) {
+        setError('Camera API not supported');
+        setIsRunning(false);
+        void runPreflight();
+        return;
+      }
       try {
-        stream = await navigator.mediaDevices.getUserMedia({ video: true });
-        if (videoRef.current) {
-          videoRef.current.srcObject = stream;
-          await videoRef.current.play();
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: true,
+        });
+        streamRef.current = stream;
+        if (!active) {
+          stream.getTracks().forEach((t) => t.stop());
+          return;
         }
-      } catch {
-        // ignore errors
+        const video = videoRef.current;
+        if (video) {
+          video.srcObject = stream;
+          await video.play().catch(() => {});
+        }
+        setError('');
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'NotAllowedError') {
+          setError('Camera access was denied');
+        } else {
+          setError('Could not start camera');
+        }
+        setIsRunning(false);
+        void runPreflight();
       }
     };
-    start();
+
+    void start();
+
     return () => {
-      if (stream) {
-        stream.getTracks().forEach((t) => t.stop());
+      active = false;
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+      const video = videoRef.current;
+      if (video) {
+        video.srcObject = null;
       }
     };
-  }, []);
+  }, [isRunning, runPreflight]);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    void runPreflight();
+    return () => {
+      isMountedRef.current = false;
+      if (permissionStatusRef.current?.onchange) {
+        permissionStatusRef.current.onchange = null;
+      }
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+      if (video) {
+        video.srcObject = null;
+      }
+    };
+  }, [runPreflight]);
 
   const handleLoaded = () => {
     const video = videoRef.current;
@@ -43,6 +324,7 @@ const CameraApp: React.FC = () => {
   };
 
   const startDrawing = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!isRunning) return;
     setDrawing(true);
     const { x, y } = getPos(e);
     const ctx = overlayRef.current!.getContext('2d');
@@ -54,7 +336,7 @@ const CameraApp: React.FC = () => {
   };
 
   const draw = (e: React.MouseEvent<HTMLCanvasElement>) => {
-    if (!drawing) return;
+    if (!drawing || !isRunning) return;
     const { x, y } = getPos(e);
     const ctx = overlayRef.current!.getContext('2d');
     if (!ctx) return;
@@ -66,15 +348,16 @@ const CameraApp: React.FC = () => {
     setDrawing(false);
   };
 
-  const clearOverlay = () => {
+  const clearOverlay = useCallback(() => {
     const overlay = overlayRef.current;
     if (!overlay) return;
     const ctx = overlay.getContext('2d');
     if (!ctx) return;
     ctx.clearRect(0, 0, overlay.width, overlay.height);
-  };
+  }, []);
 
   const takeSnapshot = () => {
+    if (!isRunning) return;
     const video = videoRef.current;
     const overlay = overlayRef.current;
     if (!video || !overlay) return;
@@ -88,8 +371,126 @@ const CameraApp: React.FC = () => {
     setSnapshot(canvas.toDataURL('image/png'));
   };
 
+  const startCamera = useCallback(async () => {
+    if (isRunning || preflightLoading) return;
+    if (preflightStatus !== 'ready') {
+      const ready = await runPreflight();
+      if (!ready) return;
+    }
+    setError('');
+    setIsRunning(true);
+  }, [isRunning, preflightLoading, preflightStatus, runPreflight]);
+
+  const stopCamera = useCallback(() => {
+    setIsRunning(false);
+    setError('');
+    clearOverlay();
+  }, [clearOverlay]);
+
+  const retryPreflight = useCallback(() => {
+    void runPreflight();
+  }, [runPreflight]);
+
+  const statusColors: Record<CheckStatus, string> = {
+    pass: 'text-green-300',
+    warn: 'text-yellow-300',
+    fail: 'text-red-300',
+  };
+
+  const statusLabels: Record<CheckStatus, string> = {
+    pass: 'OK',
+    warn: 'Review',
+    fail: 'Blocked',
+  };
+
+  const preflightSummary =
+    preflightStatus === 'ready'
+      ? 'All systems go — you can start the camera.'
+      : preflightStatus === 'blocked'
+        ? 'Resolve the highlighted issues before starting.'
+        : 'Running device and permission checks...';
+
+  const preflightSummaryColor =
+    preflightStatus === 'ready'
+      ? 'text-green-300'
+      : preflightStatus === 'blocked'
+        ? 'text-red-300'
+        : 'text-yellow-300';
+
+  const startDisabled = preflightLoading || preflightStatus !== 'ready' || isRunning;
+
   return (
     <div className="h-full w-full p-4 bg-gray-900 text-white overflow-auto flex flex-col items-center space-y-4">
+      <div className="w-full max-w-sm">
+        <div className="w-full rounded-md border border-white/10 bg-black/50 p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-base font-semibold">Preflight checks</h2>
+            <span
+              className={`text-xs font-semibold uppercase ${preflightSummaryColor}`}
+            >
+              {preflightStatus === 'ready'
+                ? 'Ready'
+                : preflightStatus === 'blocked'
+                  ? 'Blocked'
+                  : 'Checking'}
+            </span>
+          </div>
+          <p className={`text-sm ${preflightSummaryColor}`}>{preflightSummary}</p>
+          {preflightLoading ? (
+            <p className="text-xs text-gray-300">Checking camera and permission status…</p>
+          ) : (
+            <ul className="space-y-3 text-sm">
+              {preflightChecks.map((check) => (
+                <li
+                  key={check.id}
+                  className="rounded border border-white/10 bg-black/30 p-3"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium">{check.label}</span>
+                    <span
+                      className={`text-xs font-semibold uppercase ${statusColors[check.status]}`}
+                    >
+                      {statusLabels[check.status]}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-xs text-gray-200">{check.message}</p>
+                  {check.suggestion && (
+                    <p className="mt-1 text-xs italic text-gray-400">{check.suggestion}</p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="flex flex-wrap gap-2 pt-2">
+            <button
+              type="button"
+              onClick={retryPreflight}
+              className="rounded bg-gray-700 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={preflightLoading}
+            >
+              {preflightLoading ? 'Checking…' : 'Re-run checks'}
+            </button>
+            <button
+              type="button"
+              onClick={() => void startCamera()}
+              className="rounded bg-blue-600 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={startDisabled}
+            >
+              {isRunning ? 'Camera running' : 'Start camera'}
+            </button>
+            {isRunning && (
+              <button
+                type="button"
+                onClick={stopCamera}
+                className="rounded bg-red-600 px-3 py-1 text-sm"
+              >
+                Stop camera
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+
       <div className="relative">
         <video
           ref={videoRef}
@@ -106,12 +507,19 @@ const CameraApp: React.FC = () => {
           onMouseUp={stopDrawing}
           onMouseLeave={stopDrawing}
         />
+        {!isRunning && (
+          <div className="absolute inset-0 flex items-center justify-center rounded bg-black/70 text-center text-xs text-gray-200">
+            Start the camera once preflight passes to access the live feed.
+          </div>
+        )}
       </div>
+      {error && <p className="text-sm text-red-500">{error}</p>}
       <div className="space-x-2">
         <button
           type="button"
           onClick={takeSnapshot}
-          className="px-4 py-2 bg-blue-700 rounded"
+          className="px-4 py-2 bg-blue-700 rounded disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={!isRunning}
         >
           Snapshot
         </button>

--- a/components/apps/qr/index.tsx
+++ b/components/apps/qr/index.tsx
@@ -1,25 +1,236 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import QRCode from 'qrcode';
+
+type CheckStatus = 'pass' | 'warn' | 'fail';
+
+interface PreflightCheck {
+  id: string;
+  label: string;
+  status: CheckStatus;
+  message: string;
+  suggestion?: string;
+}
+
+interface PreflightDiagnostics {
+  hasMediaDevices: boolean;
+  enumerateSupported: boolean;
+  getUserMediaSupported: boolean;
+  ready: boolean;
+  videoDeviceCount?: number;
+  permissionState: PermissionState | 'unsupported' | 'error';
+  enumerateError?: string;
+  permissionError?: string;
+  devices?: Array<{ kind: string; label: string }>;
+  checks: Array<{ id: string; status: CheckStatus }>;
+}
 
 const QRScanner: React.FC = () => {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const controlsRef = useRef<{ stop: () => void } | null>(null);
   const trackRef = useRef<MediaStreamTrack | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  const permissionStatusRef = useRef<PermissionStatus | null>(null);
+  const isMountedRef = useRef(true);
   const [result, setResult] = useState('');
   const [error, setError] = useState('');
   const [facing, setFacing] = useState<'environment' | 'user'>('environment');
   const [torch, setTorch] = useState(false);
   const [preview, setPreview] = useState('');
+  const [preflightChecks, setPreflightChecks] = useState<PreflightCheck[]>([]);
+  const [preflightStatus, setPreflightStatus] = useState<'pending' | 'ready' | 'blocked'>('pending');
+  const [preflightLoading, setPreflightLoading] = useState(true);
+  const [isRunning, setIsRunning] = useState(false);
+
+  const runPreflight = useCallback(async (): Promise<boolean> => {
+    if (!isMountedRef.current) return false;
+    setPreflightLoading(true);
+    setPreflightStatus('pending');
+
+    const hasMediaDevices = Boolean(navigator.mediaDevices);
+    const getUserMediaSupported = Boolean(navigator.mediaDevices?.getUserMedia);
+    const enumerateSupported = typeof navigator.mediaDevices?.enumerateDevices === 'function';
+
+    const checks: PreflightCheck[] = [];
+    const diagnostics: PreflightDiagnostics = {
+      hasMediaDevices,
+      enumerateSupported,
+      getUserMediaSupported,
+      ready: false,
+      permissionState: 'unsupported',
+      checks: [],
+    };
+
+    if (!hasMediaDevices) {
+      checks.push({
+        id: 'media-devices',
+        label: 'Media Devices API',
+        status: 'fail',
+        message: 'Camera APIs are not available in this browser.',
+        suggestion: 'Use a modern browser that supports MediaDevices.',
+      });
+    } else {
+      checks.push({
+        id: 'media-devices',
+        label: 'Media Devices API',
+        status: 'pass',
+        message: 'Media devices API detected.',
+      });
+
+      if (!getUserMediaSupported) {
+        checks.push({
+          id: 'get-user-media',
+          label: 'Camera stream support',
+          status: 'fail',
+          message: 'Camera streaming is not supported.',
+          suggestion: 'Use a browser that supports navigator.mediaDevices.getUserMedia.',
+        });
+      } else {
+        checks.push({
+          id: 'get-user-media',
+          label: 'Camera stream support',
+          status: 'pass',
+          message: 'Browser can start camera streams.',
+        });
+      }
+
+      if (!enumerateSupported) {
+        checks.push({
+          id: 'enumerate-devices',
+          label: 'Device enumeration',
+          status: 'fail',
+          message: 'Cannot list connected cameras.',
+          suggestion: 'Allow camera permissions or try reconnecting your webcam.',
+        });
+      } else {
+        try {
+          const devices = await navigator.mediaDevices!.enumerateDevices();
+          diagnostics.devices = devices.map((device) => ({
+            kind: device.kind,
+            label: device.label || device.deviceId,
+          }));
+          const videoDevices = devices.filter((device) => device.kind === 'videoinput');
+          diagnostics.videoDeviceCount = videoDevices.length;
+          if (videoDevices.length === 0) {
+            checks.push({
+              id: 'camera-availability',
+              label: 'Connected cameras',
+              status: 'fail',
+              message: 'No camera detected.',
+              suggestion: 'Connect a webcam and ensure no other app is using it.',
+            });
+          } else {
+            checks.push({
+              id: 'camera-availability',
+              label: 'Connected cameras',
+              status: 'pass',
+              message: `Found ${videoDevices.length} camera${videoDevices.length > 1 ? 's' : ''} ready to use.`,
+            });
+          }
+        } catch (err) {
+          diagnostics.enumerateError = err instanceof Error ? err.message : String(err);
+          checks.push({
+            id: 'camera-availability',
+            label: 'Connected cameras',
+            status: 'fail',
+            message: 'Could not list cameras.',
+            suggestion: 'Ensure the browser has permission to access media devices.',
+          });
+        }
+      }
+    }
+
+    let permissionState: PermissionState | 'unsupported' | 'error' = 'unsupported';
+    if ('permissions' in navigator && typeof navigator.permissions?.query === 'function') {
+      try {
+        const status = await navigator.permissions.query({
+          name: 'camera' as PermissionName,
+        });
+        if (permissionStatusRef.current?.onchange) {
+          permissionStatusRef.current.onchange = null;
+        }
+        permissionStatusRef.current = status;
+        status.onchange = () => {
+          void runPreflight();
+        };
+        permissionState = status.state;
+        if (status.state === 'denied') {
+          checks.push({
+            id: 'camera-permission',
+            label: 'Camera permission',
+            status: 'fail',
+            message: 'Camera access has been denied.',
+            suggestion: 'Update your browser settings to allow camera access for this site.',
+          });
+        } else if (status.state === 'prompt') {
+          checks.push({
+            id: 'camera-permission',
+            label: 'Camera permission',
+            status: 'warn',
+            message: 'Camera access will be requested when starting.',
+            suggestion: 'Be ready to approve the permission prompt when it appears.',
+          });
+        } else {
+          checks.push({
+            id: 'camera-permission',
+            label: 'Camera permission',
+            status: 'pass',
+            message: 'Camera permission already granted.',
+          });
+        }
+      } catch (err) {
+        diagnostics.permissionError = err instanceof Error ? err.message : String(err);
+        permissionState = 'error';
+        checks.push({
+          id: 'camera-permission',
+          label: 'Camera permission',
+          status: 'warn',
+          message: 'Unable to read camera permission status.',
+          suggestion: 'Start the scanner to trigger the permission prompt.',
+        });
+      }
+    } else {
+      checks.push({
+        id: 'camera-permission',
+        label: 'Camera permission',
+        status: 'warn',
+        message: 'Browser does not expose permission status.',
+        suggestion: 'Starting the scanner may show a permission prompt.',
+      });
+    }
+
+    const ready = checks.every((check) => check.status !== 'fail');
+    diagnostics.permissionState = permissionState;
+    diagnostics.ready = ready;
+    diagnostics.checks = checks.map((check) => ({ id: check.id, status: check.status }));
+
+    if (isMountedRef.current) {
+      setPreflightChecks(checks);
+      setPreflightStatus(ready ? 'ready' : 'blocked');
+      setPreflightLoading(false);
+    }
+
+    if (ready) {
+      console.info('[QR Scanner] Preflight diagnostics', diagnostics);
+    } else {
+      console.warn('[QR Scanner] Preflight diagnostics', diagnostics);
+    }
+
+    return ready;
+  }, []);
 
   useEffect(() => {
+    if (!isRunning) return undefined;
+
     let active = true;
     const video = videoRef.current;
+
     const start = async () => {
       if (!navigator.mediaDevices?.getUserMedia) {
         setError('Camera API not supported');
+        setIsRunning(false);
+        void runPreflight();
         return;
       }
       try {
@@ -35,6 +246,7 @@ const QRScanner: React.FC = () => {
           videoEl.srcObject = stream;
           await videoEl.play();
         }
+        setError('');
         if ('BarcodeDetector' in window) {
           const detector = new (window as any).BarcodeDetector({ formats: ['qr_code'] });
           const scan = async () => {
@@ -71,9 +283,13 @@ const QRScanner: React.FC = () => {
         } else {
           setError('Could not start camera');
         }
+        setIsRunning(false);
+        void runPreflight();
       }
     };
-    start();
+
+    void start();
+
     return () => {
       active = false;
       controlsRef.current?.stop?.();
@@ -81,7 +297,7 @@ const QRScanner: React.FC = () => {
       if (video) video.srcObject = null;
       trackRef.current = null;
     };
-  }, [facing]);
+  }, [facing, isRunning, runPreflight]);
 
   useEffect(() => {
     const track = trackRef.current as any;
@@ -90,6 +306,33 @@ const QRScanner: React.FC = () => {
     if (!capabilities?.torch) return;
     track.applyConstraints({ advanced: [{ torch }] }).catch(() => {});
   }, [torch]);
+
+  useEffect(() => {
+    if (isRunning) return;
+    controlsRef.current?.stop?.();
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    const video = videoRef.current;
+    if (video) {
+      video.srcObject = null;
+    }
+    trackRef.current = null;
+  }, [isRunning]);
+
+  useEffect(() => {
+    const initialVideo = videoRef.current;
+    void runPreflight();
+    return () => {
+      isMountedRef.current = false;
+      if (permissionStatusRef.current?.onchange) {
+        permissionStatusRef.current.onchange = null;
+      }
+      controlsRef.current?.stop?.();
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+      if (initialVideo) {
+        initialVideo.srcObject = null;
+      }
+    };
+  }, [runPreflight]);
 
   useEffect(() => {
     if (result) {
@@ -113,16 +356,142 @@ const QRScanner: React.FC = () => {
     setFacing((f) => (f === 'environment' ? 'user' : 'environment'));
   };
 
+  const startScanner = useCallback(async () => {
+    if (isRunning || preflightLoading) return;
+    if (preflightStatus !== 'ready') {
+      const ready = await runPreflight();
+      if (!ready) return;
+    }
+    setError('');
+    setIsRunning(true);
+  }, [isRunning, preflightLoading, preflightStatus, runPreflight]);
+
+  const stopScanner = useCallback(() => {
+    setIsRunning(false);
+  }, []);
+
+  const retryPreflight = useCallback(() => {
+    void runPreflight();
+  }, [runPreflight]);
+
+  const statusColors: Record<CheckStatus, string> = {
+    pass: 'text-green-300',
+    warn: 'text-yellow-300',
+    fail: 'text-red-300',
+  };
+
+  const statusLabels: Record<CheckStatus, string> = {
+    pass: 'OK',
+    warn: 'Review',
+    fail: 'Blocked',
+  };
+
+  const preflightSummary =
+    preflightStatus === 'ready'
+      ? 'All systems go — you can start scanning.'
+      : preflightStatus === 'blocked'
+        ? 'Resolve the highlighted issues before starting.'
+        : 'Running device and permission checks...';
+
+  const preflightSummaryColor =
+    preflightStatus === 'ready'
+      ? 'text-green-300'
+      : preflightStatus === 'blocked'
+        ? 'text-red-300'
+        : 'text-yellow-300';
+
+  const startDisabled = preflightLoading || preflightStatus !== 'ready' || isRunning;
+
   return (
     <div className="p-4 space-y-4 text-white bg-ub-cool-grey h-full flex flex-col items-center">
+      <div className="w-full max-w-sm">
+        <div className="w-full rounded-md border border-white/10 bg-black/50 p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-base font-semibold">Preflight checks</h2>
+            <span
+              className={`text-xs font-semibold uppercase ${preflightSummaryColor}`}
+            >
+              {preflightStatus === 'ready'
+                ? 'Ready'
+                : preflightStatus === 'blocked'
+                  ? 'Blocked'
+                  : 'Checking'}
+            </span>
+          </div>
+          <p className={`text-sm ${preflightSummaryColor}`}>{preflightSummary}</p>
+          {preflightLoading ? (
+            <p className="text-xs text-gray-300">Checking camera and permission status…</p>
+          ) : (
+            <ul className="space-y-3 text-sm">
+              {preflightChecks.map((check) => (
+                <li
+                  key={check.id}
+                  className="rounded border border-white/10 bg-black/30 p-3"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium">{check.label}</span>
+                    <span
+                      className={`text-xs font-semibold uppercase ${statusColors[check.status]}`}
+                    >
+                      {statusLabels[check.status]}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-xs text-gray-200">{check.message}</p>
+                  {check.suggestion && (
+                    <p className="mt-1 text-xs italic text-gray-400">{check.suggestion}</p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="flex flex-wrap gap-2 pt-2">
+            <button
+              type="button"
+              onClick={retryPreflight}
+              className="rounded bg-gray-700 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={preflightLoading}
+            >
+              {preflightLoading ? 'Checking…' : 'Re-run checks'}
+            </button>
+            <button
+              type="button"
+              onClick={() => void startScanner()}
+              className="rounded bg-blue-600 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={startDisabled}
+            >
+              {isRunning ? 'Scanner running' : 'Start scanner'}
+            </button>
+            {isRunning && (
+              <button
+                type="button"
+                onClick={stopScanner}
+                className="rounded bg-red-600 px-3 py-1 text-sm"
+              >
+                Stop scanner
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+
       <div className="relative w-full max-w-sm">
-        <video ref={videoRef} className="w-full rounded-md border-2 border-white bg-black" />
+        <video
+          ref={videoRef}
+          aria-label="QR scanner preview"
+          className="w-full rounded-md border-2 border-white bg-black"
+        />
+        {!isRunning && (
+          <div className="absolute inset-0 flex items-center justify-center rounded-md bg-black/70 text-center text-xs text-gray-200">
+            Start the scanner once preflight passes to access the camera feed.
+          </div>
+        )}
         <div className="absolute top-2 right-2 flex gap-2">
           <button
             type="button"
             onClick={toggleTorch}
             aria-label="Toggle flashlight"
-            className="p-1 bg-black/50 rounded"
+            className="p-1 bg-black/50 rounded disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={!isRunning}
           >
             <FlashIcon className="w-6 h-6" />
           </button>
@@ -130,7 +499,8 @@ const QRScanner: React.FC = () => {
             type="button"
             onClick={switchCamera}
             aria-label="Switch camera"
-            className="p-1 bg-black/50 rounded"
+            className="p-1 bg-black/50 rounded disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={!isRunning}
           >
             <SwitchCameraIcon className="w-6 h-6" />
           </button>


### PR DESCRIPTION
## Summary
- add a preflight diagnostics panel to the camera app that inspects MediaDevices and permission state before capture
- block the capture flow until required checks pass, surface remediation tips, and log detailed diagnostics
- add focused unit tests that mock missing devices and denied permissions to verify the preflight logic

## Testing
- yarn lint *(fails: pre-existing jsx-a11y and no-top-level-window violations across unrelated apps)*
- yarn test __tests__/camera.preflight.test.tsx __tests__/qr_scanner.preflight.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc0651e708832891d91d2798d95b26