### PR TITLE
[clipboard] add pinning and export controls

### DIFF
--- a/__tests__/clipboard-manager.test.tsx
+++ b/__tests__/clipboard-manager.test.tsx
@@ -1,0 +1,201 @@
+import 'fake-indexeddb/auto';
+
+// Provide a lightweight structuredClone polyfill for fake-indexeddb
+// in environments where it is missing.
+// @ts-ignore
+if (typeof globalThis.structuredClone !== 'function') {
+  // @ts-ignore
+  globalThis.structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
+}
+
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import ClipboardManager from '../components/apps/ClipboardManager';
+
+declare global {
+  interface Navigator {
+    permissions?: {
+      query: (params: { name: string }) => Promise<{ state: PermissionState }>;
+    };
+  }
+}
+
+beforeEach(() => {
+  (navigator as any).clipboard = {
+    readText: jest.fn(),
+    writeText: jest.fn(),
+  };
+  (navigator as any).permissions = {
+    query: jest.fn().mockResolvedValue({ state: 'granted' }),
+  };
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+async function triggerCopy() {
+  await act(async () => {
+    document.dispatchEvent(new Event('copy'));
+  });
+  await waitFor(() =>
+    expect((navigator as any).clipboard.readText).toHaveBeenCalled()
+  );
+}
+
+function getEntryByText(text: string) {
+  const entries = screen.getAllByTestId('clipboard-entry');
+  return entries.find((entry) => within(entry).queryByText(text));
+}
+
+test('pinned entries survive reload', async () => {
+  const readTextMock = (navigator as any).clipboard
+    .readText as jest.MockedFunction<() => Promise<string>>;
+  readTextMock.mockResolvedValue('first item');
+
+  const { unmount } = render(<ClipboardManager />);
+  await triggerCopy();
+  expect(await screen.findByText('first item')).toBeInTheDocument();
+
+  const pinButton = await screen.findByRole('button', { name: /pin entry/i });
+  fireEvent.click(pinButton);
+  await screen.findByTestId('pinned-list');
+
+  unmount();
+
+  render(<ClipboardManager />);
+  await screen.findByText('first item');
+  await screen.findByTestId('pinned-list');
+  expect(await screen.findByRole('button', { name: /unpin entry/i })).toBeInTheDocument();
+});
+
+test('exports selected entries as JSON', async () => {
+  const readTextMock = (navigator as any).clipboard
+    .readText as jest.MockedFunction<() => Promise<string>>;
+  readTextMock
+    .mockResolvedValueOnce('first entry')
+    .mockResolvedValueOnce('second entry');
+
+  render(<ClipboardManager />);
+  await triggerCopy();
+  expect(await screen.findByText('first entry')).toBeInTheDocument();
+  await triggerCopy();
+  expect(await screen.findByText('second entry')).toBeInTheDocument();
+
+  const firstEntry = getEntryByText('first entry');
+  expect(firstEntry).toBeTruthy();
+  const firstLabelInput = within(firstEntry!)
+    .getByLabelText('entry label') as HTMLInputElement;
+  fireEvent.change(firstLabelInput, { target: { value: 'First label' } });
+  fireEvent.blur(firstLabelInput);
+  await waitFor(() =>
+    expect(
+      (within(getEntryByText('first entry')!)
+        .getByLabelText('entry label') as HTMLInputElement
+      ).value
+    ).toBe('First label')
+  );
+
+  const secondEntry = getEntryByText('second entry');
+  expect(secondEntry).toBeTruthy();
+  const pinButton = within(secondEntry!).getByRole('button', { name: /pin entry/i });
+  fireEvent.click(pinButton);
+  await waitFor(() =>
+    expect(
+      within(getEntryByText('second entry')!)
+        .getByRole('button', { name: /unpin entry/i })
+    ).toBeInTheDocument()
+  );
+
+  const firstCheckbox = within(getEntryByText('first entry')!)
+    .getByRole('checkbox');
+  const secondCheckbox = within(getEntryByText('second entry')!)
+    .getByRole('checkbox');
+  fireEvent.click(firstCheckbox);
+  fireEvent.click(secondCheckbox);
+
+  const exportButton = screen.getByRole('button', { name: /export selected/i });
+  expect(exportButton).not.toBeDisabled();
+
+  const originalCreate = URL.createObjectURL;
+  const originalRevoke = URL.revokeObjectURL;
+  const originalBlob = Blob;
+  const createObjectURLSpy = jest.fn(() => 'blob:url');
+  const revokeObjectURLSpy = jest.fn();
+  (URL as any).createObjectURL = createObjectURLSpy;
+  (URL as any).revokeObjectURL = revokeObjectURLSpy;
+  const clickSpy = jest
+    .spyOn(HTMLAnchorElement.prototype, 'click')
+    .mockImplementation(() => {});
+  (global as any).Blob = class BlobMock {
+    private data: string;
+    public type: string;
+    constructor(parts: any[] = [], options?: { type?: string }) {
+      this.data = parts
+        .map((part) =>
+          typeof part === 'string' ? part : JSON.stringify(part)
+        )
+        .join('');
+      this.type = options?.type ?? '';
+    }
+    text() {
+      return Promise.resolve(this.data);
+    }
+    arrayBuffer() {
+      const buffer = Buffer.from(this.data, 'utf-8');
+      return Promise.resolve(
+        buffer.buffer.slice(
+          buffer.byteOffset,
+          buffer.byteOffset + buffer.byteLength
+        )
+      );
+    }
+  } as any;
+
+  try {
+    fireEvent.click(exportButton);
+
+    await waitFor(() => expect(createObjectURLSpy).toHaveBeenCalledTimes(1));
+    expect(clickSpy).toHaveBeenCalled();
+    const blob = createObjectURLSpy.mock.calls[0][0] as Blob;
+    const exportedText = await (async () => {
+      if (typeof (blob as any).text === 'function') {
+        return (blob as any).text();
+      }
+      if (typeof (blob as any).arrayBuffer === 'function') {
+        const buffer = await (blob as any).arrayBuffer();
+        return Buffer.from(buffer).toString('utf-8');
+      }
+      throw new Error('Unable to read blob contents');
+    })();
+    const data = JSON.parse(exportedText);
+    expect(Array.isArray(data)).toBe(true);
+    expect(data).toHaveLength(2);
+    expect(data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: 'first entry',
+          label: 'First label',
+          pinned: false,
+        }),
+        expect.objectContaining({
+          text: 'second entry',
+          pinned: true,
+        }),
+      ])
+    );
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:url');
+  } finally {
+    clickSpy.mockRestore();
+    (URL as any).createObjectURL = originalCreate;
+    (URL as any).revokeObjectURL = originalRevoke;
+    (global as any).Blob = originalBlob;
+  }
+});

--- a/components/apps/ClipboardManager.tsx
+++ b/components/apps/ClipboardManager.tsx
@@ -7,6 +7,8 @@ interface ClipItem {
   id?: number;
   text: string;
   created: number;
+  label?: string;
+  pinned?: boolean;
 }
 
 const DB_NAME = 'clipboard-manager';
@@ -31,6 +33,8 @@ function getDB() {
 
 const ClipboardManager: React.FC = () => {
   const [items, setItems] = useState<ClipItem[]>([]);
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [labelDrafts, setLabelDrafts] = useState<Record<number, string>>({});
 
   const loadItems = useCallback(async () => {
     try {
@@ -39,7 +43,25 @@ const ClipboardManager: React.FC = () => {
       const db = await dbp;
 
       const all = await db.getAll(STORE_NAME);
-      setItems(all.sort((a, b) => (b.id ?? 0) - (a.id ?? 0)));
+      const sorted = [...all].sort((a, b) => {
+        if (!!b.pinned !== !!a.pinned) {
+          return (b.pinned ? 1 : 0) - (a.pinned ? 1 : 0);
+        }
+        return (b.id ?? 0) - (a.id ?? 0);
+      });
+      setItems(sorted);
+      setSelectedIds((prev) =>
+        prev.filter((id) => sorted.some((item) => item.id === id))
+      );
+      setLabelDrafts((prev) => {
+        const next: Record<number, string> = {};
+        sorted.forEach((item) => {
+          if (typeof item.id === 'number' && prev[item.id] !== undefined) {
+            next[item.id] = prev[item.id];
+          }
+        });
+        return next;
+      });
     } catch {
       // ignore errors
     }
@@ -55,6 +77,36 @@ const ClipboardManager: React.FC = () => {
 
         const tx = db.transaction(STORE_NAME, 'readwrite');
         await tx.store.add({ text, created: Date.now() });
+        await tx.done;
+        await loadItems();
+      } catch {
+        // ignore errors
+      }
+    },
+    [loadItems]
+  );
+
+  const updateItem = useCallback(
+    async (id: number, updates: Partial<ClipItem>) => {
+      try {
+        const dbp = getDB();
+        if (!dbp) return;
+        const db = await dbp;
+
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        const store = tx.store;
+        const existing = await store.get(id);
+        if (!existing) {
+          await tx.done;
+          return;
+        }
+
+        const updated: ClipItem = { ...existing, ...updates };
+        if ('label' in updates && (!updates.label || updates.label.trim() === '')) {
+          delete updated.label;
+        }
+
+        await store.put(updated);
         await tx.done;
         await loadItems();
       } catch {
@@ -108,30 +160,196 @@ const ClipboardManager: React.FC = () => {
 
       await db.clear(STORE_NAME);
       setItems([]);
+      setSelectedIds([]);
+      setLabelDrafts({});
     } catch {
       // ignore errors
     }
   };
 
-  return (
-    <div className="p-4 space-y-2 text-white bg-ub-cool-grey h-full overflow-auto">
-      <button
-        className="px-2 py-1 bg-gray-700 hover:bg-gray-600"
-        onClick={clearHistory}
+  const togglePin = (item: ClipItem) => {
+    if (typeof item.id !== 'number') return;
+    void updateItem(item.id, { pinned: !item.pinned });
+  };
+
+  const handleLabelChange = (id: number, value: string) => {
+    setLabelDrafts((prev) => ({ ...prev, [id]: value }));
+  };
+
+  const commitLabel = async (id: number, value: string) => {
+    const trimmed = value.trim();
+    const existing = items.find((entry) => entry.id === id);
+    if (existing && (existing.label ?? '') === trimmed) {
+      setLabelDrafts((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+      return;
+    }
+    await updateItem(id, trimmed ? { label: trimmed } : { label: '' });
+    setLabelDrafts((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  };
+
+  const toggleSelection = (id?: number) => {
+    if (typeof id !== 'number') return;
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((existing) => existing !== id) : [...prev, id]
+    );
+  };
+
+  const exportSelected = () => {
+    if (typeof window === 'undefined') return;
+    const createUrl = window.URL?.createObjectURL;
+    const revokeUrl = window.URL?.revokeObjectURL;
+    if (!createUrl) return;
+
+    const selectedSet = new Set(selectedIds);
+    const entries = items.filter(
+      (item) => typeof item.id === 'number' && selectedSet.has(item.id)
+    );
+    if (entries.length === 0) return;
+
+    const payload = entries.map((item) => ({
+      id: item.id,
+      text: item.text,
+      created: item.created,
+      ...(item.label ? { label: item.label } : {}),
+      pinned: !!item.pinned,
+    }));
+
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: 'application/json',
+    });
+    const url = createUrl(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    const timestamp = new Date().toISOString().replace(/[:]/g, '-');
+    anchor.download = `clipboard-entries-${timestamp}.json`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    revokeUrl?.(url);
+  };
+
+  const pinnedItems = items.filter((item) => item.pinned);
+  const historyItems = items.filter((item) => !item.pinned);
+
+  const renderEntry = (item: ClipItem) => {
+    const id = item.id;
+    const labelValue =
+      typeof id === 'number'
+        ? labelDrafts[id] !== undefined
+          ? labelDrafts[id]
+          : item.label ?? ''
+        : item.label ?? '';
+    return (
+      <li
+        key={item.id ?? item.created}
+        data-testid="clipboard-entry"
+        className="p-3 rounded bg-gray-800"
       >
-        Clear History
-      </button>
-      <ul className="space-y-1">
-        {items.map((item) => (
-          <li
-            key={item.id}
-            className="cursor-pointer hover:underline"
-            onClick={() => writeToClipboard(item.text)}
-          >
-            {item.text}
-          </li>
-        ))}
-      </ul>
+        <div className="flex flex-col gap-2">
+          <div className="flex items-start gap-3">
+            <input
+              type="checkbox"
+              aria-label={`Select ${item.label || item.text}`}
+              className="mt-1"
+              checked={typeof id === 'number' ? selectedIds.includes(id) : false}
+              onChange={() => toggleSelection(id)}
+            />
+            <div className="flex-1 space-y-1">
+              <input
+                type="text"
+                value={labelValue}
+                placeholder="Add label"
+                aria-label="entry label"
+                className="w-full px-2 py-1 text-sm text-white bg-gray-700 rounded focus:outline-none focus:ring"
+                onChange={(e) => {
+                  if (typeof id === 'number') {
+                    handleLabelChange(id, e.target.value);
+                  }
+                }}
+                onBlur={() => {
+                  if (typeof id === 'number') {
+                    void commitLabel(id, labelValue);
+                  }
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && typeof id === 'number') {
+                    event.preventDefault();
+                    void commitLabel(id, labelValue);
+                  }
+                }}
+              />
+              <div className="text-xs text-gray-400">
+                {new Date(item.created).toLocaleString()}
+              </div>
+            </div>
+            <div className="flex flex-col gap-1">
+              <button
+                type="button"
+                className="px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 rounded"
+                aria-label={item.pinned ? 'unpin entry' : 'pin entry'}
+                onClick={() => togglePin(item)}
+              >
+                {item.pinned ? 'Unpin' : 'Pin'}
+              </button>
+              <button
+                type="button"
+                className="px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 rounded"
+                aria-label="copy entry"
+                onClick={() => writeToClipboard(item.text)}
+              >
+                Copy
+              </button>
+            </div>
+          </div>
+          <div className="text-sm whitespace-pre-wrap break-words">{item.text}</div>
+        </div>
+      </li>
+    );
+  };
+
+  return (
+    <div className="p-4 space-y-4 text-white bg-ub-cool-grey h-full overflow-auto">
+      <div className="flex gap-2">
+        <button
+          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          onClick={clearHistory}
+        >
+          Clear History
+        </button>
+        <button
+          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded disabled:opacity-50"
+          onClick={exportSelected}
+          disabled={selectedIds.length === 0}
+        >
+          Export Selected
+        </button>
+      </div>
+      {pinnedItems.length > 0 && (
+        <section className="space-y-2" data-testid="pinned-list">
+          <h2 className="text-xs font-semibold tracking-widest uppercase text-gray-300">
+            Pinned
+          </h2>
+          <ul className="space-y-2">{pinnedItems.map(renderEntry)}</ul>
+        </section>
+      )}
+      <section className="space-y-2">
+        <h2 className="text-xs font-semibold tracking-widest uppercase text-gray-300">
+          History
+        </h2>
+        {historyItems.length > 0 ? (
+          <ul className="space-y-2">{historyItems.map(renderEntry)}</ul>
+        ) : (
+          <div className="text-sm text-gray-300">No clipboard history yet.</div>
+        )}
+      </section>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add pinning, labeling, and export controls to the clipboard manager with IndexedDB persistence
- render pinned entries separately from history and allow inline label editing
- add Jest coverage for pinned persistence and export payloads

## Testing
- yarn test clipboard-manager
- yarn lint *(fails: existing accessibility violations in unrelated apps)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0655d9888328bc973e211c009235