### PR TITLE
feat: add grouped search palette actions

### DIFF
--- a/components/menu/SearchPalette.tsx
+++ b/components/menu/SearchPalette.tsx
@@ -1,0 +1,217 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+import quickActionsConfig from '../../data/quick-actions.json';
+import type {
+  QuickActionDefinition,
+  QuickActionsRegistry,
+  SearchResult,
+  SearchResultType,
+} from '../../utils/searchActions';
+import { isQuickActionSupported, runQuickAction } from '../../utils/searchActions';
+
+const TYPE_ORDER: SearchResultType[] = ['apps', 'settings', 'files', 'commands', 'help'];
+
+const TYPE_LABELS: Record<SearchResultType, string> = {
+  apps: 'Apps',
+  settings: 'Settings',
+  files: 'Files',
+  commands: 'Commands',
+  help: 'Help',
+};
+
+const quickActions = quickActionsConfig as QuickActionsRegistry;
+
+type SearchPaletteProps = {
+  results: SearchResult[];
+  onClose?: () => void;
+  emptyMessage?: string;
+};
+
+type CollapsedState = Record<SearchResultType, boolean>;
+
+const INITIAL_COLLAPSED_STATE: CollapsedState = {
+  apps: false,
+  settings: false,
+  files: false,
+  commands: false,
+  help: false,
+};
+
+const getResultDetails = (result: SearchResult): string | undefined => {
+  if (result.meta) return result.meta;
+  switch (result.type) {
+    case 'files':
+      return result.path;
+    case 'commands':
+      return result.shell ? `${result.shell}: ${result.command}` : result.command;
+    case 'help':
+      return result.url;
+    case 'settings':
+      return result.section ?? result.item ?? undefined;
+    default:
+      return undefined;
+  }
+};
+
+const SectionHeader: React.FC<{
+  type: SearchResultType;
+  count: number;
+  collapsed: boolean;
+  onToggle: (type: SearchResultType) => void;
+}> = ({ type, count, collapsed, onToggle }) => (
+  <button
+    type="button"
+    onClick={() => onToggle(type)}
+    className="flex w-full items-center justify-between bg-slate-900/80 px-4 py-2 text-left text-sm font-semibold uppercase tracking-wide text-slate-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+    aria-expanded={!collapsed}
+    aria-controls={`search-group-${type}`}
+  >
+    <span>{TYPE_LABELS[type]}</span>
+    <span className="flex items-center gap-2">
+      <span className="inline-flex min-w-[2rem] justify-center rounded-full bg-slate-700 px-2 py-0.5 text-xs font-bold text-slate-100">
+        {count}
+      </span>
+      <svg
+        className={`h-4 w-4 transition-transform ${collapsed ? '-rotate-90' : 'rotate-0'}`}
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.189l3.71-3.958a.75.75 0 1 1 1.08 1.04l-4.25 4.53a.75.75 0 0 1-1.08 0l-4.25-4.53a.75.75 0 0 1 .02-1.06z" />
+      </svg>
+    </span>
+  </button>
+);
+
+const ActionButton: React.FC<{
+  action: QuickActionDefinition;
+  type: SearchResultType;
+  onActivate: () => void;
+}> = ({ action, type, onActivate }) => {
+  const [showTooltip, setShowTooltip] = useState(false);
+  const tooltipId = `${type}-${action.id}-tooltip`;
+
+  return (
+    <div className="relative inline-flex">
+      <button
+        type="button"
+        className="rounded border border-slate-600 bg-slate-800 px-2 py-1 text-xs font-semibold text-slate-100 transition hover:border-emerald-400 hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+        onClick={onActivate}
+        onFocus={() => setShowTooltip(true)}
+        onBlur={() => setShowTooltip(false)}
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+        aria-describedby={tooltipId}
+      >
+        {action.label}
+      </button>
+      <div
+        role="tooltip"
+        id={tooltipId}
+        className={`pointer-events-none absolute left-1/2 top-full z-20 mt-2 -translate-x-1/2 whitespace-nowrap rounded bg-black/80 px-2 py-1 text-[11px] font-medium text-white shadow transition-opacity duration-150 ${showTooltip ? 'opacity-100' : 'opacity-0'}`}
+      >
+        {action.tooltip}
+      </div>
+      <span className="sr-only">{action.tooltip}</span>
+    </div>
+  );
+};
+
+const SearchPalette: React.FC<SearchPaletteProps> = ({ results, onClose, emptyMessage }) => {
+  const router = useRouter();
+  const [collapsed, setCollapsed] = useState<CollapsedState>(INITIAL_COLLAPSED_STATE);
+
+  const groupedResults = useMemo(() => {
+    return results.reduce<Record<SearchResultType, SearchResult[]>>((acc, result) => {
+      acc[result.type].push(result);
+      return acc;
+    }, {
+      apps: [],
+      settings: [],
+      files: [],
+      commands: [],
+      help: [],
+    });
+  }, [results]);
+
+  const toggleSection = useCallback((type: SearchResultType) => {
+    setCollapsed((prev) => ({ ...prev, [type]: !prev[type] }));
+  }, []);
+
+  const handleAction = useCallback(
+    async (actionId: string, result: SearchResult) => {
+      await runQuickAction(actionId, result, router, onClose);
+    },
+    [router, onClose],
+  );
+
+  const hasResults = results.length > 0;
+
+  return (
+    <div className="max-h-[70vh] w-full overflow-y-auto rounded-lg bg-slate-900/90 text-slate-100 shadow-2xl">
+      {!hasResults && (
+        <p className="px-4 py-6 text-center text-sm text-slate-300">
+          {emptyMessage ?? 'No matches found. Try a different search term.'}
+        </p>
+      )}
+      {TYPE_ORDER.map((type) => {
+        const entries = groupedResults[type];
+        if (!entries.length) return null;
+        const availableActions = (quickActions[type] || []).filter((action) =>
+          isQuickActionSupported(type, action.id),
+        );
+
+        return (
+          <section key={type} className="border-t border-slate-800 first:border-t-0">
+            <SectionHeader
+              type={type}
+              count={entries.length}
+              collapsed={collapsed[type]}
+              onToggle={toggleSection}
+            />
+            {!collapsed[type] && (
+              <ul id={`search-group-${type}`} className="divide-y divide-slate-800" role="list">
+                {entries.map((result) => {
+                  const detail = getResultDetails(result);
+                  return (
+                    <li key={`${type}-${result.id}`} className="px-4 py-3 hover:bg-slate-800/60 focus-within:bg-slate-800/60">
+                      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between md:gap-4">
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-semibold text-slate-100">{result.title}</p>
+                          {result.description && (
+                            <p className="mt-1 text-xs text-slate-300">{result.description}</p>
+                          )}
+                          {detail && (
+                            <p className="mt-1 truncate text-xs font-mono text-slate-400" title={detail}>
+                              {detail}
+                            </p>
+                          )}
+                        </div>
+                        {availableActions.length > 0 && (
+                          <div className="flex flex-wrap gap-2">
+                            {availableActions.map((action) => (
+                              <ActionButton
+                                key={`${result.id}-${action.id}`}
+                                action={action}
+                                type={type}
+                                onActivate={() => {
+                                  void handleAction(action.id, result);
+                                }}
+                              />
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+};
+
+export default SearchPalette;

--- a/data/quick-actions.json
+++ b/data/quick-actions.json
@@ -1,0 +1,67 @@
+{
+  "apps": [
+    {
+      "id": "open",
+      "label": "Launch",
+      "tooltip": "Open the application inside the desktop workspace."
+    },
+    {
+      "id": "inspect",
+      "label": "Details",
+      "tooltip": "View this application in the app catalog."
+    }
+  ],
+  "settings": [
+    {
+      "id": "open",
+      "label": "Open",
+      "tooltip": "Jump directly to this setting panel."
+    },
+    {
+      "id": "section",
+      "label": "Section",
+      "tooltip": "Open the broader section that contains this setting."
+    }
+  ],
+  "files": [
+    {
+      "id": "open",
+      "label": "Open",
+      "tooltip": "Open the file explorer to this location."
+    },
+    {
+      "id": "copyPath",
+      "label": "Copy path",
+      "tooltip": "Copy the file path to the clipboard."
+    },
+    {
+      "id": "preview",
+      "label": "Preview",
+      "tooltip": "Open the file in a new browser tab."
+    }
+  ],
+  "commands": [
+    {
+      "id": "run",
+      "label": "Run",
+      "tooltip": "Send the command to the terminal app."
+    },
+    {
+      "id": "copy",
+      "label": "Copy",
+      "tooltip": "Copy the command to the clipboard."
+    }
+  ],
+  "help": [
+    {
+      "id": "open",
+      "label": "Open",
+      "tooltip": "Open the help article in a new tab."
+    },
+    {
+      "id": "copy",
+      "label": "Copy link",
+      "tooltip": "Copy the article URL to the clipboard."
+    }
+  ]
+}

--- a/utils/searchActions.ts
+++ b/utils/searchActions.ts
@@ -1,0 +1,185 @@
+import type { NextRouter } from 'next/router';
+
+export type SearchResultType = 'apps' | 'settings' | 'files' | 'commands' | 'help';
+
+export interface BaseSearchResult {
+  id: string;
+  title: string;
+  description?: string;
+  icon?: string;
+  meta?: string;
+}
+
+export interface AppSearchResult extends BaseSearchResult {
+  type: 'apps';
+  /**
+   * Optional explicit app id in case it differs from the result id.
+   */
+  appId?: string;
+  /**
+   * Optional href for deep linking into the public apps catalog page.
+   */
+  href?: string;
+}
+
+export interface SettingsSearchResult extends BaseSearchResult {
+  type: 'settings';
+  /**
+   * Item identifier used to jump directly to a settings panel.
+   */
+  item?: string;
+  /**
+   * Optional section anchor in the settings app.
+   */
+  section?: string;
+}
+
+export interface FileSearchResult extends BaseSearchResult {
+  type: 'files';
+  /**
+   * Absolute or virtual path for the file.
+   */
+  path: string;
+  /**
+   * Optional external URL to preview or download the file.
+   */
+  href?: string;
+}
+
+export interface CommandSearchResult extends BaseSearchResult {
+  type: 'commands';
+  /**
+   * Shell command that can be copied or executed.
+   */
+  command: string;
+  /**
+   * Optional shell label (bash, zsh, powershell, etc.).
+   */
+  shell?: string;
+}
+
+export interface HelpSearchResult extends BaseSearchResult {
+  type: 'help';
+  /**
+   * External link to documentation or a knowledge-base article.
+   */
+  url: string;
+}
+
+export type SearchResult =
+  | AppSearchResult
+  | SettingsSearchResult
+  | FileSearchResult
+  | CommandSearchResult
+  | HelpSearchResult;
+
+export interface QuickActionDefinition {
+  id: string;
+  label: string;
+  tooltip: string;
+  icon?: string;
+}
+
+export type QuickActionsRegistry = Record<SearchResultType, QuickActionDefinition[]>;
+
+type QuickActionHandler = (result: SearchResult, router: NextRouter) => Promise<void> | void;
+
+const actionHandlers: Record<SearchResultType, Record<string, QuickActionHandler>> = {
+  apps: {
+    open: (result) => {
+      if (result.type !== 'apps') return;
+      const appId = result.appId ?? result.id;
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('open-app', { detail: appId }));
+      }
+    },
+    inspect: (result, router) => {
+      if (result.type !== 'apps') return;
+      const href = result.href ?? `/apps/${result.id}`;
+      void router.push(href);
+    },
+  },
+  settings: {
+    open: (result, router) => {
+      if (result.type !== 'settings') return;
+      const item = result.item ?? result.id;
+      void router.push(`/apps/settings?item=${encodeURIComponent(item)}`);
+    },
+    section: (result, router) => {
+      if (result.type !== 'settings') return;
+      const section = result.section ?? result.item ?? result.id;
+      void router.push(`/apps/settings?section=${encodeURIComponent(section)}`);
+    },
+  },
+  files: {
+    open: (result) => {
+      if (result.type !== 'files') return;
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('open-app', { detail: 'file-explorer' }));
+      }
+    },
+    copyPath: async (result) => {
+      if (result.type !== 'files') return;
+      if (typeof navigator !== 'undefined' && navigator.clipboard) {
+        await navigator.clipboard.writeText(result.path);
+      }
+    },
+    preview: (result) => {
+      if (result.type !== 'files') return;
+      if (!result.href) return;
+      if (typeof window !== 'undefined') {
+        window.open(result.href, '_blank', 'noopener');
+      }
+    },
+  },
+  commands: {
+    run: (result) => {
+      if (result.type !== 'commands') return;
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('open-app', { detail: 'terminal' }));
+        window.dispatchEvent(
+          new CustomEvent('terminal:queue-command', { detail: { command: result.command } }),
+        );
+      }
+    },
+    copy: async (result) => {
+      if (result.type !== 'commands') return;
+      if (typeof navigator !== 'undefined' && navigator.clipboard) {
+        await navigator.clipboard.writeText(result.command);
+      }
+    },
+  },
+  help: {
+    open: (result) => {
+      if (result.type !== 'help') return;
+      if (typeof window !== 'undefined') {
+        window.open(result.url, '_blank', 'noopener');
+      }
+    },
+    copy: async (result) => {
+      if (result.type !== 'help') return;
+      if (typeof navigator !== 'undefined' && navigator.clipboard) {
+        await navigator.clipboard.writeText(result.url);
+      }
+    },
+  },
+};
+
+export const isQuickActionSupported = (type: SearchResultType, actionId: string): boolean =>
+  Boolean(actionHandlers[type]?.[actionId]);
+
+export const runQuickAction = async (
+  actionId: string,
+  result: SearchResult,
+  router: NextRouter,
+  onAfterAction?: () => void,
+): Promise<void> => {
+  const handler = actionHandlers[result.type]?.[actionId];
+  if (!handler) {
+    return;
+  }
+  await handler(result, router);
+  if (onAfterAction) onAfterAction();
+};
+
+export const getQuickActionHandlers = () => actionHandlers;


### PR DESCRIPTION
## Summary
- add a SearchPalette component with collapsible result groups and tooltip-aware quick actions
- define search action handlers and expose quick action metadata via JSON configuration

## Testing
- yarn lint *(fails: repository already has hundreds of jsx-a11y and top-level window/document lint violations in legacy apps)*
- yarn test *(fails: existing suites such as Modal and Nmap NSE fail without environment shims for localStorage and network mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68cab671a8488328b14e8279a70c70dd