### PR TITLE
[ui] add panel spacing tokens

### DIFF
--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -1,9 +1,11 @@
 .windowYBorder {
-  height: calc(100% - 10px);
-  width: calc(100% + 10px);
+  --window-handle-offset: calc(var(--panel-padding) + (var(--panel-gap) / 2));
+  height: calc(100% - var(--window-handle-offset));
+  width: calc(100% + var(--window-handle-offset));
 }
 
 .windowXBorder {
-  height: calc(100% + 10px);
-  width: calc(100% - 10px);
+  --window-handle-offset: calc(var(--panel-padding) + (var(--panel-gap) / 2));
+  height: calc(100% + var(--window-handle-offset));
+  width: calc(100% - var(--window-handle-offset));
 }

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -114,22 +114,29 @@ const WhiskerMenu: React.FC = () => {
     return () => document.removeEventListener('mousedown', handleClick);
   }, [open]);
 
+  const panelButtonStyle: React.CSSProperties = {
+    paddingInline: 'var(--panel-padding)',
+    paddingBlock: 'calc(var(--panel-padding) / 2)',
+    gap: 'var(--panel-gap)'
+  };
+
   return (
     <div className="relative">
       <button
         ref={buttonRef}
         type="button"
         onClick={() => setOpen(o => !o)}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        className="flex items-center outline-none transition duration-100 ease-in-out border-b-2 border-transparent"
+        style={panelButtonStyle}
       >
         <Image
           src="/themes/Yaru/status/decompiler-symbolic.svg"
           alt="Menu"
           width={16}
           height={16}
-          className="inline mr-1"
+          className="h-4 w-4"
         />
-        Applications
+        <span className="whitespace-nowrap">Applications</span>
       </button>
       {open && (
         <div

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -11,19 +11,36 @@ export default class Navbar extends Component {
 		this.state = {
 			status_card: false
 		};
-	}
+        }
 
-	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
+        render() {
+                const panelContainerStyle = {
+                        paddingInline: 'var(--panel-padding)',
+                        paddingBlock: 'calc(var(--panel-padding) / 2)',
+                        gap: 'var(--panel-gap)'
+                };
+                const panelButtonStyle = {
+                        paddingInline: 'var(--panel-padding)',
+                        paddingBlock: 'calc(var(--panel-padding) / 2)'
+                };
+                const panelIconStyle = {
+                        paddingInline: 'calc(var(--panel-padding) / 2)',
+                        paddingBlock: 'calc(var(--panel-padding) / 2)'
+                };
+                return (
+                        <div
+                                className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50"
+                                style={panelContainerStyle}
+                        >
+                                <div style={panelIconStyle}>
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
                                 <WhiskerMenu />
                                 <div
                                         className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                                'text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent'
                                         }
+                                        style={panelButtonStyle}
                                 >
                                         <Clock />
                                 </div>
@@ -35,13 +52,14 @@ export default class Navbar extends Component {
                                                 this.setState({ status_card: !this.state.status_card });
                                         }}
                                         className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
+                                                'relative outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange '
                                         }
+                                        style={panelButtonStyle}
                                 >
                                         <Status />
                                         <QuickSettings open={this.state.status_card} />
                                 </button>
-			</div>
+                        </div>
 		);
 	}
 }

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -15,8 +15,22 @@ export default function Taskbar(props) {
         }
     };
 
+    const panelContainerStyle = {
+        paddingInline: 'var(--panel-padding)',
+        gap: 'var(--panel-gap)'
+    };
+    const panelButtonStyle = {
+        paddingInline: 'var(--panel-padding)',
+        paddingBlock: 'calc(var(--panel-padding) / 2)',
+        gap: 'var(--panel-gap)'
+    };
+
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div
+            className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40"
+            role="toolbar"
+            style={panelContainerStyle}
+        >
             {runningApps.map(app => (
                 <button
                     key={app.id}
@@ -26,7 +40,8 @@ export default function Taskbar(props) {
                     data-app-id={app.id}
                     onClick={() => handleClick(app)}
                     className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                        'relative flex items-center rounded hover:bg-white hover:bg-opacity-10'}
+                    style={panelButtonStyle}
                 >
                     <Image
                         width={24}
@@ -36,7 +51,7 @@ export default function Taskbar(props) {
                         alt=""
                         sizes="24px"
                     />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                    <span className="text-sm text-white whitespace-nowrap">{app.title}</span>
                     {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
                         <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
                     )}

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -41,6 +41,10 @@
   --space-5: 1.5rem;
   --space-6: 2rem;
 
+  /* Panel layout spacing (mirrors Kali top/bottom bars ~8px padding, 4px gaps) */
+  --panel-padding: clamp(0.375rem, 0.25rem + 1vw, 0.5rem);
+  --panel-gap: clamp(0.1875rem, 0.125rem + 0.5vw, 0.25rem);
+
   /* Radius */
   --radius-sm: 2px;
   --radius-md: 4px;


### PR DESCRIPTION
## Summary
- capture the Kali top/bottom panel spacing as `--panel-padding` and `--panel-gap` design tokens
- apply the tokens to the navbar, whisker menu button, taskbar, and window resize chrome for consistent spacing
- clamp the panel spacing tokens for smaller viewports so the desktop chrome stays proportionate on mobile widths

## Testing
- yarn lint *(fails: existing repo-wide jsx-a11y and no-top-level-window violations)*
- yarn test *(fails: existing suites such as window keyboard handling and reconng localStorage access)*

------
https://chatgpt.com/codex/tasks/task_e_68ca949ccc1083288e557b5fd54d2148