### PR TITLE
[settings] replace settings tabs with navigation tree

### DIFF
--- a/apps/settings/components/NavigationTree.tsx
+++ b/apps/settings/components/NavigationTree.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
+import type { NavigationItem } from "../navigation";
+import { getNavigationPath } from "../navigation";
+
+interface NavigationTreeProps {
+  items: NavigationItem[];
+  activeId: string;
+  onSelect: (id: string) => void;
+  className?: string;
+}
+
+interface VisibleItem {
+  node: NavigationItem;
+  level: number;
+  parentId?: string;
+  isLeaf: boolean;
+}
+
+const getVisibleItems = (
+  items: NavigationItem[],
+  expandedIds: Set<string>,
+  level = 1,
+  parentId?: string
+): VisibleItem[] => {
+  const result: VisibleItem[] = [];
+  for (const item of items) {
+    const isLeaf = !item.children || item.children.length === 0;
+    result.push({ node: item, level, parentId, isLeaf });
+    if (!isLeaf && expandedIds.has(item.id)) {
+      result.push(
+        ...getVisibleItems(item.children ?? [], expandedIds, level + 1, item.id)
+      );
+    }
+  }
+  return result;
+};
+
+export default function NavigationTree({
+  items,
+  activeId,
+  onSelect,
+  className,
+}: NavigationTreeProps) {
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(
+    () => new Set(getNavigationPath(activeId).slice(0, -1))
+  );
+  const [focusedId, setFocusedId] = useState<string>(activeId);
+  const itemRefs = useRef(new Map<string, HTMLButtonElement>());
+
+  const visibleItems = useMemo(
+    () => getVisibleItems(items, expandedIds),
+    [items, expandedIds]
+  );
+
+  useEffect(() => {
+    const path = getNavigationPath(activeId);
+    if (path.length <= 1) return;
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      path.slice(0, -1).forEach((id) => next.add(id));
+      return next;
+    });
+  }, [activeId]);
+
+  useEffect(() => {
+    setFocusedId(activeId);
+  }, [activeId]);
+
+  useEffect(() => {
+    const ref = itemRefs.current.get(focusedId);
+    ref?.focus();
+  }, [focusedId, visibleItems]);
+
+  const registerRef = useCallback((id: string, node: HTMLButtonElement | null) => {
+    if (!node) {
+      itemRefs.current.delete(id);
+    } else {
+      itemRefs.current.set(id, node);
+    }
+  }, []);
+
+  const toggleExpand = useCallback((id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const focusByIndex = useCallback(
+    (index: number) => {
+      if (index < 0 || index >= visibleItems.length) return;
+      setFocusedId(visibleItems[index].node.id);
+    },
+    [visibleItems]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>, item: VisibleItem) => {
+      const index = visibleItems.findIndex((entry) => entry.node.id === item.node.id);
+      const isExpanded = !item.isLeaf && expandedIds.has(item.node.id);
+
+      switch (event.key) {
+        case "ArrowDown": {
+          event.preventDefault();
+          focusByIndex(index + 1);
+          break;
+        }
+        case "ArrowUp": {
+          event.preventDefault();
+          focusByIndex(index - 1);
+          break;
+        }
+        case "ArrowRight": {
+          event.preventDefault();
+          if (!item.isLeaf) {
+            if (!isExpanded) {
+              toggleExpand(item.node.id);
+            } else {
+              focusByIndex(index + 1);
+            }
+          }
+          break;
+        }
+        case "ArrowLeft": {
+          event.preventDefault();
+          if (!item.isLeaf && isExpanded) {
+            toggleExpand(item.node.id);
+          } else if (item.parentId) {
+            const parentIndex = visibleItems.findIndex(
+              (entry) => entry.node.id === item.parentId
+            );
+            if (parentIndex >= 0) {
+              focusByIndex(parentIndex);
+            }
+          }
+          break;
+        }
+        case "Home": {
+          event.preventDefault();
+          focusByIndex(0);
+          break;
+        }
+        case "End": {
+          event.preventDefault();
+          focusByIndex(visibleItems.length - 1);
+          break;
+        }
+        case "Enter":
+        case " ": {
+          event.preventDefault();
+          if (item.isLeaf) {
+            onSelect(item.node.id);
+          } else {
+            toggleExpand(item.node.id);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [expandedIds, focusByIndex, onSelect, toggleExpand, visibleItems]
+  );
+
+  return (
+    <div className={className}>
+      <div role="tree" aria-label="Settings sections" className="space-y-1">
+        {visibleItems.map((item) => {
+          const isExpanded = !item.isLeaf && expandedIds.has(item.node.id);
+          const isActive = item.node.id === activeId;
+          const paddingLeft = 12 + (item.level - 1) * 16;
+
+          return (
+            <div role="none" key={item.node.id}>
+              <button
+                type="button"
+                role="treeitem"
+                ref={(node) => registerRef(item.node.id, node)}
+                aria-level={item.level}
+                aria-expanded={!item.isLeaf ? isExpanded : undefined}
+                aria-selected={item.isLeaf ? isActive : undefined}
+                tabIndex={focusedId === item.node.id ? 0 : -1}
+                onKeyDown={(event) => handleKeyDown(event, item)}
+                onClick={() => {
+                  setFocusedId(item.node.id);
+                  if (item.isLeaf) {
+                    onSelect(item.node.id);
+                  } else {
+                    toggleExpand(item.node.id);
+                  }
+                }}
+                className={`flex w-full items-center gap-2 rounded px-3 py-2 text-left text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange focus-visible:ring-offset-2 focus-visible:ring-offset-transparent ${
+                  isActive
+                    ? "bg-ub-window-title text-white"
+                    : "text-ubt-grey hover:bg-ub-warm-grey hover:bg-opacity-10"
+                }`}
+                style={{ paddingLeft }}
+              >
+                {!item.isLeaf && (
+                  <span
+                    aria-hidden="true"
+                    className={`inline-block text-xs transition-transform ${
+                      isExpanded ? "rotate-90" : ""
+                    }`}
+                  >
+                    ▶
+                  </span>
+                )}
+                <span className="truncate">{item.node.label}</span>
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
@@ -10,10 +10,26 @@ import {
   importSettings as importSettingsData,
 } from "../../utils/settingsStore";
 import KeymapOverlay from "./components/KeymapOverlay";
-import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import NavigationTree from "./components/NavigationTree";
+import {
+  SETTINGS_NAVIGATION,
+  DEFAULT_SECTION_ID,
+  getNavigationItem,
+  getNavigationPath,
+  isLeafId,
+} from "./navigation";
 
-export default function Settings() {
+interface SettingsProps {
+  initialSectionId?: string;
+}
+
+type SettingsWindow = Window & { __settingsSectionTarget?: string };
+
+const sanitizeSectionId = (value?: string | null): string | undefined =>
+  value && isLeafId(value) ? value : undefined;
+
+export default function Settings({ initialSectionId }: SettingsProps = {}) {
   const {
     accent,
     setAccent,
@@ -34,13 +50,45 @@ export default function Settings() {
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const tabs = [
-    { id: "appearance", label: "Appearance" },
-    { id: "accessibility", label: "Accessibility" },
-    { id: "privacy", label: "Privacy" },
-  ] as const;
-  type TabId = (typeof tabs)[number]["id"];
-  const [activeTab, setActiveTab] = useState<TabId>("appearance");
+  const pickInitialSection = () => {
+    const fromProp = sanitizeSectionId(initialSectionId);
+    if (typeof window === "undefined") {
+      return fromProp ?? DEFAULT_SECTION_ID;
+    }
+    const params = new URLSearchParams(window.location.search);
+    const fromQuery = sanitizeSectionId(params.get("section"));
+    const pending = sanitizeSectionId(
+      (window as SettingsWindow).__settingsSectionTarget
+    );
+    return fromProp ?? fromQuery ?? pending ?? DEFAULT_SECTION_ID;
+  };
+
+  const [activeSection, setActiveSection] = useState<string>(pickInitialSection);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    delete (window as SettingsWindow).__settingsSectionTarget;
+  }, []);
+
+  useEffect(() => {
+    const target = sanitizeSectionId(initialSectionId);
+    if (target && target !== activeSection) {
+      setActiveSection(target);
+    }
+  }, [initialSectionId, activeSection]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handleNavigate = (event: Event) => {
+      const detail = (event as CustomEvent<{ section?: string }>).detail;
+      const next = sanitizeSectionId(detail?.section);
+      if (next && next !== activeSection) {
+        setActiveSection(next);
+      }
+    };
+    window.addEventListener("settings:navigate", handleNavigate);
+    return () => window.removeEventListener("settings:navigate", handleNavigate);
+  }, [activeSection]);
 
   const wallpapers = [
     "wall-1",
@@ -105,201 +153,315 @@ export default function Settings() {
 
   const [showKeymap, setShowKeymap] = useState(false);
 
-  return (
-    <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
-      <div className="flex justify-center border-b border-gray-900">
-        <Tabs tabs={tabs} active={activeTab} onChange={setActiveTab} />
-      </div>
-      {activeTab === "appearance" && (
-        <>
-          <div
-            className="md:w-2/5 w-2/3 h-1/3 m-auto my-4"
-            style={{
-              backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
-              backgroundSize: "cover",
-              backgroundRepeat: "no-repeat",
-              backgroundPosition: "center center",
-            }}
-          ></div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Theme:</label>
-            <select
-              value={theme}
-              onChange={(e) => setTheme(e.target.value)}
-              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-            >
-              <option value="default">Default</option>
-              <option value="dark">Dark</option>
-              <option value="neon">Neon</option>
-              <option value="matrix">Matrix</option>
-            </select>
-          </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Accent:</label>
-            <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
-              {ACCENT_OPTIONS.map((c) => (
-                <button
-                  key={c}
-                  aria-label={`select-accent-${c}`}
-                  role="radio"
-                  aria-checked={accent === c}
-                  onClick={() => setAccent(c)}
-                  className={`w-8 h-8 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
-                  style={{ backgroundColor: c }}
-                />
+  const activeItem = useMemo(
+    () => getNavigationItem(activeSection),
+    [activeSection]
+  );
+  const parentItem = useMemo(() => {
+    const path = getNavigationPath(activeSection);
+    const parentId = path.length > 1 ? path[path.length - 2] : undefined;
+    return parentId ? getNavigationItem(parentId) : undefined;
+  }, [activeSection]);
+
+  const wallpaperPreview = (
+    <div className="flex justify-center">
+      <div
+        role="img"
+        aria-label={`Wallpaper preview ${wallpaper.replace("wall-", "").trim()}`}
+        className="w-full max-w-xl aspect-video rounded-lg border border-gray-900 shadow-inner"
+        style={{
+          backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
+          backgroundSize: "cover",
+          backgroundRepeat: "no-repeat",
+          backgroundPosition: "center center",
+        }}
+      ></div>
+    </div>
+  );
+
+  const renderSection = () => {
+    switch (activeSection) {
+      case "appearance.theme":
+        return (
+          <section
+            aria-labelledby="settings-section-title"
+            className="space-y-6"
+          >
+            {wallpaperPreview}
+            <div className="flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
+              <label htmlFor="theme-select" className="text-ubt-grey">
+                Theme:
+              </label>
+              <select
+                id="theme-select"
+                value={theme}
+                onChange={(e) => setTheme(e.target.value)}
+                className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+              >
+                <option value="default">Default</option>
+                <option value="dark">Dark</option>
+                <option value="neon">Neon</option>
+                <option value="matrix">Matrix</option>
+              </select>
+            </div>
+            <div className="flex flex-col items-center gap-3">
+              <span className="text-ubt-grey">Accent:</span>
+              <div
+                aria-label="Accent color picker"
+                role="radiogroup"
+                className="flex gap-2"
+              >
+                {ACCENT_OPTIONS.map((c) => (
+                  <button
+                    key={c}
+                    aria-label={`select-accent-${c}`}
+                    role="radio"
+                    aria-checked={accent === c}
+                    onClick={() => setAccent(c)}
+                    className={`w-8 h-8 rounded-full border-2 ${
+                      accent === c ? "border-white" : "border-transparent"
+                    }`}
+                    style={{ backgroundColor: c }}
+                  />
+                ))}
+              </div>
+            </div>
+          </section>
+        );
+      case "appearance.wallpaper":
+        return (
+          <section
+            aria-labelledby="settings-section-title"
+            className="space-y-6"
+          >
+            {wallpaperPreview}
+            <div className="flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
+              <label htmlFor="wallpaper-slider" className="text-ubt-grey">
+                Wallpaper:
+              </label>
+              <input
+                id="wallpaper-slider"
+                type="range"
+                min="0"
+                max={wallpapers.length - 1}
+                step="1"
+                value={wallpapers.indexOf(wallpaper)}
+                onChange={(e) =>
+                  changeBackground(wallpapers[parseInt(e.target.value, 10)])
+                }
+                className="ubuntu-slider"
+                aria-label="Wallpaper"
+              />
+            </div>
+            <div className="flex justify-center">
+              <BackgroundSlideshow />
+            </div>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900 pt-4">
+              {wallpapers.map((name) => (
+                <div
+                  key={name}
+                  role="button"
+                  aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
+                  aria-pressed={name === wallpaper}
+                  tabIndex={0}
+                  onClick={() => changeBackground(name)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      changeBackground(name);
+                    }
+                  }}
+                  className={`${
+                    name === wallpaper ? "border-yellow-700" : "border-transparent"
+                  } md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80`}
+                  style={{
+                    backgroundImage: `url(/wallpapers/${name}.webp)`,
+                    backgroundSize: "cover",
+                    backgroundRepeat: "no-repeat",
+                    backgroundPosition: "center center",
+                  }}
+                ></div>
               ))}
             </div>
-          </div>
-          <div className="flex justify-center my-4">
-            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>
-            <input
-              id="wallpaper-slider"
-              type="range"
-              min="0"
-              max={wallpapers.length - 1}
-              step="1"
-              value={wallpapers.indexOf(wallpaper)}
-              onChange={(e) =>
-                changeBackground(wallpapers[parseInt(e.target.value, 10)])
-              }
-              className="ubuntu-slider"
-              aria-label="Wallpaper"
-            />
-          </div>
-          <div className="flex justify-center my-4">
-            <BackgroundSlideshow />
-          </div>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
-            {wallpapers.map((name) => (
-              <div
-                key={name}
-                role="button"
-                aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
-                aria-pressed={name === wallpaper}
-                tabIndex={0}
-                onClick={() => changeBackground(name)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    changeBackground(name);
-                  }
-                }}
-                className={
-                  (name === wallpaper
-                    ? " border-yellow-700 "
-                    : " border-transparent ") +
-                  " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"
-                }
-                style={{
-                  backgroundImage: `url(/wallpapers/${name}.webp)`,
-                  backgroundSize: "cover",
-                  backgroundRepeat: "no-repeat",
-                  backgroundPosition: "center center",
-                }}
-              ></div>
-            ))}
-          </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
-            <button
-              onClick={handleReset}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
+          </section>
+        );
+      case "appearance.reset":
+        return (
+          <section
+            aria-labelledby="settings-section-title"
+            className="space-y-4 text-center"
+          >
+            <p className="text-sm text-ubt-grey">
+              Resetting clears your saved theme, wallpaper, and layout
+              preferences.
+            </p>
+            <div className="flex justify-center">
+              <button
+                onClick={handleReset}
+                className="px-4 py-2 rounded bg-ub-orange text-white"
+              >
+                Reset Desktop
+              </button>
+            </div>
+          </section>
+        );
+      case "accessibility.display":
+        return (
+          <section
+            aria-labelledby="settings-section-title"
+            className="space-y-6"
+          >
+            <div className="flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
+              <label htmlFor="font-scale" className="text-ubt-grey">
+                Icon Size:
+              </label>
+              <input
+                id="font-scale"
+                type="range"
+                min="0.75"
+                max="1.5"
+                step="0.05"
+                value={fontScale}
+                onChange={(e) => setFontScale(parseFloat(e.target.value))}
+                className="ubuntu-slider"
+                aria-label="Icon size"
+              />
+            </div>
+            <div className="flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
+              <label htmlFor="density-select" className="text-ubt-grey">
+                Density:
+              </label>
+              <select
+                id="density-select"
+                value={density}
+                onChange={(e) => setDensity(e.target.value as any)}
+                className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+              >
+                <option value="regular">Regular</option>
+                <option value="compact">Compact</option>
+              </select>
+            </div>
+          </section>
+        );
+      case "accessibility.interaction":
+        return (
+          <section
+            aria-labelledby="settings-section-title"
+            className="space-y-4"
+          >
+            <div className="flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
+              <span className="text-ubt-grey">Reduced Motion:</span>
+              <ToggleSwitch
+                checked={reducedMotion}
+                onChange={setReducedMotion}
+                ariaLabel="Reduced Motion"
+              />
+            </div>
+            <div className="flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
+              <span className="text-ubt-grey">High Contrast:</span>
+              <ToggleSwitch
+                checked={highContrast}
+                onChange={setHighContrast}
+                ariaLabel="High Contrast"
+              />
+            </div>
+            <div className="flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
+              <span className="text-ubt-grey">Haptics:</span>
+              <ToggleSwitch
+                checked={haptics}
+                onChange={setHaptics}
+                ariaLabel="Haptics"
+              />
+            </div>
+            <div className="flex justify-center pt-2">
+              <button
+                onClick={() => setShowKeymap(true)}
+                className="px-4 py-2 rounded bg-ub-orange text-white"
+              >
+                Edit Shortcuts
+              </button>
+            </div>
+          </section>
+        );
+      case "privacy.data":
+        return (
+          <section
+            aria-labelledby="settings-section-title"
+            className="space-y-4 text-center"
+          >
+            <p className="text-sm text-ubt-grey">
+              Export a backup of your desktop preferences or restore a saved
+              configuration.
+            </p>
+            <div className="flex justify-center gap-4">
+              <button
+                onClick={handleExport}
+                className="px-4 py-2 rounded bg-ub-orange text-white"
+              >
+                Export Settings
+              </button>
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                className="px-4 py-2 rounded bg-ub-orange text-white"
+              >
+                Import Settings
+              </button>
+            </div>
+          </section>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="w-full flex flex-col flex-grow z-20 max-h-full windowMainScreen select-none bg-ub-cool-grey">
+      <div className="flex flex-1 flex-col md:flex-row overflow-hidden border-b md:border-b-0 md:border-r-0">
+        <aside className="md:w-64 border-b md:border-b-0 md:border-r border-gray-900 bg-ub-cool-grey/70 overflow-y-auto">
+          <NavigationTree
+            items={SETTINGS_NAVIGATION}
+            activeId={activeSection}
+            onSelect={(id) => {
+              const next = sanitizeSectionId(id);
+              if (next) setActiveSection(next);
+            }}
+            className="p-3"
+          />
+        </aside>
+        <main className="flex-1 overflow-y-auto p-4 md:p-6 text-ubt-grey select-text">
+          <header className="mb-6">
+            {parentItem && (
+              <p className="text-xs uppercase tracking-wide text-ubt-grey">
+                {parentItem.label}
+              </p>
+            )}
+            <h2
+              id="settings-section-title"
+              className="text-2xl font-semibold text-white"
             >
-              Reset Desktop
-            </button>
-          </div>
-        </>
-      )}
-      {activeTab === "accessibility" && (
-        <>
-          <div className="flex justify-center my-4">
-            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">Icon Size:</label>
-            <input
-              id="font-scale"
-              type="range"
-              min="0.75"
-              max="1.5"
-              step="0.05"
-              value={fontScale}
-              onChange={(e) => setFontScale(parseFloat(e.target.value))}
-              className="ubuntu-slider"
-              aria-label="Icon size"
-            />
-          </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Density:</label>
-            <select
-              value={density}
-              onChange={(e) => setDensity(e.target.value as any)}
-              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-            >
-              <option value="regular">Regular</option>
-              <option value="compact">Compact</option>
-            </select>
-          </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">Reduced Motion:</span>
-            <ToggleSwitch
-              checked={reducedMotion}
-              onChange={setReducedMotion}
-              ariaLabel="Reduced Motion"
-            />
-          </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">High Contrast:</span>
-            <ToggleSwitch
-              checked={highContrast}
-              onChange={setHighContrast}
-              ariaLabel="High Contrast"
-            />
-          </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">Haptics:</span>
-            <ToggleSwitch
-              checked={haptics}
-              onChange={setHaptics}
-              ariaLabel="Haptics"
-            />
-          </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
-            <button
-              onClick={() => setShowKeymap(true)}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Edit Shortcuts
-            </button>
-          </div>
-        </>
-      )}
-      {activeTab === "privacy" && (
-        <>
-          <div className="flex justify-center my-4 space-x-4">
-            <button
-              onClick={handleExport}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Export Settings
-            </button>
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Import Settings
-            </button>
-          </div>
-        </>
-      )}
-        <input
-          type="file"
-          accept="application/json"
-          ref={fileInputRef}
-          aria-label="Import settings file"
-          onChange={(e) => {
-            const file = e.target.files && e.target.files[0];
-            if (file) handleImport(file);
-            e.target.value = "";
-          }}
-          className="hidden"
-        />
+              {activeItem?.label ?? "Settings"}
+            </h2>
+            {activeItem?.description && (
+              <p className="mt-1 text-sm text-ubt-grey">
+                {activeItem.description}
+              </p>
+            )}
+          </header>
+          {renderSection()}
+        </main>
+      </div>
+      <input
+        type="file"
+        accept="application/json"
+        ref={fileInputRef}
+        aria-label="Import settings file"
+        onChange={(e) => {
+          const file = e.target.files && e.target.files[0];
+          if (file) handleImport(file);
+          e.target.value = "";
+        }}
+        className="hidden"
+      />
       <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
     </div>
   );

--- a/apps/settings/navigation.ts
+++ b/apps/settings/navigation.ts
@@ -1,0 +1,101 @@
+export interface NavigationItem {
+  id: string;
+  label: string;
+  description?: string;
+  children?: NavigationItem[];
+}
+
+export const SETTINGS_NAVIGATION: NavigationItem[] = [
+  {
+    id: "appearance",
+    label: "Appearance",
+    children: [
+      {
+        id: "appearance.theme",
+        label: "Theme & Accent",
+        description: "Set the desktop theme and accent color palette.",
+      },
+      {
+        id: "appearance.wallpaper",
+        label: "Wallpaper & Slideshow",
+        description: "Choose wallpapers or enable the rotating slideshow.",
+      },
+      {
+        id: "appearance.reset",
+        label: "Reset Desktop",
+        description: "Restore wallpapers, colors, and layout defaults.",
+      },
+    ],
+  },
+  {
+    id: "accessibility",
+    label: "Accessibility",
+    children: [
+      {
+        id: "accessibility.display",
+        label: "Display & Layout",
+        description: "Adjust icon sizing and overall interface density.",
+      },
+      {
+        id: "accessibility.interaction",
+        label: "Interaction",
+        description: "Toggle accessibility helpers and manage shortcuts.",
+      },
+    ],
+  },
+  {
+    id: "privacy",
+    label: "Privacy & Data",
+    children: [
+      {
+        id: "privacy.data",
+        label: "Import & Export",
+        description: "Back up or restore your desktop configuration.",
+      },
+    ],
+  },
+];
+
+const navigationMap = new Map<string, NavigationItem>();
+const navigationPaths = new Map<string, string[]>();
+
+const buildIndex = (
+  items: NavigationItem[],
+  parentPath: string[] = []
+): void => {
+  items.forEach((item) => {
+    const currentPath = [...parentPath, item.id];
+    navigationMap.set(item.id, item);
+    navigationPaths.set(item.id, currentPath);
+    if (item.children && item.children.length > 0) {
+      buildIndex(item.children, currentPath);
+    }
+  });
+};
+
+buildIndex(SETTINGS_NAVIGATION);
+
+const findFirstLeaf = (items: NavigationItem[]): NavigationItem | undefined => {
+  for (const item of items) {
+    if (item.children && item.children.length > 0) {
+      const leaf = findFirstLeaf(item.children);
+      if (leaf) return leaf;
+    } else {
+      return item;
+    }
+  }
+  return undefined;
+};
+
+export const DEFAULT_SECTION_ID = findFirstLeaf(SETTINGS_NAVIGATION)?.id ?? "";
+
+export const getNavigationItem = (id: string): NavigationItem | undefined =>
+  navigationMap.get(id);
+
+export const getNavigationPath = (id: string): string[] =>
+  navigationPaths.get(id) ?? [];
+
+export const isLeafId = (id: string): boolean => {
+  const item = navigationMap.get(id);
+  return !!item && (!item.children || item.children.length === 0);
+};

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -17,8 +17,12 @@ function DesktopMenu(props) {
         props.openApp("terminal");
     }
 
-    const openSettings = () => {
-        props.openApp("settings");
+    const openSettings = (section) => {
+        if (section) {
+            props.openApp("settings", { section });
+        } else {
+            props.openApp("settings");
+        }
     }
 
     const checkFullScreen = () => {
@@ -87,7 +91,7 @@ function DesktopMenu(props) {
             </button>
             <Devider />
             <button
-                onClick={openSettings}
+                onClick={() => openSettings("appearance.wallpaper")}
                 type="button"
                 role="menuitem"
                 aria-label="Change Background"
@@ -100,7 +104,7 @@ function DesktopMenu(props) {
                 <span className="ml-5">Display Settings</span>
             </div>
             <button
-                onClick={openSettings}
+                onClick={() => openSettings()}
                 type="button"
                 role="menuitem"
                 aria-label="Settings"


### PR DESCRIPTION
## Summary
- add a structured navigation schema for settings sections and render it through a keyboard-friendly tree component
- rework the settings page to use the tree selection, presenting themed, wallpaper, accessibility, and privacy sections with contextual descriptions
- let desktop launchers pass a target section when opening the settings app so shortcuts can jump directly into the new tree

## Testing
- yarn lint *(fails: pre-existing jsx-a11y/control-has-associated-label and no-top-level-window errors across unrelated apps)*
- yarn test *(fails: existing act warnings in window/pdf viewer/about suites)*

------
https://chatgpt.com/codex/tasks/task_e_68cab66418948328b1b13ebbd105c2dd