### PR TITLE
[ui] centralize interactive hover tokens

### DIFF
--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -534,13 +534,13 @@ const Game2048 = () => {
       <>
         <div className="mb-2 flex flex-wrap gap-2 items-center">
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 interactive-surface rounded"
             onClick={reset}
           >
             Reset
           </button>
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded disabled:opacity-50"
+            className="px-4 py-2 bg-gray-700 interactive-surface rounded disabled:opacity-50"
             onClick={undo}
             disabled={history.length === 0 || undosLeft === 0}
           >
@@ -577,13 +577,13 @@ const Game2048 = () => {
             </select>
           </label>
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 interactive-surface rounded"
             onClick={() => setDemo((d) => !d)}
           >
             {demo ? 'Stop' : 'Demo'}
           </button>
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 interactive-surface rounded"
             onClick={close}
           >
             Close

--- a/components/apps/ClipboardManager.tsx
+++ b/components/apps/ClipboardManager.tsx
@@ -116,7 +116,7 @@ const ClipboardManager: React.FC = () => {
   return (
     <div className="p-4 space-y-2 text-white bg-ub-cool-grey h-full overflow-auto">
       <button
-        className="px-2 py-1 bg-gray-700 hover:bg-gray-600"
+        className="px-2 py-1 bg-gray-700 interactive-surface"
         onClick={clearHistory}
       >
         Clear History

--- a/components/apps/archive/Calc/index.tsx
+++ b/components/apps/archive/Calc/index.tsx
@@ -214,7 +214,7 @@ const Calc: React.FC<CalcProps> = ({ addFolder, openApp }) => {
           <button
             aria-label="copy"
             onClick={() => handleCopy(display)}
-            className="ml-2 px-2 py-1 bg-gray-800 hover:bg-gray-700 rounded text-sm min-w-[24px] min-h-[24px]"
+            className="ml-2 px-2 py-1 bg-gray-800 interactive-surface rounded text-sm min-w-[24px] min-h-[24px]"
           >
             Copy
           </button>
@@ -223,35 +223,35 @@ const Calc: React.FC<CalcProps> = ({ addFolder, openApp }) => {
           <button
             aria-label="memory add"
             onClick={handleMemoryAdd}
-            className="px-2 py-1 bg-gray-800 hover:bg-gray-700 rounded text-sm min-w-[24px] min-h-[24px]"
+            className="px-2 py-1 bg-gray-800 interactive-surface rounded text-sm min-w-[24px] min-h-[24px]"
           >
             M+
           </button>
           <button
             aria-label="memory subtract"
             onClick={handleMemorySubtract}
-            className="px-2 py-1 bg-gray-800 hover:bg-gray-700 rounded text-sm min-w-[24px] min-h-[24px]"
+            className="px-2 py-1 bg-gray-800 interactive-surface rounded text-sm min-w-[24px] min-h-[24px]"
           >
             M-
           </button>
           <button
             aria-label="memory recall"
             onClick={handleMemoryRecall}
-            className="px-2 py-1 bg-gray-800 hover:bg-gray-700 rounded text-sm min-w-[24px] min-h-[24px]"
+            className="px-2 py-1 bg-gray-800 interactive-surface rounded text-sm min-w-[24px] min-h-[24px]"
           >
             MR
           </button>
           <button
             aria-label="toggle scientific"
             onClick={() => setShowSci((s) => !s)}
-            className="px-2 py-1 bg-gray-800 hover:bg-gray-700 rounded text-sm min-w-[24px] min-h-[24px]"
+            className="px-2 py-1 bg-gray-800 interactive-surface rounded text-sm min-w-[24px] min-h-[24px]"
           >
             Sci
           </button>
           <button
             aria-label="toggle date diff"
             onClick={() => setShowDateDiff((s) => !s)}
-            className="px-2 py-1 bg-gray-800 hover:bg-gray-700 rounded text-sm min-w-[24px] min-h-[24px]"
+            className="px-2 py-1 bg-gray-800 interactive-surface rounded text-sm min-w-[24px] min-h-[24px]"
           >
             Date
           </button>
@@ -262,7 +262,7 @@ const Calc: React.FC<CalcProps> = ({ addFolder, openApp }) => {
               <button
                 key={idx}
                 aria-label={btn.ariaLabel}
-                className="bg-gray-800 hover:bg-gray-700 rounded text-xl flex items-center justify-center min-w-[24px] min-h-[24px]"
+                className="bg-gray-800 interactive-surface rounded text-xl flex items-center justify-center min-w-[24px] min-h-[24px]"
                 onClick={btn.onClick}
               >
                 {btn.label}
@@ -275,7 +275,7 @@ const Calc: React.FC<CalcProps> = ({ addFolder, openApp }) => {
             <button
               key={idx}
               aria-label={btn.ariaLabel || btn.label}
-              className={`bg-gray-800 hover:bg-gray-700 rounded text-xl flex items-center justify-center min-w-[24px] min-h-[24px] ${
+              className={`bg-gray-800 interactive-surface rounded text-xl flex items-center justify-center min-w-[24px] min-h-[24px] ${
                 btn.colSpan ? `col-span-${btn.colSpan}` : ''
               }`}
               onClick={() => handleButton(btn)}
@@ -310,7 +310,7 @@ const Calc: React.FC<CalcProps> = ({ addFolder, openApp }) => {
           <button
             aria-label="clear history"
             onClick={() => setHistory([])}
-            className="px-2 py-1 bg-gray-800 hover:bg-gray-700 rounded text-sm min-w-[24px] min-h-[24px]"
+            className="px-2 py-1 bg-gray-800 interactive-surface rounded text-sm min-w-[24px] min-h-[24px]"
           >
             Clear
           </button>
@@ -322,7 +322,7 @@ const Calc: React.FC<CalcProps> = ({ addFolder, openApp }) => {
               <button
                 aria-label={`copy history ${idx}`}
                 onClick={() => handleCopy(`${expr} = ${result}`)}
-                className="ml-2 px-1 bg-gray-700 hover:bg-gray-600 rounded text-xs min-w-[24px] min-h-[24px]"
+                className="ml-2 px-1 bg-gray-700 interactive-surface rounded text-xs min-w-[24px] min-h-[24px]"
               >
                 Copy
               </button>

--- a/components/apps/ascii_art/index.js
+++ b/components/apps/ascii_art/index.js
@@ -491,35 +491,35 @@ export default function AsciiArt() {
         <button
           type="button"
           onClick={copyAscii}
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
         >
           Copy Text
         </button>
         <button
           type="button"
           onClick={downloadAnsi}
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
         >
           ANSI
         </button>
         <button
           type="button"
           onClick={downloadTxt}
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
         >
           TXT
         </button>
         <button
           type="button"
           onClick={downloadPng}
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
         >
           Export PNG
         </button>
         <button
           type="button"
           onClick={toggleTypingMode}
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
         >
           {typingMode ? 'Image Mode' : 'Typing Mode'}
         </button>
@@ -528,14 +528,14 @@ export default function AsciiArt() {
             <button
               type="button"
               onClick={undo}
-              className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+              className="px-2 py-1 bg-gray-700 interactive-surface rounded"
             >
               Undo
             </button>
             <button
               type="button"
               onClick={redo}
-              className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+              className="px-2 py-1 bg-gray-700 interactive-surface rounded"
             >
               Redo
             </button>
@@ -544,7 +544,7 @@ export default function AsciiArt() {
         <button
           type="button"
           onClick={playAltText}
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
         >
           Alt
         </button>

--- a/components/apps/checkers.js
+++ b/components/apps/checkers.js
@@ -397,31 +397,31 @@ const Checkers = () => {
       </label>
       <div className="space-x-2 mb-2">
         <button
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
           onClick={reset}
         >
           Reset
         </button>
         <button
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
           onClick={undo}
         >
           Undo
         </button>
         <button
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
           onClick={() => setPaused((p) => !p)}
         >
           {paused ? 'Resume' : 'Pause'}
         </button>
         <button
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
           onClick={() => setSound((s) => !s)}
         >
           {sound ? 'Sound On' : 'Sound Off'}
         </button>
         <button
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
           onClick={showHint}
         >
           Hint

--- a/components/apps/checkers/index.tsx
+++ b/components/apps/checkers/index.tsx
@@ -493,7 +493,7 @@ const Checkers = () => {
       <div className="mt-4 space-x-2">
         {winner || draw ? (
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 interactive-surface rounded"
             onClick={reset}
           >
             Reset
@@ -513,25 +513,25 @@ const Checkers = () => {
               </select>
             </label>
             <button
-              className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+              className="px-2 py-1 bg-gray-700 interactive-surface rounded"
               onClick={undo}
             >
               Undo
             </button>
             <button
-              className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+              className="px-2 py-1 bg-gray-700 interactive-surface rounded"
               onClick={redo}
             >
               Redo
             </button>
             <button
-              className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+              className="px-2 py-1 bg-gray-700 interactive-surface rounded"
               onClick={hintMove}
             >
               Hint
             </button>
             <button
-              className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+              className="px-2 py-1 bg-gray-700 interactive-surface rounded"
               onClick={toggleShowLegal}
               aria-pressed={showLegal}
             >
@@ -540,7 +540,7 @@ const Checkers = () => {
           </>
         )}
         <button
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
           onClick={exportMoves}
         >
           Export Moves

--- a/components/apps/connect-four.js
+++ b/components/apps/connect-four.js
@@ -292,7 +292,7 @@ export default function ConnectFour() {
           </div>
         )}
         <button
-          className="absolute top-2 right-2 px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="absolute top-2 right-2 px-3 py-1 bg-gray-700 interactive-surface rounded"
           onClick={reset}
         >
           Restart
@@ -357,7 +357,7 @@ export default function ConnectFour() {
         </div>
         <div className="mt-4 flex gap-2">
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 interactive-surface rounded"
             onClick={undo}
             disabled={game.history.length === 0 || animDisc}
           >

--- a/components/apps/figlet/index.js
+++ b/components/apps/figlet/index.js
@@ -392,28 +392,28 @@ const FigletApp = () => {
         />
         <button
           onClick={() => setWrap((w) => !w)}
-          className="px-2 bg-gray-700 hover:bg-gray-600 rounded text-white"
+          className="px-2 bg-gray-700 interactive-surface rounded text-white"
           aria-label="Toggle wrap"
         >
           {wrap ? 'No Wrap' : 'Wrap'}
         </button>
         <button
           onClick={copyAll}
-          className="px-2 bg-blue-700 hover:bg-blue-600 rounded text-white"
+          className="px-2 bg-blue-700 text-white rounded interactive-surface"
           aria-label="Copy all"
         >
           Copy All
         </button>
         <button
           onClick={exportPNG}
-          className="px-2 bg-green-700 hover:bg-green-600 rounded text-white"
+          className="px-2 bg-green-700 text-white rounded interactive-surface"
           aria-label="Export PNG"
         >
           PNG
         </button>
         <button
           onClick={exportText}
-          className="px-2 bg-purple-700 hover:bg-purple-600 rounded text-white"
+          className="px-2 bg-purple-700 text-white rounded interactive-surface"
           aria-label="Export text file"
         >
           TXT

--- a/components/apps/flappy-bird.js
+++ b/components/apps/flappy-bird.js
@@ -763,7 +763,7 @@ const FlappyBird = () => {
             </select>
           </label>
           <button
-            className="px-6 py-3 w-32 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-6 py-3 w-32 bg-gray-700 interactive-surface rounded"
             onClick={() => {
               try {
                 localStorage.setItem("flappy-bird-skin", String(skin));

--- a/components/apps/game.js
+++ b/components/apps/game.js
@@ -68,7 +68,7 @@ const GameApp = () => {
       score={<div className="text-xl">{status}</div>}
       controls={
         <button
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-4 py-2 bg-gray-700 interactive-surface rounded"
           onClick={reset}
         >
           Reset
@@ -79,7 +79,7 @@ const GameApp = () => {
         {squares.map((value, idx) => (
           <button
             key={idx}
-            className="w-16 h-16 bg-gray-700 hover:bg-gray-600 text-2xl flex items-center justify-center"
+            className="w-16 h-16 bg-gray-700 interactive-surface text-2xl flex items-center justify-center"
             onClick={() => handleClick(idx)}
           >
             {value}

--- a/components/apps/gomoku.js
+++ b/components/apps/gomoku.js
@@ -76,7 +76,7 @@ const Gomoku = () => {
         )}
       </div>
       <button
-        className="mt-4 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+        className="mt-4 px-4 py-2 bg-gray-700 interactive-surface rounded"
         onClick={reset}
       >
         Reset

--- a/components/apps/john/index.js
+++ b/components/apps/john/index.js
@@ -421,7 +421,7 @@ const JohnApp = () => {
         <div className="flex items-center gap-2">
           <button
             type="submit"
-            className="px-4 py-1 bg-gray-700 hover:bg-gray-600 rounded self-start"
+            className="px-4 py-1 bg-gray-700 interactive-surface rounded self-start"
             disabled={loading}
           >
             {loading ? 'Running...' : 'Crack'}
@@ -430,7 +430,7 @@ const JohnApp = () => {
             <button
               type="button"
               onClick={handleCancel}
-              className="px-4 py-1 bg-red-700 hover:bg-red-600 rounded"
+              className="px-4 py-1 bg-red-700 text-white rounded interactive-surface"
             >
               Cancel
             </button>
@@ -496,7 +496,7 @@ const JohnApp = () => {
             <button
               type="button"
               onClick={handleExport}
-              className="self-start px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded text-sm"
+              className="self-start px-3 py-1 bg-gray-700 interactive-surface rounded text-sm"
             >
               Export
             </button>

--- a/components/apps/memory.js
+++ b/components/apps/memory.js
@@ -367,18 +367,18 @@ const MemoryBoard = ({ player, themePacks, onWin }) => {
         <div data-testid="combo-meter">Combo: {streak}</div>
       </div>
       <div className="flex space-x-2">
-        <button onClick={reset} className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded">
+        <button onClick={reset} className="px-2 py-1 bg-gray-700 interactive-surface rounded">
           Reset
         </button>
         <button
           onClick={() => setPaused((p) => !p)}
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
         >
           {paused ? 'Resume' : 'Pause'}
         </button>
         <button
           onClick={() => setSound((s) => !s)}
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
         >
           Sound: {sound ? 'On' : 'Off'}
         </button>
@@ -386,7 +386,7 @@ const MemoryBoard = ({ player, themePacks, onWin }) => {
           aria-label="Deck"
           value={deckType}
           onChange={(e) => setDeckType(e.target.value)}
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded text-white"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded text-white"
         >
           <option value="emoji">Emoji</option>
           <option value="pattern">Pattern</option>
@@ -398,7 +398,7 @@ const MemoryBoard = ({ player, themePacks, onWin }) => {
             aria-label="Pattern theme"
             value={patternTheme}
             onChange={(e) => setPatternTheme(e.target.value)}
-            className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded text-white"
+            className="px-2 py-1 bg-gray-700 interactive-surface rounded text-white"
           >
             {Object.keys(PATTERN_THEMES).map((t) => (
               <option key={t} value={t}>
@@ -412,7 +412,7 @@ const MemoryBoard = ({ player, themePacks, onWin }) => {
             aria-label="Theme pack"
             value={themeName}
             onChange={(e) => setThemeName(e.target.value)}
-            className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded text-white"
+            className="px-2 py-1 bg-gray-700 interactive-surface rounded text-white"
           >
             {Object.keys(themePacks).map((t) => (
               <option key={t} value={t}>
@@ -425,7 +425,7 @@ const MemoryBoard = ({ player, themePacks, onWin }) => {
           aria-label="Timer mode"
           value={timerMode}
           onChange={(e) => setTimerMode(e.target.value)}
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded text-white"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded text-white"
         >
           <option value="countup">Count Up</option>
           <option value="countdown">Countdown</option>
@@ -434,7 +434,7 @@ const MemoryBoard = ({ player, themePacks, onWin }) => {
           aria-label="Grid size"
           value={size}
           onChange={(e) => setSize(Number(e.target.value))}
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded text-white"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded text-white"
         >
           <option value={2}>2x2</option>
           <option value={4}>4x4</option>
@@ -491,13 +491,13 @@ const Memory = () => {
         <div className="mb-4 flex space-x-2 items-center">
           <button
             onClick={() => setPlayerCount((c) => (c === 1 ? 2 : 1))}
-            className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-2 py-1 bg-gray-700 interactive-surface rounded"
           >
             {playerCount === 1 ? 'Two Players' : 'One Player'}
           </button>
           <button
             onClick={handleDownloadTheme}
-            className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-2 py-1 bg-gray-700 interactive-surface rounded"
           >
             Download Theme Pack
           </button>

--- a/components/apps/minesweeper.js
+++ b/components/apps/minesweeper.js
@@ -1017,7 +1017,7 @@ const Minesweeper = () => {
         {shareCode && (
           <button
             onClick={copyCode}
-            className="px-1 py-0.5 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-1 py-0.5 bg-gray-700 interactive-surface rounded"
           >
             Copy Code
           </button>
@@ -1032,7 +1032,7 @@ const Minesweeper = () => {
         />
         <button
           onClick={loadFromCode}
-          className="px-1 py-0.5 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-1 py-0.5 bg-gray-700 interactive-surface rounded"
         >
           Load
         </button>
@@ -1097,26 +1097,26 @@ const Minesweeper = () => {
       <div className="flex space-x-2">
         {hasSave && (
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 interactive-surface rounded"
             onClick={loadSaved}
           >
             Load Save
           </button>
         )}
         <button
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-4 py-2 bg-gray-700 interactive-surface rounded"
           onClick={togglePause}
         >
           {paused ? 'Resume' : 'Pause'}
         </button>
         <button
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-4 py-2 bg-gray-700 interactive-surface rounded"
           onClick={toggleSound}
         >
           {sound ? 'Sound: On' : 'Sound: Off'}
         </button>
         <button
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-4 py-2 bg-gray-700 interactive-surface rounded"
           onClick={() => setShowSettings(true)}
         >
           Settings

--- a/components/apps/nikto/index.js
+++ b/components/apps/nikto/index.js
@@ -232,7 +232,7 @@ const NiktoApp = () => {
                 {list.map((f) => (
                   <tr
                     key={f.path}
-                    className="odd:bg-gray-900 cursor-pointer hover:bg-gray-700"
+                    className="odd:bg-gray-900 cursor-pointer interactive-surface"
                     onClick={() => setSelected(f)}
                   >
                     <td className="p-2">{f.path}</td>

--- a/components/apps/nonogram.js
+++ b/components/apps/nonogram.js
@@ -505,32 +505,32 @@ const Nonogram = () => {
       />
       <div className="mt-2 space-x-2">
         <button
-          className="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-3 py-1 bg-gray-700 interactive-surface rounded"
           onClick={() => setMode(mode === "paint" ? "mark" : "paint")}
         >
           Mode: {mode === "paint" ? "Paint" : "Mark"}
         </button>
         <button
-          className="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-3 py-1 bg-gray-700 interactive-surface rounded"
           onClick={reset}
         >
           Reset
         </button>
         <button
-          className="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-3 py-1 bg-gray-700 interactive-surface rounded"
           onClick={handleHint}
         >
           Hint
         </button>
         <button
-          className="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-3 py-1 bg-gray-700 interactive-surface rounded"
           onClick={() => setPaused((p) => !p)}
         >
           {paused ? "Resume" : "Pause"}
         </button>
         <button
           className={`px-3 py-1 rounded ${
-            sound ? "bg-gray-700 hover:bg-gray-600" : "bg-gray-500"
+            sound ? "bg-gray-700 interactive-surface" : "bg-gray-500"
           }`}
           onClick={() => setSound((s) => !s)}
         >
@@ -538,7 +538,7 @@ const Nonogram = () => {
         </button>
         <button
           className={`px-3 py-1 rounded ${
-            preventIllegal ? "bg-gray-700 hover:bg-gray-600" : "bg-gray-500"
+            preventIllegal ? "bg-gray-700 interactive-surface" : "bg-gray-500"
           }`}
           onClick={() => setPreventIllegal((p) => !p)}
         >

--- a/components/apps/pong.js
+++ b/components/apps/pong.js
@@ -777,19 +777,19 @@ const PongInner = () => {
 
       <div className="mt-2 space-x-2">
         <button
-          className="px-4 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-4 py-1 bg-gray-700 interactive-surface rounded"
           onClick={() => setPaused((p) => !p)}
         >
           {paused ? 'Resume' : 'Pause'}
         </button>
         <button
-          className="px-4 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-4 py-1 bg-gray-700 interactive-surface rounded"
           onClick={() => setSound((s) => !s)}
         >
           Sound: {sound ? 'On' : 'Off'}
         </button>
         <button
-          className="px-4 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-4 py-1 bg-gray-700 interactive-surface rounded"
           onClick={reset}
         >
           Reset

--- a/components/apps/quote_generator.js
+++ b/components/apps/quote_generator.js
@@ -285,31 +285,31 @@ const QuoteGenerator = () => {
         </div>
         <div className="flex flex-wrap justify-center gap-2 mt-4">
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 interactive-surface rounded"
             onClick={prevQuote}
           >
             Prev
           </button>
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 interactive-surface rounded"
             onClick={nextQuote}
           >
             Next
           </button>
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 interactive-surface rounded"
             onClick={copyQuote}
           >
             Copy
           </button>
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 interactive-surface rounded"
             onClick={tweetQuote}
           >
             Tweet
           </button>
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 interactive-surface rounded"
             onClick={shareCard}
           >
             Share as Card

--- a/components/apps/reconng/components/ReportTemplates.tsx
+++ b/components/apps/reconng/components/ReportTemplates.tsx
@@ -112,14 +112,14 @@ export default function ReportTemplates() {
         <button
           type="button"
           onClick={exportReport}
-          className="bg-blue-600 hover:bg-blue-500 px-2 py-1 rounded"
+          className="bg-blue-600 text-white px-2 py-1 rounded interactive-surface"
         >
           Export
         </button>
         <button
           type="button"
           onClick={() => setShowDialog(true)}
-          className="bg-gray-600 hover:bg-gray-500 px-2 py-1 rounded"
+          className="bg-gray-600 px-2 py-1 rounded interactive-surface"
         >
           Import/Share
         </button>
@@ -141,14 +141,14 @@ export default function ReportTemplates() {
             <button
               type="button"
               onClick={copyShare}
-              className="bg-blue-600 hover:bg-blue-500 px-2 py-1 rounded"
+              className="bg-blue-600 text-white px-2 py-1 rounded interactive-surface"
             >
               Copy
             </button>
             <button
               type="button"
               onClick={() => setShowDialog(false)}
-              className="bg-gray-600 hover:bg-gray-500 px-2 py-1 rounded"
+              className="bg-gray-600 px-2 py-1 rounded interactive-surface"
             >
               Close
             </button>

--- a/components/apps/reconng/index.js
+++ b/components/apps/reconng/index.js
@@ -525,7 +525,7 @@ const ReconNG = () => {
             <button
               type="button"
               onClick={runModule}
-              className="bg-blue-600 hover:bg-blue-500 px-3 py-1 rounded"
+              className="bg-blue-600 text-white px-3 py-1 rounded interactive-surface"
             >
               Run
             </button>
@@ -566,10 +566,10 @@ const ReconNG = () => {
           ))}
           {currentWorkspace.graph.length > 0 && (
             <div className="flex gap-2 mt-2">
-              <button type="button" onClick={exportCSV} className="bg-gray-800 px-2 py-1">
+              <button type="button" onClick={exportCSV} className="bg-gray-800 px-2 py-1 interactive-surface">
                 Export CSV
               </button>
-              <button type="button" onClick={exportJSON} className="bg-gray-800 px-2 py-1">
+              <button type="button" onClick={exportJSON} className="bg-gray-800 px-2 py-1 interactive-surface">
                 Export JSON
               </button>
             </div>
@@ -584,7 +584,7 @@ const ReconNG = () => {
           <button
             type="button"
             onClick={runChain}
-            className="mb-2 bg-blue-600 hover:bg-blue-500 px-3 py-1 rounded"
+            className="mb-2 bg-blue-600 text-white px-3 py-1 rounded interactive-surface"
           >
             Run Chain
           </button>
@@ -616,7 +616,7 @@ const ReconNG = () => {
                   onClick={() =>
                     setShowApiKeys({ ...showApiKeys, [m]: !showApiKeys[m] })
                   }
-                  className="ml-2 px-2 py-1 bg-gray-700"
+                  className="ml-2 px-2 py-1 bg-gray-700 interactive-surface"
                 >
                   {showApiKeys[m] ? 'Hide' : 'Show'}
                 </button>

--- a/components/apps/reversi.js
+++ b/components/apps/reversi.js
@@ -410,14 +410,14 @@ const Reversi = () => {
       <div className="mt-1 text-sm text-gray-300">{tip}</div>
       <div className="mt-2 flex space-x-2 items-center">
         <button
-          className="w-6 h-6 bg-gray-700 hover:bg-gray-600 rounded flex items-center justify-center"
+          className="w-6 h-6 bg-gray-700 interactive-surface rounded flex items-center justify-center"
           onClick={reset}
           aria-label="Reset"
         >
           <img src="/themes/Yaru/status/chrome_refresh.svg" width="24" height="24" alt="" />
         </button>
         <button
-          className="w-6 h-6 bg-gray-700 hover:bg-gray-600 rounded flex items-center justify-center disabled:opacity-50"
+          className="w-6 h-6 bg-gray-700 interactive-surface rounded flex items-center justify-center disabled:opacity-50"
           onClick={undo}
           disabled={!history.length}
           aria-label="Undo"
@@ -428,25 +428,25 @@ const Reversi = () => {
           </svg>
         </button>
         <button
-          className="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-3 py-1 bg-gray-700 interactive-surface rounded"
           onClick={() => setPaused((p) => !p)}
         >
           {paused ? 'Resume' : 'Pause'}
         </button>
         <button
-          className="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-3 py-1 bg-gray-700 interactive-surface rounded"
           onClick={() => setSound((s) => !s)}
         >
           {sound ? 'Sound: On' : 'Sound: Off'}
         </button>
         <button
-          className="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-3 py-1 bg-gray-700 interactive-surface rounded"
           onClick={() => setDiskTheme((t) => (t === 'dark' ? 'light' : 'dark'))}
         >
           {diskTheme === 'dark' ? 'Theme: Dark' : 'Theme: Light'}
         </button>
         <select
-          className="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-3 py-1 bg-gray-700 interactive-surface rounded"
           value={difficulty}
           onChange={(e) => setDifficulty(e.target.value)}
         >
@@ -457,7 +457,7 @@ const Reversi = () => {
           ))}
         </select>
         <button
-          className="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-3 py-1 bg-gray-700 interactive-surface rounded"
           onClick={() => setUseBook((b) => !b)}
         >
           {useBook ? 'Book: On' : 'Book: Off'}

--- a/components/apps/screen-recorder.tsx
+++ b/components/apps/screen-recorder.tsx
@@ -81,7 +81,7 @@ function ScreenRecorder() {
                 <button
                     type="button"
                     onClick={startRecording}
-                    className="px-4 py-2 rounded bg-ub-dracula hover:bg-ub-dracula-dark"
+                    className="px-4 py-2 rounded bg-ub-dracula text-white interactive-surface"
                 >
                     Start Recording
                 </button>
@@ -90,7 +90,7 @@ function ScreenRecorder() {
                 <button
                     type="button"
                     onClick={stopRecording}
-                    className="px-4 py-2 rounded bg-red-600 hover:bg-red-700"
+                    className="px-4 py-2 rounded bg-red-600 text-white interactive-surface"
                 >
                     Stop Recording
                 </button>
@@ -101,7 +101,7 @@ function ScreenRecorder() {
                     <button
                         type="button"
                         onClick={saveRecording}
-                        className="px-4 py-2 rounded bg-ub-dracula hover:bg-ub-dracula-dark"
+                        className="px-4 py-2 rounded bg-ub-dracula text-white interactive-surface"
                     >
                         Save Recording
                     </button>

--- a/components/apps/simon.js
+++ b/components/apps/simon.js
@@ -391,7 +391,7 @@ const Simon = () => {
         </div>
         <div className="flex flex-wrap gap-4 items-center">
           <select
-            className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-2 py-1 bg-gray-700 interactive-surface rounded"
             value={mode}
             onChange={(e) => setMode(e.target.value)}
           >
@@ -411,7 +411,7 @@ const Simon = () => {
             <span>{tempo} BPM</span>
           </div>
           <input
-            className="px-2 py-1 w-24 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-2 py-1 w-24 bg-gray-700 interactive-surface rounded"
             placeholder="Seed"
             value={seed}
             onChange={(e) => setSeed(e.target.value)}
@@ -421,10 +421,8 @@ const Simon = () => {
               <button
                 key={m}
                 onClick={() => setPlayMode(m)}
-                className={`px-2 py-1 rounded-full border ${
-                  playMode === m
-                    ? "bg-gray-600 border-white"
-                    : "bg-gray-700 border-gray-500 hover:bg-gray-600"
+                className={`px-2 py-1 rounded-full border interactive-surface ${
+                  playMode === m ? "bg-gray-600 border-white" : "bg-gray-700 border-gray-500"
                 }`}
               >
                 {m === "strict" ? "Strict" : "Normal"}
@@ -432,7 +430,7 @@ const Simon = () => {
             ))}
           </div>
           <select
-            className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-2 py-1 bg-gray-700 interactive-surface rounded"
             value={timing}
             onChange={(e) => setTiming(e.target.value)}
           >
@@ -480,7 +478,7 @@ const Simon = () => {
             Audio only
           </label>
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 interactive-surface rounded"
             onClick={startGame}
           >
             Start

--- a/components/apps/solitaire/index.tsx
+++ b/components/apps/solitaire/index.tsx
@@ -630,7 +630,7 @@ const Solitaire = () => {
       <div className="h-full w-full bg-green-700 text-white select-none p-2">
         <div className="flex justify-end mb-2">
           <select
-            className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-2 py-1 bg-gray-700 interactive-surface rounded"
             value={variant}
             onChange={(e) => {
               const v = e.target.value as Variant;
@@ -723,7 +723,7 @@ const Solitaire = () => {
         </div>
         <div>Daily Streak: {stats.dailyStreak}</div>
         <select
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
           value={variant}
           onChange={(e) => {
             const v = e.target.value as Variant;
@@ -736,25 +736,25 @@ const Solitaire = () => {
           <option value="freecell">FreeCell</option>
         </select>
         <button
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
           onClick={() => start(drawMode, variant, true)}
         >
           Daily Deal
         </button>
         <button
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
           onClick={showHint}
         >
           Hint
         </button>
         <button
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
           onClick={runSolver}
         >
           Solve
         </button>
         <button
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
           onClick={() => {
             const mode = drawMode === 1 ? 3 : 1;
             ReactGA.event({
@@ -768,7 +768,7 @@ const Solitaire = () => {
           Draw {drawMode === 1 ? '1' : '3'}
         </button>
         <button
-          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-2 py-1 bg-gray-700 interactive-surface rounded"
           onClick={() => {
             const opts = [3, 1, Infinity];
             const next = opts[(opts.indexOf(passLimit) + 1) % opts.length];
@@ -878,7 +878,7 @@ const Solitaire = () => {
       </div>
       <div className="mt-4">
         <button
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-4 py-2 bg-gray-700 interactive-surface rounded"
           onClick={() => start(drawMode, variant, isDaily)}
         >
           Restart

--- a/components/apps/tictactoe.js
+++ b/components/apps/tictactoe.js
@@ -184,13 +184,13 @@ const TicTacToe = () => {
         <div className="mb-4">Choose X or O</div>
         <div className="flex space-x-4">
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 interactive-surface rounded"
             onClick={() => startGame('X')}
           >
             {currentSkin.X}
           </button>
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 interactive-surface rounded"
             onClick={() => startGame('O')}
           >
             {currentSkin.O}
@@ -256,7 +256,7 @@ const TicTacToe = () => {
       </div>
       <div className="flex space-x-4 mt-4">
         <button
-          className="px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded"
+          className="px-4 py-2 bg-blue-600 text-white rounded interactive-surface"
           onClick={() => {
             setBoard(createBoard(size));
             setStatus(`${currentSkin[player]}'s turn`);
@@ -266,7 +266,7 @@ const TicTacToe = () => {
           Restart
         </button>
         <button
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-4 py-2 bg-gray-700 interactive-surface rounded"
           onClick={() => {
             setPlayer(null);
             setAi(null);

--- a/components/apps/trash/index.tsx
+++ b/components/apps/trash/index.tsx
@@ -106,28 +106,28 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
           <button
             onClick={restore}
             disabled={selected === null}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded interactive-surface focus-visible:ring-2 focus-visible:ring-ub-orange disabled:opacity-50"
           >
             Restore
           </button>
           <button
             onClick={restoreAll}
             disabled={items.length === 0}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded interactive-surface focus-visible:ring-2 focus-visible:ring-ub-orange disabled:opacity-50"
           >
             Restore All
           </button>
           <button
             onClick={remove}
             disabled={selected === null}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded interactive-surface focus-visible:ring-2 focus-visible:ring-ub-orange disabled:opacity-50"
           >
             Delete
           </button>
           <button
             onClick={empty}
             disabled={items.length === 0}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded interactive-surface focus-visible:ring-2 focus-visible:ring-ub-orange disabled:opacity-50"
           >
             Empty
           </button>

--- a/components/apps/vscode.jsx
+++ b/components/apps/vscode.jsx
@@ -77,7 +77,7 @@ export default function VsCodeWrapper({ openApp }) {
                 <li key={`${item.type}-${item.id}`}>
                   <button
                     onClick={() => selectItem(item)}
-                    className="w-full text-left px-2 py-1 rounded hover:bg-gray-700"
+                    className="w-full text-left px-2 py-1 rounded interactive-surface"
                   >
                     {item.title}
                   </button>

--- a/components/apps/word-search.js
+++ b/components/apps/word-search.js
@@ -605,25 +605,25 @@ const WordSearch = () => {
           </div>
           <div className="flex flex-col gap-2">
             <button
-              className="px-4 py-1 bg-gray-700 hover:bg-gray-600"
+              className="px-4 py-1 bg-gray-700 interactive-surface"
               onClick={useHint}
             >
               Hint
             </button>
             <button
-              className="px-4 py-1 bg-gray-700 hover:bg-gray-600"
+              className="px-4 py-1 bg-gray-700 interactive-surface"
               onClick={() => reset(true)}
             >
               New Puzzle
             </button>
             <button
-              className="px-4 py-1 bg-gray-700 hover:bg-gray-600"
+              className="px-4 py-1 bg-gray-700 interactive-surface"
               onClick={() => setPaused((p) => !p)}
             >
               {paused ? "Resume" : "Pause"}
             </button>
             <button
-              className="px-4 py-1 bg-gray-700 hover:bg-gray-600"
+              className="px-4 py-1 bg-gray-700 interactive-surface"
               onClick={() => setSound((s) => !s)}
             >
               {sound ? "Sound Off" : "Sound On"}
@@ -666,7 +666,7 @@ const WordSearch = () => {
                 onChange={(e) => setSeed(e.target.value)}
               />
               <button
-                className="px-2 py-1 bg-gray-700 hover:bg-gray-600"
+                className="px-2 py-1 bg-gray-700 interactive-surface"
                 onClick={() => reset(true, seed)}
               >
                 Load
@@ -674,13 +674,13 @@ const WordSearch = () => {
             </div>
             <div className="flex gap-1">
               <button
-                className="flex-1 px-4 py-1 bg-gray-700 hover:bg-gray-600"
+                className="flex-1 px-4 py-1 bg-gray-700 interactive-surface"
                 onClick={share}
               >
                 Share
               </button>
               <button
-                className="flex-1 px-4 py-1 bg-gray-700 hover:bg-gray-600"
+                className="flex-1 px-4 py-1 bg-gray-700 interactive-surface"
                 onClick={() => window.print()}
               >
                 Print
@@ -747,7 +747,7 @@ const WordSearch = () => {
                 onChange={(e) => setNewListWords(e.target.value)}
               />
               <button
-                className="px-2 py-1 bg-gray-700 hover:bg-gray-600"
+                className="px-2 py-1 bg-gray-700 interactive-surface"
                 onClick={addList}
               >
                 Save List

--- a/components/apps/wordle.js
+++ b/components/apps/wordle.js
@@ -464,14 +464,14 @@ const Wordle = () => {
           />
           <button
             type="submit"
-            className="px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-3 py-2 bg-gray-700 interactive-surface rounded"
           >
             Submit
           </button>
           <button
             type="button"
             onClick={handleAnalyze}
-            className="px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-3 py-2 bg-gray-700 interactive-surface rounded"
           >
             Analyze
           </button>
@@ -482,7 +482,7 @@ const Wordle = () => {
         <div className="flex flex-col items-center space-y-2">
           <button
             onClick={share}
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-4 py-2 bg-gray-700 interactive-surface rounded"
           >
             Share
           </button>

--- a/components/apps/x.js
+++ b/components/apps/x.js
@@ -131,10 +131,10 @@ export default function XApp() {
                 key={h}
                 type="button"
                 onClick={() => setFeedUser(h)}
-                className={`px-2 py-1 rounded-full text-sm ${
+                className={`px-2 py-1 rounded-full text-sm interactive-surface ${
                   feedUser === h
                     ? 'bg-blue-600 text-white'
-                    : 'bg-gray-700 text-gray-100 hover:bg-gray-600'
+                    : 'bg-gray-700 text-gray-100'
                 }`}
               >
                 {h}

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import useFocusTrap from '../../hooks/useFocusTrap';
 import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+import ContextMenuItem from '../menu/context-menu-item';
 
 export interface MenuItem {
   label: React.ReactNode;
@@ -102,18 +103,16 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
         'cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
     >
       {items.map((item, i) => (
-        <button
+        <ContextMenuItem
           key={i}
-          role="menuitem"
           tabIndex={-1}
           onClick={() => {
             item.onSelect();
             setOpen(false);
           }}
-          className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
         >
           {item.label}
-        </button>
+        </ContextMenuItem>
       ))}
     </div>
   );

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react'
 import useFocusTrap from '../../hooks/useFocusTrap'
 import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+import ContextMenuItem from '../menu/context-menu-item'
 
 function AppMenu(props) {
     const menuRef = useRef(null)
@@ -30,15 +31,12 @@ function AppMenu(props) {
             onKeyDown={handleKeyDown}
             className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
         >
-            <button
-                type="button"
+            <ContextMenuItem
                 onClick={handlePin}
-                role="menuitem"
                 aria-label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
-            </button>
+            </ContextMenuItem>
         </div>
     )
 }

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react'
 import useFocusTrap from '../../hooks/useFocusTrap'
 import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+import ContextMenuItem from '../menu/context-menu-item'
 
 function DefaultMenu(props) {
     const menuRef = useRef(null)
@@ -30,7 +31,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Linkedin"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="interactive-surface w-full block cursor-default px-3 py-1 rounded mb-1.5"
             >
                 <span className="ml-5">🙋‍♂️</span> <span className="ml-2">Follow on <strong>Linkedin</strong></span>
             </a>
@@ -40,7 +41,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Github"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="interactive-surface w-full block cursor-default px-3 py-1 rounded mb-1.5"
             >
                 <span className="ml-5">🤝</span> <span className="ml-2">Follow on <strong>Github</strong></span>
             </a>
@@ -50,20 +51,17 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Contact Me"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="interactive-surface w-full block cursor-default px-3 py-1 rounded mb-1.5"
             >
                 <span className="ml-5">📥</span> <span className="ml-2">Contact Me</span>
             </a>
             <Devider />
-            <button
-                type="button"
+            <ContextMenuItem
                 onClick={() => { localStorage.clear(); window.location.reload() }}
-                role="menuitem"
                 aria-label="Reset Kali Linux"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">🧹</span> <span className="ml-2">Reset Kali Linux</span>
-            </button>
+            </ContextMenuItem>
         </div>
     )
 }

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import logger from '../../utils/logger'
+import ContextMenuItem from '../menu/context-menu-item'
 
 function DesktopMenu(props) {
 
@@ -50,84 +51,63 @@ function DesktopMenu(props) {
             aria-label="Desktop context menu"
             className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
         >
-            <button
+            <ContextMenuItem
                 onClick={props.addNewFolder}
-                type="button"
-                role="menuitem"
                 aria-label="New Folder"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
                 <span className="ml-5">New Folder</span>
-            </button>
-            <button
+            </ContextMenuItem>
+            <ContextMenuItem
                 onClick={props.openShortcutSelector}
-                type="button"
-                role="menuitem"
                 aria-label="Create Shortcut"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
                 <span className="ml-5">Create Shortcut...</span>
-            </button>
+            </ContextMenuItem>
             <Devider />
-            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <ContextMenuItem disabled aria-label="Paste" className="text-gray-400">
                 <span className="ml-5">Paste</span>
-            </div>
+            </ContextMenuItem>
             <Devider />
-            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <ContextMenuItem disabled aria-label="Show Desktop in Files" className="text-gray-400">
                 <span className="ml-5">Show Desktop in Files</span>
-            </div>
-            <button
+            </ContextMenuItem>
+            <ContextMenuItem
                 onClick={openTerminal}
-                type="button"
-                role="menuitem"
                 aria-label="Open in Terminal"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
                 <span className="ml-5">Open in Terminal</span>
-            </button>
+            </ContextMenuItem>
             <Devider />
-            <button
+            <ContextMenuItem
                 onClick={openSettings}
-                type="button"
-                role="menuitem"
                 aria-label="Change Background"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
                 <span className="ml-5">Change Background...</span>
-            </button>
+            </ContextMenuItem>
             <Devider />
-            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <ContextMenuItem disabled aria-label="Display Settings" className="text-gray-400">
                 <span className="ml-5">Display Settings</span>
-            </div>
-            <button
+            </ContextMenuItem>
+            <ContextMenuItem
                 onClick={openSettings}
-                type="button"
-                role="menuitem"
                 aria-label="Settings"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
                 <span className="ml-5">Settings</span>
-            </button>
+            </ContextMenuItem>
             <Devider />
-            <button
+            <ContextMenuItem
                 onClick={goFullScreen}
-                type="button"
-                role="menuitem"
                 aria-label={isFullScreen ? "Exit Full Screen" : "Enter Full Screen"}
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
                 <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
-            </button>
+            </ContextMenuItem>
             <Devider />
-            <button
+            <ContextMenuItem
                 onClick={props.clearSession}
-                type="button"
-                role="menuitem"
                 aria-label="Clear Session"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
                 <span className="ml-5">Clear Session</span>
-            </button>
+            </ContextMenuItem>
         </div>
     )
 }

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import useFocusTrap from '../../hooks/useFocusTrap';
 import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+import ContextMenuItem from '../menu/context-menu-item';
 
 function TaskbarMenu(props) {
     const menuRef = useRef(null);
@@ -32,24 +33,18 @@ function TaskbarMenu(props) {
             onKeyDown={handleKeyDown}
             className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-40 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm'}
         >
-            <button
-                type="button"
+            <ContextMenuItem
                 onClick={handleMinimize}
-                role="menuitem"
                 aria-label={props.minimized ? 'Restore Window' : 'Minimize Window'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">{props.minimized ? 'Restore' : 'Minimize'}</span>
-            </button>
-            <button
-                type="button"
+            </ContextMenuItem>
+            <ContextMenuItem
                 onClick={handleClose}
-                role="menuitem"
                 aria-label="Close Window"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">Close</span>
-            </button>
+            </ContextMenuItem>
         </div>
     );
 }

--- a/components/menu/context-menu-item.tsx
+++ b/components/menu/context-menu-item.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+type ContextMenuItemProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  /** Indent content when an icon placeholder is present */
+  inset?: boolean;
+};
+
+const ContextMenuItem = React.forwardRef<HTMLButtonElement, ContextMenuItemProps>(
+  ({ className = '', children, disabled, inset, type = 'button', ...props }, ref) => {
+    const classes = [
+      'interactive-surface',
+      'w-full',
+      'text-left',
+      'cursor-default',
+      'px-3',
+      'py-1',
+      'rounded',
+      'text-sm',
+      'mb-1.5',
+      inset ? 'pl-8' : '',
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <button
+        {...props}
+        ref={ref}
+        type={type}
+        role={props.role ?? 'menuitem'}
+        disabled={disabled}
+        aria-disabled={disabled || props['aria-disabled'] ? true : undefined}
+        data-disabled={disabled ? 'true' : undefined}
+        className={classes}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+
+ContextMenuItem.displayName = 'ContextMenuItem';
+
+export default ContextMenuItem;

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -25,8 +25,7 @@ export default function Taskbar(props) {
                     data-context="taskbar"
                     data-app-id={app.id}
                     onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                    className={`${props.focused_windows[app.id] && !props.minimized_windows[app.id] ? 'bg-white bg-opacity-20 ' : ''}relative flex items-center mx-1 px-2 py-1 rounded interactive-surface`}
                 >
                     <Image
                         width={24}

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -4,16 +4,67 @@
 
 @layer utilities {
   .transition-hover {
-    @apply transition ease-out duration-150;
+    transition-property: background-color, color, border-color, box-shadow, opacity;
+    transition-duration: var(--motion-fast);
+    transition-timing-function: ease-out;
   }
   .transition-active {
-    @apply transition ease-out duration-100;
+    transition-property: transform;
+    transition-duration: var(--motion-fast);
+    transition-timing-function: ease-out;
+  }
+}
+
+@layer components {
+  .interactive-surface {
+    --interactive-hover-color: var(--color-hover);
+    --interactive-active-color: var(--color-active);
+    transition: background-color var(--motion-fast) ease-out,
+      color var(--motion-fast) ease-out,
+      border-color var(--motion-fast) ease-out,
+      box-shadow var(--motion-fast) ease-out,
+      transform var(--motion-fast) ease-out;
+  }
+
+  .interactive-surface:hover,
+  .interactive-surface:focus-visible {
+    background-color: var(--interactive-hover-color);
+  }
+
+  .interactive-surface:active {
+    background-color: var(--interactive-active-color);
+  }
+
+  .interactive-surface:focus-visible {
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline-offset: 2px;
+  }
+
+  .interactive-surface:disabled,
+  .interactive-surface[aria-disabled='true'],
+  .interactive-surface[data-disabled='true'] {
+    cursor: not-allowed;
+    opacity: 0.6;
   }
 }
 
 @layer base {
   button {
     @apply transition-hover transition-active;
+  }
+
+  button:hover,
+  button:focus-visible {
+    background-color: var(--color-hover);
+  }
+
+  button:active {
+    background-color: var(--color-active);
+  }
+
+  button:focus-visible {
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline-offset: 2px;
   }
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -26,6 +26,9 @@
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
   --kali-bg: rgba(15, 19, 23, 0.85);
+  /* XFCE highlight accents */
+  --color-hover: rgba(82, 148, 226, 0.24);
+  --color-active: rgba(82, 148, 226, 0.4);
 
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
@@ -77,6 +80,8 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --color-hover: rgba(255, 255, 0, 0.4);
+  --color-active: rgba(255, 255, 0, 0.6);
 }
 
 /* Dyslexia-friendly fonts */


### PR DESCRIPTION
## Summary
- add shared XFCE-inspired hover and active color tokens and an interactive-surface utility
- refactor context menu items, taskbar buttons, and app buttons to adopt the shared hover styling and keyboard focus handling
- introduce a reusable context menu item component to simplify menu markup

## Testing
- `yarn lint` *(fails: existing accessibility errors across legacy apps)*
- `yarn test` *(fails: pre-existing unit tests such as window focus handling and API contact suite)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9484ae108328873dce106c146e7f