### PR TITLE
[settings] add interface scale presets

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
+import { SCALE_PRESETS, ScalePresetId, isScalePresetId } from "../../utils/scalePresets";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
   resetSettings,
@@ -25,6 +26,8 @@ export default function Settings() {
     setReducedMotion,
     fontScale,
     setFontScale,
+    scalePreset,
+    setScalePreset,
     highContrast,
     setHighContrast,
     haptics,
@@ -55,6 +58,10 @@ export default function Settings() {
 
   const changeBackground = (name: string) => setWallpaper(name);
 
+  const currentScalePreset = SCALE_PRESETS.find(
+    (preset) => preset.id === scalePreset
+  );
+
   const handleExport = async () => {
     const data = await exportSettingsData();
     const blob = new Blob([data], { type: "application/json" });
@@ -77,6 +84,8 @@ export default function Settings() {
       if (parsed.reducedMotion !== undefined)
         setReducedMotion(parsed.reducedMotion);
       if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
+      if (parsed.scalePreset !== undefined && isScalePresetId(parsed.scalePreset))
+        setScalePreset(parsed.scalePreset);
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
       if (parsed.theme !== undefined) setTheme(parsed.theme);
@@ -99,6 +108,7 @@ export default function Settings() {
     setDensity(defaults.density as any);
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
+    setScalePreset(defaults.scalePreset as ScalePresetId);
     setHighContrast(defaults.highContrast);
     setTheme("default");
   };
@@ -149,6 +159,26 @@ export default function Settings() {
                 />
               ))}
             </div>
+          </div>
+          <div className="flex flex-col items-center my-4 gap-2 text-center">
+            <label htmlFor="interface-scale" className="text-ubt-grey font-medium">
+              Interface Scale
+            </label>
+            <select
+              id="interface-scale"
+              value={scalePreset}
+              onChange={(e) => setScalePreset(e.target.value as ScalePresetId)}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            >
+              {SCALE_PRESETS.map((preset) => (
+                <option key={preset.id} value={preset.id}>
+                  {preset.label}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-ubt-grey max-w-xs">
+              {currentScalePreset?.description}
+            </p>
           </div>
           <div className="flex justify-center my-4">
             <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>

--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -3,6 +3,8 @@
 import React, { useState, useEffect } from "react";
 import Tabs from "../Tabs";
 import ToggleSwitch from "../ToggleSwitch";
+import { useSettings } from "../../hooks/useSettings";
+import { SCALE_PRESETS } from "../../utils/scalePresets";
 
 const PANEL_PREFIX = "xfce.panel.";
 
@@ -15,6 +17,8 @@ export default function Preferences() {
     { id: "opacity", label: "Opacity" },
     { id: "items", label: "Items" },
   ];
+
+  const { scalePreset, setScalePreset } = useSettings();
 
   const [active, setActive] = useState<TabId>("display");
 
@@ -127,7 +131,36 @@ export default function Preferences() {
           </div>
         )}
         {active === "appearance" && (
-          <p className="text-ubt-grey">Appearance settings are not available yet.</p>
+          <div className="space-y-4">
+            <p className="text-ubt-grey text-sm">
+              Choose how large text and controls should appear across the desktop.
+            </p>
+            <div className="space-y-3">
+              {SCALE_PRESETS.map((preset) => (
+                <label
+                  key={preset.id}
+                  className={`flex items-start gap-3 rounded border px-3 py-2 transition-colors ${
+                    scalePreset === preset.id
+                      ? "border-ub-border-orange bg-ub-lite-abrgn"
+                      : "border-transparent bg-ub-cool-grey"
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="panel-scale"
+                    value={preset.id}
+                    checked={scalePreset === preset.id}
+                    onChange={() => setScalePreset(preset.id)}
+                    className="mt-1"
+                  />
+                  <div>
+                    <p className="font-medium text-white">{preset.label}</p>
+                    <p className="text-xs text-ubt-grey">{preset.description}</p>
+                  </div>
+                </label>
+              ))}
+            </div>
+          </div>
         )}
         {active === "opacity" && (
           <p className="text-ubt-grey">Opacity settings are not available yet.</p>

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -34,12 +34,14 @@
   --game-color-danger: #b91c1c;
 
   /* Spacing scale */
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-  --space-5: 1.5rem;
-  --space-6: 2rem;
+  --user-space-scale: 1;
+  --space-scale: calc(var(--preset-space-scale) * var(--user-space-scale));
+  --space-1: calc(0.25rem * var(--space-scale));
+  --space-2: calc(0.5rem * var(--space-scale));
+  --space-3: calc(0.75rem * var(--space-scale));
+  --space-4: calc(1rem * var(--space-scale));
+  --space-5: calc(1.5rem * var(--space-scale));
+  --space-6: calc(2rem * var(--space-scale));
 
   /* Radius */
   --radius-sm: 2px;
@@ -54,12 +56,30 @@
 
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
-  --font-multiplier: 1;
+  --user-font-scale: 1;
+  --font-multiplier: calc(var(--preset-font-scale) * var(--user-font-scale));
+  --preset-font-scale: 1;
+  --preset-space-scale: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;
+}
+
+:root[data-scale='compact'] {
+  --preset-font-scale: 0.9;
+  --preset-space-scale: 0.85;
+}
+
+:root[data-scale='balanced'] {
+  --preset-font-scale: 1;
+  --preset-space-scale: 1;
+}
+
+:root[data-scale='comfortable'] {
+  --preset-font-scale: 1.1;
+  --preset-space-scale: 1.2;
 }
 
 /* High contrast theme */

--- a/utils/scalePresets.ts
+++ b/utils/scalePresets.ts
@@ -1,0 +1,46 @@
+export type ScalePresetId = 'compact' | 'balanced' | 'comfortable';
+
+export interface ScalePresetDefinition {
+  id: ScalePresetId;
+  label: string;
+  description: string;
+  fontScale: number;
+  spacingScale: number;
+}
+
+export const SCALE_PRESETS: readonly ScalePresetDefinition[] = [
+  {
+    id: 'compact',
+    label: 'Compact',
+    description: 'Tighter typography and spacing for dense layouts.',
+    fontScale: 0.9,
+    spacingScale: 0.85,
+  },
+  {
+    id: 'balanced',
+    label: 'Balanced',
+    description: 'Default scale tuned for the Kali desktop look.',
+    fontScale: 1,
+    spacingScale: 1,
+  },
+  {
+    id: 'comfortable',
+    label: 'Comfortable',
+    description: 'Roomier spacing with slightly larger text.',
+    fontScale: 1.1,
+    spacingScale: 1.2,
+  },
+];
+
+export const SCALE_PRESET_MAP: Record<ScalePresetId, ScalePresetDefinition> = SCALE_PRESETS.reduce(
+  (acc, preset) => {
+    acc[preset.id] = preset;
+    return acc;
+  },
+  {} as Record<ScalePresetId, ScalePresetDefinition>,
+);
+
+export const DEFAULT_SCALE_PRESET: ScalePresetId = 'balanced';
+
+export const isScalePresetId = (value: string | null | undefined): value is ScalePresetId =>
+  !!value && value in SCALE_PRESET_MAP;


### PR DESCRIPTION
## Summary
- add reusable scale preset definitions and map them into the theme tokens
- surface the interface scale selector in settings and panel appearance tabs with persisted state
- guard settings storage helpers against storage errors and compose font/spacing scaling through CSS variables

## Testing
- yarn lint *(fails: existing repo violations unrelated to these changes)*
- CI=1 yarn test *(fails: window snapping and nmap NSE tests already unstable)*

------
https://chatgpt.com/codex/tasks/task_e_68caa9d7e6088328b227a673caed6b7a