### PR TITLE
[screen-recorder] expand capture controls

### DIFF
--- a/__tests__/screen-recorder.test.tsx
+++ b/__tests__/screen-recorder.test.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import ScreenRecorder from '../components/apps/screen-recorder';
+
+type MockBlobEvent = { data: Blob };
+
+class MockMediaRecorder {
+    public ondataavailable: ((event: MockBlobEvent) => void) | null = null;
+
+    public onstop: (() => void) | null = null;
+
+    constructor(public readonly stream: MediaStream) {}
+
+    public start = () => {
+        // no-op for tests
+    };
+
+    public stop = () => {
+        this.ondataavailable?.({ data: new Blob(['mock'], { type: 'video/webm' }) });
+        this.onstop?.();
+    };
+}
+
+const mockGetDisplayMedia = jest.fn();
+
+const createMockStream = () => {
+    const track = { stop: jest.fn() };
+    return {
+        getTracks: () => [track],
+    } as unknown as MediaStream;
+};
+
+const finishCountdown = async () => {
+    for (let i = 0; i < 3; i += 1) {
+        await act(async () => {
+            jest.advanceTimersByTime(1000);
+        });
+    }
+};
+
+describe('ScreenRecorder', () => {
+    const originalMediaDevices = navigator.mediaDevices;
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    const originalMediaRecorder = (global as { MediaRecorder?: typeof MediaRecorder }).MediaRecorder;
+
+    beforeAll(() => {
+        Object.defineProperty(window.navigator, 'mediaDevices', {
+            configurable: true,
+            value: { getDisplayMedia: mockGetDisplayMedia },
+        });
+
+        Object.defineProperty(global, 'MediaRecorder', {
+            configurable: true,
+            writable: true,
+            value: MockMediaRecorder,
+        });
+
+        Object.defineProperty(URL, 'createObjectURL', {
+            configurable: true,
+            writable: true,
+            value: jest.fn(() => 'blob:mock-url'),
+        });
+
+        Object.defineProperty(URL, 'revokeObjectURL', {
+            configurable: true,
+            writable: true,
+            value: jest.fn(),
+        });
+    });
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        mockGetDisplayMedia.mockReset();
+    });
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers();
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    afterAll(() => {
+        Object.defineProperty(window.navigator, 'mediaDevices', {
+            configurable: true,
+            value: originalMediaDevices,
+        });
+
+        Object.defineProperty(URL, 'createObjectURL', {
+            configurable: true,
+            writable: true,
+            value: originalCreateObjectURL,
+        });
+
+        Object.defineProperty(URL, 'revokeObjectURL', {
+            configurable: true,
+            writable: true,
+            value: originalRevokeObjectURL,
+        });
+
+        if (originalMediaRecorder) {
+            Object.defineProperty(global, 'MediaRecorder', {
+                configurable: true,
+                writable: true,
+                value: originalMediaRecorder,
+            });
+        } else {
+            // Remove the mock if MediaRecorder did not originally exist.
+            Reflect.deleteProperty(global as { MediaRecorder?: typeof MediaRecorder }, 'MediaRecorder');
+        }
+    });
+
+    it('starts recording after the countdown with default options', async () => {
+        mockGetDisplayMedia.mockResolvedValueOnce(createMockStream());
+
+        render(<ScreenRecorder />);
+
+        fireEvent.click(screen.getByRole('button', { name: /start recording/i }));
+
+        expect(screen.getByTestId('countdown-overlay')).toBeInTheDocument();
+        expect(screen.getByTestId('countdown-value')).toHaveTextContent('3');
+
+        await finishCountdown();
+
+        await waitFor(() => expect(mockGetDisplayMedia).toHaveBeenCalledTimes(1));
+        expect(mockGetDisplayMedia).toHaveBeenCalledWith(
+            expect.objectContaining({
+                audio: true,
+                video: expect.objectContaining({
+                    cursor: 'always',
+                    displaySurface: 'monitor',
+                }),
+            }),
+        );
+
+        await waitFor(() => expect(screen.getByRole('button', { name: /stop recording/i })).toBeInTheDocument());
+
+        fireEvent.click(screen.getByRole('button', { name: /stop recording/i }));
+
+        await waitFor(() => expect(screen.getByRole('button', { name: /save recording/i })).toBeInTheDocument());
+    });
+
+    it('allows selecting a browser tab without audio', async () => {
+        mockGetDisplayMedia.mockResolvedValueOnce(createMockStream());
+
+        render(<ScreenRecorder />);
+
+        fireEvent.click(screen.getByText('Browser Tab'));
+        fireEvent.click(screen.getByLabelText('Capture audio'));
+
+        fireEvent.click(screen.getByRole('button', { name: /start recording/i }));
+
+        await finishCountdown();
+
+        await waitFor(() => expect(mockGetDisplayMedia).toHaveBeenCalledTimes(1));
+        expect(mockGetDisplayMedia).toHaveBeenCalledWith(
+            expect.objectContaining({
+                audio: false,
+                video: expect.objectContaining({
+                    displaySurface: 'browser',
+                }),
+            }),
+        );
+    });
+
+    it('shows a friendly message and offers retry on permission errors', async () => {
+        mockGetDisplayMedia.mockRejectedValueOnce(new DOMException('Permission denied', 'NotAllowedError'));
+
+        render(<ScreenRecorder />);
+
+        fireEvent.click(screen.getByRole('button', { name: /start recording/i }));
+
+        await finishCountdown();
+
+        await waitFor(() =>
+            expect(screen.getByRole('alert')).toHaveTextContent(
+                'Screen capture was blocked. Please allow access in your browser settings and try again.',
+            ),
+        );
+
+        mockGetDisplayMedia.mockResolvedValueOnce(createMockStream());
+
+        fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+        expect(screen.getByTestId('countdown-overlay')).toBeInTheDocument();
+
+        await finishCountdown();
+
+        await waitFor(() => expect(mockGetDisplayMedia).toHaveBeenCalledTimes(2));
+    });
+});
+

--- a/components/apps/screen-recorder.tsx
+++ b/components/apps/screen-recorder.tsx
@@ -1,17 +1,69 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+type DisplaySurfaceOption = 'monitor' | 'window' | 'browser';
+
+type DisplayMediaTrackConstraints = MediaTrackConstraints & { displaySurface?: DisplaySurfaceOption };
+
+const DISPLAY_SURFACE_OPTIONS: Array<{ value: DisplaySurfaceOption; label: string; helper: string }> = [
+    {
+        value: 'monitor',
+        label: 'Entire Screen',
+        helper: 'Capture everything visible on your display.',
+    },
+    {
+        value: 'window',
+        label: 'Application Window',
+        helper: 'Share a specific app window only.',
+    },
+    {
+        value: 'browser',
+        label: 'Browser Tab',
+        helper: 'Share a browser tab with smoother playback.',
+    },
+];
+
+const getFriendlyError = (error: unknown) => {
+    if (error instanceof DOMException) {
+        if (error.name === 'NotAllowedError') {
+            return 'Screen capture was blocked. Please allow access in your browser settings and try again.';
+        }
+        if (error.name === 'NotFoundError') {
+            return 'No screen, window, or tab was available to capture. Select a source in the prompt and try again.';
+        }
+        return error.message || 'We were unable to start screen capture. Please try again.';
+    }
+
+    return 'We were unable to start screen capture. Please try again.';
+};
 
 function ScreenRecorder() {
     const [recording, setRecording] = useState(false);
     const [videoUrl, setVideoUrl] = useState<string | null>(null);
+    const [selectedSurface, setSelectedSurface] = useState<DisplaySurfaceOption>('monitor');
+    const [includeAudio, setIncludeAudio] = useState(true);
+    const [isPreparing, setIsPreparing] = useState(false);
+    const [countdownValue, setCountdownValue] = useState<number | null>(null);
+    const [error, setError] = useState<string | null>(null);
     const recorderRef = useRef<MediaRecorder | null>(null);
     const chunksRef = useRef<Blob[]>([]);
     const streamRef = useRef<MediaStream | null>(null);
 
-    const startRecording = async () => {
+    const resetVideoUrl = useCallback(() => {
+        if (videoUrl) {
+            URL.revokeObjectURL(videoUrl);
+            setVideoUrl(null);
+        }
+    }, [videoUrl]);
+
+    const startRecording = useCallback(async () => {
         try {
+            resetVideoUrl();
             const stream = await navigator.mediaDevices.getDisplayMedia({
-                video: true,
-                audio: true,
+                video: {
+                    cursor: 'always',
+                    displaySurface: selectedSurface,
+                } as DisplayMediaTrackConstraints,
+                audio: includeAudio,
             });
             streamRef.current = stream;
             const recorder = new MediaRecorder(stream);
@@ -28,10 +80,17 @@ function ScreenRecorder() {
             recorder.start();
             recorderRef.current = recorder;
             setRecording(true);
-        } catch {
-            // ignore
+            setError(null);
+        } catch (err) {
+            setError(getFriendlyError(err));
+            streamRef.current?.getTracks().forEach((t) => t.stop());
+            streamRef.current = null;
+            setRecording(false);
+        } finally {
+            setIsPreparing(false);
+            setCountdownValue(null);
         }
-    };
+    }, [includeAudio, resetVideoUrl, selectedSurface]);
 
     const stopRecording = () => {
         recorderRef.current?.stop();
@@ -68,44 +127,162 @@ function ScreenRecorder() {
         }
     };
 
+    const beginPreparation = () => {
+        setError(null);
+        setIsPreparing(true);
+        setCountdownValue(3);
+    };
+
+    const cancelPreparation = () => {
+        setIsPreparing(false);
+        setCountdownValue(null);
+    };
+
+    useEffect(() => {
+        if (countdownValue === null) return;
+
+        if (countdownValue === 0) {
+            setIsPreparing(false);
+            setCountdownValue(null);
+            void startRecording();
+            return;
+        }
+
+        const timeoutId = window.setTimeout(() => {
+            setCountdownValue((value) => (typeof value === 'number' ? value - 1 : value));
+        }, 1000);
+
+        return () => {
+            window.clearTimeout(timeoutId);
+        };
+    }, [countdownValue, startRecording]);
+
     useEffect(() => {
         return () => {
+            resetVideoUrl();
             streamRef.current?.getTracks().forEach((t) => t.stop());
             recorderRef.current?.stop();
         };
-    }, []);
+    }, [resetVideoUrl]);
 
     return (
-        <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white space-y-4 p-4">
-            {!recording && (
-                <button
-                    type="button"
-                    onClick={startRecording}
-                    className="px-4 py-2 rounded bg-ub-dracula hover:bg-ub-dracula-dark"
+        <div className="relative h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4">
+            <div className="w-full max-w-xl space-y-6">
+                <div className="space-y-4 rounded-lg bg-ub-terminal px-4 py-5 shadow-md">
+                    <fieldset className="space-y-3">
+                        <legend className="text-sm font-semibold uppercase tracking-wide text-ubt-warm-grey">
+                            Capture source
+                        </legend>
+                        <div className="grid gap-3 sm:grid-cols-3">
+                            {DISPLAY_SURFACE_OPTIONS.map((option) => (
+                                <label
+                                    key={option.value}
+                                    className={`flex cursor-pointer flex-col rounded border px-3 py-2 transition hover:border-ub-dracula ${
+                                        selectedSurface === option.value
+                                            ? 'border-ub-dracula bg-ub-grey'
+                                            : 'border-ubc-dark'
+                                    }`}
+                                >
+                                    <span className="text-sm font-medium">{option.label}</span>
+                                    <span className="mt-1 text-xs text-ubt-warm-grey">{option.helper}</span>
+                                    <input
+                                        type="radio"
+                                        name="display-surface"
+                                        value={option.value}
+                                        checked={selectedSurface === option.value}
+                                        onChange={() => setSelectedSurface(option.value)}
+                                        className="sr-only"
+                                    />
+                                </label>
+                            ))}
+                        </div>
+                    </fieldset>
+
+                    <label className="flex items-center space-x-2 text-sm">
+                        <input
+                            type="checkbox"
+                            checked={includeAudio}
+                            onChange={(event) => setIncludeAudio(event.target.checked)}
+                        />
+                        <span>Capture audio</span>
+                    </label>
+                </div>
+
+                {error && (
+                    <div className="space-y-3 rounded-lg border border-red-500 bg-red-900/40 px-4 py-3" role="alert">
+                        <p className="text-sm font-medium text-red-100">{error}</p>
+                        <div className="flex gap-3">
+                            <button
+                                type="button"
+                                onClick={beginPreparation}
+                                className="rounded bg-ub-dracula px-3 py-1 text-sm font-semibold hover:bg-ub-dracula-dark"
+                            >
+                                Try again
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => setError(null)}
+                                className="rounded border border-red-400 px-3 py-1 text-sm hover:bg-red-800/40"
+                            >
+                                Dismiss
+                            </button>
+                        </div>
+                    </div>
+                )}
+
+                <div className="flex items-center gap-4">
+                    {!recording && (
+                        <button
+                            type="button"
+                            onClick={beginPreparation}
+                            disabled={isPreparing}
+                            className="rounded bg-ub-dracula px-4 py-2 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-60 hover:bg-ub-dracula-dark"
+                        >
+                            Start recording
+                        </button>
+                    )}
+                    {recording && (
+                        <button
+                            type="button"
+                            onClick={stopRecording}
+                            className="rounded bg-red-600 px-4 py-2 text-sm font-semibold transition hover:bg-red-700"
+                        >
+                            Stop recording
+                        </button>
+                    )}
+                </div>
+
+                {videoUrl && !recording && (
+                    <div className="space-y-3">
+                        <video src={videoUrl} controls className="max-h-72 w-full rounded border border-ub-grey" />
+                        <button
+                            type="button"
+                            onClick={saveRecording}
+                            className="rounded bg-ub-dracula px-4 py-2 text-sm font-semibold transition hover:bg-ub-dracula-dark"
+                        >
+                            Save recording
+                        </button>
+                    </div>
+                )}
+            </div>
+
+            {isPreparing && (
+                <div
+                    className="absolute inset-0 flex flex-col items-center justify-center bg-black/80 text-center"
+                    data-testid="countdown-overlay"
                 >
-                    Start Recording
-                </button>
-            )}
-            {recording && (
-                <button
-                    type="button"
-                    onClick={stopRecording}
-                    className="px-4 py-2 rounded bg-red-600 hover:bg-red-700"
-                >
-                    Stop Recording
-                </button>
-            )}
-            {videoUrl && !recording && (
-                <>
-                    <video src={videoUrl} controls className="max-w-full" />
+                    <div className="text-6xl font-extrabold" data-testid="countdown-value">
+                        {countdownValue}
+                    </div>
+                    <p className="mt-2 text-sm text-ubt-warm-grey">Recording will begin shortly…</p>
                     <button
                         type="button"
-                        onClick={saveRecording}
-                        className="px-4 py-2 rounded bg-ub-dracula hover:bg-ub-dracula-dark"
+                        onClick={cancelPreparation}
+                        className="mt-4 rounded border border-white/60 px-4 py-2 text-sm font-semibold hover:bg-white/10"
                     >
-                        Save Recording
+                        Cancel
                     </button>
-                </>
+                </div>
             )}
         </div>
     );


### PR DESCRIPTION
## Summary
- add capture controls to choose screen/window/tab sources, toggle audio, and display a countdown overlay before recording starts
- handle permission errors with helpful messaging plus retry and cancel flows
- add unit tests that mock getDisplayMedia to cover countdown, option selection, and error handling

## Testing
- yarn lint *(fails: pre-existing accessibility and window/document lint errors in unrelated apps)*
- yarn test screen-recorder


------
https://chatgpt.com/codex/tasks/task_e_68cc0653bdec8328aff5dbbcea4ad818