### PR TITLE
feat(settings): add accessibility navigation and analytics tracking

### DIFF
--- a/__tests__/settingsNavigation.test.tsx
+++ b/__tests__/settingsNavigation.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen, within, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Settings from '../apps/settings';
+import { SettingsContext } from '../hooks/useSettings';
+
+describe('Settings navigation', () => {
+  const originalFetch = global.fetch;
+  const noop = () => {};
+  const contextValue = {
+    accent: '#1793d1',
+    setAccent: jest.fn(),
+    wallpaper: 'wall-1',
+    setWallpaper: jest.fn(),
+    density: 'regular',
+    setDensity: jest.fn(),
+    reducedMotion: false,
+    setReducedMotion: jest.fn(),
+    fontScale: 1,
+    setFontScale: jest.fn(),
+    highContrast: false,
+    setHighContrast: jest.fn(),
+    largeHitAreas: false,
+    setLargeHitAreas: noop,
+    pongSpin: true,
+    setPongSpin: noop,
+    allowNetwork: false,
+    setAllowNetwork: noop,
+    haptics: true,
+    setHaptics: jest.fn(),
+    theme: 'default',
+    setTheme: jest.fn(),
+  };
+
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({ json: async () => [] } as any);
+  });
+
+  afterEach(() => {
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      // @ts-expect-error allow cleanup when fetch is undefined
+      delete global.fetch;
+    }
+    jest.resetAllMocks();
+  });
+
+  const renderSettings = () =>
+    render(
+      <SettingsContext.Provider value={contextValue as any}>
+        <Settings />
+      </SettingsContext.Provider>
+    );
+
+  it('supports keyboard traversal of the navigation tree', async () => {
+    const user = userEvent.setup();
+    renderSettings();
+    const tree = await screen.findByRole('tree', { name: /settings sections/i });
+    const items = within(tree).getAllByRole('treeitem');
+    items[0].focus();
+    await user.keyboard('{ArrowDown}');
+    expect(items[1]).toHaveFocus();
+  });
+
+  it('focuses deep linked controls when receiving a settings-deeplink event', async () => {
+    renderSettings();
+    expect(screen.queryByLabelText('Icon size')).toBeNull();
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('settings-deeplink', {
+          detail: { section: 'accessibility', item: 'font-scale' },
+        })
+      );
+    });
+    const slider = await screen.findByLabelText('Icon size');
+    await waitFor(() => expect(slider).toHaveFocus());
+  });
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useMemo, useEffect, useCallback } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
@@ -12,6 +12,84 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import useRovingTabIndex from "../../hooks/useRovingTabIndex";
+
+const TAB_DEFINITIONS = [
+  { id: "appearance", label: "Appearance" },
+  { id: "accessibility", label: "Accessibility" },
+  { id: "privacy", label: "Privacy" },
+] as const;
+
+type TabId = (typeof TAB_DEFINITIONS)[number]["id"];
+
+type CanonicalItem =
+  | "theme"
+  | "accent-color"
+  | "wallpaper"
+  | "wallpaper-gallery"
+  | "reset-desktop"
+  | "font-scale"
+  | "density"
+  | "reduced-motion"
+  | "high-contrast"
+  | "haptics"
+  | "edit-shortcuts"
+  | "export-settings"
+  | "import-settings";
+
+const SECTION_ITEMS: Record<TabId, { id: CanonicalItem; label: string }[]> = {
+  appearance: [
+    { id: "theme", label: "Theme" },
+    { id: "accent-color", label: "Accent color" },
+    { id: "wallpaper", label: "Wallpaper slider" },
+    { id: "wallpaper-gallery", label: "Wallpaper gallery" },
+    { id: "reset-desktop", label: "Reset desktop" },
+  ],
+  accessibility: [
+    { id: "font-scale", label: "Icon size" },
+    { id: "density", label: "Density" },
+    { id: "reduced-motion", label: "Reduced motion" },
+    { id: "high-contrast", label: "High contrast" },
+    { id: "haptics", label: "Haptics" },
+    { id: "edit-shortcuts", label: "Edit shortcuts" },
+  ],
+  privacy: [
+    { id: "export-settings", label: "Export settings" },
+    { id: "import-settings", label: "Import settings" },
+  ],
+};
+
+const ITEM_ALIASES: Record<string, CanonicalItem> = {
+  theme: "theme",
+  "accent": "accent-color",
+  "accent-color": "accent-color",
+  "accentcolor": "accent-color",
+  wallpaper: "wallpaper",
+  "wallpaper-slider": "wallpaper",
+  "wallpaper-gallery": "wallpaper-gallery",
+  "wallpapergallery": "wallpaper-gallery",
+  reset: "reset-desktop",
+  "reset-desktop": "reset-desktop",
+  "font-scale": "font-scale",
+  "font-size": "font-scale",
+  "icon-size": "font-scale",
+  density: "density",
+  "reduced-motion": "reduced-motion",
+  "high-contrast": "high-contrast",
+  haptics: "haptics",
+  "edit-shortcuts": "edit-shortcuts",
+  shortcuts: "edit-shortcuts",
+  export: "export-settings",
+  "export-settings": "export-settings",
+  import: "import-settings",
+  "import-settings": "import-settings",
+};
+
+const toCanonicalItem = (value?: string | CanonicalItem | null): CanonicalItem | null => {
+  if (!value) return null;
+  if (typeof value !== "string") return value;
+  return ITEM_ALIASES[value.toLowerCase()] ?? null;
+};
 
 export default function Settings() {
   const {
@@ -34,13 +112,10 @@ export default function Settings() {
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const tabs = [
-    { id: "appearance", label: "Appearance" },
-    { id: "accessibility", label: "Accessibility" },
-    { id: "privacy", label: "Privacy" },
-  ] as const;
-  type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
+  const [showKeymap, setShowKeymap] = useState(false);
+  const [currentItem, setCurrentItem] = useState<CanonicalItem | null>("theme");
+  const [pendingFocus, setPendingFocus] = useState<CanonicalItem | null>(null);
 
   const wallpapers = [
     "wall-1",
@@ -52,6 +127,160 @@ export default function Settings() {
     "wall-7",
     "wall-8",
   ];
+
+  const navRef = useRef<HTMLDivElement>(null);
+  const themeSelectRef = useRef<HTMLSelectElement>(null);
+  const accentGroupRef = useRef<HTMLDivElement>(null);
+  const wallpaperSliderRef = useRef<HTMLInputElement>(null);
+  const wallpaperGridRef = useRef<HTMLDivElement>(null);
+  const resetButtonRef = useRef<HTMLButtonElement>(null);
+  const fontScaleRef = useRef<HTMLInputElement>(null);
+  const densitySelectRef = useRef<HTMLSelectElement>(null);
+  const reducedMotionRef = useRef<HTMLDivElement>(null);
+  const highContrastRef = useRef<HTMLDivElement>(null);
+  const hapticsRef = useRef<HTMLDivElement>(null);
+  const keymapButtonRef = useRef<HTMLButtonElement>(null);
+  const exportButtonRef = useRef<HTMLButtonElement>(null);
+  const importButtonRef = useRef<HTMLButtonElement>(null);
+
+  useRovingTabIndex(navRef, true, "vertical", { selectors: '[role="treeitem"]' });
+  useRovingTabIndex(accentGroupRef, activeTab === "appearance", "horizontal", {
+    selectors: '[role="radio"]',
+  });
+  useRovingTabIndex(wallpaperGridRef, activeTab === "appearance", "horizontal", {
+    selectors: '[data-wallpaper-option]',
+  });
+
+  const navSections = useMemo(
+    () =>
+      TAB_DEFINITIONS.map((tab) => ({
+        ...tab,
+        items: SECTION_ITEMS[tab.id],
+      })),
+    []
+  );
+
+  const sectionFirstItem = useMemo(() => {
+    const map = new Map<TabId, CanonicalItem | null>();
+    navSections.forEach((section) => {
+      map.set(section.id, section.items[0]?.id ?? null);
+    });
+    return map;
+  }, [navSections]);
+
+  const findSectionForItem = useCallback(
+    (value: CanonicalItem | string | null | undefined): TabId | null => {
+      const canonical = toCanonicalItem(value);
+      if (!canonical) return null;
+      const match = navSections.find((section) =>
+        section.items.some((item) => item.id === canonical)
+      );
+      return (match?.id as TabId | undefined) ?? null;
+    },
+    [navSections]
+  );
+
+  const focusControl = useCallback(
+    (item: CanonicalItem | null) => {
+      if (!item) return;
+      const focusMap: Record<CanonicalItem, () => void> = {
+        theme: () => themeSelectRef.current?.focus(),
+        "accent-color": () => {
+          const target =
+            accentGroupRef.current?.querySelector<HTMLElement>(
+              '[role="radio"][aria-checked="true"]'
+            ) ?? accentGroupRef.current?.querySelector<HTMLElement>('[role="radio"]');
+          target?.focus();
+        },
+        wallpaper: () => wallpaperSliderRef.current?.focus(),
+        "wallpaper-gallery": () =>
+          wallpaperGridRef.current
+            ?.querySelector<HTMLElement>('[data-wallpaper-option]')
+            ?.focus(),
+        "reset-desktop": () => resetButtonRef.current?.focus(),
+        "font-scale": () => fontScaleRef.current?.focus(),
+        density: () => densitySelectRef.current?.focus(),
+        "reduced-motion": () =>
+          reducedMotionRef.current?.querySelector<HTMLButtonElement>("button")?.focus(),
+        "high-contrast": () =>
+          highContrastRef.current?.querySelector<HTMLButtonElement>("button")?.focus(),
+        haptics: () =>
+          hapticsRef.current?.querySelector<HTMLButtonElement>("button")?.focus(),
+        "edit-shortcuts": () => keymapButtonRef.current?.focus(),
+        "export-settings": () => exportButtonRef.current?.focus(),
+        "import-settings": () => importButtonRef.current?.focus(),
+      };
+      const focusFn = focusMap[item];
+      if (focusFn) focusFn();
+    },
+    []
+  );
+
+  const queueFocus = useCallback(
+    (value?: string | CanonicalItem | null) => {
+      const canonical = toCanonicalItem(value);
+      if (!canonical) return;
+      setCurrentItem(canonical);
+      setPendingFocus(canonical);
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!pendingFocus) return;
+    const frame = window.requestAnimationFrame(() => {
+      focusControl(pendingFocus);
+      setPendingFocus(null);
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [pendingFocus, focusControl]);
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ section?: string; item?: string }>).detail ?? {};
+      const canonicalItem = toCanonicalItem(detail.item ?? null);
+      if (canonicalItem) {
+        const owning = findSectionForItem(canonicalItem);
+        if (owning) {
+          setActiveTab(owning);
+        }
+        queueFocus(canonicalItem);
+        return;
+      }
+      if (typeof detail.section === "string") {
+        const normalized = detail.section.toLowerCase();
+        const tab = TAB_DEFINITIONS.find((t) => t.id === normalized);
+        if (tab) {
+          setActiveTab(tab.id);
+          const fallback = sectionFirstItem.get(tab.id);
+          if (fallback) {
+            queueFocus(fallback);
+          }
+        }
+      }
+    };
+    window.addEventListener("settings-deeplink", handler as EventListener);
+    return () => window.removeEventListener("settings-deeplink", handler as EventListener);
+  }, [findSectionForItem, queueFocus, sectionFirstItem]);
+
+  useEffect(() => {
+    if (!currentItem) {
+      const fallback = sectionFirstItem.get(activeTab);
+      if (fallback) {
+        setCurrentItem(fallback);
+      }
+      return;
+    }
+    const owning = findSectionForItem(currentItem);
+    if (owning && owning !== activeTab) {
+      const fallback = sectionFirstItem.get(activeTab);
+      if (fallback) {
+        setCurrentItem(fallback);
+      } else {
+        setCurrentItem(null);
+      }
+    }
+  }, [activeTab, currentItem, findSectionForItem, sectionFirstItem]);
 
   const changeBackground = (name: string) => setWallpaper(name);
 
@@ -103,191 +332,283 @@ export default function Settings() {
     setTheme("default");
   };
 
-  const [showKeymap, setShowKeymap] = useState(false);
-
   return (
-    <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
-      <div className="flex justify-center border-b border-gray-900">
-        <Tabs tabs={tabs} active={activeTab} onChange={setActiveTab} />
-      </div>
-      {activeTab === "appearance" && (
-        <>
-          <div
-            className="md:w-2/5 w-2/3 h-1/3 m-auto my-4"
-            style={{
-              backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
-              backgroundSize: "cover",
-              backgroundRepeat: "no-repeat",
-              backgroundPosition: "center center",
-            }}
-          ></div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Theme:</label>
-            <select
-              value={theme}
-              onChange={(e) => setTheme(e.target.value)}
-              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-            >
-              <option value="default">Default</option>
-              <option value="dark">Dark</option>
-              <option value="neon">Neon</option>
-              <option value="matrix">Matrix</option>
-            </select>
-          </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Accent:</label>
-            <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
-              {ACCENT_OPTIONS.map((c) => (
+    <div className="w-full flex flex-col md:flex-row flex-grow z-20 max-h-full windowMainScreen select-none bg-ub-cool-grey">
+      <aside
+        ref={navRef}
+        className="settings-sidebar md:w-72 w-full border-b md:border-b-0 md:border-r border-gray-900 p-4 overflow-y-auto"
+      >
+        <ul role="tree" aria-label="Settings sections" className="space-y-2">
+          {navSections.map((section, index) => {
+            const isActiveSection = activeTab === section.id;
+            return (
+              <li key={section.id}>
                 <button
-                  key={c}
-                  aria-label={`select-accent-${c}`}
-                  role="radio"
-                  aria-checked={accent === c}
-                  onClick={() => setAccent(c)}
-                  className={`w-8 h-8 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
-                  style={{ backgroundColor: c }}
+                  type="button"
+                  role="treeitem"
+                  aria-level={1}
+                  aria-expanded={isActiveSection}
+                  aria-selected={isActiveSection}
+                  tabIndex={index === 0 ? 0 : -1}
+                  data-tree-section={section.id}
+                  className={`settings-tree-trigger ${
+                    isActiveSection ? "settings-tree-trigger--active" : ""
+                  }`}
+                  onClick={() => {
+                    setActiveTab(section.id);
+                    const fallback = sectionFirstItem.get(section.id);
+                    if (fallback) {
+                      setCurrentItem(fallback);
+                    }
+                  }}
+                >
+                  {section.label}
+                </button>
+                <ul
+                  role="group"
+                  aria-label={`${section.label} settings`}
+                  className="mt-2 space-y-1"
+                  hidden={!isActiveSection}
+                >
+                  {section.items.map((item) => (
+                    <li key={item.id}>
+                      <button
+                        type="button"
+                        role="treeitem"
+                        aria-level={2}
+                        aria-selected={currentItem === item.id}
+                        tabIndex={-1}
+                        data-settings-item={item.id}
+                        className={`settings-tree-link ${
+                          currentItem === item.id ? "settings-tree-link--active" : ""
+                        }`}
+                        onClick={() => {
+                          setActiveTab(section.id);
+                          queueFocus(item.id);
+                        }}
+                      >
+                        {item.label}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            );
+          })}
+        </ul>
+      </aside>
+      <div className="flex-1 overflow-y-auto">
+        <div className="flex justify-center border-b border-gray-900">
+          <Tabs tabs={TAB_DEFINITIONS} active={activeTab} onChange={setActiveTab} />
+        </div>
+        {activeTab === "appearance" && (
+          <div className="px-6 py-6 space-y-6 text-ubt-grey">
+            <div
+              className="md:w-2/5 w-3/4 h-48 md:h-56 m-auto rounded-lg border border-ubt-cool-grey"
+              style={{
+                backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
+                backgroundSize: "cover",
+                backgroundRepeat: "no-repeat",
+                backgroundPosition: "center center",
+              }}
+              aria-hidden="true"
+            />
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <label className="text-ubt-grey" htmlFor="theme-select">
+                Theme:
+              </label>
+              <select
+                id="theme-select"
+                ref={themeSelectRef}
+                value={theme}
+                onChange={(e) => setTheme(e.target.value)}
+                className="bg-ub-cool-grey text-ubt-grey px-3 py-2 rounded border border-ubt-cool-grey settings-control"
+              >
+                <option value="default">Default</option>
+                <option value="dark">Dark</option>
+                <option value="neon">Neon</option>
+                <option value="matrix">Matrix</option>
+              </select>
+            </div>
+            <div className="flex flex-col items-center gap-2">
+              <span className="text-ubt-grey">Accent:</span>
+              <div
+                ref={accentGroupRef}
+                aria-label="Accent color picker"
+                role="radiogroup"
+                className="flex flex-wrap justify-center gap-2"
+              >
+                {ACCENT_OPTIONS.map((c) => (
+                  <button
+                    key={c}
+                    type="button"
+                    aria-label={`select-accent-${c}`}
+                    role="radio"
+                    aria-checked={accent === c}
+                    onClick={() => setAccent(c)}
+                    className={`settings-accent-option settings-control ${
+                      accent === c ? "settings-accent-option--active" : ""
+                    }`}
+                    style={{ backgroundColor: c }}
+                  />
+                ))}
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <label htmlFor="wallpaper-slider" className="text-ubt-grey">
+                Wallpaper:
+              </label>
+              <input
+                id="wallpaper-slider"
+                ref={wallpaperSliderRef}
+                type="range"
+                min="0"
+                max={wallpapers.length - 1}
+                step="1"
+                value={wallpapers.indexOf(wallpaper)}
+                onChange={(e) =>
+                  changeBackground(wallpapers[parseInt(e.target.value, 10)])
+                }
+                className="ubuntu-slider settings-control"
+                aria-label="Wallpaper"
+              />
+            </div>
+            <div className="flex justify-center">
+              <BackgroundSlideshow />
+            </div>
+            <div
+              ref={wallpaperGridRef}
+              className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900 pt-4"
+            >
+              {wallpapers.map((name) => (
+                <button
+                  key={name}
+                  type="button"
+                  data-wallpaper-option
+                  aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
+                  aria-pressed={name === wallpaper}
+                  onClick={() => changeBackground(name)}
+                  className={`settings-wallpaper-option ${
+                    name === wallpaper ? "settings-wallpaper-option--active" : ""
+                  }`}
+                  style={{
+                    backgroundImage: `url(/wallpapers/${name}.webp)`,
+                    backgroundSize: "cover",
+                    backgroundRepeat: "no-repeat",
+                    backgroundPosition: "center center",
+                  }}
                 />
               ))}
             </div>
+            <div className="border-t border-gray-900 pt-4 flex justify-center">
+              <button
+                ref={resetButtonRef}
+                onClick={handleReset}
+                className="px-4 py-2 rounded bg-ub-orange text-white settings-control"
+              >
+                Reset Desktop
+              </button>
+            </div>
           </div>
-          <div className="flex justify-center my-4">
-            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>
-            <input
-              id="wallpaper-slider"
-              type="range"
-              min="0"
-              max={wallpapers.length - 1}
-              step="1"
-              value={wallpapers.indexOf(wallpaper)}
-              onChange={(e) =>
-                changeBackground(wallpapers[parseInt(e.target.value, 10)])
-              }
-              className="ubuntu-slider"
-              aria-label="Wallpaper"
-            />
-          </div>
-          <div className="flex justify-center my-4">
-            <BackgroundSlideshow />
-          </div>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
-            {wallpapers.map((name) => (
-              <div
-                key={name}
-                role="button"
-                aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
-                aria-pressed={name === wallpaper}
-                tabIndex={0}
-                onClick={() => changeBackground(name)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    changeBackground(name);
-                  }
-                }}
-                className={
-                  (name === wallpaper
-                    ? " border-yellow-700 "
-                    : " border-transparent ") +
-                  " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"
-                }
-                style={{
-                  backgroundImage: `url(/wallpapers/${name}.webp)`,
-                  backgroundSize: "cover",
-                  backgroundRepeat: "no-repeat",
-                  backgroundPosition: "center center",
-                }}
-              ></div>
-            ))}
-          </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
-            <button
-              onClick={handleReset}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
+        )}
+        {activeTab === "accessibility" && (
+          <div className="px-6 py-6 space-y-6 text-ubt-grey">
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <label htmlFor="font-scale" className="text-ubt-grey">
+                Icon Size:
+              </label>
+              <input
+                id="font-scale"
+                ref={fontScaleRef}
+                type="range"
+                min="0.75"
+                max="1.5"
+                step="0.05"
+                value={fontScale}
+                onChange={(e) => setFontScale(parseFloat(e.target.value))}
+                className="ubuntu-slider settings-control"
+                aria-label="Icon size"
+              />
+            </div>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <label htmlFor="density-select" className="text-ubt-grey">
+                Density:
+              </label>
+              <select
+                id="density-select"
+                ref={densitySelectRef}
+                value={density}
+                onChange={(e) => setDensity(e.target.value as any)}
+                className="bg-ub-cool-grey text-ubt-grey px-3 py-2 rounded border border-ubt-cool-grey settings-control"
+              >
+                <option value="regular">Regular</option>
+                <option value="compact">Compact</option>
+              </select>
+            </div>
+            <div
+              ref={reducedMotionRef}
+              className="flex justify-center items-center gap-3"
             >
-              Reset Desktop
-            </button>
-          </div>
-        </>
-      )}
-      {activeTab === "accessibility" && (
-        <>
-          <div className="flex justify-center my-4">
-            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">Icon Size:</label>
-            <input
-              id="font-scale"
-              type="range"
-              min="0.75"
-              max="1.5"
-              step="0.05"
-              value={fontScale}
-              onChange={(e) => setFontScale(parseFloat(e.target.value))}
-              className="ubuntu-slider"
-              aria-label="Icon size"
-            />
-          </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Density:</label>
-            <select
-              value={density}
-              onChange={(e) => setDensity(e.target.value as any)}
-              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+              <span className="text-ubt-grey">Reduced Motion:</span>
+              <ToggleSwitch
+                checked={reducedMotion}
+                onChange={setReducedMotion}
+                ariaLabel="Reduced Motion"
+                className="settings-control"
+              />
+            </div>
+            <div
+              ref={highContrastRef}
+              className="flex justify-center items-center gap-3"
             >
-              <option value="regular">Regular</option>
-              <option value="compact">Compact</option>
-            </select>
+              <span className="text-ubt-grey">High Contrast:</span>
+              <ToggleSwitch
+                checked={highContrast}
+                onChange={setHighContrast}
+                ariaLabel="High Contrast"
+                className="settings-control"
+              />
+            </div>
+            <div ref={hapticsRef} className="flex justify-center items-center gap-3">
+              <span className="text-ubt-grey">Haptics:</span>
+              <ToggleSwitch
+                checked={haptics}
+                onChange={setHaptics}
+                ariaLabel="Haptics"
+                className="settings-control"
+              />
+            </div>
+            <div className="border-t border-gray-900 pt-4 flex justify-center">
+              <button
+                ref={keymapButtonRef}
+                onClick={() => setShowKeymap(true)}
+                className="px-4 py-2 rounded bg-ub-orange text-white settings-control"
+              >
+                Edit Shortcuts
+              </button>
+            </div>
           </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">Reduced Motion:</span>
-            <ToggleSwitch
-              checked={reducedMotion}
-              onChange={setReducedMotion}
-              ariaLabel="Reduced Motion"
-            />
+        )}
+        {activeTab === "privacy" && (
+          <div className="px-6 py-6 space-y-6 text-ubt-grey">
+            <div className="flex flex-wrap items-center justify-center gap-4">
+              <button
+                ref={exportButtonRef}
+                onClick={handleExport}
+                className="px-4 py-2 rounded bg-ub-orange text-white settings-control"
+              >
+                Export Settings
+              </button>
+              <button
+                ref={importButtonRef}
+                onClick={() => fileInputRef.current?.click()}
+                className="px-4 py-2 rounded bg-ub-orange text-white settings-control"
+              >
+                Import Settings
+              </button>
+            </div>
           </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">High Contrast:</span>
-            <ToggleSwitch
-              checked={highContrast}
-              onChange={setHighContrast}
-              ariaLabel="High Contrast"
-            />
-          </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">Haptics:</span>
-            <ToggleSwitch
-              checked={haptics}
-              onChange={setHaptics}
-              ariaLabel="Haptics"
-            />
-          </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
-            <button
-              onClick={() => setShowKeymap(true)}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Edit Shortcuts
-            </button>
-          </div>
-        </>
-      )}
-      {activeTab === "privacy" && (
-        <>
-          <div className="flex justify-center my-4 space-x-4">
-            <button
-              onClick={handleExport}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Export Settings
-            </button>
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Import Settings
-            </button>
-          </div>
-        </>
-      )}
+        )}
         <input
           type="file"
           accept="application/json"
@@ -300,7 +621,8 @@ export default function Settings() {
           }}
           className="hidden"
         />
-      <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
+        <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
+      </div>
     </div>
   );
 }

--- a/hooks/useRovingTabIndex.ts
+++ b/hooks/useRovingTabIndex.ts
@@ -6,20 +6,38 @@ import { useEffect } from 'react';
  * or role="option" will participate in the roving behaviour. This covers
  * common patterns such as tabs, menus and listboxes.
  */
+interface RovingOptions {
+  selectors?: string;
+}
+
 export default function useRovingTabIndex(
   ref: React.RefObject<HTMLElement>,
   active: boolean = true,
-  orientation: 'horizontal' | 'vertical' = 'horizontal'
+  orientation: 'horizontal' | 'vertical' = 'horizontal',
+  options: RovingOptions = {}
 ) {
   useEffect(() => {
     const node = ref.current;
     if (!node || !active) return;
 
-    const items = Array.from(
-      node.querySelectorAll<HTMLElement>(
-        '[role="tab"], [role="menuitem"], [role="option"]'
-      )
-    );
+    const selectors =
+      options.selectors ||
+      '[role="tab"], [role="menuitem"], [role="option"], [role="radio"], [role="treeitem"]';
+
+    const filterVisible = (elements: HTMLElement[]) =>
+      elements.filter((el) => {
+        if (el.hasAttribute('disabled') || el.getAttribute('aria-disabled') === 'true') {
+          return false;
+        }
+        if (el.closest('[hidden]')) return false;
+        if (el.closest('[aria-hidden="true"]')) return false;
+        return true;
+      });
+
+    const getItems = () =>
+      filterVisible(Array.from(node.querySelectorAll<HTMLElement>(selectors)));
+
+    let items = getItems();
     if (items.length === 0) return;
 
     let index = items.findIndex((el) => el.tabIndex === 0);
@@ -27,24 +45,52 @@ export default function useRovingTabIndex(
     items.forEach((el, i) => (el.tabIndex = i === index ? 0 : -1));
 
     const handleKey = (e: KeyboardEvent) => {
-      const forward = orientation === 'horizontal' ? ['ArrowRight', 'ArrowDown'] : ['ArrowDown'];
-      const backward = orientation === 'horizontal' ? ['ArrowLeft', 'ArrowUp'] : ['ArrowUp'];
-      if (forward.includes(e.key)) {
-        e.preventDefault();
-        index = (index + 1) % items.length;
-        items.forEach((el, i) => (el.tabIndex = i === index ? 0 : -1));
-        items[index].focus();
-      } else if (backward.includes(e.key)) {
-        e.preventDefault();
-        index = (index - 1 + items.length) % items.length;
-        items.forEach((el, i) => (el.tabIndex = i === index ? 0 : -1));
-        items[index].focus();
+      const forward =
+        orientation === 'horizontal'
+          ? ['ArrowRight', 'ArrowDown']
+          : ['ArrowDown'];
+      const backward =
+        orientation === 'horizontal'
+          ? ['ArrowLeft', 'ArrowUp']
+          : ['ArrowUp'];
+      if (!forward.includes(e.key) && !backward.includes(e.key)) return;
+
+      const visibleItems = getItems();
+      if (visibleItems.length === 0) return;
+
+      items = visibleItems;
+      const focused = items.findIndex((el) => el.tabIndex === 0 && el === document.activeElement);
+      if (focused >= 0) {
+        index = focused;
       }
+
+      e.preventDefault();
+      if (forward.includes(e.key)) {
+        index = (index + 1) % items.length;
+      } else {
+        index = (index - 1 + items.length) % items.length;
+      }
+      items.forEach((el, i) => (el.tabIndex = i === index ? 0 : -1));
+      items[index].focus();
+    };
+
+    const handleFocusIn = (event: FocusEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      const visibleItems = getItems();
+      if (visibleItems.length === 0) return;
+      items = visibleItems;
+      const focused = items.findIndex((el) => el === target);
+      if (focused === -1) return;
+      index = focused;
+      items.forEach((el, i) => (el.tabIndex = i === index ? 0 : -1));
     };
 
     node.addEventListener('keydown', handleKey);
+    node.addEventListener('focusin', handleFocusIn);
     return () => {
       node.removeEventListener('keydown', handleKey);
+      node.removeEventListener('focusin', handleFocusIn);
     };
-  }, [ref, active, orientation]);
+  }, [ref, active, orientation, options.selectors]);
 }

--- a/pages/apps/settings.jsx
+++ b/pages/apps/settings.jsx
@@ -1,8 +1,35 @@
+import { useEffect, useRef } from 'react';
 import dynamic from 'next/dynamic';
+import { useRouter } from 'next/router';
 
 const SettingsApp = dynamic(() => import('../../apps/settings'), { ssr: false });
 
+const getQueryValue = (value) => {
+  if (Array.isArray(value)) return value[0];
+  return value ?? undefined;
+};
+
 export default function SettingsPage() {
+  const router = useRouter();
+  const lastPayload = useRef('');
+
+  useEffect(() => {
+    if (!router.isReady || typeof window === 'undefined') return;
+    const section = getQueryValue(router.query.section);
+    const item = getQueryValue(router.query.item);
+    const detail = {};
+    if (section) detail.section = section;
+    if (item) detail.item = item;
+    if (Object.keys(detail).length === 0) {
+      lastPayload.current = '';
+      return;
+    }
+    const serialized = JSON.stringify(detail);
+    if (serialized === lastPayload.current) return;
+    lastPayload.current = serialized;
+    window.dispatchEvent(new CustomEvent('settings-deeplink', { detail }));
+  }, [router.isReady, router.query]);
+
   return <SettingsApp />;
 }
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -516,6 +516,77 @@ textarea:focus-visible {
     outline-offset: 2px;
 }
 
+/* Settings navigation and controls */
+.settings-sidebar {
+    background-color: color-mix(in srgb, var(--color-bg), transparent 20%);
+}
+
+.settings-tree-trigger,
+.settings-tree-link {
+    display: block;
+    width: 100%;
+    text-align: start;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    color: inherit;
+    background: transparent;
+    border: none;
+}
+
+.settings-tree-trigger--active,
+.settings-tree-link--active {
+    background-color: color-mix(in srgb, var(--color-control-accent), transparent 75%);
+}
+
+.settings-tree-link--active {
+    border-inline-start: 3px solid var(--color-control-accent);
+    padding-inline-start: calc(0.75rem + 3px);
+}
+
+.settings-tree-trigger:focus-visible,
+.settings-tree-link:focus-visible,
+.settings-control:focus-visible {
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline-offset: 2px;
+}
+
+.settings-accent-option {
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 9999px;
+    border: 2px solid transparent;
+}
+
+.settings-accent-option--active {
+    border-color: var(--focus-outline-color);
+}
+
+.settings-wallpaper-option {
+    width: 7rem;
+    height: 5rem;
+    border-radius: 0.5rem;
+    border: 4px solid transparent;
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+@media (min-width: 768px) {
+    .settings-wallpaper-option {
+        width: 9rem;
+        height: 6rem;
+    }
+}
+
+.settings-wallpaper-option--active {
+    border-color: var(--color-control-accent);
+}
+
+.settings-wallpaper-option:focus-visible {
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline-offset: 2px;
+}
+
 /* Enable scroll snapping for gallery containers */
 .gallery-container {
     scroll-snap-type: x mandatory;

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -28,3 +28,109 @@ export const logGameEnd = (game: string, label?: string): void => {
 export const logGameError = (game: string, message?: string): void => {
   logEvent({ category: game, action: 'error', label: message });
 };
+
+const envAnalyticsEnabled =
+  typeof process !== 'undefined' && process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true';
+const isTestEnv = typeof process !== 'undefined' && process.env.NODE_ENV === 'test';
+const canEmitStudyMetrics = envAnalyticsEnabled || isTestEnv;
+
+const getTimestamp = () =>
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+
+let clickDepth = 0;
+let sessionStart: number | null = null;
+let lastInteraction: number | null = null;
+let listenersAttached = false;
+
+const startSession = () => {
+  if (sessionStart === null) {
+    sessionStart = getTimestamp();
+    lastInteraction = sessionStart;
+  }
+};
+
+const sendStudyEvent = (action: string, data: { clickDepth: number; dwellMs: number }) => {
+  if (!canEmitStudyMetrics) return;
+  const event: EventInput = {
+    category: 'study',
+    action,
+    label: JSON.stringify(data),
+    nonInteraction: true,
+  } as EventInput;
+  if (action === 'session_summary') {
+    (event as Record<string, unknown>).value = data.clickDepth;
+  }
+  safeEvent(event);
+};
+
+export const recordStudyClick = (): void => {
+  if (!canEmitStudyMetrics) return;
+  startSession();
+  clickDepth += 1;
+  lastInteraction = getTimestamp();
+  const dwell = Math.round((lastInteraction ?? sessionStart!) - (sessionStart ?? 0));
+  sendStudyEvent('click', { clickDepth, dwellMs: dwell });
+};
+
+export const flushStudyMetrics = (): void => {
+  if (!canEmitStudyMetrics) {
+    clickDepth = 0;
+    sessionStart = null;
+    lastInteraction = null;
+    return;
+  }
+  if (sessionStart === null || clickDepth === 0) {
+    clickDepth = 0;
+    sessionStart = null;
+    lastInteraction = null;
+    return;
+  }
+  const now = lastInteraction ?? getTimestamp();
+  const dwell = Math.round(now - sessionStart);
+  sendStudyEvent('session_summary', { clickDepth, dwellMs: dwell });
+  clickDepth = 0;
+  sessionStart = null;
+  lastInteraction = null;
+};
+
+const handleVisibilityChange = () => {
+  if (typeof document === 'undefined') return;
+  if (document.visibilityState === 'hidden') {
+    flushStudyMetrics();
+  }
+};
+
+const attachStudyListeners = () => {
+  if (listenersAttached || !canEmitStudyMetrics) return;
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  window.addEventListener('click', recordStudyClick, { capture: true });
+  window.addEventListener('pagehide', flushStudyMetrics);
+  window.addEventListener('beforeunload', flushStudyMetrics);
+  document.addEventListener('visibilitychange', handleVisibilityChange);
+  listenersAttached = true;
+};
+
+if (envAnalyticsEnabled) {
+  attachStudyListeners();
+}
+
+export const __STUDY_TEST_ONLY = {
+  reset(): void {
+    if (listenersAttached && typeof window !== 'undefined' && typeof document !== 'undefined') {
+      window.removeEventListener('click', recordStudyClick, { capture: true } as EventListenerOptions);
+      window.removeEventListener('pagehide', flushStudyMetrics);
+      window.removeEventListener('beforeunload', flushStudyMetrics);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    }
+    clickDepth = 0;
+    sessionStart = null;
+    lastInteraction = null;
+    listenersAttached = false;
+  },
+  getMetrics(): { clickDepth: number; sessionStart: number | null } {
+    return { clickDepth, sessionStart };
+  },
+  attach: attachStudyListeners,
+};


### PR DESCRIPTION
## Summary
- dispatch a settings-deeplink custom event from the settings page when section/item query params are present
- refactor the settings app with a keyboard friendly sidebar tree, roving focus, and updated control focus styles, plus deep-link handling
- capture click depth and dwell analytics and add navigation/deep-link tests

## Testing
- yarn lint *(fails: repository has existing jsx-a11y/no-top-level-window violations)*
- yarn test __tests__/settingsNavigation.test.tsx
- yarn test *(fails: existing suites such as __tests__/window.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cab66a2c208328b0727a6110ccfea8