### PR TITLE
[evidence] add evidence export zip

### DIFF
--- a/components/apps/evidence-vault/index.js
+++ b/components/apps/evidence-vault/index.js
@@ -1,5 +1,60 @@
 import React, { useRef, useState, useEffect } from 'react';
 
+const textEncoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
+
+const ensureArrayBuffer = (input) => {
+  if (input instanceof ArrayBuffer) {
+    return input;
+  }
+  if (ArrayBuffer.isView(input)) {
+    return input.buffer.slice(
+      input.byteOffset,
+      input.byteOffset + input.byteLength,
+    );
+  }
+  throw new TypeError('Unsupported data type for hashing');
+};
+
+const bufferToHex = (buffer) =>
+  Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+const computeSha256 = async (data) => {
+  try {
+    if (typeof crypto === 'undefined' || !crypto.subtle) {
+      return 'sha256:unsupported';
+    }
+    const digest = await crypto.subtle.digest('SHA-256', ensureArrayBuffer(data));
+    return `sha256:${bufferToHex(digest)}`;
+  } catch (err) {
+    console.error('Unable to compute SHA-256 hash', err);
+    return 'sha256:error';
+  }
+};
+
+const encodeText = (value) => {
+  if (!textEncoder) {
+    return new Uint8Array();
+  }
+  return textEncoder.encode(value);
+};
+
+const sanitizeFilename = (value) => {
+  const cleaned = value.replace(/[^a-z0-9_.-]+/gi, '_');
+  return cleaned || 'evidence';
+};
+
+const formatTimestamp = (isoString) => {
+  if (!isoString) return 'Unknown time';
+  try {
+    return new Date(isoString).toLocaleString();
+  } catch (error) {
+    console.error('Failed to format timestamp', error);
+    return isoString;
+  }
+};
+
 // Build hierarchical tree from slash-delimited tags
 const buildTagTree = (items) => {
   const root = {};
@@ -19,15 +74,21 @@ const buildTagTree = (items) => {
   return root;
 };
 
-const TagTree = ({ data, onSelect }) => (
+const TagTree = ({ data, onSelect, path = [] }) => (
   <ul className="pl-4">
     {Object.entries(data).map(([name, node]) => (
-      <TagTreeNode key={name} name={name} node={node} onSelect={onSelect} />
+      <TagTreeNode
+        key={name}
+        name={name}
+        node={node}
+        onSelect={onSelect}
+        path={[...path, name]}
+      />
     ))}
   </ul>
 );
 
-const TagTreeNode = ({ name, node, onSelect }) => {
+const TagTreeNode = ({ name, node, onSelect, path }) => {
   const hasChildren = Object.keys(node.children).length > 0;
   return (
     <li className="mb-1">
@@ -36,17 +97,19 @@ const TagTreeNode = ({ name, node, onSelect }) => {
           <summary className="cursor-pointer">{name}</summary>
           {node.items.length > 0 && (
             <button
-              onClick={() => onSelect(node)}
+              type="button"
+              onClick={() => onSelect(node, path)}
               className="ml-2 text-xs text-blue-400 hover:underline"
             >
               View items
             </button>
           )}
-          <TagTree data={node.children} onSelect={onSelect} />
+          <TagTree data={node.children} onSelect={onSelect} path={path} />
         </details>
       ) : (
         <button
-          onClick={() => onSelect(node)}
+          type="button"
+          onClick={() => onSelect(node, path)}
           className="text-left hover:underline focus:outline-none"
         >
           {name}
@@ -56,15 +119,49 @@ const TagTreeNode = ({ name, node, onSelect }) => {
   );
 };
 
+const triggerDownload = (blob, filename) => {
+  if (typeof window === 'undefined') return;
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+};
+
 const EvidenceVaultApp = () => {
   const [items, setItems] = useState([]);
-  const [selectedNode, setSelectedNode] = useState(null);
+  const [selectedBranch, setSelectedBranch] = useState(null);
+  const [selectedIds, setSelectedIds] = useState(() => new Set());
+  const [isExporting, setIsExporting] = useState(false);
+  const [isManifestDownloading, setIsManifestDownloading] = useState(false);
   const fileInputRef = useRef(null);
 
   useEffect(() => {
     // reset selection when items change
-    setSelectedNode(null);
+    setSelectedBranch(null);
+    setSelectedIds((prev) => {
+      const validIds = new Set(items.map((item) => item.id));
+      const filtered = Array.from(prev).filter((id) => validIds.has(id));
+      return new Set(filtered);
+    });
   }, [items]);
+
+  useEffect(
+    () => () => {
+      if (typeof URL === 'undefined' || typeof URL.revokeObjectURL !== 'function') {
+        return;
+      }
+      items.forEach((item) => {
+        if (item.type === 'file' && item.url) {
+          URL.revokeObjectURL(item.url);
+        }
+      });
+    },
+    [items],
+  );
 
   const addNote = () => {
     const title = prompt('Note title');
@@ -75,9 +172,10 @@ const EvidenceVaultApp = () => {
       .split(',')
       .map((t) => t.trim())
       .filter(Boolean);
+    const createdAt = new Date().toISOString();
     setItems((prev) => [
       ...prev,
-      { id: Date.now(), type: 'note', title, content, tags },
+      { id: Date.now(), type: 'note', title, content, tags, createdAt },
     ]);
   };
 
@@ -90,36 +188,209 @@ const EvidenceVaultApp = () => {
       .map((t) => t.trim())
       .filter(Boolean);
     const url = URL.createObjectURL(file);
+    const createdAt = new Date().toISOString();
     setItems((prev) => [
       ...prev,
-      { id: Date.now(), type: 'file', name: file.name, url, tags },
+      {
+        id: Date.now(),
+        type: 'file',
+        name: file.name,
+        file,
+        url,
+        tags,
+        createdAt,
+      },
     ]);
     e.target.value = '';
   };
 
+  const toggleSelect = (id) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const selectVisible = () => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      const visibleItems = selectedBranch ? selectedBranch.node.items : items;
+      visibleItems.forEach((item) => {
+        next.add(item.id);
+      });
+      return next;
+    });
+  };
+
+  const clearSelection = () => {
+    setSelectedIds(new Set());
+  };
+
+  const prepareManifest = async (selectedItems) => {
+    const exportedAt = new Date().toISOString();
+    const uniqueTags = new Set();
+    const manifestItems = [];
+    const fileEntries = [];
+    let noteCount = 0;
+    let fileCount = 0;
+
+    for (const item of selectedItems) {
+      const itemTags = item.tags.length ? item.tags : ['uncategorized'];
+      itemTags.forEach((tag) => uniqueTags.add(tag));
+      if (item.type === 'note') {
+        const encodedContent = encodeText(item.content || '');
+        const hash = await computeSha256(encodedContent);
+        manifestItems.push({
+          id: item.id,
+          type: 'note',
+          title: item.title,
+          content: item.content,
+          tags: itemTags,
+          createdAt: item.createdAt,
+          size: encodedContent.byteLength,
+          hash,
+        });
+        noteCount += 1;
+      } else if (item.type === 'file' && item.file) {
+        const arrayBuffer = await item.file.arrayBuffer();
+        const hash = await computeSha256(arrayBuffer);
+        const safeName = sanitizeFilename(item.name || 'evidence');
+        const fileName = `${item.id}-${safeName}`;
+        manifestItems.push({
+          id: item.id,
+          type: 'file',
+          name: item.name,
+          tags: itemTags,
+          createdAt: item.createdAt,
+          size: item.file.size,
+          hash,
+          path: `files/${fileName}`,
+          mimeType: item.file.type || undefined,
+          lastModified: item.file.lastModified
+            ? new Date(item.file.lastModified).toISOString()
+            : undefined,
+        });
+        fileEntries.push({
+          fileName,
+          file: item.file,
+        });
+        fileCount += 1;
+      }
+    }
+
+    const manifest = {
+      version: 1,
+      generatedAt: exportedAt,
+      workspace: {
+        origin: typeof window !== 'undefined' ? window.location.origin : 'unknown',
+        path: typeof window !== 'undefined' ? window.location.pathname : '/',
+        exportedBy: 'Evidence Vault Simulation',
+        filter: selectedBranch ? selectedBranch.path.join('/') : 'all-items',
+        totalSelected: selectedItems.length,
+        totalAvailable: items.length,
+        tagSummary: Array.from(uniqueTags).sort(),
+        notesSelected: noteCount,
+        filesSelected: fileCount,
+        appVersion: 'simulated-1.0',
+      },
+      items: manifestItems,
+    };
+
+    return { manifest, fileEntries };
+  };
+
+  const exportSelected = async () => {
+    if (selectedIds.size === 0) {
+      alert('Select at least one item to export.');
+      return;
+    }
+    try {
+      setIsExporting(true);
+      const selectedItems = items.filter((item) => selectedIds.has(item.id));
+      const { manifest, fileEntries } = await prepareManifest(selectedItems);
+      const JSZip = (await import('jszip')).default;
+      const zip = new JSZip();
+      const filesFolder = zip.folder('files');
+      fileEntries.forEach(({ fileName, file }) => {
+        filesFolder?.file(fileName, file);
+      });
+      zip.file('index.json', JSON.stringify(manifest, null, 2));
+      const blob = await zip.generateAsync({ type: 'blob', compression: 'DEFLATE' });
+      triggerDownload(blob, `evidence-export-${Date.now()}.zip`);
+    } catch (error) {
+      console.error('Failed to export evidence package', error);
+      alert('Failed to export evidence package. Check the console for details.');
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const exportManifestOnly = async () => {
+    if (selectedIds.size === 0) {
+      alert('Select at least one item to export.');
+      return;
+    }
+    try {
+      setIsManifestDownloading(true);
+      const selectedItems = items.filter((item) => selectedIds.has(item.id));
+      const { manifest } = await prepareManifest(selectedItems);
+      const sanitizedManifest = {
+        ...manifest,
+        items: manifest.items.map(({ content, ...rest }) => rest),
+      };
+      const response = await fetch('/api/evidence/export', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ manifest: sanitizedManifest }),
+      });
+      if (!response.ok) {
+        throw new Error(`API responded with status ${response.status}`);
+      }
+      const blob = await response.blob();
+      triggerDownload(blob, `evidence-manifest-${Date.now()}.zip`);
+    } catch (error) {
+      console.error('Failed to export manifest', error);
+      alert('Unable to download manifest archive. See console for more information.');
+    } finally {
+      setIsManifestDownloading(false);
+    }
+  };
+
   const treeData = buildTagTree(items);
-  const displayItems = selectedNode ? selectedNode.items : items;
+  const displayItems = selectedBranch ? selectedBranch.node.items : items;
+  const selectedCount = selectedIds.size;
+  const activeFilterLabel = selectedBranch ? selectedBranch.path.join(' / ') : null;
 
   return (
     <div className="h-full w-full bg-gray-900 text-white p-4 flex">
       <div className="w-1/3 border-r border-gray-700 pr-2 overflow-auto">
         <button
-          onClick={() => setSelectedNode(null)}
+          type="button"
+          onClick={() => setSelectedBranch(null)}
           className="text-sm text-blue-400 hover:underline mb-2"
         >
           All Items
         </button>
-        <TagTree data={treeData} onSelect={setSelectedNode} />
+        <TagTree data={treeData} onSelect={(node, path) => setSelectedBranch({ node, path })} />
       </div>
       <div className="flex-1 pl-4 flex flex-col">
-        <div className="mb-2 space-x-2">
+        <div className="mb-2 flex flex-wrap gap-2">
           <button
+            type="button"
             onClick={addNote}
             className="px-2 py-1 bg-blue-600 rounded"
           >
             Add Note
           </button>
           <button
+            type="button"
             onClick={() => fileInputRef.current?.click()}
             className="px-2 py-1 bg-blue-600 rounded"
           >
@@ -131,35 +402,99 @@ const EvidenceVaultApp = () => {
             className="hidden"
             onChange={handleFileChange}
           />
+          <button
+            type="button"
+            onClick={selectVisible}
+            className="px-2 py-1 bg-gray-700 rounded"
+            disabled={displayItems.length === 0}
+          >
+            Select Visible
+          </button>
+          <button
+            type="button"
+            onClick={clearSelection}
+            className="px-2 py-1 bg-gray-700 rounded"
+            disabled={selectedCount === 0}
+          >
+            Clear Selection
+          </button>
+          <button
+            type="button"
+            onClick={exportSelected}
+            className="px-2 py-1 bg-green-600 rounded disabled:opacity-60"
+            disabled={selectedCount === 0 || isExporting}
+          >
+            {isExporting ? 'Packaging…' : 'Export Selected'}
+          </button>
+          <button
+            type="button"
+            onClick={exportManifestOnly}
+            className="px-2 py-1 bg-purple-600 rounded disabled:opacity-60"
+            disabled={selectedCount === 0 || isManifestDownloading}
+          >
+            {isManifestDownloading ? 'Preparing…' : 'Manifest via API'}
+          </button>
         </div>
-        <ul className="flex-1 overflow-auto space-y-2">
-          {displayItems.map((item) => (
-            <li key={item.id} className="p-2 bg-gray-800 rounded">
-              {item.type === 'note' ? (
-                <div>
-                  <h4 className="font-semibold">{item.title}</h4>
-                  <p className="text-sm whitespace-pre-wrap">{item.content}</p>
-                </div>
-              ) : (
-                <div>
-                  <h4 className="font-semibold">{item.name}</h4>
-                  <a
-                    href={item.url}
-                    download
-                    className="text-blue-400 underline text-sm"
-                  >
-                    Download
-                  </a>
-                </div>
-              )}
-              {item.tags.length > 0 && (
-                <p className="text-xs mt-1 text-gray-400">
-                  Tags: {item.tags.join(', ')}
-                </p>
-              )}
-            </li>
-          ))}
-        </ul>
+        <p className="text-xs text-gray-400 mb-2">
+          {selectedCount} item(s) selected
+          {activeFilterLabel ? ` in ${activeFilterLabel}` : ''}
+        </p>
+        {displayItems.length === 0 ? (
+          <div className="flex-1 flex items-center justify-center text-gray-400 text-sm">
+            No items to display. Add notes or files to begin building your evidence set.
+          </div>
+        ) : (
+          <ul className="flex-1 overflow-auto space-y-2">
+            {displayItems.map((item) => {
+              const isSelected = selectedIds.has(item.id);
+              return (
+                <li
+                  key={item.id}
+                  className={`p-2 bg-gray-800 rounded border ${
+                    isSelected ? 'border-blue-500' : 'border-transparent'
+                  }`}
+                >
+                  <div className="flex items-start gap-2">
+                    <input
+                      type="checkbox"
+                      className="mt-1"
+                      checked={isSelected}
+                      onChange={() => toggleSelect(item.id)}
+                      aria-label={`Select ${item.type}`}
+                    />
+                    <div className="flex-1">
+                      {item.type === 'note' ? (
+                        <div>
+                          <h4 className="font-semibold">{item.title}</h4>
+                          <p className="text-sm whitespace-pre-wrap">{item.content}</p>
+                        </div>
+                      ) : (
+                        <div>
+                          <h4 className="font-semibold">{item.name}</h4>
+                          <a
+                            href={item.url}
+                            download
+                            className="text-blue-400 underline text-sm"
+                          >
+                            Download original
+                          </a>
+                        </div>
+                      )}
+                      {item.tags.length > 0 && (
+                        <p className="text-xs mt-1 text-gray-400">
+                          Tags: {item.tags.join(', ')}
+                        </p>
+                      )}
+                      <p className="text-xs mt-1 text-gray-500">
+                        Recorded: {formatTimestamp(item.createdAt)}
+                      </p>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
       </div>
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "idb": "7.1.1",
     "idb-keyval": "^6.2.1",
     "jspdf": "^3.0.2",
+    "jszip": "^3.10.1",
     "kaitai-struct": "^0.10.0",
     "leaflet": "^1.9.4",
     "marked": "^16.2.1",

--- a/pages/api/evidence/export.ts
+++ b/pages/api/evidence/export.ts
@@ -1,0 +1,150 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import JSZip from 'jszip';
+
+type RawManifest = {
+  version?: unknown;
+  generatedAt?: unknown;
+  workspace?: unknown;
+  items?: unknown;
+};
+
+type SanitizedManifest = {
+  version: number;
+  generatedAt: string;
+  workspace: Record<string, unknown>;
+  items: Array<Record<string, unknown>>;
+};
+
+const removeUndefined = (input: Record<string, unknown>) =>
+  Object.fromEntries(
+    Object.entries(input).filter(([, value]) => value !== undefined),
+  );
+
+const sanitizeWorkspace = (value: unknown): Record<string, unknown> => {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+
+  const workspace = value as Record<string, unknown>;
+  const sanitized: Record<string, unknown> = {};
+
+  const stringKeys = ['origin', 'path', 'exportedBy', 'filter', 'appVersion'] as const;
+  stringKeys.forEach((key) => {
+    const candidate = workspace[key];
+    if (typeof candidate === 'string') {
+      sanitized[key] = candidate;
+    }
+  });
+
+  const numberKeys = ['totalSelected', 'totalAvailable', 'notesSelected', 'filesSelected'] as const;
+  numberKeys.forEach((key) => {
+    const candidate = workspace[key];
+    if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+      sanitized[key] = candidate;
+    }
+  });
+
+  const tagSummary = workspace.tagSummary;
+  if (Array.isArray(tagSummary)) {
+    const tags = tagSummary
+      .map((tag) => String(tag).trim())
+      .filter((tag) => tag.length > 0);
+    if (tags.length > 0) {
+      sanitized.tagSummary = tags;
+    }
+  }
+
+  return sanitized;
+};
+
+const sanitizeItem = (value: unknown): Record<string, unknown> | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const item = value as Record<string, unknown>;
+  const sanitized: Record<string, unknown> = {};
+
+  const idValue = item.id;
+  if (typeof idValue === 'string' || typeof idValue === 'number') {
+    sanitized.id = idValue;
+  }
+
+  const typeValue = item.type;
+  if (typeof typeValue === 'string') {
+    sanitized.type = typeValue;
+  }
+
+  const stringKeys = ['title', 'name', 'hash', 'path', 'mimeType', 'createdAt', 'lastModified'] as const;
+  stringKeys.forEach((key) => {
+    const candidate = item[key];
+    if (typeof candidate === 'string') {
+      sanitized[key] = candidate;
+    }
+  });
+
+  if (typeof item.size === 'number' && Number.isFinite(item.size)) {
+    sanitized.size = item.size;
+  }
+
+  if (Array.isArray(item.tags)) {
+    const tags = item.tags
+      .map((tag) => String(tag).trim())
+      .filter((tag) => tag.length > 0);
+    if (tags.length > 0) {
+      sanitized.tags = tags;
+    }
+  }
+
+  return Object.keys(sanitized).length > 0 ? removeUndefined(sanitized) : null;
+};
+
+const sanitizeManifest = (payload: RawManifest): SanitizedManifest => {
+  const generatedAt =
+    typeof payload.generatedAt === 'string' ? payload.generatedAt : new Date().toISOString();
+  const version = typeof payload.version === 'number' ? payload.version : 1;
+  const itemsSource = Array.isArray(payload.items) ? payload.items : [];
+  const items = itemsSource
+    .map((entry) => sanitizeItem(entry))
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry));
+
+  return {
+    version,
+    generatedAt,
+    workspace: sanitizeWorkspace(payload.workspace),
+    items,
+  };
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { manifest } = (req.body || {}) as { manifest?: RawManifest };
+
+  if (!manifest || typeof manifest !== 'object') {
+    res.status(400).json({ error: 'Manifest payload required' });
+    return;
+  }
+
+  try {
+    const sanitized = sanitizeManifest(manifest);
+    const zip = new JSZip();
+    zip.file('index.json', JSON.stringify(sanitized, null, 2));
+    const archive = await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+
+    res.setHeader('Content-Type', 'application/zip');
+    res.setHeader('Content-Disposition', 'attachment; filename="evidence-manifest.zip"');
+    res.setHeader('Cache-Control', 'no-store');
+    res.status(200).send(archive);
+  } catch (error) {
+    console.error('Manifest export failed', error);
+    res.status(500).json({ error: 'Unable to generate manifest archive' });
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5791,6 +5791,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-util-is@npm:~1.0.0":
+  version: 1.0.3
+  resolution: "core-util-is@npm:1.0.3"
+  checksum: 10c0/90a0e40abbddfd7618f8ccd63a74d88deea94e77d0e8dbbea059fa7ebebb8fbb4e2909667fe26f3a467073de1a542ebe6ae4c73a73745ac5833786759cd906c9
+  languageName: node
+  linkType: hard
+
 "cose-base@npm:^1.0.0":
   version: 1.0.3
   resolution: "cose-base@npm:1.0.3"
@@ -8095,6 +8102,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immediate@npm:~3.0.5":
+  version: 3.0.6
+  resolution: "immediate@npm:3.0.6"
+  checksum: 10c0/f8ba7ede69bee9260241ad078d2d535848745ff5f6995c7c7cb41cfdc9ccc213f66e10fa5afb881f90298b24a3f7344b637b592beb4f54e582770cdce3f1f039
+  languageName: node
+  linkType: hard
+
 "import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
   version: 3.3.1
   resolution: "import-fresh@npm:3.3.1"
@@ -8135,6 +8149,13 @@ __metadata:
   version: 1.4.2
   resolution: "index-array-by@npm:1.4.2"
   checksum: 10c0/70cfb089148678236c620f471f75b3bec85da65f24cd44ea601c1eae8f6e0da5e1899cee08ed3a276bea1943b6f910fe6fa388276bca4667c6738bb44eae08cb
+  languageName: node
+  linkType: hard
+
+"inherits@npm:~2.0.3":
+  version: 2.0.4
+  resolution: "inherits@npm:2.0.4"
+  checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
   languageName: node
   linkType: hard
 
@@ -8531,6 +8552,13 @@ __metadata:
   version: 2.0.5
   resolution: "isarray@npm:2.0.5"
   checksum: 10c0/4199f14a7a13da2177c66c31080008b7124331956f47bca57dd0b6ea9f11687aa25e565a2c7a2b519bc86988d10398e3049a1f5df13c9f6b7664154690ae79fd
+  languageName: node
+  linkType: hard
+
+"isarray@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "isarray@npm:1.0.0"
+  checksum: 10c0/18b5be6669be53425f0b84098732670ed4e727e3af33bc7f948aac01782110eb9a18b3b329c5323bcdd3acdaae547ee077d3951317e7f133bff7105264b3003d
   languageName: node
   linkType: hard
 
@@ -9417,6 +9445,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jszip@npm:^3.10.1":
+  version: 3.10.1
+  resolution: "jszip@npm:3.10.1"
+  dependencies:
+    lie: "npm:~3.3.0"
+    pako: "npm:~1.0.2"
+    readable-stream: "npm:~2.3.6"
+    setimmediate: "npm:^1.0.5"
+  checksum: 10c0/58e01ec9c4960383fb8b38dd5f67b83ccc1ec215bf74c8a5b32f42b6e5fb79fada5176842a11409c4051b5b94275044851814a31076bf49e1be218d3ef57c863
+  languageName: node
+  linkType: hard
+
 "kaitai-struct@npm:^0.10.0":
   version: 0.10.0
   resolution: "kaitai-struct@npm:0.10.0"
@@ -9523,6 +9563,15 @@ __metadata:
     prelude-ls: "npm:~1.1.2"
     type-check: "npm:~0.3.2"
   checksum: 10c0/e440df9de4233da0b389cd55bd61f0f6aaff766400bebbccd1231b81801f6dbc1d816c676ebe8d70566394b749fa624b1ed1c68070e9c94999f0bdecc64cb676
+  languageName: node
+  linkType: hard
+
+"lie@npm:~3.3.0":
+  version: 3.3.0
+  resolution: "lie@npm:3.3.0"
+  dependencies:
+    immediate: "npm:~3.0.5"
+  checksum: 10c0/56dd113091978f82f9dc5081769c6f3b947852ecf9feccaf83e14a123bc630c2301439ce6182521e5fbafbde88e88ac38314327a4e0493a1bea7e0699a7af808
   languageName: node
   linkType: hard
 
@@ -10663,6 +10712,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pako@npm:~1.0.2":
+  version: 1.0.11
+  resolution: "pako@npm:1.0.11"
+  checksum: 10c0/86dd99d8b34c3930345b8bbeb5e1cd8a05f608eeb40967b293f72fe469d0e9c88b783a8777e4cc7dc7c91ce54c5e93d88ff4b4f060e6ff18408fd21030d9ffbe
+  languageName: node
+  linkType: hard
+
 "parent-module@npm:^1.0.0":
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
@@ -11080,6 +11136,13 @@ __metadata:
   version: 5.0.0
   resolution: "proc-log@npm:5.0.0"
   checksum: 10c0/bbe5edb944b0ad63387a1d5b1911ae93e05ce8d0f60de1035b218cdcceedfe39dbd2c697853355b70f1a090f8f58fe90da487c85216bf9671f9499d1a897e9e3
+  languageName: node
+  linkType: hard
+
+"process-nextick-args@npm:~2.0.0":
+  version: 2.0.1
+  resolution: "process-nextick-args@npm:2.0.1"
+  checksum: 10c0/bec089239487833d46b59d80327a1605e1c5287eaad770a291add7f45fda1bb5e28b38e0e061add0a1d0ee0984788ce74fa394d345eed1c420cacf392c554367
   languageName: node
   linkType: hard
 
@@ -12009,6 +12072,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readable-stream@npm:~2.3.6":
+  version: 2.3.8
+  resolution: "readable-stream@npm:2.3.8"
+  dependencies:
+    core-util-is: "npm:~1.0.0"
+    inherits: "npm:~2.0.3"
+    isarray: "npm:~1.0.0"
+    process-nextick-args: "npm:~2.0.0"
+    safe-buffer: "npm:~5.1.1"
+    string_decoder: "npm:~1.1.1"
+    util-deprecate: "npm:~1.0.1"
+  checksum: 10c0/7efdb01f3853bc35ac62ea25493567bf588773213f5f4a79f9c365e1ad13bab845ac0dae7bc946270dc40c3929483228415e92a3fc600cc7e4548992f41ee3fa
+  languageName: node
+  linkType: hard
+
 "readdirp@npm:~3.6.0":
   version: 3.6.0
   resolution: "readdirp@npm:3.6.0"
@@ -12335,6 +12413,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
+  version: 5.1.2
+  resolution: "safe-buffer@npm:5.1.2"
+  checksum: 10c0/780ba6b5d99cc9a40f7b951d47152297d0e260f0df01472a1b99d4889679a4b94a13d644f7dbc4f022572f09ae9005fa2fbb93bbbd83643316f365a3e9a45b21
+  languageName: node
+  linkType: hard
+
 "safe-push-apply@npm:^1.0.0":
   version: 1.0.0
   resolution: "safe-push-apply@npm:1.0.0"
@@ -12491,6 +12576,13 @@ __metadata:
     es-errors: "npm:^1.3.0"
     es-object-atoms: "npm:^1.0.0"
   checksum: 10c0/ca5c3ccbba479d07c30460e367e66337cec825560b11e8ba9c5ebe13a2a0d6021ae34eddf94ff3dfe17a3104dc1f191519cb6c48378b503e5c3f36393938776a
+  languageName: node
+  linkType: hard
+
+"setimmediate@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "setimmediate@npm:1.0.5"
+  checksum: 10c0/5bae81bfdbfbd0ce992893286d49c9693c82b1bcc00dcaaf3a09c8f428fdeacf4190c013598b81875dfac2b08a572422db7df779a99332d0fce186d15a3e4d49
   languageName: node
   linkType: hard
 
@@ -12964,6 +13056,15 @@ __metadata:
     define-properties: "npm:^1.2.1"
     es-object-atoms: "npm:^1.0.0"
   checksum: 10c0/d53af1899959e53c83b64a5fd120be93e067da740e7e75acb433849aa640782fb6c7d4cd5b84c954c84413745a3764df135a8afeb22908b86a835290788d8366
+  languageName: node
+  linkType: hard
+
+"string_decoder@npm:~1.1.1":
+  version: 1.1.1
+  resolution: "string_decoder@npm:1.1.1"
+  dependencies:
+    safe-buffer: "npm:~5.1.0"
+  checksum: 10c0/b4f89f3a92fd101b5653ca3c99550e07bdf9e13b35037e9e2a1c7b47cec4e55e06ff3fc468e314a0b5e80bfbaf65c1ca5a84978764884ae9413bec1fc6ca924e
   languageName: node
   linkType: hard
 
@@ -13920,6 +14021,7 @@ __metadata:
     jest: "npm:30.0.5"
     jest-environment-jsdom: "npm:30.0.5"
     jspdf: "npm:^3.0.2"
+    jszip: "npm:^3.10.1"
     kaitai-struct: "npm:^0.10.0"
     leaflet: "npm:^1.9.4"
     magic-string: "npm:0.30.18"
@@ -14086,7 +14188,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util-deprecate@npm:^1.0.2":
+"util-deprecate@npm:^1.0.2, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942


### PR DESCRIPTION
## Summary
- add ZIP export workflow to the Evidence Vault with hashed metadata and workspace context
- introduce an `/api/evidence/export` route that emits sanitized manifest archives without handling binaries
- expand the UI to manage selections and offer manifest-only downloads using JSZip

## Testing
- yarn lint *(fails: existing accessibility and lint violations in unrelated apps)*
- yarn test *(fails: existing failing suites and jsdom localStorage errors in unrelated areas)*

------
https://chatgpt.com/codex/tasks/task_e_68cab69edeb48328bf556d4928ff5e3e