### PR TITLE
[recon-ng] add package planner warnings

### DIFF
--- a/__tests__/packagePlanner.test.ts
+++ b/__tests__/packagePlanner.test.ts
@@ -1,0 +1,45 @@
+import {
+  describeConflict,
+  evaluateToggle,
+  getHeldPackages,
+} from '../apps/recon-ng/packagePlanner';
+
+describe('package planner', () => {
+  it('reports held packages with reasons', () => {
+    const warnings = getHeldPackages(['DNS Enumeration', 'Port Scan']);
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        name: 'DNS Enumeration',
+        reason: expect.stringContaining('Held'),
+      }),
+    ]);
+  });
+
+  it('flags conflicts when removing a pinned package', () => {
+    const plan = ['DNS Enumeration', 'WHOIS Lookup', 'Reverse IP Lookup'];
+    const evaluation = evaluateToggle(plan, 'Reverse IP Lookup');
+    expect(evaluation.isRemoval).toBe(true);
+    expect(evaluation.conflicts).toHaveLength(1);
+    expect(evaluation.conflicts[0]).toMatchObject({
+      package: 'Reverse IP Lookup',
+      type: 'pinned-package',
+    });
+    expect(describeConflict(evaluation.conflicts[0])).toMatch(/pinned/i);
+  });
+
+  it('detects pinned dependents when removing shared dependencies', () => {
+    const plan = [
+      'DNS Enumeration',
+      'WHOIS Lookup',
+      'Reverse IP Lookup',
+      'Port Scan',
+    ];
+    const evaluation = evaluateToggle(plan, 'WHOIS Lookup');
+    expect(evaluation.conflicts).toHaveLength(1);
+    const conflict = evaluation.conflicts[0];
+    expect(conflict.type).toBe('pinned-dependent');
+    expect(conflict.dependents).toContain('Reverse IP Lookup');
+    expect(describeConflict(conflict)).toMatch(/depends on/i);
+  });
+});
+

--- a/apps/recon-ng/packageMetadata.ts
+++ b/apps/recon-ng/packageMetadata.ts
@@ -1,0 +1,63 @@
+export interface PackageMarker {
+  /** Human-readable explanation for the marker */
+  reason: string;
+}
+
+export interface PackageMetadata {
+  name: string;
+  description: string;
+  deps: string[];
+  tags: string[];
+  /** Packages that are pinned should trigger a prompt before removal. */
+  pinned?: PackageMarker;
+  /** Held packages are surfaced as warnings in the planner UI. */
+  held?: PackageMarker;
+}
+
+const PACKAGE_MAP: Record<string, PackageMetadata> = {
+  'DNS Enumeration': {
+    name: 'DNS Enumeration',
+    description:
+      'Collect authoritative records to seed additional recon modules.',
+    deps: [],
+    tags: ['dns', 'recon'],
+    held: {
+      reason:
+        'Held to preserve baseline DNS snapshots for historical comparisons.',
+    },
+  },
+  'WHOIS Lookup': {
+    name: 'WHOIS Lookup',
+    description: 'Enrich domains with ownership records.',
+    deps: ['DNS Enumeration'],
+    tags: ['whois', 'network'],
+  },
+  'Reverse IP Lookup': {
+    name: 'Reverse IP Lookup',
+    description: 'Pivot from IPs to co-hosted domains.',
+    deps: ['WHOIS Lookup'],
+    tags: ['ip'],
+    pinned: {
+      reason:
+        'Pinned for production workspaces that rely on stable pivot chains.',
+    },
+  },
+  'Port Scan': {
+    name: 'Port Scan',
+    description: 'Enumerate TCP services to profile exposed hosts.',
+    deps: ['Reverse IP Lookup'],
+    tags: ['ports', 'network'],
+  },
+};
+
+export const packageList: PackageMetadata[] = Object.values(PACKAGE_MAP);
+
+export const packageNames = packageList.map((pkg) => pkg.name);
+
+export const packageMap: Readonly<Record<string, PackageMetadata>> =
+  PACKAGE_MAP;
+
+export const getPackage = (name: string): PackageMetadata | undefined =>
+  PACKAGE_MAP[name];
+
+export default packageList;

--- a/apps/recon-ng/packagePlanner.ts
+++ b/apps/recon-ng/packagePlanner.ts
@@ -1,0 +1,127 @@
+import { getPackage, packageList } from './packageMetadata';
+
+export interface HeldPackageWarning {
+  name: string;
+  reason: string;
+}
+
+export type PlannerConflictType = 'pinned-package' | 'pinned-dependent';
+
+export interface PlannerConflict {
+  package: string;
+  type: PlannerConflictType;
+  /** Additional context when the conflict is triggered by dependents. */
+  dependents?: string[];
+  reason: string;
+}
+
+export interface ToggleEvaluation {
+  nextPlan: string[];
+  conflicts: PlannerConflict[];
+  isRemoval: boolean;
+}
+
+const dependentsGraph: Map<string, string[]> = new Map();
+
+packageList.forEach((pkg) => {
+  pkg.deps.forEach((dep) => {
+    const list = dependentsGraph.get(dep) ?? [];
+    list.push(pkg.name);
+    dependentsGraph.set(dep, list);
+  });
+});
+
+const unique = (values: string[]): string[] => Array.from(new Set(values));
+
+const findPinnedDependents = (name: string, plan: string[]): string[] => {
+  const visited = new Set<string>();
+  const pinned: string[] = [];
+  const queue = [...(dependentsGraph.get(name) ?? [])];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+
+    const meta = getPackage(current);
+    if (!meta) continue;
+
+    if (plan.includes(current) && meta.pinned) {
+      pinned.push(current);
+    }
+
+    const dependents = dependentsGraph.get(current) ?? [];
+    dependents.forEach((dep) => {
+      if (!visited.has(dep)) {
+        queue.push(dep);
+      }
+    });
+  }
+
+  return unique(pinned);
+};
+
+export const getHeldPackages = (selection: string[]): HeldPackageWarning[] =>
+  selection
+    .map((name) => getPackage(name))
+    .filter(
+      (pkg): pkg is NonNullable<ReturnType<typeof getPackage>> & {
+        held: { reason: string };
+      } => Boolean(pkg?.held),
+    )
+    .map((pkg) => ({ name: pkg.name, reason: pkg.held!.reason }));
+
+export const evaluateToggle = (
+  plan: string[],
+  name: string,
+): ToggleEvaluation => {
+  const pkg = getPackage(name);
+  const isRemoval = plan.includes(name);
+  const nextPlan = isRemoval ? plan.filter((p) => p !== name) : [...plan, name];
+
+  if (!pkg) {
+    return { nextPlan, conflicts: [], isRemoval };
+  }
+
+  const conflicts: PlannerConflict[] = [];
+
+  if (isRemoval) {
+    if (pkg.pinned) {
+      conflicts.push({
+        package: pkg.name,
+        type: 'pinned-package',
+        reason: pkg.pinned.reason,
+      });
+    }
+
+    const pinnedDependents = findPinnedDependents(pkg.name, plan);
+    if (pinnedDependents.length > 0) {
+      conflicts.push({
+        package: pkg.name,
+        type: 'pinned-dependent',
+        dependents: pinnedDependents,
+        reason:
+          pinnedDependents.length === 1
+            ? `${pinnedDependents[0]} is pinned and depends on ${pkg.name}.`
+            : `Pinned packages ${pinnedDependents.join(', ')} depend on ${
+                pkg.name
+              }.`,
+      });
+    }
+  }
+
+  return { nextPlan, conflicts, isRemoval };
+};
+
+export const describeConflict = (conflict: PlannerConflict): string => {
+  if (conflict.type === 'pinned-package') {
+    return `${conflict.package} is pinned: ${conflict.reason}`;
+  }
+  if (conflict.dependents && conflict.dependents.length > 0) {
+    return `${conflict.reason}`;
+  }
+  return conflict.reason;
+};
+
+export const hasConflicts = (conflicts: PlannerConflict[]): boolean =>
+  conflicts.length > 0;


### PR DESCRIPTION
## Summary
- add metadata describing held and pinned recon-ng packages for the planner
- surface held warnings, confirm-on-conflict flows, and export annotations in the ModulePlanner UI
- validate held, pinned, and conflict scenarios with focused unit tests

## Testing
- yarn lint *(fails: repository has pre-existing accessibility and no-top-level-window lint violations)*
- yarn test packagePlanner

------
https://chatgpt.com/codex/tasks/task_e_68cab6833804832897584e53687eddd6