### PR TITLE
[ui] Add touch mode support and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ See Vercel's [Speed Insights Quickstart](https://vercel.com/docs/speed-insights/
 - Client-side only **simulations** of security tools (no real exploitation)
 - A large set of games rendered in-browser (Canvas/DOM), with a shared `GameLayout`
 
+### Touch mode & input accessibility
+
+- Automatically detects coarse-pointer devices and exposes a Quick Settings toggle so visitors can opt into touch mode manually.
+- Touch mode updates the CSS spacing scale and hit-area tokens so every interactive element meets or exceeds the 44&nbsp;px minimum target recommended by WCAG for comfortable tapping.
+- A simulated on-screen keyboard (`components/ui/TouchKeyboard.tsx`) listens for focus events and provides touch entry for inputs and textareas across the desktop UI.
+- End-to-end coverage (`playwright/tests/touch.spec.ts`) verifies the toggle, the HTML class flag, and keyboard input against a focused search field.
+
 ### Gamepad Input & Remapping
 
 Games can listen for normalized gamepad events via `utils/gamepad.ts`. The manager polls

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,32 @@ import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const {
+        accent,
+        setAccent,
+        wallpaper,
+        setWallpaper,
+        density,
+        setDensity,
+        reducedMotion,
+        setReducedMotion,
+        largeHitAreas,
+        setLargeHitAreas,
+        fontScale,
+        setFontScale,
+        highContrast,
+        setHighContrast,
+        pongSpin,
+        setPongSpin,
+        allowNetwork,
+        setAllowNetwork,
+        haptics,
+        setHaptics,
+        theme,
+        setTheme,
+        touchMode,
+        setTouchMode,
+    } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -57,14 +82,14 @@ export function Settings() {
 
     return (
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
-            <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
+            <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-[var(--space-4)]" style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Theme:</label>
+            <div className="flex flex-wrap items-center justify-center gap-[var(--space-3)] my-[var(--space-3)]">
+                <label className="text-ubt-grey">Theme:</label>
                 <select
                     value={theme}
                     onChange={(e) => setTheme(e.target.value)}
-                    className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                    className="hit-area rounded border border-ubt-cool-grey bg-ub-cool-grey px-[var(--space-3)] text-ubt-grey"
                 >
                     <option value="default">Default</option>
                     <option value="dark">Dark</option>
@@ -72,9 +97,9 @@ export function Settings() {
                     <option value="matrix">Matrix</option>
                 </select>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Accent:</label>
-                <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
+            <div className="flex flex-wrap items-center justify-center gap-[var(--space-3)] my-[var(--space-3)]">
+                <span className="text-ubt-grey">Accent:</span>
+                <div aria-label="Accent color picker" role="radiogroup" className="flex flex-wrap gap-[var(--space-2)]">
                     {ACCENT_OPTIONS.map((c) => (
                         <button
                             key={c}
@@ -82,25 +107,25 @@ export function Settings() {
                             role="radio"
                             aria-checked={accent === c}
                             onClick={() => setAccent(c)}
-                            className={`w-8 h-8 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
-                            style={{ backgroundColor: c }}
+                            className={`hit-area rounded-full border-2 focus:outline-none focus:ring-2 focus:ring-ub-orange ${accent === c ? 'border-white' : 'border-transparent'}`}
+                            style={{ backgroundColor: c, width: 'var(--hit-area)', height: 'var(--hit-area)' }}
                         />
                     ))}
                 </div>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Density:</label>
+            <div className="flex flex-wrap items-center justify-center gap-[var(--space-3)] my-[var(--space-3)]">
+                <label className="text-ubt-grey">Density:</label>
                 <select
                     value={density}
                     onChange={(e) => setDensity(e.target.value)}
-                    className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                    className="hit-area rounded border border-ubt-cool-grey bg-ub-cool-grey px-[var(--space-3)] text-ubt-grey"
                 >
                     <option value="regular">Regular</option>
                     <option value="compact">Compact</option>
                 </select>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Font Size:</label>
+            <div className="flex flex-col items-center gap-[var(--space-2)] my-[var(--space-3)]">
+                <label className="text-ubt-grey">Font Size:</label>
                 <input
                     type="range"
                     min="0.75"
@@ -108,83 +133,82 @@ export function Settings() {
                     step="0.05"
                     value={fontScale}
                     onChange={(e) => setFontScale(parseFloat(e.target.value))}
-                    className="ubuntu-slider"
+                    className="ubuntu-slider w-3/4"
                 />
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
+            <div className="flex flex-col items-center gap-[var(--space-2)] my-[var(--space-3)]">
+                <label className="hit-area flex min-h-[var(--hit-area)] w-72 max-w-full items-center justify-between gap-[var(--space-2)] rounded-md border border-transparent px-[var(--space-3)] text-ubt-grey transition-colors hover:border-ubt-cool-grey">
+                    <span>Reduced Motion</span>
                     <input
                         type="checkbox"
                         checked={reducedMotion}
                         onChange={(e) => setReducedMotion(e.target.checked)}
-                        className="mr-2"
+                        className="h-[calc(var(--hit-area)/2)] w-[calc(var(--hit-area)/2)]"
                     />
-                    Reduced Motion
                 </label>
-            </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
+                <label className="hit-area flex min-h-[var(--hit-area)] w-72 max-w-full items-center justify-between gap-[var(--space-2)] rounded-md border border-transparent px-[var(--space-3)] text-ubt-grey transition-colors hover:border-ubt-cool-grey">
+                    <span>Large Hit Areas</span>
                     <input
                         type="checkbox"
                         checked={largeHitAreas}
                         onChange={(e) => setLargeHitAreas(e.target.checked)}
-                        className="mr-2"
+                        className="h-[calc(var(--hit-area)/2)] w-[calc(var(--hit-area)/2)]"
                     />
-                    Large Hit Areas
                 </label>
-            </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
+                <label className="hit-area flex min-h-[var(--hit-area)] w-72 max-w-full items-center justify-between gap-[var(--space-2)] rounded-md border border-transparent px-[var(--space-3)] text-ubt-grey transition-colors hover:border-ubt-cool-grey">
+                    <span>High Contrast</span>
                     <input
                         type="checkbox"
                         checked={highContrast}
                         onChange={(e) => setHighContrast(e.target.checked)}
-                        className="mr-2"
+                        className="h-[calc(var(--hit-area)/2)] w-[calc(var(--hit-area)/2)]"
                     />
-                    High Contrast
                 </label>
-            </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
+                <label className="hit-area flex min-h-[var(--hit-area)] w-72 max-w-full items-center justify-between gap-[var(--space-2)] rounded-md border border-transparent px-[var(--space-3)] text-ubt-grey transition-colors hover:border-ubt-cool-grey">
+                    <span>Touch Mode</span>
+                    <input
+                        type="checkbox"
+                        checked={touchMode}
+                        onChange={(e) => setTouchMode(e.target.checked)}
+                        className="h-[calc(var(--hit-area)/2)] w-[calc(var(--hit-area)/2)]"
+                    />
+                </label>
+                <label className="hit-area flex min-h-[var(--hit-area)] w-72 max-w-full items-center justify-between gap-[var(--space-2)] rounded-md border border-transparent px-[var(--space-3)] text-ubt-grey transition-colors hover:border-ubt-cool-grey">
+                    <span>Allow Network Requests</span>
                     <input
                         type="checkbox"
                         checked={allowNetwork}
                         onChange={(e) => setAllowNetwork(e.target.checked)}
-                        className="mr-2"
+                        className="h-[calc(var(--hit-area)/2)] w-[calc(var(--hit-area)/2)]"
                     />
-                    Allow Network Requests
                 </label>
-            </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
+                <label className="hit-area flex min-h-[var(--hit-area)] w-72 max-w-full items-center justify-between gap-[var(--space-2)] rounded-md border border-transparent px-[var(--space-3)] text-ubt-grey transition-colors hover:border-ubt-cool-grey">
+                    <span>Haptics</span>
                     <input
                         type="checkbox"
                         checked={haptics}
                         onChange={(e) => setHaptics(e.target.checked)}
-                        className="mr-2"
+                        className="h-[calc(var(--hit-area)/2)] w-[calc(var(--hit-area)/2)]"
                     />
-                    Haptics
                 </label>
-            </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
+                <label className="hit-area flex min-h-[var(--hit-area)] w-72 max-w-full items-center justify-between gap-[var(--space-2)] rounded-md border border-transparent px-[var(--space-3)] text-ubt-grey transition-colors hover:border-ubt-cool-grey">
+                    <span>Pong Spin</span>
                     <input
                         type="checkbox"
                         checked={pongSpin}
                         onChange={(e) => setPongSpin(e.target.checked)}
-                        className="mr-2"
+                        className="h-[calc(var(--hit-area)/2)] w-[calc(var(--hit-area)/2)]"
                     />
-                    Pong Spin
                 </label>
             </div>
-            <div className="flex justify-center my-4">
+            <div className="flex justify-center my-[var(--space-4)]">
                 <div
-                    className="p-4 rounded transition-colors duration-300 motion-reduce:transition-none"
+                    className="rounded p-[var(--space-4)] transition-colors duration-300 motion-reduce:transition-none"
                     style={{ backgroundColor: '#0f1317', color: '#ffffff' }}
                 >
                     <p className="mb-2 text-center">Preview</p>
                     <button
-                        className="px-2 py-1 rounded"
+                        className="hit-area rounded px-[var(--space-3)] py-[var(--space-2)]"
                         style={{ backgroundColor: accent, color: accentText() }}
                     >
                         Accent
@@ -195,7 +219,7 @@ export function Settings() {
                     <span ref={liveRegion} role="status" aria-live="polite" className="sr-only"></span>
                 </div>
             </div>
-            <div className="flex flex-wrap justify-center items-center border-t border-gray-900">
+            <div className="flex flex-wrap items-center justify-center gap-[var(--space-3)] border-t border-gray-900 py-[var(--space-3)]">
                 {
                     wallpapers.map((name, index) => (
                         <div
@@ -219,7 +243,7 @@ export function Settings() {
                     ))
                 }
             </div>
-            <div className="flex justify-center my-4 border-t border-gray-900 pt-4 space-x-4">
+            <div className="flex flex-wrap items-center justify-center gap-[var(--space-3)] border-t border-gray-900 pt-[var(--space-3)]">
                 <button
                     onClick={async () => {
                         const data = await exportSettingsData();
@@ -231,13 +255,13 @@ export function Settings() {
                         a.click();
                         URL.revokeObjectURL(url);
                     }}
-                    className="px-4 py-2 rounded bg-ub-orange text-white"
+                    className="hit-area rounded bg-ub-orange px-[var(--space-4)] py-[var(--space-2)] text-white transition-colors hover:bg-ub-orange/80"
                 >
                     Export Settings
                 </button>
                 <button
                     onClick={() => fileInput.current && fileInput.current.click()}
-                    className="px-4 py-2 rounded bg-ub-orange text-white"
+                    className="hit-area rounded bg-ub-orange px-[var(--space-4)] py-[var(--space-2)] text-white transition-colors hover:bg-ub-orange/80"
                 >
                     Import Settings
                 </button>
@@ -251,9 +275,13 @@ export function Settings() {
                         setLargeHitAreas(defaults.largeHitAreas);
                         setFontScale(defaults.fontScale);
                         setHighContrast(defaults.highContrast);
+                        setAllowNetwork(defaults.allowNetwork);
+                        setHaptics(defaults.haptics);
+                        setPongSpin(defaults.pongSpin);
+                        setTouchMode(defaults.touchMode);
                         setTheme('default');
                     }}
-                    className="px-4 py-2 rounded bg-ub-orange text-white"
+                    className="hit-area rounded bg-ub-orange px-[var(--space-4)] py-[var(--space-2)] text-white transition-colors hover:bg-ub-orange/80"
                 >
                     Reset Desktop
                 </button>
@@ -275,6 +303,10 @@ export function Settings() {
                         if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
                         if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
                         if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
+                        if (parsed.allowNetwork !== undefined) setAllowNetwork(parsed.allowNetwork);
+                        if (parsed.haptics !== undefined) setHaptics(parsed.haptics);
+                        if (parsed.pongSpin !== undefined) setPongSpin(parsed.pongSpin);
+                        if (parsed.touchMode !== undefined) setTouchMode(parsed.touchMode);
                         if (parsed.theme !== undefined) { setTheme(parsed.theme); }
                     } catch (err) {
                         console.error('Invalid settings', err);

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -677,7 +677,9 @@ export default Window
 export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
     return (
         <div
-            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
+            className={
+                'relative flex w-full select-none items-center rounded-b-none border-t-2 border-white border-opacity-5 bg-ub-window-title px-[var(--space-4)] text-white min-h-[var(--hit-area)]'
+            }
             tabIndex={0}
             role="button"
             aria-grabbed={grabbed}
@@ -734,12 +736,12 @@ export function WindowEditButtons(props) {
     const { togglePin } = useDocPiP(props.pip || (() => null));
     const pipSupported = typeof window !== 'undefined' && !!window.documentPictureInPicture;
     return (
-        <div className="absolute select-none right-0 top-0 mt-1 mr-1 flex justify-center items-center h-11 min-w-[8.25rem]">
+        <div className="absolute right-0 top-0 flex min-h-[var(--hit-area)] min-w-[8.25rem] items-center justify-center gap-[var(--space-2)] pr-[var(--space-2)] pt-[var(--space-1)] mr-[var(--space-1)] mt-[var(--space-1)] select-none">
             {pipSupported && props.pip && (
                 <button
                     type="button"
                     aria-label="Window pin"
-                    className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                    className="hit-area mx-[var(--space-1)] flex items-center justify-center rounded-full bg-white/0 px-[var(--space-2)] text-white transition-colors hover:bg-white/10"
                     onClick={togglePin}
                 >
                     <NextImage
@@ -755,7 +757,7 @@ export function WindowEditButtons(props) {
             <button
                 type="button"
                 aria-label="Window minimize"
-                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                className="hit-area mx-[var(--space-1)] flex items-center justify-center rounded-full bg-white/0 px-[var(--space-2)] text-white transition-colors hover:bg-white/10"
                 onClick={props.minimize}
             >
                 <NextImage
@@ -773,7 +775,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window restore"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className="hit-area mx-[var(--space-1)] flex items-center justify-center rounded-full bg-white/0 px-[var(--space-2)] text-white transition-colors hover:bg-white/10"
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -789,7 +791,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window maximize"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className="hit-area mx-[var(--space-1)] flex items-center justify-center rounded-full bg-white/0 px-[var(--space-2)] text-white transition-colors hover:bg-white/10"
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -807,7 +809,7 @@ export function WindowEditButtons(props) {
                 type="button"
                 id={`close-${props.id}`}
                 aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
+                className="hit-area mx-[var(--space-1)] flex cursor-default items-center justify-center rounded-full bg-ub-cool-grey/90 px-[var(--space-2)] text-white transition-colors hover:bg-ub-cool-grey"
                 onClick={props.close}
             >
                 <NextImage

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -837,16 +837,23 @@ export class Desktop extends Component {
 
         return (
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
-                <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
+                <div className="w-full flex flex-col items-start gap-[var(--space-3)] px-[var(--space-4)] py-[var(--space-4)]">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <input
+                        className="context-menu-bg w-10/12 rounded border-2 border-blue-700 px-[var(--space-2)] py-[var(--space-2)] outline-none"
+                        id="folder-name-input"
+                        type="text"
+                        autoComplete="off"
+                        spellCheck="false"
+                        autoFocus={true}
+                    />
                 </div>
                 <div className="flex">
                     <button
                         type="button"
                         onClick={addFolder}
                         aria-label="Create folder"
-                        className="w-1/2 px-4 py-2 border border-gray-900 border-opacity-50 border-r-0 hover:bg-ub-warm-grey hover:bg-opacity-10 hover:border-opacity-50"
+                        className="hit-area w-1/2 border border-gray-900 border-opacity-50 border-r-0 px-[var(--space-4)] py-[var(--space-2)] transition-colors hover:border-opacity-50 hover:bg-ub-warm-grey/10"
                     >
                         Create
                     </button>
@@ -854,7 +861,7 @@ export class Desktop extends Component {
                         type="button"
                         onClick={removeCard}
                         aria-label="Cancel folder creation"
-                        className="w-1/2 px-4 py-2 border border-gray-900 border-opacity-50 hover:bg-ub-warm-grey hover:bg-opacity-10 hover:border-opacity-50"
+                        className="hit-area w-1/2 border border-gray-900 border-opacity-50 px-[var(--space-4)] py-[var(--space-2)] transition-colors hover:border-opacity-50 hover:bg-ub-warm-grey/10"
                     >
                         Cancel
                     </button>

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,56 +1,97 @@
 "use client";
 
+import { useMemo } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
+import { useSettings } from '../../hooks/useSettings';
+import { isDarkTheme } from '../../utils/theme';
 
 interface Props {
   open: boolean;
 }
 
 const QuickSettings = ({ open }: Props) => {
-  const [theme, setTheme] = usePersistentState('qs-theme', 'light');
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
-  const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const {
+    theme,
+    setTheme,
+    reducedMotion,
+    setReducedMotion,
+    touchMode,
+    setTouchMode,
+  } = useSettings();
 
-  useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark');
-  }, [theme]);
+  const containerClasses = useMemo(
+    () =>
+      [
+        'absolute right-3 top-9 z-50 w-64 rounded-lg border border-black/20 bg-ub-cool-grey shadow-lg transition-all duration-200',
+        'px-[var(--space-4)] py-[var(--space-4)]',
+        open
+          ? 'pointer-events-auto opacity-100 translate-y-0'
+          : 'pointer-events-none opacity-0 -translate-y-2',
+      ].join(' '),
+    [open],
+  );
 
-  useEffect(() => {
-    document.documentElement.classList.toggle('reduce-motion', reduceMotion);
-  }, [reduceMotion]);
+  const toggleThemeLabel = isDarkTheme(theme) ? 'Dark' : 'Default';
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
-        open ? '' : 'hidden'
-      }`}
+      className={containerClasses}
+      data-state={open ? 'open' : 'closed'}
+      aria-hidden={!open}
     >
-      <div className="px-4 pb-2">
+      <div className="flex flex-col gap-[var(--space-3)] text-sm text-white">
         <button
-          className="w-full flex justify-between"
-          onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+          type="button"
+          className="hit-area flex items-center justify-between gap-[var(--space-3)] rounded-md bg-white/5 px-[var(--space-3)] text-left font-medium tracking-wide transition-colors hover:bg-white/10"
+          onClick={() => setTheme(isDarkTheme(theme) ? 'default' : 'dark')}
         >
           <span>Theme</span>
-          <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
+          <span>{toggleThemeLabel}</span>
         </button>
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
-        <input
-          type="checkbox"
-          checked={reduceMotion}
-          onChange={() => setReduceMotion(!reduceMotion)}
-        />
+        <label className="hit-area flex items-center justify-between gap-[var(--space-3)] rounded-md bg-white/5 px-[var(--space-3)] font-medium text-white transition-colors hover:bg-white/10">
+          <span>Sound</span>
+          <input
+            type="checkbox"
+            className="h-[calc(var(--hit-area)/2)] w-[calc(var(--hit-area)/2)]"
+            checked={sound}
+            onChange={() => setSound(!sound)}
+          />
+        </label>
+        <label className="hit-area flex items-center justify-between gap-[var(--space-3)] rounded-md bg-white/5 px-[var(--space-3)] font-medium text-white transition-colors hover:bg-white/10">
+          <span>Network</span>
+          <input
+            type="checkbox"
+            className="h-[calc(var(--hit-area)/2)] w-[calc(var(--hit-area)/2)]"
+            checked={online}
+            onChange={() => setOnline(!online)}
+          />
+        </label>
+        <label
+          className="hit-area flex items-center justify-between gap-[var(--space-3)] rounded-md bg-white/5 px-[var(--space-3)] font-medium text-white transition-colors hover:bg-white/10"
+          data-testid="quick-settings-reduced-motion"
+        >
+          <span>Reduced motion</span>
+          <input
+            type="checkbox"
+            className="h-[calc(var(--hit-area)/2)] w-[calc(var(--hit-area)/2)]"
+            checked={reducedMotion}
+            onChange={() => setReducedMotion(!reducedMotion)}
+          />
+        </label>
+        <label
+          className="hit-area flex items-center justify-between gap-[var(--space-3)] rounded-md bg-white/5 px-[var(--space-3)] font-medium text-white transition-colors hover:bg-white/10"
+          data-testid="quick-settings-touch"
+        >
+          <span>Touch mode</span>
+          <input
+            type="checkbox"
+            className="h-[calc(var(--hit-area)/2)] w-[calc(var(--hit-area)/2)]"
+            checked={touchMode}
+            onChange={() => setTouchMode(!touchMode)}
+          />
+        </label>
       </div>
     </div>
   );

--- a/components/ui/TouchKeyboard.tsx
+++ b/components/ui/TouchKeyboard.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSettings } from '../../hooks/useSettings';
+
+type EditableElement = HTMLInputElement | HTMLTextAreaElement;
+
+const DISALLOWED_INPUT_TYPES = new Set([
+  'button',
+  'submit',
+  'reset',
+  'checkbox',
+  'radio',
+  'file',
+  'color',
+  'image',
+  'range',
+]);
+
+const KEY_LAYOUT: string[][] = [
+  ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'],
+  ['q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p'],
+  ['a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l'],
+  ['Shift', 'z', 'x', 'c', 'v', 'b', 'n', 'm', '⌫'],
+  ['Space', 'Enter', 'Hide'],
+];
+
+const isEditableElement = (target: EventTarget | null): target is EditableElement => {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target instanceof HTMLTextAreaElement) {
+    return !target.readOnly && !target.disabled;
+  }
+  if (target instanceof HTMLInputElement) {
+    if (DISALLOWED_INPUT_TYPES.has(target.type)) return false;
+    return !target.readOnly && !target.disabled;
+  }
+  return false;
+};
+
+const TouchKeyboard = () => {
+  const { touchMode } = useSettings();
+  const [visible, setVisible] = useState(false);
+  const [target, setTarget] = useState<EditableElement | null>(null);
+  const [shift, setShift] = useState(false);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!touchMode) {
+      setVisible(false);
+      setTarget(null);
+      setShift(false);
+      return;
+    }
+
+    const handleFocus = (event: FocusEvent) => {
+      const element = event.target as HTMLElement | null;
+      if (isEditableElement(element)) {
+        setTarget(element);
+        setVisible(true);
+      } else if (!overlayRef.current?.contains(element)) {
+        setVisible(false);
+        setTarget(null);
+        setShift(false);
+      }
+    };
+
+    document.addEventListener('focusin', handleFocus);
+    return () => {
+      document.removeEventListener('focusin', handleFocus);
+    };
+  }, [touchMode]);
+
+  const ensureTarget = useCallback(() => {
+    if (!target || !target.isConnected) {
+      setTarget(null);
+      setVisible(false);
+      setShift(false);
+      return false;
+    }
+    return true;
+  }, [target]);
+
+  const commitValue = useCallback(
+    (value: string, selection: number) => {
+      if (!ensureTarget() || !target) return;
+      target.value = value;
+      try {
+        target.setSelectionRange(selection, selection);
+      } catch {
+        /* ignored */
+      }
+      target.dispatchEvent(new Event('input', { bubbles: true }));
+    },
+    [ensureTarget, target],
+  );
+
+  const insertText = useCallback(
+    (text: string) => {
+      if (!ensureTarget() || !target) return;
+      const start = target.selectionStart ?? target.value.length;
+      const end = target.selectionEnd ?? target.value.length;
+      const nextValue = target.value.slice(0, start) + text + target.value.slice(end);
+      const caret = start + text.length;
+      commitValue(nextValue, caret);
+    },
+    [commitValue, ensureTarget, target],
+  );
+
+  const handleBackspace = useCallback(() => {
+    if (!ensureTarget() || !target) return;
+    const start = target.selectionStart ?? target.value.length;
+    const end = target.selectionEnd ?? target.value.length;
+    if (start === 0 && end === 0) return;
+    const deleteStart = start === end ? Math.max(start - 1, 0) : start;
+    const nextValue = target.value.slice(0, deleteStart) + target.value.slice(end);
+    commitValue(nextValue, deleteStart);
+  }, [commitValue, ensureTarget, target]);
+
+  const handleEnter = useCallback(() => {
+    if (!ensureTarget() || !target) return;
+    if (target instanceof HTMLTextAreaElement) {
+      insertText('\n');
+      return;
+    }
+    target.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    target.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', bubbles: true }));
+    const form = target.form;
+    if (form && typeof form.requestSubmit === 'function') {
+      form.requestSubmit();
+    }
+    setVisible(false);
+    setTarget(null);
+    setShift(false);
+  }, [ensureTarget, insertText, target]);
+
+  const handleKey = useCallback(
+    (key: string) => {
+      if (!ensureTarget() || !target) return;
+      target.focus({ preventScroll: true });
+      switch (key) {
+        case 'Shift':
+          setShift((prev) => !prev);
+          break;
+        case '⌫':
+          handleBackspace();
+          break;
+        case 'Space':
+          insertText(' ');
+          break;
+        case 'Enter':
+          handleEnter();
+          break;
+        case 'Hide':
+          setVisible(false);
+          setTarget(null);
+          setShift(false);
+          target.blur();
+          break;
+        default: {
+          const character = shift ? key.toUpperCase() : key;
+          insertText(character);
+          if (shift) setShift(false);
+          break;
+        }
+      }
+    },
+    [ensureTarget, handleBackspace, handleEnter, insertText, shift, target],
+  );
+
+  const renderedKeys = useMemo(() => KEY_LAYOUT, []);
+
+  if (!touchMode && !visible) {
+    return null;
+  }
+
+  const keyboardState = visible && target ? 'open' : 'closed';
+
+  return (
+    <div
+      ref={overlayRef}
+      data-testid="touch-keyboard"
+      data-state={keyboardState}
+      className={`fixed inset-x-0 bottom-0 z-50 transition-all duration-200 ${
+        keyboardState === 'open'
+          ? 'pointer-events-auto translate-y-0 opacity-100'
+          : 'pointer-events-none translate-y-full opacity-0'
+      }`}
+      aria-hidden={keyboardState !== 'open'}
+    >
+      <div className="mx-auto max-w-4xl rounded-t-2xl border border-black/30 bg-ub-cool-grey px-[var(--space-4)] py-[var(--space-4)] shadow-2xl">
+        <div className="mb-[var(--space-3)] flex items-center justify-between text-sm text-ubt-grey">
+          <span>Touch keyboard</span>
+          <button
+            type="button"
+            className="hit-area rounded-full bg-white/10 px-[var(--space-2)] text-xs font-semibold uppercase tracking-wide text-white transition-colors hover:bg-white/20"
+            onPointerDown={(event) => event.preventDefault()}
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => {
+              setVisible(false);
+              setTarget(null);
+              setShift(false);
+              target?.blur();
+            }}
+            data-testid="touch-keyboard-hide"
+          >
+            Hide
+          </button>
+        </div>
+        <div className="flex flex-col gap-[var(--space-2)]">
+          {renderedKeys.map((row, rowIndex) => (
+            <div
+              key={rowIndex}
+              className="flex w-full justify-center gap-[var(--space-2)]"
+            >
+              {row.map((key) => {
+                const isShift = key === 'Shift';
+                const isSpace = key === 'Space';
+                const isHide = key === 'Hide';
+                const isEnter = key === 'Enter';
+                const widthClass = isSpace ? 'flex-[2] px-[var(--space-4)]' : 'px-[var(--space-3)]';
+                const pressed = isShift && shift;
+                const keyNameForTest = key === '⌫' ? 'backspace' : key.toLowerCase();
+                const testId = `touch-keyboard-key-${keyNameForTest.replace(/[^a-z0-9]+/g, '-')}`;
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    tabIndex={-1}
+                    aria-pressed={pressed || undefined}
+                    data-testid={testId}
+                    onPointerDown={(event) => event.preventDefault()}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => handleKey(key)}
+                    className={`hit-area flex items-center justify-center rounded-lg bg-white/10 text-base capitalize text-white transition-colors hover:bg-white/20 ${widthClass} ${
+                      pressed ? 'bg-white/30' : ''
+                    } ${isHide ? 'text-xs font-semibold uppercase' : ''} ${
+                      isEnter ? 'font-semibold' : ''
+                    }`}
+                  >
+                    {key === 'Space' ? 'Space' : key}
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TouchKeyboard;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import TouchKeyboard from '../components/ui/TouchKeyboard';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -161,6 +162,7 @@ function MyApp(props) {
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />
             <ShortcutOverlay />
+            <TouchKeyboard />
             <Analytics
               beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testDir: '.',
+  testMatch: ['tests/**/*.spec.ts', 'playwright/**/*.spec.ts'],
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/playwright/tests/touch.spec.ts
+++ b/playwright/tests/touch.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Touch mode experience', () => {
+  test('enables touch mode and shows the touch keyboard on focus', async ({ page }) => {
+    await page.goto('/');
+
+    const html = page.locator('html');
+
+    await page.locator('#status-bar').click();
+    const touchToggle = page.getByTestId('quick-settings-touch');
+    await expect(touchToggle).toBeVisible();
+
+    const initialClass = await html.getAttribute('class');
+    if (initialClass?.includes('touch-mode')) {
+      await touchToggle.click();
+      await expect(html).not.toHaveAttribute('class', /touch-mode/);
+    }
+
+    await touchToggle.click();
+    await expect(html).toHaveAttribute('class', /touch-mode/);
+
+    await page.locator('#status-bar').click();
+
+    await page.getByRole('button', { name: /applications/i }).click();
+    const searchInput = page.getByPlaceholder('Search');
+    await expect(searchInput).toBeVisible();
+
+    await searchInput.click();
+    const keyboard = page.getByTestId('touch-keyboard');
+    await expect(keyboard).toHaveAttribute('data-state', 'open');
+
+    await page.getByTestId('touch-keyboard-key-a').click();
+    await expect(searchInput).toHaveValue(/a$/i);
+
+    await page.getByTestId('touch-keyboard-hide').click();
+    await expect(keyboard).toHaveAttribute('data-state', 'closed');
+  });
+});

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -89,6 +89,10 @@
   --hit-area: 48px;
 }
 
+.touch-mode {
+  --hit-area: 56px;
+}
+
 /* Reduced motion */
 .reduced-motion {
   --motion-fast: 0ms;

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,20 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  touchMode: false,
+};
+
+const detectTouchMode = () => {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.touchMode;
+  try {
+    return (
+      'ontouchstart' in window ||
+      navigator.maxTouchPoints > 0 ||
+      window.matchMedia('(pointer: coarse)').matches
+    );
+  } catch {
+    return DEFAULT_SETTINGS.touchMode;
+  }
 };
 
 export async function getAccent() {
@@ -113,6 +127,20 @@ export async function setPongSpin(value) {
   window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
 }
 
+export async function getTouchMode() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.touchMode;
+  const stored = window.localStorage.getItem('touch-mode');
+  if (stored !== null) {
+    return stored === 'true';
+  }
+  return detectTouchMode();
+}
+
+export async function setTouchMode(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('touch-mode', value ? 'true' : 'false');
+}
+
 export async function getAllowNetwork() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
   return window.localStorage.getItem('allow-network') === 'true';
@@ -137,6 +165,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('touch-mode');
 }
 
 export async function exportSettings() {
@@ -151,6 +180,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    touchMode,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +192,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getTouchMode(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +206,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    touchMode,
     theme,
   });
 }
@@ -199,6 +231,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    touchMode,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +244,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (touchMode !== undefined) await setTouchMode(touchMode);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add a touch mode flag in the shared settings store and provider, adjust spacing tokens, and expose the toggle in Quick Settings and the Settings app
- upgrade window controls, folder dialog, and touch-centric styles to honour the minimum hit area tokens and surface a simulated touch keyboard overlay
- document the touch workflow and add a Playwright test plus configuration updates for the new interaction

## Testing
- yarn lint *(fails: repository has pre-existing accessibility lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68cb19c8c4a483289515d20d01d56d2b