### PR TITLE
[settings] add subsection navigation sidebar

### DIFF
--- a/apps/settings/components/SubsectionSidebar.tsx
+++ b/apps/settings/components/SubsectionSidebar.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import {
+  type KeyboardEvent,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { settingsSubsections, type SettingsTabId } from "../navigation";
+
+interface SubsectionSidebarProps {
+  activeTab: SettingsTabId;
+  scrollContainerRef: RefObject<HTMLElement | null>;
+}
+
+const focusElement = (element: HTMLAnchorElement | null) => {
+  if (element) {
+    element.focus();
+  }
+};
+
+const SubsectionSidebar = ({
+  activeTab,
+  scrollContainerRef,
+}: SubsectionSidebarProps) => {
+  const sections = useMemo(() => settingsSubsections[activeTab] ?? [], [activeTab]);
+  const [activeSection, setActiveSection] = useState<string>(
+    sections[0]?.id ?? ""
+  );
+  const linkRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+
+  const observerRoot = scrollContainerRef.current;
+
+  useEffect(() => {
+    setActiveSection(sections[0]?.id ?? "");
+  }, [sections]);
+
+  useEffect(() => {
+    if (!sections.length) {
+      return;
+    }
+
+    const targets = sections
+      .map((section) => document.getElementById(section.id))
+      .filter((element): element is HTMLElement => Boolean(element));
+
+    if (!targets.length) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visibleEntries = entries.filter((entry) => entry.isIntersecting);
+
+        if (visibleEntries.length > 0) {
+          const topMost = visibleEntries.reduce((closest, entry) =>
+            entry.boundingClientRect.top < closest.boundingClientRect.top
+              ? entry
+              : closest
+          );
+          setActiveSection(topMost.target.id);
+          return;
+        }
+
+        const nearest = [...entries].sort(
+          (a, b) =>
+            Math.abs(a.boundingClientRect.top) - Math.abs(b.boundingClientRect.top)
+        )[0];
+
+        if (nearest) {
+          setActiveSection(nearest.target.id);
+        }
+      },
+      {
+        root: observerRoot ?? null,
+        rootMargin: "-40% 0px -40% 0px",
+        threshold: [0, 0.25, 0.5, 0.75, 1],
+      }
+    );
+
+    targets.forEach((element) => observer.observe(element));
+
+    return () => observer.disconnect();
+  }, [sections, observerRoot]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLAnchorElement>, index: number) => {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        const nextIndex = Math.min(index + 1, sections.length - 1);
+        focusElement(linkRefs.current[nextIndex] ?? null);
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        const prevIndex = Math.max(index - 1, 0);
+        focusElement(linkRefs.current[prevIndex] ?? null);
+      } else if (event.key === "Home") {
+        event.preventDefault();
+        focusElement(linkRefs.current[0] ?? null);
+      } else if (event.key === "End") {
+        event.preventDefault();
+        focusElement(linkRefs.current[sections.length - 1] ?? null);
+      }
+    },
+    [sections.length]
+  );
+
+  if (!sections.length) {
+    return null;
+  }
+
+  return (
+    <aside className="w-60 shrink-0 border-r border-gray-900 bg-ub-cool-grey/70">
+      <nav aria-label="Settings subsections" className="sticky top-0 max-h-full overflow-y-auto px-4 py-6">
+        <ul className="flex flex-col gap-1">
+          {sections.map((section, index) => {
+            const isActive = section.id === activeSection;
+            return (
+              <li key={section.id}>
+                <a
+                  href={`#${section.id}`}
+                  aria-current={isActive ? "true" : undefined}
+                  className={`block rounded px-3 py-2 text-sm transition focus:outline-none focus:ring-2 focus:ring-ubt-blue/60 ${
+                    isActive
+                      ? "bg-ub-orange text-white"
+                      : "text-ubt-grey hover:bg-ubt-grey/20"
+                  }`}
+                  ref={(element) => {
+                    linkRefs.current[index] = element;
+                  }}
+                  onKeyDown={(event) => handleKeyDown(event, index)}
+                  onClick={() => setActiveSection(section.id)}
+                >
+                  {section.label}
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </aside>
+  );
+};
+
+export default SubsectionSidebar;

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,8 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import SubsectionSidebar from "./components/SubsectionSidebar";
+import { settingsTabs, type SettingsTabId } from "./navigation";
 
 export default function Settings() {
   const {
@@ -33,14 +35,10 @@ export default function Settings() {
     setTheme,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
 
-  const tabs = [
-    { id: "appearance", label: "Appearance" },
-    { id: "accessibility", label: "Accessibility" },
-    { id: "privacy", label: "Privacy" },
-  ] as const;
-  type TabId = (typeof tabs)[number]["id"];
-  const [activeTab, setActiveTab] = useState<TabId>("appearance");
+  const tabs = settingsTabs;
+  const [activeTab, setActiveTab] = useState<SettingsTabId>("appearance");
 
   const wallpapers = [
     "wall-1",
@@ -105,201 +103,330 @@ export default function Settings() {
 
   const [showKeymap, setShowKeymap] = useState(false);
 
+  const headingClass =
+    "text-sm font-semibold uppercase tracking-wide text-ubt-light";
+  const labelClass = "text-ubt-grey";
+
   return (
-    <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
+    <div className="w-full flex flex-col flex-grow z-20 max-h-full overflow-hidden windowMainScreen select-none bg-ub-cool-grey">
       <div className="flex justify-center border-b border-gray-900">
         <Tabs tabs={tabs} active={activeTab} onChange={setActiveTab} />
       </div>
-      {activeTab === "appearance" && (
-        <>
-          <div
-            className="md:w-2/5 w-2/3 h-1/3 m-auto my-4"
-            style={{
-              backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
-              backgroundSize: "cover",
-              backgroundRepeat: "no-repeat",
-              backgroundPosition: "center center",
-            }}
-          ></div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Theme:</label>
-            <select
-              value={theme}
-              onChange={(e) => setTheme(e.target.value)}
-              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-            >
-              <option value="default">Default</option>
-              <option value="dark">Dark</option>
-              <option value="neon">Neon</option>
-              <option value="matrix">Matrix</option>
-            </select>
-          </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Accent:</label>
-            <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
-              {ACCENT_OPTIONS.map((c) => (
-                <button
-                  key={c}
-                  aria-label={`select-accent-${c}`}
-                  role="radio"
-                  aria-checked={accent === c}
-                  onClick={() => setAccent(c)}
-                  className={`w-8 h-8 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
-                  style={{ backgroundColor: c }}
-                />
-              ))}
-            </div>
-          </div>
-          <div className="flex justify-center my-4">
-            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>
-            <input
-              id="wallpaper-slider"
-              type="range"
-              min="0"
-              max={wallpapers.length - 1}
-              step="1"
-              value={wallpapers.indexOf(wallpaper)}
-              onChange={(e) =>
-                changeBackground(wallpapers[parseInt(e.target.value, 10)])
-              }
-              className="ubuntu-slider"
-              aria-label="Wallpaper"
-            />
-          </div>
-          <div className="flex justify-center my-4">
-            <BackgroundSlideshow />
-          </div>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
-            {wallpapers.map((name) => (
-              <div
-                key={name}
-                role="button"
-                aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
-                aria-pressed={name === wallpaper}
-                tabIndex={0}
-                onClick={() => changeBackground(name)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    changeBackground(name);
-                  }
-                }}
-                className={
-                  (name === wallpaper
-                    ? " border-yellow-700 "
-                    : " border-transparent ") +
-                  " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"
-                }
-                style={{
-                  backgroundImage: `url(/wallpapers/${name}.webp)`,
-                  backgroundSize: "cover",
-                  backgroundRepeat: "no-repeat",
-                  backgroundPosition: "center center",
-                }}
-              ></div>
-            ))}
-          </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
-            <button
-              onClick={handleReset}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Reset Desktop
-            </button>
-          </div>
-        </>
-      )}
-      {activeTab === "accessibility" && (
-        <>
-          <div className="flex justify-center my-4">
-            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">Icon Size:</label>
-            <input
-              id="font-scale"
-              type="range"
-              min="0.75"
-              max="1.5"
-              step="0.05"
-              value={fontScale}
-              onChange={(e) => setFontScale(parseFloat(e.target.value))}
-              className="ubuntu-slider"
-              aria-label="Icon size"
-            />
-          </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Density:</label>
-            <select
-              value={density}
-              onChange={(e) => setDensity(e.target.value as any)}
-              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-            >
-              <option value="regular">Regular</option>
-              <option value="compact">Compact</option>
-            </select>
-          </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">Reduced Motion:</span>
-            <ToggleSwitch
-              checked={reducedMotion}
-              onChange={setReducedMotion}
-              ariaLabel="Reduced Motion"
-            />
-          </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">High Contrast:</span>
-            <ToggleSwitch
-              checked={highContrast}
-              onChange={setHighContrast}
-              ariaLabel="High Contrast"
-            />
-          </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">Haptics:</span>
-            <ToggleSwitch
-              checked={haptics}
-              onChange={setHaptics}
-              ariaLabel="Haptics"
-            />
-          </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
-            <button
-              onClick={() => setShowKeymap(true)}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Edit Shortcuts
-            </button>
-          </div>
-        </>
-      )}
-      {activeTab === "privacy" && (
-        <>
-          <div className="flex justify-center my-4 space-x-4">
-            <button
-              onClick={handleExport}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Export Settings
-            </button>
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Import Settings
-            </button>
-          </div>
-        </>
-      )}
-        <input
-          type="file"
-          accept="application/json"
-          ref={fileInputRef}
-          aria-label="Import settings file"
-          onChange={(e) => {
-            const file = e.target.files && e.target.files[0];
-            if (file) handleImport(file);
-            e.target.value = "";
-          }}
-          className="hidden"
+      <div className="flex flex-1 min-h-0">
+        <SubsectionSidebar
+          activeTab={activeTab}
+          scrollContainerRef={contentRef}
         />
+        <div
+          ref={contentRef}
+          className="flex-1 overflow-y-auto px-6 py-6 space-y-10"
+        >
+          {activeTab === "appearance" && (
+            <div className="space-y-10">
+              <section aria-labelledby="appearance-preview" className="space-y-4">
+                <h2 id="appearance-preview" className={headingClass}>
+                  Preview
+                </h2>
+                <div
+                  className="mx-auto h-48 w-full max-w-xl rounded border border-gray-900"
+                  style={{
+                    backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
+                    backgroundSize: "cover",
+                    backgroundRepeat: "no-repeat",
+                    backgroundPosition: "center center",
+                  }}
+                  aria-hidden="true"
+                />
+              </section>
+
+              <section aria-labelledby="appearance-theme" className="space-y-4">
+                <h2 id="appearance-theme" className={headingClass}>
+                  Theme
+                </h2>
+                <div className="flex flex-wrap items-center gap-4">
+                  <label htmlFor="theme-select" className={labelClass}>
+                    Theme
+                  </label>
+                  <select
+                    id="theme-select"
+                    value={theme}
+                    onChange={(e) => setTheme(e.target.value)}
+                    className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                  >
+                    <option value="default">Default</option>
+                    <option value="dark">Dark</option>
+                    <option value="neon">Neon</option>
+                    <option value="matrix">Matrix</option>
+                  </select>
+                </div>
+              </section>
+
+              <section aria-labelledby="appearance-accent" className="space-y-4">
+                <h2 id="appearance-accent" className={headingClass}>
+                  Accent
+                </h2>
+                <div className="flex flex-wrap items-center gap-4">
+                  <span className={labelClass}>Accent color</span>
+                  <div
+                    aria-label="Accent color picker"
+                    role="radiogroup"
+                    className="flex flex-wrap gap-2"
+                  >
+                    {ACCENT_OPTIONS.map((c) => (
+                      <button
+                        key={c}
+                        aria-label={`select-accent-${c}`}
+                        role="radio"
+                        aria-checked={accent === c}
+                        onClick={() => setAccent(c)}
+                        className={`h-8 w-8 rounded-full border-2 ${
+                          accent === c ? "border-white" : "border-transparent"
+                        }`}
+                        style={{ backgroundColor: c }}
+                      />
+                    ))}
+                  </div>
+                </div>
+              </section>
+
+              <section aria-labelledby="appearance-wallpaper" className="space-y-4">
+                <h2 id="appearance-wallpaper" className={headingClass}>
+                  Wallpaper
+                </h2>
+                <div className="flex flex-wrap items-center gap-4">
+                  <label htmlFor="wallpaper-slider" className={labelClass}>
+                    Wallpaper
+                  </label>
+                  <input
+                    id="wallpaper-slider"
+                    type="range"
+                    min="0"
+                    max={wallpapers.length - 1}
+                    step="1"
+                    value={wallpapers.indexOf(wallpaper)}
+                    onChange={(e) =>
+                      changeBackground(wallpapers[parseInt(e.target.value, 10)])
+                    }
+                    className="ubuntu-slider"
+                    aria-label="Wallpaper"
+                  />
+                </div>
+              </section>
+
+              <section
+                aria-labelledby="appearance-slideshow"
+                className="space-y-4"
+              >
+                <h2 id="appearance-slideshow" className={headingClass}>
+                  Background Slideshow
+                </h2>
+                <div className="max-w-md">
+                  <BackgroundSlideshow />
+                </div>
+              </section>
+
+              <section aria-labelledby="appearance-library" className="space-y-4">
+                <h2 id="appearance-library" className={headingClass}>
+                  Wallpaper Gallery
+                </h2>
+                <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+                  {wallpapers.map((name) => (
+                    <div
+                      key={name}
+                      role="button"
+                      aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
+                      aria-pressed={name === wallpaper}
+                      tabIndex={0}
+                      onClick={() => changeBackground(name)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          changeBackground(name);
+                        }
+                      }}
+                      className={
+                        (name === wallpaper
+                          ? " border-yellow-700 "
+                          : " border-transparent ") +
+                        " aspect-video rounded border-4 border-opacity-80 outline-none"
+                      }
+                      style={{
+                        backgroundImage: `url(/wallpapers/${name}.webp)`,
+                        backgroundSize: "cover",
+                        backgroundRepeat: "no-repeat",
+                        backgroundPosition: "center center",
+                      }}
+                    ></div>
+                  ))}
+                </div>
+              </section>
+
+              <section aria-labelledby="appearance-reset" className="space-y-4">
+                <h2 id="appearance-reset" className={headingClass}>
+                  Reset
+                </h2>
+                <button
+                  onClick={handleReset}
+                  className="rounded bg-ub-orange px-4 py-2 text-white"
+                >
+                  Reset Desktop
+                </button>
+              </section>
+            </div>
+          )}
+
+          {activeTab === "accessibility" && (
+            <div className="space-y-10">
+              <section
+                aria-labelledby="accessibility-icon-size"
+                className="space-y-4"
+              >
+                <h2 id="accessibility-icon-size" className={headingClass}>
+                  Icon Size
+                </h2>
+                <div className="flex flex-wrap items-center gap-4">
+                  <label htmlFor="font-scale" className={labelClass}>
+                    Icon Size
+                  </label>
+                  <input
+                    id="font-scale"
+                    type="range"
+                    min="0.75"
+                    max="1.5"
+                    step="0.05"
+                    value={fontScale}
+                    onChange={(e) => setFontScale(parseFloat(e.target.value))}
+                    className="ubuntu-slider"
+                    aria-label="Icon size"
+                  />
+                </div>
+              </section>
+
+              <section
+                aria-labelledby="accessibility-density"
+                className="space-y-4"
+              >
+                <h2 id="accessibility-density" className={headingClass}>
+                  Interface Density
+                </h2>
+                <div className="flex flex-wrap items-center gap-4">
+                  <label className={labelClass}>Density</label>
+                  <select
+                    value={density}
+                    onChange={(e) => setDensity(e.target.value as any)}
+                    className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                  >
+                    <option value="regular">Regular</option>
+                    <option value="compact">Compact</option>
+                  </select>
+                </div>
+              </section>
+
+              <section
+                aria-labelledby="accessibility-reduced-motion"
+                className="space-y-4"
+              >
+                <h2 id="accessibility-reduced-motion" className={headingClass}>
+                  Reduced Motion
+                </h2>
+                <div className="flex flex-wrap items-center gap-4">
+                  <span className={labelClass}>Reduced Motion</span>
+                  <ToggleSwitch
+                    checked={reducedMotion}
+                    onChange={setReducedMotion}
+                    ariaLabel="Reduced Motion"
+                  />
+                </div>
+              </section>
+
+              <section
+                aria-labelledby="accessibility-high-contrast"
+                className="space-y-4"
+              >
+                <h2 id="accessibility-high-contrast" className={headingClass}>
+                  High Contrast
+                </h2>
+                <div className="flex flex-wrap items-center gap-4">
+                  <span className={labelClass}>High Contrast</span>
+                  <ToggleSwitch
+                    checked={highContrast}
+                    onChange={setHighContrast}
+                    ariaLabel="High Contrast"
+                  />
+                </div>
+              </section>
+
+              <section
+                aria-labelledby="accessibility-haptics"
+                className="space-y-4"
+              >
+                <h2 id="accessibility-haptics" className={headingClass}>
+                  Haptics
+                </h2>
+                <div className="flex flex-wrap items-center gap-4">
+                  <span className={labelClass}>Haptics</span>
+                  <ToggleSwitch
+                    checked={haptics}
+                    onChange={setHaptics}
+                    ariaLabel="Haptics"
+                  />
+                </div>
+              </section>
+
+              <section
+                aria-labelledby="accessibility-shortcuts"
+                className="space-y-4"
+              >
+                <h2 id="accessibility-shortcuts" className={headingClass}>
+                  Keyboard Shortcuts
+                </h2>
+                <button
+                  onClick={() => setShowKeymap(true)}
+                  className="rounded bg-ub-orange px-4 py-2 text-white"
+                >
+                  Edit Shortcuts
+                </button>
+              </section>
+            </div>
+          )}
+
+          {activeTab === "privacy" && (
+            <div className="space-y-10">
+              <section aria-labelledby="privacy-backup" className="space-y-4">
+                <h2 id="privacy-backup" className={headingClass}>
+                  Backup &amp; Restore
+                </h2>
+                <div className="flex flex-wrap items-center gap-4">
+                  <button
+                    onClick={handleExport}
+                    className="rounded bg-ub-orange px-4 py-2 text-white"
+                  >
+                    Export Settings
+                  </button>
+                  <button
+                    onClick={() => fileInputRef.current?.click()}
+                    className="rounded bg-ub-orange px-4 py-2 text-white"
+                  >
+                    Import Settings
+                  </button>
+                </div>
+              </section>
+            </div>
+          )}
+        </div>
+      </div>
+      <input
+        type="file"
+        accept="application/json"
+        ref={fileInputRef}
+        aria-label="Import settings file"
+        onChange={(e) => {
+          const file = e.target.files && e.target.files[0];
+          if (file) handleImport(file);
+          e.target.value = "";
+        }}
+        className="hidden"
+      />
       <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
     </div>
   );

--- a/apps/settings/navigation.ts
+++ b/apps/settings/navigation.ts
@@ -1,0 +1,35 @@
+export const settingsTabs = [
+  { id: "appearance", label: "Appearance" },
+  { id: "accessibility", label: "Accessibility" },
+  { id: "privacy", label: "Privacy" },
+] as const;
+
+export type SettingsTabId = (typeof settingsTabs)[number]["id"];
+
+export type SettingsSubsection = {
+  id: string;
+  label: string;
+};
+
+export const settingsSubsections: Record<SettingsTabId, SettingsSubsection[]> = {
+  appearance: [
+    { id: "appearance-preview", label: "Preview" },
+    { id: "appearance-theme", label: "Theme" },
+    { id: "appearance-accent", label: "Accent" },
+    { id: "appearance-wallpaper", label: "Wallpaper" },
+    { id: "appearance-slideshow", label: "Background Slideshow" },
+    { id: "appearance-library", label: "Wallpaper Gallery" },
+    { id: "appearance-reset", label: "Reset" },
+  ],
+  accessibility: [
+    { id: "accessibility-icon-size", label: "Icon Size" },
+    { id: "accessibility-density", label: "Interface Density" },
+    { id: "accessibility-reduced-motion", label: "Reduced Motion" },
+    { id: "accessibility-high-contrast", label: "High Contrast" },
+    { id: "accessibility-haptics", label: "Haptics" },
+    { id: "accessibility-shortcuts", label: "Keyboard Shortcuts" },
+  ],
+  privacy: [
+    { id: "privacy-backup", label: "Backup & Restore" },
+  ],
+};


### PR DESCRIPTION
## Summary
- add navigation metadata for settings subsections and render a sticky sidebar with active highlight and keyboard navigation
- refactor settings tabs into a two-column layout with independently scrolling content and anchored subsections

## Testing
- yarn lint *(fails: existing repo-wide accessibility lint errors)*
- yarn test *(fails: existing Jest failures and jsdom localStorage error)*

------
https://chatgpt.com/codex/tasks/task_e_68cab66800cc832885891b006a86ad95