### PR TITLE
[apps] add snapshot manager utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,11 +373,16 @@ Browse all apps, games, and security tool demos at `/apps`, which presents a sea
 | Todoist | /apps/todoist | Utility / Media |
 | Gedit | /apps/gedit | Utility / Media |
 | Settings | /apps/settings | Utility / Media |
+| Snapshot Manager | /apps/snapshot-manager | Utility / Media |
 | Trash | /apps/trash | Utility / Media |
 | Project Gallery | /apps/project-gallery | Utility / Media |
 | Quote | /apps/quote | Utility / Media |
 
 > The VS Code app now embeds a StackBlitz IDE via iframe instead of the local Monaco editor.
+
+Snapshot Manager captures mocked system snapshots before risky updates, surfaces open
+files that would be closed during a rollback, and simulates a countdown that never
+exceeds the two-minute completion target.
 
 The Spotify app lets you customize a mood-to-playlist mapping. Use the in-app form to
 add, reorder, or delete moods; selections persist in the browser's Origin Private File

--- a/__tests__/components/apps/snapshot-manager.test.tsx
+++ b/__tests__/components/apps/snapshot-manager.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import SnapshotManager from '../../../components/apps/snapshot-manager';
+import { Desktop } from '../../../components/screen/desktop';
+import {
+  resetSnapshotStore,
+  triggerPreUpdateHooks,
+} from '../../../utils/snapshotStore';
+
+jest.mock('react-ga4', () => ({ event: jest.fn(), send: jest.fn() }));
+
+jest.mock('../../../utils/snapshotStore', () => {
+  const actual = jest.requireActual('../../../utils/snapshotStore');
+  return {
+    ...actual,
+    triggerPreUpdateHooks: jest.fn((event) => actual.triggerPreUpdateHooks(event)),
+  };
+});
+
+describe('Snapshot Manager', () => {
+  beforeEach(() => {
+    resetSnapshotStore();
+  });
+
+  it('creates snapshots through the UI', async () => {
+    await act(async () => {
+      render(<SnapshotManager />);
+    });
+
+    expect(screen.getByText('Baseline install')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Name this snapshot'), {
+      target: { value: 'Manual snapshot' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create snapshot/i }));
+
+    expect(await screen.findByText('Manual snapshot')).toBeInTheDocument();
+  });
+
+  it('warns about open files before rolling back', async () => {
+    await act(async () => {
+      render(<SnapshotManager />);
+    });
+
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    fireEvent.click(screen.getAllByRole('button', { name: /rollback/i })[0]);
+
+    expect(confirmSpy).toHaveBeenCalled();
+    const message = confirmSpy.mock.calls[0]?.[0] as string;
+    expect(message).toContain('Open files flagged for closure');
+    expect(message).toContain('incident-response.md');
+    expect(message).toContain('Target completion under 2 minutes');
+    confirmSpy.mockRestore();
+
+    expect(
+      screen.getByText(/Rollback in progress for/i),
+    ).toBeInTheDocument();
+
+    expect(
+      await screen.findByText(/Rollback complete for/i, {}, { timeout: 5000 }),
+    ).toBeInTheDocument();
+  });
+
+  it('invokes pre-update hooks when desktop opens plugin manager', () => {
+    const desktop = new Desktop();
+    jest.spyOn(desktop, 'setState').mockImplementation(() => {});
+    jest.spyOn(desktop, 'focus').mockImplementation(() => {});
+    jest.spyOn(desktop, 'saveSession').mockImplementation(() => {});
+    (triggerPreUpdateHooks as jest.Mock).mockClear();
+
+    desktop.openApp('plugin-manager');
+
+    expect(triggerPreUpdateHooks).toHaveBeenCalledWith({
+      type: 'open-app',
+      appId: 'plugin-manager',
+    });
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -77,6 +77,7 @@ const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
 const TrashApp = createDynamicApp('trash', 'Trash');
 const SerialTerminalApp = createDynamicApp('serial-terminal', 'Serial Terminal');
+const SnapshotManagerApp = createDynamicApp('snapshot-manager', 'Snapshot Manager');
 
 
 const WiresharkApp = createDynamicApp('wireshark', 'Wireshark');
@@ -163,6 +164,7 @@ const displayProjectGallery = createDisplay(ProjectGalleryApp);
 const displayTrash = createDisplay(TrashApp);
 const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
+const displaySnapshotManager = createDisplay(SnapshotManagerApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
 
@@ -230,6 +232,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayClipboardManager,
+  },
+  {
+    id: 'snapshot-manager',
+    title: 'Snapshot Manager',
+    icon: '/themes/Yaru/apps/camera.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displaySnapshotManager,
   },
   {
     id: 'figlet',

--- a/components/apps/snapshot-manager/index.tsx
+++ b/components/apps/snapshot-manager/index.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  type SnapshotRecord,
+  type RollbackState,
+  listSnapshots,
+  subscribe as subscribeSnapshots,
+  createSnapshot,
+  rollbackSnapshot,
+  getOpenFiles,
+  getRollbackState,
+} from '../../../utils/snapshotStore';
+
+type Props = {
+  openApp?: (id: string) => void;
+};
+
+const formatDateTime = (value: number) => new Date(value).toLocaleString();
+
+const describeOrigin = (snapshot: SnapshotRecord) =>
+  snapshot.origin === 'auto' ? 'Automatic' : 'Manual';
+
+const describeStatus = (snapshot: SnapshotRecord) => {
+  switch (snapshot.status) {
+    case 'creating':
+      return 'Creating…';
+    case 'restoring':
+      return 'Restoring…';
+    default:
+      return 'Ready';
+  }
+};
+
+const formatDuration = (ms?: number | null) => {
+  if (!ms) return '0s';
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes === 0) {
+    return `${seconds}s`;
+  }
+  return `${minutes}m ${seconds}s`;
+};
+
+const formatSince = (value?: number) => {
+  if (!value) return '—';
+  const diff = Date.now() - value;
+  if (diff < 60_000) return 'Just now';
+  if (diff < 3_600_000) {
+    const mins = Math.round(diff / 60_000);
+    return `${mins} minute${mins === 1 ? '' : 's'} ago`;
+  }
+  if (diff < 86_400_000) {
+    const hrs = Math.round(diff / 3_600_000);
+    return `${hrs} hour${hrs === 1 ? '' : 's'} ago`;
+  }
+  return formatDateTime(value);
+};
+
+const SnapshotManager: React.FC<Props> = () => {
+  const [snapshots, setSnapshots] = useState<SnapshotRecord[]>(() => listSnapshots());
+  const [rollback, setRollback] = useState<RollbackState>(() => getRollbackState());
+  const [label, setLabel] = useState('Pre-update snapshot');
+  const [error, setError] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [tick, setTick] = useState(Date.now());
+  const openFiles = useMemo(() => getOpenFiles(), []);
+
+  useEffect(() => {
+    const unsubscribe = subscribeSnapshots((nextSnapshots, nextRollback) => {
+      setSnapshots(nextSnapshots);
+      setRollback(nextRollback);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    if (rollback.status !== 'running' || !rollback.expectedCompletion) return;
+    const id = setInterval(() => setTick(Date.now()), 1_000);
+    return () => clearInterval(id);
+  }, [rollback.status, rollback.expectedCompletion]);
+
+  useEffect(() => {
+    if (rollback.status === 'completed') {
+      const id = setTimeout(() => setRollback(getRollbackState()), 4_000);
+      return () => clearTimeout(id);
+    }
+    return undefined;
+  }, [rollback.status]);
+
+  const sortedSnapshots = useMemo(
+    () => [...snapshots].sort((a, b) => b.createdAt - a.createdAt),
+    [snapshots],
+  );
+
+  const activeSnapshot = rollback.snapshotId
+    ? snapshots.find((snapshot) => snapshot.id === rollback.snapshotId)
+    : undefined;
+
+  const remainingSeconds = useMemo(() => {
+    if (rollback.status !== 'running' || !rollback.expectedCompletion) return null;
+    const diff = Math.max(0, rollback.expectedCompletion - tick);
+    return Math.round(diff / 1000);
+  }, [rollback.expectedCompletion, rollback.status, tick]);
+
+  const formattedCountdown = useMemo(() => {
+    if (remainingSeconds === null) return null;
+    const minutes = Math.floor(remainingSeconds / 60);
+    const seconds = remainingSeconds % 60;
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+  }, [remainingSeconds]);
+
+  const handleCreate: React.FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    if (!label.trim()) {
+      setError('Enter a name for the snapshot.');
+      return;
+    }
+    setError(null);
+    setIsCreating(true);
+    try {
+      await createSnapshot(label.trim(), {
+        origin: 'manual',
+        description: 'Manual checkpoint via Snapshot Manager.',
+      });
+      setLabel('Pre-update snapshot');
+    } catch (err) {
+      console.error('Failed to create snapshot', err);
+      setError('Unable to create snapshot. Please retry.');
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleRollback = async (snapshot: SnapshotRecord) => {
+    const warningLines = openFiles.length
+      ? `\n\nOpen files flagged for closure:\n${openFiles.map((file) => ` • ${file}`).join('\n')}`
+      : '';
+    const message = `Rolling back to "${snapshot.label}" will revert running apps and unsaved work.${warningLines}\n\nEnsure everything critical is saved. Continue? Target completion under 2 minutes.`;
+    if (!window.confirm(message)) return;
+    try {
+      await rollbackSnapshot(snapshot.id);
+    } catch (err) {
+      console.error('Rollback failed', err);
+      setError('Snapshot rollback failed. Try again after reviewing logs.');
+    }
+  };
+
+  const busy = rollback.status === 'running';
+  const progressPercent = Math.round(rollback.progress * 100);
+
+  return (
+    <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white">
+      <div className="px-4 py-3 border-b border-black bg-ub-warm-grey bg-opacity-40">
+        <h1 className="text-lg font-semibold">Snapshot Manager</h1>
+        <p className="text-sm text-gray-200">
+          Capture restore points before risky updates and monitor rollback timing targets.
+        </p>
+        <form className="mt-3 flex flex-wrap gap-2" onSubmit={handleCreate}>
+          <label className="sr-only" htmlFor="snapshot-label">
+            Snapshot label
+          </label>
+          <input
+            id="snapshot-label"
+            value={label}
+            onChange={(event) => setLabel(event.target.value)}
+            className="px-3 py-2 bg-black bg-opacity-30 border border-black rounded flex-1 min-w-[12rem] focus:outline-none focus:ring-2 focus:ring-ub-orange"
+            placeholder="Name this snapshot"
+          />
+          <button
+            type="submit"
+            disabled={isCreating}
+            className="px-4 py-2 bg-ub-drk-abrgn hover:bg-ub-orange focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-60"
+          >
+            {isCreating ? 'Creating…' : 'Create snapshot'}
+          </button>
+        </form>
+        {error && <p className="mt-2 text-sm text-red-300" role="alert">{error}</p>}
+        <div className="mt-3 text-xs text-gray-300">
+          <span className="font-semibold">Open files monitored:</span>
+          <ul className="list-disc ml-5 mt-1 space-y-1">
+            {openFiles.map((file) => (
+              <li key={file}>{file}</li>
+            ))}
+          </ul>
+        </div>
+        {rollback.status !== 'idle' && (
+          <div className="mt-3 text-sm">
+            {rollback.status === 'running' && (
+              <div>
+                <p>
+                  Rollback in progress for{' '}
+                  <span className="font-semibold">{activeSnapshot?.label ?? 'selected snapshot'}</span>
+                  . Target completion {formatDuration(rollback.etaMs)} (≤ 2 minutes).
+                </p>
+                {formattedCountdown && (
+                  <p className="text-xs text-gray-300">Projected remaining: {formattedCountdown}</p>
+                )}
+                <div className="mt-2 h-2 bg-black bg-opacity-40 rounded">
+                  <div
+                    className="h-full bg-ub-orange rounded transition-all duration-500"
+                    style={{ width: `${progressPercent}%` }}
+                    aria-label={`Rollback progress ${progressPercent}%`}
+                  />
+                </div>
+              </div>
+            )}
+            {rollback.status === 'completed' && (
+              <p className="text-xs text-green-300">
+                Rollback complete for {activeSnapshot?.label ?? 'selected snapshot'}.
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+      <div className="flex-1 overflow-auto p-4">
+        <table className="w-full text-sm bg-black bg-opacity-20 rounded">
+          <thead>
+            <tr className="text-left text-xs uppercase tracking-wide text-gray-300">
+              <th className="px-3 py-2">Label</th>
+              <th className="px-3 py-2">Created</th>
+              <th className="px-3 py-2">Origin</th>
+              <th className="px-3 py-2">Size</th>
+              <th className="px-3 py-2">Status</th>
+              <th className="px-3 py-2">Last restored</th>
+              <th className="px-3 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedSnapshots.map((snapshot) => (
+              <tr
+                key={snapshot.id}
+                className="border-t border-black border-opacity-30 hover:bg-black hover:bg-opacity-30"
+              >
+                <td className="px-3 py-2 font-medium" title={snapshot.description}>
+                  {snapshot.label}
+                </td>
+                <td className="px-3 py-2 whitespace-nowrap">{formatDateTime(snapshot.createdAt)}</td>
+                <td className="px-3 py-2">{describeOrigin(snapshot)}</td>
+                <td className="px-3 py-2">{snapshot.size}</td>
+                <td className="px-3 py-2">{describeStatus(snapshot)}</td>
+                <td className="px-3 py-2">{formatSince(snapshot.lastRestoredAt)}</td>
+                <td className="px-3 py-2 text-right">
+                  <button
+                    onClick={() => handleRollback(snapshot)}
+                    disabled={snapshot.status !== 'ready' || busy}
+                    className="px-3 py-1 bg-black bg-opacity-60 hover:bg-opacity-80 rounded focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+                  >
+                    Rollback
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {sortedSnapshots.length === 0 && (
+          <p className="mt-6 text-center text-sm text-gray-300">
+            No snapshots available. Create one before starting an update.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SnapshotManager;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -22,6 +22,7 @@ import TaskbarMenu from '../context-menus/taskbar-menu';
 import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import { triggerPreUpdateHooks } from '../../utils/snapshotStore';
 import { useSnapSetting } from '../../hooks/usePersistentState';
 
 export class Desktop extends Component {
@@ -593,6 +594,10 @@ export class Desktop extends Component {
 
         // if the app is disabled
         if (this.state.disabled_apps[objId]) return;
+
+        triggerPreUpdateHooks({ type: 'open-app', appId: objId }).catch((error) => {
+            console.error('Pre-update hook failed', error);
+        });
 
         // if app is already open, focus it instead of spawning a new window
         if (this.state.closed_windows[objId] === false) {

--- a/utils/snapshotStore.ts
+++ b/utils/snapshotStore.ts
@@ -1,0 +1,278 @@
+export type SnapshotOrigin = 'manual' | 'auto';
+export type SnapshotStatus = 'ready' | 'creating' | 'restoring';
+
+export interface SnapshotRecord {
+  id: string;
+  label: string;
+  createdAt: number;
+  description: string;
+  origin: SnapshotOrigin;
+  size: string;
+  status: SnapshotStatus;
+  lastRestoredAt?: number;
+}
+
+export type RollbackStatus = 'idle' | 'running' | 'completed';
+
+export interface RollbackState {
+  status: RollbackStatus;
+  snapshotId: string | null;
+  startedAt: number | null;
+  etaMs: number | null;
+  expectedCompletion: number | null;
+  progress: number;
+  completedAt: number | null;
+}
+
+export interface PreUpdateEvent {
+  type: 'open-app' | 'system-update' | 'pre-flight';
+  appId?: string;
+  label?: string;
+  details?: Record<string, unknown>;
+}
+
+export type PreUpdateHook = (event: PreUpdateEvent) => void | Promise<void>;
+
+type SnapshotListener = (snapshots: SnapshotRecord[], rollback: RollbackState) => void;
+
+const OPEN_FILES = [
+  '/home/kali/Documents/incident-response.md',
+  '/home/kali/Reports/weekly-diff.md',
+  '/home/kali/tools/plugin-change-log.txt',
+];
+
+const initialSnapshots: SnapshotRecord[] = [
+  {
+    id: 'snap-baseline',
+    label: 'Baseline install',
+    createdAt: Date.now() - 1000 * 60 * 60 * 24 * 7,
+    description: 'Factory image before personalization.',
+    origin: 'auto',
+    size: '2.2 GB',
+    status: 'ready',
+  },
+  {
+    id: 'snap-plugin-prep',
+    label: 'Before plugin sync',
+    createdAt: Date.now() - 1000 * 60 * 60 * 24 * 2,
+    description: 'Automatically captured prior to syncing plugins.',
+    origin: 'auto',
+    size: '2.4 GB',
+    status: 'ready',
+  },
+  {
+    id: 'snap-analyst',
+    label: 'Manual checkpoint',
+    createdAt: Date.now() - 1000 * 60 * 60 * 6,
+    description: 'Analyst-triggered snapshot before field demo.',
+    origin: 'manual',
+    size: '2.1 GB',
+    status: 'ready',
+  },
+];
+
+let snapshots = initialSnapshots.map((snapshot) => ({ ...snapshot }));
+
+let rollbackState: RollbackState = {
+  status: 'idle',
+  snapshotId: null,
+  startedAt: null,
+  etaMs: null,
+  expectedCompletion: null,
+  progress: 0,
+  completedAt: null,
+};
+
+let rollbackTimer: ReturnType<typeof setTimeout> | null = null;
+let rollbackInterval: ReturnType<typeof setInterval> | null = null;
+
+const listeners = new Set<SnapshotListener>();
+const preUpdateHooks = new Set<PreUpdateHook>();
+
+const notify = () => {
+  const nextSnapshots = snapshots.map((snapshot) => ({ ...snapshot }));
+  const nextRollback: RollbackState = { ...rollbackState };
+  listeners.forEach((listener) => listener(nextSnapshots, nextRollback));
+};
+
+const generateId = () => `snap-${Math.random().toString(36).slice(2, 8)}`;
+
+const SIMULATION_SPEED = 60;
+
+export const listSnapshots = () => snapshots.map((snapshot) => ({ ...snapshot }));
+
+export const getRollbackState = () => ({ ...rollbackState });
+
+export const getOpenFiles = () => [...OPEN_FILES];
+
+export const subscribe = (listener: SnapshotListener) => {
+  listeners.add(listener);
+  listener(listSnapshots(), getRollbackState());
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const registerPreUpdateHook = (hook: PreUpdateHook) => {
+  preUpdateHooks.add(hook);
+  return () => {
+    preUpdateHooks.delete(hook);
+  };
+};
+
+export const triggerPreUpdateHooks = async (event: PreUpdateEvent) => {
+  const hooks = Array.from(preUpdateHooks);
+  await Promise.all(hooks.map((hook) => Promise.resolve().then(() => hook(event))));
+};
+
+export const createSnapshot = async (
+  label: string,
+  options?: {
+    origin?: SnapshotOrigin;
+    description?: string;
+  },
+) => {
+  const trimmed = label.trim() || 'Untitled snapshot';
+  const now = Date.now();
+  const snapshot: SnapshotRecord = {
+    id: generateId(),
+    label: trimmed,
+    createdAt: now,
+    description: options?.description ?? '',
+    origin: options?.origin ?? 'manual',
+    size: `${(1.9 + Math.random() * 0.7).toFixed(1)} GB`,
+    status: 'creating',
+  };
+
+  snapshots = [snapshot, ...snapshots];
+  notify();
+
+  await new Promise<void>((resolve) => {
+    setTimeout(() => {
+      snapshots = snapshots.map((item) =>
+        item.id === snapshot.id ? { ...item, status: 'ready' } : item,
+      );
+      notify();
+      resolve();
+    }, 600);
+  });
+
+  return snapshots.find((item) => item.id === snapshot.id)!;
+};
+
+export const rollbackSnapshot = async (snapshotId: string) => {
+  const target = snapshots.find((snapshot) => snapshot.id === snapshotId);
+  if (!target) {
+    throw new Error('Snapshot not found');
+  }
+
+  if (rollbackTimer) {
+    clearTimeout(rollbackTimer);
+    rollbackTimer = null;
+  }
+
+  if (rollbackInterval) {
+    clearInterval(rollbackInterval);
+    rollbackInterval = null;
+  }
+
+  const startedAt = Date.now();
+  const etaMs = Math.min(110_000, Math.max(55_000, Math.round(60_000 + Math.random() * 25_000)));
+  const actualDuration = Math.max(600, Math.round(etaMs / SIMULATION_SPEED));
+
+  rollbackState = {
+    status: 'running',
+    snapshotId,
+    startedAt,
+    etaMs,
+    expectedCompletion: startedAt + etaMs,
+    progress: 0,
+    completedAt: null,
+  };
+
+  snapshots = snapshots.map((snapshot) =>
+    snapshot.id === snapshotId
+      ? { ...snapshot, status: 'restoring' }
+      : { ...snapshot, status: snapshot.status === 'restoring' ? 'ready' : snapshot.status },
+  );
+  notify();
+
+  rollbackInterval = setInterval(() => {
+    const elapsed = Date.now() - startedAt;
+    const simulatedElapsed = Math.min(etaMs, elapsed * SIMULATION_SPEED);
+    const progress = Math.min(1, simulatedElapsed / etaMs);
+    rollbackState = {
+      ...rollbackState,
+      progress,
+    };
+    notify();
+  }, 200);
+
+  await new Promise<void>((resolve) => {
+    rollbackTimer = setTimeout(() => {
+      if (rollbackInterval) {
+        clearInterval(rollbackInterval);
+        rollbackInterval = null;
+      }
+      const completedAt = Date.now();
+      rollbackState = {
+        status: 'completed',
+        snapshotId,
+        startedAt,
+        etaMs,
+        expectedCompletion: null,
+        progress: 1,
+        completedAt,
+      };
+      snapshots = snapshots.map((snapshot) =>
+        snapshot.id === snapshotId
+          ? { ...snapshot, status: 'ready', lastRestoredAt: completedAt }
+          : { ...snapshot, status: 'ready' },
+      );
+      notify();
+      resolve();
+    }, actualDuration);
+  });
+};
+
+export const resetSnapshotStore = () => {
+  snapshots = initialSnapshots.map((snapshot) => ({ ...snapshot }));
+  if (rollbackTimer) {
+    clearTimeout(rollbackTimer);
+    rollbackTimer = null;
+  }
+  if (rollbackInterval) {
+    clearInterval(rollbackInterval);
+    rollbackInterval = null;
+  }
+  rollbackState = {
+    status: 'idle',
+    snapshotId: null,
+    startedAt: null,
+    etaMs: null,
+    expectedCompletion: null,
+    progress: 0,
+    completedAt: null,
+  };
+  notify();
+};
+
+const autoSnapshotTargets = new Set(['plugin-manager', 'settings']);
+
+registerPreUpdateHook((event) => {
+  if (event.type === 'open-app' && event.appId && autoSnapshotTargets.has(event.appId)) {
+    return createSnapshot(`Pre-update: ${event.appId}`, {
+      origin: 'auto',
+      description: `Automatic checkpoint before opening ${event.appId}.`,
+    });
+  }
+
+  if (event.type === 'system-update') {
+    return createSnapshot(event.label ?? 'System update checkpoint', {
+      origin: 'auto',
+      description: 'Captured before applying system update.',
+    });
+  }
+
+  return undefined;
+});


### PR DESCRIPTION
## Summary
- add a snapshot store with mocked restore points, rollback timers, and pre-update hook registration
- build the Snapshot Manager app UI, register it in the catalog, and document the new utility
- trigger pre-update hooks from the desktop launcher and cover the flow with component tests

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations in legacy apps)*
- yarn test snapshot-manager

------
https://chatgpt.com/codex/tasks/task_e_68cb19e0cd408328b1e9122f738b1aba