### PR TITLE
[tower-defense] add telemetry export

### DIFF
--- a/__tests__/apps/tower-defense/telemetry.test.tsx
+++ b/__tests__/apps/tower-defense/telemetry.test.tsx
@@ -1,0 +1,22 @@
+import { serializeTelemetryToCsv, WaveTelemetryRow } from "../../../apps/tower-defense";
+
+describe("tower defense telemetry export", () => {
+  it("includes header and formatted rows", () => {
+    const rows: WaveTelemetryRow[] = [
+      { wave: 2, leaks: 1, damage: 40, earned: 30, spent: 20 },
+      { wave: 1, leaks: 0, damage: 10, earned: 5, spent: 15 },
+    ];
+
+    const csv = serializeTelemetryToCsv(rows);
+
+    expect(csv.split("\n")[0]).toBe("Wave,Leaks,Tower Damage,Economy");
+    expect(csv.split("\n").slice(1)).toEqual([
+      "2,1,40,+30 / -20 (+10)",
+      "1,0,10,+5 / -15 (-10)",
+    ]);
+  });
+
+  it("returns only the header when there is no telemetry", () => {
+    expect(serializeTelemetryToCsv([])).toBe("Wave,Leaks,Tower Damage,Economy");
+  });
+});


### PR DESCRIPTION
## Summary
- track per-wave leaks, tower damage, and economy data in the tower defense app
- surface a telemetry panel with CSV export that mirrors on-screen columns
- add Jest coverage for the telemetry CSV serialization helper

## Testing
- yarn lint *(fails: existing repo accessibility and no-top-level-window lint violations)*
- yarn test telemetry

------
https://chatgpt.com/codex/tasks/task_e_68cc27f29b3c83289da55ebb7a907080