### PR TITLE
[reports] add template registry and authoring docs

### DIFF
--- a/docs/content/report-templates.md
+++ b/docs/content/report-templates.md
@@ -1,0 +1,100 @@
+# Report template authoring guidelines
+
+This project now supports reusable report templates that mix Markdown/MDX content with structured metadata. Use the guidance below whenever you add or update a template so that the build-time registry stays consistent.
+
+## Directory layout
+
+```
+templates/
+  reports/
+    <template-id>.mdx          # Human-readable content with placeholders
+    <template-id>.json         # Metadata describing layout, cover fields, and sections
+public/
+  images/
+    report-templates/
+      <template-id>.svg        # Optional preview thumbnail used by the registry
+```
+
+Keep filenames lowercase with hyphen-separated identifiers. The JSON filename **must** match the MDX template to keep imports simple (`security-overview.mdx` ⇔ `security-overview.json`).
+
+## Metadata schema
+
+Each `templates/reports/<template-id>.json` file should follow the structure consumed by `utils/reportTemplates.ts`:
+
+- **id** – Unique slug that also matches the filename. Used as the primary key for lookup.
+- **name** – Marketing-friendly label displayed in selection UIs.
+- **description** – One or two sentences summarizing when to use the template.
+- **layout** – Object describing the page format. Supported keys:
+  - `format` (e.g., `A4`, `US-Letter`)
+  - `orientation` (`portrait` or `landscape`)
+  - `columns` (integer)
+  - `theme` (free-form string describing the visual theme)
+  - `margin` (optional string such as `1in` or `24mm`)
+- **cover** – Array of cover field descriptors. Each item exposes:
+  - `field` – Data key referenced in MDX as `{{cover.<field>}}`
+  - `label` – Friendly label for builders/editors
+  - `type` – Expected data type (`string`, `date`, `image`, or `markdown`)
+  - `required` – Defaults to `true`. Set to `false` if the field is optional.
+  - `helperText` – Optional hint surfaced by future editors.
+- **sections** – Array of ordered content blocks rendered after the cover. Every section includes:
+  - `slug`, `title`, and `description`
+  - `required` – Defaults to `true`; mark optional sections with `false`
+  - `variables` – Array describing the data keys used by the MDX file. Two shapes are available:
+    - Scalar variables: `{ "key": "executiveSummary", "type": "markdown", "required": true }`
+    - Collections: `{ "key": "timeline", "type": "collection", "itemFields": [ ... ] }`
+      - Collection `itemFields` can define nested requirements such as `timestamp`, `description`, or `owner`
+- **preview.thumbnail** – Relative path (usually `"/images/report-templates/<template-id>.svg"`) rendered by the template picker.
+
+The registry automatically derives `requiredVariables` and `optionalVariables` by combining section and cover configuration, so keeping these arrays accurate avoids runtime validation gaps.
+
+## MDX authoring tips
+
+- Placeholders follow a Mustache-inspired convention (e.g., `{{executiveSummary}}`, `{{#each keyFindings}}`). They are treated as text today and can be swapped out by the rendering pipeline later.
+- Wrap optional content with `{{#if ...}}` directives to show intent, even if the control flow is handled upstream.
+- Keep headings consistent with the metadata sections so the preview registry stays intuitive for end users.
+- Include HTML comments at the top of the MDX file that point to the matching JSON metadata for maintainers.
+
+### Example snippet
+
+```mdx
+# {{cover.title}}
+
+**Client:** {{cover.client}}  \\
+**Assessment Date:** {{cover.assessmentDate}}
+
+## Executive Summary
+
+{{executiveSummary}}
+
+## Key Findings
+
+{{#each keyFindings}}
+- **{{title}}** ({{severity}})
+  - {{impact}}
+  - {{remediation}}
+{{/each}}
+```
+
+## Registry integration
+
+The registry that powers template discovery lives at `utils/reportTemplates.ts`.
+
+- Import the new metadata JSON in this file and add it to the `rawTemplates` array.
+- The helper builds the `templatePath`, `previewThumbnail`, and `requiredVariables` list automatically. Keep metadata accurate so these derived values stay trustworthy.
+- Exposed helpers:
+  - `reportTemplates` – Full definitions, including layout, cover, sections, and derived variable lists
+  - `listReportTemplateSummaries()` – Lightweight objects suitable for selection menus
+  - `getReportTemplate(id)` – Lookup helper for runtime rendering
+
+If your template requires additional runtime assets (images, charts, etc.), colocate them under `public/images/report-templates/<template-id>/` and reference them with relative paths inside the MDX body or metadata.
+
+## Preview thumbnails
+
+Use lightweight SVGs for thumbnails so they load quickly and mirror the dark-terminal aesthetic of the portfolio. Include descriptive `<title>` and `<desc>` elements for accessibility. The registry does not attempt to validate the asset, so ensure the file path resolves to avoid broken previews.
+
+## Validation checklist
+
+1. Run `yarn lint` to catch TypeScript or linting errors introduced by the new registry or templates.
+2. Run `yarn test` to ensure existing unit tests still pass.
+3. Manually open the MDX files to verify placeholders align with the metadata keys.
+4. Update this document whenever the metadata contract evolves.

--- a/public/images/report-templates/incident-response.svg
+++ b/public/images/report-templates/incident-response.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="400" viewBox="0 0 640 400" role="img" aria-labelledby="title desc">
+  <title id="title">Incident Response Report Preview</title>
+  <desc id="desc">Stylized preview of the incident response after action report template.</desc>
+  <defs>
+    <linearGradient id="ir-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a1200" />
+      <stop offset="100%" stop-color="#2c1f04" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="400" fill="url(#ir-bg)" rx="24" />
+  <rect x="44" y="44" width="552" height="92" rx="14" fill="#2f2510" stroke="#f59e0b" stroke-width="2" />
+  <rect x="44" y="152" width="552" height="144" rx="14" fill="#1f1707" stroke="#f59e0b" stroke-dasharray="10 6" stroke-width="1.8" />
+  <rect x="44" y="312" width="552" height="44" rx="10" fill="#422006" stroke="#fed7aa" stroke-width="1.2" />
+  <text x="72" y="102" font-family="'Fira Code', 'Courier New', monospace" font-size="26" fill="#fed7aa">Incident Response</text>
+  <text x="72" y="196" font-family="'Fira Code', 'Courier New', monospace" font-size="18" fill="#fcd34d">Timeline ▸ Containment ▸ Recovery</text>
+  <text x="72" y="338" font-family="'Fira Code', 'Courier New', monospace" font-size="16" fill="#fde68a">Lessons Learned • Follow-up Actions</text>
+</svg>

--- a/public/images/report-templates/security-overview.svg
+++ b/public/images/report-templates/security-overview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="400" viewBox="0 0 640 400" role="img" aria-labelledby="title desc">
+  <title id="title">Security Assessment Overview Preview</title>
+  <desc id="desc">Stylized preview of the security assessment overview report template.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#101421" />
+      <stop offset="100%" stop-color="#182b3a" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="400" fill="url(#bg)" rx="24" />
+  <rect x="48" y="48" width="544" height="80" rx="12" fill="#1f2937" stroke="#38bdf8" stroke-width="2" />
+  <rect x="48" y="152" width="544" height="72" rx="12" fill="#111827" stroke="#38bdf8" stroke-width="1.5" />
+  <rect x="48" y="240" width="544" height="112" rx="12" fill="#0f172a" stroke="#94a3b8" stroke-dasharray="8 6" stroke-width="1.5" />
+  <text x="72" y="98" font-family="'Fira Code', 'Courier New', monospace" font-size="28" fill="#e0f2fe">Security Assessment</text>
+  <text x="72" y="190" font-family="'Fira Code', 'Courier New', monospace" font-size="18" fill="#bae6fd">Executive Summary • Scope • Methodology</text>
+  <text x="72" y="286" font-family="'Fira Code', 'Courier New', monospace" font-size="16" fill="#f8fafc">Key Findings ▸ Risk Heatmap ▸ Roadmap</text>
+</svg>

--- a/templates/reports/incident-response.json
+++ b/templates/reports/incident-response.json
@@ -1,0 +1,145 @@
+{
+  "id": "incident-response",
+  "name": "Incident Response After Action Report",
+  "description": "Chronological review of an incident response engagement with lessons learned and remediation tasks.",
+  "layout": {
+    "format": "US-Letter",
+    "orientation": "portrait",
+    "columns": 1,
+    "theme": "amber-on-charcoal",
+    "margin": "0.75in"
+  },
+  "cover": [
+    { "field": "title", "label": "Report Title", "type": "string", "required": true },
+    { "field": "incidentName", "label": "Incident Name", "type": "string", "required": true },
+    { "field": "client", "label": "Client", "type": "string", "required": true },
+    { "field": "preparedBy", "label": "Prepared By", "type": "string", "required": true },
+    { "field": "responseLead", "label": "Response Lead", "type": "string", "required": true },
+    { "field": "reportDate", "label": "Report Date", "type": "date", "required": true },
+    { "field": "version", "label": "Version", "type": "string", "required": false },
+    { "field": "classification", "label": "Classification", "type": "string", "required": false }
+  ],
+  "sections": [
+    {
+      "slug": "executive-summary",
+      "title": "Executive Summary",
+      "description": "Concise overview of the incident, impact, and overall response effectiveness.",
+      "required": true,
+      "variables": [
+        {
+          "key": "executiveSummary",
+          "type": "markdown",
+          "required": true,
+          "description": "Narrative accessible to leadership on what occurred, why it matters, and how the team responded."
+        }
+      ]
+    },
+    {
+      "slug": "timeline",
+      "title": "Incident Timeline",
+      "description": "Minute-by-minute account of detection, triage, containment, and recovery activities.",
+      "required": true,
+      "variables": [
+        {
+          "key": "timeline",
+          "type": "collection",
+          "required": true,
+          "description": "Chronological entries representing major milestones and decisions.",
+          "itemFields": [
+            { "field": "timestamp", "type": "string", "required": true },
+            { "field": "description", "type": "markdown", "required": true },
+            { "field": "owner", "type": "string", "required": false },
+            { "field": "notes", "type": "markdown", "required": false }
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "impact",
+      "title": "Impact Assessment",
+      "description": "Business and technical impact of the incident across availability, integrity, and confidentiality.",
+      "required": true,
+      "variables": [
+        {
+          "key": "impactAssessment",
+          "type": "markdown",
+          "required": true,
+          "description": "Summary of affected services, data exposure, and downstream effects."
+        }
+      ]
+    },
+    {
+      "slug": "containment",
+      "title": "Containment and Eradication",
+      "description": "Steps taken to halt attacker activity and remove persistence.",
+      "required": true,
+      "variables": [
+        {
+          "key": "containment",
+          "type": "markdown",
+          "required": true,
+          "description": "Detail actions, tooling, and decision points executed during containment."
+        }
+      ]
+    },
+    {
+      "slug": "recovery",
+      "title": "Recovery Status",
+      "description": "System restoration progress and validation testing.",
+      "required": true,
+      "variables": [
+        {
+          "key": "recoveryStatus",
+          "type": "markdown",
+          "required": true,
+          "description": "Outline of service restoration, validation steps, and outstanding risks."
+        }
+      ]
+    },
+    {
+      "slug": "lessons-learned",
+      "title": "Lessons Learned",
+      "description": "Process, tooling, and communication improvements identified during the response.",
+      "required": true,
+      "variables": [
+        {
+          "key": "lessonsLearned",
+          "type": "markdown",
+          "required": true,
+          "description": "Insights on what worked, what needs refinement, and how to reinforce readiness."
+        }
+      ]
+    },
+    {
+      "slug": "follow-up",
+      "title": "Follow-up Actions",
+      "description": "Trackable remediation tasks, owners, and timelines.",
+      "required": true,
+      "variables": [
+        {
+          "key": "followUpActions",
+          "type": "markdown",
+          "required": true,
+          "description": "List of tasks assigned to teams with due dates or milestones."
+        }
+      ]
+    },
+    {
+      "slug": "evidence",
+      "title": "Evidence Log",
+      "description": "Reference to collected logs, forensics images, and communication transcripts.",
+      "required": false,
+      "variables": [
+        {
+          "key": "evidenceLog",
+          "type": "markdown",
+          "required": false,
+          "description": "Bulleted appendix capturing artifacts retained for compliance."
+        }
+      ]
+    }
+  ],
+  "preview": {
+    "thumbnail": "/images/report-templates/incident-response.svg"
+  }
+}

--- a/templates/reports/incident-response.mdx
+++ b/templates/reports/incident-response.mdx
@@ -1,0 +1,64 @@
+<!--
+  Incident Response After Action Template
+  Expects data keys declared in templates/reports/incident-response.json
+-->
+
+# {{cover.title}}
+
+**Incident Name:** {{cover.incidentName}}  \
+**Client:** {{cover.client}}  \
+**Prepared By:** {{cover.preparedBy}}  \
+**Response Lead:** {{cover.responseLead}}  \
+**Report Date:** {{cover.reportDate}}  \
+**Document Version:** {{cover.version}}
+
+---
+
+## Executive Summary
+
+{{executiveSummary}}
+
+---
+
+## Incident Timeline
+
+{{#each timeline}}
+- **{{timestamp}}** — {{description}} _(Owner: {{owner}})_
+{{/each}}
+
+---
+
+## Impact Assessment
+
+{{impactAssessment}}
+
+---
+
+## Containment and Eradication
+
+{{containment}}
+
+---
+
+## Recovery Status
+
+{{recoveryStatus}}
+
+---
+
+## Lessons Learned
+
+{{lessonsLearned}}
+
+---
+
+## Follow-up Actions
+
+{{followUpActions}}
+
+---
+
+## Appendix — Evidence Log
+
+{{evidenceLog}}
+

--- a/templates/reports/security-overview.json
+++ b/templates/reports/security-overview.json
@@ -1,0 +1,131 @@
+{
+  "id": "security-overview",
+  "name": "Security Assessment Overview",
+  "description": "Summarize the current security posture, top risks, and prioritized remediation roadmap for leadership stakeholders.",
+  "layout": {
+    "format": "A4",
+    "orientation": "portrait",
+    "columns": 1,
+    "theme": "midnight-terminal",
+    "margin": "1in"
+  },
+  "cover": [
+    { "field": "title", "label": "Report Title", "type": "string", "required": true },
+    { "field": "subtitle", "label": "Subtitle", "type": "string", "required": false },
+    { "field": "client", "label": "Client", "type": "string", "required": true },
+    { "field": "assessmentDate", "label": "Assessment Date", "type": "date", "required": true },
+    { "field": "preparedBy", "label": "Prepared By", "type": "string", "required": true },
+    { "field": "version", "label": "Version", "type": "string", "required": false },
+    { "field": "confidentiality", "label": "Classification", "type": "string", "required": false }
+  ],
+  "sections": [
+    {
+      "slug": "executive-summary",
+      "title": "Executive Summary",
+      "description": "High-level synopsis written for senior leadership and non-technical stakeholders.",
+      "required": true,
+      "variables": [
+        {
+          "key": "executiveSummary",
+          "type": "markdown",
+          "required": true,
+          "description": "Narrative summary of the assessment purpose, current security posture, and most urgent calls to action."
+        }
+      ]
+    },
+    {
+      "slug": "assessment-scope",
+      "title": "Assessment Scope",
+      "description": "Systems, business units, and time period covered by the engagement.",
+      "required": true,
+      "variables": [
+        {
+          "key": "assessmentScope",
+          "type": "markdown",
+          "required": true,
+          "description": "Summary of in-scope assets, environments, and constraints."
+        }
+      ]
+    },
+    {
+      "slug": "methodology",
+      "title": "Methodology",
+      "description": "Testing approach, frameworks, and tooling used during the assessment.",
+      "required": true,
+      "variables": [
+        {
+          "key": "methodology",
+          "type": "markdown",
+          "required": true,
+          "description": "Description of testing methodology, mapping to industry frameworks when applicable."
+        }
+      ]
+    },
+    {
+      "slug": "key-findings",
+      "title": "Key Findings",
+      "description": "Prioritized technical and procedural gaps that require remediation.",
+      "required": true,
+      "variables": [
+        {
+          "key": "keyFindings",
+          "type": "collection",
+          "required": true,
+          "description": "Ordered list of the top findings with impact and remediation guidance.",
+          "itemFields": [
+            { "field": "title", "type": "string", "required": true },
+            { "field": "severity", "type": "string", "required": true },
+            { "field": "impact", "type": "markdown", "required": true },
+            { "field": "evidence", "type": "markdown", "required": false },
+            { "field": "remediation", "type": "markdown", "required": true }
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "risk-overview",
+      "title": "Risk Heatmap",
+      "description": "Visual summary of likelihood vs impact to highlight concentration of risk.",
+      "required": false,
+      "variables": [
+        {
+          "key": "riskOverview",
+          "type": "markdown",
+          "required": false,
+          "description": "Narrative or embedded graphic summarizing how findings cluster across risk categories."
+        }
+      ]
+    },
+    {
+      "slug": "roadmap",
+      "title": "Prioritized Roadmap",
+      "description": "Actionable next steps grouped by priority horizon.",
+      "required": true,
+      "variables": [
+        {
+          "key": "roadmap",
+          "type": "markdown",
+          "required": true,
+          "description": "Plan summarizing remediation initiatives and owners."
+        }
+      ]
+    },
+    {
+      "slug": "appendix-artifacts",
+      "title": "Artifacts Reviewed",
+      "description": "Documents, configurations, and evidence collected during the engagement.",
+      "required": false,
+      "variables": [
+        {
+          "key": "artifactsReviewed",
+          "type": "markdown",
+          "required": false,
+          "description": "Bulleted appendix enumerating logs, screenshots, and data sources used."
+        }
+      ]
+    }
+  ],
+  "preview": {
+    "thumbnail": "/images/report-templates/security-overview.svg"
+  }
+}

--- a/templates/reports/security-overview.mdx
+++ b/templates/reports/security-overview.mdx
@@ -1,0 +1,72 @@
+<!--
+  Security Assessment Overview Template
+  Expects data keys declared in templates/reports/security-overview.json
+-->
+
+# {{cover.title}}
+
+> {{cover.subtitle}}
+
+**Client:** {{cover.client}}  \
+**Assessment Date:** {{cover.assessmentDate}}  \
+**Prepared By:** {{cover.preparedBy}}  \
+**Document Version:** {{cover.version}}  \
+{{#if cover.confidentiality}}**Classification:** {{cover.confidentiality}}{{/if}}
+
+---
+
+## Executive Summary
+
+{{executiveSummary}}
+
+---
+
+## Assessment Scope
+
+{{assessmentScope}}
+
+---
+
+## Methodology
+
+{{methodology}}
+
+---
+
+## Key Findings
+
+{{#each keyFindings}}
+### {{title}} — {{severity}}
+
+**Impact**
+
+{{impact}}
+
+**Evidence**
+
+{{evidence}}
+
+**Recommendation**
+
+{{remediation}}
+
+{{/each}}
+
+---
+
+## Risk Heatmap
+
+{{riskOverview}}
+
+---
+
+## Prioritized Roadmap
+
+{{roadmap}}
+
+---
+
+## Appendix A — Artifacts Reviewed
+
+{{artifactsReviewed}}
+

--- a/utils/reportTemplates.ts
+++ b/utils/reportTemplates.ts
@@ -1,0 +1,185 @@
+import securityOverviewMeta from '@/templates/reports/security-overview.json';
+import incidentResponseMeta from '@/templates/reports/incident-response.json';
+
+export type ReportOrientation = 'portrait' | 'landscape';
+export type ReportVariableType = 'string' | 'markdown' | 'date' | 'image';
+
+export interface ReportLayoutConfig {
+  format: string;
+  orientation: ReportOrientation;
+  columns: number;
+  theme: string;
+  margin?: string;
+}
+
+export interface ReportCoverField {
+  field: string;
+  label: string;
+  type: ReportVariableType;
+  required?: boolean;
+  helperText?: string;
+}
+
+interface BaseSectionVariableMeta {
+  key: string;
+  description?: string;
+  required?: boolean;
+}
+
+export interface ScalarSectionVariableMeta extends BaseSectionVariableMeta {
+  type: ReportVariableType;
+}
+
+export interface CollectionVariableField {
+  field: string;
+  type: ReportVariableType;
+  required?: boolean;
+  description?: string;
+}
+
+export interface CollectionSectionVariableMeta extends BaseSectionVariableMeta {
+  type: 'collection';
+  itemFields: CollectionVariableField[];
+}
+
+export type SectionVariableMeta = ScalarSectionVariableMeta | CollectionSectionVariableMeta;
+
+export interface ReportTemplateSection {
+  slug: string;
+  title: string;
+  description: string;
+  required?: boolean;
+  variables: SectionVariableMeta[];
+}
+
+export interface ReportTemplateMetadata {
+  id: string;
+  name: string;
+  description: string;
+  layout: ReportLayoutConfig;
+  cover: ReportCoverField[];
+  sections: ReportTemplateSection[];
+  preview: {
+    thumbnail: string;
+  };
+}
+
+export interface ReportTemplateDefinition extends ReportTemplateMetadata {
+  templatePath: string;
+  previewThumbnail: string;
+  requiredVariables: string[];
+  optionalVariables: string[];
+}
+
+const TEMPLATE_BASE_PATH = 'templates/reports';
+
+type VariableBuckets = {
+  required: string[];
+  optional: string[];
+};
+
+const rawTemplates: ReportTemplateMetadata[] = [securityOverviewMeta, incidentResponseMeta];
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+function isCollection(variable: SectionVariableMeta): variable is CollectionSectionVariableMeta {
+  return variable.type === 'collection';
+}
+
+function pushPath(buckets: VariableBuckets, path: string, isRequired: boolean) {
+  if (isRequired) {
+    buckets.required.push(path);
+  } else {
+    buckets.optional.push(path);
+  }
+}
+
+function collectCoverPaths(cover: ReportCoverField[]): VariableBuckets {
+  const buckets: VariableBuckets = { required: [], optional: [] };
+
+  cover.forEach((field) => {
+    const dataPath = `cover.${field.field}`;
+    const isRequired = field.required !== false;
+    pushPath(buckets, dataPath, isRequired);
+  });
+
+  return buckets;
+}
+
+function collectSectionPaths(sections: ReportTemplateSection[]): VariableBuckets {
+  const buckets: VariableBuckets = { required: [], optional: [] };
+
+  sections.forEach((section) => {
+    const sectionRequired = section.required !== false;
+
+    section.variables.forEach((variable) => {
+      const variableRequired = sectionRequired && variable.required !== false;
+
+      if (isCollection(variable)) {
+        const basePath = variable.key;
+        pushPath(buckets, basePath, variableRequired);
+
+        variable.itemFields.forEach((item) => {
+          const itemPath = `${basePath}[].${item.field}`;
+          const itemRequired = variableRequired && item.required !== false;
+          pushPath(buckets, itemPath, itemRequired);
+        });
+      } else {
+        pushPath(buckets, variable.key, variableRequired);
+      }
+    });
+  });
+
+  return buckets;
+}
+
+function buildDefinition(meta: ReportTemplateMetadata): ReportTemplateDefinition {
+  const coverPaths = collectCoverPaths(meta.cover);
+  const sectionPaths = collectSectionPaths(meta.sections);
+
+  const requiredVariables = unique([...coverPaths.required, ...sectionPaths.required]);
+  const optionalVariables = unique([...coverPaths.optional, ...sectionPaths.optional]);
+
+  return {
+    ...meta,
+    templatePath: `${TEMPLATE_BASE_PATH}/${meta.id}.mdx`,
+    previewThumbnail: meta.preview.thumbnail,
+    requiredVariables,
+    optionalVariables,
+  };
+}
+
+const builtTemplates = rawTemplates.map(buildDefinition);
+
+export const reportTemplates: ReportTemplateDefinition[] = builtTemplates;
+
+export const reportTemplateMap: Record<string, ReportTemplateDefinition> = builtTemplates.reduce<
+  Record<string, ReportTemplateDefinition>
+>((acc, template) => {
+  acc[template.id] = template;
+  return acc;
+}, {});
+
+export interface ReportTemplateSummary {
+  id: string;
+  name: string;
+  description: string;
+  previewThumbnail: string;
+  requiredVariables: string[];
+}
+
+export function listReportTemplateSummaries(): ReportTemplateSummary[] {
+  return reportTemplates.map((template) => ({
+    id: template.id,
+    name: template.name,
+    description: template.description,
+    previewThumbnail: template.previewThumbnail,
+    requiredVariables: template.requiredVariables,
+  }));
+}
+
+export function getReportTemplate(id: string): ReportTemplateDefinition | undefined {
+  return reportTemplateMap[id];
+}


### PR DESCRIPTION
## Summary
- add security overview and incident response report templates with matching metadata and svg previews
- introduce a report template registry module that derives variable requirements and exposes lookup helpers
- document the template authoring workflow, metadata schema, and validation steps

## Testing
- yarn lint *(fails: numerous pre-existing accessibility/no-top-level-window lint errors outside this change)*
- yarn test *(fails: existing jest suites continue to fail and warn about missing env configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cab69248788328befc8100f3cbb602