### PR TITLE
ui: align window radius tokens with kali curvature

### DIFF
--- a/apps/settings/components/KeymapOverlay.tsx
+++ b/apps/settings/components/KeymapOverlay.tsx
@@ -74,7 +74,7 @@ export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
               data-conflict={conflicts.has(s.keys) ? 'true' : 'false'}
               className={
                 conflicts.has(s.keys)
-                  ? 'flex justify-between bg-red-600/70 px-2 py-1 rounded'
+                  ? 'flex justify-between bg-red-600/70 px-2 py-1 rounded-[var(--radius-sm)]'
                   : 'flex justify-between px-2 py-1'
               }
             >
@@ -83,7 +83,7 @@ export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
               <button
                 type="button"
                 onClick={() => setRebinding(s.description)}
-                className="px-2 py-1 bg-ub-orange text-white rounded text-sm"
+                className="px-2 py-1 bg-ub-orange text-white rounded-[var(--radius-sm)] text-sm"
               >
                 {rebinding === s.description ? 'Press keys...' : 'Rebind'}
               </button>

--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -90,13 +90,13 @@ const BadgeList = ({ badges, className = '' }) => {
         >
           <div
             ref={modalRef}
-            className="bg-white text-black p-4 rounded shadow max-w-sm"
+            className="bg-white text-black p-4 rounded-[var(--radius-lg)] shadow max-w-sm"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="font-bold mb-2">{selected.label}</div>
             <div className="text-sm">{selected.description}</div>
             <button
-              className="mt-4 px-2 py-1 bg-blue-600 text-white rounded"
+              className="mt-4 px-2 py-1 bg-blue-600 text-white rounded-[var(--radius-sm)]"
               onClick={closeModal}
             >
               Close

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -217,19 +217,19 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           <div
             className="absolute inset-0 bg-black bg-opacity-75 z-50 flex items-center justify-center"
             role="dialog"
-          aria-modal="true"
-        >
-          <button
-            type="button"
-            onClick={resume}
-            className="px-4 py-2 bg-gray-700 text-white rounded focus:outline-none focus:ring"
-            autoFocus
+            aria-modal="true"
           >
-            Resume
-          </button>
-        </div>
-      )}
-      <div className="absolute top-2 right-2 z-40 flex space-x-2">
+            <button
+              type="button"
+              onClick={resume}
+              className="px-4 py-2 bg-gray-700 text-white rounded-[var(--radius-md)] focus:outline-none focus:ring"
+              autoFocus
+            >
+              Resume
+            </button>
+          </div>
+        )}
+        <div className="absolute top-2 right-2 z-40 flex space-x-2">
         <button
           type="button"
           onClick={() => setPaused((p) => !p)}

--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -216,7 +216,7 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
       role="dialog"
       aria-modal="true"
     >
-      <div className="max-w-md p-4 bg-gray-800 rounded shadow-lg">
+      <div className="max-w-md p-4 bg-gray-800 rounded-[var(--radius-lg)] shadow-lg">
         <h2 className="text-xl font-bold mb-2">{gameId} Help</h2>
         <p className="mb-2">
           <strong>Objective:</strong> {info.objective}
@@ -244,8 +244,8 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
         )}
         <button
           onClick={onClose}
-          className="mt-4 px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
-        >
+          className="mt-4 px-3 py-1 bg-gray-700 rounded-[var(--radius-sm)] focus:outline-none focus:ring"
+          >
           Close
         </button>
       </div>

--- a/components/apps/beef/GuideOverlay.js
+++ b/components/apps/beef/GuideOverlay.js
@@ -51,7 +51,7 @@ export default function GuideOverlay({ onClose }) {
       tabIndex={-1}
       onKeyDown={onKeyDown}
     >
-      <div className="max-w-md p-4 bg-gray-800 rounded shadow-lg">
+      <div className="max-w-md p-4 bg-gray-800 rounded-[var(--radius-lg)] shadow-lg">
         <div className="mb-2 text-center font-bold">
           Demo data, no live scanning
         </div>
@@ -62,7 +62,7 @@ export default function GuideOverlay({ onClose }) {
             type="button"
             onClick={prev}
             disabled={step === 0}
-            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded-[var(--radius-sm)] disabled:opacity-50 focus:outline-none focus:ring"
           >
             Prev
           </button>
@@ -71,7 +71,7 @@ export default function GuideOverlay({ onClose }) {
             type="button"
             onClick={next}
             disabled={step === STEPS.length - 1}
-            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded-[var(--radius-sm)] disabled:opacity-50 focus:outline-none focus:ring"
           >
             Next
           </button>
@@ -86,7 +86,7 @@ export default function GuideOverlay({ onClose }) {
         </label>
         <button
           onClick={handleClose}
-          className="mt-4 px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+          className="mt-4 px-3 py-1 bg-gray-700 rounded-[var(--radius-sm)] focus:outline-none focus:ring"
         >
           Close
         </button>

--- a/components/apps/openvas/index.js
+++ b/components/apps/openvas/index.js
@@ -541,18 +541,18 @@ const OpenVASApp = () => {
           aria-modal="true"
           className="fixed inset-0 bg-black/70 flex items-center justify-center p-4"
         >
-          <div className="bg-gray-800 p-4 rounded max-w-md w-full">
+          <div className="bg-gray-800 p-4 rounded-[var(--radius-lg)] max-w-md w-full">
             <h3 className="text-lg mb-2">Host {activeHost.host} Findings</h3>
             <ul className="space-y-2 max-h-60 overflow-auto">
               {activeHost.vulns.map((v, i) => (
-                <li key={i} className="p-2 bg-gray-700 rounded">
+                <li key={i} className="p-2 bg-gray-700 rounded-[var(--radius-md)]">
                   <div className="flex items-center justify-between">
                     <span className="font-semibold">{v.title}</span>
                     <div className="flex gap-1 ml-2">
-                      <span className="px-2 py-0.5 rounded text-xs bg-red-700">
+                      <span className="px-2 py-0.5 rounded-[var(--radius-sm)] text-xs bg-red-700">
                         CVSS {v.cvss}
                       </span>
-                      <span className="px-2 py-0.5 rounded text-xs bg-blue-700">
+                      <span className="px-2 py-0.5 rounded-[var(--radius-sm)] text-xs bg-blue-700">
                         EPSS {(v.epss * 100).toFixed(1)}%
                       </span>
                     </div>
@@ -561,7 +561,7 @@ const OpenVASApp = () => {
                     {v.remediation.map((tag) => (
                       <span
                         key={tag}
-                        className="inline-block mr-1 mb-1 px-2 py-0.5 bg-gray-600 rounded text-xs"
+                        className="inline-block mr-1 mb-1 px-2 py-0.5 bg-gray-600 rounded-[var(--radius-sm)] text-xs"
                       >
                         {tag}
                       </span>
@@ -573,7 +573,7 @@ const OpenVASApp = () => {
             <button
               type="button"
               onClick={() => setActiveHost(null)}
-              className="mt-4 px-3 py-1 bg-blue-600 rounded"
+              className="mt-4 px-3 py-1 bg-blue-600 rounded-[var(--radius-sm)]"
             >
               Close
             </button>
@@ -586,7 +586,7 @@ const OpenVASApp = () => {
           aria-modal="true"
           className="fixed inset-0 bg-black/70 flex items-center justify-center p-4"
         >
-          <div className="bg-gray-800 p-4 rounded max-w-md w-full">
+          <div className="bg-gray-800 p-4 rounded-[var(--radius-lg)] max-w-md w-full">
             <h3 className="text-lg mb-2">Issue Detail</h3>
             <p
               className="mb-2"
@@ -594,12 +594,12 @@ const OpenVASApp = () => {
             />
             <div className="flex gap-2 mb-2">
               {selected.cvss !== undefined && (
-                <span className="px-2 py-0.5 bg-red-700 rounded text-xs">
+                <span className="px-2 py-0.5 bg-red-700 rounded-[var(--radius-sm)] text-xs">
                   CVSS {selected.cvss}
                 </span>
               )}
               {selected.epss !== undefined && (
-                <span className="px-2 py-0.5 bg-blue-700 rounded text-xs">
+                <span className="px-2 py-0.5 bg-blue-700 rounded-[var(--radius-sm)] text-xs">
                   EPSS {(selected.epss * 100).toFixed(1)}%
                 </span>
               )}
@@ -612,7 +612,7 @@ const OpenVASApp = () => {
             <button
               type="button"
               onClick={() => setSelected(null)}
-              className="px-3 py-1 bg-blue-600 rounded"
+              className="px-3 py-1 bg-blue-600 rounded-[var(--radius-sm)]"
             >
               Close
             </button>

--- a/components/apps/radare2/GuideOverlay.js
+++ b/components/apps/radare2/GuideOverlay.js
@@ -48,7 +48,7 @@ export default function GuideOverlay({ onClose }) {
       role="dialog"
       aria-modal="true"
     >
-      <div className="max-w-md p-4 bg-gray-800 rounded shadow-lg">
+      <div className="max-w-md p-4 bg-gray-800 rounded-[var(--radius-lg)] shadow-lg">
         <h2 className="text-xl font-bold mb-2">Radare2 Tutorial</h2>
         <p className="mb-4">{STEPS[step]}</p>
         <div className="flex justify-between mb-4">
@@ -56,7 +56,7 @@ export default function GuideOverlay({ onClose }) {
             type="button"
             onClick={prev}
             disabled={step === 0}
-            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded-[var(--radius-sm)] disabled:opacity-50 focus:outline-none focus:ring"
           >
             Prev
           </button>
@@ -65,7 +65,7 @@ export default function GuideOverlay({ onClose }) {
             type="button"
             onClick={next}
             disabled={step === STEPS.length - 1}
-            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded-[var(--radius-sm)] disabled:opacity-50 focus:outline-none focus:ring"
           >
             Next
           </button>
@@ -89,7 +89,7 @@ export default function GuideOverlay({ onClose }) {
           </a>
           <button
             onClick={handleClose}
-            className="px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded-[var(--radius-sm)] focus:outline-none focus:ring"
           >
             Close
           </button>

--- a/components/apps/solitaire/index.tsx
+++ b/components/apps/solitaire/index.tsx
@@ -671,7 +671,7 @@ const Solitaire = () => {
           <button
             type="button"
             onClick={resume}
-            className="px-4 py-2 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+            className="px-4 py-2 bg-gray-700 text-white rounded-[var(--radius-md)] focus:outline-none focus:ring"
             autoFocus
           >
             Resume

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -635,7 +635,19 @@ export class Window extends Component {
                 >
                     <div
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        className={
+                            this.state.cursorType +
+                            " " +
+                            (this.state.closed ? " closed-window " : "") +
+                            (this.state.maximized
+                                ? ` duration-300 ${styles.windowMaximized}`
+                                : ` ${styles.windowFrame}`) +
+                            (this.props.minimized ? " opacity-0 invisible duration-200 " : "") +
+                            (this.state.grabbed ? " opacity-70 " : "") +
+                            (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") +
+                            (this.props.isFocused ? " z-30 " : " z-20 notFocused") +
+                            " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"
+                        }
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -7,3 +7,11 @@
   height: calc(100% + 10px);
   width: calc(100% - 10px);
 }
+
+.windowFrame {
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+}
+
+.windowMaximized {
+  border-radius: 0;
+}

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -99,7 +99,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
       aria-hidden={!open}
       style={{ left: pos.x, top: pos.y }}
       className={(open ? 'block ' : 'hidden ') +
-        'cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+        'cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded-[var(--radius-md)] text-white py-4 absolute z-50 text-sm'}
     >
       {items.map((item, i) => (
         <button

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -28,7 +28,7 @@ function AppMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
-            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded-[var(--radius-md)] text-white py-4 absolute z-50 text-sm'}
         >
             <button
                 type="button"

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -20,7 +20,7 @@ function DefaultMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
-            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded-[var(--radius-md)] text-white py-4 absolute z-50 text-sm"}
         >
 
             <Devider />

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -48,7 +48,7 @@ function DesktopMenu(props) {
             id="desktop-menu"
             role="menu"
             aria-label="Desktop context menu"
-            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded-[var(--radius-md)] text-white py-4 absolute z-50 text-sm"}
         >
             <button
                 onClick={props.addNewFolder}

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -30,7 +30,7 @@ function TaskbarMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
-            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-40 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm'}
+            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-40 context-menu-bg border text-left border-gray-900 rounded-[var(--radius-md)] text-white py-2 absolute z-50 text-sm'}
         >
             <button
                 type="button"

--- a/styles/index.css
+++ b/styles/index.css
@@ -144,7 +144,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 .windowMainScreen::-webkit-scrollbar-thumb {
     background-color: var(--color-border);
-    border-radius: 5px;
+    border-radius: var(--radius-sm);
 }
 
 /* SideBarApp Scale image onClick */
@@ -268,7 +268,7 @@ dialog {
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: 0.25rem;
+    border-radius: var(--radius-md);
 }
 
 .card-front {
@@ -315,7 +315,7 @@ dialog {
 .chip {
     width: 2.5rem;
     height: 2.5rem;
-    border-radius: 9999px;
+    border-radius: var(--radius-round);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -42,9 +42,10 @@
   --space-6: 2rem;
 
   /* Radius */
-  --radius-sm: 2px;
-  --radius-md: 4px;
-  --radius-lg: 8px;
+  /* Radius scale tuned to Kali XFCE curvature */
+  --radius-sm: 3px;
+  --radius-md: 5px;
+  --radius-lg: 7px;
   --radius-round: 9999px;
 
   /* Motion durations */


### PR DESCRIPTION
## Summary
- tune the shared radius scale to the Kali XFCE window curvature
- apply the new radius tokens to window chrome, context menus, and modal panels for consistent rounding

## Testing
- yarn lint *(fails: existing accessibility violations in unrelated apps)*
- yarn test *(fails: existing test and environment issues in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68ca94a5256483288dcecdeb15cfd86e