### PR TITLE
[a11y] improve focus rings and add axe coverage

### DIFF
--- a/__tests__/accessibility/components.test.tsx
+++ b/__tests__/accessibility/components.test.tsx
@@ -1,0 +1,69 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { axe } from 'jest-axe';
+
+jest.mock('marked', () => ({ marked: { parse: (md: string) => md } }));
+jest.mock('dompurify', () => ({
+  __esModule: true,
+  default: { sanitize: (html: string) => html },
+  sanitize: (html: string) => html,
+}));
+
+import HelpPanel from '../../components/HelpPanel';
+import Tabs from '../../components/Tabs';
+import ToggleSwitch from '../../components/ToggleSwitch';
+
+describe('core interactive components accessibility', () => {
+  it('Tabs renders without accessibility violations', async () => {
+    const tabs = [
+      { id: 'first', label: 'First tab' },
+      { id: 'second', label: 'Second tab' },
+    ] as const;
+
+    function Harness() {
+      const [active, setActive] = React.useState<typeof tabs[number]['id']>('first');
+      const panelIdFor = (id: typeof tabs[number]['id']) => `harness-panel-${id}`;
+
+      return (
+        <div>
+          <Tabs
+            tabs={tabs}
+            active={active}
+            onChange={setActive}
+            idPrefix="harness-tab"
+            getPanelId={(id) => panelIdFor(id)}
+          />
+          {tabs.map((tab) => (
+            <section
+              key={tab.id}
+              id={panelIdFor(tab.id)}
+              role="tabpanel"
+              aria-labelledby={`harness-tab-${tab.id}`}
+              hidden={active !== tab.id}
+            >
+              <p>{tab.label}</p>
+            </section>
+          ))}
+        </div>
+      );
+    }
+
+    const { container } = render(<Harness />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('ToggleSwitch renders without accessibility violations', async () => {
+    const { container } = render(
+      <ToggleSwitch ariaLabel="Enable feature" checked={false} onChange={() => {}} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('HelpPanel button renders without accessibility violations when closed', async () => {
+    const { container } = render(<HelpPanel appId="sample" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/components/HelpPanel.tsx
+++ b/components/HelpPanel.tsx
@@ -47,6 +47,7 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
   }, []);
 
   const toggle = () => setOpen((o) => !o);
+  const panelId = `help-panel-${appId}`;
 
   return (
     <>
@@ -54,8 +55,10 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
         type="button"
         aria-label="Help"
         aria-expanded={open}
+        aria-haspopup="dialog"
+        aria-controls={open ? panelId : undefined}
         onClick={toggle}
-        className="fixed top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+        className="fixed top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center"
       >
         ?
       </button>
@@ -65,9 +68,22 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
           onClick={toggle}
         >
           <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Help panel"
+            id={panelId}
             className="bg-white text-black p-4 rounded max-w-md w-full h-full overflow-auto"
             onClick={(e) => e.stopPropagation()}
           >
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={toggle}
+                className="rounded px-2 py-1 text-sm text-gray-700 hover:text-black"
+              >
+                Close
+              </button>
+            </div>
             <div dangerouslySetInnerHTML={{ __html: html }} />
           </div>
         </div>

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -11,6 +11,13 @@ interface TabsProps<T extends string> {
   active: T;
   onChange: (id: T) => void;
   className?: string;
+  /** Prefix applied to the generated tab ids so multiple tablists can coexist */
+  idPrefix?: string;
+  /**
+   * Optional helper for wiring aria-controls to a tabpanel id. Receives the
+   * logical tab id and the generated DOM id for the tab button.
+   */
+  getPanelId?: (id: T, tabDomId: string) => string;
 }
 
 export default function Tabs<T extends string>({
@@ -18,23 +25,34 @@ export default function Tabs<T extends string>({
   active,
   onChange,
   className = "",
+  idPrefix,
+  getPanelId,
 }: TabsProps<T>) {
+  const autoPrefix = React.useId();
+  const resolvedPrefix = idPrefix ?? `tab-${autoPrefix}`;
   return (
     <div role="tablist" className={`flex ${className}`.trim()}>
-      {tabs.map((t) => (
-        <button
-          key={t.id}
-          role="tab"
-          aria-selected={active === t.id}
-          tabIndex={active === t.id ? 0 : -1}
-          onClick={() => onChange(t.id)}
-          className={`px-4 py-2 focus:outline-none ${
-            active === t.id ? "bg-ub-orange text-white" : "text-ubt-grey"
-          }`}
-        >
-          {t.label}
-        </button>
-      ))}
+      {tabs.map((t) => {
+        const tabDomId = `${resolvedPrefix}-${t.id}`;
+        const panelId = getPanelId ? getPanelId(t.id, tabDomId) : undefined;
+        return (
+          <button
+            key={t.id}
+            id={tabDomId}
+            type="button"
+            role="tab"
+            aria-selected={active === t.id}
+            aria-controls={panelId}
+            tabIndex={active === t.id ? 0 : -1}
+            onClick={() => onChange(t.id)}
+            className={`px-4 py-2 ${
+              active === t.id ? "bg-ub-orange text-white" : "text-ubt-grey"
+            }`}
+          >
+            {t.label}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/components/ToggleSwitch.tsx
+++ b/components/ToggleSwitch.tsx
@@ -16,11 +16,12 @@ export default function ToggleSwitch({
 }: ToggleSwitchProps) {
   return (
     <button
+      type="button"
       role="switch"
       aria-checked={checked}
       aria-label={ariaLabel}
       onClick={() => onChange(!checked)}
-      className={`relative inline-flex w-10 h-5 rounded-full transition-colors focus:outline-none ${
+      className={`relative inline-flex w-10 h-5 rounded-full transition-colors ${
         checked ? "bg-ub-orange" : "bg-ubt-cool-grey"
       } ${className}`.trim()}
     >

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -807,7 +807,7 @@ export function WindowEditButtons(props) {
                 type="button"
                 id={`close-${props.id}`}
                 aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
+                className="mx-1 cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
                 onClick={props.close}
             >
                 <NextImage

--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -60,11 +60,25 @@ export default function Preferences() {
     localStorage.setItem(`${PANEL_PREFIX}autohide`, autohide ? "true" : "false");
   }, [autohide]);
 
+  const panelIdFor = (id: TabId) => `preferences-panel-${id}`;
+
   return (
     <div>
-      <Tabs tabs={TABS} active={active} onChange={setActive} />
+      <Tabs
+        tabs={TABS}
+        active={active}
+        onChange={setActive}
+        idPrefix="preferences-tab"
+        getPanelId={(id) => panelIdFor(id)}
+      />
       <div className="p-4">
-        {active === "display" && (
+        <section
+          id={panelIdFor("display")}
+          role="tabpanel"
+          aria-labelledby="preferences-tab-display"
+          hidden={active !== "display"}
+          aria-hidden={active !== "display"}
+        >
           <div className="space-y-4">
             <div className="flex items-center justify-between">
               <label htmlFor="orientation" className="text-ubt-grey">
@@ -91,8 +105,14 @@ export default function Preferences() {
               />
             </div>
           </div>
-        )}
-        {active === "measurements" && (
+        </section>
+        <section
+          id={panelIdFor("measurements")}
+          role="tabpanel"
+          aria-labelledby="preferences-tab-measurements"
+          hidden={active !== "measurements"}
+          aria-hidden={active !== "measurements"}
+        >
           <div className="space-y-4">
             <div className="flex items-center justify-between">
               <label htmlFor="panel-size" className="text-ubt-grey">
@@ -125,16 +145,34 @@ export default function Preferences() {
               />
             </div>
           </div>
-        )}
-        {active === "appearance" && (
+        </section>
+        <section
+          id={panelIdFor("appearance")}
+          role="tabpanel"
+          aria-labelledby="preferences-tab-appearance"
+          hidden={active !== "appearance"}
+          aria-hidden={active !== "appearance"}
+        >
           <p className="text-ubt-grey">Appearance settings are not available yet.</p>
-        )}
-        {active === "opacity" && (
+        </section>
+        <section
+          id={panelIdFor("opacity")}
+          role="tabpanel"
+          aria-labelledby="preferences-tab-opacity"
+          hidden={active !== "opacity"}
+          aria-hidden={active !== "opacity"}
+        >
           <p className="text-ubt-grey">Opacity settings are not available yet.</p>
-        )}
-        {active === "items" && (
+        </section>
+        <section
+          id={panelIdFor("items")}
+          role="tabpanel"
+          aria-labelledby="preferences-tab-items"
+          hidden={active !== "items"}
+          aria-hidden={active !== "items"}
+        >
           <p className="text-ubt-grey">Item settings are not available yet.</p>
-        )}
+        </section>
       </div>
     </div>
   );

--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -12,18 +12,25 @@ interface Props {
 const Breadcrumbs: React.FC<Props> = ({ path, onNavigate }) => {
   return (
     <nav className="flex items-center space-x-1 text-white" aria-label="Breadcrumb">
-      {path.map((seg, idx) => (
-        <React.Fragment key={idx}>
-          <button
-            type="button"
-            onClick={() => onNavigate(idx)}
-            className="hover:underline focus:outline-none"
-          >
-            {seg.name || '/'}
-          </button>
-          {idx < path.length - 1 && <span>/</span>}
-        </React.Fragment>
-      ))}
+      {path.map((seg, idx) => {
+        const isCurrent = idx === path.length - 1;
+        return (
+          <React.Fragment key={idx}>
+            {isCurrent ? (
+              <span aria-current="page">{seg.name || '/'}</span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => onNavigate(idx)}
+                className="hover:underline"
+              >
+                {seg.name || '/'}
+              </button>
+            )}
+            {idx < path.length - 1 && <span>/</span>}
+          </React.Fragment>
+        );
+      })}
     </nav>
   );
 };

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -37,8 +37,9 @@ const Toast: React.FC<ToastProps> = ({
       <span>{message}</span>
       {onAction && actionLabel && (
         <button
+          type="button"
           onClick={onAction}
-          className="ml-4 underline focus:outline-none"
+          className="ml-4 underline"
         >
           {actionLabel}
         </button>

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,5 @@
 import { TextEncoder, TextDecoder } from 'util';
+import { toHaveNoViolations } from 'jest-axe';
 // Polyfill structuredClone before requiring modules that depend on it
 // @ts-ignore
 if (typeof global.structuredClone !== 'function') {
@@ -7,6 +8,8 @@ if (typeof global.structuredClone !== 'function') {
 }
 require('fake-indexeddb/auto');
 import '@testing-library/jest-dom';
+
+expect.extend(toHaveNoViolations);
 
 // Provide TextEncoder/TextDecoder for libraries that expect them in the test environment
 // @ts-ignore

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "fake-indexeddb": "^6.1.0",
     "fast-glob": "^3.3.3",
     "jest": "30.0.5",
+    "jest-axe": "^9.0.0",
     "jest-environment-jsdom": "30.0.5",
     "magic-string": "0.30.18",
     "node-mocks-http": "1.17.2",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,7 +16,7 @@
   --color-border: #2a2e36; /* subtle borders */
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
-  --color-focus-ring: var(--color-accent);
+  --color-focus-ring: var(--focus-outline-color);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   accent-color: var(--color-control-accent);
@@ -74,6 +74,7 @@ html[data-theme='matrix'] {
 }
 
 *:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
-  outline-offset: 2px;
+  outline: var(--focus-outline-width) solid var(--color-focus-ring);
+  outline-offset: var(--focus-outline-offset);
+  box-shadow: var(--focus-ring-shadow);
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -18,8 +18,9 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
 
 a:focus-visible,
 button:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
-    outline-offset: 2px;
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline-offset: var(--focus-outline-offset);
+    box-shadow: var(--focus-ring-shadow);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -58,8 +58,10 @@
   /* Minimum interactive target size */
   --hit-area: 32px;
   /* Focus outline */
-  --focus-outline-color: var(--color-ubt-blue);
-  --focus-outline-width: 2px;
+  --focus-outline-color: #facc15; /* vivid amber provides 8.6:1 contrast on dark surfaces */
+  --focus-outline-width: 3px;
+  --focus-outline-offset: 3px;
+  --focus-ring-shadow: 0 0 0 4px rgba(250, 204, 21, 0.3);
 }
 
 /* High contrast theme */
@@ -77,6 +79,8 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --focus-outline-color: #ffffff;
+  --focus-ring-shadow: 0 0 0 4px rgba(255, 255, 255, 0.35);
 }
 
 /* Dyslexia-friendly fonts */
@@ -116,5 +120,7 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+    --focus-outline-color: #ffffff;
+    --focus-ring-shadow: 0 0 0 4px rgba(255, 255, 255, 0.45);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2201,6 +2201,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/schemas@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "@jest/schemas@npm:29.6.3"
+  dependencies:
+    "@sinclair/typebox": "npm:^0.27.8"
+  checksum: 10c0/b329e89cd5f20b9278ae1233df74016ebf7b385e0d14b9f4c1ad18d096c4c19d1e687aa113a9c976b16ec07f021ae53dea811fb8c1248a50ac34fbe009fdf6be
+  languageName: node
+  linkType: hard
+
 "@jest/snapshot-utils@npm:30.0.5":
   version: 30.0.5
   resolution: "@jest/snapshot-utils@npm:30.0.5"
@@ -2997,6 +3006,13 @@ __metadata:
   version: 2.0.0
   resolution: "@sideway/pinpoint@npm:2.0.0"
   checksum: 10c0/d2ca75dacaf69b8fc0bb8916a204e01def3105ee44d8be16c355e5f58189eb94039e15ce831f3d544f229889ccfa35562a0ce2516179f3a7ee1bbe0b71e55b36
+  languageName: node
+  linkType: hard
+
+"@sinclair/typebox@npm:^0.27.8":
+  version: 0.27.8
+  resolution: "@sinclair/typebox@npm:0.27.8"
+  checksum: 10c0/ef6351ae073c45c2ac89494dbb3e1f87cc60a93ce4cde797b782812b6f97da0d620ae81973f104b43c9b7eaa789ad20ba4f6a1359f1cc62f63729a55a7d22d4e
   languageName: node
   linkType: hard
 
@@ -4959,6 +4975,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axe-core@npm:4.9.1":
+  version: 4.9.1
+  resolution: "axe-core@npm:4.9.1"
+  checksum: 10c0/ac9e5a0c6fa115a43ebffc32a1d2189e1ca6431b5a78e88cdcf94a72a25c5964185682edd94fe6bdb1cb4266c0d06301b022866e0e50dcdf6e3cefe556470110
+  languageName: node
+  linkType: hard
+
 "axe-core@npm:^4.10.0, axe-core@npm:~4.10.3":
   version: 4.10.3
   resolution: "axe-core@npm:4.10.3"
@@ -5463,7 +5486,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.2":
+"chalk@npm:4.1.2, chalk@npm:^4.0.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -6329,6 +6352,13 @@ __metadata:
   version: 1.2.2
   resolution: "didyoumean@npm:1.2.2"
   checksum: 10c0/95d0b53d23b851aacff56dfadb7ecfedce49da4232233baecfeecb7710248c4aa03f0aa8995062f0acafaf925adf8536bd7044a2e68316fd7d411477599bc27b
+  languageName: node
+  linkType: hard
+
+"diff-sequences@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "diff-sequences@npm:29.6.3"
+  checksum: 10c0/32e27ac7dbffdf2fb0eb5a84efd98a9ad084fbabd5ac9abb8757c6770d5320d2acd172830b28c4add29bb873d59420601dfc805ac4064330ce59b1adfd0593b2
   languageName: node
   linkType: hard
 
@@ -8654,6 +8684,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-axe@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "jest-axe@npm:9.0.0"
+  dependencies:
+    axe-core: "npm:4.9.1"
+    chalk: "npm:4.1.2"
+    jest-matcher-utils: "npm:29.2.2"
+    lodash.merge: "npm:4.6.2"
+  checksum: 10c0/5cf60b455b72df6c9defdf542a75a853d26d9dbdefe4e29c7b974b4e72b0127caddbc994d6f39faad3606ea8d5b2bf63f7717352fb918edeb7598612088f97b2
+  languageName: node
+  linkType: hard
+
 "jest-changed-files@npm:30.0.5":
   version: 30.0.5
   resolution: "jest-changed-files@npm:30.0.5"
@@ -8785,6 +8827,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:^29.2.1":
+  version: 29.7.0
+  resolution: "jest-diff@npm:29.7.0"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    diff-sequences: "npm:^29.6.3"
+    jest-get-type: "npm:^29.6.3"
+    pretty-format: "npm:^29.7.0"
+  checksum: 10c0/89a4a7f182590f56f526443dde69acefb1f2f0c9e59253c61d319569856c4931eae66b8a3790c443f529267a0ddba5ba80431c585deed81827032b2b2a1fc999
+  languageName: node
+  linkType: hard
+
 "jest-docblock@npm:30.0.1":
   version: 30.0.1
   resolution: "jest-docblock@npm:30.0.1"
@@ -8840,6 +8894,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-get-type@npm:^29.2.0, jest-get-type@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "jest-get-type@npm:29.6.3"
+  checksum: 10c0/552e7a97a983d3c2d4e412a44eb7de0430ff773dd99f7500962c268d6dfbfa431d7d08f919c9d960530e5f7f78eb47f267ad9b318265e5092b3ff9ede0db7c2b
+  languageName: node
+  linkType: hard
+
 "jest-haste-map@npm:30.0.5":
   version: 30.0.5
   resolution: "jest-haste-map@npm:30.0.5"
@@ -8869,6 +8930,18 @@ __metadata:
     "@jest/get-type": "npm:30.0.1"
     pretty-format: "npm:30.0.5"
   checksum: 10c0/04207ab6f44dec22d3d656b5f3b4f334440f4c01ccd21c55474f26706530244d34b8dc9922c9449e00e8649e5da1b8de4aca58c9895c9de19951d5ecdc0ff113
+  languageName: node
+  linkType: hard
+
+"jest-matcher-utils@npm:29.2.2":
+  version: 29.2.2
+  resolution: "jest-matcher-utils@npm:29.2.2"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    jest-diff: "npm:^29.2.1"
+    jest-get-type: "npm:^29.2.0"
+    pretty-format: "npm:^29.2.1"
+  checksum: 10c0/a554e683bcd18cc11e1e018597771051e88cb3bf79cdbb5896f7550bd4c787e473ba4727336db2049fea6149e21546c8f1cde4b78a76eb595199cfeaba6450b1
   languageName: node
   linkType: hard
 
@@ -9595,7 +9668,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.merge@npm:^4.6.2":
+"lodash.merge@npm:4.6.2, lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: 10c0/402fa16a1edd7538de5b5903a90228aa48eb5533986ba7fa26606a49db2572bf414ff73a2c9f5d5fd36b31c46a5d5c7e1527749c07cbcf965ccff5fbdf32c506
@@ -11076,6 +11149,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:^29.2.1, pretty-format@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "pretty-format@npm:29.7.0"
+  dependencies:
+    "@jest/schemas": "npm:^29.6.3"
+    ansi-styles: "npm:^5.0.0"
+    react-is: "npm:^18.0.0"
+  checksum: 10c0/edc5ff89f51916f036c62ed433506b55446ff739358de77207e63e88a28ca2894caac6e73dcb68166a606e51c8087d32d400473e6a9fdd2dbe743f46c9c0276f
+  languageName: node
+  linkType: hard
+
 "proc-log@npm:^5.0.0":
   version: 5.0.0
   resolution: "proc-log@npm:5.0.0"
@@ -11920,7 +12004,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^18.2.0, react-is@npm:^18.3.1":
+"react-is@npm:^18.0.0, react-is@npm:^18.2.0, react-is@npm:^18.3.1":
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: 10c0/f2f1e60010c683479e74c63f96b09fb41603527cd131a9959e2aee1e5a8b0caf270b365e5ca77d4a6b18aae659b60a86150bb3979073528877029b35aecd2072
@@ -13918,6 +14002,7 @@ __metadata:
     idb: "npm:7.1.1"
     idb-keyval: "npm:^6.2.1"
     jest: "npm:30.0.5"
+    jest-axe: "npm:^9.0.0"
     jest-environment-jsdom: "npm:30.0.5"
     jspdf: "npm:^3.0.2"
     kaitai-struct: "npm:^0.10.0"


### PR DESCRIPTION
## Summary
- raise the design tokens for focus rings to a high-contrast palette and wire the global CSS to use the new variables
- stop suppressing focus styles on key interactive components while adding missing ARIA metadata and tabbable dialog affordances
- add a focused jest-axe suite plus matcher wiring so core controls get explicit accessibility regression coverage

## Testing
- yarn lint *(fails: repository contains numerous existing jsx-a11y/control-has-associated-label violations outside the change scope)*
- yarn test __tests__/accessibility/components.test.tsx --runTestsByPath


------
https://chatgpt.com/codex/tasks/task_e_68caa9d651248328b018bddf20f3d754