### PR TITLE
[post-exploitation] Add fuzzy search navigation

### DIFF
--- a/__tests__/post_exploitation.test.tsx
+++ b/__tests__/post_exploitation.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PostExploitation from '../pages/post_exploitation';
+
+describe('PostExploitation search experience', () => {
+  it('returns fuzzy matches for approximate queries', async () => {
+    const user = userEvent.setup();
+    render(<PostExploitation />);
+
+    const input = screen.getByPlaceholderText(/search modules/i);
+    await user.type(input, 'hash dum');
+
+    expect(await screen.findByTestId('module-card-hashdump')).toBeInTheDocument();
+    expect(screen.queryByTestId('module-card-getsystem')).not.toBeInTheDocument();
+  });
+
+  it('highlights the regions returned by the fuzzy matcher', async () => {
+    const user = userEvent.setup();
+    render(<PostExploitation />);
+
+    const input = screen.getByPlaceholderText(/search modules/i);
+    await user.type(input, 'hash dum');
+
+    const card = await screen.findByTestId('module-card-hashdump');
+    expect(card.querySelectorAll('mark')).not.toHaveLength(0);
+  });
+
+  it('supports keyboard navigation and selection via Enter', async () => {
+    const user = userEvent.setup();
+    render(<PostExploitation />);
+
+    const input = screen.getByPlaceholderText(/search modules/i);
+    input.focus();
+
+    await user.keyboard('{ArrowDown}');
+
+    const keyscanCard = await screen.findByTestId('module-card-keyscan_start');
+    await waitFor(() => expect(keyscanCard).toHaveClass('bg-gray-100'));
+
+    await user.keyboard('{Enter}');
+
+    expect(
+      await screen.findByRole('heading', { level: 2, name: 'keyscan_start' })
+    ).toBeInTheDocument();
+  });
+});

--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -1,4 +1,6 @@
+import type { FuseResultMatch } from 'fuse.js';
 import Image from 'next/image';
+import type { ReactNode } from 'react';
 import { ModuleMetadata } from '../modules/metadata';
 
 interface ModuleCardProps {
@@ -7,21 +9,63 @@ interface ModuleCardProps {
   selected: boolean;
   /** Current search query for highlighting */
   query?: string;
+  /** Fuse.js matches for highlighting */
+  matches?: readonly FuseResultMatch[];
 }
 
-function highlight(text: string, query: string | undefined) {
-  if (!query) return text;
-  const lower = text.toLowerCase();
-  const q = query.toLowerCase();
-  const idx = lower.indexOf(q);
-  if (idx === -1) return text;
-  return (
-    <>
-      {text.slice(0, idx)}
-      <mark>{text.slice(idx, idx + q.length)}</mark>
-      {text.slice(idx + q.length)}
-    </>
-  );
+function highlight(
+  text: string,
+  matches: readonly FuseResultMatch[] | undefined,
+  key: string,
+  fallbackQuery?: string
+): ReactNode {
+  const normalizedKey = key.toLowerCase();
+  const match = matches?.find((m) => {
+    const keyValue = Array.isArray(m.key) ? m.key.join('.') : m.key;
+    return keyValue?.toLowerCase() === normalizedKey;
+  });
+
+  if (match && match.indices.length > 0) {
+    const parts: ReactNode[] = [];
+    let lastIndex = 0;
+
+    match.indices.forEach(([start, end], idx) => {
+      if (start > lastIndex) {
+        parts.push(text.slice(lastIndex, start));
+      }
+
+      parts.push(
+        <mark key={`${normalizedKey}-${idx}-${start}-${end}`}>
+          {text.slice(start, end + 1)}
+        </mark>
+      );
+
+      lastIndex = end + 1;
+    });
+
+    if (lastIndex < text.length) {
+      parts.push(text.slice(lastIndex));
+    }
+
+    return <>{parts}</>;
+  }
+
+  if (fallbackQuery) {
+    const lower = text.toLowerCase();
+    const q = fallbackQuery.toLowerCase();
+    const idx = lower.indexOf(q);
+    if (idx !== -1) {
+      return (
+        <>
+          {text.slice(0, idx)}
+          <mark>{text.slice(idx, idx + q.length)}</mark>
+          {text.slice(idx + q.length)}
+        </>
+      );
+    }
+  }
+
+  return text;
 }
 
 export default function ModuleCard({
@@ -29,17 +73,23 @@ export default function ModuleCard({
   onSelect,
   selected,
   query,
+  matches,
 }: ModuleCardProps) {
   return (
     <button
       onClick={() => onSelect(module)}
+      data-testid={`module-card-${module.name}`}
       className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
         selected ? 'bg-gray-100' : ''
       }`}
     >
       <div className="flex-1 pr-2 font-mono">
-        <h3 className="font-bold">{highlight(module.name, query)}</h3>
-        <p className="text-sm">{highlight(module.description, query)}</p>
+        <h3 className="font-bold">
+          {highlight(module.name, matches, 'name', query)}
+        </h3>
+        <p className="text-sm">
+          {highlight(module.description, matches, 'description', query)}
+        </p>
       </div>
       <div className="flex flex-col gap-2 items-center">
         <Image

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "dompurify": "^3.2.6",
     "fast-xml-parser": "^4.3.5",
     "figlet": "^1.8.2",
+    "fuse.js": "^7.1.0",
     "hash-wasm": "^4.12.0",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -1,15 +1,26 @@
 "use client";
 
-import React, { useState } from 'react';
+import Fuse from 'fuse.js';
+import type { FuseResultMatch } from 'fuse.js';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import VirtualList from 'rc-virtual-list';
+import ModuleCard from '../components/ModuleCard';
 import Meta from '../components/SEO/Meta';
 import modules, { ModuleMetadata } from '../modules/metadata';
-import ModuleCard from '../components/ModuleCard';
-import VirtualList from 'rc-virtual-list';
+
+type ModuleSearchResult = {
+  item: ModuleMetadata;
+  matches?: readonly FuseResultMatch[];
+  score?: number;
+};
+
+type ModuleSearchResultWithIndex = ModuleSearchResult & { index: number };
 
 export default function PostExploitation() {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState<ModuleMetadata | null>(null);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [activeIndex, setActiveIndex] = useState<number>(0);
 
   const transcript = `meterpreter > getuid\nServer username: NT AUTHORITY\\SYSTEM\nmeterpreter > keyscan_start\nStarting the keystroke sniffer...\nmeterpreter > run persistence_service\n[*] Creating service accomplished\n`;
 
@@ -19,18 +30,116 @@ export default function PostExploitation() {
 
   const allTags = Array.from(new Set(modules.flatMap((m) => m.tags))).sort();
 
+  const fuse = useMemo(
+    () =>
+      new Fuse(modules, {
+        includeMatches: true,
+        threshold: 0.35,
+        ignoreLocation: true,
+        keys: [
+          { name: 'name', weight: 0.6 },
+          { name: 'description', weight: 0.3 },
+          { name: 'tags', weight: 0.1 },
+        ],
+      }),
+    []
+  );
+
+  const searchResults = useMemo<ModuleSearchResult[]>(() => {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      return modules.map((module) => ({ item: module }));
+    }
+
+    return fuse.search(trimmed, { limit: modules.length }).map((result) => ({
+      item: result.item,
+      matches: result.matches,
+      score: result.score,
+    }));
+  }, [fuse, query]);
+
+  const filteredResults = useMemo<ModuleSearchResult[]>(() => {
+    if (selectedTags.length === 0) {
+      return searchResults;
+    }
+
+    return searchResults.filter((result) =>
+      result.item.tags.some((tag) => selectedTags.includes(tag))
+    );
+  }, [searchResults, selectedTags]);
+
+  useEffect(() => {
+    if (filteredResults.length === 0) {
+      setActiveIndex(-1);
+      setSelected((prev) => (prev ? null : prev));
+      return;
+    }
+
+    setActiveIndex((prev) => {
+      if (prev < 0) return 0;
+      if (prev >= filteredResults.length) {
+        return filteredResults.length - 1;
+      }
+      return prev;
+    });
+
+    setSelected((prev) => {
+      if (!prev) return prev;
+      const stillExists = filteredResults.some(
+        (result) => result.item.name === prev.name
+      );
+      if (stillExists) {
+        return prev;
+      }
+      return filteredResults[0]?.item ?? null;
+    });
+  }, [filteredResults]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (!filteredResults.length) {
+        return;
+      }
+
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setActiveIndex((prev) => {
+          if (prev < 0) return 0;
+          return Math.min(prev + 1, filteredResults.length - 1);
+        });
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setActiveIndex((prev) => {
+          if (prev <= 0) {
+            return 0;
+          }
+          return prev - 1;
+        });
+      } else if (event.key === 'Enter') {
+        if (activeIndex >= 0 && activeIndex < filteredResults.length) {
+          event.preventDefault();
+          const next = filteredResults[activeIndex].item;
+          setSelected(next);
+        }
+      }
+    },
+    [activeIndex, filteredResults]
+  );
+
+  const resultsWithIndex = useMemo<ModuleSearchResultWithIndex[]>(
+    () =>
+      filteredResults.map((result, index) => ({
+        ...result,
+        index,
+      })),
+    [filteredResults]
+  );
+
   const toggleTag = (tag: string) => {
     setSelectedTags((prev) =>
       prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
     );
   };
-
-  const filtered = modules.filter(
-    (m) =>
-      m.name.toLowerCase().includes(query.toLowerCase()) &&
-      (selectedTags.length === 0 ||
-        m.tags.some((t) => selectedTags.includes(t)))
-  );
 
   return (
     <>
@@ -55,39 +164,55 @@ export default function PostExploitation() {
             placeholder="Search modules..."
             value={query}
             onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            aria-label="Search modules"
             className="mb-4 w-full rounded border p-2"
           />
           <div className="mb-4 flex flex-wrap gap-2">
-            {allTags.map((tag) => (
-              <label key={tag} className="flex items-center space-x-1">
-                <input
-                  type="checkbox"
-                  checked={selectedTags.includes(tag)}
-                  onChange={() => toggleTag(tag)}
-                  className="rounded"
-                />
-                <span>{tag}</span>
-              </label>
-            ))}
+            {allTags.map((tag) => {
+              const checkboxId = `module-tag-${tag.replace(/\s+/g, '-')}`;
+              return (
+                <div key={tag} className="flex items-center space-x-1">
+                  <input
+                    id={checkboxId}
+                    type="checkbox"
+                    checked={selectedTags.includes(tag)}
+                    onChange={() => toggleTag(tag)}
+                    aria-label={tag}
+                    className="rounded"
+                  />
+                  <label htmlFor={checkboxId} className="cursor-pointer">
+                    {tag}
+                  </label>
+                </div>
+              );
+            })}
           </div>
-          {filtered.length === 0 ? (
+          {resultsWithIndex.length === 0 ? (
             <p>No modules match your search.</p>
           ) : (
             <VirtualList
-              data={filtered}
+              data={resultsWithIndex}
               height={600}
               itemHeight={120}
-              itemKey="name"
+              itemKey={(result) => result.item.name}
               component="ul"
               className="grid gap-4 list-none p-0"
             >
-              {(m: ModuleMetadata) => (
-                <li key={m.name}>
+              {(result: ModuleSearchResultWithIndex) => (
+                <li key={result.item.name}>
                   <ModuleCard
-                    module={m}
-                    onSelect={setSelected}
-                    selected={selected?.name === m.name}
-                    query={query}
+                    module={result.item}
+                    onSelect={(module) => {
+                      setSelected(module);
+                      setActiveIndex(result.index);
+                    }}
+                    selected={
+                      selected?.name === result.item.name ||
+                      result.index === activeIndex
+                    }
+                    query={query.trim()}
+                    matches={result.matches}
                   />
                 </li>
               )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7640,6 +7640,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fuse.js@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "fuse.js@npm:7.1.0"
+  checksum: 10c0/c0d1b1d192a4bdf3eade897453ddd28aff96b70bf3e49161a45880f9845ebaee97265595db633776700a5bcf8942223c752754a848d70c508c3c9fd997faad1e
+  languageName: node
+  linkType: hard
+
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -13911,6 +13918,7 @@ __metadata:
     fast-glob: "npm:^3.3.3"
     fast-xml-parser: "npm:^4.3.5"
     figlet: "npm:^1.8.2"
+    fuse.js: "npm:^7.1.0"
     hash-wasm: "npm:^4.12.0"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"


### PR DESCRIPTION
## Summary
- integrate Fuse.js-based fuzzy scoring for post-exploitation modules with match highlighting
- add keyboard navigation and active selection syncing for search results
- extend ModuleCard highlighting support and add unit tests covering fuzzy matching and navigation

## Testing
- yarn lint *(fails: repository has numerous pre-existing accessibility violations in other apps)*
- yarn exec eslint pages/post_exploitation.tsx components/ModuleCard.tsx __tests__/post_exploitation.test.tsx
- yarn test __tests__/post_exploitation.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc06563224832882aeda4033849ef4