### PR TITLE
[clipboard-manager] add keyboard shortcut and test

### DIFF
--- a/components/apps/ClipboardManager.tsx
+++ b/components/apps/ClipboardManager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { getDb } from '../../utils/safeIDB';
 
 interface ClipItem {
@@ -31,6 +31,20 @@ function getDB() {
 
 const ClipboardManager: React.FC = () => {
   const [items, setItems] = useState<ClipItem[]>([]);
+  const [toast, setToast] = useState('');
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const toastTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showToast = useCallback((message: string) => {
+    setToast(message);
+    if (toastTimeoutRef.current) {
+      clearTimeout(toastTimeoutRef.current);
+    }
+    toastTimeoutRef.current = setTimeout(() => {
+      setToast('');
+      toastTimeoutRef.current = null;
+    }, 2000);
+  }, []);
 
   const loadItems = useCallback(async () => {
     try {
@@ -88,17 +102,89 @@ const ClipboardManager: React.FC = () => {
     return () => document.removeEventListener('copy', handleCopy);
   }, [handleCopy]);
 
-  const writeToClipboard = async (text: string) => {
+  const writeToClipboard = useCallback(async (text: string) => {
+    if (!text) return false;
     try {
       const perm = await (navigator.permissions as any)?.query?.({
         name: 'clipboard-write' as any,
       });
-      if (perm && perm.state === 'denied') return;
+      if (perm && perm.state === 'denied') return false;
       await navigator.clipboard.writeText(text);
+      return true;
     } catch (err) {
       console.error('Clipboard write failed:', err);
+      return false;
     }
-  };
+  }, []);
+
+  const insertTextIntoElement = useCallback((element: Element, text: string) => {
+    if (!text) return false;
+    if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+      const start = element.selectionStart ?? element.value.length;
+      const end = element.selectionEnd ?? element.value.length;
+      const nextValue = element.value.slice(0, start) + text + element.value.slice(end);
+      element.value = nextValue;
+      const cursor = start + text.length;
+      if (typeof element.setSelectionRange === 'function') {
+        element.setSelectionRange(cursor, cursor);
+      }
+      element.dispatchEvent(new Event('input', { bubbles: true }));
+      return true;
+    }
+    if (element instanceof HTMLElement && element.isContentEditable) {
+      if (typeof document.execCommand === 'function') {
+        return document.execCommand('insertText', false, text);
+      }
+      element.innerText += text;
+      return true;
+    }
+    return false;
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (toastTimeoutRef.current) {
+        clearTimeout(toastTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleShortcut = async (event: KeyboardEvent) => {
+      if (!rootRef.current || !event.altKey || event.key.toLowerCase() !== 'v') return;
+
+      const windowEl = rootRef.current.closest('.opened-window');
+      if (windowEl && windowEl.classList.contains('notFocused')) return;
+
+      const latest = items[0];
+      if (!latest) {
+        showToast('Clipboard history is empty');
+        return;
+      }
+
+      const active = document.activeElement as HTMLElement | null;
+      if (!active || !rootRef.current.contains(active)) {
+        showToast('Focus a target field to paste');
+        return;
+      }
+
+      event.preventDefault();
+
+      const wrote = await writeToClipboard(latest.text);
+      const inserted = insertTextIntoElement(active, latest.text);
+
+      if (wrote && inserted) {
+        showToast('Pasted last entry');
+      } else if (!wrote) {
+        showToast('Clipboard unavailable');
+      } else {
+        showToast('Unable to paste into the selected field');
+      }
+    };
+
+    window.addEventListener('keydown', handleShortcut);
+    return () => window.removeEventListener('keydown', handleShortcut);
+  }, [items, insertTextIntoElement, showToast, writeToClipboard]);
 
   const clearHistory = async () => {
     try {
@@ -114,13 +200,41 @@ const ClipboardManager: React.FC = () => {
   };
 
   return (
-    <div className="p-4 space-y-2 text-white bg-ub-cool-grey h-full overflow-auto">
+    <div
+      ref={rootRef}
+      className="p-4 space-y-3 text-white bg-ub-cool-grey h-full overflow-auto"
+    >
       <button
         className="px-2 py-1 bg-gray-700 hover:bg-gray-600"
         onClick={clearHistory}
       >
         Clear History
       </button>
+      <div>
+        <label htmlFor="clipboard-target" className="block text-sm font-semibold">
+          Paste target
+        </label>
+        <textarea
+          id="clipboard-target"
+          data-testid="clipboard-target"
+          className="mt-1 w-full rounded border border-white/20 bg-black/40 p-2 text-white focus:outline-none focus:ring focus:ring-blue-500/40"
+          placeholder="Focus this field and press Alt+V to paste the most recent entry"
+          rows={4}
+        />
+        <p className="mt-1 text-xs text-gray-300">
+          Tip: copy content to build history, then use Alt+V to paste the latest entry.
+        </p>
+      </div>
+      {toast && (
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="clipboard-toast"
+          className="rounded bg-black/40 px-2 py-1 text-sm text-green-300"
+        >
+          {toast}
+        </div>
+      )}
       <ul className="space-y-1">
         {items.map((item) => (
           <li

--- a/pages/apps/clipboard-manager.jsx
+++ b/pages/apps/clipboard-manager.jsx
@@ -1,0 +1,19 @@
+import dynamic from 'next/dynamic';
+
+const ClipboardManagerApp = dynamic(
+  () =>
+    import('../../components/apps/ClipboardManager').then((mod) => mod.default),
+  {
+    ssr: false,
+    loading: () => <p>Loading...</p>,
+  }
+);
+
+export default function ClipboardManagerPage() {
+  return (
+    <main className="min-h-screen bg-ub-cool-grey p-4 text-white">
+      <ClipboardManagerApp />
+    </main>
+  );
+}
+

--- a/tests/clipboard-manager.spec.ts
+++ b/tests/clipboard-manager.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Clipboard Manager shortcut', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      const store = { text: '' };
+
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: {
+          writeText: async (text: string) => {
+            store.text = text;
+          },
+          readText: async () => store.text,
+        },
+      });
+
+      const originalPermissions = (navigator as any).permissions || {};
+      Object.defineProperty(navigator, 'permissions', {
+        configurable: true,
+        value: {
+          ...originalPermissions,
+          query: async () => ({ state: 'granted' }),
+        },
+      });
+    });
+  });
+
+  test('Alt+V pastes last clipboard entry into target field', async ({ page }) => {
+    await page.goto('/apps/clipboard-manager');
+
+    await page.evaluate(async () => {
+      await navigator.clipboard.writeText('First entry');
+      document.dispatchEvent(new Event('copy'));
+      await navigator.clipboard.writeText('Latest entry');
+      document.dispatchEvent(new Event('copy'));
+    });
+
+    await expect(page.getByRole('listitem').first()).toHaveText('Latest entry');
+
+    const target = page.getByTestId('clipboard-target');
+    await target.click();
+    await page.keyboard.press('Alt+V');
+
+    await expect(target).toHaveValue('Latest entry');
+    await expect(page.getByTestId('clipboard-toast')).toHaveText('Pasted last entry');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add an Alt+V shortcut in the clipboard manager window to copy the most recent entry into the focused target and show a toast
- add a standalone `/apps/clipboard-manager` page and inline paste target for manual and automated testing
- create a Playwright spec that stubs the clipboard, simulates the shortcut, and asserts the target field receives the latest entry

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window lint errors across unrelated files)*
- yarn test *(fails: pre-existing suites such as window, nmapNse, PopularModules, useSettings hitting localStorage, etc.)*
- npx playwright test *(fails: Playwright browsers not installed in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc06550d3c832892998dc99e866f25