### PR TITLE
[games] ensure minesweeper first click is safe

### DIFF
--- a/__tests__/apps/minesweeper/safe-first-click.test.tsx
+++ b/__tests__/apps/minesweeper/safe-first-click.test.tsx
@@ -1,0 +1,61 @@
+import { generateBoard } from '../../../games/minesweeper/generator';
+import type { Cell } from '../../../games/minesweeper/save';
+
+type Board = Cell[][];
+
+const collectZeroRegion = (board: Board, startX: number, startY: number) => {
+  const visited = new Set<string>();
+  const queue: Array<[number, number]> = [[startX, startY]];
+  while (queue.length) {
+    const [x, y] = queue.shift()!;
+    if (x < 0 || x >= board.length || y < 0 || y >= board[x].length) continue;
+    const key = `${x},${y}`;
+    if (visited.has(key)) continue;
+    const cell = board[x][y];
+    visited.add(key);
+    if (cell.adjacent !== 0) continue;
+    for (let dx = -1; dx <= 1; dx += 1) {
+      for (let dy = -1; dy <= 1; dy += 1) {
+        if (dx === 0 && dy === 0) continue;
+        queue.push([x + dx, y + dy]);
+      }
+    }
+  }
+  return visited;
+};
+
+describe('Minesweeper safe first click', () => {
+  const seeds = [12345, 67890, 987654321];
+  const positions: Array<[number, number]> = [
+    [0, 0],
+    [0, 7],
+    [7, 0],
+    [7, 7],
+    [3, 3],
+    [4, 2],
+  ];
+
+  test.each(seeds.flatMap((seed) => positions.map(([x, y]) => [seed, x, y])))
+    ('seed %d safe region at (%d,%d)', (seed, x, y) => {
+      const board = generateBoard(seed as number, {
+        startX: x as number,
+        startY: y as number,
+      });
+      const cell = board[x as number][y as number];
+      expect(cell.mine).toBe(false);
+      expect(cell.adjacent).toBe(0);
+
+      for (let dx = -1; dx <= 1; dx += 1) {
+        for (let dy = -1; dy <= 1; dy += 1) {
+          const nx = (x as number) + dx;
+          const ny = (y as number) + dy;
+          if (nx < 0 || nx >= board.length || ny < 0 || ny >= board.length) continue;
+          expect(board[nx][ny].mine).toBe(false);
+          expect(board[nx][ny].adjacent).toBe(0);
+        }
+      }
+
+      const revealed = collectZeroRegion(board, x as number, y as number);
+      expect(revealed.size).toBeGreaterThan(1);
+    });
+});

--- a/components/apps/minesweeper.js
+++ b/components/apps/minesweeper.js
@@ -71,12 +71,15 @@ const generateBoard = (seed, sx, sy) => {
   }
 
   const safe = new Set();
-  for (let dx = -1; dx <= 1; dx++) {
-    for (let dy = -1; dy <= 1; dy++) {
-      const nx = sx + dx;
-      const ny = sy + dy;
-      if (nx >= 0 && nx < BOARD_SIZE && ny >= 0 && ny < BOARD_SIZE) {
-        safe.add(nx * BOARD_SIZE + ny);
+  if (typeof sx === 'number' && typeof sy === 'number') {
+    const SAFE_RADIUS = 2;
+    for (let dx = -SAFE_RADIUS; dx <= SAFE_RADIUS; dx++) {
+      for (let dy = -SAFE_RADIUS; dy <= SAFE_RADIUS; dy++) {
+        const nx = sx + dx;
+        const ny = sy + dy;
+        if (nx >= 0 && nx < BOARD_SIZE && ny >= 0 && ny < BOARD_SIZE) {
+          safe.add(nx * BOARD_SIZE + ny);
+        }
       }
     }
   }
@@ -589,12 +592,13 @@ const Minesweeper = () => {
 
   const handleClick = async (x, y) => {
     if (status === 'lost' || status === 'won' || paused) return;
-    if (!board) {
+    if (status === 'ready') {
       await startGame(x, y);
       playSound('reveal');
       return;
     }
 
+    if (!board) return;
     const newBoard = cloneBoard(board);
     const cell = newBoard[x][y];
 
@@ -1157,5 +1161,6 @@ const Minesweeper = () => {
   );
 };
 
+export { generateBoard };
 export default Minesweeper;
 

--- a/games/minesweeper/generator.ts
+++ b/games/minesweeper/generator.ts
@@ -42,8 +42,9 @@ export function generateBoard(
   }
 
   const safe = new Set<number>();
-  for (let dx = -1; dx <= 1; dx++) {
-    for (let dy = -1; dy <= 1; dy++) {
+  const SAFE_RADIUS = 2;
+  for (let dx = -SAFE_RADIUS; dx <= SAFE_RADIUS; dx++) {
+    for (let dy = -SAFE_RADIUS; dy <= SAFE_RADIUS; dy++) {
       const nx = startX + dx;
       const ny = startY + dy;
       if (nx >= 0 && nx < size && ny >= 0 && ny < size) {


### PR DESCRIPTION
## Summary
- expand the exclusion radius when seeding Minesweeper boards so the initial click opens a zero region
- apply the same safe zone logic to the shared generator utility
- add coverage that checks multiple seeds and coordinates for safe first-click behavior

## Testing
- yarn test --runTestsByPath __tests__/minesweeper.generate.test.ts
- yarn test --runTestsByPath __tests__/apps/minesweeper/safe-first-click.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68cc27f6de7483288274d8188aa99744