### PR TITLE
[apps] Add Minesweeper timer and leaderboard tests

### DIFF
--- a/__tests__/apps/minesweeper/leaderboard.test.tsx
+++ b/__tests__/apps/minesweeper/leaderboard.test.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MinesweeperApp from '../../../apps/minesweeper';
+
+jest.mock('../../../components/apps/minesweeper', () => {
+  const React = require('react');
+  return function MockMinesweeper({
+    onGameStart,
+    onGameEnd,
+    onStatusChange,
+    onPausedChange,
+    difficulty,
+  }: any) {
+    React.useEffect(() => {
+      onStatusChange?.('ready');
+    }, [onStatusChange]);
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() => {
+            onGameStart?.({ difficulty, elapsed: 0 });
+            onStatusChange?.('playing');
+          }}
+        >
+          Start
+        </button>
+        <button type="button" onClick={() => onPausedChange?.(true)}>
+          Pause
+        </button>
+        <button type="button" onClick={() => onPausedChange?.(false)}>
+          Resume
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            onGameEnd?.({ result: 'won', time: 1.5, difficulty });
+            onStatusChange?.('won');
+          }}
+        >
+          Win
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            onGameEnd?.({ result: 'lost', time: 2, difficulty });
+            onStatusChange?.('lost');
+          }}
+        >
+          Lose
+        </button>
+      </div>
+    );
+  };
+});
+
+describe('Minesweeper leaderboard', () => {
+  let promptSpy: jest.SpyInstance<string | null, [message?: string, _default?: string]>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    jest.useFakeTimers();
+    promptSpy = jest.spyOn(window, 'prompt').mockReturnValue('Tester');
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    promptSpy.mockRestore();
+  });
+
+  it('starts the timer on game start and stops it on win', () => {
+    render(<MinesweeperApp />);
+    const startButton = screen.getByRole('button', { name: /start/i });
+    const winButton = screen.getByRole('button', { name: /win/i });
+    const timerDisplay = screen.getByTestId('timer-display');
+
+    expect(timerDisplay).toHaveTextContent('0.00s');
+
+    fireEvent.click(startButton);
+    act(() => {
+      jest.advanceTimersByTime(2500);
+    });
+    expect(timerDisplay).toHaveTextContent('2.50s');
+
+    fireEvent.click(winButton);
+    expect(timerDisplay).toHaveTextContent('1.50s');
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(timerDisplay).toHaveTextContent('1.50s');
+  });
+
+  it('records leaderboard entries per difficulty and supports clearing records', () => {
+    render(<MinesweeperApp />);
+    promptSpy.mockReturnValueOnce('Alice').mockReturnValueOnce('Bob').mockReturnValue('Tester');
+    fireEvent.click(screen.getByRole('button', { name: /start/i }));
+    fireEvent.click(screen.getByRole('button', { name: /win/i }));
+
+    expect(promptSpy).toHaveBeenCalled();
+    expect(screen.getByText(/Alice/)).toBeInTheDocument();
+    const leaderboardList = screen.getByTestId('leaderboard-list');
+    expect(within(leaderboardList).getByText(/1\.50s/)).toBeInTheDocument();
+
+    let stored = JSON.parse(localStorage.getItem('minesweeper:leaderboard') || '{}');
+    expect(stored.beginner).toHaveLength(1);
+
+    fireEvent.change(screen.getByTestId('difficulty-select'), {
+      target: { value: 'expert' },
+    });
+    expect(screen.getByText(/No records yet/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /start/i }));
+    fireEvent.click(screen.getByRole('button', { name: /win/i }));
+
+    expect(screen.getByText(/Bob/)).toBeInTheDocument();
+
+    stored = JSON.parse(localStorage.getItem('minesweeper:leaderboard') || '{}');
+    expect(stored.beginner).toHaveLength(1);
+    expect(stored.expert).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /clear leaderboard/i }));
+    expect(screen.getByText(/No records yet/i)).toBeInTheDocument();
+
+    stored = JSON.parse(localStorage.getItem('minesweeper:leaderboard') || '{}');
+    Object.values(stored).forEach((entries: unknown) => {
+      expect(Array.isArray(entries)).toBe(true);
+      expect(entries).toHaveLength(0);
+    });
+  });
+});

--- a/apps/minesweeper/index.js
+++ b/apps/minesweeper/index.js
@@ -1,1 +1,297 @@
-export { default } from '../../components/apps/minesweeper';
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Minesweeper from '../../components/apps/minesweeper';
+
+const LEADERBOARD_STORAGE_KEY = 'minesweeper:leaderboard';
+const SELECTED_DIFFICULTY_KEY = 'minesweeper:selectedDifficulty';
+const MAX_LEADERBOARD_ENTRIES = 5;
+
+const DIFFICULTIES = {
+  beginner: { label: 'Beginner' },
+  intermediate: { label: 'Intermediate' },
+  expert: { label: 'Expert' },
+};
+
+const createEmptyLeaderboard = () =>
+  Object.fromEntries(Object.keys(DIFFICULTIES).map((key) => [key, []]));
+
+const TimerDisplay = ({ elapsedMs }) => (
+  <div className="text-lg font-mono" data-testid="timer-display">
+    Time: {(elapsedMs / 1000).toFixed(2)}s
+  </div>
+);
+
+const sanitizeEntries = (raw) =>
+  raw
+    .filter((entry) => entry && typeof entry.time === 'number' && Number.isFinite(entry.time))
+    .map((entry) => ({
+      name: typeof entry.name === 'string' && entry.name.trim() ? entry.name.trim() : 'Anonymous',
+      time: entry.time,
+      achievedAt: entry.achievedAt ?? null,
+    }))
+    .sort((a, b) => a.time - b.time)
+    .slice(0, MAX_LEADERBOARD_ENTRIES);
+
+const MinesweeperApp = () => {
+  const [difficulty, setDifficulty] = useState('beginner');
+  const [status, setStatus] = useState('ready');
+  const [leaderboard, setLeaderboard] = useState(createEmptyLeaderboard);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [running, setRunning] = useState(false);
+
+  const startRef = useRef(null);
+  const elapsedRef = useRef(0);
+  const hasLoadedLeaderboard = useRef(false);
+
+  useEffect(() => {
+    elapsedRef.current = elapsedMs;
+  }, [elapsedMs]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const storedDifficulty = window.localStorage.getItem(SELECTED_DIFFICULTY_KEY);
+      if (storedDifficulty && DIFFICULTIES[storedDifficulty]) {
+        setDifficulty(storedDifficulty);
+      }
+    } catch {
+      /* ignore stored difficulty errors */
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const raw = window.localStorage.getItem(LEADERBOARD_STORAGE_KEY);
+      if (!raw) {
+        hasLoadedLeaderboard.current = true;
+        return;
+      }
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object') {
+        hasLoadedLeaderboard.current = true;
+        return;
+      }
+      const next = createEmptyLeaderboard();
+      Object.keys(next).forEach((key) => {
+        if (Array.isArray(parsed[key])) {
+          next[key] = sanitizeEntries(parsed[key]);
+        }
+      });
+      setLeaderboard(next);
+    } catch {
+      setLeaderboard(createEmptyLeaderboard());
+    } finally {
+      hasLoadedLeaderboard.current = true;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!hasLoadedLeaderboard.current || typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(LEADERBOARD_STORAGE_KEY, JSON.stringify(leaderboard));
+    } catch {
+      /* ignore persistence errors */
+    }
+  }, [leaderboard]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(SELECTED_DIFFICULTY_KEY, difficulty);
+    } catch {
+      /* ignore persistence errors */
+    }
+  }, [difficulty]);
+
+  useEffect(() => {
+    if (!running) return;
+    const id = setInterval(() => {
+      if (startRef.current != null) {
+        setElapsedMs(Date.now() - startRef.current);
+      }
+    }, 100);
+    return () => clearInterval(id);
+  }, [running]);
+
+  const startTimer = useCallback((elapsedSeconds = 0) => {
+    const offset = Math.max(0, elapsedSeconds * 1000);
+    setElapsedMs(offset);
+    startRef.current = Date.now() - offset;
+    setRunning(true);
+  }, []);
+
+  const stopTimer = useCallback((finalSeconds) => {
+    let finalMs = elapsedRef.current;
+    if (typeof finalSeconds === 'number' && Number.isFinite(finalSeconds)) {
+      finalMs = Math.max(0, finalSeconds * 1000);
+    } else if (startRef.current != null) {
+      finalMs = Date.now() - startRef.current;
+    }
+    startRef.current = null;
+    setElapsedMs(finalMs);
+    setRunning(false);
+  }, []);
+
+  const resetTimer = useCallback(() => {
+    startRef.current = null;
+    setElapsedMs(0);
+    setRunning(false);
+  }, []);
+
+  const pauseTimer = useCallback(() => {
+    if (startRef.current == null) return;
+    setElapsedMs(Date.now() - startRef.current);
+    startRef.current = null;
+    setRunning(false);
+  }, []);
+
+  const resumeTimer = useCallback(() => {
+    const offset = elapsedRef.current;
+    startRef.current = Date.now() - offset;
+    setRunning(true);
+  }, []);
+
+  const handleGameStart = useCallback(
+    ({ elapsed = 0 } = {}) => {
+      startTimer(elapsed);
+    },
+    [startTimer],
+  );
+
+  const handleGameEnd = useCallback(
+    ({ result, time, difficulty: eventDifficulty } = {}) => {
+      stopTimer(time);
+      if (result !== 'won' || typeof time !== 'number' || !Number.isFinite(time)) return;
+      const diffKey = eventDifficulty && DIFFICULTIES[eventDifficulty] ? eventDifficulty : difficulty;
+      setLeaderboard((prev) => {
+        const entries = prev[diffKey] ?? [];
+        const qualifies =
+          entries.length < MAX_LEADERBOARD_ENTRIES ||
+          time < entries[entries.length - 1]?.time;
+        if (!qualifies) return prev;
+        let name = 'Anonymous';
+        if (
+          typeof window !== 'undefined' &&
+          typeof window.prompt === 'function'
+        ) {
+          const response = window.prompt('New record! Enter your name', '');
+          if (typeof response === 'string') {
+            const trimmed = response.trim();
+            if (trimmed) name = trimmed;
+          }
+        }
+        const updated = [...entries, { name, time, achievedAt: Date.now() }]
+          .sort((a, b) => a.time - b.time)
+          .slice(0, MAX_LEADERBOARD_ENTRIES);
+        return { ...prev, [diffKey]: updated };
+      });
+    },
+    [difficulty, stopTimer],
+  );
+
+  const handleStatusChange = useCallback(
+    (nextStatus) => {
+      setStatus(nextStatus);
+      if (nextStatus === 'ready') {
+        resetTimer();
+      }
+    },
+    [resetTimer],
+  );
+
+  const handlePausedChange = useCallback(
+    (isPaused) => {
+      if (isPaused) {
+        pauseTimer();
+      } else if (status === 'playing') {
+        resumeTimer();
+      }
+    },
+    [pauseTimer, resumeTimer, status],
+  );
+
+  const handleClear = useCallback(() => {
+    setLeaderboard(createEmptyLeaderboard());
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.removeItem(LEADERBOARD_STORAGE_KEY);
+      } catch {
+        /* ignore storage errors */
+      }
+    }
+  }, []);
+
+  const leaderboardEntries = useMemo(
+    () => leaderboard[difficulty] ?? [],
+    [difficulty, leaderboard],
+  );
+
+  return (
+    <div className="flex flex-col gap-4 lg:flex-row">
+      <div className="flex-1">
+        <Minesweeper
+          key={difficulty}
+          difficulty={difficulty}
+          onGameStart={handleGameStart}
+          onGameEnd={handleGameEnd}
+          onStatusChange={handleStatusChange}
+          onPausedChange={handlePausedChange}
+        />
+      </div>
+      <aside className="w-full rounded-lg bg-gray-900 p-4 text-white shadow-lg lg:w-72">
+        <h2 className="text-xl font-semibold">Leaderboard</h2>
+        <label
+          htmlFor="minesweeper-difficulty"
+          className="mt-3 block text-sm font-medium text-gray-300"
+        >
+          Difficulty
+        </label>
+        <select
+          id="minesweeper-difficulty"
+          data-testid="difficulty-select"
+          className="mt-1 w-full rounded border border-gray-700 bg-gray-800 px-2 py-1 text-sm"
+          value={difficulty}
+          onChange={(event) => {
+            const value = event.target.value;
+            if (DIFFICULTIES[value]) setDifficulty(value);
+          }}
+        >
+          {Object.entries(DIFFICULTIES).map(([value, { label }]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+        <TimerDisplay elapsedMs={elapsedMs} />
+        <ol
+          className="mt-4 space-y-1 text-sm"
+          data-testid="leaderboard-list"
+          aria-live="polite"
+        >
+          {leaderboardEntries.length === 0 ? (
+            <li className="text-gray-400">No records yet.</li>
+          ) : (
+            leaderboardEntries.map((entry, index) => (
+              <li key={`${entry.name}-${entry.time}-${entry.achievedAt ?? index}`}>
+                <span className="font-mono">{String(index + 1).padStart(2, '0')}.</span>{' '}
+                <span className="font-semibold">{entry.name}</span>{' '}
+                <span>{entry.time.toFixed(2)}s</span>
+              </li>
+            ))
+          )}
+        </ol>
+        <button
+          type="button"
+          className="mt-4 w-full rounded bg-red-600 px-3 py-2 text-sm font-medium hover:bg-red-500"
+          onClick={handleClear}
+        >
+          Clear leaderboard
+        </button>
+      </aside>
+    </div>
+  );
+};
+
+export default MinesweeperApp;


### PR DESCRIPTION
## Summary
- implement a Minesweeper wrapper with a timer, difficulty persistence, and leaderboard storage
- expose timer/game lifecycle callbacks from the Minesweeper component to drive the wrapper UI
- add Jest coverage for timer behavior and leaderboard persistence

## Testing
- yarn test __tests__/apps/minesweeper/leaderboard.test.tsx
- yarn lint *(fails: numerous existing jsx-a11y/control-has-associated-label and no-top-level-window errors throughout repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cc27f7dbc48328877d090706cbeaad