### PR TITLE
[screen] Refresh boot sequence visuals

### DIFF
--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -1,41 +1,65 @@
 import React from 'react'
 import Image from 'next/image'
+import styles from './booting_screen.module.css'
 
-function BootingScreen(props) {
+function BootingScreen({ visible, isShutDown, turnOn }) {
+    const isVisible = visible || isShutDown
 
     return (
         <div
             style={{
-                ...(props.visible || props.isShutDown ? { zIndex: "100" } : { zIndex: "-20" }),
+                ...(isVisible ? { zIndex: '100' } : { zIndex: '-20' }),
                 contentVisibility: 'auto',
             }}
-            className={(props.visible || props.isShutDown ? " visible opacity-100" : " invisible opacity-0 ") + " absolute duration-500 select-none flex flex-col justify-around items-center top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen bg-black"}>
-            <Image
-                width={400}
-                height={400}
-                className="md:w-1/4 w-1/2"
-                src="/themes/Yaru/status/cof_orange_hex.svg"
-                alt="Ubuntu Logo"
-                sizes="(max-width: 768px) 50vw, 25vw"
-                priority
-            />
-            <div className="w-10 h-10 flex justify-center items-center rounded-full outline-none cursor-pointer" onClick={props.turnOn} >
-                {(props.isShutDown
-                    ? <div className="bg-white rounded-full flex justify-center items-center w-10 h-10 hover:bg-gray-300"><Image width={32} height={32} className="w-8" src="/themes/Yaru/status/power-button.svg" alt="Power Button" sizes="32px" priority/></div>
-                    : <Image width={40} height={40} className={" w-10 " + (props.visible ? " animate-spin " : "")} src="/themes/Yaru/status/process-working-symbolic.svg" alt="Ubuntu Process Symbol" sizes="40px" priority/>)}
+            className={`${styles.screen} ${isVisible ? styles.screenVisible : styles.screenHidden}`}
+        >
+            <div className={styles.logoCluster}>
+                <div className={styles.logoWrapper}>
+                    <span className={styles.logoGlow} aria-hidden="true" />
+                    <Image
+                        width={512}
+                        height={160}
+                        className={styles.logo}
+                        src="/images/kali-wordmark.svg"
+                        alt="Kali Linux logo"
+                        sizes="(max-width: 768px) 70vw, 30vw"
+                        priority
+                    />
+                </div>
+                <p className={styles.tagline}>Initializing the Kali Linux desktop environment</p>
             </div>
-            <Image
-                width={200}
-                height={100}
-                className="md:w-1/5 w-1/2"
-                src="/themes/Yaru/status/ubuntu_white_hex.svg"
-                alt="Kali Linux Name"
-                sizes="(max-width: 768px) 50vw, 20vw"
-            />
-            <div className="text-white mb-4">
-                <a className="underline" href="https://www.linkedin.com/in/unnippillil/" rel="noopener noreferrer" target="_blank">linkedin</a>
-                <span className="font-bold mx-1">|</span>
-                <a href="https://github.com/Alex-Unnippillil" rel="noopener noreferrer" target="_blank" className="underline">github</a>
+
+            <div className={styles.progressArea}>
+                {isShutDown ? (
+                    <button type="button" className={styles.powerButton} onClick={turnOn}>
+                        <Image
+                            width={40}
+                            height={40}
+                            className={styles.powerIcon}
+                            src="/themes/Yaru/status/power-button.svg"
+                            alt="Power Button"
+                            sizes="40px"
+                            priority
+                        />
+                        <span className={styles.powerLabel}>Power On</span>
+                    </button>
+                ) : (
+                    <div className={styles.spinner} role="status" aria-live="polite">
+                        <span className={styles.visuallyHidden}>Booting Kali Linux</span>
+                    </div>
+                )}
+            </div>
+
+            <div className={styles.links}>
+                <a href="https://www.linkedin.com/in/unnippillil/" rel="noopener noreferrer" target="_blank">
+                    LinkedIn
+                </a>
+                <span className={styles.linksDivider} aria-hidden="true">
+                    |
+                </span>
+                <a href="https://github.com/Alex-Unnippillil" rel="noopener noreferrer" target="_blank">
+                    GitHub
+                </a>
             </div>
         </div>
     )

--- a/components/screen/booting_screen.module.css
+++ b/components/screen/booting_screen.module.css
@@ -1,0 +1,276 @@
+.screen {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-rows: 1fr auto auto;
+  justify-items: center;
+  align-items: center;
+  padding: clamp(2rem, 8vh, 4rem) clamp(1.5rem, 6vw, 4rem);
+  background:
+    radial-gradient(circle at 50% 22%, rgba(23, 147, 209, 0.24), rgba(23, 147, 209, 0) 58%),
+    linear-gradient(135deg, #02060a 0%, #010307 100%);
+  color: #f4f7fb;
+  transition: opacity 400ms ease, visibility 400ms ease;
+  opacity: 0;
+  visibility: hidden;
+  user-select: none;
+  overflow: hidden;
+}
+
+.screenVisible {
+  opacity: 1;
+  visibility: visible;
+}
+
+.screenHidden {
+  pointer-events: none;
+}
+
+.logoCluster {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(1.25rem, 4vh, 2.5rem);
+  text-align: center;
+}
+
+.logoWrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 4vw, 2.75rem);
+  border-radius: 1.5rem;
+  background: rgba(6, 14, 24, 0.7);
+  border: 1px solid rgba(23, 147, 209, 0.28);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45), 0 0 64px rgba(23, 147, 209, 0.32);
+  isolation: isolate;
+}
+
+.logoGlow {
+  position: absolute;
+  inset: 12%;
+  border-radius: 1.25rem;
+  background: radial-gradient(circle at 50% 50%, rgba(23, 147, 209, 0.4), rgba(23, 147, 209, 0));
+  filter: blur(24px);
+  opacity: 0.75;
+  z-index: -1;
+  pointer-events: none;
+}
+
+.logo {
+  width: min(420px, 70vw);
+  height: auto;
+  opacity: 0;
+  transform: translateY(14px) scale(0.96);
+  animation: kaliLogoFade 1.3s cubic-bezier(0.23, 1, 0.32, 1) forwards;
+  filter: drop-shadow(0 26px 36px rgba(23, 147, 209, 0.3));
+}
+
+.tagline {
+  margin: 0;
+  font-size: clamp(0.95rem, 1.8vw, 1.15rem);
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  color: rgba(244, 247, 251, 0.75);
+}
+
+.progressArea {
+  min-height: clamp(4rem, 8vh, 5rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.spinner {
+  position: relative;
+  width: clamp(3.5rem, 12vw, 4.75rem);
+  height: clamp(3.5rem, 12vw, 4.75rem);
+  border-radius: 9999px;
+  background: conic-gradient(from 90deg, rgba(23, 147, 209, 0.12) 0deg, rgba(23, 147, 209, 0.55) 140deg, rgba(23, 147, 209, 0.12) 360deg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: kaliSpinner 1.1s linear infinite;
+  box-shadow: 0 0 0 1px rgba(23, 147, 209, 0.35), 0 0 18px rgba(23, 147, 209, 0.25);
+}
+
+.spinner::after {
+  content: '';
+  position: absolute;
+  inset: 20%;
+  border-radius: 9999px;
+  background: radial-gradient(circle at 40% 40%, rgba(23, 147, 209, 0.45), rgba(4, 9, 15, 0.92) 70%);
+  box-shadow: inset 0 0 12px rgba(23, 147, 209, 0.25);
+}
+
+.powerButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(23, 147, 209, 0.4);
+  background: rgba(6, 14, 24, 0.8);
+  color: inherit;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.powerButton:hover,
+.powerButton:focus-visible {
+  background: rgba(23, 147, 209, 0.16);
+  box-shadow: 0 0 0 1px rgba(23, 147, 209, 0.6), 0 0 28px rgba(23, 147, 209, 0.32);
+  transform: translateY(-1px);
+}
+
+.powerButton:focus-visible {
+  outline: none;
+}
+
+.powerIcon {
+  width: 2.5rem;
+  height: 2.5rem;
+  filter: drop-shadow(0 0 14px rgba(23, 147, 209, 0.35));
+}
+
+.powerLabel {
+  white-space: nowrap;
+}
+
+.links {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: rgba(244, 247, 251, 0.75);
+  font-size: clamp(0.85rem, 1.6vw, 1rem);
+}
+
+.links a {
+  color: inherit;
+  text-decoration: none;
+  position: relative;
+  padding-bottom: 0.15rem;
+}
+
+.links a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 1px;
+  background: rgba(23, 147, 209, 0.8);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 160ms ease;
+}
+
+.links a:hover::after,
+.links a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.links a:focus-visible {
+  outline: none;
+  color: #ffffff;
+}
+
+.linksDivider {
+  opacity: 0.45;
+  font-weight: 700;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes kaliLogoFade {
+  0% {
+    opacity: 0;
+    transform: translateY(28px) scale(0.94);
+    filter: drop-shadow(0 0 0 rgba(23, 147, 209, 0));
+  }
+
+  60% {
+    opacity: 1;
+    transform: translateY(0) scale(1.01);
+    filter: drop-shadow(0 30px 64px rgba(23, 147, 209, 0.35));
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    filter: drop-shadow(0 22px 40px rgba(23, 147, 209, 0.3));
+  }
+}
+
+@keyframes kaliSpinner {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 640px) {
+  .screen {
+    grid-template-rows: auto auto auto;
+    row-gap: 2.5rem;
+  }
+
+  .logoWrapper {
+    padding: 1.5rem;
+  }
+
+  .tagline {
+    letter-spacing: 0.18em;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .screen {
+    transition-duration: 0ms;
+  }
+
+  .logo {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  .spinner {
+    animation: none;
+    background: rgba(23, 147, 209, 0.35);
+  }
+}
+
+:global(.reduced-motion) :local(.screen) {
+  transition-duration: 0ms;
+}
+
+:global(.reduced-motion) :local(.logo) {
+  animation: none;
+  opacity: 1;
+  transform: none;
+}
+
+:global(.reduced-motion) :local(.spinner) {
+  animation: none;
+  background: rgba(23, 147, 209, 0.35);
+}

--- a/public/images/kali-wordmark.svg
+++ b/public/images/kali-wordmark.svg
@@ -1,0 +1,9 @@
+<svg width="512" height="160" viewBox="0 0 512 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="8" y="8" width="496" height="144" rx="20" fill="#040A11" stroke="#1793D1" stroke-width="2" opacity="0.55" />
+  <path d="M64 124V36H92V78.7L145 36H187L120.5 92.5L189 124H142.5L92 99.5V124H64Z" fill="#1793D1" />
+  <path d="M207 124L260 36H295.5L349 124H318.5L306.6 102.4H249.4L237.5 124H207ZM278.4 63.9L259.7 98.6H296.3L278.4 63.9Z" fill="#1793D1" />
+  <path d="M364 36H394V104.5H466V124H364V36Z" fill="#1793D1" />
+  <path d="M474 36H506V124H474V36Z" fill="#1793D1" />
+  <path d="M40 36H24V124H40V36Z" fill="#1793D1" />
+  <path d="M24 28C24 21.3726 29.3726 16 36 16H476C482.627 16 488 21.3726 488 28V132C488 138.627 482.627 144 476 144H36C29.3726 144 24 138.627 24 132V28Z" stroke="#0C1F2E" stroke-width="4" opacity="0.35" />
+</svg>


### PR DESCRIPTION
## Summary
- redesign the boot screen component to stage the Kali wordmark, fade-in animation, and spinning status indicator
- move boot splash styling into a dedicated CSS module with Kali-inspired keyframes and reduced-motion overrides
- add a Kali wordmark SVG asset used by the splash screen

## Testing
- `yarn lint` *(fails: existing accessibility violations across legacy app forms and public game scripts)*
- `yarn test` *(fails: existing suites for ubuntu boot flow, settings store, and other legacy UI warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ca94b5682c8328888047f025d9be89