### PR TITLE
[terminal] align prompt with kali style

### DIFF
--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -147,10 +147,9 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
 
   const prompt = useCallback(() => {
     if (!termRef.current) return;
-    termRef.current.writeln(
-      '\x1b[1;34m┌──(\x1b[0m\x1b[1;36mkali\x1b[0m\x1b[1;34m㉿\x1b[0m\x1b[1;36mkali\x1b[0m\x1b[1;34m)-[\x1b[0m\x1b[1;32m~\x1b[0m\x1b[1;34m]\x1b[0m',
+    termRef.current.write(
+      '\x1b[1;34mkali\x1b[0m@\x1b[1;37mkali\x1b[0m:\x1b[1;37m~\x1b[0m$ ',
     );
-    termRef.current.write('\x1b[1;34m└─\x1b[0m$ ');
   }, []);
 
   const handleCopy = () => {
@@ -313,6 +312,10 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
           background: '#0f1317',
           foreground: '#f5f5f5',
           cursor: '#1793d1',
+          blue: '#1793d1',
+          brightBlue: '#1793d1',
+          white: '#f5f5f5',
+          brightWhite: '#ffffff',
         },
       });
       const fit = new FitAddon();

--- a/styles/index.css
+++ b/styles/index.css
@@ -173,6 +173,16 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: cursor-pulse 1s steps(2) infinite;
 }
 
+.xterm .xterm-fg-4,
+.xterm .xterm-fg-12 {
+    color: var(--color-primary);
+}
+
+.xterm .xterm-fg-7,
+.xterm .xterm-fg-15 {
+    color: var(--color-text);
+}
+
 dialog {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- switch the terminal prompt to a single line `kali@kali:~$` sequence with ANSI colors
- extend the xterm theme and CSS overrides so the Kali blue username and white host/path colors display reliably

## Testing
- yarn lint *(fails: existing accessibility violations across other apps)*
- yarn test *(fails: existing suite failures and missing Supabase/localStorage context)*

------
https://chatgpt.com/codex/tasks/task_e_68ca94ae40408328bef8bfe48ef5dd09