### PR TITLE
[panel] add system clock widget

### DIFF
--- a/components/panel/SystemClock.tsx
+++ b/components/panel/SystemClock.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type SystemClockProps = {
+  /**
+   * Optional additional class names to append to the panel clock wrapper.
+   */
+  className?: string;
+};
+
+const FALLBACK_LOCALE = "en-GB";
+
+type DateTimeFormatter = (date: Date, locale: string) => string;
+
+const formatClock: DateTimeFormatter = (date, locale) => {
+  const weekday = date.toLocaleDateString(locale, { weekday: "short" });
+  const day = date.toLocaleDateString(locale, { day: "2-digit" });
+  const month = date.toLocaleDateString(locale, { month: "short" });
+  const time = date.toLocaleTimeString(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  });
+
+  return `${weekday} ${day} ${month}, ${time}`;
+};
+
+const formatTooltip: DateTimeFormatter = (date, locale) =>
+  date.toLocaleString(locale, {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  });
+
+const getPreferredLocale = (): string => {
+  if (typeof navigator !== "undefined" && navigator.language) {
+    return navigator.language;
+  }
+
+  return FALLBACK_LOCALE;
+};
+
+export default function SystemClock({ className }: SystemClockProps) {
+  const [now, setNow] = useState(() => new Date());
+  const [locale, setLocale] = useState(FALLBACK_LOCALE);
+
+  useEffect(() => {
+    setLocale(getPreferredLocale());
+
+    const update = () => setNow(new Date());
+    update();
+
+    const intervalId = window.setInterval(update, 1000);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  const displayValue = useMemo(() => formatClock(now, locale), [now, locale]);
+  const tooltipValue = useMemo(() => formatTooltip(now, locale), [now, locale]);
+
+  const baseClassName =
+    "font-ubuntu text-sm text-ubt-grey tracking-wide leading-none select-none";
+  const combinedClassName = className
+    ? `${baseClassName} ${className}`
+    : baseClassName;
+
+  return (
+    <time
+      className={combinedClassName}
+      dateTime={now.toISOString()}
+      title={tooltipValue}
+      suppressHydrationWarning
+    >
+      {displayValue}
+    </time>
+  );
+}

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
+import SystemClock from '../panel/SystemClock';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
@@ -16,32 +17,38 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => (
-                <button
-                    key={app.id}
-                    type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
-                    onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
-                    />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
-                </button>
-            ))}
+        <div
+            className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center px-2 z-40"
+            role="toolbar"
+        >
+            <div className="flex items-center flex-1 overflow-x-auto">
+                {runningApps.map(app => (
+                    <button
+                        key={app.id}
+                        type="button"
+                        aria-label={app.title}
+                        data-context="taskbar"
+                        data-app-id={app.id}
+                        onClick={() => handleClick(app)}
+                        className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
+                            'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                    >
+                        <Image
+                            width={24}
+                            height={24}
+                            className="w-5 h-5"
+                            src={app.icon.replace('./', '/')}
+                            alt=""
+                            sizes="24px"
+                        />
+                        <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                        {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
+                            <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
+                        )}
+                    </button>
+                ))}
+            </div>
+            <SystemClock className="ml-3 flex-shrink-0 text-right" />
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add a reusable SystemClock component that renders a Kali-style 24h clock with tooltip formatting
- wire the clock into the taskbar and align it with existing panel styling
- ensure the clock updates every second via an interval hook

## Testing
- yarn lint *(fails: existing accessibility violations across multiple apps)*
- yarn test *(fails: existing unit test failures and watch-mode warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ca94a3c4188328aab2cc903807cf14