### PR TITLE
[workspaces] add tests and e2e coverage for workspace manager

### DIFF
--- a/__tests__/useWorkspaces.test.tsx
+++ b/__tests__/useWorkspaces.test.tsx
@@ -1,0 +1,148 @@
+import { renderHook, act } from '@testing-library/react';
+import useWorkspaces from '../hooks/useWorkspaces';
+import logger from '../utils/logger';
+
+describe('useWorkspaces', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it('creates a new workspace and sets it active', () => {
+    const { result } = renderHook(() => useWorkspaces());
+
+    act(() => {
+      const outcome = result.current.createWorkspace('Red Team');
+      expect(outcome.success).toBe(true);
+      expect(outcome.profile?.name).toBe('Red Team');
+    });
+
+    const names = result.current.profiles.map((profile) => profile.name);
+    expect(names).toContain('Red Team');
+    expect(result.current.activeProfile.name).toBe('Red Team');
+  });
+
+  it('switches the active workspace', () => {
+    const { result } = renderHook(() => useWorkspaces());
+
+    act(() => {
+      result.current.createWorkspace('Blue Team');
+    });
+
+    const defaultId = result.current.profiles.find(
+      (profile) => profile.name === 'Default Workspace',
+    )!.id;
+
+    act(() => {
+      result.current.switchWorkspace(defaultId);
+    });
+
+    expect(result.current.activeProfile.id).toBe(defaultId);
+  });
+
+  it('exports workspace data including active workspace', () => {
+    const { result } = renderHook(() => useWorkspaces());
+
+    act(() => {
+      const outcome = result.current.createWorkspace('Recon');
+      expect(outcome.success).toBe(true);
+      result.current.setApps(['terminal', 'wireshark']);
+    });
+
+    const exported = result.current.exportWorkspaces();
+    const parsed = JSON.parse(exported);
+
+    expect(parsed).toEqual({
+      version: 1,
+      activeId: result.current.activeId,
+      profiles: result.current.profiles.map(({ id, name, apps }) => ({ id, name, apps })),
+    });
+  });
+
+  it('imports workspaces from exported data', () => {
+    const sourceHook = renderHook(() => useWorkspaces());
+
+    act(() => {
+      const outcome = sourceHook.result.current.createWorkspace('Forensics');
+      expect(outcome.success).toBe(true);
+    });
+
+    act(() => {
+      sourceHook.result.current.setApps(['autopsy', 'volatility']);
+    });
+
+    const exported = sourceHook.result.current.exportWorkspaces();
+    const parsed = JSON.parse(exported);
+    const exportedForensics = parsed.profiles.find(
+      (profile: { name: string }) => profile.name === 'Forensics',
+    );
+    expect(exportedForensics?.apps).toEqual(['autopsy', 'volatility']);
+
+    window.localStorage.clear();
+    jest.restoreAllMocks();
+
+    const { result } = renderHook(() => useWorkspaces());
+
+    let outcome;
+    act(() => {
+      outcome = result.current.importWorkspaces(exported);
+    });
+
+    expect(outcome.success).toBe(true);
+    expect(outcome.imported).toBeGreaterThan(0);
+
+    const names = result.current.profiles.map((profile) => profile.name);
+    expect(names).toContain('Forensics');
+
+    const importedForensics = result.current.profiles.find(
+      (profile) => profile.name === 'Forensics',
+    );
+    expect(importedForensics?.apps).toEqual(['autopsy', 'volatility']);
+    expect(result.current.activeProfile.name).toBe('Forensics');
+    expect(result.current.activeProfile.apps).toEqual(['autopsy', 'volatility']);
+  });
+
+  it('renames imported workspaces that conflict with existing ones', () => {
+    const { result } = renderHook(() => useWorkspaces());
+
+    act(() => {
+      result.current.createWorkspace('Alpha');
+    });
+
+    const payload = JSON.stringify({
+      version: 1,
+      activeId: 'alpha-external',
+      profiles: [
+        { id: 'alpha-external', name: 'Alpha', apps: ['terminal'] },
+        { id: 'bravo-external', name: 'Bravo', apps: ['chrome'] },
+      ],
+    });
+
+    act(() => {
+      const outcome = result.current.importWorkspaces(payload);
+      expect(outcome.success).toBe(true);
+      expect(outcome.conflicts).toEqual([
+        { original: 'Alpha', resolved: 'Alpha (Imported)' },
+      ]);
+      expect(outcome.imported).toBe(2);
+    });
+
+    const names = result.current.profiles.map((profile) => profile.name);
+    expect(names).toContain('Alpha');
+    expect(names).toContain('Alpha (Imported)');
+    expect(names).toContain('Bravo');
+  });
+
+  it('logs and reports an error when import fails', () => {
+    const spy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+    const { result } = renderHook(() => useWorkspaces());
+
+    act(() => {
+      const outcome = result.current.importWorkspaces('not-json');
+      expect(outcome.success).toBe(false);
+      expect(outcome.imported).toBe(0);
+    });
+
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -77,6 +77,7 @@ const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
 const TrashApp = createDynamicApp('trash', 'Trash');
 const SerialTerminalApp = createDynamicApp('serial-terminal', 'Serial Terminal');
+const WorkspacesApp = createDynamicApp('workspaces', 'Workspaces');
 
 
 const WiresharkApp = createDynamicApp('wireshark', 'Wireshark');
@@ -162,6 +163,7 @@ const displayQuote = createDisplay(QuoteApp);
 const displayProjectGallery = createDisplay(ProjectGalleryApp);
 const displayTrash = createDisplay(TrashApp);
 const displayStickyNotes = createDisplay(StickyNotesApp);
+const displayWorkspaces = createDisplay(WorkspacesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
@@ -691,6 +693,15 @@ const apps = [
     favourite: true,
     desktop_shortcut: false,
     screen: displaySettings,
+  },
+  {
+    id: 'workspaces',
+    title: 'Workspaces',
+    icon: '/themes/Yaru/system/view-app-grid-symbolic.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayWorkspaces,
   },
   {
     id: 'files',

--- a/apps/workspaces/index.tsx
+++ b/apps/workspaces/index.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import useWorkspaces from '../../hooks/useWorkspaces';
+
+const APP_LIBRARY = [
+  { id: 'terminal', name: 'Terminal' },
+  { id: 'chrome', name: 'Chrome' },
+  { id: 'gedit', name: 'Gedit' },
+  { id: 'spotify', name: 'Spotify' },
+  { id: 'wireshark', name: 'Wireshark' },
+];
+
+type Status =
+  | { type: 'info' | 'success' | 'error'; message: string; details?: string[] }
+  | null;
+
+const statusStyles: Record<'info' | 'success' | 'error', string> = {
+  info: 'bg-blue-900 bg-opacity-70',
+  success: 'bg-green-900 bg-opacity-70',
+  error: 'bg-red-900 bg-opacity-70',
+};
+
+const WorkspaceManager = () => {
+  const {
+    profiles,
+    activeProfile,
+    activeId,
+    createWorkspace,
+    switchWorkspace,
+    toggleApp,
+    setApps,
+    exportWorkspaces,
+    importWorkspaces,
+  } = useWorkspaces();
+  const [newName, setNewName] = useState('');
+  const [exported, setExported] = useState('');
+  const [importText, setImportText] = useState('');
+  const [status, setStatus] = useState<Status>(null);
+
+  const activeApps = useMemo(
+    () => new Set(activeProfile?.apps ?? []),
+    [activeProfile],
+  );
+
+  const handleCreate = (event: React.FormEvent) => {
+    event.preventDefault();
+    const outcome = createWorkspace(newName);
+    if (outcome.success) {
+      setStatus({
+        type: 'success',
+        message: `Workspace "${outcome.profile?.name ?? newName}" created.`,
+      });
+      setNewName('');
+    } else if (outcome.reason === 'duplicate') {
+      setStatus({
+        type: 'error',
+        message: 'A workspace with that name already exists.',
+      });
+    } else {
+      setStatus({ type: 'error', message: 'Enter a workspace name to create one.' });
+    }
+  };
+
+  const handleSwitch = (id: string) => {
+    switchWorkspace(id);
+    setStatus(null);
+  };
+
+  const handleExport = () => {
+    setExported(exportWorkspaces());
+    setStatus({
+      type: 'info',
+      message: 'Workspaces exported. Copy the JSON below to save a backup.',
+    });
+  };
+
+  const handleImport = () => {
+    const outcome = importWorkspaces(importText);
+    if (outcome.success) {
+      const details =
+        outcome.conflicts.length > 0
+          ? outcome.conflicts.map(({ original, resolved }) => `${original} → ${resolved}`)
+          : undefined;
+      setStatus({
+        type: 'success',
+        message: outcome.message,
+        details,
+      });
+      setImportText('');
+    } else {
+      setStatus({ type: 'error', message: outcome.message });
+    }
+  };
+
+  const handleClearApps = () => {
+    setApps([]);
+    setStatus({ type: 'info', message: 'Cleared all apps from the current workspace.' });
+  };
+
+  return (
+    <div className="min-h-screen bg-ub-cool-grey text-white p-4 space-y-6" data-testid="workspace-manager">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">Workspace Profiles</h1>
+        <p className="text-sm text-gray-300">
+          Save combinations of apps and switch between them instantly.
+        </p>
+      </header>
+
+      <section className="space-y-3" aria-label="Workspace selection">
+        <form onSubmit={handleCreate} className="flex flex-wrap gap-2 items-center">
+          <label htmlFor="workspace-name" className="sr-only">
+            Workspace name
+          </label>
+          <input
+            id="workspace-name"
+            value={newName}
+            onChange={(event) => setNewName(event.target.value)}
+            placeholder="New workspace name"
+            className="px-3 py-2 rounded text-black min-w-[200px]"
+            data-testid="workspace-name-input"
+          />
+          <button
+            type="submit"
+            className="px-3 py-2 bg-ub-orange text-black rounded"
+            data-testid="create-workspace"
+          >
+            Create workspace
+          </button>
+        </form>
+        <div className="flex flex-wrap gap-2">
+          {profiles.map((profile) => (
+            <button
+              key={profile.id}
+              type="button"
+              onClick={() => handleSwitch(profile.id)}
+              className={`px-3 py-2 rounded border transition-colors ${
+                profile.id === activeId
+                  ? 'border-ub-orange bg-black bg-opacity-40'
+                  : 'border-transparent bg-black bg-opacity-20 hover:bg-opacity-30'
+              }`}
+              data-testid={`workspace-tab-${profile.id}`}
+              aria-pressed={profile.id === activeId}
+            >
+              {profile.name}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {status && (
+        <div
+          role="status"
+          className={`rounded p-3 text-sm ${statusStyles[status.type]}`}
+          data-testid="workspace-status"
+        >
+          <p>{status.message}</p>
+          {status.details && status.details.length > 0 && (
+            <ul className="mt-2 list-disc list-inside space-y-1">
+              {status.details.map((detail) => (
+                <li key={detail}>{detail}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      <section className="space-y-3" aria-label="Workspace apps">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">
+            Apps in "{activeProfile?.name ?? 'Workspace'}"
+          </h2>
+          <button
+            type="button"
+            onClick={handleClearApps}
+            className="px-3 py-1 text-sm border border-gray-500 rounded"
+            data-testid="clear-workspace-apps"
+          >
+            Clear selection
+          </button>
+        </div>
+        <div
+          className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3"
+          data-testid="app-toggle-grid"
+        >
+          {APP_LIBRARY.map((app) => (
+            <label
+              key={app.id}
+              htmlFor={`app-toggle-${app.id}`}
+              className="flex items-center gap-3 bg-black bg-opacity-20 rounded px-3 py-2 cursor-pointer"
+            >
+              <input
+                id={`app-toggle-${app.id}`}
+                type="checkbox"
+                checked={activeApps.has(app.id)}
+                onChange={() => toggleApp(app.id)}
+                data-testid={`app-toggle-${app.id}`}
+              />
+              <span>{app.name}</span>
+            </label>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-2" aria-label="Backup and restore">
+        <h2 className="text-lg font-semibold">Backup &amp; Restore</h2>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={handleExport}
+            className="px-3 py-2 rounded border border-gray-600 bg-black bg-opacity-30 hover:bg-opacity-50"
+            data-testid="export-workspaces"
+          >
+            Export
+          </button>
+          <button
+            type="button"
+            onClick={handleImport}
+            className="px-3 py-2 rounded border border-gray-600 bg-black bg-opacity-30 hover:bg-opacity-50"
+            data-testid="import-workspaces"
+          >
+            Restore
+          </button>
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="workspace-export" className="block text-sm text-gray-300">
+            Backup JSON
+          </label>
+          <textarea
+            id="workspace-export"
+            value={exported}
+            readOnly
+            rows={4}
+            className="w-full rounded bg-black bg-opacity-20 p-2 text-sm"
+            data-testid="export-output"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="workspace-import" className="block text-sm text-gray-300">
+            Paste a backup to restore
+          </label>
+          <textarea
+            id="workspace-import"
+            value={importText}
+            onChange={(event) => setImportText(event.target.value)}
+            rows={4}
+            className="w-full rounded bg-black bg-opacity-20 p-2 text-sm"
+            placeholder='{"version":1,"profiles":[]}'
+            data-testid="import-input"
+          />
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default WorkspaceManager;

--- a/components/apps/workspaces/index.tsx
+++ b/components/apps/workspaces/index.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../apps/workspaces';

--- a/hooks/useWorkspaces.ts
+++ b/hooks/useWorkspaces.ts
@@ -1,0 +1,291 @@
+'use client';
+
+import { useCallback, useEffect, useMemo } from 'react';
+import usePersistentState from './usePersistentState';
+import logger from '../utils/logger';
+
+export interface WorkspaceProfile {
+  id: string;
+  name: string;
+  apps: string[];
+}
+
+export interface WorkspaceImportConflict {
+  original: string;
+  resolved: string;
+}
+
+export interface WorkspaceImportResult {
+  success: boolean;
+  message: string;
+  imported: number;
+  conflicts: WorkspaceImportConflict[];
+}
+
+export interface CreateWorkspaceResult {
+  success: boolean;
+  profile?: WorkspaceProfile;
+  reason?: 'empty' | 'duplicate';
+}
+
+const WORKSPACE_STORAGE_KEY = 'desktop-workspaces';
+const ACTIVE_STORAGE_KEY = 'desktop-workspaces-active';
+
+const DEFAULT_WORKSPACE: WorkspaceProfile = {
+  id: 'workspace-default',
+  name: 'Default Workspace',
+  apps: [],
+};
+
+const sanitizeApps = (apps: unknown): string[] => {
+  if (!Array.isArray(apps)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const entry of apps) {
+    if (typeof entry === 'string' && !seen.has(entry)) {
+      seen.add(entry);
+      result.push(entry);
+    }
+  }
+  return result;
+};
+
+const generateId = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `ws-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const isWorkspaceProfile = (value: unknown): value is WorkspaceProfile => {
+  if (!value || typeof value !== 'object') return false;
+  const profile = value as WorkspaceProfile;
+  return (
+    typeof profile.id === 'string' &&
+    typeof profile.name === 'string' &&
+    Array.isArray(profile.apps) &&
+    profile.apps.every((app) => typeof app === 'string')
+  );
+};
+
+const isWorkspaceArray = (value: unknown): value is WorkspaceProfile[] =>
+  Array.isArray(value) && value.every(isWorkspaceProfile);
+
+const ensureDefaultWorkspace = (value: WorkspaceProfile[]): WorkspaceProfile[] =>
+  value.length === 0 ? [DEFAULT_WORKSPACE] : value;
+
+export default function useWorkspaces() {
+  const [profiles, setProfiles] = usePersistentState<WorkspaceProfile[]>(
+    WORKSPACE_STORAGE_KEY,
+    () => [DEFAULT_WORKSPACE],
+    isWorkspaceArray,
+  );
+
+  const [activeId, setActiveId] = usePersistentState<string>(
+    ACTIVE_STORAGE_KEY,
+    () => DEFAULT_WORKSPACE.id,
+    (value): value is string => typeof value === 'string',
+  );
+
+  useEffect(() => {
+    setProfiles((current) => ensureDefaultWorkspace(current));
+  }, [setProfiles]);
+
+  useEffect(() => {
+    if (!profiles.some((profile) => profile.id === activeId) && profiles.length) {
+      setActiveId(profiles[0].id);
+    }
+  }, [profiles, activeId, setActiveId]);
+
+  const activeProfile = useMemo(
+    () => profiles.find((profile) => profile.id === activeId) ?? profiles[0],
+    [profiles, activeId],
+  );
+
+  const createWorkspace = useCallback(
+    (name: string): CreateWorkspaceResult => {
+      const trimmed = name.trim();
+      if (!trimmed) {
+        return { success: false, reason: 'empty' };
+      }
+
+      let created: WorkspaceProfile | undefined;
+      setProfiles((current) => {
+        if (
+          current.some(
+            (profile) => profile.name.toLowerCase() === trimmed.toLowerCase(),
+          )
+        ) {
+          return current;
+        }
+        created = { id: generateId(), name: trimmed, apps: [] };
+        return [...current, created];
+      });
+
+      if (created) {
+        setActiveId(created.id);
+        return { success: true, profile: created };
+      }
+
+      return { success: false, reason: 'duplicate' };
+    },
+    [setProfiles, setActiveId],
+  );
+
+  const switchWorkspace = useCallback(
+    (id: string) => {
+      if (profiles.some((profile) => profile.id === id)) {
+        setActiveId(id);
+      }
+    },
+    [profiles, setActiveId],
+  );
+
+  const setApps = useCallback(
+    (apps: string[]) => {
+      setProfiles((current) =>
+        current.map((profile) =>
+          profile.id === activeId
+            ? { ...profile, apps: sanitizeApps(apps) }
+            : profile,
+        ),
+      );
+    },
+    [activeId, setProfiles],
+  );
+
+  const toggleApp = useCallback(
+    (appId: string) => {
+      setProfiles((current) =>
+        current.map((profile) => {
+          if (profile.id !== activeId) return profile;
+          const hasApp = profile.apps.includes(appId);
+          const apps = hasApp
+            ? profile.apps.filter((id) => id !== appId)
+            : [...profile.apps, appId];
+          return { ...profile, apps };
+        }),
+      );
+    },
+    [activeId, setProfiles],
+  );
+
+  const exportWorkspaces = useCallback(
+    () =>
+      JSON.stringify({
+        version: 1,
+        activeId,
+        profiles: profiles.map(({ id, name, apps }) => ({ id, name, apps })),
+      }),
+    [profiles, activeId],
+  );
+
+  const importWorkspaces = useCallback(
+    (payload: string): WorkspaceImportResult => {
+      try {
+        const parsed = JSON.parse(payload);
+        if (!parsed || typeof parsed !== 'object') {
+          throw new Error('Invalid workspace payload');
+        }
+
+        const rawProfiles = (parsed as { profiles?: unknown }).profiles;
+        const importedActiveId = (parsed as { activeId?: unknown }).activeId;
+
+        if (!Array.isArray(rawProfiles) || rawProfiles.length === 0) {
+          logger.error('Workspace import failed: empty payload', parsed);
+          return {
+            success: false,
+            message: 'No workspaces were found in the provided backup.',
+            imported: 0,
+            conflicts: [],
+          };
+        }
+
+        const existingNames = new Set(profiles.map((profile) => profile.name));
+        const conflicts: WorkspaceImportConflict[] = [];
+        const idMap = new Map<string, string>();
+
+        const ensureUniqueName = (name: string) => {
+          if (!existingNames.has(name)) {
+            existingNames.add(name);
+            return name;
+          }
+          let suffix = 1;
+          let candidate = `${name} (Imported)`;
+          while (existingNames.has(candidate)) {
+            suffix += 1;
+            candidate = `${name} (Imported ${suffix})`;
+          }
+          conflicts.push({ original: name, resolved: candidate });
+          existingNames.add(candidate);
+          return candidate;
+        };
+
+        const sanitized = rawProfiles.reduce<WorkspaceProfile[]>((acc, raw, index) => {
+          if (!raw || typeof raw !== 'object') return acc;
+          const workspace = raw as { id?: unknown; name?: unknown; apps?: unknown };
+          const baseName =
+            typeof workspace.name === 'string' && workspace.name.trim()
+              ? workspace.name.trim()
+              : `Imported Workspace ${index + 1}`;
+          const name = ensureUniqueName(baseName);
+          const id = generateId();
+          if (typeof workspace.id === 'string') {
+            idMap.set(workspace.id, id);
+          }
+          acc.push({ id, name, apps: sanitizeApps(workspace.apps) });
+          return acc;
+        }, []);
+
+        if (sanitized.length === 0) {
+          logger.error('Workspace import failed: nothing usable', parsed);
+          return {
+            success: false,
+            message: 'No compatible workspaces found in the backup.',
+            imported: 0,
+            conflicts: [],
+          };
+        }
+
+        const nextProfiles = [...profiles, ...sanitized];
+        setProfiles(nextProfiles);
+
+        const mappedActiveId =
+          typeof importedActiveId === 'string'
+            ? idMap.get(importedActiveId) ?? sanitized[0].id
+            : sanitized[0].id;
+        setActiveId(mappedActiveId);
+
+        return {
+          success: true,
+          message: `Restored ${sanitized.length} workspace${
+            sanitized.length > 1 ? 's' : ''
+          }.`,
+          imported: sanitized.length,
+          conflicts,
+        };
+      } catch (error) {
+        logger.error('Workspace import failed', error);
+        return {
+          success: false,
+          message: 'Unable to restore workspaces. Please verify the backup file and try again.',
+          imported: 0,
+          conflicts: [],
+        };
+      }
+    },
+    [profiles, setProfiles, setActiveId],
+  );
+
+  return {
+    profiles,
+    activeProfile,
+    activeId,
+    createWorkspace,
+    switchWorkspace,
+    setApps,
+    toggleApp,
+    exportWorkspaces,
+    importWorkspaces,
+  } as const;
+}

--- a/pages/apps/workspaces.tsx
+++ b/pages/apps/workspaces.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const WorkspacePage = dynamic(() => import('../../apps/workspaces'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default WorkspacePage;

--- a/playwright/workspaces.spec.ts
+++ b/playwright/workspaces.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+
+const APP_IDS = ['terminal', 'chrome', 'gedit', 'spotify', 'wireshark'] as const;
+
+test.describe('Workspace profiles', () => {
+  test('switching between profiles preserves app selections', async ({ page }) => {
+    await page.goto('/apps/workspaces');
+    await expect(page.getByTestId('workspace-manager')).toBeVisible();
+
+    const toggle = (id: (typeof APP_IDS)[number]) => page.getByTestId(`app-toggle-${id}`);
+
+    // Ensure default workspace is selected and mark five apps as active
+    for (const id of APP_IDS) {
+      await toggle(id).check();
+      await expect(toggle(id)).toBeChecked();
+    }
+
+    await page.getByTestId('workspace-name-input').fill('Profile Bravo');
+    await page.getByTestId('create-workspace').click();
+
+    const bravoTab = page.locator('[data-testid^="workspace-tab-"]').filter({ hasText: 'Profile Bravo' });
+    await expect(bravoTab).toBeVisible();
+    await bravoTab.click();
+
+    // Newly created profile should start empty
+    for (const id of APP_IDS) {
+      await expect(toggle(id)).not.toBeChecked();
+      await toggle(id).check();
+    }
+
+    // Switch back to default profile and ensure previous selections persist
+    const defaultTab = page.locator('[data-testid^="workspace-tab-"]').first();
+    await defaultTab.click();
+    for (const id of APP_IDS) {
+      await expect(toggle(id)).toBeChecked();
+    }
+
+    // Reload to verify persistence across sessions
+    await page.reload();
+    await expect(defaultTab).toBeVisible();
+    for (const id of APP_IDS) {
+      await expect(toggle(id)).toBeChecked();
+    }
+
+    // Switch to the second profile and confirm its selections remained
+    await bravoTab.click();
+    for (const id of APP_IDS) {
+      await expect(toggle(id)).toBeChecked();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- implement a dedicated `useWorkspaces` hook that persists profiles, handles import/export conflicts, and logs restore errors
- surface a workspace manager UI with friendly status messaging and register it in the app catalog
- add Jest coverage for workspace flows and a Playwright scenario that verifies profile switching persistence

## Testing
- yarn lint *(fails: repo has numerous pre-existing accessibility and lint violations)*
- yarn test *(fails: existing window and other suites already failing)*
- npx playwright test *(fails: existing suites such as nmap NSE and install button already failing)*

------
https://chatgpt.com/codex/tasks/task_e_68cab6a801dc8328bacf4d495ad831e4