### PR TITLE
[ui] add iconographic status patterns

### DIFF
--- a/apps/word_search/index.tsx
+++ b/apps/word_search/index.tsx
@@ -9,6 +9,7 @@ import GameLayout from '../../components/apps/GameLayout';
 import { SettingsProvider, useSettings } from '../../components/apps/GameSettingsContext';
 import { PUZZLE_PACKS, PackName } from '../../games/word-search/packs';
 import ListImport from '../../games/word-search/components/ListImport';
+import AlertBanner from '../../components/common/AlertBanner';
 
 const WORD_COUNT = 5;
 const GRID_SIZE = 12;
@@ -413,9 +414,9 @@ const WordSearchInner: React.FC<WordSearchInnerProps> = ({ getDailySeed }) => {
 
   if (error) {
     return (
-      <div className="p-4 text-red-600" role="alert">
+      <AlertBanner tone="danger" className="m-4" title="Word search failed to load">
         {error}
-      </div>
+      </AlertBanner>
     );
   }
 

--- a/components/ExternalFrame.js
+++ b/components/ExternalFrame.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Head from 'next/head';
+import AlertBanner from './common/AlertBanner';
 
 const ALLOWLIST = ['https://vscode.dev', 'https://stackblitz.com'];
 
@@ -44,12 +45,18 @@ export default function ExternalFrame({ src, title, prefetch = false, onLoad: on
       )}
       <div className="h-full w-full flex flex-col">
         {cookiesBlocked && (
-          <div role="alert" className="bg-red-600 text-white text-sm p-2 text-center">
-            Third-party cookies are blocked{' '}
-            <button onClick={() => setShowDialog(true)} className="underline">
-              Instructions
-            </button>
-          </div>
+          <AlertBanner
+            tone="danger"
+            title="Third-party cookies blocked"
+            className="text-sm justify-center text-center"
+          >
+            <span>
+              Enable third-party cookies or open instructions{' '}
+              <button onClick={() => setShowDialog(true)} className="underline">
+                Instructions
+              </button>
+            </span>
+          </AlertBanner>
         )}
         <div className="relative flex-1">
           <a

--- a/components/WarningBanner.tsx
+++ b/components/WarningBanner.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
+import AlertBanner from './common/AlertBanner';
 
 interface WarningBannerProps {
   children: React.ReactNode;
+  title?: string;
 }
 
-export default function WarningBanner({ children }: WarningBannerProps) {
+export default function WarningBanner({ children, title }: WarningBannerProps) {
   return (
-    <div className="flex items-center bg-amber-100 text-amber-900 p-2" role="alert">
-      <span className="mr-2" role="img" aria-label="warning">
-        ⚠️
-      </span>
-      <span>{children}</span>
-    </div>
+    <AlertBanner tone="warning" title={title}>
+      {children}
+    </AlertBanner>
   );
 }

--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -2,6 +2,7 @@ import React, { useRef, useEffect, useState } from 'react';
 import useCanvasResize from '../../hooks/useCanvasResize';
 import { CAR_SKINS, loadSkinAssets } from '../../apps/games/car-racer/customization';
 import { hasOffscreenCanvas } from '../../utils/feature';
+import AlertBanner from '../common/AlertBanner';
 
 // Canvas dimensions
 const WIDTH = 300;
@@ -659,12 +660,15 @@ const CarRacer = () => {
       {!runningRef.current && (
         <div
           className="absolute inset-0 bg-black bg-opacity-60 flex items-center justify-center z-20"
-          role="alert"
+          role="presentation"
         >
-          <div className="text-center">
-            <div className="text-2xl mb-2">Crash!</div>
-            <div className="text-sm">Press Reset to play again</div>
-          </div>
+          <AlertBanner
+            tone="danger"
+            title="Crash!"
+            className="max-w-xs text-center flex-col items-center"
+          >
+            Press Reset to play again
+          </AlertBanner>
         </div>
       )}
     </div>

--- a/components/apps/converter/TemperatureConverter.js
+++ b/components/apps/converter/TemperatureConverter.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { unitMap, unitDetails, convertUnit } from './unitData';
+import AlertBanner from '../../common/AlertBanner';
 
 const TemperatureConverter = () => {
   const category = 'temperature';
@@ -152,7 +153,11 @@ const TemperatureConverter = () => {
           Swap Units
         </button>
       </div>
-      {error && <div className="text-red-400" role="alert">{error}</div>}
+      {error && (
+        <AlertBanner tone="danger" className="mt-2">
+          {error}
+        </AlertBanner>
+      )}
       <div data-testid="temp-result" className="mt-2">
         {leftVal && rightVal && `${format(leftVal, fromUnit)} = ${format(rightVal, toUnit)}`}
       </div>

--- a/components/apps/converter/UnitConverter.js
+++ b/components/apps/converter/UnitConverter.js
@@ -6,6 +6,7 @@ import {
   convertUnit,
 } from './unitData';
 import usePersistentState from '../../../hooks/usePersistentState';
+import AlertBanner from '../../common/AlertBanner';
 
 const categories = allCategories;
 
@@ -267,9 +268,9 @@ const UnitConverter = () => {
         </button>
       </div>
       {error && (
-        <div className="text-red-400" role="alert">
+        <AlertBanner tone="danger" className="mt-2">
           {error}
-        </div>
+        </AlertBanner>
       )}
       <div data-testid="unit-result" className="mt-2">
         {leftVal && rightVal && `${format(leftVal, fromUnit)} = ${format(rightVal, toUnit)}`}

--- a/components/apps/nessus/index.js
+++ b/components/apps/nessus/index.js
@@ -4,6 +4,7 @@ import PluginFeedViewer from './PluginFeedViewer';
 import ScanComparison from './ScanComparison';
 import PluginScoreHeatmap from './PluginScoreHeatmap';
 import FormError from '../../ui/FormError';
+import StatusBadge from '../../common/StatusBadge';
 
 // helpers for persistent storage of jobs and false positives
 export const loadJobDefinitions = () => {
@@ -357,9 +358,10 @@ const Nessus = () => {
       <ul className="space-y-1">
         {scans.map((scan) => (
           <li key={scan.id} className="border-b border-gray-700 pb-1">
-            <div className="flex justify-between items-center">
-              <span>
-                {scan.name} - {scan.status}
+            <div className="flex justify-between items-center gap-2">
+              <span className="flex items-center gap-2">
+                {scan.name}
+                <StatusBadge status={scan.status} />
               </span>
               <button
                 className="text-xs bg-yellow-600 px-2 py-1 rounded"

--- a/components/apps/openvas/task-overview.js
+++ b/components/apps/openvas/task-overview.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import FeedStatusCard from './feed-status-card';
 import TaskRunChart from './task-run-chart';
+import StatusBadge from '../../common/StatusBadge';
 
 const TaskOverview = () => {
   const tasks = [
@@ -18,9 +19,9 @@ const TaskOverview = () => {
         <TaskRunChart />
         <ul className="text-sm space-y-1 mt-2">
           {tasks.map((t) => (
-            <li key={t.name} className="flex justify-between">
+            <li key={t.name} className="flex items-center justify-between gap-2">
               <span>{t.name}</span>
-              <span>{t.status}</span>
+              <StatusBadge status={t.status} />
             </li>
           ))}
         </ul>

--- a/components/apps/openvas/task-run-chart.js
+++ b/components/apps/openvas/task-run-chart.js
@@ -1,16 +1,94 @@
 import React from 'react';
 import history from './task-history.json';
+import { STATUS_TONE_METADATA, resolveTone } from '../../common/statusMeta';
 
 const statuses = ['Queued', 'Running', 'Completed'];
-const colors = {
-  Queued: 'fill-blue-500',
-  Running: 'fill-yellow-500',
-  Completed: 'fill-green-500',
+const markerSize = 4;
+
+const patternIdForTone = (tone) => `openvas-status-${tone}`;
+
+const renderMarker = (d, i, x, y) => {
+  const tone = resolveTone(d.status, 'info');
+  const metadata = STATUS_TONE_METADATA[tone];
+  const fillId = patternIdForTone(tone);
+  const fill = `url(#${fillId})`;
+  const stroke = `var(${metadata.accentVar})`;
+  const title = `${d.status} at ${d.time}`;
+  const markerKey = `${d.time}-${i}`;
+  const common = {
+    fill,
+    stroke,
+    strokeWidth: 1,
+  };
+
+  if (tone === 'success') {
+    return (
+      <circle key={markerKey} {...common} cx={x} cy={y} r={markerSize + 1}>
+        <title>{title}</title>
+      </circle>
+    );
+  }
+
+  if (tone === 'warning') {
+    return (
+      <rect
+        key={markerKey}
+        {...common}
+        x={x - (markerSize + 0.5)}
+        y={y - (markerSize + 0.5)}
+        width={(markerSize + 0.5) * 2}
+        height={(markerSize + 0.5) * 2}
+        rx={1}
+      >
+        <title>{title}</title>
+      </rect>
+    );
+  }
+
+  if (tone === 'danger') {
+    return (
+      <polygon
+        key={markerKey}
+        {...common}
+        points={`${x},${y - (markerSize + 1)} ${x - (markerSize + 1)},${y} ${x},${y + (markerSize + 1)} ${x + (markerSize + 1)},${y}`}
+      >
+        <title>{title}</title>
+      </polygon>
+    );
+  }
+
+  if (tone === 'neutral') {
+    return (
+      <rect
+        key={markerKey}
+        {...common}
+        x={x - (markerSize + 1)}
+        y={y - 1}
+        width={(markerSize + 1) * 2}
+        height={2}
+      >
+        <title>{title}</title>
+      </rect>
+    );
+  }
+
+  return (
+    <polygon
+      key={markerKey}
+      {...common}
+      points={`${x},${y - (markerSize + 1)} ${x - (markerSize + 1)},${y + (markerSize + 1)} ${x + (markerSize + 1)},${y + (markerSize + 1)}`}
+    >
+      <title>{title}</title>
+    </polygon>
+  );
 };
 
 const TaskRunChart = () => {
   const height = 40;
   const width = history.length * 20 + 20;
+  const tonesInUse = Array.from(
+    new Set(history.map((d) => resolveTone(d.status, 'info')))
+  );
   const points = history
     .map((d, i) => {
       const x = i * 20 + 10;
@@ -26,6 +104,36 @@ const TaskRunChart = () => {
       role="img"
       aria-label="Task runs and status changes over time"
     >
+      <defs>
+        {tonesInUse.map((tone) => {
+          const meta = STATUS_TONE_METADATA[tone];
+          const id = patternIdForTone(tone);
+          const size = 8;
+          return (
+            <pattern
+              key={tone}
+              id={id}
+              patternUnits="userSpaceOnUse"
+              width={size}
+              height={size}
+            >
+              <rect width={size} height={size} fill={`var(${meta.colorVar})`} />
+              <path
+                d={`M0 ${size} L${size} 0`}
+                stroke={`var(${meta.accentVar})`}
+                strokeWidth={1.5}
+                strokeLinecap="square"
+              />
+              <path
+                d={`M${-size / 2} ${size / 2} L${size / 2} ${-size / 2}`}
+                stroke={`var(${meta.accentVar})`}
+                strokeWidth={1.5}
+                strokeLinecap="square"
+              />
+            </pattern>
+          );
+        })}
+      </defs>
       {statuses.map((s, idx) => {
         const y = height - (idx / (statuses.length - 1)) * height;
         return (
@@ -35,7 +143,7 @@ const TaskRunChart = () => {
               y1={y}
               x2={width}
               y2={y}
-              className="stroke-gray-600"
+              stroke="var(--status-neutral-strong)"
               strokeWidth="0.5"
             />
             <text
@@ -48,12 +156,18 @@ const TaskRunChart = () => {
           </g>
         );
       })}
-      <polyline points={points} fill="none" stroke="white" strokeWidth="1" />
+      <polyline
+        points={points}
+        fill="none"
+        stroke="var(--status-neutral-strong)"
+        strokeDasharray="4 2"
+        strokeWidth="1"
+      />
       {history.map((d, i) => {
         const x = i * 20 + 10;
         const y =
           height - (statuses.indexOf(d.status) / (statuses.length - 1)) * height;
-        return <circle key={d.time} cx={x} cy={y} r="2" className={colors[d.status]} />;
+        return renderMarker(d, i, x, y);
       })}
     </svg>
   );

--- a/components/apps/solitaire/index.tsx
+++ b/components/apps/solitaire/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import ReactGA from 'react-ga4';
 import usePrefersReducedMotion from '../../../hooks/usePrefersReducedMotion';
+import AlertBanner from '../../common/AlertBanner';
 import {
   initializeGame,
   drawFromStock,
@@ -702,12 +703,18 @@ const Solitaire = () => {
         ))}
       {won && (
         <div
-          className={`absolute inset-0 flex items-center justify-center bg-black bg-opacity-80 text-2xl ${
+          className={`absolute inset-0 flex items-center justify-center bg-black bg-opacity-80 ${
             !prefersReducedMotion ? 'animate-pulse' : ''
           }`}
-          role="alert"
+          role="presentation"
         >
-          You win!
+          <AlertBanner
+            tone="success"
+            title="You win!"
+            className="max-w-sm text-center flex-col items-center text-lg"
+          >
+            Redeal to play again or explore another variant from the menu.
+          </AlertBanner>
         </div>
       )}
       <div className="flex justify-between mb-2 flex-wrap gap-2">

--- a/components/common/AlertBanner.tsx
+++ b/components/common/AlertBanner.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { STATUS_TONE_METADATA, StatusTone } from './statusMeta';
+
+type AlertBannerProps = React.HTMLAttributes<HTMLDivElement> & {
+  tone?: StatusTone;
+  title?: string;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+const AlertBanner: React.FC<AlertBannerProps> = ({
+  tone = 'info',
+  title,
+  icon,
+  className = '',
+  children,
+  ...props
+}) => {
+  const metadata = STATUS_TONE_METADATA[tone];
+  const mergedClassName = `alert-banner ${className}`.trim();
+  return (
+    <div role="alert" data-tone={tone} className={mergedClassName} {...props}>
+      <span className="alert-banner__icon" aria-hidden="true">
+        {icon ?? metadata.icon}
+      </span>
+      <div className="alert-banner__body">
+        {title && <p className="alert-banner__title">{title}</p>}
+        <div>{children}</div>
+      </div>
+    </div>
+  );
+};
+
+export default AlertBanner;

--- a/components/common/StatusBadge.tsx
+++ b/components/common/StatusBadge.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { STATUS_TONE_METADATA, StatusTone, resolveTone } from './statusMeta';
+
+type StatusBadgeProps = {
+  status: string;
+  tone?: StatusTone;
+  icon?: React.ReactNode;
+  className?: string;
+  srLabel?: string;
+};
+
+const StatusBadge: React.FC<StatusBadgeProps> = ({
+  status,
+  tone,
+  icon,
+  className = '',
+  srLabel,
+}) => {
+  const resolvedTone = tone ?? resolveTone(status);
+  const metadata = STATUS_TONE_METADATA[resolvedTone];
+  const label = status.trim();
+  return (
+    <span
+      className={`status-badge ${className}`.trim()}
+      data-tone={resolvedTone}
+      aria-label={srLabel}
+    >
+      <span className="status-badge__icon" aria-hidden="true">
+        {icon ?? metadata.icon}
+      </span>
+      <span className="status-badge__text">{label}</span>
+    </span>
+  );
+};
+
+export default StatusBadge;

--- a/components/common/statusMeta.ts
+++ b/components/common/statusMeta.ts
@@ -1,0 +1,66 @@
+export type StatusTone = 'info' | 'success' | 'warning' | 'danger' | 'neutral';
+
+export interface ToneMetadata {
+  icon: string;
+  label: string;
+  colorVar: `--${string}`;
+  accentVar: `--${string}`;
+  contrastVar: `--${string}`;
+}
+
+export const STATUS_TONE_METADATA: Record<StatusTone, ToneMetadata> = {
+  info: {
+    icon: 'ℹ️',
+    label: 'Information',
+    colorVar: '--status-info',
+    accentVar: '--status-info-strong',
+    contrastVar: '--status-info-contrast',
+  },
+  success: {
+    icon: '✔️',
+    label: 'Success',
+    colorVar: '--status-success',
+    accentVar: '--status-success-strong',
+    contrastVar: '--status-success-contrast',
+  },
+  warning: {
+    icon: '⚠️',
+    label: 'Warning',
+    colorVar: '--status-warning',
+    accentVar: '--status-warning-strong',
+    contrastVar: '--status-warning-contrast',
+  },
+  danger: {
+    icon: '✖️',
+    label: 'Critical',
+    colorVar: '--status-danger',
+    accentVar: '--status-danger-strong',
+    contrastVar: '--status-danger-contrast',
+  },
+  neutral: {
+    icon: '•',
+    label: 'Neutral',
+    colorVar: '--status-neutral',
+    accentVar: '--status-neutral-strong',
+    contrastVar: '--status-neutral-contrast',
+  },
+};
+
+const KEYWORD_TONES: Array<{ tone: StatusTone; keywords: string[] }> = [
+  { tone: 'success', keywords: ['success', 'successful', 'passed', 'complete', 'completed', 'ok', 'ready', 'resolved', 'healthy'] },
+  { tone: 'danger', keywords: ['error', 'failed', 'failure', 'critical', 'crash', 'blocked', 'offline', 'stopped', 'lost', 'breach'] },
+  { tone: 'warning', keywords: ['running', 'processing', 'active', 'in progress', 'progress', 'executing', 'warming', 'updating'] },
+  { tone: 'info', keywords: ['queued', 'queue', 'pending', 'waiting', 'scheduled', 'info', 'informational', 'notice'] },
+  { tone: 'neutral', keywords: ['paused', 'idle', 'draft', 'unknown', 'standby'] },
+];
+
+export function resolveTone(input: string | null | undefined, fallback: StatusTone = 'info'): StatusTone {
+  if (!input) return fallback;
+  const normalized = input.toLowerCase().trim();
+  for (const { tone, keywords } of KEYWORD_TONES) {
+    if (keywords.some((keyword) => normalized.includes(keyword))) {
+      return tone;
+    }
+  }
+  return fallback;
+}

--- a/components/core/ErrorBoundary.tsx
+++ b/components/core/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { createLogger } from '../../lib/logger';
+import AlertBanner from '../common/AlertBanner';
 
 interface Props {
   children: ReactNode;
@@ -28,10 +29,13 @@ class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.hasError) {
       return (
-        <div role="alert" className="p-4 text-center">
-          <h1 className="text-xl font-bold">Something went wrong.</h1>
-          <p>Please refresh the page or try again.</p>
-        </div>
+        <AlertBanner
+          tone="danger"
+          title="Something went wrong"
+          className="flex-col items-center text-center"
+        >
+          Please refresh the page or try again.
+        </AlertBanner>
       );
     }
 

--- a/components/simulator/index.tsx
+++ b/components/simulator/index.tsx
@@ -5,6 +5,7 @@ import type {
   SimulatorParserResponse,
   ParsedLine,
 } from '../../workers/simulatorParser.worker';
+import AlertBanner from '../common/AlertBanner';
 interface TabDefinition { id: string; title: string; content: React.ReactNode; }
 
 const LAB_BANNER = 'For lab use only. Commands are never executed.';
@@ -164,9 +165,9 @@ const Simulator: React.FC = () => {
         <label htmlFor="labmode" className="font-semibold">Lab Mode</label>
       </div>
       {!labMode && (
-        <div className="bg-yellow-100 text-yellow-800 p-2" role="alert">
+        <AlertBanner tone="warning" title="Lab mode recommended">
           {LAB_BANNER}
-        </div>
+        </AlertBanner>
       )}
       <div className="space-y-2" aria-label="Command builder">
         <input aria-label="Command input" className="border p-1 w-full" value={command} onChange={e=>setCommand(e.target.value)} />

--- a/docs/color-accessibility.md
+++ b/docs/color-accessibility.md
@@ -1,0 +1,52 @@
+# Status Color Accessibility
+
+This document records the status palette, iconography, and validation workflow for badges, alerts, and other status-driven UI ele
+ments.
+
+## Palette tokens
+
+The tokens live in `styles/tokens.css` and expose a color-blind friendly set based on the Okabe–Ito palette. Each tone has a bas
+ e hue, an accent used for stripes/borders, and a contrast color for text.
+
+| Tone     | Base token            | Accent token              | Contrast token              | Hex values |
+|----------|----------------------|---------------------------|-----------------------------|------------|
+| Info     | `--status-info`      | `--status-info-strong`    | `--status-info-contrast`    | `#0072B2`, `#004B7C`, `#F2F8FF` |
+| Success  | `--status-success`   | `--status-success-strong` | `--status-success-contrast` | `#007F5F`, `#005D44`, `#F5FDF8` |
+| Warning  | `--status-warning`   | `--status-warning-strong` | `--status-warning-contrast` | `#E69F00`, `#B87400`, `#1A1200` |
+| Danger   | `--status-danger`    | `--status-danger-strong`  | `--status-danger-contrast`  | `#D55E00`, `#953F00`, `#1A0A00` |
+| Neutral  | `--status-neutral`   | `--status-neutral-strong` | `--status-neutral-contrast` | `#7F7F7F`, `#5A5A5A`, `#111111` |
+
+The same tones drive the Tailwind aliases (`--color-ubt-green`, `--color-ubt-blue`, etc.) so inline utility classes stay in sync
+ with the new hues.
+
+## Usage patterns
+
+- `.status-badge` supplies icon + text badges with diagonal stripe patterns. Apply using the `<StatusBadge />` component for con
+  sistent semantics and tone inference.
+- `.alert-banner` powers system alerts (warnings, errors, etc.) via the `<AlertBanner />` component. Content flows in a flex cont
+  ainer so text, buttons, and titles align cleanly.
+- SVG timelines such as the OpenVAS task chart use tone-driven markers with unique shapes (triangle, square, circle, diamond) an
+  d pattern fills to differentiate state without relying solely on color.
+
+These cues ensure color-only differences are backed by iconography, text labels, and texture.
+
+## Validation workflow
+
+Run the automated palette check after adjusting tokens:
+
+```bash
+node scripts/validate-status-colors.mjs
+```
+
+The script simulates protanopia, deuteranopia, and tritanopia using matrix transforms, then prints contrast ratios between each 
+status color and its companion contrast token. Use the output to confirm ratios ≥ 4.5:1 for body text and that simulated colors 
+still remain distinct.
+
+For manual review, Chrome DevTools (Rendering → Emulate vision deficiencies) or the Stark Figma plugin can be used to cross-che
+ck the UI. Focus on:
+
+1. Task status chips (`<StatusBadge />`).
+2. Alert banners in simulator, ExternalFrame, and form validation flows.
+3. SVG charts that formerly relied on color-only dots.
+
+Document findings alongside screenshots in pull requests when introducing new tones.

--- a/scripts/validate-status-colors.mjs
+++ b/scripts/validate-status-colors.mjs
@@ -1,0 +1,80 @@
+const palette = {
+  info: { base: '#0072B2', accent: '#004B7C', contrast: '#F2F8FF' },
+  success: { base: '#007F5F', accent: '#005D44', contrast: '#F5FDF8' },
+  warning: { base: '#E69F00', accent: '#B87400', contrast: '#1A1200' },
+  danger: { base: '#D55E00', accent: '#953F00', contrast: '#1A0A00' },
+  neutral: { base: '#7F7F7F', accent: '#5A5A5A', contrast: '#111111' },
+};
+
+const deficiencyMatrices = {
+  protanopia: [
+    [0.56667, 0.43333, 0],
+    [0.55833, 0.44167, 0],
+    [0, 0.24167, 0.75833],
+  ],
+  deuteranopia: [
+    [0.625, 0.375, 0],
+    [0.7, 0.3, 0],
+    [0, 0.3, 0.7],
+  ],
+  tritanopia: [
+    [0.95, 0.05, 0],
+    [0, 0.43333, 0.56667],
+    [0, 0.475, 0.525],
+  ],
+};
+
+function hexToRgb(hex) {
+  const normalized = hex.replace('#', '').trim();
+  const value = normalized.length === 3
+    ? normalized.split('').map((ch) => ch + ch).join('')
+    : normalized;
+  const intVal = parseInt(value, 16);
+  return [16, 8, 0].map((shift) => (intVal >> shift) & 0xff);
+}
+
+function rgbToHex(rgb) {
+  const hex = rgb
+    .map((channel) => Math.round(channel).toString(16).padStart(2, '0'))
+    .join('');
+  return `#${hex.toUpperCase()}`;
+}
+
+function applyMatrix(rgb, matrix) {
+  const [r, g, b] = rgb.map((c) => c / 255);
+  const transformed = [
+    r * matrix[0][0] + g * matrix[0][1] + b * matrix[0][2],
+    r * matrix[1][0] + g * matrix[1][1] + b * matrix[1][2],
+    r * matrix[2][0] + g * matrix[2][1] + b * matrix[2][2],
+  ];
+  return transformed.map((value) => Math.min(Math.max(value, 0), 1) * 255);
+}
+
+function relativeLuminance(hex) {
+  const [r, g, b] = hexToRgb(hex).map((channel) => channel / 255);
+  const linear = [r, g, b].map((value) =>
+    value <= 0.04045 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4)
+  );
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+}
+
+function contrastRatio(hexA, hexB) {
+  const lumA = relativeLuminance(hexA);
+  const lumB = relativeLuminance(hexB);
+  const lighter = Math.max(lumA, lumB);
+  const darker = Math.min(lumA, lumB);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+for (const [tone, values] of Object.entries(palette)) {
+  const ratio = contrastRatio(values.base, values.contrast);
+  console.log(`\n${tone.toUpperCase()}`);
+  console.log(` Base ${values.base} vs text ${values.contrast} → contrast ${ratio.toFixed(2)}:1`);
+  for (const [deficiency, matrix] of Object.entries(deficiencyMatrices)) {
+    const simulated = rgbToHex(applyMatrix(hexToRgb(values.base), matrix));
+    const simulatedRatio = contrastRatio(simulated, values.contrast);
+    console.log(`  ${deficiency.padEnd(12)} ${simulated} (contrast ${simulatedRatio.toFixed(2)}:1)`);
+  }
+}
+
+console.log('\nValidation complete. Ratios ≥ 4.50:1 meet WCAG AA for normal text.');

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -73,6 +73,100 @@ html[data-theme='matrix'] {
   color: var(--color-inverse);
 }
 
+.status-badge,
+.alert-banner {
+  --status-bg: var(--status-info);
+  --status-stripe: var(--status-info-strong);
+  --status-ink: var(--status-info-contrast);
+  color: var(--status-ink);
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 0.125rem 0.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--status-stripe), black 15%);
+  background-color: var(--status-bg);
+  background-image: repeating-linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--status-bg), white 8%) 0 12px,
+    color-mix(in srgb, var(--status-stripe), var(--status-bg) 60%) 12px 24px
+  );
+  text-transform: none;
+  line-height: 1.3;
+}
+
+.status-badge__icon {
+  font-size: 0.875rem;
+  line-height: 1;
+}
+
+.status-badge[data-tone='success'],
+.alert-banner[data-tone='success'] {
+  --status-bg: var(--status-success);
+  --status-stripe: var(--status-success-strong);
+  --status-ink: var(--status-success-contrast);
+}
+
+.status-badge[data-tone='warning'],
+.alert-banner[data-tone='warning'] {
+  --status-bg: var(--status-warning);
+  --status-stripe: var(--status-warning-strong);
+  --status-ink: var(--status-warning-contrast);
+}
+
+.status-badge[data-tone='danger'],
+.alert-banner[data-tone='danger'] {
+  --status-bg: var(--status-danger);
+  --status-stripe: var(--status-danger-strong);
+  --status-ink: var(--status-danger-contrast);
+}
+
+.status-badge[data-tone='neutral'],
+.alert-banner[data-tone='neutral'] {
+  --status-bg: var(--status-neutral);
+  --status-stripe: var(--status-neutral-strong);
+  --status-ink: var(--status-neutral-contrast);
+}
+
+.alert-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--status-stripe), black 20%);
+  background-color: var(--status-bg);
+  background-image: repeating-linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--status-bg), white 6%) 0 16px,
+    color-mix(in srgb, var(--status-stripe), var(--status-bg) 55%) 16px 32px
+  );
+  box-shadow: 0 1px 4px color-mix(in srgb, var(--status-stripe), transparent 70%);
+}
+
+.alert-banner__icon {
+  font-size: 1.25rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.alert-banner__title {
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.alert-banner__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 *:focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -16,11 +16,11 @@
   --color-ubt-grey: #F6F6F5;
   --color-ubt-warm-grey: #AEA79F;
   --color-ubt-cool-grey: #333333;
-  --color-ubt-blue: #62A0EA;
-  --color-ubt-green: #73D216;
-  --color-ubt-gedit-orange: #F39A21;
-  --color-ubt-gedit-blue: #50B6C6;
-  --color-ubt-gedit-dark: #003B70;
+  --color-ubt-blue: #56b4e9;
+  --color-ubt-green: #007f5f;
+  --color-ubt-gedit-orange: #e69f00;
+  --color-ubt-gedit-blue: #56b4e9;
+  --color-ubt-gedit-dark: #004c7f;
   --color-ub-border-orange: #1793d1;
   --color-ub-dark-grey: #2a2e36;
   --color-bg: #0f1317;
@@ -28,10 +28,27 @@
   --kali-bg: rgba(15, 19, 23, 0.85);
 
   /* Game palette tokens */
-  --game-color-secondary: #1d4ed8;
-  --game-color-success: #15803d;
-  --game-color-warning: #d97706;
-  --game-color-danger: #b91c1c;
+  --game-color-secondary: #0072b2;
+  --game-color-success: #007f5f;
+  --game-color-warning: #e69f00;
+  --game-color-danger: #d55e00;
+
+  /* Status palette */
+  --status-info: #0072b2;
+  --status-info-strong: #004b7c;
+  --status-info-contrast: #f2f8ff;
+  --status-success: #007f5f;
+  --status-success-strong: #005d44;
+  --status-success-contrast: #f5fdf8;
+  --status-warning: #e69f00;
+  --status-warning-strong: #b87400;
+  --status-warning-contrast: #1a1200;
+  --status-danger: #d55e00;
+  --status-danger-strong: #953f00;
+  --status-danger-contrast: #1a0a00;
+  --status-neutral: #7f7f7f;
+  --status-neutral-strong: #5a5a5a;
+  --status-neutral-contrast: #111111;
 
   /* Spacing scale */
   --space-1: 0.25rem;


### PR DESCRIPTION
## Summary
- refresh the status color tokens with color-blind friendly values and add reusable AlertBanner/StatusBadge components with stripe patterns
- update simulator, Nessus, OpenVAS, and converter UIs to pair status icons with patterned badges and alerts instead of color-only states
- document the validation process in docs/color-accessibility.md and add a CLI script to simulate color-vision deficiencies

## Testing
- yarn lint *(fails: repository already has numerous jsx-a11y and no-top-level-window violations outside this change)*
- yarn test --watch=false *(fails: known window snapping, nmap-NSE clipboard tests, plus jsdom localStorage limitations unrelated to this change)*
- node scripts/validate-status-colors.mjs


------
https://chatgpt.com/codex/tasks/task_e_68caa9d9db708328958df35a1a2cddea