### PR TITLE
[menu] add whisker launcher

### DIFF
--- a/components/menu/WhiskerMenu.module.css
+++ b/components/menu/WhiskerMenu.module.css
@@ -1,0 +1,363 @@
+.container {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 60;
+}
+
+.panel {
+  pointer-events: auto;
+  position: fixed;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  width: min(720px, calc(100vw - 2rem));
+  max-height: min(540px, calc(100vh - 5rem));
+  border-radius: 14px;
+  border: 1px solid rgba(92, 135, 195, 0.28);
+  background: linear-gradient(135deg, rgba(22, 28, 36, 0.98), rgba(14, 18, 26, 0.94));
+  box-shadow:
+    0 18px 46px rgba(6, 10, 16, 0.55),
+    0 0 0 1px rgba(40, 70, 110, 0.45) inset,
+    0 0 32px rgba(70, 120, 190, 0.18);
+  color: #ecf5ff;
+  overflow: hidden;
+  backdrop-filter: blur(12px);
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  padding: 18px 16px 18px 18px;
+  gap: 18px;
+  background: radial-gradient(circle at 0% 0%, rgba(74, 127, 206, 0.26), transparent 60%),
+    linear-gradient(140deg, rgba(30, 40, 56, 0.85), rgba(20, 26, 36, 0.92));
+  border-right: 1px solid rgba(90, 130, 180, 0.22);
+}
+
+.sectionTitle {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(160, 200, 240, 0.78);
+}
+
+.favoritesList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 220px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.favoriteButton {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  text-align: left;
+  font-size: 0.88rem;
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease;
+}
+
+.favoriteButton:hover,
+.favoriteButton:focus-visible {
+  background: rgba(115, 165, 235, 0.22);
+  color: #f7fbff;
+  outline: none;
+}
+
+.favoriteIcon {
+  flex: none;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: rgba(12, 16, 22, 0.75);
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.favoriteLabel {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.emptyFavorites {
+  font-size: 0.78rem;
+  line-height: 1.4;
+  color: rgba(175, 210, 245, 0.6);
+}
+
+.categoryList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.categoryButton {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: rgba(200, 225, 255, 0.86);
+  font-size: 0.86rem;
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease, transform 0.18s ease;
+}
+
+.categoryIcon {
+  flex: none;
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+  background: rgba(14, 18, 26, 0.78);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.categoryButton:hover,
+.categoryButton:focus-visible {
+  background: rgba(120, 175, 240, 0.14);
+  color: #f6f9ff;
+  outline: none;
+}
+
+.categoryActive {
+  background: linear-gradient(90deg, rgba(108, 174, 255, 0.38), rgba(58, 115, 230, 0.32));
+  color: #ffffff;
+  box-shadow: inset 0 0 0 1px rgba(110, 170, 255, 0.45);
+  transform: translateX(2px);
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  padding: 18px;
+  gap: 14px;
+  min-width: 0;
+}
+
+.searchRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.searchInput {
+  flex: 1;
+  padding: 9px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(100, 150, 210, 0.3);
+  background: rgba(18, 24, 34, 0.85);
+  color: #f2f7ff;
+  font-size: 0.92rem;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+.searchInput::placeholder {
+  color: rgba(185, 210, 240, 0.55);
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: rgba(122, 190, 255, 0.8);
+  box-shadow: 0 0 0 2px rgba(122, 190, 255, 0.2);
+  background: rgba(12, 18, 28, 0.95);
+}
+
+.body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 170px 1fr;
+  gap: 18px;
+  min-height: 0;
+}
+
+.resultsCard {
+  background: rgba(10, 14, 22, 0.82);
+  border-radius: 14px;
+  border: 1px solid rgba(78, 115, 170, 0.26);
+  box-shadow: inset 0 0 0 1px rgba(40, 70, 110, 0.3);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.resultsHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.resultsTitle {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #f5f9ff;
+}
+
+.resultsMeta {
+  font-size: 0.75rem;
+  color: rgba(190, 215, 245, 0.62);
+}
+
+.appList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow-y: auto;
+}
+
+.appRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 6px;
+  border-radius: 10px;
+  transition: background 0.18s ease, transform 0.18s ease;
+}
+
+.appRow:hover,
+.appRow:focus-within {
+  background: rgba(120, 178, 245, 0.16);
+}
+
+.appRowActive {
+  background: linear-gradient(90deg, rgba(118, 186, 255, 0.35), rgba(78, 134, 230, 0.34));
+  box-shadow: inset 0 0 0 1px rgba(120, 188, 255, 0.5);
+  transform: translateX(2px);
+}
+
+.appMain {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  flex: 1;
+  cursor: pointer;
+}
+
+.appMain:focus-visible {
+  outline: none;
+}
+
+.appIcon {
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(18, 24, 34, 0.8);
+  overflow: hidden;
+}
+
+.appLabel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.appTitle {
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: #f7fbff;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.appSubtitle {
+  font-size: 0.72rem;
+  color: rgba(185, 210, 240, 0.6);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.favoriteToggle {
+  background: none;
+  border: none;
+  color: rgba(210, 230, 255, 0.7);
+  cursor: pointer;
+  font-size: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border-radius: 50%;
+  transition: color 0.18s ease, background 0.18s ease;
+  flex: none;
+  min-width: 32px;
+}
+
+.favoriteToggle:hover,
+.favoriteToggle:focus-visible {
+  color: #ffd479;
+  background: rgba(255, 212, 121, 0.18);
+  outline: none;
+}
+
+.favoriteToggleActive {
+  color: #ffc24b;
+}
+
+.emptyState {
+  margin-top: 12px;
+  font-size: 0.85rem;
+  color: rgba(190, 215, 245, 0.72);
+  text-align: center;
+}
+
+.muted {
+  color: rgba(185, 210, 240, 0.6);
+}
+
+.footerHint {
+  font-size: 0.72rem;
+  color: rgba(160, 190, 230, 0.55);
+  margin-top: 8px;
+}
+
+@media (max-width: 880px) {
+  .panel {
+    grid-template-columns: 1fr;
+    width: min(640px, calc(100vw - 1.5rem));
+  }
+
+  .sidebar {
+    border-right: none;
+    border-bottom: 1px solid rgba(90, 130, 180, 0.22);
+  }
+
+  .body {
+    grid-template-columns: 1fr;
+  }
+}
+

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -1,184 +1,511 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
-import Image from 'next/image';
-import UbuntuApp from '../base/ubuntu_app';
-import apps, { utilities, games } from '../../apps.config';
-import { safeLocalStorage } from '../../utils/safeStorage';
+'use client';
 
-type AppMeta = {
-  id: string;
-  title: string;
-  icon: string;
-  disabled?: boolean;
-  favourite?: boolean;
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import Image from 'next/image';
+
+import styles from './WhiskerMenu.module.css';
+import { safeLocalStorage } from '../../utils/safeStorage';
+import {
+  defaultCategoryId,
+  whiskerApps,
+  whiskerCategories,
+  type WhiskerAppMeta,
+} from '../../modules/apps.config';
+
+export interface WhiskerMenuHandle {
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+}
+
+interface WhiskerMenuProps {
+  anchorRef?: React.RefObject<HTMLElement | null>;
+  onOpenChange?: (open: boolean) => void;
+}
+
+const FAVORITE_STORAGE_KEY = 'whisker:favorites';
+const RECENT_STORAGE_KEY = 'recentApps';
+
+const APP_INDEX = new Map(whiskerApps.map((app) => [app.id, app]));
+const DEFAULT_FAVORITE_IDS = whiskerApps
+  .filter((app) => app.favourite)
+  .map((app) => app.id);
+const LAUNCHABLE_APPS = whiskerApps.filter((app) => !app.disabled);
+const CATEGORY_INDEX = new Map(
+  whiskerCategories.map((category) => [category.id, category])
+);
+
+const sanitizeIds = (ids: string[]): string[] =>
+  Array.from(new Set(ids)).filter((id) => APP_INDEX.has(id));
+
+const readFavoriteStorage = (): string[] | null => {
+  if (!safeLocalStorage) return null;
+  const stored = safeLocalStorage.getItem(FAVORITE_STORAGE_KEY);
+  if (!stored) return null;
+  try {
+    const parsed = JSON.parse(stored);
+    if (Array.isArray(parsed)) {
+      return sanitizeIds(parsed as string[]);
+    }
+  } catch {
+    return null;
+  }
+  return null;
 };
 
-const CATEGORIES = [
-  { id: 'all', label: 'All' },
-  { id: 'favorites', label: 'Favorites' },
-  { id: 'recent', label: 'Recent' },
-  { id: 'utilities', label: 'Utilities' },
-  { id: 'games', label: 'Games' }
-];
-
-const WhiskerMenu: React.FC = () => {
-  const [open, setOpen] = useState(false);
-  const [category, setCategory] = useState('all');
-  const [query, setQuery] = useState('');
-  const [highlight, setHighlight] = useState(0);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  const allApps: AppMeta[] = apps as any;
-  const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
-  const recentApps = useMemo(() => {
-    try {
-      const ids: string[] = JSON.parse(safeLocalStorage?.getItem('recentApps') || '[]');
-      return ids.map(id => allApps.find(a => a.id === id)).filter(Boolean) as AppMeta[];
-    } catch {
-      return [];
+const readRecentStorage = (): string[] => {
+  if (!safeLocalStorage) return [];
+  const stored = safeLocalStorage.getItem(RECENT_STORAGE_KEY);
+  if (!stored) return [];
+  try {
+    const parsed = JSON.parse(stored);
+    if (Array.isArray(parsed)) {
+      return sanitizeIds(parsed as string[]);
     }
-  }, [allApps, open]);
-  const utilityApps: AppMeta[] = utilities as any;
-  const gameApps: AppMeta[] = games as any;
+  } catch {
+    return [];
+  }
+  return [];
+};
 
-  const currentApps = useMemo(() => {
-    let list: AppMeta[];
-    switch (category) {
-      case 'favorites':
-        list = favoriteApps;
-        break;
-      case 'recent':
-        list = recentApps;
-        break;
-      case 'utilities':
-        list = utilityApps;
-        break;
-      case 'games':
-        list = gameApps;
-        break;
-      default:
-        list = allApps;
-    }
-    if (query) {
-      const q = query.toLowerCase();
-      list = list.filter(a => a.title.toLowerCase().includes(q));
-    }
-    return list;
-  }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps]);
+const WhiskerMenu = forwardRef<WhiskerMenuHandle, WhiskerMenuProps>(
+  ({ anchorRef, onOpenChange }, ref) => {
+    const [open, setOpen] = useState(false);
+    const [categoryId, setCategoryId] = useState(defaultCategoryId);
+    const [query, setQuery] = useState('');
+    const [highlightIndex, setHighlightIndex] = useState(0);
+    const [favoriteIds, setFavoriteIds] = useState<string[]>(() =>
+      readFavoriteStorage() ?? DEFAULT_FAVORITE_IDS
+    );
+    const [recentIds, setRecentIds] = useState<string[]>(() =>
+      readRecentStorage()
+    );
+    const [position, setPosition] = useState<{ left: number; bottom: number }>(
+      { left: 18, bottom: 80 }
+    );
 
-  useEffect(() => {
-    if (!open) return;
-    setHighlight(0);
-  }, [open, category, query]);
+    const menuRef = useRef<HTMLDivElement>(null);
+    const searchRef = useRef<HTMLInputElement>(null);
 
-  const openSelectedApp = (id: string) => {
-    window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
-    setOpen(false);
-  };
+    useImperativeHandle(ref, () => ({
+      open: () => setOpen(true),
+      close: () => setOpen(false),
+      toggle: () => setOpen((value) => !value),
+    }));
 
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Meta' && !e.ctrlKey && !e.shiftKey && !e.altKey) {
-        e.preventDefault();
-        setOpen(o => !o);
+    useEffect(() => {
+      if (typeof onOpenChange === 'function') {
+        onOpenChange(open);
+      }
+    }, [open, onOpenChange]);
+
+    useEffect(() => {
+      if (!safeLocalStorage) return;
+      const stored = readFavoriteStorage();
+      if (stored) {
+        setFavoriteIds(stored);
+      }
+    }, []);
+
+    useEffect(() => {
+      if (!safeLocalStorage) return;
+      safeLocalStorage.setItem(
+        FAVORITE_STORAGE_KEY,
+        JSON.stringify(favoriteIds)
+      );
+    }, [favoriteIds]);
+
+    useEffect(() => {
+      if (!safeLocalStorage) return;
+      setRecentIds(readRecentStorage());
+    }, []);
+
+    useEffect(() => {
+      if (!open) {
+        setHighlightIndex(0);
         return;
       }
-      if (!open) return;
-      if (e.key === 'Escape') {
-        setOpen(false);
-      } else if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        setHighlight(h => Math.min(h + 1, currentApps.length - 1));
-      } else if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        setHighlight(h => Math.max(h - 1, 0));
-      } else if (e.key === 'Enter') {
-        e.preventDefault();
-        const app = currentApps[highlight];
-        if (app) openSelectedApp(app.id);
-      }
-    };
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [open, currentApps, highlight]);
+      setCategoryId(defaultCategoryId);
+      setQuery('');
+    }, [open]);
 
-  useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
+    useEffect(() => {
       if (!open) return;
-      const target = e.target as Node;
-      if (!menuRef.current?.contains(target) && !buttonRef.current?.contains(target)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, [open]);
+      const handleStorage = (event: StorageEvent) => {
+        if (event.key && event.key !== RECENT_STORAGE_KEY) return;
+        setRecentIds(readRecentStorage());
+      };
+      const refresh = () => setRecentIds(readRecentStorage());
+      refresh();
+      window.addEventListener('storage', handleStorage);
+      window.addEventListener('focus', refresh);
+      return () => {
+        window.removeEventListener('storage', handleStorage);
+        window.removeEventListener('focus', refresh);
+      };
+    }, [open]);
 
-  return (
-    <div className="relative">
-      <button
-        ref={buttonRef}
-        type="button"
-        onClick={() => setOpen(o => !o)}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
-      >
-        <Image
-          src="/themes/Yaru/status/decompiler-symbolic.svg"
-          alt="Menu"
-          width={16}
-          height={16}
-          className="inline mr-1"
-        />
-        Applications
-      </button>
-      {open && (
-        <div
-          ref={menuRef}
-          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
-          tabIndex={-1}
-          onBlur={(e) => {
-            if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-              setOpen(false);
-            }
-          }}
-        >
-          <div className="flex flex-col bg-gray-800 p-2">
-            {CATEGORIES.map(cat => (
-              <button
-                key={cat.id}
-                className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
-                onClick={() => setCategory(cat.id)}
-              >
-                {cat.label}
-              </button>
-            ))}
-          </div>
-          <div className="p-3">
-            <input
-              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
-              placeholder="Search"
-              value={query}
-              onChange={e => setQuery(e.target.value)}
-              autoFocus
-            />
-            <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
-              {currentApps.map((app, idx) => (
-                <div key={app.id} className={idx === highlight ? 'ring-2 ring-ubb-orange' : ''}>
-                  <UbuntuApp
-                    id={app.id}
-                    icon={app.icon}
-                    name={app.title}
-                    openApp={() => openSelectedApp(app.id)}
-                    disabled={app.disabled}
-                  />
+    useEffect(() => {
+      if (!open) return;
+      const focusId = window.requestAnimationFrame(() => {
+        searchRef.current?.focus();
+      });
+      return () => window.cancelAnimationFrame(focusId);
+    }, [open]);
+
+    useEffect(() => {
+      if (!open) return;
+      const updatePosition = () => {
+        const rect = anchorRef?.current?.getBoundingClientRect();
+        const width = menuRef.current?.offsetWidth ?? Math.min(720, window.innerWidth - 32);
+        const safeWidth = Math.min(width, window.innerWidth - 24);
+        const maxLeft = Math.max(12, window.innerWidth - safeWidth - 12);
+        const left = rect
+          ? Math.min(Math.max(12, rect.left), maxLeft)
+          : Math.min(18, maxLeft);
+        const bottom = rect
+          ? Math.max(16, window.innerHeight - rect.top + 12)
+          : Math.max(64, window.innerHeight - 420);
+        setPosition({ left, bottom });
+      };
+      const frame = window.requestAnimationFrame(updatePosition);
+      window.addEventListener('resize', updatePosition);
+      return () => {
+        window.cancelAnimationFrame(frame);
+        window.removeEventListener('resize', updatePosition);
+      };
+    }, [open, anchorRef]);
+
+    useEffect(() => {
+      if (!open) return;
+      const handlePointer = (event: MouseEvent | TouchEvent) => {
+        const target = event.target as Node;
+        if (menuRef.current?.contains(target)) return;
+        if (anchorRef?.current && anchorRef.current.contains(target as Node))
+          return;
+        setOpen(false);
+      };
+      window.addEventListener('mousedown', handlePointer);
+      window.addEventListener('touchstart', handlePointer, { passive: true });
+      return () => {
+        window.removeEventListener('mousedown', handlePointer);
+        window.removeEventListener('touchstart', handlePointer);
+      };
+    }, [open, anchorRef]);
+
+    const favoriteIdSet = useMemo(
+      () => new Set(favoriteIds),
+      [favoriteIds]
+    );
+
+    const favoriteApps = useMemo(() => {
+      const items: WhiskerAppMeta[] = [];
+      favoriteIds.forEach((id) => {
+        const app = APP_INDEX.get(id);
+        if (app && !app.disabled) {
+          items.push(app);
+        }
+      });
+      return items;
+    }, [favoriteIds]);
+
+    const recentApps = useMemo(() => {
+      const seen = new Set<string>();
+      const items: WhiskerAppMeta[] = [];
+      recentIds.forEach((id) => {
+        if (seen.has(id)) return;
+        const app = APP_INDEX.get(id);
+        if (!app || app.disabled) return;
+        seen.add(id);
+        items.push(app);
+      });
+      return items;
+    }, [recentIds]);
+
+    const categoryApps = useMemo(() => {
+      if (query.trim()) return LAUNCHABLE_APPS;
+      if (categoryId === 'favorites') return favoriteApps;
+      if (categoryId === 'recent') return recentApps;
+      if (categoryId === 'all') return LAUNCHABLE_APPS;
+      const category = CATEGORY_INDEX.get(categoryId);
+      if (!category) return [];
+      const items: WhiskerAppMeta[] = [];
+      category.appIds.forEach((id) => {
+        const app = APP_INDEX.get(id);
+        if (app && !app.disabled) {
+          items.push(app);
+        }
+      });
+      return items;
+    }, [categoryId, favoriteApps, recentApps, query]);
+
+    const displayApps = useMemo(() => {
+      const searchTerm = query.trim().toLowerCase();
+      if (searchTerm) {
+        return LAUNCHABLE_APPS.filter((app) =>
+          app.title.toLowerCase().includes(searchTerm) ||
+          app.id.toLowerCase().includes(searchTerm)
+        ).sort((a, b) => a.title.localeCompare(b.title));
+      }
+      if (categoryId === 'all') {
+        return [...categoryApps].sort((a, b) =>
+          a.title.localeCompare(b.title)
+        );
+      }
+      return categoryApps;
+    }, [categoryApps, categoryId, query]);
+
+    useEffect(() => {
+      if (!open) return;
+      setHighlightIndex(0);
+    }, [categoryId, query, open]);
+
+    useEffect(() => {
+      if (!open) return;
+      setHighlightIndex((current) => {
+        if (!displayApps.length) return 0;
+        return Math.min(current, displayApps.length - 1);
+      });
+    }, [displayApps.length, open]);
+
+    useEffect(() => {
+      if (!open) return;
+      const handleKey = (event: KeyboardEvent) => {
+        if (!open) return;
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          setOpen(false);
+          return;
+        }
+        if (!displayApps.length) return;
+        if (event.key === 'ArrowDown') {
+          event.preventDefault();
+          setHighlightIndex((index) =>
+            Math.min(index + 1, displayApps.length - 1)
+          );
+        } else if (event.key === 'ArrowUp') {
+          event.preventDefault();
+          setHighlightIndex((index) => Math.max(index - 1, 0));
+        } else if (event.key === 'Home') {
+          event.preventDefault();
+          setHighlightIndex(0);
+        } else if (event.key === 'End') {
+          event.preventDefault();
+          setHighlightIndex(displayApps.length - 1);
+        } else if (event.key === 'Enter') {
+          event.preventDefault();
+          const app = displayApps[highlightIndex];
+          if (app) {
+            window.dispatchEvent(
+              new CustomEvent('open-app', { detail: app.id })
+            );
+            setOpen(false);
+          }
+        }
+      };
+      window.addEventListener('keydown', handleKey);
+      return () => window.removeEventListener('keydown', handleKey);
+    }, [open, displayApps, highlightIndex]);
+
+    const activeCategory = CATEGORY_INDEX.get(categoryId);
+    const resultsLabel = query.trim()
+      ? 'Search results'
+      : activeCategory?.label ?? 'Applications';
+
+    const toggleFavorite = (id: string) => {
+      setFavoriteIds((prev) => {
+        const exists = prev.includes(id);
+        if (exists) {
+          return prev.filter((item) => item !== id);
+        }
+        return [id, ...prev.filter((item) => item !== id)];
+      });
+    };
+
+    const handleLaunch = (id: string) => {
+      window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
+      setOpen(false);
+    };
+
+    return (
+      <div className={styles.container} aria-hidden={!open}>
+        {open && (
+          <div
+            ref={menuRef}
+            className={styles.panel}
+            style={{
+              left: `${position.left}px`,
+              bottom: `${position.bottom}px`,
+            }}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Application launcher"
+          >
+            <aside className={styles.sidebar}>
+              <div>
+                <p className={styles.sectionTitle}>Favorites</p>
+                <ul className={styles.favoritesList}>
+                  {favoriteApps.map((app) => (
+                    <li key={app.id}>
+                      <button
+                        type="button"
+                        className={styles.favoriteButton}
+                        onClick={() => handleLaunch(app.id)}
+                      >
+                        <span className={styles.favoriteIcon}>
+                          <Image
+                            src={app.icon.replace('./', '/')}
+                            alt=""
+                            width={26}
+                            height={26}
+                            sizes="26px"
+                          />
+                        </span>
+                        <span className={styles.favoriteLabel}>{app.title}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+                {favoriteApps.length === 0 && (
+                  <p className={styles.emptyFavorites}>
+                    Pin apps using the star button.
+                  </p>
+                )}
+              </div>
+              <p className={styles.footerHint}>
+                Press the Super key to open the launcher.
+              </p>
+            </aside>
+            <div className={styles.main}>
+              <div className={styles.searchRow}>
+                <input
+                  ref={searchRef}
+                  type="search"
+                  className={styles.searchInput}
+                  placeholder="Search applications"
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  aria-label="Search applications"
+                />
+              </div>
+              <div className={styles.body}>
+                <nav
+                  className={styles.categoryList}
+                  aria-label="Application categories"
+                >
+                  {whiskerCategories.map((category) => {
+                    const isActive = category.id === categoryId && !query.trim();
+                    return (
+                      <button
+                        key={category.id}
+                        type="button"
+                        className={`${styles.categoryButton} ${
+                          isActive ? styles.categoryActive : ''
+                        }`}
+                        onClick={() => {
+                          setCategoryId(category.id);
+                          setQuery('');
+                          setHighlightIndex(0);
+                        }}
+                      >
+                        <span className={styles.categoryIcon}>
+                          <Image
+                            src={category.icon}
+                            alt=""
+                            width={22}
+                            height={22}
+                            sizes="22px"
+                          />
+                        </span>
+                        <span>{category.label}</span>
+                      </button>
+                    );
+                  })}
+                </nav>
+                <div className={styles.resultsCard}>
+                  <div className={styles.resultsHeader}>
+                    <span className={styles.resultsTitle}>{resultsLabel}</span>
+                    <span className={styles.resultsMeta}>
+                      {displayApps.length} app
+                      {displayApps.length === 1 ? '' : 's'}
+                    </span>
+                  </div>
+                  <ul className={styles.appList} role="list">
+                    {displayApps.map((app, index) => {
+                      const active = index === highlightIndex;
+                      const isFavourite = favoriteIdSet.has(app.id);
+                      return (
+                        <li key={app.id}>
+                          <div
+                            className={`${styles.appRow} ${
+                              active ? styles.appRowActive : ''
+                            }`}
+                          >
+                            <button
+                              type="button"
+                              className={styles.appMain}
+                              onMouseEnter={() => setHighlightIndex(index)}
+                              onFocus={() => setHighlightIndex(index)}
+                              onClick={() => handleLaunch(app.id)}
+                            >
+                              <span className={styles.appIcon}>
+                                <Image
+                                  src={app.icon.replace('./', '/')}
+                                  alt=""
+                                  width={32}
+                                  height={32}
+                                  sizes="32px"
+                                />
+                              </span>
+                              <span className={styles.appLabel}>
+                                <span className={styles.appTitle}>{app.title}</span>
+                                <span className={styles.appSubtitle}>{app.id}</span>
+                              </span>
+                            </button>
+                            <button
+                              type="button"
+                              className={`${styles.favoriteToggle} ${
+                                isFavourite ? styles.favoriteToggleActive : ''
+                              }`}
+                              aria-pressed={isFavourite}
+                              aria-label={
+                                isFavourite
+                                  ? `Remove ${app.title} from favorites`
+                                  : `Add ${app.title} to favorites`
+                              }
+                              onFocus={() => setHighlightIndex(index)}
+                              onClick={() => toggleFavorite(app.id)}
+                            >
+                              {isFavourite ? '★' : '☆'}
+                            </button>
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                  {displayApps.length === 0 && (
+                    <p className={styles.emptyState}>
+                      No applications found. Try a different search term.
+                    </p>
+                  )}
                 </div>
-              ))}
+              </div>
             </div>
           </div>
-        </div>
-      )}
-    </div>
-  );
-};
+        )}
+      </div>
+    );
+  }
+);
+
+WhiskerMenu.displayName = 'WhiskerMenu';
 
 export default WhiskerMenu;
+

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,7 +3,6 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
-import WhiskerMenu from '../menu/WhiskerMenu';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -19,7 +18,6 @@ export default class Navbar extends Component {
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
-                                <WhiskerMenu />
                                 <div
                                         className={
                                                 'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,8 +1,12 @@
-import React from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
+import WhiskerMenu from '../menu/WhiskerMenu';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const launcherRef = useRef(null);
+    const menuRef = useRef(null);
+    const [menuOpen, setMenuOpen] = useState(false);
 
     const handleClick = (app) => {
         const id = app.id;
@@ -15,8 +19,44 @@ export default function Taskbar(props) {
         }
     };
 
+    const toggleMenu = useCallback(() => {
+        if (menuRef.current && typeof menuRef.current.toggle === 'function') {
+            menuRef.current.toggle();
+        }
+    }, []);
+
+    useEffect(() => {
+        const handleShortcut = (event) => {
+            if (event.key === 'Meta' && !event.altKey && !event.ctrlKey && !event.shiftKey) {
+                event.preventDefault();
+                toggleMenu();
+            }
+        };
+        window.addEventListener('keydown', handleShortcut);
+        return () => window.removeEventListener('keydown', handleShortcut);
+    }, [toggleMenu]);
+
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div className="absolute bottom-0 left-0 z-40 flex h-10 w-full items-center gap-1 bg-black bg-opacity-50 px-2" role="toolbar">
+            <button
+                ref={launcherRef}
+                type="button"
+                aria-label="Open applications menu"
+                aria-haspopup="true"
+                aria-expanded={menuOpen}
+                onClick={toggleMenu}
+                className="mr-2 flex items-center gap-2 rounded px-3 py-2 text-sm font-semibold tracking-wide text-white transition hover:bg-white hover:bg-opacity-10 focus:outline-none focus:ring-2 focus:ring-ubb-orange focus:ring-offset-2 focus:ring-offset-black/40"
+            >
+                <Image
+                    src="/themes/Yaru/status/icons8-kali-linux.svg"
+                    alt="Kali applications menu"
+                    width={24}
+                    height={24}
+                    sizes="24px"
+                />
+                <span className="hidden sm:inline">Applications</span>
+            </button>
+            <WhiskerMenu ref={menuRef} anchorRef={launcherRef} onOpenChange={setMenuOpen} />
             {runningApps.map(app => (
                 <button
                     key={app.id}

--- a/modules/apps.config.ts
+++ b/modules/apps.config.ts
@@ -1,0 +1,196 @@
+import apps, { utilities, games } from '../apps.config';
+
+export interface WhiskerAppMeta {
+  id: string;
+  title: string;
+  icon: string;
+  disabled?: boolean;
+  favourite?: boolean;
+}
+
+export interface WhiskerCategoryMeta {
+  id: string;
+  label: string;
+  icon: string;
+  description?: string;
+  appIds: string[];
+}
+
+const rawApps = apps as WhiskerAppMeta[];
+
+const appIndex = new Map(rawApps.map((app) => [app.id, app]));
+
+const dedupe = (ids: string[]) =>
+  Array.from(new Set(ids)).filter((id) => appIndex.has(id));
+
+const utilitiesIds = dedupe((utilities as WhiskerAppMeta[]).map((app) => app.id));
+const gamesIds = dedupe((games as WhiskerAppMeta[]).map((app) => app.id));
+
+const securityIds = dedupe([
+  'autopsy',
+  'beef',
+  'ble-sensor',
+  'dsniff',
+  'evidence-vault',
+  'ettercap',
+  'ghidra',
+  'hashcat',
+  'hydra',
+  'john',
+  'kismet',
+  'metasploit',
+  'mimikatz',
+  'mimikatz/offline',
+  'msf-post',
+  'nessus',
+  'nikto',
+  'nmap-nse',
+  'openvas',
+  'radare2',
+  'reaver',
+  'recon-ng',
+  'security-tools',
+  'volatility',
+  'wireshark',
+]);
+
+const developmentIds = dedupe([
+  'terminal',
+  'vscode',
+  'ssh',
+  'http',
+  'html-rewriter',
+  'serial-terminal',
+  'x',
+]);
+
+const internetIds = dedupe([
+  'chrome',
+  'spotify',
+  'youtube',
+  'weather',
+  'x',
+]);
+
+const productivityIds = dedupe([
+  'calculator',
+  'converter',
+  'gedit',
+  'project-gallery',
+  'quote',
+  'sticky_notes',
+  'todoist',
+  'weather-widget',
+  'contact',
+]);
+
+const systemIds = dedupe([
+  'about',
+  'settings',
+  'files',
+  'plugin-manager',
+  'resource-monitor',
+  'screen-recorder',
+  'trash',
+]);
+
+const assigned = new Set([
+  ...utilitiesIds,
+  ...gamesIds,
+  ...securityIds,
+  ...developmentIds,
+  ...internetIds,
+  ...productivityIds,
+  ...systemIds,
+]);
+
+const otherIds = dedupe(
+  rawApps
+    .map((app) => app.id)
+    .filter((id) => !assigned.has(id))
+);
+
+export const whiskerApps = rawApps;
+
+export const defaultCategoryId = 'favorites';
+
+export const whiskerCategories: WhiskerCategoryMeta[] = [
+  {
+    id: 'favorites',
+    label: 'Favorites',
+    icon: '/themes/Yaru/status/projects.svg',
+    appIds: [],
+  },
+  {
+    id: 'recent',
+    label: 'Recent',
+    icon: '/themes/Yaru/status/process-working-symbolic.svg',
+    appIds: [],
+  },
+  {
+    id: 'all',
+    label: 'All Applications',
+    icon: '/themes/Yaru/system/view-app-grid-symbolic.svg',
+    appIds: dedupe(rawApps.map((app) => app.id)),
+  },
+  {
+    id: 'security',
+    label: 'Offensive Security',
+    icon: '/themes/Yaru/apps/metasploit.svg',
+    appIds: securityIds,
+  },
+  {
+    id: 'development',
+    label: 'Development',
+    icon: '/themes/Yaru/apps/vscode.png',
+    appIds: developmentIds,
+  },
+  {
+    id: 'internet',
+    label: 'Internet',
+    icon: '/themes/Yaru/apps/chrome.png',
+    appIds: internetIds,
+  },
+  {
+    id: 'productivity',
+    label: 'Productivity',
+    icon: '/themes/Yaru/apps/todoist.png',
+    appIds: productivityIds,
+  },
+  {
+    id: 'system',
+    label: 'System',
+    icon: '/themes/Yaru/apps/gnome-control-center.png',
+    appIds: systemIds,
+  },
+  {
+    id: 'utilities',
+    label: 'Utilities',
+    icon: '/themes/Yaru/apps/gedit.png',
+    appIds: utilitiesIds,
+  },
+  {
+    id: 'games',
+    label: 'Games',
+    icon: '/themes/Yaru/apps/tetris.svg',
+    appIds: gamesIds,
+  },
+  {
+    id: 'other',
+    label: 'Extras',
+    icon: '/themes/Yaru/apps/project-gallery.svg',
+    appIds: otherIds,
+  },
+];
+
+export const getAppsForCategory = (categoryId: string): WhiskerAppMeta[] => {
+  if (categoryId === 'favorites' || categoryId === 'recent') return [];
+  const category = whiskerCategories.find((cat) => cat.id === categoryId);
+  if (!category) return [];
+  return category.appIds
+    .map((id) => appIndex.get(id))
+    .filter((app): app is WhiskerAppMeta => Boolean(app));
+};
+
+export const getAppById = (appId: string) => appIndex.get(appId);
+


### PR DESCRIPTION
## Summary
- build a new WhiskerMenu component with categorized listings, favorites management, and Kali-styled layout
- add a CSS module and supporting modules/apps.config.ts to group applications by category for the launcher
- wire the taskbar launcher button and meta-key shortcut to the menu and retire the old navbar trigger

## Testing
- yarn eslint components/menu/WhiskerMenu.tsx components/screen/taskbar.js components/screen/navbar.js modules/apps.config.ts
- yarn lint *(fails: repository has pre-existing accessibility and top-level window lint errors across legacy apps)*
- yarn test *(fails: repository has pre-existing act/localStorage issues in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68ca94a44530832893c7c95b56754dba