### PR TITLE
[clipboard] add privacy mode toggle

### DIFF
--- a/__tests__/clipboardManager.test.tsx
+++ b/__tests__/clipboardManager.test.tsx
@@ -1,0 +1,100 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('../utils/safeIDB', () => ({
+  getDb: jest.fn(),
+}));
+
+import ClipboardManager from '../components/apps/ClipboardManager';
+import { getDb } from '../utils/safeIDB';
+
+const createPermissionStatus = (state: PermissionState) =>
+  ({
+    state,
+    onchange: null,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }) as unknown as PermissionStatus;
+
+describe('ClipboardManager privacy mode', () => {
+  beforeEach(() => {
+    (getDb as jest.Mock).mockReset();
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  const setup = async (permissionState: PermissionState = 'granted') => {
+    const add = jest.fn().mockResolvedValue(undefined);
+    const transaction = jest.fn(() => ({
+      store: { add },
+      done: Promise.resolve(),
+    }));
+    const clear = jest.fn().mockResolvedValue(undefined);
+    const getAll = jest.fn().mockResolvedValue([]);
+    const mockDb = {
+      transaction,
+      clear,
+      getAll,
+    } as const;
+
+    (getDb as jest.Mock).mockResolvedValue(mockDb);
+
+    const readText = jest.fn().mockResolvedValue('secret note');
+    const writeText = jest.fn();
+    const query = jest
+      .fn()
+      .mockResolvedValue(createPermissionStatus(permissionState));
+
+    const mockNavigator = {
+      clipboard: { readText, writeText },
+      permissions: { query },
+    } as unknown as Navigator;
+
+    const user = userEvent.setup();
+    render(<ClipboardManager nav={mockNavigator} />);
+
+    await waitFor(() => expect(query).toHaveBeenCalled());
+
+    return {
+      transaction,
+      readText,
+      query,
+      user,
+    };
+  };
+
+  test('skips IndexedDB persistence when privacy mode is enabled', async () => {
+    const { query, user, readText, transaction } = await setup();
+
+    const toggle = screen.getByRole('checkbox', { name: /privacy mode/i });
+    await user.click(toggle);
+    expect(toggle).toBeChecked();
+
+    act(() => {
+      document.dispatchEvent(new Event('copy', { bubbles: true }));
+    });
+
+    await waitFor(() => expect(query).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(readText).toHaveBeenCalledTimes(1));
+    expect(transaction).not.toHaveBeenCalled();
+
+    expect(await screen.findByText('secret note')).toBeInTheDocument();
+  });
+
+  test('shows CTA when clipboard read permission is denied', async () => {
+    const { query, readText } = await setup('denied');
+
+    expect(
+      await screen.findByText(/clipboard access is blocked/i),
+    ).toBeInTheDocument();
+
+    act(() => {
+      document.dispatchEvent(new Event('copy', { bubbles: true }));
+    });
+
+    await waitFor(() => expect(query).toHaveBeenCalledTimes(2));
+    expect(readText).not.toHaveBeenCalled();
+  });
+});
+

--- a/components/apps/ClipboardManager.tsx
+++ b/components/apps/ClipboardManager.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
 import { getDb } from '../../utils/safeIDB';
 
 interface ClipItem {
@@ -29,10 +30,36 @@ function getDB() {
   return dbPromise;
 }
 
-const ClipboardManager: React.FC = () => {
+const createEphemeralItem = (text: string): ClipItem => {
+  const timestamp = Date.now();
+  return { id: timestamp + Math.random(), text, created: timestamp };
+};
+
+type PermissionStatusState = PermissionState | 'unknown';
+
+interface ClipboardManagerProps {
+  nav?: Navigator | null;
+}
+
+const ClipboardManager: React.FC<ClipboardManagerProps> = ({ nav }) => {
   const [items, setItems] = useState<ClipItem[]>([]);
+  const [privacyMode, setPrivacyMode] = usePersistentState<boolean>(
+    'clipboard:privacy-mode',
+    false,
+  );
+  const [permissionState, setPermissionState] = useState<PermissionStatusState>(
+    'unknown',
+  );
+  const navigatorRef = useMemo(
+    () => nav ?? (typeof window !== 'undefined' ? window.navigator : undefined),
+    [nav],
+  );
 
   const loadItems = useCallback(async () => {
+    if (privacyMode) {
+      setItems([]);
+      return;
+    }
     try {
       const dbp = getDB();
       if (!dbp) return;
@@ -43,11 +70,18 @@ const ClipboardManager: React.FC = () => {
     } catch {
       // ignore errors
     }
-  }, []);
+  }, [privacyMode]);
 
   const addItem = useCallback(
     async (text: string) => {
       if (!text) return;
+      if (privacyMode) {
+        setItems((prev) => {
+          if (prev[0]?.text === text) return prev;
+          return [createEphemeralItem(text), ...prev];
+        });
+        return;
+      }
       try {
         const dbp = getDB();
         if (!dbp) return;
@@ -61,46 +95,98 @@ const ClipboardManager: React.FC = () => {
         // ignore errors
       }
     },
-    [loadItems]
+    [privacyMode, loadItems],
   );
 
   useEffect(() => {
-    loadItems();
+    void loadItems();
   }, [loadItems]);
 
-  const handleCopy = useCallback(async () => {
+  const checkReadPermission = useCallback(async () => {
     try {
-      const perm = await (navigator.permissions as any)?.query?.({
-        name: 'clipboard-read' as any,
-      });
-      if (perm && perm.state === 'denied') return;
-      const text = await navigator.clipboard.readText();
+      if (!navigatorRef) {
+        setPermissionState('unknown');
+        return 'unknown';
+      }
+      const permissions = navigatorRef.permissions;
+      if (!permissions?.query) {
+        setPermissionState('unknown');
+        return 'unknown';
+      }
+      const status = await permissions.query({
+        name: 'clipboard-read' as PermissionName,
+      } as PermissionDescriptor);
+      setPermissionState(status.state);
+      return status.state;
+    } catch {
+      setPermissionState('unknown');
+      return 'unknown';
+    }
+  }, [navigatorRef]);
+
+  useEffect(() => {
+    void checkReadPermission();
+  }, [checkReadPermission]);
+
+  const readClipboard = useCallback(async () => {
+    try {
+      const perm = await checkReadPermission();
+      if (perm === 'denied') {
+        return;
+      }
+      const clipboard = navigatorRef?.clipboard;
+      if (!clipboard?.readText) {
+        console.error('Clipboard API not available');
+        return;
+      }
+      const text = await clipboard.readText();
       if (text && (!items[0] || items[0].text !== text)) {
         await addItem(text);
       }
+      setPermissionState('granted');
     } catch (err) {
+      if ((err as DOMException)?.name === 'NotAllowedError') {
+        setPermissionState('denied');
+      }
       console.error('Clipboard read failed:', err);
     }
-  }, [items, addItem]);
+  }, [items, addItem, checkReadPermission]);
+
+  const handleCopy = useCallback(() => {
+    void readClipboard();
+  }, [readClipboard]);
 
   useEffect(() => {
     document.addEventListener('copy', handleCopy);
     return () => document.removeEventListener('copy', handleCopy);
   }, [handleCopy]);
 
-  const writeToClipboard = async (text: string) => {
-    try {
-      const perm = await (navigator.permissions as any)?.query?.({
-        name: 'clipboard-write' as any,
-      });
-      if (perm && perm.state === 'denied') return;
-      await navigator.clipboard.writeText(text);
-    } catch (err) {
-      console.error('Clipboard write failed:', err);
-    }
-  };
+  const writeToClipboard = useCallback(
+    async (text: string) => {
+      try {
+        const permissions = navigatorRef?.permissions;
+        const perm = await permissions?.query?.({
+          name: 'clipboard-write' as PermissionName,
+        } as PermissionDescriptor);
+        if (perm && perm.state === 'denied') return;
+        const clipboard = navigatorRef?.clipboard;
+        if (!clipboard?.writeText) {
+          console.error('Clipboard API not available');
+          return;
+        }
+        await clipboard.writeText(text);
+      } catch (err) {
+        console.error('Clipboard write failed:', err);
+      }
+    },
+    [navigatorRef],
+  );
 
   const clearHistory = async () => {
+    if (privacyMode) {
+      setItems([]);
+      return;
+    }
     try {
       const dbp = getDB();
       if (!dbp) return;
@@ -114,13 +200,39 @@ const ClipboardManager: React.FC = () => {
   };
 
   return (
-    <div className="p-4 space-y-2 text-white bg-ub-cool-grey h-full overflow-auto">
-      <button
-        className="px-2 py-1 bg-gray-700 hover:bg-gray-600"
-        onClick={clearHistory}
-      >
-        Clear History
-      </button>
+    <div className="p-4 space-y-3 text-white bg-ub-cool-grey h-full overflow-auto">
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          className="px-2 py-1 bg-gray-700 hover:bg-gray-600"
+          onClick={clearHistory}
+        >
+          Clear History
+        </button>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={privacyMode}
+            onChange={(event) => setPrivacyMode(event.target.checked)}
+          />
+          Privacy mode
+        </label>
+        {privacyMode && (
+          <span className="text-xs text-gray-300">
+            Clipboard entries stay in-memory only.
+          </span>
+        )}
+      </div>
+      {permissionState === 'denied' && (
+        <div className="space-y-2 rounded border border-red-500/40 bg-red-900/40 p-3 text-sm">
+          <p>Clipboard access is blocked. Enable permissions to capture entries.</p>
+          <button
+            className="px-2 py-1 bg-red-700 hover:bg-red-600"
+            onClick={() => void readClipboard()}
+          >
+            Retry clipboard access
+          </button>
+        </div>
+      )}
       <ul className="space-y-1">
         {items.map((item) => (
           <li


### PR DESCRIPTION
## Summary
- request clipboard permissions before reading and surface a CTA when access is denied
- add a persisted privacy mode that keeps clipboard history in-memory only and bypasses IndexedDB writes
- cover the privacy mode and denied-permission flows with focused unit tests

## Testing
- yarn test __tests__/clipboardManager.test.tsx
- yarn lint # fails with existing jsx-a11y/no-top-level-window errors across the repo

------
https://chatgpt.com/codex/tasks/task_e_68cc0656eb2883289554ae86574d9e41