### PR TITLE
[core] Harden fetch retries and loading fallback

### DIFF
--- a/__tests__/fetchProxy.test.ts
+++ b/__tests__/fetchProxy.test.ts
@@ -1,0 +1,151 @@
+type FetchProxyModule = typeof import('../lib/fetchProxy');
+
+describe('fetchProxy retry behavior', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
+  let originalFetch: typeof global.fetch;
+  let getActiveFetches: FetchProxyModule['getActiveFetches'] = () => [];
+
+  const importProxy = async () => {
+    jest.resetModules();
+    delete (globalThis as any).__fetchProxyInstalled;
+    const mod = await import('../lib/fetchProxy');
+    getActiveFetches = mod.getActiveFetches;
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    originalFetch = global.fetch;
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  const createMockResponse = (status: number, headers: Record<string, string> = {}) => {
+    const headerMap = new Map(
+      Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+    );
+    const clone = () => ({
+      arrayBuffer: async () => new ArrayBuffer(0),
+    });
+    return {
+      status,
+      headers: {
+        get: (key: string) => headerMap.get(key.toLowerCase()) ?? null,
+      },
+      clone,
+    } as unknown as Response;
+  };
+
+  const flushPromises = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
+  afterEach(() => {
+    jest.useRealTimers();
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    global.fetch = originalFetch;
+    delete (globalThis as any).__fetchProxyInstalled;
+    jest.resetModules();
+  });
+
+  it('retries recoverable statuses with exponential backoff and resolves', async () => {
+    const responses = [
+      createMockResponse(429),
+      createMockResponse(500),
+      createMockResponse(200),
+    ];
+    const fetchMock = jest
+      .fn<Promise<Response>, [RequestInfo | URL, RequestInit | undefined]>()
+      .mockResolvedValueOnce(responses[0])
+      .mockResolvedValueOnce(responses[1])
+      .mockResolvedValueOnce(responses[2]);
+
+    global.fetch = fetchMock as any;
+    await importProxy();
+
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+
+    const promise = global.fetch('/api/data');
+    await flushPromises();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getActiveFetches()).toHaveLength(1);
+
+    jest.advanceTimersByTime(200);
+    await flushPromises();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    jest.advanceTimersByTime(400);
+    await flushPromises();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    await flushPromises();
+    const response = await promise;
+    expect(response.status).toBe(200);
+    expect(getActiveFetches()).toHaveLength(0);
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    expect(setTimeoutSpy).toHaveBeenNthCalledWith(1, expect.any(Function), 200);
+    expect(setTimeoutSpy).toHaveBeenNthCalledWith(2, expect.any(Function), 400);
+
+    setTimeoutSpy.mockRestore();
+  });
+
+  it('logs when recoverable status persists after max attempts', async () => {
+    const responses = [
+      createMockResponse(500),
+      createMockResponse(500),
+      createMockResponse(500),
+    ];
+    const fetchMock = jest
+      .fn<Promise<Response>, [RequestInfo | URL, RequestInit | undefined]>()
+      .mockResolvedValueOnce(responses[0])
+      .mockResolvedValueOnce(responses[1])
+      .mockResolvedValueOnce(responses[2]);
+
+    global.fetch = fetchMock as any;
+    await importProxy();
+
+    const promise = global.fetch('/api/error');
+    await flushPromises();
+
+    jest.advanceTimersByTime(200);
+    await flushPromises();
+    jest.advanceTimersByTime(400);
+    await flushPromises();
+
+    await flushPromises();
+    const response = await promise;
+    expect(response.status).toBe(500);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Fetch returned recoverable status after max attempts',
+      expect.objectContaining({ url: '/api/error', status: 500, attempts: 3 }),
+    );
+  });
+
+  it('logs error and rethrows when fetch rejects repeatedly', async () => {
+    const error = new Error('network down');
+    const fetchMock = jest
+      .fn<Promise<Response>, [RequestInfo | URL, RequestInit | undefined]>()
+      .mockRejectedValue(error);
+
+    global.fetch = fetchMock as any;
+    await importProxy();
+
+    const promise = global.fetch('/api/fail');
+    await flushPromises();
+
+    jest.advanceTimersByTime(200);
+    await flushPromises();
+    jest.advanceTimersByTime(400);
+    await flushPromises();
+
+    await expect(promise).rejects.toThrow('network down');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Fetch request failed after retries',
+      expect.objectContaining({ url: '/api/fail', attempts: 3, error }),
+    );
+  });
+});

--- a/components/common/MainContentSkeleton.tsx
+++ b/components/common/MainContentSkeleton.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export default function MainContentSkeleton() {
+  return (
+    <div
+      className="min-h-screen w-full bg-black/40 text-white"
+      role="status"
+      aria-live="polite"
+      aria-label="Loading desktop environment"
+      aria-busy="true"
+    >
+      <div className="animate-pulse space-y-6 p-6">
+        <div className="h-6 w-48 rounded bg-white/20" />
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div
+              key={index}
+              className="rounded-lg border border-white/10 bg-white/5 p-4 shadow-lg shadow-black/20"
+            >
+              <div className="mb-4 h-32 rounded bg-white/10" />
+              <div className="space-y-2">
+                <div className="h-4 w-3/4 rounded bg-white/10" />
+                <div className="h-4 w-2/3 rounded bg-white/10" />
+                <div className="h-3 w-1/2 rounded bg-white/10" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/fetchProxy.ts
+++ b/lib/fetchProxy.ts
@@ -1,3 +1,5 @@
+import { createLogger } from './logger';
+
 export interface FetchLog {
   id: number;
   url: string;
@@ -10,6 +12,8 @@ export interface FetchLog {
   responseSize?: number;
   fromServiceWorkerCache?: boolean;
   error?: unknown;
+  attempts?: number;
+  lastError?: unknown;
 }
 
 export type FetchEntry = FetchLog;
@@ -19,6 +23,13 @@ let counter = 0;
 
 const now = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
 
+const log = createLogger();
+
+const RECOVERABLE_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504]);
+const MAX_ATTEMPTS = 3;
+const BASE_DELAY_MS = 200;
+const MAX_DELAY_MS = 5000;
+
 function bodySize(body: BodyInit | null | undefined): number | undefined {
   if (body == null) return 0;
   if (typeof body === 'string') return new TextEncoder().encode(body).length;
@@ -26,6 +37,37 @@ function bodySize(body: BodyInit | null | undefined): number | undefined {
   if (body instanceof ArrayBuffer) return body.byteLength;
   if (ArrayBuffer.isView(body)) return body.byteLength;
   return undefined;
+}
+
+function parseRetryAfter(header: string | null): number | null {
+  if (!header) return null;
+  const seconds = Number(header);
+  if (!Number.isNaN(seconds) && seconds >= 0) {
+    return Math.min(seconds * 1000, MAX_DELAY_MS);
+  }
+  const date = Date.parse(header);
+  if (!Number.isNaN(date)) {
+    const delay = date - Date.now();
+    if (delay > 0) return Math.min(delay, MAX_DELAY_MS);
+  }
+  return null;
+}
+
+function getBackoffDelay(attempt: number, retryAfter?: string | null): number {
+  const parsed = parseRetryAfter(retryAfter ?? null);
+  if (parsed != null) return parsed;
+  const expo = BASE_DELAY_MS * 2 ** (attempt - 1);
+  return Math.min(expo, MAX_DELAY_MS);
+}
+
+function shouldRetryStatus(status: number): boolean {
+  return RECOVERABLE_STATUS_CODES.has(status);
+}
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
 export function getActiveFetches(): FetchLog[] {
@@ -75,12 +117,12 @@ if (typeof globalThis.fetch === 'function' && !(globalThis as any).__fetchProxyI
       method,
       startTime: now(),
       requestSize: init?.body ? bodySize(init.body) : undefined,
+      attempts: 0,
     };
     active.set(id, record);
     notify('start', record);
 
-    try {
-      const response = await originalFetch(input as any, init);
+    const finalizeSuccess = (response: Response) => {
       const end = now();
       record.endTime = end;
       record.duration = end - record.startTime;
@@ -117,15 +159,95 @@ if (typeof globalThis.fetch === 'function' && !(globalThis as any).__fetchProxyI
         finalize();
       }
 
+      delete record.lastError;
       return response;
-    } catch (err) {
+    };
+
+    const finalizeError = (err: unknown) => {
       const end = now();
       record.endTime = end;
       record.duration = end - record.startTime;
       record.error = err;
       active.delete(id);
       notify('end', record);
-      throw err;
+    };
+
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+      record.attempts = attempt;
+      try {
+        const response = await originalFetch(input as any, init);
+        record.status = response.status;
+
+        if (shouldRetryStatus(response.status) && attempt < MAX_ATTEMPTS) {
+          const delay = getBackoffDelay(attempt, response.headers.get('retry-after'));
+          record.lastError = { status: response.status };
+          console.warn('Fetch received recoverable status, retrying', {
+            url,
+            status: response.status,
+            attempt,
+            retryIn: delay,
+          });
+          log.warn('Fetch received recoverable status, retrying', {
+            url,
+            status: response.status,
+            attempt,
+            retryIn: delay,
+          });
+          await sleep(delay);
+          continue;
+        }
+
+        if (shouldRetryStatus(response.status) && attempt === MAX_ATTEMPTS) {
+          console.warn('Fetch returned recoverable status after max attempts', {
+            url,
+            status: response.status,
+            attempts: attempt,
+          });
+          log.warn('Fetch returned recoverable status after max attempts', {
+            url,
+            status: response.status,
+            attempts: attempt,
+          });
+        }
+
+        return finalizeSuccess(response);
+      } catch (err) {
+        lastError = err;
+        record.lastError = err;
+        if (attempt === MAX_ATTEMPTS) {
+          finalizeError(err);
+          console.error('Fetch request failed after retries', {
+            url,
+            attempts: attempt,
+            error: err,
+          });
+          log.error('Fetch request failed after retries', {
+            url,
+            attempts: attempt,
+            error: err,
+          });
+          throw err;
+        }
+        const delay = getBackoffDelay(attempt);
+        console.warn('Fetch attempt failed, retrying', {
+          url,
+          attempt,
+          retryIn: delay,
+          error: err,
+        });
+        log.warn('Fetch attempt failed, retrying', {
+          url,
+          attempt,
+          retryIn: delay,
+          error: err,
+        });
+        await sleep(delay);
+      }
     }
+
+    finalizeError(lastError);
+    throw lastError ?? new Error('Fetch failed');
   };
 }

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,8 @@
 import dynamic from 'next/dynamic';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
+import ErrorBoundary from '../components/core/ErrorBoundary';
+import MainContentSkeleton from '../components/common/MainContentSkeleton';
 
 const Ubuntu = dynamic(
   () =>
@@ -10,8 +12,16 @@ const Ubuntu = dynamic(
     }),
   {
     ssr: false,
-    loading: () => <p>Loading Ubuntu...</p>,
+    loading: () => <MainContentSkeleton />,
   }
+);
+const InstallButtonSkeleton = () => (
+  <div
+    role="status"
+    aria-label="Loading install options"
+    aria-busy="true"
+    className="mx-auto mt-6 h-12 w-56 animate-pulse rounded bg-white/10"
+  />
 );
 const InstallButton = dynamic(
   () =>
@@ -21,7 +31,7 @@ const InstallButton = dynamic(
     }),
   {
     ssr: false,
-    loading: () => <p>Loading install options...</p>,
+    loading: () => <InstallButtonSkeleton />,
   }
 );
 
@@ -34,9 +44,13 @@ const App = () => (
       Skip to content
     </a>
     <Meta />
-    <Ubuntu />
-    <BetaBadge />
-    <InstallButton />
+    <ErrorBoundary>
+      <>
+        <Ubuntu />
+        <BetaBadge />
+        <InstallButton />
+      </>
+    </ErrorBoundary>
   </>
 );
 


### PR DESCRIPTION
## Summary
- wrap the main landing content in an error boundary and replace text fallbacks with skeleton loaders
- add exponential backoff retry handling and structured logging to the global fetch proxy
- cover recoverable HTTP status flows and failure logging with new Jest tests using mocked fetch responses

## Testing
- yarn test --runTestsByPath __tests__/fetchProxy.test.ts
- yarn lint *(fails: existing accessibility and no-top-level-window lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0658484c8328b56e95b73ab3891f