### PR TITLE
feat(update-center): add scheduler-backed restart management

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -63,6 +63,7 @@ const NonogramApp = createDynamicApp('nonogram', 'Nonogram');
 const TetrisApp = createDynamicApp('tetris', 'Tetris');
 const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 const FileExplorerApp = createDynamicApp('file-explorer', 'Files');
+const UpdateCenterApp = createDynamicApp('update-center', 'Update Center');
 const Radare2App = createDynamicApp('radare2', 'Radare2');
 const AboutAlexApp = createDynamicApp('alex', 'About Alex');
 
@@ -153,6 +154,7 @@ const displayNonogram = createDisplay(NonogramApp);
 const displayTetris = createDisplay(TetrisApp);
 const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayFileExplorer = createDisplay(FileExplorerApp);
+const displayUpdateCenter = createDisplay(UpdateCenterApp);
 const displayRadare2 = createDisplay(Radare2App);
 const displayAboutAlex = createDisplay(AboutAlexApp);
 
@@ -691,6 +693,15 @@ const apps = [
     favourite: true,
     desktop_shortcut: false,
     screen: displaySettings,
+  },
+  {
+    id: 'update-center',
+    title: 'Update Center',
+    icon: '/themes/Yaru/apps/gnome-control-center.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayUpdateCenter,
   },
   {
     id: 'files',

--- a/apps/update-center/index.tsx
+++ b/apps/update-center/index.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import UpdateCenter from '../../components/apps/update-center';
+
+export default function UpdateCenterApp() {
+  return <UpdateCenter />;
+}

--- a/components/apps/update-center/index.tsx
+++ b/components/apps/update-center/index.tsx
@@ -1,0 +1,762 @@
+'use client';
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import Modal from '../../base/Modal';
+import {
+  SCHEDULER_EVENT,
+  addPreferredWindow,
+  getPreferredWindows,
+  getQuietHours,
+  getPendingDeferredRestart,
+  getScheduledRestarts,
+  removePreferredWindow,
+  removeScheduledRestart,
+  rescheduleRestart,
+  scheduleRestart,
+  setQuietHours,
+  type QuietHoursPreference,
+  type RestartDraft,
+  type RestartWindow,
+  type ScheduledRestart,
+} from '../../../utils/updateScheduler';
+
+const DAY_OPTIONS = [
+  { value: 0, label: 'Sun', full: 'Sunday' },
+  { value: 1, label: 'Mon', full: 'Monday' },
+  { value: 2, label: 'Tue', full: 'Tuesday' },
+  { value: 3, label: 'Wed', full: 'Wednesday' },
+  { value: 4, label: 'Thu', full: 'Thursday' },
+  { value: 5, label: 'Fri', full: 'Friday' },
+  { value: 6, label: 'Sat', full: 'Saturday' },
+] as const;
+
+const MINUTES_IN_DAY = 24 * 60;
+
+const padTime = (value: number) => value.toString().padStart(2, '0');
+
+const formatTimeValue = (minutes: number) => {
+  const safe = ((minutes % MINUTES_IN_DAY) + MINUTES_IN_DAY) % MINUTES_IN_DAY;
+  const hours = Math.floor(safe / 60);
+  const mins = safe % 60;
+  return `${padTime(hours)}:${padTime(mins)}`;
+};
+
+const parseTimeValue = (value: string) => {
+  if (!value) return 0;
+  const [hoursRaw, minutesRaw] = value.split(':');
+  const hours = Number.parseInt(hoursRaw ?? '0', 10);
+  const minutes = Number.parseInt(minutesRaw ?? '0', 10);
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return 0;
+  const total = hours * 60 + minutes;
+  return ((total % MINUTES_IN_DAY) + MINUTES_IN_DAY) % MINUTES_IN_DAY;
+};
+
+const formatDateTimeInput = (iso: string) => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  return `${date.getFullYear()}-${padTime(date.getMonth() + 1)}-${padTime(date.getDate())}T${padTime(
+    date.getHours(),
+  )}:${padTime(date.getMinutes())}`;
+};
+
+const formatDateTimeReadable = (iso: string) => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return 'Unknown time';
+  return date.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+};
+
+const generateId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `restart-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+};
+
+const formatWindowDays = (window: RestartWindow) => {
+  if (window.days.length === 0 || window.days.length === 7) return 'Daily';
+  const sorted = window.days.slice().sort((a, b) => a - b);
+  const weekdays = [1, 2, 3, 4, 5];
+  const weekends = [0, 6];
+  if (sorted.length === weekdays.length && weekdays.every((day) => sorted.includes(day))) {
+    return 'Weekdays';
+  }
+  if (sorted.length === weekends.length && weekends.every((day) => sorted.includes(day))) {
+    return 'Weekend';
+  }
+  return sorted
+    .map((day) => DAY_OPTIONS.find((opt) => opt.value === day)?.label ?? day.toString())
+    .join(', ');
+};
+
+const describeWindow = (window: RestartWindow) =>
+  `${formatWindowDays(window)} • ${formatTimeValue(window.startMinutes)} – ${formatTimeValue(
+    window.endMinutes,
+  )}`;
+
+const UpdateCenter = () => {
+  const [quietHours, setQuietHoursState] = useState<QuietHoursPreference | null>(null);
+  const [quietEnabled, setQuietEnabled] = useState(false);
+  const [quietStart, setQuietStart] = useState('22:00');
+  const [quietEnd, setQuietEnd] = useState('06:00');
+  const [quietStatus, setQuietStatus] = useState<string | null>(null);
+  const [quietError, setQuietError] = useState<string | null>(null);
+
+  const [windows, setWindows] = useState<RestartWindow[]>([]);
+  const [windowMessage, setWindowMessage] = useState<string | null>(null);
+  const [windowError, setWindowError] = useState<string | null>(null);
+  const [newWindowLabel, setNewWindowLabel] = useState('');
+  const [newWindowStart, setNewWindowStart] = useState('02:00');
+  const [newWindowEnd, setNewWindowEnd] = useState('04:00');
+  const [newWindowDays, setNewWindowDays] = useState<number[]>([1, 2, 3, 4, 5]);
+
+  const [restarts, setRestarts] = useState<ScheduledRestart[]>([]);
+  const [restartMessage, setRestartMessage] = useState<string | null>(null);
+  const [restartError, setRestartError] = useState<string | null>(null);
+
+  const [rescheduleOpen, setRescheduleOpen] = useState(false);
+  const [selectedRestart, setSelectedRestart] = useState<ScheduledRestart | null>(null);
+  const [rescheduleValue, setRescheduleValue] = useState('');
+  const [rescheduleWindowId, setRescheduleWindowId] = useState<string>('custom');
+  const [rescheduleNote, setRescheduleNote] = useState('');
+  const [rescheduleError, setRescheduleError] = useState<string | null>(null);
+
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const windowLookup = useMemo(() => new Map(windows.map((entry) => [entry.id, entry])), [windows]);
+
+  const refreshState = useCallback(async () => {
+    try {
+      setLoadError(null);
+      const [quiet, storedWindows, storedRestarts] = await Promise.all([
+        getQuietHours(),
+        getPreferredWindows(),
+        getScheduledRestarts(),
+      ]);
+      setQuietHoursState(quiet);
+      setQuietEnabled(quiet.enabled);
+      setQuietStart(formatTimeValue(quiet.startMinutes));
+      setQuietEnd(formatTimeValue(quiet.endMinutes));
+      setWindows(storedWindows);
+      setRestarts(storedRestarts);
+      setLoading(false);
+    } catch {
+      setLoadError('Unable to load update preferences. Please try again.');
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      await refreshState();
+      if (!active) return;
+      try {
+        const deferred = await getPendingDeferredRestart();
+        if (deferred) {
+          setRestartMessage(
+            `Deferred restart pending for ${formatDateTimeReadable(deferred.scheduledTime)}.`,
+          );
+        }
+      } catch {
+        /* ignore */
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [refreshState]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const handler = () => {
+      void refreshState();
+    };
+    window.addEventListener(SCHEDULER_EVENT, handler);
+    return () => window.removeEventListener(SCHEDULER_EVENT, handler);
+  }, [refreshState]);
+
+  useEffect(() => {
+    if (!quietStatus) return;
+    const timer = window.setTimeout(() => setQuietStatus(null), 4000);
+    return () => window.clearTimeout(timer);
+  }, [quietStatus]);
+
+  useEffect(() => {
+    if (!windowMessage) return;
+    const timer = window.setTimeout(() => setWindowMessage(null), 4000);
+    return () => window.clearTimeout(timer);
+  }, [windowMessage]);
+
+  useEffect(() => {
+    if (!restartMessage) return;
+    const timer = window.setTimeout(() => setRestartMessage(null), 5000);
+    return () => window.clearTimeout(timer);
+  }, [restartMessage]);
+
+  useEffect(() => {
+    if (!selectedRestart) return;
+    setRescheduleValue(formatDateTimeInput(selectedRestart.scheduledTime));
+    setRescheduleWindowId(selectedRestart.windowId ?? 'custom');
+    setRescheduleNote(selectedRestart.notes ?? '');
+    setRescheduleError(null);
+  }, [selectedRestart]);
+
+  const toggleDay = (day: number) => {
+    setNewWindowDays((prev) => {
+      if (prev.includes(day)) {
+        return prev.filter((entry) => entry !== day);
+      }
+      return [...prev, day].sort((a, b) => a - b);
+    });
+  };
+
+  const handleSaveQuietHours = async () => {
+    try {
+      setQuietError(null);
+      const payload: QuietHoursPreference = {
+        enabled: quietEnabled,
+        startMinutes: parseTimeValue(quietStart),
+        endMinutes: parseTimeValue(quietEnd),
+      };
+      const updated = await setQuietHours(payload);
+      setQuietHoursState(updated);
+      setQuietStart(formatTimeValue(updated.startMinutes));
+      setQuietEnd(formatTimeValue(updated.endMinutes));
+      setQuietEnabled(updated.enabled);
+      setQuietStatus('Quiet hours saved');
+    } catch {
+      setQuietError('Failed to save quiet hours');
+    }
+  };
+
+  const handleAddWindow = async () => {
+    setWindowError(null);
+    setWindowMessage(null);
+    if (!newWindowLabel.trim()) {
+      setWindowError('Enter a name for the window.');
+      return;
+    }
+    if (newWindowDays.length === 0) {
+      setWindowError('Select at least one day.');
+      return;
+    }
+    try {
+      const entry: RestartWindow = {
+        id: generateId(),
+        label: newWindowLabel.trim(),
+        days: newWindowDays.slice().sort((a, b) => a - b),
+        startMinutes: parseTimeValue(newWindowStart),
+        endMinutes: parseTimeValue(newWindowEnd),
+      };
+      const updated = await addPreferredWindow(entry);
+      setWindows(updated);
+      setWindowMessage('Restart window saved');
+      setNewWindowLabel('');
+    } catch {
+      setWindowError('Failed to save restart window');
+    }
+  };
+
+  const handleRemoveWindow = async (id: string) => {
+    try {
+      const updated = await removePreferredWindow(id);
+      setWindows(updated);
+    } catch {
+      setWindowError('Unable to remove window');
+    }
+  };
+
+  const handleRescheduleClick = (restart: ScheduledRestart) => {
+    setSelectedRestart(restart);
+    setRescheduleOpen(true);
+  };
+
+  const closeReschedule = () => {
+    setRescheduleOpen(false);
+    setSelectedRestart(null);
+    setRescheduleValue('');
+    setRescheduleWindowId('custom');
+    setRescheduleNote('');
+    setRescheduleError(null);
+  };
+
+  const confirmReschedule = async () => {
+    if (!selectedRestart) return;
+    if (!rescheduleValue) {
+      setRescheduleError('Choose a new date and time.');
+      return;
+    }
+    const nextDate = new Date(rescheduleValue);
+    if (Number.isNaN(nextDate.getTime())) {
+      setRescheduleError('Enter a valid date and time.');
+      return;
+    }
+    try {
+      const updated = await rescheduleRestart(selectedRestart.id, nextDate.toISOString(), {
+        windowId: rescheduleWindowId === 'custom' ? undefined : rescheduleWindowId,
+        note: rescheduleNote.trim() || undefined,
+      });
+      setRestarts(updated);
+      setRestartMessage('Restart rescheduled');
+      closeReschedule();
+    } catch {
+      setRescheduleError('Unable to reschedule restart');
+    }
+  };
+
+  const handleScheduleSample = async () => {
+    try {
+      setRestartError(null);
+      const target = windows[0];
+      const base = new Date();
+      if (target) {
+        const hours = Math.floor(target.startMinutes / 60);
+        const minutes = target.startMinutes % 60;
+        base.setHours(hours, minutes, 0, 0);
+      } else {
+        base.setHours(2, 0, 0, 0);
+      }
+      if (base.getTime() <= Date.now()) {
+        base.setDate(base.getDate() + 1);
+      }
+      const draft: RestartDraft = {
+        id: generateId(),
+        label: `Maintenance window ${base.toLocaleDateString()}`,
+        scheduledTime: base.toISOString(),
+        status: 'scheduled',
+        windowId: target?.id,
+      };
+      const updated = await scheduleRestart(draft);
+      setRestarts(updated);
+      setRestartMessage('Simulated maintenance scheduled');
+    } catch {
+      setRestartError('Unable to schedule a simulated restart');
+    }
+  };
+
+  const handleRemoveRestart = async (id: string) => {
+    try {
+      const updated = await removeScheduledRestart(id);
+      setRestarts(updated);
+    } catch {
+      setRestartError('Failed to update restart list');
+    }
+  };
+
+  const upcomingRestarts = useMemo(() => {
+    const now = Date.now();
+    return restarts.filter((entry) => {
+      const time = new Date(entry.scheduledTime).getTime();
+      if (Number.isNaN(time)) return false;
+      if (entry.status === 'cancelled' || entry.status === 'completed') return false;
+      return time >= now;
+    });
+  }, [restarts]);
+
+  const pastRestarts = useMemo(() => {
+    const now = Date.now();
+    return restarts.filter((entry) => {
+      const time = new Date(entry.scheduledTime).getTime();
+      if (Number.isNaN(time)) return false;
+      return time < now || entry.status === 'completed' || entry.status === 'cancelled';
+    });
+  }, [restarts]);
+
+  const deferredRestart = useMemo(
+    () => upcomingRestarts.find((entry) => entry.status === 'deferred') ?? null,
+    [upcomingRestarts],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center bg-ub-cool-grey text-white">
+        <p>Loading Update Center…</p>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center bg-ub-cool-grey text-white">
+        <p className="text-red-400">{loadError}</p>
+        <button
+          type="button"
+          onClick={() => {
+            setLoading(true);
+            void refreshState();
+          }}
+          className="mt-4 rounded border border-gray-600 px-4 py-2 text-sm hover:border-gray-400"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col bg-ub-cool-grey text-white">
+      <header className="border-b border-gray-900 px-6 py-4">
+        <h1 className="text-2xl font-semibold">Update Center</h1>
+        <p className="text-sm text-ubt-grey">
+          Manage quiet hours, preferred restart windows, and upcoming maintenance.
+        </p>
+      </header>
+      <main className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+          <section className="rounded-lg border border-gray-900 bg-black/30 p-5">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold">Quiet hours</h2>
+                <p className="text-sm text-ubt-grey">
+                  Automatic restarts are paused while quiet hours are active.
+                </p>
+              </div>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={quietEnabled}
+                  onChange={() => setQuietEnabled((prev) => !prev)}
+                  className="h-4 w-4"
+                  aria-label="Toggle quiet hours"
+                />
+                <span>{quietEnabled ? 'Enabled' : 'Disabled'}</span>
+              </label>
+            </div>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              <label className="flex flex-col text-sm">
+                <span className="mb-1 text-ubt-grey">Start time</span>
+                <input
+                  type="time"
+                  value={quietStart}
+                  onChange={(event) => setQuietStart(event.target.value)}
+                  className="rounded border border-gray-700 bg-gray-900 px-3 py-2 text-white focus:border-orange-400 focus:outline-none"
+                />
+              </label>
+              <label className="flex flex-col text-sm">
+                <span className="mb-1 text-ubt-grey">End time</span>
+                <input
+                  type="time"
+                  value={quietEnd}
+                  onChange={(event) => setQuietEnd(event.target.value)}
+                  className="rounded border border-gray-700 bg-gray-900 px-3 py-2 text-white focus:border-orange-400 focus:outline-none"
+                />
+              </label>
+            </div>
+            {quietHours && (
+              <p className="mt-3 text-xs text-ubt-grey">
+                Current range: {formatTimeValue(quietHours.startMinutes)} –{' '}
+                {formatTimeValue(quietHours.endMinutes)}.
+              </p>
+            )}
+            {quietError && <p className="mt-3 text-sm text-red-400">{quietError}</p>}
+            {quietStatus && <p className="mt-3 text-sm text-green-400">{quietStatus}</p>}
+            <div className="mt-4 flex justify-end">
+              <button
+                type="button"
+                onClick={handleSaveQuietHours}
+                className="rounded bg-ub-orange px-4 py-2 text-sm text-white hover:bg-orange-500"
+              >
+                Save quiet hours
+              </button>
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-gray-900 bg-black/30 p-5">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold">Preferred restart windows</h2>
+                <p className="text-sm text-ubt-grey">
+                  Define when maintenance can reboot the system without interrupting your work.
+                </p>
+              </div>
+            </div>
+            <div className="mt-4 space-y-3">
+              {windows.length === 0 ? (
+                <p className="text-sm text-ubt-grey">No preferred windows saved yet.</p>
+              ) : (
+                windows.map((window) => (
+                  <div
+                    key={window.id}
+                    className="flex flex-col gap-3 rounded border border-gray-800 bg-black/20 p-4 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div>
+                      <p className="text-base font-medium">{window.label}</p>
+                      <p className="text-xs text-ubt-grey">{describeWindow(window)}</p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveWindow(window.id)}
+                      className="self-start rounded border border-red-700 px-3 py-1 text-xs text-red-200 hover:border-red-500 hover:text-red-100"
+                      aria-label={`Remove ${window.label}`}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
+            <div className="mt-6 rounded-lg border border-dashed border-gray-700 bg-black/20 p-4">
+              <h3 className="text-sm font-semibold text-ubt-grey">Add a new window</h3>
+              <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                <label className="flex flex-col text-sm">
+                  <span className="mb-1 text-ubt-grey">Name</span>
+                  <input
+                    type="text"
+                    value={newWindowLabel}
+                    onChange={(event) => setNewWindowLabel(event.target.value)}
+                    className="rounded border border-gray-700 bg-gray-900 px-3 py-2 text-white focus:border-orange-400 focus:outline-none"
+                    placeholder="Example: Weeknight window"
+                  />
+                </label>
+                <label className="flex flex-col text-sm">
+                  <span className="mb-1 text-ubt-grey">Start</span>
+                  <input
+                    type="time"
+                    value={newWindowStart}
+                    onChange={(event) => setNewWindowStart(event.target.value)}
+                    className="rounded border border-gray-700 bg-gray-900 px-3 py-2 text-white focus:border-orange-400 focus:outline-none"
+                  />
+                </label>
+                <label className="flex flex-col text-sm">
+                  <span className="mb-1 text-ubt-grey">End</span>
+                  <input
+                    type="time"
+                    value={newWindowEnd}
+                    onChange={(event) => setNewWindowEnd(event.target.value)}
+                    className="rounded border border-gray-700 bg-gray-900 px-3 py-2 text-white focus:border-orange-400 focus:outline-none"
+                  />
+                </label>
+              </div>
+              <div className="mt-3">
+                <span className="text-xs uppercase tracking-wide text-ubt-grey">Days</span>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {DAY_OPTIONS.map((day) => {
+                    const selected = newWindowDays.includes(day.value);
+                    return (
+                      <button
+                        type="button"
+                        key={day.value}
+                        onClick={() => toggleDay(day.value)}
+                        className={`rounded border px-3 py-1 text-xs transition-colors ${
+                          selected
+                            ? 'border-ub-orange bg-ub-orange/20 text-ub-orange'
+                            : 'border-gray-700 text-ubt-grey hover:border-gray-500 hover:text-white'
+                        }`}
+                        aria-pressed={selected}
+                      >
+                        {day.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              {windowError && <p className="mt-3 text-sm text-red-400">{windowError}</p>}
+              {windowMessage && <p className="mt-3 text-sm text-green-400">{windowMessage}</p>}
+              <div className="mt-4 flex justify-end">
+                <button
+                  type="button"
+                  onClick={handleAddWindow}
+                  className="rounded bg-ub-green px-4 py-2 text-sm text-black hover:bg-green-400"
+                >
+                  Save window
+                </button>
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-gray-900 bg-black/30 p-5">
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold">Upcoming restarts</h2>
+                <p className="text-sm text-ubt-grey">
+                  Review scheduled maintenance and move it when plans change.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={handleScheduleSample}
+                className="self-start rounded border border-gray-700 px-3 py-1 text-xs hover:border-ub-orange"
+              >
+                Schedule simulation
+              </button>
+            </div>
+            {restartError && <p className="mt-3 text-sm text-red-400">{restartError}</p>}
+            {restartMessage && <p className="mt-3 text-sm text-green-400">{restartMessage}</p>}
+            {deferredRestart && (
+              <div className="mt-4 rounded border border-yellow-800 bg-yellow-900/40 p-3 text-sm text-yellow-100">
+                <p className="font-semibold">Deferred restart pending</p>
+                <p className="mt-1 text-xs">
+                  {deferredRestart.label} is deferred until{' '}
+                  {formatDateTimeReadable(deferredRestart.scheduledTime)}.
+                </p>
+              </div>
+            )}
+            <div className="mt-4 space-y-4">
+              {upcomingRestarts.length === 0 ? (
+                <p className="text-sm text-ubt-grey">No restarts scheduled.</p>
+              ) : (
+                upcomingRestarts.map((restart) => {
+                  const relatedWindow = restart.windowId
+                    ? windowLookup.get(restart.windowId)
+                    : undefined;
+                  return (
+                    <div
+                      key={restart.id}
+                      className="rounded border border-gray-800 bg-black/20 p-4 shadow"
+                    >
+                      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                        <div>
+                          <div className="flex items-center gap-2">
+                            <p className="text-base font-semibold">{restart.label}</p>
+                            <span
+                              className={`rounded px-2 py-0.5 text-xs uppercase tracking-wide ${
+                                restart.status === 'deferred'
+                                  ? 'bg-yellow-900 text-yellow-200'
+                                  : 'bg-ub-blue text-black'
+                              }`}
+                            >
+                              {restart.status === 'deferred'
+                                ? 'Deferred'
+                                : restart.status === 'scheduled'
+                                ? 'Scheduled'
+                                : restart.status}
+                            </span>
+                          </div>
+                          <p className="mt-1 text-sm text-ubt-grey">
+                            {formatDateTimeReadable(restart.scheduledTime)}
+                          </p>
+                          {restart.deferredFrom && restart.status === 'deferred' && (
+                            <p className="mt-1 text-xs text-yellow-200">
+                              Previously planned for {formatDateTimeReadable(restart.deferredFrom)}
+                            </p>
+                          )}
+                          {relatedWindow && (
+                            <p className="mt-1 text-xs text-ubt-grey">
+                              Window: {relatedWindow.label} ({describeWindow(relatedWindow)})
+                            </p>
+                          )}
+                          {restart.notes && (
+                            <p className="mt-1 text-xs text-ubt-grey">Note: {restart.notes}</p>
+                          )}
+                        </div>
+                        <div className="flex flex-col items-end gap-2 text-sm">
+                          <button
+                            type="button"
+                            onClick={() => handleRescheduleClick(restart)}
+                            className="rounded bg-ub-orange px-3 py-1 text-white hover:bg-orange-500"
+                          >
+                            Reschedule
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveRestart(restart.id)}
+                            className="text-xs text-ubt-grey underline hover:text-white"
+                          >
+                            Dismiss
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+            {pastRestarts.length > 0 && (
+              <div className="mt-6">
+                <h3 className="text-sm font-semibold text-ubt-grey">History</h3>
+                <ul className="mt-2 space-y-2 text-xs text-ubt-grey">
+                  {pastRestarts.map((restart) => (
+                    <li key={`history-${restart.id}`}>
+                      <span className="font-medium text-white">{restart.label}</span> •{' '}
+                      {formatDateTimeReadable(restart.scheduledTime)} ({restart.status})
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </section>
+        </div>
+      </main>
+
+      <Modal isOpen={rescheduleOpen} onClose={closeReschedule}>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+          <div className="w-full max-w-lg rounded-lg border border-gray-800 bg-ub-cool-grey p-6 shadow-xl">
+            <h2 className="text-lg font-semibold">Reschedule restart</h2>
+            {selectedRestart && (
+              <>
+                <p className="mt-1 text-sm text-ubt-grey">{selectedRestart.label}</p>
+                <div className="mt-4 space-y-3">
+                  <label className="flex flex-col text-sm">
+                    <span className="mb-1 text-ubt-grey">New date &amp; time</span>
+                    <input
+                      type="datetime-local"
+                      value={rescheduleValue}
+                      onChange={(event) => setRescheduleValue(event.target.value)}
+                      className="rounded border border-gray-700 bg-gray-900 px-3 py-2 text-white focus:border-orange-400 focus:outline-none"
+                    />
+                  </label>
+                  <label className="flex flex-col text-sm">
+                    <span className="mb-1 text-ubt-grey">Preferred window</span>
+                    <select
+                      value={rescheduleWindowId}
+                      onChange={(event) => setRescheduleWindowId(event.target.value)}
+                      className="rounded border border-gray-700 bg-gray-900 px-3 py-2 text-white focus:border-orange-400 focus:outline-none"
+                    >
+                      <option value="custom">Custom time</option>
+                      {windows.map((window) => (
+                        <option key={window.id} value={window.id}>
+                          {window.label} ({formatTimeValue(window.startMinutes)} –{' '}
+                          {formatTimeValue(window.endMinutes)})
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="flex flex-col text-sm">
+                    <span className="mb-1 text-ubt-grey">Notes</span>
+                    <textarea
+                      rows={3}
+                      value={rescheduleNote}
+                      onChange={(event) => setRescheduleNote(event.target.value)}
+                      className="rounded border border-gray-700 bg-gray-900 px-3 py-2 text-white focus:border-orange-400 focus:outline-none"
+                    />
+                  </label>
+                </div>
+                {rescheduleError && (
+                  <p className="mt-3 text-sm text-red-400">{rescheduleError}</p>
+                )}
+                <div className="mt-6 flex justify-end gap-3">
+                  <button
+                    type="button"
+                    onClick={closeReschedule}
+                    className="rounded border border-gray-600 px-4 py-2 text-sm hover:border-gray-400"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={confirmReschedule}
+                    className="rounded bg-ub-orange px-4 py-2 text-sm text-white hover:bg-orange-500"
+                  >
+                    Confirm reschedule
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+export default UpdateCenter;
+

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  SCHEDULER_EVENT,
+  getPendingDeferredRestart,
+  type ScheduledRestart,
+} from '../../utils/updateScheduler';
 
 interface Props {
   open: boolean;
@@ -12,6 +17,16 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const [deferredRestart, setDeferredRestart] = useState<ScheduledRestart | null>(null);
+
+  const refreshDeferredRestart = useCallback(async () => {
+    try {
+      const restart = await getPendingDeferredRestart();
+      setDeferredRestart(restart);
+    } catch {
+      setDeferredRestart(null);
+    }
+  }, []);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -21,12 +36,49 @@ const QuickSettings = ({ open }: Props) => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
 
+  useEffect(() => {
+    void refreshDeferredRestart();
+  }, [refreshDeferredRestart]);
+
+  useEffect(() => {
+    if (!open) return;
+    void refreshDeferredRestart();
+  }, [open, refreshDeferredRestart]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const handler = () => {
+      void refreshDeferredRestart();
+    };
+    window.addEventListener(SCHEDULER_EVENT, handler);
+    return () => window.removeEventListener(SCHEDULER_EVENT, handler);
+  }, [refreshDeferredRestart]);
+
+  let deferredTimeLabel = '';
+  if (deferredRestart) {
+    const date = new Date(deferredRestart.scheduledTime);
+    deferredTimeLabel = Number.isNaN(date.getTime())
+      ? 'soon'
+      : date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+  }
+
   return (
     <div
       className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
         open ? '' : 'hidden'
       }`}
     >
+      {deferredRestart && (
+        <div className="px-4 pb-3">
+          <div className="rounded border border-yellow-800 bg-yellow-900/60 p-3 text-xs text-yellow-100">
+            <p className="font-semibold">Deferred restart pending</p>
+            <p className="mt-1 leading-relaxed">
+              {deferredRestart.label} is rescheduled for {deferredTimeLabel}. Open the Update Center to
+              choose a different window.
+            </p>
+          </div>
+        </div>
+      )}
       <div className="px-4 pb-2">
         <button
           className="w-full flex justify-between"

--- a/pages/apps/update-center.jsx
+++ b/pages/apps/update-center.jsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const UpdateCenterApp = dynamic(() => import('../../apps/update-center'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function UpdateCenterPage() {
+  return <UpdateCenterApp />;
+}

--- a/utils/updateScheduler.ts
+++ b/utils/updateScheduler.ts
@@ -1,0 +1,442 @@
+import { getDb } from './safeIDB';
+
+const DB_NAME = 'update-scheduler';
+const DB_VERSION = 1;
+const STORE_KEY = 'state';
+const STORE_NAME = 'scheduler';
+
+export const SCHEDULER_EVENT = 'update-scheduler-change';
+
+const MINUTES_IN_DAY = 24 * 60;
+
+export type RestartStatus = 'scheduled' | 'deferred' | 'completed' | 'cancelled';
+
+export interface QuietHoursPreference {
+  enabled: boolean;
+  startMinutes: number;
+  endMinutes: number;
+}
+
+export interface RestartWindow {
+  id: string;
+  label: string;
+  days: number[];
+  startMinutes: number;
+  endMinutes: number;
+  notes?: string;
+}
+
+export interface ScheduledRestart {
+  id: string;
+  label: string;
+  scheduledTime: string;
+  status: RestartStatus;
+  windowId?: string;
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+  deferredFrom?: string;
+}
+
+export interface SchedulerState {
+  quietHours: QuietHoursPreference;
+  preferredWindows: RestartWindow[];
+  restarts: ScheduledRestart[];
+}
+
+export type RestartDraft = Omit<
+  ScheduledRestart,
+  'status' | 'createdAt' | 'updatedAt' | 'deferredFrom'
+> & {
+  status?: RestartStatus;
+};
+
+export interface RescheduleOptions {
+  windowId?: string;
+  note?: string;
+  label?: string;
+}
+
+declare global {
+  interface WindowEventMap {
+    'update-scheduler-change': CustomEvent<SchedulerState>;
+  }
+}
+
+let dbPromise: ReturnType<typeof getDb> | null = null;
+let cachedState: SchedulerState | null = null;
+
+function openDb() {
+  if (!dbPromise) {
+    dbPromise = getDb(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME);
+        }
+      },
+    });
+  }
+  return dbPromise;
+}
+
+function clone<T>(value: T): T {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+function clampMinutes(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  const rounded = Math.round(value);
+  return ((rounded % MINUTES_IN_DAY) + MINUTES_IN_DAY) % MINUTES_IN_DAY;
+}
+
+function toNumber(value: unknown, fallback: number): number {
+  const num = typeof value === 'string' ? Number.parseInt(value, 10) : Number(value);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+function normalizeQuietHours(value: unknown): QuietHoursPreference {
+  if (!value || typeof value !== 'object') {
+    return {
+      enabled: false,
+      startMinutes: 22 * 60,
+      endMinutes: 6 * 60,
+    };
+  }
+  const record = value as Partial<QuietHoursPreference> & Record<string, unknown>;
+  return {
+    enabled: Boolean(record.enabled),
+    startMinutes: clampMinutes(toNumber(record.startMinutes, 22 * 60)),
+    endMinutes: clampMinutes(toNumber(record.endMinutes, 6 * 60)),
+  };
+}
+
+function normalizeWindow(value: unknown): RestartWindow | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Partial<RestartWindow> & Record<string, unknown>;
+  if (typeof record.id !== 'string' || record.id.length === 0) return null;
+  const days = Array.isArray(record.days)
+    ? Array.from(
+        new Set(
+          record.days
+            .map((day) => Number(day))
+            .filter((day) => Number.isInteger(day) && day >= 0 && day <= 6),
+        ),
+      ).sort((a, b) => a - b)
+    : [];
+  return {
+    id: record.id,
+    label: typeof record.label === 'string' && record.label.length > 0 ? record.label : record.id,
+    startMinutes: clampMinutes(toNumber(record.startMinutes, 2 * 60)),
+    endMinutes: clampMinutes(toNumber(record.endMinutes, 4 * 60)),
+    days,
+    notes: typeof record.notes === 'string' && record.notes.length > 0 ? record.notes : undefined,
+  };
+}
+
+const ALLOWED_STATUSES: RestartStatus[] = ['scheduled', 'deferred', 'completed', 'cancelled'];
+
+function normalizeStoredRestart(value: unknown): ScheduledRestart | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Partial<ScheduledRestart> & Record<string, unknown>;
+  if (
+    typeof record.id !== 'string' ||
+    record.id.length === 0 ||
+    typeof record.label !== 'string' ||
+    record.label.length === 0 ||
+    typeof record.scheduledTime !== 'string'
+  ) {
+    return null;
+  }
+  const status = ALLOWED_STATUSES.includes(record.status as RestartStatus)
+    ? (record.status as RestartStatus)
+    : 'scheduled';
+  const createdAt = typeof record.createdAt === 'string' ? record.createdAt : record.scheduledTime;
+  const updatedAt = typeof record.updatedAt === 'string' ? record.updatedAt : createdAt;
+  const deferredFrom = typeof record.deferredFrom === 'string' ? record.deferredFrom : undefined;
+  const windowId = typeof record.windowId === 'string' ? record.windowId : undefined;
+  const notes = typeof record.notes === 'string' ? record.notes : undefined;
+  return {
+    id: record.id,
+    label: record.label,
+    scheduledTime: record.scheduledTime,
+    status,
+    windowId,
+    notes,
+    createdAt,
+    updatedAt,
+    deferredFrom,
+  };
+}
+
+function sortWindows(windows: RestartWindow[]): RestartWindow[] {
+  return windows
+    .slice()
+    .sort((a, b) => a.label.localeCompare(b.label) || a.startMinutes - b.startMinutes);
+}
+
+function sortRestarts(restarts: ScheduledRestart[]): ScheduledRestart[] {
+  return restarts
+    .slice()
+    .sort(
+      (a, b) => new Date(a.scheduledTime).getTime() - new Date(b.scheduledTime).getTime(),
+    );
+}
+
+function createDefaultState(): SchedulerState {
+  return {
+    quietHours: {
+      enabled: false,
+      startMinutes: 22 * 60,
+      endMinutes: 6 * 60,
+    },
+    preferredWindows: [],
+    restarts: [],
+  };
+}
+
+function normalizeState(raw?: Partial<SchedulerState>): SchedulerState {
+  const base = createDefaultState();
+  if (!raw) {
+    return base;
+  }
+  if (raw.quietHours) {
+    base.quietHours = normalizeQuietHours(raw.quietHours);
+  }
+  if (Array.isArray(raw.preferredWindows)) {
+    base.preferredWindows = sortWindows(
+      raw.preferredWindows
+        .map((entry) => normalizeWindow(entry))
+        .filter((entry): entry is RestartWindow => entry !== null),
+    );
+  }
+  if (Array.isArray(raw.restarts)) {
+    base.restarts = sortRestarts(
+      raw.restarts
+        .map((entry) => normalizeStoredRestart(entry))
+        .filter((entry): entry is ScheduledRestart => entry !== null),
+    );
+  }
+  return base;
+}
+
+async function readState(): Promise<SchedulerState> {
+  if (cachedState) {
+    return clone(cachedState);
+  }
+  const dbp = openDb();
+  if (!dbp) {
+    const state = createDefaultState();
+    cachedState = clone(state);
+    return clone(state);
+  }
+  try {
+    const db = await dbp;
+    const stored = (await db.get(STORE_NAME, STORE_KEY)) as SchedulerState | undefined;
+    const normalized = normalizeState(stored ?? undefined);
+    cachedState = clone(normalized);
+    return clone(normalized);
+  } catch {
+    const state = createDefaultState();
+    cachedState = clone(state);
+    return clone(state);
+  }
+}
+
+async function persistState(state: SchedulerState): Promise<void> {
+  cachedState = clone(state);
+  const dbp = openDb();
+  if (dbp) {
+    try {
+      const db = await dbp;
+      await db.put(STORE_NAME, cachedState, STORE_KEY);
+    } catch {
+      // ignore storage errors
+    }
+  }
+  if (typeof window !== 'undefined') {
+    const detail = clone(cachedState);
+    window.dispatchEvent(new CustomEvent(SCHEDULER_EVENT, { detail }));
+  }
+}
+
+function normalizeRestartDraft(
+  draft: RestartDraft,
+  previous?: ScheduledRestart,
+): ScheduledRestart {
+  const now = new Date().toISOString();
+  const status = draft.status ?? previous?.status ?? 'scheduled';
+  let deferredFrom = previous?.deferredFrom;
+  if (status === 'deferred') {
+    const previousTime = previous?.scheduledTime;
+    if (previousTime && previousTime !== draft.scheduledTime) {
+      deferredFrom = previous?.deferredFrom ?? previousTime;
+    }
+  }
+  return {
+    id: draft.id,
+    label: draft.label,
+    scheduledTime: draft.scheduledTime,
+    status,
+    windowId: draft.windowId ?? previous?.windowId,
+    notes: draft.notes ?? previous?.notes,
+    createdAt: previous?.createdAt ?? now,
+    updatedAt: now,
+    deferredFrom,
+  };
+}
+
+export async function getSchedulerState(): Promise<SchedulerState> {
+  const state = await readState();
+  return clone(state);
+}
+
+export async function getQuietHours(): Promise<QuietHoursPreference> {
+  const state = await readState();
+  return clone(state.quietHours);
+}
+
+export async function setQuietHours(
+  preference: QuietHoursPreference,
+): Promise<QuietHoursPreference> {
+  const state = await readState();
+  state.quietHours = normalizeQuietHours(preference);
+  await persistState(state);
+  return clone(state.quietHours);
+}
+
+export async function getPreferredWindows(): Promise<RestartWindow[]> {
+  const state = await readState();
+  return clone(state.preferredWindows);
+}
+
+export async function addPreferredWindow(window: RestartWindow): Promise<RestartWindow[]> {
+  const state = await readState();
+  const normalized = normalizeWindow(window);
+  if (!normalized) {
+    return clone(state.preferredWindows);
+  }
+  const existingIndex = state.preferredWindows.findIndex((entry) => entry.id === normalized.id);
+  if (existingIndex >= 0) {
+    state.preferredWindows.splice(existingIndex, 1, normalized);
+  } else {
+    state.preferredWindows.push(normalized);
+  }
+  state.preferredWindows = sortWindows(state.preferredWindows);
+  await persistState(state);
+  return clone(state.preferredWindows);
+}
+
+export async function updatePreferredWindow(
+  window: RestartWindow,
+): Promise<RestartWindow[]> {
+  return addPreferredWindow(window);
+}
+
+export async function removePreferredWindow(id: string): Promise<RestartWindow[]> {
+  const state = await readState();
+  state.preferredWindows = state.preferredWindows.filter((entry) => entry.id !== id);
+  await persistState(state);
+  return clone(state.preferredWindows);
+}
+
+export async function getScheduledRestarts(): Promise<ScheduledRestart[]> {
+  const state = await readState();
+  return clone(sortRestarts(state.restarts));
+}
+
+export async function scheduleRestart(
+  draft: RestartDraft,
+): Promise<ScheduledRestart[]> {
+  const state = await readState();
+  const index = state.restarts.findIndex((entry) => entry.id === draft.id);
+  const previous = index >= 0 ? state.restarts[index] : undefined;
+  const normalized = normalizeRestartDraft(draft, previous);
+  if (index >= 0) {
+    state.restarts.splice(index, 1, normalized);
+  } else {
+    state.restarts.push(normalized);
+  }
+  state.restarts = sortRestarts(state.restarts);
+  await persistState(state);
+  return clone(state.restarts);
+}
+
+export async function rescheduleRestart(
+  id: string,
+  scheduledTime: string,
+  options: RescheduleOptions = {},
+): Promise<ScheduledRestart[]> {
+  const state = await readState();
+  const index = state.restarts.findIndex((entry) => entry.id === id);
+  if (index === -1) {
+    return clone(sortRestarts(state.restarts));
+  }
+  const previous = state.restarts[index];
+  const draft: RestartDraft = {
+    id,
+    label: options.label ?? previous.label,
+    scheduledTime,
+    status: 'deferred',
+    windowId: options.windowId ?? previous.windowId,
+    notes: options.note ?? previous.notes,
+  };
+  const normalized = normalizeRestartDraft(draft, {
+    ...previous,
+    deferredFrom: previous.deferredFrom ?? previous.scheduledTime,
+  });
+  normalized.deferredFrom = previous.deferredFrom ?? previous.scheduledTime;
+  state.restarts.splice(index, 1, normalized);
+  state.restarts = sortRestarts(state.restarts);
+  await persistState(state);
+  return clone(state.restarts);
+}
+
+export async function updateRestartStatus(
+  id: string,
+  status: RestartStatus,
+): Promise<ScheduledRestart[]> {
+  const state = await readState();
+  const index = state.restarts.findIndex((entry) => entry.id === id);
+  if (index === -1) {
+    return clone(sortRestarts(state.restarts));
+  }
+  state.restarts[index] = {
+    ...state.restarts[index],
+    status,
+    updatedAt: new Date().toISOString(),
+  };
+  await persistState(state);
+  return clone(sortRestarts(state.restarts));
+}
+
+export async function removeScheduledRestart(id: string): Promise<ScheduledRestart[]> {
+  const state = await readState();
+  state.restarts = state.restarts.filter((entry) => entry.id !== id);
+  await persistState(state);
+  return clone(state.restarts);
+}
+
+export async function getUpcomingRestart(): Promise<ScheduledRestart | null> {
+  const restarts = await getScheduledRestarts();
+  const now = Date.now();
+  return (
+    restarts.find((entry) => {
+      if (entry.status === 'cancelled') return false;
+      return new Date(entry.scheduledTime).getTime() >= now;
+    }) ?? null
+  );
+}
+
+export async function getPendingDeferredRestart(): Promise<ScheduledRestart | null> {
+  const restarts = await getScheduledRestarts();
+  const now = Date.now();
+  return (
+    restarts.find(
+      (entry) =>
+        entry.status === 'deferred' && new Date(entry.scheduledTime).getTime() >= now,
+    ) ?? null
+  );
+}


### PR DESCRIPTION
## Summary
- add an IndexedDB-backed update scheduler that tracks quiet hours, preferred windows, and restart state
- build an Update Center app for managing restart windows and rescheduling with confirmation modal
- surface deferred restart warnings in quick settings and register the new app in the desktop catalog

## Testing
- yarn lint *(fails: repo contains numerous pre-existing accessibility violations)*
- yarn test *(fails: existing suites such as nmapNse and modal tests are already red)*

------
https://chatgpt.com/codex/tasks/task_e_68cab67b529883288d846d084ccd4b3e