### PR TITLE
[settings] centralize search hook

### DIFF
--- a/apps/settings/hooks/useSectionSearch.ts
+++ b/apps/settings/hooks/useSectionSearch.ts
@@ -1,0 +1,63 @@
+import { useMemo, useState } from 'react';
+import {
+  navigation,
+  SettingsControl,
+  SettingsSection,
+  SettingsSectionId,
+} from '../navigation';
+
+export type SectionSearchResult = SettingsControl;
+
+const normalize = (value: string) => value.trim().toLowerCase();
+
+export interface UseSectionSearch {
+  query: string;
+  setQuery: (value: string) => void;
+  clear: () => void;
+  results: SectionSearchResult[];
+  highlightSlugs: Set<string>;
+  hasQuery: boolean;
+  section?: SettingsSection;
+  normalizedQuery: string;
+}
+
+export function useSectionSearch(activeSectionId: SettingsSectionId): UseSectionSearch {
+  const [query, setQuery] = useState('');
+
+  const section = useMemo(
+    () => navigation.find((item) => item.id === activeSectionId),
+    [activeSectionId],
+  );
+
+  const normalizedQuery = useMemo(() => normalize(query), [query]);
+
+  const results = useMemo(() => {
+    if (!section || normalizedQuery.length === 0) return [];
+    return section.controls.filter((control) => {
+      const haystack = [
+        control.label,
+        control.description,
+        ...(control.keywords ?? []),
+      ].filter(Boolean) as string[];
+      return haystack.some((value) => value.toLowerCase().includes(normalizedQuery));
+    });
+  }, [section, normalizedQuery]);
+
+  const highlightSlugs = useMemo(
+    () => new Set(results.map((control) => control.slug)),
+    [results],
+  );
+
+  const clear = () => setQuery('');
+
+  return {
+    query,
+    setQuery,
+    clear,
+    results,
+    highlightSlugs,
+    hasQuery: normalizedQuery.length > 0,
+    section,
+    normalizedQuery,
+  };
+}

--- a/apps/settings/navigation.ts
+++ b/apps/settings/navigation.ts
@@ -1,0 +1,123 @@
+export type SettingsSectionId = 'appearance' | 'accessibility' | 'privacy';
+
+export interface SettingsControl {
+  slug: string;
+  label: string;
+  description?: string;
+  keywords?: string[];
+}
+
+export interface SettingsSection {
+  id: SettingsSectionId;
+  label: string;
+  controls: SettingsControl[];
+}
+
+export const navigation: ReadonlyArray<SettingsSection> = [
+  {
+    id: 'appearance',
+    label: 'Appearance',
+    controls: [
+      {
+        slug: 'theme',
+        label: 'Theme',
+        description: 'Switch between desktop themes',
+        keywords: ['mode', 'dark', 'light', 'neon', 'matrix'],
+      },
+      {
+        slug: 'accent',
+        label: 'Accent color',
+        description: 'Adjust highlight color used across the UI',
+        keywords: ['color', 'highlight', 'primary'],
+      },
+      {
+        slug: 'wallpaper-slider',
+        label: 'Wallpaper slider',
+        description: 'Scrub through wallpapers using the range input',
+        keywords: ['background', 'image', 'preview'],
+      },
+      {
+        slug: 'wallpaper-slideshow',
+        label: 'Background slideshow',
+        description: 'Cycle selected wallpapers automatically',
+        keywords: ['rotate', 'cycle', 'timer', 'slideshow'],
+      },
+      {
+        slug: 'wallpaper-gallery',
+        label: 'Wallpaper gallery',
+        description: 'Select a wallpaper from the gallery grid',
+        keywords: ['background', 'image', 'grid', 'thumbnail'],
+      },
+      {
+        slug: 'reset-desktop',
+        label: 'Reset desktop',
+        description: 'Restore default wallpaper, accent and density',
+        keywords: ['factory reset', 'defaults', 'restore'],
+      },
+    ],
+  },
+  {
+    id: 'accessibility',
+    label: 'Accessibility',
+    controls: [
+      {
+        slug: 'icon-size',
+        label: 'Icon size',
+        description: 'Scale app icons and UI typography',
+        keywords: ['font', 'size', 'scale', 'accessibility'],
+      },
+      {
+        slug: 'density',
+        label: 'Density',
+        description: 'Adjust spacing between interface elements',
+        keywords: ['spacing', 'compact', 'layout'],
+      },
+      {
+        slug: 'reduced-motion',
+        label: 'Reduced motion',
+        description: 'Toggle motion-reduced animations',
+        keywords: ['animation', 'motion', 'prefers reduced motion'],
+      },
+      {
+        slug: 'high-contrast',
+        label: 'High contrast',
+        description: 'Improve color contrast for readability',
+        keywords: ['contrast', 'accessibility', 'vision'],
+      },
+      {
+        slug: 'haptics',
+        label: 'Haptics',
+        description: 'Enable tactile feedback for supported actions',
+        keywords: ['vibration', 'feedback'],
+      },
+      {
+        slug: 'keyboard-shortcuts',
+        label: 'Keyboard shortcuts',
+        description: 'Edit desktop shortcut bindings',
+        keywords: ['keymap', 'rebinding', 'shortcuts'],
+      },
+    ],
+  },
+  {
+    id: 'privacy',
+    label: 'Privacy',
+    controls: [
+      {
+        slug: 'export-settings',
+        label: 'Export settings',
+        description: 'Download a backup of your desktop preferences',
+        keywords: ['backup', 'download', 'json'],
+      },
+      {
+        slug: 'import-settings',
+        label: 'Import settings',
+        description: 'Restore desktop preferences from a file',
+        keywords: ['upload', 'restore', 'json'],
+      },
+    ],
+  },
+];
+
+export const getSectionById = (
+  id: SettingsSectionId,
+): SettingsSection | undefined => navigation.find((section) => section.id === id);

--- a/styles/index.css
+++ b/styles/index.css
@@ -530,3 +530,62 @@ textarea:focus-visible {
     color: #000 !important;
 }
 
+.settings-search-target {
+    position: relative;
+    border-radius: 0.75rem;
+    transition: box-shadow 160ms ease, background-color 160ms ease;
+}
+
+.settings-search-highlight {
+    background-color: color-mix(in srgb, var(--color-primary), transparent 88%);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary), transparent 55%);
+}
+
+.settings-search-active {
+    background-color: color-mix(in srgb, var(--color-primary), transparent 80%);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary), transparent 45%);
+}
+
+.settings-search-results {
+    display: grid;
+    gap: var(--space-2, 0.5rem);
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+.settings-search-result-button {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-2, 0.5rem);
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--color-primary), transparent 70%);
+    background-color: color-mix(in srgb, var(--color-primary), transparent 90%);
+    color: var(--color-text);
+    transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.settings-search-result-button:hover,
+.settings-search-result-button:focus-visible {
+    background-color: color-mix(in srgb, var(--color-primary), transparent 75%);
+    border-color: color-mix(in srgb, var(--color-primary), transparent 40%);
+    color: var(--color-inverse);
+    outline: none;
+    box-shadow: 0 0 0 2px var(--color-focus-ring);
+}
+
+.settings-search-result-meta {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.settings-search-empty {
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.75rem;
+    background-color: color-mix(in srgb, var(--color-primary), transparent 92%);
+}
+

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -28,3 +28,32 @@ export const logGameEnd = (game: string, label?: string): void => {
 export const logGameError = (game: string, message?: string): void => {
   logEvent({ category: game, action: 'error', label: message });
 };
+
+interface SettingsSearchEvent {
+  query: string;
+  sectionId: string;
+  controlSlug: string;
+  position?: number;
+  total?: number;
+}
+
+export const logSettingsSearchNavigation = ({
+  query,
+  sectionId,
+  controlSlug,
+  position,
+  total,
+}: SettingsSearchEvent): void => {
+  const params: Record<string, unknown> = {
+    section_id: sectionId,
+    control_slug: controlSlug,
+    query,
+  };
+  if (typeof position === 'number') {
+    params.match_position = position + 1;
+  }
+  if (typeof total === 'number') {
+    params.match_total = total;
+  }
+  safeEvent('settings_search', params);
+};


### PR DESCRIPTION
## Summary
- add navigation metadata describing settings sections and controls for search
- extract a reusable section-aware search hook and update the settings landing view with result highlights and analytics logging
- introduce highlight utilities for search results in the stylesheet

## Testing
- yarn lint *(fails: pre-existing accessibility violations across numerous apps)*
- yarn test *(fails: pre-existing suite failures around window handling and localStorage access)*

------
https://chatgpt.com/codex/tasks/task_e_68cab66a6c188328827dd07ae52e91b6