### PR TITLE
[weather] Add persistent unit toggle

### DIFF
--- a/__tests__/weatherUnits.test.ts
+++ b/__tests__/weatherUnits.test.ts
@@ -1,0 +1,23 @@
+import { convertTemperature, formatTemperature } from '../apps/weather/utils';
+
+describe('weather unit conversions', () => {
+  it('keeps metric values unchanged', () => {
+    expect(convertTemperature(10, 'metric')).toBe(10);
+    expect(convertTemperature(-5.5, 'metric')).toBe(-5.5);
+  });
+
+  it('converts to Fahrenheit when imperial', () => {
+    expect(convertTemperature(0, 'imperial')).toBeCloseTo(32);
+    expect(convertTemperature(25, 'imperial')).toBeCloseTo(77);
+  });
+
+  it('formats metric temperatures with symbol and rounding', () => {
+    expect(formatTemperature(10.6, 'metric')).toBe('11°C');
+    expect(formatTemperature(-2.2, 'metric')).toBe('-2°C');
+  });
+
+  it('formats imperial temperatures with symbol and rounding', () => {
+    expect(formatTemperature(21.1, 'imperial')).toBe('70°F');
+    expect(formatTemperature(-40, 'imperial')).toBe('-40°F');
+  });
+});

--- a/apps/weather/components/CityDetail.tsx
+++ b/apps/weather/components/CityDetail.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { City } from '../state';
+import { City, useWeatherUnits } from '../state';
+import { convertTemperature } from '../utils';
 
 interface Props {
   city: City;
@@ -9,7 +10,7 @@ interface Props {
 }
 
 export default function CityDetail({ city, onClose }: Props) {
-  const [unit, setUnit] = useState<'C' | 'F'>('C');
+  const [units, setUnits] = useWeatherUnits();
   const [hourly, setHourly] = useState<number[]>([]);
   const [precip, setPrecip] = useState<number | null>(null);
 
@@ -25,7 +26,7 @@ export default function CityDetail({ city, onClose }: Props) {
       .catch(() => {});
   }, [city]);
 
-  const temps = unit === 'C' ? hourly : hourly.map((t) => t * 1.8 + 32);
+  const temps = hourly.map((t) => convertTemperature(t, units));
   const slice = temps.slice(0, 24);
   const min = Math.min(...slice);
   const max = Math.max(...slice);
@@ -48,14 +49,18 @@ export default function CityDetail({ city, onClose }: Props) {
         </div>
         <div className="flex gap-1.5 mb-4">
           <button
-            className={`px-1.5 rounded ${unit === 'C' ? 'bg-blue-600' : 'bg-white/20'}`}
-            onClick={() => setUnit('C')}
+            className={`px-1.5 rounded ${
+              units === 'metric' ? 'bg-blue-600' : 'bg-white/20'
+            }`}
+            onClick={() => setUnits('metric')}
           >
             °C
           </button>
           <button
-            className={`px-1.5 rounded ${unit === 'F' ? 'bg-blue-600' : 'bg-white/20'}`}
-            onClick={() => setUnit('F')}
+            className={`px-1.5 rounded ${
+              units === 'imperial' ? 'bg-blue-600' : 'bg-white/20'
+            }`}
+            onClick={() => setUnits('imperial')}
           >
             °F
           </button>

--- a/apps/weather/components/Forecast.tsx
+++ b/apps/weather/components/Forecast.tsx
@@ -1,9 +1,15 @@
 'use client';
 
 import WeatherIcon from './WeatherIcon';
-import { ForecastDay } from '../state';
+import { ForecastDay, WeatherUnits } from '../state';
+import { formatTemperature } from '../utils';
 
-export default function Forecast({ days }: { days: ForecastDay[] }) {
+interface ForecastProps {
+  days: ForecastDay[];
+  units: WeatherUnits;
+}
+
+export default function Forecast({ days, units }: ForecastProps) {
   return (
     <div className="flex gap-1.5">
       {days.map((d) => (
@@ -12,7 +18,9 @@ export default function Forecast({ days }: { days: ForecastDay[] }) {
           className="flex flex-col items-center p-1.5 bg-white/10 rounded"
         >
           <WeatherIcon code={d.condition} />
-          <div className="text-sm mt-1">{Math.round(d.temp)}°</div>
+          <div className="text-sm mt-1">
+            {formatTemperature(d.temp, units)}
+          </div>
         </div>
       ))}
     </div>

--- a/apps/weather/index.tsx
+++ b/apps/weather/index.tsx
@@ -4,11 +4,14 @@ import { useEffect, useRef, useState } from 'react';
 import useWeatherState, {
   City,
   ForecastDay,
+  WeatherUnits,
   useWeatherGroups,
   useCurrentGroup,
+  useWeatherUnits,
 } from './state';
 import Forecast from './components/Forecast';
 import CityDetail from './components/CityDetail';
+import { formatTemperature } from './utils';
 
 interface ReadingUpdate {
   temp: number;
@@ -16,16 +19,20 @@ interface ReadingUpdate {
   time: number;
 }
 
-function CityTile({ city }: { city: City }) {
+function CityTile({ city, units }: { city: City; units: WeatherUnits }) {
   return (
     <div>
       <div className="font-bold mb-1.5">{city.name}</div>
       {city.lastReading ? (
-        <div className="mb-1.5">{Math.round(city.lastReading.temp)}°C</div>
+        <div className="mb-1.5">
+          {formatTemperature(city.lastReading.temp, units)}
+        </div>
       ) : (
         <div className="opacity-70 mb-1.5">No data</div>
       )}
-      {city.forecast && <Forecast days={city.forecast.slice(0, 5)} />}
+      {city.forecast && (
+        <Forecast days={city.forecast.slice(0, 5)} units={units} />
+      )}
     </div>
   );
 }
@@ -34,6 +41,7 @@ export default function WeatherApp() {
   const [cities, setCities] = useWeatherState();
   const [groups, setGroups] = useWeatherGroups();
   const [currentGroup, setCurrentGroup] = useCurrentGroup();
+  const [units, setUnits] = useWeatherUnits();
   const [name, setName] = useState('');
   const [lat, setLat] = useState('');
   const [lon, setLon] = useState('');
@@ -166,6 +174,25 @@ export default function WeatherApp() {
           </button>
         ))}
       </div>
+      <div className="flex items-center gap-1.5 mb-4">
+        <span className="text-sm opacity-80">Units</span>
+        <button
+          className={`px-2 rounded ${
+            units === 'metric' ? 'bg-blue-600' : 'bg-white/20'
+          }`}
+          onClick={() => setUnits('metric')}
+        >
+          °C
+        </button>
+        <button
+          className={`px-2 rounded ${
+            units === 'imperial' ? 'bg-blue-600' : 'bg-white/20'
+          }`}
+          onClick={() => setUnits('imperial')}
+        >
+          °F
+        </button>
+      </div>
       <div className="flex gap-2 mb-4">
         <input
           className="text-black px-1"
@@ -200,7 +227,7 @@ export default function WeatherApp() {
             onClick={() => setSelected(city)}
             className="bg-white/10 p-4 rounded cursor-pointer"
           >
-            <CityTile city={city} />
+            <CityTile city={city} units={units} />
           </div>
         ))}
       </div>

--- a/apps/weather/state.ts
+++ b/apps/weather/state.ts
@@ -14,6 +14,8 @@ export interface ForecastDay {
   condition: number;
 }
 
+export type WeatherUnits = 'metric' | 'imperial';
+
 export interface City {
   id: string;
   name: string;
@@ -66,5 +68,12 @@ const isStringOrNull = (v: unknown): v is string | null =>
 
 export function useCurrentGroup() {
   return usePersistentState<string | null>('weather-current-group', null, isStringOrNull);
+}
+
+const isWeatherUnits = (value: unknown): value is WeatherUnits =>
+  value === 'metric' || value === 'imperial';
+
+export function useWeatherUnits() {
+  return usePersistentState<WeatherUnits>('weather-units', 'metric', isWeatherUnits);
 }
 

--- a/apps/weather/utils.ts
+++ b/apps/weather/utils.ts
@@ -1,0 +1,18 @@
+import { WeatherUnits } from './state';
+
+const FAHRENHEIT_FACTOR = 9 / 5;
+
+export function convertTemperature(value: number, units: WeatherUnits): number {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+
+  return units === 'imperial' ? value * FAHRENHEIT_FACTOR + 32 : value;
+}
+
+export function formatTemperature(value: number, units: WeatherUnits): string {
+  const converted = convertTemperature(value, units);
+  const rounded = Math.round(converted);
+  const suffix = units === 'imperial' ? '°F' : '°C';
+  return `${rounded}${suffix}`;
+}


### PR DESCRIPTION
## Summary
- add a shared weather unit state with a persistent toggle in the app UI
- convert city tiles, forecasts, and detail charts according to the selected units
- add utility helpers with unit tests covering conversion and formatting logic

## Testing
- [x] yarn test weatherUnits
- [ ] yarn lint *(fails with existing accessibility violations in unrelated apps)*

------
https://chatgpt.com/codex/tasks/task_e_68cc06587a48832896886eb2b06fd5ba