### PR TITLE
desktop: pause hidden windows and add visibility tests

### DIFF
--- a/__tests__/desktopVisibility.test.ts
+++ b/__tests__/desktopVisibility.test.ts
@@ -1,0 +1,56 @@
+describe('Desktop window visibility tracking', () => {
+  let desktop: any;
+
+  beforeEach(() => {
+    const { Desktop } = require('../components/screen/desktop');
+    desktop = new Desktop();
+    desktop.props = desktop.props || {};
+    desktop.setState = jest.fn(function setState(this: any, updater: any, callback?: () => void) {
+      const next = typeof updater === 'function' ? updater(this.state, this.props) : updater;
+      if (next && typeof next === 'object') {
+        this.state = { ...this.state, ...next };
+      }
+      if (typeof callback === 'function') {
+        callback();
+      }
+    });
+    desktop.state.window_visibility = {};
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('records visibility transitions and emits events', () => {
+    const handler = jest.fn();
+    window.addEventListener('desktop-window-visibility', handler);
+
+    desktop.state.window_visibility['demo-app'] = false;
+    desktop.setWindowVisibility('demo-app', true);
+
+    expect(desktop.state.window_visibility['demo-app']).toBe(true);
+    expect(handler).toHaveBeenLastCalledWith(
+      expect.objectContaining({ detail: { id: 'demo-app', visible: true } }),
+    );
+
+    desktop.setWindowVisibility('demo-app', false);
+    expect(desktop.state.window_visibility['demo-app']).toBe(false);
+    expect(handler).toHaveBeenLastCalledWith(
+      expect.objectContaining({ detail: { id: 'demo-app', visible: false } }),
+    );
+
+    window.removeEventListener('desktop-window-visibility', handler);
+  });
+
+  it('avoids redundant updates when state is unchanged', () => {
+    const handler = jest.fn();
+    window.addEventListener('desktop-window-visibility', handler);
+
+    desktop.state.window_visibility['demo-app'] = true;
+    desktop.setWindowVisibility('demo-app', true);
+
+    expect(handler).not.toHaveBeenCalled();
+
+    window.removeEventListener('desktop-window-visibility', handler);
+  });
+});

--- a/__tests__/resourceMonitorVisibility.test.tsx
+++ b/__tests__/resourceMonitorVisibility.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import ResourceMonitor from '../components/apps/resource_monitor';
+
+describe('ResourceMonitor visibility integration', () => {
+  const originalWorker = global.Worker;
+  let workerInstance: { postMessage: jest.Mock; terminate: jest.Mock };
+  let rafMock: jest.SpyInstance;
+  let cafMock: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    workerInstance = {
+      postMessage: jest.fn(),
+      terminate: jest.fn(),
+    };
+    global.Worker = jest.fn(() => workerInstance) as any;
+
+    rafMock = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        return setTimeout(() => cb(performance.now()), 16) as unknown as number;
+      });
+
+    cafMock = jest
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation((handle: number) => {
+        clearTimeout(handle as unknown as ReturnType<typeof setTimeout>);
+      });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    rafMock.mockRestore();
+    cafMock.mockRestore();
+    global.Worker = originalWorker;
+  });
+
+  it('pauses workers when hidden and resumes when visible', () => {
+    const { rerender, unmount } = render(<ResourceMonitor visible />);
+
+    expect(workerInstance.postMessage).toHaveBeenCalledWith({ type: 'start' });
+
+    workerInstance.postMessage.mockClear();
+    rerender(<ResourceMonitor visible={false} />);
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(workerInstance.postMessage).toHaveBeenCalledWith({ type: 'stop' });
+
+    workerInstance.postMessage.mockClear();
+    rerender(<ResourceMonitor visible />);
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(workerInstance.postMessage).toHaveBeenCalledWith({ type: 'start' });
+
+    workerInstance.postMessage.mockClear();
+    unmount();
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(workerInstance.terminate).toHaveBeenCalled();
+    expect(workerInstance.postMessage).not.toHaveBeenCalled();
+    expect(cafMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- extend the desktop window manager to persist per-window visibility state and broadcast hide/show events
- teach the base window to surface visibility to its content so apps can pause rendering when minimized
- update the resource monitor to halt timers when hidden and add unit tests covering the new visibility plumbing

## Testing
- yarn test __tests__/desktopVisibility.test.ts __tests__/resourceMonitorVisibility.test.tsx --runInBand
- yarn lint *(fails: pre-existing accessibility and no-top-level-window violations outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68caa9ea8bd0832895a31115dfe2e458