### PR TITLE
[tests] add clipboard manager heap regression coverage

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -18,4 +18,4 @@ jobs:
           yarn dev &
           npx wait-on http://localhost:3000
       - run: npx pa11y-ci --config pa11yci.json
-      - run: npx playwright test playwright/a11y.spec.ts
+      - run: npx playwright test playwright/a11y.spec.ts playwright/clipboard-manager.spec.ts

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,12 +8,30 @@ function nonce() {
 
 export function middleware(req: NextRequest) {
   const n = nonce();
+  const isDev = process.env.NODE_ENV !== 'production';
+  const scriptSrc = [
+    "'self'",
+    "'unsafe-inline'",
+    isDev ? "'unsafe-eval'" : '',
+    `'nonce-${n}'`,
+    'https://vercel.live',
+    'https://platform.twitter.com',
+    'https://syndication.twitter.com',
+    'https://cdn.syndication.twimg.com',
+    'https://www.youtube.com',
+    'https://www.google.com',
+    'https://www.gstatic.com',
+    'https://cdn.jsdelivr.net',
+    'https://cdnjs.cloudflare.com',
+  ]
+    .filter(Boolean)
+    .join(' ');
   const csp = [
     "default-src 'self'",
     "img-src 'self' https: data:",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
-    `script-src 'self' 'unsafe-inline' 'nonce-${n}' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com`,
+    `script-src ${scriptSrc}`,
     "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://stackblitz.com",
     "frame-src 'self' https://vercel.live https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
     "frame-ancestors 'self'",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,13 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testDir: '.',
+  testMatch: '**/*.spec.ts',
+  testIgnore: ['**/__tests__/**'],
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    launchOptions: {
+      args: ['--enable-precise-memory-info'],
+    },
   },
 });

--- a/playwright/clipboard-manager.spec.ts
+++ b/playwright/clipboard-manager.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect, Page } from '@playwright/test';
+
+const CLIPBOARD_ENTRY_COUNT = 500;
+const CLIPBOARD_PAYLOAD_SIZE = 1024;
+const SEED_GROWTH_EXPECTATION = 300_000;
+const HEAP_CHECK_INTERVAL = 200;
+
+async function readHeapUsage(page: Page): Promise<number | null> {
+  return page.evaluate(() => {
+    const perf = performance as Performance & {
+      memory?: { usedJSHeapSize: number };
+    };
+    return perf.memory?.usedJSHeapSize ?? null;
+  });
+}
+
+async function waitForHeapBelow(
+  page: Page,
+  threshold: number,
+  timeout = 10_000,
+): Promise<number | null> {
+  const started = Date.now();
+  let last = await readHeapUsage(page);
+  while (Date.now() - started < timeout) {
+    await page.waitForTimeout(HEAP_CHECK_INTERVAL);
+    const current = await readHeapUsage(page);
+    if (current !== null) {
+      last = current;
+      if (current <= threshold) {
+        return current;
+      }
+    }
+  }
+  return last;
+}
+
+test('Clipboard Manager clears history and recovers heap usage', async ({ page, context, baseURL }) => {
+  test.setTimeout(120_000);
+  const origin = baseURL ?? 'http://localhost:3000';
+  await context.grantPermissions(['clipboard-read', 'clipboard-write'], { origin });
+
+  await page.addInitScript(() => {
+    const store: { value: string } = { value: '' };
+    const clipboard = {
+      writeText(text: string) {
+        store.value = text;
+        return Promise.resolve();
+      },
+      readText() {
+        return Promise.resolve(store.value);
+      },
+    };
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      get() {
+        return clipboard;
+      },
+    });
+    const nav = navigator as Navigator & { permissions?: any };
+    const allow = new Set(['clipboard-read', 'clipboard-write']);
+    const originalQuery = nav.permissions?.query?.bind(nav.permissions);
+    if (nav.permissions) {
+      nav.permissions.query = (descriptor: any) => {
+        const name = descriptor?.name;
+        if (name && allow.has(name)) {
+          return Promise.resolve({ state: 'granted', onchange: null });
+        }
+        return originalQuery
+          ? originalQuery(descriptor)
+          : Promise.resolve({ state: 'prompt', onchange: null });
+      };
+    } else {
+      (nav as any).permissions = {
+        query: () => Promise.resolve({ state: 'granted', onchange: null }),
+      };
+    }
+  });
+
+  await page.goto('/');
+  await page.waitForFunction(() => document.getElementById('desktop') !== null);
+  await page.evaluate(() => {
+    window.dispatchEvent(new CustomEvent('open-app', { detail: 'clipboard-manager' }));
+  });
+
+  const windowRoot = page.locator('#clipboard-manager');
+  await expect(windowRoot).toBeVisible({ timeout: 30_000 });
+  const listItems = windowRoot.getByRole('listitem');
+
+  const baselineHeap = await readHeapUsage(page);
+  expect(baselineHeap, 'performance.memory should be available in Chromium').not.toBeNull();
+  console.log(`[heap] baseline=${baselineHeap ?? -1}`);
+
+  await page.evaluate(
+    async ({ total, payloadSize }) => {
+      const payload = 'X'.repeat(payloadSize);
+      for (let i = 0; i < total; i++) {
+        const text = `Clipboard entry ${i} ${payload}`;
+        await navigator.clipboard.writeText(text);
+        document.dispatchEvent(new Event('copy', { bubbles: true }));
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+    },
+    { total: CLIPBOARD_ENTRY_COUNT, payloadSize: CLIPBOARD_PAYLOAD_SIZE },
+  );
+
+  await expect(listItems).toHaveCount(CLIPBOARD_ENTRY_COUNT, { timeout: 30_000 });
+
+  await page.waitForTimeout(1000);
+  const afterSeedHeap = await readHeapUsage(page);
+  expect(afterSeedHeap).not.toBeNull();
+  const baselineValue = baselineHeap ?? 0;
+  const seededValue = afterSeedHeap ?? baselineValue;
+  const growth = seededValue - baselineValue;
+  console.log(`[heap] growth baseline=${baselineValue} seeded=${seededValue} delta=${growth}`);
+  expect(growth).toBeGreaterThanOrEqual(SEED_GROWTH_EXPECTATION);
+
+  await windowRoot.getByRole('button', { name: 'Clear History' }).click();
+  await expect(listItems).toHaveCount(0, { timeout: 15_000 });
+
+  const tolerance = Math.max(200_000, (seededValue - baselineValue) * 0.1);
+  const target = baselineValue + tolerance;
+  const recoveredHeap = await waitForHeapBelow(page, target, 20_000);
+
+  test.info().annotations.push({
+    type: 'heap-usage',
+    description: `baseline=${baselineValue} seeded=${seededValue} cleared=${recoveredHeap ?? -1} target<=${target}`,
+  });
+  console.log(
+    `[heap] baseline=${baselineValue} seeded=${seededValue} cleared=${recoveredHeap} target<=${target}`,
+  );
+
+  expect(recoveredHeap).not.toBeNull();
+  expect((recoveredHeap ?? Number.POSITIVE_INFINITY)).toBeLessThanOrEqual(target);
+});


### PR DESCRIPTION
## Summary
- add a Playwright clipboard manager resiliency spec that seeds 500 clipboard entries, records heap telemetry, and verifies recovery after clearing history
- relax the development CSP to include `unsafe-eval` and launch Chromium with precise memory flags so heap metrics are available during the test
- extend the shared Playwright config and accessibility workflow to pick up the new spec alongside existing suites

## Testing
- npx playwright test playwright/clipboard-manager.spec.ts
- yarn lint *(fails: pre-existing jsx-a11y/control-has-associated-label and no-top-level-window violations across legacy apps)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0654d8908328b867590fa3631078