### PR TITLE
[emoji] add keyboard-driven emoji picker

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -12,6 +12,7 @@ import { displayFiglet } from './components/apps/figlet';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayScreenRecorder } from './components/apps/screen-recorder';
 import { displayNikto } from './components/apps/nikto';
+import { displayEmojiPicker } from './components/apps/emoji/Picker';
 
 export const chromeDefaultTiles = [
   { title: 'MDN', url: 'https://developer.mozilla.org/' },
@@ -230,6 +231,19 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayClipboardManager,
+  },
+  {
+    id: 'emoji-picker',
+    title: 'Emoji Picker',
+    icon: '/themes/Yaru/apps/emoji.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayEmojiPicker,
+    resizable: false,
+    allowMaximize: false,
+    defaultWidth: 42,
+    defaultHeight: 60,
   },
   {
     id: 'figlet',

--- a/components/apps/emoji/Picker.tsx
+++ b/components/apps/emoji/Picker.tsx
@@ -1,0 +1,332 @@
+'use client';
+
+import React, {
+  FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import emojiJson from '../../../data/emoji.json';
+import copyToClipboard from '../../../utils/clipboard';
+import {
+  EMOJI_TONES,
+  EmojiTone,
+  clearRecentEmojis,
+  getPreferredTone,
+  getRecentEmojis,
+  pushRecentEmoji,
+  setPreferredTone,
+} from '../../../utils/settings/emoji';
+import {
+  EditableSnapshot,
+  canInsert,
+  captureEditableSnapshot,
+  insertText,
+  restoreEditableSnapshot,
+} from '../../../modules/desktop/inputBridge';
+
+interface EmojiSkin {
+  tone: string;
+  unified: string;
+  emoji: string;
+}
+
+interface EmojiEntry {
+  emoji: string;
+  name: string;
+  shortcodes: string[];
+  keywords?: string[];
+  skins: EmojiSkin[];
+  version?: number;
+}
+
+const emojiData = emojiJson as EmojiEntry[];
+
+const tonePreview: Record<EmojiTone, string> = {
+  default: '🖐️',
+  light: '🖐🏻',
+  'medium-light': '🖐🏼',
+  medium: '🖐🏽',
+  'medium-dark': '🖐🏾',
+  dark: '🖐🏿',
+};
+
+const MAX_RESULTS = 400;
+
+const buildEmojiMap = (entries: EmojiEntry[]) => {
+  const map = new Map<string, EmojiEntry>();
+  entries.forEach((entry) => {
+    entry.skins.forEach((skin) => {
+      if (skin.emoji) {
+        map.set(skin.emoji, entry);
+      }
+    });
+  });
+  return map;
+};
+
+const toDisplayCodes = (codes: string[]) =>
+  codes
+    .slice(0, 4)
+    .map((code) => `:${code}:`)
+    .join(' ');
+
+const matchesQuery = (entry: EmojiEntry, query: string) => {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  if (entry.name.toLowerCase().includes(q)) return true;
+  if (entry.shortcodes.some((code) => code.toLowerCase().includes(q))) return true;
+  if (entry.keywords?.some((word) => word.toLowerCase().includes(q))) return true;
+  return false;
+};
+
+const EmojiPicker: React.FC = () => {
+  const [query, setQuery] = useState('');
+  const [tone, setTone] = useState<EmojiTone>('default');
+  const [snapshot, setSnapshot] = useState<EditableSnapshot | null>(null);
+  const [recents, setRecents] = useState<string[]>([]);
+
+  useEffect(() => {
+    const snap = captureEditableSnapshot();
+    setSnapshot(snap);
+    setTone(getPreferredTone());
+    setRecents(getRecentEmojis());
+    const timer = window.setTimeout(() => {
+      const input = document.getElementById('emoji-search-input') as HTMLInputElement | null;
+      input?.focus();
+      input?.select();
+    }, 60);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  const emojiMap = useMemo(() => buildEmojiMap(emojiData), []);
+
+  const filteredEmojis = useMemo(() => {
+    const results = emojiData.filter((entry) => matchesQuery(entry, query));
+    return results.slice(0, MAX_RESULTS);
+  }, [query]);
+
+  const recentEntries = useMemo(
+    () =>
+      recents
+        .map((char) => {
+          const entry = emojiMap.get(char);
+          if (!entry) return null;
+          return { entry, char };
+        })
+        .filter(
+          (value): value is { entry: EmojiEntry; char: string } =>
+            value !== null
+        ),
+    [emojiMap, recents]
+  );
+
+  const resolveEmoji = useCallback(
+    (entry: EmojiEntry, preferredTone?: EmojiTone) => {
+      const desiredTone = preferredTone ?? tone;
+      const match = entry.skins.find((skin) => skin.tone === desiredTone);
+      return match?.emoji ?? entry.skins[0]?.emoji ?? entry.emoji;
+    },
+    [tone]
+  );
+
+  const closeWindow = useCallback(() => {
+    window.setTimeout(() => {
+      document.getElementById('close-emoji-picker')?.click();
+    }, 0);
+  }, []);
+
+  const handleToneChange = useCallback((next: EmojiTone) => {
+    setTone(next);
+    setPreferredTone(next);
+  }, []);
+
+  const handleInsert = useCallback(
+    async (entry: EmojiEntry, explicitChar?: string) => {
+      const char = explicitChar ?? resolveEmoji(entry);
+      if (!char) return;
+
+      if (snapshot) {
+        restoreEditableSnapshot(snapshot);
+      }
+      const target = snapshot?.element ?? null;
+      const inserted = insertText(char, target ?? undefined);
+      if (inserted) {
+        setRecents(pushRecentEmoji(char));
+        closeWindow();
+        return;
+      }
+
+      const copied = await copyToClipboard(char);
+      if (copied) {
+        setRecents(pushRecentEmoji(char));
+      }
+      closeWindow();
+    },
+    [closeWindow, resolveEmoji, snapshot]
+  );
+
+  const handleCopy = useCallback(
+    async (entry: EmojiEntry, explicitChar?: string) => {
+      const char = explicitChar ?? resolveEmoji(entry);
+      if (!char) return;
+      const copied = await copyToClipboard(char);
+      if (copied) {
+        setRecents(pushRecentEmoji(char));
+      }
+      closeWindow();
+    },
+    [closeWindow, resolveEmoji]
+  );
+
+  const handleSearchSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!filteredEmojis.length) return;
+      void handleInsert(filteredEmojis[0]);
+    },
+    [filteredEmojis, handleInsert]
+  );
+
+  const canDirectInsert = useMemo(() => canInsert(snapshot), [snapshot]);
+
+  const clearRecents = useCallback(() => {
+    clearRecentEmojis();
+    setRecents([]);
+  }, []);
+
+  return (
+    <div className="flex h-full w-full flex-col bg-ub-cool-grey text-white">
+      <header className="border-b border-black/40 px-4 py-3">
+        <h1 className="text-lg font-semibold">Emoji Picker</h1>
+        <p className="text-xs text-ubt-grey">
+          Press Ctrl+Period anywhere to search emoji. Enter inserts the first match.
+        </p>
+      </header>
+      <div className="flex flex-1 flex-col gap-4 overflow-hidden px-4 py-4">
+        <form className="flex flex-col gap-3 md:flex-row md:items-center" onSubmit={handleSearchSubmit}>
+          <input
+            id="emoji-search-input"
+            type="search"
+            autoComplete="off"
+            placeholder="Search by name or :shortcode:"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            className="w-full rounded border border-black/40 bg-black/40 px-3 py-2 text-base text-white focus:outline-none focus:ring-2 focus:ring-ubt-bg-shimmer"
+          />
+          <div className="flex items-center gap-2">
+            {EMOJI_TONES.map((itemTone) => (
+              <button
+                key={itemTone}
+                type="button"
+                onClick={() => handleToneChange(itemTone)}
+                className={`flex h-10 w-10 items-center justify-center rounded-full border transition ${
+                  tone === itemTone
+                    ? 'border-white bg-white/10'
+                    : 'border-transparent bg-black/30 hover:bg-black/40'
+                }`}
+                aria-pressed={tone === itemTone}
+                title={`Use ${itemTone.replace('-', ' ')} tone`}
+              >
+                <span className="text-xl" aria-hidden="true">
+                  {tonePreview[itemTone]}
+                </span>
+              </button>
+            ))}
+          </div>
+        </form>
+        {!canDirectInsert && (
+          <div className="rounded border border-yellow-600/50 bg-yellow-600/10 px-3 py-2 text-xs text-yellow-200">
+            Focus an input or editable area before opening the picker to enable direct insert.
+          </div>
+        )}
+        {recentEntries.length > 0 && (
+          <section className="space-y-2">
+            <div className="flex items-center justify-between text-xs uppercase tracking-wide text-ubt-grey">
+              <span>Recent</span>
+              <button
+                type="button"
+                onClick={clearRecents}
+                className="text-ubt-grey hover:text-white"
+              >
+                Clear
+              </button>
+            </div>
+            <div className="grid grid-cols-8 gap-2 md:grid-cols-12">
+              {recentEntries.map(({ entry, char }) => (
+                <button
+                  key={`${entry.name}-${char}`}
+                  type="button"
+                  onClick={() =>
+                    canDirectInsert ? void handleInsert(entry, char) : void handleCopy(entry, char)
+                  }
+                  className="flex items-center justify-center rounded-lg border border-black/20 bg-black/30 py-2 transition hover:border-white/40 hover:bg-black/50"
+                  title={`${entry.name} (${char})`}
+                >
+                  <span className="text-2xl" aria-hidden="true">
+                    {char}
+                  </span>
+                  <span className="sr-only">{entry.name}</span>
+                </button>
+              ))}
+            </div>
+          </section>
+        )}
+        <div className="flex-1 overflow-auto">
+          {filteredEmojis.length === 0 ? (
+            <div className="flex h-full items-center justify-center text-sm text-ubt-grey">
+              No emoji found.
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              {filteredEmojis.map((entry) => {
+                const displayChar = resolveEmoji(entry);
+                return (
+                  <div
+                    key={entry.skins[0]?.unified ?? entry.emoji}
+                    className="flex items-center gap-3 rounded-lg border border-black/30 bg-black/20 p-3"
+                  >
+                    <div className="flex h-12 w-12 items-center justify-center rounded bg-black/40 text-3xl">
+                      <span aria-hidden="true">{displayChar}</span>
+                      <span className="sr-only">{entry.name}</span>
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-semibold">{entry.name}</p>
+                      <p className="truncate text-xs text-ubt-grey">{toDisplayCodes(entry.shortcodes)}</p>
+                      <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                        <button
+                          type="button"
+                          onClick={() => void handleInsert(entry)}
+                          disabled={!canDirectInsert}
+                          className={`rounded px-2 py-1 transition ${
+                            canDirectInsert
+                              ? 'bg-ubt-bg-shimmer/80 text-black hover:bg-ubt-bg-shimmer'
+                              : 'bg-black/40 text-ubt-grey cursor-not-allowed'
+                          }`}
+                        >
+                          Insert
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void handleCopy(entry)}
+                          className="rounded bg-black/50 px-2 py-1 text-white transition hover:bg-black/70"
+                        >
+                          Copy
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const displayEmojiPicker = () => <EmojiPicker />;
+
+export default EmojiPicker;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -155,6 +155,9 @@ export class Desktop extends Component {
         } else if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'v') {
             e.preventDefault();
             this.openApp('clipboard-manager');
+        } else if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && e.key === '.') {
+            e.preventDefault();
+            this.openApp('emoji-picker');
         }
         else if (e.altKey && e.key === 'Tab') {
             e.preventDefault();

--- a/data/emoji.json
+++ b/data/emoji.json
@@ -1,0 +1,46522 @@
+[
+  {
+    "emoji": "💯",
+    "name": "Hundred Points",
+    "shortcodes": [
+      "100"
+    ],
+    "keywords": [
+      "100",
+      "score",
+      "perfect",
+      "numbers",
+      "century",
+      "exam",
+      "quiz",
+      "test",
+      "pass"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4af",
+        "emoji": "💯"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔢",
+    "name": "Input Numbers",
+    "shortcodes": [
+      "1234"
+    ],
+    "keywords": [
+      "1234",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f522",
+        "emoji": "🔢"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😀",
+    "name": "Grinning Face",
+    "shortcodes": [
+      "grinning"
+    ],
+    "keywords": [
+      "smile",
+      "happy",
+      "joy",
+      ":D",
+      "grin"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f600",
+        "emoji": "😀"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😃",
+    "name": "Grinning Face with Big Eyes",
+    "shortcodes": [
+      "smiley"
+    ],
+    "keywords": [
+      "smiley",
+      "happy",
+      "joy",
+      "haha",
+      ":D",
+      ":)",
+      "smile",
+      "funny",
+      "=)",
+      "=-)"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f603",
+        "emoji": "😃"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😄",
+    "name": "Grinning Face with Smiling Eyes",
+    "shortcodes": [
+      "smile"
+    ],
+    "keywords": [
+      "smile",
+      "happy",
+      "joy",
+      "funny",
+      "haha",
+      "laugh",
+      "like",
+      ":D",
+      ":)",
+      "C:",
+      "c:",
+      ":-D"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f604",
+        "emoji": "😄"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😁",
+    "name": "Beaming Face with Smiling Eyes",
+    "shortcodes": [
+      "grin"
+    ],
+    "keywords": [
+      "grin",
+      "happy",
+      "smile",
+      "joy",
+      "kawaii"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f601",
+        "emoji": "😁"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😆",
+    "name": "Grinning Squinting Face",
+    "shortcodes": [
+      "laughing",
+      "satisfied"
+    ],
+    "keywords": [
+      "laughing",
+      "satisfied",
+      "happy",
+      "joy",
+      "lol",
+      "haha",
+      "glad",
+      "XD",
+      "laugh",
+      ":>",
+      ":->"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f606",
+        "emoji": "😆"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😅",
+    "name": "Grinning Face with Sweat",
+    "shortcodes": [
+      "sweat_smile"
+    ],
+    "keywords": [
+      "smile",
+      "hot",
+      "happy",
+      "laugh",
+      "relief"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f605",
+        "emoji": "😅"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤣",
+    "name": "Rolling on the Floor Laughing",
+    "shortcodes": [
+      "rolling_on_the_floor_laughing"
+    ],
+    "keywords": [
+      "face",
+      "lol",
+      "haha",
+      "rofl"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f923",
+        "emoji": "🤣"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "😂",
+    "name": "Face with Tears of Joy",
+    "shortcodes": [
+      "joy"
+    ],
+    "keywords": [
+      "cry",
+      "weep",
+      "happy",
+      "happytears",
+      "haha"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f602",
+        "emoji": "😂"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🙂",
+    "name": "Slightly Smiling Face",
+    "shortcodes": [
+      "slightly_smiling_face"
+    ],
+    "keywords": [
+      "smile",
+      ":)",
+      "(:",
+      ":-)"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f642",
+        "emoji": "🙂"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🙃",
+    "name": "Upside-Down Face",
+    "shortcodes": [
+      "upside_down_face"
+    ],
+    "keywords": [
+      "upside",
+      "down",
+      "flipped",
+      "silly",
+      "smile"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f643",
+        "emoji": "🙃"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🫠",
+    "name": "Melting Face",
+    "shortcodes": [
+      "melting_face"
+    ],
+    "keywords": [
+      "hot",
+      "heat"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fae0",
+        "emoji": "🫠"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "😉",
+    "name": "Winking Face",
+    "shortcodes": [
+      "wink"
+    ],
+    "keywords": [
+      "wink",
+      "happy",
+      "mischievous",
+      "secret",
+      ";)",
+      "smile",
+      "eye",
+      ";-)"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f609",
+        "emoji": "😉"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😊",
+    "name": "Smiling Face with Smiling Eyes",
+    "shortcodes": [
+      "blush"
+    ],
+    "keywords": [
+      "blush",
+      "smile",
+      "happy",
+      "flushed",
+      "crush",
+      "embarrassed",
+      "shy",
+      "joy",
+      ":)"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f60a",
+        "emoji": "😊"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😇",
+    "name": "Smiling Face with Halo",
+    "shortcodes": [
+      "innocent"
+    ],
+    "keywords": [
+      "innocent",
+      "angel",
+      "heaven"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f607",
+        "emoji": "😇"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥰",
+    "name": "Smiling Face with Hearts",
+    "shortcodes": [
+      "smiling_face_with_3_hearts"
+    ],
+    "keywords": [
+      "3",
+      "love",
+      "like",
+      "affection",
+      "valentines",
+      "infatuation",
+      "crush",
+      "adore"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f970",
+        "emoji": "🥰"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "😍",
+    "name": "Smiling Face with Heart-Eyes",
+    "shortcodes": [
+      "heart_eyes"
+    ],
+    "keywords": [
+      "heart",
+      "eyes",
+      "love",
+      "like",
+      "affection",
+      "valentines",
+      "infatuation",
+      "crush"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f60d",
+        "emoji": "😍"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤩",
+    "name": "Star-Struck",
+    "shortcodes": [
+      "star-struck",
+      "grinning_face_with_star_eyes"
+    ],
+    "keywords": [
+      "star",
+      "struck",
+      "grinning",
+      "face",
+      "with",
+      "eyes",
+      "smile",
+      "starry"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f929",
+        "emoji": "🤩"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "😘",
+    "name": "Face Blowing a Kiss",
+    "shortcodes": [
+      "kissing_heart"
+    ],
+    "keywords": [
+      "kissing",
+      "heart",
+      "love",
+      "like",
+      "affection",
+      "valentines",
+      "infatuation",
+      ":*",
+      ":-*"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f618",
+        "emoji": "😘"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😗",
+    "name": "Kissing Face",
+    "shortcodes": [
+      "kissing"
+    ],
+    "keywords": [
+      "love",
+      "like",
+      "3",
+      "valentines",
+      "infatuation",
+      "kiss"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f617",
+        "emoji": "😗"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☺️",
+    "name": "Smiling Face",
+    "shortcodes": [
+      "relaxed"
+    ],
+    "keywords": [
+      "relaxed",
+      "blush",
+      "massage",
+      "happiness"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "263a-fe0f",
+        "emoji": "☺️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😚",
+    "name": "Kissing Face with Closed Eyes",
+    "shortcodes": [
+      "kissing_closed_eyes"
+    ],
+    "keywords": [
+      "love",
+      "like",
+      "affection",
+      "valentines",
+      "infatuation",
+      "kiss"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f61a",
+        "emoji": "😚"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😙",
+    "name": "Kissing Face with Smiling Eyes",
+    "shortcodes": [
+      "kissing_smiling_eyes"
+    ],
+    "keywords": [
+      "affection",
+      "valentines",
+      "infatuation",
+      "kiss"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f619",
+        "emoji": "😙"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥲",
+    "name": "Smiling Face with Tear",
+    "shortcodes": [
+      "smiling_face_with_tear"
+    ],
+    "keywords": [
+      "sad",
+      "cry",
+      "pretend"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f972",
+        "emoji": "🥲"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "😋",
+    "name": "Face Savoring Food",
+    "shortcodes": [
+      "yum"
+    ],
+    "keywords": [
+      "yum",
+      "happy",
+      "joy",
+      "tongue",
+      "smile",
+      "silly",
+      "yummy",
+      "nom",
+      "delicious",
+      "savouring"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f60b",
+        "emoji": "😋"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😛",
+    "name": "Face with Tongue",
+    "shortcodes": [
+      "stuck_out_tongue"
+    ],
+    "keywords": [
+      "stuck",
+      "out",
+      "prank",
+      "childish",
+      "playful",
+      "mischievous",
+      "smile",
+      ":p",
+      ":-p",
+      ":P",
+      ":-P",
+      ":b",
+      ":-b"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f61b",
+        "emoji": "😛"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😜",
+    "name": "Winking Face with Tongue",
+    "shortcodes": [
+      "stuck_out_tongue_winking_eye"
+    ],
+    "keywords": [
+      "stuck",
+      "out",
+      "eye",
+      "prank",
+      "childish",
+      "playful",
+      "mischievous",
+      "smile",
+      "wink",
+      ";p",
+      ";-p",
+      ";b",
+      ";-b",
+      ";P",
+      ";-P"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f61c",
+        "emoji": "😜"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤪",
+    "name": "Zany Face",
+    "shortcodes": [
+      "zany_face",
+      "grinning_face_with_one_large_and_one_small_eye"
+    ],
+    "keywords": [
+      "grinning",
+      "with",
+      "one",
+      "large",
+      "and",
+      "small",
+      "eye",
+      "goofy",
+      "crazy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f92a",
+        "emoji": "🤪"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "😝",
+    "name": "Squinting Face with Tongue",
+    "shortcodes": [
+      "stuck_out_tongue_closed_eyes"
+    ],
+    "keywords": [
+      "stuck",
+      "out",
+      "closed",
+      "eyes",
+      "prank",
+      "playful",
+      "mischievous",
+      "smile"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f61d",
+        "emoji": "😝"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤑",
+    "name": "Money-Mouth Face",
+    "shortcodes": [
+      "money_mouth_face"
+    ],
+    "keywords": [
+      "money",
+      "mouth",
+      "rich",
+      "dollar"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f911",
+        "emoji": "🤑"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤗",
+    "name": "Hugging Face",
+    "shortcodes": [
+      "hugging_face"
+    ],
+    "keywords": [
+      "smile",
+      "hug"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f917",
+        "emoji": "🤗"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤭",
+    "name": "Face with Hand over Mouth",
+    "shortcodes": [
+      "face_with_hand_over_mouth",
+      "smiling_face_with_smiling_eyes_and_hand_covering_mouth"
+    ],
+    "keywords": [
+      "smiling",
+      "eyes",
+      "and",
+      "covering",
+      "whoops",
+      "shock",
+      "surprise"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f92d",
+        "emoji": "🤭"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🫢",
+    "name": "Face with Open Eyes and Hand over Mouth",
+    "shortcodes": [
+      "face_with_open_eyes_and_hand_over_mouth"
+    ],
+    "keywords": [
+      "silence",
+      "secret",
+      "shock",
+      "surprise"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fae2",
+        "emoji": "🫢"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🫣",
+    "name": "Face with Peeking Eye",
+    "shortcodes": [
+      "face_with_peeking_eye"
+    ],
+    "keywords": [
+      "scared",
+      "frightening",
+      "embarrassing"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fae3",
+        "emoji": "🫣"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🤫",
+    "name": "Shushing Face",
+    "shortcodes": [
+      "shushing_face",
+      "face_with_finger_covering_closed_lips"
+    ],
+    "keywords": [
+      "with",
+      "finger",
+      "covering",
+      "closed",
+      "lips",
+      "quiet",
+      "shhh"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f92b",
+        "emoji": "🤫"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🤔",
+    "name": "Thinking Face",
+    "shortcodes": [
+      "thinking_face"
+    ],
+    "keywords": [
+      "hmmm",
+      "think",
+      "consider"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f914",
+        "emoji": "🤔"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🫡",
+    "name": "Saluting Face",
+    "shortcodes": [
+      "saluting_face"
+    ],
+    "keywords": [
+      "respect",
+      "salute"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fae1",
+        "emoji": "🫡"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🤐",
+    "name": "Zipper-Mouth Face",
+    "shortcodes": [
+      "zipper_mouth_face"
+    ],
+    "keywords": [
+      "zipper",
+      "mouth",
+      "sealed",
+      "secret"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f910",
+        "emoji": "🤐"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤨",
+    "name": "Face with Raised Eyebrow",
+    "shortcodes": [
+      "face_with_raised_eyebrow",
+      "face_with_one_eyebrow_raised"
+    ],
+    "keywords": [
+      "one",
+      "distrust",
+      "scepticism",
+      "disapproval",
+      "disbelief",
+      "surprise"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f928",
+        "emoji": "🤨"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "😐",
+    "name": "Neutral Face",
+    "shortcodes": [
+      "neutral_face"
+    ],
+    "keywords": [
+      "indifference",
+      "meh",
+      ":",
+      "",
+      ":|",
+      ":-|"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f610",
+        "emoji": "😐"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😑",
+    "name": "Expressionless Face",
+    "shortcodes": [
+      "expressionless"
+    ],
+    "keywords": [
+      "indifferent",
+      "-",
+      "",
+      "meh",
+      "deadpan",
+      "-_-"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f611",
+        "emoji": "😑"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😶",
+    "name": "Face Without Mouth",
+    "shortcodes": [
+      "no_mouth"
+    ],
+    "keywords": [
+      "no",
+      "hellokitty"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f636",
+        "emoji": "😶"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🫥",
+    "name": "Dotted Line Face",
+    "shortcodes": [
+      "dotted_line_face"
+    ],
+    "keywords": [
+      "invisible",
+      "lonely",
+      "isolation",
+      "depression"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fae5",
+        "emoji": "🫥"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "😶‍🌫️",
+    "name": "Face in Clouds",
+    "shortcodes": [
+      "face_in_clouds"
+    ],
+    "keywords": [
+      "shower",
+      "steam",
+      "dream"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f636-200d-1f32b-fe0f",
+        "emoji": "😶‍🌫️"
+      }
+    ],
+    "version": 13.1
+  },
+  {
+    "emoji": "😏",
+    "name": "Smirking Face",
+    "shortcodes": [
+      "smirk"
+    ],
+    "keywords": [
+      "smirk",
+      "smile",
+      "mean",
+      "prank",
+      "smug",
+      "sarcasm"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f60f",
+        "emoji": "😏"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😒",
+    "name": "Unamused Face",
+    "shortcodes": [
+      "unamused"
+    ],
+    "keywords": [
+      "indifference",
+      "bored",
+      "straight",
+      "serious",
+      "sarcasm",
+      "unimpressed",
+      "skeptical",
+      "dubious",
+      "side",
+      "eye",
+      ":("
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f612",
+        "emoji": "😒"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🙄",
+    "name": "Face with Rolling Eyes",
+    "shortcodes": [
+      "face_with_rolling_eyes"
+    ],
+    "keywords": [
+      "eyeroll",
+      "frustrated"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f644",
+        "emoji": "🙄"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😬",
+    "name": "Grimacing Face",
+    "shortcodes": [
+      "grimacing"
+    ],
+    "keywords": [
+      "grimace",
+      "teeth"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f62c",
+        "emoji": "😬"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😮‍💨",
+    "name": "Face Exhaling",
+    "shortcodes": [
+      "face_exhaling"
+    ],
+    "keywords": [
+      "relieve",
+      "relief",
+      "tired",
+      "sigh"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f62e-200d-1f4a8",
+        "emoji": "😮‍💨"
+      }
+    ],
+    "version": 13.1
+  },
+  {
+    "emoji": "🤥",
+    "name": "Lying Face",
+    "shortcodes": [
+      "lying_face"
+    ],
+    "keywords": [
+      "lie",
+      "pinocchio"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f925",
+        "emoji": "🤥"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "😌",
+    "name": "Relieved Face",
+    "shortcodes": [
+      "relieved"
+    ],
+    "keywords": [
+      "relaxed",
+      "phew",
+      "massage",
+      "happiness"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f60c",
+        "emoji": "😌"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😔",
+    "name": "Pensive Face",
+    "shortcodes": [
+      "pensive"
+    ],
+    "keywords": [
+      "sad",
+      "depressed",
+      "upset"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f614",
+        "emoji": "😔"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😪",
+    "name": "Sleepy Face",
+    "shortcodes": [
+      "sleepy"
+    ],
+    "keywords": [
+      "tired",
+      "rest",
+      "nap"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f62a",
+        "emoji": "😪"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤤",
+    "name": "Drooling Face",
+    "shortcodes": [
+      "drooling_face"
+    ],
+    "keywords": [],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f924",
+        "emoji": "🤤"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "😴",
+    "name": "Sleeping Face",
+    "shortcodes": [
+      "sleeping"
+    ],
+    "keywords": [
+      "tired",
+      "sleepy",
+      "night",
+      "zzz"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f634",
+        "emoji": "😴"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😷",
+    "name": "Face with Medical Mask",
+    "shortcodes": [
+      "mask"
+    ],
+    "keywords": [
+      "sick",
+      "ill",
+      "disease"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f637",
+        "emoji": "😷"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤒",
+    "name": "Face with Thermometer",
+    "shortcodes": [
+      "face_with_thermometer"
+    ],
+    "keywords": [
+      "sick",
+      "temperature",
+      "cold",
+      "fever"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f912",
+        "emoji": "🤒"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤕",
+    "name": "Face with Head-Bandage",
+    "shortcodes": [
+      "face_with_head_bandage"
+    ],
+    "keywords": [
+      "head",
+      "bandage",
+      "injured",
+      "clumsy",
+      "hurt"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f915",
+        "emoji": "🤕"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤢",
+    "name": "Nauseated Face",
+    "shortcodes": [
+      "nauseated_face"
+    ],
+    "keywords": [
+      "vomit",
+      "gross",
+      "green",
+      "sick",
+      "throw",
+      "up",
+      "ill"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f922",
+        "emoji": "🤢"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🤮",
+    "name": "Face Vomiting",
+    "shortcodes": [
+      "face_vomiting",
+      "face_with_open_mouth_vomiting"
+    ],
+    "keywords": [
+      "with",
+      "open",
+      "mouth",
+      "sick"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f92e",
+        "emoji": "🤮"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🤧",
+    "name": "Sneezing Face",
+    "shortcodes": [
+      "sneezing_face"
+    ],
+    "keywords": [
+      "gesundheit",
+      "sneeze",
+      "sick",
+      "allergy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f927",
+        "emoji": "🤧"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🥵",
+    "name": "Hot Face",
+    "shortcodes": [
+      "hot_face"
+    ],
+    "keywords": [
+      "feverish",
+      "heat",
+      "red",
+      "sweating"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f975",
+        "emoji": "🥵"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🥶",
+    "name": "Cold Face",
+    "shortcodes": [
+      "cold_face"
+    ],
+    "keywords": [
+      "blue",
+      "freezing",
+      "frozen",
+      "frostbite",
+      "icicles"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f976",
+        "emoji": "🥶"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🥴",
+    "name": "Woozy Face",
+    "shortcodes": [
+      "woozy_face"
+    ],
+    "keywords": [
+      "dizzy",
+      "intoxicated",
+      "tipsy",
+      "wavy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f974",
+        "emoji": "🥴"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "😵",
+    "name": "Dizzy Face",
+    "shortcodes": [
+      "dizzy_face"
+    ],
+    "keywords": [
+      "spent",
+      "unconscious",
+      "xox"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f635",
+        "emoji": "😵"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😵‍💫",
+    "name": "Face with Spiral Eyes",
+    "shortcodes": [
+      "face_with_spiral_eyes"
+    ],
+    "keywords": [
+      "sick",
+      "ill",
+      "confused",
+      "nauseous",
+      "nausea"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f635-200d-1f4ab",
+        "emoji": "😵‍💫"
+      }
+    ],
+    "version": 13.1
+  },
+  {
+    "emoji": "🤯",
+    "name": "Exploding Head",
+    "shortcodes": [
+      "exploding_head",
+      "shocked_face_with_exploding_head"
+    ],
+    "keywords": [
+      "shocked",
+      "face",
+      "with",
+      "mind",
+      "blown"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f92f",
+        "emoji": "🤯"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🤠",
+    "name": "Cowboy Hat Face",
+    "shortcodes": [
+      "face_with_cowboy_hat"
+    ],
+    "keywords": [
+      "with",
+      "cowgirl"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f920",
+        "emoji": "🤠"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🥳",
+    "name": "Partying Face",
+    "shortcodes": [
+      "partying_face"
+    ],
+    "keywords": [
+      "celebration",
+      "woohoo"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f973",
+        "emoji": "🥳"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🥸",
+    "name": "Disguised Face",
+    "shortcodes": [
+      "disguised_face"
+    ],
+    "keywords": [
+      "pretent",
+      "brows",
+      "glasses",
+      "moustache"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f978",
+        "emoji": "🥸"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "😎",
+    "name": "Smiling Face with Sunglasses",
+    "shortcodes": [
+      "sunglasses"
+    ],
+    "keywords": [
+      "cool",
+      "smile",
+      "summer",
+      "beach",
+      "sunglass",
+      "8)"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f60e",
+        "emoji": "😎"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤓",
+    "name": "Nerd Face",
+    "shortcodes": [
+      "nerd_face"
+    ],
+    "keywords": [
+      "nerdy",
+      "geek",
+      "dork"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f913",
+        "emoji": "🤓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧐",
+    "name": "Face with Monocle",
+    "shortcodes": [
+      "face_with_monocle"
+    ],
+    "keywords": [
+      "stuffy",
+      "wealthy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d0",
+        "emoji": "🧐"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "😕",
+    "name": "Confused Face",
+    "shortcodes": [
+      "confused"
+    ],
+    "keywords": [
+      "indifference",
+      "huh",
+      "weird",
+      "hmmm",
+      ":/",
+      ":\\",
+      ":-\\",
+      ":-/"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f615",
+        "emoji": "😕"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🫤",
+    "name": "Face with Diagonal Mouth",
+    "shortcodes": [
+      "face_with_diagonal_mouth"
+    ],
+    "keywords": [
+      "skeptic",
+      "confuse",
+      "frustrated",
+      "indifferent"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fae4",
+        "emoji": "🫤"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "😟",
+    "name": "Worried Face",
+    "shortcodes": [
+      "worried"
+    ],
+    "keywords": [
+      "concern",
+      "nervous",
+      ":("
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f61f",
+        "emoji": "😟"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🙁",
+    "name": "Slightly Frowning Face",
+    "shortcodes": [
+      "slightly_frowning_face"
+    ],
+    "keywords": [
+      "disappointed",
+      "sad",
+      "upset"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f641",
+        "emoji": "🙁"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☹️",
+    "name": "Frowning Face",
+    "shortcodes": [
+      "white_frowning_face"
+    ],
+    "keywords": [
+      "white",
+      "sad",
+      "upset",
+      "frown"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2639-fe0f",
+        "emoji": "☹️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😮",
+    "name": "Face with Open Mouth",
+    "shortcodes": [
+      "open_mouth"
+    ],
+    "keywords": [
+      "surprise",
+      "impressed",
+      "wow",
+      "whoa",
+      ":O",
+      ":o",
+      ":-o",
+      ":-O"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f62e",
+        "emoji": "😮"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😯",
+    "name": "Hushed Face",
+    "shortcodes": [
+      "hushed"
+    ],
+    "keywords": [
+      "woo",
+      "shh"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f62f",
+        "emoji": "😯"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😲",
+    "name": "Astonished Face",
+    "shortcodes": [
+      "astonished"
+    ],
+    "keywords": [
+      "xox",
+      "surprised",
+      "poisoned"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f632",
+        "emoji": "😲"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😳",
+    "name": "Flushed Face",
+    "shortcodes": [
+      "flushed"
+    ],
+    "keywords": [
+      "blush",
+      "shy",
+      "flattered"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f633",
+        "emoji": "😳"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥺",
+    "name": "Pleading Face",
+    "shortcodes": [
+      "pleading_face"
+    ],
+    "keywords": [
+      "begging",
+      "mercy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f97a",
+        "emoji": "🥺"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🥹",
+    "name": "Face Holding Back Tears",
+    "shortcodes": [
+      "face_holding_back_tears"
+    ],
+    "keywords": [
+      "touched",
+      "gratitude"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f979",
+        "emoji": "🥹"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "😦",
+    "name": "Frowning Face with Open Mouth",
+    "shortcodes": [
+      "frowning"
+    ],
+    "keywords": [
+      "aw",
+      "what"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f626",
+        "emoji": "😦"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😧",
+    "name": "Anguished Face",
+    "shortcodes": [
+      "anguished"
+    ],
+    "keywords": [
+      "stunned",
+      "nervous",
+      "D:"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f627",
+        "emoji": "😧"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😨",
+    "name": "Fearful Face",
+    "shortcodes": [
+      "fearful"
+    ],
+    "keywords": [
+      "scared",
+      "terrified",
+      "nervous",
+      "oops",
+      "huh"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f628",
+        "emoji": "😨"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😰",
+    "name": "Anxious Face with Sweat",
+    "shortcodes": [
+      "cold_sweat"
+    ],
+    "keywords": [
+      "cold",
+      "nervous"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f630",
+        "emoji": "😰"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😥",
+    "name": "Sad but Relieved Face",
+    "shortcodes": [
+      "disappointed_relieved"
+    ],
+    "keywords": [
+      "disappointed",
+      "phew",
+      "sweat",
+      "nervous"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f625",
+        "emoji": "😥"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😢",
+    "name": "Crying Face",
+    "shortcodes": [
+      "cry"
+    ],
+    "keywords": [
+      "cry",
+      "tears",
+      "sad",
+      "depressed",
+      "upset",
+      ":'("
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f622",
+        "emoji": "😢"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😭",
+    "name": "Loudly Crying Face",
+    "shortcodes": [
+      "sob"
+    ],
+    "keywords": [
+      "sob",
+      "cry",
+      "tears",
+      "sad",
+      "upset",
+      "depressed",
+      ":'("
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f62d",
+        "emoji": "😭"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😱",
+    "name": "Face Screaming in Fear",
+    "shortcodes": [
+      "scream"
+    ],
+    "keywords": [
+      "scream",
+      "munch",
+      "scared",
+      "omg"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f631",
+        "emoji": "😱"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😖",
+    "name": "Confounded Face",
+    "shortcodes": [
+      "confounded"
+    ],
+    "keywords": [
+      "confused",
+      "sick",
+      "unwell",
+      "oops",
+      ":S"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f616",
+        "emoji": "😖"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😣",
+    "name": "Persevering Face",
+    "shortcodes": [
+      "persevere"
+    ],
+    "keywords": [
+      "persevere",
+      "sick",
+      "no",
+      "upset",
+      "oops"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f623",
+        "emoji": "😣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😞",
+    "name": "Disappointed Face",
+    "shortcodes": [
+      "disappointed"
+    ],
+    "keywords": [
+      "sad",
+      "upset",
+      "depressed",
+      ":(",
+      "):",
+      ":-("
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f61e",
+        "emoji": "😞"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😓",
+    "name": "Face with Cold Sweat",
+    "shortcodes": [
+      "sweat"
+    ],
+    "keywords": [
+      "downcast",
+      "hot",
+      "sad",
+      "tired",
+      "exercise"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f613",
+        "emoji": "😓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😩",
+    "name": "Weary Face",
+    "shortcodes": [
+      "weary"
+    ],
+    "keywords": [
+      "tired",
+      "sleepy",
+      "sad",
+      "frustrated",
+      "upset"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f629",
+        "emoji": "😩"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😫",
+    "name": "Tired Face",
+    "shortcodes": [
+      "tired_face"
+    ],
+    "keywords": [
+      "sick",
+      "whine",
+      "upset",
+      "frustrated"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f62b",
+        "emoji": "😫"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥱",
+    "name": "Yawning Face",
+    "shortcodes": [
+      "yawning_face"
+    ],
+    "keywords": [
+      "tired",
+      "sleepy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f971",
+        "emoji": "🥱"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "😤",
+    "name": "Face with Look of Triumph",
+    "shortcodes": [
+      "triumph"
+    ],
+    "keywords": [
+      "steam",
+      "from",
+      "nose",
+      "gas",
+      "phew",
+      "proud",
+      "pride"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f624",
+        "emoji": "😤"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😡",
+    "name": "Pouting Face",
+    "shortcodes": [
+      "rage"
+    ],
+    "keywords": [
+      "rage",
+      "angry",
+      "mad",
+      "hate",
+      "despise"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f621",
+        "emoji": "😡"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😠",
+    "name": "Angry Face",
+    "shortcodes": [
+      "angry"
+    ],
+    "keywords": [
+      "mad",
+      "annoyed",
+      "frustrated",
+      ">:(",
+      ">:-("
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f620",
+        "emoji": "😠"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤬",
+    "name": "Face with Symbols on Mouth",
+    "shortcodes": [
+      "face_with_symbols_on_mouth",
+      "serious_face_with_symbols_covering_mouth"
+    ],
+    "keywords": [
+      "serious",
+      "covering",
+      "swearing",
+      "cursing",
+      "cussing",
+      "profanity",
+      "expletive"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f92c",
+        "emoji": "🤬"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "😈",
+    "name": "Smiling Face with Horns",
+    "shortcodes": [
+      "smiling_imp"
+    ],
+    "keywords": [
+      "imp",
+      "devil"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f608",
+        "emoji": "😈"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👿",
+    "name": "Imp",
+    "shortcodes": [
+      "imp"
+    ],
+    "keywords": [
+      "angry",
+      "face",
+      "with",
+      "horns",
+      "devil"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f47f",
+        "emoji": "👿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💀",
+    "name": "Skull",
+    "shortcodes": [
+      "skull"
+    ],
+    "keywords": [
+      "dead",
+      "skeleton",
+      "creepy",
+      "death"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f480",
+        "emoji": "💀"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☠️",
+    "name": "Skull and Crossbones",
+    "shortcodes": [
+      "skull_and_crossbones"
+    ],
+    "keywords": [
+      "poison",
+      "danger",
+      "deadly",
+      "scary",
+      "death",
+      "pirate",
+      "evil"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2620-fe0f",
+        "emoji": "☠️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💩",
+    "name": "Pile of Poo",
+    "shortcodes": [
+      "hankey",
+      "poop",
+      "shit"
+    ],
+    "keywords": [
+      "hankey",
+      "poop",
+      "shit",
+      "shitface",
+      "fail",
+      "turd"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4a9",
+        "emoji": "💩"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤡",
+    "name": "Clown Face",
+    "shortcodes": [
+      "clown_face"
+    ],
+    "keywords": [],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f921",
+        "emoji": "🤡"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "👹",
+    "name": "Ogre",
+    "shortcodes": [
+      "japanese_ogre"
+    ],
+    "keywords": [
+      "japanese",
+      "monster",
+      "red",
+      "mask",
+      "halloween",
+      "scary",
+      "creepy",
+      "devil",
+      "demon"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f479",
+        "emoji": "👹"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👺",
+    "name": "Goblin",
+    "shortcodes": [
+      "japanese_goblin"
+    ],
+    "keywords": [
+      "japanese",
+      "red",
+      "evil",
+      "mask",
+      "monster",
+      "scary",
+      "creepy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f47a",
+        "emoji": "👺"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👻",
+    "name": "Ghost",
+    "shortcodes": [
+      "ghost"
+    ],
+    "keywords": [
+      "halloween",
+      "spooky",
+      "scary"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f47b",
+        "emoji": "👻"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👽",
+    "name": "Alien",
+    "shortcodes": [
+      "alien"
+    ],
+    "keywords": [
+      "UFO",
+      "paul",
+      "weird",
+      "outer",
+      "space"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f47d",
+        "emoji": "👽"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👾",
+    "name": "Alien Monster",
+    "shortcodes": [
+      "space_invader"
+    ],
+    "keywords": [
+      "space",
+      "invader",
+      "game",
+      "arcade",
+      "play"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f47e",
+        "emoji": "👾"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤖",
+    "name": "Robot",
+    "shortcodes": [
+      "robot_face"
+    ],
+    "keywords": [
+      "face",
+      "computer",
+      "machine",
+      "bot"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f916",
+        "emoji": "🤖"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😺",
+    "name": "Grinning Cat",
+    "shortcodes": [
+      "smiley_cat"
+    ],
+    "keywords": [
+      "smiley",
+      "animal",
+      "cats",
+      "happy",
+      "smile"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f63a",
+        "emoji": "😺"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😸",
+    "name": "Grinning Cat with Smiling Eyes",
+    "shortcodes": [
+      "smile_cat"
+    ],
+    "keywords": [
+      "smile",
+      "animal",
+      "cats"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f638",
+        "emoji": "😸"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😹",
+    "name": "Cat with Tears of Joy",
+    "shortcodes": [
+      "joy_cat"
+    ],
+    "keywords": [
+      "animal",
+      "cats",
+      "haha",
+      "happy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f639",
+        "emoji": "😹"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😻",
+    "name": "Smiling Cat with Heart-Eyes",
+    "shortcodes": [
+      "heart_eyes_cat"
+    ],
+    "keywords": [
+      "heart",
+      "eyes",
+      "animal",
+      "love",
+      "like",
+      "affection",
+      "cats",
+      "valentines"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f63b",
+        "emoji": "😻"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😼",
+    "name": "Cat with Wry Smile",
+    "shortcodes": [
+      "smirk_cat"
+    ],
+    "keywords": [
+      "smirk",
+      "animal",
+      "cats"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f63c",
+        "emoji": "😼"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😽",
+    "name": "Kissing Cat",
+    "shortcodes": [
+      "kissing_cat"
+    ],
+    "keywords": [
+      "animal",
+      "cats",
+      "kiss"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f63d",
+        "emoji": "😽"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🙀",
+    "name": "Weary Cat",
+    "shortcodes": [
+      "scream_cat"
+    ],
+    "keywords": [
+      "scream",
+      "animal",
+      "cats",
+      "munch",
+      "scared"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f640",
+        "emoji": "🙀"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😿",
+    "name": "Crying Cat",
+    "shortcodes": [
+      "crying_cat_face"
+    ],
+    "keywords": [
+      "face",
+      "animal",
+      "tears",
+      "weep",
+      "sad",
+      "cats",
+      "upset",
+      "cry"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f63f",
+        "emoji": "😿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "😾",
+    "name": "Pouting Cat",
+    "shortcodes": [
+      "pouting_cat"
+    ],
+    "keywords": [
+      "animal",
+      "cats"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f63e",
+        "emoji": "😾"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🙈",
+    "name": "See-No-Evil Monkey",
+    "shortcodes": [
+      "see_no_evil"
+    ],
+    "keywords": [
+      "see",
+      "no",
+      "evil",
+      "animal",
+      "nature",
+      "haha"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f648",
+        "emoji": "🙈"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🙉",
+    "name": "Hear-No-Evil Monkey",
+    "shortcodes": [
+      "hear_no_evil"
+    ],
+    "keywords": [
+      "hear",
+      "no",
+      "evil",
+      "animal",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f649",
+        "emoji": "🙉"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🙊",
+    "name": "Speak-No-Evil Monkey",
+    "shortcodes": [
+      "speak_no_evil"
+    ],
+    "keywords": [
+      "speak",
+      "no",
+      "evil",
+      "animal",
+      "nature",
+      "omg"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f64a",
+        "emoji": "🙊"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💋",
+    "name": "Kiss Mark",
+    "shortcodes": [
+      "kiss"
+    ],
+    "keywords": [
+      "face",
+      "lips",
+      "love",
+      "like",
+      "affection",
+      "valentines"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f48b",
+        "emoji": "💋"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💌",
+    "name": "Love Letter",
+    "shortcodes": [
+      "love_letter"
+    ],
+    "keywords": [
+      "email",
+      "like",
+      "affection",
+      "envelope",
+      "valentines"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f48c",
+        "emoji": "💌"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💘",
+    "name": "Heart with Arrow",
+    "shortcodes": [
+      "cupid"
+    ],
+    "keywords": [
+      "cupid",
+      "love",
+      "like",
+      "affection",
+      "valentines"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f498",
+        "emoji": "💘"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💝",
+    "name": "Heart with Ribbon",
+    "shortcodes": [
+      "gift_heart"
+    ],
+    "keywords": [
+      "gift",
+      "love",
+      "valentines"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f49d",
+        "emoji": "💝"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💖",
+    "name": "Sparkling Heart",
+    "shortcodes": [
+      "sparkling_heart"
+    ],
+    "keywords": [
+      "love",
+      "like",
+      "affection",
+      "valentines"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f496",
+        "emoji": "💖"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💗",
+    "name": "Growing Heart",
+    "shortcodes": [
+      "heartpulse"
+    ],
+    "keywords": [
+      "heartpulse",
+      "like",
+      "love",
+      "affection",
+      "valentines",
+      "pink"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f497",
+        "emoji": "💗"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💓",
+    "name": "Beating Heart",
+    "shortcodes": [
+      "heartbeat"
+    ],
+    "keywords": [
+      "heartbeat",
+      "love",
+      "like",
+      "affection",
+      "valentines",
+      "pink"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f493",
+        "emoji": "💓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💞",
+    "name": "Revolving Hearts",
+    "shortcodes": [
+      "revolving_hearts"
+    ],
+    "keywords": [
+      "love",
+      "like",
+      "affection",
+      "valentines"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f49e",
+        "emoji": "💞"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💕",
+    "name": "Two Hearts",
+    "shortcodes": [
+      "two_hearts"
+    ],
+    "keywords": [
+      "love",
+      "like",
+      "affection",
+      "valentines",
+      "heart"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f495",
+        "emoji": "💕"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💟",
+    "name": "Heart Decoration",
+    "shortcodes": [
+      "heart_decoration"
+    ],
+    "keywords": [
+      "purple",
+      "square",
+      "love",
+      "like"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f49f",
+        "emoji": "💟"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "❣️",
+    "name": "Heart Exclamation",
+    "shortcodes": [
+      "heavy_heart_exclamation_mark_ornament"
+    ],
+    "keywords": [
+      "heavy",
+      "mark",
+      "ornament",
+      "decoration",
+      "love"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2763-fe0f",
+        "emoji": "❣️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💔",
+    "name": "Broken Heart",
+    "shortcodes": [
+      "broken_heart"
+    ],
+    "keywords": [
+      "sad",
+      "sorry",
+      "break",
+      "heartbreak",
+      "</3"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f494",
+        "emoji": "💔"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "❤️‍🔥",
+    "name": "Heart on Fire",
+    "shortcodes": [
+      "heart_on_fire"
+    ],
+    "keywords": [
+      "passionate",
+      "enthusiastic"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2764-fe0f-200d-1f525",
+        "emoji": "❤️‍🔥"
+      }
+    ],
+    "version": 13.1
+  },
+  {
+    "emoji": "❤️‍🩹",
+    "name": "Mending Heart",
+    "shortcodes": [
+      "mending_heart"
+    ],
+    "keywords": [
+      "broken",
+      "bandage",
+      "wounded"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2764-fe0f-200d-1fa79",
+        "emoji": "❤️‍🩹"
+      }
+    ],
+    "version": 13.1
+  },
+  {
+    "emoji": "❤️",
+    "name": "Red Heart",
+    "shortcodes": [
+      "heart"
+    ],
+    "keywords": [
+      "love",
+      "like",
+      "valentines",
+      "<3"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2764-fe0f",
+        "emoji": "❤️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧡",
+    "name": "Orange Heart",
+    "shortcodes": [
+      "orange_heart"
+    ],
+    "keywords": [
+      "love",
+      "like",
+      "affection",
+      "valentines"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9e1",
+        "emoji": "🧡"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "💛",
+    "name": "Yellow Heart",
+    "shortcodes": [
+      "yellow_heart"
+    ],
+    "keywords": [
+      "love",
+      "like",
+      "affection",
+      "valentines",
+      "<3"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f49b",
+        "emoji": "💛"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💚",
+    "name": "Green Heart",
+    "shortcodes": [
+      "green_heart"
+    ],
+    "keywords": [
+      "love",
+      "like",
+      "affection",
+      "valentines",
+      "<3"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f49a",
+        "emoji": "💚"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💙",
+    "name": "Blue Heart",
+    "shortcodes": [
+      "blue_heart"
+    ],
+    "keywords": [
+      "love",
+      "like",
+      "affection",
+      "valentines",
+      "<3"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f499",
+        "emoji": "💙"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💜",
+    "name": "Purple Heart",
+    "shortcodes": [
+      "purple_heart"
+    ],
+    "keywords": [
+      "love",
+      "like",
+      "affection",
+      "valentines",
+      "<3"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f49c",
+        "emoji": "💜"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤎",
+    "name": "Brown Heart",
+    "shortcodes": [
+      "brown_heart"
+    ],
+    "keywords": [
+      "coffee"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f90e",
+        "emoji": "🤎"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🖤",
+    "name": "Black Heart",
+    "shortcodes": [
+      "black_heart"
+    ],
+    "keywords": [
+      "evil"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5a4",
+        "emoji": "🖤"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🤍",
+    "name": "White Heart",
+    "shortcodes": [
+      "white_heart"
+    ],
+    "keywords": [
+      "pure"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f90d",
+        "emoji": "🤍"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "💢",
+    "name": "Anger Symbol",
+    "shortcodes": [
+      "anger"
+    ],
+    "keywords": [
+      "angry",
+      "mad"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4a2",
+        "emoji": "💢"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💥",
+    "name": "Collision",
+    "shortcodes": [
+      "boom",
+      "collision"
+    ],
+    "keywords": [
+      "boom",
+      "bomb",
+      "explode",
+      "explosion",
+      "blown"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4a5",
+        "emoji": "💥"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💫",
+    "name": "Dizzy",
+    "shortcodes": [
+      "dizzy"
+    ],
+    "keywords": [
+      "star",
+      "sparkle",
+      "shoot",
+      "magic"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4ab",
+        "emoji": "💫"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💦",
+    "name": "Sweat Droplets",
+    "shortcodes": [
+      "sweat_drops"
+    ],
+    "keywords": [
+      "drops",
+      "water",
+      "drip",
+      "oops"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4a6",
+        "emoji": "💦"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💨",
+    "name": "Dash Symbol",
+    "shortcodes": [
+      "dash"
+    ],
+    "keywords": [
+      "dashing",
+      "away",
+      "wind",
+      "air",
+      "fast",
+      "shoo",
+      "fart",
+      "smoke",
+      "puff"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4a8",
+        "emoji": "💨"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕳️",
+    "name": "Hole",
+    "shortcodes": [
+      "hole"
+    ],
+    "keywords": [
+      "embarrassing"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f573-fe0f",
+        "emoji": "🕳️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💣",
+    "name": "Bomb",
+    "shortcodes": [
+      "bomb"
+    ],
+    "keywords": [
+      "boom",
+      "explode",
+      "explosion",
+      "terrorism"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4a3",
+        "emoji": "💣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💬",
+    "name": "Speech Balloon",
+    "shortcodes": [
+      "speech_balloon"
+    ],
+    "keywords": [
+      "bubble",
+      "words",
+      "message",
+      "talk",
+      "chatting"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4ac",
+        "emoji": "💬"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👁️‍🗨️",
+    "name": "Eye in Speech Bubble",
+    "shortcodes": [
+      "eye-in-speech-bubble"
+    ],
+    "keywords": [
+      "in-speech-bubble",
+      "info"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f441-fe0f-200d-1f5e8-fe0f",
+        "emoji": "👁️‍🗨️"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🗨️",
+    "name": "Left Speech Bubble",
+    "shortcodes": [
+      "left_speech_bubble"
+    ],
+    "keywords": [
+      "words",
+      "message",
+      "talk",
+      "chatting"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5e8-fe0f",
+        "emoji": "🗨️"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🗯️",
+    "name": "Right Anger Bubble",
+    "shortcodes": [
+      "right_anger_bubble"
+    ],
+    "keywords": [
+      "caption",
+      "speech",
+      "thinking",
+      "mad"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5ef-fe0f",
+        "emoji": "🗯️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💭",
+    "name": "Thought Balloon",
+    "shortcodes": [
+      "thought_balloon"
+    ],
+    "keywords": [
+      "bubble",
+      "cloud",
+      "speech",
+      "thinking",
+      "dream"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4ad",
+        "emoji": "💭"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💤",
+    "name": "Zzz",
+    "shortcodes": [
+      "zzz"
+    ],
+    "keywords": [
+      "sleepy",
+      "tired",
+      "dream"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4a4",
+        "emoji": "💤"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👋",
+    "name": "Waving Hand",
+    "shortcodes": [
+      "wave"
+    ],
+    "keywords": [
+      "wave",
+      "hands",
+      "gesture",
+      "goodbye",
+      "solong",
+      "farewell",
+      "hello",
+      "hi",
+      "palm"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f44b",
+        "emoji": "👋"
+      },
+      {
+        "tone": "light",
+        "unified": "1f44b-1f3fb",
+        "emoji": "👋🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f44b-1f3fc",
+        "emoji": "👋🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f44b-1f3fd",
+        "emoji": "👋🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f44b-1f3fe",
+        "emoji": "👋🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f44b-1f3ff",
+        "emoji": "👋🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤚",
+    "name": "Raised Back of Hand",
+    "shortcodes": [
+      "raised_back_of_hand"
+    ],
+    "keywords": [
+      "fingers",
+      "backhand"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f91a",
+        "emoji": "🤚"
+      },
+      {
+        "tone": "light",
+        "unified": "1f91a-1f3fb",
+        "emoji": "🤚🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f91a-1f3fc",
+        "emoji": "🤚🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f91a-1f3fd",
+        "emoji": "🤚🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f91a-1f3fe",
+        "emoji": "🤚🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f91a-1f3ff",
+        "emoji": "🤚🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🖐️",
+    "name": "Hand with Fingers Splayed",
+    "shortcodes": [
+      "raised_hand_with_fingers_splayed"
+    ],
+    "keywords": [
+      "raised",
+      "palm"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f590-fe0f",
+        "emoji": "🖐️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f590-1f3fb",
+        "emoji": "🖐🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f590-1f3fc",
+        "emoji": "🖐🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f590-1f3fd",
+        "emoji": "🖐🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f590-1f3fe",
+        "emoji": "🖐🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f590-1f3ff",
+        "emoji": "🖐🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "✋",
+    "name": "Raised Hand",
+    "shortcodes": [
+      "hand",
+      "raised_hand"
+    ],
+    "keywords": [
+      "fingers",
+      "stop",
+      "highfive",
+      "high",
+      "five",
+      "palm",
+      "ban"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "270b",
+        "emoji": "✋"
+      },
+      {
+        "tone": "light",
+        "unified": "270b-1f3fb",
+        "emoji": "✋🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "270b-1f3fc",
+        "emoji": "✋🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "270b-1f3fd",
+        "emoji": "✋🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "270b-1f3fe",
+        "emoji": "✋🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "270b-1f3ff",
+        "emoji": "✋🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🖖",
+    "name": "Vulcan Salute",
+    "shortcodes": [
+      "spock-hand"
+    ],
+    "keywords": [
+      "spock",
+      "hand",
+      "fingers",
+      "star",
+      "trek"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f596",
+        "emoji": "🖖"
+      },
+      {
+        "tone": "light",
+        "unified": "1f596-1f3fb",
+        "emoji": "🖖🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f596-1f3fc",
+        "emoji": "🖖🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f596-1f3fd",
+        "emoji": "🖖🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f596-1f3fe",
+        "emoji": "🖖🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f596-1f3ff",
+        "emoji": "🖖🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🫱",
+    "name": "Rightwards Hand",
+    "shortcodes": [
+      "rightwards_hand"
+    ],
+    "keywords": [
+      "palm",
+      "offer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faf1",
+        "emoji": "🫱"
+      },
+      {
+        "tone": "light",
+        "unified": "1faf1-1f3fb",
+        "emoji": "🫱🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1faf1-1f3fc",
+        "emoji": "🫱🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1faf1-1f3fd",
+        "emoji": "🫱🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1faf1-1f3fe",
+        "emoji": "🫱🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1faf1-1f3ff",
+        "emoji": "🫱🏿"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🫲",
+    "name": "Leftwards Hand",
+    "shortcodes": [
+      "leftwards_hand"
+    ],
+    "keywords": [
+      "palm",
+      "offer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faf2",
+        "emoji": "🫲"
+      },
+      {
+        "tone": "light",
+        "unified": "1faf2-1f3fb",
+        "emoji": "🫲🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1faf2-1f3fc",
+        "emoji": "🫲🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1faf2-1f3fd",
+        "emoji": "🫲🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1faf2-1f3fe",
+        "emoji": "🫲🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1faf2-1f3ff",
+        "emoji": "🫲🏿"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🫳",
+    "name": "Palm Down Hand",
+    "shortcodes": [
+      "palm_down_hand"
+    ],
+    "keywords": [
+      "drop"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faf3",
+        "emoji": "🫳"
+      },
+      {
+        "tone": "light",
+        "unified": "1faf3-1f3fb",
+        "emoji": "🫳🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1faf3-1f3fc",
+        "emoji": "🫳🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1faf3-1f3fd",
+        "emoji": "🫳🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1faf3-1f3fe",
+        "emoji": "🫳🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1faf3-1f3ff",
+        "emoji": "🫳🏿"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🫴",
+    "name": "Palm Up Hand",
+    "shortcodes": [
+      "palm_up_hand"
+    ],
+    "keywords": [
+      "lift",
+      "offer",
+      "demand"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faf4",
+        "emoji": "🫴"
+      },
+      {
+        "tone": "light",
+        "unified": "1faf4-1f3fb",
+        "emoji": "🫴🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1faf4-1f3fc",
+        "emoji": "🫴🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1faf4-1f3fd",
+        "emoji": "🫴🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1faf4-1f3fe",
+        "emoji": "🫴🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1faf4-1f3ff",
+        "emoji": "🫴🏿"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "👌",
+    "name": "Ok Hand",
+    "shortcodes": [
+      "ok_hand"
+    ],
+    "keywords": [
+      "fingers",
+      "limbs",
+      "perfect",
+      "okay"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f44c",
+        "emoji": "👌"
+      },
+      {
+        "tone": "light",
+        "unified": "1f44c-1f3fb",
+        "emoji": "👌🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f44c-1f3fc",
+        "emoji": "👌🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f44c-1f3fd",
+        "emoji": "👌🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f44c-1f3fe",
+        "emoji": "👌🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f44c-1f3ff",
+        "emoji": "👌🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤌",
+    "name": "Pinched Fingers",
+    "shortcodes": [
+      "pinched_fingers"
+    ],
+    "keywords": [
+      "size",
+      "tiny",
+      "small"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f90c",
+        "emoji": "🤌"
+      },
+      {
+        "tone": "light",
+        "unified": "1f90c-1f3fb",
+        "emoji": "🤌🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f90c-1f3fc",
+        "emoji": "🤌🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f90c-1f3fd",
+        "emoji": "🤌🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f90c-1f3fe",
+        "emoji": "🤌🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f90c-1f3ff",
+        "emoji": "🤌🏿"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🤏",
+    "name": "Pinching Hand",
+    "shortcodes": [
+      "pinching_hand"
+    ],
+    "keywords": [
+      "tiny",
+      "small",
+      "size"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f90f",
+        "emoji": "🤏"
+      },
+      {
+        "tone": "light",
+        "unified": "1f90f-1f3fb",
+        "emoji": "🤏🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f90f-1f3fc",
+        "emoji": "🤏🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f90f-1f3fd",
+        "emoji": "🤏🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f90f-1f3fe",
+        "emoji": "🤏🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f90f-1f3ff",
+        "emoji": "🤏🏿"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "✌️",
+    "name": "Victory Hand",
+    "shortcodes": [
+      "v"
+    ],
+    "keywords": [
+      "v",
+      "fingers",
+      "ohyeah",
+      "peace",
+      "two"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "270c-fe0f",
+        "emoji": "✌️"
+      },
+      {
+        "tone": "light",
+        "unified": "270c-1f3fb",
+        "emoji": "✌🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "270c-1f3fc",
+        "emoji": "✌🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "270c-1f3fd",
+        "emoji": "✌🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "270c-1f3fe",
+        "emoji": "✌🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "270c-1f3ff",
+        "emoji": "✌🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤞",
+    "name": "Crossed Fingers",
+    "shortcodes": [
+      "crossed_fingers",
+      "hand_with_index_and_middle_fingers_crossed"
+    ],
+    "keywords": [
+      "hand",
+      "with",
+      "index",
+      "and",
+      "middle",
+      "good",
+      "lucky"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f91e",
+        "emoji": "🤞"
+      },
+      {
+        "tone": "light",
+        "unified": "1f91e-1f3fb",
+        "emoji": "🤞🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f91e-1f3fc",
+        "emoji": "🤞🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f91e-1f3fd",
+        "emoji": "🤞🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f91e-1f3fe",
+        "emoji": "🤞🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f91e-1f3ff",
+        "emoji": "🤞🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🫰",
+    "name": "Hand with Index Finger and Thumb Crossed",
+    "shortcodes": [
+      "hand_with_index_finger_and_thumb_crossed"
+    ],
+    "keywords": [
+      "heart",
+      "love",
+      "money",
+      "expensive"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faf0",
+        "emoji": "🫰"
+      },
+      {
+        "tone": "light",
+        "unified": "1faf0-1f3fb",
+        "emoji": "🫰🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1faf0-1f3fc",
+        "emoji": "🫰🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1faf0-1f3fd",
+        "emoji": "🫰🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1faf0-1f3fe",
+        "emoji": "🫰🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1faf0-1f3ff",
+        "emoji": "🫰🏿"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🤟",
+    "name": "Love-You Gesture",
+    "shortcodes": [
+      "i_love_you_hand_sign"
+    ],
+    "keywords": [
+      "i",
+      "love",
+      "you",
+      "hand",
+      "sign",
+      "fingers"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f91f",
+        "emoji": "🤟"
+      },
+      {
+        "tone": "light",
+        "unified": "1f91f-1f3fb",
+        "emoji": "🤟🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f91f-1f3fc",
+        "emoji": "🤟🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f91f-1f3fd",
+        "emoji": "🤟🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f91f-1f3fe",
+        "emoji": "🤟🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f91f-1f3ff",
+        "emoji": "🤟🏿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🤘",
+    "name": "Sign of the Horns",
+    "shortcodes": [
+      "the_horns",
+      "sign_of_the_horns"
+    ],
+    "keywords": [
+      "hand",
+      "fingers",
+      "evil",
+      "eye",
+      "rock",
+      "on"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f918",
+        "emoji": "🤘"
+      },
+      {
+        "tone": "light",
+        "unified": "1f918-1f3fb",
+        "emoji": "🤘🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f918-1f3fc",
+        "emoji": "🤘🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f918-1f3fd",
+        "emoji": "🤘🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f918-1f3fe",
+        "emoji": "🤘🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f918-1f3ff",
+        "emoji": "🤘🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤙",
+    "name": "Call Me Hand",
+    "shortcodes": [
+      "call_me_hand"
+    ],
+    "keywords": [
+      "hands",
+      "gesture",
+      "shaka"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f919",
+        "emoji": "🤙"
+      },
+      {
+        "tone": "light",
+        "unified": "1f919-1f3fb",
+        "emoji": "🤙🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f919-1f3fc",
+        "emoji": "🤙🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f919-1f3fd",
+        "emoji": "🤙🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f919-1f3fe",
+        "emoji": "🤙🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f919-1f3ff",
+        "emoji": "🤙🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "👈",
+    "name": "Backhand Index Pointing Left",
+    "shortcodes": [
+      "point_left"
+    ],
+    "keywords": [
+      "point",
+      "direction",
+      "fingers",
+      "hand"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f448",
+        "emoji": "👈"
+      },
+      {
+        "tone": "light",
+        "unified": "1f448-1f3fb",
+        "emoji": "👈🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f448-1f3fc",
+        "emoji": "👈🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f448-1f3fd",
+        "emoji": "👈🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f448-1f3fe",
+        "emoji": "👈🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f448-1f3ff",
+        "emoji": "👈🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👉",
+    "name": "Backhand Index Pointing Right",
+    "shortcodes": [
+      "point_right"
+    ],
+    "keywords": [
+      "point",
+      "fingers",
+      "hand",
+      "direction"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f449",
+        "emoji": "👉"
+      },
+      {
+        "tone": "light",
+        "unified": "1f449-1f3fb",
+        "emoji": "👉🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f449-1f3fc",
+        "emoji": "👉🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f449-1f3fd",
+        "emoji": "👉🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f449-1f3fe",
+        "emoji": "👉🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f449-1f3ff",
+        "emoji": "👉🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👆",
+    "name": "Backhand Index Pointing Up",
+    "shortcodes": [
+      "point_up_2"
+    ],
+    "keywords": [
+      "point",
+      "2",
+      "fingers",
+      "hand",
+      "direction"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f446",
+        "emoji": "👆"
+      },
+      {
+        "tone": "light",
+        "unified": "1f446-1f3fb",
+        "emoji": "👆🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f446-1f3fc",
+        "emoji": "👆🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f446-1f3fd",
+        "emoji": "👆🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f446-1f3fe",
+        "emoji": "👆🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f446-1f3ff",
+        "emoji": "👆🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🖕",
+    "name": "Middle Finger",
+    "shortcodes": [
+      "middle_finger",
+      "reversed_hand_with_middle_finger_extended"
+    ],
+    "keywords": [
+      "reversed",
+      "hand",
+      "with",
+      "extended",
+      "fingers",
+      "rude",
+      "flipping"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f595",
+        "emoji": "🖕"
+      },
+      {
+        "tone": "light",
+        "unified": "1f595-1f3fb",
+        "emoji": "🖕🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f595-1f3fc",
+        "emoji": "🖕🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f595-1f3fd",
+        "emoji": "🖕🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f595-1f3fe",
+        "emoji": "🖕🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f595-1f3ff",
+        "emoji": "🖕🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👇",
+    "name": "Backhand Index Pointing Down",
+    "shortcodes": [
+      "point_down"
+    ],
+    "keywords": [
+      "point",
+      "fingers",
+      "hand",
+      "direction"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f447",
+        "emoji": "👇"
+      },
+      {
+        "tone": "light",
+        "unified": "1f447-1f3fb",
+        "emoji": "👇🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f447-1f3fc",
+        "emoji": "👇🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f447-1f3fd",
+        "emoji": "👇🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f447-1f3fe",
+        "emoji": "👇🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f447-1f3ff",
+        "emoji": "👇🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☝️",
+    "name": "Index Pointing Up",
+    "shortcodes": [
+      "point_up"
+    ],
+    "keywords": [
+      "point",
+      "hand",
+      "fingers",
+      "direction"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "261d-fe0f",
+        "emoji": "☝️"
+      },
+      {
+        "tone": "light",
+        "unified": "261d-1f3fb",
+        "emoji": "☝🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "261d-1f3fc",
+        "emoji": "☝🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "261d-1f3fd",
+        "emoji": "☝🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "261d-1f3fe",
+        "emoji": "☝🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "261d-1f3ff",
+        "emoji": "☝🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🫵",
+    "name": "Index Pointing at the Viewer",
+    "shortcodes": [
+      "index_pointing_at_the_viewer"
+    ],
+    "keywords": [
+      "you",
+      "recruit"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faf5",
+        "emoji": "🫵"
+      },
+      {
+        "tone": "light",
+        "unified": "1faf5-1f3fb",
+        "emoji": "🫵🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1faf5-1f3fc",
+        "emoji": "🫵🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1faf5-1f3fd",
+        "emoji": "🫵🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1faf5-1f3fe",
+        "emoji": "🫵🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1faf5-1f3ff",
+        "emoji": "🫵🏿"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "👍",
+    "name": "Thumbs Up",
+    "shortcodes": [
+      "+1",
+      "thumbsup"
+    ],
+    "keywords": [
+      "+1",
+      "thumbsup",
+      "yes",
+      "awesome",
+      "good",
+      "agree",
+      "accept",
+      "cool",
+      "hand",
+      "like"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f44d",
+        "emoji": "👍"
+      },
+      {
+        "tone": "light",
+        "unified": "1f44d-1f3fb",
+        "emoji": "👍🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f44d-1f3fc",
+        "emoji": "👍🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f44d-1f3fd",
+        "emoji": "👍🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f44d-1f3fe",
+        "emoji": "👍🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f44d-1f3ff",
+        "emoji": "👍🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👎",
+    "name": "Thumbs Down",
+    "shortcodes": [
+      "-1",
+      "thumbsdown"
+    ],
+    "keywords": [
+      "-1",
+      "thumbsdown",
+      "no",
+      "dislike",
+      "hand"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f44e",
+        "emoji": "👎"
+      },
+      {
+        "tone": "light",
+        "unified": "1f44e-1f3fb",
+        "emoji": "👎🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f44e-1f3fc",
+        "emoji": "👎🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f44e-1f3fd",
+        "emoji": "👎🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f44e-1f3fe",
+        "emoji": "👎🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f44e-1f3ff",
+        "emoji": "👎🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "✊",
+    "name": "Raised Fist",
+    "shortcodes": [
+      "fist"
+    ],
+    "keywords": [
+      "fingers",
+      "hand",
+      "grasp"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "270a",
+        "emoji": "✊"
+      },
+      {
+        "tone": "light",
+        "unified": "270a-1f3fb",
+        "emoji": "✊🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "270a-1f3fc",
+        "emoji": "✊🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "270a-1f3fd",
+        "emoji": "✊🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "270a-1f3fe",
+        "emoji": "✊🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "270a-1f3ff",
+        "emoji": "✊🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👊",
+    "name": "Oncoming Fist",
+    "shortcodes": [
+      "facepunch",
+      "punch"
+    ],
+    "keywords": [
+      "facepunch",
+      "punch",
+      "angry",
+      "violence",
+      "hit",
+      "attack",
+      "hand"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f44a",
+        "emoji": "👊"
+      },
+      {
+        "tone": "light",
+        "unified": "1f44a-1f3fb",
+        "emoji": "👊🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f44a-1f3fc",
+        "emoji": "👊🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f44a-1f3fd",
+        "emoji": "👊🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f44a-1f3fe",
+        "emoji": "👊🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f44a-1f3ff",
+        "emoji": "👊🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤛",
+    "name": "Left-Facing Fist",
+    "shortcodes": [
+      "left-facing_fist"
+    ],
+    "keywords": [
+      "left",
+      "facing",
+      "hand",
+      "fistbump"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f91b",
+        "emoji": "🤛"
+      },
+      {
+        "tone": "light",
+        "unified": "1f91b-1f3fb",
+        "emoji": "🤛🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f91b-1f3fc",
+        "emoji": "🤛🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f91b-1f3fd",
+        "emoji": "🤛🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f91b-1f3fe",
+        "emoji": "🤛🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f91b-1f3ff",
+        "emoji": "🤛🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🤜",
+    "name": "Right-Facing Fist",
+    "shortcodes": [
+      "right-facing_fist"
+    ],
+    "keywords": [
+      "right",
+      "facing",
+      "hand",
+      "fistbump"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f91c",
+        "emoji": "🤜"
+      },
+      {
+        "tone": "light",
+        "unified": "1f91c-1f3fb",
+        "emoji": "🤜🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f91c-1f3fc",
+        "emoji": "🤜🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f91c-1f3fd",
+        "emoji": "🤜🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f91c-1f3fe",
+        "emoji": "🤜🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f91c-1f3ff",
+        "emoji": "🤜🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "👏",
+    "name": "Clapping Hands",
+    "shortcodes": [
+      "clap"
+    ],
+    "keywords": [
+      "clap",
+      "praise",
+      "applause",
+      "congrats",
+      "yay"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f44f",
+        "emoji": "👏"
+      },
+      {
+        "tone": "light",
+        "unified": "1f44f-1f3fb",
+        "emoji": "👏🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f44f-1f3fc",
+        "emoji": "👏🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f44f-1f3fd",
+        "emoji": "👏🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f44f-1f3fe",
+        "emoji": "👏🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f44f-1f3ff",
+        "emoji": "👏🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🙌",
+    "name": "Raising Hands",
+    "shortcodes": [
+      "raised_hands"
+    ],
+    "keywords": [
+      "raised",
+      "gesture",
+      "hooray",
+      "yea",
+      "celebration"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f64c",
+        "emoji": "🙌"
+      },
+      {
+        "tone": "light",
+        "unified": "1f64c-1f3fb",
+        "emoji": "🙌🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f64c-1f3fc",
+        "emoji": "🙌🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f64c-1f3fd",
+        "emoji": "🙌🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f64c-1f3fe",
+        "emoji": "🙌🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f64c-1f3ff",
+        "emoji": "🙌🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🫶",
+    "name": "Heart Hands",
+    "shortcodes": [
+      "heart_hands"
+    ],
+    "keywords": [
+      "love",
+      "appreciation",
+      "support"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faf6",
+        "emoji": "🫶"
+      },
+      {
+        "tone": "light",
+        "unified": "1faf6-1f3fb",
+        "emoji": "🫶🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1faf6-1f3fc",
+        "emoji": "🫶🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1faf6-1f3fd",
+        "emoji": "🫶🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1faf6-1f3fe",
+        "emoji": "🫶🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1faf6-1f3ff",
+        "emoji": "🫶🏿"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "👐",
+    "name": "Open Hands",
+    "shortcodes": [
+      "open_hands"
+    ],
+    "keywords": [
+      "fingers",
+      "butterfly"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f450",
+        "emoji": "👐"
+      },
+      {
+        "tone": "light",
+        "unified": "1f450-1f3fb",
+        "emoji": "👐🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f450-1f3fc",
+        "emoji": "👐🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f450-1f3fd",
+        "emoji": "👐🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f450-1f3fe",
+        "emoji": "👐🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f450-1f3ff",
+        "emoji": "👐🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤲",
+    "name": "Palms Up Together",
+    "shortcodes": [
+      "palms_up_together"
+    ],
+    "keywords": [
+      "hands",
+      "gesture",
+      "cupped",
+      "prayer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f932",
+        "emoji": "🤲"
+      },
+      {
+        "tone": "light",
+        "unified": "1f932-1f3fb",
+        "emoji": "🤲🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f932-1f3fc",
+        "emoji": "🤲🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f932-1f3fd",
+        "emoji": "🤲🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f932-1f3fe",
+        "emoji": "🤲🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f932-1f3ff",
+        "emoji": "🤲🏿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🤝",
+    "name": "Handshake",
+    "shortcodes": [
+      "handshake"
+    ],
+    "keywords": [
+      "agreement",
+      "shake"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f91d",
+        "emoji": "🤝"
+      },
+      {
+        "tone": "light",
+        "unified": "1f91d-1f3fb",
+        "emoji": "🤝🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f91d-1f3fc",
+        "emoji": "🤝🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f91d-1f3fd",
+        "emoji": "🤝🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f91d-1f3fe",
+        "emoji": "🤝🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f91d-1f3ff",
+        "emoji": "🤝🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🙏",
+    "name": "Folded Hands",
+    "shortcodes": [
+      "pray"
+    ],
+    "keywords": [
+      "pray",
+      "please",
+      "hope",
+      "wish",
+      "namaste",
+      "highfive",
+      "high",
+      "five"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f64f",
+        "emoji": "🙏"
+      },
+      {
+        "tone": "light",
+        "unified": "1f64f-1f3fb",
+        "emoji": "🙏🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f64f-1f3fc",
+        "emoji": "🙏🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f64f-1f3fd",
+        "emoji": "🙏🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f64f-1f3fe",
+        "emoji": "🙏🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f64f-1f3ff",
+        "emoji": "🙏🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "✍️",
+    "name": "Writing Hand",
+    "shortcodes": [
+      "writing_hand"
+    ],
+    "keywords": [
+      "lower",
+      "left",
+      "ballpoint",
+      "pen",
+      "stationery",
+      "write",
+      "compose"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "270d-fe0f",
+        "emoji": "✍️"
+      },
+      {
+        "tone": "light",
+        "unified": "270d-1f3fb",
+        "emoji": "✍🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "270d-1f3fc",
+        "emoji": "✍🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "270d-1f3fd",
+        "emoji": "✍🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "270d-1f3fe",
+        "emoji": "✍🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "270d-1f3ff",
+        "emoji": "✍🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💅",
+    "name": "Nail Polish",
+    "shortcodes": [
+      "nail_care"
+    ],
+    "keywords": [
+      "care",
+      "beauty",
+      "manicure",
+      "finger",
+      "fashion"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f485",
+        "emoji": "💅"
+      },
+      {
+        "tone": "light",
+        "unified": "1f485-1f3fb",
+        "emoji": "💅🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f485-1f3fc",
+        "emoji": "💅🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f485-1f3fd",
+        "emoji": "💅🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f485-1f3fe",
+        "emoji": "💅🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f485-1f3ff",
+        "emoji": "💅🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤳",
+    "name": "Selfie",
+    "shortcodes": [
+      "selfie"
+    ],
+    "keywords": [
+      "camera",
+      "phone"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f933",
+        "emoji": "🤳"
+      },
+      {
+        "tone": "light",
+        "unified": "1f933-1f3fb",
+        "emoji": "🤳🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f933-1f3fc",
+        "emoji": "🤳🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f933-1f3fd",
+        "emoji": "🤳🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f933-1f3fe",
+        "emoji": "🤳🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f933-1f3ff",
+        "emoji": "🤳🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "💪",
+    "name": "Flexed Biceps",
+    "shortcodes": [
+      "muscle"
+    ],
+    "keywords": [
+      "muscle",
+      "arm",
+      "flex",
+      "hand",
+      "summer",
+      "strong"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4aa",
+        "emoji": "💪"
+      },
+      {
+        "tone": "light",
+        "unified": "1f4aa-1f3fb",
+        "emoji": "💪🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f4aa-1f3fc",
+        "emoji": "💪🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f4aa-1f3fd",
+        "emoji": "💪🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f4aa-1f3fe",
+        "emoji": "💪🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f4aa-1f3ff",
+        "emoji": "💪🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦾",
+    "name": "Mechanical Arm",
+    "shortcodes": [
+      "mechanical_arm"
+    ],
+    "keywords": [
+      "accessibility"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9be",
+        "emoji": "🦾"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🦿",
+    "name": "Mechanical Leg",
+    "shortcodes": [
+      "mechanical_leg"
+    ],
+    "keywords": [
+      "accessibility"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9bf",
+        "emoji": "🦿"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🦵",
+    "name": "Leg",
+    "shortcodes": [
+      "leg"
+    ],
+    "keywords": [
+      "kick",
+      "limb"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9b5",
+        "emoji": "🦵"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9b5-1f3fb",
+        "emoji": "🦵🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9b5-1f3fc",
+        "emoji": "🦵🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9b5-1f3fd",
+        "emoji": "🦵🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9b5-1f3fe",
+        "emoji": "🦵🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9b5-1f3ff",
+        "emoji": "🦵🏿"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🦶",
+    "name": "Foot",
+    "shortcodes": [
+      "foot"
+    ],
+    "keywords": [
+      "kick",
+      "stomp"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9b6",
+        "emoji": "🦶"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9b6-1f3fb",
+        "emoji": "🦶🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9b6-1f3fc",
+        "emoji": "🦶🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9b6-1f3fd",
+        "emoji": "🦶🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9b6-1f3fe",
+        "emoji": "🦶🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9b6-1f3ff",
+        "emoji": "🦶🏿"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "👂",
+    "name": "Ear",
+    "shortcodes": [
+      "ear"
+    ],
+    "keywords": [
+      "face",
+      "hear",
+      "sound",
+      "listen"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f442",
+        "emoji": "👂"
+      },
+      {
+        "tone": "light",
+        "unified": "1f442-1f3fb",
+        "emoji": "👂🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f442-1f3fc",
+        "emoji": "👂🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f442-1f3fd",
+        "emoji": "👂🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f442-1f3fe",
+        "emoji": "👂🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f442-1f3ff",
+        "emoji": "👂🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦻",
+    "name": "Ear with Hearing Aid",
+    "shortcodes": [
+      "ear_with_hearing_aid"
+    ],
+    "keywords": [
+      "accessibility"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9bb",
+        "emoji": "🦻"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9bb-1f3fb",
+        "emoji": "🦻🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9bb-1f3fc",
+        "emoji": "🦻🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9bb-1f3fd",
+        "emoji": "🦻🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9bb-1f3fe",
+        "emoji": "🦻🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9bb-1f3ff",
+        "emoji": "🦻🏿"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "👃",
+    "name": "Nose",
+    "shortcodes": [
+      "nose"
+    ],
+    "keywords": [
+      "smell",
+      "sniff"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f443",
+        "emoji": "👃"
+      },
+      {
+        "tone": "light",
+        "unified": "1f443-1f3fb",
+        "emoji": "👃🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f443-1f3fc",
+        "emoji": "👃🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f443-1f3fd",
+        "emoji": "👃🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f443-1f3fe",
+        "emoji": "👃🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f443-1f3ff",
+        "emoji": "👃🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧠",
+    "name": "Brain",
+    "shortcodes": [
+      "brain"
+    ],
+    "keywords": [
+      "smart",
+      "intelligent"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9e0",
+        "emoji": "🧠"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🫀",
+    "name": "Anatomical Heart",
+    "shortcodes": [
+      "anatomical_heart"
+    ],
+    "keywords": [
+      "health",
+      "heartbeat"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fac0",
+        "emoji": "🫀"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🫁",
+    "name": "Lungs",
+    "shortcodes": [
+      "lungs"
+    ],
+    "keywords": [
+      "breathe"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fac1",
+        "emoji": "🫁"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🦷",
+    "name": "Tooth",
+    "shortcodes": [
+      "tooth"
+    ],
+    "keywords": [
+      "teeth",
+      "dentist"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9b7",
+        "emoji": "🦷"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🦴",
+    "name": "Bone",
+    "shortcodes": [
+      "bone"
+    ],
+    "keywords": [
+      "skeleton"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9b4",
+        "emoji": "🦴"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "👀",
+    "name": "Eyes",
+    "shortcodes": [
+      "eyes"
+    ],
+    "keywords": [
+      "look",
+      "watch",
+      "stalk",
+      "peek",
+      "see"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f440",
+        "emoji": "👀"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👁️",
+    "name": "Eye",
+    "shortcodes": [
+      "eye"
+    ],
+    "keywords": [
+      "face",
+      "look",
+      "see",
+      "watch",
+      "stare"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f441-fe0f",
+        "emoji": "👁️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👅",
+    "name": "Tongue",
+    "shortcodes": [
+      "tongue"
+    ],
+    "keywords": [
+      "mouth",
+      "playful"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f445",
+        "emoji": "👅"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👄",
+    "name": "Mouth",
+    "shortcodes": [
+      "lips"
+    ],
+    "keywords": [
+      "lips",
+      "kiss"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f444",
+        "emoji": "👄"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🫦",
+    "name": "Biting Lip",
+    "shortcodes": [
+      "biting_lip"
+    ],
+    "keywords": [
+      "flirt",
+      "sexy",
+      "pain",
+      "worry"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fae6",
+        "emoji": "🫦"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "👶",
+    "name": "Baby",
+    "shortcodes": [
+      "baby"
+    ],
+    "keywords": [
+      "child",
+      "boy",
+      "girl",
+      "toddler"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f476",
+        "emoji": "👶"
+      },
+      {
+        "tone": "light",
+        "unified": "1f476-1f3fb",
+        "emoji": "👶🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f476-1f3fc",
+        "emoji": "👶🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f476-1f3fd",
+        "emoji": "👶🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f476-1f3fe",
+        "emoji": "👶🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f476-1f3ff",
+        "emoji": "👶🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧒",
+    "name": "Child",
+    "shortcodes": [
+      "child"
+    ],
+    "keywords": [
+      "gender",
+      "neutral",
+      "young"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d2",
+        "emoji": "🧒"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d2-1f3fb",
+        "emoji": "🧒🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d2-1f3fc",
+        "emoji": "🧒🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d2-1f3fd",
+        "emoji": "🧒🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d2-1f3fe",
+        "emoji": "🧒🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d2-1f3ff",
+        "emoji": "🧒🏿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "👦",
+    "name": "Boy",
+    "shortcodes": [
+      "boy"
+    ],
+    "keywords": [
+      "man",
+      "male",
+      "guy",
+      "teenager"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f466",
+        "emoji": "👦"
+      },
+      {
+        "tone": "light",
+        "unified": "1f466-1f3fb",
+        "emoji": "👦🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f466-1f3fc",
+        "emoji": "👦🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f466-1f3fd",
+        "emoji": "👦🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f466-1f3fe",
+        "emoji": "👦🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f466-1f3ff",
+        "emoji": "👦🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👧",
+    "name": "Girl",
+    "shortcodes": [
+      "girl"
+    ],
+    "keywords": [
+      "female",
+      "woman",
+      "teenager"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f467",
+        "emoji": "👧"
+      },
+      {
+        "tone": "light",
+        "unified": "1f467-1f3fb",
+        "emoji": "👧🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f467-1f3fc",
+        "emoji": "👧🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f467-1f3fd",
+        "emoji": "👧🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f467-1f3fe",
+        "emoji": "👧🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f467-1f3ff",
+        "emoji": "👧🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧑",
+    "name": "Adult",
+    "shortcodes": [
+      "adult"
+    ],
+    "keywords": [
+      "person",
+      "gender",
+      "neutral"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1",
+        "emoji": "🧑"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb",
+        "emoji": "🧑🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc",
+        "emoji": "🧑🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd",
+        "emoji": "🧑🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe",
+        "emoji": "🧑🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff",
+        "emoji": "🧑🏿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "👱",
+    "name": "Person Blond Hair",
+    "shortcodes": [
+      "person_with_blond_hair"
+    ],
+    "keywords": [
+      "with",
+      "hairstyle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f471",
+        "emoji": "👱"
+      },
+      {
+        "tone": "light",
+        "unified": "1f471-1f3fb",
+        "emoji": "👱🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f471-1f3fc",
+        "emoji": "👱🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f471-1f3fd",
+        "emoji": "👱🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f471-1f3fe",
+        "emoji": "👱🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f471-1f3ff",
+        "emoji": "👱🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👨",
+    "name": "Man",
+    "shortcodes": [
+      "man"
+    ],
+    "keywords": [
+      "mustache",
+      "father",
+      "dad",
+      "guy",
+      "classy",
+      "sir",
+      "moustache"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468",
+        "emoji": "👨"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb",
+        "emoji": "👨🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc",
+        "emoji": "👨🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd",
+        "emoji": "👨🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe",
+        "emoji": "👨🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff",
+        "emoji": "👨🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧔",
+    "name": "Person Beard",
+    "shortcodes": [
+      "bearded_person"
+    ],
+    "keywords": [
+      "bearded",
+      "man",
+      "bewhiskered"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d4",
+        "emoji": "🧔"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d4-1f3fb",
+        "emoji": "🧔🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d4-1f3fc",
+        "emoji": "🧔🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d4-1f3fd",
+        "emoji": "🧔🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d4-1f3fe",
+        "emoji": "🧔🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d4-1f3ff",
+        "emoji": "🧔🏿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧔‍♂️",
+    "name": "Man: Beard",
+    "shortcodes": [
+      "man_with_beard"
+    ],
+    "keywords": [
+      "man",
+      "with",
+      "facial",
+      "hair"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d4-200d-2642-fe0f",
+        "emoji": "🧔‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d4-1f3fb-200d-2642-fe0f",
+        "emoji": "🧔🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d4-1f3fc-200d-2642-fe0f",
+        "emoji": "🧔🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d4-1f3fd-200d-2642-fe0f",
+        "emoji": "🧔🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d4-1f3fe-200d-2642-fe0f",
+        "emoji": "🧔🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d4-1f3ff-200d-2642-fe0f",
+        "emoji": "🧔🏿‍♂️"
+      }
+    ],
+    "version": 13.1
+  },
+  {
+    "emoji": "🧔‍♀️",
+    "name": "Woman: Beard",
+    "shortcodes": [
+      "woman_with_beard"
+    ],
+    "keywords": [
+      "woman",
+      "with",
+      "facial",
+      "hair"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d4-200d-2640-fe0f",
+        "emoji": "🧔‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d4-1f3fb-200d-2640-fe0f",
+        "emoji": "🧔🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d4-1f3fc-200d-2640-fe0f",
+        "emoji": "🧔🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d4-1f3fd-200d-2640-fe0f",
+        "emoji": "🧔🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d4-1f3fe-200d-2640-fe0f",
+        "emoji": "🧔🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d4-1f3ff-200d-2640-fe0f",
+        "emoji": "🧔🏿‍♀️"
+      }
+    ],
+    "version": 13.1
+  },
+  {
+    "emoji": "👨‍🦰",
+    "name": "Man: Red Hair",
+    "shortcodes": [
+      "red_haired_man"
+    ],
+    "keywords": [
+      "haired",
+      "man",
+      "hairstyle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f9b0",
+        "emoji": "👨‍🦰"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f9b0",
+        "emoji": "👨🏻‍🦰"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f9b0",
+        "emoji": "👨🏼‍🦰"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f9b0",
+        "emoji": "👨🏽‍🦰"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f9b0",
+        "emoji": "👨🏾‍🦰"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f9b0",
+        "emoji": "👨🏿‍🦰"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "👨‍🦱",
+    "name": "Man: Curly Hair",
+    "shortcodes": [
+      "curly_haired_man"
+    ],
+    "keywords": [
+      "haired",
+      "man",
+      "hairstyle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f9b1",
+        "emoji": "👨‍🦱"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f9b1",
+        "emoji": "👨🏻‍🦱"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f9b1",
+        "emoji": "👨🏼‍🦱"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f9b1",
+        "emoji": "👨🏽‍🦱"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f9b1",
+        "emoji": "👨🏾‍🦱"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f9b1",
+        "emoji": "👨🏿‍🦱"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "👨‍🦳",
+    "name": "Man: White Hair",
+    "shortcodes": [
+      "white_haired_man"
+    ],
+    "keywords": [
+      "haired",
+      "man",
+      "old",
+      "elder"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f9b3",
+        "emoji": "👨‍🦳"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f9b3",
+        "emoji": "👨🏻‍🦳"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f9b3",
+        "emoji": "👨🏼‍🦳"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f9b3",
+        "emoji": "👨🏽‍🦳"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f9b3",
+        "emoji": "👨🏾‍🦳"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f9b3",
+        "emoji": "👨🏿‍🦳"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "👨‍🦲",
+    "name": "Man: Bald",
+    "shortcodes": [
+      "bald_man"
+    ],
+    "keywords": [
+      "man",
+      "hairless"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f9b2",
+        "emoji": "👨‍🦲"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f9b2",
+        "emoji": "👨🏻‍🦲"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f9b2",
+        "emoji": "👨🏼‍🦲"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f9b2",
+        "emoji": "👨🏽‍🦲"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f9b2",
+        "emoji": "👨🏾‍🦲"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f9b2",
+        "emoji": "👨🏿‍🦲"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "👩",
+    "name": "Woman",
+    "shortcodes": [
+      "woman"
+    ],
+    "keywords": [
+      "female",
+      "girls",
+      "lady"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469",
+        "emoji": "👩"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb",
+        "emoji": "👩🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc",
+        "emoji": "👩🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd",
+        "emoji": "👩🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe",
+        "emoji": "👩🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff",
+        "emoji": "👩🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👩‍🦰",
+    "name": "Woman: Red Hair",
+    "shortcodes": [
+      "red_haired_woman"
+    ],
+    "keywords": [
+      "haired",
+      "woman",
+      "hairstyle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f9b0",
+        "emoji": "👩‍🦰"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f9b0",
+        "emoji": "👩🏻‍🦰"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f9b0",
+        "emoji": "👩🏼‍🦰"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f9b0",
+        "emoji": "👩🏽‍🦰"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f9b0",
+        "emoji": "👩🏾‍🦰"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f9b0",
+        "emoji": "👩🏿‍🦰"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🧑‍🦰",
+    "name": "Person: Red Hair",
+    "shortcodes": [
+      "red_haired_person"
+    ],
+    "keywords": [
+      "haired",
+      "person",
+      "hairstyle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f9b0",
+        "emoji": "🧑‍🦰"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f9b0",
+        "emoji": "🧑🏻‍🦰"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f9b0",
+        "emoji": "🧑🏼‍🦰"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f9b0",
+        "emoji": "🧑🏽‍🦰"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f9b0",
+        "emoji": "🧑🏾‍🦰"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f9b0",
+        "emoji": "🧑🏿‍🦰"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👩‍🦱",
+    "name": "Woman: Curly Hair",
+    "shortcodes": [
+      "curly_haired_woman"
+    ],
+    "keywords": [
+      "haired",
+      "woman",
+      "hairstyle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f9b1",
+        "emoji": "👩‍🦱"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f9b1",
+        "emoji": "👩🏻‍🦱"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f9b1",
+        "emoji": "👩🏼‍🦱"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f9b1",
+        "emoji": "👩🏽‍🦱"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f9b1",
+        "emoji": "👩🏾‍🦱"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f9b1",
+        "emoji": "👩🏿‍🦱"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🧑‍🦱",
+    "name": "Person: Curly Hair",
+    "shortcodes": [
+      "curly_haired_person"
+    ],
+    "keywords": [
+      "haired",
+      "person",
+      "hairstyle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f9b1",
+        "emoji": "🧑‍🦱"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f9b1",
+        "emoji": "🧑🏻‍🦱"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f9b1",
+        "emoji": "🧑🏼‍🦱"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f9b1",
+        "emoji": "🧑🏽‍🦱"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f9b1",
+        "emoji": "🧑🏾‍🦱"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f9b1",
+        "emoji": "🧑🏿‍🦱"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👩‍🦳",
+    "name": "Woman: White Hair",
+    "shortcodes": [
+      "white_haired_woman"
+    ],
+    "keywords": [
+      "haired",
+      "woman",
+      "old",
+      "elder"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f9b3",
+        "emoji": "👩‍🦳"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f9b3",
+        "emoji": "👩🏻‍🦳"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f9b3",
+        "emoji": "👩🏼‍🦳"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f9b3",
+        "emoji": "👩🏽‍🦳"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f9b3",
+        "emoji": "👩🏾‍🦳"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f9b3",
+        "emoji": "👩🏿‍🦳"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🧑‍🦳",
+    "name": "Person: White Hair",
+    "shortcodes": [
+      "white_haired_person"
+    ],
+    "keywords": [
+      "haired",
+      "person",
+      "elder",
+      "old"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f9b3",
+        "emoji": "🧑‍🦳"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f9b3",
+        "emoji": "🧑🏻‍🦳"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f9b3",
+        "emoji": "🧑🏼‍🦳"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f9b3",
+        "emoji": "🧑🏽‍🦳"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f9b3",
+        "emoji": "🧑🏾‍🦳"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f9b3",
+        "emoji": "🧑🏿‍🦳"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👩‍🦲",
+    "name": "Woman: Bald",
+    "shortcodes": [
+      "bald_woman"
+    ],
+    "keywords": [
+      "woman",
+      "hairless"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f9b2",
+        "emoji": "👩‍🦲"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f9b2",
+        "emoji": "👩🏻‍🦲"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f9b2",
+        "emoji": "👩🏼‍🦲"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f9b2",
+        "emoji": "👩🏽‍🦲"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f9b2",
+        "emoji": "👩🏾‍🦲"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f9b2",
+        "emoji": "👩🏿‍🦲"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🧑‍🦲",
+    "name": "Person: Bald",
+    "shortcodes": [
+      "bald_person"
+    ],
+    "keywords": [
+      "person",
+      "hairless"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f9b2",
+        "emoji": "🧑‍🦲"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f9b2",
+        "emoji": "🧑🏻‍🦲"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f9b2",
+        "emoji": "🧑🏼‍🦲"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f9b2",
+        "emoji": "🧑🏽‍🦲"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f9b2",
+        "emoji": "🧑🏾‍🦲"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f9b2",
+        "emoji": "🧑🏿‍🦲"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👱‍♀️",
+    "name": "Woman: Blond Hair",
+    "shortcodes": [
+      "blond-haired-woman"
+    ],
+    "keywords": [
+      "haired-woman",
+      "woman",
+      "female",
+      "girl",
+      "blonde",
+      "person"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f471-200d-2640-fe0f",
+        "emoji": "👱‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f471-1f3fb-200d-2640-fe0f",
+        "emoji": "👱🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f471-1f3fc-200d-2640-fe0f",
+        "emoji": "👱🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f471-1f3fd-200d-2640-fe0f",
+        "emoji": "👱🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f471-1f3fe-200d-2640-fe0f",
+        "emoji": "👱🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f471-1f3ff-200d-2640-fe0f",
+        "emoji": "👱🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👱‍♂️",
+    "name": "Man: Blond Hair",
+    "shortcodes": [
+      "blond-haired-man"
+    ],
+    "keywords": [
+      "haired-man",
+      "man",
+      "male",
+      "boy",
+      "blonde",
+      "guy",
+      "person"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f471-200d-2642-fe0f",
+        "emoji": "👱‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f471-1f3fb-200d-2642-fe0f",
+        "emoji": "👱🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f471-1f3fc-200d-2642-fe0f",
+        "emoji": "👱🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f471-1f3fd-200d-2642-fe0f",
+        "emoji": "👱🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f471-1f3fe-200d-2642-fe0f",
+        "emoji": "👱🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f471-1f3ff-200d-2642-fe0f",
+        "emoji": "👱🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧓",
+    "name": "Older Adult",
+    "shortcodes": [
+      "older_adult"
+    ],
+    "keywords": [
+      "person",
+      "human",
+      "elder",
+      "senior",
+      "gender",
+      "neutral"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d3",
+        "emoji": "🧓"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d3-1f3fb",
+        "emoji": "🧓🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d3-1f3fc",
+        "emoji": "🧓🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d3-1f3fd",
+        "emoji": "🧓🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d3-1f3fe",
+        "emoji": "🧓🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d3-1f3ff",
+        "emoji": "🧓🏿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "👴",
+    "name": "Old Man",
+    "shortcodes": [
+      "older_man"
+    ],
+    "keywords": [
+      "older",
+      "human",
+      "male",
+      "men",
+      "elder",
+      "senior"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f474",
+        "emoji": "👴"
+      },
+      {
+        "tone": "light",
+        "unified": "1f474-1f3fb",
+        "emoji": "👴🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f474-1f3fc",
+        "emoji": "👴🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f474-1f3fd",
+        "emoji": "👴🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f474-1f3fe",
+        "emoji": "👴🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f474-1f3ff",
+        "emoji": "👴🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👵",
+    "name": "Old Woman",
+    "shortcodes": [
+      "older_woman"
+    ],
+    "keywords": [
+      "older",
+      "human",
+      "female",
+      "women",
+      "lady",
+      "elder",
+      "senior"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f475",
+        "emoji": "👵"
+      },
+      {
+        "tone": "light",
+        "unified": "1f475-1f3fb",
+        "emoji": "👵🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f475-1f3fc",
+        "emoji": "👵🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f475-1f3fd",
+        "emoji": "👵🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f475-1f3fe",
+        "emoji": "👵🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f475-1f3ff",
+        "emoji": "👵🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🙍",
+    "name": "Person Frowning",
+    "shortcodes": [
+      "person_frowning"
+    ],
+    "keywords": [
+      "worried"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f64d",
+        "emoji": "🙍"
+      },
+      {
+        "tone": "light",
+        "unified": "1f64d-1f3fb",
+        "emoji": "🙍🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f64d-1f3fc",
+        "emoji": "🙍🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f64d-1f3fd",
+        "emoji": "🙍🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f64d-1f3fe",
+        "emoji": "🙍🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f64d-1f3ff",
+        "emoji": "🙍🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🙍‍♂️",
+    "name": "Man Frowning",
+    "shortcodes": [
+      "man-frowning"
+    ],
+    "keywords": [
+      "male",
+      "boy",
+      "sad",
+      "depressed",
+      "discouraged",
+      "unhappy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f64d-200d-2642-fe0f",
+        "emoji": "🙍‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f64d-1f3fb-200d-2642-fe0f",
+        "emoji": "🙍🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f64d-1f3fc-200d-2642-fe0f",
+        "emoji": "🙍🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f64d-1f3fd-200d-2642-fe0f",
+        "emoji": "🙍🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f64d-1f3fe-200d-2642-fe0f",
+        "emoji": "🙍🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f64d-1f3ff-200d-2642-fe0f",
+        "emoji": "🙍🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🙍‍♀️",
+    "name": "Woman Frowning",
+    "shortcodes": [
+      "woman-frowning"
+    ],
+    "keywords": [
+      "female",
+      "girl",
+      "sad",
+      "depressed",
+      "discouraged",
+      "unhappy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f64d-200d-2640-fe0f",
+        "emoji": "🙍‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f64d-1f3fb-200d-2640-fe0f",
+        "emoji": "🙍🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f64d-1f3fc-200d-2640-fe0f",
+        "emoji": "🙍🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f64d-1f3fd-200d-2640-fe0f",
+        "emoji": "🙍🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f64d-1f3fe-200d-2640-fe0f",
+        "emoji": "🙍🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f64d-1f3ff-200d-2640-fe0f",
+        "emoji": "🙍🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🙎",
+    "name": "Person Pouting",
+    "shortcodes": [
+      "person_with_pouting_face"
+    ],
+    "keywords": [
+      "with",
+      "face",
+      "upset"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f64e",
+        "emoji": "🙎"
+      },
+      {
+        "tone": "light",
+        "unified": "1f64e-1f3fb",
+        "emoji": "🙎🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f64e-1f3fc",
+        "emoji": "🙎🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f64e-1f3fd",
+        "emoji": "🙎🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f64e-1f3fe",
+        "emoji": "🙎🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f64e-1f3ff",
+        "emoji": "🙎🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🙎‍♂️",
+    "name": "Man Pouting",
+    "shortcodes": [
+      "man-pouting"
+    ],
+    "keywords": [
+      "male",
+      "boy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f64e-200d-2642-fe0f",
+        "emoji": "🙎‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f64e-1f3fb-200d-2642-fe0f",
+        "emoji": "🙎🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f64e-1f3fc-200d-2642-fe0f",
+        "emoji": "🙎🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f64e-1f3fd-200d-2642-fe0f",
+        "emoji": "🙎🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f64e-1f3fe-200d-2642-fe0f",
+        "emoji": "🙎🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f64e-1f3ff-200d-2642-fe0f",
+        "emoji": "🙎🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🙎‍♀️",
+    "name": "Woman Pouting",
+    "shortcodes": [
+      "woman-pouting"
+    ],
+    "keywords": [
+      "female",
+      "girl"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f64e-200d-2640-fe0f",
+        "emoji": "🙎‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f64e-1f3fb-200d-2640-fe0f",
+        "emoji": "🙎🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f64e-1f3fc-200d-2640-fe0f",
+        "emoji": "🙎🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f64e-1f3fd-200d-2640-fe0f",
+        "emoji": "🙎🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f64e-1f3fe-200d-2640-fe0f",
+        "emoji": "🙎🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f64e-1f3ff-200d-2640-fe0f",
+        "emoji": "🙎🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🙅",
+    "name": "Person Gesturing No",
+    "shortcodes": [
+      "no_good"
+    ],
+    "keywords": [
+      "good",
+      "decline"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f645",
+        "emoji": "🙅"
+      },
+      {
+        "tone": "light",
+        "unified": "1f645-1f3fb",
+        "emoji": "🙅🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f645-1f3fc",
+        "emoji": "🙅🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f645-1f3fd",
+        "emoji": "🙅🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f645-1f3fe",
+        "emoji": "🙅🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f645-1f3ff",
+        "emoji": "🙅🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🙅‍♂️",
+    "name": "Man Gesturing No",
+    "shortcodes": [
+      "man-gesturing-no"
+    ],
+    "keywords": [
+      "gesturing-no",
+      "male",
+      "boy",
+      "nope"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f645-200d-2642-fe0f",
+        "emoji": "🙅‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f645-1f3fb-200d-2642-fe0f",
+        "emoji": "🙅🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f645-1f3fc-200d-2642-fe0f",
+        "emoji": "🙅🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f645-1f3fd-200d-2642-fe0f",
+        "emoji": "🙅🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f645-1f3fe-200d-2642-fe0f",
+        "emoji": "🙅🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f645-1f3ff-200d-2642-fe0f",
+        "emoji": "🙅🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🙅‍♀️",
+    "name": "Woman Gesturing No",
+    "shortcodes": [
+      "woman-gesturing-no"
+    ],
+    "keywords": [
+      "gesturing-no",
+      "female",
+      "girl",
+      "nope"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f645-200d-2640-fe0f",
+        "emoji": "🙅‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f645-1f3fb-200d-2640-fe0f",
+        "emoji": "🙅🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f645-1f3fc-200d-2640-fe0f",
+        "emoji": "🙅🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f645-1f3fd-200d-2640-fe0f",
+        "emoji": "🙅🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f645-1f3fe-200d-2640-fe0f",
+        "emoji": "🙅🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f645-1f3ff-200d-2640-fe0f",
+        "emoji": "🙅🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🙆",
+    "name": "Person Gesturing Ok",
+    "shortcodes": [
+      "ok_woman"
+    ],
+    "keywords": [
+      "woman",
+      "agree"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f646",
+        "emoji": "🙆"
+      },
+      {
+        "tone": "light",
+        "unified": "1f646-1f3fb",
+        "emoji": "🙆🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f646-1f3fc",
+        "emoji": "🙆🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f646-1f3fd",
+        "emoji": "🙆🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f646-1f3fe",
+        "emoji": "🙆🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f646-1f3ff",
+        "emoji": "🙆🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🙆‍♂️",
+    "name": "Man Gesturing Ok",
+    "shortcodes": [
+      "man-gesturing-ok"
+    ],
+    "keywords": [
+      "gesturing-ok",
+      "men",
+      "boy",
+      "male",
+      "blue",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f646-200d-2642-fe0f",
+        "emoji": "🙆‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f646-1f3fb-200d-2642-fe0f",
+        "emoji": "🙆🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f646-1f3fc-200d-2642-fe0f",
+        "emoji": "🙆🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f646-1f3fd-200d-2642-fe0f",
+        "emoji": "🙆🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f646-1f3fe-200d-2642-fe0f",
+        "emoji": "🙆🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f646-1f3ff-200d-2642-fe0f",
+        "emoji": "🙆🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🙆‍♀️",
+    "name": "Woman Gesturing Ok",
+    "shortcodes": [
+      "woman-gesturing-ok"
+    ],
+    "keywords": [
+      "gesturing-ok",
+      "women",
+      "girl",
+      "female",
+      "pink",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f646-200d-2640-fe0f",
+        "emoji": "🙆‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f646-1f3fb-200d-2640-fe0f",
+        "emoji": "🙆🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f646-1f3fc-200d-2640-fe0f",
+        "emoji": "🙆🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f646-1f3fd-200d-2640-fe0f",
+        "emoji": "🙆🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f646-1f3fe-200d-2640-fe0f",
+        "emoji": "🙆🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f646-1f3ff-200d-2640-fe0f",
+        "emoji": "🙆🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "💁",
+    "name": "Person Tipping Hand",
+    "shortcodes": [
+      "information_desk_person"
+    ],
+    "keywords": [
+      "information",
+      "desk"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f481",
+        "emoji": "💁"
+      },
+      {
+        "tone": "light",
+        "unified": "1f481-1f3fb",
+        "emoji": "💁🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f481-1f3fc",
+        "emoji": "💁🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f481-1f3fd",
+        "emoji": "💁🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f481-1f3fe",
+        "emoji": "💁🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f481-1f3ff",
+        "emoji": "💁🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💁‍♂️",
+    "name": "Man Tipping Hand",
+    "shortcodes": [
+      "man-tipping-hand"
+    ],
+    "keywords": [
+      "tipping-hand",
+      "male",
+      "boy",
+      "human",
+      "information"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f481-200d-2642-fe0f",
+        "emoji": "💁‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f481-1f3fb-200d-2642-fe0f",
+        "emoji": "💁🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f481-1f3fc-200d-2642-fe0f",
+        "emoji": "💁🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f481-1f3fd-200d-2642-fe0f",
+        "emoji": "💁🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f481-1f3fe-200d-2642-fe0f",
+        "emoji": "💁🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f481-1f3ff-200d-2642-fe0f",
+        "emoji": "💁🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "💁‍♀️",
+    "name": "Woman Tipping Hand",
+    "shortcodes": [
+      "woman-tipping-hand"
+    ],
+    "keywords": [
+      "tipping-hand",
+      "female",
+      "girl",
+      "human",
+      "information"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f481-200d-2640-fe0f",
+        "emoji": "💁‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f481-1f3fb-200d-2640-fe0f",
+        "emoji": "💁🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f481-1f3fc-200d-2640-fe0f",
+        "emoji": "💁🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f481-1f3fd-200d-2640-fe0f",
+        "emoji": "💁🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f481-1f3fe-200d-2640-fe0f",
+        "emoji": "💁🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f481-1f3ff-200d-2640-fe0f",
+        "emoji": "💁🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🙋",
+    "name": "Person Raising Hand",
+    "shortcodes": [
+      "raising_hand"
+    ],
+    "keywords": [
+      "question"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f64b",
+        "emoji": "🙋"
+      },
+      {
+        "tone": "light",
+        "unified": "1f64b-1f3fb",
+        "emoji": "🙋🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f64b-1f3fc",
+        "emoji": "🙋🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f64b-1f3fd",
+        "emoji": "🙋🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f64b-1f3fe",
+        "emoji": "🙋🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f64b-1f3ff",
+        "emoji": "🙋🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🙋‍♂️",
+    "name": "Man Raising Hand",
+    "shortcodes": [
+      "man-raising-hand"
+    ],
+    "keywords": [
+      "raising-hand",
+      "male",
+      "boy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f64b-200d-2642-fe0f",
+        "emoji": "🙋‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f64b-1f3fb-200d-2642-fe0f",
+        "emoji": "🙋🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f64b-1f3fc-200d-2642-fe0f",
+        "emoji": "🙋🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f64b-1f3fd-200d-2642-fe0f",
+        "emoji": "🙋🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f64b-1f3fe-200d-2642-fe0f",
+        "emoji": "🙋🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f64b-1f3ff-200d-2642-fe0f",
+        "emoji": "🙋🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🙋‍♀️",
+    "name": "Woman Raising Hand",
+    "shortcodes": [
+      "woman-raising-hand"
+    ],
+    "keywords": [
+      "raising-hand",
+      "female",
+      "girl"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f64b-200d-2640-fe0f",
+        "emoji": "🙋‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f64b-1f3fb-200d-2640-fe0f",
+        "emoji": "🙋🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f64b-1f3fc-200d-2640-fe0f",
+        "emoji": "🙋🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f64b-1f3fd-200d-2640-fe0f",
+        "emoji": "🙋🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f64b-1f3fe-200d-2640-fe0f",
+        "emoji": "🙋🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f64b-1f3ff-200d-2640-fe0f",
+        "emoji": "🙋🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧏",
+    "name": "Deaf Person",
+    "shortcodes": [
+      "deaf_person"
+    ],
+    "keywords": [
+      "accessibility"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9cf",
+        "emoji": "🧏"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9cf-1f3fb",
+        "emoji": "🧏🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9cf-1f3fc",
+        "emoji": "🧏🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9cf-1f3fd",
+        "emoji": "🧏🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9cf-1f3fe",
+        "emoji": "🧏🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9cf-1f3ff",
+        "emoji": "🧏🏿"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🧏‍♂️",
+    "name": "Deaf Man",
+    "shortcodes": [
+      "deaf_man"
+    ],
+    "keywords": [
+      "accessibility"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9cf-200d-2642-fe0f",
+        "emoji": "🧏‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9cf-1f3fb-200d-2642-fe0f",
+        "emoji": "🧏🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9cf-1f3fc-200d-2642-fe0f",
+        "emoji": "🧏🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9cf-1f3fd-200d-2642-fe0f",
+        "emoji": "🧏🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9cf-1f3fe-200d-2642-fe0f",
+        "emoji": "🧏🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9cf-1f3ff-200d-2642-fe0f",
+        "emoji": "🧏🏿‍♂️"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🧏‍♀️",
+    "name": "Deaf Woman",
+    "shortcodes": [
+      "deaf_woman"
+    ],
+    "keywords": [
+      "accessibility"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9cf-200d-2640-fe0f",
+        "emoji": "🧏‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9cf-1f3fb-200d-2640-fe0f",
+        "emoji": "🧏🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9cf-1f3fc-200d-2640-fe0f",
+        "emoji": "🧏🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9cf-1f3fd-200d-2640-fe0f",
+        "emoji": "🧏🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9cf-1f3fe-200d-2640-fe0f",
+        "emoji": "🧏🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9cf-1f3ff-200d-2640-fe0f",
+        "emoji": "🧏🏿‍♀️"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🙇",
+    "name": "Person Bowing",
+    "shortcodes": [
+      "bow"
+    ],
+    "keywords": [
+      "bow",
+      "respectiful"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f647",
+        "emoji": "🙇"
+      },
+      {
+        "tone": "light",
+        "unified": "1f647-1f3fb",
+        "emoji": "🙇🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f647-1f3fc",
+        "emoji": "🙇🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f647-1f3fd",
+        "emoji": "🙇🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f647-1f3fe",
+        "emoji": "🙇🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f647-1f3ff",
+        "emoji": "🙇🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🙇‍♂️",
+    "name": "Man Bowing",
+    "shortcodes": [
+      "man-bowing"
+    ],
+    "keywords": [
+      "male",
+      "boy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f647-200d-2642-fe0f",
+        "emoji": "🙇‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f647-1f3fb-200d-2642-fe0f",
+        "emoji": "🙇🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f647-1f3fc-200d-2642-fe0f",
+        "emoji": "🙇🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f647-1f3fd-200d-2642-fe0f",
+        "emoji": "🙇🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f647-1f3fe-200d-2642-fe0f",
+        "emoji": "🙇🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f647-1f3ff-200d-2642-fe0f",
+        "emoji": "🙇🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🙇‍♀️",
+    "name": "Woman Bowing",
+    "shortcodes": [
+      "woman-bowing"
+    ],
+    "keywords": [
+      "female",
+      "girl"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f647-200d-2640-fe0f",
+        "emoji": "🙇‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f647-1f3fb-200d-2640-fe0f",
+        "emoji": "🙇🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f647-1f3fc-200d-2640-fe0f",
+        "emoji": "🙇🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f647-1f3fd-200d-2640-fe0f",
+        "emoji": "🙇🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f647-1f3fe-200d-2640-fe0f",
+        "emoji": "🙇🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f647-1f3ff-200d-2640-fe0f",
+        "emoji": "🙇🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🤦",
+    "name": "Face Palm",
+    "shortcodes": [
+      "face_palm"
+    ],
+    "keywords": [
+      "person",
+      "facepalming",
+      "disappointed"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f926",
+        "emoji": "🤦"
+      },
+      {
+        "tone": "light",
+        "unified": "1f926-1f3fb",
+        "emoji": "🤦🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f926-1f3fc",
+        "emoji": "🤦🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f926-1f3fd",
+        "emoji": "🤦🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f926-1f3fe",
+        "emoji": "🤦🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f926-1f3ff",
+        "emoji": "🤦🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🤦‍♂️",
+    "name": "Man Facepalming",
+    "shortcodes": [
+      "man-facepalming"
+    ],
+    "keywords": [
+      "male",
+      "boy",
+      "disbelief"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f926-200d-2642-fe0f",
+        "emoji": "🤦‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f926-1f3fb-200d-2642-fe0f",
+        "emoji": "🤦🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f926-1f3fc-200d-2642-fe0f",
+        "emoji": "🤦🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f926-1f3fd-200d-2642-fe0f",
+        "emoji": "🤦🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f926-1f3fe-200d-2642-fe0f",
+        "emoji": "🤦🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f926-1f3ff-200d-2642-fe0f",
+        "emoji": "🤦🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🤦‍♀️",
+    "name": "Woman Facepalming",
+    "shortcodes": [
+      "woman-facepalming"
+    ],
+    "keywords": [
+      "female",
+      "girl",
+      "disbelief"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f926-200d-2640-fe0f",
+        "emoji": "🤦‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f926-1f3fb-200d-2640-fe0f",
+        "emoji": "🤦🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f926-1f3fc-200d-2640-fe0f",
+        "emoji": "🤦🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f926-1f3fd-200d-2640-fe0f",
+        "emoji": "🤦🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f926-1f3fe-200d-2640-fe0f",
+        "emoji": "🤦🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f926-1f3ff-200d-2640-fe0f",
+        "emoji": "🤦🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🤷",
+    "name": "Shrug",
+    "shortcodes": [
+      "shrug"
+    ],
+    "keywords": [
+      "person",
+      "shrugging",
+      "regardless"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f937",
+        "emoji": "🤷"
+      },
+      {
+        "tone": "light",
+        "unified": "1f937-1f3fb",
+        "emoji": "🤷🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f937-1f3fc",
+        "emoji": "🤷🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f937-1f3fd",
+        "emoji": "🤷🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f937-1f3fe",
+        "emoji": "🤷🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f937-1f3ff",
+        "emoji": "🤷🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🤷‍♂️",
+    "name": "Man Shrugging",
+    "shortcodes": [
+      "man-shrugging"
+    ],
+    "keywords": [
+      "male",
+      "boy",
+      "confused",
+      "indifferent",
+      "doubt"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f937-200d-2642-fe0f",
+        "emoji": "🤷‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f937-1f3fb-200d-2642-fe0f",
+        "emoji": "🤷🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f937-1f3fc-200d-2642-fe0f",
+        "emoji": "🤷🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f937-1f3fd-200d-2642-fe0f",
+        "emoji": "🤷🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f937-1f3fe-200d-2642-fe0f",
+        "emoji": "🤷🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f937-1f3ff-200d-2642-fe0f",
+        "emoji": "🤷🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🤷‍♀️",
+    "name": "Woman Shrugging",
+    "shortcodes": [
+      "woman-shrugging"
+    ],
+    "keywords": [
+      "female",
+      "girl",
+      "confused",
+      "indifferent",
+      "doubt"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f937-200d-2640-fe0f",
+        "emoji": "🤷‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f937-1f3fb-200d-2640-fe0f",
+        "emoji": "🤷🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f937-1f3fc-200d-2640-fe0f",
+        "emoji": "🤷🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f937-1f3fd-200d-2640-fe0f",
+        "emoji": "🤷🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f937-1f3fe-200d-2640-fe0f",
+        "emoji": "🤷🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f937-1f3ff-200d-2640-fe0f",
+        "emoji": "🤷🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧑‍⚕️",
+    "name": "Health Worker",
+    "shortcodes": [
+      "health_worker"
+    ],
+    "keywords": [
+      "hospital"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-2695-fe0f",
+        "emoji": "🧑‍⚕️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-2695-fe0f",
+        "emoji": "🧑🏻‍⚕️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-2695-fe0f",
+        "emoji": "🧑🏼‍⚕️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-2695-fe0f",
+        "emoji": "🧑🏽‍⚕️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-2695-fe0f",
+        "emoji": "🧑🏾‍⚕️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-2695-fe0f",
+        "emoji": "🧑🏿‍⚕️"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍⚕️",
+    "name": "Man Health Worker",
+    "shortcodes": [
+      "male-doctor"
+    ],
+    "keywords": [
+      "male",
+      "doctor",
+      "nurse",
+      "therapist",
+      "healthcare",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-2695-fe0f",
+        "emoji": "👨‍⚕️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-2695-fe0f",
+        "emoji": "👨🏻‍⚕️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-2695-fe0f",
+        "emoji": "👨🏼‍⚕️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-2695-fe0f",
+        "emoji": "👨🏽‍⚕️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-2695-fe0f",
+        "emoji": "👨🏾‍⚕️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-2695-fe0f",
+        "emoji": "👨🏿‍⚕️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍⚕️",
+    "name": "Woman Health Worker",
+    "shortcodes": [
+      "female-doctor"
+    ],
+    "keywords": [
+      "female",
+      "doctor",
+      "nurse",
+      "therapist",
+      "healthcare",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-2695-fe0f",
+        "emoji": "👩‍⚕️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-2695-fe0f",
+        "emoji": "👩🏻‍⚕️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-2695-fe0f",
+        "emoji": "👩🏼‍⚕️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-2695-fe0f",
+        "emoji": "👩🏽‍⚕️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-2695-fe0f",
+        "emoji": "👩🏾‍⚕️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-2695-fe0f",
+        "emoji": "👩🏿‍⚕️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧑‍🎓",
+    "name": "Student",
+    "shortcodes": [
+      "student"
+    ],
+    "keywords": [
+      "learn"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f393",
+        "emoji": "🧑‍🎓"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f393",
+        "emoji": "🧑🏻‍🎓"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f393",
+        "emoji": "🧑🏼‍🎓"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f393",
+        "emoji": "🧑🏽‍🎓"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f393",
+        "emoji": "🧑🏾‍🎓"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f393",
+        "emoji": "🧑🏿‍🎓"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍🎓",
+    "name": "Man Student",
+    "shortcodes": [
+      "male-student"
+    ],
+    "keywords": [
+      "male",
+      "graduate",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f393",
+        "emoji": "👨‍🎓"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f393",
+        "emoji": "👨🏻‍🎓"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f393",
+        "emoji": "👨🏼‍🎓"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f393",
+        "emoji": "👨🏽‍🎓"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f393",
+        "emoji": "👨🏾‍🎓"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f393",
+        "emoji": "👨🏿‍🎓"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍🎓",
+    "name": "Woman Student",
+    "shortcodes": [
+      "female-student"
+    ],
+    "keywords": [
+      "female",
+      "graduate",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f393",
+        "emoji": "👩‍🎓"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f393",
+        "emoji": "👩🏻‍🎓"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f393",
+        "emoji": "👩🏼‍🎓"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f393",
+        "emoji": "👩🏽‍🎓"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f393",
+        "emoji": "👩🏾‍🎓"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f393",
+        "emoji": "👩🏿‍🎓"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧑‍🏫",
+    "name": "Teacher",
+    "shortcodes": [
+      "teacher"
+    ],
+    "keywords": [
+      "professor"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f3eb",
+        "emoji": "🧑‍🏫"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f3eb",
+        "emoji": "🧑🏻‍🏫"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f3eb",
+        "emoji": "🧑🏼‍🏫"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f3eb",
+        "emoji": "🧑🏽‍🏫"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f3eb",
+        "emoji": "🧑🏾‍🏫"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f3eb",
+        "emoji": "🧑🏿‍🏫"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍🏫",
+    "name": "Man Teacher",
+    "shortcodes": [
+      "male-teacher"
+    ],
+    "keywords": [
+      "male",
+      "instructor",
+      "professor",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f3eb",
+        "emoji": "👨‍🏫"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f3eb",
+        "emoji": "👨🏻‍🏫"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f3eb",
+        "emoji": "👨🏼‍🏫"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f3eb",
+        "emoji": "👨🏽‍🏫"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f3eb",
+        "emoji": "👨🏾‍🏫"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f3eb",
+        "emoji": "👨🏿‍🏫"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍🏫",
+    "name": "Woman Teacher",
+    "shortcodes": [
+      "female-teacher"
+    ],
+    "keywords": [
+      "female",
+      "instructor",
+      "professor",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f3eb",
+        "emoji": "👩‍🏫"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f3eb",
+        "emoji": "👩🏻‍🏫"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f3eb",
+        "emoji": "👩🏼‍🏫"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f3eb",
+        "emoji": "👩🏽‍🏫"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f3eb",
+        "emoji": "👩🏾‍🏫"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f3eb",
+        "emoji": "👩🏿‍🏫"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧑‍⚖️",
+    "name": "Judge",
+    "shortcodes": [
+      "judge"
+    ],
+    "keywords": [
+      "law"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-2696-fe0f",
+        "emoji": "🧑‍⚖️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-2696-fe0f",
+        "emoji": "🧑🏻‍⚖️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-2696-fe0f",
+        "emoji": "🧑🏼‍⚖️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-2696-fe0f",
+        "emoji": "🧑🏽‍⚖️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-2696-fe0f",
+        "emoji": "🧑🏾‍⚖️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-2696-fe0f",
+        "emoji": "🧑🏿‍⚖️"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍⚖️",
+    "name": "Man Judge",
+    "shortcodes": [
+      "male-judge"
+    ],
+    "keywords": [
+      "male",
+      "justice",
+      "court",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-2696-fe0f",
+        "emoji": "👨‍⚖️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-2696-fe0f",
+        "emoji": "👨🏻‍⚖️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-2696-fe0f",
+        "emoji": "👨🏼‍⚖️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-2696-fe0f",
+        "emoji": "👨🏽‍⚖️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-2696-fe0f",
+        "emoji": "👨🏾‍⚖️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-2696-fe0f",
+        "emoji": "👨🏿‍⚖️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍⚖️",
+    "name": "Woman Judge",
+    "shortcodes": [
+      "female-judge"
+    ],
+    "keywords": [
+      "female",
+      "justice",
+      "court",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-2696-fe0f",
+        "emoji": "👩‍⚖️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-2696-fe0f",
+        "emoji": "👩🏻‍⚖️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-2696-fe0f",
+        "emoji": "👩🏼‍⚖️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-2696-fe0f",
+        "emoji": "👩🏽‍⚖️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-2696-fe0f",
+        "emoji": "👩🏾‍⚖️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-2696-fe0f",
+        "emoji": "👩🏿‍⚖️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧑‍🌾",
+    "name": "Farmer",
+    "shortcodes": [
+      "farmer"
+    ],
+    "keywords": [
+      "crops"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f33e",
+        "emoji": "🧑‍🌾"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f33e",
+        "emoji": "🧑🏻‍🌾"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f33e",
+        "emoji": "🧑🏼‍🌾"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f33e",
+        "emoji": "🧑🏽‍🌾"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f33e",
+        "emoji": "🧑🏾‍🌾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f33e",
+        "emoji": "🧑🏿‍🌾"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍🌾",
+    "name": "Man Farmer",
+    "shortcodes": [
+      "male-farmer"
+    ],
+    "keywords": [
+      "male",
+      "rancher",
+      "gardener",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f33e",
+        "emoji": "👨‍🌾"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f33e",
+        "emoji": "👨🏻‍🌾"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f33e",
+        "emoji": "👨🏼‍🌾"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f33e",
+        "emoji": "👨🏽‍🌾"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f33e",
+        "emoji": "👨🏾‍🌾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f33e",
+        "emoji": "👨🏿‍🌾"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍🌾",
+    "name": "Woman Farmer",
+    "shortcodes": [
+      "female-farmer"
+    ],
+    "keywords": [
+      "female",
+      "rancher",
+      "gardener",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f33e",
+        "emoji": "👩‍🌾"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f33e",
+        "emoji": "👩🏻‍🌾"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f33e",
+        "emoji": "👩🏼‍🌾"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f33e",
+        "emoji": "👩🏽‍🌾"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f33e",
+        "emoji": "👩🏾‍🌾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f33e",
+        "emoji": "👩🏿‍🌾"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧑‍🍳",
+    "name": "Cook",
+    "shortcodes": [
+      "cook"
+    ],
+    "keywords": [
+      "food",
+      "kitchen",
+      "culinary"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f373",
+        "emoji": "🧑‍🍳"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f373",
+        "emoji": "🧑🏻‍🍳"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f373",
+        "emoji": "🧑🏼‍🍳"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f373",
+        "emoji": "🧑🏽‍🍳"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f373",
+        "emoji": "🧑🏾‍🍳"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f373",
+        "emoji": "🧑🏿‍🍳"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍🍳",
+    "name": "Man Cook",
+    "shortcodes": [
+      "male-cook"
+    ],
+    "keywords": [
+      "male",
+      "chef",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f373",
+        "emoji": "👨‍🍳"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f373",
+        "emoji": "👨🏻‍🍳"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f373",
+        "emoji": "👨🏼‍🍳"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f373",
+        "emoji": "👨🏽‍🍳"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f373",
+        "emoji": "👨🏾‍🍳"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f373",
+        "emoji": "👨🏿‍🍳"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍🍳",
+    "name": "Woman Cook",
+    "shortcodes": [
+      "female-cook"
+    ],
+    "keywords": [
+      "female",
+      "chef",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f373",
+        "emoji": "👩‍🍳"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f373",
+        "emoji": "👩🏻‍🍳"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f373",
+        "emoji": "👩🏼‍🍳"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f373",
+        "emoji": "👩🏽‍🍳"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f373",
+        "emoji": "👩🏾‍🍳"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f373",
+        "emoji": "👩🏿‍🍳"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧑‍🔧",
+    "name": "Mechanic",
+    "shortcodes": [
+      "mechanic"
+    ],
+    "keywords": [
+      "worker",
+      "technician"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f527",
+        "emoji": "🧑‍🔧"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f527",
+        "emoji": "🧑🏻‍🔧"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f527",
+        "emoji": "🧑🏼‍🔧"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f527",
+        "emoji": "🧑🏽‍🔧"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f527",
+        "emoji": "🧑🏾‍🔧"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f527",
+        "emoji": "🧑🏿‍🔧"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍🔧",
+    "name": "Man Mechanic",
+    "shortcodes": [
+      "male-mechanic"
+    ],
+    "keywords": [
+      "male",
+      "plumber",
+      "human",
+      "wrench"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f527",
+        "emoji": "👨‍🔧"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f527",
+        "emoji": "👨🏻‍🔧"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f527",
+        "emoji": "👨🏼‍🔧"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f527",
+        "emoji": "👨🏽‍🔧"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f527",
+        "emoji": "👨🏾‍🔧"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f527",
+        "emoji": "👨🏿‍🔧"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍🔧",
+    "name": "Woman Mechanic",
+    "shortcodes": [
+      "female-mechanic"
+    ],
+    "keywords": [
+      "female",
+      "plumber",
+      "human",
+      "wrench"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f527",
+        "emoji": "👩‍🔧"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f527",
+        "emoji": "👩🏻‍🔧"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f527",
+        "emoji": "👩🏼‍🔧"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f527",
+        "emoji": "👩🏽‍🔧"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f527",
+        "emoji": "👩🏾‍🔧"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f527",
+        "emoji": "👩🏿‍🔧"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧑‍🏭",
+    "name": "Factory Worker",
+    "shortcodes": [
+      "factory_worker"
+    ],
+    "keywords": [
+      "labor"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f3ed",
+        "emoji": "🧑‍🏭"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f3ed",
+        "emoji": "🧑🏻‍🏭"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f3ed",
+        "emoji": "🧑🏼‍🏭"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f3ed",
+        "emoji": "🧑🏽‍🏭"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f3ed",
+        "emoji": "🧑🏾‍🏭"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f3ed",
+        "emoji": "🧑🏿‍🏭"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍🏭",
+    "name": "Man Factory Worker",
+    "shortcodes": [
+      "male-factory-worker"
+    ],
+    "keywords": [
+      "male",
+      "factory-worker",
+      "assembly",
+      "industrial",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f3ed",
+        "emoji": "👨‍🏭"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f3ed",
+        "emoji": "👨🏻‍🏭"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f3ed",
+        "emoji": "👨🏼‍🏭"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f3ed",
+        "emoji": "👨🏽‍🏭"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f3ed",
+        "emoji": "👨🏾‍🏭"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f3ed",
+        "emoji": "👨🏿‍🏭"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍🏭",
+    "name": "Woman Factory Worker",
+    "shortcodes": [
+      "female-factory-worker"
+    ],
+    "keywords": [
+      "female",
+      "factory-worker",
+      "assembly",
+      "industrial",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f3ed",
+        "emoji": "👩‍🏭"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f3ed",
+        "emoji": "👩🏻‍🏭"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f3ed",
+        "emoji": "👩🏼‍🏭"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f3ed",
+        "emoji": "👩🏽‍🏭"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f3ed",
+        "emoji": "👩🏾‍🏭"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f3ed",
+        "emoji": "👩🏿‍🏭"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧑‍💼",
+    "name": "Office Worker",
+    "shortcodes": [
+      "office_worker"
+    ],
+    "keywords": [
+      "business"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f4bc",
+        "emoji": "🧑‍💼"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f4bc",
+        "emoji": "🧑🏻‍💼"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f4bc",
+        "emoji": "🧑🏼‍💼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f4bc",
+        "emoji": "🧑🏽‍💼"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f4bc",
+        "emoji": "🧑🏾‍💼"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f4bc",
+        "emoji": "🧑🏿‍💼"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍💼",
+    "name": "Man Office Worker",
+    "shortcodes": [
+      "male-office-worker"
+    ],
+    "keywords": [
+      "male",
+      "office-worker",
+      "business",
+      "manager",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f4bc",
+        "emoji": "👨‍💼"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f4bc",
+        "emoji": "👨🏻‍💼"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f4bc",
+        "emoji": "👨🏼‍💼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f4bc",
+        "emoji": "👨🏽‍💼"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f4bc",
+        "emoji": "👨🏾‍💼"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f4bc",
+        "emoji": "👨🏿‍💼"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍💼",
+    "name": "Woman Office Worker",
+    "shortcodes": [
+      "female-office-worker"
+    ],
+    "keywords": [
+      "female",
+      "office-worker",
+      "business",
+      "manager",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f4bc",
+        "emoji": "👩‍💼"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f4bc",
+        "emoji": "👩🏻‍💼"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f4bc",
+        "emoji": "👩🏼‍💼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f4bc",
+        "emoji": "👩🏽‍💼"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f4bc",
+        "emoji": "👩🏾‍💼"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f4bc",
+        "emoji": "👩🏿‍💼"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧑‍🔬",
+    "name": "Scientist",
+    "shortcodes": [
+      "scientist"
+    ],
+    "keywords": [
+      "chemistry"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f52c",
+        "emoji": "🧑‍🔬"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f52c",
+        "emoji": "🧑🏻‍🔬"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f52c",
+        "emoji": "🧑🏼‍🔬"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f52c",
+        "emoji": "🧑🏽‍🔬"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f52c",
+        "emoji": "🧑🏾‍🔬"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f52c",
+        "emoji": "🧑🏿‍🔬"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍🔬",
+    "name": "Man Scientist",
+    "shortcodes": [
+      "male-scientist"
+    ],
+    "keywords": [
+      "male",
+      "biologist",
+      "chemist",
+      "engineer",
+      "physicist",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f52c",
+        "emoji": "👨‍🔬"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f52c",
+        "emoji": "👨🏻‍🔬"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f52c",
+        "emoji": "👨🏼‍🔬"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f52c",
+        "emoji": "👨🏽‍🔬"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f52c",
+        "emoji": "👨🏾‍🔬"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f52c",
+        "emoji": "👨🏿‍🔬"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍🔬",
+    "name": "Woman Scientist",
+    "shortcodes": [
+      "female-scientist"
+    ],
+    "keywords": [
+      "female",
+      "biologist",
+      "chemist",
+      "engineer",
+      "physicist",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f52c",
+        "emoji": "👩‍🔬"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f52c",
+        "emoji": "👩🏻‍🔬"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f52c",
+        "emoji": "👩🏼‍🔬"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f52c",
+        "emoji": "👩🏽‍🔬"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f52c",
+        "emoji": "👩🏾‍🔬"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f52c",
+        "emoji": "👩🏿‍🔬"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧑‍💻",
+    "name": "Technologist",
+    "shortcodes": [
+      "technologist"
+    ],
+    "keywords": [
+      "computer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f4bb",
+        "emoji": "🧑‍💻"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f4bb",
+        "emoji": "🧑🏻‍💻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f4bb",
+        "emoji": "🧑🏼‍💻"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f4bb",
+        "emoji": "🧑🏽‍💻"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f4bb",
+        "emoji": "🧑🏾‍💻"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f4bb",
+        "emoji": "🧑🏿‍💻"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍💻",
+    "name": "Man Technologist",
+    "shortcodes": [
+      "male-technologist"
+    ],
+    "keywords": [
+      "male",
+      "coder",
+      "developer",
+      "engineer",
+      "programmer",
+      "software",
+      "human",
+      "laptop",
+      "computer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f4bb",
+        "emoji": "👨‍💻"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f4bb",
+        "emoji": "👨🏻‍💻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f4bb",
+        "emoji": "👨🏼‍💻"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f4bb",
+        "emoji": "👨🏽‍💻"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f4bb",
+        "emoji": "👨🏾‍💻"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f4bb",
+        "emoji": "👨🏿‍💻"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍💻",
+    "name": "Woman Technologist",
+    "shortcodes": [
+      "female-technologist"
+    ],
+    "keywords": [
+      "female",
+      "coder",
+      "developer",
+      "engineer",
+      "programmer",
+      "software",
+      "human",
+      "laptop",
+      "computer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f4bb",
+        "emoji": "👩‍💻"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f4bb",
+        "emoji": "👩🏻‍💻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f4bb",
+        "emoji": "👩🏼‍💻"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f4bb",
+        "emoji": "👩🏽‍💻"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f4bb",
+        "emoji": "👩🏾‍💻"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f4bb",
+        "emoji": "👩🏿‍💻"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧑‍🎤",
+    "name": "Singer",
+    "shortcodes": [
+      "singer"
+    ],
+    "keywords": [
+      "song",
+      "artist",
+      "performer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f3a4",
+        "emoji": "🧑‍🎤"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f3a4",
+        "emoji": "🧑🏻‍🎤"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f3a4",
+        "emoji": "🧑🏼‍🎤"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f3a4",
+        "emoji": "🧑🏽‍🎤"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f3a4",
+        "emoji": "🧑🏾‍🎤"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f3a4",
+        "emoji": "🧑🏿‍🎤"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍🎤",
+    "name": "Man Singer",
+    "shortcodes": [
+      "male-singer"
+    ],
+    "keywords": [
+      "male",
+      "rockstar",
+      "entertainer",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f3a4",
+        "emoji": "👨‍🎤"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f3a4",
+        "emoji": "👨🏻‍🎤"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f3a4",
+        "emoji": "👨🏼‍🎤"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f3a4",
+        "emoji": "👨🏽‍🎤"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f3a4",
+        "emoji": "👨🏾‍🎤"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f3a4",
+        "emoji": "👨🏿‍🎤"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍🎤",
+    "name": "Woman Singer",
+    "shortcodes": [
+      "female-singer"
+    ],
+    "keywords": [
+      "female",
+      "rockstar",
+      "entertainer",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f3a4",
+        "emoji": "👩‍🎤"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f3a4",
+        "emoji": "👩🏻‍🎤"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f3a4",
+        "emoji": "👩🏼‍🎤"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f3a4",
+        "emoji": "👩🏽‍🎤"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f3a4",
+        "emoji": "👩🏾‍🎤"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f3a4",
+        "emoji": "👩🏿‍🎤"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧑‍🎨",
+    "name": "Artist",
+    "shortcodes": [
+      "artist"
+    ],
+    "keywords": [
+      "painting",
+      "draw",
+      "creativity"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f3a8",
+        "emoji": "🧑‍🎨"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f3a8",
+        "emoji": "🧑🏻‍🎨"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f3a8",
+        "emoji": "🧑🏼‍🎨"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f3a8",
+        "emoji": "🧑🏽‍🎨"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f3a8",
+        "emoji": "🧑🏾‍🎨"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f3a8",
+        "emoji": "🧑🏿‍🎨"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍🎨",
+    "name": "Man Artist",
+    "shortcodes": [
+      "male-artist"
+    ],
+    "keywords": [
+      "male",
+      "painter",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f3a8",
+        "emoji": "👨‍🎨"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f3a8",
+        "emoji": "👨🏻‍🎨"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f3a8",
+        "emoji": "👨🏼‍🎨"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f3a8",
+        "emoji": "👨🏽‍🎨"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f3a8",
+        "emoji": "👨🏾‍🎨"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f3a8",
+        "emoji": "👨🏿‍🎨"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍🎨",
+    "name": "Woman Artist",
+    "shortcodes": [
+      "female-artist"
+    ],
+    "keywords": [
+      "female",
+      "painter",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f3a8",
+        "emoji": "👩‍🎨"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f3a8",
+        "emoji": "👩🏻‍🎨"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f3a8",
+        "emoji": "👩🏼‍🎨"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f3a8",
+        "emoji": "👩🏽‍🎨"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f3a8",
+        "emoji": "👩🏾‍🎨"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f3a8",
+        "emoji": "👩🏿‍🎨"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧑‍✈️",
+    "name": "Pilot",
+    "shortcodes": [
+      "pilot"
+    ],
+    "keywords": [
+      "fly",
+      "plane",
+      "airplane"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-2708-fe0f",
+        "emoji": "🧑‍✈️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-2708-fe0f",
+        "emoji": "🧑🏻‍✈️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-2708-fe0f",
+        "emoji": "🧑🏼‍✈️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-2708-fe0f",
+        "emoji": "🧑🏽‍✈️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-2708-fe0f",
+        "emoji": "🧑🏾‍✈️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-2708-fe0f",
+        "emoji": "🧑🏿‍✈️"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍✈️",
+    "name": "Man Pilot",
+    "shortcodes": [
+      "male-pilot"
+    ],
+    "keywords": [
+      "male",
+      "aviator",
+      "plane",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-2708-fe0f",
+        "emoji": "👨‍✈️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-2708-fe0f",
+        "emoji": "👨🏻‍✈️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-2708-fe0f",
+        "emoji": "👨🏼‍✈️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-2708-fe0f",
+        "emoji": "👨🏽‍✈️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-2708-fe0f",
+        "emoji": "👨🏾‍✈️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-2708-fe0f",
+        "emoji": "👨🏿‍✈️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍✈️",
+    "name": "Woman Pilot",
+    "shortcodes": [
+      "female-pilot"
+    ],
+    "keywords": [
+      "female",
+      "aviator",
+      "plane",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-2708-fe0f",
+        "emoji": "👩‍✈️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-2708-fe0f",
+        "emoji": "👩🏻‍✈️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-2708-fe0f",
+        "emoji": "👩🏼‍✈️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-2708-fe0f",
+        "emoji": "👩🏽‍✈️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-2708-fe0f",
+        "emoji": "👩🏾‍✈️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-2708-fe0f",
+        "emoji": "👩🏿‍✈️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧑‍🚀",
+    "name": "Astronaut",
+    "shortcodes": [
+      "astronaut"
+    ],
+    "keywords": [
+      "outerspace"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f680",
+        "emoji": "🧑‍🚀"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f680",
+        "emoji": "🧑🏻‍🚀"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f680",
+        "emoji": "🧑🏼‍🚀"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f680",
+        "emoji": "🧑🏽‍🚀"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f680",
+        "emoji": "🧑🏾‍🚀"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f680",
+        "emoji": "🧑🏿‍🚀"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍🚀",
+    "name": "Man Astronaut",
+    "shortcodes": [
+      "male-astronaut"
+    ],
+    "keywords": [
+      "male",
+      "space",
+      "rocket",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f680",
+        "emoji": "👨‍🚀"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f680",
+        "emoji": "👨🏻‍🚀"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f680",
+        "emoji": "👨🏼‍🚀"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f680",
+        "emoji": "👨🏽‍🚀"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f680",
+        "emoji": "👨🏾‍🚀"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f680",
+        "emoji": "👨🏿‍🚀"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍🚀",
+    "name": "Woman Astronaut",
+    "shortcodes": [
+      "female-astronaut"
+    ],
+    "keywords": [
+      "female",
+      "space",
+      "rocket",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f680",
+        "emoji": "👩‍🚀"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f680",
+        "emoji": "👩🏻‍🚀"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f680",
+        "emoji": "👩🏼‍🚀"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f680",
+        "emoji": "👩🏽‍🚀"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f680",
+        "emoji": "👩🏾‍🚀"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f680",
+        "emoji": "👩🏿‍🚀"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧑‍🚒",
+    "name": "Firefighter",
+    "shortcodes": [
+      "firefighter"
+    ],
+    "keywords": [
+      "fire"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f692",
+        "emoji": "🧑‍🚒"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f692",
+        "emoji": "🧑🏻‍🚒"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f692",
+        "emoji": "🧑🏼‍🚒"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f692",
+        "emoji": "🧑🏽‍🚒"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f692",
+        "emoji": "🧑🏾‍🚒"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f692",
+        "emoji": "🧑🏿‍🚒"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍🚒",
+    "name": "Man Firefighter",
+    "shortcodes": [
+      "male-firefighter"
+    ],
+    "keywords": [
+      "male",
+      "fireman",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f692",
+        "emoji": "👨‍🚒"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f692",
+        "emoji": "👨🏻‍🚒"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f692",
+        "emoji": "👨🏼‍🚒"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f692",
+        "emoji": "👨🏽‍🚒"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f692",
+        "emoji": "👨🏾‍🚒"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f692",
+        "emoji": "👨🏿‍🚒"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍🚒",
+    "name": "Woman Firefighter",
+    "shortcodes": [
+      "female-firefighter"
+    ],
+    "keywords": [
+      "female",
+      "fireman",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f692",
+        "emoji": "👩‍🚒"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f692",
+        "emoji": "👩🏻‍🚒"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f692",
+        "emoji": "👩🏼‍🚒"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f692",
+        "emoji": "👩🏽‍🚒"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f692",
+        "emoji": "👩🏾‍🚒"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f692",
+        "emoji": "👩🏿‍🚒"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👮",
+    "name": "Police Officer",
+    "shortcodes": [
+      "cop"
+    ],
+    "keywords": [
+      "cop"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f46e",
+        "emoji": "👮"
+      },
+      {
+        "tone": "light",
+        "unified": "1f46e-1f3fb",
+        "emoji": "👮🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f46e-1f3fc",
+        "emoji": "👮🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f46e-1f3fd",
+        "emoji": "👮🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f46e-1f3fe",
+        "emoji": "👮🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f46e-1f3ff",
+        "emoji": "👮🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👮‍♂️",
+    "name": "Man Police Officer",
+    "shortcodes": [
+      "male-police-officer"
+    ],
+    "keywords": [
+      "male",
+      "police-officer",
+      "law",
+      "legal",
+      "enforcement",
+      "arrest",
+      "911"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f46e-200d-2642-fe0f",
+        "emoji": "👮‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f46e-1f3fb-200d-2642-fe0f",
+        "emoji": "👮🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f46e-1f3fc-200d-2642-fe0f",
+        "emoji": "👮🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f46e-1f3fd-200d-2642-fe0f",
+        "emoji": "👮🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f46e-1f3fe-200d-2642-fe0f",
+        "emoji": "👮🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f46e-1f3ff-200d-2642-fe0f",
+        "emoji": "👮🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👮‍♀️",
+    "name": "Woman Police Officer",
+    "shortcodes": [
+      "female-police-officer"
+    ],
+    "keywords": [
+      "female",
+      "police-officer",
+      "law",
+      "legal",
+      "enforcement",
+      "arrest",
+      "911"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f46e-200d-2640-fe0f",
+        "emoji": "👮‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f46e-1f3fb-200d-2640-fe0f",
+        "emoji": "👮🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f46e-1f3fc-200d-2640-fe0f",
+        "emoji": "👮🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f46e-1f3fd-200d-2640-fe0f",
+        "emoji": "👮🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f46e-1f3fe-200d-2640-fe0f",
+        "emoji": "👮🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f46e-1f3ff-200d-2640-fe0f",
+        "emoji": "👮🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🕵️",
+    "name": "Detective",
+    "shortcodes": [
+      "sleuth_or_spy"
+    ],
+    "keywords": [
+      "sleuth",
+      "or",
+      "spy",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f575-fe0f",
+        "emoji": "🕵️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f575-1f3fb",
+        "emoji": "🕵🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f575-1f3fc",
+        "emoji": "🕵🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f575-1f3fd",
+        "emoji": "🕵🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f575-1f3fe",
+        "emoji": "🕵🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f575-1f3ff",
+        "emoji": "🕵🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕵️‍♂️",
+    "name": "Man Detective",
+    "shortcodes": [
+      "male-detective"
+    ],
+    "keywords": [
+      "male",
+      "crime"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f575-fe0f-200d-2642-fe0f",
+        "emoji": "🕵️‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f575-1f3fb-200d-2642-fe0f",
+        "emoji": "🕵🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f575-1f3fc-200d-2642-fe0f",
+        "emoji": "🕵🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f575-1f3fd-200d-2642-fe0f",
+        "emoji": "🕵🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f575-1f3fe-200d-2642-fe0f",
+        "emoji": "🕵🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f575-1f3ff-200d-2642-fe0f",
+        "emoji": "🕵🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🕵️‍♀️",
+    "name": "Woman Detective",
+    "shortcodes": [
+      "female-detective"
+    ],
+    "keywords": [
+      "female",
+      "human",
+      "spy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f575-fe0f-200d-2640-fe0f",
+        "emoji": "🕵️‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f575-1f3fb-200d-2640-fe0f",
+        "emoji": "🕵🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f575-1f3fc-200d-2640-fe0f",
+        "emoji": "🕵🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f575-1f3fd-200d-2640-fe0f",
+        "emoji": "🕵🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f575-1f3fe-200d-2640-fe0f",
+        "emoji": "🕵🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f575-1f3ff-200d-2640-fe0f",
+        "emoji": "🕵🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "💂",
+    "name": "Guard",
+    "shortcodes": [
+      "guardsman"
+    ],
+    "keywords": [
+      "guardsman",
+      "protect"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f482",
+        "emoji": "💂"
+      },
+      {
+        "tone": "light",
+        "unified": "1f482-1f3fb",
+        "emoji": "💂🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f482-1f3fc",
+        "emoji": "💂🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f482-1f3fd",
+        "emoji": "💂🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f482-1f3fe",
+        "emoji": "💂🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f482-1f3ff",
+        "emoji": "💂🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💂‍♂️",
+    "name": "Man Guard",
+    "shortcodes": [
+      "male-guard"
+    ],
+    "keywords": [
+      "male",
+      "uk",
+      "gb",
+      "british",
+      "guy",
+      "royal"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f482-200d-2642-fe0f",
+        "emoji": "💂‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f482-1f3fb-200d-2642-fe0f",
+        "emoji": "💂🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f482-1f3fc-200d-2642-fe0f",
+        "emoji": "💂🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f482-1f3fd-200d-2642-fe0f",
+        "emoji": "💂🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f482-1f3fe-200d-2642-fe0f",
+        "emoji": "💂🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f482-1f3ff-200d-2642-fe0f",
+        "emoji": "💂🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "💂‍♀️",
+    "name": "Woman Guard",
+    "shortcodes": [
+      "female-guard"
+    ],
+    "keywords": [
+      "female",
+      "uk",
+      "gb",
+      "british",
+      "royal"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f482-200d-2640-fe0f",
+        "emoji": "💂‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f482-1f3fb-200d-2640-fe0f",
+        "emoji": "💂🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f482-1f3fc-200d-2640-fe0f",
+        "emoji": "💂🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f482-1f3fd-200d-2640-fe0f",
+        "emoji": "💂🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f482-1f3fe-200d-2640-fe0f",
+        "emoji": "💂🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f482-1f3ff-200d-2640-fe0f",
+        "emoji": "💂🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🥷",
+    "name": "Ninja",
+    "shortcodes": [
+      "ninja"
+    ],
+    "keywords": [
+      "ninjutsu",
+      "skills",
+      "japanese"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f977",
+        "emoji": "🥷"
+      },
+      {
+        "tone": "light",
+        "unified": "1f977-1f3fb",
+        "emoji": "🥷🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f977-1f3fc",
+        "emoji": "🥷🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f977-1f3fd",
+        "emoji": "🥷🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f977-1f3fe",
+        "emoji": "🥷🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f977-1f3ff",
+        "emoji": "🥷🏿"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "👷",
+    "name": "Construction Worker",
+    "shortcodes": [
+      "construction_worker"
+    ],
+    "keywords": [
+      "labor",
+      "build"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f477",
+        "emoji": "👷"
+      },
+      {
+        "tone": "light",
+        "unified": "1f477-1f3fb",
+        "emoji": "👷🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f477-1f3fc",
+        "emoji": "👷🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f477-1f3fd",
+        "emoji": "👷🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f477-1f3fe",
+        "emoji": "👷🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f477-1f3ff",
+        "emoji": "👷🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👷‍♂️",
+    "name": "Man Construction Worker",
+    "shortcodes": [
+      "male-construction-worker"
+    ],
+    "keywords": [
+      "male",
+      "construction-worker",
+      "human",
+      "wip",
+      "guy",
+      "build",
+      "labor"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f477-200d-2642-fe0f",
+        "emoji": "👷‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f477-1f3fb-200d-2642-fe0f",
+        "emoji": "👷🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f477-1f3fc-200d-2642-fe0f",
+        "emoji": "👷🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f477-1f3fd-200d-2642-fe0f",
+        "emoji": "👷🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f477-1f3fe-200d-2642-fe0f",
+        "emoji": "👷🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f477-1f3ff-200d-2642-fe0f",
+        "emoji": "👷🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👷‍♀️",
+    "name": "Woman Construction Worker",
+    "shortcodes": [
+      "female-construction-worker"
+    ],
+    "keywords": [
+      "female",
+      "construction-worker",
+      "human",
+      "wip",
+      "build",
+      "labor"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f477-200d-2640-fe0f",
+        "emoji": "👷‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f477-1f3fb-200d-2640-fe0f",
+        "emoji": "👷🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f477-1f3fc-200d-2640-fe0f",
+        "emoji": "👷🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f477-1f3fd-200d-2640-fe0f",
+        "emoji": "👷🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f477-1f3fe-200d-2640-fe0f",
+        "emoji": "👷🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f477-1f3ff-200d-2640-fe0f",
+        "emoji": "👷🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🫅",
+    "name": "Person with Crown",
+    "shortcodes": [
+      "person_with_crown"
+    ],
+    "keywords": [
+      "royalty",
+      "power"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fac5",
+        "emoji": "🫅"
+      },
+      {
+        "tone": "light",
+        "unified": "1fac5-1f3fb",
+        "emoji": "🫅🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1fac5-1f3fc",
+        "emoji": "🫅🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1fac5-1f3fd",
+        "emoji": "🫅🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1fac5-1f3fe",
+        "emoji": "🫅🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1fac5-1f3ff",
+        "emoji": "🫅🏿"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🤴",
+    "name": "Prince",
+    "shortcodes": [
+      "prince"
+    ],
+    "keywords": [
+      "boy",
+      "man",
+      "male",
+      "crown",
+      "royal",
+      "king"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f934",
+        "emoji": "🤴"
+      },
+      {
+        "tone": "light",
+        "unified": "1f934-1f3fb",
+        "emoji": "🤴🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f934-1f3fc",
+        "emoji": "🤴🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f934-1f3fd",
+        "emoji": "🤴🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f934-1f3fe",
+        "emoji": "🤴🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f934-1f3ff",
+        "emoji": "🤴🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "👸",
+    "name": "Princess",
+    "shortcodes": [
+      "princess"
+    ],
+    "keywords": [
+      "girl",
+      "woman",
+      "female",
+      "blond",
+      "crown",
+      "royal",
+      "queen"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f478",
+        "emoji": "👸"
+      },
+      {
+        "tone": "light",
+        "unified": "1f478-1f3fb",
+        "emoji": "👸🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f478-1f3fc",
+        "emoji": "👸🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f478-1f3fd",
+        "emoji": "👸🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f478-1f3fe",
+        "emoji": "👸🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f478-1f3ff",
+        "emoji": "👸🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👳",
+    "name": "Man with Turban",
+    "shortcodes": [
+      "man_with_turban"
+    ],
+    "keywords": [
+      "person",
+      "wearing",
+      "headdress"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f473",
+        "emoji": "👳"
+      },
+      {
+        "tone": "light",
+        "unified": "1f473-1f3fb",
+        "emoji": "👳🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f473-1f3fc",
+        "emoji": "👳🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f473-1f3fd",
+        "emoji": "👳🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f473-1f3fe",
+        "emoji": "👳🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f473-1f3ff",
+        "emoji": "👳🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👳‍♂️",
+    "name": "Man Wearing Turban",
+    "shortcodes": [
+      "man-wearing-turban"
+    ],
+    "keywords": [
+      "wearing-turban",
+      "male",
+      "indian",
+      "hinduism",
+      "arabs"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f473-200d-2642-fe0f",
+        "emoji": "👳‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f473-1f3fb-200d-2642-fe0f",
+        "emoji": "👳🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f473-1f3fc-200d-2642-fe0f",
+        "emoji": "👳🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f473-1f3fd-200d-2642-fe0f",
+        "emoji": "👳🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f473-1f3fe-200d-2642-fe0f",
+        "emoji": "👳🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f473-1f3ff-200d-2642-fe0f",
+        "emoji": "👳🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👳‍♀️",
+    "name": "Woman Wearing Turban",
+    "shortcodes": [
+      "woman-wearing-turban"
+    ],
+    "keywords": [
+      "wearing-turban",
+      "female",
+      "indian",
+      "hinduism",
+      "arabs"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f473-200d-2640-fe0f",
+        "emoji": "👳‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f473-1f3fb-200d-2640-fe0f",
+        "emoji": "👳🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f473-1f3fc-200d-2640-fe0f",
+        "emoji": "👳🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f473-1f3fd-200d-2640-fe0f",
+        "emoji": "👳🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f473-1f3fe-200d-2640-fe0f",
+        "emoji": "👳🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f473-1f3ff-200d-2640-fe0f",
+        "emoji": "👳🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👲",
+    "name": "Man with Gua Pi Mao",
+    "shortcodes": [
+      "man_with_gua_pi_mao"
+    ],
+    "keywords": [
+      "skullcap",
+      "male",
+      "boy",
+      "chinese"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f472",
+        "emoji": "👲"
+      },
+      {
+        "tone": "light",
+        "unified": "1f472-1f3fb",
+        "emoji": "👲🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f472-1f3fc",
+        "emoji": "👲🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f472-1f3fd",
+        "emoji": "👲🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f472-1f3fe",
+        "emoji": "👲🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f472-1f3ff",
+        "emoji": "👲🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧕",
+    "name": "Woman with Headscarf",
+    "shortcodes": [
+      "person_with_headscarf"
+    ],
+    "keywords": [
+      "person",
+      "female",
+      "hijab",
+      "mantilla",
+      "tichel"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d5",
+        "emoji": "🧕"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d5-1f3fb",
+        "emoji": "🧕🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d5-1f3fc",
+        "emoji": "🧕🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d5-1f3fd",
+        "emoji": "🧕🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d5-1f3fe",
+        "emoji": "🧕🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d5-1f3ff",
+        "emoji": "🧕🏿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🤵",
+    "name": "Man in Tuxedo",
+    "shortcodes": [
+      "person_in_tuxedo"
+    ],
+    "keywords": [
+      "person",
+      "couple",
+      "marriage",
+      "wedding",
+      "groom"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f935",
+        "emoji": "🤵"
+      },
+      {
+        "tone": "light",
+        "unified": "1f935-1f3fb",
+        "emoji": "🤵🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f935-1f3fc",
+        "emoji": "🤵🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f935-1f3fd",
+        "emoji": "🤵🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f935-1f3fe",
+        "emoji": "🤵🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f935-1f3ff",
+        "emoji": "🤵🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🤵‍♂️",
+    "name": "Man in Tuxedo",
+    "shortcodes": [
+      "man_in_tuxedo"
+    ],
+    "keywords": [
+      "formal",
+      "fashion"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f935-200d-2642-fe0f",
+        "emoji": "🤵‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f935-1f3fb-200d-2642-fe0f",
+        "emoji": "🤵🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f935-1f3fc-200d-2642-fe0f",
+        "emoji": "🤵🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f935-1f3fd-200d-2642-fe0f",
+        "emoji": "🤵🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f935-1f3fe-200d-2642-fe0f",
+        "emoji": "🤵🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f935-1f3ff-200d-2642-fe0f",
+        "emoji": "🤵🏿‍♂️"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🤵‍♀️",
+    "name": "Woman in Tuxedo",
+    "shortcodes": [
+      "woman_in_tuxedo"
+    ],
+    "keywords": [
+      "formal",
+      "fashion"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f935-200d-2640-fe0f",
+        "emoji": "🤵‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f935-1f3fb-200d-2640-fe0f",
+        "emoji": "🤵🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f935-1f3fc-200d-2640-fe0f",
+        "emoji": "🤵🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f935-1f3fd-200d-2640-fe0f",
+        "emoji": "🤵🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f935-1f3fe-200d-2640-fe0f",
+        "emoji": "🤵🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f935-1f3ff-200d-2640-fe0f",
+        "emoji": "🤵🏿‍♀️"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "👰",
+    "name": "Bride with Veil",
+    "shortcodes": [
+      "bride_with_veil"
+    ],
+    "keywords": [
+      "couple",
+      "marriage",
+      "wedding",
+      "woman"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f470",
+        "emoji": "👰"
+      },
+      {
+        "tone": "light",
+        "unified": "1f470-1f3fb",
+        "emoji": "👰🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f470-1f3fc",
+        "emoji": "👰🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f470-1f3fd",
+        "emoji": "👰🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f470-1f3fe",
+        "emoji": "👰🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f470-1f3ff",
+        "emoji": "👰🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👰‍♂️",
+    "name": "Man with Veil",
+    "shortcodes": [
+      "man_with_veil"
+    ],
+    "keywords": [
+      "wedding",
+      "marriage"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f470-200d-2642-fe0f",
+        "emoji": "👰‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f470-1f3fb-200d-2642-fe0f",
+        "emoji": "👰🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f470-1f3fc-200d-2642-fe0f",
+        "emoji": "👰🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f470-1f3fd-200d-2642-fe0f",
+        "emoji": "👰🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f470-1f3fe-200d-2642-fe0f",
+        "emoji": "👰🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f470-1f3ff-200d-2642-fe0f",
+        "emoji": "👰🏿‍♂️"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "👰‍♀️",
+    "name": "Woman with Veil",
+    "shortcodes": [
+      "woman_with_veil"
+    ],
+    "keywords": [
+      "wedding",
+      "marriage"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f470-200d-2640-fe0f",
+        "emoji": "👰‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f470-1f3fb-200d-2640-fe0f",
+        "emoji": "👰🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f470-1f3fc-200d-2640-fe0f",
+        "emoji": "👰🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f470-1f3fd-200d-2640-fe0f",
+        "emoji": "👰🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f470-1f3fe-200d-2640-fe0f",
+        "emoji": "👰🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f470-1f3ff-200d-2640-fe0f",
+        "emoji": "👰🏿‍♀️"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🤰",
+    "name": "Pregnant Woman",
+    "shortcodes": [
+      "pregnant_woman"
+    ],
+    "keywords": [
+      "baby"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f930",
+        "emoji": "🤰"
+      },
+      {
+        "tone": "light",
+        "unified": "1f930-1f3fb",
+        "emoji": "🤰🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f930-1f3fc",
+        "emoji": "🤰🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f930-1f3fd",
+        "emoji": "🤰🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f930-1f3fe",
+        "emoji": "🤰🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f930-1f3ff",
+        "emoji": "🤰🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🫃",
+    "name": "Pregnant Man",
+    "shortcodes": [
+      "pregnant_man"
+    ],
+    "keywords": [
+      "baby",
+      "belly"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fac3",
+        "emoji": "🫃"
+      },
+      {
+        "tone": "light",
+        "unified": "1fac3-1f3fb",
+        "emoji": "🫃🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1fac3-1f3fc",
+        "emoji": "🫃🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1fac3-1f3fd",
+        "emoji": "🫃🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1fac3-1f3fe",
+        "emoji": "🫃🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1fac3-1f3ff",
+        "emoji": "🫃🏿"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🫄",
+    "name": "Pregnant Person",
+    "shortcodes": [
+      "pregnant_person"
+    ],
+    "keywords": [
+      "baby",
+      "belly"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fac4",
+        "emoji": "🫄"
+      },
+      {
+        "tone": "light",
+        "unified": "1fac4-1f3fb",
+        "emoji": "🫄🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1fac4-1f3fc",
+        "emoji": "🫄🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1fac4-1f3fd",
+        "emoji": "🫄🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1fac4-1f3fe",
+        "emoji": "🫄🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1fac4-1f3ff",
+        "emoji": "🫄🏿"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🤱",
+    "name": "Breast-Feeding",
+    "shortcodes": [
+      "breast-feeding"
+    ],
+    "keywords": [
+      "breast",
+      "feeding",
+      "nursing",
+      "baby"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f931",
+        "emoji": "🤱"
+      },
+      {
+        "tone": "light",
+        "unified": "1f931-1f3fb",
+        "emoji": "🤱🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f931-1f3fc",
+        "emoji": "🤱🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f931-1f3fd",
+        "emoji": "🤱🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f931-1f3fe",
+        "emoji": "🤱🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f931-1f3ff",
+        "emoji": "🤱🏿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "👩‍🍼",
+    "name": "Woman Feeding Baby",
+    "shortcodes": [
+      "woman_feeding_baby"
+    ],
+    "keywords": [
+      "birth",
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f37c",
+        "emoji": "👩‍🍼"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f37c",
+        "emoji": "👩🏻‍🍼"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f37c",
+        "emoji": "👩🏼‍🍼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f37c",
+        "emoji": "👩🏽‍🍼"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f37c",
+        "emoji": "👩🏾‍🍼"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f37c",
+        "emoji": "👩🏿‍🍼"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "👨‍🍼",
+    "name": "Man Feeding Baby",
+    "shortcodes": [
+      "man_feeding_baby"
+    ],
+    "keywords": [
+      "birth",
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f37c",
+        "emoji": "👨‍🍼"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f37c",
+        "emoji": "👨🏻‍🍼"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f37c",
+        "emoji": "👨🏼‍🍼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f37c",
+        "emoji": "👨🏽‍🍼"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f37c",
+        "emoji": "👨🏾‍🍼"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f37c",
+        "emoji": "👨🏿‍🍼"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🧑‍🍼",
+    "name": "Person Feeding Baby",
+    "shortcodes": [
+      "person_feeding_baby"
+    ],
+    "keywords": [
+      "birth",
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f37c",
+        "emoji": "🧑‍🍼"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f37c",
+        "emoji": "🧑🏻‍🍼"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f37c",
+        "emoji": "🧑🏼‍🍼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f37c",
+        "emoji": "🧑🏽‍🍼"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f37c",
+        "emoji": "🧑🏾‍🍼"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f37c",
+        "emoji": "🧑🏿‍🍼"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "👼",
+    "name": "Baby Angel",
+    "shortcodes": [
+      "angel"
+    ],
+    "keywords": [
+      "heaven",
+      "wings",
+      "halo"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f47c",
+        "emoji": "👼"
+      },
+      {
+        "tone": "light",
+        "unified": "1f47c-1f3fb",
+        "emoji": "👼🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f47c-1f3fc",
+        "emoji": "👼🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f47c-1f3fd",
+        "emoji": "👼🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f47c-1f3fe",
+        "emoji": "👼🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f47c-1f3ff",
+        "emoji": "👼🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎅",
+    "name": "Santa Claus",
+    "shortcodes": [
+      "santa"
+    ],
+    "keywords": [
+      "festival",
+      "man",
+      "male",
+      "xmas",
+      "father",
+      "christmas"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f385",
+        "emoji": "🎅"
+      },
+      {
+        "tone": "light",
+        "unified": "1f385-1f3fb",
+        "emoji": "🎅🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f385-1f3fc",
+        "emoji": "🎅🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f385-1f3fd",
+        "emoji": "🎅🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f385-1f3fe",
+        "emoji": "🎅🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f385-1f3ff",
+        "emoji": "🎅🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤶",
+    "name": "Mrs. Claus",
+    "shortcodes": [
+      "mrs_claus",
+      "mother_christmas"
+    ],
+    "keywords": [
+      "mrs",
+      "mother",
+      "christmas",
+      "woman",
+      "female",
+      "xmas"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f936",
+        "emoji": "🤶"
+      },
+      {
+        "tone": "light",
+        "unified": "1f936-1f3fb",
+        "emoji": "🤶🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f936-1f3fc",
+        "emoji": "🤶🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f936-1f3fd",
+        "emoji": "🤶🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f936-1f3fe",
+        "emoji": "🤶🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f936-1f3ff",
+        "emoji": "🤶🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🧑‍🎄",
+    "name": "Mx Claus",
+    "shortcodes": [
+      "mx_claus"
+    ],
+    "keywords": [
+      "christmas"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f384",
+        "emoji": "🧑‍🎄"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f384",
+        "emoji": "🧑🏻‍🎄"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f384",
+        "emoji": "🧑🏼‍🎄"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f384",
+        "emoji": "🧑🏽‍🎄"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f384",
+        "emoji": "🧑🏾‍🎄"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f384",
+        "emoji": "🧑🏿‍🎄"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🦸",
+    "name": "Superhero",
+    "shortcodes": [
+      "superhero"
+    ],
+    "keywords": [
+      "marvel"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9b8",
+        "emoji": "🦸"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9b8-1f3fb",
+        "emoji": "🦸🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9b8-1f3fc",
+        "emoji": "🦸🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9b8-1f3fd",
+        "emoji": "🦸🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9b8-1f3fe",
+        "emoji": "🦸🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9b8-1f3ff",
+        "emoji": "🦸🏿"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🦸‍♂️",
+    "name": "Man Superhero",
+    "shortcodes": [
+      "male_superhero"
+    ],
+    "keywords": [
+      "male",
+      "good",
+      "hero",
+      "superpowers"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9b8-200d-2642-fe0f",
+        "emoji": "🦸‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9b8-1f3fb-200d-2642-fe0f",
+        "emoji": "🦸🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9b8-1f3fc-200d-2642-fe0f",
+        "emoji": "🦸🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9b8-1f3fd-200d-2642-fe0f",
+        "emoji": "🦸🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9b8-1f3fe-200d-2642-fe0f",
+        "emoji": "🦸🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9b8-1f3ff-200d-2642-fe0f",
+        "emoji": "🦸🏿‍♂️"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🦸‍♀️",
+    "name": "Woman Superhero",
+    "shortcodes": [
+      "female_superhero"
+    ],
+    "keywords": [
+      "female",
+      "good",
+      "heroine",
+      "superpowers"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9b8-200d-2640-fe0f",
+        "emoji": "🦸‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9b8-1f3fb-200d-2640-fe0f",
+        "emoji": "🦸🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9b8-1f3fc-200d-2640-fe0f",
+        "emoji": "🦸🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9b8-1f3fd-200d-2640-fe0f",
+        "emoji": "🦸🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9b8-1f3fe-200d-2640-fe0f",
+        "emoji": "🦸🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9b8-1f3ff-200d-2640-fe0f",
+        "emoji": "🦸🏿‍♀️"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🦹",
+    "name": "Supervillain",
+    "shortcodes": [
+      "supervillain"
+    ],
+    "keywords": [
+      "marvel"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9b9",
+        "emoji": "🦹"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9b9-1f3fb",
+        "emoji": "🦹🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9b9-1f3fc",
+        "emoji": "🦹🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9b9-1f3fd",
+        "emoji": "🦹🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9b9-1f3fe",
+        "emoji": "🦹🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9b9-1f3ff",
+        "emoji": "🦹🏿"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🦹‍♂️",
+    "name": "Man Supervillain",
+    "shortcodes": [
+      "male_supervillain"
+    ],
+    "keywords": [
+      "male",
+      "evil",
+      "bad",
+      "criminal",
+      "hero",
+      "superpowers"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9b9-200d-2642-fe0f",
+        "emoji": "🦹‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9b9-1f3fb-200d-2642-fe0f",
+        "emoji": "🦹🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9b9-1f3fc-200d-2642-fe0f",
+        "emoji": "🦹🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9b9-1f3fd-200d-2642-fe0f",
+        "emoji": "🦹🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9b9-1f3fe-200d-2642-fe0f",
+        "emoji": "🦹🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9b9-1f3ff-200d-2642-fe0f",
+        "emoji": "🦹🏿‍♂️"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🦹‍♀️",
+    "name": "Woman Supervillain",
+    "shortcodes": [
+      "female_supervillain"
+    ],
+    "keywords": [
+      "female",
+      "evil",
+      "bad",
+      "criminal",
+      "heroine",
+      "superpowers"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9b9-200d-2640-fe0f",
+        "emoji": "🦹‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9b9-1f3fb-200d-2640-fe0f",
+        "emoji": "🦹🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9b9-1f3fc-200d-2640-fe0f",
+        "emoji": "🦹🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9b9-1f3fd-200d-2640-fe0f",
+        "emoji": "🦹🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9b9-1f3fe-200d-2640-fe0f",
+        "emoji": "🦹🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9b9-1f3ff-200d-2640-fe0f",
+        "emoji": "🦹🏿‍♀️"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🧙",
+    "name": "Mage",
+    "shortcodes": [
+      "mage"
+    ],
+    "keywords": [
+      "magic"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d9",
+        "emoji": "🧙"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d9-1f3fb",
+        "emoji": "🧙🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d9-1f3fc",
+        "emoji": "🧙🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d9-1f3fd",
+        "emoji": "🧙🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d9-1f3fe",
+        "emoji": "🧙🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d9-1f3ff",
+        "emoji": "🧙🏿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧙‍♂️",
+    "name": "Man Mage",
+    "shortcodes": [
+      "male_mage"
+    ],
+    "keywords": [
+      "male",
+      "sorcerer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d9-200d-2642-fe0f",
+        "emoji": "🧙‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d9-1f3fb-200d-2642-fe0f",
+        "emoji": "🧙🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d9-1f3fc-200d-2642-fe0f",
+        "emoji": "🧙🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d9-1f3fd-200d-2642-fe0f",
+        "emoji": "🧙🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d9-1f3fe-200d-2642-fe0f",
+        "emoji": "🧙🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d9-1f3ff-200d-2642-fe0f",
+        "emoji": "🧙🏿‍♂️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧙‍♀️",
+    "name": "Woman Mage",
+    "shortcodes": [
+      "female_mage"
+    ],
+    "keywords": [
+      "female",
+      "witch"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d9-200d-2640-fe0f",
+        "emoji": "🧙‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d9-1f3fb-200d-2640-fe0f",
+        "emoji": "🧙🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d9-1f3fc-200d-2640-fe0f",
+        "emoji": "🧙🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d9-1f3fd-200d-2640-fe0f",
+        "emoji": "🧙🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d9-1f3fe-200d-2640-fe0f",
+        "emoji": "🧙🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d9-1f3ff-200d-2640-fe0f",
+        "emoji": "🧙🏿‍♀️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧚",
+    "name": "Fairy",
+    "shortcodes": [
+      "fairy"
+    ],
+    "keywords": [
+      "wings",
+      "magical"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9da",
+        "emoji": "🧚"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9da-1f3fb",
+        "emoji": "🧚🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9da-1f3fc",
+        "emoji": "🧚🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9da-1f3fd",
+        "emoji": "🧚🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9da-1f3fe",
+        "emoji": "🧚🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9da-1f3ff",
+        "emoji": "🧚🏿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧚‍♂️",
+    "name": "Man Fairy",
+    "shortcodes": [
+      "male_fairy"
+    ],
+    "keywords": [
+      "male"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9da-200d-2642-fe0f",
+        "emoji": "🧚‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9da-1f3fb-200d-2642-fe0f",
+        "emoji": "🧚🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9da-1f3fc-200d-2642-fe0f",
+        "emoji": "🧚🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9da-1f3fd-200d-2642-fe0f",
+        "emoji": "🧚🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9da-1f3fe-200d-2642-fe0f",
+        "emoji": "🧚🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9da-1f3ff-200d-2642-fe0f",
+        "emoji": "🧚🏿‍♂️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧚‍♀️",
+    "name": "Woman Fairy",
+    "shortcodes": [
+      "female_fairy"
+    ],
+    "keywords": [
+      "female"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9da-200d-2640-fe0f",
+        "emoji": "🧚‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9da-1f3fb-200d-2640-fe0f",
+        "emoji": "🧚🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9da-1f3fc-200d-2640-fe0f",
+        "emoji": "🧚🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9da-1f3fd-200d-2640-fe0f",
+        "emoji": "🧚🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9da-1f3fe-200d-2640-fe0f",
+        "emoji": "🧚🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9da-1f3ff-200d-2640-fe0f",
+        "emoji": "🧚🏿‍♀️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧛",
+    "name": "Vampire",
+    "shortcodes": [
+      "vampire"
+    ],
+    "keywords": [
+      "blood",
+      "twilight"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9db",
+        "emoji": "🧛"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9db-1f3fb",
+        "emoji": "🧛🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9db-1f3fc",
+        "emoji": "🧛🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9db-1f3fd",
+        "emoji": "🧛🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9db-1f3fe",
+        "emoji": "🧛🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9db-1f3ff",
+        "emoji": "🧛🏿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧛‍♂️",
+    "name": "Man Vampire",
+    "shortcodes": [
+      "male_vampire"
+    ],
+    "keywords": [
+      "male",
+      "dracula"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9db-200d-2642-fe0f",
+        "emoji": "🧛‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9db-1f3fb-200d-2642-fe0f",
+        "emoji": "🧛🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9db-1f3fc-200d-2642-fe0f",
+        "emoji": "🧛🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9db-1f3fd-200d-2642-fe0f",
+        "emoji": "🧛🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9db-1f3fe-200d-2642-fe0f",
+        "emoji": "🧛🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9db-1f3ff-200d-2642-fe0f",
+        "emoji": "🧛🏿‍♂️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧛‍♀️",
+    "name": "Woman Vampire",
+    "shortcodes": [
+      "female_vampire"
+    ],
+    "keywords": [
+      "female"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9db-200d-2640-fe0f",
+        "emoji": "🧛‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9db-1f3fb-200d-2640-fe0f",
+        "emoji": "🧛🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9db-1f3fc-200d-2640-fe0f",
+        "emoji": "🧛🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9db-1f3fd-200d-2640-fe0f",
+        "emoji": "🧛🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9db-1f3fe-200d-2640-fe0f",
+        "emoji": "🧛🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9db-1f3ff-200d-2640-fe0f",
+        "emoji": "🧛🏿‍♀️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧜",
+    "name": "Merperson",
+    "shortcodes": [
+      "merperson"
+    ],
+    "keywords": [
+      "sea"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9dc",
+        "emoji": "🧜"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9dc-1f3fb",
+        "emoji": "🧜🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9dc-1f3fc",
+        "emoji": "🧜🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9dc-1f3fd",
+        "emoji": "🧜🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9dc-1f3fe",
+        "emoji": "🧜🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9dc-1f3ff",
+        "emoji": "🧜🏿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧜‍♂️",
+    "name": "Merman",
+    "shortcodes": [
+      "merman"
+    ],
+    "keywords": [
+      "man",
+      "male",
+      "triton"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9dc-200d-2642-fe0f",
+        "emoji": "🧜‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9dc-1f3fb-200d-2642-fe0f",
+        "emoji": "🧜🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9dc-1f3fc-200d-2642-fe0f",
+        "emoji": "🧜🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9dc-1f3fd-200d-2642-fe0f",
+        "emoji": "🧜🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9dc-1f3fe-200d-2642-fe0f",
+        "emoji": "🧜🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9dc-1f3ff-200d-2642-fe0f",
+        "emoji": "🧜🏿‍♂️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧜‍♀️",
+    "name": "Mermaid",
+    "shortcodes": [
+      "mermaid"
+    ],
+    "keywords": [
+      "woman",
+      "female",
+      "merwoman",
+      "ariel"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9dc-200d-2640-fe0f",
+        "emoji": "🧜‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9dc-1f3fb-200d-2640-fe0f",
+        "emoji": "🧜🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9dc-1f3fc-200d-2640-fe0f",
+        "emoji": "🧜🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9dc-1f3fd-200d-2640-fe0f",
+        "emoji": "🧜🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9dc-1f3fe-200d-2640-fe0f",
+        "emoji": "🧜🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9dc-1f3ff-200d-2640-fe0f",
+        "emoji": "🧜🏿‍♀️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧝",
+    "name": "Elf",
+    "shortcodes": [
+      "elf"
+    ],
+    "keywords": [
+      "magical"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9dd",
+        "emoji": "🧝"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9dd-1f3fb",
+        "emoji": "🧝🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9dd-1f3fc",
+        "emoji": "🧝🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9dd-1f3fd",
+        "emoji": "🧝🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9dd-1f3fe",
+        "emoji": "🧝🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9dd-1f3ff",
+        "emoji": "🧝🏿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧝‍♂️",
+    "name": "Man Elf",
+    "shortcodes": [
+      "male_elf"
+    ],
+    "keywords": [
+      "male"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9dd-200d-2642-fe0f",
+        "emoji": "🧝‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9dd-1f3fb-200d-2642-fe0f",
+        "emoji": "🧝🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9dd-1f3fc-200d-2642-fe0f",
+        "emoji": "🧝🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9dd-1f3fd-200d-2642-fe0f",
+        "emoji": "🧝🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9dd-1f3fe-200d-2642-fe0f",
+        "emoji": "🧝🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9dd-1f3ff-200d-2642-fe0f",
+        "emoji": "🧝🏿‍♂️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧝‍♀️",
+    "name": "Woman Elf",
+    "shortcodes": [
+      "female_elf"
+    ],
+    "keywords": [
+      "female"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9dd-200d-2640-fe0f",
+        "emoji": "🧝‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9dd-1f3fb-200d-2640-fe0f",
+        "emoji": "🧝🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9dd-1f3fc-200d-2640-fe0f",
+        "emoji": "🧝🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9dd-1f3fd-200d-2640-fe0f",
+        "emoji": "🧝🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9dd-1f3fe-200d-2640-fe0f",
+        "emoji": "🧝🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9dd-1f3ff-200d-2640-fe0f",
+        "emoji": "🧝🏿‍♀️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧞",
+    "name": "Genie",
+    "shortcodes": [
+      "genie"
+    ],
+    "keywords": [
+      "magical",
+      "wishes"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9de",
+        "emoji": "🧞"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧞‍♂️",
+    "name": "Man Genie",
+    "shortcodes": [
+      "male_genie"
+    ],
+    "keywords": [
+      "male"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9de-200d-2642-fe0f",
+        "emoji": "🧞‍♂️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧞‍♀️",
+    "name": "Woman Genie",
+    "shortcodes": [
+      "female_genie"
+    ],
+    "keywords": [
+      "female"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9de-200d-2640-fe0f",
+        "emoji": "🧞‍♀️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧟",
+    "name": "Zombie",
+    "shortcodes": [
+      "zombie"
+    ],
+    "keywords": [
+      "dead"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9df",
+        "emoji": "🧟"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧟‍♂️",
+    "name": "Man Zombie",
+    "shortcodes": [
+      "male_zombie"
+    ],
+    "keywords": [
+      "male",
+      "dracula",
+      "undead",
+      "walking",
+      "dead"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9df-200d-2642-fe0f",
+        "emoji": "🧟‍♂️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧟‍♀️",
+    "name": "Woman Zombie",
+    "shortcodes": [
+      "female_zombie"
+    ],
+    "keywords": [
+      "female",
+      "undead",
+      "walking",
+      "dead"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9df-200d-2640-fe0f",
+        "emoji": "🧟‍♀️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧌",
+    "name": "Troll",
+    "shortcodes": [
+      "troll"
+    ],
+    "keywords": [
+      "mystical",
+      "monster"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9cc",
+        "emoji": "🧌"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "💆",
+    "name": "Face Massage",
+    "shortcodes": [
+      "massage"
+    ],
+    "keywords": [
+      "person",
+      "getting",
+      "relax"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f486",
+        "emoji": "💆"
+      },
+      {
+        "tone": "light",
+        "unified": "1f486-1f3fb",
+        "emoji": "💆🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f486-1f3fc",
+        "emoji": "💆🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f486-1f3fd",
+        "emoji": "💆🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f486-1f3fe",
+        "emoji": "💆🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f486-1f3ff",
+        "emoji": "💆🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💆‍♂️",
+    "name": "Man Getting Massage",
+    "shortcodes": [
+      "man-getting-massage"
+    ],
+    "keywords": [
+      "getting-massage",
+      "male",
+      "boy",
+      "head"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f486-200d-2642-fe0f",
+        "emoji": "💆‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f486-1f3fb-200d-2642-fe0f",
+        "emoji": "💆🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f486-1f3fc-200d-2642-fe0f",
+        "emoji": "💆🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f486-1f3fd-200d-2642-fe0f",
+        "emoji": "💆🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f486-1f3fe-200d-2642-fe0f",
+        "emoji": "💆🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f486-1f3ff-200d-2642-fe0f",
+        "emoji": "💆🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "💆‍♀️",
+    "name": "Woman Getting Massage",
+    "shortcodes": [
+      "woman-getting-massage"
+    ],
+    "keywords": [
+      "getting-massage",
+      "female",
+      "girl",
+      "head"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f486-200d-2640-fe0f",
+        "emoji": "💆‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f486-1f3fb-200d-2640-fe0f",
+        "emoji": "💆🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f486-1f3fc-200d-2640-fe0f",
+        "emoji": "💆🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f486-1f3fd-200d-2640-fe0f",
+        "emoji": "💆🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f486-1f3fe-200d-2640-fe0f",
+        "emoji": "💆🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f486-1f3ff-200d-2640-fe0f",
+        "emoji": "💆🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "💇",
+    "name": "Haircut",
+    "shortcodes": [
+      "haircut"
+    ],
+    "keywords": [
+      "person",
+      "getting",
+      "hairstyle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f487",
+        "emoji": "💇"
+      },
+      {
+        "tone": "light",
+        "unified": "1f487-1f3fb",
+        "emoji": "💇🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f487-1f3fc",
+        "emoji": "💇🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f487-1f3fd",
+        "emoji": "💇🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f487-1f3fe",
+        "emoji": "💇🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f487-1f3ff",
+        "emoji": "💇🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💇‍♂️",
+    "name": "Man Getting Haircut",
+    "shortcodes": [
+      "man-getting-haircut"
+    ],
+    "keywords": [
+      "getting-haircut",
+      "male",
+      "boy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f487-200d-2642-fe0f",
+        "emoji": "💇‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f487-1f3fb-200d-2642-fe0f",
+        "emoji": "💇🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f487-1f3fc-200d-2642-fe0f",
+        "emoji": "💇🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f487-1f3fd-200d-2642-fe0f",
+        "emoji": "💇🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f487-1f3fe-200d-2642-fe0f",
+        "emoji": "💇🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f487-1f3ff-200d-2642-fe0f",
+        "emoji": "💇🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "💇‍♀️",
+    "name": "Woman Getting Haircut",
+    "shortcodes": [
+      "woman-getting-haircut"
+    ],
+    "keywords": [
+      "getting-haircut",
+      "female",
+      "girl"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f487-200d-2640-fe0f",
+        "emoji": "💇‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f487-1f3fb-200d-2640-fe0f",
+        "emoji": "💇🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f487-1f3fc-200d-2640-fe0f",
+        "emoji": "💇🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f487-1f3fd-200d-2640-fe0f",
+        "emoji": "💇🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f487-1f3fe-200d-2640-fe0f",
+        "emoji": "💇🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f487-1f3ff-200d-2640-fe0f",
+        "emoji": "💇🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🚶",
+    "name": "Pedestrian",
+    "shortcodes": [
+      "walking"
+    ],
+    "keywords": [
+      "walking",
+      "person",
+      "move"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6b6",
+        "emoji": "🚶"
+      },
+      {
+        "tone": "light",
+        "unified": "1f6b6-1f3fb",
+        "emoji": "🚶🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f6b6-1f3fc",
+        "emoji": "🚶🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f6b6-1f3fd",
+        "emoji": "🚶🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f6b6-1f3fe",
+        "emoji": "🚶🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f6b6-1f3ff",
+        "emoji": "🚶🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚶‍♂️",
+    "name": "Man Walking",
+    "shortcodes": [
+      "man-walking"
+    ],
+    "keywords": [
+      "human",
+      "feet",
+      "steps"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6b6-200d-2642-fe0f",
+        "emoji": "🚶‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f6b6-1f3fb-200d-2642-fe0f",
+        "emoji": "🚶🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f6b6-1f3fc-200d-2642-fe0f",
+        "emoji": "🚶🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f6b6-1f3fd-200d-2642-fe0f",
+        "emoji": "🚶🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f6b6-1f3fe-200d-2642-fe0f",
+        "emoji": "🚶🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f6b6-1f3ff-200d-2642-fe0f",
+        "emoji": "🚶🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🚶‍♀️",
+    "name": "Woman Walking",
+    "shortcodes": [
+      "woman-walking"
+    ],
+    "keywords": [
+      "human",
+      "feet",
+      "steps",
+      "female"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6b6-200d-2640-fe0f",
+        "emoji": "🚶‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f6b6-1f3fb-200d-2640-fe0f",
+        "emoji": "🚶🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f6b6-1f3fc-200d-2640-fe0f",
+        "emoji": "🚶🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f6b6-1f3fd-200d-2640-fe0f",
+        "emoji": "🚶🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f6b6-1f3fe-200d-2640-fe0f",
+        "emoji": "🚶🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f6b6-1f3ff-200d-2640-fe0f",
+        "emoji": "🚶🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧍",
+    "name": "Standing Person",
+    "shortcodes": [
+      "standing_person"
+    ],
+    "keywords": [
+      "still"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9cd",
+        "emoji": "🧍"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9cd-1f3fb",
+        "emoji": "🧍🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9cd-1f3fc",
+        "emoji": "🧍🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9cd-1f3fd",
+        "emoji": "🧍🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9cd-1f3fe",
+        "emoji": "🧍🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9cd-1f3ff",
+        "emoji": "🧍🏿"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🧍‍♂️",
+    "name": "Man Standing",
+    "shortcodes": [
+      "man_standing"
+    ],
+    "keywords": [
+      "still"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9cd-200d-2642-fe0f",
+        "emoji": "🧍‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9cd-1f3fb-200d-2642-fe0f",
+        "emoji": "🧍🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9cd-1f3fc-200d-2642-fe0f",
+        "emoji": "🧍🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9cd-1f3fd-200d-2642-fe0f",
+        "emoji": "🧍🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9cd-1f3fe-200d-2642-fe0f",
+        "emoji": "🧍🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9cd-1f3ff-200d-2642-fe0f",
+        "emoji": "🧍🏿‍♂️"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🧍‍♀️",
+    "name": "Woman Standing",
+    "shortcodes": [
+      "woman_standing"
+    ],
+    "keywords": [
+      "still"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9cd-200d-2640-fe0f",
+        "emoji": "🧍‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9cd-1f3fb-200d-2640-fe0f",
+        "emoji": "🧍🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9cd-1f3fc-200d-2640-fe0f",
+        "emoji": "🧍🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9cd-1f3fd-200d-2640-fe0f",
+        "emoji": "🧍🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9cd-1f3fe-200d-2640-fe0f",
+        "emoji": "🧍🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9cd-1f3ff-200d-2640-fe0f",
+        "emoji": "🧍🏿‍♀️"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🧎",
+    "name": "Kneeling Person",
+    "shortcodes": [
+      "kneeling_person"
+    ],
+    "keywords": [
+      "pray",
+      "respectful"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9ce",
+        "emoji": "🧎"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9ce-1f3fb",
+        "emoji": "🧎🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9ce-1f3fc",
+        "emoji": "🧎🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9ce-1f3fd",
+        "emoji": "🧎🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9ce-1f3fe",
+        "emoji": "🧎🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9ce-1f3ff",
+        "emoji": "🧎🏿"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🧎‍♂️",
+    "name": "Man Kneeling",
+    "shortcodes": [
+      "man_kneeling"
+    ],
+    "keywords": [
+      "pray",
+      "respectful"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9ce-200d-2642-fe0f",
+        "emoji": "🧎‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9ce-1f3fb-200d-2642-fe0f",
+        "emoji": "🧎🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9ce-1f3fc-200d-2642-fe0f",
+        "emoji": "🧎🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9ce-1f3fd-200d-2642-fe0f",
+        "emoji": "🧎🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9ce-1f3fe-200d-2642-fe0f",
+        "emoji": "🧎🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9ce-1f3ff-200d-2642-fe0f",
+        "emoji": "🧎🏿‍♂️"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🧎‍♀️",
+    "name": "Woman Kneeling",
+    "shortcodes": [
+      "woman_kneeling"
+    ],
+    "keywords": [
+      "respectful",
+      "pray"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9ce-200d-2640-fe0f",
+        "emoji": "🧎‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9ce-1f3fb-200d-2640-fe0f",
+        "emoji": "🧎🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9ce-1f3fc-200d-2640-fe0f",
+        "emoji": "🧎🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9ce-1f3fd-200d-2640-fe0f",
+        "emoji": "🧎🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9ce-1f3fe-200d-2640-fe0f",
+        "emoji": "🧎🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9ce-1f3ff-200d-2640-fe0f",
+        "emoji": "🧎🏿‍♀️"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🧑‍🦯",
+    "name": "Person with White Cane",
+    "shortcodes": [
+      "person_with_probing_cane"
+    ],
+    "keywords": [
+      "probing",
+      "blind"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f9af",
+        "emoji": "🧑‍🦯"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f9af",
+        "emoji": "🧑🏻‍🦯"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f9af",
+        "emoji": "🧑🏼‍🦯"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f9af",
+        "emoji": "🧑🏽‍🦯"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f9af",
+        "emoji": "🧑🏾‍🦯"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f9af",
+        "emoji": "🧑🏿‍🦯"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍🦯",
+    "name": "Man with White Cane",
+    "shortcodes": [
+      "man_with_probing_cane"
+    ],
+    "keywords": [
+      "probing",
+      "blind"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f9af",
+        "emoji": "👨‍🦯"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f9af",
+        "emoji": "👨🏻‍🦯"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f9af",
+        "emoji": "👨🏼‍🦯"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f9af",
+        "emoji": "👨🏽‍🦯"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f9af",
+        "emoji": "👨🏾‍🦯"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f9af",
+        "emoji": "👨🏿‍🦯"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "👩‍🦯",
+    "name": "Woman with White Cane",
+    "shortcodes": [
+      "woman_with_probing_cane"
+    ],
+    "keywords": [
+      "probing",
+      "blind"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f9af",
+        "emoji": "👩‍🦯"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f9af",
+        "emoji": "👩🏻‍🦯"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f9af",
+        "emoji": "👩🏼‍🦯"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f9af",
+        "emoji": "👩🏽‍🦯"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f9af",
+        "emoji": "👩🏾‍🦯"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f9af",
+        "emoji": "👩🏿‍🦯"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🧑‍🦼",
+    "name": "Person in Motorized Wheelchair",
+    "shortcodes": [
+      "person_in_motorized_wheelchair"
+    ],
+    "keywords": [
+      "disability",
+      "accessibility"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f9bc",
+        "emoji": "🧑‍🦼"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f9bc",
+        "emoji": "🧑🏻‍🦼"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f9bc",
+        "emoji": "🧑🏼‍🦼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f9bc",
+        "emoji": "🧑🏽‍🦼"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f9bc",
+        "emoji": "🧑🏾‍🦼"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f9bc",
+        "emoji": "🧑🏿‍🦼"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍🦼",
+    "name": "Man in Motorized Wheelchair",
+    "shortcodes": [
+      "man_in_motorized_wheelchair"
+    ],
+    "keywords": [
+      "disability",
+      "accessibility"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f9bc",
+        "emoji": "👨‍🦼"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f9bc",
+        "emoji": "👨🏻‍🦼"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f9bc",
+        "emoji": "👨🏼‍🦼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f9bc",
+        "emoji": "👨🏽‍🦼"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f9bc",
+        "emoji": "👨🏾‍🦼"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f9bc",
+        "emoji": "👨🏿‍🦼"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "👩‍🦼",
+    "name": "Woman in Motorized Wheelchair",
+    "shortcodes": [
+      "woman_in_motorized_wheelchair"
+    ],
+    "keywords": [
+      "disability",
+      "accessibility"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f9bc",
+        "emoji": "👩‍🦼"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f9bc",
+        "emoji": "👩🏻‍🦼"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f9bc",
+        "emoji": "👩🏼‍🦼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f9bc",
+        "emoji": "👩🏽‍🦼"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f9bc",
+        "emoji": "👩🏾‍🦼"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f9bc",
+        "emoji": "👩🏿‍🦼"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🧑‍🦽",
+    "name": "Person in Manual Wheelchair",
+    "shortcodes": [
+      "person_in_manual_wheelchair"
+    ],
+    "keywords": [
+      "disability",
+      "accessibility"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f9bd",
+        "emoji": "🧑‍🦽"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f9bd",
+        "emoji": "🧑🏻‍🦽"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f9bd",
+        "emoji": "🧑🏼‍🦽"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f9bd",
+        "emoji": "🧑🏽‍🦽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f9bd",
+        "emoji": "🧑🏾‍🦽"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f9bd",
+        "emoji": "🧑🏿‍🦽"
+      }
+    ],
+    "version": 12.1
+  },
+  {
+    "emoji": "👨‍🦽",
+    "name": "Man in Manual Wheelchair",
+    "shortcodes": [
+      "man_in_manual_wheelchair"
+    ],
+    "keywords": [
+      "disability",
+      "accessibility"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f9bd",
+        "emoji": "👨‍🦽"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-1f9bd",
+        "emoji": "👨🏻‍🦽"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-1f9bd",
+        "emoji": "👨🏼‍🦽"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-1f9bd",
+        "emoji": "👨🏽‍🦽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-1f9bd",
+        "emoji": "👨🏾‍🦽"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-1f9bd",
+        "emoji": "👨🏿‍🦽"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "👩‍🦽",
+    "name": "Woman in Manual Wheelchair",
+    "shortcodes": [
+      "woman_in_manual_wheelchair"
+    ],
+    "keywords": [
+      "disability",
+      "accessibility"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f9bd",
+        "emoji": "👩‍🦽"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-1f9bd",
+        "emoji": "👩🏻‍🦽"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-1f9bd",
+        "emoji": "👩🏼‍🦽"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-1f9bd",
+        "emoji": "👩🏽‍🦽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-1f9bd",
+        "emoji": "👩🏾‍🦽"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-1f9bd",
+        "emoji": "👩🏿‍🦽"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🏃",
+    "name": "Runner",
+    "shortcodes": [
+      "runner",
+      "running"
+    ],
+    "keywords": [
+      "running",
+      "person",
+      "move"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3c3",
+        "emoji": "🏃"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3c3-1f3fb",
+        "emoji": "🏃🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3c3-1f3fc",
+        "emoji": "🏃🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3c3-1f3fd",
+        "emoji": "🏃🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3c3-1f3fe",
+        "emoji": "🏃🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3c3-1f3ff",
+        "emoji": "🏃🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏃‍♂️",
+    "name": "Man Running",
+    "shortcodes": [
+      "man-running"
+    ],
+    "keywords": [
+      "walking",
+      "exercise",
+      "race"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3c3-200d-2642-fe0f",
+        "emoji": "🏃‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3c3-1f3fb-200d-2642-fe0f",
+        "emoji": "🏃🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3c3-1f3fc-200d-2642-fe0f",
+        "emoji": "🏃🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3c3-1f3fd-200d-2642-fe0f",
+        "emoji": "🏃🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3c3-1f3fe-200d-2642-fe0f",
+        "emoji": "🏃🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3c3-1f3ff-200d-2642-fe0f",
+        "emoji": "🏃🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🏃‍♀️",
+    "name": "Woman Running",
+    "shortcodes": [
+      "woman-running"
+    ],
+    "keywords": [
+      "walking",
+      "exercise",
+      "race",
+      "female"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3c3-200d-2640-fe0f",
+        "emoji": "🏃‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3c3-1f3fb-200d-2640-fe0f",
+        "emoji": "🏃🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3c3-1f3fc-200d-2640-fe0f",
+        "emoji": "🏃🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3c3-1f3fd-200d-2640-fe0f",
+        "emoji": "🏃🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3c3-1f3fe-200d-2640-fe0f",
+        "emoji": "🏃🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3c3-1f3ff-200d-2640-fe0f",
+        "emoji": "🏃🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "💃",
+    "name": "Dancer",
+    "shortcodes": [
+      "dancer"
+    ],
+    "keywords": [
+      "woman",
+      "dancing",
+      "female",
+      "girl",
+      "fun"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f483",
+        "emoji": "💃"
+      },
+      {
+        "tone": "light",
+        "unified": "1f483-1f3fb",
+        "emoji": "💃🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f483-1f3fc",
+        "emoji": "💃🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f483-1f3fd",
+        "emoji": "💃🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f483-1f3fe",
+        "emoji": "💃🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f483-1f3ff",
+        "emoji": "💃🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕺",
+    "name": "Man Dancing",
+    "shortcodes": [
+      "man_dancing"
+    ],
+    "keywords": [
+      "male",
+      "boy",
+      "fun",
+      "dancer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f57a",
+        "emoji": "🕺"
+      },
+      {
+        "tone": "light",
+        "unified": "1f57a-1f3fb",
+        "emoji": "🕺🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f57a-1f3fc",
+        "emoji": "🕺🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f57a-1f3fd",
+        "emoji": "🕺🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f57a-1f3fe",
+        "emoji": "🕺🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f57a-1f3ff",
+        "emoji": "🕺🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🕴️",
+    "name": "Person in Suit Levitating",
+    "shortcodes": [
+      "man_in_business_suit_levitating"
+    ],
+    "keywords": [
+      "man",
+      "business",
+      "levitate",
+      "hover",
+      "jump"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f574-fe0f",
+        "emoji": "🕴️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f574-1f3fb",
+        "emoji": "🕴🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f574-1f3fc",
+        "emoji": "🕴🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f574-1f3fd",
+        "emoji": "🕴🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f574-1f3fe",
+        "emoji": "🕴🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f574-1f3ff",
+        "emoji": "🕴🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👯",
+    "name": "Woman with Bunny Ears",
+    "shortcodes": [
+      "dancers"
+    ],
+    "keywords": [
+      "dancers",
+      "people",
+      "perform",
+      "costume"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f46f",
+        "emoji": "👯"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👯‍♂️",
+    "name": "Men with Bunny Ears",
+    "shortcodes": [
+      "men-with-bunny-ears-partying",
+      "man-with-bunny-ears-partying"
+    ],
+    "keywords": [
+      "with-bunny-ears-partying",
+      "man",
+      "male",
+      "boys"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f46f-200d-2642-fe0f",
+        "emoji": "👯‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👯‍♀️",
+    "name": "Women with Bunny Ears",
+    "shortcodes": [
+      "women-with-bunny-ears-partying",
+      "woman-with-bunny-ears-partying"
+    ],
+    "keywords": [
+      "with-bunny-ears-partying",
+      "woman",
+      "female",
+      "girls"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f46f-200d-2640-fe0f",
+        "emoji": "👯‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧖",
+    "name": "Person in Steamy Room",
+    "shortcodes": [
+      "person_in_steamy_room"
+    ],
+    "keywords": [
+      "relax",
+      "spa"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d6",
+        "emoji": "🧖"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d6-1f3fb",
+        "emoji": "🧖🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d6-1f3fc",
+        "emoji": "🧖🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d6-1f3fd",
+        "emoji": "🧖🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d6-1f3fe",
+        "emoji": "🧖🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d6-1f3ff",
+        "emoji": "🧖🏿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧖‍♂️",
+    "name": "Man in Steamy Room",
+    "shortcodes": [
+      "man_in_steamy_room"
+    ],
+    "keywords": [
+      "male",
+      "spa",
+      "steamroom",
+      "sauna"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d6-200d-2642-fe0f",
+        "emoji": "🧖‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d6-1f3fb-200d-2642-fe0f",
+        "emoji": "🧖🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d6-1f3fc-200d-2642-fe0f",
+        "emoji": "🧖🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d6-1f3fd-200d-2642-fe0f",
+        "emoji": "🧖🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d6-1f3fe-200d-2642-fe0f",
+        "emoji": "🧖🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d6-1f3ff-200d-2642-fe0f",
+        "emoji": "🧖🏿‍♂️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧖‍♀️",
+    "name": "Woman in Steamy Room",
+    "shortcodes": [
+      "woman_in_steamy_room"
+    ],
+    "keywords": [
+      "female",
+      "spa",
+      "steamroom",
+      "sauna"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d6-200d-2640-fe0f",
+        "emoji": "🧖‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d6-1f3fb-200d-2640-fe0f",
+        "emoji": "🧖🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d6-1f3fc-200d-2640-fe0f",
+        "emoji": "🧖🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d6-1f3fd-200d-2640-fe0f",
+        "emoji": "🧖🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d6-1f3fe-200d-2640-fe0f",
+        "emoji": "🧖🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d6-1f3ff-200d-2640-fe0f",
+        "emoji": "🧖🏿‍♀️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧗",
+    "name": "Person Climbing",
+    "shortcodes": [
+      "person_climbing"
+    ],
+    "keywords": [
+      "sport"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d7",
+        "emoji": "🧗"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d7-1f3fb",
+        "emoji": "🧗🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d7-1f3fc",
+        "emoji": "🧗🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d7-1f3fd",
+        "emoji": "🧗🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d7-1f3fe",
+        "emoji": "🧗🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d7-1f3ff",
+        "emoji": "🧗🏿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧗‍♂️",
+    "name": "Man Climbing",
+    "shortcodes": [
+      "man_climbing"
+    ],
+    "keywords": [
+      "sports",
+      "hobby",
+      "male",
+      "rock"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d7-200d-2642-fe0f",
+        "emoji": "🧗‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d7-1f3fb-200d-2642-fe0f",
+        "emoji": "🧗🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d7-1f3fc-200d-2642-fe0f",
+        "emoji": "🧗🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d7-1f3fd-200d-2642-fe0f",
+        "emoji": "🧗🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d7-1f3fe-200d-2642-fe0f",
+        "emoji": "🧗🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d7-1f3ff-200d-2642-fe0f",
+        "emoji": "🧗🏿‍♂️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧗‍♀️",
+    "name": "Woman Climbing",
+    "shortcodes": [
+      "woman_climbing"
+    ],
+    "keywords": [
+      "sports",
+      "hobby",
+      "female",
+      "rock"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d7-200d-2640-fe0f",
+        "emoji": "🧗‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d7-1f3fb-200d-2640-fe0f",
+        "emoji": "🧗🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d7-1f3fc-200d-2640-fe0f",
+        "emoji": "🧗🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d7-1f3fd-200d-2640-fe0f",
+        "emoji": "🧗🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d7-1f3fe-200d-2640-fe0f",
+        "emoji": "🧗🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d7-1f3ff-200d-2640-fe0f",
+        "emoji": "🧗🏿‍♀️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🤺",
+    "name": "Fencer",
+    "shortcodes": [
+      "fencer"
+    ],
+    "keywords": [
+      "person",
+      "fencing",
+      "sports",
+      "sword"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f93a",
+        "emoji": "🤺"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🏇",
+    "name": "Horse Racing",
+    "shortcodes": [
+      "horse_racing"
+    ],
+    "keywords": [
+      "animal",
+      "betting",
+      "competition",
+      "gambling",
+      "luck"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3c7",
+        "emoji": "🏇"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3c7-1f3fb",
+        "emoji": "🏇🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3c7-1f3fc",
+        "emoji": "🏇🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3c7-1f3fd",
+        "emoji": "🏇🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3c7-1f3fe",
+        "emoji": "🏇🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3c7-1f3ff",
+        "emoji": "🏇🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛷️",
+    "name": "Skier",
+    "shortcodes": [
+      "skier"
+    ],
+    "keywords": [
+      "sports",
+      "winter",
+      "snow"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26f7-fe0f",
+        "emoji": "⛷️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏂",
+    "name": "Snowboarder",
+    "shortcodes": [
+      "snowboarder"
+    ],
+    "keywords": [
+      "sports",
+      "winter"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3c2",
+        "emoji": "🏂"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3c2-1f3fb",
+        "emoji": "🏂🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3c2-1f3fc",
+        "emoji": "🏂🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3c2-1f3fd",
+        "emoji": "🏂🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3c2-1f3fe",
+        "emoji": "🏂🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3c2-1f3ff",
+        "emoji": "🏂🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏌️",
+    "name": "Person Golfing",
+    "shortcodes": [
+      "golfer"
+    ],
+    "keywords": [
+      "golfer",
+      "sports",
+      "business"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3cc-fe0f",
+        "emoji": "🏌️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3cc-1f3fb",
+        "emoji": "🏌🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3cc-1f3fc",
+        "emoji": "🏌🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3cc-1f3fd",
+        "emoji": "🏌🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3cc-1f3fe",
+        "emoji": "🏌🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3cc-1f3ff",
+        "emoji": "🏌🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏌️‍♂️",
+    "name": "Man Golfing",
+    "shortcodes": [
+      "man-golfing"
+    ],
+    "keywords": [
+      "sport"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3cc-fe0f-200d-2642-fe0f",
+        "emoji": "🏌️‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3cc-1f3fb-200d-2642-fe0f",
+        "emoji": "🏌🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3cc-1f3fc-200d-2642-fe0f",
+        "emoji": "🏌🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3cc-1f3fd-200d-2642-fe0f",
+        "emoji": "🏌🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3cc-1f3fe-200d-2642-fe0f",
+        "emoji": "🏌🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3cc-1f3ff-200d-2642-fe0f",
+        "emoji": "🏌🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🏌️‍♀️",
+    "name": "Woman Golfing",
+    "shortcodes": [
+      "woman-golfing"
+    ],
+    "keywords": [
+      "sports",
+      "business",
+      "female"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3cc-fe0f-200d-2640-fe0f",
+        "emoji": "🏌️‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3cc-1f3fb-200d-2640-fe0f",
+        "emoji": "🏌🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3cc-1f3fc-200d-2640-fe0f",
+        "emoji": "🏌🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3cc-1f3fd-200d-2640-fe0f",
+        "emoji": "🏌🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3cc-1f3fe-200d-2640-fe0f",
+        "emoji": "🏌🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3cc-1f3ff-200d-2640-fe0f",
+        "emoji": "🏌🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🏄",
+    "name": "Surfer",
+    "shortcodes": [
+      "surfer"
+    ],
+    "keywords": [
+      "person",
+      "surfing",
+      "sport",
+      "sea"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3c4",
+        "emoji": "🏄"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3c4-1f3fb",
+        "emoji": "🏄🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3c4-1f3fc",
+        "emoji": "🏄🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3c4-1f3fd",
+        "emoji": "🏄🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3c4-1f3fe",
+        "emoji": "🏄🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3c4-1f3ff",
+        "emoji": "🏄🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏄‍♂️",
+    "name": "Man Surfing",
+    "shortcodes": [
+      "man-surfing"
+    ],
+    "keywords": [
+      "sports",
+      "ocean",
+      "sea",
+      "summer",
+      "beach"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3c4-200d-2642-fe0f",
+        "emoji": "🏄‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3c4-1f3fb-200d-2642-fe0f",
+        "emoji": "🏄🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3c4-1f3fc-200d-2642-fe0f",
+        "emoji": "🏄🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3c4-1f3fd-200d-2642-fe0f",
+        "emoji": "🏄🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3c4-1f3fe-200d-2642-fe0f",
+        "emoji": "🏄🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3c4-1f3ff-200d-2642-fe0f",
+        "emoji": "🏄🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🏄‍♀️",
+    "name": "Woman Surfing",
+    "shortcodes": [
+      "woman-surfing"
+    ],
+    "keywords": [
+      "sports",
+      "ocean",
+      "sea",
+      "summer",
+      "beach",
+      "female"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3c4-200d-2640-fe0f",
+        "emoji": "🏄‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3c4-1f3fb-200d-2640-fe0f",
+        "emoji": "🏄🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3c4-1f3fc-200d-2640-fe0f",
+        "emoji": "🏄🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3c4-1f3fd-200d-2640-fe0f",
+        "emoji": "🏄🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3c4-1f3fe-200d-2640-fe0f",
+        "emoji": "🏄🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3c4-1f3ff-200d-2640-fe0f",
+        "emoji": "🏄🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🚣",
+    "name": "Rowboat",
+    "shortcodes": [
+      "rowboat"
+    ],
+    "keywords": [
+      "person",
+      "rowing",
+      "boat",
+      "sport",
+      "move"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6a3",
+        "emoji": "🚣"
+      },
+      {
+        "tone": "light",
+        "unified": "1f6a3-1f3fb",
+        "emoji": "🚣🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f6a3-1f3fc",
+        "emoji": "🚣🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f6a3-1f3fd",
+        "emoji": "🚣🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f6a3-1f3fe",
+        "emoji": "🚣🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f6a3-1f3ff",
+        "emoji": "🚣🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚣‍♂️",
+    "name": "Man Rowing Boat",
+    "shortcodes": [
+      "man-rowing-boat"
+    ],
+    "keywords": [
+      "rowing-boat",
+      "sports",
+      "hobby",
+      "water",
+      "ship"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6a3-200d-2642-fe0f",
+        "emoji": "🚣‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f6a3-1f3fb-200d-2642-fe0f",
+        "emoji": "🚣🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f6a3-1f3fc-200d-2642-fe0f",
+        "emoji": "🚣🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f6a3-1f3fd-200d-2642-fe0f",
+        "emoji": "🚣🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f6a3-1f3fe-200d-2642-fe0f",
+        "emoji": "🚣🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f6a3-1f3ff-200d-2642-fe0f",
+        "emoji": "🚣🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🚣‍♀️",
+    "name": "Woman Rowing Boat",
+    "shortcodes": [
+      "woman-rowing-boat"
+    ],
+    "keywords": [
+      "rowing-boat",
+      "sports",
+      "hobby",
+      "water",
+      "ship",
+      "female"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6a3-200d-2640-fe0f",
+        "emoji": "🚣‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f6a3-1f3fb-200d-2640-fe0f",
+        "emoji": "🚣🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f6a3-1f3fc-200d-2640-fe0f",
+        "emoji": "🚣🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f6a3-1f3fd-200d-2640-fe0f",
+        "emoji": "🚣🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f6a3-1f3fe-200d-2640-fe0f",
+        "emoji": "🚣🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f6a3-1f3ff-200d-2640-fe0f",
+        "emoji": "🚣🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🏊",
+    "name": "Swimmer",
+    "shortcodes": [
+      "swimmer"
+    ],
+    "keywords": [
+      "person",
+      "swimming",
+      "sport",
+      "pool"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3ca",
+        "emoji": "🏊"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3ca-1f3fb",
+        "emoji": "🏊🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3ca-1f3fc",
+        "emoji": "🏊🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3ca-1f3fd",
+        "emoji": "🏊🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3ca-1f3fe",
+        "emoji": "🏊🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3ca-1f3ff",
+        "emoji": "🏊🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏊‍♂️",
+    "name": "Man Swimming",
+    "shortcodes": [
+      "man-swimming"
+    ],
+    "keywords": [
+      "sports",
+      "exercise",
+      "human",
+      "athlete",
+      "water",
+      "summer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3ca-200d-2642-fe0f",
+        "emoji": "🏊‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3ca-1f3fb-200d-2642-fe0f",
+        "emoji": "🏊🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3ca-1f3fc-200d-2642-fe0f",
+        "emoji": "🏊🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3ca-1f3fd-200d-2642-fe0f",
+        "emoji": "🏊🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3ca-1f3fe-200d-2642-fe0f",
+        "emoji": "🏊🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3ca-1f3ff-200d-2642-fe0f",
+        "emoji": "🏊🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🏊‍♀️",
+    "name": "Woman Swimming",
+    "shortcodes": [
+      "woman-swimming"
+    ],
+    "keywords": [
+      "sports",
+      "exercise",
+      "human",
+      "athlete",
+      "water",
+      "summer",
+      "female"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3ca-200d-2640-fe0f",
+        "emoji": "🏊‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3ca-1f3fb-200d-2640-fe0f",
+        "emoji": "🏊🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3ca-1f3fc-200d-2640-fe0f",
+        "emoji": "🏊🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3ca-1f3fd-200d-2640-fe0f",
+        "emoji": "🏊🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3ca-1f3fe-200d-2640-fe0f",
+        "emoji": "🏊🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3ca-1f3ff-200d-2640-fe0f",
+        "emoji": "🏊🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "⛹️",
+    "name": "Person Bouncing Ball",
+    "shortcodes": [
+      "person_with_ball"
+    ],
+    "keywords": [
+      "with",
+      "sports",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26f9-fe0f",
+        "emoji": "⛹️"
+      },
+      {
+        "tone": "light",
+        "unified": "26f9-1f3fb",
+        "emoji": "⛹🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "26f9-1f3fc",
+        "emoji": "⛹🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "26f9-1f3fd",
+        "emoji": "⛹🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "26f9-1f3fe",
+        "emoji": "⛹🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "26f9-1f3ff",
+        "emoji": "⛹🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛹️‍♂️",
+    "name": "Man Bouncing Ball",
+    "shortcodes": [
+      "man-bouncing-ball"
+    ],
+    "keywords": [
+      "bouncing-ball",
+      "sport"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26f9-fe0f-200d-2642-fe0f",
+        "emoji": "⛹️‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "26f9-1f3fb-200d-2642-fe0f",
+        "emoji": "⛹🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "26f9-1f3fc-200d-2642-fe0f",
+        "emoji": "⛹🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "26f9-1f3fd-200d-2642-fe0f",
+        "emoji": "⛹🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "26f9-1f3fe-200d-2642-fe0f",
+        "emoji": "⛹🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "26f9-1f3ff-200d-2642-fe0f",
+        "emoji": "⛹🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "⛹️‍♀️",
+    "name": "Woman Bouncing Ball",
+    "shortcodes": [
+      "woman-bouncing-ball"
+    ],
+    "keywords": [
+      "bouncing-ball",
+      "sports",
+      "human",
+      "female"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26f9-fe0f-200d-2640-fe0f",
+        "emoji": "⛹️‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "26f9-1f3fb-200d-2640-fe0f",
+        "emoji": "⛹🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "26f9-1f3fc-200d-2640-fe0f",
+        "emoji": "⛹🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "26f9-1f3fd-200d-2640-fe0f",
+        "emoji": "⛹🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "26f9-1f3fe-200d-2640-fe0f",
+        "emoji": "⛹🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "26f9-1f3ff-200d-2640-fe0f",
+        "emoji": "⛹🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🏋️",
+    "name": "Person Lifting Weights",
+    "shortcodes": [
+      "weight_lifter"
+    ],
+    "keywords": [
+      "weight",
+      "lifter",
+      "sports",
+      "training",
+      "exercise"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3cb-fe0f",
+        "emoji": "🏋️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3cb-1f3fb",
+        "emoji": "🏋🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3cb-1f3fc",
+        "emoji": "🏋🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3cb-1f3fd",
+        "emoji": "🏋🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3cb-1f3fe",
+        "emoji": "🏋🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3cb-1f3ff",
+        "emoji": "🏋🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏋️‍♂️",
+    "name": "Man Lifting Weights",
+    "shortcodes": [
+      "man-lifting-weights"
+    ],
+    "keywords": [
+      "lifting-weights",
+      "sport"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3cb-fe0f-200d-2642-fe0f",
+        "emoji": "🏋️‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3cb-1f3fb-200d-2642-fe0f",
+        "emoji": "🏋🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3cb-1f3fc-200d-2642-fe0f",
+        "emoji": "🏋🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3cb-1f3fd-200d-2642-fe0f",
+        "emoji": "🏋🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3cb-1f3fe-200d-2642-fe0f",
+        "emoji": "🏋🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3cb-1f3ff-200d-2642-fe0f",
+        "emoji": "🏋🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🏋️‍♀️",
+    "name": "Woman Lifting Weights",
+    "shortcodes": [
+      "woman-lifting-weights"
+    ],
+    "keywords": [
+      "lifting-weights",
+      "sports",
+      "training",
+      "exercise",
+      "female"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3cb-fe0f-200d-2640-fe0f",
+        "emoji": "🏋️‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f3cb-1f3fb-200d-2640-fe0f",
+        "emoji": "🏋🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f3cb-1f3fc-200d-2640-fe0f",
+        "emoji": "🏋🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f3cb-1f3fd-200d-2640-fe0f",
+        "emoji": "🏋🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f3cb-1f3fe-200d-2640-fe0f",
+        "emoji": "🏋🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f3cb-1f3ff-200d-2640-fe0f",
+        "emoji": "🏋🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🚴",
+    "name": "Bicyclist",
+    "shortcodes": [
+      "bicyclist"
+    ],
+    "keywords": [
+      "person",
+      "biking",
+      "sport",
+      "move"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6b4",
+        "emoji": "🚴"
+      },
+      {
+        "tone": "light",
+        "unified": "1f6b4-1f3fb",
+        "emoji": "🚴🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f6b4-1f3fc",
+        "emoji": "🚴🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f6b4-1f3fd",
+        "emoji": "🚴🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f6b4-1f3fe",
+        "emoji": "🚴🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f6b4-1f3ff",
+        "emoji": "🚴🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚴‍♂️",
+    "name": "Man Biking",
+    "shortcodes": [
+      "man-biking"
+    ],
+    "keywords": [
+      "sports",
+      "bike",
+      "exercise",
+      "hipster"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6b4-200d-2642-fe0f",
+        "emoji": "🚴‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f6b4-1f3fb-200d-2642-fe0f",
+        "emoji": "🚴🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f6b4-1f3fc-200d-2642-fe0f",
+        "emoji": "🚴🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f6b4-1f3fd-200d-2642-fe0f",
+        "emoji": "🚴🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f6b4-1f3fe-200d-2642-fe0f",
+        "emoji": "🚴🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f6b4-1f3ff-200d-2642-fe0f",
+        "emoji": "🚴🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🚴‍♀️",
+    "name": "Woman Biking",
+    "shortcodes": [
+      "woman-biking"
+    ],
+    "keywords": [
+      "sports",
+      "bike",
+      "exercise",
+      "hipster",
+      "female"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6b4-200d-2640-fe0f",
+        "emoji": "🚴‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f6b4-1f3fb-200d-2640-fe0f",
+        "emoji": "🚴🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f6b4-1f3fc-200d-2640-fe0f",
+        "emoji": "🚴🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f6b4-1f3fd-200d-2640-fe0f",
+        "emoji": "🚴🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f6b4-1f3fe-200d-2640-fe0f",
+        "emoji": "🚴🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f6b4-1f3ff-200d-2640-fe0f",
+        "emoji": "🚴🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🚵",
+    "name": "Mountain Bicyclist",
+    "shortcodes": [
+      "mountain_bicyclist"
+    ],
+    "keywords": [
+      "person",
+      "biking",
+      "sport",
+      "move"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6b5",
+        "emoji": "🚵"
+      },
+      {
+        "tone": "light",
+        "unified": "1f6b5-1f3fb",
+        "emoji": "🚵🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f6b5-1f3fc",
+        "emoji": "🚵🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f6b5-1f3fd",
+        "emoji": "🚵🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f6b5-1f3fe",
+        "emoji": "🚵🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f6b5-1f3ff",
+        "emoji": "🚵🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚵‍♂️",
+    "name": "Man Mountain Biking",
+    "shortcodes": [
+      "man-mountain-biking"
+    ],
+    "keywords": [
+      "mountain-biking",
+      "transportation",
+      "sports",
+      "human",
+      "race",
+      "bike"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6b5-200d-2642-fe0f",
+        "emoji": "🚵‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f6b5-1f3fb-200d-2642-fe0f",
+        "emoji": "🚵🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f6b5-1f3fc-200d-2642-fe0f",
+        "emoji": "🚵🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f6b5-1f3fd-200d-2642-fe0f",
+        "emoji": "🚵🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f6b5-1f3fe-200d-2642-fe0f",
+        "emoji": "🚵🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f6b5-1f3ff-200d-2642-fe0f",
+        "emoji": "🚵🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🚵‍♀️",
+    "name": "Woman Mountain Biking",
+    "shortcodes": [
+      "woman-mountain-biking"
+    ],
+    "keywords": [
+      "mountain-biking",
+      "transportation",
+      "sports",
+      "human",
+      "race",
+      "bike",
+      "female"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6b5-200d-2640-fe0f",
+        "emoji": "🚵‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f6b5-1f3fb-200d-2640-fe0f",
+        "emoji": "🚵🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f6b5-1f3fc-200d-2640-fe0f",
+        "emoji": "🚵🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f6b5-1f3fd-200d-2640-fe0f",
+        "emoji": "🚵🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f6b5-1f3fe-200d-2640-fe0f",
+        "emoji": "🚵🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f6b5-1f3ff-200d-2640-fe0f",
+        "emoji": "🚵🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🤸",
+    "name": "Person Cartwheeling",
+    "shortcodes": [
+      "person_doing_cartwheel"
+    ],
+    "keywords": [
+      "doing",
+      "cartwheel",
+      "sport",
+      "gymnastic"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f938",
+        "emoji": "🤸"
+      },
+      {
+        "tone": "light",
+        "unified": "1f938-1f3fb",
+        "emoji": "🤸🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f938-1f3fc",
+        "emoji": "🤸🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f938-1f3fd",
+        "emoji": "🤸🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f938-1f3fe",
+        "emoji": "🤸🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f938-1f3ff",
+        "emoji": "🤸🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🤸‍♂️",
+    "name": "Man Cartwheeling",
+    "shortcodes": [
+      "man-cartwheeling"
+    ],
+    "keywords": [
+      "gymnastics"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f938-200d-2642-fe0f",
+        "emoji": "🤸‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f938-1f3fb-200d-2642-fe0f",
+        "emoji": "🤸🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f938-1f3fc-200d-2642-fe0f",
+        "emoji": "🤸🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f938-1f3fd-200d-2642-fe0f",
+        "emoji": "🤸🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f938-1f3fe-200d-2642-fe0f",
+        "emoji": "🤸🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f938-1f3ff-200d-2642-fe0f",
+        "emoji": "🤸🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🤸‍♀️",
+    "name": "Woman Cartwheeling",
+    "shortcodes": [
+      "woman-cartwheeling"
+    ],
+    "keywords": [
+      "gymnastics"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f938-200d-2640-fe0f",
+        "emoji": "🤸‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f938-1f3fb-200d-2640-fe0f",
+        "emoji": "🤸🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f938-1f3fc-200d-2640-fe0f",
+        "emoji": "🤸🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f938-1f3fd-200d-2640-fe0f",
+        "emoji": "🤸🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f938-1f3fe-200d-2640-fe0f",
+        "emoji": "🤸🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f938-1f3ff-200d-2640-fe0f",
+        "emoji": "🤸🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🤼",
+    "name": "Wrestlers",
+    "shortcodes": [
+      "wrestlers"
+    ],
+    "keywords": [
+      "people",
+      "wrestling",
+      "sport"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f93c",
+        "emoji": "🤼"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🤼‍♂️",
+    "name": "Men Wrestling",
+    "shortcodes": [
+      "man-wrestling"
+    ],
+    "keywords": [
+      "man",
+      "sports",
+      "wrestlers"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f93c-200d-2642-fe0f",
+        "emoji": "🤼‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🤼‍♀️",
+    "name": "Women Wrestling",
+    "shortcodes": [
+      "woman-wrestling"
+    ],
+    "keywords": [
+      "woman",
+      "sports",
+      "wrestlers"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f93c-200d-2640-fe0f",
+        "emoji": "🤼‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🤽",
+    "name": "Water Polo",
+    "shortcodes": [
+      "water_polo"
+    ],
+    "keywords": [
+      "person",
+      "playing",
+      "sport"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f93d",
+        "emoji": "🤽"
+      },
+      {
+        "tone": "light",
+        "unified": "1f93d-1f3fb",
+        "emoji": "🤽🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f93d-1f3fc",
+        "emoji": "🤽🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f93d-1f3fd",
+        "emoji": "🤽🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f93d-1f3fe",
+        "emoji": "🤽🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f93d-1f3ff",
+        "emoji": "🤽🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🤽‍♂️",
+    "name": "Man Playing Water Polo",
+    "shortcodes": [
+      "man-playing-water-polo"
+    ],
+    "keywords": [
+      "playing-water-polo",
+      "sports",
+      "pool"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f93d-200d-2642-fe0f",
+        "emoji": "🤽‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f93d-1f3fb-200d-2642-fe0f",
+        "emoji": "🤽🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f93d-1f3fc-200d-2642-fe0f",
+        "emoji": "🤽🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f93d-1f3fd-200d-2642-fe0f",
+        "emoji": "🤽🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f93d-1f3fe-200d-2642-fe0f",
+        "emoji": "🤽🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f93d-1f3ff-200d-2642-fe0f",
+        "emoji": "🤽🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🤽‍♀️",
+    "name": "Woman Playing Water Polo",
+    "shortcodes": [
+      "woman-playing-water-polo"
+    ],
+    "keywords": [
+      "playing-water-polo",
+      "sports",
+      "pool"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f93d-200d-2640-fe0f",
+        "emoji": "🤽‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f93d-1f3fb-200d-2640-fe0f",
+        "emoji": "🤽🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f93d-1f3fc-200d-2640-fe0f",
+        "emoji": "🤽🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f93d-1f3fd-200d-2640-fe0f",
+        "emoji": "🤽🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f93d-1f3fe-200d-2640-fe0f",
+        "emoji": "🤽🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f93d-1f3ff-200d-2640-fe0f",
+        "emoji": "🤽🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🤾",
+    "name": "Handball",
+    "shortcodes": [
+      "handball"
+    ],
+    "keywords": [
+      "person",
+      "playing",
+      "sport"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f93e",
+        "emoji": "🤾"
+      },
+      {
+        "tone": "light",
+        "unified": "1f93e-1f3fb",
+        "emoji": "🤾🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f93e-1f3fc",
+        "emoji": "🤾🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f93e-1f3fd",
+        "emoji": "🤾🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f93e-1f3fe",
+        "emoji": "🤾🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f93e-1f3ff",
+        "emoji": "🤾🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🤾‍♂️",
+    "name": "Man Playing Handball",
+    "shortcodes": [
+      "man-playing-handball"
+    ],
+    "keywords": [
+      "playing-handball",
+      "sports"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f93e-200d-2642-fe0f",
+        "emoji": "🤾‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f93e-1f3fb-200d-2642-fe0f",
+        "emoji": "🤾🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f93e-1f3fc-200d-2642-fe0f",
+        "emoji": "🤾🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f93e-1f3fd-200d-2642-fe0f",
+        "emoji": "🤾🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f93e-1f3fe-200d-2642-fe0f",
+        "emoji": "🤾🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f93e-1f3ff-200d-2642-fe0f",
+        "emoji": "🤾🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🤾‍♀️",
+    "name": "Woman Playing Handball",
+    "shortcodes": [
+      "woman-playing-handball"
+    ],
+    "keywords": [
+      "playing-handball",
+      "sports"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f93e-200d-2640-fe0f",
+        "emoji": "🤾‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f93e-1f3fb-200d-2640-fe0f",
+        "emoji": "🤾🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f93e-1f3fc-200d-2640-fe0f",
+        "emoji": "🤾🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f93e-1f3fd-200d-2640-fe0f",
+        "emoji": "🤾🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f93e-1f3fe-200d-2640-fe0f",
+        "emoji": "🤾🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f93e-1f3ff-200d-2640-fe0f",
+        "emoji": "🤾🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🤹",
+    "name": "Juggling",
+    "shortcodes": [
+      "juggling"
+    ],
+    "keywords": [
+      "person",
+      "performance",
+      "balance"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f939",
+        "emoji": "🤹"
+      },
+      {
+        "tone": "light",
+        "unified": "1f939-1f3fb",
+        "emoji": "🤹🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f939-1f3fc",
+        "emoji": "🤹🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f939-1f3fd",
+        "emoji": "🤹🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f939-1f3fe",
+        "emoji": "🤹🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f939-1f3ff",
+        "emoji": "🤹🏿"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🤹‍♂️",
+    "name": "Man Juggling",
+    "shortcodes": [
+      "man-juggling"
+    ],
+    "keywords": [
+      "juggle",
+      "balance",
+      "skill",
+      "multitask"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f939-200d-2642-fe0f",
+        "emoji": "🤹‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f939-1f3fb-200d-2642-fe0f",
+        "emoji": "🤹🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f939-1f3fc-200d-2642-fe0f",
+        "emoji": "🤹🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f939-1f3fd-200d-2642-fe0f",
+        "emoji": "🤹🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f939-1f3fe-200d-2642-fe0f",
+        "emoji": "🤹🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f939-1f3ff-200d-2642-fe0f",
+        "emoji": "🤹🏿‍♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🤹‍♀️",
+    "name": "Woman Juggling",
+    "shortcodes": [
+      "woman-juggling"
+    ],
+    "keywords": [
+      "juggle",
+      "balance",
+      "skill",
+      "multitask"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f939-200d-2640-fe0f",
+        "emoji": "🤹‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f939-1f3fb-200d-2640-fe0f",
+        "emoji": "🤹🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f939-1f3fc-200d-2640-fe0f",
+        "emoji": "🤹🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f939-1f3fd-200d-2640-fe0f",
+        "emoji": "🤹🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f939-1f3fe-200d-2640-fe0f",
+        "emoji": "🤹🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f939-1f3ff-200d-2640-fe0f",
+        "emoji": "🤹🏿‍♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🧘",
+    "name": "Person in Lotus Position",
+    "shortcodes": [
+      "person_in_lotus_position"
+    ],
+    "keywords": [
+      "meditate"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d8",
+        "emoji": "🧘"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d8-1f3fb",
+        "emoji": "🧘🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d8-1f3fc",
+        "emoji": "🧘🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d8-1f3fd",
+        "emoji": "🧘🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d8-1f3fe",
+        "emoji": "🧘🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d8-1f3ff",
+        "emoji": "🧘🏿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧘‍♂️",
+    "name": "Man in Lotus Position",
+    "shortcodes": [
+      "man_in_lotus_position"
+    ],
+    "keywords": [
+      "male",
+      "meditation",
+      "yoga",
+      "serenity",
+      "zen",
+      "mindfulness"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d8-200d-2642-fe0f",
+        "emoji": "🧘‍♂️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d8-1f3fb-200d-2642-fe0f",
+        "emoji": "🧘🏻‍♂️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d8-1f3fc-200d-2642-fe0f",
+        "emoji": "🧘🏼‍♂️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d8-1f3fd-200d-2642-fe0f",
+        "emoji": "🧘🏽‍♂️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d8-1f3fe-200d-2642-fe0f",
+        "emoji": "🧘🏾‍♂️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d8-1f3ff-200d-2642-fe0f",
+        "emoji": "🧘🏿‍♂️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧘‍♀️",
+    "name": "Woman in Lotus Position",
+    "shortcodes": [
+      "woman_in_lotus_position"
+    ],
+    "keywords": [
+      "female",
+      "meditation",
+      "yoga",
+      "serenity",
+      "zen",
+      "mindfulness"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d8-200d-2640-fe0f",
+        "emoji": "🧘‍♀️"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d8-1f3fb-200d-2640-fe0f",
+        "emoji": "🧘🏻‍♀️"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d8-1f3fc-200d-2640-fe0f",
+        "emoji": "🧘🏼‍♀️"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d8-1f3fd-200d-2640-fe0f",
+        "emoji": "🧘🏽‍♀️"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d8-1f3fe-200d-2640-fe0f",
+        "emoji": "🧘🏾‍♀️"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d8-1f3ff-200d-2640-fe0f",
+        "emoji": "🧘🏿‍♀️"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🛀",
+    "name": "Bath",
+    "shortcodes": [
+      "bath"
+    ],
+    "keywords": [
+      "person",
+      "taking",
+      "clean",
+      "shower",
+      "bathroom"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6c0",
+        "emoji": "🛀"
+      },
+      {
+        "tone": "light",
+        "unified": "1f6c0-1f3fb",
+        "emoji": "🛀🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f6c0-1f3fc",
+        "emoji": "🛀🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f6c0-1f3fd",
+        "emoji": "🛀🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f6c0-1f3fe",
+        "emoji": "🛀🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f6c0-1f3ff",
+        "emoji": "🛀🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛌",
+    "name": "Person in Bed",
+    "shortcodes": [
+      "sleeping_accommodation"
+    ],
+    "keywords": [
+      "sleeping",
+      "accommodation",
+      "rest"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6cc",
+        "emoji": "🛌"
+      },
+      {
+        "tone": "light",
+        "unified": "1f6cc-1f3fb",
+        "emoji": "🛌🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f6cc-1f3fc",
+        "emoji": "🛌🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f6cc-1f3fd",
+        "emoji": "🛌🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f6cc-1f3fe",
+        "emoji": "🛌🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f6cc-1f3ff",
+        "emoji": "🛌🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧑‍🤝‍🧑",
+    "name": "People Holding Hands",
+    "shortcodes": [
+      "people_holding_hands"
+    ],
+    "keywords": [
+      "friendship"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9d1-200d-1f91d-200d-1f9d1",
+        "emoji": "🧑‍🤝‍🧑"
+      },
+      {
+        "tone": "light",
+        "unified": "1f9d1-1f3fb-200d-1f91d-200d-1f9d1-1f3fb",
+        "emoji": "🧑🏻‍🤝‍🧑🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f9d1-1f3fc-200d-1f91d-200d-1f9d1-1f3fc",
+        "emoji": "🧑🏼‍🤝‍🧑🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f9d1-1f3fd-200d-1f91d-200d-1f9d1-1f3fd",
+        "emoji": "🧑🏽‍🤝‍🧑🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f9d1-1f3fe-200d-1f91d-200d-1f9d1-1f3fe",
+        "emoji": "🧑🏾‍🤝‍🧑🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f9d1-1f3ff-200d-1f91d-200d-1f9d1-1f3ff",
+        "emoji": "🧑🏿‍🤝‍🧑🏿"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "👭",
+    "name": "Women Holding Hands",
+    "shortcodes": [
+      "two_women_holding_hands",
+      "women_holding_hands"
+    ],
+    "keywords": [
+      "two",
+      "pair",
+      "friendship",
+      "couple",
+      "love",
+      "like",
+      "female",
+      "people",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f46d",
+        "emoji": "👭"
+      },
+      {
+        "tone": "light",
+        "unified": "1f46d-1f3fb",
+        "emoji": "👭🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f46d-1f3fc",
+        "emoji": "👭🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f46d-1f3fd",
+        "emoji": "👭🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f46d-1f3fe",
+        "emoji": "👭🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f46d-1f3ff",
+        "emoji": "👭🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👫",
+    "name": "Man and Woman Holding Hands",
+    "shortcodes": [
+      "man_and_woman_holding_hands",
+      "woman_and_man_holding_hands",
+      "couple"
+    ],
+    "keywords": [
+      "couple",
+      "pair",
+      "people",
+      "human",
+      "love",
+      "date",
+      "dating",
+      "like",
+      "affection",
+      "valentines",
+      "marriage"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f46b",
+        "emoji": "👫"
+      },
+      {
+        "tone": "light",
+        "unified": "1f46b-1f3fb",
+        "emoji": "👫🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f46b-1f3fc",
+        "emoji": "👫🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f46b-1f3fd",
+        "emoji": "👫🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f46b-1f3fe",
+        "emoji": "👫🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f46b-1f3ff",
+        "emoji": "👫🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👬",
+    "name": "Men Holding Hands",
+    "shortcodes": [
+      "two_men_holding_hands",
+      "men_holding_hands"
+    ],
+    "keywords": [
+      "two",
+      "pair",
+      "couple",
+      "love",
+      "like",
+      "bromance",
+      "friendship",
+      "people",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f46c",
+        "emoji": "👬"
+      },
+      {
+        "tone": "light",
+        "unified": "1f46c-1f3fb",
+        "emoji": "👬🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f46c-1f3fc",
+        "emoji": "👬🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f46c-1f3fd",
+        "emoji": "👬🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f46c-1f3fe",
+        "emoji": "👬🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f46c-1f3ff",
+        "emoji": "👬🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💏",
+    "name": "Kiss",
+    "shortcodes": [
+      "couplekiss"
+    ],
+    "keywords": [
+      "couplekiss",
+      "pair",
+      "valentines",
+      "love",
+      "like",
+      "dating",
+      "marriage"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f48f",
+        "emoji": "💏"
+      },
+      {
+        "tone": "light",
+        "unified": "1f48f-1f3fb",
+        "emoji": "💏🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f48f-1f3fc",
+        "emoji": "💏🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f48f-1f3fd",
+        "emoji": "💏🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f48f-1f3fe",
+        "emoji": "💏🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f48f-1f3ff",
+        "emoji": "💏🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👩‍❤️‍💋‍👨",
+    "name": "Kiss: Woman, Man",
+    "shortcodes": [
+      "woman-kiss-man"
+    ],
+    "keywords": [
+      "woman",
+      "kiss-man",
+      "kiss",
+      "love"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-2764-fe0f-200d-1f48b-200d-1f468",
+        "emoji": "👩‍❤️‍💋‍👨"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fb",
+        "emoji": "👩🏻‍❤️‍💋‍👨🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fc",
+        "emoji": "👩🏼‍❤️‍💋‍👨🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fd",
+        "emoji": "👩🏽‍❤️‍💋‍👨🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fe",
+        "emoji": "👩🏾‍❤️‍💋‍👨🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3ff",
+        "emoji": "👩🏿‍❤️‍💋‍👨🏿"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👨‍❤️‍💋‍👨",
+    "name": "Kiss: Man, Man",
+    "shortcodes": [
+      "man-kiss-man"
+    ],
+    "keywords": [
+      "kiss-man",
+      "kiss",
+      "pair",
+      "valentines",
+      "love",
+      "like",
+      "dating",
+      "marriage"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-2764-fe0f-200d-1f48b-200d-1f468",
+        "emoji": "👨‍❤️‍💋‍👨"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fb",
+        "emoji": "👨🏻‍❤️‍💋‍👨🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fc",
+        "emoji": "👨🏼‍❤️‍💋‍👨🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fd",
+        "emoji": "👨🏽‍❤️‍💋‍👨🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fe",
+        "emoji": "👨🏾‍❤️‍💋‍👨🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3ff",
+        "emoji": "👨🏿‍❤️‍💋‍👨🏿"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👩‍❤️‍💋‍👩",
+    "name": "Kiss: Woman, Woman",
+    "shortcodes": [
+      "woman-kiss-woman"
+    ],
+    "keywords": [
+      "kiss-woman",
+      "kiss",
+      "pair",
+      "valentines",
+      "love",
+      "like",
+      "dating",
+      "marriage"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-2764-fe0f-200d-1f48b-200d-1f469",
+        "emoji": "👩‍❤️‍💋‍👩"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fb",
+        "emoji": "👩🏻‍❤️‍💋‍👩🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fc",
+        "emoji": "👩🏼‍❤️‍💋‍👩🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fd",
+        "emoji": "👩🏽‍❤️‍💋‍👩🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fe",
+        "emoji": "👩🏾‍❤️‍💋‍👩🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3ff",
+        "emoji": "👩🏿‍❤️‍💋‍👩🏿"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "💑",
+    "name": "Couple with Heart",
+    "shortcodes": [
+      "couple_with_heart"
+    ],
+    "keywords": [
+      "pair",
+      "love",
+      "like",
+      "affection",
+      "human",
+      "dating",
+      "valentines",
+      "marriage"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f491",
+        "emoji": "💑"
+      },
+      {
+        "tone": "light",
+        "unified": "1f491-1f3fb",
+        "emoji": "💑🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f491-1f3fc",
+        "emoji": "💑🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f491-1f3fd",
+        "emoji": "💑🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f491-1f3fe",
+        "emoji": "💑🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f491-1f3ff",
+        "emoji": "💑🏿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👩‍❤️‍👨",
+    "name": "Couple with Heart: Woman, Man",
+    "shortcodes": [
+      "woman-heart-man"
+    ],
+    "keywords": [
+      "woman",
+      "heart-man",
+      "heart",
+      "love"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-2764-fe0f-200d-1f468",
+        "emoji": "👩‍❤️‍👨"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-2764-fe0f-200d-1f468-1f3fb",
+        "emoji": "👩🏻‍❤️‍👨🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-2764-fe0f-200d-1f468-1f3fc",
+        "emoji": "👩🏼‍❤️‍👨🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-2764-fe0f-200d-1f468-1f3fd",
+        "emoji": "👩🏽‍❤️‍👨🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-2764-fe0f-200d-1f468-1f3fe",
+        "emoji": "👩🏾‍❤️‍👨🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-2764-fe0f-200d-1f468-1f3ff",
+        "emoji": "👩🏿‍❤️‍👨🏿"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👨‍❤️‍👨",
+    "name": "Couple with Heart: Man, Man",
+    "shortcodes": [
+      "man-heart-man"
+    ],
+    "keywords": [
+      "heart-man",
+      "heart",
+      "pair",
+      "love",
+      "like",
+      "affection",
+      "human",
+      "dating",
+      "valentines",
+      "marriage"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-2764-fe0f-200d-1f468",
+        "emoji": "👨‍❤️‍👨"
+      },
+      {
+        "tone": "light",
+        "unified": "1f468-1f3fb-200d-2764-fe0f-200d-1f468-1f3fb",
+        "emoji": "👨🏻‍❤️‍👨🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f468-1f3fc-200d-2764-fe0f-200d-1f468-1f3fc",
+        "emoji": "👨🏼‍❤️‍👨🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f468-1f3fd-200d-2764-fe0f-200d-1f468-1f3fd",
+        "emoji": "👨🏽‍❤️‍👨🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f468-1f3fe-200d-2764-fe0f-200d-1f468-1f3fe",
+        "emoji": "👨🏾‍❤️‍👨🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f468-1f3ff-200d-2764-fe0f-200d-1f468-1f3ff",
+        "emoji": "👨🏿‍❤️‍👨🏿"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👩‍❤️‍👩",
+    "name": "Couple with Heart: Woman, Woman",
+    "shortcodes": [
+      "woman-heart-woman"
+    ],
+    "keywords": [
+      "heart-woman",
+      "heart",
+      "pair",
+      "love",
+      "like",
+      "affection",
+      "human",
+      "dating",
+      "valentines",
+      "marriage"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-2764-fe0f-200d-1f469",
+        "emoji": "👩‍❤️‍👩"
+      },
+      {
+        "tone": "light",
+        "unified": "1f469-1f3fb-200d-2764-fe0f-200d-1f469-1f3fb",
+        "emoji": "👩🏻‍❤️‍👩🏻"
+      },
+      {
+        "tone": "medium-light",
+        "unified": "1f469-1f3fc-200d-2764-fe0f-200d-1f469-1f3fc",
+        "emoji": "👩🏼‍❤️‍👩🏼"
+      },
+      {
+        "tone": "medium",
+        "unified": "1f469-1f3fd-200d-2764-fe0f-200d-1f469-1f3fd",
+        "emoji": "👩🏽‍❤️‍👩🏽"
+      },
+      {
+        "tone": "medium-dark",
+        "unified": "1f469-1f3fe-200d-2764-fe0f-200d-1f469-1f3fe",
+        "emoji": "👩🏾‍❤️‍👩🏾"
+      },
+      {
+        "tone": "dark",
+        "unified": "1f469-1f3ff-200d-2764-fe0f-200d-1f469-1f3ff",
+        "emoji": "👩🏿‍❤️‍👩🏿"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👪",
+    "name": "Family",
+    "shortcodes": [
+      "family"
+    ],
+    "keywords": [
+      "home",
+      "parents",
+      "child",
+      "mom",
+      "dad",
+      "father",
+      "mother",
+      "people",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f46a",
+        "emoji": "👪"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👨‍👩‍👦",
+    "name": "Family: Man, Woman, Boy",
+    "shortcodes": [
+      "man-woman-boy"
+    ],
+    "keywords": [
+      "man",
+      "woman-boy",
+      "family",
+      "woman",
+      "love"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f469-200d-1f466",
+        "emoji": "👨‍👩‍👦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👨‍👩‍👧",
+    "name": "Family: Man, Woman, Girl",
+    "shortcodes": [
+      "man-woman-girl"
+    ],
+    "keywords": [
+      "man",
+      "woman-girl",
+      "family",
+      "woman",
+      "home",
+      "parents",
+      "people",
+      "human",
+      "child"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f469-200d-1f467",
+        "emoji": "👨‍👩‍👧"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👨‍👩‍👧‍👦",
+    "name": "Family: Man, Woman, Girl, Boy",
+    "shortcodes": [
+      "man-woman-girl-boy"
+    ],
+    "keywords": [
+      "man",
+      "woman-girl-boy",
+      "family",
+      "woman",
+      "girl",
+      "home",
+      "parents",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f469-200d-1f467-200d-1f466",
+        "emoji": "👨‍👩‍👧‍👦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👨‍👩‍👦‍👦",
+    "name": "Family: Man, Woman, Boy, Boy",
+    "shortcodes": [
+      "man-woman-boy-boy"
+    ],
+    "keywords": [
+      "man",
+      "woman-boy-boy",
+      "family",
+      "woman",
+      "home",
+      "parents",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f469-200d-1f466-200d-1f466",
+        "emoji": "👨‍👩‍👦‍👦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👨‍👩‍👧‍👧",
+    "name": "Family: Man, Woman, Girl, Girl",
+    "shortcodes": [
+      "man-woman-girl-girl"
+    ],
+    "keywords": [
+      "man",
+      "woman-girl-girl",
+      "family",
+      "woman",
+      "home",
+      "parents",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f469-200d-1f467-200d-1f467",
+        "emoji": "👨‍👩‍👧‍👧"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👨‍👨‍👦",
+    "name": "Family: Man, Man, Boy",
+    "shortcodes": [
+      "man-man-boy"
+    ],
+    "keywords": [
+      "man",
+      "man-boy",
+      "family",
+      "home",
+      "parents",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f468-200d-1f466",
+        "emoji": "👨‍👨‍👦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👨‍👨‍👧",
+    "name": "Family: Man, Man, Girl",
+    "shortcodes": [
+      "man-man-girl"
+    ],
+    "keywords": [
+      "man",
+      "man-girl",
+      "family",
+      "home",
+      "parents",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f468-200d-1f467",
+        "emoji": "👨‍👨‍👧"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👨‍👨‍👧‍👦",
+    "name": "Family: Man, Man, Girl, Boy",
+    "shortcodes": [
+      "man-man-girl-boy"
+    ],
+    "keywords": [
+      "man",
+      "man-girl-boy",
+      "family",
+      "girl",
+      "home",
+      "parents",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f468-200d-1f467-200d-1f466",
+        "emoji": "👨‍👨‍👧‍👦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👨‍👨‍👦‍👦",
+    "name": "Family: Man, Man, Boy, Boy",
+    "shortcodes": [
+      "man-man-boy-boy"
+    ],
+    "keywords": [
+      "man",
+      "man-boy-boy",
+      "family",
+      "home",
+      "parents",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f468-200d-1f466-200d-1f466",
+        "emoji": "👨‍👨‍👦‍👦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👨‍👨‍👧‍👧",
+    "name": "Family: Man, Man, Girl, Girl",
+    "shortcodes": [
+      "man-man-girl-girl"
+    ],
+    "keywords": [
+      "man",
+      "man-girl-girl",
+      "family",
+      "home",
+      "parents",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f468-200d-1f467-200d-1f467",
+        "emoji": "👨‍👨‍👧‍👧"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👩‍👩‍👦",
+    "name": "Family: Woman, Woman, Boy",
+    "shortcodes": [
+      "woman-woman-boy"
+    ],
+    "keywords": [
+      "woman",
+      "woman-boy",
+      "family",
+      "home",
+      "parents",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f469-200d-1f466",
+        "emoji": "👩‍👩‍👦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👩‍👩‍👧",
+    "name": "Family: Woman, Woman, Girl",
+    "shortcodes": [
+      "woman-woman-girl"
+    ],
+    "keywords": [
+      "woman",
+      "woman-girl",
+      "family",
+      "home",
+      "parents",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f469-200d-1f467",
+        "emoji": "👩‍👩‍👧"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👩‍👩‍👧‍👦",
+    "name": "Family: Woman, Woman, Girl, Boy",
+    "shortcodes": [
+      "woman-woman-girl-boy"
+    ],
+    "keywords": [
+      "woman",
+      "woman-girl-boy",
+      "family",
+      "girl",
+      "home",
+      "parents",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f469-200d-1f467-200d-1f466",
+        "emoji": "👩‍👩‍👧‍👦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👩‍👩‍👦‍👦",
+    "name": "Family: Woman, Woman, Boy, Boy",
+    "shortcodes": [
+      "woman-woman-boy-boy"
+    ],
+    "keywords": [
+      "woman",
+      "woman-boy-boy",
+      "family",
+      "home",
+      "parents",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f469-200d-1f466-200d-1f466",
+        "emoji": "👩‍👩‍👦‍👦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👩‍👩‍👧‍👧",
+    "name": "Family: Woman, Woman, Girl, Girl",
+    "shortcodes": [
+      "woman-woman-girl-girl"
+    ],
+    "keywords": [
+      "woman",
+      "woman-girl-girl",
+      "family",
+      "home",
+      "parents",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f469-200d-1f467-200d-1f467",
+        "emoji": "👩‍👩‍👧‍👧"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "👨‍👦",
+    "name": "Family: Man, Boy",
+    "shortcodes": [
+      "man-boy"
+    ],
+    "keywords": [
+      "man",
+      "family",
+      "home",
+      "parent",
+      "people",
+      "human",
+      "child"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f466",
+        "emoji": "👨‍👦"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👨‍👦‍👦",
+    "name": "Family: Man, Boy, Boy",
+    "shortcodes": [
+      "man-boy-boy"
+    ],
+    "keywords": [
+      "man",
+      "boy-boy",
+      "family",
+      "home",
+      "parent",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f466-200d-1f466",
+        "emoji": "👨‍👦‍👦"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👨‍👧",
+    "name": "Family: Man, Girl",
+    "shortcodes": [
+      "man-girl"
+    ],
+    "keywords": [
+      "man",
+      "family",
+      "home",
+      "parent",
+      "people",
+      "human",
+      "child"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f467",
+        "emoji": "👨‍👧"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👨‍👧‍👦",
+    "name": "Family: Man, Girl, Boy",
+    "shortcodes": [
+      "man-girl-boy"
+    ],
+    "keywords": [
+      "man",
+      "girl-boy",
+      "family",
+      "girl",
+      "home",
+      "parent",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f467-200d-1f466",
+        "emoji": "👨‍👧‍👦"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👨‍👧‍👧",
+    "name": "Family: Man, Girl, Girl",
+    "shortcodes": [
+      "man-girl-girl"
+    ],
+    "keywords": [
+      "man",
+      "girl-girl",
+      "family",
+      "home",
+      "parent",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f468-200d-1f467-200d-1f467",
+        "emoji": "👨‍👧‍👧"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍👦",
+    "name": "Family: Woman, Boy",
+    "shortcodes": [
+      "woman-boy"
+    ],
+    "keywords": [
+      "woman",
+      "family",
+      "home",
+      "parent",
+      "people",
+      "human",
+      "child"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f466",
+        "emoji": "👩‍👦"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍👦‍👦",
+    "name": "Family: Woman, Boy, Boy",
+    "shortcodes": [
+      "woman-boy-boy"
+    ],
+    "keywords": [
+      "woman",
+      "boy-boy",
+      "family",
+      "home",
+      "parent",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f466-200d-1f466",
+        "emoji": "👩‍👦‍👦"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍👧",
+    "name": "Family: Woman, Girl",
+    "shortcodes": [
+      "woman-girl"
+    ],
+    "keywords": [
+      "woman",
+      "family",
+      "home",
+      "parent",
+      "people",
+      "human",
+      "child"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f467",
+        "emoji": "👩‍👧"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍👧‍👦",
+    "name": "Family: Woman, Girl, Boy",
+    "shortcodes": [
+      "woman-girl-boy"
+    ],
+    "keywords": [
+      "woman",
+      "girl-boy",
+      "family",
+      "girl",
+      "home",
+      "parent",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f467-200d-1f466",
+        "emoji": "👩‍👧‍👦"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "👩‍👧‍👧",
+    "name": "Family: Woman, Girl, Girl",
+    "shortcodes": [
+      "woman-girl-girl"
+    ],
+    "keywords": [
+      "woman",
+      "girl-girl",
+      "family",
+      "home",
+      "parent",
+      "people",
+      "human",
+      "children"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f469-200d-1f467-200d-1f467",
+        "emoji": "👩‍👧‍👧"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🗣️",
+    "name": "Speaking Head",
+    "shortcodes": [
+      "speaking_head_in_silhouette"
+    ],
+    "keywords": [
+      "in",
+      "silhouette",
+      "user",
+      "person",
+      "human",
+      "sing",
+      "say",
+      "talk"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5e3-fe0f",
+        "emoji": "🗣️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👤",
+    "name": "Bust in Silhouette",
+    "shortcodes": [
+      "bust_in_silhouette"
+    ],
+    "keywords": [
+      "user",
+      "person",
+      "human"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f464",
+        "emoji": "👤"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👥",
+    "name": "Busts in Silhouette",
+    "shortcodes": [
+      "busts_in_silhouette"
+    ],
+    "keywords": [
+      "user",
+      "person",
+      "human",
+      "group",
+      "team"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f465",
+        "emoji": "👥"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🫂",
+    "name": "People Hugging",
+    "shortcodes": [
+      "people_hugging"
+    ],
+    "keywords": [
+      "care"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fac2",
+        "emoji": "🫂"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "👣",
+    "name": "Footprints",
+    "shortcodes": [
+      "footprints"
+    ],
+    "keywords": [
+      "feet",
+      "tracking",
+      "walking",
+      "beach"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f463",
+        "emoji": "👣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐵",
+    "name": "Monkey Face",
+    "shortcodes": [
+      "monkey_face"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "circus",
+      ":o)"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f435",
+        "emoji": "🐵"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐒",
+    "name": "Monkey",
+    "shortcodes": [
+      "monkey"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "banana",
+      "circus"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f412",
+        "emoji": "🐒"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦍",
+    "name": "Gorilla",
+    "shortcodes": [
+      "gorilla"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "circus"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f98d",
+        "emoji": "🦍"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🦧",
+    "name": "Orangutan",
+    "shortcodes": [
+      "orangutan"
+    ],
+    "keywords": [
+      "animal"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9a7",
+        "emoji": "🦧"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🐶",
+    "name": "Dog Face",
+    "shortcodes": [
+      "dog"
+    ],
+    "keywords": [
+      "animal",
+      "friend",
+      "nature",
+      "woof",
+      "puppy",
+      "pet",
+      "faithful"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f436",
+        "emoji": "🐶"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐕",
+    "name": "Dog",
+    "shortcodes": [
+      "dog2"
+    ],
+    "keywords": [
+      "dog2",
+      "animal",
+      "nature",
+      "friend",
+      "doge",
+      "pet",
+      "faithful"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f415",
+        "emoji": "🐕"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦮",
+    "name": "Guide Dog",
+    "shortcodes": [
+      "guide_dog"
+    ],
+    "keywords": [
+      "animal",
+      "blind"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9ae",
+        "emoji": "🦮"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🐕‍🦺",
+    "name": "Service Dog",
+    "shortcodes": [
+      "service_dog"
+    ],
+    "keywords": [
+      "blind",
+      "animal"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f415-200d-1f9ba",
+        "emoji": "🐕‍🦺"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🐩",
+    "name": "Poodle",
+    "shortcodes": [
+      "poodle"
+    ],
+    "keywords": [
+      "dog",
+      "animal",
+      "101",
+      "nature",
+      "pet"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f429",
+        "emoji": "🐩"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐺",
+    "name": "Wolf",
+    "shortcodes": [
+      "wolf"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "wild"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f43a",
+        "emoji": "🐺"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦊",
+    "name": "Fox",
+    "shortcodes": [
+      "fox_face"
+    ],
+    "keywords": [
+      "face",
+      "animal",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f98a",
+        "emoji": "🦊"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🦝",
+    "name": "Raccoon",
+    "shortcodes": [
+      "raccoon"
+    ],
+    "keywords": [
+      "animal",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f99d",
+        "emoji": "🦝"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🐱",
+    "name": "Cat Face",
+    "shortcodes": [
+      "cat"
+    ],
+    "keywords": [
+      "animal",
+      "meow",
+      "nature",
+      "pet",
+      "kitten"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f431",
+        "emoji": "🐱"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐈",
+    "name": "Cat",
+    "shortcodes": [
+      "cat2"
+    ],
+    "keywords": [
+      "cat2",
+      "animal",
+      "meow",
+      "pet",
+      "cats"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f408",
+        "emoji": "🐈"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐈‍⬛",
+    "name": "Black Cat",
+    "shortcodes": [
+      "black_cat"
+    ],
+    "keywords": [
+      "superstition",
+      "luck"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f408-200d-2b1b",
+        "emoji": "🐈‍⬛"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🦁",
+    "name": "Lion",
+    "shortcodes": [
+      "lion_face"
+    ],
+    "keywords": [
+      "face",
+      "animal",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f981",
+        "emoji": "🦁"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐯",
+    "name": "Tiger Face",
+    "shortcodes": [
+      "tiger"
+    ],
+    "keywords": [
+      "animal",
+      "cat",
+      "danger",
+      "wild",
+      "nature",
+      "roar"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f42f",
+        "emoji": "🐯"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐅",
+    "name": "Tiger",
+    "shortcodes": [
+      "tiger2"
+    ],
+    "keywords": [
+      "tiger2",
+      "animal",
+      "nature",
+      "roar"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f405",
+        "emoji": "🐅"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐆",
+    "name": "Leopard",
+    "shortcodes": [
+      "leopard"
+    ],
+    "keywords": [
+      "animal",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f406",
+        "emoji": "🐆"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐴",
+    "name": "Horse Face",
+    "shortcodes": [
+      "horse"
+    ],
+    "keywords": [
+      "animal",
+      "brown",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f434",
+        "emoji": "🐴"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐎",
+    "name": "Horse",
+    "shortcodes": [
+      "racehorse"
+    ],
+    "keywords": [
+      "racehorse",
+      "animal",
+      "gamble",
+      "luck"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f40e",
+        "emoji": "🐎"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦄",
+    "name": "Unicorn",
+    "shortcodes": [
+      "unicorn_face"
+    ],
+    "keywords": [
+      "face",
+      "animal",
+      "nature",
+      "mystical"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f984",
+        "emoji": "🦄"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦓",
+    "name": "Zebra",
+    "shortcodes": [
+      "zebra_face"
+    ],
+    "keywords": [
+      "face",
+      "animal",
+      "nature",
+      "stripes",
+      "safari"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f993",
+        "emoji": "🦓"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🦌",
+    "name": "Deer",
+    "shortcodes": [
+      "deer"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "horns",
+      "venison"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f98c",
+        "emoji": "🦌"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🦬",
+    "name": "Bison",
+    "shortcodes": [
+      "bison"
+    ],
+    "keywords": [
+      "ox"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9ac",
+        "emoji": "🦬"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🐮",
+    "name": "Cow Face",
+    "shortcodes": [
+      "cow"
+    ],
+    "keywords": [
+      "beef",
+      "ox",
+      "animal",
+      "nature",
+      "moo",
+      "milk"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f42e",
+        "emoji": "🐮"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐂",
+    "name": "Ox",
+    "shortcodes": [
+      "ox"
+    ],
+    "keywords": [
+      "animal",
+      "cow",
+      "beef"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f402",
+        "emoji": "🐂"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐃",
+    "name": "Water Buffalo",
+    "shortcodes": [
+      "water_buffalo"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "ox",
+      "cow"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f403",
+        "emoji": "🐃"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐄",
+    "name": "Cow",
+    "shortcodes": [
+      "cow2"
+    ],
+    "keywords": [
+      "cow2",
+      "beef",
+      "ox",
+      "animal",
+      "nature",
+      "moo",
+      "milk"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f404",
+        "emoji": "🐄"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐷",
+    "name": "Pig Face",
+    "shortcodes": [
+      "pig"
+    ],
+    "keywords": [
+      "animal",
+      "oink",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f437",
+        "emoji": "🐷"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐖",
+    "name": "Pig",
+    "shortcodes": [
+      "pig2"
+    ],
+    "keywords": [
+      "pig2",
+      "animal",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f416",
+        "emoji": "🐖"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐗",
+    "name": "Boar",
+    "shortcodes": [
+      "boar"
+    ],
+    "keywords": [
+      "animal",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f417",
+        "emoji": "🐗"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐽",
+    "name": "Pig Nose",
+    "shortcodes": [
+      "pig_nose"
+    ],
+    "keywords": [
+      "animal",
+      "oink"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f43d",
+        "emoji": "🐽"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐏",
+    "name": "Ram",
+    "shortcodes": [
+      "ram"
+    ],
+    "keywords": [
+      "animal",
+      "sheep",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f40f",
+        "emoji": "🐏"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐑",
+    "name": "Ewe",
+    "shortcodes": [
+      "sheep"
+    ],
+    "keywords": [
+      "sheep",
+      "animal",
+      "nature",
+      "wool",
+      "shipit"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f411",
+        "emoji": "🐑"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐐",
+    "name": "Goat",
+    "shortcodes": [
+      "goat"
+    ],
+    "keywords": [
+      "animal",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f410",
+        "emoji": "🐐"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐪",
+    "name": "Camel",
+    "shortcodes": [
+      "dromedary_camel"
+    ],
+    "keywords": [
+      "dromedary",
+      "animal",
+      "hot",
+      "desert",
+      "hump"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f42a",
+        "emoji": "🐪"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐫",
+    "name": "Bactrian Camel",
+    "shortcodes": [
+      "camel"
+    ],
+    "keywords": [
+      "two",
+      "hump",
+      "animal",
+      "nature",
+      "hot",
+      "desert"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f42b",
+        "emoji": "🐫"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦙",
+    "name": "Llama",
+    "shortcodes": [
+      "llama"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "alpaca"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f999",
+        "emoji": "🦙"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🦒",
+    "name": "Giraffe",
+    "shortcodes": [
+      "giraffe_face"
+    ],
+    "keywords": [
+      "face",
+      "animal",
+      "nature",
+      "spots",
+      "safari"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f992",
+        "emoji": "🦒"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🐘",
+    "name": "Elephant",
+    "shortcodes": [
+      "elephant"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "nose",
+      "th",
+      "circus"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f418",
+        "emoji": "🐘"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦣",
+    "name": "Mammoth",
+    "shortcodes": [
+      "mammoth"
+    ],
+    "keywords": [
+      "elephant",
+      "tusks"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9a3",
+        "emoji": "🦣"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🦏",
+    "name": "Rhinoceros",
+    "shortcodes": [
+      "rhinoceros"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "horn"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f98f",
+        "emoji": "🦏"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🦛",
+    "name": "Hippopotamus",
+    "shortcodes": [
+      "hippopotamus"
+    ],
+    "keywords": [
+      "animal",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f99b",
+        "emoji": "🦛"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🐭",
+    "name": "Mouse Face",
+    "shortcodes": [
+      "mouse"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "cheese",
+      "wedge",
+      "rodent"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f42d",
+        "emoji": "🐭"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐁",
+    "name": "Mouse",
+    "shortcodes": [
+      "mouse2"
+    ],
+    "keywords": [
+      "mouse2",
+      "animal",
+      "nature",
+      "rodent"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f401",
+        "emoji": "🐁"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐀",
+    "name": "Rat",
+    "shortcodes": [
+      "rat"
+    ],
+    "keywords": [
+      "animal",
+      "mouse",
+      "rodent"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f400",
+        "emoji": "🐀"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐹",
+    "name": "Hamster",
+    "shortcodes": [
+      "hamster"
+    ],
+    "keywords": [
+      "animal",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f439",
+        "emoji": "🐹"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐰",
+    "name": "Rabbit Face",
+    "shortcodes": [
+      "rabbit"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "pet",
+      "spring",
+      "magic",
+      "bunny"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f430",
+        "emoji": "🐰"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐇",
+    "name": "Rabbit",
+    "shortcodes": [
+      "rabbit2"
+    ],
+    "keywords": [
+      "rabbit2",
+      "animal",
+      "nature",
+      "pet",
+      "magic",
+      "spring"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f407",
+        "emoji": "🐇"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐿️",
+    "name": "Chipmunk",
+    "shortcodes": [
+      "chipmunk"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "rodent",
+      "squirrel"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f43f-fe0f",
+        "emoji": "🐿️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦫",
+    "name": "Beaver",
+    "shortcodes": [
+      "beaver"
+    ],
+    "keywords": [
+      "animal",
+      "rodent"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9ab",
+        "emoji": "🦫"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🦔",
+    "name": "Hedgehog",
+    "shortcodes": [
+      "hedgehog"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "spiny"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f994",
+        "emoji": "🦔"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🦇",
+    "name": "Bat",
+    "shortcodes": [
+      "bat"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "blind",
+      "vampire"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f987",
+        "emoji": "🦇"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🐻",
+    "name": "Bear",
+    "shortcodes": [
+      "bear"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "wild"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f43b",
+        "emoji": "🐻"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐻‍❄️",
+    "name": "Polar Bear",
+    "shortcodes": [
+      "polar_bear"
+    ],
+    "keywords": [
+      "animal",
+      "arctic"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f43b-200d-2744-fe0f",
+        "emoji": "🐻‍❄️"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🐨",
+    "name": "Koala",
+    "shortcodes": [
+      "koala"
+    ],
+    "keywords": [
+      "animal",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f428",
+        "emoji": "🐨"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐼",
+    "name": "Panda",
+    "shortcodes": [
+      "panda_face"
+    ],
+    "keywords": [
+      "face",
+      "animal",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f43c",
+        "emoji": "🐼"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦥",
+    "name": "Sloth",
+    "shortcodes": [
+      "sloth"
+    ],
+    "keywords": [
+      "animal"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9a5",
+        "emoji": "🦥"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🦦",
+    "name": "Otter",
+    "shortcodes": [
+      "otter"
+    ],
+    "keywords": [
+      "animal"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9a6",
+        "emoji": "🦦"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🦨",
+    "name": "Skunk",
+    "shortcodes": [
+      "skunk"
+    ],
+    "keywords": [
+      "animal"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9a8",
+        "emoji": "🦨"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🦘",
+    "name": "Kangaroo",
+    "shortcodes": [
+      "kangaroo"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "australia",
+      "joey",
+      "hop",
+      "marsupial"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f998",
+        "emoji": "🦘"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🦡",
+    "name": "Badger",
+    "shortcodes": [
+      "badger"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "honey"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9a1",
+        "emoji": "🦡"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🐾",
+    "name": "Paw Prints",
+    "shortcodes": [
+      "feet",
+      "paw_prints"
+    ],
+    "keywords": [
+      "feet",
+      "animal",
+      "tracking",
+      "footprints",
+      "dog",
+      "cat",
+      "pet"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f43e",
+        "emoji": "🐾"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦃",
+    "name": "Turkey",
+    "shortcodes": [
+      "turkey"
+    ],
+    "keywords": [
+      "animal",
+      "bird"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f983",
+        "emoji": "🦃"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐔",
+    "name": "Chicken",
+    "shortcodes": [
+      "chicken"
+    ],
+    "keywords": [
+      "animal",
+      "cluck",
+      "nature",
+      "bird"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f414",
+        "emoji": "🐔"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐓",
+    "name": "Rooster",
+    "shortcodes": [
+      "rooster"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "chicken"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f413",
+        "emoji": "🐓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐣",
+    "name": "Hatching Chick",
+    "shortcodes": [
+      "hatching_chick"
+    ],
+    "keywords": [
+      "animal",
+      "chicken",
+      "egg",
+      "born",
+      "baby",
+      "bird"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f423",
+        "emoji": "🐣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐤",
+    "name": "Baby Chick",
+    "shortcodes": [
+      "baby_chick"
+    ],
+    "keywords": [
+      "animal",
+      "chicken",
+      "bird"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f424",
+        "emoji": "🐤"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐥",
+    "name": "Front-Facing Baby Chick",
+    "shortcodes": [
+      "hatched_chick"
+    ],
+    "keywords": [
+      "hatched",
+      "front",
+      "facing",
+      "animal",
+      "chicken",
+      "bird"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f425",
+        "emoji": "🐥"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐦",
+    "name": "Bird",
+    "shortcodes": [
+      "bird"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "fly",
+      "tweet",
+      "spring"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f426",
+        "emoji": "🐦"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐧",
+    "name": "Penguin",
+    "shortcodes": [
+      "penguin"
+    ],
+    "keywords": [
+      "animal",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f427",
+        "emoji": "🐧"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕊️",
+    "name": "Dove",
+    "shortcodes": [
+      "dove_of_peace"
+    ],
+    "keywords": [
+      "of",
+      "peace",
+      "animal",
+      "bird"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f54a-fe0f",
+        "emoji": "🕊️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦅",
+    "name": "Eagle",
+    "shortcodes": [
+      "eagle"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "bird"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f985",
+        "emoji": "🦅"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🦆",
+    "name": "Duck",
+    "shortcodes": [
+      "duck"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "bird",
+      "mallard"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f986",
+        "emoji": "🦆"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🦢",
+    "name": "Swan",
+    "shortcodes": [
+      "swan"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "bird"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9a2",
+        "emoji": "🦢"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🦉",
+    "name": "Owl",
+    "shortcodes": [
+      "owl"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "bird",
+      "hoot"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f989",
+        "emoji": "🦉"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🦤",
+    "name": "Dodo",
+    "shortcodes": [
+      "dodo"
+    ],
+    "keywords": [
+      "animal",
+      "bird"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9a4",
+        "emoji": "🦤"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🪶",
+    "name": "Feather",
+    "shortcodes": [
+      "feather"
+    ],
+    "keywords": [
+      "bird",
+      "fly"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fab6",
+        "emoji": "🪶"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🦩",
+    "name": "Flamingo",
+    "shortcodes": [
+      "flamingo"
+    ],
+    "keywords": [
+      "animal"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9a9",
+        "emoji": "🦩"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🦚",
+    "name": "Peacock",
+    "shortcodes": [
+      "peacock"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "peahen",
+      "bird"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f99a",
+        "emoji": "🦚"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🦜",
+    "name": "Parrot",
+    "shortcodes": [
+      "parrot"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "bird",
+      "pirate",
+      "talk"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f99c",
+        "emoji": "🦜"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🐸",
+    "name": "Frog",
+    "shortcodes": [
+      "frog"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "croak",
+      "toad"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f438",
+        "emoji": "🐸"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐊",
+    "name": "Crocodile",
+    "shortcodes": [
+      "crocodile"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "reptile",
+      "lizard",
+      "alligator"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f40a",
+        "emoji": "🐊"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐢",
+    "name": "Turtle",
+    "shortcodes": [
+      "turtle"
+    ],
+    "keywords": [
+      "animal",
+      "slow",
+      "nature",
+      "tortoise"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f422",
+        "emoji": "🐢"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦎",
+    "name": "Lizard",
+    "shortcodes": [
+      "lizard"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "reptile"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f98e",
+        "emoji": "🦎"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🐍",
+    "name": "Snake",
+    "shortcodes": [
+      "snake"
+    ],
+    "keywords": [
+      "animal",
+      "evil",
+      "nature",
+      "hiss",
+      "python"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f40d",
+        "emoji": "🐍"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐲",
+    "name": "Dragon Face",
+    "shortcodes": [
+      "dragon_face"
+    ],
+    "keywords": [
+      "animal",
+      "myth",
+      "nature",
+      "chinese",
+      "green"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f432",
+        "emoji": "🐲"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐉",
+    "name": "Dragon",
+    "shortcodes": [
+      "dragon"
+    ],
+    "keywords": [
+      "animal",
+      "myth",
+      "nature",
+      "chinese",
+      "green"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f409",
+        "emoji": "🐉"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦕",
+    "name": "Sauropod",
+    "shortcodes": [
+      "sauropod"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "dinosaur",
+      "brachiosaurus",
+      "brontosaurus",
+      "diplodocus",
+      "extinct"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f995",
+        "emoji": "🦕"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🦖",
+    "name": "T-Rex",
+    "shortcodes": [
+      "t-rex"
+    ],
+    "keywords": [
+      "t",
+      "rex",
+      "animal",
+      "nature",
+      "dinosaur",
+      "tyrannosaurus",
+      "extinct"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f996",
+        "emoji": "🦖"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🐳",
+    "name": "Spouting Whale",
+    "shortcodes": [
+      "whale"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "sea",
+      "ocean"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f433",
+        "emoji": "🐳"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐋",
+    "name": "Whale",
+    "shortcodes": [
+      "whale2"
+    ],
+    "keywords": [
+      "whale2",
+      "animal",
+      "nature",
+      "sea",
+      "ocean"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f40b",
+        "emoji": "🐋"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐬",
+    "name": "Dolphin",
+    "shortcodes": [
+      "dolphin",
+      "flipper"
+    ],
+    "keywords": [
+      "flipper",
+      "animal",
+      "nature",
+      "fish",
+      "sea",
+      "ocean",
+      "fins",
+      "beach"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f42c",
+        "emoji": "🐬"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦭",
+    "name": "Seal",
+    "shortcodes": [
+      "seal"
+    ],
+    "keywords": [
+      "animal",
+      "creature",
+      "sea"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9ad",
+        "emoji": "🦭"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🐟",
+    "name": "Fish",
+    "shortcodes": [
+      "fish"
+    ],
+    "keywords": [
+      "animal",
+      "food",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f41f",
+        "emoji": "🐟"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐠",
+    "name": "Tropical Fish",
+    "shortcodes": [
+      "tropical_fish"
+    ],
+    "keywords": [
+      "animal",
+      "swim",
+      "ocean",
+      "beach",
+      "nemo"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f420",
+        "emoji": "🐠"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐡",
+    "name": "Blowfish",
+    "shortcodes": [
+      "blowfish"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "food",
+      "sea",
+      "ocean"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f421",
+        "emoji": "🐡"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦈",
+    "name": "Shark",
+    "shortcodes": [
+      "shark"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "fish",
+      "sea",
+      "ocean",
+      "jaws",
+      "fins",
+      "beach"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f988",
+        "emoji": "🦈"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🐙",
+    "name": "Octopus",
+    "shortcodes": [
+      "octopus"
+    ],
+    "keywords": [
+      "animal",
+      "creature",
+      "ocean",
+      "sea",
+      "nature",
+      "beach"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f419",
+        "emoji": "🐙"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐚",
+    "name": "Spiral Shell",
+    "shortcodes": [
+      "shell"
+    ],
+    "keywords": [
+      "nature",
+      "sea",
+      "beach"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f41a",
+        "emoji": "🐚"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪸",
+    "name": "Coral",
+    "shortcodes": [
+      "coral"
+    ],
+    "keywords": [
+      "ocean",
+      "sea",
+      "reef"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fab8",
+        "emoji": "🪸"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🐌",
+    "name": "Snail",
+    "shortcodes": [
+      "snail"
+    ],
+    "keywords": [
+      "slow",
+      "animal",
+      "shell"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f40c",
+        "emoji": "🐌"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦋",
+    "name": "Butterfly",
+    "shortcodes": [
+      "butterfly"
+    ],
+    "keywords": [
+      "animal",
+      "insect",
+      "nature",
+      "caterpillar"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f98b",
+        "emoji": "🦋"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🐛",
+    "name": "Bug",
+    "shortcodes": [
+      "bug"
+    ],
+    "keywords": [
+      "animal",
+      "insect",
+      "nature",
+      "worm"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f41b",
+        "emoji": "🐛"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐜",
+    "name": "Ant",
+    "shortcodes": [
+      "ant"
+    ],
+    "keywords": [
+      "animal",
+      "insect",
+      "nature",
+      "bug"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f41c",
+        "emoji": "🐜"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🐝",
+    "name": "Honeybee",
+    "shortcodes": [
+      "bee",
+      "honeybee"
+    ],
+    "keywords": [
+      "bee",
+      "animal",
+      "insect",
+      "nature",
+      "bug",
+      "spring",
+      "honey"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f41d",
+        "emoji": "🐝"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪲",
+    "name": "Beetle",
+    "shortcodes": [
+      "beetle"
+    ],
+    "keywords": [
+      "insect"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fab2",
+        "emoji": "🪲"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🐞",
+    "name": "Lady Beetle",
+    "shortcodes": [
+      "ladybug",
+      "lady_beetle"
+    ],
+    "keywords": [
+      "ladybug",
+      "animal",
+      "insect",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f41e",
+        "emoji": "🐞"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦗",
+    "name": "Cricket",
+    "shortcodes": [
+      "cricket"
+    ],
+    "keywords": [
+      "animal",
+      "chirp"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f997",
+        "emoji": "🦗"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🪳",
+    "name": "Cockroach",
+    "shortcodes": [
+      "cockroach"
+    ],
+    "keywords": [
+      "insect",
+      "pests"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fab3",
+        "emoji": "🪳"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🕷️",
+    "name": "Spider",
+    "shortcodes": [
+      "spider"
+    ],
+    "keywords": [
+      "animal",
+      "arachnid"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f577-fe0f",
+        "emoji": "🕷️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕸️",
+    "name": "Spider Web",
+    "shortcodes": [
+      "spider_web"
+    ],
+    "keywords": [
+      "animal",
+      "insect",
+      "arachnid",
+      "silk"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f578-fe0f",
+        "emoji": "🕸️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦂",
+    "name": "Scorpion",
+    "shortcodes": [
+      "scorpion"
+    ],
+    "keywords": [
+      "animal",
+      "arachnid"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f982",
+        "emoji": "🦂"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦟",
+    "name": "Mosquito",
+    "shortcodes": [
+      "mosquito"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "insect",
+      "malaria"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f99f",
+        "emoji": "🦟"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🪰",
+    "name": "Fly",
+    "shortcodes": [
+      "fly"
+    ],
+    "keywords": [
+      "insect"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fab0",
+        "emoji": "🪰"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🪱",
+    "name": "Worm",
+    "shortcodes": [
+      "worm"
+    ],
+    "keywords": [
+      "animal"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fab1",
+        "emoji": "🪱"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🦠",
+    "name": "Microbe",
+    "shortcodes": [
+      "microbe"
+    ],
+    "keywords": [
+      "amoeba",
+      "bacteria",
+      "germs",
+      "virus"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9a0",
+        "emoji": "🦠"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "💐",
+    "name": "Bouquet",
+    "shortcodes": [
+      "bouquet"
+    ],
+    "keywords": [
+      "flowers",
+      "nature",
+      "spring"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f490",
+        "emoji": "💐"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌸",
+    "name": "Cherry Blossom",
+    "shortcodes": [
+      "cherry_blossom"
+    ],
+    "keywords": [
+      "nature",
+      "plant",
+      "spring",
+      "flower"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f338",
+        "emoji": "🌸"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💮",
+    "name": "White Flower",
+    "shortcodes": [
+      "white_flower"
+    ],
+    "keywords": [
+      "japanese",
+      "spring"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4ae",
+        "emoji": "💮"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪷",
+    "name": "Lotus",
+    "shortcodes": [
+      "lotus"
+    ],
+    "keywords": [
+      "flower",
+      "calm",
+      "meditation"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fab7",
+        "emoji": "🪷"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🏵️",
+    "name": "Rosette",
+    "shortcodes": [
+      "rosette"
+    ],
+    "keywords": [
+      "flower",
+      "decoration",
+      "military"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3f5-fe0f",
+        "emoji": "🏵️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌹",
+    "name": "Rose",
+    "shortcodes": [
+      "rose"
+    ],
+    "keywords": [
+      "flowers",
+      "valentines",
+      "love",
+      "spring"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f339",
+        "emoji": "🌹"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥀",
+    "name": "Wilted Flower",
+    "shortcodes": [
+      "wilted_flower"
+    ],
+    "keywords": [
+      "plant",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f940",
+        "emoji": "🥀"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🌺",
+    "name": "Hibiscus",
+    "shortcodes": [
+      "hibiscus"
+    ],
+    "keywords": [
+      "plant",
+      "vegetable",
+      "flowers",
+      "beach"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f33a",
+        "emoji": "🌺"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌻",
+    "name": "Sunflower",
+    "shortcodes": [
+      "sunflower"
+    ],
+    "keywords": [
+      "nature",
+      "plant",
+      "fall"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f33b",
+        "emoji": "🌻"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌼",
+    "name": "Blossom",
+    "shortcodes": [
+      "blossom"
+    ],
+    "keywords": [
+      "nature",
+      "flowers",
+      "yellow"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f33c",
+        "emoji": "🌼"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌷",
+    "name": "Tulip",
+    "shortcodes": [
+      "tulip"
+    ],
+    "keywords": [
+      "flowers",
+      "plant",
+      "nature",
+      "summer",
+      "spring"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f337",
+        "emoji": "🌷"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌱",
+    "name": "Seedling",
+    "shortcodes": [
+      "seedling"
+    ],
+    "keywords": [
+      "plant",
+      "nature",
+      "grass",
+      "lawn",
+      "spring"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f331",
+        "emoji": "🌱"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪴",
+    "name": "Potted Plant",
+    "shortcodes": [
+      "potted_plant"
+    ],
+    "keywords": [
+      "greenery",
+      "house"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fab4",
+        "emoji": "🪴"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🌲",
+    "name": "Evergreen Tree",
+    "shortcodes": [
+      "evergreen_tree"
+    ],
+    "keywords": [
+      "plant",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f332",
+        "emoji": "🌲"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌳",
+    "name": "Deciduous Tree",
+    "shortcodes": [
+      "deciduous_tree"
+    ],
+    "keywords": [
+      "plant",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f333",
+        "emoji": "🌳"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌴",
+    "name": "Palm Tree",
+    "shortcodes": [
+      "palm_tree"
+    ],
+    "keywords": [
+      "plant",
+      "vegetable",
+      "nature",
+      "summer",
+      "beach",
+      "mojito",
+      "tropical"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f334",
+        "emoji": "🌴"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌵",
+    "name": "Cactus",
+    "shortcodes": [
+      "cactus"
+    ],
+    "keywords": [
+      "vegetable",
+      "plant",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f335",
+        "emoji": "🌵"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌾",
+    "name": "Ear of Rice",
+    "shortcodes": [
+      "ear_of_rice"
+    ],
+    "keywords": [
+      "sheaf",
+      "nature",
+      "plant"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f33e",
+        "emoji": "🌾"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌿",
+    "name": "Herb",
+    "shortcodes": [
+      "herb"
+    ],
+    "keywords": [
+      "vegetable",
+      "plant",
+      "medicine",
+      "weed",
+      "grass",
+      "lawn"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f33f",
+        "emoji": "🌿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☘️",
+    "name": "Shamrock",
+    "shortcodes": [
+      "shamrock"
+    ],
+    "keywords": [
+      "vegetable",
+      "plant",
+      "nature",
+      "irish",
+      "clover"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2618-fe0f",
+        "emoji": "☘️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍀",
+    "name": "Four Leaf Clover",
+    "shortcodes": [
+      "four_leaf_clover"
+    ],
+    "keywords": [
+      "vegetable",
+      "plant",
+      "nature",
+      "lucky",
+      "irish"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f340",
+        "emoji": "🍀"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍁",
+    "name": "Maple Leaf",
+    "shortcodes": [
+      "maple_leaf"
+    ],
+    "keywords": [
+      "nature",
+      "plant",
+      "vegetable",
+      "ca",
+      "fall"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f341",
+        "emoji": "🍁"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍂",
+    "name": "Fallen Leaf",
+    "shortcodes": [
+      "fallen_leaf"
+    ],
+    "keywords": [
+      "nature",
+      "plant",
+      "vegetable",
+      "leaves"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f342",
+        "emoji": "🍂"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍃",
+    "name": "Leaf Fluttering in Wind",
+    "shortcodes": [
+      "leaves"
+    ],
+    "keywords": [
+      "leaves",
+      "nature",
+      "plant",
+      "tree",
+      "vegetable",
+      "grass",
+      "lawn",
+      "spring"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f343",
+        "emoji": "🍃"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪹",
+    "name": "Empty Nest",
+    "shortcodes": [
+      "empty_nest"
+    ],
+    "keywords": [
+      "bird"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fab9",
+        "emoji": "🪹"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🪺",
+    "name": "Nest with Eggs",
+    "shortcodes": [
+      "nest_with_eggs"
+    ],
+    "keywords": [
+      "bird"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faba",
+        "emoji": "🪺"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🍇",
+    "name": "Grapes",
+    "shortcodes": [
+      "grapes"
+    ],
+    "keywords": [
+      "fruit",
+      "food",
+      "wine"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f347",
+        "emoji": "🍇"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍈",
+    "name": "Melon",
+    "shortcodes": [
+      "melon"
+    ],
+    "keywords": [
+      "fruit",
+      "nature",
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f348",
+        "emoji": "🍈"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍉",
+    "name": "Watermelon",
+    "shortcodes": [
+      "watermelon"
+    ],
+    "keywords": [
+      "fruit",
+      "food",
+      "picnic",
+      "summer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f349",
+        "emoji": "🍉"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍊",
+    "name": "Tangerine",
+    "shortcodes": [
+      "tangerine"
+    ],
+    "keywords": [
+      "food",
+      "fruit",
+      "nature",
+      "orange"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f34a",
+        "emoji": "🍊"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍋",
+    "name": "Lemon",
+    "shortcodes": [
+      "lemon"
+    ],
+    "keywords": [
+      "fruit",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f34b",
+        "emoji": "🍋"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍌",
+    "name": "Banana",
+    "shortcodes": [
+      "banana"
+    ],
+    "keywords": [
+      "fruit",
+      "food",
+      "monkey"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f34c",
+        "emoji": "🍌"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍍",
+    "name": "Pineapple",
+    "shortcodes": [
+      "pineapple"
+    ],
+    "keywords": [
+      "fruit",
+      "nature",
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f34d",
+        "emoji": "🍍"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥭",
+    "name": "Mango",
+    "shortcodes": [
+      "mango"
+    ],
+    "keywords": [
+      "fruit",
+      "food",
+      "tropical"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f96d",
+        "emoji": "🥭"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🍎",
+    "name": "Red Apple",
+    "shortcodes": [
+      "apple"
+    ],
+    "keywords": [
+      "fruit",
+      "mac",
+      "school"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f34e",
+        "emoji": "🍎"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍏",
+    "name": "Green Apple",
+    "shortcodes": [
+      "green_apple"
+    ],
+    "keywords": [
+      "fruit",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f34f",
+        "emoji": "🍏"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍐",
+    "name": "Pear",
+    "shortcodes": [
+      "pear"
+    ],
+    "keywords": [
+      "fruit",
+      "nature",
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f350",
+        "emoji": "🍐"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍑",
+    "name": "Peach",
+    "shortcodes": [
+      "peach"
+    ],
+    "keywords": [
+      "fruit",
+      "nature",
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f351",
+        "emoji": "🍑"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍒",
+    "name": "Cherries",
+    "shortcodes": [
+      "cherries"
+    ],
+    "keywords": [
+      "food",
+      "fruit"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f352",
+        "emoji": "🍒"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍓",
+    "name": "Strawberry",
+    "shortcodes": [
+      "strawberry"
+    ],
+    "keywords": [
+      "fruit",
+      "food",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f353",
+        "emoji": "🍓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🫐",
+    "name": "Blueberries",
+    "shortcodes": [
+      "blueberries"
+    ],
+    "keywords": [
+      "fruit"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fad0",
+        "emoji": "🫐"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🥝",
+    "name": "Kiwifruit",
+    "shortcodes": [
+      "kiwifruit"
+    ],
+    "keywords": [
+      "kiwi",
+      "fruit",
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f95d",
+        "emoji": "🥝"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🍅",
+    "name": "Tomato",
+    "shortcodes": [
+      "tomato"
+    ],
+    "keywords": [
+      "fruit",
+      "vegetable",
+      "nature",
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f345",
+        "emoji": "🍅"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🫒",
+    "name": "Olive",
+    "shortcodes": [
+      "olive"
+    ],
+    "keywords": [
+      "fruit"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fad2",
+        "emoji": "🫒"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🥥",
+    "name": "Coconut",
+    "shortcodes": [
+      "coconut"
+    ],
+    "keywords": [
+      "fruit",
+      "nature",
+      "food",
+      "palm"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f965",
+        "emoji": "🥥"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🥑",
+    "name": "Avocado",
+    "shortcodes": [
+      "avocado"
+    ],
+    "keywords": [
+      "fruit",
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f951",
+        "emoji": "🥑"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🍆",
+    "name": "Eggplant",
+    "shortcodes": [
+      "eggplant"
+    ],
+    "keywords": [
+      "vegetable",
+      "nature",
+      "food",
+      "aubergine"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f346",
+        "emoji": "🍆"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥔",
+    "name": "Potato",
+    "shortcodes": [
+      "potato"
+    ],
+    "keywords": [
+      "food",
+      "tuber",
+      "vegatable",
+      "starch"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f954",
+        "emoji": "🥔"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🥕",
+    "name": "Carrot",
+    "shortcodes": [
+      "carrot"
+    ],
+    "keywords": [
+      "vegetable",
+      "food",
+      "orange"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f955",
+        "emoji": "🥕"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🌽",
+    "name": "Ear of Corn",
+    "shortcodes": [
+      "corn"
+    ],
+    "keywords": [
+      "food",
+      "vegetable",
+      "plant"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f33d",
+        "emoji": "🌽"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌶️",
+    "name": "Hot Pepper",
+    "shortcodes": [
+      "hot_pepper"
+    ],
+    "keywords": [
+      "food",
+      "spicy",
+      "chilli",
+      "chili"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f336-fe0f",
+        "emoji": "🌶️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🫑",
+    "name": "Bell Pepper",
+    "shortcodes": [
+      "bell_pepper"
+    ],
+    "keywords": [
+      "fruit",
+      "plant"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fad1",
+        "emoji": "🫑"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🥒",
+    "name": "Cucumber",
+    "shortcodes": [
+      "cucumber"
+    ],
+    "keywords": [
+      "fruit",
+      "food",
+      "pickle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f952",
+        "emoji": "🥒"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🥬",
+    "name": "Leafy Green",
+    "shortcodes": [
+      "leafy_green"
+    ],
+    "keywords": [
+      "food",
+      "vegetable",
+      "plant",
+      "bok",
+      "choy",
+      "cabbage",
+      "kale",
+      "lettuce"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f96c",
+        "emoji": "🥬"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🥦",
+    "name": "Broccoli",
+    "shortcodes": [
+      "broccoli"
+    ],
+    "keywords": [
+      "fruit",
+      "food",
+      "vegetable"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f966",
+        "emoji": "🥦"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧄",
+    "name": "Garlic",
+    "shortcodes": [
+      "garlic"
+    ],
+    "keywords": [
+      "food",
+      "spice",
+      "cook"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9c4",
+        "emoji": "🧄"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🧅",
+    "name": "Onion",
+    "shortcodes": [
+      "onion"
+    ],
+    "keywords": [
+      "cook",
+      "food",
+      "spice"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9c5",
+        "emoji": "🧅"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🍄",
+    "name": "Mushroom",
+    "shortcodes": [
+      "mushroom"
+    ],
+    "keywords": [
+      "plant",
+      "vegetable"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f344",
+        "emoji": "🍄"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥜",
+    "name": "Peanuts",
+    "shortcodes": [
+      "peanuts"
+    ],
+    "keywords": [
+      "food",
+      "nut"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f95c",
+        "emoji": "🥜"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🫘",
+    "name": "Beans",
+    "shortcodes": [
+      "beans"
+    ],
+    "keywords": [
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fad8",
+        "emoji": "🫘"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🌰",
+    "name": "Chestnut",
+    "shortcodes": [
+      "chestnut"
+    ],
+    "keywords": [
+      "food",
+      "squirrel"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f330",
+        "emoji": "🌰"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍞",
+    "name": "Bread",
+    "shortcodes": [
+      "bread"
+    ],
+    "keywords": [
+      "food",
+      "wheat",
+      "breakfast",
+      "toast"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f35e",
+        "emoji": "🍞"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥐",
+    "name": "Croissant",
+    "shortcodes": [
+      "croissant"
+    ],
+    "keywords": [
+      "food",
+      "bread",
+      "french"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f950",
+        "emoji": "🥐"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🥖",
+    "name": "Baguette Bread",
+    "shortcodes": [
+      "baguette_bread"
+    ],
+    "keywords": [
+      "food",
+      "french"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f956",
+        "emoji": "🥖"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🫓",
+    "name": "Flatbread",
+    "shortcodes": [
+      "flatbread"
+    ],
+    "keywords": [
+      "flour",
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fad3",
+        "emoji": "🫓"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🥨",
+    "name": "Pretzel",
+    "shortcodes": [
+      "pretzel"
+    ],
+    "keywords": [
+      "food",
+      "bread",
+      "twisted"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f968",
+        "emoji": "🥨"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🥯",
+    "name": "Bagel",
+    "shortcodes": [
+      "bagel"
+    ],
+    "keywords": [
+      "food",
+      "bread",
+      "bakery",
+      "schmear"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f96f",
+        "emoji": "🥯"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🥞",
+    "name": "Pancakes",
+    "shortcodes": [
+      "pancakes"
+    ],
+    "keywords": [
+      "food",
+      "breakfast",
+      "flapjacks",
+      "hotcakes"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f95e",
+        "emoji": "🥞"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🧇",
+    "name": "Waffle",
+    "shortcodes": [
+      "waffle"
+    ],
+    "keywords": [
+      "food",
+      "breakfast"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9c7",
+        "emoji": "🧇"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🧀",
+    "name": "Cheese Wedge",
+    "shortcodes": [
+      "cheese_wedge"
+    ],
+    "keywords": [
+      "food",
+      "chadder"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9c0",
+        "emoji": "🧀"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍖",
+    "name": "Meat on Bone",
+    "shortcodes": [
+      "meat_on_bone"
+    ],
+    "keywords": [
+      "good",
+      "food",
+      "drumstick"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f356",
+        "emoji": "🍖"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍗",
+    "name": "Poultry Leg",
+    "shortcodes": [
+      "poultry_leg"
+    ],
+    "keywords": [
+      "food",
+      "meat",
+      "drumstick",
+      "bird",
+      "chicken",
+      "turkey"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f357",
+        "emoji": "🍗"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥩",
+    "name": "Cut of Meat",
+    "shortcodes": [
+      "cut_of_meat"
+    ],
+    "keywords": [
+      "food",
+      "cow",
+      "chop",
+      "lambchop",
+      "porkchop"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f969",
+        "emoji": "🥩"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🥓",
+    "name": "Bacon",
+    "shortcodes": [
+      "bacon"
+    ],
+    "keywords": [
+      "food",
+      "breakfast",
+      "pork",
+      "pig",
+      "meat"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f953",
+        "emoji": "🥓"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🍔",
+    "name": "Hamburger",
+    "shortcodes": [
+      "hamburger"
+    ],
+    "keywords": [
+      "meat",
+      "fast",
+      "food",
+      "beef",
+      "cheeseburger",
+      "mcdonalds",
+      "burger",
+      "king"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f354",
+        "emoji": "🍔"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍟",
+    "name": "French Fries",
+    "shortcodes": [
+      "fries"
+    ],
+    "keywords": [
+      "chips",
+      "snack",
+      "fast",
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f35f",
+        "emoji": "🍟"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍕",
+    "name": "Pizza",
+    "shortcodes": [
+      "pizza"
+    ],
+    "keywords": [
+      "food",
+      "party"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f355",
+        "emoji": "🍕"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌭",
+    "name": "Hot Dog",
+    "shortcodes": [
+      "hotdog"
+    ],
+    "keywords": [
+      "hotdog",
+      "food",
+      "frankfurter"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f32d",
+        "emoji": "🌭"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥪",
+    "name": "Sandwich",
+    "shortcodes": [
+      "sandwich"
+    ],
+    "keywords": [
+      "food",
+      "lunch",
+      "bread"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f96a",
+        "emoji": "🥪"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🌮",
+    "name": "Taco",
+    "shortcodes": [
+      "taco"
+    ],
+    "keywords": [
+      "food",
+      "mexican"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f32e",
+        "emoji": "🌮"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌯",
+    "name": "Burrito",
+    "shortcodes": [
+      "burrito"
+    ],
+    "keywords": [
+      "food",
+      "mexican"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f32f",
+        "emoji": "🌯"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🫔",
+    "name": "Tamale",
+    "shortcodes": [
+      "tamale"
+    ],
+    "keywords": [
+      "food",
+      "masa"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fad4",
+        "emoji": "🫔"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🥙",
+    "name": "Stuffed Flatbread",
+    "shortcodes": [
+      "stuffed_flatbread"
+    ],
+    "keywords": [
+      "food",
+      "gyro"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f959",
+        "emoji": "🥙"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🧆",
+    "name": "Falafel",
+    "shortcodes": [
+      "falafel"
+    ],
+    "keywords": [
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9c6",
+        "emoji": "🧆"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🥚",
+    "name": "Egg",
+    "shortcodes": [
+      "egg"
+    ],
+    "keywords": [
+      "food",
+      "chicken",
+      "breakfast"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f95a",
+        "emoji": "🥚"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🍳",
+    "name": "Cooking",
+    "shortcodes": [
+      "fried_egg",
+      "cooking"
+    ],
+    "keywords": [
+      "fried",
+      "egg",
+      "food",
+      "breakfast",
+      "kitchen"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f373",
+        "emoji": "🍳"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥘",
+    "name": "Shallow Pan of Food",
+    "shortcodes": [
+      "shallow_pan_of_food"
+    ],
+    "keywords": [
+      "cooking",
+      "casserole",
+      "paella"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f958",
+        "emoji": "🥘"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🍲",
+    "name": "Pot of Food",
+    "shortcodes": [
+      "stew"
+    ],
+    "keywords": [
+      "stew",
+      "meat",
+      "soup"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f372",
+        "emoji": "🍲"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🫕",
+    "name": "Fondue",
+    "shortcodes": [
+      "fondue"
+    ],
+    "keywords": [
+      "cheese",
+      "pot",
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fad5",
+        "emoji": "🫕"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🥣",
+    "name": "Bowl with Spoon",
+    "shortcodes": [
+      "bowl_with_spoon"
+    ],
+    "keywords": [
+      "food",
+      "breakfast",
+      "cereal",
+      "oatmeal",
+      "porridge"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f963",
+        "emoji": "🥣"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🥗",
+    "name": "Green Salad",
+    "shortcodes": [
+      "green_salad"
+    ],
+    "keywords": [
+      "food",
+      "healthy",
+      "lettuce"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f957",
+        "emoji": "🥗"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🍿",
+    "name": "Popcorn",
+    "shortcodes": [
+      "popcorn"
+    ],
+    "keywords": [
+      "food",
+      "movie",
+      "theater",
+      "films",
+      "snack"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f37f",
+        "emoji": "🍿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧈",
+    "name": "Butter",
+    "shortcodes": [
+      "butter"
+    ],
+    "keywords": [
+      "food",
+      "cook"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9c8",
+        "emoji": "🧈"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🧂",
+    "name": "Salt",
+    "shortcodes": [
+      "salt"
+    ],
+    "keywords": [
+      "condiment",
+      "shaker"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9c2",
+        "emoji": "🧂"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🥫",
+    "name": "Canned Food",
+    "shortcodes": [
+      "canned_food"
+    ],
+    "keywords": [
+      "soup"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f96b",
+        "emoji": "🥫"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🍱",
+    "name": "Bento Box",
+    "shortcodes": [
+      "bento"
+    ],
+    "keywords": [
+      "food",
+      "japanese"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f371",
+        "emoji": "🍱"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍘",
+    "name": "Rice Cracker",
+    "shortcodes": [
+      "rice_cracker"
+    ],
+    "keywords": [
+      "food",
+      "japanese"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f358",
+        "emoji": "🍘"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍙",
+    "name": "Rice Ball",
+    "shortcodes": [
+      "rice_ball"
+    ],
+    "keywords": [
+      "food",
+      "japanese"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f359",
+        "emoji": "🍙"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍚",
+    "name": "Cooked Rice",
+    "shortcodes": [
+      "rice"
+    ],
+    "keywords": [
+      "food",
+      "china",
+      "asian"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f35a",
+        "emoji": "🍚"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍛",
+    "name": "Curry Rice",
+    "shortcodes": [
+      "curry"
+    ],
+    "keywords": [
+      "food",
+      "spicy",
+      "hot",
+      "indian"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f35b",
+        "emoji": "🍛"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍜",
+    "name": "Steaming Bowl",
+    "shortcodes": [
+      "ramen"
+    ],
+    "keywords": [
+      "ramen",
+      "food",
+      "japanese",
+      "noodle",
+      "chopsticks"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f35c",
+        "emoji": "🍜"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍝",
+    "name": "Spaghetti",
+    "shortcodes": [
+      "spaghetti"
+    ],
+    "keywords": [
+      "food",
+      "italian",
+      "noodle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f35d",
+        "emoji": "🍝"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍠",
+    "name": "Roasted Sweet Potato",
+    "shortcodes": [
+      "sweet_potato"
+    ],
+    "keywords": [
+      "food",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f360",
+        "emoji": "🍠"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍢",
+    "name": "Oden",
+    "shortcodes": [
+      "oden"
+    ],
+    "keywords": [
+      "food",
+      "japanese"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f362",
+        "emoji": "🍢"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍣",
+    "name": "Sushi",
+    "shortcodes": [
+      "sushi"
+    ],
+    "keywords": [
+      "food",
+      "fish",
+      "japanese",
+      "rice"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f363",
+        "emoji": "🍣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍤",
+    "name": "Fried Shrimp",
+    "shortcodes": [
+      "fried_shrimp"
+    ],
+    "keywords": [
+      "food",
+      "animal",
+      "appetizer",
+      "summer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f364",
+        "emoji": "🍤"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍥",
+    "name": "Fish Cake with Swirl",
+    "shortcodes": [
+      "fish_cake"
+    ],
+    "keywords": [
+      "food",
+      "japan",
+      "sea",
+      "beach",
+      "narutomaki",
+      "pink",
+      "kamaboko",
+      "surimi",
+      "ramen"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f365",
+        "emoji": "🍥"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥮",
+    "name": "Moon Cake",
+    "shortcodes": [
+      "moon_cake"
+    ],
+    "keywords": [
+      "food",
+      "autumn"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f96e",
+        "emoji": "🥮"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🍡",
+    "name": "Dango",
+    "shortcodes": [
+      "dango"
+    ],
+    "keywords": [
+      "food",
+      "dessert",
+      "sweet",
+      "japanese",
+      "barbecue",
+      "meat"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f361",
+        "emoji": "🍡"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥟",
+    "name": "Dumpling",
+    "shortcodes": [
+      "dumpling"
+    ],
+    "keywords": [
+      "food",
+      "empanada",
+      "pierogi",
+      "potsticker"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f95f",
+        "emoji": "🥟"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🥠",
+    "name": "Fortune Cookie",
+    "shortcodes": [
+      "fortune_cookie"
+    ],
+    "keywords": [
+      "food",
+      "prophecy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f960",
+        "emoji": "🥠"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🥡",
+    "name": "Takeout Box",
+    "shortcodes": [
+      "takeout_box"
+    ],
+    "keywords": [
+      "food",
+      "leftovers"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f961",
+        "emoji": "🥡"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🦀",
+    "name": "Crab",
+    "shortcodes": [
+      "crab"
+    ],
+    "keywords": [
+      "animal",
+      "crustacean"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f980",
+        "emoji": "🦀"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦞",
+    "name": "Lobster",
+    "shortcodes": [
+      "lobster"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "bisque",
+      "claws",
+      "seafood"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f99e",
+        "emoji": "🦞"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🦐",
+    "name": "Shrimp",
+    "shortcodes": [
+      "shrimp"
+    ],
+    "keywords": [
+      "animal",
+      "ocean",
+      "nature",
+      "seafood"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f990",
+        "emoji": "🦐"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🦑",
+    "name": "Squid",
+    "shortcodes": [
+      "squid"
+    ],
+    "keywords": [
+      "animal",
+      "nature",
+      "ocean",
+      "sea"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f991",
+        "emoji": "🦑"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🦪",
+    "name": "Oyster",
+    "shortcodes": [
+      "oyster"
+    ],
+    "keywords": [
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9aa",
+        "emoji": "🦪"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🍦",
+    "name": "Soft Ice Cream",
+    "shortcodes": [
+      "icecream"
+    ],
+    "keywords": [
+      "icecream",
+      "food",
+      "hot",
+      "dessert",
+      "summer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f366",
+        "emoji": "🍦"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍧",
+    "name": "Shaved Ice",
+    "shortcodes": [
+      "shaved_ice"
+    ],
+    "keywords": [
+      "hot",
+      "dessert",
+      "summer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f367",
+        "emoji": "🍧"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍨",
+    "name": "Ice Cream",
+    "shortcodes": [
+      "ice_cream"
+    ],
+    "keywords": [
+      "food",
+      "hot",
+      "dessert"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f368",
+        "emoji": "🍨"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍩",
+    "name": "Doughnut",
+    "shortcodes": [
+      "doughnut"
+    ],
+    "keywords": [
+      "food",
+      "dessert",
+      "snack",
+      "sweet",
+      "donut"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f369",
+        "emoji": "🍩"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍪",
+    "name": "Cookie",
+    "shortcodes": [
+      "cookie"
+    ],
+    "keywords": [
+      "food",
+      "snack",
+      "oreo",
+      "chocolate",
+      "sweet",
+      "dessert"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f36a",
+        "emoji": "🍪"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎂",
+    "name": "Birthday Cake",
+    "shortcodes": [
+      "birthday"
+    ],
+    "keywords": [
+      "food",
+      "dessert"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f382",
+        "emoji": "🎂"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍰",
+    "name": "Shortcake",
+    "shortcodes": [
+      "cake"
+    ],
+    "keywords": [
+      "cake",
+      "food",
+      "dessert"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f370",
+        "emoji": "🍰"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧁",
+    "name": "Cupcake",
+    "shortcodes": [
+      "cupcake"
+    ],
+    "keywords": [
+      "food",
+      "dessert",
+      "bakery",
+      "sweet"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9c1",
+        "emoji": "🧁"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🥧",
+    "name": "Pie",
+    "shortcodes": [
+      "pie"
+    ],
+    "keywords": [
+      "food",
+      "dessert",
+      "pastry"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f967",
+        "emoji": "🥧"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🍫",
+    "name": "Chocolate Bar",
+    "shortcodes": [
+      "chocolate_bar"
+    ],
+    "keywords": [
+      "food",
+      "snack",
+      "dessert",
+      "sweet"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f36b",
+        "emoji": "🍫"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍬",
+    "name": "Candy",
+    "shortcodes": [
+      "candy"
+    ],
+    "keywords": [
+      "snack",
+      "dessert",
+      "sweet",
+      "lolly"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f36c",
+        "emoji": "🍬"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍭",
+    "name": "Lollipop",
+    "shortcodes": [
+      "lollipop"
+    ],
+    "keywords": [
+      "food",
+      "snack",
+      "candy",
+      "sweet"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f36d",
+        "emoji": "🍭"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍮",
+    "name": "Custard",
+    "shortcodes": [
+      "custard"
+    ],
+    "keywords": [
+      "dessert",
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f36e",
+        "emoji": "🍮"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍯",
+    "name": "Honey Pot",
+    "shortcodes": [
+      "honey_pot"
+    ],
+    "keywords": [
+      "bees",
+      "sweet",
+      "kitchen"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f36f",
+        "emoji": "🍯"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍼",
+    "name": "Baby Bottle",
+    "shortcodes": [
+      "baby_bottle"
+    ],
+    "keywords": [
+      "food",
+      "container",
+      "milk"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f37c",
+        "emoji": "🍼"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥛",
+    "name": "Glass of Milk",
+    "shortcodes": [
+      "glass_of_milk"
+    ],
+    "keywords": [
+      "beverage",
+      "drink",
+      "cow"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f95b",
+        "emoji": "🥛"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "☕",
+    "name": "Hot Beverage",
+    "shortcodes": [
+      "coffee"
+    ],
+    "keywords": [
+      "coffee",
+      "caffeine",
+      "latte",
+      "espresso"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2615",
+        "emoji": "☕"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🫖",
+    "name": "Teapot",
+    "shortcodes": [
+      "teapot"
+    ],
+    "keywords": [
+      "drink",
+      "hot"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fad6",
+        "emoji": "🫖"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🍵",
+    "name": "Teacup Without Handle",
+    "shortcodes": [
+      "tea"
+    ],
+    "keywords": [
+      "tea",
+      "drink",
+      "bowl",
+      "breakfast",
+      "green",
+      "british"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f375",
+        "emoji": "🍵"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍶",
+    "name": "Sake",
+    "shortcodes": [
+      "sake"
+    ],
+    "keywords": [
+      "wine",
+      "drink",
+      "drunk",
+      "beverage",
+      "japanese",
+      "alcohol",
+      "booze"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f376",
+        "emoji": "🍶"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍾",
+    "name": "Bottle with Popping Cork",
+    "shortcodes": [
+      "champagne"
+    ],
+    "keywords": [
+      "champagne",
+      "drink",
+      "wine",
+      "celebration"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f37e",
+        "emoji": "🍾"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍷",
+    "name": "Wine Glass",
+    "shortcodes": [
+      "wine_glass"
+    ],
+    "keywords": [
+      "drink",
+      "beverage",
+      "drunk",
+      "alcohol",
+      "booze"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f377",
+        "emoji": "🍷"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍸",
+    "name": "Cocktail Glass",
+    "shortcodes": [
+      "cocktail"
+    ],
+    "keywords": [
+      "drink",
+      "drunk",
+      "alcohol",
+      "beverage",
+      "booze",
+      "mojito"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f378",
+        "emoji": "🍸"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍹",
+    "name": "Tropical Drink",
+    "shortcodes": [
+      "tropical_drink"
+    ],
+    "keywords": [
+      "beverage",
+      "cocktail",
+      "summer",
+      "beach",
+      "alcohol",
+      "booze",
+      "mojito"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f379",
+        "emoji": "🍹"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍺",
+    "name": "Beer Mug",
+    "shortcodes": [
+      "beer"
+    ],
+    "keywords": [
+      "relax",
+      "beverage",
+      "drink",
+      "drunk",
+      "party",
+      "pub",
+      "summer",
+      "alcohol",
+      "booze"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f37a",
+        "emoji": "🍺"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍻",
+    "name": "Clinking Beer Mugs",
+    "shortcodes": [
+      "beers"
+    ],
+    "keywords": [
+      "beers",
+      "relax",
+      "beverage",
+      "drink",
+      "drunk",
+      "party",
+      "pub",
+      "summer",
+      "alcohol",
+      "booze"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f37b",
+        "emoji": "🍻"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥂",
+    "name": "Clinking Glasses",
+    "shortcodes": [
+      "clinking_glasses"
+    ],
+    "keywords": [
+      "beverage",
+      "drink",
+      "party",
+      "alcohol",
+      "celebrate",
+      "cheers",
+      "wine",
+      "champagne",
+      "toast"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f942",
+        "emoji": "🥂"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🥃",
+    "name": "Tumbler Glass",
+    "shortcodes": [
+      "tumbler_glass"
+    ],
+    "keywords": [
+      "drink",
+      "beverage",
+      "drunk",
+      "alcohol",
+      "liquor",
+      "booze",
+      "bourbon",
+      "scotch",
+      "whisky",
+      "shot"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f943",
+        "emoji": "🥃"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🫗",
+    "name": "Pouring Liquid",
+    "shortcodes": [
+      "pouring_liquid"
+    ],
+    "keywords": [
+      "cup",
+      "water"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fad7",
+        "emoji": "🫗"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🥤",
+    "name": "Cup with Straw",
+    "shortcodes": [
+      "cup_with_straw"
+    ],
+    "keywords": [
+      "drink",
+      "soda"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f964",
+        "emoji": "🥤"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧋",
+    "name": "Bubble Tea",
+    "shortcodes": [
+      "bubble_tea"
+    ],
+    "keywords": [
+      "taiwan",
+      "boba",
+      "milk",
+      "straw"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9cb",
+        "emoji": "🧋"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🧃",
+    "name": "Beverage Box",
+    "shortcodes": [
+      "beverage_box"
+    ],
+    "keywords": [
+      "drink"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9c3",
+        "emoji": "🧃"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🧉",
+    "name": "Mate",
+    "shortcodes": [
+      "mate_drink"
+    ],
+    "keywords": [
+      "drink",
+      "tea",
+      "beverage"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9c9",
+        "emoji": "🧉"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🧊",
+    "name": "Ice",
+    "shortcodes": [
+      "ice_cube"
+    ],
+    "keywords": [
+      "cube",
+      "water",
+      "cold"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9ca",
+        "emoji": "🧊"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🥢",
+    "name": "Chopsticks",
+    "shortcodes": [
+      "chopsticks"
+    ],
+    "keywords": [
+      "food"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f962",
+        "emoji": "🥢"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🍽️",
+    "name": "Fork and Knife with Plate",
+    "shortcodes": [
+      "knife_fork_plate"
+    ],
+    "keywords": [
+      "food",
+      "eat",
+      "meal",
+      "lunch",
+      "dinner",
+      "restaurant"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f37d-fe0f",
+        "emoji": "🍽️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🍴",
+    "name": "Fork and Knife",
+    "shortcodes": [
+      "fork_and_knife"
+    ],
+    "keywords": [
+      "cutlery",
+      "kitchen"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f374",
+        "emoji": "🍴"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥄",
+    "name": "Spoon",
+    "shortcodes": [
+      "spoon"
+    ],
+    "keywords": [
+      "cutlery",
+      "kitchen",
+      "tableware"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f944",
+        "emoji": "🥄"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🔪",
+    "name": "Hocho",
+    "shortcodes": [
+      "hocho",
+      "knife"
+    ],
+    "keywords": [
+      "knife",
+      "kitchen",
+      "blade",
+      "cutlery",
+      "weapon"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f52a",
+        "emoji": "🔪"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🫙",
+    "name": "Jar",
+    "shortcodes": [
+      "jar"
+    ],
+    "keywords": [
+      "container",
+      "sauce"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fad9",
+        "emoji": "🫙"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🏺",
+    "name": "Amphora",
+    "shortcodes": [
+      "amphora"
+    ],
+    "keywords": [
+      "vase",
+      "jar"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3fa",
+        "emoji": "🏺"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌍",
+    "name": "Earth Globe Europe-Africa",
+    "shortcodes": [
+      "earth_africa"
+    ],
+    "keywords": [
+      "africa",
+      "showing",
+      "europe",
+      "world",
+      "international"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f30d",
+        "emoji": "🌍"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌎",
+    "name": "Earth Globe Americas",
+    "shortcodes": [
+      "earth_americas"
+    ],
+    "keywords": [
+      "showing",
+      "world",
+      "USA",
+      "international"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f30e",
+        "emoji": "🌎"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌏",
+    "name": "Earth Globe Asia-Australia",
+    "shortcodes": [
+      "earth_asia"
+    ],
+    "keywords": [
+      "asia",
+      "showing",
+      "australia",
+      "world",
+      "east",
+      "international"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f30f",
+        "emoji": "🌏"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌐",
+    "name": "Globe with Meridians",
+    "shortcodes": [
+      "globe_with_meridians"
+    ],
+    "keywords": [
+      "earth",
+      "international",
+      "world",
+      "internet",
+      "interweb",
+      "i18n"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f310",
+        "emoji": "🌐"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗺️",
+    "name": "World Map",
+    "shortcodes": [
+      "world_map"
+    ],
+    "keywords": [
+      "location",
+      "direction"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5fa-fe0f",
+        "emoji": "🗺️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗾",
+    "name": "Map of Japan",
+    "shortcodes": [
+      "japan"
+    ],
+    "keywords": [
+      "nation",
+      "country",
+      "japanese",
+      "asia"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5fe",
+        "emoji": "🗾"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧭",
+    "name": "Compass",
+    "shortcodes": [
+      "compass"
+    ],
+    "keywords": [
+      "magnetic",
+      "navigation",
+      "orienteering"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9ed",
+        "emoji": "🧭"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🏔️",
+    "name": "Snow-Capped Mountain",
+    "shortcodes": [
+      "snow_capped_mountain"
+    ],
+    "keywords": [
+      "snow",
+      "capped",
+      "photo",
+      "nature",
+      "environment",
+      "winter",
+      "cold"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3d4-fe0f",
+        "emoji": "🏔️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛰️",
+    "name": "Mountain",
+    "shortcodes": [
+      "mountain"
+    ],
+    "keywords": [
+      "photo",
+      "nature",
+      "environment"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26f0-fe0f",
+        "emoji": "⛰️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌋",
+    "name": "Volcano",
+    "shortcodes": [
+      "volcano"
+    ],
+    "keywords": [
+      "photo",
+      "nature",
+      "disaster"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f30b",
+        "emoji": "🌋"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗻",
+    "name": "Mount Fuji",
+    "shortcodes": [
+      "mount_fuji"
+    ],
+    "keywords": [
+      "photo",
+      "mountain",
+      "nature",
+      "japanese"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5fb",
+        "emoji": "🗻"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏕️",
+    "name": "Camping",
+    "shortcodes": [
+      "camping"
+    ],
+    "keywords": [
+      "photo",
+      "outdoors",
+      "tent"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3d5-fe0f",
+        "emoji": "🏕️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏖️",
+    "name": "Beach with Umbrella",
+    "shortcodes": [
+      "beach_with_umbrella"
+    ],
+    "keywords": [
+      "weather",
+      "summer",
+      "sunny",
+      "sand",
+      "mojito"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3d6-fe0f",
+        "emoji": "🏖️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏜️",
+    "name": "Desert",
+    "shortcodes": [
+      "desert"
+    ],
+    "keywords": [
+      "photo",
+      "warm",
+      "saharah"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3dc-fe0f",
+        "emoji": "🏜️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏝️",
+    "name": "Desert Island",
+    "shortcodes": [
+      "desert_island"
+    ],
+    "keywords": [
+      "photo",
+      "tropical",
+      "mojito"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3dd-fe0f",
+        "emoji": "🏝️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏞️",
+    "name": "National Park",
+    "shortcodes": [
+      "national_park"
+    ],
+    "keywords": [
+      "photo",
+      "environment",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3de-fe0f",
+        "emoji": "🏞️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏟️",
+    "name": "Stadium",
+    "shortcodes": [
+      "stadium"
+    ],
+    "keywords": [
+      "photo",
+      "place",
+      "sports",
+      "concert",
+      "venue"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3df-fe0f",
+        "emoji": "🏟️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏛️",
+    "name": "Classical Building",
+    "shortcodes": [
+      "classical_building"
+    ],
+    "keywords": [
+      "art",
+      "culture",
+      "history"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3db-fe0f",
+        "emoji": "🏛️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏗️",
+    "name": "Building Construction",
+    "shortcodes": [
+      "building_construction"
+    ],
+    "keywords": [
+      "wip",
+      "working",
+      "progress"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3d7-fe0f",
+        "emoji": "🏗️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧱",
+    "name": "Brick",
+    "shortcodes": [
+      "bricks"
+    ],
+    "keywords": [
+      "bricks"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9f1",
+        "emoji": "🧱"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🪨",
+    "name": "Rock",
+    "shortcodes": [
+      "rock"
+    ],
+    "keywords": [
+      "stone"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faa8",
+        "emoji": "🪨"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🪵",
+    "name": "Wood",
+    "shortcodes": [
+      "wood"
+    ],
+    "keywords": [
+      "nature",
+      "timber",
+      "trunk"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fab5",
+        "emoji": "🪵"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🛖",
+    "name": "Hut",
+    "shortcodes": [
+      "hut"
+    ],
+    "keywords": [
+      "house",
+      "structure"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6d6",
+        "emoji": "🛖"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🏘️",
+    "name": "Houses",
+    "shortcodes": [
+      "house_buildings"
+    ],
+    "keywords": [
+      "house",
+      "buildings",
+      "photo"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3d8-fe0f",
+        "emoji": "🏘️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏚️",
+    "name": "Derelict House",
+    "shortcodes": [
+      "derelict_house_building"
+    ],
+    "keywords": [
+      "building",
+      "abandon",
+      "evict",
+      "broken"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3da-fe0f",
+        "emoji": "🏚️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏠",
+    "name": "House",
+    "shortcodes": [
+      "house"
+    ],
+    "keywords": [
+      "building",
+      "home"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3e0",
+        "emoji": "🏠"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏡",
+    "name": "House with Garden",
+    "shortcodes": [
+      "house_with_garden"
+    ],
+    "keywords": [
+      "home",
+      "plant",
+      "nature"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3e1",
+        "emoji": "🏡"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏢",
+    "name": "Office Building",
+    "shortcodes": [
+      "office"
+    ],
+    "keywords": [
+      "bureau",
+      "work"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3e2",
+        "emoji": "🏢"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏣",
+    "name": "Japanese Post Office",
+    "shortcodes": [
+      "post_office"
+    ],
+    "keywords": [
+      "building",
+      "envelope",
+      "communication"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3e3",
+        "emoji": "🏣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏤",
+    "name": "Post Office",
+    "shortcodes": [
+      "european_post_office"
+    ],
+    "keywords": [
+      "european",
+      "building",
+      "email"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3e4",
+        "emoji": "🏤"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏥",
+    "name": "Hospital",
+    "shortcodes": [
+      "hospital"
+    ],
+    "keywords": [
+      "building",
+      "health",
+      "surgery",
+      "doctor"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3e5",
+        "emoji": "🏥"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏦",
+    "name": "Bank",
+    "shortcodes": [
+      "bank"
+    ],
+    "keywords": [
+      "building",
+      "money",
+      "sales",
+      "cash",
+      "business",
+      "enterprise"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3e6",
+        "emoji": "🏦"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏨",
+    "name": "Hotel",
+    "shortcodes": [
+      "hotel"
+    ],
+    "keywords": [
+      "building",
+      "accomodation",
+      "checkin"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3e8",
+        "emoji": "🏨"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏩",
+    "name": "Love Hotel",
+    "shortcodes": [
+      "love_hotel"
+    ],
+    "keywords": [
+      "like",
+      "affection",
+      "dating"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3e9",
+        "emoji": "🏩"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏪",
+    "name": "Convenience Store",
+    "shortcodes": [
+      "convenience_store"
+    ],
+    "keywords": [
+      "building",
+      "shopping",
+      "groceries"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3ea",
+        "emoji": "🏪"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏫",
+    "name": "School",
+    "shortcodes": [
+      "school"
+    ],
+    "keywords": [
+      "building",
+      "student",
+      "education",
+      "learn",
+      "teach"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3eb",
+        "emoji": "🏫"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏬",
+    "name": "Department Store",
+    "shortcodes": [
+      "department_store"
+    ],
+    "keywords": [
+      "building",
+      "shopping",
+      "mall"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3ec",
+        "emoji": "🏬"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏭",
+    "name": "Factory",
+    "shortcodes": [
+      "factory"
+    ],
+    "keywords": [
+      "building",
+      "industry",
+      "pollution",
+      "smoke"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3ed",
+        "emoji": "🏭"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏯",
+    "name": "Japanese Castle",
+    "shortcodes": [
+      "japanese_castle"
+    ],
+    "keywords": [
+      "photo",
+      "building"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3ef",
+        "emoji": "🏯"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏰",
+    "name": "Castle",
+    "shortcodes": [
+      "european_castle"
+    ],
+    "keywords": [
+      "european",
+      "building",
+      "royalty",
+      "history"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3f0",
+        "emoji": "🏰"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💒",
+    "name": "Wedding",
+    "shortcodes": [
+      "wedding"
+    ],
+    "keywords": [
+      "love",
+      "like",
+      "affection",
+      "couple",
+      "marriage",
+      "bride",
+      "groom"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f492",
+        "emoji": "💒"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗼",
+    "name": "Tokyo Tower",
+    "shortcodes": [
+      "tokyo_tower"
+    ],
+    "keywords": [
+      "photo",
+      "japanese"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5fc",
+        "emoji": "🗼"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗽",
+    "name": "Statue of Liberty",
+    "shortcodes": [
+      "statue_of_liberty"
+    ],
+    "keywords": [
+      "american",
+      "newyork"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5fd",
+        "emoji": "🗽"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛪",
+    "name": "Church",
+    "shortcodes": [
+      "church"
+    ],
+    "keywords": [
+      "building",
+      "religion",
+      "christ"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26ea",
+        "emoji": "⛪"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕌",
+    "name": "Mosque",
+    "shortcodes": [
+      "mosque"
+    ],
+    "keywords": [
+      "islam",
+      "worship",
+      "minaret"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f54c",
+        "emoji": "🕌"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛕",
+    "name": "Hindu Temple",
+    "shortcodes": [
+      "hindu_temple"
+    ],
+    "keywords": [
+      "religion"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6d5",
+        "emoji": "🛕"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🕍",
+    "name": "Synagogue",
+    "shortcodes": [
+      "synagogue"
+    ],
+    "keywords": [
+      "judaism",
+      "worship",
+      "temple",
+      "jewish"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f54d",
+        "emoji": "🕍"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛩️",
+    "name": "Shinto Shrine",
+    "shortcodes": [
+      "shinto_shrine"
+    ],
+    "keywords": [
+      "temple",
+      "japan",
+      "kyoto"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26e9-fe0f",
+        "emoji": "⛩️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕋",
+    "name": "Kaaba",
+    "shortcodes": [
+      "kaaba"
+    ],
+    "keywords": [
+      "mecca",
+      "mosque",
+      "islam"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f54b",
+        "emoji": "🕋"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛲",
+    "name": "Fountain",
+    "shortcodes": [
+      "fountain"
+    ],
+    "keywords": [
+      "photo",
+      "summer",
+      "water",
+      "fresh"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26f2",
+        "emoji": "⛲"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛺",
+    "name": "Tent",
+    "shortcodes": [
+      "tent"
+    ],
+    "keywords": [
+      "photo",
+      "camping",
+      "outdoors"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26fa",
+        "emoji": "⛺"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌁",
+    "name": "Foggy",
+    "shortcodes": [
+      "foggy"
+    ],
+    "keywords": [
+      "photo",
+      "mountain"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f301",
+        "emoji": "🌁"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌃",
+    "name": "Night with Stars",
+    "shortcodes": [
+      "night_with_stars"
+    ],
+    "keywords": [
+      "evening",
+      "city",
+      "downtown"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f303",
+        "emoji": "🌃"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏙️",
+    "name": "Cityscape",
+    "shortcodes": [
+      "cityscape"
+    ],
+    "keywords": [
+      "photo",
+      "night",
+      "life",
+      "urban"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3d9-fe0f",
+        "emoji": "🏙️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌄",
+    "name": "Sunrise over Mountains",
+    "shortcodes": [
+      "sunrise_over_mountains"
+    ],
+    "keywords": [
+      "view",
+      "vacation",
+      "photo"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f304",
+        "emoji": "🌄"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌅",
+    "name": "Sunrise",
+    "shortcodes": [
+      "sunrise"
+    ],
+    "keywords": [
+      "morning",
+      "view",
+      "vacation",
+      "photo"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f305",
+        "emoji": "🌅"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌆",
+    "name": "Cityscape at Dusk",
+    "shortcodes": [
+      "city_sunset"
+    ],
+    "keywords": [
+      "city",
+      "sunset",
+      "photo",
+      "evening",
+      "sky",
+      "buildings"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f306",
+        "emoji": "🌆"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌇",
+    "name": "Sunset",
+    "shortcodes": [
+      "city_sunrise"
+    ],
+    "keywords": [
+      "city",
+      "sunrise",
+      "photo",
+      "good",
+      "morning",
+      "dawn"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f307",
+        "emoji": "🌇"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌉",
+    "name": "Bridge at Night",
+    "shortcodes": [
+      "bridge_at_night"
+    ],
+    "keywords": [
+      "photo",
+      "sanfrancisco"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f309",
+        "emoji": "🌉"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♨️",
+    "name": "Hot Springs",
+    "shortcodes": [
+      "hotsprings"
+    ],
+    "keywords": [
+      "hotsprings",
+      "bath",
+      "warm",
+      "relax"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2668-fe0f",
+        "emoji": "♨️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎠",
+    "name": "Carousel Horse",
+    "shortcodes": [
+      "carousel_horse"
+    ],
+    "keywords": [
+      "photo",
+      "carnival"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3a0",
+        "emoji": "🎠"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛝",
+    "name": "Playground Slide",
+    "shortcodes": [
+      "playground_slide"
+    ],
+    "keywords": [
+      "fun",
+      "park"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6dd",
+        "emoji": "🛝"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🎡",
+    "name": "Ferris Wheel",
+    "shortcodes": [
+      "ferris_wheel"
+    ],
+    "keywords": [
+      "photo",
+      "carnival",
+      "londoneye"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3a1",
+        "emoji": "🎡"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎢",
+    "name": "Roller Coaster",
+    "shortcodes": [
+      "roller_coaster"
+    ],
+    "keywords": [
+      "carnival",
+      "playground",
+      "photo",
+      "fun"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3a2",
+        "emoji": "🎢"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💈",
+    "name": "Barber Pole",
+    "shortcodes": [
+      "barber"
+    ],
+    "keywords": [
+      "hair",
+      "salon",
+      "style"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f488",
+        "emoji": "💈"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎪",
+    "name": "Circus Tent",
+    "shortcodes": [
+      "circus_tent"
+    ],
+    "keywords": [
+      "festival",
+      "carnival",
+      "party"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3aa",
+        "emoji": "🎪"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚂",
+    "name": "Locomotive",
+    "shortcodes": [
+      "steam_locomotive"
+    ],
+    "keywords": [
+      "steam",
+      "transportation",
+      "vehicle",
+      "train"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f682",
+        "emoji": "🚂"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚃",
+    "name": "Railway Car",
+    "shortcodes": [
+      "railway_car"
+    ],
+    "keywords": [
+      "transportation",
+      "vehicle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f683",
+        "emoji": "🚃"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚄",
+    "name": "High-Speed Train",
+    "shortcodes": [
+      "bullettrain_side"
+    ],
+    "keywords": [
+      "bullettrain",
+      "side",
+      "high",
+      "speed",
+      "transportation",
+      "vehicle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f684",
+        "emoji": "🚄"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚅",
+    "name": "Bullet Train",
+    "shortcodes": [
+      "bullettrain_front"
+    ],
+    "keywords": [
+      "bullettrain",
+      "front",
+      "transportation",
+      "vehicle",
+      "speed",
+      "fast",
+      "public",
+      "travel"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f685",
+        "emoji": "🚅"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚆",
+    "name": "Train",
+    "shortcodes": [
+      "train2"
+    ],
+    "keywords": [
+      "train2",
+      "transportation",
+      "vehicle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f686",
+        "emoji": "🚆"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚇",
+    "name": "Metro",
+    "shortcodes": [
+      "metro"
+    ],
+    "keywords": [
+      "transportation",
+      "blue",
+      "square",
+      "mrt",
+      "underground",
+      "tube"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f687",
+        "emoji": "🚇"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚈",
+    "name": "Light Rail",
+    "shortcodes": [
+      "light_rail"
+    ],
+    "keywords": [
+      "transportation",
+      "vehicle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f688",
+        "emoji": "🚈"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚉",
+    "name": "Station",
+    "shortcodes": [
+      "station"
+    ],
+    "keywords": [
+      "transportation",
+      "vehicle",
+      "public"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f689",
+        "emoji": "🚉"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚊",
+    "name": "Tram",
+    "shortcodes": [
+      "tram"
+    ],
+    "keywords": [
+      "transportation",
+      "vehicle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f68a",
+        "emoji": "🚊"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚝",
+    "name": "Monorail",
+    "shortcodes": [
+      "monorail"
+    ],
+    "keywords": [
+      "transportation",
+      "vehicle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f69d",
+        "emoji": "🚝"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚞",
+    "name": "Mountain Railway",
+    "shortcodes": [
+      "mountain_railway"
+    ],
+    "keywords": [
+      "transportation",
+      "vehicle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f69e",
+        "emoji": "🚞"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚋",
+    "name": "Tram Car",
+    "shortcodes": [
+      "train"
+    ],
+    "keywords": [
+      "train",
+      "transportation",
+      "vehicle",
+      "carriage",
+      "public",
+      "travel"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f68b",
+        "emoji": "🚋"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚌",
+    "name": "Bus",
+    "shortcodes": [
+      "bus"
+    ],
+    "keywords": [
+      "car",
+      "vehicle",
+      "transportation"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f68c",
+        "emoji": "🚌"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚍",
+    "name": "Oncoming Bus",
+    "shortcodes": [
+      "oncoming_bus"
+    ],
+    "keywords": [
+      "vehicle",
+      "transportation"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f68d",
+        "emoji": "🚍"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚎",
+    "name": "Trolleybus",
+    "shortcodes": [
+      "trolleybus"
+    ],
+    "keywords": [
+      "bart",
+      "transportation",
+      "vehicle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f68e",
+        "emoji": "🚎"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚐",
+    "name": "Minibus",
+    "shortcodes": [
+      "minibus"
+    ],
+    "keywords": [
+      "vehicle",
+      "car",
+      "transportation"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f690",
+        "emoji": "🚐"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚑",
+    "name": "Ambulance",
+    "shortcodes": [
+      "ambulance"
+    ],
+    "keywords": [
+      "health",
+      "911",
+      "hospital"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f691",
+        "emoji": "🚑"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚒",
+    "name": "Fire Engine",
+    "shortcodes": [
+      "fire_engine"
+    ],
+    "keywords": [
+      "transportation",
+      "cars",
+      "vehicle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f692",
+        "emoji": "🚒"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚓",
+    "name": "Police Car",
+    "shortcodes": [
+      "police_car"
+    ],
+    "keywords": [
+      "vehicle",
+      "cars",
+      "transportation",
+      "law",
+      "legal",
+      "enforcement"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f693",
+        "emoji": "🚓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚔",
+    "name": "Oncoming Police Car",
+    "shortcodes": [
+      "oncoming_police_car"
+    ],
+    "keywords": [
+      "vehicle",
+      "law",
+      "legal",
+      "enforcement",
+      "911"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f694",
+        "emoji": "🚔"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚕",
+    "name": "Taxi",
+    "shortcodes": [
+      "taxi"
+    ],
+    "keywords": [
+      "uber",
+      "vehicle",
+      "cars",
+      "transportation"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f695",
+        "emoji": "🚕"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚖",
+    "name": "Oncoming Taxi",
+    "shortcodes": [
+      "oncoming_taxi"
+    ],
+    "keywords": [
+      "vehicle",
+      "cars",
+      "uber"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f696",
+        "emoji": "🚖"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚗",
+    "name": "Automobile",
+    "shortcodes": [
+      "car",
+      "red_car"
+    ],
+    "keywords": [
+      "car",
+      "red",
+      "transportation",
+      "vehicle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f697",
+        "emoji": "🚗"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚘",
+    "name": "Oncoming Automobile",
+    "shortcodes": [
+      "oncoming_automobile"
+    ],
+    "keywords": [
+      "car",
+      "vehicle",
+      "transportation"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f698",
+        "emoji": "🚘"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚙",
+    "name": "Recreational Vehicle",
+    "shortcodes": [
+      "blue_car"
+    ],
+    "keywords": [
+      "blue",
+      "car",
+      "sport",
+      "utility",
+      "transportation"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f699",
+        "emoji": "🚙"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛻",
+    "name": "Pickup Truck",
+    "shortcodes": [
+      "pickup_truck"
+    ],
+    "keywords": [
+      "car",
+      "transportation"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6fb",
+        "emoji": "🛻"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🚚",
+    "name": "Delivery Truck",
+    "shortcodes": [
+      "truck"
+    ],
+    "keywords": [
+      "cars",
+      "transportation"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f69a",
+        "emoji": "🚚"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚛",
+    "name": "Articulated Lorry",
+    "shortcodes": [
+      "articulated_lorry"
+    ],
+    "keywords": [
+      "vehicle",
+      "cars",
+      "transportation",
+      "express"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f69b",
+        "emoji": "🚛"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚜",
+    "name": "Tractor",
+    "shortcodes": [
+      "tractor"
+    ],
+    "keywords": [
+      "vehicle",
+      "car",
+      "farming",
+      "agriculture"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f69c",
+        "emoji": "🚜"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏎️",
+    "name": "Racing Car",
+    "shortcodes": [
+      "racing_car"
+    ],
+    "keywords": [
+      "sports",
+      "race",
+      "fast",
+      "formula",
+      "f1"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3ce-fe0f",
+        "emoji": "🏎️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏍️",
+    "name": "Motorcycle",
+    "shortcodes": [
+      "racing_motorcycle"
+    ],
+    "keywords": [
+      "racing",
+      "race",
+      "sports",
+      "fast"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3cd-fe0f",
+        "emoji": "🏍️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛵",
+    "name": "Motor Scooter",
+    "shortcodes": [
+      "motor_scooter"
+    ],
+    "keywords": [
+      "vehicle",
+      "vespa",
+      "sasha"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6f5",
+        "emoji": "🛵"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🦽",
+    "name": "Manual Wheelchair",
+    "shortcodes": [
+      "manual_wheelchair"
+    ],
+    "keywords": [
+      "accessibility"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9bd",
+        "emoji": "🦽"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🦼",
+    "name": "Motorized Wheelchair",
+    "shortcodes": [
+      "motorized_wheelchair"
+    ],
+    "keywords": [
+      "accessibility"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9bc",
+        "emoji": "🦼"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🛺",
+    "name": "Auto Rickshaw",
+    "shortcodes": [
+      "auto_rickshaw"
+    ],
+    "keywords": [
+      "move",
+      "transportation"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6fa",
+        "emoji": "🛺"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🚲",
+    "name": "Bicycle",
+    "shortcodes": [
+      "bike"
+    ],
+    "keywords": [
+      "bike",
+      "sports",
+      "exercise",
+      "hipster"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6b2",
+        "emoji": "🚲"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛴",
+    "name": "Scooter",
+    "shortcodes": [
+      "scooter"
+    ],
+    "keywords": [
+      "kick",
+      "vehicle",
+      "razor"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6f4",
+        "emoji": "🛴"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🛹",
+    "name": "Skateboard",
+    "shortcodes": [
+      "skateboard"
+    ],
+    "keywords": [
+      "board"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6f9",
+        "emoji": "🛹"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🛼",
+    "name": "Roller Skate",
+    "shortcodes": [
+      "roller_skate"
+    ],
+    "keywords": [
+      "footwear",
+      "sports"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6fc",
+        "emoji": "🛼"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🚏",
+    "name": "Bus Stop",
+    "shortcodes": [
+      "busstop"
+    ],
+    "keywords": [
+      "busstop",
+      "transportation",
+      "wait"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f68f",
+        "emoji": "🚏"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛣️",
+    "name": "Motorway",
+    "shortcodes": [
+      "motorway"
+    ],
+    "keywords": [
+      "road",
+      "cupertino",
+      "interstate",
+      "highway"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6e3-fe0f",
+        "emoji": "🛣️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛤️",
+    "name": "Railway Track",
+    "shortcodes": [
+      "railway_track"
+    ],
+    "keywords": [
+      "train",
+      "transportation"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6e4-fe0f",
+        "emoji": "🛤️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛢️",
+    "name": "Oil Drum",
+    "shortcodes": [
+      "oil_drum"
+    ],
+    "keywords": [
+      "barrell"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6e2-fe0f",
+        "emoji": "🛢️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛽",
+    "name": "Fuel Pump",
+    "shortcodes": [
+      "fuelpump"
+    ],
+    "keywords": [
+      "fuelpump",
+      "gas",
+      "station",
+      "petroleum"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26fd",
+        "emoji": "⛽"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛞",
+    "name": "Wheel",
+    "shortcodes": [
+      "wheel"
+    ],
+    "keywords": [
+      "car",
+      "transport"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6de",
+        "emoji": "🛞"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🚨",
+    "name": "Police Car Light",
+    "shortcodes": [
+      "rotating_light"
+    ],
+    "keywords": [
+      "rotating",
+      "ambulance",
+      "911",
+      "emergency",
+      "alert",
+      "error",
+      "pinged",
+      "law",
+      "legal"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6a8",
+        "emoji": "🚨"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚥",
+    "name": "Horizontal Traffic Light",
+    "shortcodes": [
+      "traffic_light"
+    ],
+    "keywords": [
+      "transportation",
+      "signal"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6a5",
+        "emoji": "🚥"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚦",
+    "name": "Vertical Traffic Light",
+    "shortcodes": [
+      "vertical_traffic_light"
+    ],
+    "keywords": [
+      "transportation",
+      "driving"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6a6",
+        "emoji": "🚦"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛑",
+    "name": "Stop Sign",
+    "shortcodes": [
+      "octagonal_sign"
+    ],
+    "keywords": [
+      "octagonal"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6d1",
+        "emoji": "🛑"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🚧",
+    "name": "Construction",
+    "shortcodes": [
+      "construction"
+    ],
+    "keywords": [
+      "wip",
+      "progress",
+      "caution",
+      "warning"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6a7",
+        "emoji": "🚧"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⚓",
+    "name": "Anchor",
+    "shortcodes": [
+      "anchor"
+    ],
+    "keywords": [
+      "ship",
+      "ferry",
+      "sea",
+      "boat"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2693",
+        "emoji": "⚓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛟",
+    "name": "Ring Buoy",
+    "shortcodes": [
+      "ring_buoy"
+    ],
+    "keywords": [
+      "life",
+      "saver",
+      "preserver"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6df",
+        "emoji": "🛟"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "⛵",
+    "name": "Sailboat",
+    "shortcodes": [
+      "boat",
+      "sailboat"
+    ],
+    "keywords": [
+      "boat",
+      "ship",
+      "summer",
+      "transportation",
+      "water",
+      "sailing"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26f5",
+        "emoji": "⛵"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛶",
+    "name": "Canoe",
+    "shortcodes": [
+      "canoe"
+    ],
+    "keywords": [
+      "boat",
+      "paddle",
+      "water",
+      "ship"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6f6",
+        "emoji": "🛶"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🚤",
+    "name": "Speedboat",
+    "shortcodes": [
+      "speedboat"
+    ],
+    "keywords": [
+      "ship",
+      "transportation",
+      "vehicle",
+      "summer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6a4",
+        "emoji": "🚤"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛳️",
+    "name": "Passenger Ship",
+    "shortcodes": [
+      "passenger_ship"
+    ],
+    "keywords": [
+      "yacht",
+      "cruise",
+      "ferry"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6f3-fe0f",
+        "emoji": "🛳️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛴️",
+    "name": "Ferry",
+    "shortcodes": [
+      "ferry"
+    ],
+    "keywords": [
+      "boat",
+      "ship",
+      "yacht"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26f4-fe0f",
+        "emoji": "⛴️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛥️",
+    "name": "Motor Boat",
+    "shortcodes": [
+      "motor_boat"
+    ],
+    "keywords": [
+      "ship"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6e5-fe0f",
+        "emoji": "🛥️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚢",
+    "name": "Ship",
+    "shortcodes": [
+      "ship"
+    ],
+    "keywords": [
+      "transportation",
+      "titanic",
+      "deploy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6a2",
+        "emoji": "🚢"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "✈️",
+    "name": "Airplane",
+    "shortcodes": [
+      "airplane"
+    ],
+    "keywords": [
+      "vehicle",
+      "transportation",
+      "flight",
+      "fly"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2708-fe0f",
+        "emoji": "✈️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛩️",
+    "name": "Small Airplane",
+    "shortcodes": [
+      "small_airplane"
+    ],
+    "keywords": [
+      "flight",
+      "transportation",
+      "fly",
+      "vehicle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6e9-fe0f",
+        "emoji": "🛩️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛫",
+    "name": "Airplane Departure",
+    "shortcodes": [
+      "airplane_departure"
+    ],
+    "keywords": [
+      "airport",
+      "flight",
+      "landing"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6eb",
+        "emoji": "🛫"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛬",
+    "name": "Airplane Arrival",
+    "shortcodes": [
+      "airplane_arriving"
+    ],
+    "keywords": [
+      "arriving",
+      "airport",
+      "flight",
+      "boarding"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6ec",
+        "emoji": "🛬"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪂",
+    "name": "Parachute",
+    "shortcodes": [
+      "parachute"
+    ],
+    "keywords": [
+      "fly",
+      "glide"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa82",
+        "emoji": "🪂"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "💺",
+    "name": "Seat",
+    "shortcodes": [
+      "seat"
+    ],
+    "keywords": [
+      "sit",
+      "airplane",
+      "transport",
+      "bus",
+      "flight",
+      "fly"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4ba",
+        "emoji": "💺"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚁",
+    "name": "Helicopter",
+    "shortcodes": [
+      "helicopter"
+    ],
+    "keywords": [
+      "transportation",
+      "vehicle",
+      "fly"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f681",
+        "emoji": "🚁"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚟",
+    "name": "Suspension Railway",
+    "shortcodes": [
+      "suspension_railway"
+    ],
+    "keywords": [
+      "vehicle",
+      "transportation"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f69f",
+        "emoji": "🚟"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚠",
+    "name": "Mountain Cableway",
+    "shortcodes": [
+      "mountain_cableway"
+    ],
+    "keywords": [
+      "transportation",
+      "vehicle",
+      "ski"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6a0",
+        "emoji": "🚠"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚡",
+    "name": "Aerial Tramway",
+    "shortcodes": [
+      "aerial_tramway"
+    ],
+    "keywords": [
+      "transportation",
+      "vehicle",
+      "ski"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6a1",
+        "emoji": "🚡"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛰️",
+    "name": "Satellite",
+    "shortcodes": [
+      "satellite"
+    ],
+    "keywords": [
+      "communication",
+      "gps",
+      "orbit",
+      "spaceflight",
+      "NASA",
+      "ISS"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6f0-fe0f",
+        "emoji": "🛰️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚀",
+    "name": "Rocket",
+    "shortcodes": [
+      "rocket"
+    ],
+    "keywords": [
+      "launch",
+      "ship",
+      "staffmode",
+      "NASA",
+      "outer",
+      "space",
+      "fly"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f680",
+        "emoji": "🚀"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛸",
+    "name": "Flying Saucer",
+    "shortcodes": [
+      "flying_saucer"
+    ],
+    "keywords": [
+      "transportation",
+      "vehicle",
+      "ufo"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6f8",
+        "emoji": "🛸"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🛎️",
+    "name": "Bellhop Bell",
+    "shortcodes": [
+      "bellhop_bell"
+    ],
+    "keywords": [
+      "service"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6ce-fe0f",
+        "emoji": "🛎️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧳",
+    "name": "Luggage",
+    "shortcodes": [
+      "luggage"
+    ],
+    "keywords": [
+      "packing",
+      "travel"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9f3",
+        "emoji": "🧳"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "⌛",
+    "name": "Hourglass",
+    "shortcodes": [
+      "hourglass"
+    ],
+    "keywords": [
+      "done",
+      "time",
+      "clock",
+      "oldschool",
+      "limit",
+      "exam",
+      "quiz",
+      "test"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "231b",
+        "emoji": "⌛"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⏳",
+    "name": "Hourglass Not Done",
+    "shortcodes": [
+      "hourglass_flowing_sand"
+    ],
+    "keywords": [
+      "flowing",
+      "sand",
+      "oldschool",
+      "time",
+      "countdown"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "23f3",
+        "emoji": "⏳"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⌚",
+    "name": "Watch",
+    "shortcodes": [
+      "watch"
+    ],
+    "keywords": [
+      "time",
+      "accessories"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "231a",
+        "emoji": "⌚"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⏰",
+    "name": "Alarm Clock",
+    "shortcodes": [
+      "alarm_clock"
+    ],
+    "keywords": [
+      "time",
+      "wake"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "23f0",
+        "emoji": "⏰"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⏱️",
+    "name": "Stopwatch",
+    "shortcodes": [
+      "stopwatch"
+    ],
+    "keywords": [
+      "time",
+      "deadline"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "23f1-fe0f",
+        "emoji": "⏱️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⏲️",
+    "name": "Timer Clock",
+    "shortcodes": [
+      "timer_clock"
+    ],
+    "keywords": [
+      "alarm"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "23f2-fe0f",
+        "emoji": "⏲️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕰️",
+    "name": "Mantelpiece Clock",
+    "shortcodes": [
+      "mantelpiece_clock"
+    ],
+    "keywords": [
+      "time"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f570-fe0f",
+        "emoji": "🕰️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕛",
+    "name": "Twelve O’clock",
+    "shortcodes": [
+      "clock12"
+    ],
+    "keywords": [
+      "clock12",
+      "o",
+      "clock",
+      "time",
+      "noon",
+      "midnight",
+      "midday",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f55b",
+        "emoji": "🕛"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕧",
+    "name": "Twelve-Thirty",
+    "shortcodes": [
+      "clock1230"
+    ],
+    "keywords": [
+      "clock1230",
+      "twelve",
+      "thirty",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f567",
+        "emoji": "🕧"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕐",
+    "name": "One O’clock",
+    "shortcodes": [
+      "clock1"
+    ],
+    "keywords": [
+      "clock1",
+      "o",
+      "clock",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f550",
+        "emoji": "🕐"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕜",
+    "name": "One-Thirty",
+    "shortcodes": [
+      "clock130"
+    ],
+    "keywords": [
+      "clock130",
+      "one",
+      "thirty",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f55c",
+        "emoji": "🕜"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕑",
+    "name": "Two O’clock",
+    "shortcodes": [
+      "clock2"
+    ],
+    "keywords": [
+      "clock2",
+      "o",
+      "clock",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f551",
+        "emoji": "🕑"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕝",
+    "name": "Two-Thirty",
+    "shortcodes": [
+      "clock230"
+    ],
+    "keywords": [
+      "clock230",
+      "two",
+      "thirty",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f55d",
+        "emoji": "🕝"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕒",
+    "name": "Three O’clock",
+    "shortcodes": [
+      "clock3"
+    ],
+    "keywords": [
+      "clock3",
+      "o",
+      "clock",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f552",
+        "emoji": "🕒"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕞",
+    "name": "Three-Thirty",
+    "shortcodes": [
+      "clock330"
+    ],
+    "keywords": [
+      "clock330",
+      "three",
+      "thirty",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f55e",
+        "emoji": "🕞"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕓",
+    "name": "Four O’clock",
+    "shortcodes": [
+      "clock4"
+    ],
+    "keywords": [
+      "clock4",
+      "o",
+      "clock",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f553",
+        "emoji": "🕓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕟",
+    "name": "Four-Thirty",
+    "shortcodes": [
+      "clock430"
+    ],
+    "keywords": [
+      "clock430",
+      "four",
+      "thirty",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f55f",
+        "emoji": "🕟"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕔",
+    "name": "Five O’clock",
+    "shortcodes": [
+      "clock5"
+    ],
+    "keywords": [
+      "clock5",
+      "o",
+      "clock",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f554",
+        "emoji": "🕔"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕠",
+    "name": "Five-Thirty",
+    "shortcodes": [
+      "clock530"
+    ],
+    "keywords": [
+      "clock530",
+      "five",
+      "thirty",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f560",
+        "emoji": "🕠"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕕",
+    "name": "Six O’clock",
+    "shortcodes": [
+      "clock6"
+    ],
+    "keywords": [
+      "clock6",
+      "o",
+      "clock",
+      "time",
+      "late",
+      "early",
+      "schedule",
+      "dawn",
+      "dusk"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f555",
+        "emoji": "🕕"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕡",
+    "name": "Six-Thirty",
+    "shortcodes": [
+      "clock630"
+    ],
+    "keywords": [
+      "clock630",
+      "six",
+      "thirty",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f561",
+        "emoji": "🕡"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕖",
+    "name": "Seven O’clock",
+    "shortcodes": [
+      "clock7"
+    ],
+    "keywords": [
+      "clock7",
+      "o",
+      "clock",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f556",
+        "emoji": "🕖"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕢",
+    "name": "Seven-Thirty",
+    "shortcodes": [
+      "clock730"
+    ],
+    "keywords": [
+      "clock730",
+      "seven",
+      "thirty",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f562",
+        "emoji": "🕢"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕗",
+    "name": "Eight O’clock",
+    "shortcodes": [
+      "clock8"
+    ],
+    "keywords": [
+      "clock8",
+      "o",
+      "clock",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f557",
+        "emoji": "🕗"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕣",
+    "name": "Eight-Thirty",
+    "shortcodes": [
+      "clock830"
+    ],
+    "keywords": [
+      "clock830",
+      "eight",
+      "thirty",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f563",
+        "emoji": "🕣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕘",
+    "name": "Nine O’clock",
+    "shortcodes": [
+      "clock9"
+    ],
+    "keywords": [
+      "clock9",
+      "o",
+      "clock",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f558",
+        "emoji": "🕘"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕤",
+    "name": "Nine-Thirty",
+    "shortcodes": [
+      "clock930"
+    ],
+    "keywords": [
+      "clock930",
+      "nine",
+      "thirty",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f564",
+        "emoji": "🕤"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕙",
+    "name": "Ten O’clock",
+    "shortcodes": [
+      "clock10"
+    ],
+    "keywords": [
+      "clock10",
+      "o",
+      "clock",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f559",
+        "emoji": "🕙"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕥",
+    "name": "Ten-Thirty",
+    "shortcodes": [
+      "clock1030"
+    ],
+    "keywords": [
+      "clock1030",
+      "ten",
+      "thirty",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f565",
+        "emoji": "🕥"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕚",
+    "name": "Eleven O’clock",
+    "shortcodes": [
+      "clock11"
+    ],
+    "keywords": [
+      "clock11",
+      "o",
+      "clock",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f55a",
+        "emoji": "🕚"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕦",
+    "name": "Eleven-Thirty",
+    "shortcodes": [
+      "clock1130"
+    ],
+    "keywords": [
+      "clock1130",
+      "eleven",
+      "thirty",
+      "time",
+      "late",
+      "early",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f566",
+        "emoji": "🕦"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌑",
+    "name": "New Moon",
+    "shortcodes": [
+      "new_moon"
+    ],
+    "keywords": [
+      "nature",
+      "twilight",
+      "planet",
+      "space",
+      "night",
+      "evening",
+      "sleep"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f311",
+        "emoji": "🌑"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌒",
+    "name": "Waxing Crescent Moon",
+    "shortcodes": [
+      "waxing_crescent_moon"
+    ],
+    "keywords": [
+      "nature",
+      "twilight",
+      "planet",
+      "space",
+      "night",
+      "evening",
+      "sleep"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f312",
+        "emoji": "🌒"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌓",
+    "name": "First Quarter Moon",
+    "shortcodes": [
+      "first_quarter_moon"
+    ],
+    "keywords": [
+      "nature",
+      "twilight",
+      "planet",
+      "space",
+      "night",
+      "evening",
+      "sleep"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f313",
+        "emoji": "🌓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌔",
+    "name": "Waxing Gibbous Moon",
+    "shortcodes": [
+      "moon",
+      "waxing_gibbous_moon"
+    ],
+    "keywords": [
+      "nature",
+      "night",
+      "sky",
+      "gray",
+      "twilight",
+      "planet",
+      "space",
+      "evening",
+      "sleep"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f314",
+        "emoji": "🌔"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌕",
+    "name": "Full Moon",
+    "shortcodes": [
+      "full_moon"
+    ],
+    "keywords": [
+      "nature",
+      "yellow",
+      "twilight",
+      "planet",
+      "space",
+      "night",
+      "evening",
+      "sleep"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f315",
+        "emoji": "🌕"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌖",
+    "name": "Waning Gibbous Moon",
+    "shortcodes": [
+      "waning_gibbous_moon"
+    ],
+    "keywords": [
+      "nature",
+      "twilight",
+      "planet",
+      "space",
+      "night",
+      "evening",
+      "sleep",
+      "waxing"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f316",
+        "emoji": "🌖"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌗",
+    "name": "Last Quarter Moon",
+    "shortcodes": [
+      "last_quarter_moon"
+    ],
+    "keywords": [
+      "nature",
+      "twilight",
+      "planet",
+      "space",
+      "night",
+      "evening",
+      "sleep"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f317",
+        "emoji": "🌗"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌘",
+    "name": "Waning Crescent Moon",
+    "shortcodes": [
+      "waning_crescent_moon"
+    ],
+    "keywords": [
+      "nature",
+      "twilight",
+      "planet",
+      "space",
+      "night",
+      "evening",
+      "sleep"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f318",
+        "emoji": "🌘"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌙",
+    "name": "Crescent Moon",
+    "shortcodes": [
+      "crescent_moon"
+    ],
+    "keywords": [
+      "night",
+      "sleep",
+      "sky",
+      "evening",
+      "magic"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f319",
+        "emoji": "🌙"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌚",
+    "name": "New Moon Face",
+    "shortcodes": [
+      "new_moon_with_face"
+    ],
+    "keywords": [
+      "with",
+      "nature",
+      "twilight",
+      "planet",
+      "space",
+      "night",
+      "evening",
+      "sleep"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f31a",
+        "emoji": "🌚"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌛",
+    "name": "First Quarter Moon Face",
+    "shortcodes": [
+      "first_quarter_moon_with_face"
+    ],
+    "keywords": [
+      "with",
+      "nature",
+      "twilight",
+      "planet",
+      "space",
+      "night",
+      "evening",
+      "sleep"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f31b",
+        "emoji": "🌛"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌜",
+    "name": "Last Quarter Moon Face",
+    "shortcodes": [
+      "last_quarter_moon_with_face"
+    ],
+    "keywords": [
+      "with",
+      "nature",
+      "twilight",
+      "planet",
+      "space",
+      "night",
+      "evening",
+      "sleep"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f31c",
+        "emoji": "🌜"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌡️",
+    "name": "Thermometer",
+    "shortcodes": [
+      "thermometer"
+    ],
+    "keywords": [
+      "weather",
+      "temperature",
+      "hot",
+      "cold"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f321-fe0f",
+        "emoji": "🌡️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☀️",
+    "name": "Sun",
+    "shortcodes": [
+      "sunny"
+    ],
+    "keywords": [
+      "sunny",
+      "weather",
+      "nature",
+      "brightness",
+      "summer",
+      "beach",
+      "spring"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2600-fe0f",
+        "emoji": "☀️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌝",
+    "name": "Full Moon Face",
+    "shortcodes": [
+      "full_moon_with_face"
+    ],
+    "keywords": [
+      "with",
+      "nature",
+      "twilight",
+      "planet",
+      "space",
+      "night",
+      "evening",
+      "sleep"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f31d",
+        "emoji": "🌝"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌞",
+    "name": "Sun with Face",
+    "shortcodes": [
+      "sun_with_face"
+    ],
+    "keywords": [
+      "nature",
+      "morning",
+      "sky"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f31e",
+        "emoji": "🌞"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪐",
+    "name": "Ringed Planet",
+    "shortcodes": [
+      "ringed_planet"
+    ],
+    "keywords": [
+      "outerspace"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa90",
+        "emoji": "🪐"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "⭐",
+    "name": "Star",
+    "shortcodes": [
+      "star"
+    ],
+    "keywords": [
+      "night",
+      "yellow"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2b50",
+        "emoji": "⭐"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌟",
+    "name": "Glowing Star",
+    "shortcodes": [
+      "star2"
+    ],
+    "keywords": [
+      "star2",
+      "night",
+      "sparkle",
+      "awesome",
+      "good",
+      "magic"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f31f",
+        "emoji": "🌟"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌠",
+    "name": "Shooting Star",
+    "shortcodes": [
+      "stars"
+    ],
+    "keywords": [
+      "stars",
+      "night",
+      "photo"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f320",
+        "emoji": "🌠"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌌",
+    "name": "Milky Way",
+    "shortcodes": [
+      "milky_way"
+    ],
+    "keywords": [
+      "photo",
+      "space",
+      "stars"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f30c",
+        "emoji": "🌌"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☁️",
+    "name": "Cloud",
+    "shortcodes": [
+      "cloud"
+    ],
+    "keywords": [
+      "weather",
+      "sky"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2601-fe0f",
+        "emoji": "☁️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛅",
+    "name": "Sun Behind Cloud",
+    "shortcodes": [
+      "partly_sunny"
+    ],
+    "keywords": [
+      "partly",
+      "sunny",
+      "weather",
+      "nature",
+      "cloudy",
+      "morning",
+      "fall",
+      "spring"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26c5",
+        "emoji": "⛅"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛈️",
+    "name": "Cloud with Lightning and Rain",
+    "shortcodes": [
+      "thunder_cloud_and_rain"
+    ],
+    "keywords": [
+      "thunder",
+      "weather"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26c8-fe0f",
+        "emoji": "⛈️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌤️",
+    "name": "Sun Behind Small Cloud",
+    "shortcodes": [
+      "mostly_sunny",
+      "sun_small_cloud"
+    ],
+    "keywords": [
+      "mostly",
+      "sunny",
+      "weather"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f324-fe0f",
+        "emoji": "🌤️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌥️",
+    "name": "Sun Behind Large Cloud",
+    "shortcodes": [
+      "barely_sunny",
+      "sun_behind_cloud"
+    ],
+    "keywords": [
+      "barely",
+      "sunny",
+      "weather"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f325-fe0f",
+        "emoji": "🌥️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌦️",
+    "name": "Sun Behind Rain Cloud",
+    "shortcodes": [
+      "partly_sunny_rain",
+      "sun_behind_rain_cloud"
+    ],
+    "keywords": [
+      "partly",
+      "sunny",
+      "weather"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f326-fe0f",
+        "emoji": "🌦️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌧️",
+    "name": "Cloud with Rain",
+    "shortcodes": [
+      "rain_cloud"
+    ],
+    "keywords": [
+      "weather"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f327-fe0f",
+        "emoji": "🌧️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌨️",
+    "name": "Cloud with Snow",
+    "shortcodes": [
+      "snow_cloud"
+    ],
+    "keywords": [
+      "weather"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f328-fe0f",
+        "emoji": "🌨️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌩️",
+    "name": "Cloud with Lightning",
+    "shortcodes": [
+      "lightning",
+      "lightning_cloud"
+    ],
+    "keywords": [
+      "weather",
+      "thunder"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f329-fe0f",
+        "emoji": "🌩️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌪️",
+    "name": "Tornado",
+    "shortcodes": [
+      "tornado",
+      "tornado_cloud"
+    ],
+    "keywords": [
+      "cloud",
+      "weather",
+      "cyclone",
+      "twister"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f32a-fe0f",
+        "emoji": "🌪️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌫️",
+    "name": "Fog",
+    "shortcodes": [
+      "fog"
+    ],
+    "keywords": [
+      "weather"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f32b-fe0f",
+        "emoji": "🌫️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌬️",
+    "name": "Wind Face",
+    "shortcodes": [
+      "wind_blowing_face"
+    ],
+    "keywords": [
+      "blowing",
+      "gust",
+      "air"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f32c-fe0f",
+        "emoji": "🌬️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌀",
+    "name": "Cyclone",
+    "shortcodes": [
+      "cyclone"
+    ],
+    "keywords": [
+      "weather",
+      "swirl",
+      "blue",
+      "cloud",
+      "vortex",
+      "spiral",
+      "whirlpool",
+      "spin",
+      "tornado",
+      "hurricane",
+      "typhoon"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f300",
+        "emoji": "🌀"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌈",
+    "name": "Rainbow",
+    "shortcodes": [
+      "rainbow"
+    ],
+    "keywords": [
+      "nature",
+      "happy",
+      "unicorn",
+      "face",
+      "photo",
+      "sky",
+      "spring"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f308",
+        "emoji": "🌈"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌂",
+    "name": "Closed Umbrella",
+    "shortcodes": [
+      "closed_umbrella"
+    ],
+    "keywords": [
+      "weather",
+      "rain",
+      "drizzle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f302",
+        "emoji": "🌂"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☂️",
+    "name": "Umbrella",
+    "shortcodes": [
+      "umbrella"
+    ],
+    "keywords": [
+      "weather",
+      "spring"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2602-fe0f",
+        "emoji": "☂️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☔",
+    "name": "Umbrella with Rain Drops",
+    "shortcodes": [
+      "umbrella_with_rain_drops"
+    ],
+    "keywords": [
+      "rainy",
+      "weather",
+      "spring"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2614",
+        "emoji": "☔"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛱️",
+    "name": "Umbrella on Ground",
+    "shortcodes": [
+      "umbrella_on_ground"
+    ],
+    "keywords": [
+      "weather",
+      "summer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26f1-fe0f",
+        "emoji": "⛱️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⚡",
+    "name": "High Voltage",
+    "shortcodes": [
+      "zap"
+    ],
+    "keywords": [
+      "zap",
+      "thunder",
+      "weather",
+      "lightning",
+      "bolt",
+      "fast"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26a1",
+        "emoji": "⚡"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "❄️",
+    "name": "Snowflake",
+    "shortcodes": [
+      "snowflake"
+    ],
+    "keywords": [
+      "winter",
+      "season",
+      "cold",
+      "weather",
+      "christmas",
+      "xmas"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2744-fe0f",
+        "emoji": "❄️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☃️",
+    "name": "Snowman",
+    "shortcodes": [
+      "snowman"
+    ],
+    "keywords": [
+      "winter",
+      "season",
+      "cold",
+      "weather",
+      "christmas",
+      "xmas",
+      "frozen"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2603-fe0f",
+        "emoji": "☃️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛄",
+    "name": "Snowman Without Snow",
+    "shortcodes": [
+      "snowman_without_snow"
+    ],
+    "keywords": [
+      "winter",
+      "season",
+      "cold",
+      "weather",
+      "christmas",
+      "xmas",
+      "frozen"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26c4",
+        "emoji": "⛄"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☄️",
+    "name": "Comet",
+    "shortcodes": [
+      "comet"
+    ],
+    "keywords": [
+      "space"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2604-fe0f",
+        "emoji": "☄️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔥",
+    "name": "Fire",
+    "shortcodes": [
+      "fire"
+    ],
+    "keywords": [
+      "hot",
+      "cook",
+      "flame"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f525",
+        "emoji": "🔥"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💧",
+    "name": "Droplet",
+    "shortcodes": [
+      "droplet"
+    ],
+    "keywords": [
+      "water",
+      "drip",
+      "faucet",
+      "spring"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4a7",
+        "emoji": "💧"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🌊",
+    "name": "Water Wave",
+    "shortcodes": [
+      "ocean"
+    ],
+    "keywords": [
+      "ocean",
+      "sea",
+      "nature",
+      "tsunami",
+      "disaster"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f30a",
+        "emoji": "🌊"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎃",
+    "name": "Jack-O-Lantern",
+    "shortcodes": [
+      "jack_o_lantern"
+    ],
+    "keywords": [
+      "jack",
+      "o",
+      "lantern",
+      "halloween",
+      "light",
+      "pumpkin",
+      "creepy",
+      "fall"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f383",
+        "emoji": "🎃"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎄",
+    "name": "Christmas Tree",
+    "shortcodes": [
+      "christmas_tree"
+    ],
+    "keywords": [
+      "festival",
+      "vacation",
+      "december",
+      "xmas",
+      "celebration"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f384",
+        "emoji": "🎄"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎆",
+    "name": "Fireworks",
+    "shortcodes": [
+      "fireworks"
+    ],
+    "keywords": [
+      "photo",
+      "festival",
+      "carnival",
+      "congratulations"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f386",
+        "emoji": "🎆"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎇",
+    "name": "Sparkler",
+    "shortcodes": [
+      "sparkler"
+    ],
+    "keywords": [
+      "stars",
+      "night",
+      "shine"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f387",
+        "emoji": "🎇"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧨",
+    "name": "Firecracker",
+    "shortcodes": [
+      "firecracker"
+    ],
+    "keywords": [
+      "dynamite",
+      "boom",
+      "explode",
+      "explosion",
+      "explosive"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9e8",
+        "emoji": "🧨"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "✨",
+    "name": "Sparkles",
+    "shortcodes": [
+      "sparkles"
+    ],
+    "keywords": [
+      "stars",
+      "shine",
+      "shiny",
+      "cool",
+      "awesome",
+      "good",
+      "magic"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2728",
+        "emoji": "✨"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎈",
+    "name": "Balloon",
+    "shortcodes": [
+      "balloon"
+    ],
+    "keywords": [
+      "party",
+      "celebration",
+      "birthday",
+      "circus"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f388",
+        "emoji": "🎈"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎉",
+    "name": "Party Popper",
+    "shortcodes": [
+      "tada"
+    ],
+    "keywords": [
+      "tada",
+      "congratulations",
+      "birthday",
+      "magic",
+      "circus",
+      "celebration"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f389",
+        "emoji": "🎉"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎊",
+    "name": "Confetti Ball",
+    "shortcodes": [
+      "confetti_ball"
+    ],
+    "keywords": [
+      "festival",
+      "party",
+      "birthday",
+      "circus"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f38a",
+        "emoji": "🎊"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎋",
+    "name": "Tanabata Tree",
+    "shortcodes": [
+      "tanabata_tree"
+    ],
+    "keywords": [
+      "plant",
+      "nature",
+      "branch",
+      "summer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f38b",
+        "emoji": "🎋"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎍",
+    "name": "Pine Decoration",
+    "shortcodes": [
+      "bamboo"
+    ],
+    "keywords": [
+      "bamboo",
+      "plant",
+      "nature",
+      "vegetable",
+      "panda"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f38d",
+        "emoji": "🎍"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎎",
+    "name": "Japanese Dolls",
+    "shortcodes": [
+      "dolls"
+    ],
+    "keywords": [
+      "toy",
+      "kimono"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f38e",
+        "emoji": "🎎"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎏",
+    "name": "Carp Streamer",
+    "shortcodes": [
+      "flags"
+    ],
+    "keywords": [
+      "flags",
+      "fish",
+      "japanese",
+      "koinobori",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f38f",
+        "emoji": "🎏"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎐",
+    "name": "Wind Chime",
+    "shortcodes": [
+      "wind_chime"
+    ],
+    "keywords": [
+      "nature",
+      "ding",
+      "spring",
+      "bell"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f390",
+        "emoji": "🎐"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎑",
+    "name": "Moon Viewing Ceremony",
+    "shortcodes": [
+      "rice_scene"
+    ],
+    "keywords": [
+      "rice",
+      "scene",
+      "photo",
+      "japan",
+      "asia",
+      "tsukimi"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f391",
+        "emoji": "🎑"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧧",
+    "name": "Red Envelope",
+    "shortcodes": [
+      "red_envelope"
+    ],
+    "keywords": [
+      "gift"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9e7",
+        "emoji": "🧧"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🎀",
+    "name": "Ribbon",
+    "shortcodes": [
+      "ribbon"
+    ],
+    "keywords": [
+      "decoration",
+      "pink",
+      "girl",
+      "bowtie"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f380",
+        "emoji": "🎀"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎁",
+    "name": "Wrapped Gift",
+    "shortcodes": [
+      "gift"
+    ],
+    "keywords": [
+      "present",
+      "birthday",
+      "christmas",
+      "xmas"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f381",
+        "emoji": "🎁"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎗️",
+    "name": "Reminder Ribbon",
+    "shortcodes": [
+      "reminder_ribbon"
+    ],
+    "keywords": [
+      "sports",
+      "cause",
+      "support",
+      "awareness"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f397-fe0f",
+        "emoji": "🎗️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎟️",
+    "name": "Admission Tickets",
+    "shortcodes": [
+      "admission_tickets"
+    ],
+    "keywords": [
+      "sports",
+      "concert",
+      "entrance"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f39f-fe0f",
+        "emoji": "🎟️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎫",
+    "name": "Ticket",
+    "shortcodes": [
+      "ticket"
+    ],
+    "keywords": [
+      "event",
+      "concert",
+      "pass"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3ab",
+        "emoji": "🎫"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎖️",
+    "name": "Military Medal",
+    "shortcodes": [
+      "medal"
+    ],
+    "keywords": [
+      "award",
+      "winning",
+      "army"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f396-fe0f",
+        "emoji": "🎖️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏆",
+    "name": "Trophy",
+    "shortcodes": [
+      "trophy"
+    ],
+    "keywords": [
+      "win",
+      "award",
+      "contest",
+      "place",
+      "ftw",
+      "ceremony"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3c6",
+        "emoji": "🏆"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏅",
+    "name": "Sports Medal",
+    "shortcodes": [
+      "sports_medal"
+    ],
+    "keywords": [
+      "award",
+      "winning"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3c5",
+        "emoji": "🏅"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥇",
+    "name": "1st Place Medal",
+    "shortcodes": [
+      "first_place_medal"
+    ],
+    "keywords": [
+      "first",
+      "award",
+      "winning"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f947",
+        "emoji": "🥇"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🥈",
+    "name": "2nd Place Medal",
+    "shortcodes": [
+      "second_place_medal"
+    ],
+    "keywords": [
+      "second",
+      "award"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f948",
+        "emoji": "🥈"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🥉",
+    "name": "3rd Place Medal",
+    "shortcodes": [
+      "third_place_medal"
+    ],
+    "keywords": [
+      "third",
+      "award"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f949",
+        "emoji": "🥉"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "⚽",
+    "name": "Soccer Ball",
+    "shortcodes": [
+      "soccer"
+    ],
+    "keywords": [
+      "sports",
+      "football"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26bd",
+        "emoji": "⚽"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⚾",
+    "name": "Baseball",
+    "shortcodes": [
+      "baseball"
+    ],
+    "keywords": [
+      "sports",
+      "balls"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26be",
+        "emoji": "⚾"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥎",
+    "name": "Softball",
+    "shortcodes": [
+      "softball"
+    ],
+    "keywords": [
+      "sports",
+      "balls"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f94e",
+        "emoji": "🥎"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🏀",
+    "name": "Basketball",
+    "shortcodes": [
+      "basketball"
+    ],
+    "keywords": [
+      "sports",
+      "balls",
+      "NBA"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3c0",
+        "emoji": "🏀"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏐",
+    "name": "Volleyball",
+    "shortcodes": [
+      "volleyball"
+    ],
+    "keywords": [
+      "sports",
+      "balls"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3d0",
+        "emoji": "🏐"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏈",
+    "name": "American Football",
+    "shortcodes": [
+      "football"
+    ],
+    "keywords": [
+      "sports",
+      "balls",
+      "NFL"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3c8",
+        "emoji": "🏈"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏉",
+    "name": "Rugby Football",
+    "shortcodes": [
+      "rugby_football"
+    ],
+    "keywords": [
+      "sports",
+      "team"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3c9",
+        "emoji": "🏉"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎾",
+    "name": "Tennis",
+    "shortcodes": [
+      "tennis"
+    ],
+    "keywords": [
+      "sports",
+      "balls",
+      "green"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3be",
+        "emoji": "🎾"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥏",
+    "name": "Flying Disc",
+    "shortcodes": [
+      "flying_disc"
+    ],
+    "keywords": [
+      "sports",
+      "frisbee",
+      "ultimate"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f94f",
+        "emoji": "🥏"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🎳",
+    "name": "Bowling",
+    "shortcodes": [
+      "bowling"
+    ],
+    "keywords": [
+      "sports",
+      "fun",
+      "play"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3b3",
+        "emoji": "🎳"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏏",
+    "name": "Cricket Game",
+    "shortcodes": [
+      "cricket_bat_and_ball"
+    ],
+    "keywords": [
+      "bat",
+      "and",
+      "ball",
+      "sports"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3cf",
+        "emoji": "🏏"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏑",
+    "name": "Field Hockey",
+    "shortcodes": [
+      "field_hockey_stick_and_ball"
+    ],
+    "keywords": [
+      "stick",
+      "and",
+      "ball",
+      "sports"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3d1",
+        "emoji": "🏑"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏒",
+    "name": "Ice Hockey",
+    "shortcodes": [
+      "ice_hockey_stick_and_puck"
+    ],
+    "keywords": [
+      "stick",
+      "and",
+      "puck",
+      "sports"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3d2",
+        "emoji": "🏒"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥍",
+    "name": "Lacrosse",
+    "shortcodes": [
+      "lacrosse"
+    ],
+    "keywords": [
+      "sports",
+      "ball",
+      "stick"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f94d",
+        "emoji": "🥍"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🏓",
+    "name": "Ping Pong",
+    "shortcodes": [
+      "table_tennis_paddle_and_ball"
+    ],
+    "keywords": [
+      "table",
+      "tennis",
+      "paddle",
+      "and",
+      "ball",
+      "sports",
+      "pingpong"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3d3",
+        "emoji": "🏓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏸",
+    "name": "Badminton",
+    "shortcodes": [
+      "badminton_racquet_and_shuttlecock"
+    ],
+    "keywords": [
+      "racquet",
+      "and",
+      "shuttlecock",
+      "sports"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3f8",
+        "emoji": "🏸"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥊",
+    "name": "Boxing Glove",
+    "shortcodes": [
+      "boxing_glove"
+    ],
+    "keywords": [
+      "sports",
+      "fighting"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f94a",
+        "emoji": "🥊"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🥋",
+    "name": "Martial Arts Uniform",
+    "shortcodes": [
+      "martial_arts_uniform"
+    ],
+    "keywords": [
+      "judo",
+      "karate",
+      "taekwondo"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f94b",
+        "emoji": "🥋"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🥅",
+    "name": "Goal Net",
+    "shortcodes": [
+      "goal_net"
+    ],
+    "keywords": [
+      "sports"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f945",
+        "emoji": "🥅"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "⛳",
+    "name": "Flag in Hole",
+    "shortcodes": [
+      "golf"
+    ],
+    "keywords": [
+      "golf",
+      "sports",
+      "business",
+      "summer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26f3",
+        "emoji": "⛳"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛸️",
+    "name": "Ice Skate",
+    "shortcodes": [
+      "ice_skate"
+    ],
+    "keywords": [
+      "sports"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26f8-fe0f",
+        "emoji": "⛸️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎣",
+    "name": "Fishing Pole",
+    "shortcodes": [
+      "fishing_pole_and_fish"
+    ],
+    "keywords": [
+      "and",
+      "fish",
+      "food",
+      "hobby",
+      "summer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3a3",
+        "emoji": "🎣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🤿",
+    "name": "Diving Mask",
+    "shortcodes": [
+      "diving_mask"
+    ],
+    "keywords": [
+      "sport",
+      "ocean"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f93f",
+        "emoji": "🤿"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🎽",
+    "name": "Running Shirt",
+    "shortcodes": [
+      "running_shirt_with_sash"
+    ],
+    "keywords": [
+      "with",
+      "sash",
+      "play",
+      "pageant"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3bd",
+        "emoji": "🎽"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎿",
+    "name": "Skis",
+    "shortcodes": [
+      "ski"
+    ],
+    "keywords": [
+      "ski",
+      "sports",
+      "winter",
+      "cold",
+      "snow"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3bf",
+        "emoji": "🎿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛷",
+    "name": "Sled",
+    "shortcodes": [
+      "sled"
+    ],
+    "keywords": [
+      "sleigh",
+      "luge",
+      "toboggan"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6f7",
+        "emoji": "🛷"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🥌",
+    "name": "Curling Stone",
+    "shortcodes": [
+      "curling_stone"
+    ],
+    "keywords": [
+      "sports"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f94c",
+        "emoji": "🥌"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🎯",
+    "name": "Bullseye",
+    "shortcodes": [
+      "dart"
+    ],
+    "keywords": [
+      "dart",
+      "direct",
+      "hit",
+      "game",
+      "play",
+      "bar",
+      "target"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3af",
+        "emoji": "🎯"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪀",
+    "name": "Yo-Yo",
+    "shortcodes": [
+      "yo-yo"
+    ],
+    "keywords": [
+      "yo",
+      "toy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa80",
+        "emoji": "🪀"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🪁",
+    "name": "Kite",
+    "shortcodes": [
+      "kite"
+    ],
+    "keywords": [
+      "wind",
+      "fly"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa81",
+        "emoji": "🪁"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🎱",
+    "name": "Billiards",
+    "shortcodes": [
+      "8ball"
+    ],
+    "keywords": [
+      "8ball",
+      "pool",
+      "8",
+      "ball",
+      "hobby",
+      "game",
+      "luck",
+      "magic"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3b1",
+        "emoji": "🎱"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔮",
+    "name": "Crystal Ball",
+    "shortcodes": [
+      "crystal_ball"
+    ],
+    "keywords": [
+      "disco",
+      "party",
+      "magic",
+      "circus",
+      "fortune",
+      "teller"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f52e",
+        "emoji": "🔮"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪄",
+    "name": "Magic Wand",
+    "shortcodes": [
+      "magic_wand"
+    ],
+    "keywords": [
+      "supernature",
+      "power"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa84",
+        "emoji": "🪄"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🧿",
+    "name": "Nazar Amulet",
+    "shortcodes": [
+      "nazar_amulet"
+    ],
+    "keywords": [
+      "bead",
+      "charm"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9ff",
+        "emoji": "🧿"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🪬",
+    "name": "Hamsa",
+    "shortcodes": [
+      "hamsa"
+    ],
+    "keywords": [
+      "religion",
+      "protection"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faac",
+        "emoji": "🪬"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🎮",
+    "name": "Video Game",
+    "shortcodes": [
+      "video_game"
+    ],
+    "keywords": [
+      "play",
+      "console",
+      "PS4",
+      "controller"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3ae",
+        "emoji": "🎮"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕹️",
+    "name": "Joystick",
+    "shortcodes": [
+      "joystick"
+    ],
+    "keywords": [
+      "game",
+      "play"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f579-fe0f",
+        "emoji": "🕹️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎰",
+    "name": "Slot Machine",
+    "shortcodes": [
+      "slot_machine"
+    ],
+    "keywords": [
+      "bet",
+      "gamble",
+      "vegas",
+      "fruit",
+      "luck",
+      "casino"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3b0",
+        "emoji": "🎰"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎲",
+    "name": "Game Die",
+    "shortcodes": [
+      "game_die"
+    ],
+    "keywords": [
+      "dice",
+      "random",
+      "tabletop",
+      "play",
+      "luck"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3b2",
+        "emoji": "🎲"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧩",
+    "name": "Puzzle Piece",
+    "shortcodes": [
+      "jigsaw"
+    ],
+    "keywords": [
+      "jigsaw",
+      "interlocking"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9e9",
+        "emoji": "🧩"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🧸",
+    "name": "Teddy Bear",
+    "shortcodes": [
+      "teddy_bear"
+    ],
+    "keywords": [
+      "plush",
+      "stuffed"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9f8",
+        "emoji": "🧸"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🪅",
+    "name": "Pinata",
+    "shortcodes": [
+      "pinata"
+    ],
+    "keywords": [
+      "mexico",
+      "candy",
+      "celebration"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa85",
+        "emoji": "🪅"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🪩",
+    "name": "Mirror Ball",
+    "shortcodes": [
+      "mirror_ball"
+    ],
+    "keywords": [
+      "disco",
+      "dance",
+      "party"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faa9",
+        "emoji": "🪩"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🪆",
+    "name": "Nesting Dolls",
+    "shortcodes": [
+      "nesting_dolls"
+    ],
+    "keywords": [
+      "matryoshka",
+      "toy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa86",
+        "emoji": "🪆"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "♠️",
+    "name": "Spade Suit",
+    "shortcodes": [
+      "spades"
+    ],
+    "keywords": [
+      "spades",
+      "poker",
+      "cards",
+      "suits",
+      "magic"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2660-fe0f",
+        "emoji": "♠️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♥️",
+    "name": "Heart Suit",
+    "shortcodes": [
+      "hearts"
+    ],
+    "keywords": [
+      "hearts",
+      "poker",
+      "cards",
+      "magic",
+      "suits"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2665-fe0f",
+        "emoji": "♥️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♦️",
+    "name": "Diamond Suit",
+    "shortcodes": [
+      "diamonds"
+    ],
+    "keywords": [
+      "diamonds",
+      "poker",
+      "cards",
+      "magic",
+      "suits"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2666-fe0f",
+        "emoji": "♦️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♣️",
+    "name": "Club Suit",
+    "shortcodes": [
+      "clubs"
+    ],
+    "keywords": [
+      "clubs",
+      "poker",
+      "cards",
+      "magic",
+      "suits"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2663-fe0f",
+        "emoji": "♣️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♟️",
+    "name": "Chess Pawn",
+    "shortcodes": [
+      "chess_pawn"
+    ],
+    "keywords": [
+      "expendable"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "265f-fe0f",
+        "emoji": "♟️"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🃏",
+    "name": "Joker",
+    "shortcodes": [
+      "black_joker"
+    ],
+    "keywords": [
+      "black",
+      "poker",
+      "cards",
+      "game",
+      "play",
+      "magic"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f0cf",
+        "emoji": "🃏"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🀄",
+    "name": "Mahjong Red Dragon",
+    "shortcodes": [
+      "mahjong"
+    ],
+    "keywords": [
+      "game",
+      "play",
+      "chinese",
+      "kanji"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f004",
+        "emoji": "🀄"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎴",
+    "name": "Flower Playing Cards",
+    "shortcodes": [
+      "flower_playing_cards"
+    ],
+    "keywords": [
+      "game",
+      "sunset",
+      "red"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3b4",
+        "emoji": "🎴"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎭",
+    "name": "Performing Arts",
+    "shortcodes": [
+      "performing_arts"
+    ],
+    "keywords": [
+      "acting",
+      "theater",
+      "drama"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3ad",
+        "emoji": "🎭"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🖼️",
+    "name": "Framed Picture",
+    "shortcodes": [
+      "frame_with_picture"
+    ],
+    "keywords": [
+      "frame",
+      "with",
+      "photography"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5bc-fe0f",
+        "emoji": "🖼️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎨",
+    "name": "Artist Palette",
+    "shortcodes": [
+      "art"
+    ],
+    "keywords": [
+      "art",
+      "design",
+      "paint",
+      "draw",
+      "colors"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3a8",
+        "emoji": "🎨"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧵",
+    "name": "Thread",
+    "shortcodes": [
+      "thread"
+    ],
+    "keywords": [
+      "needle",
+      "sewing",
+      "spool",
+      "string"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9f5",
+        "emoji": "🧵"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🪡",
+    "name": "Sewing Needle",
+    "shortcodes": [
+      "sewing_needle"
+    ],
+    "keywords": [
+      "stitches"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faa1",
+        "emoji": "🪡"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🧶",
+    "name": "Yarn",
+    "shortcodes": [
+      "yarn"
+    ],
+    "keywords": [
+      "ball",
+      "crochet",
+      "knit"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9f6",
+        "emoji": "🧶"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🪢",
+    "name": "Knot",
+    "shortcodes": [
+      "knot"
+    ],
+    "keywords": [
+      "rope",
+      "scout"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faa2",
+        "emoji": "🪢"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "👓",
+    "name": "Glasses",
+    "shortcodes": [
+      "eyeglasses"
+    ],
+    "keywords": [
+      "eyeglasses",
+      "fashion",
+      "accessories",
+      "eyesight",
+      "nerdy",
+      "dork",
+      "geek"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f453",
+        "emoji": "👓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕶️",
+    "name": "Sunglasses",
+    "shortcodes": [
+      "dark_sunglasses"
+    ],
+    "keywords": [
+      "dark",
+      "face",
+      "cool",
+      "accessories"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f576-fe0f",
+        "emoji": "🕶️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥽",
+    "name": "Goggles",
+    "shortcodes": [
+      "goggles"
+    ],
+    "keywords": [
+      "eyes",
+      "protection",
+      "safety"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f97d",
+        "emoji": "🥽"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🥼",
+    "name": "Lab Coat",
+    "shortcodes": [
+      "lab_coat"
+    ],
+    "keywords": [
+      "doctor",
+      "experiment",
+      "scientist",
+      "chemist"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f97c",
+        "emoji": "🥼"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🦺",
+    "name": "Safety Vest",
+    "shortcodes": [
+      "safety_vest"
+    ],
+    "keywords": [
+      "protection"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9ba",
+        "emoji": "🦺"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "👔",
+    "name": "Necktie",
+    "shortcodes": [
+      "necktie"
+    ],
+    "keywords": [
+      "shirt",
+      "suitup",
+      "formal",
+      "fashion",
+      "cloth",
+      "business"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f454",
+        "emoji": "👔"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👕",
+    "name": "T-Shirt",
+    "shortcodes": [
+      "shirt",
+      "tshirt"
+    ],
+    "keywords": [
+      "shirt",
+      "tshirt",
+      "t",
+      "fashion",
+      "cloth",
+      "casual",
+      "tee"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f455",
+        "emoji": "👕"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👖",
+    "name": "Jeans",
+    "shortcodes": [
+      "jeans"
+    ],
+    "keywords": [
+      "fashion",
+      "shopping"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f456",
+        "emoji": "👖"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧣",
+    "name": "Scarf",
+    "shortcodes": [
+      "scarf"
+    ],
+    "keywords": [
+      "neck",
+      "winter",
+      "clothes"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9e3",
+        "emoji": "🧣"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧤",
+    "name": "Gloves",
+    "shortcodes": [
+      "gloves"
+    ],
+    "keywords": [
+      "hands",
+      "winter",
+      "clothes"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9e4",
+        "emoji": "🧤"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧥",
+    "name": "Coat",
+    "shortcodes": [
+      "coat"
+    ],
+    "keywords": [
+      "jacket"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9e5",
+        "emoji": "🧥"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🧦",
+    "name": "Socks",
+    "shortcodes": [
+      "socks"
+    ],
+    "keywords": [
+      "stockings",
+      "clothes"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9e6",
+        "emoji": "🧦"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "👗",
+    "name": "Dress",
+    "shortcodes": [
+      "dress"
+    ],
+    "keywords": [
+      "clothes",
+      "fashion",
+      "shopping"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f457",
+        "emoji": "👗"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👘",
+    "name": "Kimono",
+    "shortcodes": [
+      "kimono"
+    ],
+    "keywords": [
+      "dress",
+      "fashion",
+      "women",
+      "female",
+      "japanese"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f458",
+        "emoji": "👘"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥻",
+    "name": "Sari",
+    "shortcodes": [
+      "sari"
+    ],
+    "keywords": [
+      "dress"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f97b",
+        "emoji": "🥻"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🩱",
+    "name": "One-Piece Swimsuit",
+    "shortcodes": [
+      "one-piece_swimsuit"
+    ],
+    "keywords": [
+      "one",
+      "piece",
+      "fashion"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa71",
+        "emoji": "🩱"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🩲",
+    "name": "Briefs",
+    "shortcodes": [
+      "briefs"
+    ],
+    "keywords": [
+      "clothing"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa72",
+        "emoji": "🩲"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🩳",
+    "name": "Shorts",
+    "shortcodes": [
+      "shorts"
+    ],
+    "keywords": [
+      "clothing"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa73",
+        "emoji": "🩳"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "👙",
+    "name": "Bikini",
+    "shortcodes": [
+      "bikini"
+    ],
+    "keywords": [
+      "swimming",
+      "female",
+      "woman",
+      "girl",
+      "fashion",
+      "beach",
+      "summer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f459",
+        "emoji": "👙"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👚",
+    "name": "Womans Clothes",
+    "shortcodes": [
+      "womans_clothes"
+    ],
+    "keywords": [
+      "woman",
+      "s",
+      "fashion",
+      "shopping",
+      "bags",
+      "female"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f45a",
+        "emoji": "👚"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👛",
+    "name": "Purse",
+    "shortcodes": [
+      "purse"
+    ],
+    "keywords": [
+      "fashion",
+      "accessories",
+      "money",
+      "sales",
+      "shopping"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f45b",
+        "emoji": "👛"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👜",
+    "name": "Handbag",
+    "shortcodes": [
+      "handbag"
+    ],
+    "keywords": [
+      "fashion",
+      "accessory",
+      "accessories",
+      "shopping"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f45c",
+        "emoji": "👜"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👝",
+    "name": "Pouch",
+    "shortcodes": [
+      "pouch"
+    ],
+    "keywords": [
+      "clutch",
+      "bag",
+      "accessories",
+      "shopping"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f45d",
+        "emoji": "👝"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛍️",
+    "name": "Shopping Bags",
+    "shortcodes": [
+      "shopping_bags"
+    ],
+    "keywords": [
+      "mall",
+      "buy",
+      "purchase"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6cd-fe0f",
+        "emoji": "🛍️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎒",
+    "name": "Backpack",
+    "shortcodes": [
+      "school_satchel"
+    ],
+    "keywords": [
+      "school",
+      "satchel",
+      "student",
+      "education",
+      "bag"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f392",
+        "emoji": "🎒"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🩴",
+    "name": "Thong Sandal",
+    "shortcodes": [
+      "thong_sandal"
+    ],
+    "keywords": [
+      "footwear",
+      "summer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa74",
+        "emoji": "🩴"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "👞",
+    "name": "Mans Shoe",
+    "shortcodes": [
+      "mans_shoe",
+      "shoe"
+    ],
+    "keywords": [
+      "man",
+      "s",
+      "fashion",
+      "male"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f45e",
+        "emoji": "👞"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👟",
+    "name": "Running Shoe",
+    "shortcodes": [
+      "athletic_shoe"
+    ],
+    "keywords": [
+      "athletic",
+      "shoes",
+      "sports",
+      "sneakers"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f45f",
+        "emoji": "👟"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🥾",
+    "name": "Hiking Boot",
+    "shortcodes": [
+      "hiking_boot"
+    ],
+    "keywords": [
+      "backpacking",
+      "camping"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f97e",
+        "emoji": "🥾"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🥿",
+    "name": "Flat Shoe",
+    "shortcodes": [
+      "womans_flat_shoe"
+    ],
+    "keywords": [
+      "womans",
+      "ballet",
+      "slip",
+      "on",
+      "slipper"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f97f",
+        "emoji": "🥿"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "👠",
+    "name": "High-Heeled Shoe",
+    "shortcodes": [
+      "high_heel"
+    ],
+    "keywords": [
+      "high",
+      "heel",
+      "heeled",
+      "fashion",
+      "shoes",
+      "female",
+      "pumps",
+      "stiletto"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f460",
+        "emoji": "👠"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👡",
+    "name": "Womans Sandal",
+    "shortcodes": [
+      "sandal"
+    ],
+    "keywords": [
+      "woman",
+      "s",
+      "shoes",
+      "fashion",
+      "flip",
+      "flops"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f461",
+        "emoji": "👡"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🩰",
+    "name": "Ballet Shoes",
+    "shortcodes": [
+      "ballet_shoes"
+    ],
+    "keywords": [
+      "dance"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa70",
+        "emoji": "🩰"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "👢",
+    "name": "Womans Boots",
+    "shortcodes": [
+      "boot"
+    ],
+    "keywords": [
+      "boot",
+      "woman",
+      "s",
+      "shoes",
+      "fashion"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f462",
+        "emoji": "👢"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👑",
+    "name": "Crown",
+    "shortcodes": [
+      "crown"
+    ],
+    "keywords": [
+      "king",
+      "kod",
+      "leader",
+      "royalty",
+      "lord"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f451",
+        "emoji": "👑"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "👒",
+    "name": "Womans Hat",
+    "shortcodes": [
+      "womans_hat"
+    ],
+    "keywords": [
+      "woman",
+      "s",
+      "fashion",
+      "accessories",
+      "female",
+      "lady",
+      "spring"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f452",
+        "emoji": "👒"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎩",
+    "name": "Top Hat",
+    "shortcodes": [
+      "tophat"
+    ],
+    "keywords": [
+      "tophat",
+      "magic",
+      "gentleman",
+      "classy",
+      "circus"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3a9",
+        "emoji": "🎩"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎓",
+    "name": "Graduation Cap",
+    "shortcodes": [
+      "mortar_board"
+    ],
+    "keywords": [
+      "mortar",
+      "board",
+      "school",
+      "college",
+      "degree",
+      "university",
+      "hat",
+      "legal",
+      "learn",
+      "education"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f393",
+        "emoji": "🎓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧢",
+    "name": "Billed Cap",
+    "shortcodes": [
+      "billed_cap"
+    ],
+    "keywords": [
+      "baseball"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9e2",
+        "emoji": "🧢"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🪖",
+    "name": "Military Helmet",
+    "shortcodes": [
+      "military_helmet"
+    ],
+    "keywords": [
+      "army",
+      "protection"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa96",
+        "emoji": "🪖"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "⛑️",
+    "name": "Rescue Worker’s Helmet",
+    "shortcodes": [
+      "helmet_with_white_cross"
+    ],
+    "keywords": [
+      "with",
+      "white",
+      "cross",
+      "worker",
+      "s",
+      "construction",
+      "build"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26d1-fe0f",
+        "emoji": "⛑️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📿",
+    "name": "Prayer Beads",
+    "shortcodes": [
+      "prayer_beads"
+    ],
+    "keywords": [
+      "dhikr",
+      "religious"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4ff",
+        "emoji": "📿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💄",
+    "name": "Lipstick",
+    "shortcodes": [
+      "lipstick"
+    ],
+    "keywords": [
+      "female",
+      "girl",
+      "fashion",
+      "woman"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f484",
+        "emoji": "💄"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💍",
+    "name": "Ring",
+    "shortcodes": [
+      "ring"
+    ],
+    "keywords": [
+      "wedding",
+      "propose",
+      "marriage",
+      "valentines",
+      "diamond",
+      "fashion",
+      "jewelry",
+      "gem",
+      "engagement"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f48d",
+        "emoji": "💍"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💎",
+    "name": "Gem Stone",
+    "shortcodes": [
+      "gem"
+    ],
+    "keywords": [
+      "blue",
+      "ruby",
+      "diamond",
+      "jewelry"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f48e",
+        "emoji": "💎"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔇",
+    "name": "Muted Speaker",
+    "shortcodes": [
+      "mute"
+    ],
+    "keywords": [
+      "mute",
+      "sound",
+      "volume",
+      "silence",
+      "quiet"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f507",
+        "emoji": "🔇"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔈",
+    "name": "Speaker",
+    "shortcodes": [
+      "speaker"
+    ],
+    "keywords": [
+      "low",
+      "volume",
+      "sound",
+      "silence",
+      "broadcast"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f508",
+        "emoji": "🔈"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔉",
+    "name": "Speaker Medium Volume",
+    "shortcodes": [
+      "sound"
+    ],
+    "keywords": [
+      "sound",
+      "broadcast"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f509",
+        "emoji": "🔉"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔊",
+    "name": "Speaker High Volume",
+    "shortcodes": [
+      "loud_sound"
+    ],
+    "keywords": [
+      "loud",
+      "sound",
+      "noise",
+      "noisy",
+      "broadcast"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f50a",
+        "emoji": "🔊"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📢",
+    "name": "Loudspeaker",
+    "shortcodes": [
+      "loudspeaker"
+    ],
+    "keywords": [
+      "volume",
+      "sound"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4e2",
+        "emoji": "📢"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📣",
+    "name": "Megaphone",
+    "shortcodes": [
+      "mega"
+    ],
+    "keywords": [
+      "mega",
+      "sound",
+      "speaker",
+      "volume"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4e3",
+        "emoji": "📣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📯",
+    "name": "Postal Horn",
+    "shortcodes": [
+      "postal_horn"
+    ],
+    "keywords": [
+      "instrument",
+      "music"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4ef",
+        "emoji": "📯"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔔",
+    "name": "Bell",
+    "shortcodes": [
+      "bell"
+    ],
+    "keywords": [
+      "sound",
+      "notification",
+      "christmas",
+      "xmas",
+      "chime"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f514",
+        "emoji": "🔔"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔕",
+    "name": "Bell with Slash",
+    "shortcodes": [
+      "no_bell"
+    ],
+    "keywords": [
+      "no",
+      "sound",
+      "volume",
+      "mute",
+      "quiet",
+      "silent"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f515",
+        "emoji": "🔕"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎼",
+    "name": "Musical Score",
+    "shortcodes": [
+      "musical_score"
+    ],
+    "keywords": [
+      "treble",
+      "clef",
+      "compose"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3bc",
+        "emoji": "🎼"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎵",
+    "name": "Musical Note",
+    "shortcodes": [
+      "musical_note"
+    ],
+    "keywords": [
+      "score",
+      "tone",
+      "sound"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3b5",
+        "emoji": "🎵"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎶",
+    "name": "Musical Notes",
+    "shortcodes": [
+      "notes"
+    ],
+    "keywords": [
+      "music",
+      "score"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3b6",
+        "emoji": "🎶"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎙️",
+    "name": "Studio Microphone",
+    "shortcodes": [
+      "studio_microphone"
+    ],
+    "keywords": [
+      "sing",
+      "recording",
+      "artist",
+      "talkshow"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f399-fe0f",
+        "emoji": "🎙️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎚️",
+    "name": "Level Slider",
+    "shortcodes": [
+      "level_slider"
+    ],
+    "keywords": [
+      "scale"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f39a-fe0f",
+        "emoji": "🎚️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎛️",
+    "name": "Control Knobs",
+    "shortcodes": [
+      "control_knobs"
+    ],
+    "keywords": [
+      "dial"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f39b-fe0f",
+        "emoji": "🎛️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎤",
+    "name": "Microphone",
+    "shortcodes": [
+      "microphone"
+    ],
+    "keywords": [
+      "sound",
+      "music",
+      "PA",
+      "sing",
+      "talkshow"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3a4",
+        "emoji": "🎤"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎧",
+    "name": "Headphone",
+    "shortcodes": [
+      "headphones"
+    ],
+    "keywords": [
+      "headphones",
+      "music",
+      "score",
+      "gadgets"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3a7",
+        "emoji": "🎧"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📻",
+    "name": "Radio",
+    "shortcodes": [
+      "radio"
+    ],
+    "keywords": [
+      "communication",
+      "music",
+      "podcast",
+      "program"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4fb",
+        "emoji": "📻"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎷",
+    "name": "Saxophone",
+    "shortcodes": [
+      "saxophone"
+    ],
+    "keywords": [
+      "music",
+      "instrument",
+      "jazz",
+      "blues"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3b7",
+        "emoji": "🎷"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪗",
+    "name": "Accordion",
+    "shortcodes": [
+      "accordion"
+    ],
+    "keywords": [
+      "music"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa97",
+        "emoji": "🪗"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🎸",
+    "name": "Guitar",
+    "shortcodes": [
+      "guitar"
+    ],
+    "keywords": [
+      "music",
+      "instrument"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3b8",
+        "emoji": "🎸"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎹",
+    "name": "Musical Keyboard",
+    "shortcodes": [
+      "musical_keyboard"
+    ],
+    "keywords": [
+      "piano",
+      "instrument",
+      "compose"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3b9",
+        "emoji": "🎹"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎺",
+    "name": "Trumpet",
+    "shortcodes": [
+      "trumpet"
+    ],
+    "keywords": [
+      "music",
+      "brass"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3ba",
+        "emoji": "🎺"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎻",
+    "name": "Violin",
+    "shortcodes": [
+      "violin"
+    ],
+    "keywords": [
+      "music",
+      "instrument",
+      "orchestra",
+      "symphony"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3bb",
+        "emoji": "🎻"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪕",
+    "name": "Banjo",
+    "shortcodes": [
+      "banjo"
+    ],
+    "keywords": [
+      "music",
+      "instructment"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa95",
+        "emoji": "🪕"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🥁",
+    "name": "Drum",
+    "shortcodes": [
+      "drum_with_drumsticks"
+    ],
+    "keywords": [
+      "with",
+      "drumsticks",
+      "music",
+      "instrument",
+      "snare"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f941",
+        "emoji": "🥁"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🪘",
+    "name": "Long Drum",
+    "shortcodes": [
+      "long_drum"
+    ],
+    "keywords": [
+      "music"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa98",
+        "emoji": "🪘"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "📱",
+    "name": "Mobile Phone",
+    "shortcodes": [
+      "iphone"
+    ],
+    "keywords": [
+      "iphone",
+      "technology",
+      "apple",
+      "gadgets",
+      "dial"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4f1",
+        "emoji": "📱"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📲",
+    "name": "Mobile Phone with Arrow",
+    "shortcodes": [
+      "calling"
+    ],
+    "keywords": [
+      "calling",
+      "iphone",
+      "incoming"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4f2",
+        "emoji": "📲"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☎️",
+    "name": "Telephone",
+    "shortcodes": [
+      "phone",
+      "telephone"
+    ],
+    "keywords": [
+      "phone",
+      "technology",
+      "communication",
+      "dial"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "260e-fe0f",
+        "emoji": "☎️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📞",
+    "name": "Telephone Receiver",
+    "shortcodes": [
+      "telephone_receiver"
+    ],
+    "keywords": [
+      "technology",
+      "communication",
+      "dial"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4de",
+        "emoji": "📞"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📟",
+    "name": "Pager",
+    "shortcodes": [
+      "pager"
+    ],
+    "keywords": [
+      "bbcall",
+      "oldschool",
+      "90s"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4df",
+        "emoji": "📟"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📠",
+    "name": "Fax Machine",
+    "shortcodes": [
+      "fax"
+    ],
+    "keywords": [
+      "communication",
+      "technology"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4e0",
+        "emoji": "📠"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔋",
+    "name": "Battery",
+    "shortcodes": [
+      "battery"
+    ],
+    "keywords": [
+      "power",
+      "energy",
+      "sustain"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f50b",
+        "emoji": "🔋"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪫",
+    "name": "Low Battery",
+    "shortcodes": [
+      "low_battery"
+    ],
+    "keywords": [
+      "drained",
+      "dead"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faab",
+        "emoji": "🪫"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🔌",
+    "name": "Electric Plug",
+    "shortcodes": [
+      "electric_plug"
+    ],
+    "keywords": [
+      "charger",
+      "power"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f50c",
+        "emoji": "🔌"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💻",
+    "name": "Laptop",
+    "shortcodes": [
+      "computer"
+    ],
+    "keywords": [
+      "computer",
+      "technology",
+      "screen",
+      "display",
+      "monitor"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4bb",
+        "emoji": "💻"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🖥️",
+    "name": "Desktop Computer",
+    "shortcodes": [
+      "desktop_computer"
+    ],
+    "keywords": [
+      "technology",
+      "computing",
+      "screen"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5a5-fe0f",
+        "emoji": "🖥️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🖨️",
+    "name": "Printer",
+    "shortcodes": [
+      "printer"
+    ],
+    "keywords": [
+      "paper",
+      "ink"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5a8-fe0f",
+        "emoji": "🖨️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⌨️",
+    "name": "Keyboard",
+    "shortcodes": [
+      "keyboard"
+    ],
+    "keywords": [
+      "technology",
+      "computer",
+      "type",
+      "input",
+      "text"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2328-fe0f",
+        "emoji": "⌨️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🖱️",
+    "name": "Computer Mouse",
+    "shortcodes": [
+      "three_button_mouse"
+    ],
+    "keywords": [
+      "three",
+      "button",
+      "click"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5b1-fe0f",
+        "emoji": "🖱️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🖲️",
+    "name": "Trackball",
+    "shortcodes": [
+      "trackball"
+    ],
+    "keywords": [
+      "technology",
+      "trackpad"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5b2-fe0f",
+        "emoji": "🖲️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💽",
+    "name": "Minidisc",
+    "shortcodes": [
+      "minidisc"
+    ],
+    "keywords": [
+      "computer",
+      "disk",
+      "technology",
+      "record",
+      "data",
+      "90s"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4bd",
+        "emoji": "💽"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💾",
+    "name": "Floppy Disk",
+    "shortcodes": [
+      "floppy_disk"
+    ],
+    "keywords": [
+      "oldschool",
+      "technology",
+      "save",
+      "90s",
+      "80s"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4be",
+        "emoji": "💾"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💿",
+    "name": "Optical Disc",
+    "shortcodes": [
+      "cd"
+    ],
+    "keywords": [
+      "cd",
+      "disk",
+      "technology",
+      "dvd",
+      "90s"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4bf",
+        "emoji": "💿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📀",
+    "name": "Dvd",
+    "shortcodes": [
+      "dvd"
+    ],
+    "keywords": [
+      "cd",
+      "disk",
+      "disc"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4c0",
+        "emoji": "📀"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧮",
+    "name": "Abacus",
+    "shortcodes": [
+      "abacus"
+    ],
+    "keywords": [
+      "calculation"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9ee",
+        "emoji": "🧮"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🎥",
+    "name": "Movie Camera",
+    "shortcodes": [
+      "movie_camera"
+    ],
+    "keywords": [
+      "film",
+      "record"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3a5",
+        "emoji": "🎥"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎞️",
+    "name": "Film Frames",
+    "shortcodes": [
+      "film_frames"
+    ],
+    "keywords": [
+      "movie"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f39e-fe0f",
+        "emoji": "🎞️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📽️",
+    "name": "Film Projector",
+    "shortcodes": [
+      "film_projector"
+    ],
+    "keywords": [
+      "video",
+      "tape",
+      "record",
+      "movie"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4fd-fe0f",
+        "emoji": "📽️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎬",
+    "name": "Clapper Board",
+    "shortcodes": [
+      "clapper"
+    ],
+    "keywords": [
+      "movie",
+      "film",
+      "record"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3ac",
+        "emoji": "🎬"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📺",
+    "name": "Television",
+    "shortcodes": [
+      "tv"
+    ],
+    "keywords": [
+      "tv",
+      "technology",
+      "program",
+      "oldschool",
+      "show"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4fa",
+        "emoji": "📺"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📷",
+    "name": "Camera",
+    "shortcodes": [
+      "camera"
+    ],
+    "keywords": [
+      "gadgets",
+      "photography"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4f7",
+        "emoji": "📷"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📸",
+    "name": "Camera with Flash",
+    "shortcodes": [
+      "camera_with_flash"
+    ],
+    "keywords": [
+      "photography",
+      "gadgets"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4f8",
+        "emoji": "📸"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📹",
+    "name": "Video Camera",
+    "shortcodes": [
+      "video_camera"
+    ],
+    "keywords": [
+      "film",
+      "record"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4f9",
+        "emoji": "📹"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📼",
+    "name": "Videocassette",
+    "shortcodes": [
+      "vhs"
+    ],
+    "keywords": [
+      "vhs",
+      "record",
+      "video",
+      "oldschool",
+      "90s",
+      "80s"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4fc",
+        "emoji": "📼"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔍",
+    "name": "Magnifying Glass Tilted Left",
+    "shortcodes": [
+      "mag"
+    ],
+    "keywords": [
+      "mag",
+      "search",
+      "zoom",
+      "find",
+      "detective"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f50d",
+        "emoji": "🔍"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔎",
+    "name": "Magnifying Glass Tilted Right",
+    "shortcodes": [
+      "mag_right"
+    ],
+    "keywords": [
+      "mag",
+      "search",
+      "zoom",
+      "find",
+      "detective"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f50e",
+        "emoji": "🔎"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕯️",
+    "name": "Candle",
+    "shortcodes": [
+      "candle"
+    ],
+    "keywords": [
+      "fire",
+      "wax"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f56f-fe0f",
+        "emoji": "🕯️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💡",
+    "name": "Light Bulb",
+    "shortcodes": [
+      "bulb"
+    ],
+    "keywords": [
+      "electricity",
+      "idea"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4a1",
+        "emoji": "💡"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔦",
+    "name": "Flashlight",
+    "shortcodes": [
+      "flashlight"
+    ],
+    "keywords": [
+      "dark",
+      "camping",
+      "sight",
+      "night"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f526",
+        "emoji": "🔦"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏮",
+    "name": "Izakaya Lantern",
+    "shortcodes": [
+      "izakaya_lantern",
+      "lantern"
+    ],
+    "keywords": [
+      "red",
+      "paper",
+      "light",
+      "halloween",
+      "spooky"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3ee",
+        "emoji": "🏮"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪔",
+    "name": "Diya Lamp",
+    "shortcodes": [
+      "diya_lamp"
+    ],
+    "keywords": [
+      "lighting"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa94",
+        "emoji": "🪔"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "📔",
+    "name": "Notebook with Decorative Cover",
+    "shortcodes": [
+      "notebook_with_decorative_cover"
+    ],
+    "keywords": [
+      "classroom",
+      "notes",
+      "record",
+      "paper",
+      "study"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4d4",
+        "emoji": "📔"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📕",
+    "name": "Closed Book",
+    "shortcodes": [
+      "closed_book"
+    ],
+    "keywords": [
+      "read",
+      "library",
+      "knowledge",
+      "textbook",
+      "learn"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4d5",
+        "emoji": "📕"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📖",
+    "name": "Open Book",
+    "shortcodes": [
+      "book",
+      "open_book"
+    ],
+    "keywords": [
+      "read",
+      "library",
+      "knowledge",
+      "literature",
+      "learn",
+      "study"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4d6",
+        "emoji": "📖"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📗",
+    "name": "Green Book",
+    "shortcodes": [
+      "green_book"
+    ],
+    "keywords": [
+      "read",
+      "library",
+      "knowledge",
+      "study"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4d7",
+        "emoji": "📗"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📘",
+    "name": "Blue Book",
+    "shortcodes": [
+      "blue_book"
+    ],
+    "keywords": [
+      "read",
+      "library",
+      "knowledge",
+      "learn",
+      "study"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4d8",
+        "emoji": "📘"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📙",
+    "name": "Orange Book",
+    "shortcodes": [
+      "orange_book"
+    ],
+    "keywords": [
+      "read",
+      "library",
+      "knowledge",
+      "textbook",
+      "study"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4d9",
+        "emoji": "📙"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📚",
+    "name": "Books",
+    "shortcodes": [
+      "books"
+    ],
+    "keywords": [
+      "literature",
+      "library",
+      "study"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4da",
+        "emoji": "📚"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📓",
+    "name": "Notebook",
+    "shortcodes": [
+      "notebook"
+    ],
+    "keywords": [
+      "stationery",
+      "record",
+      "notes",
+      "paper",
+      "study"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4d3",
+        "emoji": "📓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📒",
+    "name": "Ledger",
+    "shortcodes": [
+      "ledger"
+    ],
+    "keywords": [
+      "notes",
+      "paper"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4d2",
+        "emoji": "📒"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📃",
+    "name": "Page with Curl",
+    "shortcodes": [
+      "page_with_curl"
+    ],
+    "keywords": [
+      "documents",
+      "office",
+      "paper"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4c3",
+        "emoji": "📃"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📜",
+    "name": "Scroll",
+    "shortcodes": [
+      "scroll"
+    ],
+    "keywords": [
+      "documents",
+      "ancient",
+      "history",
+      "paper"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4dc",
+        "emoji": "📜"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📄",
+    "name": "Page Facing Up",
+    "shortcodes": [
+      "page_facing_up"
+    ],
+    "keywords": [
+      "documents",
+      "office",
+      "paper",
+      "information"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4c4",
+        "emoji": "📄"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📰",
+    "name": "Newspaper",
+    "shortcodes": [
+      "newspaper"
+    ],
+    "keywords": [
+      "press",
+      "headline"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4f0",
+        "emoji": "📰"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗞️",
+    "name": "Rolled-Up Newspaper",
+    "shortcodes": [
+      "rolled_up_newspaper"
+    ],
+    "keywords": [
+      "rolled",
+      "up",
+      "press",
+      "headline"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5de-fe0f",
+        "emoji": "🗞️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📑",
+    "name": "Bookmark Tabs",
+    "shortcodes": [
+      "bookmark_tabs"
+    ],
+    "keywords": [
+      "favorite",
+      "save",
+      "order",
+      "tidy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4d1",
+        "emoji": "📑"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔖",
+    "name": "Bookmark",
+    "shortcodes": [
+      "bookmark"
+    ],
+    "keywords": [
+      "favorite",
+      "label",
+      "save"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f516",
+        "emoji": "🔖"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏷️",
+    "name": "Label",
+    "shortcodes": [
+      "label"
+    ],
+    "keywords": [
+      "sale",
+      "tag"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3f7-fe0f",
+        "emoji": "🏷️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💰",
+    "name": "Money Bag",
+    "shortcodes": [
+      "moneybag"
+    ],
+    "keywords": [
+      "moneybag",
+      "dollar",
+      "payment",
+      "coins",
+      "sale"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4b0",
+        "emoji": "💰"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪙",
+    "name": "Coin",
+    "shortcodes": [
+      "coin"
+    ],
+    "keywords": [
+      "money",
+      "currency"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa99",
+        "emoji": "🪙"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "💴",
+    "name": "Yen Banknote",
+    "shortcodes": [
+      "yen"
+    ],
+    "keywords": [
+      "money",
+      "sales",
+      "japanese",
+      "dollar",
+      "currency"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4b4",
+        "emoji": "💴"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💵",
+    "name": "Dollar Banknote",
+    "shortcodes": [
+      "dollar"
+    ],
+    "keywords": [
+      "money",
+      "sales",
+      "bill",
+      "currency"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4b5",
+        "emoji": "💵"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💶",
+    "name": "Euro Banknote",
+    "shortcodes": [
+      "euro"
+    ],
+    "keywords": [
+      "money",
+      "sales",
+      "dollar",
+      "currency"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4b6",
+        "emoji": "💶"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💷",
+    "name": "Pound Banknote",
+    "shortcodes": [
+      "pound"
+    ],
+    "keywords": [
+      "british",
+      "sterling",
+      "money",
+      "sales",
+      "bills",
+      "uk",
+      "england",
+      "currency"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4b7",
+        "emoji": "💷"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💸",
+    "name": "Money with Wings",
+    "shortcodes": [
+      "money_with_wings"
+    ],
+    "keywords": [
+      "dollar",
+      "bills",
+      "payment",
+      "sale"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4b8",
+        "emoji": "💸"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💳",
+    "name": "Credit Card",
+    "shortcodes": [
+      "credit_card"
+    ],
+    "keywords": [
+      "money",
+      "sales",
+      "dollar",
+      "bill",
+      "payment",
+      "shopping"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4b3",
+        "emoji": "💳"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧾",
+    "name": "Receipt",
+    "shortcodes": [
+      "receipt"
+    ],
+    "keywords": [
+      "accounting",
+      "expenses"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9fe",
+        "emoji": "🧾"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "💹",
+    "name": "Chart Increasing with Yen",
+    "shortcodes": [
+      "chart"
+    ],
+    "keywords": [
+      "green",
+      "square",
+      "graph",
+      "presentation",
+      "stats"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4b9",
+        "emoji": "💹"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "✉️",
+    "name": "Envelope",
+    "shortcodes": [
+      "email",
+      "envelope"
+    ],
+    "keywords": [
+      "email",
+      "letter",
+      "postal",
+      "inbox",
+      "communication"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2709-fe0f",
+        "emoji": "✉️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📧",
+    "name": "E-Mail",
+    "shortcodes": [
+      "e-mail"
+    ],
+    "keywords": [
+      "e",
+      "mail",
+      "communication",
+      "inbox"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4e7",
+        "emoji": "📧"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📨",
+    "name": "Incoming Envelope",
+    "shortcodes": [
+      "incoming_envelope"
+    ],
+    "keywords": [
+      "email",
+      "inbox"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4e8",
+        "emoji": "📨"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📩",
+    "name": "Envelope with Arrow",
+    "shortcodes": [
+      "envelope_with_arrow"
+    ],
+    "keywords": [
+      "email",
+      "communication"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4e9",
+        "emoji": "📩"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📤",
+    "name": "Outbox Tray",
+    "shortcodes": [
+      "outbox_tray"
+    ],
+    "keywords": [
+      "inbox",
+      "email"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4e4",
+        "emoji": "📤"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📥",
+    "name": "Inbox Tray",
+    "shortcodes": [
+      "inbox_tray"
+    ],
+    "keywords": [
+      "email",
+      "documents"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4e5",
+        "emoji": "📥"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📦",
+    "name": "Package",
+    "shortcodes": [
+      "package"
+    ],
+    "keywords": [
+      "mail",
+      "gift",
+      "cardboard",
+      "box",
+      "moving"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4e6",
+        "emoji": "📦"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📫",
+    "name": "Closed Mailbox with Raised Flag",
+    "shortcodes": [
+      "mailbox"
+    ],
+    "keywords": [
+      "email",
+      "inbox",
+      "communication"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4eb",
+        "emoji": "📫"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📪",
+    "name": "Closed Mailbox with Lowered Flag",
+    "shortcodes": [
+      "mailbox_closed"
+    ],
+    "keywords": [
+      "email",
+      "communication",
+      "inbox"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4ea",
+        "emoji": "📪"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📬",
+    "name": "Open Mailbox with Raised Flag",
+    "shortcodes": [
+      "mailbox_with_mail"
+    ],
+    "keywords": [
+      "mail",
+      "email",
+      "inbox",
+      "communication"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4ec",
+        "emoji": "📬"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📭",
+    "name": "Open Mailbox with Lowered Flag",
+    "shortcodes": [
+      "mailbox_with_no_mail"
+    ],
+    "keywords": [
+      "no",
+      "mail",
+      "email",
+      "inbox"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4ed",
+        "emoji": "📭"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📮",
+    "name": "Postbox",
+    "shortcodes": [
+      "postbox"
+    ],
+    "keywords": [
+      "email",
+      "letter",
+      "envelope"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4ee",
+        "emoji": "📮"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗳️",
+    "name": "Ballot Box with Ballot",
+    "shortcodes": [
+      "ballot_box_with_ballot"
+    ],
+    "keywords": [
+      "election",
+      "vote"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5f3-fe0f",
+        "emoji": "🗳️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "✏️",
+    "name": "Pencil",
+    "shortcodes": [
+      "pencil2"
+    ],
+    "keywords": [
+      "pencil2",
+      "stationery",
+      "write",
+      "paper",
+      "writing",
+      "school",
+      "study"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "270f-fe0f",
+        "emoji": "✏️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "✒️",
+    "name": "Black Nib",
+    "shortcodes": [
+      "black_nib"
+    ],
+    "keywords": [
+      "pen",
+      "stationery",
+      "writing",
+      "write"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2712-fe0f",
+        "emoji": "✒️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🖋️",
+    "name": "Fountain Pen",
+    "shortcodes": [
+      "lower_left_fountain_pen"
+    ],
+    "keywords": [
+      "lower",
+      "left",
+      "stationery",
+      "writing",
+      "write"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f58b-fe0f",
+        "emoji": "🖋️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🖊️",
+    "name": "Pen",
+    "shortcodes": [
+      "lower_left_ballpoint_pen"
+    ],
+    "keywords": [
+      "lower",
+      "left",
+      "ballpoint",
+      "stationery",
+      "writing",
+      "write"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f58a-fe0f",
+        "emoji": "🖊️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🖌️",
+    "name": "Paintbrush",
+    "shortcodes": [
+      "lower_left_paintbrush"
+    ],
+    "keywords": [
+      "lower",
+      "left",
+      "drawing",
+      "creativity",
+      "art"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f58c-fe0f",
+        "emoji": "🖌️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🖍️",
+    "name": "Crayon",
+    "shortcodes": [
+      "lower_left_crayon"
+    ],
+    "keywords": [
+      "lower",
+      "left",
+      "drawing",
+      "creativity"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f58d-fe0f",
+        "emoji": "🖍️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📝",
+    "name": "Memo",
+    "shortcodes": [
+      "memo",
+      "pencil"
+    ],
+    "keywords": [
+      "pencil",
+      "write",
+      "documents",
+      "stationery",
+      "paper",
+      "writing",
+      "legal",
+      "exam",
+      "quiz",
+      "test",
+      "study",
+      "compose"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4dd",
+        "emoji": "📝"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💼",
+    "name": "Briefcase",
+    "shortcodes": [
+      "briefcase"
+    ],
+    "keywords": [
+      "business",
+      "documents",
+      "work",
+      "law",
+      "legal",
+      "job",
+      "career"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4bc",
+        "emoji": "💼"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📁",
+    "name": "File Folder",
+    "shortcodes": [
+      "file_folder"
+    ],
+    "keywords": [
+      "documents",
+      "business",
+      "office"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4c1",
+        "emoji": "📁"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📂",
+    "name": "Open File Folder",
+    "shortcodes": [
+      "open_file_folder"
+    ],
+    "keywords": [
+      "documents",
+      "load"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4c2",
+        "emoji": "📂"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗂️",
+    "name": "Card Index Dividers",
+    "shortcodes": [
+      "card_index_dividers"
+    ],
+    "keywords": [
+      "organizing",
+      "business",
+      "stationery"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5c2-fe0f",
+        "emoji": "🗂️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📅",
+    "name": "Calendar",
+    "shortcodes": [
+      "date"
+    ],
+    "keywords": [
+      "date",
+      "schedule"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4c5",
+        "emoji": "📅"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📆",
+    "name": "Tear-off Calendar",
+    "shortcodes": [
+      "calendar"
+    ],
+    "keywords": [
+      "tear",
+      "off",
+      "schedule",
+      "date",
+      "planning"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4c6",
+        "emoji": "📆"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗒️",
+    "name": "Spiral Notepad",
+    "shortcodes": [
+      "spiral_note_pad"
+    ],
+    "keywords": [
+      "note",
+      "pad",
+      "memo",
+      "stationery"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5d2-fe0f",
+        "emoji": "🗒️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗓️",
+    "name": "Spiral Calendar",
+    "shortcodes": [
+      "spiral_calendar_pad"
+    ],
+    "keywords": [
+      "pad",
+      "date",
+      "schedule",
+      "planning"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5d3-fe0f",
+        "emoji": "🗓️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📇",
+    "name": "Card Index",
+    "shortcodes": [
+      "card_index"
+    ],
+    "keywords": [
+      "business",
+      "stationery"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4c7",
+        "emoji": "📇"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📈",
+    "name": "Chart Increasing",
+    "shortcodes": [
+      "chart_with_upwards_trend"
+    ],
+    "keywords": [
+      "with",
+      "upwards",
+      "trend",
+      "graph",
+      "presentation",
+      "stats",
+      "recovery",
+      "business",
+      "economics",
+      "money",
+      "sales",
+      "good",
+      "success"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4c8",
+        "emoji": "📈"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📉",
+    "name": "Chart Decreasing",
+    "shortcodes": [
+      "chart_with_downwards_trend"
+    ],
+    "keywords": [
+      "with",
+      "downwards",
+      "trend",
+      "graph",
+      "presentation",
+      "stats",
+      "recession",
+      "business",
+      "economics",
+      "money",
+      "sales",
+      "bad",
+      "failure"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4c9",
+        "emoji": "📉"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📊",
+    "name": "Bar Chart",
+    "shortcodes": [
+      "bar_chart"
+    ],
+    "keywords": [
+      "graph",
+      "presentation",
+      "stats"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4ca",
+        "emoji": "📊"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📋",
+    "name": "Clipboard",
+    "shortcodes": [
+      "clipboard"
+    ],
+    "keywords": [
+      "stationery",
+      "documents"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4cb",
+        "emoji": "📋"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📌",
+    "name": "Pushpin",
+    "shortcodes": [
+      "pushpin"
+    ],
+    "keywords": [
+      "stationery",
+      "mark",
+      "here"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4cc",
+        "emoji": "📌"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📍",
+    "name": "Round Pushpin",
+    "shortcodes": [
+      "round_pushpin"
+    ],
+    "keywords": [
+      "stationery",
+      "location",
+      "map",
+      "here"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4cd",
+        "emoji": "📍"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📎",
+    "name": "Paperclip",
+    "shortcodes": [
+      "paperclip"
+    ],
+    "keywords": [
+      "documents",
+      "stationery"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4ce",
+        "emoji": "📎"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🖇️",
+    "name": "Linked Paperclips",
+    "shortcodes": [
+      "linked_paperclips"
+    ],
+    "keywords": [
+      "documents",
+      "stationery"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f587-fe0f",
+        "emoji": "🖇️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📏",
+    "name": "Straight Ruler",
+    "shortcodes": [
+      "straight_ruler"
+    ],
+    "keywords": [
+      "stationery",
+      "calculate",
+      "length",
+      "math",
+      "school",
+      "drawing",
+      "architect",
+      "sketch"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4cf",
+        "emoji": "📏"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📐",
+    "name": "Triangular Ruler",
+    "shortcodes": [
+      "triangular_ruler"
+    ],
+    "keywords": [
+      "stationery",
+      "math",
+      "architect",
+      "sketch"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4d0",
+        "emoji": "📐"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "✂️",
+    "name": "Scissors",
+    "shortcodes": [
+      "scissors"
+    ],
+    "keywords": [
+      "stationery",
+      "cut"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2702-fe0f",
+        "emoji": "✂️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗃️",
+    "name": "Card File Box",
+    "shortcodes": [
+      "card_file_box"
+    ],
+    "keywords": [
+      "business",
+      "stationery"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5c3-fe0f",
+        "emoji": "🗃️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗄️",
+    "name": "File Cabinet",
+    "shortcodes": [
+      "file_cabinet"
+    ],
+    "keywords": [
+      "filing",
+      "organizing"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5c4-fe0f",
+        "emoji": "🗄️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗑️",
+    "name": "Wastebasket",
+    "shortcodes": [
+      "wastebasket"
+    ],
+    "keywords": [
+      "bin",
+      "trash",
+      "rubbish",
+      "garbage",
+      "toss"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5d1-fe0f",
+        "emoji": "🗑️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔒",
+    "name": "Lock",
+    "shortcodes": [
+      "lock"
+    ],
+    "keywords": [
+      "locked",
+      "security",
+      "password",
+      "padlock"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f512",
+        "emoji": "🔒"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔓",
+    "name": "Unlocked",
+    "shortcodes": [
+      "unlock"
+    ],
+    "keywords": [
+      "unlock",
+      "privacy",
+      "security"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f513",
+        "emoji": "🔓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔏",
+    "name": "Locked with Pen",
+    "shortcodes": [
+      "lock_with_ink_pen"
+    ],
+    "keywords": [
+      "lock",
+      "ink",
+      "security",
+      "secret"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f50f",
+        "emoji": "🔏"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔐",
+    "name": "Locked with Key",
+    "shortcodes": [
+      "closed_lock_with_key"
+    ],
+    "keywords": [
+      "closed",
+      "lock",
+      "security",
+      "privacy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f510",
+        "emoji": "🔐"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔑",
+    "name": "Key",
+    "shortcodes": [
+      "key"
+    ],
+    "keywords": [
+      "lock",
+      "door",
+      "password"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f511",
+        "emoji": "🔑"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗝️",
+    "name": "Old Key",
+    "shortcodes": [
+      "old_key"
+    ],
+    "keywords": [
+      "lock",
+      "door",
+      "password"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5dd-fe0f",
+        "emoji": "🗝️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔨",
+    "name": "Hammer",
+    "shortcodes": [
+      "hammer"
+    ],
+    "keywords": [
+      "tools",
+      "build",
+      "create"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f528",
+        "emoji": "🔨"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪓",
+    "name": "Axe",
+    "shortcodes": [
+      "axe"
+    ],
+    "keywords": [
+      "tool",
+      "chop",
+      "cut"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa93",
+        "emoji": "🪓"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "⛏️",
+    "name": "Pick",
+    "shortcodes": [
+      "pick"
+    ],
+    "keywords": [
+      "tools",
+      "dig"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26cf-fe0f",
+        "emoji": "⛏️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⚒️",
+    "name": "Hammer and Pick",
+    "shortcodes": [
+      "hammer_and_pick"
+    ],
+    "keywords": [
+      "tools",
+      "build",
+      "create"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2692-fe0f",
+        "emoji": "⚒️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛠️",
+    "name": "Hammer and Wrench",
+    "shortcodes": [
+      "hammer_and_wrench"
+    ],
+    "keywords": [
+      "tools",
+      "build",
+      "create"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6e0-fe0f",
+        "emoji": "🛠️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗡️",
+    "name": "Dagger",
+    "shortcodes": [
+      "dagger_knife"
+    ],
+    "keywords": [
+      "knife",
+      "weapon"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5e1-fe0f",
+        "emoji": "🗡️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⚔️",
+    "name": "Crossed Swords",
+    "shortcodes": [
+      "crossed_swords"
+    ],
+    "keywords": [
+      "weapon"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2694-fe0f",
+        "emoji": "⚔️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔫",
+    "name": "Pistol",
+    "shortcodes": [
+      "gun"
+    ],
+    "keywords": [
+      "gun",
+      "violence",
+      "weapon",
+      "revolver"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f52b",
+        "emoji": "🔫"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪃",
+    "name": "Boomerang",
+    "shortcodes": [
+      "boomerang"
+    ],
+    "keywords": [
+      "weapon"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa83",
+        "emoji": "🪃"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🏹",
+    "name": "Bow and Arrow",
+    "shortcodes": [
+      "bow_and_arrow"
+    ],
+    "keywords": [
+      "sports"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3f9",
+        "emoji": "🏹"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛡️",
+    "name": "Shield",
+    "shortcodes": [
+      "shield"
+    ],
+    "keywords": [
+      "protection",
+      "security"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6e1-fe0f",
+        "emoji": "🛡️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪚",
+    "name": "Carpentry Saw",
+    "shortcodes": [
+      "carpentry_saw"
+    ],
+    "keywords": [
+      "cut",
+      "chop"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa9a",
+        "emoji": "🪚"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🔧",
+    "name": "Wrench",
+    "shortcodes": [
+      "wrench"
+    ],
+    "keywords": [
+      "tools",
+      "diy",
+      "ikea",
+      "fix",
+      "maintainer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f527",
+        "emoji": "🔧"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪛",
+    "name": "Screwdriver",
+    "shortcodes": [
+      "screwdriver"
+    ],
+    "keywords": [
+      "tools"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa9b",
+        "emoji": "🪛"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🔩",
+    "name": "Nut and Bolt",
+    "shortcodes": [
+      "nut_and_bolt"
+    ],
+    "keywords": [
+      "handy",
+      "tools",
+      "fix"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f529",
+        "emoji": "🔩"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⚙️",
+    "name": "Gear",
+    "shortcodes": [
+      "gear"
+    ],
+    "keywords": [
+      "cog"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2699-fe0f",
+        "emoji": "⚙️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗜️",
+    "name": "Clamp",
+    "shortcodes": [
+      "compression"
+    ],
+    "keywords": [
+      "compression",
+      "tool"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5dc-fe0f",
+        "emoji": "🗜️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⚖️",
+    "name": "Balance Scale",
+    "shortcodes": [
+      "scales"
+    ],
+    "keywords": [
+      "scales",
+      "law",
+      "fairness",
+      "weight"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2696-fe0f",
+        "emoji": "⚖️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🦯",
+    "name": "White Cane",
+    "shortcodes": [
+      "probing_cane"
+    ],
+    "keywords": [
+      "probing",
+      "accessibility"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9af",
+        "emoji": "🦯"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🔗",
+    "name": "Link",
+    "shortcodes": [
+      "link"
+    ],
+    "keywords": [
+      "rings",
+      "url"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f517",
+        "emoji": "🔗"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛓️",
+    "name": "Chains",
+    "shortcodes": [
+      "chains"
+    ],
+    "keywords": [
+      "lock",
+      "arrest"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26d3-fe0f",
+        "emoji": "⛓️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪝",
+    "name": "Hook",
+    "shortcodes": [
+      "hook"
+    ],
+    "keywords": [
+      "tools"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa9d",
+        "emoji": "🪝"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🧰",
+    "name": "Toolbox",
+    "shortcodes": [
+      "toolbox"
+    ],
+    "keywords": [
+      "tools",
+      "diy",
+      "fix",
+      "maintainer",
+      "mechanic"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9f0",
+        "emoji": "🧰"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🧲",
+    "name": "Magnet",
+    "shortcodes": [
+      "magnet"
+    ],
+    "keywords": [
+      "attraction",
+      "magnetic"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9f2",
+        "emoji": "🧲"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🪜",
+    "name": "Ladder",
+    "shortcodes": [
+      "ladder"
+    ],
+    "keywords": [
+      "tools"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa9c",
+        "emoji": "🪜"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "⚗️",
+    "name": "Alembic",
+    "shortcodes": [
+      "alembic"
+    ],
+    "keywords": [
+      "distilling",
+      "science",
+      "experiment",
+      "chemistry"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2697-fe0f",
+        "emoji": "⚗️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🧪",
+    "name": "Test Tube",
+    "shortcodes": [
+      "test_tube"
+    ],
+    "keywords": [
+      "chemistry",
+      "experiment",
+      "lab",
+      "science"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9ea",
+        "emoji": "🧪"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🧫",
+    "name": "Petri Dish",
+    "shortcodes": [
+      "petri_dish"
+    ],
+    "keywords": [
+      "bacteria",
+      "biology",
+      "culture",
+      "lab"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9eb",
+        "emoji": "🧫"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🧬",
+    "name": "Dna",
+    "shortcodes": [
+      "dna"
+    ],
+    "keywords": [
+      "biologist",
+      "genetics",
+      "life"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9ec",
+        "emoji": "🧬"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🔬",
+    "name": "Microscope",
+    "shortcodes": [
+      "microscope"
+    ],
+    "keywords": [
+      "laboratory",
+      "experiment",
+      "zoomin",
+      "science",
+      "study"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f52c",
+        "emoji": "🔬"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔭",
+    "name": "Telescope",
+    "shortcodes": [
+      "telescope"
+    ],
+    "keywords": [
+      "stars",
+      "space",
+      "zoom",
+      "science",
+      "astronomy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f52d",
+        "emoji": "🔭"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📡",
+    "name": "Satellite Antenna",
+    "shortcodes": [
+      "satellite_antenna"
+    ],
+    "keywords": [
+      "communication",
+      "future",
+      "radio",
+      "space"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4e1",
+        "emoji": "📡"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💉",
+    "name": "Syringe",
+    "shortcodes": [
+      "syringe"
+    ],
+    "keywords": [
+      "health",
+      "hospital",
+      "drugs",
+      "blood",
+      "medicine",
+      "needle",
+      "doctor",
+      "nurse"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f489",
+        "emoji": "💉"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🩸",
+    "name": "Drop of Blood",
+    "shortcodes": [
+      "drop_of_blood"
+    ],
+    "keywords": [
+      "period",
+      "hurt",
+      "harm",
+      "wound"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa78",
+        "emoji": "🩸"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "💊",
+    "name": "Pill",
+    "shortcodes": [
+      "pill"
+    ],
+    "keywords": [
+      "health",
+      "medicine",
+      "doctor",
+      "pharmacy",
+      "drug"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f48a",
+        "emoji": "💊"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🩹",
+    "name": "Adhesive Bandage",
+    "shortcodes": [
+      "adhesive_bandage"
+    ],
+    "keywords": [
+      "heal"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa79",
+        "emoji": "🩹"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🩼",
+    "name": "Crutch",
+    "shortcodes": [
+      "crutch"
+    ],
+    "keywords": [
+      "accessibility",
+      "assist"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa7c",
+        "emoji": "🩼"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🩺",
+    "name": "Stethoscope",
+    "shortcodes": [
+      "stethoscope"
+    ],
+    "keywords": [
+      "health"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa7a",
+        "emoji": "🩺"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🩻",
+    "name": "X-Ray",
+    "shortcodes": [
+      "x-ray"
+    ],
+    "keywords": [
+      "x",
+      "ray",
+      "skeleton",
+      "medicine"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa7b",
+        "emoji": "🩻"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🚪",
+    "name": "Door",
+    "shortcodes": [
+      "door"
+    ],
+    "keywords": [
+      "house",
+      "entry",
+      "exit"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6aa",
+        "emoji": "🚪"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛗",
+    "name": "Elevator",
+    "shortcodes": [
+      "elevator"
+    ],
+    "keywords": [
+      "lift"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6d7",
+        "emoji": "🛗"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🪞",
+    "name": "Mirror",
+    "shortcodes": [
+      "mirror"
+    ],
+    "keywords": [
+      "reflection"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa9e",
+        "emoji": "🪞"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🪟",
+    "name": "Window",
+    "shortcodes": [
+      "window"
+    ],
+    "keywords": [
+      "scenery"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa9f",
+        "emoji": "🪟"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🛏️",
+    "name": "Bed",
+    "shortcodes": [
+      "bed"
+    ],
+    "keywords": [
+      "sleep",
+      "rest"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6cf-fe0f",
+        "emoji": "🛏️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛋️",
+    "name": "Couch and Lamp",
+    "shortcodes": [
+      "couch_and_lamp"
+    ],
+    "keywords": [
+      "read",
+      "chill"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6cb-fe0f",
+        "emoji": "🛋️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪑",
+    "name": "Chair",
+    "shortcodes": [
+      "chair"
+    ],
+    "keywords": [
+      "sit",
+      "furniture"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa91",
+        "emoji": "🪑"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🚽",
+    "name": "Toilet",
+    "shortcodes": [
+      "toilet"
+    ],
+    "keywords": [
+      "restroom",
+      "wc",
+      "washroom",
+      "bathroom",
+      "potty"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6bd",
+        "emoji": "🚽"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪠",
+    "name": "Plunger",
+    "shortcodes": [
+      "plunger"
+    ],
+    "keywords": [
+      "toilet"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faa0",
+        "emoji": "🪠"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🚿",
+    "name": "Shower",
+    "shortcodes": [
+      "shower"
+    ],
+    "keywords": [
+      "clean",
+      "water",
+      "bathroom"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6bf",
+        "emoji": "🚿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛁",
+    "name": "Bathtub",
+    "shortcodes": [
+      "bathtub"
+    ],
+    "keywords": [
+      "clean",
+      "shower",
+      "bathroom"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6c1",
+        "emoji": "🛁"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪤",
+    "name": "Mouse Trap",
+    "shortcodes": [
+      "mouse_trap"
+    ],
+    "keywords": [
+      "cheese"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faa4",
+        "emoji": "🪤"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🪒",
+    "name": "Razor",
+    "shortcodes": [
+      "razor"
+    ],
+    "keywords": [
+      "cut"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fa92",
+        "emoji": "🪒"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🧴",
+    "name": "Lotion Bottle",
+    "shortcodes": [
+      "lotion_bottle"
+    ],
+    "keywords": [
+      "moisturizer",
+      "sunscreen"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9f4",
+        "emoji": "🧴"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🧷",
+    "name": "Safety Pin",
+    "shortcodes": [
+      "safety_pin"
+    ],
+    "keywords": [
+      "diaper"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9f7",
+        "emoji": "🧷"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🧹",
+    "name": "Broom",
+    "shortcodes": [
+      "broom"
+    ],
+    "keywords": [
+      "cleaning",
+      "sweeping",
+      "witch"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9f9",
+        "emoji": "🧹"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🧺",
+    "name": "Basket",
+    "shortcodes": [
+      "basket"
+    ],
+    "keywords": [
+      "laundry"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9fa",
+        "emoji": "🧺"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🧻",
+    "name": "Roll of Paper",
+    "shortcodes": [
+      "roll_of_paper"
+    ],
+    "keywords": [],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9fb",
+        "emoji": "🧻"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🪣",
+    "name": "Bucket",
+    "shortcodes": [
+      "bucket"
+    ],
+    "keywords": [
+      "water",
+      "container"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faa3",
+        "emoji": "🪣"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🧼",
+    "name": "Soap",
+    "shortcodes": [
+      "soap"
+    ],
+    "keywords": [
+      "bar",
+      "bathing",
+      "cleaning",
+      "lather"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9fc",
+        "emoji": "🧼"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🫧",
+    "name": "Bubbles",
+    "shortcodes": [
+      "bubbles"
+    ],
+    "keywords": [
+      "soap",
+      "fun",
+      "carbonation",
+      "sparkling"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1fae7",
+        "emoji": "🫧"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🪥",
+    "name": "Toothbrush",
+    "shortcodes": [
+      "toothbrush"
+    ],
+    "keywords": [
+      "hygiene",
+      "dental"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faa5",
+        "emoji": "🪥"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🧽",
+    "name": "Sponge",
+    "shortcodes": [
+      "sponge"
+    ],
+    "keywords": [
+      "absorbing",
+      "cleaning",
+      "porous"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9fd",
+        "emoji": "🧽"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🧯",
+    "name": "Fire Extinguisher",
+    "shortcodes": [
+      "fire_extinguisher"
+    ],
+    "keywords": [
+      "quench"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f9ef",
+        "emoji": "🧯"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🛒",
+    "name": "Shopping Cart",
+    "shortcodes": [
+      "shopping_trolley"
+    ],
+    "keywords": [
+      "trolley"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6d2",
+        "emoji": "🛒"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "emoji": "🚬",
+    "name": "Cigarette",
+    "shortcodes": [
+      "smoking"
+    ],
+    "keywords": [
+      "smoking",
+      "kills",
+      "tobacco",
+      "joint",
+      "smoke"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6ac",
+        "emoji": "🚬"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⚰️",
+    "name": "Coffin",
+    "shortcodes": [
+      "coffin"
+    ],
+    "keywords": [
+      "vampire",
+      "dead",
+      "die",
+      "death",
+      "rip",
+      "graveyard",
+      "cemetery",
+      "casket",
+      "funeral",
+      "box"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26b0-fe0f",
+        "emoji": "⚰️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪦",
+    "name": "Headstone",
+    "shortcodes": [
+      "headstone"
+    ],
+    "keywords": [
+      "death",
+      "rip",
+      "grave"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faa6",
+        "emoji": "🪦"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "⚱️",
+    "name": "Funeral Urn",
+    "shortcodes": [
+      "funeral_urn"
+    ],
+    "keywords": [
+      "dead",
+      "die",
+      "death",
+      "rip",
+      "ashes"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26b1-fe0f",
+        "emoji": "⚱️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🗿",
+    "name": "Moai",
+    "shortcodes": [
+      "moyai"
+    ],
+    "keywords": [
+      "moyai",
+      "rock",
+      "easter",
+      "island"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f5ff",
+        "emoji": "🗿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🪧",
+    "name": "Placard",
+    "shortcodes": [
+      "placard"
+    ],
+    "keywords": [
+      "announcement"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faa7",
+        "emoji": "🪧"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🪪",
+    "name": "Identification Card",
+    "shortcodes": [
+      "identification_card"
+    ],
+    "keywords": [
+      "document"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1faaa",
+        "emoji": "🪪"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "🏧",
+    "name": "Atm Sign",
+    "shortcodes": [
+      "atm"
+    ],
+    "keywords": [
+      "money",
+      "sales",
+      "cash",
+      "blue",
+      "square",
+      "payment",
+      "bank"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3e7",
+        "emoji": "🏧"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚮",
+    "name": "Litter in Bin Sign",
+    "shortcodes": [
+      "put_litter_in_its_place"
+    ],
+    "keywords": [
+      "put",
+      "its",
+      "place",
+      "blue",
+      "square",
+      "human",
+      "info"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6ae",
+        "emoji": "🚮"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚰",
+    "name": "Potable Water",
+    "shortcodes": [
+      "potable_water"
+    ],
+    "keywords": [
+      "blue",
+      "square",
+      "liquid",
+      "restroom",
+      "cleaning",
+      "faucet"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6b0",
+        "emoji": "🚰"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♿",
+    "name": "Wheelchair Symbol",
+    "shortcodes": [
+      "wheelchair"
+    ],
+    "keywords": [
+      "blue",
+      "square",
+      "disabled",
+      "accessibility"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "267f",
+        "emoji": "♿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚹",
+    "name": "Men’s Room",
+    "shortcodes": [
+      "mens"
+    ],
+    "keywords": [
+      "mens",
+      "men",
+      "s",
+      "toilet",
+      "restroom",
+      "wc",
+      "blue",
+      "square",
+      "gender",
+      "male"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6b9",
+        "emoji": "🚹"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚺",
+    "name": "Women’s Room",
+    "shortcodes": [
+      "womens"
+    ],
+    "keywords": [
+      "womens",
+      "women",
+      "s",
+      "purple",
+      "square",
+      "woman",
+      "female",
+      "toilet",
+      "loo",
+      "restroom",
+      "gender"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6ba",
+        "emoji": "🚺"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚻",
+    "name": "Restroom",
+    "shortcodes": [
+      "restroom"
+    ],
+    "keywords": [
+      "blue",
+      "square",
+      "toilet",
+      "refresh",
+      "wc",
+      "gender"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6bb",
+        "emoji": "🚻"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚼",
+    "name": "Baby Symbol",
+    "shortcodes": [
+      "baby_symbol"
+    ],
+    "keywords": [
+      "orange",
+      "square",
+      "child"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6bc",
+        "emoji": "🚼"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚾",
+    "name": "Water Closet",
+    "shortcodes": [
+      "wc"
+    ],
+    "keywords": [
+      "wc",
+      "toilet",
+      "restroom",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6be",
+        "emoji": "🚾"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛂",
+    "name": "Passport Control",
+    "shortcodes": [
+      "passport_control"
+    ],
+    "keywords": [
+      "custom",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6c2",
+        "emoji": "🛂"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛃",
+    "name": "Customs",
+    "shortcodes": [
+      "customs"
+    ],
+    "keywords": [
+      "passport",
+      "border",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6c3",
+        "emoji": "🛃"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛄",
+    "name": "Baggage Claim",
+    "shortcodes": [
+      "baggage_claim"
+    ],
+    "keywords": [
+      "blue",
+      "square",
+      "airport",
+      "transport"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6c4",
+        "emoji": "🛄"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛅",
+    "name": "Left Luggage",
+    "shortcodes": [
+      "left_luggage"
+    ],
+    "keywords": [
+      "blue",
+      "square",
+      "travel"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6c5",
+        "emoji": "🛅"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⚠️",
+    "name": "Warning",
+    "shortcodes": [
+      "warning"
+    ],
+    "keywords": [
+      "exclamation",
+      "wip",
+      "alert",
+      "error",
+      "problem",
+      "issue"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26a0-fe0f",
+        "emoji": "⚠️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚸",
+    "name": "Children Crossing",
+    "shortcodes": [
+      "children_crossing"
+    ],
+    "keywords": [
+      "school",
+      "warning",
+      "danger",
+      "sign",
+      "driving",
+      "yellow",
+      "diamond"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6b8",
+        "emoji": "🚸"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛔",
+    "name": "No Entry",
+    "shortcodes": [
+      "no_entry"
+    ],
+    "keywords": [
+      "limit",
+      "security",
+      "privacy",
+      "bad",
+      "denied",
+      "stop",
+      "circle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26d4",
+        "emoji": "⛔"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚫",
+    "name": "Prohibited",
+    "shortcodes": [
+      "no_entry_sign"
+    ],
+    "keywords": [
+      "no",
+      "entry",
+      "sign",
+      "forbid",
+      "stop",
+      "limit",
+      "denied",
+      "disallow",
+      "circle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6ab",
+        "emoji": "🚫"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚳",
+    "name": "No Bicycles",
+    "shortcodes": [
+      "no_bicycles"
+    ],
+    "keywords": [
+      "cyclist",
+      "prohibited",
+      "circle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6b3",
+        "emoji": "🚳"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚭",
+    "name": "No Smoking",
+    "shortcodes": [
+      "no_smoking"
+    ],
+    "keywords": [
+      "cigarette",
+      "blue",
+      "square",
+      "smell",
+      "smoke"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6ad",
+        "emoji": "🚭"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚯",
+    "name": "No Littering",
+    "shortcodes": [
+      "do_not_litter"
+    ],
+    "keywords": [
+      "do",
+      "not",
+      "litter",
+      "trash",
+      "bin",
+      "garbage",
+      "circle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6af",
+        "emoji": "🚯"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚱",
+    "name": "Non-Potable Water",
+    "shortcodes": [
+      "non-potable_water"
+    ],
+    "keywords": [
+      "non",
+      "potable",
+      "drink",
+      "faucet",
+      "tap",
+      "circle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6b1",
+        "emoji": "🚱"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚷",
+    "name": "No Pedestrians",
+    "shortcodes": [
+      "no_pedestrians"
+    ],
+    "keywords": [
+      "rules",
+      "crossing",
+      "walking",
+      "circle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6b7",
+        "emoji": "🚷"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📵",
+    "name": "No Mobile Phones",
+    "shortcodes": [
+      "no_mobile_phones"
+    ],
+    "keywords": [
+      "iphone",
+      "mute",
+      "circle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4f5",
+        "emoji": "📵"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔞",
+    "name": "No One Under Eighteen",
+    "shortcodes": [
+      "underage"
+    ],
+    "keywords": [
+      "underage",
+      "18",
+      "drink",
+      "pub",
+      "night",
+      "minor",
+      "circle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f51e",
+        "emoji": "🔞"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☢️",
+    "name": "Radioactive",
+    "shortcodes": [
+      "radioactive_sign"
+    ],
+    "keywords": [
+      "sign",
+      "nuclear",
+      "danger"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2622-fe0f",
+        "emoji": "☢️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☣️",
+    "name": "Biohazard",
+    "shortcodes": [
+      "biohazard_sign"
+    ],
+    "keywords": [
+      "sign",
+      "danger"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2623-fe0f",
+        "emoji": "☣️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⬆️",
+    "name": "Up Arrow",
+    "shortcodes": [
+      "arrow_up"
+    ],
+    "keywords": [
+      "blue",
+      "square",
+      "continue",
+      "top",
+      "direction"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2b06-fe0f",
+        "emoji": "⬆️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "↗️",
+    "name": "Up-Right Arrow",
+    "shortcodes": [
+      "arrow_upper_right"
+    ],
+    "keywords": [
+      "upper",
+      "right",
+      "up",
+      "blue",
+      "square",
+      "point",
+      "direction",
+      "diagonal",
+      "northeast"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2197-fe0f",
+        "emoji": "↗️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "➡️",
+    "name": "Right Arrow",
+    "shortcodes": [
+      "arrow_right"
+    ],
+    "keywords": [
+      "blue",
+      "square",
+      "next"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "27a1-fe0f",
+        "emoji": "➡️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "↘️",
+    "name": "South East Arrow",
+    "shortcodes": [
+      "arrow_lower_right"
+    ],
+    "keywords": [
+      "lower",
+      "right",
+      "down",
+      "blue",
+      "square",
+      "direction",
+      "diagonal",
+      "southeast"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2198-fe0f",
+        "emoji": "↘️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⬇️",
+    "name": "Down Arrow",
+    "shortcodes": [
+      "arrow_down"
+    ],
+    "keywords": [
+      "blue",
+      "square",
+      "direction",
+      "bottom"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2b07-fe0f",
+        "emoji": "⬇️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "↙️",
+    "name": "Down-Left Arrow",
+    "shortcodes": [
+      "arrow_lower_left"
+    ],
+    "keywords": [
+      "lower",
+      "left",
+      "down",
+      "blue",
+      "square",
+      "direction",
+      "diagonal",
+      "southwest"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2199-fe0f",
+        "emoji": "↙️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⬅️",
+    "name": "Left Arrow",
+    "shortcodes": [
+      "arrow_left"
+    ],
+    "keywords": [
+      "blue",
+      "square",
+      "previous",
+      "back"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2b05-fe0f",
+        "emoji": "⬅️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "↖️",
+    "name": "Up-Left Arrow",
+    "shortcodes": [
+      "arrow_upper_left"
+    ],
+    "keywords": [
+      "upper",
+      "left",
+      "up",
+      "blue",
+      "square",
+      "point",
+      "direction",
+      "diagonal",
+      "northwest"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2196-fe0f",
+        "emoji": "↖️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "↕️",
+    "name": "Up Down Arrow",
+    "shortcodes": [
+      "arrow_up_down"
+    ],
+    "keywords": [
+      "blue",
+      "square",
+      "direction",
+      "way",
+      "vertical"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2195-fe0f",
+        "emoji": "↕️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "↔️",
+    "name": "Left Right Arrow",
+    "shortcodes": [
+      "left_right_arrow"
+    ],
+    "keywords": [
+      "shape",
+      "direction",
+      "horizontal",
+      "sideways"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2194-fe0f",
+        "emoji": "↔️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "↩️",
+    "name": "Right Arrow Curving Left",
+    "shortcodes": [
+      "leftwards_arrow_with_hook"
+    ],
+    "keywords": [
+      "leftwards",
+      "with",
+      "hook",
+      "back",
+      "return",
+      "blue",
+      "square",
+      "undo",
+      "enter"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "21a9-fe0f",
+        "emoji": "↩️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "↪️",
+    "name": "Left Arrow Curving Right",
+    "shortcodes": [
+      "arrow_right_hook"
+    ],
+    "keywords": [
+      "hook",
+      "blue",
+      "square",
+      "return",
+      "rotate",
+      "direction"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "21aa-fe0f",
+        "emoji": "↪️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⤴️",
+    "name": "Right Arrow Curving Up",
+    "shortcodes": [
+      "arrow_heading_up"
+    ],
+    "keywords": [
+      "heading",
+      "blue",
+      "square",
+      "direction",
+      "top"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2934-fe0f",
+        "emoji": "⤴️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⤵️",
+    "name": "Right Arrow Curving Down",
+    "shortcodes": [
+      "arrow_heading_down"
+    ],
+    "keywords": [
+      "heading",
+      "blue",
+      "square",
+      "direction",
+      "bottom"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2935-fe0f",
+        "emoji": "⤵️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔃",
+    "name": "Clockwise Vertical Arrows",
+    "shortcodes": [
+      "arrows_clockwise"
+    ],
+    "keywords": [
+      "sync",
+      "cycle",
+      "round",
+      "repeat"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f503",
+        "emoji": "🔃"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔄",
+    "name": "Counterclockwise Arrows Button",
+    "shortcodes": [
+      "arrows_counterclockwise"
+    ],
+    "keywords": [
+      "blue",
+      "square",
+      "sync",
+      "cycle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f504",
+        "emoji": "🔄"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔙",
+    "name": "Back Arrow",
+    "shortcodes": [
+      "back"
+    ],
+    "keywords": [
+      "words",
+      "return"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f519",
+        "emoji": "🔙"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔚",
+    "name": "End Arrow",
+    "shortcodes": [
+      "end"
+    ],
+    "keywords": [
+      "words"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f51a",
+        "emoji": "🔚"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔛",
+    "name": "On! Arrow",
+    "shortcodes": [
+      "on"
+    ],
+    "keywords": [
+      "on",
+      "words"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f51b",
+        "emoji": "🔛"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔜",
+    "name": "Soon Arrow",
+    "shortcodes": [
+      "soon"
+    ],
+    "keywords": [
+      "words"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f51c",
+        "emoji": "🔜"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔝",
+    "name": "Top Arrow",
+    "shortcodes": [
+      "top"
+    ],
+    "keywords": [
+      "words",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f51d",
+        "emoji": "🔝"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🛐",
+    "name": "Place of Worship",
+    "shortcodes": [
+      "place_of_worship"
+    ],
+    "keywords": [
+      "religion",
+      "church",
+      "temple",
+      "prayer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6d0",
+        "emoji": "🛐"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⚛️",
+    "name": "Atom Symbol",
+    "shortcodes": [
+      "atom_symbol"
+    ],
+    "keywords": [
+      "science",
+      "physics",
+      "chemistry"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "269b-fe0f",
+        "emoji": "⚛️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕉️",
+    "name": "Om",
+    "shortcodes": [
+      "om_symbol"
+    ],
+    "keywords": [
+      "symbol",
+      "hinduism",
+      "buddhism",
+      "sikhism",
+      "jainism"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f549-fe0f",
+        "emoji": "🕉️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "✡️",
+    "name": "Star of David",
+    "shortcodes": [
+      "star_of_david"
+    ],
+    "keywords": [
+      "judaism"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2721-fe0f",
+        "emoji": "✡️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☸️",
+    "name": "Wheel of Dharma",
+    "shortcodes": [
+      "wheel_of_dharma"
+    ],
+    "keywords": [
+      "hinduism",
+      "buddhism",
+      "sikhism",
+      "jainism"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2638-fe0f",
+        "emoji": "☸️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☯️",
+    "name": "Yin Yang",
+    "shortcodes": [
+      "yin_yang"
+    ],
+    "keywords": [
+      "balance"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "262f-fe0f",
+        "emoji": "☯️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "✝️",
+    "name": "Latin Cross",
+    "shortcodes": [
+      "latin_cross"
+    ],
+    "keywords": [
+      "christianity"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "271d-fe0f",
+        "emoji": "✝️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☦️",
+    "name": "Orthodox Cross",
+    "shortcodes": [
+      "orthodox_cross"
+    ],
+    "keywords": [
+      "suppedaneum",
+      "religion"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2626-fe0f",
+        "emoji": "☦️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☪️",
+    "name": "Star and Crescent",
+    "shortcodes": [
+      "star_and_crescent"
+    ],
+    "keywords": [
+      "islam"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "262a-fe0f",
+        "emoji": "☪️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☮️",
+    "name": "Peace Symbol",
+    "shortcodes": [
+      "peace_symbol"
+    ],
+    "keywords": [
+      "hippie"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "262e-fe0f",
+        "emoji": "☮️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🕎",
+    "name": "Menorah",
+    "shortcodes": [
+      "menorah_with_nine_branches"
+    ],
+    "keywords": [
+      "with",
+      "nine",
+      "branches",
+      "hanukkah",
+      "candles",
+      "jewish"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f54e",
+        "emoji": "🕎"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔯",
+    "name": "Dotted Six-Pointed Star",
+    "shortcodes": [
+      "six_pointed_star"
+    ],
+    "keywords": [
+      "six",
+      "pointed",
+      "purple",
+      "square",
+      "religion",
+      "jewish",
+      "hexagram"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f52f",
+        "emoji": "🔯"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♈",
+    "name": "Aries",
+    "shortcodes": [
+      "aries"
+    ],
+    "keywords": [
+      "sign",
+      "purple",
+      "square",
+      "zodiac",
+      "astrology"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2648",
+        "emoji": "♈"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♉",
+    "name": "Taurus",
+    "shortcodes": [
+      "taurus"
+    ],
+    "keywords": [
+      "purple",
+      "square",
+      "sign",
+      "zodiac",
+      "astrology"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2649",
+        "emoji": "♉"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♊",
+    "name": "Gemini",
+    "shortcodes": [
+      "gemini"
+    ],
+    "keywords": [
+      "sign",
+      "zodiac",
+      "purple",
+      "square",
+      "astrology"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "264a",
+        "emoji": "♊"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♋",
+    "name": "Cancer",
+    "shortcodes": [
+      "cancer"
+    ],
+    "keywords": [
+      "sign",
+      "zodiac",
+      "purple",
+      "square",
+      "astrology"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "264b",
+        "emoji": "♋"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♌",
+    "name": "Leo",
+    "shortcodes": [
+      "leo"
+    ],
+    "keywords": [
+      "sign",
+      "purple",
+      "square",
+      "zodiac",
+      "astrology"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "264c",
+        "emoji": "♌"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♍",
+    "name": "Virgo",
+    "shortcodes": [
+      "virgo"
+    ],
+    "keywords": [
+      "sign",
+      "zodiac",
+      "purple",
+      "square",
+      "astrology"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "264d",
+        "emoji": "♍"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♎",
+    "name": "Libra",
+    "shortcodes": [
+      "libra"
+    ],
+    "keywords": [
+      "sign",
+      "purple",
+      "square",
+      "zodiac",
+      "astrology"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "264e",
+        "emoji": "♎"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♏",
+    "name": "Scorpio",
+    "shortcodes": [
+      "scorpius"
+    ],
+    "keywords": [
+      "scorpius",
+      "sign",
+      "zodiac",
+      "purple",
+      "square",
+      "astrology"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "264f",
+        "emoji": "♏"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♐",
+    "name": "Sagittarius",
+    "shortcodes": [
+      "sagittarius"
+    ],
+    "keywords": [
+      "sign",
+      "zodiac",
+      "purple",
+      "square",
+      "astrology"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2650",
+        "emoji": "♐"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♑",
+    "name": "Capricorn",
+    "shortcodes": [
+      "capricorn"
+    ],
+    "keywords": [
+      "sign",
+      "zodiac",
+      "purple",
+      "square",
+      "astrology"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2651",
+        "emoji": "♑"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♒",
+    "name": "Aquarius",
+    "shortcodes": [
+      "aquarius"
+    ],
+    "keywords": [
+      "sign",
+      "purple",
+      "square",
+      "zodiac",
+      "astrology"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2652",
+        "emoji": "♒"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♓",
+    "name": "Pisces",
+    "shortcodes": [
+      "pisces"
+    ],
+    "keywords": [
+      "purple",
+      "square",
+      "sign",
+      "zodiac",
+      "astrology"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2653",
+        "emoji": "♓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⛎",
+    "name": "Ophiuchus",
+    "shortcodes": [
+      "ophiuchus"
+    ],
+    "keywords": [
+      "sign",
+      "purple",
+      "square",
+      "constellation",
+      "astrology"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26ce",
+        "emoji": "⛎"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔀",
+    "name": "Shuffle Tracks Button",
+    "shortcodes": [
+      "twisted_rightwards_arrows"
+    ],
+    "keywords": [
+      "twisted",
+      "rightwards",
+      "arrows",
+      "blue",
+      "square",
+      "music",
+      "random"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f500",
+        "emoji": "🔀"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔁",
+    "name": "Repeat Button",
+    "shortcodes": [
+      "repeat"
+    ],
+    "keywords": [
+      "loop",
+      "record"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f501",
+        "emoji": "🔁"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔂",
+    "name": "Repeat Single Button",
+    "shortcodes": [
+      "repeat_one"
+    ],
+    "keywords": [
+      "one",
+      "blue",
+      "square",
+      "loop"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f502",
+        "emoji": "🔂"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "▶️",
+    "name": "Play Button",
+    "shortcodes": [
+      "arrow_forward"
+    ],
+    "keywords": [
+      "arrow",
+      "forward",
+      "blue",
+      "square",
+      "right",
+      "direction"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "25b6-fe0f",
+        "emoji": "▶️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⏩",
+    "name": "Fast-Forward Button",
+    "shortcodes": [
+      "fast_forward"
+    ],
+    "keywords": [
+      "fast",
+      "forward",
+      "blue",
+      "square",
+      "play",
+      "speed",
+      "continue"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "23e9",
+        "emoji": "⏩"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⏭️",
+    "name": "Next Track Button",
+    "shortcodes": [
+      "black_right_pointing_double_triangle_with_vertical_bar"
+    ],
+    "keywords": [
+      "black",
+      "right",
+      "pointing",
+      "double",
+      "triangle",
+      "with",
+      "vertical",
+      "bar",
+      "forward",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "23ed-fe0f",
+        "emoji": "⏭️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⏯️",
+    "name": "Play or Pause Button",
+    "shortcodes": [
+      "black_right_pointing_triangle_with_double_vertical_bar"
+    ],
+    "keywords": [
+      "black",
+      "right",
+      "pointing",
+      "triangle",
+      "with",
+      "double",
+      "vertical",
+      "bar",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "23ef-fe0f",
+        "emoji": "⏯️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "◀️",
+    "name": "Reverse Button",
+    "shortcodes": [
+      "arrow_backward"
+    ],
+    "keywords": [
+      "arrow",
+      "backward",
+      "blue",
+      "square",
+      "left",
+      "direction"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "25c0-fe0f",
+        "emoji": "◀️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⏪",
+    "name": "Fast Reverse Button",
+    "shortcodes": [
+      "rewind"
+    ],
+    "keywords": [
+      "rewind",
+      "play",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "23ea",
+        "emoji": "⏪"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⏮️",
+    "name": "Last Track Button",
+    "shortcodes": [
+      "black_left_pointing_double_triangle_with_vertical_bar"
+    ],
+    "keywords": [
+      "black",
+      "left",
+      "pointing",
+      "double",
+      "triangle",
+      "with",
+      "vertical",
+      "bar",
+      "backward"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "23ee-fe0f",
+        "emoji": "⏮️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔼",
+    "name": "Upwards Button",
+    "shortcodes": [
+      "arrow_up_small"
+    ],
+    "keywords": [
+      "arrow",
+      "up",
+      "small",
+      "blue",
+      "square",
+      "triangle",
+      "direction",
+      "point",
+      "forward",
+      "top"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f53c",
+        "emoji": "🔼"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⏫",
+    "name": "Fast Up Button",
+    "shortcodes": [
+      "arrow_double_up"
+    ],
+    "keywords": [
+      "arrow",
+      "double",
+      "blue",
+      "square",
+      "direction",
+      "top"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "23eb",
+        "emoji": "⏫"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔽",
+    "name": "Downwards Button",
+    "shortcodes": [
+      "arrow_down_small"
+    ],
+    "keywords": [
+      "arrow",
+      "down",
+      "small",
+      "blue",
+      "square",
+      "direction",
+      "bottom"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f53d",
+        "emoji": "🔽"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⏬",
+    "name": "Fast Down Button",
+    "shortcodes": [
+      "arrow_double_down"
+    ],
+    "keywords": [
+      "arrow",
+      "double",
+      "blue",
+      "square",
+      "direction",
+      "bottom"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "23ec",
+        "emoji": "⏬"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⏸️",
+    "name": "Pause Button",
+    "shortcodes": [
+      "double_vertical_bar"
+    ],
+    "keywords": [
+      "double",
+      "vertical",
+      "bar",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "23f8-fe0f",
+        "emoji": "⏸️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⏹️",
+    "name": "Stop Button",
+    "shortcodes": [
+      "black_square_for_stop"
+    ],
+    "keywords": [
+      "black",
+      "square",
+      "for",
+      "blue"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "23f9-fe0f",
+        "emoji": "⏹️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⏺️",
+    "name": "Record Button",
+    "shortcodes": [
+      "black_circle_for_record"
+    ],
+    "keywords": [
+      "black",
+      "circle",
+      "for",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "23fa-fe0f",
+        "emoji": "⏺️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⏏️",
+    "name": "Eject Button",
+    "shortcodes": [
+      "eject"
+    ],
+    "keywords": [
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "23cf-fe0f",
+        "emoji": "⏏️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎦",
+    "name": "Cinema",
+    "shortcodes": [
+      "cinema"
+    ],
+    "keywords": [
+      "blue",
+      "square",
+      "record",
+      "film",
+      "movie",
+      "curtain",
+      "stage",
+      "theater"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3a6",
+        "emoji": "🎦"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔅",
+    "name": "Dim Button",
+    "shortcodes": [
+      "low_brightness"
+    ],
+    "keywords": [
+      "low",
+      "brightness",
+      "sun",
+      "afternoon",
+      "warm",
+      "summer"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f505",
+        "emoji": "🔅"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔆",
+    "name": "Bright Button",
+    "shortcodes": [
+      "high_brightness"
+    ],
+    "keywords": [
+      "high",
+      "brightness",
+      "sun",
+      "light"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f506",
+        "emoji": "🔆"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📶",
+    "name": "Antenna Bars",
+    "shortcodes": [
+      "signal_strength"
+    ],
+    "keywords": [
+      "signal",
+      "strength",
+      "blue",
+      "square",
+      "reception",
+      "phone",
+      "internet",
+      "connection",
+      "wifi",
+      "bluetooth"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4f6",
+        "emoji": "📶"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📳",
+    "name": "Vibration Mode",
+    "shortcodes": [
+      "vibration_mode"
+    ],
+    "keywords": [
+      "orange",
+      "square",
+      "phone"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4f3",
+        "emoji": "📳"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📴",
+    "name": "Mobile Phone off",
+    "shortcodes": [
+      "mobile_phone_off"
+    ],
+    "keywords": [
+      "mute",
+      "orange",
+      "square",
+      "silence",
+      "quiet"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4f4",
+        "emoji": "📴"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "♀️",
+    "name": "Female Sign",
+    "shortcodes": [
+      "female_sign"
+    ],
+    "keywords": [
+      "woman",
+      "women",
+      "lady",
+      "girl"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2640-fe0f",
+        "emoji": "♀️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "♂️",
+    "name": "Male Sign",
+    "shortcodes": [
+      "male_sign"
+    ],
+    "keywords": [
+      "man",
+      "boy",
+      "men"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2642-fe0f",
+        "emoji": "♂️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "⚧️",
+    "name": "Transgender Symbol",
+    "shortcodes": [
+      "transgender_symbol"
+    ],
+    "keywords": [
+      "lgbtq"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26a7-fe0f",
+        "emoji": "⚧️"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "✖️",
+    "name": "Multiply",
+    "shortcodes": [
+      "heavy_multiplication_x"
+    ],
+    "keywords": [
+      "heavy",
+      "multiplication",
+      "x",
+      "sign",
+      "math",
+      "calculation"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2716-fe0f",
+        "emoji": "✖️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "➕",
+    "name": "Plus",
+    "shortcodes": [
+      "heavy_plus_sign"
+    ],
+    "keywords": [
+      "heavy",
+      "sign",
+      "math",
+      "calculation",
+      "addition",
+      "more",
+      "increase"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2795",
+        "emoji": "➕"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "➖",
+    "name": "Minus",
+    "shortcodes": [
+      "heavy_minus_sign"
+    ],
+    "keywords": [
+      "heavy",
+      "sign",
+      "math",
+      "calculation",
+      "subtract",
+      "less"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2796",
+        "emoji": "➖"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "➗",
+    "name": "Divide",
+    "shortcodes": [
+      "heavy_division_sign"
+    ],
+    "keywords": [
+      "heavy",
+      "division",
+      "sign",
+      "math",
+      "calculation"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2797",
+        "emoji": "➗"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🟰",
+    "name": "Heavy Equals Sign",
+    "shortcodes": [
+      "heavy_equals_sign"
+    ],
+    "keywords": [
+      "math"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f7f0",
+        "emoji": "🟰"
+      }
+    ],
+    "version": 14
+  },
+  {
+    "emoji": "♾️",
+    "name": "Infinity",
+    "shortcodes": [
+      "infinity"
+    ],
+    "keywords": [
+      "forever"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "267e-fe0f",
+        "emoji": "♾️"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "‼️",
+    "name": "Double Exclamation Mark",
+    "shortcodes": [
+      "bangbang"
+    ],
+    "keywords": [
+      "bangbang",
+      "surprise"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "203c-fe0f",
+        "emoji": "‼️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⁉️",
+    "name": "Exclamation Question Mark",
+    "shortcodes": [
+      "interrobang"
+    ],
+    "keywords": [
+      "interrobang",
+      "wat",
+      "punctuation",
+      "surprise"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2049-fe0f",
+        "emoji": "⁉️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "❓",
+    "name": "Red Question Mark",
+    "shortcodes": [
+      "question"
+    ],
+    "keywords": [
+      "doubt",
+      "confused"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2753",
+        "emoji": "❓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "❔",
+    "name": "White Question Mark",
+    "shortcodes": [
+      "grey_question"
+    ],
+    "keywords": [
+      "grey",
+      "doubts",
+      "gray",
+      "huh",
+      "confused"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2754",
+        "emoji": "❔"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "❕",
+    "name": "White Exclamation Mark",
+    "shortcodes": [
+      "grey_exclamation"
+    ],
+    "keywords": [
+      "grey",
+      "surprise",
+      "punctuation",
+      "gray",
+      "wow",
+      "warning"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2755",
+        "emoji": "❕"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "❗",
+    "name": "Red Exclamation Mark",
+    "shortcodes": [
+      "exclamation",
+      "heavy_exclamation_mark"
+    ],
+    "keywords": [
+      "heavy",
+      "danger",
+      "surprise",
+      "punctuation",
+      "wow",
+      "warning"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2757",
+        "emoji": "❗"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "〰️",
+    "name": "Wavy Dash",
+    "shortcodes": [
+      "wavy_dash"
+    ],
+    "keywords": [
+      "draw",
+      "line",
+      "moustache",
+      "mustache",
+      "squiggle",
+      "scribble"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "3030-fe0f",
+        "emoji": "〰️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💱",
+    "name": "Currency Exchange",
+    "shortcodes": [
+      "currency_exchange"
+    ],
+    "keywords": [
+      "money",
+      "sales",
+      "dollar",
+      "travel"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4b1",
+        "emoji": "💱"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💲",
+    "name": "Heavy Dollar Sign",
+    "shortcodes": [
+      "heavy_dollar_sign"
+    ],
+    "keywords": [
+      "money",
+      "sales",
+      "payment",
+      "currency",
+      "buck"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4b2",
+        "emoji": "💲"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⚕️",
+    "name": "Medical Symbol",
+    "shortcodes": [
+      "medical_symbol",
+      "staff_of_aesculapius"
+    ],
+    "keywords": [
+      "staff",
+      "of",
+      "aesculapius",
+      "health",
+      "hospital"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2695-fe0f",
+        "emoji": "⚕️"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "♻️",
+    "name": "Recycling Symbol",
+    "shortcodes": [
+      "recycle"
+    ],
+    "keywords": [
+      "recycle",
+      "arrow",
+      "environment",
+      "garbage",
+      "trash"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "267b-fe0f",
+        "emoji": "♻️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⚜️",
+    "name": "Fleur-De-Lis",
+    "shortcodes": [
+      "fleur_de_lis"
+    ],
+    "keywords": [
+      "fleur",
+      "de",
+      "lis",
+      "decorative",
+      "scout"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "269c-fe0f",
+        "emoji": "⚜️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔱",
+    "name": "Trident Emblem",
+    "shortcodes": [
+      "trident"
+    ],
+    "keywords": [
+      "weapon",
+      "spear"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f531",
+        "emoji": "🔱"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "📛",
+    "name": "Name Badge",
+    "shortcodes": [
+      "name_badge"
+    ],
+    "keywords": [
+      "fire",
+      "forbid"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4db",
+        "emoji": "📛"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔰",
+    "name": "Japanese Symbol for Beginner",
+    "shortcodes": [
+      "beginner"
+    ],
+    "keywords": [
+      "badge",
+      "shield"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f530",
+        "emoji": "🔰"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⭕",
+    "name": "Hollow Red Circle",
+    "shortcodes": [
+      "o"
+    ],
+    "keywords": [
+      "o",
+      "round"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2b55",
+        "emoji": "⭕"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "✅",
+    "name": "Check Mark Button",
+    "shortcodes": [
+      "white_check_mark"
+    ],
+    "keywords": [
+      "white",
+      "green",
+      "square",
+      "ok",
+      "agree",
+      "vote",
+      "election",
+      "answer",
+      "tick"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2705",
+        "emoji": "✅"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "☑️",
+    "name": "Check Box with Check",
+    "shortcodes": [
+      "ballot_box_with_check"
+    ],
+    "keywords": [
+      "ballot",
+      "ok",
+      "agree",
+      "confirm",
+      "black",
+      "square",
+      "vote",
+      "election",
+      "yes",
+      "tick"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2611-fe0f",
+        "emoji": "☑️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "✔️",
+    "name": "Check Mark",
+    "shortcodes": [
+      "heavy_check_mark"
+    ],
+    "keywords": [
+      "heavy",
+      "ok",
+      "nike",
+      "answer",
+      "yes",
+      "tick"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2714-fe0f",
+        "emoji": "✔️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "❌",
+    "name": "Cross Mark",
+    "shortcodes": [
+      "x"
+    ],
+    "keywords": [
+      "x",
+      "no",
+      "delete",
+      "remove",
+      "cancel",
+      "red"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "274c",
+        "emoji": "❌"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "❎",
+    "name": "Cross Mark Button",
+    "shortcodes": [
+      "negative_squared_cross_mark"
+    ],
+    "keywords": [
+      "negative",
+      "squared",
+      "x",
+      "green",
+      "square",
+      "no",
+      "deny"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "274e",
+        "emoji": "❎"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "➰",
+    "name": "Curly Loop",
+    "shortcodes": [
+      "curly_loop"
+    ],
+    "keywords": [
+      "scribble",
+      "draw",
+      "shape",
+      "squiggle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "27b0",
+        "emoji": "➰"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "➿",
+    "name": "Double Curly Loop",
+    "shortcodes": [
+      "loop"
+    ],
+    "keywords": [
+      "tape",
+      "cassette"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "27bf",
+        "emoji": "➿"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "〽️",
+    "name": "Part Alternation Mark",
+    "shortcodes": [
+      "part_alternation_mark"
+    ],
+    "keywords": [
+      "graph",
+      "presentation",
+      "stats",
+      "business",
+      "economics",
+      "bad"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "303d-fe0f",
+        "emoji": "〽️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "✳️",
+    "name": "Eight Spoked Asterisk",
+    "shortcodes": [
+      "eight_spoked_asterisk"
+    ],
+    "keywords": [
+      "star",
+      "sparkle",
+      "green",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2733-fe0f",
+        "emoji": "✳️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "✴️",
+    "name": "Eight-Pointed Star",
+    "shortcodes": [
+      "eight_pointed_black_star"
+    ],
+    "keywords": [
+      "eight",
+      "pointed",
+      "black",
+      "orange",
+      "square",
+      "shape",
+      "polygon"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2734-fe0f",
+        "emoji": "✴️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "❇️",
+    "name": "Sparkle",
+    "shortcodes": [
+      "sparkle"
+    ],
+    "keywords": [
+      "stars",
+      "green",
+      "square",
+      "awesome",
+      "good",
+      "fireworks"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2747-fe0f",
+        "emoji": "❇️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "©️",
+    "name": "Copyright",
+    "shortcodes": [
+      "copyright"
+    ],
+    "keywords": [
+      "ip",
+      "license",
+      "circle",
+      "law",
+      "legal"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "00a9-fe0f",
+        "emoji": "©️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "®️",
+    "name": "Registered",
+    "shortcodes": [
+      "registered"
+    ],
+    "keywords": [
+      "alphabet",
+      "circle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "00ae-fe0f",
+        "emoji": "®️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "™️",
+    "name": "Trade Mark",
+    "shortcodes": [
+      "tm"
+    ],
+    "keywords": [
+      "tm",
+      "trademark",
+      "brand",
+      "law",
+      "legal"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2122-fe0f",
+        "emoji": "™️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "#️⃣",
+    "name": "Hash Key",
+    "shortcodes": [
+      "hash"
+    ],
+    "keywords": [
+      "keycap",
+      "",
+      "symbol",
+      "blue",
+      "square",
+      "twitter"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "0023-fe0f-20e3",
+        "emoji": "#️⃣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "*️⃣",
+    "name": "Keycap: *",
+    "shortcodes": [
+      "keycap_star"
+    ],
+    "keywords": [
+      "keycap",
+      "star",
+      ""
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "002a-fe0f-20e3",
+        "emoji": "*️⃣"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "0️⃣",
+    "name": "Keycap 0",
+    "shortcodes": [
+      "zero"
+    ],
+    "keywords": [
+      "zero",
+      "numbers",
+      "blue",
+      "square",
+      "null"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "0030-fe0f-20e3",
+        "emoji": "0️⃣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "1️⃣",
+    "name": "Keycap 1",
+    "shortcodes": [
+      "one"
+    ],
+    "keywords": [
+      "one",
+      "blue",
+      "square",
+      "numbers"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "0031-fe0f-20e3",
+        "emoji": "1️⃣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "2️⃣",
+    "name": "Keycap 2",
+    "shortcodes": [
+      "two"
+    ],
+    "keywords": [
+      "two",
+      "numbers",
+      "prime",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "0032-fe0f-20e3",
+        "emoji": "2️⃣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "3️⃣",
+    "name": "Keycap 3",
+    "shortcodes": [
+      "three"
+    ],
+    "keywords": [
+      "three",
+      "numbers",
+      "prime",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "0033-fe0f-20e3",
+        "emoji": "3️⃣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "4️⃣",
+    "name": "Keycap 4",
+    "shortcodes": [
+      "four"
+    ],
+    "keywords": [
+      "four",
+      "numbers",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "0034-fe0f-20e3",
+        "emoji": "4️⃣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "5️⃣",
+    "name": "Keycap 5",
+    "shortcodes": [
+      "five"
+    ],
+    "keywords": [
+      "five",
+      "numbers",
+      "blue",
+      "square",
+      "prime"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "0035-fe0f-20e3",
+        "emoji": "5️⃣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "6️⃣",
+    "name": "Keycap 6",
+    "shortcodes": [
+      "six"
+    ],
+    "keywords": [
+      "six",
+      "numbers",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "0036-fe0f-20e3",
+        "emoji": "6️⃣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "7️⃣",
+    "name": "Keycap 7",
+    "shortcodes": [
+      "seven"
+    ],
+    "keywords": [
+      "seven",
+      "numbers",
+      "blue",
+      "square",
+      "prime"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "0037-fe0f-20e3",
+        "emoji": "7️⃣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "8️⃣",
+    "name": "Keycap 8",
+    "shortcodes": [
+      "eight"
+    ],
+    "keywords": [
+      "eight",
+      "blue",
+      "square",
+      "numbers"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "0038-fe0f-20e3",
+        "emoji": "8️⃣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "9️⃣",
+    "name": "Keycap 9",
+    "shortcodes": [
+      "nine"
+    ],
+    "keywords": [
+      "nine",
+      "blue",
+      "square",
+      "numbers"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "0039-fe0f-20e3",
+        "emoji": "9️⃣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔟",
+    "name": "Keycap 10",
+    "shortcodes": [
+      "keycap_ten"
+    ],
+    "keywords": [
+      "ten",
+      "numbers",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f51f",
+        "emoji": "🔟"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔠",
+    "name": "Input Latin Uppercase",
+    "shortcodes": [
+      "capital_abcd"
+    ],
+    "keywords": [
+      "capital",
+      "abcd",
+      "alphabet",
+      "words",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f520",
+        "emoji": "🔠"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔡",
+    "name": "Input Latin Lowercase",
+    "shortcodes": [
+      "abcd"
+    ],
+    "keywords": [
+      "abcd",
+      "blue",
+      "square",
+      "alphabet"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f521",
+        "emoji": "🔡"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔣",
+    "name": "Input Symbols",
+    "shortcodes": [
+      "symbols"
+    ],
+    "keywords": [
+      "blue",
+      "square",
+      "music",
+      "note",
+      "ampersand",
+      "percent",
+      "glyphs",
+      "characters"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f523",
+        "emoji": "🔣"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔤",
+    "name": "Input Latin Letters",
+    "shortcodes": [
+      "abc"
+    ],
+    "keywords": [
+      "abc",
+      "blue",
+      "square",
+      "alphabet"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f524",
+        "emoji": "🔤"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🅰️",
+    "name": "A Button (blood Type)",
+    "shortcodes": [
+      "a"
+    ],
+    "keywords": [
+      "red",
+      "square",
+      "alphabet",
+      "letter"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f170-fe0f",
+        "emoji": "🅰️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🆎",
+    "name": "Negative Squared Ab",
+    "shortcodes": [
+      "ab"
+    ],
+    "keywords": [
+      "button",
+      "red",
+      "square",
+      "alphabet"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f18e",
+        "emoji": "🆎"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🅱️",
+    "name": "B Button (blood Type)",
+    "shortcodes": [
+      "b"
+    ],
+    "keywords": [
+      "red",
+      "square",
+      "alphabet",
+      "letter"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f171-fe0f",
+        "emoji": "🅱️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🆑",
+    "name": "Cl Button",
+    "shortcodes": [
+      "cl"
+    ],
+    "keywords": [
+      "alphabet",
+      "words",
+      "red",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f191",
+        "emoji": "🆑"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🆒",
+    "name": "Cool Button",
+    "shortcodes": [
+      "cool"
+    ],
+    "keywords": [
+      "words",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f192",
+        "emoji": "🆒"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🆓",
+    "name": "Free Button",
+    "shortcodes": [
+      "free"
+    ],
+    "keywords": [
+      "blue",
+      "square",
+      "words"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f193",
+        "emoji": "🆓"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "ℹ️",
+    "name": "Information",
+    "shortcodes": [
+      "information_source"
+    ],
+    "keywords": [
+      "source",
+      "blue",
+      "square",
+      "alphabet",
+      "letter"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2139-fe0f",
+        "emoji": "ℹ️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🆔",
+    "name": "Id Button",
+    "shortcodes": [
+      "id"
+    ],
+    "keywords": [
+      "purple",
+      "square",
+      "words"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f194",
+        "emoji": "🆔"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "Ⓜ️",
+    "name": "Circled M",
+    "shortcodes": [
+      "m"
+    ],
+    "keywords": [
+      "alphabet",
+      "blue",
+      "circle",
+      "letter"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "24c2-fe0f",
+        "emoji": "Ⓜ️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🆕",
+    "name": "New Button",
+    "shortcodes": [
+      "new"
+    ],
+    "keywords": [
+      "blue",
+      "square",
+      "words",
+      "start"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f195",
+        "emoji": "🆕"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🆖",
+    "name": "Ng Button",
+    "shortcodes": [
+      "ng"
+    ],
+    "keywords": [
+      "blue",
+      "square",
+      "words",
+      "shape",
+      "icon"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f196",
+        "emoji": "🆖"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🅾️",
+    "name": "O Button (blood Type)",
+    "shortcodes": [
+      "o2"
+    ],
+    "keywords": [
+      "o2",
+      "alphabet",
+      "red",
+      "square",
+      "letter"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f17e-fe0f",
+        "emoji": "🅾️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🆗",
+    "name": "Ok Button",
+    "shortcodes": [
+      "ok"
+    ],
+    "keywords": [
+      "good",
+      "agree",
+      "yes",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f197",
+        "emoji": "🆗"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🅿️",
+    "name": "P Button",
+    "shortcodes": [
+      "parking"
+    ],
+    "keywords": [
+      "parking",
+      "cars",
+      "blue",
+      "square",
+      "alphabet",
+      "letter"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f17f-fe0f",
+        "emoji": "🅿️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🆘",
+    "name": "Sos Button",
+    "shortcodes": [
+      "sos"
+    ],
+    "keywords": [
+      "help",
+      "red",
+      "square",
+      "words",
+      "emergency",
+      "911"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f198",
+        "emoji": "🆘"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🆙",
+    "name": "Up! Button",
+    "shortcodes": [
+      "up"
+    ],
+    "keywords": [
+      "up",
+      "blue",
+      "square",
+      "above",
+      "high"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f199",
+        "emoji": "🆙"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🆚",
+    "name": "Vs Button",
+    "shortcodes": [
+      "vs"
+    ],
+    "keywords": [
+      "words",
+      "orange",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f19a",
+        "emoji": "🆚"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🈁",
+    "name": "Squared Katakana Koko",
+    "shortcodes": [
+      "koko"
+    ],
+    "keywords": [
+      "japanese",
+      "here",
+      "button",
+      "blue",
+      "square",
+      "destination"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f201",
+        "emoji": "🈁"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🈂️",
+    "name": "Squared Katakana Sa",
+    "shortcodes": [
+      "sa"
+    ],
+    "keywords": [
+      "japanese",
+      "service",
+      "charge",
+      "button",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f202-fe0f",
+        "emoji": "🈂️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🈷️",
+    "name": "Japanese “monthly Amount” Button",
+    "shortcodes": [
+      "u6708"
+    ],
+    "keywords": [
+      "u6708",
+      "monthly",
+      "amount",
+      "chinese",
+      "month",
+      "moon",
+      "orange",
+      "square",
+      "kanji"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f237-fe0f",
+        "emoji": "🈷️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🈶",
+    "name": "Squared Cjk Unified Ideograph-6709",
+    "shortcodes": [
+      "u6709"
+    ],
+    "keywords": [
+      "u6709",
+      "japanese",
+      "not",
+      "free",
+      "of",
+      "charge",
+      "button",
+      "orange",
+      "square",
+      "chinese",
+      "have",
+      "kanji"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f236",
+        "emoji": "🈶"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🈯",
+    "name": "Japanese “reserved” Button",
+    "shortcodes": [
+      "u6307"
+    ],
+    "keywords": [
+      "u6307",
+      "reserved",
+      "chinese",
+      "point",
+      "green",
+      "square",
+      "kanji"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f22f",
+        "emoji": "🈯"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🉐",
+    "name": "Japanese “bargain” Button",
+    "shortcodes": [
+      "ideograph_advantage"
+    ],
+    "keywords": [
+      "ideograph",
+      "advantage",
+      "bargain",
+      "chinese",
+      "kanji",
+      "obtain",
+      "get",
+      "circle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f250",
+        "emoji": "🉐"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🈹",
+    "name": "Japanese “discount” Button",
+    "shortcodes": [
+      "u5272"
+    ],
+    "keywords": [
+      "u5272",
+      "discount",
+      "cut",
+      "divide",
+      "chinese",
+      "kanji",
+      "pink",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f239",
+        "emoji": "🈹"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🈚",
+    "name": "Japanese “free of Charge” Button",
+    "shortcodes": [
+      "u7121"
+    ],
+    "keywords": [
+      "u7121",
+      "free",
+      "charge",
+      "nothing",
+      "chinese",
+      "kanji",
+      "orange",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f21a",
+        "emoji": "🈚"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🈲",
+    "name": "Japanese “prohibited” Button",
+    "shortcodes": [
+      "u7981"
+    ],
+    "keywords": [
+      "u7981",
+      "prohibited",
+      "kanji",
+      "chinese",
+      "forbidden",
+      "limit",
+      "restricted",
+      "red",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f232",
+        "emoji": "🈲"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🉑",
+    "name": "Circled Ideograph Accept",
+    "shortcodes": [
+      "accept"
+    ],
+    "keywords": [
+      "japanese",
+      "acceptable",
+      "button",
+      "ok",
+      "good",
+      "chinese",
+      "kanji",
+      "agree",
+      "yes",
+      "orange",
+      "circle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f251",
+        "emoji": "🉑"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🈸",
+    "name": "Japanese “application” Button",
+    "shortcodes": [
+      "u7533"
+    ],
+    "keywords": [
+      "u7533",
+      "application",
+      "chinese",
+      "kanji",
+      "orange",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f238",
+        "emoji": "🈸"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🈴",
+    "name": "Japanese “passing Grade” Button",
+    "shortcodes": [
+      "u5408"
+    ],
+    "keywords": [
+      "u5408",
+      "passing",
+      "grade",
+      "chinese",
+      "join",
+      "kanji",
+      "red",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f234",
+        "emoji": "🈴"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🈳",
+    "name": "Japanese “vacancy” Button",
+    "shortcodes": [
+      "u7a7a"
+    ],
+    "keywords": [
+      "u7a7a",
+      "vacancy",
+      "kanji",
+      "chinese",
+      "empty",
+      "sky",
+      "blue",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f233",
+        "emoji": "🈳"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "㊗️",
+    "name": "Circled Ideograph Congratulation",
+    "shortcodes": [
+      "congratulations"
+    ],
+    "keywords": [
+      "congratulations",
+      "japanese",
+      "button",
+      "chinese",
+      "kanji",
+      "red",
+      "circle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "3297-fe0f",
+        "emoji": "㊗️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "㊙️",
+    "name": "Circled Ideograph Secret",
+    "shortcodes": [
+      "secret"
+    ],
+    "keywords": [
+      "japanese",
+      "button",
+      "privacy",
+      "chinese",
+      "sshh",
+      "kanji",
+      "red",
+      "circle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "3299-fe0f",
+        "emoji": "㊙️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🈺",
+    "name": "Squared Cjk Unified Ideograph-55b6",
+    "shortcodes": [
+      "u55b6"
+    ],
+    "keywords": [
+      "u55b6",
+      "japanese",
+      "open",
+      "for",
+      "business",
+      "button",
+      "opening",
+      "hours",
+      "orange",
+      "square"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f23a",
+        "emoji": "🈺"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🈵",
+    "name": "Japanese “no Vacancy” Button",
+    "shortcodes": [
+      "u6e80"
+    ],
+    "keywords": [
+      "u6e80",
+      "no",
+      "vacancy",
+      "full",
+      "chinese",
+      "red",
+      "square",
+      "kanji"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f235",
+        "emoji": "🈵"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔴",
+    "name": "Red Circle",
+    "shortcodes": [
+      "red_circle"
+    ],
+    "keywords": [
+      "shape",
+      "error",
+      "danger"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f534",
+        "emoji": "🔴"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🟠",
+    "name": "Orange Circle",
+    "shortcodes": [
+      "large_orange_circle"
+    ],
+    "keywords": [
+      "large",
+      "round"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f7e0",
+        "emoji": "🟠"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🟡",
+    "name": "Yellow Circle",
+    "shortcodes": [
+      "large_yellow_circle"
+    ],
+    "keywords": [
+      "large",
+      "round"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f7e1",
+        "emoji": "🟡"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🟢",
+    "name": "Green Circle",
+    "shortcodes": [
+      "large_green_circle"
+    ],
+    "keywords": [
+      "large",
+      "round"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f7e2",
+        "emoji": "🟢"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🔵",
+    "name": "Blue Circle",
+    "shortcodes": [
+      "large_blue_circle"
+    ],
+    "keywords": [
+      "large",
+      "shape",
+      "icon",
+      "button"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f535",
+        "emoji": "🔵"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🟣",
+    "name": "Purple Circle",
+    "shortcodes": [
+      "large_purple_circle"
+    ],
+    "keywords": [
+      "large",
+      "round"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f7e3",
+        "emoji": "🟣"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🟤",
+    "name": "Brown Circle",
+    "shortcodes": [
+      "large_brown_circle"
+    ],
+    "keywords": [
+      "large",
+      "round"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f7e4",
+        "emoji": "🟤"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "⚫",
+    "name": "Black Circle",
+    "shortcodes": [
+      "black_circle"
+    ],
+    "keywords": [
+      "shape",
+      "button",
+      "round"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26ab",
+        "emoji": "⚫"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⚪",
+    "name": "White Circle",
+    "shortcodes": [
+      "white_circle"
+    ],
+    "keywords": [
+      "shape",
+      "round"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "26aa",
+        "emoji": "⚪"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🟥",
+    "name": "Red Square",
+    "shortcodes": [
+      "large_red_square"
+    ],
+    "keywords": [
+      "large"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f7e5",
+        "emoji": "🟥"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🟧",
+    "name": "Orange Square",
+    "shortcodes": [
+      "large_orange_square"
+    ],
+    "keywords": [
+      "large"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f7e7",
+        "emoji": "🟧"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🟨",
+    "name": "Yellow Square",
+    "shortcodes": [
+      "large_yellow_square"
+    ],
+    "keywords": [
+      "large"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f7e8",
+        "emoji": "🟨"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🟩",
+    "name": "Green Square",
+    "shortcodes": [
+      "large_green_square"
+    ],
+    "keywords": [
+      "large"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f7e9",
+        "emoji": "🟩"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🟦",
+    "name": "Blue Square",
+    "shortcodes": [
+      "large_blue_square"
+    ],
+    "keywords": [
+      "large"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f7e6",
+        "emoji": "🟦"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🟪",
+    "name": "Purple Square",
+    "shortcodes": [
+      "large_purple_square"
+    ],
+    "keywords": [
+      "large"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f7ea",
+        "emoji": "🟪"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "🟫",
+    "name": "Brown Square",
+    "shortcodes": [
+      "large_brown_square"
+    ],
+    "keywords": [
+      "large"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f7eb",
+        "emoji": "🟫"
+      }
+    ],
+    "version": 12
+  },
+  {
+    "emoji": "⬛",
+    "name": "Black Large Square",
+    "shortcodes": [
+      "black_large_square"
+    ],
+    "keywords": [
+      "shape",
+      "icon",
+      "button"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2b1b",
+        "emoji": "⬛"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "⬜",
+    "name": "White Large Square",
+    "shortcodes": [
+      "white_large_square"
+    ],
+    "keywords": [
+      "shape",
+      "icon",
+      "stone",
+      "button"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "2b1c",
+        "emoji": "⬜"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "◼️",
+    "name": "Black Medium Square",
+    "shortcodes": [
+      "black_medium_square"
+    ],
+    "keywords": [
+      "shape",
+      "button",
+      "icon"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "25fc-fe0f",
+        "emoji": "◼️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "◻️",
+    "name": "White Medium Square",
+    "shortcodes": [
+      "white_medium_square"
+    ],
+    "keywords": [
+      "shape",
+      "stone",
+      "icon"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "25fb-fe0f",
+        "emoji": "◻️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "◾",
+    "name": "Black Medium Small Square",
+    "shortcodes": [
+      "black_medium_small_square"
+    ],
+    "keywords": [
+      "icon",
+      "shape",
+      "button"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "25fe",
+        "emoji": "◾"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "◽",
+    "name": "White Medium Small Square",
+    "shortcodes": [
+      "white_medium_small_square"
+    ],
+    "keywords": [
+      "shape",
+      "stone",
+      "icon",
+      "button"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "25fd",
+        "emoji": "◽"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "▪️",
+    "name": "Black Small Square",
+    "shortcodes": [
+      "black_small_square"
+    ],
+    "keywords": [
+      "shape",
+      "icon"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "25aa-fe0f",
+        "emoji": "▪️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "▫️",
+    "name": "White Small Square",
+    "shortcodes": [
+      "white_small_square"
+    ],
+    "keywords": [
+      "shape",
+      "icon"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "25ab-fe0f",
+        "emoji": "▫️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔶",
+    "name": "Large Orange Diamond",
+    "shortcodes": [
+      "large_orange_diamond"
+    ],
+    "keywords": [
+      "shape",
+      "jewel",
+      "gem"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f536",
+        "emoji": "🔶"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔷",
+    "name": "Large Blue Diamond",
+    "shortcodes": [
+      "large_blue_diamond"
+    ],
+    "keywords": [
+      "shape",
+      "jewel",
+      "gem"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f537",
+        "emoji": "🔷"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔸",
+    "name": "Small Orange Diamond",
+    "shortcodes": [
+      "small_orange_diamond"
+    ],
+    "keywords": [
+      "shape",
+      "jewel",
+      "gem"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f538",
+        "emoji": "🔸"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔹",
+    "name": "Small Blue Diamond",
+    "shortcodes": [
+      "small_blue_diamond"
+    ],
+    "keywords": [
+      "shape",
+      "jewel",
+      "gem"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f539",
+        "emoji": "🔹"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔺",
+    "name": "Red Triangle Pointed Up",
+    "shortcodes": [
+      "small_red_triangle"
+    ],
+    "keywords": [
+      "small",
+      "shape",
+      "direction",
+      "top"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f53a",
+        "emoji": "🔺"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔻",
+    "name": "Red Triangle Pointed Down",
+    "shortcodes": [
+      "small_red_triangle_down"
+    ],
+    "keywords": [
+      "small",
+      "shape",
+      "direction",
+      "bottom"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f53b",
+        "emoji": "🔻"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "💠",
+    "name": "Diamond with a Dot",
+    "shortcodes": [
+      "diamond_shape_with_a_dot_inside"
+    ],
+    "keywords": [
+      "shape",
+      "inside",
+      "jewel",
+      "blue",
+      "gem",
+      "crystal",
+      "fancy"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f4a0",
+        "emoji": "💠"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔘",
+    "name": "Radio Button",
+    "shortcodes": [
+      "radio_button"
+    ],
+    "keywords": [
+      "input",
+      "old",
+      "music",
+      "circle"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f518",
+        "emoji": "🔘"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔳",
+    "name": "White Square Button",
+    "shortcodes": [
+      "white_square_button"
+    ],
+    "keywords": [
+      "shape",
+      "input"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f533",
+        "emoji": "🔳"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🔲",
+    "name": "Black Square Button",
+    "shortcodes": [
+      "black_square_button"
+    ],
+    "keywords": [
+      "shape",
+      "input",
+      "frame"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f532",
+        "emoji": "🔲"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏁",
+    "name": "Chequered Flag",
+    "shortcodes": [
+      "checkered_flag"
+    ],
+    "keywords": [
+      "checkered",
+      "contest",
+      "finishline",
+      "race",
+      "gokart"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3c1",
+        "emoji": "🏁"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🚩",
+    "name": "Triangular Flag",
+    "shortcodes": [
+      "triangular_flag_on_post"
+    ],
+    "keywords": [
+      "on",
+      "post",
+      "mark",
+      "milestone",
+      "place"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f6a9",
+        "emoji": "🚩"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🎌",
+    "name": "Crossed Flags",
+    "shortcodes": [
+      "crossed_flags"
+    ],
+    "keywords": [
+      "japanese",
+      "nation",
+      "country",
+      "border"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f38c",
+        "emoji": "🎌"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏴",
+    "name": "Black Flag",
+    "shortcodes": [
+      "waving_black_flag"
+    ],
+    "keywords": [
+      "waving",
+      "pirate"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3f4",
+        "emoji": "🏴"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏳️",
+    "name": "White Flag",
+    "shortcodes": [
+      "waving_white_flag"
+    ],
+    "keywords": [
+      "waving",
+      "losing",
+      "loser",
+      "lost",
+      "surrender",
+      "give",
+      "up",
+      "fail"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3f3-fe0f",
+        "emoji": "🏳️"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🏳️‍🌈",
+    "name": "Rainbow Flag",
+    "shortcodes": [
+      "rainbow-flag"
+    ],
+    "keywords": [
+      "pride",
+      "gay",
+      "lgbt",
+      "glbt",
+      "queer",
+      "homosexual",
+      "lesbian",
+      "bisexual",
+      "transgender"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3f3-fe0f-200d-1f308",
+        "emoji": "🏳️‍🌈"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🏳️‍⚧️",
+    "name": "Transgender Flag",
+    "shortcodes": [
+      "transgender_flag"
+    ],
+    "keywords": [
+      "lgbtq"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3f3-fe0f-200d-26a7-fe0f",
+        "emoji": "🏳️‍⚧️"
+      }
+    ],
+    "version": 13
+  },
+  {
+    "emoji": "🏴‍☠️",
+    "name": "Pirate Flag",
+    "shortcodes": [
+      "pirate_flag"
+    ],
+    "keywords": [
+      "skull",
+      "crossbones",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3f4-200d-2620-fe0f",
+        "emoji": "🏴‍☠️"
+      }
+    ],
+    "version": 11
+  },
+  {
+    "emoji": "🇦🇨",
+    "name": "Ascension Island Flag",
+    "shortcodes": [
+      "flag-ac"
+    ],
+    "keywords": [
+      "ac"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1e8",
+        "emoji": "🇦🇨"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇦🇩",
+    "name": "Andorra Flag",
+    "shortcodes": [
+      "flag-ad"
+    ],
+    "keywords": [
+      "ad",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1e9",
+        "emoji": "🇦🇩"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇦🇪",
+    "name": "United Arab Emirates Flag",
+    "shortcodes": [
+      "flag-ae"
+    ],
+    "keywords": [
+      "ae",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1ea",
+        "emoji": "🇦🇪"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇦🇫",
+    "name": "Afghanistan Flag",
+    "shortcodes": [
+      "flag-af"
+    ],
+    "keywords": [
+      "af",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1eb",
+        "emoji": "🇦🇫"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇦🇬",
+    "name": "Antigua & Barbuda Flag",
+    "shortcodes": [
+      "flag-ag"
+    ],
+    "keywords": [
+      "ag",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1ec",
+        "emoji": "🇦🇬"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇦🇮",
+    "name": "Anguilla Flag",
+    "shortcodes": [
+      "flag-ai"
+    ],
+    "keywords": [
+      "ai",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1ee",
+        "emoji": "🇦🇮"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇦🇱",
+    "name": "Albania Flag",
+    "shortcodes": [
+      "flag-al"
+    ],
+    "keywords": [
+      "al",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1f1",
+        "emoji": "🇦🇱"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇦🇲",
+    "name": "Armenia Flag",
+    "shortcodes": [
+      "flag-am"
+    ],
+    "keywords": [
+      "am",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1f2",
+        "emoji": "🇦🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇦🇴",
+    "name": "Angola Flag",
+    "shortcodes": [
+      "flag-ao"
+    ],
+    "keywords": [
+      "ao",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1f4",
+        "emoji": "🇦🇴"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇦🇶",
+    "name": "Antarctica Flag",
+    "shortcodes": [
+      "flag-aq"
+    ],
+    "keywords": [
+      "aq",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1f6",
+        "emoji": "🇦🇶"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇦🇷",
+    "name": "Argentina Flag",
+    "shortcodes": [
+      "flag-ar"
+    ],
+    "keywords": [
+      "ar",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1f7",
+        "emoji": "🇦🇷"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇦🇸",
+    "name": "American Samoa Flag",
+    "shortcodes": [
+      "flag-as"
+    ],
+    "keywords": [
+      "as",
+      "ws",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1f8",
+        "emoji": "🇦🇸"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇦🇹",
+    "name": "Austria Flag",
+    "shortcodes": [
+      "flag-at"
+    ],
+    "keywords": [
+      "at",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1f9",
+        "emoji": "🇦🇹"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇦🇺",
+    "name": "Australia Flag",
+    "shortcodes": [
+      "flag-au"
+    ],
+    "keywords": [
+      "au",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1fa",
+        "emoji": "🇦🇺"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇦🇼",
+    "name": "Aruba Flag",
+    "shortcodes": [
+      "flag-aw"
+    ],
+    "keywords": [
+      "aw",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1fc",
+        "emoji": "🇦🇼"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇦🇽",
+    "name": "Åland Islands Flag",
+    "shortcodes": [
+      "flag-ax"
+    ],
+    "keywords": [
+      "ax",
+      "aland",
+      "Aland",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1fd",
+        "emoji": "🇦🇽"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇦🇿",
+    "name": "Azerbaijan Flag",
+    "shortcodes": [
+      "flag-az"
+    ],
+    "keywords": [
+      "az",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e6-1f1ff",
+        "emoji": "🇦🇿"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇦",
+    "name": "Bosnia & Herzegovina Flag",
+    "shortcodes": [
+      "flag-ba"
+    ],
+    "keywords": [
+      "ba",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1e6",
+        "emoji": "🇧🇦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇧",
+    "name": "Barbados Flag",
+    "shortcodes": [
+      "flag-bb"
+    ],
+    "keywords": [
+      "bb",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1e7",
+        "emoji": "🇧🇧"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇩",
+    "name": "Bangladesh Flag",
+    "shortcodes": [
+      "flag-bd"
+    ],
+    "keywords": [
+      "bd",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1e9",
+        "emoji": "🇧🇩"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇪",
+    "name": "Belgium Flag",
+    "shortcodes": [
+      "flag-be"
+    ],
+    "keywords": [
+      "be",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1ea",
+        "emoji": "🇧🇪"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇫",
+    "name": "Burkina Faso Flag",
+    "shortcodes": [
+      "flag-bf"
+    ],
+    "keywords": [
+      "bf",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1eb",
+        "emoji": "🇧🇫"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇬",
+    "name": "Bulgaria Flag",
+    "shortcodes": [
+      "flag-bg"
+    ],
+    "keywords": [
+      "bg",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1ec",
+        "emoji": "🇧🇬"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇭",
+    "name": "Bahrain Flag",
+    "shortcodes": [
+      "flag-bh"
+    ],
+    "keywords": [
+      "bh",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1ed",
+        "emoji": "🇧🇭"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇮",
+    "name": "Burundi Flag",
+    "shortcodes": [
+      "flag-bi"
+    ],
+    "keywords": [
+      "bi",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1ee",
+        "emoji": "🇧🇮"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇯",
+    "name": "Benin Flag",
+    "shortcodes": [
+      "flag-bj"
+    ],
+    "keywords": [
+      "bj",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1ef",
+        "emoji": "🇧🇯"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇱",
+    "name": "St. Barthélemy Flag",
+    "shortcodes": [
+      "flag-bl"
+    ],
+    "keywords": [
+      "bl",
+      "st",
+      "barthelemy",
+      "saint",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1f1",
+        "emoji": "🇧🇱"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇲",
+    "name": "Bermuda Flag",
+    "shortcodes": [
+      "flag-bm"
+    ],
+    "keywords": [
+      "bm",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1f2",
+        "emoji": "🇧🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇳",
+    "name": "Brunei Flag",
+    "shortcodes": [
+      "flag-bn"
+    ],
+    "keywords": [
+      "bn",
+      "darussalam",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1f3",
+        "emoji": "🇧🇳"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇴",
+    "name": "Bolivia Flag",
+    "shortcodes": [
+      "flag-bo"
+    ],
+    "keywords": [
+      "bo",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1f4",
+        "emoji": "🇧🇴"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇶",
+    "name": "Caribbean Netherlands Flag",
+    "shortcodes": [
+      "flag-bq"
+    ],
+    "keywords": [
+      "bq",
+      "bonaire",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1f6",
+        "emoji": "🇧🇶"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇷",
+    "name": "Brazil Flag",
+    "shortcodes": [
+      "flag-br"
+    ],
+    "keywords": [
+      "br",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1f7",
+        "emoji": "🇧🇷"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇸",
+    "name": "Bahamas Flag",
+    "shortcodes": [
+      "flag-bs"
+    ],
+    "keywords": [
+      "bs",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1f8",
+        "emoji": "🇧🇸"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇹",
+    "name": "Bhutan Flag",
+    "shortcodes": [
+      "flag-bt"
+    ],
+    "keywords": [
+      "bt",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1f9",
+        "emoji": "🇧🇹"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇻",
+    "name": "Bouvet Island Flag",
+    "shortcodes": [
+      "flag-bv"
+    ],
+    "keywords": [
+      "bv",
+      "norway"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1fb",
+        "emoji": "🇧🇻"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇼",
+    "name": "Botswana Flag",
+    "shortcodes": [
+      "flag-bw"
+    ],
+    "keywords": [
+      "bw",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1fc",
+        "emoji": "🇧🇼"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇾",
+    "name": "Belarus Flag",
+    "shortcodes": [
+      "flag-by"
+    ],
+    "keywords": [
+      "by",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1fe",
+        "emoji": "🇧🇾"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇧🇿",
+    "name": "Belize Flag",
+    "shortcodes": [
+      "flag-bz"
+    ],
+    "keywords": [
+      "bz",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e7-1f1ff",
+        "emoji": "🇧🇿"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇦",
+    "name": "Canada Flag",
+    "shortcodes": [
+      "flag-ca"
+    ],
+    "keywords": [
+      "ca",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1e6",
+        "emoji": "🇨🇦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇨",
+    "name": "Cocos (keeling) Islands Flag",
+    "shortcodes": [
+      "flag-cc"
+    ],
+    "keywords": [
+      "cc",
+      "keeling",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1e8",
+        "emoji": "🇨🇨"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇩",
+    "name": "Congo - Kinshasa Flag",
+    "shortcodes": [
+      "flag-cd"
+    ],
+    "keywords": [
+      "cd",
+      "democratic",
+      "republic",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1e9",
+        "emoji": "🇨🇩"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇫",
+    "name": "Central African Republic Flag",
+    "shortcodes": [
+      "flag-cf"
+    ],
+    "keywords": [
+      "cf",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1eb",
+        "emoji": "🇨🇫"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇬",
+    "name": "Congo - Brazzaville Flag",
+    "shortcodes": [
+      "flag-cg"
+    ],
+    "keywords": [
+      "cg",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1ec",
+        "emoji": "🇨🇬"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇭",
+    "name": "Switzerland Flag",
+    "shortcodes": [
+      "flag-ch"
+    ],
+    "keywords": [
+      "ch",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1ed",
+        "emoji": "🇨🇭"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇮",
+    "name": "Côte D’ivoire Flag",
+    "shortcodes": [
+      "flag-ci"
+    ],
+    "keywords": [
+      "ci",
+      "cote",
+      "d",
+      "ivoire",
+      "ivory",
+      "coast",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1ee",
+        "emoji": "🇨🇮"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇰",
+    "name": "Cook Islands Flag",
+    "shortcodes": [
+      "flag-ck"
+    ],
+    "keywords": [
+      "ck",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1f0",
+        "emoji": "🇨🇰"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇱",
+    "name": "Chile Flag",
+    "shortcodes": [
+      "flag-cl"
+    ],
+    "keywords": [
+      "cl",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1f1",
+        "emoji": "🇨🇱"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇲",
+    "name": "Cameroon Flag",
+    "shortcodes": [
+      "flag-cm"
+    ],
+    "keywords": [
+      "cm",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1f2",
+        "emoji": "🇨🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇳",
+    "name": "China Flag",
+    "shortcodes": [
+      "cn",
+      "flag-cn"
+    ],
+    "keywords": [
+      "cn",
+      "chinese",
+      "prc",
+      "country",
+      "nation",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1f3",
+        "emoji": "🇨🇳"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🇨🇴",
+    "name": "Colombia Flag",
+    "shortcodes": [
+      "flag-co"
+    ],
+    "keywords": [
+      "co",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1f4",
+        "emoji": "🇨🇴"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇵",
+    "name": "Clipperton Island Flag",
+    "shortcodes": [
+      "flag-cp"
+    ],
+    "keywords": [
+      "cp"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1f5",
+        "emoji": "🇨🇵"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇷",
+    "name": "Costa Rica Flag",
+    "shortcodes": [
+      "flag-cr"
+    ],
+    "keywords": [
+      "cr",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1f7",
+        "emoji": "🇨🇷"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇺",
+    "name": "Cuba Flag",
+    "shortcodes": [
+      "flag-cu"
+    ],
+    "keywords": [
+      "cu",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1fa",
+        "emoji": "🇨🇺"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇻",
+    "name": "Cape Verde Flag",
+    "shortcodes": [
+      "flag-cv"
+    ],
+    "keywords": [
+      "cv",
+      "cabo",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1fb",
+        "emoji": "🇨🇻"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇼",
+    "name": "Curaçao Flag",
+    "shortcodes": [
+      "flag-cw"
+    ],
+    "keywords": [
+      "cw",
+      "curacao",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1fc",
+        "emoji": "🇨🇼"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇽",
+    "name": "Christmas Island Flag",
+    "shortcodes": [
+      "flag-cx"
+    ],
+    "keywords": [
+      "cx",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1fd",
+        "emoji": "🇨🇽"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇾",
+    "name": "Cyprus Flag",
+    "shortcodes": [
+      "flag-cy"
+    ],
+    "keywords": [
+      "cy",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1fe",
+        "emoji": "🇨🇾"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇨🇿",
+    "name": "Czechia Flag",
+    "shortcodes": [
+      "flag-cz"
+    ],
+    "keywords": [
+      "cz",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e8-1f1ff",
+        "emoji": "🇨🇿"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇩🇪",
+    "name": "Germany Flag",
+    "shortcodes": [
+      "de",
+      "flag-de"
+    ],
+    "keywords": [
+      "de",
+      "german",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e9-1f1ea",
+        "emoji": "🇩🇪"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🇩🇬",
+    "name": "Diego Garcia Flag",
+    "shortcodes": [
+      "flag-dg"
+    ],
+    "keywords": [
+      "dg"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e9-1f1ec",
+        "emoji": "🇩🇬"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇩🇯",
+    "name": "Djibouti Flag",
+    "shortcodes": [
+      "flag-dj"
+    ],
+    "keywords": [
+      "dj",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e9-1f1ef",
+        "emoji": "🇩🇯"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇩🇰",
+    "name": "Denmark Flag",
+    "shortcodes": [
+      "flag-dk"
+    ],
+    "keywords": [
+      "dk",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e9-1f1f0",
+        "emoji": "🇩🇰"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇩🇲",
+    "name": "Dominica Flag",
+    "shortcodes": [
+      "flag-dm"
+    ],
+    "keywords": [
+      "dm",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e9-1f1f2",
+        "emoji": "🇩🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇩🇴",
+    "name": "Dominican Republic Flag",
+    "shortcodes": [
+      "flag-do"
+    ],
+    "keywords": [
+      "do",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e9-1f1f4",
+        "emoji": "🇩🇴"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇩🇿",
+    "name": "Algeria Flag",
+    "shortcodes": [
+      "flag-dz"
+    ],
+    "keywords": [
+      "dz",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1e9-1f1ff",
+        "emoji": "🇩🇿"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇪🇦",
+    "name": "Ceuta & Melilla Flag",
+    "shortcodes": [
+      "flag-ea"
+    ],
+    "keywords": [
+      "ea"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ea-1f1e6",
+        "emoji": "🇪🇦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇪🇨",
+    "name": "Ecuador Flag",
+    "shortcodes": [
+      "flag-ec"
+    ],
+    "keywords": [
+      "ec",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ea-1f1e8",
+        "emoji": "🇪🇨"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇪🇪",
+    "name": "Estonia Flag",
+    "shortcodes": [
+      "flag-ee"
+    ],
+    "keywords": [
+      "ee",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ea-1f1ea",
+        "emoji": "🇪🇪"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇪🇬",
+    "name": "Egypt Flag",
+    "shortcodes": [
+      "flag-eg"
+    ],
+    "keywords": [
+      "eg",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ea-1f1ec",
+        "emoji": "🇪🇬"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇪🇭",
+    "name": "Western Sahara Flag",
+    "shortcodes": [
+      "flag-eh"
+    ],
+    "keywords": [
+      "eh",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ea-1f1ed",
+        "emoji": "🇪🇭"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇪🇷",
+    "name": "Eritrea Flag",
+    "shortcodes": [
+      "flag-er"
+    ],
+    "keywords": [
+      "er",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ea-1f1f7",
+        "emoji": "🇪🇷"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇪🇸",
+    "name": "Spain Flag",
+    "shortcodes": [
+      "es",
+      "flag-es"
+    ],
+    "keywords": [
+      "es",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ea-1f1f8",
+        "emoji": "🇪🇸"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🇪🇹",
+    "name": "Ethiopia Flag",
+    "shortcodes": [
+      "flag-et"
+    ],
+    "keywords": [
+      "et",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ea-1f1f9",
+        "emoji": "🇪🇹"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇪🇺",
+    "name": "European Union Flag",
+    "shortcodes": [
+      "flag-eu"
+    ],
+    "keywords": [
+      "eu",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ea-1f1fa",
+        "emoji": "🇪🇺"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇫🇮",
+    "name": "Finland Flag",
+    "shortcodes": [
+      "flag-fi"
+    ],
+    "keywords": [
+      "fi",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1eb-1f1ee",
+        "emoji": "🇫🇮"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇫🇯",
+    "name": "Fiji Flag",
+    "shortcodes": [
+      "flag-fj"
+    ],
+    "keywords": [
+      "fj",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1eb-1f1ef",
+        "emoji": "🇫🇯"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇫🇰",
+    "name": "Falkland Islands Flag",
+    "shortcodes": [
+      "flag-fk"
+    ],
+    "keywords": [
+      "fk",
+      "malvinas",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1eb-1f1f0",
+        "emoji": "🇫🇰"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇫🇲",
+    "name": "Micronesia Flag",
+    "shortcodes": [
+      "flag-fm"
+    ],
+    "keywords": [
+      "fm",
+      "federated",
+      "states",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1eb-1f1f2",
+        "emoji": "🇫🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇫🇴",
+    "name": "Faroe Islands Flag",
+    "shortcodes": [
+      "flag-fo"
+    ],
+    "keywords": [
+      "fo",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1eb-1f1f4",
+        "emoji": "🇫🇴"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇫🇷",
+    "name": "France Flag",
+    "shortcodes": [
+      "fr",
+      "flag-fr"
+    ],
+    "keywords": [
+      "fr",
+      "banner",
+      "nation",
+      "french",
+      "country"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1eb-1f1f7",
+        "emoji": "🇫🇷"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🇬🇦",
+    "name": "Gabon Flag",
+    "shortcodes": [
+      "flag-ga"
+    ],
+    "keywords": [
+      "ga",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1e6",
+        "emoji": "🇬🇦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇧",
+    "name": "United Kingdom Flag",
+    "shortcodes": [
+      "gb",
+      "uk",
+      "flag-gb"
+    ],
+    "keywords": [
+      "gb",
+      "uk",
+      "great",
+      "britain",
+      "northern",
+      "ireland",
+      "nation",
+      "country",
+      "banner",
+      "british",
+      "UK",
+      "english",
+      "england",
+      "union",
+      "jack"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1e7",
+        "emoji": "🇬🇧"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🇬🇩",
+    "name": "Grenada Flag",
+    "shortcodes": [
+      "flag-gd"
+    ],
+    "keywords": [
+      "gd",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1e9",
+        "emoji": "🇬🇩"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇪",
+    "name": "Georgia Flag",
+    "shortcodes": [
+      "flag-ge"
+    ],
+    "keywords": [
+      "ge",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1ea",
+        "emoji": "🇬🇪"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇫",
+    "name": "French Guiana Flag",
+    "shortcodes": [
+      "flag-gf"
+    ],
+    "keywords": [
+      "gf",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1eb",
+        "emoji": "🇬🇫"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇬",
+    "name": "Guernsey Flag",
+    "shortcodes": [
+      "flag-gg"
+    ],
+    "keywords": [
+      "gg",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1ec",
+        "emoji": "🇬🇬"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇭",
+    "name": "Ghana Flag",
+    "shortcodes": [
+      "flag-gh"
+    ],
+    "keywords": [
+      "gh",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1ed",
+        "emoji": "🇬🇭"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇮",
+    "name": "Gibraltar Flag",
+    "shortcodes": [
+      "flag-gi"
+    ],
+    "keywords": [
+      "gi",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1ee",
+        "emoji": "🇬🇮"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇱",
+    "name": "Greenland Flag",
+    "shortcodes": [
+      "flag-gl"
+    ],
+    "keywords": [
+      "gl",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1f1",
+        "emoji": "🇬🇱"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇲",
+    "name": "Gambia Flag",
+    "shortcodes": [
+      "flag-gm"
+    ],
+    "keywords": [
+      "gm",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1f2",
+        "emoji": "🇬🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇳",
+    "name": "Guinea Flag",
+    "shortcodes": [
+      "flag-gn"
+    ],
+    "keywords": [
+      "gn",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1f3",
+        "emoji": "🇬🇳"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇵",
+    "name": "Guadeloupe Flag",
+    "shortcodes": [
+      "flag-gp"
+    ],
+    "keywords": [
+      "gp",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1f5",
+        "emoji": "🇬🇵"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇶",
+    "name": "Equatorial Guinea Flag",
+    "shortcodes": [
+      "flag-gq"
+    ],
+    "keywords": [
+      "gq",
+      "gn",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1f6",
+        "emoji": "🇬🇶"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇷",
+    "name": "Greece Flag",
+    "shortcodes": [
+      "flag-gr"
+    ],
+    "keywords": [
+      "gr",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1f7",
+        "emoji": "🇬🇷"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇸",
+    "name": "South Georgia & South Sandwich Islands Flag",
+    "shortcodes": [
+      "flag-gs"
+    ],
+    "keywords": [
+      "gs",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1f8",
+        "emoji": "🇬🇸"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇹",
+    "name": "Guatemala Flag",
+    "shortcodes": [
+      "flag-gt"
+    ],
+    "keywords": [
+      "gt",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1f9",
+        "emoji": "🇬🇹"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇺",
+    "name": "Guam Flag",
+    "shortcodes": [
+      "flag-gu"
+    ],
+    "keywords": [
+      "gu",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1fa",
+        "emoji": "🇬🇺"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇼",
+    "name": "Guinea-Bissau Flag",
+    "shortcodes": [
+      "flag-gw"
+    ],
+    "keywords": [
+      "gw",
+      "guinea",
+      "bissau",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1fc",
+        "emoji": "🇬🇼"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇬🇾",
+    "name": "Guyana Flag",
+    "shortcodes": [
+      "flag-gy"
+    ],
+    "keywords": [
+      "gy",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ec-1f1fe",
+        "emoji": "🇬🇾"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇭🇰",
+    "name": "Hong Kong Sar China Flag",
+    "shortcodes": [
+      "flag-hk"
+    ],
+    "keywords": [
+      "hk",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ed-1f1f0",
+        "emoji": "🇭🇰"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇭🇲",
+    "name": "Heard & Mcdonald Islands Flag",
+    "shortcodes": [
+      "flag-hm"
+    ],
+    "keywords": [
+      "hm"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ed-1f1f2",
+        "emoji": "🇭🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇭🇳",
+    "name": "Honduras Flag",
+    "shortcodes": [
+      "flag-hn"
+    ],
+    "keywords": [
+      "hn",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ed-1f1f3",
+        "emoji": "🇭🇳"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇭🇷",
+    "name": "Croatia Flag",
+    "shortcodes": [
+      "flag-hr"
+    ],
+    "keywords": [
+      "hr",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ed-1f1f7",
+        "emoji": "🇭🇷"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇭🇹",
+    "name": "Haiti Flag",
+    "shortcodes": [
+      "flag-ht"
+    ],
+    "keywords": [
+      "ht",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ed-1f1f9",
+        "emoji": "🇭🇹"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇭🇺",
+    "name": "Hungary Flag",
+    "shortcodes": [
+      "flag-hu"
+    ],
+    "keywords": [
+      "hu",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ed-1f1fa",
+        "emoji": "🇭🇺"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇮🇨",
+    "name": "Canary Islands Flag",
+    "shortcodes": [
+      "flag-ic"
+    ],
+    "keywords": [
+      "ic",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ee-1f1e8",
+        "emoji": "🇮🇨"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇮🇩",
+    "name": "Indonesia Flag",
+    "shortcodes": [
+      "flag-id"
+    ],
+    "keywords": [
+      "id",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ee-1f1e9",
+        "emoji": "🇮🇩"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇮🇪",
+    "name": "Ireland Flag",
+    "shortcodes": [
+      "flag-ie"
+    ],
+    "keywords": [
+      "ie",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ee-1f1ea",
+        "emoji": "🇮🇪"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇮🇱",
+    "name": "Israel Flag",
+    "shortcodes": [
+      "flag-il"
+    ],
+    "keywords": [
+      "il",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ee-1f1f1",
+        "emoji": "🇮🇱"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇮🇲",
+    "name": "Isle of Man Flag",
+    "shortcodes": [
+      "flag-im"
+    ],
+    "keywords": [
+      "im",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ee-1f1f2",
+        "emoji": "🇮🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇮🇳",
+    "name": "India Flag",
+    "shortcodes": [
+      "flag-in"
+    ],
+    "keywords": [
+      "in",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ee-1f1f3",
+        "emoji": "🇮🇳"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇮🇴",
+    "name": "British Indian Ocean Territory Flag",
+    "shortcodes": [
+      "flag-io"
+    ],
+    "keywords": [
+      "io",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ee-1f1f4",
+        "emoji": "🇮🇴"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇮🇶",
+    "name": "Iraq Flag",
+    "shortcodes": [
+      "flag-iq"
+    ],
+    "keywords": [
+      "iq",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ee-1f1f6",
+        "emoji": "🇮🇶"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇮🇷",
+    "name": "Iran Flag",
+    "shortcodes": [
+      "flag-ir"
+    ],
+    "keywords": [
+      "ir",
+      "islamic",
+      "republic",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ee-1f1f7",
+        "emoji": "🇮🇷"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇮🇸",
+    "name": "Iceland Flag",
+    "shortcodes": [
+      "flag-is"
+    ],
+    "keywords": [
+      "is",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ee-1f1f8",
+        "emoji": "🇮🇸"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇮🇹",
+    "name": "Italy Flag",
+    "shortcodes": [
+      "it",
+      "flag-it"
+    ],
+    "keywords": [
+      "it",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ee-1f1f9",
+        "emoji": "🇮🇹"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🇯🇪",
+    "name": "Jersey Flag",
+    "shortcodes": [
+      "flag-je"
+    ],
+    "keywords": [
+      "je",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ef-1f1ea",
+        "emoji": "🇯🇪"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇯🇲",
+    "name": "Jamaica Flag",
+    "shortcodes": [
+      "flag-jm"
+    ],
+    "keywords": [
+      "jm",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ef-1f1f2",
+        "emoji": "🇯🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇯🇴",
+    "name": "Jordan Flag",
+    "shortcodes": [
+      "flag-jo"
+    ],
+    "keywords": [
+      "jo",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ef-1f1f4",
+        "emoji": "🇯🇴"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇯🇵",
+    "name": "Japan Flag",
+    "shortcodes": [
+      "jp",
+      "flag-jp"
+    ],
+    "keywords": [
+      "jp",
+      "japanese",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ef-1f1f5",
+        "emoji": "🇯🇵"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🇰🇪",
+    "name": "Kenya Flag",
+    "shortcodes": [
+      "flag-ke"
+    ],
+    "keywords": [
+      "ke",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f0-1f1ea",
+        "emoji": "🇰🇪"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇰🇬",
+    "name": "Kyrgyzstan Flag",
+    "shortcodes": [
+      "flag-kg"
+    ],
+    "keywords": [
+      "kg",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f0-1f1ec",
+        "emoji": "🇰🇬"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇰🇭",
+    "name": "Cambodia Flag",
+    "shortcodes": [
+      "flag-kh"
+    ],
+    "keywords": [
+      "kh",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f0-1f1ed",
+        "emoji": "🇰🇭"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇰🇮",
+    "name": "Kiribati Flag",
+    "shortcodes": [
+      "flag-ki"
+    ],
+    "keywords": [
+      "ki",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f0-1f1ee",
+        "emoji": "🇰🇮"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇰🇲",
+    "name": "Comoros Flag",
+    "shortcodes": [
+      "flag-km"
+    ],
+    "keywords": [
+      "km",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f0-1f1f2",
+        "emoji": "🇰🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇰🇳",
+    "name": "St. Kitts & Nevis Flag",
+    "shortcodes": [
+      "flag-kn"
+    ],
+    "keywords": [
+      "kn",
+      "st",
+      "saint",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f0-1f1f3",
+        "emoji": "🇰🇳"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇰🇵",
+    "name": "North Korea Flag",
+    "shortcodes": [
+      "flag-kp"
+    ],
+    "keywords": [
+      "kp",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f0-1f1f5",
+        "emoji": "🇰🇵"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇰🇷",
+    "name": "South Korea Flag",
+    "shortcodes": [
+      "kr",
+      "flag-kr"
+    ],
+    "keywords": [
+      "kr",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f0-1f1f7",
+        "emoji": "🇰🇷"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🇰🇼",
+    "name": "Kuwait Flag",
+    "shortcodes": [
+      "flag-kw"
+    ],
+    "keywords": [
+      "kw",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f0-1f1fc",
+        "emoji": "🇰🇼"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇰🇾",
+    "name": "Cayman Islands Flag",
+    "shortcodes": [
+      "flag-ky"
+    ],
+    "keywords": [
+      "ky",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f0-1f1fe",
+        "emoji": "🇰🇾"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇰🇿",
+    "name": "Kazakhstan Flag",
+    "shortcodes": [
+      "flag-kz"
+    ],
+    "keywords": [
+      "kz",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f0-1f1ff",
+        "emoji": "🇰🇿"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇱🇦",
+    "name": "Laos Flag",
+    "shortcodes": [
+      "flag-la"
+    ],
+    "keywords": [
+      "la",
+      "lao",
+      "democratic",
+      "republic",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f1-1f1e6",
+        "emoji": "🇱🇦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇱🇧",
+    "name": "Lebanon Flag",
+    "shortcodes": [
+      "flag-lb"
+    ],
+    "keywords": [
+      "lb",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f1-1f1e7",
+        "emoji": "🇱🇧"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇱🇨",
+    "name": "St. Lucia Flag",
+    "shortcodes": [
+      "flag-lc"
+    ],
+    "keywords": [
+      "lc",
+      "st",
+      "saint",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f1-1f1e8",
+        "emoji": "🇱🇨"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇱🇮",
+    "name": "Liechtenstein Flag",
+    "shortcodes": [
+      "flag-li"
+    ],
+    "keywords": [
+      "li",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f1-1f1ee",
+        "emoji": "🇱🇮"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇱🇰",
+    "name": "Sri Lanka Flag",
+    "shortcodes": [
+      "flag-lk"
+    ],
+    "keywords": [
+      "lk",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f1-1f1f0",
+        "emoji": "🇱🇰"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇱🇷",
+    "name": "Liberia Flag",
+    "shortcodes": [
+      "flag-lr"
+    ],
+    "keywords": [
+      "lr",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f1-1f1f7",
+        "emoji": "🇱🇷"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇱🇸",
+    "name": "Lesotho Flag",
+    "shortcodes": [
+      "flag-ls"
+    ],
+    "keywords": [
+      "ls",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f1-1f1f8",
+        "emoji": "🇱🇸"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇱🇹",
+    "name": "Lithuania Flag",
+    "shortcodes": [
+      "flag-lt"
+    ],
+    "keywords": [
+      "lt",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f1-1f1f9",
+        "emoji": "🇱🇹"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇱🇺",
+    "name": "Luxembourg Flag",
+    "shortcodes": [
+      "flag-lu"
+    ],
+    "keywords": [
+      "lu",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f1-1f1fa",
+        "emoji": "🇱🇺"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇱🇻",
+    "name": "Latvia Flag",
+    "shortcodes": [
+      "flag-lv"
+    ],
+    "keywords": [
+      "lv",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f1-1f1fb",
+        "emoji": "🇱🇻"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇱🇾",
+    "name": "Libya Flag",
+    "shortcodes": [
+      "flag-ly"
+    ],
+    "keywords": [
+      "ly",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f1-1f1fe",
+        "emoji": "🇱🇾"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇦",
+    "name": "Morocco Flag",
+    "shortcodes": [
+      "flag-ma"
+    ],
+    "keywords": [
+      "ma",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1e6",
+        "emoji": "🇲🇦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇨",
+    "name": "Monaco Flag",
+    "shortcodes": [
+      "flag-mc"
+    ],
+    "keywords": [
+      "mc",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1e8",
+        "emoji": "🇲🇨"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇩",
+    "name": "Moldova Flag",
+    "shortcodes": [
+      "flag-md"
+    ],
+    "keywords": [
+      "md",
+      "republic",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1e9",
+        "emoji": "🇲🇩"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇪",
+    "name": "Montenegro Flag",
+    "shortcodes": [
+      "flag-me"
+    ],
+    "keywords": [
+      "me",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1ea",
+        "emoji": "🇲🇪"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇫",
+    "name": "St. Martin Flag",
+    "shortcodes": [
+      "flag-mf"
+    ],
+    "keywords": [
+      "mf",
+      "st"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1eb",
+        "emoji": "🇲🇫"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇬",
+    "name": "Madagascar Flag",
+    "shortcodes": [
+      "flag-mg"
+    ],
+    "keywords": [
+      "mg",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1ec",
+        "emoji": "🇲🇬"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇭",
+    "name": "Marshall Islands Flag",
+    "shortcodes": [
+      "flag-mh"
+    ],
+    "keywords": [
+      "mh",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1ed",
+        "emoji": "🇲🇭"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇰",
+    "name": "North Macedonia Flag",
+    "shortcodes": [
+      "flag-mk"
+    ],
+    "keywords": [
+      "mk",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1f0",
+        "emoji": "🇲🇰"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇱",
+    "name": "Mali Flag",
+    "shortcodes": [
+      "flag-ml"
+    ],
+    "keywords": [
+      "ml",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1f1",
+        "emoji": "🇲🇱"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇲",
+    "name": "Myanmar (burma) Flag",
+    "shortcodes": [
+      "flag-mm"
+    ],
+    "keywords": [
+      "mm",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1f2",
+        "emoji": "🇲🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇳",
+    "name": "Mongolia Flag",
+    "shortcodes": [
+      "flag-mn"
+    ],
+    "keywords": [
+      "mn",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1f3",
+        "emoji": "🇲🇳"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇴",
+    "name": "Macao Sar China Flag",
+    "shortcodes": [
+      "flag-mo"
+    ],
+    "keywords": [
+      "mo",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1f4",
+        "emoji": "🇲🇴"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇵",
+    "name": "Northern Mariana Islands Flag",
+    "shortcodes": [
+      "flag-mp"
+    ],
+    "keywords": [
+      "mp",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1f5",
+        "emoji": "🇲🇵"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇶",
+    "name": "Martinique Flag",
+    "shortcodes": [
+      "flag-mq"
+    ],
+    "keywords": [
+      "mq",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1f6",
+        "emoji": "🇲🇶"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇷",
+    "name": "Mauritania Flag",
+    "shortcodes": [
+      "flag-mr"
+    ],
+    "keywords": [
+      "mr",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1f7",
+        "emoji": "🇲🇷"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇸",
+    "name": "Montserrat Flag",
+    "shortcodes": [
+      "flag-ms"
+    ],
+    "keywords": [
+      "ms",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1f8",
+        "emoji": "🇲🇸"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇹",
+    "name": "Malta Flag",
+    "shortcodes": [
+      "flag-mt"
+    ],
+    "keywords": [
+      "mt",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1f9",
+        "emoji": "🇲🇹"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇺",
+    "name": "Mauritius Flag",
+    "shortcodes": [
+      "flag-mu"
+    ],
+    "keywords": [
+      "mu",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1fa",
+        "emoji": "🇲🇺"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇻",
+    "name": "Maldives Flag",
+    "shortcodes": [
+      "flag-mv"
+    ],
+    "keywords": [
+      "mv",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1fb",
+        "emoji": "🇲🇻"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇼",
+    "name": "Malawi Flag",
+    "shortcodes": [
+      "flag-mw"
+    ],
+    "keywords": [
+      "mw",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1fc",
+        "emoji": "🇲🇼"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇽",
+    "name": "Mexico Flag",
+    "shortcodes": [
+      "flag-mx"
+    ],
+    "keywords": [
+      "mx",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1fd",
+        "emoji": "🇲🇽"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇾",
+    "name": "Malaysia Flag",
+    "shortcodes": [
+      "flag-my"
+    ],
+    "keywords": [
+      "my",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1fe",
+        "emoji": "🇲🇾"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇲🇿",
+    "name": "Mozambique Flag",
+    "shortcodes": [
+      "flag-mz"
+    ],
+    "keywords": [
+      "mz",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f2-1f1ff",
+        "emoji": "🇲🇿"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇳🇦",
+    "name": "Namibia Flag",
+    "shortcodes": [
+      "flag-na"
+    ],
+    "keywords": [
+      "na",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f3-1f1e6",
+        "emoji": "🇳🇦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇳🇨",
+    "name": "New Caledonia Flag",
+    "shortcodes": [
+      "flag-nc"
+    ],
+    "keywords": [
+      "nc",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f3-1f1e8",
+        "emoji": "🇳🇨"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇳🇪",
+    "name": "Niger Flag",
+    "shortcodes": [
+      "flag-ne"
+    ],
+    "keywords": [
+      "ne",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f3-1f1ea",
+        "emoji": "🇳🇪"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇳🇫",
+    "name": "Norfolk Island Flag",
+    "shortcodes": [
+      "flag-nf"
+    ],
+    "keywords": [
+      "nf",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f3-1f1eb",
+        "emoji": "🇳🇫"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇳🇬",
+    "name": "Nigeria Flag",
+    "shortcodes": [
+      "flag-ng"
+    ],
+    "keywords": [
+      "ng",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f3-1f1ec",
+        "emoji": "🇳🇬"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇳🇮",
+    "name": "Nicaragua Flag",
+    "shortcodes": [
+      "flag-ni"
+    ],
+    "keywords": [
+      "ni",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f3-1f1ee",
+        "emoji": "🇳🇮"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇳🇱",
+    "name": "Netherlands Flag",
+    "shortcodes": [
+      "flag-nl"
+    ],
+    "keywords": [
+      "nl",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f3-1f1f1",
+        "emoji": "🇳🇱"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇳🇴",
+    "name": "Norway Flag",
+    "shortcodes": [
+      "flag-no"
+    ],
+    "keywords": [
+      "no",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f3-1f1f4",
+        "emoji": "🇳🇴"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇳🇵",
+    "name": "Nepal Flag",
+    "shortcodes": [
+      "flag-np"
+    ],
+    "keywords": [
+      "np",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f3-1f1f5",
+        "emoji": "🇳🇵"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇳🇷",
+    "name": "Nauru Flag",
+    "shortcodes": [
+      "flag-nr"
+    ],
+    "keywords": [
+      "nr",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f3-1f1f7",
+        "emoji": "🇳🇷"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇳🇺",
+    "name": "Niue Flag",
+    "shortcodes": [
+      "flag-nu"
+    ],
+    "keywords": [
+      "nu",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f3-1f1fa",
+        "emoji": "🇳🇺"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇳🇿",
+    "name": "New Zealand Flag",
+    "shortcodes": [
+      "flag-nz"
+    ],
+    "keywords": [
+      "nz",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f3-1f1ff",
+        "emoji": "🇳🇿"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇴🇲",
+    "name": "Oman Flag",
+    "shortcodes": [
+      "flag-om"
+    ],
+    "keywords": [
+      "om",
+      "symbol",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f4-1f1f2",
+        "emoji": "🇴🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇵🇦",
+    "name": "Panama Flag",
+    "shortcodes": [
+      "flag-pa"
+    ],
+    "keywords": [
+      "pa",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f5-1f1e6",
+        "emoji": "🇵🇦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇵🇪",
+    "name": "Peru Flag",
+    "shortcodes": [
+      "flag-pe"
+    ],
+    "keywords": [
+      "pe",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f5-1f1ea",
+        "emoji": "🇵🇪"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇵🇫",
+    "name": "French Polynesia Flag",
+    "shortcodes": [
+      "flag-pf"
+    ],
+    "keywords": [
+      "pf",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f5-1f1eb",
+        "emoji": "🇵🇫"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇵🇬",
+    "name": "Papua New Guinea Flag",
+    "shortcodes": [
+      "flag-pg"
+    ],
+    "keywords": [
+      "pg",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f5-1f1ec",
+        "emoji": "🇵🇬"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇵🇭",
+    "name": "Philippines Flag",
+    "shortcodes": [
+      "flag-ph"
+    ],
+    "keywords": [
+      "ph",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f5-1f1ed",
+        "emoji": "🇵🇭"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇵🇰",
+    "name": "Pakistan Flag",
+    "shortcodes": [
+      "flag-pk"
+    ],
+    "keywords": [
+      "pk",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f5-1f1f0",
+        "emoji": "🇵🇰"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇵🇱",
+    "name": "Poland Flag",
+    "shortcodes": [
+      "flag-pl"
+    ],
+    "keywords": [
+      "pl",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f5-1f1f1",
+        "emoji": "🇵🇱"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇵🇲",
+    "name": "St. Pierre & Miquelon Flag",
+    "shortcodes": [
+      "flag-pm"
+    ],
+    "keywords": [
+      "pm",
+      "st",
+      "saint",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f5-1f1f2",
+        "emoji": "🇵🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇵🇳",
+    "name": "Pitcairn Islands Flag",
+    "shortcodes": [
+      "flag-pn"
+    ],
+    "keywords": [
+      "pn",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f5-1f1f3",
+        "emoji": "🇵🇳"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇵🇷",
+    "name": "Puerto Rico Flag",
+    "shortcodes": [
+      "flag-pr"
+    ],
+    "keywords": [
+      "pr",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f5-1f1f7",
+        "emoji": "🇵🇷"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇵🇸",
+    "name": "Palestinian Territories Flag",
+    "shortcodes": [
+      "flag-ps"
+    ],
+    "keywords": [
+      "ps",
+      "palestine",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f5-1f1f8",
+        "emoji": "🇵🇸"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇵🇹",
+    "name": "Portugal Flag",
+    "shortcodes": [
+      "flag-pt"
+    ],
+    "keywords": [
+      "pt",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f5-1f1f9",
+        "emoji": "🇵🇹"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇵🇼",
+    "name": "Palau Flag",
+    "shortcodes": [
+      "flag-pw"
+    ],
+    "keywords": [
+      "pw",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f5-1f1fc",
+        "emoji": "🇵🇼"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇵🇾",
+    "name": "Paraguay Flag",
+    "shortcodes": [
+      "flag-py"
+    ],
+    "keywords": [
+      "py",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f5-1f1fe",
+        "emoji": "🇵🇾"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇶🇦",
+    "name": "Qatar Flag",
+    "shortcodes": [
+      "flag-qa"
+    ],
+    "keywords": [
+      "qa",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f6-1f1e6",
+        "emoji": "🇶🇦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇷🇪",
+    "name": "Réunion Flag",
+    "shortcodes": [
+      "flag-re"
+    ],
+    "keywords": [
+      "re",
+      "reunion",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f7-1f1ea",
+        "emoji": "🇷🇪"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇷🇴",
+    "name": "Romania Flag",
+    "shortcodes": [
+      "flag-ro"
+    ],
+    "keywords": [
+      "ro",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f7-1f1f4",
+        "emoji": "🇷🇴"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇷🇸",
+    "name": "Serbia Flag",
+    "shortcodes": [
+      "flag-rs"
+    ],
+    "keywords": [
+      "rs",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f7-1f1f8",
+        "emoji": "🇷🇸"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇷🇺",
+    "name": "Russia Flag",
+    "shortcodes": [
+      "ru",
+      "flag-ru"
+    ],
+    "keywords": [
+      "ru",
+      "russian",
+      "federation",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f7-1f1fa",
+        "emoji": "🇷🇺"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🇷🇼",
+    "name": "Rwanda Flag",
+    "shortcodes": [
+      "flag-rw"
+    ],
+    "keywords": [
+      "rw",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f7-1f1fc",
+        "emoji": "🇷🇼"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇦",
+    "name": "Saudi Arabia Flag",
+    "shortcodes": [
+      "flag-sa"
+    ],
+    "keywords": [
+      "sa",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1e6",
+        "emoji": "🇸🇦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇧",
+    "name": "Solomon Islands Flag",
+    "shortcodes": [
+      "flag-sb"
+    ],
+    "keywords": [
+      "sb",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1e7",
+        "emoji": "🇸🇧"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇨",
+    "name": "Seychelles Flag",
+    "shortcodes": [
+      "flag-sc"
+    ],
+    "keywords": [
+      "sc",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1e8",
+        "emoji": "🇸🇨"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇩",
+    "name": "Sudan Flag",
+    "shortcodes": [
+      "flag-sd"
+    ],
+    "keywords": [
+      "sd",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1e9",
+        "emoji": "🇸🇩"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇪",
+    "name": "Sweden Flag",
+    "shortcodes": [
+      "flag-se"
+    ],
+    "keywords": [
+      "se",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1ea",
+        "emoji": "🇸🇪"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇬",
+    "name": "Singapore Flag",
+    "shortcodes": [
+      "flag-sg"
+    ],
+    "keywords": [
+      "sg",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1ec",
+        "emoji": "🇸🇬"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇭",
+    "name": "St. Helena Flag",
+    "shortcodes": [
+      "flag-sh"
+    ],
+    "keywords": [
+      "sh",
+      "st",
+      "saint",
+      "ascension",
+      "tristan",
+      "cunha",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1ed",
+        "emoji": "🇸🇭"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇮",
+    "name": "Slovenia Flag",
+    "shortcodes": [
+      "flag-si"
+    ],
+    "keywords": [
+      "si",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1ee",
+        "emoji": "🇸🇮"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇯",
+    "name": "Svalbard & Jan Mayen Flag",
+    "shortcodes": [
+      "flag-sj"
+    ],
+    "keywords": [
+      "sj"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1ef",
+        "emoji": "🇸🇯"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇰",
+    "name": "Slovakia Flag",
+    "shortcodes": [
+      "flag-sk"
+    ],
+    "keywords": [
+      "sk",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1f0",
+        "emoji": "🇸🇰"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇱",
+    "name": "Sierra Leone Flag",
+    "shortcodes": [
+      "flag-sl"
+    ],
+    "keywords": [
+      "sl",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1f1",
+        "emoji": "🇸🇱"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇲",
+    "name": "San Marino Flag",
+    "shortcodes": [
+      "flag-sm"
+    ],
+    "keywords": [
+      "sm",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1f2",
+        "emoji": "🇸🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇳",
+    "name": "Senegal Flag",
+    "shortcodes": [
+      "flag-sn"
+    ],
+    "keywords": [
+      "sn",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1f3",
+        "emoji": "🇸🇳"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇴",
+    "name": "Somalia Flag",
+    "shortcodes": [
+      "flag-so"
+    ],
+    "keywords": [
+      "so",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1f4",
+        "emoji": "🇸🇴"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇷",
+    "name": "Suriname Flag",
+    "shortcodes": [
+      "flag-sr"
+    ],
+    "keywords": [
+      "sr",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1f7",
+        "emoji": "🇸🇷"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇸",
+    "name": "South Sudan Flag",
+    "shortcodes": [
+      "flag-ss"
+    ],
+    "keywords": [
+      "ss",
+      "sd",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1f8",
+        "emoji": "🇸🇸"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇹",
+    "name": "São Tomé & Príncipe Flag",
+    "shortcodes": [
+      "flag-st"
+    ],
+    "keywords": [
+      "st",
+      "sao",
+      "tome",
+      "principe",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1f9",
+        "emoji": "🇸🇹"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇻",
+    "name": "El Salvador Flag",
+    "shortcodes": [
+      "flag-sv"
+    ],
+    "keywords": [
+      "sv",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1fb",
+        "emoji": "🇸🇻"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇽",
+    "name": "Sint Maarten Flag",
+    "shortcodes": [
+      "flag-sx"
+    ],
+    "keywords": [
+      "sx",
+      "dutch",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1fd",
+        "emoji": "🇸🇽"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇾",
+    "name": "Syria Flag",
+    "shortcodes": [
+      "flag-sy"
+    ],
+    "keywords": [
+      "sy",
+      "syrian",
+      "arab",
+      "republic",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1fe",
+        "emoji": "🇸🇾"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇸🇿",
+    "name": "Eswatini Flag",
+    "shortcodes": [
+      "flag-sz"
+    ],
+    "keywords": [
+      "sz",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f8-1f1ff",
+        "emoji": "🇸🇿"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇦",
+    "name": "Tristan Da Cunha Flag",
+    "shortcodes": [
+      "flag-ta"
+    ],
+    "keywords": [
+      "ta"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1e6",
+        "emoji": "🇹🇦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇨",
+    "name": "Turks & Caicos Islands Flag",
+    "shortcodes": [
+      "flag-tc"
+    ],
+    "keywords": [
+      "tc",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1e8",
+        "emoji": "🇹🇨"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇩",
+    "name": "Chad Flag",
+    "shortcodes": [
+      "flag-td"
+    ],
+    "keywords": [
+      "td",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1e9",
+        "emoji": "🇹🇩"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇫",
+    "name": "French Southern Territories Flag",
+    "shortcodes": [
+      "flag-tf"
+    ],
+    "keywords": [
+      "tf",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1eb",
+        "emoji": "🇹🇫"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇬",
+    "name": "Togo Flag",
+    "shortcodes": [
+      "flag-tg"
+    ],
+    "keywords": [
+      "tg",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1ec",
+        "emoji": "🇹🇬"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇭",
+    "name": "Thailand Flag",
+    "shortcodes": [
+      "flag-th"
+    ],
+    "keywords": [
+      "th",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1ed",
+        "emoji": "🇹🇭"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇯",
+    "name": "Tajikistan Flag",
+    "shortcodes": [
+      "flag-tj"
+    ],
+    "keywords": [
+      "tj",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1ef",
+        "emoji": "🇹🇯"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇰",
+    "name": "Tokelau Flag",
+    "shortcodes": [
+      "flag-tk"
+    ],
+    "keywords": [
+      "tk",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1f0",
+        "emoji": "🇹🇰"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇱",
+    "name": "Timor-Leste Flag",
+    "shortcodes": [
+      "flag-tl"
+    ],
+    "keywords": [
+      "tl",
+      "timor",
+      "leste",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1f1",
+        "emoji": "🇹🇱"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇲",
+    "name": "Turkmenistan Flag",
+    "shortcodes": [
+      "flag-tm"
+    ],
+    "keywords": [
+      "tm",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1f2",
+        "emoji": "🇹🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇳",
+    "name": "Tunisia Flag",
+    "shortcodes": [
+      "flag-tn"
+    ],
+    "keywords": [
+      "tn",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1f3",
+        "emoji": "🇹🇳"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇴",
+    "name": "Tonga Flag",
+    "shortcodes": [
+      "flag-to"
+    ],
+    "keywords": [
+      "to",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1f4",
+        "emoji": "🇹🇴"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇷",
+    "name": "Turkey Flag",
+    "shortcodes": [
+      "flag-tr"
+    ],
+    "keywords": [
+      "tr",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1f7",
+        "emoji": "🇹🇷"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇹",
+    "name": "Trinidad & Tobago Flag",
+    "shortcodes": [
+      "flag-tt"
+    ],
+    "keywords": [
+      "tt",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1f9",
+        "emoji": "🇹🇹"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇻",
+    "name": "Tuvalu Flag",
+    "shortcodes": [
+      "flag-tv"
+    ],
+    "keywords": [
+      "tv",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1fb",
+        "emoji": "🇹🇻"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇼",
+    "name": "Taiwan Flag",
+    "shortcodes": [
+      "flag-tw"
+    ],
+    "keywords": [
+      "tw",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1fc",
+        "emoji": "🇹🇼"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇹🇿",
+    "name": "Tanzania Flag",
+    "shortcodes": [
+      "flag-tz"
+    ],
+    "keywords": [
+      "tz",
+      "united",
+      "republic",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1f9-1f1ff",
+        "emoji": "🇹🇿"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇺🇦",
+    "name": "Ukraine Flag",
+    "shortcodes": [
+      "flag-ua"
+    ],
+    "keywords": [
+      "ua",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fa-1f1e6",
+        "emoji": "🇺🇦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇺🇬",
+    "name": "Uganda Flag",
+    "shortcodes": [
+      "flag-ug"
+    ],
+    "keywords": [
+      "ug",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fa-1f1ec",
+        "emoji": "🇺🇬"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇺🇲",
+    "name": "U.s. Outlying Islands Flag",
+    "shortcodes": [
+      "flag-um"
+    ],
+    "keywords": [
+      "um",
+      "u",
+      "s"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fa-1f1f2",
+        "emoji": "🇺🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇺🇳",
+    "name": "United Nations Flag",
+    "shortcodes": [
+      "flag-un"
+    ],
+    "keywords": [
+      "un",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fa-1f1f3",
+        "emoji": "🇺🇳"
+      }
+    ],
+    "version": 4
+  },
+  {
+    "emoji": "🇺🇸",
+    "name": "United States Flag",
+    "shortcodes": [
+      "us",
+      "flag-us"
+    ],
+    "keywords": [
+      "us",
+      "america",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fa-1f1f8",
+        "emoji": "🇺🇸"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "emoji": "🇺🇾",
+    "name": "Uruguay Flag",
+    "shortcodes": [
+      "flag-uy"
+    ],
+    "keywords": [
+      "uy",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fa-1f1fe",
+        "emoji": "🇺🇾"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇺🇿",
+    "name": "Uzbekistan Flag",
+    "shortcodes": [
+      "flag-uz"
+    ],
+    "keywords": [
+      "uz",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fa-1f1ff",
+        "emoji": "🇺🇿"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇻🇦",
+    "name": "Vatican City Flag",
+    "shortcodes": [
+      "flag-va"
+    ],
+    "keywords": [
+      "va",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fb-1f1e6",
+        "emoji": "🇻🇦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇻🇨",
+    "name": "St. Vincent & Grenadines Flag",
+    "shortcodes": [
+      "flag-vc"
+    ],
+    "keywords": [
+      "vc",
+      "st",
+      "saint",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fb-1f1e8",
+        "emoji": "🇻🇨"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇻🇪",
+    "name": "Venezuela Flag",
+    "shortcodes": [
+      "flag-ve"
+    ],
+    "keywords": [
+      "ve",
+      "bolivarian",
+      "republic",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fb-1f1ea",
+        "emoji": "🇻🇪"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇻🇬",
+    "name": "British Virgin Islands Flag",
+    "shortcodes": [
+      "flag-vg"
+    ],
+    "keywords": [
+      "vg",
+      "bvi",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fb-1f1ec",
+        "emoji": "🇻🇬"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇻🇮",
+    "name": "U.s. Virgin Islands Flag",
+    "shortcodes": [
+      "flag-vi"
+    ],
+    "keywords": [
+      "vi",
+      "u",
+      "s",
+      "us",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fb-1f1ee",
+        "emoji": "🇻🇮"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇻🇳",
+    "name": "Vietnam Flag",
+    "shortcodes": [
+      "flag-vn"
+    ],
+    "keywords": [
+      "vn",
+      "viet",
+      "nam",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fb-1f1f3",
+        "emoji": "🇻🇳"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇻🇺",
+    "name": "Vanuatu Flag",
+    "shortcodes": [
+      "flag-vu"
+    ],
+    "keywords": [
+      "vu",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fb-1f1fa",
+        "emoji": "🇻🇺"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇼🇫",
+    "name": "Wallis & Futuna Flag",
+    "shortcodes": [
+      "flag-wf"
+    ],
+    "keywords": [
+      "wf",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fc-1f1eb",
+        "emoji": "🇼🇫"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇼🇸",
+    "name": "Samoa Flag",
+    "shortcodes": [
+      "flag-ws"
+    ],
+    "keywords": [
+      "ws",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fc-1f1f8",
+        "emoji": "🇼🇸"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇽🇰",
+    "name": "Kosovo Flag",
+    "shortcodes": [
+      "flag-xk"
+    ],
+    "keywords": [
+      "xk",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fd-1f1f0",
+        "emoji": "🇽🇰"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇾🇪",
+    "name": "Yemen Flag",
+    "shortcodes": [
+      "flag-ye"
+    ],
+    "keywords": [
+      "ye",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fe-1f1ea",
+        "emoji": "🇾🇪"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇾🇹",
+    "name": "Mayotte Flag",
+    "shortcodes": [
+      "flag-yt"
+    ],
+    "keywords": [
+      "yt",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1fe-1f1f9",
+        "emoji": "🇾🇹"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇿🇦",
+    "name": "South Africa Flag",
+    "shortcodes": [
+      "flag-za"
+    ],
+    "keywords": [
+      "za",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ff-1f1e6",
+        "emoji": "🇿🇦"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇿🇲",
+    "name": "Zambia Flag",
+    "shortcodes": [
+      "flag-zm"
+    ],
+    "keywords": [
+      "zm",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ff-1f1f2",
+        "emoji": "🇿🇲"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🇿🇼",
+    "name": "Zimbabwe Flag",
+    "shortcodes": [
+      "flag-zw"
+    ],
+    "keywords": [
+      "zw",
+      "nation",
+      "country",
+      "banner"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f1ff-1f1fc",
+        "emoji": "🇿🇼"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "emoji": "🏴󠁧󠁢󠁥󠁮󠁧󠁿",
+    "name": "England Flag",
+    "shortcodes": [
+      "flag-england"
+    ],
+    "keywords": [
+      "english"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3f4-e0067-e0062-e0065-e006e-e0067-e007f",
+        "emoji": "🏴󠁧󠁢󠁥󠁮󠁧󠁿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🏴󠁧󠁢󠁳󠁣󠁴󠁿",
+    "name": "Scotland Flag",
+    "shortcodes": [
+      "flag-scotland"
+    ],
+    "keywords": [
+      "scottish"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3f4-e0067-e0062-e0073-e0063-e0074-e007f",
+        "emoji": "🏴󠁧󠁢󠁳󠁣󠁴󠁿"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "emoji": "🏴󠁧󠁢󠁷󠁬󠁳󠁿",
+    "name": "Wales Flag",
+    "shortcodes": [
+      "flag-wales"
+    ],
+    "keywords": [
+      "welsh"
+    ],
+    "skins": [
+      {
+        "tone": "default",
+        "unified": "1f3f4-e0067-e0062-e0077-e006c-e0073-e007f",
+        "emoji": "🏴󠁧󠁢󠁷󠁬󠁳󠁿"
+      }
+    ],
+    "version": 5
+  }
+]

--- a/modules/desktop/inputBridge.ts
+++ b/modules/desktop/inputBridge.ts
@@ -1,0 +1,198 @@
+const TEXT_INPUT_TYPES = new Set([
+  'text',
+  'search',
+  'url',
+  'tel',
+  'password',
+  'email',
+  'number',
+  'textarea',
+]);
+
+export type TextLikeElement = HTMLInputElement | HTMLTextAreaElement;
+export type EditableElement = TextLikeElement | HTMLElement;
+
+type InputSelection = {
+  kind: 'input';
+  start: number;
+  end: number;
+};
+
+type ContentEditableSelection = {
+  kind: 'contenteditable';
+  range: Range;
+};
+
+export type EditableSnapshot = {
+  element: EditableElement;
+  selection?: InputSelection | ContentEditableSelection;
+};
+
+const isTextInputElement = (element: Element | null): element is TextLikeElement => {
+  if (!element) return false;
+  if (element instanceof HTMLTextAreaElement) return !element.readOnly && !element.disabled;
+  if (element instanceof HTMLInputElement) {
+    if (element.readOnly || element.disabled) return false;
+    const type = element.type?.toLowerCase();
+    return TEXT_INPUT_TYPES.has(type || 'text');
+  }
+  return false;
+};
+
+const isContentEditable = (element: Element | null): element is HTMLElement => {
+  if (!element) return false;
+  return element instanceof HTMLElement && element.isContentEditable;
+};
+
+export const getActiveEditable = (): EditableElement | null => {
+  if (typeof document === 'undefined') return null;
+  const active = document.activeElement;
+  if (isTextInputElement(active) || isContentEditable(active)) {
+    return active as EditableElement;
+  }
+  if (active instanceof HTMLElement && active.shadowRoot) {
+    const shadowActive = active.shadowRoot.activeElement;
+    if (isTextInputElement(shadowActive) || isContentEditable(shadowActive)) {
+      return shadowActive as EditableElement;
+    }
+  }
+  return null;
+};
+
+export const captureEditableSnapshot = (): EditableSnapshot | null => {
+  if (typeof window === 'undefined') return null;
+  const element = getActiveEditable();
+  if (!element) return null;
+
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    const start = element.selectionStart ?? element.value.length;
+    const end = element.selectionEnd ?? element.value.length;
+    return {
+      element,
+      selection: {
+        kind: 'input',
+        start,
+        end,
+      },
+    };
+  }
+
+  if (element instanceof HTMLElement && element.isContentEditable) {
+    const selection = window.getSelection();
+    if (selection && selection.rangeCount > 0) {
+      return {
+        element,
+        selection: {
+          kind: 'contenteditable',
+          range: selection.getRangeAt(0).cloneRange(),
+        },
+      };
+    }
+    return { element };
+  }
+
+  return null;
+};
+
+export const focusEditableElement = (element: EditableElement | null): boolean => {
+  if (!element || typeof element.focus !== 'function') return false;
+  element.focus();
+  return true;
+};
+
+export const restoreEditableSnapshot = (snapshot: EditableSnapshot | null): boolean => {
+  if (typeof window === 'undefined' || !snapshot) return false;
+  const { element, selection } = snapshot;
+  if (!focusEditableElement(element)) return false;
+
+  if (!selection) {
+    return true;
+  }
+
+  if (selection.kind === 'input' && element instanceof HTMLInputElement) {
+    element.setSelectionRange(selection.start, selection.end);
+    return true;
+  }
+
+  if (selection.kind === 'input' && element instanceof HTMLTextAreaElement) {
+    element.setSelectionRange(selection.start, selection.end);
+    return true;
+  }
+
+  if (
+    selection.kind === 'contenteditable' &&
+    element instanceof HTMLElement &&
+    element.isContentEditable
+  ) {
+    const windowSelection = window.getSelection();
+    if (!windowSelection) return false;
+    windowSelection.removeAllRanges();
+    windowSelection.addRange(selection.range.cloneRange());
+    return true;
+  }
+
+  return false;
+};
+
+const dispatchInputEvents = (element: HTMLElement) => {
+  element.dispatchEvent(new Event('input', { bubbles: true }));
+  element.dispatchEvent(new Event('change', { bubbles: true }));
+};
+
+export const insertText = (
+  text: string,
+  target?: EditableElement | null
+): boolean => {
+  if (typeof document === 'undefined') return false;
+  const element = (target ?? getActiveEditable()) as EditableElement | null;
+  if (!element) return false;
+
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    const start = element.selectionStart ?? element.value.length;
+    const end = element.selectionEnd ?? element.value.length;
+    const value = element.value;
+    const newValue = `${value.slice(0, start)}${text}${value.slice(end)}`;
+    element.value = newValue;
+    const caret = start + text.length;
+    element.setSelectionRange(caret, caret);
+    dispatchInputEvents(element);
+    return true;
+  }
+
+  if (element instanceof HTMLElement && element.isContentEditable) {
+    const selection = window.getSelection();
+    if (!selection) return false;
+    if (selection.rangeCount === 0) {
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      range.collapse(false);
+      selection.addRange(range);
+    }
+    const range = selection.getRangeAt(0);
+    range.deleteContents();
+    const textNode = document.createTextNode(text);
+    range.insertNode(textNode);
+    range.setStartAfter(textNode);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    dispatchInputEvents(element);
+    return true;
+  }
+
+  return false;
+};
+
+export const canInsert = (snapshot?: EditableSnapshot | null): boolean => {
+  if (snapshot?.element) return true;
+  return getActiveEditable() !== null;
+};
+
+export default {
+  getActiveEditable,
+  captureEditableSnapshot,
+  restoreEditableSnapshot,
+  focusEditableElement,
+  insertText,
+  canInsert,
+};

--- a/public/themes/Yaru/apps/emoji.svg
+++ b/public/themes/Yaru/apps/emoji.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title>Emoji Picker Icon</title>
+  <defs>
+    <radialGradient id="emojiFace" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#fff176" />
+      <stop offset="65%" stop-color="#fbc02d" />
+      <stop offset="100%" stop-color="#f57f17" />
+    </radialGradient>
+  </defs>
+  <circle cx="32" cy="32" r="28" fill="url(#emojiFace)" stroke="#f9a825" stroke-width="2" />
+  <ellipse cx="22" cy="26" rx="4" ry="6" fill="#3e2723" />
+  <ellipse cx="42" cy="26" rx="4" ry="6" fill="#3e2723" />
+  <path
+    d="M20 38c2.5 6 8 10 12 10s9.5-4 12-10"
+    fill="none"
+    stroke="#3e2723"
+    stroke-width="3"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/utils/settings/emoji.ts
+++ b/utils/settings/emoji.ts
@@ -1,0 +1,63 @@
+import { safeLocalStorage } from '../safeStorage';
+
+export type EmojiTone =
+  | 'default'
+  | 'light'
+  | 'medium-light'
+  | 'medium'
+  | 'medium-dark'
+  | 'dark';
+
+export const EMOJI_TONES: EmojiTone[] = [
+  'default',
+  'light',
+  'medium-light',
+  'medium',
+  'medium-dark',
+  'dark',
+];
+
+const TONE_KEY = 'emoji-preferred-tone';
+const RECENTS_KEY = 'emoji-recent-list';
+const MAX_RECENTS = 30;
+const DEFAULT_TONE: EmojiTone = 'default';
+
+const isEmojiTone = (value: string): value is EmojiTone =>
+  (EMOJI_TONES as string[]).includes(value);
+
+export const getPreferredTone = (): EmojiTone => {
+  if (!safeLocalStorage) return DEFAULT_TONE;
+  const stored = safeLocalStorage.getItem(TONE_KEY);
+  if (stored && isEmojiTone(stored)) return stored;
+  return DEFAULT_TONE;
+};
+
+export const setPreferredTone = (tone: EmojiTone): void => {
+  safeLocalStorage?.setItem(TONE_KEY, tone);
+};
+
+export const getRecentEmojis = (): string[] => {
+  if (!safeLocalStorage) return [];
+  try {
+    const raw = safeLocalStorage.getItem(RECENTS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((item): item is string => typeof item === 'string');
+  } catch {
+    return [];
+  }
+};
+
+export const pushRecentEmoji = (emoji: string): string[] => {
+  if (!emoji) return getRecentEmojis();
+  const current = getRecentEmojis().filter((entry) => entry !== emoji);
+  current.unshift(emoji);
+  const trimmed = current.slice(0, MAX_RECENTS);
+  safeLocalStorage?.setItem(RECENTS_KEY, JSON.stringify(trimmed));
+  return trimmed;
+};
+
+export const clearRecentEmojis = (): void => {
+  safeLocalStorage?.removeItem(RECENTS_KEY);
+};


### PR DESCRIPTION
## Summary
- add an emoji picker overlay with search, recents, skin tone selection, and copy/insert actions
- bridge focused inputs and persist tone/recents data for the picker
- register the picker in the utilities catalog with a ctrl+period shortcut and bundle local assets

## Testing
- `yarn lint` *(fails: repository has pre-existing accessibility and no-top-level-window lint errors)*
- `yarn test` *(fails: suite contains long-standing act/localStorage expectations and accessibility test issues)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4668da1c8328b4a9f39bb24d8c22