### PR TITLE
[ui] share desktop title bar

### DIFF
--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -1,8 +1,10 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import Image from 'next/image';
 import urlsnarfFixture from '../../../public/demo-data/dsniff/urlsnarf.json';
 import arpspoofFixture from '../../../public/demo-data/dsniff/arpspoof.json';
 import pcapFixture from '../../../public/demo-data/dsniff/pcap.json';
 import TerminalOutput from '../../TerminalOutput';
+import TitleBar from '../../base/TitleBar';
 
 // Simple parser that attempts to extract protocol, host and remaining details
 // Each parsed line is also given a synthetic timestamp for display purposes
@@ -348,17 +350,43 @@ const Dsniff = () => {
     return searchMatch && filterMatch && protocolMatch;
   });
 
+  const headerButtonStyle = useMemo(
+    () => ({
+      background: 'color-mix(in srgb, var(--color-surface), transparent 45%)',
+      borderColor: 'color-mix(in srgb, var(--color-border), transparent 20%)',
+    }),
+    [],
+  );
+
+  const headerButtonClass =
+    'rounded border px-3 py-1 text-xs font-medium transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]';
+
   return (
     <div className="h-full w-full bg-ub-cool-grey text-white p-2 overflow-auto">
-      <div className="mb-2 flex items-center justify-between">
-        <h1 className="text-lg">dsniff</h1>
-        <button
-          onClick={exportSummary}
-          className="px-2 py-1 bg-ub-grey rounded text-xs focus:outline-none focus:ring-2 focus:ring-yellow-400"
-        >
-          Export summary
-        </button>
-      </div>
+      <TitleBar
+        headingLevel={1}
+        icon={
+          <Image
+            src="/themes/Yaru/apps/dsniff.svg"
+            alt="dsniff icon"
+            width={28}
+            height={28}
+            sizes="28px"
+            priority
+          />
+        }
+        title="dsniff"
+        actions={
+          <button
+            type="button"
+            onClick={exportSummary}
+            className={headerButtonClass}
+            style={headerButtonStyle}
+          >
+            Export summary
+          </button>
+        }
+      />
       <div className="mb-2 text-yellow-300 text-sm">
         For lab use only – simulated traffic
       </div>

--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -1,9 +1,10 @@
 "use client";
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import useOPFS from '../../hooks/useOPFS';
 import { getDb } from '../../utils/safeIDB';
 import Breadcrumbs from '../ui/Breadcrumbs';
+import TitleBar from '../base/TitleBar';
 
 export async function openFileDialog(options = {}) {
   if (typeof window !== 'undefined' && window.showOpenFilePicker) {
@@ -295,24 +296,61 @@ export default function FileExplorer() {
     );
   }
 
+  const headerButtonStyle = useMemo(
+    () => ({
+      background: 'color-mix(in srgb, var(--color-surface), transparent 45%)',
+      borderColor: 'color-mix(in srgb, var(--color-border), transparent 20%)',
+    }),
+    [],
+  );
+
+  const headerButtonClass =
+    'rounded border px-2 py-1 text-xs font-medium transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)] disabled:opacity-50';
+
   return (
     <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white text-sm">
-      <div className="flex items-center space-x-2 p-2 bg-ub-warm-grey bg-opacity-40">
-        <button onClick={openFolder} className="px-2 py-1 bg-black bg-opacity-50 rounded">
-          Open Folder
-        </button>
-        {path.length > 1 && (
-          <button onClick={goBack} className="px-2 py-1 bg-black bg-opacity-50 rounded">
-            Back
-          </button>
-        )}
-        <Breadcrumbs path={path} onNavigate={navigateTo} />
-        {currentFile && (
-          <button onClick={saveFile} className="px-2 py-1 bg-black bg-opacity-50 rounded">
-            Save
-          </button>
-        )}
-      </div>
+      <TitleBar
+        headingLevel={1}
+        title="File Explorer"
+        actions={
+          <>
+            <button
+              type="button"
+              onClick={openFolder}
+              className={headerButtonClass}
+              style={headerButtonStyle}
+            >
+              Open Folder
+            </button>
+            {path.length > 1 && (
+              <button
+                type="button"
+                onClick={goBack}
+                className={headerButtonClass}
+                style={headerButtonStyle}
+              >
+                Back
+              </button>
+            )}
+            <div
+              className="flex flex-wrap items-center gap-2"
+              style={{ flex: '1 1 12rem' }}
+            >
+              <Breadcrumbs path={path} onNavigate={navigateTo} />
+              {currentFile && (
+                <button
+                  type="button"
+                  onClick={saveFile}
+                  className={headerButtonClass}
+                  style={headerButtonStyle}
+                >
+                  Save
+                </button>
+              )}
+            </div>
+          </>
+        }
+      />
       <div className="flex flex-1 overflow-hidden">
         <div className="w-40 overflow-auto border-r border-gray-600">
           <div className="p-2 font-bold">Recent</div>

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -3,7 +3,14 @@ import Image from 'next/image';
 import ReactGA from 'react-ga4';
 import emailjs from '@emailjs/browser';
 import ProgressBar from '../ui/ProgressBar';
+import TitleBar from '../base/TitleBar';
 import { createDisplay } from '../../utils/createDynamicApp';
+
+const headerButtonClass = 'rounded border px-3 py-1 text-xs font-medium transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)] disabled:opacity-50';
+const headerButtonStyle = {
+    background: 'color-mix(in srgb, var(--color-surface), transparent 45%)',
+    borderColor: 'color-mix(in srgb, var(--color-border), transparent 20%)',
+};
 
 export class Gedit extends Component {
 
@@ -144,12 +151,31 @@ export class Gedit extends Component {
         const messageInvalid = this.state.messageTouched && this.state.messageError;
         return (
             <div className="w-full h-full relative flex flex-col bg-ub-cool-grey text-white select-none">
-                <div className="flex items-center justify-between w-full bg-ub-gedit-light bg-opacity-60 border-b border-t border-blue-400 text-sm">
-                    <span className="font-bold ml-2">Send a Message to Me</span>
-                    <div className="flex">
-                        <div onClick={this.sendMessage} className="border border-black bg-black bg-opacity-50 px-3 py-0.5 my-1 mx-1 rounded hover:bg-opacity-80">Send</div>
-                    </div>
-                </div>
+                <TitleBar
+                    headingLevel={1}
+                    icon={
+                        <Image
+                            src="/themes/Yaru/apps/gedit.png"
+                            alt="Gedit icon"
+                            width={28}
+                            height={28}
+                            sizes="28px"
+                            priority
+                        />
+                    }
+                    title="Send a Message to Me"
+                    actions={
+                        <button
+                            type="button"
+                            onClick={this.sendMessage}
+                            className={headerButtonClass}
+                            style={headerButtonStyle}
+                            disabled={this.state.sending}
+                        >
+                            Send
+                        </button>
+                    }
+                />
                 <div className="relative flex-grow flex flex-col bg-ub-gedit-dark font-normal windowMainScreen">
                     <div className="absolute left-0 top-0 h-full px-2 bg-ub-gedit-darker"></div>
                     <div className="relative">

--- a/components/apps/trash/index.tsx
+++ b/components/apps/trash/index.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import Image from 'next/image';
+import TitleBar from '../../base/TitleBar';
 
 interface TrashItem {
   id: string;
@@ -24,6 +26,17 @@ const formatAge = (closedAt: number): string => {
 export default function Trash({ openApp }: { openApp: (id: string) => void }) {
   const [items, setItems] = useState<TrashItem[]>([]);
   const [selected, setSelected] = useState<number | null>(null);
+
+  const actionButtonStyle = useMemo(
+    () => ({
+      background: 'color-mix(in srgb, var(--color-surface), transparent 45%)',
+      borderColor: 'color-mix(in srgb, var(--color-border), transparent 20%)',
+    }),
+    [],
+  );
+
+  const actionButtonClass =
+    'rounded border px-3 py-1 text-xs font-medium transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)] disabled:opacity-50';
 
   useEffect(() => {
     const purgeDays = parseInt(localStorage.getItem('trash-purge-days') || '30', 10);
@@ -100,39 +113,60 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
 
   return (
     <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white select-none">
-      <div className="flex items-center justify-between w-full bg-ub-warm-grey bg-opacity-40 text-sm">
-        <span className="font-bold ml-2">Trash</span>
-        <div className="flex">
-          <button
-            onClick={restore}
-            disabled={selected === null}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
-          >
-            Restore
-          </button>
-          <button
-            onClick={restoreAll}
-            disabled={items.length === 0}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
-          >
-            Restore All
-          </button>
-          <button
-            onClick={remove}
-            disabled={selected === null}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
-          >
-            Delete
-          </button>
-          <button
-            onClick={empty}
-            disabled={items.length === 0}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
-          >
-            Empty
-          </button>
-        </div>
-      </div>
+      <TitleBar
+        headingLevel={1}
+        icon={
+          <Image
+            src="/themes/Yaru/status/user-trash-symbolic.svg"
+            alt="Trash icon"
+            width={28}
+            height={28}
+            sizes="28px"
+            priority
+          />
+        }
+        title="Trash"
+        actions={
+          <>
+            <button
+              type="button"
+              onClick={restore}
+              disabled={selected === null}
+              className={actionButtonClass}
+              style={actionButtonStyle}
+            >
+              Restore
+            </button>
+            <button
+              type="button"
+              onClick={restoreAll}
+              disabled={items.length === 0}
+              className={actionButtonClass}
+              style={actionButtonStyle}
+            >
+              Restore All
+            </button>
+            <button
+              type="button"
+              onClick={remove}
+              disabled={selected === null}
+              className={actionButtonClass}
+              style={actionButtonStyle}
+            >
+              Delete
+            </button>
+            <button
+              type="button"
+              onClick={empty}
+              disabled={items.length === 0}
+              className={actionButtonClass}
+              style={actionButtonStyle}
+            >
+              Empty
+            </button>
+          </>
+        }
+      />
       <div className="flex flex-wrap content-start p-2 overflow-auto">
         {items.length === 0 && <div className="w-full text-center mt-10">Trash is empty</div>}
         {items.map((item, idx) => (

--- a/components/base/TitleBar.module.css
+++ b/components/base/TitleBar.module.css
@@ -1,0 +1,74 @@
+.root {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  color: var(--color-text);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border), transparent 30%);
+  flex-wrap: wrap;
+  font-family: inherit;
+}
+
+.leading {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.icon {
+  width: clamp(1.25rem, 3vw, 1.75rem);
+  height: clamp(1.25rem, 3vw, 1.75rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+.icon :global(img),
+.icon :global(svg) {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+}
+
+.title {
+  font-weight: 600;
+  font-size: clamp(0.95rem, 2vw, 1.1rem);
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.subtitle {
+  font-size: clamp(0.75rem, 1.5vw, 0.875rem);
+  color: color-mix(in srgb, var(--color-text), transparent 35%);
+}
+
+.controls {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 0 1 auto;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+@media (max-width: 640px) {
+  .controls {
+    margin-left: 0;
+    flex-basis: 100%;
+    justify-content: flex-start;
+  }
+}

--- a/components/base/TitleBar.tsx
+++ b/components/base/TitleBar.tsx
@@ -1,0 +1,49 @@
+import { ReactNode } from 'react';
+import clsx from 'clsx';
+import styles from './TitleBar.module.css';
+
+export type TitleBarProps = {
+  /** Optional icon rendered before the title */
+  icon?: ReactNode;
+  /** Primary title content, announced as a heading. */
+  title: ReactNode;
+  /** Optional secondary text displayed under the title. */
+  subtitle?: ReactNode;
+  /** Optional action area rendered on the right side. */
+  actions?: ReactNode;
+  /** Alias for actions to support JSX children usage. */
+  children?: ReactNode;
+  /** Custom CSS class name appended to the root element. */
+  className?: string;
+  /** Heading level used for accessibility announcements. */
+  headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+};
+
+const TitleBar = ({
+  icon,
+  title,
+  subtitle,
+  actions,
+  children,
+  className,
+  headingLevel = 2,
+}: TitleBarProps) => {
+  const controls = actions ?? children;
+
+  return (
+    <header className={clsx(styles.root, className)}>
+      <div className={styles.leading}>
+        {icon ? <div className={styles.icon}>{icon}</div> : null}
+        <div className={styles.text}>
+          <span role="heading" aria-level={headingLevel} className={styles.title}>
+            {title}
+          </span>
+          {subtitle ? <span className={styles.subtitle}>{subtitle}</span> : null}
+        </div>
+      </div>
+      {controls ? <div className={styles.controls}>{controls}</div> : null}
+    </header>
+  );
+};
+
+export default TitleBar;


### PR DESCRIPTION
## Summary
- add a reusable `TitleBar` component with optional icon, title, and action slots
- refactor Trash, Gedit, File Explorer, and dsniff app shells to consume the shared title bar
- align title bar styling with design tokens for responsive typography and colors

## Testing
- yarn lint *(fails: hundreds of pre-existing `control-has-associated-label` warnings across legacy app pages and static demos)*
- yarn test --watch=false *(fails: existing suites such as `__tests__/Modal.test.tsx` and window focus tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ca94b4d7e883289cf3bc6b1fda1989