### PR TITLE
[games/2048] deterministic replay support

### DIFF
--- a/__tests__/apps/2048/replay.test.tsx
+++ b/__tests__/apps/2048/replay.test.tsx
@@ -1,0 +1,96 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import Game2048 from '../../../games/2048/index';
+
+const arraysEqual = (a: number[], b: number[]) =>
+  a.length === b.length && a.every((val, idx) => val === b[idx]);
+
+const readBoard = (element: HTMLElement): number[] => {
+  const cells = element.querySelectorAll('div > div');
+  return Array.from(cells).map((cell) => {
+    const value = Number(cell.textContent?.trim() || '0');
+    return Number.isNaN(value) ? 0 : value;
+  });
+};
+
+describe('Game 2048 replay', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  test('replays the last completed game after restart', async () => {
+    render(<Game2048 />);
+
+    const boardElement = await screen.findByTestId('game-board');
+    await waitFor(() => {
+      expect(boardElement.querySelectorAll('div > div').length).toBeGreaterThan(0);
+    });
+    const beforeMove = readBoard(boardElement);
+    const directions: Array<'ArrowLeft' | 'ArrowRight' | 'ArrowUp' | 'ArrowDown'> = [
+      'ArrowLeft',
+      'ArrowRight',
+      'ArrowUp',
+      'ArrowDown',
+    ];
+    let finalBoard = beforeMove;
+    for (const key of directions) {
+      fireEvent.keyDown(window, { key });
+      try {
+        await waitFor(() => {
+          const current = readBoard(boardElement);
+          if (!arraysEqual(current, beforeMove)) {
+            finalBoard = current;
+            return true;
+          }
+          throw new Error('board unchanged');
+        });
+        break;
+      } catch {
+        // try next direction
+      }
+    }
+    expect(finalBoard).not.toEqual(beforeMove);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restart' }));
+    const replayButton = screen.getByRole('button', { name: 'Replay' });
+    await waitFor(() => expect(replayButton).not.toBeDisabled());
+
+    fireEvent.click(replayButton);
+    await screen.findByRole('dialog');
+    const replayBoardElement = await screen.findByTestId('replay-board');
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(readBoard(replayBoardElement)).toEqual(finalBoard);
+    expect(screen.getByText(/Seed:/)).toBeInTheDocument();
+  });
+
+  test('undo removes the last move from replay history', async () => {
+    render(<Game2048 />);
+
+    const boardElement = await screen.findByTestId('game-board');
+    await waitFor(() => {
+      expect(boardElement.querySelectorAll('div > div').length).toBeGreaterThan(0);
+    });
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+    const undoButton = screen.getByRole('button', { name: /Undo/ });
+    await waitFor(() => expect(undoButton).not.toBeDisabled());
+
+    fireEvent.click(undoButton);
+    await waitFor(() => expect(screen.getByRole('button', { name: /Undo/ })).toBeDisabled());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restart' }));
+    const replayButton = screen.getByRole('button', { name: 'Replay' });
+    await waitFor(() => expect(replayButton).toBeDisabled());
+  });
+});

--- a/games/2048/replay.ts
+++ b/games/2048/replay.ts
@@ -1,31 +1,58 @@
 import { Replay } from '../../utils/replay';
-import { serialize } from '../../apps/games/rng';
 import type { Board } from '../../apps/games/_2048/logic';
 import { shareBlob } from '../../components/apps/Games/common/share';
 
-const recorder = new Replay<string>();
-let startState: { board: Board; rng: string } | null = null;
+type Direction = 'ArrowLeft' | 'ArrowRight' | 'ArrowUp' | 'ArrowDown';
 
-export function startRecording(board: Board): void {
-  startState = { board: board.map((row) => [...row]), rng: serialize() };
+type ReplayEvent = { t: number; dir: Direction };
+
+export type RecordedGame = {
+  board: Board;
+  rng: string;
+  seed: string;
+  moves: Direction[];
+  events: ReplayEvent[];
+};
+
+const recorder = new Replay<Direction>();
+let startState: { board: Board; rng: string; seed: string } | null = null;
+
+export function startRecording(board: Board, rng: string, seed: string): void {
+  startState = {
+    board: board.map((row) => [...row]),
+    rng,
+    seed,
+  };
   recorder.startRecording();
 }
 
-export function recordMove(dir: 'ArrowLeft' | 'ArrowRight' | 'ArrowUp' | 'ArrowDown'): void {
+export function recordMove(dir: Direction): void {
   recorder.record(dir);
 }
 
-export async function downloadReplay(): Promise<void> {
-  if (!startState) return;
-  const data = {
-    board: startState.board,
+export function undoRecord(): void {
+  recorder.rewind();
+}
+
+export function getReplayData(): RecordedGame | null {
+  if (!startState) return null;
+  const events = recorder.getEvents().map(({ t, data }) => ({ t, dir: data }));
+  return {
+    board: startState.board.map((row) => [...row]),
     rng: startState.rng,
-    events: recorder.getEvents().map(({ t, data }) => ({ t, dir: data })),
+    seed: startState.seed,
+    moves: events.map((evt) => evt.dir),
+    events,
   };
+}
+
+export async function downloadReplay(): Promise<void> {
+  const data = getReplayData();
+  if (!data) return;
   const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
   await shareBlob(blob, '2048-replay.json');
 }
 
-const replay = { startRecording, recordMove, downloadReplay };
+const replay = { startRecording, recordMove, undoRecord, getReplayData, downloadReplay };
 
 export default replay;

--- a/utils/replay.ts
+++ b/utils/replay.ts
@@ -18,6 +18,10 @@ export class Replay<T = any> {
     this.events.push({ t: t <= last ? last + 1 : t, data });
   }
 
+  rewind(): void {
+    this.events.pop();
+  }
+
   getEvents(): InputEvent<T>[] {
     return this.events;
   }


### PR DESCRIPTION
## Summary
- track per-game seeds, RNG state, undo checkpoints, and replay metadata in the 2048 game
- add a modal to replay the previous game deterministically with move-by-move playback
- expose recorder helpers for rewinding and serialize deterministic runs, plus regression tests

## Testing
- yarn test __tests__/apps/2048/replay.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc280836188328b59e2b4ceb23a0d9