### PR TITLE
[tower-defense] finalize offscreen rendering with regression tests

### DIFF
--- a/__tests__/apps/tower-defense/rendering.test.tsx
+++ b/__tests__/apps/tower-defense/rendering.test.tsx
@@ -1,0 +1,280 @@
+import { act, fireEvent, render } from '@testing-library/react';
+import TowerDefense from '../../../apps/tower-defense';
+import type { Projectile } from '../../../apps/games/tower-defense';
+import * as offscreen from '../../../apps/tower-defense/render/offscreen';
+
+jest.mock('../../../apps/tower-defense/render/offscreen', () => {
+  const actual = jest.requireActual(
+    '../../../apps/tower-defense/render/offscreen',
+  );
+  return {
+    __esModule: true,
+    ...actual,
+    getProjectileRenderer: jest.fn(),
+    resetProjectileRenderer: jest.fn(() => actual.resetProjectileRenderer()),
+  };
+});
+
+const offscreenActual = jest.requireActual<
+  typeof import('../../../apps/tower-defense/render/offscreen')
+>('../../../apps/tower-defense/render/offscreen');
+
+type ActualProjectileRenderer = ReturnType<
+  typeof offscreenActual.getProjectileRenderer
+>;
+type DrawParams = Parameters<ActualProjectileRenderer['draw']>;
+const getProjectileRendererMock =
+  offscreen.getProjectileRenderer as jest.MockedFunction<
+    typeof offscreenActual.getProjectileRenderer
+  >;
+
+const CANVAS_SIZE = 400;
+const CELL_SIZE = 40;
+
+const createContextMock = (canvas: HTMLCanvasElement) => {
+  const gradient = { addColorStop: jest.fn() };
+  return {
+    canvas,
+    clearRect: jest.fn(),
+    drawImage: jest.fn(),
+    beginPath: jest.fn(),
+    moveTo: jest.fn(),
+    lineTo: jest.fn(),
+    stroke: jest.fn(),
+    fillRect: jest.fn(),
+    strokeRect: jest.fn(),
+    arc: jest.fn(),
+    fill: jest.fn(),
+    fillText: jest.fn(),
+    save: jest.fn(),
+    restore: jest.fn(),
+    createRadialGradient: jest.fn(() => gradient),
+    createLinearGradient: jest.fn(() => gradient),
+  };
+};
+
+type ContextMock = ReturnType<typeof createContextMock>;
+
+const advanceFrames = (ms: number) => {
+  act(() => {
+    jest.advanceTimersByTime(ms);
+  });
+};
+
+describe('tower defense rendering layers', () => {
+  let contextMap: WeakMap<HTMLCanvasElement, ContextMock>;
+  let createdCanvases: HTMLCanvasElement[] = [];
+  let originalCreateElement: typeof document.createElement;
+  let originalRAF: typeof requestAnimationFrame | undefined;
+  let originalCAF: typeof cancelAnimationFrame | undefined;
+  type MockedProjectileRenderer = jest.Mocked<ActualProjectileRenderer> & {
+    hasContent: boolean;
+  };
+  let mockRenderer: MockedProjectileRenderer;
+  let mockCanvas: HTMLCanvasElement;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    contextMap = new WeakMap();
+    let now = 0;
+    jest.spyOn(performance, 'now').mockImplementation(() => now);
+    originalRAF = global.requestAnimationFrame;
+    originalCAF = global.cancelAnimationFrame;
+    global.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      const id = setTimeout(() => {
+        now += 16;
+        cb(now);
+      }, 16);
+      return id as unknown as number;
+    }) as typeof requestAnimationFrame;
+    global.cancelAnimationFrame = ((id: number) => {
+      clearTimeout(id);
+    }) as typeof cancelAnimationFrame;
+
+    createdCanvases = [];
+
+    jest
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation(function getContext(this: HTMLCanvasElement) {
+        if (!contextMap.has(this)) {
+          contextMap.set(this, createContextMock(this));
+        }
+        return contextMap.get(this) as unknown as CanvasRenderingContext2D;
+      });
+
+    originalCreateElement = document.createElement.bind(document);
+    jest.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      const element = originalCreateElement(tagName);
+      if (tagName.toLowerCase() === 'canvas') {
+        createdCanvases.push(element as HTMLCanvasElement);
+      }
+      return element;
+    });
+
+    mockCanvas = document.createElement('canvas');
+    mockCanvas.dataset.layer = 'tower-defense-projectiles';
+    mockRenderer = {
+      hasContent: false,
+      draw: jest.fn(
+        (projectiles: DrawParams[0], _cellSize: DrawParams[1]) => {
+          mockRenderer.hasContent = projectiles.some((p) => p.active);
+        },
+      ),
+      blit: jest.fn((ctx: CanvasRenderingContext2D) => {
+        if (!mockRenderer.hasContent) return;
+        ctx.drawImage(mockCanvas, 0, 0);
+      }),
+      resize: jest.fn(),
+      getCanvas: jest.fn(() => mockCanvas),
+    } as MockedProjectileRenderer;
+    getProjectileRendererMock.mockReturnValue(
+      mockRenderer as unknown as ActualProjectileRenderer,
+    );
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    getProjectileRendererMock.mockReset();
+    offscreenActual.resetProjectileRenderer();
+    jest.restoreAllMocks();
+    if (originalRAF) {
+      global.requestAnimationFrame = originalRAF;
+    }
+    if (originalCAF) {
+      global.cancelAnimationFrame = originalCAF;
+    }
+  });
+
+  const setupTowerDefense = () => {
+    const utils = render(<TowerDefense />);
+    const canvas = utils.container.querySelector('canvas');
+    if (!canvas) {
+      throw new Error('no canvas rendered');
+    }
+    Object.assign(canvas, {
+      getBoundingClientRect: () => ({
+        left: 0,
+        top: 0,
+        right: CANVAS_SIZE,
+        bottom: CANVAS_SIZE,
+        width: CANVAS_SIZE,
+        height: CANVAS_SIZE,
+        x: 0,
+        y: 0,
+      }),
+    });
+    advanceFrames(32);
+    const clickCell = (clientX: number, clientY: number) => {
+      act(() => {
+        fireEvent.click(canvas, { clientX, clientY });
+      });
+      advanceFrames(64);
+    };
+    return { ...utils, canvas: canvas as HTMLCanvasElement, clickCell };
+  };
+
+  const prepareBattlefield = () => {
+    const utils = setupTowerDefense();
+    utils.clickCell(20, 200);
+    utils.clickCell(380, 200);
+    act(() => {
+      fireEvent.click(utils.getByText('Finish Editing'));
+    });
+    advanceFrames(64);
+    utils.clickCell(160, 160);
+    return utils;
+  };
+
+  const getContextFor = (canvas: HTMLCanvasElement) => {
+    const ctx = contextMap.get(canvas);
+    if (!ctx) throw new Error('missing context');
+    return ctx;
+  };
+
+  test('projectiles render through offscreen buffer', () => {
+    const utils = prepareBattlefield();
+    act(() => {
+      fireEvent.click(utils.getByText('Start'));
+    });
+    advanceFrames(4000);
+    advanceFrames(4000);
+
+    expect(mockRenderer.draw).toHaveBeenCalled();
+
+    const mainCtx = getContextFor(utils.canvas);
+    const blitsMainCanvas = mockRenderer.blit.mock.calls.some(
+      ([ctx]) => ctx === mainCtx,
+    );
+    expect(blitsMainCanvas).toBe(true);
+  });
+
+  test('background redraw stays throttled after initial changes', () => {
+    prepareBattlefield();
+    const backgroundCanvas = createdCanvases.find(
+      (c) => c.dataset.layer === 'tower-defense-background',
+    );
+    expect(backgroundCanvas).toBeDefined();
+    const backgroundCtx = getContextFor(backgroundCanvas!);
+
+    // Allow initial redraws to occur
+    advanceFrames(500);
+    const clearsAfterSetup = backgroundCtx.clearRect.mock.calls.length;
+
+    // Run many frames without altering the layout and ensure no extra clears
+    advanceFrames(4000);
+    expect(backgroundCtx.clearRect.mock.calls.length).toBe(clearsAfterSetup);
+  });
+});
+
+describe('projectile renderer utility', () => {
+  let contextMap: WeakMap<HTMLCanvasElement, ContextMock>;
+
+  beforeEach(() => {
+    contextMap = new WeakMap();
+    jest
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation(function getContext(this: HTMLCanvasElement) {
+        if (!contextMap.has(this)) {
+          contextMap.set(this, createContextMock(this));
+        }
+        return contextMap.get(this) as unknown as CanvasRenderingContext2D;
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    offscreenActual.resetProjectileRenderer();
+  });
+
+  test('offscreen canvas is tagged for debugging', () => {
+    const renderer = offscreenActual.getProjectileRenderer(CANVAS_SIZE, CANVAS_SIZE);
+    const canvas = renderer.getCanvas() as HTMLCanvasElement | null;
+    expect(canvas?.dataset.layer).toBe('tower-defense-projectiles');
+  });
+
+  test('blits only when projectiles are active', () => {
+    const renderer = offscreenActual.getProjectileRenderer(CANVAS_SIZE, CANVAS_SIZE);
+    const mainCtx = createContextMock(document.createElement('canvas'));
+
+    renderer.draw([], CELL_SIZE);
+    renderer.blit(mainCtx as unknown as CanvasRenderingContext2D);
+    expect(mainCtx.drawImage).not.toHaveBeenCalled();
+
+    const projectile: Projectile = {
+      active: true,
+      x: 10,
+      y: 12,
+      targetId: 1,
+      damage: 5,
+      speed: 1,
+    };
+
+    renderer.draw([projectile], CELL_SIZE);
+    renderer.blit(mainCtx as unknown as CanvasRenderingContext2D);
+    expect(mainCtx.drawImage).toHaveBeenCalled();
+  });
+});

--- a/apps/tower-defense/render/offscreen.ts
+++ b/apps/tower-defense/render/offscreen.ts
@@ -1,0 +1,157 @@
+import type { Projectile } from '../../games/tower-defense';
+
+type CanvasLike = HTMLCanvasElement | OffscreenCanvas;
+type ContextLike =
+  | CanvasRenderingContext2D
+  | OffscreenCanvasRenderingContext2D
+  | null;
+
+type ProjectileRenderer = {
+  draw: (projectiles: Projectile[], cellSize: number) => void;
+  blit: (ctx: CanvasRenderingContext2D) => void;
+  resize: (width: number, height: number) => void;
+  getCanvas: () => CanvasLike | null;
+};
+
+const projectileSprites = new Map<number, CanvasLike>();
+
+const createCanvas = (width: number, height: number): CanvasLike | null => {
+  if (typeof OffscreenCanvas !== 'undefined') {
+    return new OffscreenCanvas(width, height);
+  }
+  if (typeof document !== 'undefined') {
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    return canvas;
+  }
+  return null;
+};
+
+const getContext = (canvas: CanvasLike | null): ContextLike =>
+  canvas ? canvas.getContext('2d') : null;
+
+const getSprite = (radius: number): CanvasLike | null => {
+  if (projectileSprites.has(radius)) {
+    return projectileSprites.get(radius) ?? null;
+  }
+  const size = radius * 2;
+  const canvas = createCanvas(size, size);
+  if (!canvas) {
+    projectileSprites.set(radius, null as unknown as CanvasLike);
+    return null;
+  }
+  const ctx = getContext(canvas);
+  if (!ctx) {
+    projectileSprites.set(radius, canvas);
+    return canvas;
+  }
+  ctx.clearRect(0, 0, size, size);
+  const gradient = ctx.createRadialGradient(
+    radius,
+    radius,
+    Math.max(1, radius / 4),
+    radius,
+    radius,
+    radius,
+  );
+  gradient.addColorStop(0, 'rgba(255,255,255,0.9)');
+  gradient.addColorStop(1, 'rgba(255,120,0,0.7)');
+  ctx.fillStyle = gradient;
+  ctx.beginPath();
+  ctx.arc(radius, radius, radius, 0, Math.PI * 2);
+  ctx.fill();
+  projectileSprites.set(radius, canvas);
+  return canvas;
+};
+
+let instance: (ProjectileRenderer & {
+  canvas: CanvasLike | null;
+  ctx: ContextLike;
+  width: number;
+  height: number;
+  hasContent: boolean;
+}) | null = null;
+
+const ensureRenderer = (
+  width: number,
+  height: number,
+): ProjectileRenderer & {
+  canvas: CanvasLike | null;
+  ctx: ContextLike;
+  hasContent: boolean;
+} => {
+  if (!instance) {
+    const canvas = createCanvas(width, height);
+    if (canvas && 'dataset' in canvas) {
+      (canvas as HTMLCanvasElement).dataset.layer = 'tower-defense-projectiles';
+    }
+    instance = {
+      canvas,
+      ctx: getContext(canvas),
+      width,
+      height,
+      hasContent: false,
+      draw(projectiles: Projectile[], cellSize: number) {
+        if (!instance?.ctx || !instance.canvas) return;
+        const ctx = instance.ctx;
+        const active = projectiles.filter((p) => p.active);
+        if (!active.length) {
+          instance.hasContent = false;
+          ctx.clearRect(0, 0, instance.width, instance.height);
+          return;
+        }
+        ctx.clearRect(0, 0, instance.width, instance.height);
+        const radius = Math.max(2, Math.round(cellSize / 6));
+        const sprite = getSprite(radius);
+        instance.hasContent = true;
+        active.forEach((projectile) => {
+          const x = projectile.x - radius;
+          const y = projectile.y - radius;
+          if (sprite) {
+            ctx.drawImage(sprite as CanvasImageSource, x, y);
+          } else {
+            ctx.beginPath();
+            ctx.arc(projectile.x, projectile.y, radius, 0, Math.PI * 2);
+            ctx.fillStyle = 'rgba(255,160,0,0.8)';
+            ctx.fill();
+          }
+        });
+      },
+      blit(ctx: CanvasRenderingContext2D) {
+        if (!instance?.canvas || !instance.hasContent) return;
+        ctx.drawImage(instance.canvas as CanvasImageSource, 0, 0);
+      },
+      resize(newWidth: number, newHeight: number) {
+        if (!instance) return;
+        instance.width = newWidth;
+        instance.height = newHeight;
+        const { canvas } = instance;
+        if (!canvas) return;
+        if ('width' in canvas) {
+          (canvas as HTMLCanvasElement).width = newWidth;
+          (canvas as HTMLCanvasElement).height = newHeight;
+        } else if (canvas instanceof OffscreenCanvas) {
+          canvas.width = newWidth;
+          canvas.height = newHeight;
+        }
+      },
+      getCanvas() {
+        return instance?.canvas ?? null;
+      },
+    };
+  } else if (instance.width !== width || instance.height !== height) {
+    instance.resize(width, height);
+  }
+  return instance;
+};
+
+export const getProjectileRenderer = (
+  width: number,
+  height: number,
+): ProjectileRenderer => ensureRenderer(width, height);
+
+export const resetProjectileRenderer = () => {
+  instance = null;
+  projectileSprites.clear();
+};


### PR DESCRIPTION
## Summary
- reuse a cached background canvas, projectile pools, and offscreen blitting in the tower defense renderer
- add an offscreen projectile renderer module that caches gradient sprites and exposes reset helpers
- cover the rendering pipeline with jest tests, including offscreen blitting, background throttling, and renderer utility behaviors

## Testing
- yarn test __tests__/apps/tower-defense/rendering.test.tsx --watch=false
- yarn lint *(fails: pre-existing jsx-a11y/control-has-associated-label & no-top-level-window errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cc27f3968883289d72772281aee65f