### PR TITLE
[games] Refine 2048 input handling

### DIFF
--- a/__tests__/apps/2048/input.test.tsx
+++ b/__tests__/apps/2048/input.test.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render } from '@testing-library/react';
+import React, { useRef } from 'react';
+import useInputController, { MOVE_THROTTLE_MS } from '@/apps/2048/inputController';
+
+if (typeof window !== 'undefined' && typeof window.PointerEvent === 'undefined') {
+  class PointerEventPolyfill extends MouseEvent {
+    pointerId: number;
+    pointerType: string;
+    isPrimary: boolean;
+
+    constructor(type: string, init: PointerEventInit = {}) {
+      super(type, init);
+      this.pointerId = init.pointerId ?? 0;
+      this.pointerType = init.pointerType ?? '';
+      this.isPrimary = init.isPrimary ?? true;
+    }
+  }
+
+  Object.defineProperty(window, 'PointerEvent', {
+    configurable: true,
+    writable: true,
+    value: PointerEventPolyfill,
+  });
+  if (typeof global !== 'undefined') {
+    Object.defineProperty(global, 'PointerEvent', {
+      configurable: true,
+      writable: true,
+      value: PointerEventPolyfill,
+    });
+  }
+}
+
+const dispatchPointerEvent = (node: Element, type: string, init: PointerEventInit) => {
+  const event = new window.PointerEvent(type, { bubbles: true, cancelable: true, ...init });
+  node.dispatchEvent(event);
+};
+
+type HarnessProps = {
+  onMove: (direction: string) => void;
+  onUndo?: () => void;
+  onRestart?: () => void;
+  disabled?: boolean;
+};
+
+const InputHarness: React.FC<HarnessProps> = ({
+  onMove,
+  onUndo = () => {},
+  onRestart = () => {},
+  disabled = false,
+}) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+  useInputController({ containerRef: ref, onMove, onUndo, onRestart, disabled });
+  return <div ref={ref} data-testid="input-surface" />;
+};
+
+describe('2048 input controller', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2023-01-01T00:00:00.000Z').getTime());
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('keeps the movement throttle under 120ms', () => {
+    expect(MOVE_THROTTLE_MS).toBeLessThanOrEqual(120);
+  });
+
+  it('throttles rapid keyboard moves', () => {
+    const onMove = jest.fn();
+    const onUndo = jest.fn();
+    const onRestart = jest.fn();
+
+    render(<InputHarness onMove={onMove} onUndo={onUndo} onRestart={onRestart} />);
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+
+    expect(onMove).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(MOVE_THROTTLE_MS);
+    fireEvent.keyDown(window, { key: 'ArrowUp' });
+
+    expect(onMove).toHaveBeenCalledTimes(2);
+    expect(onUndo).not.toHaveBeenCalled();
+    expect(onRestart).not.toHaveBeenCalled();
+  });
+
+  it('throttles swipe gestures', () => {
+    const onMove = jest.fn();
+    const { getByTestId } = render(
+      <InputHarness onMove={onMove} onUndo={() => {}} onRestart={() => {}} />
+    );
+
+    const surface = getByTestId('input-surface');
+
+    dispatchPointerEvent(surface, 'pointerdown', { pointerId: 1, clientX: 0, clientY: 0 });
+    dispatchPointerEvent(surface, 'pointerup', { pointerId: 1, clientX: 120, clientY: 10 });
+
+    expect(onMove).toHaveBeenCalledTimes(1);
+
+    dispatchPointerEvent(surface, 'pointerdown', { pointerId: 2, clientX: 0, clientY: 0 });
+    dispatchPointerEvent(surface, 'pointerup', { pointerId: 2, clientX: -120, clientY: 0 });
+
+    expect(onMove).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(MOVE_THROTTLE_MS);
+    dispatchPointerEvent(surface, 'pointerdown', { pointerId: 3, clientX: 0, clientY: 0 });
+    dispatchPointerEvent(surface, 'pointerup', { pointerId: 3, clientX: -160, clientY: -5 });
+
+    expect(onMove).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores micro swipes below the threshold', () => {
+    const onMove = jest.fn();
+    const { getByTestId } = render(
+      <InputHarness onMove={onMove} onUndo={() => {}} onRestart={() => {}} />
+    );
+
+    const surface = getByTestId('input-surface');
+
+    dispatchPointerEvent(surface, 'pointerdown', { pointerId: 4, clientX: 0, clientY: 0 });
+    dispatchPointerEvent(surface, 'pointerup', { pointerId: 4, clientX: 5, clientY: 6 });
+
+    expect(onMove).not.toHaveBeenCalled();
+  });
+});

--- a/apps/2048/inputController.ts
+++ b/apps/2048/inputController.ts
@@ -1,0 +1,156 @@
+import { RefObject, useCallback, useEffect, useRef } from 'react';
+
+export type MoveDirection = 'ArrowLeft' | 'ArrowRight' | 'ArrowUp' | 'ArrowDown';
+
+export const MOVE_THROTTLE_MS = 110;
+
+const MOVEMENT_KEYS: MoveDirection[] = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'];
+
+export interface InputControllerOptions {
+  containerRef: RefObject<HTMLElement | null>;
+  onMove: (direction: MoveDirection) => void;
+  onUndo: () => void;
+  onRestart: () => void;
+  disabled?: boolean;
+}
+
+export const useInputController = ({
+  containerRef,
+  onMove,
+  onUndo,
+  onRestart,
+  disabled = false,
+}: InputControllerOptions) => {
+  const lastMoveRef = useRef(0);
+
+  const dispatchMove = useCallback(
+    (direction: MoveDirection) => {
+      if (disabled) return;
+      const now = Date.now();
+      if (now - lastMoveRef.current < MOVE_THROTTLE_MS) {
+        return;
+      }
+      lastMoveRef.current = now;
+      onMove(direction);
+    },
+    [disabled, onMove]
+  );
+
+  useEffect(() => {
+    if (!disabled) {
+      lastMoveRef.current = 0;
+    }
+  }, [disabled]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (disabled) return;
+
+      if (MOVEMENT_KEYS.includes(event.key as MoveDirection)) {
+        event.preventDefault();
+        dispatchMove(event.key as MoveDirection);
+        return;
+      }
+
+      if (event.key === 'r' || event.key === 'R') {
+        event.preventDefault();
+        onRestart();
+        return;
+      }
+
+      if (event.key === 'u' || event.key === 'U' || event.key === 'Backspace') {
+        event.preventDefault();
+        onUndo();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [dispatchMove, onRestart, onUndo, disabled]);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return undefined;
+
+    let startX = 0;
+    let startY = 0;
+    let tracking = false;
+    const pointerIdRef: { id: number | null } = { id: null };
+    const threshold = 30;
+
+    const stopTracking = () => {
+      tracking = false;
+      pointerIdRef.id = null;
+    };
+
+    const readCoordinate = (value: unknown, fallback: number) => {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : fallback;
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (disabled) return;
+      tracking = true;
+      startX = readCoordinate(event.clientX, 0);
+      startY = readCoordinate(event.clientY, 0);
+      pointerIdRef.id = event.pointerId;
+      if (typeof node.setPointerCapture === 'function') {
+        try {
+          node.setPointerCapture(event.pointerId);
+        } catch (error) {
+          // Ignore environments that disallow pointer capture (e.g., JSDOM)
+        }
+      }
+    };
+
+    const handlePointerUp = (event: PointerEvent) => {
+      if (!tracking || disabled) {
+        stopTracking();
+        return;
+      }
+      if (pointerIdRef.id !== null && event.pointerId !== pointerIdRef.id) {
+        return;
+      }
+
+      const endX = readCoordinate(event.clientX, startX);
+      const endY = readCoordinate(event.clientY, startY);
+      const dx = endX - startX;
+      const dy = endY - startY;
+      const absX = Math.abs(dx);
+      const absY = Math.abs(dy);
+
+      if (Math.max(absX, absY) < threshold) {
+        stopTracking();
+        return;
+      }
+
+      let direction: MoveDirection;
+      if (absX > absY) {
+        direction = dx > 0 ? 'ArrowRight' : 'ArrowLeft';
+      } else {
+        direction = dy > 0 ? 'ArrowDown' : 'ArrowUp';
+      }
+
+      dispatchMove(direction);
+      stopTracking();
+    };
+
+    const cancelTracking = () => {
+      stopTracking();
+    };
+
+    node.addEventListener('pointerdown', handlePointerDown);
+    node.addEventListener('pointerup', handlePointerUp);
+    node.addEventListener('pointercancel', cancelTracking);
+    node.addEventListener('pointerleave', cancelTracking);
+
+    return () => {
+      node.removeEventListener('pointerdown', handlePointerDown);
+      node.removeEventListener('pointerup', handlePointerUp);
+      node.removeEventListener('pointercancel', cancelTracking);
+      node.removeEventListener('pointerleave', cancelTracking);
+    };
+  }, [containerRef, dispatchMove, disabled]);
+};
+
+export default useInputController;


### PR DESCRIPTION
## Summary
- move keyboard and swipe logic into a shared 2048 input controller with consistent throttling
- drive tile easing with requestAnimationFrame and respect reduced motion preferences
- cover throttling behaviour with new fake-timer input controller tests

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label violations outside this change)*
- yarn test --watch=false __tests__/apps/2048/input.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc280a8a0c83288c1fd361a948f834