### PR TITLE
[settings] add navigation schema

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -3,6 +3,7 @@ import { createDynamicApp, createDisplay } from './utils/createDynamicApp';
 import { displayX } from './components/apps/x';
 import { displaySpotify } from './components/apps/spotify';
 import { displaySettings } from './components/apps/settings';
+import { settingsNavigation } from './apps/settings/navigation';
 import { displayChrome } from './components/apps/chrome';
 import { displayGedit } from './components/apps/gedit';
 import { displayTodoist } from './components/apps/todoist';
@@ -691,6 +692,9 @@ const apps = [
     favourite: true,
     desktop_shortcut: false,
     screen: displaySettings,
+    metadata: {
+      navigation: settingsNavigation,
+    },
   },
   {
     id: 'files',

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import { themeOptions, wallpaperIds } from "./navigation";
 
 export default function Settings() {
   const {
@@ -41,17 +42,6 @@ export default function Settings() {
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
-
-  const wallpapers = [
-    "wall-1",
-    "wall-2",
-    "wall-3",
-    "wall-4",
-    "wall-5",
-    "wall-6",
-    "wall-7",
-    "wall-8",
-  ];
 
   const changeBackground = (name: string) => setWallpaper(name);
 
@@ -85,6 +75,8 @@ export default function Settings() {
     }
   };
 
+  const triggerImport = () => fileInputRef.current?.click();
+
   const handleReset = async () => {
     if (
       !window.confirm(
@@ -104,6 +96,7 @@ export default function Settings() {
   };
 
   const [showKeymap, setShowKeymap] = useState(false);
+  const openKeymap = () => setShowKeymap(true);
 
   return (
     <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
@@ -121,20 +114,24 @@ export default function Settings() {
               backgroundPosition: "center center",
             }}
           ></div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Theme:</label>
+          <div id="theme" className="flex justify-center my-4">
+            <label htmlFor="theme-select" className="mr-2 text-ubt-grey">
+              Theme:
+            </label>
             <select
+              id="theme-select"
               value={theme}
               onChange={(e) => setTheme(e.target.value)}
               className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
             >
-              <option value="default">Default</option>
-              <option value="dark">Dark</option>
-              <option value="neon">Neon</option>
-              <option value="matrix">Matrix</option>
+              {themeOptions.map(({ id, label }) => (
+                <option key={id} value={id}>
+                  {label}
+                </option>
+              ))}
             </select>
           </div>
-          <div className="flex justify-center my-4">
+          <div id="accent" className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Accent:</label>
             <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
               {ACCENT_OPTIONS.map((c) => (
@@ -150,27 +147,32 @@ export default function Settings() {
               ))}
             </div>
           </div>
-          <div className="flex justify-center my-4">
-            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>
+          <div id="wallpaper" className="flex justify-center my-4">
+            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">
+              Wallpaper:
+            </label>
             <input
               id="wallpaper-slider"
               type="range"
               min="0"
-              max={wallpapers.length - 1}
+              max={wallpaperIds.length - 1}
               step="1"
-              value={wallpapers.indexOf(wallpaper)}
+              value={wallpaperIds.indexOf(wallpaper)}
               onChange={(e) =>
-                changeBackground(wallpapers[parseInt(e.target.value, 10)])
+                changeBackground(wallpaperIds[parseInt(e.target.value, 10)])
               }
               className="ubuntu-slider"
               aria-label="Wallpaper"
             />
           </div>
-          <div className="flex justify-center my-4">
+          <div
+            id="background-slideshow"
+            className="flex justify-center my-4"
+          >
             <BackgroundSlideshow />
           </div>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
-            {wallpapers.map((name) => (
+            {wallpaperIds.map((name) => (
               <div
                 key={name}
                 role="button"
@@ -199,7 +201,10 @@ export default function Settings() {
               ></div>
             ))}
           </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
+          <div
+            id="reset-desktop"
+            className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center"
+          >
             <button
               onClick={handleReset}
               className="px-4 py-2 rounded bg-ub-orange text-white"
@@ -211,8 +216,10 @@ export default function Settings() {
       )}
       {activeTab === "accessibility" && (
         <>
-          <div className="flex justify-center my-4">
-            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">Icon Size:</label>
+          <div id="icon-size" className="flex justify-center my-4">
+            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">
+              Icon Size:
+            </label>
             <input
               id="font-scale"
               type="range"
@@ -225,9 +232,12 @@ export default function Settings() {
               aria-label="Icon size"
             />
           </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Density:</label>
+          <div id="density" className="flex justify-center my-4">
+            <label htmlFor="density-select" className="mr-2 text-ubt-grey">
+              Density:
+            </label>
             <select
+              id="density-select"
               value={density}
               onChange={(e) => setDensity(e.target.value as any)}
               className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
@@ -236,7 +246,7 @@ export default function Settings() {
               <option value="compact">Compact</option>
             </select>
           </div>
-          <div className="flex justify-center my-4 items-center">
+          <div id="reduced-motion" className="flex justify-center my-4 items-center">
             <span className="mr-2 text-ubt-grey">Reduced Motion:</span>
             <ToggleSwitch
               checked={reducedMotion}
@@ -244,7 +254,7 @@ export default function Settings() {
               ariaLabel="Reduced Motion"
             />
           </div>
-          <div className="flex justify-center my-4 items-center">
+          <div id="high-contrast" className="flex justify-center my-4 items-center">
             <span className="mr-2 text-ubt-grey">High Contrast:</span>
             <ToggleSwitch
               checked={highContrast}
@@ -252,7 +262,7 @@ export default function Settings() {
               ariaLabel="High Contrast"
             />
           </div>
-          <div className="flex justify-center my-4 items-center">
+          <div id="haptics" className="flex justify-center my-4 items-center">
             <span className="mr-2 text-ubt-grey">Haptics:</span>
             <ToggleSwitch
               checked={haptics}
@@ -260,9 +270,12 @@ export default function Settings() {
               ariaLabel="Haptics"
             />
           </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
+          <div
+            id="keyboard-shortcuts"
+            className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center"
+          >
             <button
-              onClick={() => setShowKeymap(true)}
+              onClick={openKeymap}
               className="px-4 py-2 rounded bg-ub-orange text-white"
             >
               Edit Shortcuts
@@ -274,13 +287,15 @@ export default function Settings() {
         <>
           <div className="flex justify-center my-4 space-x-4">
             <button
+              id="export-settings"
               onClick={handleExport}
               className="px-4 py-2 rounded bg-ub-orange text-white"
             >
               Export Settings
             </button>
             <button
-              onClick={() => fileInputRef.current?.click()}
+              id="import-settings"
+              onClick={triggerImport}
               className="px-4 py-2 rounded bg-ub-orange text-white"
             >
               Import Settings

--- a/apps/settings/navigation.ts
+++ b/apps/settings/navigation.ts
@@ -1,0 +1,373 @@
+export type SettingsNavigationActionKind =
+  | 'button'
+  | 'toggle'
+  | 'select'
+  | 'color'
+  | 'range';
+
+export interface SettingsNavigationActionOption {
+  id: string;
+  label: string;
+  value?: string;
+}
+
+export interface SettingsNavigationAction {
+  id: string;
+  title: string;
+  description?: string;
+  callbackId: string;
+  kind: SettingsNavigationActionKind;
+  options?: ReadonlyArray<SettingsNavigationActionOption>;
+}
+
+export interface SettingsNavigationAnchor {
+  id: string;
+  title: string;
+  description?: string;
+  callbackId?: string;
+}
+
+export interface SettingsNavigationSection {
+  id: string;
+  title: string;
+  description?: string;
+  anchors: ReadonlyArray<SettingsNavigationAnchor>;
+  topActions?: ReadonlyArray<SettingsNavigationAction>;
+}
+
+export interface SettingsNavigationBucket {
+  id:
+    | 'system'
+    | 'devices'
+    | 'network'
+    | 'privacy'
+    | 'accessibility'
+    | 'personalization'
+    | 'updates'
+    | 'about';
+  title: string;
+  sections: ReadonlyArray<SettingsNavigationSection>;
+}
+
+export const themeOptions = [
+  { id: 'default', label: 'Default' },
+  { id: 'dark', label: 'Dark' },
+  { id: 'neon', label: 'Neon' },
+  { id: 'matrix', label: 'Matrix' },
+] as const satisfies ReadonlyArray<SettingsNavigationActionOption>;
+
+export const accentColorOptions = [
+  { id: 'kali-blue', label: 'Kali Blue', value: '#1793d1' },
+  { id: 'scarlet', label: 'Scarlet Red', value: '#e53e3e' },
+  { id: 'ember', label: 'Ember Orange', value: '#d97706' },
+  { id: 'emerald', label: 'Emerald Green', value: '#38a169' },
+  { id: 'amethyst', label: 'Amethyst Purple', value: '#805ad5' },
+  { id: 'fuchsia', label: 'Fuchsia Pink', value: '#ed64a6' },
+] as const satisfies ReadonlyArray<SettingsNavigationActionOption>;
+
+export const accentColorValues = accentColorOptions.map(
+  (option) => option.value ?? option.id,
+) as readonly string[];
+
+export const wallpaperPresets = [
+  { id: 'wall-1', label: 'Wallpaper 1' },
+  { id: 'wall-2', label: 'Wallpaper 2' },
+  { id: 'wall-3', label: 'Wallpaper 3' },
+  { id: 'wall-4', label: 'Wallpaper 4' },
+  { id: 'wall-5', label: 'Wallpaper 5' },
+  { id: 'wall-6', label: 'Wallpaper 6' },
+  { id: 'wall-7', label: 'Wallpaper 7' },
+  { id: 'wall-8', label: 'Wallpaper 8' },
+] as const satisfies ReadonlyArray<SettingsNavigationActionOption>;
+
+export const wallpaperIds = wallpaperPresets.map((preset) => preset.id) as readonly string[];
+
+const densityOptions = [
+  { id: 'regular', label: 'Regular', value: 'regular' },
+  { id: 'compact', label: 'Compact', value: 'compact' },
+] as const satisfies ReadonlyArray<SettingsNavigationActionOption>;
+
+export const settingsNavigation = [
+  {
+    id: 'system',
+    title: 'System',
+    sections: [
+      {
+        id: 'system-maintenance',
+        title: 'Maintenance',
+        description: 'Restore the desktop to factory defaults when needed.',
+        anchors: [
+          {
+            id: 'reset-desktop',
+            title: 'Reset desktop',
+            description:
+              'Clear cached preferences and return to the default wallpaper and layout.',
+            callbackId: 'handleReset',
+          },
+        ],
+        topActions: [
+          {
+            id: 'reset-desktop-action',
+            title: 'Reset desktop',
+            description: 'Restore wallpapers, themes, and window layout to defaults.',
+            callbackId: 'handleReset',
+            kind: 'button',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'devices',
+    title: 'Devices',
+    sections: [
+      {
+        id: 'device-feedback',
+        title: 'Input & feedback',
+        description: 'Configure vibration-style feedback for supported controls.',
+        anchors: [
+          {
+            id: 'haptics',
+            title: 'Haptics',
+            description: 'Toggle desktop haptic feedback for compatible apps.',
+            callbackId: 'setHaptics',
+          },
+        ],
+        topActions: [
+          {
+            id: 'haptics-toggle',
+            title: 'Haptics',
+            description: 'Enable or disable vibration feedback across the desktop.',
+            callbackId: 'setHaptics',
+            kind: 'toggle',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'network',
+    title: 'Network',
+    sections: [],
+  },
+  {
+    id: 'privacy',
+    title: 'Privacy',
+    sections: [
+      {
+        id: 'privacy-data',
+        title: 'Data control',
+        description: 'Back up or restore your personalization choices.',
+        anchors: [
+          {
+            id: 'export-settings',
+            title: 'Export settings',
+            description: 'Download a JSON backup of all desktop preferences.',
+            callbackId: 'handleExport',
+          },
+          {
+            id: 'import-settings',
+            title: 'Import settings',
+            description: 'Restore a previously exported JSON configuration.',
+            callbackId: 'triggerImport',
+          },
+        ],
+        topActions: [
+          {
+            id: 'export-settings-action',
+            title: 'Export settings',
+            description: 'Download the current configuration as JSON.',
+            callbackId: 'handleExport',
+            kind: 'button',
+          },
+          {
+            id: 'import-settings-action',
+            title: 'Import settings',
+            description: 'Choose a JSON file to restore your configuration.',
+            callbackId: 'triggerImport',
+            kind: 'button',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'accessibility',
+    title: 'Accessibility',
+    sections: [
+      {
+        id: 'accessibility-display',
+        title: 'Display & layout',
+        description: 'Adjust interface scale and spacing for readability.',
+        anchors: [
+          {
+            id: 'icon-size',
+            title: 'Icon size',
+            description: 'Scale dock and desktop icons between 75% and 150%.',
+            callbackId: 'setFontScale',
+          },
+          {
+            id: 'density',
+            title: 'Interface density',
+            description: 'Toggle compact mode for tighter spacing.',
+            callbackId: 'setDensity',
+          },
+        ],
+        topActions: [
+          {
+            id: 'icon-size-action',
+            title: 'Icon size',
+            description: 'Fine-tune icon scale for comfort.',
+            callbackId: 'setFontScale',
+            kind: 'range',
+          },
+          {
+            id: 'density-action',
+            title: 'Interface density',
+            description: 'Switch between regular and compact spacing presets.',
+            callbackId: 'setDensity',
+            kind: 'select',
+            options: densityOptions,
+          },
+        ],
+      },
+      {
+        id: 'accessibility-visibility',
+        title: 'Visibility',
+        description: 'Reduce animation and boost contrast for clarity.',
+        anchors: [
+          {
+            id: 'reduced-motion',
+            title: 'Reduced motion',
+            description: 'Disable non-essential motion effects.',
+            callbackId: 'setReducedMotion',
+          },
+          {
+            id: 'high-contrast',
+            title: 'High contrast',
+            description: 'Overlay a high-contrast theme for legibility.',
+            callbackId: 'setHighContrast',
+          },
+        ],
+        topActions: [
+          {
+            id: 'reduced-motion-action',
+            title: 'Reduced motion',
+            description: 'Toggle motion-reduction across the desktop.',
+            callbackId: 'setReducedMotion',
+            kind: 'toggle',
+          },
+          {
+            id: 'high-contrast-action',
+            title: 'High contrast',
+            description: 'Enable a high-contrast overlay for UI elements.',
+            callbackId: 'setHighContrast',
+            kind: 'toggle',
+          },
+        ],
+      },
+      {
+        id: 'accessibility-input',
+        title: 'Input',
+        description: 'Customize keyboard access and shortcuts.',
+        anchors: [
+          {
+            id: 'keyboard-shortcuts',
+            title: 'Keyboard shortcuts',
+            description: 'Open the keyboard shortcut editor overlay.',
+            callbackId: 'openKeymap',
+          },
+        ],
+        topActions: [
+          {
+            id: 'keyboard-shortcuts-action',
+            title: 'Edit shortcuts',
+            description: 'Launch the overlay to remap keyboard shortcuts.',
+            callbackId: 'openKeymap',
+            kind: 'button',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'personalization',
+    title: 'Personalization',
+    sections: [
+      {
+        id: 'personalization-appearance',
+        title: 'Appearance',
+        description: 'Select themes, accent colors, and wallpapers.',
+        anchors: [
+          {
+            id: 'theme',
+            title: 'Theme',
+            description: 'Switch between bundled desktop themes.',
+            callbackId: 'setTheme',
+          },
+          {
+            id: 'accent',
+            title: 'Accent color',
+            description: 'Choose the highlight color used across the UI.',
+            callbackId: 'setAccent',
+          },
+          {
+            id: 'wallpaper',
+            title: 'Wallpaper',
+            description: 'Pick a wallpaper from the Kali-inspired gallery.',
+            callbackId: 'setWallpaper',
+          },
+        ],
+        topActions: [
+          {
+            id: 'theme-action',
+            title: 'Theme',
+            description: 'Cycle through bundled desktop themes.',
+            callbackId: 'setTheme',
+            kind: 'select',
+            options: themeOptions,
+          },
+          {
+            id: 'accent-action',
+            title: 'Accent color',
+            description: 'Pick a highlight color from the Kali palette.',
+            callbackId: 'setAccent',
+            kind: 'color',
+            options: accentColorOptions,
+          },
+          {
+            id: 'wallpaper-action',
+            title: 'Wallpaper',
+            description: 'Browse curated wallpapers for the desktop.',
+            callbackId: 'setWallpaper',
+            kind: 'select',
+            options: wallpaperPresets,
+          },
+        ],
+      },
+      {
+        id: 'personalization-backgrounds',
+        title: 'Background slideshow',
+        description: 'Rotate wallpapers on a schedule using the slideshow panel.',
+        anchors: [
+          {
+            id: 'background-slideshow',
+            title: 'Background slideshow',
+            description: 'Configure wallpaper rotation and timing.',
+          },
+        ],
+        topActions: [],
+      },
+    ],
+  },
+  {
+    id: 'updates',
+    title: 'Updates',
+    sections: [],
+  },
+  {
+    id: 'about',
+    title: 'About',
+    sections: [],
+  },
+] as const satisfies ReadonlyArray<SettingsNavigationBucket>;

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -22,18 +22,12 @@ import {
   setHaptics as saveHaptics,
   defaults,
 } from '../utils/settingsStore';
+import { accentColorValues } from '../apps/settings/navigation';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
-export const ACCENT_OPTIONS = [
-  '#1793d1', // kali blue (default)
-  '#e53e3e', // red
-  '#d97706', // orange
-  '#38a169', // green
-  '#805ad5', // purple
-  '#ed64a6', // pink
-];
+export const ACCENT_OPTIONS = accentColorValues;
 
 // Utility to lighten or darken a hex color by a percentage
 const shadeColor = (color: string, percent: number): string => {


### PR DESCRIPTION
## Summary
- add a navigation schema for settings with buckets, anchors, and top action metadata
- wire the settings UI and registry config to consume the shared schema
- derive the accent palette from the schema so colors stay in sync

## Testing
- yarn lint *(fails: repository already reports numerous jsx-a11y control label violations in unrelated apps)*
- yarn test *(fails: existing suites such as window, Nmap NSE, and ReconNG currently fail)*

------
https://chatgpt.com/codex/tasks/task_e_68cab662db248328988d50a72a00ff9e