### PR TITLE
[settings] add breadcrumbs and deep link support

### DIFF
--- a/apps/settings/components/Breadcrumbs.tsx
+++ b/apps/settings/components/Breadcrumbs.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from "react";
+
+export type SettingsSection = {
+  id: string;
+  label: string;
+  subsections?: readonly { id: string; label: string }[];
+};
+
+interface BreadcrumbsProps {
+  sections: readonly SettingsSection[];
+  activeSectionId?: string | null;
+  activeSubsectionId?: string | null;
+  rootLabel?: ReactNode;
+}
+
+const formatLabel = (value: string): string => {
+  if (!value) return "";
+  const words = value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .split(/\s+/);
+  return words
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+};
+
+export default function Breadcrumbs({
+  sections,
+  activeSectionId,
+  activeSubsectionId,
+  rootLabel = "Settings",
+}: BreadcrumbsProps) {
+  const section = activeSectionId
+    ? sections.find((entry) => entry.id === activeSectionId)
+    : undefined;
+
+  const breadcrumbs: { id: string; label: ReactNode }[] = [
+    { id: "root", label: rootLabel },
+  ];
+
+  if (activeSectionId) {
+    const sectionLabel = section?.label ?? formatLabel(activeSectionId);
+    breadcrumbs.push({ id: `section:${activeSectionId}`, label: sectionLabel });
+
+    if (activeSubsectionId) {
+      const subsectionLabel =
+        section?.subsections?.find((sub) => sub.id === activeSubsectionId)?.label ??
+        formatLabel(activeSubsectionId);
+      breadcrumbs.push({
+        id: `subsection:${activeSubsectionId}`,
+        label: subsectionLabel,
+      });
+    }
+  }
+
+  const lastIndex = breadcrumbs.length - 1;
+
+  return (
+    <nav aria-label="Breadcrumb">
+      <ol className="flex flex-wrap items-center gap-1 text-xs text-ubt-grey sm:text-sm">
+        {breadcrumbs.map((crumb, index) => {
+          const isCurrent = index === lastIndex;
+          return (
+            <li key={crumb.id} className="flex items-center">
+              <span
+                aria-current={isCurrent ? "page" : undefined}
+                className={
+                  isCurrent
+                    ? "font-semibold text-white"
+                    : "text-ubt-grey hover:text-white"
+                }
+              >
+                {crumb.label}
+              </span>
+              {index < lastIndex && <span className="mx-1 text-ubt-grey/60">/</span>}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
+import Breadcrumbs, { SettingsSection } from "./components/Breadcrumbs";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
@@ -13,7 +14,106 @@ import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
 
-export default function Settings() {
+const SECTION_DEFINITIONS = [
+  {
+    id: "appearance",
+    label: "Appearance",
+    subsections: [
+      { id: "theme", label: "Theme" },
+      { id: "accent", label: "Accent" },
+      { id: "wallpaper", label: "Wallpaper" },
+      { id: "slideshow", label: "Background Slideshow" },
+      { id: "reset", label: "Reset" },
+    ],
+  },
+  {
+    id: "accessibility",
+    label: "Accessibility",
+    subsections: [
+      { id: "icon-size", label: "Icon Size" },
+      { id: "density", label: "Density" },
+      { id: "reduced-motion", label: "Reduced Motion" },
+      { id: "high-contrast", label: "High Contrast" },
+      { id: "haptics", label: "Haptics" },
+      { id: "shortcuts", label: "Keyboard Shortcuts" },
+    ],
+  },
+  {
+    id: "privacy",
+    label: "Privacy",
+    subsections: [
+      { id: "export", label: "Export" },
+      { id: "import", label: "Import" },
+    ],
+  },
+] as const satisfies readonly SettingsSection[];
+
+type SectionDefinition = (typeof SECTION_DEFINITIONS)[number];
+type SectionId = SectionDefinition["id"];
+type NormalizedPath = { section: SectionId; subsection: string | null };
+
+const DEFAULT_SECTION_ID: SectionId = SECTION_DEFINITIONS[0].id;
+const SECTION_IDS = new Set<SectionId>(
+  SECTION_DEFINITIONS.map((section) => section.id)
+);
+const SECTION_LOOKUP = SECTION_DEFINITIONS.reduce<Record<SectionId, SectionDefinition>>(
+  (acc, section) => {
+    acc[section.id] = section;
+    return acc;
+  },
+  {} as Record<SectionId, SectionDefinition>
+);
+
+const TABS = SECTION_DEFINITIONS.map(({ id, label }) => ({ id, label })) as const;
+type TabId = (typeof TABS)[number]["id"];
+
+const normalisePath = (
+  path: readonly string[] | null | undefined
+): NormalizedPath => {
+  const segments = Array.isArray(path)
+    ? path
+        .flatMap((segment) =>
+          typeof segment === "string"
+            ? segment
+                .split("/")
+                .map((part) => part.trim())
+                .filter(Boolean)
+            : []
+        )
+        .map((segment) => segment.toLowerCase())
+    : [];
+
+  const sectionFromPath = segments.find((segment): segment is SectionId =>
+    SECTION_IDS.has(segment as SectionId)
+  );
+
+  const sectionId = sectionFromPath ?? DEFAULT_SECTION_ID;
+  const sectionDefinition = SECTION_LOOKUP[sectionId];
+  const sectionIndex = sectionFromPath ? segments.indexOf(sectionFromPath) : -1;
+  const rawSubsection =
+    sectionIndex >= 0 && sectionIndex + 1 < segments.length
+      ? segments[sectionIndex + 1]
+      : null;
+
+  if (!rawSubsection) {
+    return { section: sectionId, subsection: null };
+  }
+
+  const subsectionDefinition = sectionDefinition.subsections?.find(
+    (entry) => entry.id === rawSubsection
+  );
+
+  return {
+    section: sectionId,
+    subsection: subsectionDefinition ? subsectionDefinition.id : rawSubsection,
+  };
+};
+
+interface SettingsProps {
+  initialPath?: readonly string[] | null;
+}
+
+export default function Settings({ initialPath }: SettingsProps) {
   const {
     accent,
     setAccent,
@@ -34,13 +134,44 @@ export default function Settings() {
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const tabs = [
-    { id: "appearance", label: "Appearance" },
-    { id: "accessibility", label: "Accessibility" },
-    { id: "privacy", label: "Privacy" },
-  ] as const;
-  type TabId = (typeof tabs)[number]["id"];
-  const [activeTab, setActiveTab] = useState<TabId>("appearance");
+  const derivedPath = useMemo(() => normalisePath(initialPath), [initialPath]);
+  const [activeTab, setActiveTab] = useState<TabId>(derivedPath.section);
+  const [activeSubsection, setActiveSubsection] = useState<string | null>(
+    derivedPath.subsection
+  );
+  const previousDerivedRef = useRef<NormalizedPath | null>(null);
+  const [showKeymap, setShowKeymap] = useState(false);
+
+  useEffect(() => {
+    setActiveTab((prev) => (prev === derivedPath.section ? prev : derivedPath.section));
+    setActiveSubsection((prev) =>
+      prev === derivedPath.subsection ? prev : derivedPath.subsection
+    );
+  }, [derivedPath.section, derivedPath.subsection]);
+
+  useEffect(() => {
+    const previous = previousDerivedRef.current;
+    if (
+      derivedPath.section === "accessibility" &&
+      derivedPath.subsection === "shortcuts"
+    ) {
+      setShowKeymap(true);
+      setActiveSubsection("shortcuts");
+    } else if (
+      previous?.section === "accessibility" &&
+      previous.subsection === "shortcuts"
+    ) {
+      setShowKeymap(false);
+      setActiveSubsection((prev) => (prev === "shortcuts" ? null : prev));
+    }
+    previousDerivedRef.current = derivedPath;
+  }, [derivedPath]);
+
+  const handleTabChange = (id: TabId) => {
+    setActiveTab(id);
+    setActiveSubsection(null);
+    setShowKeymap(false);
+  };
 
   const wallpapers = [
     "wall-1",
@@ -103,12 +234,17 @@ export default function Settings() {
     setTheme("default");
   };
 
-  const [showKeymap, setShowKeymap] = useState(false);
-
   return (
     <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
       <div className="flex justify-center border-b border-gray-900">
-        <Tabs tabs={tabs} active={activeTab} onChange={setActiveTab} />
+        <Tabs tabs={TABS} active={activeTab} onChange={handleTabChange} />
+      </div>
+      <div className="border-b border-gray-900 px-4 py-2">
+        <Breadcrumbs
+          sections={SECTION_DEFINITIONS}
+          activeSectionId={activeTab}
+          activeSubsectionId={activeSubsection}
+        />
       </div>
       {activeTab === "appearance" && (
         <>
@@ -262,7 +398,10 @@ export default function Settings() {
           </div>
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
             <button
-              onClick={() => setShowKeymap(true)}
+              onClick={() => {
+                setActiveSubsection("shortcuts");
+                setShowKeymap(true);
+              }}
               className="px-4 py-2 rounded bg-ub-orange text-white"
             >
               Edit Shortcuts
@@ -300,7 +439,13 @@ export default function Settings() {
           }}
           className="hidden"
         />
-      <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
+      <KeymapOverlay
+        open={showKeymap}
+        onClose={() => {
+          setShowKeymap(false);
+          setActiveSubsection((prev) => (prev === "shortcuts" ? null : prev));
+        }}
+      />
     </div>
   );
 }

--- a/pages/apps/settings.jsx
+++ b/pages/apps/settings.jsx
@@ -1,8 +1,82 @@
 import dynamic from 'next/dynamic';
+import { useEffect, useState } from 'react';
 
 const SettingsApp = dynamic(() => import('../../apps/settings'), { ssr: false });
 
+const PRIMARY_STATE_KEYS = ['settingsPath', 'settingsSegments', 'pathSegments', 'segments'];
+const NESTED_STATE_KEYS = [...PRIMARY_STATE_KEYS, 'path'];
+
+const readSegments = (value) => {
+  if (typeof value === 'string') {
+    const segments = value
+      .split('/')
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+    return segments.length ? segments : undefined;
+  }
+
+  if (Array.isArray(value)) {
+    const segments = value.flatMap((segment) => {
+      if (typeof segment !== 'string') return [];
+      return segment
+        .split('/')
+        .map((part) => part.trim())
+        .filter(Boolean);
+    });
+    return segments.length ? segments : undefined;
+  }
+
+  return undefined;
+};
+
+const extractPathSegments = (state) => {
+  if (!state || typeof state !== 'object') {
+    return undefined;
+  }
+
+  const containers = [state];
+  if (state.state && typeof state.state === 'object') {
+    containers.push(state.state);
+  }
+
+  for (const container of containers) {
+    if (!container || typeof container !== 'object') continue;
+
+    for (const key of PRIMARY_STATE_KEYS) {
+      const segments = readSegments(container[key]);
+      if (segments) return segments;
+    }
+
+    const nested = container.settings;
+    if (nested && typeof nested === 'object') {
+      for (const key of NESTED_STATE_KEYS) {
+        const segments = readSegments(nested[key]);
+        if (segments) return segments;
+      }
+    }
+  }
+
+  return undefined;
+};
+
 export default function SettingsPage() {
-  return <SettingsApp />;
+  const [pathSegments, setPathSegments] = useState();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const updateFromState = () => {
+      const segments = extractPathSegments(window.history?.state);
+      setPathSegments(segments ?? []);
+    };
+
+    updateFromState();
+    const handlePopState = () => updateFromState();
+
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
+  return <SettingsApp initialPath={pathSegments} />;
 }
 


### PR DESCRIPTION
## Summary
- add a breadcrumb component that maps section and subsection ids into labeled navigation
- update the settings app to render the breadcrumb, track subsections, and react to deep-linked paths
- parse history state on the Next.js page to pass path segments into the settings surface

## Testing
- `yarn lint` *(fails: repository contains pre-existing jsx-a11y and no-top-level-window violations)*
- `yarn test` *(fails: existing suites such as nmapNse and settings store expect browser-only APIs)*
- `yarn eslint apps/settings/index.tsx apps/settings/components/Breadcrumbs.tsx pages/apps/settings.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68cab6661ca88328b186c9adaef5b86c