### PR TITLE
tests: cover update center flow

### DIFF
--- a/__tests__/updateCenter.test.tsx
+++ b/__tests__/updateCenter.test.tsx
@@ -1,0 +1,84 @@
+import { act, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UpdateCenter from '../components/apps/update-center';
+
+describe('UpdateCenter', () => {
+  it('allows switching release channels and updates description', async () => {
+    const user = userEvent.setup();
+    render(<UpdateCenter />);
+
+    const betaTab = screen.getByRole('tab', { name: 'Beta' });
+    await user.click(betaTab);
+
+    expect(betaTab).toHaveAttribute('aria-selected', 'true');
+    expect(
+      screen.getByText(
+        /Early preview of quarterly features. Carries faster iteration with additional telemetry hooks./i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders changelog entries for the selected channel', async () => {
+    const user = userEvent.setup();
+    render(<UpdateCenter />);
+
+    const nightlyTab = screen.getByRole('tab', { name: 'Nightly' });
+    await user.click(nightlyTab);
+
+    const list = screen.getByRole('list', { name: /Nightly changelog/i });
+    expect(
+      within(list).getByText('Fuzz nightly plugin API to catch sandbox regressions'),
+    ).toBeInTheDocument();
+    expect(within(list).getAllByRole('listitem').length).toBeGreaterThan(0);
+  });
+
+  it('defers restart while offline and resumes once reconnected', async () => {
+    const user = userEvent.setup();
+    render(<UpdateCenter />);
+
+    const originalDescriptor = Object.getOwnPropertyDescriptor(window.navigator, 'onLine');
+    Object.defineProperty(window.navigator, 'onLine', {
+      value: true,
+      configurable: true,
+    });
+
+    const checkButton = screen.getByRole('button', { name: /Check for updates/i });
+    await user.click(checkButton);
+
+    await screen.findByText(/Update 2025\.02 ready for install\./i);
+
+    const installButton = screen.getByRole('button', { name: /Install update/i });
+    await user.click(installButton);
+    await screen.findByText(/Restart required to finish/i);
+
+    Object.defineProperty(window.navigator, 'onLine', {
+      value: false,
+      configurable: true,
+    });
+
+    const restartButton = screen.getByRole('button', { name: /Restart now/i });
+    await user.click(restartButton);
+    expect(screen.getByText(/Restart deferred until you are back online/i)).toBeInTheDocument();
+
+    await act(async () => {
+      window.dispatchEvent(new Event('online'));
+    });
+
+    await screen.findByText(/Connection restored. Ready to restart./i);
+
+    Object.defineProperty(window.navigator, 'onLine', {
+      value: true,
+      configurable: true,
+    });
+
+    await user.click(restartButton);
+    await screen.findByText(/Restart complete. Running 2025\.02 on the Stable channel./i);
+
+    if (originalDescriptor) {
+      Object.defineProperty(window.navigator, 'onLine', originalDescriptor);
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (window.navigator as any).onLine;
+    }
+  });
+});

--- a/components/apps/update-center/index.tsx
+++ b/components/apps/update-center/index.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import updateManifest from '../../../data/update-center.json';
+
+interface ReleaseNote {
+  version: string;
+  date: string;
+  highlights: string[];
+}
+
+interface ReleaseChannel {
+  id: string;
+  label: string;
+  description: string;
+  currentVersion: string;
+  releases: ReleaseNote[];
+}
+
+interface UpdateManifest {
+  channels: ReleaseChannel[];
+}
+
+type UpdateStatus =
+  | 'idle'
+  | 'checking'
+  | 'ready'
+  | 'installing'
+  | 'restart'
+  | 'deferred'
+  | 'completed';
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const manifest = updateManifest as UpdateManifest;
+
+export default function UpdateCenter(): JSX.Element {
+  const channels = manifest.channels;
+  const [selectedChannelId, setSelectedChannelId] = useState<string>(
+    () => channels[0]?.id ?? '',
+  );
+  const [installedVersions, setInstalledVersions] = useState<Record<string, string>>(() =>
+    Object.fromEntries(channels.map((channel) => [channel.id, channel.currentVersion])),
+  );
+  const [status, setStatus] = useState<UpdateStatus>('idle');
+  const [message, setMessage] = useState<string>('');
+  const [availableRelease, setAvailableRelease] = useState<ReleaseNote | null>(null);
+  const deferredRestart = useRef(false);
+
+  const selectedChannel = useMemo(() => {
+    return channels.find((channel) => channel.id === selectedChannelId) ?? channels[0];
+  }, [channels, selectedChannelId]);
+
+  useEffect(() => {
+    setStatus('idle');
+    setMessage('');
+    setAvailableRelease(null);
+    deferredRestart.current = false;
+  }, [selectedChannelId]);
+
+  useEffect(() => {
+    const handleOnline = () => {
+      if (deferredRestart.current) {
+        setStatus('restart');
+        setMessage('Connection restored. Ready to restart.');
+        deferredRestart.current = false;
+      }
+    };
+
+    window.addEventListener('online', handleOnline);
+    return () => window.removeEventListener('online', handleOnline);
+  }, []);
+
+  const installedVersion = selectedChannel
+    ? installedVersions[selectedChannel.id]
+    : undefined;
+
+  const checkForUpdates = useCallback(async () => {
+    if (!selectedChannel) return;
+    setStatus('checking');
+    setMessage(`Checking ${selectedChannel.label} updates…`);
+    await delay(200);
+    const [latest] = selectedChannel.releases;
+    if (!latest) {
+      setStatus('idle');
+      setMessage('No releases published for this channel yet.');
+      setAvailableRelease(null);
+      return;
+    }
+
+    if (installedVersion && installedVersion === latest.version) {
+      setStatus('idle');
+      setMessage(`Already on the latest ${selectedChannel.label} build (${installedVersion}).`);
+      setAvailableRelease(null);
+      return;
+    }
+
+    setAvailableRelease(latest);
+    setStatus('ready');
+    setMessage(`Update ${latest.version} ready for install.`);
+  }, [installedVersion, selectedChannel]);
+
+  const installUpdate = useCallback(async () => {
+    if (!availableRelease || !selectedChannel) return;
+    setStatus('installing');
+    setMessage(`Installing ${availableRelease.version}…`);
+    await delay(250);
+    setStatus('restart');
+    setMessage(`Update ${availableRelease.version} installed. Restart required to finish.`);
+  }, [availableRelease, selectedChannel]);
+
+  const completeRestart = useCallback(() => {
+    if (!availableRelease || !selectedChannel) return;
+    setInstalledVersions((prev) => ({
+      ...prev,
+      [selectedChannel.id]: availableRelease.version,
+    }));
+    setStatus('completed');
+    setMessage(
+      `Restart complete. Running ${availableRelease.version} on the ${selectedChannel.label} channel.`,
+    );
+    setAvailableRelease(null);
+  }, [availableRelease, selectedChannel]);
+
+  const restartNow = useCallback(() => {
+    if (!availableRelease || !selectedChannel) return;
+    if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+      setStatus('deferred');
+      setMessage('Restart deferred until you are back online.');
+      deferredRestart.current = true;
+      return;
+    }
+
+    completeRestart();
+  }, [availableRelease, completeRestart, selectedChannel]);
+
+  if (!selectedChannel) {
+    return (
+      <div className="p-4 text-white bg-ub-dark">
+        <p>No update channels are configured.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-auto bg-ub-dark text-white p-4 space-y-4" data-testid="update-center">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">Update Center</h1>
+        <p className="text-sm text-gray-300">
+          Choose a release channel, review the changelog, and stage the update before restarting the
+          desktop shell.
+        </p>
+      </header>
+
+      <div role="tablist" aria-label="Release channels" className="flex flex-wrap gap-2">
+        {channels.map((channel) => {
+          const selected = channel.id === selectedChannel.id;
+          return (
+            <button
+              key={channel.id}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              aria-controls={`${channel.id}-panel`}
+              id={`${channel.id}-tab`}
+              onClick={() => setSelectedChannelId(channel.id)}
+              className={`px-3 py-1 rounded border ${
+                selected ? 'bg-ub-orange text-black border-ub-orange' : 'bg-gray-800 border-gray-600'
+              } focus:outline-none focus:ring-2 focus:ring-ubt-blue`}
+            >
+              {channel.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <section
+        role="tabpanel"
+        id={`${selectedChannel.id}-panel`}
+        aria-labelledby={`${selectedChannel.id}-tab`}
+        className="space-y-3 bg-gray-900/60 p-4 rounded border border-gray-700"
+      >
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold">{selectedChannel.label} channel</h2>
+          <p className="text-sm text-gray-300">{selectedChannel.description}</p>
+          <p className="text-xs text-gray-400" data-testid="installed-version">
+            Installed build: {installedVersion}
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={checkForUpdates}
+              className="px-3 py-1 rounded bg-ubt-blue text-white focus:outline-none focus:ring-2 focus:ring-ub-orange"
+            >
+              Check for updates
+            </button>
+            {status === 'ready' && (
+              <button
+                type="button"
+                onClick={installUpdate}
+                className="px-3 py-1 rounded bg-ub-green text-black focus:outline-none focus:ring-2 focus:ring-ubt-blue"
+              >
+                Install update
+              </button>
+            )}
+            {(status === 'restart' || status === 'deferred') && (
+              <button
+                type="button"
+                onClick={restartNow}
+                className="px-3 py-1 rounded bg-ub-orange text-black focus:outline-none focus:ring-2 focus:ring-ubt-blue"
+              >
+                Restart now
+              </button>
+            )}
+          </div>
+          {message && (
+            <p role="status" aria-live="polite" className="text-sm" data-testid="update-status">
+              {message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold">Changelog</h3>
+          <ol
+            className="space-y-3"
+            aria-label={`${selectedChannel.label} changelog`}
+            data-testid="changelog-list"
+          >
+            {selectedChannel.releases.map((release) => (
+              <li key={release.version} className="bg-gray-800/80 p-3 rounded border border-gray-700">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="font-semibold">Version {release.version}</span>
+                  <span className="text-gray-400">{release.date}</span>
+                </div>
+                <ul className="list-disc list-inside text-sm mt-2 space-y-1">
+                  {release.highlights.map((note) => (
+                    <li key={note}>{note}</li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/data/update-center.json
+++ b/data/update-center.json
@@ -1,0 +1,82 @@
+{
+  "channels": [
+    {
+      "id": "stable",
+      "label": "Stable",
+      "description": "Verified monthly builds recommended for most visitors. Prioritizes reliability and accessibility fixes.",
+      "currentVersion": "2024.10",
+      "releases": [
+        {
+          "version": "2025.02",
+          "date": "2025-02-10",
+          "highlights": [
+            "Refined desktop dock animations for smoother window launching",
+            "Faster module index hydration to cut cold boot time by 20%",
+            "Audit sweep covering 30+ keyboard navigation paths"
+          ]
+        },
+        {
+          "version": "2024.10",
+          "date": "2024-10-02",
+          "highlights": [
+            "Rolled out high-contrast wallpapers and colorblind-friendly status badges",
+            "Pinned quick access to the Plugin Catalog and module changelog",
+            "Bundled offline fixtures for Wireshark and OpenVAS demos"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "beta",
+      "label": "Beta",
+      "description": "Early preview of quarterly features. Carries faster iteration with additional telemetry hooks.",
+      "currentVersion": "2024.12",
+      "releases": [
+        {
+          "version": "2025.03",
+          "date": "2025-03-05",
+          "highlights": [
+            "Rolled in Scene Graph debugger for 3D visualizations",
+            "Beta contact workflow with scripted failure injection",
+            "Expanded analytics opt-in banner for lab participants"
+          ]
+        },
+        {
+          "version": "2024.12",
+          "date": "2024-12-08",
+          "highlights": [
+            "Previewed vector scope overlay for the screen recorder",
+            "Added beta badges to experimental catalog entries",
+            "Bundled nightly update stress-test harness"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "nightly",
+      "label": "Nightly",
+      "description": "Daily snapshots generated from the integration branch. Best suited for contributors validating fixes.",
+      "currentVersion": "2025.02-15",
+      "releases": [
+        {
+          "version": "2025.02-28",
+          "date": "2025-02-28",
+          "highlights": [
+            "Fuzz nightly plugin API to catch sandbox regressions",
+            "Surface service worker cache diffs in the developer console",
+            "Nightly telemetry scrubbing pipeline for anonymized logs"
+          ]
+        },
+        {
+          "version": "2025.02-20",
+          "date": "2025-02-20",
+          "highlights": [
+            "Introduce experimental keyboard macro recorder",
+            "Nightly theming hooks for window chrome overrides",
+            "Async plugin validator with worker mirroring"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/research/update-center-pilot.md
+++ b/docs/research/update-center-pilot.md
@@ -1,0 +1,89 @@
+# Update Center Pilot Script
+
+This script supports a **30-participant** study validating the new Update Center experience. The
+focus is on comprehension of release channels, confidence in the staged update flow, and resilience
+of the restart deferral mechanic.
+
+## 1. Participant Profile & Logistics
+
+- **Recruiting mix:**
+  - 10 returning visitors familiar with the desktop metaphor
+  - 10 security hobbyists who routinely try beta features
+  - 10 first-time visitors with minimal context
+- **Devices:** Desktop or laptop, Chrome or Firefox latest stable
+- **Session length:** 20 minutes moderated remote call, screen sharing required
+- **Pre-session survey:** Prior experience with OS update flows, comfort switching release
+  channels, expectation of restart behaviour
+
+## 2. Environment Checklist
+
+1. Provide each participant with a disposable user profile (browser guest session or clean profile).
+2. Ensure `/apps/update-center` is reachable on the staging environment seeded with pilot telemetry
+   flags disabled.
+3. Confirm analytics sampling is off and console logging of pilot markers is enabled.
+4. Prepare fallback instructions in case the service worker cache holds stale assets.
+
+## 3. Session Outline
+
+### 3.1 Introduction (2 minutes)
+
+- Welcome participant, confirm recording consent, remind them no task is graded.
+- Outline objectives: explore the Update Center, compare channels, and apply an update.
+
+### 3.2 Channel Discovery (5 minutes)
+
+1. Ask the participant to read the Stable channel description aloud.
+2. Prompt them to switch to Beta and Nightly; note how quickly they find changelog context.
+3. Probe understanding: "Who would benefit from Nightly?" Capture whether messaging resonates.
+
+**Observation goals:**
+- Time-to-first switch between channels (<30 seconds target)
+- Ability to restate the value prop of each channel without assistance
+
+### 3.3 Changelog Interpretation (4 minutes)
+
+1. Direct the participant to scan the changelog for the currently selected channel.
+2. Ask them to call out one highlight that excites them and one that raises a question.
+3. Gauge whether the list structure is scannable (headings vs. bullet density).
+
+**Observation goals:**
+- Highlight recall accuracy (target ≥80% recall of one bullet)
+- Perceived completeness of the changelog section on a 1–5 Likert scale
+
+### 3.4 Update & Restart Flow (7 minutes)
+
+1. Instruct participant to click **Check for updates** and describe the status messaging.
+2. Have them install the update and pause before restarting.
+3. Toggle browser offline mode (moderator action) and ask the participant to press **Restart now**.
+4. Once deferral appears, restore connectivity and observe if they retry restart unprompted.
+
+**Observation goals:**
+- Comprehension of the deferral message (participant explains why restart paused)
+- Latency to retry restart after connection returns (<15 seconds target)
+- Confidence rating for the overall flow (1–5)
+
+### 3.5 Wrap-up & Survey (2 minutes)
+
+- Collect open feedback on wording, perceived risk, and visual hierarchy.
+- Post-session survey (embedded form):
+  - Confidence applying updates via Update Center (1–5)
+  - Preference ranking of channels (Stable/Beta/Nightly)
+  - Perceived clarity of deferral messaging (1–5)
+
+## 4. Success Criteria
+
+A pilot run is considered successful when the following thresholds are met:
+
+- ≥26/30 participants complete the flow without moderator intervention.
+- ≥80% correctly articulate the difference between Stable and Beta descriptions.
+- ≥75% recall one changelog highlight after the scan task.
+- ≥85% understand the restart deferral message and can resume without prompt.
+- Mean confidence score ≥4.0 for the update process.
+- Qualitative feedback surfaces ≤3 critical blockers requiring redesign before public launch.
+
+## 5. Data Capture & Reporting
+
+- Use timestamped notes template capturing key quotes, hesitation moments, and status message
+  comprehension.
+- Record console logs tagged with `update-center-pilot` for correlation with observed events.
+- Summarize findings in a debrief deck with heatmaps of successful vs. assisted steps.

--- a/pages/apps/update-center.tsx
+++ b/pages/apps/update-center.tsx
@@ -1,0 +1,14 @@
+import dynamic from 'next/dynamic';
+
+const UpdateCenter = dynamic(() => import('../../components/apps/update-center'), {
+  ssr: false,
+  loading: () => <p className="p-4 text-white">Loading Update Center…</p>,
+});
+
+export default function UpdateCenterPage() {
+  return (
+    <div className="w-full h-full bg-ub-dark text-white">
+      <UpdateCenter />
+    </div>
+  );
+}

--- a/tests/update-center.spec.ts
+++ b/tests/update-center.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Update Center workflow', () => {
+  test('completes update with offline restart deferral', async ({ context, page }) => {
+    await page.goto('/apps/update-center');
+
+    await expect(page.getByRole('heading', { name: 'Update Center' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Check for updates' }).click();
+    await expect(page.getByTestId('update-status')).toContainText('Update');
+
+    await page.getByRole('button', { name: 'Install update' }).click();
+    await expect(page.getByTestId('update-status')).toContainText('Restart required');
+
+    await context.setOffline(true);
+    await expect.poll(async () => page.evaluate(() => navigator.onLine)).toBeFalsy();
+
+    await page.getByRole('button', { name: 'Restart now' }).click();
+    await expect(page.getByTestId('update-status')).toContainText('Restart deferred');
+
+    await context.setOffline(false);
+    await expect.poll(async () => page.evaluate(() => navigator.onLine)).toBeTruthy();
+    await page.evaluate(() => window.dispatchEvent(new Event('online')));
+    await expect(page.getByTestId('update-status')).toContainText('Connection restored');
+
+    await page.getByRole('button', { name: 'Restart now' }).click();
+    await expect(page.getByTestId('update-status')).toContainText('Restart complete');
+  });
+});


### PR DESCRIPTION
## Summary
- add a data-driven Update Center surface with channel selection, changelog display, and restart deferral messaging
- cover Update Center behaviour with Jest and Playwright tests
- document the 30-person pilot plan for the Update Center rollout

## Testing
- ✅ `yarn test updateCenter.test.tsx`
- ❌ `yarn lint` *(fails with pre-existing accessibility violations across legacy apps)*
- ❌ `npx playwright test update-center.spec.ts --config=playwright.config.ts` *(fails: missing system libraries required by Chromium runner)*

------
https://chatgpt.com/codex/tasks/task_e_68cab67d44248328bf0486d8579f5a67