### PR TITLE
[youtube] persist queue management

### DIFF
--- a/__tests__/apps/youtube/queue.test.tsx
+++ b/__tests__/apps/youtube/queue.test.tsx
@@ -1,0 +1,82 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import useQueueStore, {
+  QUEUE_STORAGE_KEY,
+} from '../../../apps/youtube/state/queueStore';
+import type { Video } from '../../../apps/youtube/state/watchLater';
+
+const makeVideo = (id: string): Video => ({
+  id,
+  title: `Video ${id}`,
+  thumbnail: `${id}.jpg`,
+  channelName: `Channel ${id}`,
+  channelId: `channel-${id}`,
+});
+
+describe('youtube queue store', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('hydrates from localStorage', () => {
+    const preset = [makeVideo('a'), makeVideo('b')];
+    window.localStorage.setItem(QUEUE_STORAGE_KEY, JSON.stringify(preset));
+    const { result } = renderHook(() => useQueueStore());
+
+    expect(result.current[0]).toHaveLength(2);
+    expect(result.current[0][0].id).toBe('a');
+  });
+
+  it('persists queue mutations', async () => {
+    const hook = renderHook(() => useQueueStore());
+
+    act(() => {
+      hook.result.current[1].add(makeVideo('a'));
+      hook.result.current[1].add(makeVideo('b'));
+    });
+
+    await waitFor(() => {
+      expect(hook.result.current[0].map((v) => v.id)).toEqual(['a', 'b']);
+    });
+
+    act(() => {
+      hook.result.current[1].reorder(0, 1);
+    });
+
+    await waitFor(() => {
+      expect(hook.result.current[0].map((v) => v.id)).toEqual(['b', 'a']);
+    });
+
+    hook.unmount();
+
+    const afterReorder = renderHook(() => useQueueStore());
+    expect(afterReorder.result.current[0].map((v) => v.id)).toEqual(['b', 'a']);
+
+    let next: Video | undefined;
+    act(() => {
+      next = afterReorder.result.current[1].shift();
+    });
+    expect(next?.id).toBe('b');
+
+    await waitFor(() => {
+      expect(afterReorder.result.current[0].map((v) => v.id)).toEqual(['a']);
+    });
+
+    afterReorder.unmount();
+
+    const afterShift = renderHook(() => useQueueStore());
+    expect(afterShift.result.current[0].map((v) => v.id)).toEqual(['a']);
+
+    act(() => {
+      afterShift.result.current[1].remove(0);
+    });
+
+    await waitFor(() => {
+      expect(afterShift.result.current[0]).toHaveLength(0);
+    });
+
+    afterShift.unmount();
+
+    expect(window.localStorage.getItem(QUEUE_STORAGE_KEY)).toBe('[]');
+  });
+});
+

--- a/apps/youtube/state/queueStore.ts
+++ b/apps/youtube/state/queueStore.ts
@@ -1,0 +1,97 @@
+import { useCallback, useMemo } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+import type { Video } from './watchLater';
+
+export const QUEUE_STORAGE_KEY = 'youtube:queue';
+
+function isVideo(value: any): value is Video {
+  return (
+    value &&
+    typeof value.id === 'string' &&
+    typeof value.title === 'string' &&
+    typeof value.thumbnail === 'string' &&
+    typeof value.channelName === 'string' &&
+    typeof value.channelId === 'string' &&
+    (value.start === undefined || typeof value.start === 'number') &&
+    (value.end === undefined || typeof value.end === 'number') &&
+    (value.name === undefined || typeof value.name === 'string')
+  );
+}
+
+function isVideoArray(value: unknown): value is Video[] {
+  return Array.isArray(value) && value.every(isVideo);
+}
+
+export interface QueueActions {
+  add(video: Video): void;
+  remove(index: number): void;
+  reorder(from: number, to: number): void;
+  shift(): Video | undefined;
+  clear(): void;
+}
+
+export default function useQueueStore(): [Video[], QueueActions] {
+  const [queue, setQueue, _reset, clearStorage] = usePersistentState<Video[]>(
+    QUEUE_STORAGE_KEY,
+    [],
+    isVideoArray,
+  );
+
+  const add = useCallback(
+    (video: Video) => {
+      setQueue((list) => [...list, video]);
+    },
+    [setQueue],
+  );
+
+  const remove = useCallback(
+    (index: number) => {
+      setQueue((list) => {
+        if (index < 0 || index >= list.length) return list;
+        const next = [...list];
+        next.splice(index, 1);
+        return next;
+      });
+    },
+    [setQueue],
+  );
+
+  const reorder = useCallback(
+    (from: number, to: number) => {
+      setQueue((list) => {
+        if (from === to || from < 0 || from >= list.length) return list;
+        const maxIndex = list.length - 1;
+        const target = Math.min(Math.max(to, 0), maxIndex);
+        if (target === from) return list;
+        const next = [...list];
+        const [item] = next.splice(from, 1);
+        next.splice(target, 0, item);
+        return next;
+      });
+    },
+    [setQueue],
+  );
+
+  const shift = useCallback(() => {
+    let nextItem: Video | undefined;
+    setQueue((list) => {
+      if (!list.length) return list;
+      const [first, ...rest] = list;
+      nextItem = first;
+      return rest;
+    });
+    return nextItem;
+  }, [setQueue]);
+
+  const clear = useCallback(() => {
+    clearStorage();
+  }, [clearStorage]);
+
+  const actions = useMemo<QueueActions>(
+    () => ({ add, remove, reorder, shift, clear }),
+    [add, remove, reorder, shift, clear],
+  );
+
+  return [queue, actions];
+}
+


### PR DESCRIPTION
## Summary
- add a persistent queue store with helper actions for adding, removing, reordering, and shifting videos
- wire the YouTube app to the queue store and expose new Up Next/Watch Later controls for removal, reordering, and queuing saved clips
- cover queue persistence with a dedicated hook test that exercises hydration and mutation flows

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window violations in unrelated files)*
- yarn test queue

------
https://chatgpt.com/codex/tasks/task_e_68cc280fa4c083288e4a6eb14270fca9