### PR TITLE
[packages] add package manager with pinning

### DIFF
--- a/__tests__/usePackageStore.test.ts
+++ b/__tests__/usePackageStore.test.ts
@@ -1,0 +1,52 @@
+import { act, renderHook } from '@testing-library/react';
+import usePackageStore, { PACKAGE_PIN_STORAGE_KEY } from '../hooks/usePackageStore';
+
+describe('usePackageStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('uses pinned versions when building dry run plans', () => {
+    const { result } = renderHook(() => usePackageStore());
+
+    const firstPackage = result.current.packages[0];
+    expect(firstPackage).toBeDefined();
+
+    const selectableVersions = firstPackage.versions.map((ver) => ver.version);
+    expect(selectableVersions.length).toBeGreaterThan(1);
+
+    const secondaryVersion = selectableVersions[1];
+    act(() => {
+      result.current.setVersion(firstPackage.id, secondaryVersion);
+    });
+
+    const initialPlan = result.current.plan.find((item) => item.id === firstPackage.id);
+    expect(initialPlan?.version).toBe(secondaryVersion);
+
+    const pinnedVersion = selectableVersions[0];
+    act(() => {
+      result.current.pinVersion(firstPackage.id, pinnedVersion);
+    });
+
+    const pinnedPlan = result.current.plan.find((item) => item.id === firstPackage.id);
+    expect(pinnedPlan?.version).toBe(pinnedVersion);
+
+    const storedPins = JSON.parse(localStorage.getItem(PACKAGE_PIN_STORAGE_KEY) || '{}');
+    expect(storedPins[firstPackage.id]).toBe(pinnedVersion);
+
+    const tertiaryVersion = selectableVersions[selectableVersions.length - 1];
+    act(() => {
+      result.current.setVersion(firstPackage.id, tertiaryVersion);
+    });
+
+    const planAfterSelectionChange = result.current.plan.find((item) => item.id === firstPackage.id);
+    expect(planAfterSelectionChange?.version).toBe(pinnedVersion);
+
+    act(() => {
+      result.current.clearPin(firstPackage.id);
+    });
+
+    const planAfterUnpin = result.current.plan.find((item) => item.id === firstPackage.id);
+    expect(planAfterUnpin?.version).toBe(tertiaryVersion);
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -87,6 +87,7 @@ const MetasploitApp = createDynamicApp('metasploit', 'Metasploit');
 
 const AutopsyApp = createDynamicApp('autopsy', 'Autopsy');
 const PluginManagerApp = createDynamicApp('plugin-manager', 'Plugin Manager');
+const PackageManagerApp = createDynamicApp('package-manager', 'Package Manager');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
@@ -170,6 +171,7 @@ const displayGhidra = createDisplay(GhidraApp);
 
 const displayAutopsy = createDisplay(AutopsyApp);
 const displayPluginManager = createDisplay(PluginManagerApp);
+const displayPackageManager = createDisplay(PackageManagerApp);
 
 const displayWireshark = createDisplay(WiresharkApp);
 const displayBleSensor = createDisplay(BleSensorApp);
@@ -835,6 +837,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayPluginManager,
+  },
+  {
+    id: 'package-manager',
+    title: 'Package Manager',
+    icon: '/themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayPackageManager,
   },
   {    id: 'reaver',
     title: 'Reaver',

--- a/apps/package-manager/index.tsx
+++ b/apps/package-manager/index.tsx
@@ -1,0 +1,309 @@
+'use client';
+
+import React from 'react';
+import usePackageStore from '../../hooks/usePackageStore';
+
+const PIN_ICON = '📌';
+const LAB_ICON = '🧪';
+const QUEUE_ICON = '📝';
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-400">
+      {children}
+    </h2>
+  );
+}
+
+export default function PackageManagerApp() {
+  const {
+    packages,
+    selectedPackage,
+    selectedId,
+    setSelectedId,
+    setVersion,
+    pins,
+    pinVersion,
+    clearPin,
+    queue,
+    toggleQueued,
+    plan,
+  } = usePackageStore();
+
+  const isPinned = selectedPackage ? Boolean(pins[selectedPackage.id]) : false;
+  const pinnedVersion = selectedPackage ? pins[selectedPackage.id] : undefined;
+  const selectedVersion = selectedPackage?.selectedVersion ?? '';
+  const queued = selectedPackage ? queue.includes(selectedPackage.id) : false;
+
+  const handleVersionChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    if (!selectedPackage) return;
+    setVersion(selectedPackage.id, event.target.value);
+  };
+
+  const togglePin = () => {
+    if (!selectedPackage) return;
+    if (isPinned) {
+      clearPin(selectedPackage.id);
+    } else {
+      pinVersion(selectedPackage.id, selectedVersion);
+    }
+  };
+
+  const togglePlan = () => {
+    if (!selectedPackage) return;
+    toggleQueued(selectedPackage.id);
+  };
+
+  const planForSelection = selectedPackage
+    ? plan.find((item) => item.id === selectedPackage.id)
+    : undefined;
+
+  return (
+    <div className="flex h-full w-full bg-gray-900 text-white">
+      <aside className="flex w-64 flex-col border-r border-gray-800 bg-gray-950/70">
+        <div className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-gray-400">
+          Packages
+        </div>
+        <ul className="flex-1 overflow-y-auto">
+          {packages.map((pkg) => {
+            const active = pkg.id === selectedId;
+            const pkgPinned = Boolean(pkg.pinnedVersion);
+            return (
+              <li key={pkg.id}>
+                <button
+                  type="button"
+                  onClick={() => setSelectedId(pkg.id)}
+                  className={`w-full px-4 py-3 text-left transition-colors duration-150 ${
+                    active ? 'bg-gray-800/80' : 'hover:bg-gray-800/40'
+                  }`}
+                >
+                  <div className="flex items-center justify-between text-sm font-semibold">
+                    <span>{pkg.name}</span>
+                    <div className="flex items-center gap-2 text-xs text-gray-400">
+                      {pkg.queued && (
+                        <span aria-label="Queued for dry run" title="Queued for dry run">
+                          {QUEUE_ICON}
+                        </span>
+                      )}
+                      {pkgPinned && (
+                        <span
+                          className="flex items-center gap-1 text-green-400"
+                          aria-label={`Pinned to ${pkg.pinnedVersion}`}
+                          title={`Pinned to ${pkg.pinnedVersion}`}
+                        >
+                          <span aria-hidden="true">{PIN_ICON}</span>
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <p className="mt-1 text-xs text-gray-400">{pkg.summary}</p>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </aside>
+
+      <main className="flex-1 overflow-y-auto p-6">
+        {selectedPackage ? (
+          <div className="space-y-6">
+            <header>
+              <p className="text-xs uppercase tracking-wide text-gray-400">{selectedPackage.category}</p>
+              <h1 className="text-2xl font-semibold">{selectedPackage.name}</h1>
+              <p className="mt-2 max-w-3xl text-sm text-gray-300">{selectedPackage.summary}</p>
+            </header>
+
+            <section className="grid gap-6 md:grid-cols-2">
+              <div>
+                <SectionTitle>Version</SectionTitle>
+                <select
+                  value={selectedVersion}
+                  onChange={handleVersionChange}
+                  className="w-full rounded border border-gray-700 bg-gray-800 px-3 py-2 text-sm focus:border-ub-orange focus:outline-none"
+                >
+                  {selectedPackage.versions.map((ver) => (
+                    <option key={ver.version} value={ver.version}>
+                      {ver.version}
+                      {ver.releaseDate ? ` — ${ver.releaseDate}` : ''}
+                    </option>
+                  ))}
+                </select>
+                <div className="mt-3 flex flex-wrap gap-2 text-xs text-gray-300">
+                  <button
+                    type="button"
+                    onClick={togglePin}
+                    className={`rounded px-3 py-1 font-medium transition-colors ${
+                      isPinned
+                        ? 'bg-gray-800 text-green-400 hover:bg-gray-700'
+                        : 'bg-ub-orange text-black hover:bg-ub-orange/80'
+                    }`}
+                  >
+                    {isPinned ? 'Unpin version' : 'Pin this version'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={togglePlan}
+                    className={`rounded px-3 py-1 font-medium transition-colors ${
+                      queued
+                        ? 'bg-gray-800 text-ub-orange hover:bg-gray-700'
+                        : 'bg-gray-800 text-gray-200 hover:bg-gray-700'
+                    }`}
+                  >
+                    {queued ? 'Remove from plan' : 'Add to plan'}
+                  </button>
+                  {isPinned ? (
+                    <span className="flex items-center gap-1 text-green-400" aria-live="polite">
+                      <span aria-hidden="true">{PIN_ICON}</span>
+                      Pinned to {pinnedVersion}
+                    </span>
+                  ) : (
+                    <span className="flex items-center gap-1 text-gray-400">
+                      <span aria-hidden="true">{LAB_ICON}</span>
+                      Previewing {selectedVersion || 'latest'}
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              <div className="rounded border border-gray-800 bg-gray-950/60 p-4 text-sm text-gray-300">
+                <SectionTitle>Package metadata</SectionTitle>
+                <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+                  {selectedPackage.size && (
+                    <>
+                      <dt className="text-gray-400">Size</dt>
+                      <dd>{selectedPackage.size}</dd>
+                    </>
+                  )}
+                  {selectedPackage.maintainer && (
+                    <>
+                      <dt className="text-gray-400">Maintainer</dt>
+                      <dd>{selectedPackage.maintainer}</dd>
+                    </>
+                  )}
+                  {selectedPackage.homepage && (
+                    <>
+                      <dt className="text-gray-400">Homepage</dt>
+                      <dd>
+                        <a
+                          href={selectedPackage.homepage}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-ub-orange hover:underline"
+                        >
+                          {selectedPackage.homepage.replace(/^https?:\/\//, '')}
+                        </a>
+                      </dd>
+                    </>
+                  )}
+                  {selectedPackage.dependencies?.length ? (
+                    <>
+                      <dt className="text-gray-400">Dependencies</dt>
+                      <dd>{selectedPackage.dependencies.join(', ')}</dd>
+                    </>
+                  ) : null}
+                </dl>
+                {selectedPackage.description && (
+                  <p className="mt-3 text-xs text-gray-400">{selectedPackage.description}</p>
+                )}
+              </div>
+            </section>
+
+            <section>
+              <SectionTitle>Release notes</SectionTitle>
+              <div className="space-y-3">
+                {selectedPackage.versions.map((ver) => {
+                  const isActive = ver.version === selectedVersion;
+                  const isPinnedVersion = pinnedVersion === ver.version;
+                  return (
+                    <div
+                      key={ver.version}
+                      className={`rounded border px-3 py-3 text-sm transition-colors ${
+                        isActive ? 'border-ub-orange bg-gray-800/70' : 'border-gray-800 bg-gray-900/40'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <div className="font-semibold">{ver.version}</div>
+                        <div className="flex items-center gap-3 text-xs text-gray-400">
+                          {ver.releaseDate && <span>{ver.releaseDate}</span>}
+                          {isPinnedVersion && (
+                            <span className="flex items-center gap-1 text-green-400">
+                              <span aria-hidden="true">{PIN_ICON}</span>
+                              Pinned
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      {ver.notes && <p className="mt-2 text-xs text-gray-300">{ver.notes}</p>}
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section>
+              <SectionTitle>Dry run preview</SectionTitle>
+              {planForSelection ? (
+                <div className="space-y-3">
+                  <p className="text-xs text-gray-400">
+                    Commands are simulated and never leave the browser. Pinned versions override
+                    dropdown selections when present.
+                  </p>
+                  <div className="rounded border border-gray-800 bg-black/50 p-3 font-mono text-xs text-green-400">
+                    {planForSelection.commands.map((cmd, index) => (
+                      <div key={index}>{cmd}</div>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <p className="text-xs text-gray-400">Select or queue a package to preview the dry run.</p>
+              )}
+            </section>
+          </div>
+        ) : (
+          <div className="flex h-full items-center justify-center">
+            <p className="text-sm text-gray-300">Select a package from the list to view its details.</p>
+          </div>
+        )}
+      </main>
+
+      <aside className="hidden w-80 border-l border-gray-800 bg-gray-950/80 p-5 xl:block">
+        <div className="flex items-center justify-between">
+          <SectionTitle>Plan summary</SectionTitle>
+          <span className="text-xs text-gray-500">Dry run only</span>
+        </div>
+        {plan.length === 0 ? (
+          <p className="text-xs text-gray-400">
+            The selected package is previewed automatically. Queue additional packages to stage a
+            multi-tool dry run.
+          </p>
+        ) : (
+          <ul className="space-y-4">
+            {plan.map((item) => (
+              <li key={item.id} className="rounded border border-gray-800 bg-gray-900/60 p-4 text-sm">
+                <div className="flex items-center justify-between font-semibold">
+                  <span>{item.name}</span>
+                  <span
+                    className={`flex items-center gap-1 text-xs ${
+                      item.pinned ? 'text-green-400' : 'text-gray-400'
+                    }`}
+                    aria-label={item.pinned ? `Pinned to ${item.version}` : `Preview ${item.version}`}
+                    title={item.pinned ? `Pinned to ${item.version}` : `Preview ${item.version}`}
+                  >
+                    <span aria-hidden="true">{item.pinned ? PIN_ICON : LAB_ICON}</span>
+                    {item.version}
+                  </span>
+                </div>
+                <p className="mt-2 text-xs text-gray-400">{item.summary}</p>
+                <div className="mt-3 space-y-1 rounded border border-gray-800 bg-black/50 p-2 font-mono text-[11px] text-green-400">
+                  {item.commands.map((cmd, index) => (
+                    <div key={index}>{cmd}</div>
+                  ))}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </aside>
+    </div>
+  );
+}

--- a/data/packages/index.json
+++ b/data/packages/index.json
@@ -1,0 +1,147 @@
+[
+  {
+    "id": "nmap",
+    "name": "Nmap",
+    "category": "Reconnaissance",
+    "summary": "Network mapper and port scanner used for inventorying lab subnets.",
+    "description": "Simulated package metadata for the Nmap network scanning toolkit.",
+    "homepage": "https://nmap.org/",
+    "maintainer": "Insecure.Org (simulated)",
+    "size": "6.4 MB",
+    "defaultVersion": "7.94",
+    "dependencies": ["libpcap", "openssl"],
+    "versions": [
+      {
+        "version": "7.94",
+        "releaseDate": "2024-05-13",
+        "notes": "Latest stable release with NSE script refresh and fingerprint updates."
+      },
+      {
+        "version": "7.93",
+        "releaseDate": "2023-09-21",
+        "notes": "Includes performance improvements for large IPv6 sweeps."
+      },
+      {
+        "version": "7.92",
+        "releaseDate": "2022-09-01",
+        "notes": "Long-term support build used in introductory labs."
+      }
+    ]
+  },
+  {
+    "id": "metasploit-framework",
+    "name": "Metasploit Framework",
+    "category": "Exploitation",
+    "summary": "Penetration testing framework with extensive module catalog.",
+    "description": "Simulated framework metadata showcasing common training builds.",
+    "homepage": "https://www.metasploit.com/",
+    "maintainer": "Rapid7 (simulated)",
+    "size": "110 MB",
+    "defaultVersion": "6.4.0",
+    "dependencies": ["postgresql", "ruby", "openssl"],
+    "versions": [
+      {
+        "version": "6.4.0",
+        "releaseDate": "2024-11-12",
+        "notes": "Ships with refreshed module metadata and simulated content pack."
+      },
+      {
+        "version": "6.3.5",
+        "releaseDate": "2024-05-02",
+        "notes": "Adds mock automation helpers for guided exercises."
+      },
+      {
+        "version": "6.2.1",
+        "releaseDate": "2023-08-18",
+        "notes": "Baseline used for long-running labs and capture-the-flag scenarios."
+      }
+    ]
+  },
+  {
+    "id": "hydra",
+    "name": "Hydra",
+    "category": "Password Attacks",
+    "summary": "Parallelized login cracker supporting common network services.",
+    "description": "Simulated Hydra builds for offline credential testing exercises.",
+    "homepage": "https://github.com/vanhauser-thc/thc-hydra",
+    "maintainer": "THC (simulated)",
+    "size": "3.1 MB",
+    "defaultVersion": "9.6",
+    "dependencies": ["libssh", "openssl"],
+    "versions": [
+      {
+        "version": "9.6",
+        "releaseDate": "2024-03-05",
+        "notes": "Introduces mock progress reporting API used in the portfolio demo."
+      },
+      {
+        "version": "9.5",
+        "releaseDate": "2023-06-14",
+        "notes": "Adds simulated modules for RDP and VNC credential replay exercises."
+      },
+      {
+        "version": "9.3",
+        "releaseDate": "2022-11-09",
+        "notes": "Stable training build with reduced output for classroom walkthroughs."
+      }
+    ]
+  },
+  {
+    "id": "wireshark",
+    "name": "Wireshark",
+    "category": "Network Analysis",
+    "summary": "Packet analyzer with dissectors for numerous protocols.",
+    "description": "Simulated Wireshark packages used for packet analysis labs.",
+    "homepage": "https://www.wireshark.org/",
+    "maintainer": "Wireshark Foundation (simulated)",
+    "size": "52 MB",
+    "defaultVersion": "4.2.3",
+    "dependencies": ["qt6", "glib2"],
+    "versions": [
+      {
+        "version": "4.2.3",
+        "releaseDate": "2024-04-17",
+        "notes": "Latest dissector refresh with canned PCAP samples."
+      },
+      {
+        "version": "4.2.1",
+        "releaseDate": "2023-12-06",
+        "notes": "Adds simulated WPA handshake analyzer for workshop content."
+      },
+      {
+        "version": "4.0.6",
+        "releaseDate": "2023-03-29",
+        "notes": "Long-term maintenance release used across archived labs."
+      }
+    ]
+  },
+  {
+    "id": "john",
+    "name": "John the Ripper",
+    "category": "Password Cracking",
+    "summary": "Offline password cracking utility with extensive hash support.",
+    "description": "Simulated John the Ripper builds packaged for local lab environments.",
+    "homepage": "https://www.openwall.com/john/",
+    "maintainer": "Openwall (simulated)",
+    "size": "14 MB",
+    "defaultVersion": "1.9.0-jumbo-1",
+    "dependencies": ["openssl"],
+    "versions": [
+      {
+        "version": "1.9.0-jumbo-1",
+        "releaseDate": "2024-01-23",
+        "notes": "Adds wordlist staging helpers used in the desktop demo."
+      },
+      {
+        "version": "1.9.0-jumbo-0",
+        "releaseDate": "2023-05-11",
+        "notes": "Includes simulated GPU cracking hooks for explanation overlays."
+      },
+      {
+        "version": "1.8.0",
+        "releaseDate": "2022-02-07",
+        "notes": "Reference build used for reproducible step-by-step labs."
+      }
+    ]
+  }
+]

--- a/hooks/usePackageStore.ts
+++ b/hooks/usePackageStore.ts
@@ -1,0 +1,225 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import packagesCatalog from '../data/packages/index.json';
+import { safeLocalStorage } from '../utils/safeStorage';
+
+export interface PackageVersion {
+  version: string;
+  releaseDate?: string;
+  notes?: string;
+}
+
+export interface PackageInfo {
+  id: string;
+  name: string;
+  summary: string;
+  description?: string;
+  category?: string;
+  homepage?: string;
+  maintainer?: string;
+  size?: string;
+  defaultVersion?: string;
+  dependencies?: string[];
+  versions: PackageVersion[];
+}
+
+export interface PackageWithState extends PackageInfo {
+  selectedVersion: string;
+  effectiveVersion: string;
+  pinnedVersion?: string;
+  queued: boolean;
+}
+
+export interface DryRunPlanItem {
+  id: string;
+  name: string;
+  summary: string;
+  version: string;
+  pinned: boolean;
+  commands: string[];
+}
+
+interface UsePackageStoreResult {
+  packages: PackageWithState[];
+  selectedPackage: PackageWithState | null;
+  selectedId: string;
+  setSelectedId: (id: string) => void;
+  setVersion: (pkgId: string, version: string) => void;
+  pins: Record<string, string>;
+  pinVersion: (pkgId: string, version: string) => void;
+  clearPin: (pkgId: string) => void;
+  queue: string[];
+  toggleQueued: (pkgId: string) => void;
+  plan: DryRunPlanItem[];
+}
+
+const PACKAGE_PIN_STORAGE_KEY = 'package-manager:pins';
+
+type PackageMap = Map<string, PackageInfo>;
+
+type Pins = Record<string, string>;
+
+type VersionSelections = Record<string, string>;
+
+const catalog: PackageInfo[] = packagesCatalog as PackageInfo[];
+
+const loadPins = (): Pins => {
+  if (!safeLocalStorage) return {};
+  try {
+    const stored = safeLocalStorage.getItem(PACKAGE_PIN_STORAGE_KEY);
+    if (!stored) return {};
+    const parsed = JSON.parse(stored);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as Pins;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+};
+
+const createInitialSelections = (map: PackageMap): VersionSelections => {
+  const initial: VersionSelections = {};
+  map.forEach((pkg, id) => {
+    initial[id] = pkg.defaultVersion ?? pkg.versions[0]?.version ?? '';
+  });
+  return initial;
+};
+
+export default function usePackageStore(): UsePackageStoreResult {
+  const packageMap = useMemo<PackageMap>(() => {
+    const map: PackageMap = new Map();
+    for (const pkg of catalog) {
+      map.set(pkg.id, pkg);
+    }
+    return map;
+  }, []);
+
+  const [selectedId, setSelectedId] = useState<string>(() => catalog[0]?.id ?? '');
+  const [selections, setSelections] = useState<VersionSelections>(() =>
+    createInitialSelections(packageMap)
+  );
+  const [pins, setPins] = useState<Pins>(() => loadPins());
+  const [queue, setQueue] = useState<string[]>(() => (catalog[0]?.id ? [catalog[0].id] : []));
+
+  useEffect(() => {
+    if (!safeLocalStorage) return;
+    try {
+      safeLocalStorage.setItem(PACKAGE_PIN_STORAGE_KEY, JSON.stringify(pins));
+    } catch {
+      // Ignore persistence errors (storage may be full or disabled)
+    }
+  }, [pins]);
+
+  const getDefaultVersion = useCallback(
+    (pkgId: string) => {
+      const pkg = packageMap.get(pkgId);
+      return pkg?.defaultVersion ?? pkg?.versions[0]?.version ?? '';
+    },
+    [packageMap]
+  );
+
+  const getSelectedVersion = useCallback(
+    (pkgId: string) => selections[pkgId] ?? getDefaultVersion(pkgId),
+    [selections, getDefaultVersion]
+  );
+
+  const getEffectiveVersion = useCallback(
+    (pkgId: string) => pins[pkgId] ?? getSelectedVersion(pkgId),
+    [pins, getSelectedVersion]
+  );
+
+  const setVersion = useCallback((pkgId: string, version: string) => {
+    setSelections((prev) => {
+      if (prev[pkgId] === version) return prev;
+      return { ...prev, [pkgId]: version };
+    });
+  }, []);
+
+  const pinVersion = useCallback((pkgId: string, version: string) => {
+    setPins((prev) => {
+      if (prev[pkgId] === version) return prev;
+      return { ...prev, [pkgId]: version };
+    });
+  }, []);
+
+  const clearPin = useCallback((pkgId: string) => {
+    setPins((prev) => {
+      if (!(pkgId in prev)) return prev;
+      const next = { ...prev };
+      delete next[pkgId];
+      return next;
+    });
+  }, []);
+
+  const toggleQueued = useCallback((pkgId: string) => {
+    setQueue((prev) => {
+      if (prev.includes(pkgId)) {
+        const next = prev.filter((id) => id !== pkgId);
+        return next.length ? next : [];
+      }
+      return [...prev, pkgId];
+    });
+  }, []);
+
+  const packagesWithState = useMemo<PackageWithState[]>(() =>
+    catalog.map((pkg) => ({
+      ...pkg,
+      selectedVersion: getSelectedVersion(pkg.id),
+      effectiveVersion: getEffectiveVersion(pkg.id),
+      pinnedVersion: pins[pkg.id],
+      queued: queue.includes(pkg.id),
+    })),
+    [getEffectiveVersion, getSelectedVersion, pins, queue]
+  );
+
+  const selectedPackage = useMemo<PackageWithState | null>(() => {
+    if (!selectedId) return null;
+    return packagesWithState.find((pkg) => pkg.id === selectedId) ?? null;
+  }, [packagesWithState, selectedId]);
+
+  const plan = useMemo<DryRunPlanItem[]>(() => {
+    const targets = queue.length ? queue : selectedId ? [selectedId] : [];
+    return targets
+      .map((id) => {
+        const pkg = packageMap.get(id);
+        if (!pkg) return null;
+        const version = getEffectiveVersion(id);
+        const pinned = Boolean(pins[id]);
+        const versionLabel = version || 'latest';
+        const commands: string[] = [
+          `# Inspect available versions for ${pkg.id}`,
+          `apt-cache policy ${pkg.id}`,
+          `# Simulate installing ${pkg.id}${version ? `=${version}` : ''}`,
+          `sudo apt-get install ${pkg.id}${version ? `=${version}` : ''} --dry-run`,
+        ];
+        if (pkg.dependencies?.length) {
+          commands.push(`# Dependencies: ${pkg.dependencies.join(', ')}`);
+        }
+        return {
+          id,
+          name: pkg.name,
+          summary: pkg.summary,
+          version: versionLabel,
+          pinned,
+          commands,
+        } satisfies DryRunPlanItem;
+      })
+      .filter((item): item is DryRunPlanItem => item !== null);
+  }, [queue, selectedId, packageMap, getEffectiveVersion, pins]);
+
+  return {
+    packages: packagesWithState,
+    selectedPackage,
+    selectedId,
+    setSelectedId,
+    setVersion,
+    pins,
+    pinVersion,
+    clearPin,
+    queue,
+    toggleQueued,
+    plan,
+  };
+}
+
+export { PACKAGE_PIN_STORAGE_KEY };

--- a/pages/apps/package-manager.jsx
+++ b/pages/apps/package-manager.jsx
@@ -1,0 +1,14 @@
+import dynamic from 'next/dynamic';
+
+const PackageManagerApp = dynamic(() => import('../../apps/package-manager'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-full items-center justify-center bg-gray-900 text-white">
+      Loading Package Manager...
+    </div>
+  ),
+});
+
+export default function PackageManagerPage() {
+  return <PackageManagerApp />;
+}


### PR DESCRIPTION
## Summary
- add a package catalog JSON feed and a pin-aware store hook that builds dry-run plans from the catalog
- introduce a Package Manager app with version selectors, pin controls, and a dry-run summary decorated with pin icons
- register the app in the desktop configuration and cover the pin-precedence logic with a dedicated hook test

## Testing
- yarn lint *(fails: repository already contains numerous jsx-a11y/control-has-associated-label and no-top-level-window violations)*
- yarn test --runInBand __tests__/usePackageStore.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cab68070e08328849f7d0115401f44