### PR TITLE
[games] Add Minesweeper chord shortcuts and touch support

### DIFF
--- a/__tests__/apps/minesweeper/chording.test.tsx
+++ b/__tests__/apps/minesweeper/chording.test.tsx
@@ -1,0 +1,91 @@
+import { getChordTargets, isChordCombo } from '../../../games/minesweeper/chording';
+import type { MinesweeperBoard, MinesweeperCell } from '../../../games/minesweeper/chording';
+
+describe('minesweeper chording helpers', () => {
+  const makeCell = (overrides: Partial<MinesweeperCell> = {}): MinesweeperCell => ({
+    mine: false,
+    revealed: false,
+    flagged: false,
+    question: false,
+    adjacent: 0,
+    ...overrides,
+  });
+
+  describe('isChordCombo', () => {
+    it('detects a classic left+right chord', () => {
+      expect(
+        isChordCombo({ left: true, right: true, space: false, allowSpaceModifier: true }),
+      ).toBe(true);
+    });
+
+    it('treats the spacebar as a modifier when allowed', () => {
+      expect(
+        isChordCombo({ left: true, right: false, space: true, allowSpaceModifier: true }),
+      ).toBe(true);
+    });
+
+    it('ignores the spacebar modifier when disabled', () => {
+      expect(
+        isChordCombo({ left: true, right: false, space: true, allowSpaceModifier: false }),
+      ).toBe(false);
+    });
+
+    it('requires the primary button to be active', () => {
+      expect(
+        isChordCombo({ left: false, right: true, space: true, allowSpaceModifier: true }),
+      ).toBe(false);
+    });
+  });
+
+  describe('getChordTargets', () => {
+    const buildBoard = (): MinesweeperBoard => {
+      const board: MinesweeperBoard = [
+        [makeCell(), makeCell(), makeCell()],
+        [makeCell(), makeCell({ revealed: true, adjacent: 2 }), makeCell()],
+        [makeCell(), makeCell(), makeCell()],
+      ];
+      board[0][1].flagged = true;
+      board[1][0].flagged = true;
+      board[0][0].revealed = true;
+      return board;
+    };
+
+    it('returns an empty list when the cell cannot chord', () => {
+      const board = buildBoard();
+      board[1][1].adjacent = 3;
+      expect(getChordTargets(board, 1, 1)).toEqual([]);
+    });
+
+    it('skips chording when the source cell is hidden', () => {
+      const board = buildBoard();
+      board[1][1].revealed = false;
+      expect(getChordTargets(board, 1, 1)).toEqual([]);
+    });
+
+    it('identifies hidden neighbours once flags match', () => {
+      const board = buildBoard();
+      const targets = getChordTargets(board, 1, 1);
+      expect(targets).toEqual([
+        { x: 0, y: 2 },
+        { x: 1, y: 2 },
+        { x: 2, y: 0 },
+        { x: 2, y: 1 },
+        { x: 2, y: 2 },
+      ]);
+    });
+
+    it('ignores flagged and revealed neighbours', () => {
+      const board = buildBoard();
+      board[0][2].flagged = true;
+      board[1][0].flagged = false;
+      board[2][1].revealed = true;
+      const targets = getChordTargets(board, 1, 1);
+      expect(targets).toEqual([
+        { x: 1, y: 0 },
+        { x: 1, y: 2 },
+        { x: 2, y: 0 },
+        { x: 2, y: 2 },
+      ]);
+    });
+  });
+});

--- a/apps/minesweeper/index.js
+++ b/apps/minesweeper/index.js
@@ -1,1 +1,7 @@
-export { default } from '../../components/apps/minesweeper';
+import React from 'react';
+
+import Minesweeper from '../../components/apps/minesweeper';
+
+const MinesweeperApp = () => <Minesweeper enableChordShortcuts />;
+
+export default MinesweeperApp;

--- a/games/minesweeper/chording.ts
+++ b/games/minesweeper/chording.ts
@@ -1,0 +1,65 @@
+export type MinesweeperCell = {
+  mine: boolean;
+  revealed: boolean;
+  flagged: boolean;
+  question: boolean;
+  adjacent: number;
+};
+
+export type MinesweeperBoard = MinesweeperCell[][];
+
+export type ChordTarget = { x: number; y: number };
+
+const offsets = [-1, 0, 1];
+
+export const isChordCombo = ({
+  left,
+  right,
+  space,
+  allowSpaceModifier = true,
+}: {
+  left: boolean;
+  right: boolean;
+  space: boolean;
+  allowSpaceModifier?: boolean;
+}) => {
+  if (!left) return false;
+  if (right) return true;
+  return allowSpaceModifier && space;
+};
+
+export const getChordTargets = (
+  board: MinesweeperBoard | null,
+  x: number,
+  y: number,
+): ChordTarget[] => {
+  if (!board || !board.length) return [];
+  const cell = board[x]?.[y];
+  if (!cell || !cell.revealed || cell.adjacent === 0) return [];
+
+  let flagged = 0;
+  const hidden: ChordTarget[] = [];
+
+  for (const dx of offsets) {
+    for (const dy of offsets) {
+      if (dx === 0 && dy === 0) continue;
+      const nx = x + dx;
+      const ny = y + dy;
+      const neighbor = board[nx]?.[ny];
+      if (!neighbor) continue;
+      if (neighbor.flagged) {
+        flagged += 1;
+        continue;
+      }
+      if (!neighbor.revealed) {
+        hidden.push({ x: nx, y: ny });
+      }
+    }
+  }
+
+  if (flagged !== cell.adjacent) {
+    return [];
+  }
+
+  return hidden;
+};


### PR DESCRIPTION
## Summary
- enable the Minesweeper app to opt into the new chord shortcuts hook
- implement combined mouse/keyboard/touch chord detection with long-press indicators inside the Minesweeper canvas
- add shared chording helpers and unit tests for the shortcut modifiers and neighbour targeting

## Testing
- yarn lint *(fails: existing accessibility violations across legacy apps)*
- yarn test *(fails: pre-existing window and nmapNse suites)*

------
https://chatgpt.com/codex/tasks/task_e_68cc27faa1d08328a371e1ca5d9d0a57