### PR TITLE
[reconng] enhance report export workflow

### DIFF
--- a/__tests__/reportProcessing.test.ts
+++ b/__tests__/reportProcessing.test.ts
@@ -1,0 +1,61 @@
+import type { FigureNumberingScheme } from '../components/apps/reconng/components/reportProcessing';
+import {
+  preprocessMarkdown,
+  renderTemplate,
+  stripMarkdown,
+} from '../components/apps/reconng/components/reportProcessing';
+
+const sampleFindings = [
+  {
+    title: 'Test Finding',
+    description: 'Finding description',
+    severity: 'Medium',
+  },
+];
+
+describe('renderTemplate', () => {
+  it('respects optional section toggles', () => {
+    const template = 'Intro\n{{#section appendix}}Appendix content{{/section}}';
+    const withAppendix = renderTemplate(template, sampleFindings, {
+      appendix: true,
+    });
+    expect(withAppendix).toContain('Appendix content');
+
+    const withoutAppendix = renderTemplate(template, sampleFindings, {
+      appendix: false,
+    });
+    expect(withoutAppendix).not.toContain('Appendix content');
+  });
+
+  it('renders findings tokens', () => {
+    const template = '{{#findings}}- {{index}}: {{title}} ({{severity}}){{/findings}}';
+    const rendered = renderTemplate(template, sampleFindings, {});
+    expect(rendered).toContain('1: Test Finding (Medium)');
+  });
+});
+
+describe('preprocessMarkdown', () => {
+  it('numbers figure references and adds captions', () => {
+    const base = '# Section\n![Figure: Demo](image.png)';
+    const result = preprocessMarkdown(base, { includeTableOfContents: true }, 'roman');
+    expect(result.markdown).toContain('![Figure I]');
+    expect(result.markdown).toContain('_Figure I: Demo_');
+    expect(result.markdown).toContain('Table of Contents');
+    expect(result.markdown).toContain('- [Section](#section)');
+  });
+
+  it('uses configured numbering scheme', () => {
+    const base = '# Title\n![Figure: Caption](x.png)';
+    const scheme: FigureNumberingScheme = 'alphabetic';
+    const result = preprocessMarkdown(base, { includeTableOfContents: false }, scheme);
+    expect(result.markdown).toContain('![Figure A]');
+  });
+});
+
+describe('stripMarkdown', () => {
+  it('removes emphasis and links', () => {
+    expect(stripMarkdown('**Bold** _Italic_ [link](https://example.com)')).toBe(
+      'Bold Italic link',
+    );
+  });
+});

--- a/components/apps/reconng/components/ReportTemplates.tsx
+++ b/components/apps/reconng/components/ReportTemplates.tsx
@@ -1,12 +1,19 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import jsPDF from 'jspdf';
 import usePersistentState from '../../../../hooks/usePersistentState';
 import defaultTemplates from '../../../../templates/export/report-templates.json';
-
-interface Finding {
-  title: string;
-  description: string;
-  severity: string;
-}
+import type {
+  FigureNumberingScheme,
+  Finding,
+  HeadingInfo,
+  ReportTemplate,
+  TemplateConfig,
+} from './reportProcessing';
+import {
+  preprocessMarkdown,
+  renderTemplate,
+  stripMarkdown,
+} from './reportProcessing';
 
 const mockFindings: Finding[] = [
   {
@@ -26,46 +33,413 @@ const mockFindings: Finding[] = [
   },
 ];
 
-interface TemplateDef {
-  name: string;
-  template: string;
+type TemplateMap = Record<string, ReportTemplate>;
+
+type RawBlockType =
+  | 'heading'
+  | 'paragraph'
+  | 'listItem'
+  | 'tocItem'
+  | 'figure'
+  | 'figureCaption'
+  | 'blank';
+
+interface RawBlock {
+  type: RawBlockType;
+  text?: string;
+  level?: number;
+  slug?: string;
+  targetSlug?: string;
+  indentLevel?: number;
 }
 
-const renderTemplate = (tpl: string, findings: Finding[]) =>
-  tpl.replace(/{{#findings}}([\s\S]*?){{\/findings}}/, (_, segment) =>
-    findings
-      .map((f, i) =>
-        segment
-          .replace(/{{index}}/g, String(i + 1))
-          .replace(/{{title}}/g, f.title)
-          .replace(/{{severity}}/g, f.severity)
-          .replace(/{{description}}/g, f.description),
-      )
-      .join(''),
-  );
+interface RenderBlock {
+  type: RawBlockType;
+  lines: string[];
+  fontSize: number;
+  fontStyle: 'normal' | 'bold' | 'italic';
+  lineHeight: number;
+  afterSpacing: number;
+  indent: number;
+  slug?: string;
+  targetSlug?: string;
+  bullet?: boolean;
+}
 
-export default function ReportTemplates() {
-  const [templateData, setTemplateData] = useState<Record<string, TemplateDef>>(defaultTemplates);
-  const keys = Object.keys(templateData);
-  const [template, setTemplate] = usePersistentState('reconng-report-template', keys[0]);
+interface HeadingPosition {
+  page: number;
+  y: number;
+}
 
-  const templateKey = keys.includes(template) ? template : keys[0];
-  const report = useMemo(
-    () => renderTemplate(templateData[templateKey].template, mockFindings),
-    [templateKey, templateData],
-  );
+const numberingLabels: Record<FigureNumberingScheme, string> = {
+  arabic: '1, 2, 3',
+  roman: 'I, II, III',
+  alphabetic: 'A, B, C',
+};
 
-  const exportReport = () => {
-    const blob = new Blob([report], { type: 'text/plain' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `${templateKey}-report.txt`;
-    a.click();
-    URL.revokeObjectURL(url);
+const defaultNumberingOptions: FigureNumberingScheme[] = [
+  'arabic',
+  'roman',
+  'alphabetic',
+];
+
+const templateToState = (config?: TemplateConfig) => {
+  const sectionState: Record<string, boolean> = {};
+  (config?.optionalSections || []).forEach((section) => {
+    sectionState[section.id] = section.defaultIncluded;
+  });
+  const numbering =
+    config?.figureNumbering?.default ||
+    config?.figureNumbering?.options?.[0] ||
+    'arabic';
+  return { sectionState, numbering };
+};
+
+const parseMarkdownBlocks = (
+  markdown: string,
+  headings: HeadingInfo[],
+): RawBlock[] => {
+  const lines = markdown.split(/\r?\n/);
+  const rawBlocks: RawBlock[] = [];
+  let paragraph: string[] = [];
+  const headingQueue = [...headings];
+  let inToc = false;
+
+  const flushParagraph = () => {
+    if (!paragraph.length) return;
+    rawBlocks.push({ type: 'paragraph', text: paragraph.join(' ') });
+    paragraph = [];
   };
 
+  for (const line of lines) {
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headingMatch) {
+      flushParagraph();
+      const level = headingMatch[1].length;
+      const text = headingMatch[2].trim();
+      const heading = headingQueue.shift();
+      rawBlocks.push({ type: 'heading', level, text, slug: heading?.slug });
+      inToc = text.toLowerCase().includes('table of contents');
+      continue;
+    }
+
+    const figureMatch = line.match(/^!\[(Figure[^\]]*)\]\(([^)]+)\)/);
+    if (figureMatch) {
+      flushParagraph();
+      rawBlocks.push({
+        type: 'figure',
+        text: `${figureMatch[1]} (${figureMatch[2]})`,
+      });
+      continue;
+    }
+
+    const captionMatch = line.match(/^(_Figure\s+[^:]+:\s*.+_)$/i);
+    if (captionMatch) {
+      flushParagraph();
+      rawBlocks.push({ type: 'figureCaption', text: captionMatch[1] });
+      continue;
+    }
+
+    const listMatch = line.match(/^(\s*)[-*+]\s+(.+)$/);
+    if (listMatch) {
+      flushParagraph();
+      const indentLevel = Math.floor((listMatch[1] || '').length / 2);
+      const content = listMatch[2];
+      if (inToc) {
+        const tocMatch = content.match(/^\[(.+?)\]\(#(.+?)\)/);
+        if (tocMatch) {
+          rawBlocks.push({
+            type: 'tocItem',
+            text: tocMatch[1],
+            targetSlug: tocMatch[2],
+            indentLevel,
+          });
+          continue;
+        }
+      }
+      rawBlocks.push({
+        type: 'listItem',
+        text: content,
+        indentLevel,
+      });
+      continue;
+    }
+
+    if (!line.trim()) {
+      flushParagraph();
+      rawBlocks.push({ type: 'blank' });
+      inToc = false;
+      continue;
+    }
+
+    paragraph.push(line.trim());
+  }
+
+  flushParagraph();
+  return rawBlocks;
+};
+
+const buildRenderBlocks = (
+  doc: jsPDF,
+  blocks: RawBlock[],
+  contentWidth: number,
+): RenderBlock[] => {
+  const renderBlocks: RenderBlock[] = [];
+  const baseLineHeight = 16;
+  const bulletSpacing = 14;
+
+  blocks.forEach((block) => {
+    switch (block.type) {
+      case 'heading': {
+        const level = block.level || 1;
+        const fontSize = level === 1 ? 20 : level === 2 ? 16 : level === 3 ? 14 : 13;
+        const lineHeight = Math.round(fontSize * 1.2);
+        const text = stripMarkdown(block.text || '');
+        renderBlocks.push({
+          type: 'heading',
+          lines: [text],
+          fontSize,
+          fontStyle: 'bold',
+          lineHeight,
+          afterSpacing: level === 1 ? 12 : level === 2 ? 10 : 8,
+          indent: 0,
+          slug: block.slug,
+        });
+        break;
+      }
+      case 'paragraph': {
+        const text = stripMarkdown(block.text || '');
+        const lines = doc.splitTextToSize(text, contentWidth);
+        renderBlocks.push({
+          type: 'paragraph',
+          lines,
+          fontSize: 12,
+          fontStyle: 'normal',
+          lineHeight: baseLineHeight,
+          afterSpacing: 8,
+          indent: 0,
+        });
+        break;
+      }
+      case 'listItem': {
+        const text = stripMarkdown(block.text || '');
+        const indent = (block.indentLevel || 0) * bulletSpacing + bulletSpacing;
+        const lines = doc.splitTextToSize(text, contentWidth - indent + bulletSpacing);
+        renderBlocks.push({
+          type: 'listItem',
+          lines,
+          fontSize: 12,
+          fontStyle: 'normal',
+          lineHeight: baseLineHeight,
+          afterSpacing: 6,
+          indent,
+          bullet: true,
+        });
+        break;
+      }
+      case 'tocItem': {
+        const text = stripMarkdown(block.text || '');
+        const indent = (block.indentLevel || 0) * bulletSpacing;
+        const lines = doc.splitTextToSize(text, contentWidth - indent);
+        renderBlocks.push({
+          type: 'tocItem',
+          lines,
+          fontSize: 12,
+          fontStyle: 'normal',
+          lineHeight: baseLineHeight,
+          afterSpacing: 4,
+          indent,
+          targetSlug: block.targetSlug,
+        });
+        break;
+      }
+      case 'figure': {
+        const text = stripMarkdown(block.text || '');
+        const lines = doc.splitTextToSize(text, contentWidth);
+        renderBlocks.push({
+          type: 'figure',
+          lines,
+          fontSize: 12,
+          fontStyle: 'italic',
+          lineHeight: baseLineHeight,
+          afterSpacing: 4,
+          indent: 0,
+        });
+        break;
+      }
+      case 'figureCaption': {
+        const text = stripMarkdown(block.text || '');
+        const lines = doc.splitTextToSize(text, contentWidth);
+        renderBlocks.push({
+          type: 'figureCaption',
+          lines,
+          fontSize: 11,
+          fontStyle: 'italic',
+          lineHeight: baseLineHeight,
+          afterSpacing: 10,
+          indent: bulletSpacing,
+        });
+        break;
+      }
+      default: {
+        renderBlocks.push({
+          type: 'blank',
+          lines: [],
+          fontSize: 12,
+          fontStyle: 'normal',
+          lineHeight: baseLineHeight,
+          afterSpacing: 8,
+          indent: 0,
+        });
+      }
+    }
+  });
+
+  return renderBlocks;
+};
+
+const measureBlocks = (
+  renderBlocks: RenderBlock[],
+  margin: number,
+  pageHeight: number,
+) => {
+  let y = margin;
+  let page = 1;
+  const positions = new Map<string, HeadingPosition>();
+
+  renderBlocks.forEach((block) => {
+    const blockHeight = block.lines.length * block.lineHeight;
+    if (y + blockHeight > pageHeight - margin) {
+      page += 1;
+      y = margin;
+    }
+
+    if (block.type === 'heading' && block.slug) {
+      positions.set(block.slug, { page, y });
+    }
+
+    y += blockHeight + block.afterSpacing;
+  });
+
+  return positions;
+};
+
+const drawBlocks = (
+  doc: jsPDF,
+  renderBlocks: RenderBlock[],
+  margin: number,
+  pageHeight: number,
+  headingPositions: Map<string, HeadingPosition>,
+) => {
+  let y = margin;
+  const bulletOffset = 10;
+
+  renderBlocks.forEach((block) => {
+    const blockHeight = block.lines.length * block.lineHeight;
+    if (y + blockHeight > pageHeight - margin && block.lines.length > 0) {
+      doc.addPage();
+      y = margin;
+    }
+
+    doc.setFont('helvetica', block.fontStyle);
+    doc.setFontSize(block.fontSize);
+
+    if (block.lines.length === 0) {
+      y += block.afterSpacing;
+      return;
+    }
+
+    let lineY = y;
+    block.lines.forEach((line, index) => {
+      const x = margin + block.indent;
+      if (block.type === 'listItem') {
+        if (index === 0) {
+          doc.text('\u2022', x - bulletOffset, lineY);
+        }
+        doc.text(line, x, lineY);
+      } else if (block.type === 'tocItem' && block.targetSlug) {
+        const target = headingPositions.get(block.targetSlug);
+        if (target) {
+          doc.textWithLink(line, x, lineY, {
+            pageNumber: target.page,
+            top: target.y,
+          });
+        } else {
+          doc.text(line, x, lineY);
+        }
+      } else {
+        doc.text(line, x, lineY);
+      }
+      lineY += block.lineHeight;
+    });
+
+    y = lineY + block.afterSpacing;
+  });
+};
+
+const exportMarkdown = (report: string, templateKey: string) => {
+  const blob = new Blob([report], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${templateKey}-report.md`;
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
+export default function ReportTemplates() {
+  const [templateData, setTemplateData] = useState<TemplateMap>(
+    defaultTemplates as TemplateMap,
+  );
+  const keys = Object.keys(templateData);
+  const [template, setTemplate] = usePersistentState(
+    'reconng-report-template',
+    keys[0],
+  );
+  const [sectionState, setSectionState] = useState<Record<string, boolean>>({});
+  const [numberingScheme, setNumberingScheme] =
+    useState<FigureNumberingScheme>('arabic');
   const [showDialog, setShowDialog] = useState(false);
+
+  const templateKey = keys.includes(template) ? template : keys[0];
+  const selectedTemplate = templateData[templateKey];
+
+  useEffect(() => {
+    const { sectionState: defaults, numbering } = templateToState(
+      selectedTemplate?.config,
+    );
+    setSectionState(defaults);
+    setNumberingScheme(numbering);
+  }, [templateKey, selectedTemplate]);
+
+  const templateConfig = selectedTemplate?.config;
+
+  const renderedTemplate = useMemo(
+    () =>
+      renderTemplate(
+        selectedTemplate?.template || '',
+        mockFindings,
+        sectionState,
+      ),
+    [selectedTemplate, sectionState],
+  );
+
+  const processed = useMemo(
+    () =>
+      preprocessMarkdown(
+        renderedTemplate,
+        templateConfig,
+        numberingScheme,
+      ),
+    [renderedTemplate, templateConfig, numberingScheme],
+  );
+
+  const numberingOptions = useMemo(() => {
+    const configured = templateConfig?.figureNumbering?.options;
+    return configured && configured.length > 0
+      ? configured
+      : defaultNumberingOptions;
+  }, [templateConfig]);
 
   const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -73,7 +447,7 @@ export default function ReportTemplates() {
     const reader = new FileReader();
     reader.onload = () => {
       try {
-        const parsed = JSON.parse(reader.result as string) as Record<string, TemplateDef>;
+        const parsed = JSON.parse(reader.result as string) as TemplateMap;
         setTemplateData(parsed);
         const first = Object.keys(parsed)[0];
         if (first) setTemplate(first);
@@ -85,17 +459,44 @@ export default function ReportTemplates() {
   };
 
   const shareJson = JSON.stringify(templateData, null, 2);
+
   const copyShare = () => {
     try {
       navigator.clipboard.writeText(shareJson);
     } catch {
-      // ignore
+      // ignore clipboard failures
     }
   };
 
+  const handleExportPdf = () => {
+    const measurementDoc = new jsPDF({ unit: 'pt', format: 'a4' });
+    measurementDoc.setFont('helvetica', 'normal');
+    measurementDoc.setFontSize(12);
+    const margin = 48;
+    const pageWidth = measurementDoc.internal.pageSize.getWidth();
+    const pageHeight = measurementDoc.internal.pageSize.getHeight();
+    const contentWidth = pageWidth - margin * 2;
+
+    const rawBlocks = parseMarkdownBlocks(processed.markdown, processed.headings);
+    const renderBlocks = buildRenderBlocks(measurementDoc, rawBlocks, contentWidth);
+    const headingPositions = measureBlocks(renderBlocks, margin, pageHeight);
+
+    const doc = new jsPDF({ unit: 'pt', format: 'a4' });
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(12);
+    drawBlocks(doc, renderBlocks, margin, pageHeight, headingPositions);
+    doc.save(`${templateKey}-report.pdf`);
+  };
+
+  const toggleSection = (id: string) => {
+    setSectionState((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const numberingLabel = numberingLabels[numberingScheme];
+
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center gap-2 mb-2">
+      <div className="flex flex-wrap items-center gap-2 mb-2">
         <label htmlFor="template">Template</label>
         <select
           id="template"
@@ -109,12 +510,36 @@ export default function ReportTemplates() {
             </option>
           ))}
         </select>
+        <label htmlFor="numbering" className="ml-2">
+          Figure numbering
+        </label>
+        <select
+          id="numbering"
+          value={numberingScheme}
+          onChange={(e) =>
+            setNumberingScheme(e.target.value as FigureNumberingScheme)
+          }
+          className="bg-gray-800 px-2 py-1"
+        >
+          {numberingOptions.map((option) => (
+            <option key={option} value={option}>
+              {numberingLabels[option] || option}
+            </option>
+          ))}
+        </select>
         <button
           type="button"
-          onClick={exportReport}
+          onClick={() => exportMarkdown(processed.markdown, templateKey)}
           className="bg-blue-600 hover:bg-blue-500 px-2 py-1 rounded"
         >
-          Export
+          Export Markdown
+        </button>
+        <button
+          type="button"
+          onClick={handleExportPdf}
+          className="bg-green-600 hover:bg-green-500 px-2 py-1 rounded"
+        >
+          Export PDF
         </button>
         <button
           type="button"
@@ -124,8 +549,25 @@ export default function ReportTemplates() {
           Import/Share
         </button>
       </div>
+      {templateConfig?.optionalSections?.length ? (
+        <div className="flex flex-wrap gap-3 mb-3 text-sm">
+          {templateConfig.optionalSections.map((section) => (
+            <label key={section.id} className="inline-flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={sectionState[section.id] !== false}
+                onChange={() => toggleSection(section.id)}
+              />
+              {section.label}
+            </label>
+          ))}
+        </div>
+      ) : null}
+      <div className="text-xs text-gray-300 mb-2">
+        Active figure numbering: {numberingLabel}
+      </div>
       <pre className="flex-1 bg-black p-2 overflow-auto whitespace-pre-wrap text-sm">
-        {report}
+        {processed.markdown}
       </pre>
       {showDialog && (
         <dialog open className="p-4 bg-gray-800 text-white rounded max-w-md">
@@ -158,4 +600,3 @@ export default function ReportTemplates() {
     </div>
   );
 }
-

--- a/components/apps/reconng/components/reportProcessing.ts
+++ b/components/apps/reconng/components/reportProcessing.ts
@@ -1,0 +1,238 @@
+export type FigureNumberingScheme = 'arabic' | 'roman' | 'alphabetic';
+
+export interface Finding {
+  title: string;
+  description: string;
+  severity: string;
+}
+
+export interface OptionalSectionConfig {
+  id: string;
+  label: string;
+  defaultIncluded: boolean;
+}
+
+export interface TemplateConfig {
+  includeTableOfContents?: boolean;
+  figureNumbering?: {
+    default: FigureNumberingScheme;
+    options?: FigureNumberingScheme[];
+  };
+  optionalSections?: OptionalSectionConfig[];
+}
+
+export interface ReportTemplate {
+  name: string;
+  template: string;
+  config?: TemplateConfig;
+}
+
+export interface HeadingInfo {
+  level: number;
+  title: string;
+  slug: string;
+}
+
+const figurePattern = /!\[Figure(?::\s*([^\]]+))?\]\(([^)]+)\)/g;
+
+const romanNumerals = [
+  '',
+  'I',
+  'II',
+  'III',
+  'IV',
+  'V',
+  'VI',
+  'VII',
+  'VIII',
+  'IX',
+  'X',
+  'XI',
+  'XII',
+  'XIII',
+  'XIV',
+  'XV',
+  'XVI',
+  'XVII',
+  'XVIII',
+  'XIX',
+  'XX',
+];
+
+const toRoman = (value: number) => {
+  if (value < romanNumerals.length) {
+    return romanNumerals[value];
+  }
+  const numerals: [number, string][] = [
+    [1000, 'M'],
+    [900, 'CM'],
+    [500, 'D'],
+    [400, 'CD'],
+    [100, 'C'],
+    [90, 'XC'],
+    [50, 'L'],
+    [40, 'XL'],
+    [10, 'X'],
+    [9, 'IX'],
+    [5, 'V'],
+    [4, 'IV'],
+    [1, 'I'],
+  ];
+  let num = value;
+  let result = '';
+  numerals.forEach(([n, sym]) => {
+    while (num >= n) {
+      result += sym;
+      num -= n;
+    }
+  });
+  return result;
+};
+
+const toAlphabetic = (value: number) => {
+  const base = 'A'.charCodeAt(0);
+  let num = value;
+  let result = '';
+  while (num > 0) {
+    num -= 1;
+    result = String.fromCharCode(base + (num % 26)) + result;
+    num = Math.floor(num / 26);
+  }
+  return result;
+};
+
+export const formatFigureNumber = (
+  index: number,
+  scheme: FigureNumberingScheme,
+): string => {
+  switch (scheme) {
+    case 'roman':
+      return toRoman(index);
+    case 'alphabetic':
+      return toAlphabetic(index);
+    default:
+      return String(index);
+  }
+};
+
+const applyFigureNumbering = (
+  markdown: string,
+  scheme: FigureNumberingScheme,
+) => {
+  let counter = 0;
+  return markdown.replace(figurePattern, (_, caption, url) => {
+    counter += 1;
+    const label = formatFigureNumber(counter, scheme);
+    const captionText = (caption || '').trim();
+    const alt = `Figure ${label}`;
+    const descriptive = captionText || `Figure ${label}`;
+    const captionLine = `\n_Figure ${label}: ${descriptive}_`;
+    return `![${alt}](${url})${captionLine}`;
+  });
+};
+
+const slugify = (title: string, seen: Map<string, number>) => {
+  const base = title
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-');
+  const safeBase = base || 'section';
+  const count = seen.get(safeBase) || 0;
+  seen.set(safeBase, count + 1);
+  if (count === 0) {
+    return safeBase;
+  }
+  return `${safeBase}-${count}`;
+};
+
+const extractHeadings = (markdown: string): HeadingInfo[] => {
+  const headings: HeadingInfo[] = [];
+  const seen = new Map<string, number>();
+  const headingRegex = /^(#{1,6})\s+(.+)$/gm;
+  let match: RegExpExecArray | null;
+  while ((match = headingRegex.exec(markdown))) {
+    const level = match[1].length;
+    const title = match[2].trim();
+    const slug = slugify(title, seen);
+    headings.push({ level, title, slug });
+  }
+  return headings;
+};
+
+const buildTableOfContents = (headings: HeadingInfo[]): string =>
+  headings
+    .filter((heading) => heading.level > 1 || heading.level === 1)
+    .map((heading) => {
+      const indent = '  '.repeat(Math.max(0, heading.level - 1));
+      return `${indent}- [${heading.title}](#${heading.slug})`;
+    })
+    .join('\n');
+
+export const renderTemplate = (
+  template: string,
+  findings: Finding[],
+  sections: Record<string, boolean>,
+): string => {
+  const withSections = template.replace(
+    /{{#section\s+([\w-]+)}}([\s\S]*?){{\/section}}/g,
+    (match, id: string, content: string) => {
+      if (sections[id] === false) {
+        return '';
+      }
+      return content;
+    },
+  );
+
+  return withSections.replace(
+    /{{#findings}}([\s\S]*?){{\/findings}}/g,
+    (_, segment: string) =>
+      findings
+        .map((finding, index) =>
+          segment
+            .replace(/{{index}}/g, String(index + 1))
+            .replace(/{{title}}/g, finding.title)
+            .replace(/{{severity}}/g, finding.severity)
+            .replace(/{{description}}/g, finding.description),
+        )
+        .join(''),
+  );
+};
+
+export interface PreprocessResult {
+  markdown: string;
+  headings: HeadingInfo[];
+  contentHeadings: HeadingInfo[];
+}
+
+export const preprocessMarkdown = (
+  markdown: string,
+  config: TemplateConfig | undefined,
+  scheme: FigureNumberingScheme,
+): PreprocessResult => {
+  const numbered = applyFigureNumbering(markdown, scheme);
+  const contentHeadings = extractHeadings(numbered);
+  const includeToc = config?.includeTableOfContents !== false;
+
+  let finalMarkdown = numbered;
+  if (includeToc && contentHeadings.length > 0) {
+    const toc = buildTableOfContents(contentHeadings);
+    finalMarkdown = `## Table of Contents\n${toc}\n\n${numbered}`;
+  }
+
+  const finalHeadings = extractHeadings(finalMarkdown);
+  return {
+    markdown: finalMarkdown,
+    headings: finalHeadings,
+    contentHeadings,
+  };
+};
+
+export const stripMarkdown = (text: string) =>
+  text
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/__(.+?)__/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\[(.+?)\]\([^)]+\)/g, '$1')
+    .replace(/_([^_]+)_/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1');

--- a/templates/export/report-templates.json
+++ b/templates/export/report-templates.json
@@ -1,10 +1,48 @@
 {
   "executive": {
     "name": "Executive Summary",
-    "template": "Executive Summary\n\nFindings:\n{{#findings}}- {{title}} ({{severity}})\n{{/findings}}"
+    "template": "# Executive Summary Report\n\n{{#section executiveOverview}}## Executive Overview\nThis section highlights the most critical insights discovered during the assessment.\n{{/section}}\n\n## Findings Overview\n{{#findings}}- **{{title}}** ({{severity}})\n{{/findings}}\n\n{{#section appendix}}## Appendix\n![Figure: Attack Surface Overview](figures/attack-surface.png)\nAdditional diagrams and references are included for context.\n{{/section}}\n",
+    "config": {
+      "includeTableOfContents": true,
+      "figureNumbering": {
+        "default": "roman",
+        "options": ["arabic", "roman"]
+      },
+      "optionalSections": [
+        {
+          "id": "executiveOverview",
+          "label": "Include executive overview",
+          "defaultIncluded": true
+        },
+        {
+          "id": "appendix",
+          "label": "Include appendix with figure",
+          "defaultIncluded": false
+        }
+      ]
+    }
   },
   "detailed": {
     "name": "Detailed Report",
-    "template": "Detailed Report\n\n{{#findings}}{{index}}. {{title}}\nSeverity: {{severity}}\n{{description}}\n\n{{/findings}}"
+    "template": "# Detailed Assessment\n\n{{#section summary}}## Summary\nProvide contextual information for stakeholders and outline engagement scope.\n{{/section}}\n\n## Findings\n{{#findings}}### Finding {{index}}: {{title}}\n**Severity:** {{severity}}\n{{description}}\n\n{{/findings}}\n{{#section visuals}}## Visuals\n![Figure: Sample Attack Path](figures/sample-attack-path.png)\nSupporting imagery for walkthroughs and remediation planning.\n{{/section}}\n",
+    "config": {
+      "includeTableOfContents": true,
+      "figureNumbering": {
+        "default": "arabic",
+        "options": ["arabic", "roman", "alphabetic"]
+      },
+      "optionalSections": [
+        {
+          "id": "summary",
+          "label": "Include executive summary section",
+          "defaultIncluded": true
+        },
+        {
+          "id": "visuals",
+          "label": "Include visuals section",
+          "defaultIncluded": true
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add a report processing utility that numbers figure references, generates table of contents anchors, and exposes template configuration metadata
- upgrade Recon-ng report templates UI to honour optional sections, allow figure numbering selection, and export processed markdown or anchored PDF output
- refresh default templates with headings, figure placeholders, and configuration for numbering schemes and optional sections
- add unit coverage for the markdown preprocessing helpers

## Testing
- yarn test __tests__/reportProcessing.test.ts
- yarn lint *(fails: repository has pre-existing accessibility and window/document lint violations outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68cab68aa3d88328b45f75a3453a5f89