### PR TITLE
[apps] add update center preferences UI

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -74,6 +74,8 @@ const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
+const UpdateCenterApp = createDynamicApp('update-center', 'Update Center');
+
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
 const TrashApp = createDynamicApp('trash', 'Trash');
 const SerialTerminalApp = createDynamicApp('serial-terminal', 'Serial Terminal');
@@ -167,6 +169,8 @@ const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
 
 const displayGhidra = createDisplay(GhidraApp);
+
+const displayUpdateCenter = createDisplay(UpdateCenterApp);
 
 const displayAutopsy = createDisplay(AutopsyApp);
 const displayPluginManager = createDisplay(PluginManagerApp);
@@ -691,6 +695,15 @@ const apps = [
     favourite: true,
     desktop_shortcut: false,
     screen: displaySettings,
+  },
+  {
+    id: 'update-center',
+    title: 'Update Center',
+    icon: '/themes/Yaru/apps/radar-symbolic.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayUpdateCenter,
   },
   {
     id: 'files',

--- a/apps/update-center/index.tsx
+++ b/apps/update-center/index.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import ToggleSwitch from '../../components/ToggleSwitch';
+import {
+  DEFER_WINDOW_LABELS,
+  DEFER_WINDOW_OPTIONS,
+  UPDATE_CHANNEL_OPTIONS,
+  DeferWindow,
+  UpdateChannel,
+  useUpdatePreferences,
+} from '../../hooks/useUpdatePreferences';
+
+type ExtendedNetworkInformation = NetworkInformation & { metered?: boolean };
+type NavigatorWithConnection = Navigator & {
+  connection?: ExtendedNetworkInformation;
+  mozConnection?: ExtendedNetworkInformation;
+  webkitConnection?: ExtendedNetworkInformation;
+};
+
+type ConnectionInfo = {
+  supported: boolean;
+  metered?: boolean;
+  saveData?: boolean;
+  effectiveType?: string;
+  downlink?: number;
+};
+
+const CHANNEL_HELP_ID = 'update-channel-help';
+const DEFER_HELP_ID = 'update-defer-help';
+
+const resolveConnection = (): ExtendedNetworkInformation | null => {
+  if (typeof navigator === 'undefined') return null;
+  const nav = navigator as NavigatorWithConnection;
+  return nav.connection || nav.mozConnection || nav.webkitConnection || null;
+};
+
+const describeDeferWindow = (value: DeferWindow): string => {
+  if (value === 'off') {
+    return 'Updates install as soon as they are ready.';
+  }
+  return `Updates wait for ${DEFER_WINDOW_LABELS[value]} before installing.`;
+};
+
+const describeChannel = (channel: UpdateChannel): string =>
+  UPDATE_CHANNEL_OPTIONS.find((option) => option.value === channel)?.description || '';
+
+const describeNetwork = (info: ConnectionInfo): string => {
+  if (!info.supported) {
+    return 'Network cost detection is unavailable, so downloads assume an unmetered connection.';
+  }
+  if (info.metered || info.saveData) {
+    return 'Current connection looks metered or data-saver is enabled. Large downloads pause unless you allow them.';
+  }
+  return 'Connection appears unmetered. Background downloads can run without extra charges.';
+};
+
+const formatEffectiveType = (type?: string) => (type ? type.toUpperCase() : undefined);
+
+export default function UpdateCenter() {
+  const {
+    channel,
+    setChannel,
+    autoDownload,
+    setAutoDownload,
+    allowMetered,
+    setAllowMetered,
+    deferWindow,
+    setDeferWindow,
+    isReady,
+  } = useUpdatePreferences();
+
+  const [connectionInfo, setConnectionInfo] = useState<ConnectionInfo>({ supported: false });
+
+  useEffect(() => {
+    const connection = resolveConnection();
+    if (!connection) {
+      setConnectionInfo({ supported: false });
+      return;
+    }
+
+    const update = () => {
+      setConnectionInfo({
+        supported: true,
+        metered: typeof connection.metered === 'boolean' ? connection.metered : undefined,
+        saveData: connection.saveData,
+        effectiveType: connection.effectiveType,
+        downlink: connection.downlink,
+      });
+    };
+
+    update();
+    const listener = () => update();
+    connection.addEventListener?.('change', listener);
+
+    return () => {
+      connection.removeEventListener?.('change', listener);
+    };
+  }, []);
+
+  const connectionStatus = useMemo(() => {
+    if (!connectionInfo.supported) return 'Unknown';
+    if (connectionInfo.metered || connectionInfo.saveData) return 'Metered';
+    return 'Unmetered';
+  }, [connectionInfo]);
+
+  const connectionBadgeClasses = useMemo(() => {
+    if (!connectionInfo.supported) return 'bg-ubt-cool-grey text-white';
+    return connectionInfo.metered || connectionInfo.saveData
+      ? 'bg-ub-orange text-black'
+      : 'bg-ub-green text-black';
+  }, [connectionInfo]);
+
+  const autoDownloadHelp = autoDownload
+    ? 'Downloads update packages in the background so installs are ready when you are.'
+    : 'Skips background downloads. You will fetch packages manually before installing.';
+
+  const meteredHelp = allowMetered
+    ? 'Updates can download on metered connections. Monitor your data usage when travelling.'
+    : 'Downloads pause on metered or data-saver connections to avoid unexpected charges.';
+
+  const networkDetails: string[] = [];
+  const effectiveType = formatEffectiveType(connectionInfo.effectiveType);
+  if (effectiveType) {
+    networkDetails.push(`Effective type: ${effectiveType}`);
+  }
+  if (typeof connectionInfo.downlink === 'number') {
+    networkDetails.push(`Downlink: ${connectionInfo.downlink.toFixed(1)} Mbps`);
+  }
+  if (connectionInfo.saveData) {
+    networkDetails.push('Save-Data mode is enabled.');
+  }
+
+  return (
+    <div className="h-full w-full overflow-y-auto bg-ub-cool-grey p-4 text-white">
+      <header className="mb-6 border-b border-gray-700 pb-4">
+        <h1 className="text-2xl font-semibold">Update Center</h1>
+        <p className="mt-2 text-sm text-ubt-grey">
+          Configure how the desktop fetches simulated system updates. Preferences stay on this device.
+        </p>
+      </header>
+
+      {!isReady && (
+        <p role="status" className="mb-4 text-xs text-ubt-grey">
+          Loading saved preferences…
+        </p>
+      )}
+
+      <div className={`space-y-6 ${isReady ? '' : 'pointer-events-none opacity-50'}`} aria-busy={!isReady}>
+        <section className="rounded border border-gray-700 bg-black/20 p-4">
+          <h2 className="text-lg font-semibold">Channels</h2>
+          <div className="mt-3 space-y-2 text-sm">
+            <label htmlFor="update-channel-select" className="font-medium">
+              Update channel
+            </label>
+            <select
+              id="update-channel-select"
+              aria-describedby={CHANNEL_HELP_ID}
+              value={channel}
+              onChange={(event) => setChannel(event.target.value as UpdateChannel)}
+              className="w-full rounded border border-gray-700 bg-ub-cool-grey px-3 py-2 text-white focus:outline-none focus:ring"
+            >
+              {UPDATE_CHANNEL_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <p id={CHANNEL_HELP_ID} className="text-xs text-ubt-grey">
+              {describeChannel(channel)}
+            </p>
+          </div>
+        </section>
+
+        <section className="rounded border border-gray-700 bg-black/20 p-4">
+          <h2 className="text-lg font-semibold">Automation</h2>
+          <div className="mt-3 space-y-4 text-sm">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="font-medium">Auto-download updates</p>
+                <p id="update-auto-download-help" className="text-xs text-ubt-grey">
+                  {autoDownloadHelp}
+                </p>
+              </div>
+              <ToggleSwitch
+                checked={autoDownload}
+                onChange={(next) => setAutoDownload(next)}
+                ariaLabel="Toggle automatic update downloads"
+              />
+            </div>
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="font-medium">Allow on metered networks</p>
+                <p id="update-metered-help" className="text-xs text-ubt-grey">
+                  {meteredHelp}
+                </p>
+              </div>
+              <ToggleSwitch
+                checked={allowMetered}
+                onChange={(next) => setAllowMetered(next)}
+                ariaLabel="Allow update downloads on metered connections"
+              />
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded border border-gray-700 bg-black/20 p-4">
+          <h2 className="text-lg font-semibold">Scheduling</h2>
+          <div className="mt-3 space-y-2 text-sm">
+            <label htmlFor="update-defer-select" className="font-medium">
+              Defer window
+            </label>
+            <select
+              id="update-defer-select"
+              aria-describedby={DEFER_HELP_ID}
+              value={deferWindow}
+              onChange={(event) => setDeferWindow(event.target.value as DeferWindow)}
+              className="w-full rounded border border-gray-700 bg-ub-cool-grey px-3 py-2 text-white focus:outline-none focus:ring"
+            >
+              {DEFER_WINDOW_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <p id={DEFER_HELP_ID} className="text-xs text-ubt-grey">
+              {describeDeferWindow(deferWindow)}
+            </p>
+          </div>
+        </section>
+
+        <section className="rounded border border-gray-700 bg-black/20 p-4">
+          <h2 className="text-lg font-semibold">Network status</h2>
+          <div className="mt-3 space-y-2 text-sm">
+            <div className="flex items-center gap-2">
+              <span className={`rounded-full px-2 py-1 text-xs font-semibold ${connectionBadgeClasses}`}>
+                {connectionStatus}
+              </span>
+              <p className="text-xs text-ubt-grey">{describeNetwork(connectionInfo)}</p>
+            </div>
+            {networkDetails.length > 0 && (
+              <ul className="list-disc space-y-1 pl-5 text-xs text-ubt-grey">
+                {networkDetails.map((detail) => (
+                  <li key={detail}>{detail}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/components/apps/update-center/index.tsx
+++ b/components/apps/update-center/index.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../apps/update-center';

--- a/hooks/useUpdatePreferences.ts
+++ b/hooks/useUpdatePreferences.ts
@@ -1,0 +1,155 @@
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import {
+  defaults,
+  getUpdateAllowMetered,
+  getUpdateAutoDownload,
+  getUpdateChannel,
+  getUpdateDeferWindow,
+  setUpdateAllowMetered,
+  setUpdateAutoDownload,
+  setUpdateChannel,
+  setUpdateDeferWindow,
+} from '../utils/settingsStore';
+
+export type UpdateChannel = 'security' | 'feature';
+const DEFER_VALUES = ['off', '1h', '4h', '1d', '7d'] as const;
+export type DeferWindow = (typeof DEFER_VALUES)[number];
+
+export interface UpdatePreferencesState {
+  channel: UpdateChannel;
+  setChannel: Dispatch<SetStateAction<UpdateChannel>>;
+  autoDownload: boolean;
+  setAutoDownload: Dispatch<SetStateAction<boolean>>;
+  allowMetered: boolean;
+  setAllowMetered: Dispatch<SetStateAction<boolean>>;
+  deferWindow: DeferWindow;
+  setDeferWindow: Dispatch<SetStateAction<DeferWindow>>;
+  isReady: boolean;
+}
+
+export const UPDATE_CHANNEL_OPTIONS: readonly {
+  value: UpdateChannel;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: 'security',
+    label: 'Security channel',
+    description: 'Prioritise stability with only vetted security updates.',
+  },
+  {
+    value: 'feature',
+    label: 'Feature channel',
+    description: 'Receive new features alongside security fixes as soon as they land.',
+  },
+];
+
+export const DEFER_WINDOW_LABELS: Readonly<Record<DeferWindow, string>> = {
+  off: 'Immediate install',
+  '1h': '1 hour',
+  '4h': '4 hours',
+  '1d': '1 day',
+  '7d': '7 days',
+};
+
+export const DEFER_WINDOW_OPTIONS = (
+  Object.entries(DEFER_WINDOW_LABELS) as [DeferWindow, string][]
+).map(([value, label]) => ({ value, label }));
+
+const rawDefaults = defaults as {
+  updateChannel?: string;
+  updateAutoDownload?: boolean;
+  updateAllowMetered?: boolean;
+  updateDeferWindow?: string;
+};
+
+const sanitiseChannel = (value?: string | null): UpdateChannel =>
+  value === 'feature' ? 'feature' : 'security';
+
+const sanitiseDeferWindow = (value?: string | null): DeferWindow => {
+  if (!value) return 'off';
+  return (DEFER_VALUES as readonly string[]).includes(value)
+    ? (value as DeferWindow)
+    : 'off';
+};
+
+const DEFAULT_CHANNEL = sanitiseChannel(rawDefaults.updateChannel);
+const DEFAULT_AUTO_DOWNLOAD =
+  rawDefaults.updateAutoDownload !== undefined
+    ? rawDefaults.updateAutoDownload
+    : true;
+const DEFAULT_ALLOW_METERED =
+  rawDefaults.updateAllowMetered !== undefined
+    ? rawDefaults.updateAllowMetered
+    : false;
+const DEFAULT_DEFER_WINDOW = sanitiseDeferWindow(rawDefaults.updateDeferWindow);
+
+export function useUpdatePreferences(): UpdatePreferencesState {
+  const [channel, setChannel] = useState<UpdateChannel>(DEFAULT_CHANNEL);
+  const [autoDownload, setAutoDownload] = useState<boolean>(DEFAULT_AUTO_DOWNLOAD);
+  const [allowMetered, setAllowMetered] = useState<boolean>(DEFAULT_ALLOW_METERED);
+  const [deferWindow, setDeferWindow] = useState<DeferWindow>(DEFAULT_DEFER_WINDOW);
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      const [storedChannel, storedAutoDownload, storedAllowMetered, storedDeferWindow] =
+        await Promise.all([
+          getUpdateChannel(),
+          getUpdateAutoDownload(),
+          getUpdateAllowMetered(),
+          getUpdateDeferWindow(),
+        ]);
+
+      if (cancelled) {
+        return;
+      }
+
+      setChannel(sanitiseChannel(storedChannel));
+      setAutoDownload(storedAutoDownload);
+      setAllowMetered(storedAllowMetered);
+      setDeferWindow(sanitiseDeferWindow(storedDeferWindow));
+      setIsReady(true);
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isReady) return;
+    void setUpdateChannel(channel);
+  }, [channel, isReady]);
+
+  useEffect(() => {
+    if (!isReady) return;
+    void setUpdateAutoDownload(autoDownload);
+  }, [autoDownload, isReady]);
+
+  useEffect(() => {
+    if (!isReady) return;
+    void setUpdateAllowMetered(allowMetered);
+  }, [allowMetered, isReady]);
+
+  useEffect(() => {
+    if (!isReady) return;
+    void setUpdateDeferWindow(deferWindow);
+  }, [deferWindow, isReady]);
+
+  return {
+    channel,
+    setChannel,
+    autoDownload,
+    setAutoDownload,
+    allowMetered,
+    setAllowMetered,
+    deferWindow,
+    setDeferWindow,
+    isReady,
+  };
+}

--- a/pages/apps/update-center.jsx
+++ b/pages/apps/update-center.jsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const UpdateCenterApp = dynamic(() => import('../../apps/update-center'), { ssr: false });
+
+export default function UpdateCenterPage() {
+  return <UpdateCenterApp />;
+}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,7 +14,16 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  updateChannel: 'security',
+  updateAutoDownload: true,
+  updateAllowMetered: false,
+  updateDeferWindow: 'off',
 };
+
+const UPDATE_CHANNEL_KEY = 'update-channel';
+const UPDATE_AUTO_DOWNLOAD_KEY = 'update-auto-download';
+const UPDATE_ALLOW_METERED_KEY = 'update-allow-metered';
+const UPDATE_DEFER_WINDOW_KEY = 'update-defer-window';
 
 export async function getAccent() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
@@ -123,6 +132,48 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getUpdateChannel() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.updateChannel;
+  return window.localStorage.getItem(UPDATE_CHANNEL_KEY) || DEFAULT_SETTINGS.updateChannel;
+}
+
+export async function setUpdateChannel(channel) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(UPDATE_CHANNEL_KEY, channel);
+}
+
+export async function getUpdateAutoDownload() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.updateAutoDownload;
+  const stored = window.localStorage.getItem(UPDATE_AUTO_DOWNLOAD_KEY);
+  return stored === null ? DEFAULT_SETTINGS.updateAutoDownload : stored === 'true';
+}
+
+export async function setUpdateAutoDownload(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(UPDATE_AUTO_DOWNLOAD_KEY, value ? 'true' : 'false');
+}
+
+export async function getUpdateAllowMetered() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.updateAllowMetered;
+  const stored = window.localStorage.getItem(UPDATE_ALLOW_METERED_KEY);
+  return stored === null ? DEFAULT_SETTINGS.updateAllowMetered : stored === 'true';
+}
+
+export async function setUpdateAllowMetered(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(UPDATE_ALLOW_METERED_KEY, value ? 'true' : 'false');
+}
+
+export async function getUpdateDeferWindow() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.updateDeferWindow;
+  return window.localStorage.getItem(UPDATE_DEFER_WINDOW_KEY) || DEFAULT_SETTINGS.updateDeferWindow;
+}
+
+export async function setUpdateDeferWindow(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(UPDATE_DEFER_WINDOW_KEY, value);
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +188,10 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem(UPDATE_CHANNEL_KEY);
+  window.localStorage.removeItem(UPDATE_AUTO_DOWNLOAD_KEY);
+  window.localStorage.removeItem(UPDATE_ALLOW_METERED_KEY);
+  window.localStorage.removeItem(UPDATE_DEFER_WINDOW_KEY);
 }
 
 export async function exportSettings() {
@@ -151,6 +206,10 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    updateChannel,
+    updateAutoDownload,
+    updateAllowMetered,
+    updateDeferWindow,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +221,10 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getUpdateChannel(),
+    getUpdateAutoDownload(),
+    getUpdateAllowMetered(),
+    getUpdateDeferWindow(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -176,6 +239,10 @@ export async function exportSettings() {
     allowNetwork,
     haptics,
     theme,
+    updateChannel,
+    updateAutoDownload,
+    updateAllowMetered,
+    updateDeferWindow,
   });
 }
 
@@ -200,6 +267,10 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    updateChannel,
+    updateAutoDownload,
+    updateAllowMetered,
+    updateDeferWindow,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -211,6 +282,10 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (updateChannel !== undefined) await setUpdateChannel(updateChannel);
+  if (updateAutoDownload !== undefined) await setUpdateAutoDownload(updateAutoDownload);
+  if (updateAllowMetered !== undefined) await setUpdateAllowMetered(updateAllowMetered);
+  if (updateDeferWindow !== undefined) await setUpdateDeferWindow(updateDeferWindow);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- persist update channel, auto-download, and metered network flags in the settings store
- add a `useUpdatePreferences` hook and new Update Center UI with contextual help and connection status
- register the Update Center app and page so it appears in the application catalog

## Testing
- yarn lint *(fails: existing repository lint errors around unlabeled controls and top-level window usage)*
- yarn test *(fails: pre-existing suites with act warnings and a window keyboard handler)*

------
https://chatgpt.com/codex/tasks/task_e_68cab67700448328995ef1be1489cc42