### PR TITLE
[wireshark] Add virtualized PCAP viewer with BPF filters

### DIFF
--- a/__tests__/pcapDisplayFilter.test.ts
+++ b/__tests__/pcapDisplayFilter.test.ts
@@ -1,0 +1,73 @@
+import { createBpfPredicate } from '../apps/wireshark/utils/bpf';
+import { ParsedPacket } from '../apps/wireshark/types';
+
+const basePacket = (overrides: Partial<ParsedPacket> = {}): ParsedPacket => ({
+  index: overrides.index ?? 1,
+  timestamp: overrides.timestamp ?? '1.000000',
+  src: overrides.src ?? '10.0.0.1',
+  dest: overrides.dest ?? '10.0.0.2',
+  protocol: overrides.protocol ?? 6,
+  info: overrides.info ?? 'tcp packet',
+  data: overrides.data ?? new Uint8Array(),
+  length: overrides.length ?? 64,
+  sport: overrides.sport,
+  dport: overrides.dport,
+});
+
+describe('createBpfPredicate', () => {
+  it('filters by protocol keyword', () => {
+    const packets = [
+      basePacket({ protocol: 6 }),
+      basePacket({ protocol: 17, index: 2, info: 'udp packet' }),
+    ];
+    const predicate = createBpfPredicate('tcp');
+    expect(packets.filter(predicate)).toEqual([packets[0]]);
+  });
+
+  it('matches host clauses with direction', () => {
+    const packets = [
+      basePacket({ src: '1.1.1.1', dest: '2.2.2.2' }),
+      basePacket({ index: 2, src: '3.3.3.3', dest: '1.1.1.1' }),
+    ];
+    expect(packets.filter(createBpfPredicate('host 1.1.1.1'))).toEqual(packets);
+    expect(packets.filter(createBpfPredicate('src host 1.1.1.1'))).toEqual([
+      packets[0],
+    ]);
+    expect(packets.filter(createBpfPredicate('dst host 1.1.1.1'))).toEqual([
+      packets[1],
+    ]);
+  });
+
+  it('matches port clauses with protocol and direction', () => {
+    const packets = [
+      basePacket({ sport: 80, dport: 1234 }),
+      basePacket({ index: 2, protocol: 17, sport: 53, dport: 53 }),
+    ];
+    expect(packets.filter(createBpfPredicate('port 80'))).toEqual([packets[0]]);
+    expect(packets.filter(createBpfPredicate('src port 53'))).toEqual([packets[1]]);
+    expect(packets.filter(createBpfPredicate('tcp port 80'))).toEqual([packets[0]]);
+    expect(packets.filter(createBpfPredicate('udp port 80'))).toEqual([]);
+  });
+
+  it('supports compound OR and AND expressions', () => {
+    const packets = [
+      basePacket({ sport: 80, dport: 443 }),
+      basePacket({ index: 2, sport: 8080, dport: 53, protocol: 17 }),
+      basePacket({ index: 3, src: '8.8.8.8', dport: 53, protocol: 17 }),
+    ];
+    const orPredicate = createBpfPredicate('tcp.port == 80 || tcp.port == 443');
+    expect(packets.filter(orPredicate)).toEqual([packets[0]]);
+
+    const andPredicate = createBpfPredicate('udp and dst port 53 and host 8.8.8.8');
+    expect(packets.filter(andPredicate)).toEqual([packets[2]]);
+  });
+
+  it('falls back to substring search when no clause matches', () => {
+    const packets = [
+      basePacket({ info: 'custom rule triggered', index: 5 }),
+      basePacket({ info: 'nothing interesting', index: 6 }),
+    ];
+    const predicate = createBpfPredicate('custom rule');
+    expect(packets.filter(predicate)).toEqual([packets[0]]);
+  });
+});

--- a/__tests__/pcapVirtualRange.test.ts
+++ b/__tests__/pcapVirtualRange.test.ts
@@ -1,0 +1,40 @@
+import { performance } from 'perf_hooks';
+import { calculateVirtualRange } from '../apps/wireshark/utils/virtualization';
+
+describe('calculateVirtualRange', () => {
+  it('limits visible rows for large captures', () => {
+    const range = calculateVirtualRange(0, 420, 28, 5000, 6);
+    const expectedVisible = Math.ceil(420 / 28) + 12; // base + overscan on both ends
+    expect(range.visibleCount).toBeLessThanOrEqual(expectedVisible);
+    expect(range.start).toBe(0);
+  });
+
+  it('clamps the end of the range near the bottom of the list', () => {
+    const rowHeight = 28;
+    const itemCount = 5000;
+    const viewport = 360;
+    const scrollTop = itemCount * rowHeight - viewport / 2;
+    const range = calculateVirtualRange(scrollTop, viewport, rowHeight, itemCount, 6);
+    expect(range.end).toBe(itemCount);
+    expect(range.start).toBeLessThan(itemCount);
+  });
+
+  it('falls back to a sensible height when measurements are zero', () => {
+    const range = calculateVirtualRange(0, 0, 28, 100, 6);
+    expect(range.visibleCount).toBeGreaterThan(0);
+    expect(range.totalHeight).toBe(2800);
+  });
+
+  it('computes ranges efficiently for performance critical scrolling', () => {
+    const iterations = 100_000;
+    const start = performance.now();
+    let result = 0;
+    for (let i = 0; i < iterations; i += 1) {
+      const range = calculateVirtualRange(i % 5000, 420, 28, 5000, 6);
+      result += range.visibleCount;
+    }
+    const duration = performance.now() - start;
+    expect(duration).toBeLessThan(650);
+    expect(result).toBeGreaterThan(0);
+  });
+});

--- a/apps/wireshark/components/PcapViewer.tsx
+++ b/apps/wireshark/components/PcapViewer.tsx
@@ -1,10 +1,13 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { protocolName } from '../../../components/apps/wireshark/utils';
 import FilterHelper from './FilterHelper';
 import presets from '../filters/presets.json';
 import LayerView from './LayerView';
+import { ParsedPacket } from '../types';
+import { createBpfPredicate } from '../utils/bpf';
+import { useVirtualRows } from '../utils/virtualization';
 
 
 interface PcapViewerProps {
@@ -22,33 +25,55 @@ const samples = [
   { label: 'DNS', path: '/samples/wireshark/dns.pcap' },
 ];
 
+const DEFAULT_COLUMNS = [
+  'No.',
+  'Time',
+  'Source',
+  'Destination',
+  'Protocol',
+  'Length',
+  'Info',
+] as const;
+
+const columnSizing: Record<string, string> = {
+  'No.': 'minmax(3.5rem, 4rem)',
+  Time: 'minmax(7rem, 1.5fr)',
+  Source: 'minmax(9rem, 2fr)',
+  Destination: 'minmax(9rem, 2fr)',
+  Protocol: 'minmax(6rem, 1fr)',
+  Length: 'minmax(4rem, 1fr)',
+  Info: 'minmax(12rem, 3fr)',
+};
+
+const ROW_HEIGHT = 28;
+
 // Convert bytes to hex dump string
 const toHex = (bytes: Uint8Array) =>
   Array.from(bytes, (b, i) =>
     `${b.toString(16).padStart(2, '0')}${(i + 1) % 16 === 0 ? '\n' : ' '}`
   ).join('');
 
-interface Packet {
-  timestamp: string;
-  src: string;
-  dest: string;
-  protocol: number;
-  info: string;
-  data: Uint8Array;
-  sport?: number;
-  dport?: number;
-}
-
 interface Layer {
   name: string;
   fields: Record<string, string>;
 }
 
+interface PacketMetadata {
+  src: string;
+  dest: string;
+  protocol: number;
+  info: string;
+  sport?: number;
+  dport?: number;
+}
+
 // Basic Ethernet + IPv4 parser
-const parseEthernetIpv4 = (data: Uint8Array) => {
-  if (data.length < 34) return { src: '', dest: '', protocol: 0, info: '' };
+const parseEthernetIpv4 = (data: Uint8Array): PacketMetadata => {
+  if (data.length < 34)
+    return { src: '', dest: '', protocol: 0, info: '' };
   const etherType = (data[12] << 8) | data[13];
-  if (etherType !== 0x0800) return { src: '', dest: '', protocol: 0, info: '' };
+  if (etherType !== 0x0800)
+    return { src: '', dest: '', protocol: 0, info: '' };
   const protocol = data[23];
   const src = Array.from(data.slice(26, 30)).join('.');
   const dest = Array.from(data.slice(30, 34)).join('.');
@@ -69,7 +94,7 @@ const parseEthernetIpv4 = (data: Uint8Array) => {
 };
 
 // Parse classic pcap format
-const parsePcap = (buf: ArrayBuffer): Packet[] => {
+const parsePcap = (buf: ArrayBuffer): ParsedPacket[] => {
   const view = new DataView(buf);
   const magic = view.getUint32(0, false);
   let little: boolean;
@@ -77,7 +102,8 @@ const parsePcap = (buf: ArrayBuffer): Packet[] => {
   else if (magic === 0xd4c3b2a1) little = true;
   else throw new Error('Unsupported pcap format');
   let offset = 24;
-  const packets: Packet[] = [];
+  const packets: ParsedPacket[] = [];
+  let index = 1;
   while (offset + 16 <= view.byteLength) {
     const tsSec = view.getUint32(offset, little);
     const tsUsec = view.getUint32(offset + 4, little);
@@ -86,8 +112,9 @@ const parsePcap = (buf: ArrayBuffer): Packet[] => {
     offset += 16;
     if (offset + capLen > view.byteLength) break;
     const data = new Uint8Array(buf.slice(offset, offset + capLen));
-    const meta: any = parseEthernetIpv4(data);
+    const meta = parseEthernetIpv4(data);
     packets.push({
+      index: index++,
       timestamp: `${tsSec}.${tsUsec.toString().padStart(6, '0')}`,
       src: meta.src,
       dest: meta.dest,
@@ -96,6 +123,7 @@ const parsePcap = (buf: ArrayBuffer): Packet[] => {
       sport: meta.sport,
       dport: meta.dport,
       data,
+      length: origLen,
     });
     offset += capLen;
   }
@@ -103,12 +131,13 @@ const parsePcap = (buf: ArrayBuffer): Packet[] => {
 };
 
 // Parse PCAP-NG files including section and interface blocks
-const parsePcapNg = (buf: ArrayBuffer): Packet[] => {
+const parsePcapNg = (buf: ArrayBuffer): ParsedPacket[] => {
   const view = new DataView(buf);
   let offset = 0;
   let little = true;
   const ifaces: { tsres: number }[] = [];
-  const packets: Packet[] = [];
+  const packets: ParsedPacket[] = [];
+  let index = 1;
 
   while (offset + 8 <= view.byteLength) {
     let blockType = view.getUint32(offset, little);
@@ -140,12 +169,14 @@ const parsePcapNg = (buf: ArrayBuffer): Packet[] => {
       const tsHigh = view.getUint32(offset + 12, little);
       const tsLow = view.getUint32(offset + 16, little);
       const capLen = view.getUint32(offset + 20, little);
+      const origLen = view.getUint32(offset + 24, little);
       const dataStart = offset + 28;
       const data = new Uint8Array(buf.slice(dataStart, dataStart + capLen));
-      const meta: any = parseEthernetIpv4(data);
+      const meta = parseEthernetIpv4(data);
       const res = ifaces[ifaceId]?.tsres ?? 1e-6;
       const timestamp = ((tsHigh * 2 ** 32 + tsLow) * res).toFixed(6);
       packets.push({
+        index: index++,
         timestamp,
         src: meta.src,
         dest: meta.dest,
@@ -154,6 +185,7 @@ const parsePcapNg = (buf: ArrayBuffer): Packet[] => {
         sport: meta.sport,
         dport: meta.dport,
         data,
+        length: origLen || capLen,
       });
     }
 
@@ -163,7 +195,7 @@ const parsePcapNg = (buf: ArrayBuffer): Packet[] => {
   return packets;
 };
 
-const parseWithWasm = async (buf: ArrayBuffer): Promise<Packet[]> => {
+const parseWithWasm = async (buf: ArrayBuffer): Promise<ParsedPacket[]> => {
   try {
     // Attempt to load wasm parser; fall back to JS parsing
     await WebAssembly.instantiateStreaming(
@@ -177,7 +209,7 @@ const parseWithWasm = async (buf: ArrayBuffer): Promise<Packet[]> => {
   return magic === 0x0a0d0d0a ? parsePcapNg(buf) : parsePcap(buf);
 };
 
-const decodePacketLayers = (pkt: Packet): Layer[] => {
+const decodePacketLayers = (pkt: ParsedPacket): Layer[] => {
   const data = pkt.data;
   const layers: Layer[] = [];
   if (data.length >= 14) {
@@ -235,16 +267,10 @@ const decodePacketLayers = (pkt: Packet): Layer[] => {
 };
 
 const PcapViewer: React.FC<PcapViewerProps> = ({ showLegend = true }) => {
-  const [packets, setPackets] = useState<Packet[]>([]);
+  const [packets, setPackets] = useState<ParsedPacket[]>([]);
   const [filter, setFilter] = useState('');
   const [selected, setSelected] = useState<number | null>(null);
-  const [columns, setColumns] = useState<string[]>([
-    'Time',
-    'Source',
-    'Destination',
-    'Protocol',
-    'Info',
-  ]);
+  const [columns, setColumns] = useState<string[]>([...DEFAULT_COLUMNS]);
   const [dragCol, setDragCol] = useState<string | null>(null);
 
   useEffect(() => {
@@ -289,16 +315,62 @@ const PcapViewer: React.FC<PcapViewerProps> = ({ showLegend = true }) => {
     setSelected(null);
   };
 
-  const filtered = packets.filter((p) => {
-    if (!filter) return true;
-    const term = filter.toLowerCase();
-    return (
-      p.src.toLowerCase().includes(term) ||
-      p.dest.toLowerCase().includes(term) ||
-      protocolName(p.protocol).toLowerCase().includes(term) ||
-      (p.info || '').toLowerCase().includes(term)
-    );
+  const filterPredicate = useMemo(() => createBpfPredicate(filter), [filter]);
+  const filtered = useMemo(() => {
+    if (!filter.trim()) return packets;
+    return packets.filter(filterPredicate);
+  }, [packets, filter, filterPredicate]);
+
+  useEffect(() => {
+    if (selected !== null && (selected < 0 || selected >= filtered.length)) {
+      setSelected(filtered.length ? Math.min(selected, filtered.length - 1) : null);
+    }
+  }, [filtered.length, selected]);
+
+  const gridTemplate = useMemo(
+    () =>
+      columns
+        .map((col) => columnSizing[col] ?? 'minmax(6rem, 1fr)')
+        .join(' '),
+    [columns]
+  );
+
+  const { containerRef, range } = useVirtualRows({
+    itemCount: filtered.length,
+    rowHeight: ROW_HEIGHT,
+    overscan: 6,
   });
+
+  const visiblePackets = useMemo(
+    () => filtered.slice(range.start, range.end),
+    [filtered, range.end, range.start]
+  );
+
+  const getCellValue = (pkt: ParsedPacket, col: string) => {
+    switch (col) {
+      case 'No.':
+        return pkt.index.toString();
+      case 'Time':
+        return pkt.timestamp;
+      case 'Source':
+        return pkt.src;
+      case 'Destination':
+        return pkt.dest;
+      case 'Protocol':
+        return String(protocolName(pkt.protocol));
+      case 'Length':
+        return pkt.length.toString();
+      case 'Info':
+        return pkt.info || '';
+      default:
+        return '';
+    }
+  };
+
+  const getProtocolClass = (pkt: ParsedPacket) => {
+    const proto = String(protocolName(pkt.protocol)).toUpperCase();
+    return protocolColors[proto] || '';
+  };
 
   return (
     <div className="p-4 text-white bg-ub-cool-grey h-full w-full flex flex-col space-y-2">
@@ -370,77 +442,103 @@ const PcapViewer: React.FC<PcapViewerProps> = ({ showLegend = true }) => {
             </div>
           )}
           <div className="flex flex-1 overflow-hidden space-x-2">
-            <div className="overflow-auto flex-1">
-              <table className="text-xs w-full font-mono">
-                <thead>
-                  <tr className="bg-gray-800">
-                    {columns.map((col) => (
-                      <th
-                        key={col}
-                        draggable
-                        onDragStart={() => setDragCol(col)}
-                        onDragOver={(e) => e.preventDefault()}
-                        onDrop={() => {
-                          if (!dragCol || dragCol === col) return;
-                          const updated = [...columns];
-                          const from = updated.indexOf(dragCol);
-                          const to = updated.indexOf(col);
-                          updated.splice(from, 1);
-                          updated.splice(to, 0, dragCol);
-                          setColumns(updated);
-                        }}
-                        className="px-1 text-left cursor-move"
-                      >
-                        {col}
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {filtered.map((pkt, i) => (
-                    <tr
-                      key={i}
-                      className={`cursor-pointer hover:bg-gray-700 ${
-                        selected === i
-                          ? 'outline outline-2 outline-white'
-                          : protocolColors[
-                              protocolName(pkt.protocol).toString()
-                            ] || ''
-                      }`}
-                      onClick={() => setSelected(i)}
+            <div
+              className="flex-1 flex flex-col overflow-hidden"
+              role="table"
+              aria-rowcount={filtered.length}
+            >
+              <div
+                className="bg-gray-800 grid text-xs font-semibold uppercase tracking-wide"
+                style={{ gridTemplateColumns: gridTemplate }}
+                role="row"
+              >
+                {columns.map((col) => (
+                  <div
+                    key={col}
+                    role="columnheader"
+                    draggable
+                    onDragStart={() => setDragCol(col)}
+                    onDragOver={(e) => e.preventDefault()}
+                    onDrop={() => {
+                      if (!dragCol) return;
+                      if (dragCol === col) {
+                        setDragCol(null);
+                        return;
+                      }
+                      const updated = [...columns];
+                      const from = updated.indexOf(dragCol);
+                      const to = updated.indexOf(col);
+                      if (from === -1 || to === -1) return;
+                      updated.splice(from, 1);
+                      updated.splice(to, 0, dragCol);
+                      setColumns(updated);
+                      setDragCol(null);
+                    }}
+                    onDragEnd={() => setDragCol(null)}
+                    className="px-1 py-1 cursor-move select-none"
+                  >
+                    {col}
+                  </div>
+                ))}
+              </div>
+              <div
+                ref={containerRef}
+                data-testid="pcap-scroll-container"
+                className="flex-1 overflow-auto relative border border-gray-800/60 rounded"
+                role="rowgroup"
+              >
+                {filtered.length === 0 ? (
+                  <div className="p-4 text-xs text-gray-400">
+                    No packets match the current filter.
+                  </div>
+                ) : (
+                  <div
+                    style={{
+                      height: `${range.totalHeight}px`,
+                      position: 'relative',
+                      minWidth: '100%',
+                    }}
+                  >
+                    <div
+                      style={{
+                        transform: `translateY(${range.offset}px)`,
+                        willChange: 'transform',
+                      }}
                     >
-                      {columns.map((col) => {
-                        let val = '';
-                        switch (col) {
-                          case 'Time':
-                            val = pkt.timestamp;
-                            break;
-                          case 'Source':
-                            val = pkt.src;
-                            break;
-                          case 'Destination':
-                            val = pkt.dest;
-                            break;
-                          case 'Protocol':
-                            val = protocolName(pkt.protocol);
-                            break;
-                          case 'Info':
-                            val = pkt.info;
-                            break;
-                        }
+                      {visiblePackets.map((pkt, idx) => {
+                        const actualIndex = range.start + idx;
+                        const colorClass = getProtocolClass(pkt);
+                        const isSelected = selected === actualIndex;
                         return (
-                          <td key={col} className="px-1 whitespace-nowrap">
-                            {val}
-                          </td>
+                          <div
+                            key={pkt.index}
+                            role="row"
+                            onClick={() => setSelected(actualIndex)}
+                            className={`grid items-center gap-x-2 px-1 border-b border-gray-800/40 cursor-pointer text-xs font-mono hover:bg-gray-700/70 ${
+                              colorClass
+                            } ${
+                              isSelected ? 'outline outline-2 outline-white' : ''
+                            }`}
+                            style={{
+                              gridTemplateColumns: gridTemplate,
+                              height: `${ROW_HEIGHT}px`,
+                            }}
+                          >
+                            {columns.map((col) => (
+                              <div key={col} role="cell" className="px-1 truncate">
+                                {getCellValue(pkt, col)}
+                              </div>
+                            ))}
+                          </div>
                         );
                       })}
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+                    </div>
+                  </div>
+                )}
+              </div>
             </div>
-            <div className="flex-1 bg-black overflow-auto p-2 text-xs font-mono space-y-1">
-              {selected !== null ? (
+            <div className="flex-1 bg-black overflow-auto p-2 text-xs font-mono space-y-1 border border-gray-800/60 rounded">
+              {selected !== null && filtered[selected] ? (
                 <>
                   {decodePacketLayers(filtered[selected]).map((layer, i) => (
                     <LayerView key={i} name={layer.name} fields={layer.fields} />

--- a/apps/wireshark/types.ts
+++ b/apps/wireshark/types.ts
@@ -1,0 +1,16 @@
+export interface ParsedPacket {
+  index: number;
+  timestamp: string;
+  src: string;
+  dest: string;
+  protocol: number;
+  info: string;
+  data: Uint8Array;
+  length: number;
+  sport?: number;
+  dport?: number;
+}
+
+export type PacketPredicate<T extends ParsedPacket = ParsedPacket> = (
+  packet: T
+) => boolean;

--- a/apps/wireshark/utils/bpf.ts
+++ b/apps/wireshark/utils/bpf.ts
@@ -1,0 +1,191 @@
+import { protocolName } from '../../../components/apps/wireshark/utils.js';
+import { ParsedPacket, PacketPredicate } from '../types';
+
+type Direction = 'src' | 'dst' | 'any';
+
+const protoMap: Record<string, number> = {
+  tcp: 6,
+  udp: 17,
+  icmp: 1,
+};
+
+const stripQuotes = (value: string) => value.replace(/^['"]|['"]$/g, '');
+
+const normalize = (value: string) => stripQuotes(value.trim().toLowerCase());
+
+const asPort = (value: string): number | null => {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 65535
+    ? parsed
+    : null;
+};
+
+const matchesProtocol = (packet: ParsedPacket, proto: string) => {
+  const code = protoMap[proto];
+  if (typeof code !== 'number') return false;
+  return packet.protocol === code;
+};
+
+const matchesHost = (
+  packet: ParsedPacket,
+  host: string,
+  direction: Direction
+) => {
+  const cmp = normalize(host);
+  const src = packet.src?.toLowerCase?.() ?? '';
+  const dest = packet.dest?.toLowerCase?.() ?? '';
+  if (direction === 'src') return src === cmp;
+  if (direction === 'dst') return dest === cmp;
+  return src === cmp || dest === cmp;
+};
+
+const matchesPort = (
+  packet: ParsedPacket,
+  port: number,
+  direction: Direction
+) => {
+  if (direction === 'src') return packet.sport === port;
+  if (direction === 'dst') return packet.dport === port;
+  return packet.sport === port || packet.dport === port;
+};
+
+const buildSubstringPredicate = (term: string): PacketPredicate => {
+  const lowered = term.toLowerCase();
+  return (packet) => {
+    const combined = [
+      packet.index.toString(),
+      packet.timestamp,
+      packet.src,
+      packet.dest,
+      protocolName(packet.protocol).toString(),
+      packet.length.toString(),
+      packet.info ?? '',
+    ]
+      .join(' ')
+      .toLowerCase();
+    return combined.includes(lowered);
+  };
+};
+
+const clauseToPredicate = (clause: string): PacketPredicate => {
+  const trimmed = clause.trim();
+  if (!trimmed) {
+    return () => true;
+  }
+  const lowered = trimmed.toLowerCase();
+
+  if (protoMap[lowered] !== undefined) {
+    return (packet) => matchesProtocol(packet, lowered);
+  }
+
+  const protoPort = lowered.match(/^(tcp|udp)\s+port\s+(\d+)$/);
+  if (protoPort) {
+    const port = asPort(protoPort[2]);
+    if (port !== null) {
+      const proto = protoPort[1];
+      return (packet) =>
+        matchesProtocol(packet, proto) && matchesPort(packet, port, 'any');
+    }
+  }
+
+  const directionalHost = lowered.match(
+    /^(?:(src|dst)\s+)?host\s+(\S+)$/
+  );
+  if (directionalHost) {
+    const [, dir, host] = directionalHost;
+    return (packet) => matchesHost(packet, host, (dir as Direction) ?? 'any');
+  }
+
+  const directionalPort = lowered.match(
+    /^(?:(src|dst)\s+)?port\s+(\d+)$/
+  );
+  if (directionalPort) {
+    const [, dir, portRaw] = directionalPort;
+    const port = asPort(portRaw);
+    if (port !== null) {
+      return (packet) => matchesPort(packet, port, (dir as Direction) ?? 'any');
+    }
+  }
+
+  const tcpUdpPortEquality = lowered.match(
+    /^(tcp|udp)\.port\s*==\s*(\d+)$/
+  );
+  if (tcpUdpPortEquality) {
+    const [, proto, portRaw] = tcpUdpPortEquality;
+    const port = asPort(portRaw);
+    if (port !== null) {
+      return (packet) =>
+        matchesProtocol(packet, proto) && matchesPort(packet, port, 'any');
+    }
+  }
+
+  const ipEquality = lowered.match(/^(?:ip\.addr|host)\s*==\s*(\S+)$/);
+  if (ipEquality) {
+    const host = ipEquality[1];
+    return (packet) => matchesHost(packet, host, 'any');
+  }
+
+  const directionalIpEquality = lowered.match(
+    /^(src|dst)\s+ip\.addr\s*==\s*(\S+)$/
+  );
+  if (directionalIpEquality) {
+    const [, dir, host] = directionalIpEquality;
+    return (packet) => matchesHost(packet, host, dir as Direction);
+  }
+
+  const nakedIp = lowered.match(/^(\d+\.\d+\.\d+\.\d+)$/);
+  if (nakedIp) {
+    return (packet) => matchesHost(packet, nakedIp[1], 'any');
+  }
+
+  const tlsLike = lowered.match(/^(tls|ssl)$/);
+  if (tlsLike) {
+    const keyword = tlsLike[1];
+    return (packet) => (packet.info || '').toLowerCase().includes(keyword);
+  }
+
+  const portOnly = lowered.match(/^\d{1,5}$/);
+  if (portOnly) {
+    const port = asPort(portOnly[0]);
+    if (port !== null) {
+      return (packet) => matchesPort(packet, port, 'any');
+    }
+  }
+
+  return buildSubstringPredicate(trimmed);
+};
+
+const splitOnOperators = (expression: string, operator: RegExp) =>
+  expression
+    .split(operator)
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+export const createBpfPredicate = (
+  expression: string
+): PacketPredicate => {
+  const trimmed = expression.trim();
+  if (!trimmed) {
+    return () => true;
+  }
+
+  const orParts = splitOnOperators(trimmed, /\s*(?:\|\||\bor\b)\s*/i);
+  const clauses = orParts.length > 0 ? orParts : [trimmed];
+
+  const clausePredicates = clauses.map((clause) => {
+    const andParts = splitOnOperators(clause, /\s*(?:&&|\band\b)\s*/i);
+    const predicates = andParts.map((part) => clauseToPredicate(part));
+    return (packet: ParsedPacket) => predicates.every((fn) => fn(packet));
+  });
+
+  return (packet) => clausePredicates.some((predicate) => predicate(packet));
+};
+
+export const filterPackets = <T extends ParsedPacket>(
+  packets: T[],
+  expression: string
+) => {
+  const predicate = createBpfPredicate(expression);
+  return expression.trim() ? packets.filter(predicate) : packets;
+};
+

--- a/apps/wireshark/utils/virtualization.ts
+++ b/apps/wireshark/utils/virtualization.ts
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface VirtualRange {
+  start: number;
+  end: number;
+  offset: number;
+  totalHeight: number;
+  visibleCount: number;
+}
+
+export interface UseVirtualRowsOptions {
+  itemCount: number;
+  rowHeight: number;
+  overscan?: number;
+}
+
+const ensurePositive = (value: number, fallback: number) =>
+  Number.isFinite(value) && value > 0 ? value : fallback;
+
+const defaultHeightFor = (rowHeight: number, overscan: number, count: number) => {
+  const safeRow = ensurePositive(rowHeight, 1);
+  const base = safeRow * Math.max(1, Math.min(count, overscan * 2 + 1));
+  return base;
+};
+
+export const calculateVirtualRange = (
+  scrollTop: number,
+  viewportHeight: number,
+  rowHeight: number,
+  itemCount: number,
+  overscan = 4
+): VirtualRange => {
+  const safeRowHeight = ensurePositive(rowHeight, 1);
+  const safeHeight = ensurePositive(
+    viewportHeight,
+    defaultHeightFor(safeRowHeight, overscan, itemCount)
+  );
+  const safeCount = Math.max(0, itemCount);
+  if (safeCount === 0) {
+    return { start: 0, end: 0, offset: 0, totalHeight: 0, visibleCount: 0 };
+  }
+
+  const rawStart = Math.floor(Math.max(0, scrollTop) / safeRowHeight);
+  const visible = Math.max(1, Math.ceil(safeHeight / safeRowHeight));
+  const overscanAmount = Math.max(0, Math.floor(overscan));
+  const start = Math.max(0, Math.min(rawStart - overscanAmount, safeCount - visible));
+  const end = Math.min(
+    safeCount,
+    rawStart + visible + overscanAmount
+  );
+  const offset = start * safeRowHeight;
+  const totalHeight = safeCount * safeRowHeight;
+  return { start, end, offset, totalHeight, visibleCount: end - start };
+};
+
+export interface VirtualRowsResult {
+  containerRef: React.RefObject<HTMLDivElement>;
+  range: VirtualRange;
+}
+
+const measureHeight = (
+  element: HTMLDivElement,
+  rowHeight: number,
+  overscan: number,
+  itemCount: number
+) => {
+  const measured = element.clientHeight || element.getBoundingClientRect().height;
+  return ensurePositive(
+    measured,
+    defaultHeightFor(rowHeight, overscan, itemCount)
+  );
+};
+
+export const useVirtualRows = ({
+  itemCount,
+  rowHeight,
+  overscan = 4,
+}: UseVirtualRowsOptions): VirtualRowsResult => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [range, setRange] = useState<VirtualRange>(() =>
+    calculateVirtualRange(0, rowHeight, rowHeight, itemCount, overscan)
+  );
+
+  const updateRange = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const height = measureHeight(container, rowHeight, overscan, itemCount);
+    const next = calculateVirtualRange(
+      container.scrollTop,
+      height,
+      rowHeight,
+      itemCount,
+      overscan
+    );
+    setRange((prev) =>
+      prev.start === next.start &&
+      prev.end === next.end &&
+      prev.offset === next.offset &&
+      prev.totalHeight === next.totalHeight &&
+      prev.visibleCount === next.visibleCount
+        ? prev
+        : next
+    );
+  }, [itemCount, overscan, rowHeight]);
+
+  useEffect(() => {
+    updateRange();
+  }, [updateRange]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return undefined;
+
+    const onScroll = () => updateRange();
+    const onResize = () => updateRange();
+
+    container.addEventListener('scroll', onScroll, { passive: true });
+
+    let resizeObserver: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(onResize);
+      resizeObserver.observe(container);
+    } else {
+      window.addEventListener('resize', onResize);
+    }
+
+    return () => {
+      container.removeEventListener('scroll', onScroll);
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      } else {
+        window.removeEventListener('resize', onResize);
+      }
+    };
+  }, [updateRange]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const height = measureHeight(container, rowHeight, overscan, itemCount);
+    const totalHeight = Math.max(0, itemCount * Math.max(1, rowHeight));
+    const maxScroll = Math.max(0, totalHeight - height);
+    if (container.scrollTop > maxScroll) {
+      container.scrollTop = maxScroll;
+    }
+    setRange(() =>
+      calculateVirtualRange(container.scrollTop, height, rowHeight, itemCount, overscan)
+    );
+  }, [itemCount, overscan, rowHeight]);
+
+  return { containerRef, range };
+};
+


### PR DESCRIPTION
## Summary
- extend the Wireshark packet viewer to track packet indices/lengths, expose them in the grid, and virtualize the row rendering for large captures
- add lightweight BPF-style filtering utilities and types so filters like `tcp`, host/port clauses, and compound expressions work immediately
- cover the new filter parsing and virtualization range logic with focused unit/perf tests

## Testing
- `yarn lint` *(fails: pre-existing accessibility warnings across legacy apps)*
- `yarn test` *(fails: existing window/nmap/modal suites rely on browser APIs)*
- `yarn test __tests__/pcapVirtualRange.test.ts --runInBand --watchAll=false`
- `yarn test __tests__/pcapDisplayFilter.test.ts --runInBand --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68cc1e4d172c83288eae825c8e2ec9c4