### PR TITLE
[search] bootstrap worker-backed search index

### DIFF
--- a/data/search/apps.json
+++ b/data/search/apps.json
@@ -1,0 +1,66 @@
+[
+  {
+    "id": "terminal",
+    "title": "Terminal",
+    "description": "Simulated Kali Linux shell with guided missions, autocomplete, and command history.",
+    "url": "/apps/terminal",
+    "keywords": ["shell", "cli", "bash", "simulation"],
+    "boost": 6
+  },
+  {
+    "id": "resource-monitor",
+    "title": "Resource Monitor",
+    "description": "Live CPU, memory, and network telemetry visualized with gauges and sparkline charts.",
+    "url": "/apps/resource-monitor",
+    "keywords": ["performance", "metrics", "monitoring", "cpu"],
+    "boost": 4
+  },
+  {
+    "id": "hashcat",
+    "title": "Hashcat Simulator",
+    "description": "Guided password auditing scenarios with progress dashboards and realistic attack modes.",
+    "url": "/apps/hashcat",
+    "keywords": ["password", "cracking", "security", "audit"],
+    "boost": 5
+  },
+  {
+    "id": "wireshark",
+    "title": "Packet Analyzer",
+    "description": "Wireshark-inspired capture viewer with timeline playback, filters, and traffic summaries.",
+    "url": "/apps/wireshark",
+    "keywords": ["network", "pcap", "analysis", "packets"],
+    "boost": 5
+  },
+  {
+    "id": "autopsy",
+    "title": "Autopsy Case",
+    "description": "Forensic triage sandbox that walks through sample disk artifacts and evidence tagging.",
+    "url": "/apps/autopsy",
+    "keywords": ["forensics", "disk", "artifacts", "investigation"],
+    "boost": 4
+  },
+  {
+    "id": "volatility",
+    "title": "Volatility Lab",
+    "description": "Memory forensics walkthrough featuring profile selection, plugin output, and annotations.",
+    "url": "/apps/volatility",
+    "keywords": ["memory", "forensics", "malware", "analysis"],
+    "boost": 4
+  },
+  {
+    "id": "project-gallery",
+    "title": "Project Gallery",
+    "description": "Interactive showcase of featured research, talks, and tooling with quick filters.",
+    "url": "/apps/project-gallery",
+    "keywords": ["portfolio", "projects", "talks", "demos"],
+    "boost": 3
+  },
+  {
+    "id": "wordle",
+    "title": "Wordle Daily",
+    "description": "Daily Wordle clone with accessibility-first controls, hints, and shareable grids.",
+    "url": "/apps/wordle",
+    "keywords": ["game", "puzzle", "daily", "word"],
+    "boost": 2
+  }
+]

--- a/data/search/files.json
+++ b/data/search/files.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "resume-pdf",
+    "title": "Resume (PDF)",
+    "description": "Printable resume highlighting security research, tooling, and speaking engagements.",
+    "url": "/assets/Alex-Unnippillil-Resume.pdf",
+    "path": "Documents/Resume/Alex-Unnippillil-Resume.pdf",
+    "keywords": ["resume", "cv", "pdf"],
+    "boost": 4
+  },
+  {
+    "id": "timeline",
+    "title": "Research timeline",
+    "description": "One-page overview of conference talks, publications, and notable tool releases.",
+    "url": "/assets/timeline.pdf",
+    "path": "Documents/Briefing/timeline.pdf",
+    "keywords": ["timeline", "talks", "publications"],
+    "boost": 3
+  },
+  {
+    "id": "contact-card",
+    "title": "Contact card (vCard)",
+    "description": "Drop the vCard into your address book to keep social links and email in sync.",
+    "url": "/assets/alex-unnippillil.vcf",
+    "path": "Documents/Contacts/alex-unnippillil.vcf",
+    "keywords": ["contact", "vcard", "profile"],
+    "boost": 2
+  },
+  {
+    "id": "module-report",
+    "title": "Module audit report",
+    "description": "Static HTML report summarizing module health pulled from the dependency scanner.",
+    "url": "/module-report.html",
+    "path": "Reports/module-report.html",
+    "keywords": ["report", "dependencies", "audit"],
+    "boost": 2
+  },
+  {
+    "id": "autopsy-evidence",
+    "title": "Autopsy evidence pack",
+    "description": "JSON bundle of artifacts used by the Autopsy case simulator for walkthroughs.",
+    "url": "/autopsy-demo.json",
+    "path": "Cases/autopsy-demo.json",
+    "keywords": ["forensics", "autopsy", "artifacts"],
+    "boost": 2
+  }
+]

--- a/data/search/help.json
+++ b/data/search/help.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "getting-started",
+    "title": "Getting started",
+    "description": "Step-by-step setup instructions for running the Kali Linux portfolio locally with yarn scripts.",
+    "url": "https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/docs/getting-started.md",
+    "keywords": ["setup", "installation", "environment"],
+    "boost": 3
+  },
+  {
+    "id": "architecture",
+    "title": "Architecture overview",
+    "description": "High-level tour of the window manager, desktop shell, and dynamic app loading pipeline.",
+    "url": "https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/docs/architecture.md",
+    "keywords": ["architecture", "desktop", "windows"],
+    "boost": 3
+  },
+  {
+    "id": "tasks",
+    "title": "Task backlog",
+    "description": "Curated list of polish tasks and roadmap items with references to relevant modules.",
+    "url": "https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/docs/tasks.md",
+    "keywords": ["tasks", "roadmap", "issues"],
+    "boost": 2
+  },
+  {
+    "id": "keyboard-testing",
+    "title": "Keyboard-only test plan",
+    "description": "Accessibility walkthrough describing how to exercise apps and menus without a pointing device.",
+    "url": "https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/docs/keyboard-only-test-plan.md",
+    "keywords": ["accessibility", "testing", "keyboard"],
+    "boost": 2
+  },
+  {
+    "id": "deauth-mitigation",
+    "title": "Deauth mitigation brief",
+    "description": "Explains how the simulated Wi-Fi stack models deauthentication attacks and defense strategies.",
+    "url": "https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/docs/deauth-mitigation.md",
+    "keywords": ["wifi", "mitigation", "simulation"],
+    "boost": 2
+  }
+]

--- a/data/search/settings.json
+++ b/data/search/settings.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "theme",
+    "title": "Theme presets",
+    "description": "Toggle between default, dark, neon, and matrix shells for the desktop chrome.",
+    "url": "/apps/settings",
+    "path": "settings.display.theme",
+    "keywords": ["appearance", "dark mode", "matrix", "neon"],
+    "boost": 3
+  },
+  {
+    "id": "accent",
+    "title": "Accent color picker",
+    "description": "Choose from the curated palette to recolor window chrome and highlights while checking contrast.",
+    "url": "/apps/settings",
+    "path": "settings.display.accent",
+    "keywords": ["contrast", "accessibility", "color"],
+    "boost": 3
+  },
+  {
+    "id": "wallpaper",
+    "title": "Wallpaper selector",
+    "description": "Cycle through the bundled Yaru-inspired wallpapers and preview them live on the desktop.",
+    "url": "/apps/settings",
+    "path": "settings.display.wallpaper",
+    "keywords": ["background", "wallpaper", "preview"],
+    "boost": 2
+  },
+  {
+    "id": "reduced-motion",
+    "title": "Reduced motion",
+    "description": "Disable non-essential animations for motion-sensitive visitors and keep gameplay comfortable.",
+    "url": "/apps/settings",
+    "path": "settings.accessibility.motion",
+    "keywords": ["accessibility", "animation", "motion"],
+    "boost": 3
+  },
+  {
+    "id": "large-hit-areas",
+    "title": "Large hit areas",
+    "description": "Expand control targets to make touch and keyboard navigation easier across every app.",
+    "url": "/apps/settings",
+    "path": "settings.accessibility.hit-areas",
+    "keywords": ["accessibility", "touch", "inputs"],
+    "boost": 2
+  },
+  {
+    "id": "allow-network",
+    "title": "Allow network requests",
+    "description": "Toggle simulated network access for apps that would otherwise make outbound HTTP calls.",
+    "url": "/apps/settings",
+    "path": "settings.privacy.network",
+    "keywords": ["privacy", "network", "offline"],
+    "boost": 2
+  }
+]

--- a/utils/searchIndex.ts
+++ b/utils/searchIndex.ts
@@ -1,0 +1,329 @@
+import appsSnapshot from '../data/search/apps.json';
+import filesSnapshot from '../data/search/files.json';
+import helpSnapshot from '../data/search/help.json';
+import settingsSnapshot from '../data/search/settings.json';
+import { isBrowser } from './isBrowser';
+
+import type {
+  SearchIndexRequest,
+  SearchIndexResponse,
+  SearchRecord,
+  SearchResult,
+  SearchSource,
+} from '../workers/search-index.worker';
+
+type IdleDeadlineShim = {
+  didTimeout: boolean;
+  timeRemaining: () => number;
+};
+
+type IdleCallback = (deadline: IdleDeadlineShim) => void;
+
+export type SearchQueryOptions = {
+  signal?: AbortSignal;
+  limit?: number;
+  sources?: SearchSource[];
+};
+
+interface PendingQuery {
+  resolve: (value: SearchResult[]) => void;
+  reject: (reason?: unknown) => void;
+  signal?: AbortSignal;
+  abortListener?: () => void;
+}
+
+const staticSnapshots: Record<SearchSource, SearchRecord[]> = {
+  apps: appsSnapshot as SearchRecord[],
+  settings: settingsSnapshot as SearchRecord[],
+  files: filesSnapshot as SearchRecord[],
+  help: helpSnapshot as SearchRecord[],
+};
+
+function createAbortError(): Error {
+  if (typeof DOMException !== 'undefined') {
+    return new DOMException('Query aborted', 'AbortError');
+  }
+  const error = new Error('Query aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+function toError(reason: unknown): Error {
+  if (reason instanceof Error) {
+    return reason;
+  }
+  return new Error(typeof reason === 'string' ? reason : JSON.stringify(reason));
+}
+
+class SearchIndexClient {
+  private worker?: Worker;
+
+  private ready: Promise<void>;
+
+  private pending = new Map<number, PendingQuery>();
+
+  private requestId = 0;
+
+  constructor() {
+    if (isBrowser && typeof Worker === 'function') {
+      this.worker = new Worker(new URL('../workers/search-index.worker.ts', import.meta.url));
+      this.worker.onmessage = this.handleMessage;
+      this.worker.onerror = this.handleWorkerError;
+      this.ready = this.bootstrap();
+    } else {
+      this.ready = Promise.resolve();
+    }
+  }
+
+  async query(query: string, options: SearchQueryOptions = {}): Promise<SearchResult[]> {
+    await this.ready;
+    if (!this.worker) {
+      return [];
+    }
+
+    const { signal, limit, sources } = options;
+    if (signal?.aborted) {
+      throw createAbortError();
+    }
+
+    const requestId = this.nextRequestId();
+    const message: SearchIndexRequest = {
+      kind: 'query',
+      requestId,
+      query,
+      limit,
+      sources,
+    };
+
+    return new Promise<SearchResult[]>((resolve, reject) => {
+      const pending: PendingQuery = { resolve, reject, signal };
+      const abortListener = () => {
+        if (!this.worker) {
+          return;
+        }
+        this.pending.delete(requestId);
+        const cancelMessage: SearchIndexRequest = { kind: 'cancel', requestId };
+        this.worker.postMessage(cancelMessage);
+        reject(createAbortError());
+      };
+
+      if (signal) {
+        pending.abortListener = abortListener;
+        signal.addEventListener('abort', abortListener, { once: true });
+      }
+
+      this.pending.set(requestId, pending);
+      this.worker.postMessage(message);
+    });
+  }
+
+  update(source: SearchSource, records: SearchRecord[]): void {
+    if (!this.worker || !records || records.length === 0) {
+      return;
+    }
+    void this.ready.then(() => {
+      if (!this.worker) return;
+      const message: SearchIndexRequest = { kind: 'upsert', source, records };
+      this.worker.postMessage(message);
+    });
+  }
+
+  remove(ids: string[], source?: SearchSource): void {
+    if (!this.worker || !ids || ids.length === 0) {
+      return;
+    }
+    void this.ready.then(() => {
+      if (!this.worker) return;
+      const message: SearchIndexRequest = { kind: 'remove', ids, source };
+      this.worker.postMessage(message);
+    });
+  }
+
+  refreshOnIdle(
+    source: SearchSource,
+    loader: () => Promise<SearchRecord[] | undefined | null>,
+  ): void {
+    if (!this.worker || !isBrowser) {
+      return;
+    }
+    void this.ready.then(() => {
+      this.scheduleIdle(async () => {
+        try {
+          const records = await loader();
+          if (!records || records.length === 0 || !this.worker) {
+            return;
+          }
+          const message: SearchIndexRequest = { kind: 'upsert', source, records };
+          this.worker.postMessage(message);
+        } catch (error) {
+          if (process.env.NODE_ENV !== 'production') {
+            console.warn('Search index refresh failed', error);
+          }
+        }
+      });
+    });
+  }
+
+  dispose(): void {
+    if (!this.worker) return;
+    this.worker.terminate();
+    this.worker = undefined;
+    this.pending.clear();
+  }
+
+  private async bootstrap(): Promise<void> {
+    if (!this.worker) {
+      return;
+    }
+    for (const [source, records] of Object.entries(staticSnapshots) as [SearchSource, SearchRecord[]][]) {
+      if (records.length === 0) continue;
+      const message: SearchIndexRequest = { kind: 'hydrate', source, records };
+      this.worker.postMessage(message);
+    }
+  }
+
+  private handleMessage = (event: MessageEvent<SearchIndexResponse>): void => {
+    const message = event.data;
+    switch (message.kind) {
+      case 'results':
+        this.settlePending(message.requestId, message.results);
+        break;
+      case 'error':
+        if (typeof message.requestId === 'number') {
+          this.rejectPending(message.requestId, new Error(message.message));
+        } else if (process.env.NODE_ENV !== 'production') {
+          console.warn('Search index worker error', message.message);
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  private handleWorkerError = (event: ErrorEvent): void => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('Search index worker crashed', event.error ?? event.message);
+    }
+    const error = toError(event.error ?? event.message ?? 'Search worker error');
+    const pendingKeys = Array.from(this.pending.keys());
+    for (const requestId of pendingKeys) {
+      this.rejectPending(requestId, error);
+    }
+  };
+
+  private settlePending(requestId: number, results: SearchResult[]): void {
+    const pending = this.pending.get(requestId);
+    if (!pending) {
+      return;
+    }
+    this.pending.delete(requestId);
+    if (pending.signal && pending.abortListener) {
+      pending.signal.removeEventListener('abort', pending.abortListener);
+    }
+    pending.resolve(results);
+  }
+
+  private rejectPending(requestId: number, reason: unknown): void {
+    const pending = this.pending.get(requestId);
+    if (!pending) {
+      return;
+    }
+    this.pending.delete(requestId);
+    if (pending.signal && pending.abortListener) {
+      pending.signal.removeEventListener('abort', pending.abortListener);
+    }
+    pending.reject(toError(reason));
+  }
+
+  private scheduleIdle(task: () => void | Promise<void>): void {
+    const callback: IdleCallback = () => {
+      try {
+        const result = task();
+        if (result instanceof Promise) {
+          void result.catch((error) => {
+            if (process.env.NODE_ENV !== 'production') {
+              console.warn('Search index idle task failed', error);
+            }
+          });
+        }
+      } catch (error) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn('Search index idle task failed', error);
+        }
+      }
+    };
+
+    if (!isBrowser) {
+      callback({ didTimeout: false, timeRemaining: () => 0 });
+      return;
+    }
+
+    if (typeof window.requestIdleCallback === 'function') {
+      window.requestIdleCallback(callback as any);
+    } else {
+      const start = typeof performance !== 'undefined' ? performance.now() : Date.now();
+      window.setTimeout(() => {
+        const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        callback({
+          didTimeout: false,
+          timeRemaining: () => Math.max(0, 50 - (now - start)),
+        });
+      }, 32);
+    }
+  }
+
+  private nextRequestId(): number {
+    this.requestId += 1;
+    if (this.requestId > Number.MAX_SAFE_INTEGER) {
+      this.requestId = 1;
+    }
+    return this.requestId;
+  }
+}
+
+let clientInstance: SearchIndexClient | undefined;
+
+function getClient(): SearchIndexClient | undefined {
+  if (!isBrowser) {
+    return undefined;
+  }
+  if (!clientInstance) {
+    clientInstance = new SearchIndexClient();
+  }
+  return clientInstance;
+}
+
+export async function querySearchIndex(
+  query: string,
+  options: SearchQueryOptions = {},
+): Promise<SearchResult[]> {
+  const client = getClient();
+  if (!client) {
+    return [];
+  }
+  return client.query(query, options);
+}
+
+export function updateSearchIndex(source: SearchSource, records: SearchRecord[]): void {
+  const client = getClient();
+  client?.update(source, records);
+}
+
+export function removeFromSearchIndex(ids: string[], source?: SearchSource): void {
+  const client = getClient();
+  client?.remove(ids, source);
+}
+
+export function refreshSearchIndexOnIdle(
+  source: SearchSource,
+  loader: () => Promise<SearchRecord[] | undefined | null>,
+): void {
+  const client = getClient();
+  client?.refreshOnIdle(source, loader);
+}
+
+export function isSearchIndexReady(): boolean {
+  return Boolean(getClient());
+}
+
+export type { SearchRecord, SearchResult, SearchSource };

--- a/workers/search-index.worker.ts
+++ b/workers/search-index.worker.ts
@@ -1,0 +1,466 @@
+export type SearchSource = 'apps' | 'settings' | 'files' | 'help';
+
+export interface SearchRecord {
+  id: string;
+  title: string;
+  description?: string;
+  url?: string;
+  keywords?: string[];
+  path?: string;
+  content?: string;
+  boost?: number;
+}
+
+export interface SearchResult {
+  id: string;
+  source: SearchSource;
+  title: string;
+  description?: string;
+  url?: string;
+  keywords?: string[];
+  path?: string;
+  score: number;
+}
+
+export interface HydrateMessage {
+  kind: 'hydrate';
+  source: SearchSource;
+  records: SearchRecord[];
+}
+
+export interface UpsertMessage {
+  kind: 'upsert';
+  source: SearchSource;
+  records: SearchRecord[];
+}
+
+export interface RemoveMessage {
+  kind: 'remove';
+  ids: string[];
+  source?: SearchSource;
+}
+
+export interface ClearMessage {
+  kind: 'clear';
+}
+
+export interface QueryMessage {
+  kind: 'query';
+  requestId: number;
+  query: string;
+  limit?: number;
+  sources?: SearchSource[];
+}
+
+export interface CancelMessage {
+  kind: 'cancel';
+  requestId: number;
+}
+
+export type SearchIndexRequest =
+  | HydrateMessage
+  | UpsertMessage
+  | RemoveMessage
+  | ClearMessage
+  | QueryMessage
+  | CancelMessage;
+
+export interface AckResponse {
+  kind: 'ack';
+  action: 'hydrate' | 'upsert' | 'remove' | 'clear';
+  source?: SearchSource;
+  ids?: string[];
+}
+
+export interface ErrorResponse {
+  kind: 'error';
+  message: string;
+  requestId?: number;
+}
+
+export interface ResultsResponse {
+  kind: 'results';
+  requestId: number;
+  results: SearchResult[];
+}
+
+export type SearchIndexResponse = AckResponse | ErrorResponse | ResultsResponse;
+
+type IndexedDocument = {
+  key: string;
+  id: string;
+  source: SearchSource;
+  title: string;
+  titleNormalized: string;
+  description?: string;
+  url?: string;
+  keywords?: string[];
+  path?: string;
+  content?: string;
+  boost: number;
+  fullText: string;
+  terms: string[];
+};
+
+type SearchOptions = {
+  limit?: number;
+  sources?: SearchSource[];
+};
+
+const DEFAULT_BOOST: Record<SearchSource, number> = {
+  apps: 4,
+  settings: 3,
+  files: 2,
+  help: 2,
+};
+
+class MiniSearchIndex {
+  private documents = new Map<string, IndexedDocument>();
+
+  private invertedIndex = new Map<string, Set<string>>();
+
+  private sourceMap = new Map<SearchSource, Set<string>>();
+
+  hydrate(source: SearchSource, records: SearchRecord[]): void {
+    this.removeSource(source);
+    this.upsert(source, records);
+  }
+
+  upsert(source: SearchSource, records: SearchRecord[]): void {
+    for (const record of records) {
+      if (!record?.id || !record.title) continue;
+      const indexed = this.prepareDocument(source, record);
+      this.insert(indexed);
+    }
+  }
+
+  remove(ids: string[], source?: SearchSource): void {
+    if (source) {
+      for (const id of ids) {
+        const key = this.makeKey(source, id);
+        this.removeByKey(key);
+      }
+      return;
+    }
+
+    for (const id of ids) {
+      for (const [key, doc] of this.documents.entries()) {
+        if (doc.id === id) {
+          this.removeByKey(key);
+          break;
+        }
+      }
+    }
+  }
+
+  clear(): void {
+    this.documents.clear();
+    this.invertedIndex.clear();
+    this.sourceMap.clear();
+  }
+
+  search(query: string, options: SearchOptions = {}): SearchResult[] {
+    const { limit = 20, sources } = options;
+    const normalizedQuery = normalize(query);
+    const tokens = tokenize(normalizedQuery);
+    const phrase = normalizedQuery.trim();
+
+    const hits: Array<{ doc: IndexedDocument; score: number }> = [];
+
+    for (const doc of this.documents.values()) {
+      if (sources && sources.length > 0 && !sources.includes(doc.source)) {
+        continue;
+      }
+
+      const score = this.scoreDocument(doc, tokens, phrase);
+      const threshold = doc.boost + (tokens.length > 0 ? 0.05 : 0);
+      if (tokens.length > 0 && score <= threshold) {
+        continue;
+      }
+
+      hits.push({ doc, score });
+    }
+
+    hits.sort((a, b) => {
+      if (b.score === a.score) {
+        return a.doc.title.localeCompare(b.doc.title);
+      }
+      return b.score - a.score;
+    });
+
+    const limited = hits.slice(0, Math.max(1, limit));
+
+    return limited.map(({ doc, score }) => ({
+      id: doc.id,
+      source: doc.source,
+      title: doc.title,
+      description: doc.description,
+      url: doc.url,
+      keywords: doc.keywords,
+      path: doc.path,
+      score: Number(score.toFixed(3)),
+    }));
+  }
+
+  private makeKey(source: SearchSource, id: string): string {
+    return `${source}:${id}`;
+  }
+
+  private removeSource(source: SearchSource): void {
+    const ids = this.sourceMap.get(source);
+    if (!ids) return;
+    for (const key of ids) {
+      this.removeByKey(key);
+    }
+    this.sourceMap.delete(source);
+  }
+
+  private removeByKey(key: string): void {
+    const doc = this.documents.get(key);
+    if (!doc) return;
+    this.documents.delete(key);
+    for (const term of doc.terms) {
+      const bucket = this.invertedIndex.get(term);
+      if (!bucket) continue;
+      bucket.delete(key);
+      if (bucket.size === 0) {
+        this.invertedIndex.delete(term);
+      }
+    }
+    const sourceIds = this.sourceMap.get(doc.source);
+    if (sourceIds) {
+      sourceIds.delete(key);
+      if (sourceIds.size === 0) {
+        this.sourceMap.delete(doc.source);
+      }
+    }
+  }
+
+  private insert(doc: IndexedDocument): void {
+    const existing = this.documents.get(doc.key);
+    if (existing) {
+      this.removeByKey(existing.key);
+    }
+
+    this.documents.set(doc.key, doc);
+
+    let sourceIds = this.sourceMap.get(doc.source);
+    if (!sourceIds) {
+      sourceIds = new Set<string>();
+      this.sourceMap.set(doc.source, sourceIds);
+    }
+    sourceIds.add(doc.key);
+
+    for (const term of doc.terms) {
+      if (!this.invertedIndex.has(term)) {
+        this.invertedIndex.set(term, new Set<string>());
+      }
+      this.invertedIndex.get(term)!.add(doc.key);
+    }
+  }
+
+  private prepareDocument(source: SearchSource, record: SearchRecord): IndexedDocument {
+    const key = this.makeKey(source, record.id);
+    const boost = typeof record.boost === 'number' ? record.boost : DEFAULT_BOOST[source];
+
+    const textParts = [record.title, record.description, record.keywords?.join(' '), record.path, record.content];
+    const fullText = normalize(textParts.filter(Boolean).join(' '));
+    const titleNormalized = normalize(record.title);
+
+    const termSet = new Set<string>();
+    for (const part of textParts) {
+      for (const token of tokenize(part)) {
+        termSet.add(token);
+      }
+    }
+
+    return {
+      key,
+      id: record.id,
+      source,
+      title: record.title,
+      titleNormalized,
+      description: record.description,
+      url: record.url,
+      keywords: record.keywords,
+      path: record.path,
+      content: record.content,
+      boost,
+      fullText,
+      terms: Array.from(termSet),
+    };
+  }
+
+  private scoreDocument(doc: IndexedDocument, tokens: string[], phrase: string): number {
+    let score = doc.boost;
+
+    if (tokens.length === 0) {
+      return score + Math.min(doc.terms.length * 0.02, 0.6);
+    }
+
+    if (phrase && doc.titleNormalized.includes(phrase)) {
+      score += 1.5;
+    } else if (phrase && doc.fullText.includes(phrase)) {
+      score += 1;
+    }
+
+    let hasMatch = false;
+    for (const token of tokens) {
+      const tokenScore = this.scoreToken(token, doc);
+      if (tokenScore > 0) {
+        hasMatch = true;
+        score += tokenScore;
+      }
+    }
+
+    if (!hasMatch) {
+      return doc.boost;
+    }
+
+    if (tokens.every((token) => doc.fullText.includes(token))) {
+      score += 0.5;
+    }
+
+    return score;
+  }
+
+  private scoreToken(token: string, doc: IndexedDocument): number {
+    let best = 0;
+
+    if (doc.titleNormalized.includes(token)) {
+      best = Math.max(best, 1);
+    }
+
+    if (doc.fullText.includes(token)) {
+      best = Math.max(best, 0.75);
+    }
+
+    for (const term of doc.terms) {
+      const candidateScore = scoreTerm(token, term);
+      if (candidateScore > best) {
+        best = candidateScore;
+        if (best >= 1) {
+          break;
+        }
+      }
+    }
+
+    return best;
+  }
+}
+
+function normalize(input?: string | null): string {
+  if (!input) return '';
+  return input
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}
+
+function tokenize(input?: string | null): string[] {
+  const normalized = normalize(input);
+  if (!normalized) return [];
+  const matches = normalized.match(/[a-z0-9]+/g);
+  return matches ? Array.from(new Set(matches)) : [];
+}
+
+function scoreTerm(query: string, candidate: string): number {
+  if (!query || !candidate) return 0;
+  if (candidate === query) return 1;
+  if (candidate.startsWith(query)) return 0.85;
+  if (candidate.includes(query)) return 0.65;
+
+  const distance = levenshtein(query, candidate);
+  const maxLen = Math.max(query.length, candidate.length);
+  if (maxLen === 0) return 0;
+  const similarity = 1 - distance / maxLen;
+  return similarity > 0.5 ? similarity * 0.6 : 0;
+}
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  const matrix: number[][] = [];
+
+  for (let i = 0; i <= b.length; i += 1) {
+    matrix[i] = [i];
+  }
+  for (let j = 0; j <= a.length; j += 1) {
+    matrix[0][j] = j;
+  }
+
+  for (let i = 1; i <= b.length; i += 1) {
+    for (let j = 1; j <= a.length; j += 1) {
+      if (b.charAt(i - 1) === a.charAt(j - 1)) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j - 1] + 1,
+        );
+      }
+    }
+  }
+
+  return matrix[b.length][a.length];
+}
+
+const index = new MiniSearchIndex();
+const cancelledQueries = new Set<number>();
+
+const ctx: DedicatedWorkerGlobalScope = self as DedicatedWorkerGlobalScope;
+
+ctx.onmessage = (event: MessageEvent<SearchIndexRequest>) => {
+  const message = event.data;
+
+  switch (message.kind) {
+    case 'hydrate':
+      index.hydrate(message.source, message.records ?? []);
+      ctx.postMessage({ kind: 'ack', action: 'hydrate', source: message.source } satisfies AckResponse);
+      break;
+    case 'upsert':
+      index.upsert(message.source, message.records ?? []);
+      ctx.postMessage({ kind: 'ack', action: 'upsert', source: message.source } satisfies AckResponse);
+      break;
+    case 'remove':
+      index.remove(message.ids ?? [], message.source);
+      ctx.postMessage({ kind: 'ack', action: 'remove', source: message.source, ids: message.ids } satisfies AckResponse);
+      break;
+    case 'clear':
+      index.clear();
+      ctx.postMessage({ kind: 'ack', action: 'clear' } satisfies AckResponse);
+      break;
+    case 'cancel':
+      cancelledQueries.add(message.requestId);
+      break;
+    case 'query': {
+      const { requestId } = message;
+      if (cancelledQueries.has(requestId)) {
+        cancelledQueries.delete(requestId);
+        break;
+      }
+      try {
+        const results = index.search(message.query, {
+          limit: message.limit,
+          sources: message.sources,
+        });
+        if (cancelledQueries.has(requestId)) {
+          cancelledQueries.delete(requestId);
+          break;
+        }
+        ctx.postMessage({ kind: 'results', requestId, results } satisfies ResultsResponse);
+      } catch (error) {
+        const err = error instanceof Error ? error.message : 'Unknown search error';
+        ctx.postMessage({ kind: 'error', requestId, message: err } satisfies ErrorResponse);
+      }
+      break;
+    }
+    default:
+      break;
+  }
+};
+
+export {};


### PR DESCRIPTION
## Summary
- add a dedicated search-index worker that tracks docs in an inverted index with fuzzy scoring and cancellation support
- introduce a browser-side searchIndex client wrapper that hydrates from static data, proxies queries, and schedules idle refreshes
- seed static JSON snapshots for apps, settings, files, and help content that populate the index on boot

## Testing
- yarn lint *(fails: repository has numerous existing jsx-a11y control labelling errors in legacy apps and static game bundles)*
- yarn test *(fails: pre-existing window snapping, nmap NSE, and recon-ng suites currently error under jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68cab66ce1cc8328ae96efd1ae2c34a1