### PR TITLE
[ui] Add command palette with searchable commands

### DIFF
--- a/__tests__/commandSearch.test.ts
+++ b/__tests__/commandSearch.test.ts
@@ -1,0 +1,67 @@
+import { performance } from 'perf_hooks';
+import {
+  CommandRuntimeContext,
+  fuzzySearchCommands,
+  prepareCommands,
+  resolveCommands,
+} from '../data/commands';
+
+describe('command registry search', () => {
+  const context: CommandRuntimeContext = {
+    settings: {
+      accent: '#1793d1',
+      wallpaper: 'wall-1',
+      density: 'regular',
+      reducedMotion: false,
+      fontScale: 1,
+      highContrast: false,
+      largeHitAreas: false,
+      pongSpin: true,
+      allowNetwork: true,
+      haptics: true,
+      theme: 'default',
+    },
+  };
+
+  it('resolves application and settings commands with subtitles', () => {
+    const resolved = resolveCommands(context);
+    const terminalCommand = resolved.find((command) => command.id === 'open-app-terminal');
+    expect(terminalCommand).toBeDefined();
+    const highContrast = resolved.find((command) => command.id === 'toggle-high-contrast');
+    expect(highContrast?.subtitle).toBe('Disabled');
+    const darkTheme = resolved.find((command) => command.id === 'set-theme-dark');
+    expect(darkTheme?.subtitle).toBe('Switch to Dark theme');
+    const defaultAccent = resolved.find((command) => command.id === 'set-accent-1793d1');
+    expect(defaultAccent?.subtitle).toBe('Current accent color');
+  });
+
+  it('matches commands using fuzzy search', () => {
+    const prepared = prepareCommands(resolveCommands(context));
+    const matches = fuzzySearchCommands('tm', prepared);
+    const terminal = matches.find(
+      (command) => command.action.type === 'open-app' && command.action.appId === 'terminal',
+    );
+    expect(terminal).toBeDefined();
+    const network = fuzzySearchCommands('toggle net', prepared).find(
+      (command) => command.id === 'toggle-allow-network',
+    );
+    expect(network).toBeDefined();
+  });
+
+  it('completes fuzzy searches in under 100ms', () => {
+    const prepared = prepareCommands(resolveCommands(context));
+    const queries = ['app', 'set theme', 'toggle', 'accent'];
+    const iterations = 50;
+    const start = performance.now();
+    for (let i = 0; i < iterations; i += 1) {
+      for (const query of queries) {
+        fuzzySearchCommands(query, prepared);
+      }
+    }
+    const duration = performance.now() - start;
+    const average = duration / (iterations * queries.length);
+    expect(duration).toBeLessThan(100);
+    expect(average).toBeLessThan(0.5);
+  });
+});
+

--- a/components/base/CommandPalette.tsx
+++ b/components/base/CommandPalette.tsx
@@ -1,0 +1,457 @@
+'use client';
+
+import Image from 'next/image';
+import {
+  FONT_SCALE_MAX,
+  FONT_SCALE_MIN,
+  FONT_SCALE_STEP,
+  PreparedCommand,
+  fuzzySearchCommands,
+  prepareCommands,
+  resolveCommands,
+} from '../../data/commands';
+import { useSettings } from '../../hooks/useSettings';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const isTextInputElement = (element: Element | null): boolean => {
+  if (!element) return false;
+  const tagName = element.tagName;
+  return (
+    tagName === 'INPUT' ||
+    tagName === 'TEXTAREA' ||
+    tagName === 'SELECT' ||
+    (element as HTMLElement).isContentEditable
+  );
+};
+
+type CommandGroup = {
+  section: string;
+  items: PreparedCommand[];
+};
+
+const MAX_RESULTS = 60;
+
+const CommandPalette: React.FC = () => {
+  const {
+    accent,
+    wallpaper,
+    density,
+    reducedMotion,
+    fontScale,
+    highContrast,
+    largeHitAreas,
+    pongSpin,
+    allowNetwork,
+    haptics,
+    theme,
+    setAccent,
+    setWallpaper,
+    setDensity,
+    setReducedMotion,
+    setFontScale,
+    setHighContrast,
+    setLargeHitAreas,
+    setPongSpin,
+    setAllowNetwork,
+    setHaptics,
+    setTheme,
+  } = useSettings();
+
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [highlightedIndex, setHighlightedIndex] = useState<number>(0);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const activeItemRef = useRef<HTMLButtonElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const context = useMemo(
+    () => ({
+      settings: {
+        accent,
+        wallpaper,
+        density,
+        reducedMotion,
+        fontScale,
+        highContrast,
+        largeHitAreas,
+        pongSpin,
+        allowNetwork,
+        haptics,
+        theme,
+      },
+    }),
+    [
+      accent,
+      wallpaper,
+      density,
+      reducedMotion,
+      fontScale,
+      highContrast,
+      largeHitAreas,
+      pongSpin,
+      allowNetwork,
+      haptics,
+      theme,
+    ],
+  );
+
+  const resolvedCommands = useMemo(() => resolveCommands(context), [context]);
+  const preparedCommands = useMemo(() => prepareCommands(resolvedCommands), [resolvedCommands]);
+
+  const visibleCommands = useMemo(() => {
+    const results = query ? fuzzySearchCommands(query, preparedCommands) : preparedCommands;
+    return results.slice(0, MAX_RESULTS);
+  }, [query, preparedCommands]);
+
+  const flatCommands = visibleCommands;
+
+  const groupedCommands = useMemo<CommandGroup[]>(() => {
+    const groups: CommandGroup[] = [];
+    const map = new Map<string, CommandGroup>();
+    for (const command of visibleCommands) {
+      let group = map.get(command.section);
+      if (!group) {
+        group = { section: command.section, items: [] };
+        map.set(command.section, group);
+        groups.push(group);
+      }
+      group.items.push(command);
+    }
+    return groups;
+  }, [visibleCommands]);
+
+  const closePalette = useCallback(() => {
+    setOpen(false);
+    setQuery('');
+    setHighlightedIndex(0);
+    activeItemRef.current = null;
+    const previous = previousFocusRef.current;
+    previousFocusRef.current = null;
+    if (previous && typeof previous.focus === 'function') {
+      previous.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
+        const target = event.target as Element | null;
+        if (!open && isTextInputElement(target)) {
+          return;
+        }
+        event.preventDefault();
+        if (open) {
+          closePalette();
+        } else {
+          setOpen(true);
+        }
+      } else if (open && event.key === 'Escape') {
+        event.preventDefault();
+        closePalette();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [closePalette, open]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    const raf = window.requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      window.cancelAnimationFrame(raf);
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const count = flatCommands.length;
+    if (!count) {
+      setHighlightedIndex(-1);
+    } else {
+      setHighlightedIndex(0);
+    }
+  }, [open, query, flatCommands.length]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (highlightedIndex >= flatCommands.length && flatCommands.length > 0) {
+      setHighlightedIndex(flatCommands.length - 1);
+    }
+  }, [flatCommands.length, highlightedIndex, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const node = activeItemRef.current;
+    if (node) {
+      node.scrollIntoView({ block: 'nearest' });
+    }
+  }, [highlightedIndex, open]);
+
+  const executeCommand = useCallback(
+    (command: PreparedCommand) => {
+      const { action } = command;
+      switch (action.type) {
+        case 'open-app': {
+          if (typeof window !== 'undefined') {
+            window.dispatchEvent(new CustomEvent('open-app', { detail: action.appId }));
+          }
+          break;
+        }
+        case 'toggle-setting': {
+          switch (action.setting) {
+            case 'reducedMotion':
+              setReducedMotion(!reducedMotion);
+              break;
+            case 'highContrast':
+              setHighContrast(!highContrast);
+              break;
+            case 'largeHitAreas':
+              setLargeHitAreas(!largeHitAreas);
+              break;
+            case 'allowNetwork':
+              setAllowNetwork(!allowNetwork);
+              break;
+            case 'haptics':
+              setHaptics(!haptics);
+              break;
+            case 'pongSpin':
+              setPongSpin(!pongSpin);
+              break;
+            default:
+              break;
+          }
+          break;
+        }
+        case 'set-setting': {
+          switch (action.setting) {
+            case 'theme':
+              setTheme(action.value as string);
+              break;
+            case 'density':
+              setDensity(action.value as 'regular' | 'compact');
+              break;
+            case 'accent':
+              setAccent(action.value as string);
+              break;
+            case 'wallpaper':
+              setWallpaper(action.value as string);
+              break;
+            case 'fontScale':
+              setFontScale(Number(action.value));
+              break;
+            default:
+              break;
+          }
+          break;
+        }
+        case 'adjust-font': {
+          const next = clamp(fontScale + action.delta, FONT_SCALE_MIN, FONT_SCALE_MAX);
+          const snapped = Math.round(next / FONT_SCALE_STEP) * FONT_SCALE_STEP;
+          const finalValue = clamp(snapped, FONT_SCALE_MIN, FONT_SCALE_MAX);
+          setFontScale(Number(finalValue.toFixed(2)));
+          break;
+        }
+        default:
+          break;
+      }
+      closePalette();
+    },
+    [
+      allowNetwork,
+      closePalette,
+      fontScale,
+      haptics,
+      highContrast,
+      largeHitAreas,
+      pongSpin,
+      reducedMotion,
+      setAccent,
+      setAllowNetwork,
+      setDensity,
+      setFontScale,
+      setHaptics,
+      setHighContrast,
+      setLargeHitAreas,
+      setPongSpin,
+      setReducedMotion,
+      setTheme,
+      setWallpaper,
+    ],
+  );
+
+  const handleInputKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLInputElement>) => {
+      if (!open) return;
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        if (!flatCommands.length) return;
+        setHighlightedIndex((index) => {
+          if (index < 0) return 0;
+          return Math.min(index + 1, flatCommands.length - 1);
+        });
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        if (!flatCommands.length) return;
+        setHighlightedIndex((index) => {
+          if (index < 0) return flatCommands.length - 1;
+          return Math.max(index - 1, 0);
+        });
+      } else if (event.key === 'Enter') {
+        if (highlightedIndex < 0 || !flatCommands[highlightedIndex]) return;
+        event.preventDefault();
+        executeCommand(flatCommands[highlightedIndex]);
+      } else if (event.key === 'Home') {
+        if (!flatCommands.length) return;
+        event.preventDefault();
+        setHighlightedIndex(0);
+      } else if (event.key === 'End') {
+        if (!flatCommands.length) return;
+        event.preventDefault();
+        setHighlightedIndex(flatCommands.length - 1);
+      }
+    },
+    [executeCommand, flatCommands, highlightedIndex, open],
+  );
+
+  const handleItemClick = useCallback(
+    (command: PreparedCommand) => {
+      executeCommand(command);
+    },
+    [executeCommand],
+  );
+
+  const activeCommand = highlightedIndex >= 0 ? flatCommands[highlightedIndex] : undefined;
+  const activeOptionId = activeCommand ? `command-option-${activeCommand.id}` : undefined;
+
+  return (
+    <>
+      {open && (
+        <div className="fixed inset-0 z-[1000]">
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={closePalette}
+            aria-hidden="true"
+          />
+          <div className="relative z-10 flex h-full w-full items-start justify-center px-4 pt-24">
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-label="Command palette"
+              className="w-full max-w-2xl overflow-hidden rounded-lg border border-white/10 bg-ub-grey text-white shadow-2xl"
+            >
+              <div className="border-b border-white/10 px-4 py-3">
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  onKeyDown={handleInputKeyDown}
+                  role="combobox"
+                  aria-expanded={open}
+                  aria-controls="command-palette-options"
+                  aria-activedescendant={activeOptionId}
+                  placeholder="Search apps and settings..."
+                  className="w-full bg-transparent text-lg leading-tight text-white placeholder:text-ubt-grey focus:outline-none"
+                />
+              </div>
+              <div className="max-h-[60vh] overflow-y-auto py-2" id="command-palette-options" role="listbox">
+                {flatCommands.length === 0 ? (
+                  <p className="px-4 py-6 text-sm text-ubt-grey">No commands match your search.</p>
+                ) : (
+                  groupedCommands.map((group) => {
+                    let runningIndex = -1;
+                    for (const existing of groupedCommands) {
+                      if (existing === group) break;
+                      runningIndex += existing.items.length;
+                    }
+                    return (
+                      <div key={group.section}>
+                        <div className="px-4 pt-3 pb-1 text-xs font-semibold uppercase tracking-wide text-ubt-grey">
+                          {group.section}
+                        </div>
+                        <ul className="space-y-1 px-2">
+                          {group.items.map((command, index) => {
+                            const absoluteIndex = runningIndex + index + 1;
+                            const isActive = absoluteIndex === highlightedIndex;
+                            const optionId = `command-option-${command.id}`;
+                            const setRef = (node: HTMLButtonElement | null) => {
+                              if (isActive) {
+                                activeItemRef.current = node;
+                              }
+                            };
+                            return (
+                              <li key={command.id} role="presentation">
+                                <button
+                                  type="button"
+                                  id={optionId}
+                                  role="option"
+                                  aria-selected={isActive}
+                                  className={`flex w-full items-start gap-3 rounded-md px-3 py-2 text-left text-sm transition focus:outline-none ${
+                                    isActive ? 'bg-white/10 ring-1 ring-white/20' : 'hover:bg-white/5'
+                                  }`}
+                                  onClick={() => handleItemClick(command)}
+                                  onMouseEnter={() => setHighlightedIndex(absoluteIndex)}
+                                  ref={setRef}
+                                  tabIndex={-1}
+                                >
+                                  {command.icon ? (
+                                    <Image
+                                      src={command.icon}
+                                      alt=""
+                                      width={24}
+                                      height={24}
+                                      className="mt-0.5 h-6 w-6 flex-shrink-0"
+                                      aria-hidden="true"
+                                    />
+                                  ) : (
+                                    <span className="mt-0.5 h-6 w-6 flex-shrink-0 rounded-md bg-white/10 text-center text-sm leading-6 text-white">
+                                      {command.title.charAt(0)}
+                                    </span>
+                                  )}
+                                  <span className="flex flex-col">
+                                    <span className="text-sm font-medium text-white">{command.title}</span>
+                                    {command.subtitle && (
+                                      <span className="text-xs text-ubt-grey">{command.subtitle}</span>
+                                    )}
+                                  </span>
+                                </button>
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      </div>
+                    );
+                  })
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default CommandPalette;
+

--- a/data/commands.ts
+++ b/data/commands.ts
@@ -1,0 +1,376 @@
+import apps from '../apps.config';
+import { ACCENT_OPTIONS } from '../hooks/useSettings';
+import { defaults } from '../utils/settingsStore';
+
+export const FONT_SCALE_MIN = 0.75;
+export const FONT_SCALE_MAX = 1.5;
+export const FONT_SCALE_STEP = 0.05;
+
+type AppMeta = {
+  id: string;
+  title: string;
+  icon: string;
+  disabled?: boolean;
+};
+
+export type ToggleSettingKey =
+  | 'reducedMotion'
+  | 'highContrast'
+  | 'largeHitAreas'
+  | 'allowNetwork'
+  | 'haptics'
+  | 'pongSpin';
+
+export type SelectSettingKey = 'density' | 'theme' | 'accent' | 'wallpaper';
+export type NumericSettingKey = 'fontScale';
+export type SettingKey = SelectSettingKey | NumericSettingKey;
+
+export type CommandAction =
+  | { type: 'open-app'; appId: string }
+  | { type: 'toggle-setting'; setting: ToggleSettingKey }
+  | { type: 'set-setting'; setting: SettingKey; value: string | number | boolean }
+  | { type: 'adjust-font'; delta: number };
+
+export type CommandDefinition = {
+  id: string;
+  title: string;
+  section: string;
+  subtitle?: string | ((context: CommandRuntimeContext) => string);
+  keywords?: string[];
+  icon?: string;
+  action: CommandAction;
+  hidden?: (context: CommandRuntimeContext) => boolean;
+};
+
+export type CommandSettingsState = {
+  accent: string;
+  wallpaper: string;
+  density: 'regular' | 'compact';
+  reducedMotion: boolean;
+  fontScale: number;
+  highContrast: boolean;
+  largeHitAreas: boolean;
+  pongSpin: boolean;
+  allowNetwork: boolean;
+  haptics: boolean;
+  theme: string;
+};
+
+export type CommandRuntimeContext = {
+  settings: CommandSettingsState;
+};
+
+export type ResolvedCommand = Omit<CommandDefinition, 'subtitle' | 'hidden'> & {
+  subtitle?: string;
+};
+
+export type PreparedCommand = ResolvedCommand & {
+  normalizedTitle: string;
+  normalizedSubtitle: string;
+  normalizedSection: string;
+  normalizedKeywords: string[];
+};
+
+const accentNames = ['Kali Blue', 'Red', 'Orange', 'Green', 'Purple', 'Pink'];
+const accentLabels: Record<string, string> = ACCENT_OPTIONS.reduce((acc, value, index) => {
+  acc[value] = accentNames[index] ?? value;
+  return acc;
+}, {} as Record<string, string>);
+
+const themeOptions = [
+  { value: 'default', label: 'Default theme', keywords: ['light', 'standard'] },
+  { value: 'dark', label: 'Dark theme', keywords: ['night', 'dark mode'] },
+  { value: 'neon', label: 'Neon theme', keywords: ['vibrant', 'bright'] },
+  { value: 'matrix', label: 'Matrix theme', keywords: ['terminal', 'green'] },
+];
+
+const densityOptions = [
+  { value: 'regular', label: 'Regular density', description: 'Comfortable spacing' },
+  { value: 'compact', label: 'Compact density', description: 'Tighter spacing' },
+];
+
+export const normalizeText = (value: string | undefined | null): string => {
+  if (!value) return '';
+  return value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+export const computeFuzzyScore = (source: string, query: string): number => {
+  if (!source || !query) return 0;
+
+  let score = 0;
+  let lastIndex = -1;
+
+  for (let i = 0; i < query.length; i += 1) {
+    const char = query[i];
+    const index = source.indexOf(char, lastIndex + 1);
+    if (index === -1) {
+      return 0;
+    }
+
+    if (lastIndex === -1) {
+      score += Math.max(8 - index, 1);
+    } else if (index === lastIndex + 1) {
+      score += 6;
+    } else {
+      const gap = index - lastIndex - 1;
+      score += Math.max(4 - Math.min(gap, 4), 1);
+    }
+
+    if (index === i) {
+      score += 2;
+    }
+
+    lastIndex = index;
+  }
+
+  if (source.startsWith(query)) {
+    score += 12;
+  }
+  if (source.includes(` ${query}`)) {
+    score += 8;
+  } else if (source.includes(query)) {
+    score += 4;
+  }
+
+  return score + query.length;
+};
+
+export const prepareCommands = (definitions: ResolvedCommand[]): PreparedCommand[] =>
+  definitions.map((definition) => ({
+    ...definition,
+    normalizedTitle: normalizeText(definition.title),
+    normalizedSubtitle: normalizeText(definition.subtitle),
+    normalizedSection: normalizeText(definition.section),
+    normalizedKeywords: (definition.keywords ?? []).map(normalizeText),
+  }));
+
+export const fuzzySearchCommands = (
+  query: string,
+  commands: PreparedCommand[],
+): PreparedCommand[] => {
+  const trimmed = normalizeText(query);
+  if (!trimmed) {
+    return commands;
+  }
+
+  const terms = trimmed.split(' ').filter(Boolean);
+  if (!terms.length) {
+    return commands;
+  }
+
+  const scored: { command: PreparedCommand; score: number }[] = [];
+
+  for (const command of commands) {
+    let totalScore = 0;
+    let matchesAll = true;
+
+    for (const term of terms) {
+      const titleScore = computeFuzzyScore(command.normalizedTitle, term);
+      const keywordScore = command.normalizedKeywords.reduce(
+        (best, keyword) => Math.max(best, computeFuzzyScore(keyword, term)),
+        0,
+      );
+      const subtitleScore = computeFuzzyScore(command.normalizedSubtitle, term);
+      const sectionScore = computeFuzzyScore(command.normalizedSection, term);
+
+      const termScore = Math.max(
+        titleScore * 4,
+        keywordScore * 3,
+        subtitleScore * 2,
+        sectionScore,
+      );
+
+      if (termScore <= 0) {
+        matchesAll = false;
+        break;
+      }
+
+      totalScore += termScore;
+    }
+
+    if (matchesAll) {
+      if (command.section === 'Applications') {
+        totalScore += 5;
+      }
+      scored.push({ command, score: totalScore });
+    }
+  }
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+    return a.command.title.localeCompare(b.command.title);
+  });
+
+  return scored.map((item) => item.command);
+};
+
+const formatPercent = (value: number) => `${Math.round(value * 100)}%`;
+
+const toggleCommands: CommandDefinition[] = [
+  {
+    id: 'toggle-reduced-motion',
+    title: 'Toggle reduced motion',
+    section: 'Accessibility',
+    keywords: ['animation', 'motion', 'accessibility', 'reduce'],
+    subtitle: ({ settings }) => (settings.reducedMotion ? 'Enabled' : 'Disabled'),
+    action: { type: 'toggle-setting', setting: 'reducedMotion' },
+  },
+  {
+    id: 'toggle-high-contrast',
+    title: 'Toggle high contrast',
+    section: 'Accessibility',
+    keywords: ['contrast', 'accessibility', 'vision'],
+    subtitle: ({ settings }) => (settings.highContrast ? 'Enabled' : 'Disabled'),
+    action: { type: 'toggle-setting', setting: 'highContrast' },
+  },
+  {
+    id: 'toggle-large-hit-areas',
+    title: 'Toggle large hit areas',
+    section: 'Accessibility',
+    keywords: ['touch', 'accessibility', 'inputs'],
+    subtitle: ({ settings }) => (settings.largeHitAreas ? 'Enabled' : 'Disabled'),
+    action: { type: 'toggle-setting', setting: 'largeHitAreas' },
+  },
+  {
+    id: 'toggle-haptics',
+    title: 'Toggle haptics',
+    section: 'System',
+    keywords: ['feedback', 'vibration', 'sound'],
+    subtitle: ({ settings }) => (settings.haptics ? 'Enabled' : 'Disabled'),
+    action: { type: 'toggle-setting', setting: 'haptics' },
+  },
+  {
+    id: 'toggle-allow-network',
+    title: 'Toggle network requests',
+    section: 'System',
+    keywords: ['network', 'privacy', 'requests', 'offline'],
+    subtitle: ({ settings }) => (settings.allowNetwork ? 'Allowed' : 'Blocked'),
+    action: { type: 'toggle-setting', setting: 'allowNetwork' },
+  },
+  {
+    id: 'toggle-pong-spin',
+    title: 'Toggle Pong spin',
+    section: 'System',
+    keywords: ['game', 'pong', 'spin'],
+    subtitle: ({ settings }) => (settings.pongSpin ? 'Enabled' : 'Disabled'),
+    action: { type: 'toggle-setting', setting: 'pongSpin' },
+  },
+];
+
+const fontCommands: CommandDefinition[] = [
+  {
+    id: 'font-increase',
+    title: 'Increase font size',
+    section: 'Appearance',
+    keywords: ['font', 'text', 'larger', 'zoom in'],
+    subtitle: ({ settings }) =>
+      settings.fontScale >= FONT_SCALE_MAX
+        ? `Current ${formatPercent(settings.fontScale)} (max)`
+        : `Current ${formatPercent(settings.fontScale)}`,
+    action: { type: 'adjust-font', delta: FONT_SCALE_STEP },
+  },
+  {
+    id: 'font-decrease',
+    title: 'Decrease font size',
+    section: 'Appearance',
+    keywords: ['font', 'text', 'smaller', 'zoom out'],
+    subtitle: ({ settings }) =>
+      settings.fontScale <= FONT_SCALE_MIN
+        ? `Current ${formatPercent(settings.fontScale)} (min)`
+        : `Current ${formatPercent(settings.fontScale)}`,
+    action: { type: 'adjust-font', delta: -FONT_SCALE_STEP },
+  },
+  {
+    id: 'font-reset',
+    title: 'Reset font size',
+    section: 'Appearance',
+    keywords: ['font', 'text', 'reset', 'default'],
+    subtitle: ({ settings }) =>
+      settings.fontScale === defaults.fontScale
+        ? 'Already at default size'
+        : `Current ${formatPercent(settings.fontScale)} → ${formatPercent(defaults.fontScale)}`,
+    action: { type: 'set-setting', setting: 'fontScale', value: defaults.fontScale },
+  },
+];
+
+const themeCommands: CommandDefinition[] = themeOptions.map((theme) => ({
+  id: `set-theme-${theme.value}`,
+  title: theme.label,
+  section: 'Appearance',
+  keywords: ['theme', theme.value, ...(theme.keywords ?? [])],
+  subtitle: ({ settings }) =>
+    settings.theme === theme.value ? 'Current theme' : `Switch to ${theme.label}`,
+  action: { type: 'set-setting', setting: 'theme', value: theme.value },
+}));
+
+const densityCommands: CommandDefinition[] = densityOptions.map((density) => ({
+  id: `set-density-${density.value}`,
+  title: density.label,
+  section: 'Appearance',
+  keywords: ['density', density.value, 'spacing'],
+  subtitle: ({ settings }) =>
+    settings.density === density.value
+      ? 'Current layout density'
+      : `Switch to ${density.description}`,
+  action: { type: 'set-setting', setting: 'density', value: density.value },
+}));
+
+const accentCommands: CommandDefinition[] = ACCENT_OPTIONS.map((accent) => {
+  const label = accentLabels[accent] ?? accent;
+  return {
+    id: `set-accent-${accent.replace('#', '')}`,
+    title: `Accent color: ${label}`,
+    section: 'Appearance',
+    keywords: ['accent', 'color', accent.replace('#', ''), label.toLowerCase()],
+    subtitle: ({ settings }) =>
+      settings.accent === accent ? 'Current accent color' : `Switch to ${label}`,
+    action: { type: 'set-setting', setting: 'accent', value: accent },
+  };
+});
+
+const appCommands: CommandDefinition[] = (apps as AppMeta[])
+  .filter((app) => !app.disabled)
+  .map((app) => ({
+    id: `open-app-${app.id}`,
+    title: app.title,
+    section: 'Applications',
+    subtitle: 'Open application',
+    keywords: [app.id, 'app', 'open', 'launch'],
+    icon: app.icon,
+    action: { type: 'open-app', appId: app.id },
+  }));
+
+const commandDefinitions: CommandDefinition[] = [
+  ...appCommands,
+  ...toggleCommands,
+  ...fontCommands,
+  ...themeCommands,
+  ...densityCommands,
+  ...accentCommands,
+];
+
+export function resolveCommands(context: CommandRuntimeContext): ResolvedCommand[] {
+  return commandDefinitions
+    .filter((definition) => (definition.hidden ? !definition.hidden(context) : true))
+    .map((definition) => ({
+      id: definition.id,
+      title: definition.title,
+      section: definition.section,
+      keywords: definition.keywords,
+      icon: definition.icon,
+      action: definition.action,
+      subtitle:
+        typeof definition.subtitle === 'function'
+          ? definition.subtitle(context)
+          : definition.subtitle,
+    }));
+}
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import CommandPalette from '../components/base/CommandPalette';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -160,6 +161,7 @@ function MyApp(props) {
           <PipPortalProvider>
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />
+            <CommandPalette />
             <ShortcutOverlay />
             <Analytics
               beforeSend={(e) => {


### PR DESCRIPTION
## Summary
- add a centralized command registry with fuzzy-search helpers for app launchers and settings shortcuts
- implement a keyboard-driven command palette component with global Ctrl+K shortcut and modal UI
- wire the palette into the app shell and cover registry behaviour with dedicated tests

## Testing
- yarn lint *(fails: repository has numerous pre-existing accessibility errors in legacy apps and static game scripts)*
- yarn test *(fails: suite already contains failing window/modal/nmap specs under jsdom)*
- CI=1 yarn test __tests__/commandSearch.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68caa9d131d88328aeb1b8a9ef48bbf1