### PR TITLE
[search] Add desktop indexing controls and safe storage

### DIFF
--- a/apps/metasploit/components/TargetEmulator.tsx
+++ b/apps/metasploit/components/TargetEmulator.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import seedrandom from 'seedrandom';
 import modules from '../../../components/apps/metasploit/modules.json';
 import usePersistentState from '../../../hooks/usePersistentState';
+import searchIndex from '../../../utils/searchIndex';
 
 interface ModuleInfo {
   name: string;
@@ -44,6 +45,13 @@ const TargetEmulator: React.FC = () => {
         ...prev.filter((s) => s.name !== mod.name),
         { name: mod.name, output: text },
       ]);
+      searchIndex.recordSummary({
+        id: mod.name,
+        title: `Metasploit session: ${mod.name}`,
+        summary: `Session ${sessionId} opened against ${ip}:${port}`,
+        kind: 'session',
+        updatedAt: Date.now(),
+      });
     } else {
       setOutput('Select a module to run.');
     }

--- a/apps/recon-ng/components/ModulePlanner.tsx
+++ b/apps/recon-ng/components/ModulePlanner.tsx
@@ -3,6 +3,7 @@
 import React, { useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import usePersistentState from '../../../hooks/usePersistentState';
+import searchIndex from '../../../utils/searchIndex';
 
 interface ModuleDef {
   deps: string[];
@@ -45,6 +46,16 @@ const ModulePlanner: React.FC = () => {
       ...plan.map((m) => `- ${m}`),
     ];
     setLog(lines.join('\n'));
+    searchIndex.recordSummary({
+      id: `reconng-${workspace}`,
+      title: `ReconNG workspace: ${workspace}`,
+      summary:
+        plan.length > 0
+          ? `Modules planned: ${plan.join(', ')}`
+          : 'No modules selected',
+      kind: 'workspace',
+      updatedAt: Date.now(),
+    });
   };
 
   const graphData = useMemo(() => {

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import searchIndex from "../../utils/searchIndex";
 
 export default function Settings() {
   const {
@@ -54,6 +55,22 @@ export default function Settings() {
   ];
 
   const changeBackground = (name: string) => setWallpaper(name);
+
+  const [indexingEnabled, setIndexingEnabled] = useState<boolean>(() =>
+    searchIndex.isEnabled(),
+  );
+
+  useEffect(() => {
+    const unsubscribe = searchIndex.subscribe(() => {
+      setIndexingEnabled(searchIndex.isEnabled());
+    });
+    return unsubscribe;
+  }, []);
+
+  const toggleIndexing = (value: boolean) => {
+    setIndexingEnabled(value);
+    searchIndex.setEnabled(value);
+  };
 
   const handleExport = async () => {
     const data = await exportSettingsData();
@@ -285,6 +302,23 @@ export default function Settings() {
             >
               Import Settings
             </button>
+          </div>
+          <div className="flex flex-col items-center space-y-2 text-center text-sm text-ubt-grey">
+            <div className="flex items-center space-x-3">
+              <ToggleSwitch
+                checked={indexingEnabled}
+                onChange={toggleIndexing}
+                ariaLabel="Toggle desktop search indexing"
+              />
+              <span className="text-white">
+                {indexingEnabled ? "Indexing enabled" : "Indexing disabled"}
+              </span>
+            </div>
+            <p className="max-w-lg">
+              Control whether recent sessions, workspaces, and file metadata are
+              stored locally to power desktop search. Data never leaves your
+              browser.
+            </p>
           </div>
         </>
       )}

--- a/utils/safeStorage.ts
+++ b/utils/safeStorage.ts
@@ -2,3 +2,92 @@ import { hasStorage } from './env';
 
 export const safeLocalStorage: Storage | undefined =
   hasStorage ? localStorage : undefined;
+
+const readJSON = <T>(key: string, fallback: T): T => {
+  if (!safeLocalStorage) return fallback;
+  try {
+    const raw = safeLocalStorage.getItem(key);
+    if (!raw) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+};
+
+const writeJSON = (key: string, value: unknown): void => {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // ignore quota or serialization issues
+  }
+};
+
+const removeKey = (key: string): void => {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.removeItem(key);
+  } catch {
+    // ignore storage access errors
+  }
+};
+
+const SEARCH_FILE_KEY = 'search:file-index';
+const SEARCH_SUMMARY_KEY = 'search:summaries';
+const SEARCH_INDEX_PREF_KEY = 'search:indexing-enabled';
+const SUMMARY_MAX_LENGTH = 280;
+
+export type StoredFileMetadata = {
+  path: string;
+  name: string;
+  extension: string | null;
+  modified: number | null;
+  kind?: 'file' | 'directory';
+};
+
+export type StoredSummary = {
+  id: string;
+  title: string;
+  summary: string;
+  updatedAt: number;
+  kind: 'session' | 'workspace';
+};
+
+export const readStoredFileIndex = (): StoredFileMetadata[] =>
+  readJSON<StoredFileMetadata[]>(SEARCH_FILE_KEY, []);
+
+export const writeStoredFileIndex = (entries: StoredFileMetadata[]): void =>
+  writeJSON(SEARCH_FILE_KEY, entries);
+
+export const clearStoredFileIndex = (): void => removeKey(SEARCH_FILE_KEY);
+
+export const readStoredSummaries = (): StoredSummary[] =>
+  readJSON<StoredSummary[]>(SEARCH_SUMMARY_KEY, []);
+
+export const writeStoredSummaries = (entries: StoredSummary[]): void =>
+  writeJSON(SEARCH_SUMMARY_KEY, entries);
+
+export const clearStoredSummaries = (): void => removeKey(SEARCH_SUMMARY_KEY);
+
+export const sanitizeSummary = (value: string): string =>
+  value.replace(/\s+/g, ' ').trim().slice(0, SUMMARY_MAX_LENGTH);
+
+export const getIndexingPreference = (): boolean => {
+  if (!safeLocalStorage) return true;
+  try {
+    const raw = safeLocalStorage.getItem(SEARCH_INDEX_PREF_KEY);
+    if (raw === null) return true;
+    return raw === 'true';
+  } catch {
+    return true;
+  }
+};
+
+export const setIndexingPreference = (enabled: boolean): void => {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.setItem(SEARCH_INDEX_PREF_KEY, enabled ? 'true' : 'false');
+  } catch {
+    // ignore storage write failures
+  }
+};

--- a/utils/searchIndex.ts
+++ b/utils/searchIndex.ts
@@ -1,0 +1,331 @@
+'use client';
+
+import {
+  StoredFileMetadata,
+  StoredSummary,
+  clearStoredFileIndex,
+  clearStoredSummaries,
+  getIndexingPreference,
+  readStoredFileIndex,
+  readStoredSummaries,
+  sanitizeSummary,
+  setIndexingPreference,
+  writeStoredFileIndex,
+  writeStoredSummaries,
+} from './safeStorage';
+
+declare global {
+  interface Window {
+    __searchIndexListenerInstalled?: boolean;
+  }
+}
+
+type RuntimeWindow = Window & typeof globalThis & {
+  __searchIndexListenerInstalled?: boolean;
+};
+
+const getRuntimeWindow = (): RuntimeWindow | undefined => {
+  if (typeof globalThis === 'undefined') return undefined;
+  const candidate = globalThis as Partial<RuntimeWindow>;
+  if (typeof candidate.addEventListener === 'function') {
+    return candidate as RuntimeWindow;
+  }
+  if (candidate.window && typeof candidate.window.addEventListener === 'function') {
+    return candidate.window as RuntimeWindow;
+  }
+  return undefined;
+};
+
+export type FileMetadataPayload = {
+  path: string;
+  name: string;
+  extension?: string | null;
+  modified?: number | null;
+  kind?: 'file' | 'directory';
+};
+
+export type SummaryPayload = {
+  id: string;
+  title: string;
+  summary: string;
+  updatedAt?: number;
+  kind: 'session' | 'workspace';
+};
+
+export type SearchIndexEntry = {
+  id: string;
+  title: string;
+  subtitle?: string;
+  path?: string;
+  extension?: string | null;
+  modified?: number | null;
+  summary?: string;
+  source: 'file' | 'directory' | 'session' | 'workspace';
+  updatedAt?: number;
+};
+
+const FILE_ENTRY_LIMIT = 200;
+const SUMMARY_ENTRY_LIMIT = 50;
+
+const listeners = new Set<(entries: SearchIndexEntry[]) => void>();
+
+const runtimeWindow = getRuntimeWindow();
+
+let indexingEnabled = runtimeWindow ? getIndexingPreference() : false;
+
+let fileRecords: StoredFileMetadata[] = runtimeWindow
+  ? readStoredFileIndex()
+  : [];
+
+let summaryRecords: StoredSummary[] = runtimeWindow
+  ? readStoredSummaries()
+  : [];
+
+const normalisePath = (value: string): string =>
+  value.replace(/\\/g, '/').replace(/\/+/g, '/');
+
+const buildEntries = (): SearchIndexEntry[] => {
+  const files: SearchIndexEntry[] = fileRecords.map((record) => ({
+    id: `file:${record.path}`,
+    title: record.name,
+    subtitle: record.path,
+    path: record.path,
+    extension: record.extension ?? undefined,
+    modified: record.modified ?? undefined,
+    source: (record.kind ?? 'file') as 'file' | 'directory',
+    updatedAt: record.modified ?? undefined,
+  }));
+
+  const summaries: SearchIndexEntry[] = summaryRecords.map((record) => ({
+    id: `${record.kind}:${record.id}`,
+    title: record.title,
+    summary: record.summary,
+    source: record.kind,
+    updatedAt: record.updatedAt,
+  }));
+
+  return [...files, ...summaries].sort((a, b) => {
+    const aTime = a.updatedAt ?? 0;
+    const bTime = b.updatedAt ?? 0;
+    return bTime - aTime;
+  });
+};
+
+const notify = (): void => {
+  const entries = buildEntries();
+  listeners.forEach((listener) => {
+    try {
+      listener(entries);
+    } catch (err) {
+      // Surface listener errors without breaking others
+      console.error('searchIndex listener error', err);
+    }
+  });
+};
+
+const normaliseFilePayload = (
+  entry: FileMetadataPayload,
+): StoredFileMetadata | null => {
+  const name = typeof entry.name === 'string' ? entry.name.trim() : '';
+  const path = typeof entry.path === 'string' ? entry.path.trim() : '';
+  if (!name || !path) return null;
+
+  const extension = entry.extension
+    ? entry.extension.replace(/^\./, '').toLowerCase()
+    : null;
+  const modified =
+    typeof entry.modified === 'number' && Number.isFinite(entry.modified)
+      ? entry.modified
+      : null;
+  const kind = entry.kind === 'directory' ? 'directory' : 'file';
+
+  return {
+    name,
+    path: normalisePath(path),
+    extension,
+    modified,
+    kind,
+  };
+};
+
+export const addFileMetadata = (entries: FileMetadataPayload[]): void => {
+  if (!indexingEnabled || !entries.length) return;
+
+  const byPath = new Map<string, StoredFileMetadata>();
+  fileRecords.forEach((record) => byPath.set(record.path, record));
+
+  entries.forEach((entry) => {
+    const normalised = normaliseFilePayload(entry);
+    if (!normalised) return;
+    byPath.set(normalised.path, normalised);
+  });
+
+  fileRecords = Array.from(byPath.values())
+    .sort((a, b) => (b.modified ?? 0) - (a.modified ?? 0))
+    .slice(0, FILE_ENTRY_LIMIT);
+
+  writeStoredFileIndex(fileRecords);
+  notify();
+};
+
+const clearFileRecords = (): void => {
+  fileRecords = [];
+  clearStoredFileIndex();
+};
+
+const clearSummaryRecords = (): void => {
+  summaryRecords = [];
+  clearStoredSummaries();
+};
+
+export const clearAll = (): void => {
+  clearFileRecords();
+  clearSummaryRecords();
+  notify();
+};
+
+export const recordSummary = (payload: SummaryPayload): void => {
+  if (!indexingEnabled) return;
+
+  const { id, title, kind } = payload;
+  if (!id || !title) return;
+
+  const cleaned: StoredSummary = {
+    id,
+    title,
+    summary: sanitizeSummary(payload.summary || ''),
+    updatedAt: payload.updatedAt ?? Date.now(),
+    kind,
+  };
+
+  const byId = new Map<string, StoredSummary>();
+  summaryRecords.forEach((record) =>
+    byId.set(`${record.kind}:${record.id}`, record),
+  );
+  byId.set(`${cleaned.kind}:${cleaned.id}`, cleaned);
+
+  summaryRecords = Array.from(byId.values())
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .slice(0, SUMMARY_ENTRY_LIMIT);
+
+  writeStoredSummaries(summaryRecords);
+  notify();
+};
+
+export const setEnabled = (enabled: boolean): void => {
+  indexingEnabled = enabled;
+  setIndexingPreference(enabled);
+  if (!enabled) {
+    clearAll();
+    return;
+  }
+  // when re-enabled, reload persisted data so the index picks up previous state
+  fileRecords = readStoredFileIndex();
+  summaryRecords = readStoredSummaries();
+  notify();
+};
+
+export const isEnabled = (): boolean => indexingEnabled;
+
+export const getEntries = (): SearchIndexEntry[] => buildEntries();
+
+export const search = (query: string): SearchIndexEntry[] => {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+
+  return buildEntries()
+    .filter((entry) => {
+      const fields = [
+        entry.title,
+        entry.subtitle,
+        entry.path,
+        entry.summary,
+        entry.extension ?? undefined,
+      ];
+      return fields.some((value) =>
+        typeof value === 'string' ? value.toLowerCase().includes(q) : false,
+      );
+    })
+    .slice(0, 20);
+};
+
+export const subscribe = (
+  listener: (entries: SearchIndexEntry[]) => void,
+): (() => void) => {
+  listeners.add(listener);
+  listener(buildEntries());
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+const coerceMessageEntries = (entries: unknown): FileMetadataPayload[] => {
+  if (!Array.isArray(entries)) return [];
+  return entries
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') return null;
+      const data = entry as Record<string, unknown>;
+      const name = typeof data.name === 'string' ? data.name : '';
+      const path = typeof data.path === 'string' ? data.path : name;
+      if (!name || !path) return null;
+
+      let modified: number | null = null;
+      if (typeof data.modified === 'number' && Number.isFinite(data.modified)) {
+        modified = data.modified;
+      } else if (typeof data.modified === 'string') {
+        const parsed = Date.parse(data.modified);
+        modified = Number.isNaN(parsed) ? null : parsed;
+      }
+
+      const extension =
+        typeof data.extension === 'string'
+          ? data.extension.toLowerCase()
+          : null;
+
+      const kind = data.kind === 'directory' ? 'directory' : 'file';
+
+      return {
+        name,
+        path,
+        extension,
+        modified,
+        kind,
+      } satisfies FileMetadataPayload;
+    })
+    .filter((value): value is FileMetadataPayload => Boolean(value));
+};
+
+const activeWindow = getRuntimeWindow();
+if (activeWindow && !activeWindow.__searchIndexListenerInstalled) {
+  const handleMessage = (event: MessageEvent) => {
+    if (!indexingEnabled) return;
+    if (event.origin && event.origin !== activeWindow.location.origin) return;
+
+    const data = event.data as Record<string, unknown> | null;
+    if (!data) return;
+
+    if (data.type === 'search-index:index') {
+      const payload = coerceMessageEntries(data.entries);
+      if (payload.length) addFileMetadata(payload);
+    } else if (data.type === 'search-index:purge') {
+      clearFileRecords();
+      notify();
+    }
+  };
+
+  activeWindow.addEventListener('message', handleMessage);
+  activeWindow.__searchIndexListenerInstalled = true;
+}
+
+const searchIndex = {
+  addFileMetadata,
+  clearAll,
+  getEntries,
+  isEnabled,
+  recordSummary,
+  search,
+  setEnabled,
+  subscribe,
+};
+
+export default searchIndex;


### PR DESCRIPTION
## Summary
- capture file metadata in the File Explorer and forward it to a new client search index worker
- expand safeStorage with recent summary helpers and plug the index into the Whisker menu and settings privacy toggle
- persist sanitized session/workspace summaries and expose them through the index

## Testing
- `npx eslint apps/metasploit/components/TargetEmulator.tsx apps/recon-ng/components/ModulePlanner.tsx apps/settings/index.tsx components/apps/file-explorer.js components/menu/WhiskerMenu.tsx utils/safeStorage.ts utils/searchIndex.ts`
- `yarn test --watch=false` *(fails: existing suites expect act wrappers / jsdom localStorage)*

------
https://chatgpt.com/codex/tasks/task_e_68cab66f99e48328bb487b50a4946841