### PR TITLE
[ui] add simulated resource monitor status bar

### DIFF
--- a/apps/resource-monitor/components/NetworkInsights.tsx
+++ b/apps/resource-monitor/components/NetworkInsights.tsx
@@ -32,7 +32,7 @@ export default function NetworkInsights() {
   }, [setHistory]);
 
   return (
-    <div className="p-2 text-xs text-white bg-[var(--kali-bg)]">
+    <div className="rounded-xl border border-[#123647] bg-[var(--kali-bg)]/95 p-2 text-xs text-white shadow-[0_0_18px_rgba(9,23,33,0.45)]">
       <h2 className="font-bold mb-1">Active Fetches</h2>
       <ul className="mb-2 divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
         {active.length === 0 && <li className="p-1 text-gray-400">None</li>}

--- a/apps/resource-monitor/index.tsx
+++ b/apps/resource-monitor/index.tsx
@@ -1,12 +1,16 @@
 'use client';
 
 import React from 'react';
+import StatusBar from '../../components/ui/StatusBar';
 import NetworkInsights from './components/NetworkInsights';
 
 export default function ResourceMonitorApp() {
   return (
-    <div className="h-full w-full bg-ub-cool-grey overflow-auto">
-      <NetworkInsights />
+    <div className="h-full w-full overflow-auto bg-ub-cool-grey">
+      <div className="mx-auto flex max-w-5xl flex-col gap-3 p-3">
+        <StatusBar />
+        <NetworkInsights />
+      </div>
     </div>
   );
 }

--- a/components/apps/resource_monitor.js
+++ b/components/apps/resource_monitor.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import StatusBar from '../ui/StatusBar';
 
 // Number of samples to keep in the timeline
 const MAX_POINTS = 60;
@@ -186,6 +187,9 @@ const ResourceMonitor = () => {
           {stress ? 'Stop Stress' : 'Stress Test'}
         </button>
         <span className="ml-auto text-sm">FPS: {fps.toFixed(1)}</span>
+      </div>
+      <div className="px-4">
+        <StatusBar className="w-full max-w-4xl" />
       </div>
       <div className="flex flex-1 items-center justify-evenly gap-4 p-4">
         <canvas

--- a/components/ui/StatusBar.tsx
+++ b/components/ui/StatusBar.tsx
@@ -1,0 +1,299 @@
+import React, { useEffect, useId, useMemo, useState } from 'react';
+import metricsData from '../../data/system-metrics.json';
+
+type ResourceSample = {
+  timestamp: string;
+  cpuTotal: number;
+  cpuFrequencyGHz: number;
+  perCore: number[];
+  memoryUsedGb: number;
+  memoryCachedGb: number;
+};
+
+type ResourceMetricsData = {
+  cpu: {
+    model: string;
+    cores: number;
+    threads: number;
+    baseClockGHz?: number;
+    boostClockGHz?: number;
+  };
+  memory: {
+    totalGb: number;
+    type: string;
+  };
+  samples: ResourceSample[];
+};
+
+type StatusBarProps = {
+  className?: string;
+  refreshInterval?: number;
+  sampleWindow?: number;
+};
+
+const DEFAULT_INTERVAL = 2500;
+const DEFAULT_WINDOW = 12;
+
+const clampPercent = (value: number) => {
+  if (Number.isNaN(value)) return 0;
+  return Math.max(0, Math.min(100, value));
+};
+
+const formatTimestamp = (timestamp?: string) => {
+  if (!timestamp) return '—';
+  const timePart = timestamp.split('T')[1];
+  if (!timePart) return timestamp;
+  return timePart.replace('Z', '').slice(0, 8);
+};
+
+const createSparkline = (values: number[], maxValue = 100) => {
+  if (!values.length) {
+    return { line: '', area: '' };
+  }
+
+  const height = 40;
+  const width = 100;
+  const safeMax = Math.max(maxValue, ...values, 1);
+  const step = values.length > 1 ? width / (values.length - 1) : width;
+
+  const points = values.map((value, index) => {
+    const x = Number((index * step).toFixed(2));
+    const y = Number((height - (value / safeMax) * height).toFixed(2));
+    return `${index === 0 ? 'M' : 'L'}${x} ${y}`;
+  });
+
+  const line = points.join(' ');
+  const area = `${line} L${width} ${height} L0 ${height} Z`;
+
+  return { line, area };
+};
+
+const metrics = metricsData as ResourceMetricsData;
+
+export default function StatusBar({
+  className = '',
+  refreshInterval = DEFAULT_INTERVAL,
+  sampleWindow = DEFAULT_WINDOW,
+}: StatusBarProps) {
+  const [index, setIndex] = useState(0);
+  const windowSize = Math.max(2, sampleWindow);
+  const memoryTotal = metrics.memory?.totalGb ?? 0;
+  const declaredCoreCount = metrics.cpu?.cores ?? 0;
+  const declaredThreadCount = metrics.cpu?.threads ?? 0;
+  const sampleData = metrics.samples ?? [];
+  const idPrefix = useId();
+  const cpuGradientId = `${idPrefix}-cpu`;
+  const memGradientId = `${idPrefix}-mem`;
+
+  useEffect(() => {
+    if (sampleData.length <= 1) return undefined;
+    if (typeof window === 'undefined') return undefined;
+
+    const timer = window.setInterval(() => {
+      setIndex((prev) => (prev + 1) % sampleData.length);
+    }, refreshInterval);
+
+    return () => window.clearInterval(timer);
+  }, [refreshInterval, sampleData.length]);
+
+  const currentSample = sampleData.length ? sampleData[index % sampleData.length] : undefined;
+
+  const visibleSamples = useMemo(() => {
+    if (!sampleData.length) return [];
+    const end = currentSample ? index : sampleData.length - 1;
+    const safeEnd = Math.min(end, sampleData.length - 1);
+    const start = Math.max(0, safeEnd - (windowSize - 1));
+    return sampleData.slice(start, safeEnd + 1);
+  }, [currentSample, index, windowSize, sampleData]);
+
+  const cpuHistory = useMemo(
+    () => visibleSamples.map((sample) => clampPercent(sample.cpuTotal)),
+    [visibleSamples],
+  );
+
+  const memoryHistory = useMemo(
+    () =>
+      visibleSamples.map((sample) =>
+        memoryTotal > 0 ? clampPercent((sample.memoryUsedGb / memoryTotal) * 100) : 0,
+      ),
+    [visibleSamples, memoryTotal],
+  );
+
+  const cpuSparkline = useMemo(() => createSparkline(cpuHistory), [cpuHistory]);
+  const memSparkline = useMemo(() => createSparkline(memoryHistory), [memoryHistory]);
+
+  const cpuPercent = clampPercent(currentSample?.cpuTotal ?? 0);
+  const cpuFrequency = currentSample?.cpuFrequencyGHz ?? metrics.cpu?.baseClockGHz ?? 0;
+  const cpuCores = useMemo(() => {
+    const base = currentSample?.perCore ?? [];
+    const expected = declaredCoreCount || base.length;
+    if (!expected) return base;
+    if (base.length >= expected) return base.slice(0, expected);
+    return [...base, ...Array.from({ length: expected - base.length }, () => 0)];
+  }, [currentSample, declaredCoreCount]);
+
+  const memoryUsed = currentSample?.memoryUsedGb ?? 0;
+  const memoryCached = currentSample?.memoryCachedGb ?? 0;
+  const memoryPercent = memoryTotal > 0 ? clampPercent((memoryUsed / memoryTotal) * 100) : 0;
+  const memoryAvailable = memoryTotal > 0 ? Math.max(0, memoryTotal - memoryUsed) : 0;
+
+  const timestamp = formatTimestamp(currentSample?.timestamp);
+
+  return (
+    <section
+      aria-label="Simulated system resource status"
+      className={`relative overflow-hidden rounded-xl border border-[#123647] bg-[var(--kali-bg)]/95 text-cyan-100 shadow-[0_0_18px_rgba(9,23,33,0.6)] backdrop-blur ${className}`}
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(34,211,238,0.08),_transparent_55%),_linear-gradient(135deg,_rgba(15,118,110,0.2),_rgba(59,130,246,0.05))]"
+      />
+      <div className="relative flex flex-col gap-4 p-4">
+        <header className="flex flex-wrap items-center gap-3">
+          <div className="flex items-center gap-2 text-[0.65rem] uppercase tracking-[0.35em] text-cyan-300">
+            <span className="h-2 w-2 rounded-full bg-cyan-400 shadow-[0_0_10px_rgba(34,211,238,0.8)]" />
+            <span>Resource Monitor</span>
+          </div>
+          <span className="ml-auto text-[0.65rem] font-medium tracking-[0.25em] text-cyan-100/70">
+            {timestamp}
+          </span>
+          <span className="text-[0.6rem] uppercase tracking-[0.3em] text-cyan-100/50">
+            sample {sampleData.length ? (index % sampleData.length) + 1 : 0}/{sampleData.length}
+          </span>
+        </header>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="rounded-lg border border-[#12495d]/60 bg-[#061722]/80 p-4 shadow-inner">
+            <div className="flex items-center justify-between">
+              <div className="text-[0.65rem] uppercase tracking-[0.3em] text-cyan-300">CPU Load</div>
+              <div className="text-lg font-semibold text-cyan-100">{cpuPercent.toFixed(0)}%</div>
+            </div>
+            <div className="mt-3 h-2 rounded-full bg-[#040b12]">
+              <div
+                className="h-full rounded-full bg-gradient-to-r from-[#2563eb] via-[#38bdf8] to-[#22d3ee] transition-all duration-500"
+                style={{ width: `${cpuPercent}%` }}
+                role="presentation"
+              />
+            </div>
+            <div className="mt-4 flex flex-col gap-3 md:flex-row md:items-center">
+              <svg
+                aria-hidden
+                viewBox="0 0 100 40"
+                className="h-16 w-full max-w-[150px]"
+              >
+                <defs>
+                  <linearGradient id={cpuGradientId} x1="0" x2="0" y1="0" y2="1">
+                    <stop offset="0%" stopColor="rgba(56,189,248,0.35)" />
+                    <stop offset="100%" stopColor="rgba(37,99,235,0)" />
+                  </linearGradient>
+                </defs>
+                {cpuSparkline.area && (
+                  <path d={cpuSparkline.area} fill={`url(#${cpuGradientId})`} opacity={0.9} />
+                )}
+                {cpuSparkline.line && (
+                  <path d={cpuSparkline.line} fill="none" stroke="#22d3ee" strokeWidth={1.5} strokeLinecap="round" />
+                )}
+              </svg>
+              <dl className="grid flex-1 gap-2 text-[0.7rem] text-cyan-100/70">
+                <div className="flex flex-col">
+                  <dt className="uppercase tracking-[0.2em] text-cyan-300/80">Processor</dt>
+                  <dd>{metrics.cpu?.model ?? 'Unknown CPU'}</dd>
+                </div>
+                <div className="flex flex-wrap items-baseline gap-2 text-cyan-100">
+                  <div className="text-[0.65rem] uppercase tracking-[0.2em] text-cyan-300/80">
+                    {declaredCoreCount || '?'}C/{declaredThreadCount || '?'}T
+                  </div>
+                  <div className="text-sm font-medium text-cyan-100">
+                    {cpuFrequency.toFixed(1)} GHz
+                  </div>
+                </div>
+              </dl>
+            </div>
+            {cpuCores.length > 0 && (
+              <div className="mt-4 grid grid-cols-2 gap-2 text-[0.65rem] text-cyan-100/70">
+                {cpuCores.map((value, coreIndex) => {
+                  const percent = clampPercent(value);
+                  return (
+                    <div key={`core-${coreIndex}`} className="rounded-md bg-[#071927]/70 p-2">
+                      <div className="flex items-center justify-between text-[0.6rem] uppercase tracking-[0.2em] text-cyan-300/70">
+                        <span>Core {coreIndex + 1}</span>
+                        <span>{percent.toFixed(0)}%</span>
+                      </div>
+                      <div className="mt-1.5 h-1.5 rounded-full bg-[#040b12]">
+                        <div
+                          className="h-full rounded-full bg-gradient-to-r from-[#0ea5e9] via-[#38bdf8] to-[#22d3ee] transition-all duration-500"
+                          style={{ width: `${percent}%` }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-lg border border-[#16405a]/60 bg-[#071520]/80 p-4 shadow-inner">
+            <div className="flex items-center justify-between">
+              <div className="text-[0.65rem] uppercase tracking-[0.3em] text-cyan-300">Memory</div>
+              <div className="text-lg font-semibold text-cyan-100">{memoryPercent.toFixed(0)}%</div>
+            </div>
+            <div className="mt-3 h-2 rounded-full bg-[#040b12]">
+              <div
+                className="h-full rounded-full bg-gradient-to-r from-[#8b5cf6] via-[#6366f1] to-[#22d3ee] transition-all duration-500"
+                style={{ width: `${memoryPercent}%` }}
+                role="presentation"
+              />
+            </div>
+            <div className="mt-4 flex flex-col gap-3 md:flex-row md:items-center">
+              <svg
+                aria-hidden
+                viewBox="0 0 100 40"
+                className="h-16 w-full max-w-[150px]"
+              >
+                <defs>
+                  <linearGradient id={memGradientId} x1="0" x2="0" y1="0" y2="1">
+                    <stop offset="0%" stopColor="rgba(99,102,241,0.35)" />
+                    <stop offset="100%" stopColor="rgba(139,92,246,0)" />
+                  </linearGradient>
+                </defs>
+                {memSparkline.area && (
+                  <path d={memSparkline.area} fill={`url(#${memGradientId})`} opacity={0.9} />
+                )}
+                {memSparkline.line && (
+                  <path d={memSparkline.line} fill="none" stroke="#a855f7" strokeWidth={1.5} strokeLinecap="round" />
+                )}
+              </svg>
+              <dl className="grid flex-1 gap-2 text-[0.7rem] text-cyan-100/70">
+                <div className="flex items-baseline justify-between">
+                  <dt className="uppercase tracking-[0.2em] text-cyan-300/80">Used</dt>
+                  <dd className="text-sm font-medium text-cyan-100">{memoryUsed.toFixed(1)} GB</dd>
+                </div>
+                <div className="flex items-baseline justify-between">
+                  <dt className="uppercase tracking-[0.2em] text-cyan-300/80">Cached</dt>
+                  <dd>{memoryCached.toFixed(1)} GB</dd>
+                </div>
+                <div className="flex items-baseline justify-between">
+                  <dt className="uppercase tracking-[0.2em] text-cyan-300/80">Available</dt>
+                  <dd>{memoryAvailable.toFixed(1)} GB</dd>
+                </div>
+              </dl>
+            </div>
+            <div className="mt-4 rounded-md bg-[#091c2a]/80 p-3 text-[0.65rem] text-cyan-100/70">
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                <span className="uppercase tracking-[0.25em] text-cyan-300/80">Total</span>
+                <span className="text-sm font-semibold text-cyan-100">
+                  {memoryTotal ? memoryTotal.toFixed(0) : '—'} GB {metrics.memory?.type ?? ''}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <footer className="flex flex-wrap gap-4 text-[0.6rem] uppercase tracking-[0.25em] text-cyan-100/60">
+          <span>Simulated dataset · No live system calls</span>
+          <span className="text-cyan-100/40">Refresh {Math.round(refreshInterval / 100) / 10}s</span>
+        </footer>
+      </div>
+    </section>
+  );
+}

--- a/data/system-metrics.json
+++ b/data/system-metrics.json
@@ -1,0 +1,143 @@
+{
+  "cpu": {
+    "model": "Intel Core i7-9750H",
+    "cores": 6,
+    "threads": 12,
+    "baseClockGHz": 2.6,
+    "boostClockGHz": 4.5
+  },
+  "memory": {
+    "totalGb": 16,
+    "type": "DDR4-2666"
+  },
+  "samples": [
+    {
+      "timestamp": "2024-06-01T10:00:00Z",
+      "cpuTotal": 18,
+      "cpuFrequencyGHz": 3.1,
+      "perCore": [16, 24, 15, 19, 22, 13],
+      "memoryUsedGb": 6.2,
+      "memoryCachedGb": 1.1
+    },
+    {
+      "timestamp": "2024-06-01T10:00:05Z",
+      "cpuTotal": 26,
+      "cpuFrequencyGHz": 3.4,
+      "perCore": [24, 32, 19, 27, 28, 21],
+      "memoryUsedGb": 6.5,
+      "memoryCachedGb": 1.2
+    },
+    {
+      "timestamp": "2024-06-01T10:00:10Z",
+      "cpuTotal": 35,
+      "cpuFrequencyGHz": 3.6,
+      "perCore": [31, 42, 28, 33, 38, 30],
+      "memoryUsedGb": 6.8,
+      "memoryCachedGb": 1.3
+    },
+    {
+      "timestamp": "2024-06-01T10:00:15Z",
+      "cpuTotal": 41,
+      "cpuFrequencyGHz": 3.7,
+      "perCore": [38, 47, 34, 40, 44, 36],
+      "memoryUsedGb": 7.1,
+      "memoryCachedGb": 1.4
+    },
+    {
+      "timestamp": "2024-06-01T10:00:20Z",
+      "cpuTotal": 53,
+      "cpuFrequencyGHz": 3.9,
+      "perCore": [52, 58, 44, 51, 55, 49],
+      "memoryUsedGb": 7.6,
+      "memoryCachedGb": 1.6
+    },
+    {
+      "timestamp": "2024-06-01T10:00:25Z",
+      "cpuTotal": 64,
+      "cpuFrequencyGHz": 4.1,
+      "perCore": [63, 69, 58, 60, 66, 61],
+      "memoryUsedGb": 8.1,
+      "memoryCachedGb": 1.8
+    },
+    {
+      "timestamp": "2024-06-01T10:00:30Z",
+      "cpuTotal": 71,
+      "cpuFrequencyGHz": 4.2,
+      "perCore": [70, 77, 64, 69, 72, 66],
+      "memoryUsedGb": 8.6,
+      "memoryCachedGb": 1.9
+    },
+    {
+      "timestamp": "2024-06-01T10:00:35Z",
+      "cpuTotal": 62,
+      "cpuFrequencyGHz": 4.0,
+      "perCore": [58, 65, 55, 59, 63, 51],
+      "memoryUsedGb": 8.4,
+      "memoryCachedGb": 2.0
+    },
+    {
+      "timestamp": "2024-06-01T10:00:40Z",
+      "cpuTotal": 48,
+      "cpuFrequencyGHz": 3.7,
+      "perCore": [45, 53, 40, 46, 48, 37],
+      "memoryUsedGb": 7.9,
+      "memoryCachedGb": 1.9
+    },
+    {
+      "timestamp": "2024-06-01T10:00:45Z",
+      "cpuTotal": 39,
+      "cpuFrequencyGHz": 3.5,
+      "perCore": [36, 44, 33, 39, 41, 31],
+      "memoryUsedGb": 7.4,
+      "memoryCachedGb": 1.8
+    },
+    {
+      "timestamp": "2024-06-01T10:00:50Z",
+      "cpuTotal": 28,
+      "cpuFrequencyGHz": 3.2,
+      "perCore": [24, 34, 21, 28, 30, 22],
+      "memoryUsedGb": 7.0,
+      "memoryCachedGb": 1.6
+    },
+    {
+      "timestamp": "2024-06-01T10:00:55Z",
+      "cpuTotal": 22,
+      "cpuFrequencyGHz": 3.0,
+      "perCore": [19, 27, 17, 23, 24, 16],
+      "memoryUsedGb": 6.6,
+      "memoryCachedGb": 1.5
+    },
+    {
+      "timestamp": "2024-06-01T10:01:00Z",
+      "cpuTotal": 31,
+      "cpuFrequencyGHz": 3.4,
+      "perCore": [28, 36, 25, 30, 33, 27],
+      "memoryUsedGb": 6.9,
+      "memoryCachedGb": 1.6
+    },
+    {
+      "timestamp": "2024-06-01T10:01:05Z",
+      "cpuTotal": 45,
+      "cpuFrequencyGHz": 3.8,
+      "perCore": [41, 50, 39, 44, 47, 40],
+      "memoryUsedGb": 7.5,
+      "memoryCachedGb": 1.7
+    },
+    {
+      "timestamp": "2024-06-01T10:01:10Z",
+      "cpuTotal": 58,
+      "cpuFrequencyGHz": 4.0,
+      "perCore": [55, 62, 51, 57, 60, 53],
+      "memoryUsedGb": 8.2,
+      "memoryCachedGb": 1.9
+    },
+    {
+      "timestamp": "2024-06-01T10:01:15Z",
+      "cpuTotal": 67,
+      "cpuFrequencyGHz": 4.2,
+      "perCore": [64, 71, 60, 66, 69, 63],
+      "memoryUsedGb": 8.8,
+      "memoryCachedGb": 2.1
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a reusable StatusBar component that renders Kali-styled CPU and memory metrics from mock data
- provide mock system metrics in data/system-metrics.json for the StatusBar to animate against
- surface the StatusBar inside the resource monitor experiences and refresh the NetworkInsights styling

## Testing
- yarn lint *(fails: repository contains numerous pre-existing jsx-a11y and no-top-level-window errors)*
- yarn test *(fails: existing suites for nmap NSE and contact API, plus jsdom localStorage issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ca94aff7cc8328901275b438ce3060