### PR TITLE
desktop: add window usage tracking and switcher overlay

### DIFF
--- a/__tests__/desktopWindowUsage.test.tsx
+++ b/__tests__/desktopWindowUsage.test.tsx
@@ -1,0 +1,88 @@
+import { Desktop } from '../components/screen/desktop';
+
+jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+jest.mock('html-to-image', () => ({ toPng: jest.fn(() => Promise.resolve('data:image/png;base64,')) }));
+
+describe('Desktop window usage order', () => {
+  function createDesktop() {
+    const desktop = new Desktop({});
+    desktop.setState = function setState(updater, callback) {
+      const update =
+        typeof updater === 'function' ? updater(this.state, this.props) : updater;
+      if (update && typeof update === 'object') {
+        this.state = { ...this.state, ...update };
+      }
+      if (typeof callback === 'function') {
+        callback();
+      }
+    };
+    return desktop;
+  }
+
+  it('promotes focused window to the front of the usage order', () => {
+    const desktop = createDesktop();
+    desktop.app_stack = ['window-one', 'window-two', 'window-three'];
+    desktop.state = {
+      ...desktop.state,
+      focused_windows: {
+        'window-one': true,
+        'window-two': false,
+        'window-three': false,
+      },
+      windowUsage: [...desktop.app_stack],
+    };
+
+    desktop.focus('window-two');
+
+    expect(desktop.state.windowUsage).toEqual([
+      'window-two',
+      'window-one',
+      'window-three',
+    ]);
+    expect(desktop.state.focused_windows).toEqual({
+      'window-one': false,
+      'window-two': true,
+      'window-three': false,
+    });
+  });
+
+  it('builds window switcher state using the tracked order', () => {
+    const desktop = createDesktop();
+    desktop.app_stack = ['alpha', 'beta', 'gamma'];
+    desktop.state = {
+      ...desktop.state,
+      closed_windows: { alpha: false, beta: false, gamma: false },
+      focused_windows: { alpha: true, beta: false, gamma: false },
+      windowUsage: ['alpha', 'beta', 'gamma'],
+    };
+
+    desktop.openWindowSwitcher();
+
+    expect(desktop.state.showWindowSwitcher).toBe(true);
+    expect(desktop.state.switcherWindows.map((win) => win.id)).toEqual([
+      'alpha',
+      'beta',
+      'gamma',
+    ]);
+    expect(desktop.state.switcherIndex).toBe(1);
+  });
+
+  it('selects a window and hides the switcher overlay', () => {
+    const desktop = createDesktop();
+    const openApp = jest.fn();
+    desktop.openApp = openApp;
+    desktop.state = {
+      ...desktop.state,
+      showWindowSwitcher: true,
+      switcherWindows: [{ id: 'alpha', title: 'Alpha', icon: null }],
+      switcherIndex: 0,
+    };
+
+    desktop.selectWindow('alpha');
+
+    expect(openApp).toHaveBeenCalledWith('alpha');
+    expect(desktop.state.showWindowSwitcher).toBe(false);
+    expect(desktop.state.switcherWindows).toEqual([]);
+    expect(desktop.state.switcherIndex).toBe(0);
+  });
+});

--- a/__tests__/windowSwitcherOverlay.test.tsx
+++ b/__tests__/windowSwitcherOverlay.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import WindowSwitcher from '../components/screen/window-switcher';
+
+describe('WindowSwitcher overlay interactions', () => {
+  const windows = [
+    { id: 'alpha', title: 'Alpha', icon: '/icon-alpha.png' },
+    { id: 'beta', title: 'Beta', icon: '/icon-beta.png' },
+    { id: 'gamma', title: 'Gamma', icon: '/icon-gamma.png' },
+  ];
+
+  it('invokes navigation callback for directional keys', async () => {
+    const onNavigate = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <WindowSwitcher
+        windows={windows}
+        selectedIndex={0}
+        onNavigate={onNavigate}
+        onSelect={jest.fn()}
+        onClose={jest.fn()}
+        previews={{}}
+      />
+    );
+
+    await user.keyboard('{Tab}');
+    expect(onNavigate).toHaveBeenLastCalledWith(1);
+
+    await user.keyboard('{Shift>}{Tab}{/Shift}');
+    expect(onNavigate).toHaveBeenLastCalledWith(-1);
+
+    await user.keyboard('{ArrowRight}');
+    expect(onNavigate).toHaveBeenLastCalledWith(1);
+
+    await user.keyboard('{ArrowLeft}');
+    expect(onNavigate).toHaveBeenLastCalledWith(-1);
+  });
+
+  it('activates selection with Enter and Space', async () => {
+    const onSelect = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <WindowSwitcher
+        windows={windows}
+        selectedIndex={1}
+        onNavigate={jest.fn()}
+        onSelect={onSelect}
+        onClose={jest.fn()}
+        previews={{}}
+      />
+    );
+
+    await user.keyboard('{Enter}');
+    expect(onSelect).toHaveBeenLastCalledWith('beta');
+
+    await user.keyboard(' ');
+    expect(onSelect).toHaveBeenLastCalledWith('beta');
+  });
+
+  it('calls close handler on Escape', async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <WindowSwitcher
+        windows={windows}
+        selectedIndex={0}
+        onNavigate={jest.fn()}
+        onSelect={jest.fn()}
+        onClose={onClose}
+        previews={{}}
+      />
+    );
+
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies highlight changes on pointer focus', () => {
+    const onHighlight = jest.fn();
+
+    render(
+      <WindowSwitcher
+        windows={windows}
+        selectedIndex={0}
+        onNavigate={jest.fn()}
+        onSelect={jest.fn()}
+        onClose={jest.fn()}
+        onHighlight={onHighlight}
+        previews={{}}
+      />
+    );
+
+    const options = screen.getAllByRole('option');
+    fireEvent.mouseEnter(options[2]);
+    expect(onHighlight).toHaveBeenCalledWith(2);
+
+    options[1].focus();
+    expect(onHighlight).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
## Summary
- track window usage order in desktop state and update focus/close flows
- add an Alt+Tab window switcher overlay with thumbnails and icon highlights
- cover window manager ordering and overlay keyboard navigation with new tests

## Testing
- yarn lint *(fails: repo has 577 pre-existing accessibility and no-top-level-window lint violations)*
- yarn test *(fails: repo has pre-existing unit failures including window, nmapNse, Modal, About, PDFViewer suites)*

------
https://chatgpt.com/codex/tasks/task_e_68caa9d408ec8328ba58688e838f82fb