### PR TITLE
[ui] add window transparency token

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
+import windowStyles from '../base/window.module.css';
 
 export function Settings() {
     const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
@@ -56,7 +57,7 @@ export function Settings() {
     }, [accent, accentText, contrastRatio]);
 
     return (
-        <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
+        <div className={`w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none ${windowStyles.windowBody}`}>
             <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
             </div>
             <div className="flex justify-center my-4">

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -612,6 +612,18 @@ export class Window extends Component {
     }
 
     render() {
+        const windowClasses = [
+            this.state.cursorType,
+            this.state.closed ? "closed-window" : "",
+            this.state.maximized ? "duration-300 rounded-none" : "rounded-lg rounded-b-none",
+            this.props.minimized ? "opacity-0 invisible duration-200" : "",
+            this.state.grabbed ? "opacity-70" : "",
+            this.state.snapPreview ? "ring-2 ring-blue-400" : "",
+            this.props.isFocused ? "z-30" : "z-20 notFocused",
+            "opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col",
+            styles.windowFrame,
+        ].filter(Boolean).join(" ");
+
         return (
             <>
                 {this.state.snapPreview && (
@@ -635,7 +647,7 @@ export class Window extends Component {
                 >
                     <div
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        className={windowClasses}
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}
@@ -838,7 +850,9 @@ export class WindowMainScreen extends Component {
     }
     render() {
         return (
-            <div className={"w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen" + (this.state.setDarkBg ? " bg-ub-drk-abrgn " : " bg-ub-cool-grey")}>
+            <div
+                className={`w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen ${styles.windowBody} ${this.state.setDarkBg ? styles.windowBodyDark : ""}`}
+            >
                 {this.props.screen(this.props.addFolder, this.props.openApp)}
             </div>
         )

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -1,3 +1,21 @@
+.windowFrame {
+  background-color: color-mix(in srgb, var(--color-ub-grey) calc(var(--window-opacity) * 100%), transparent);
+  color: var(--color-text);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.windowBody {
+  background-color: color-mix(in srgb, var(--color-ub-cool-grey) calc(var(--window-opacity) * 100%), transparent);
+  color: var(--color-text);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+
+.windowBodyDark {
+  background-color: color-mix(in srgb, var(--color-ub-drk-abrgn) calc(var(--window-opacity) * 100%), transparent);
+}
+
 .windowYBorder {
   height: calc(100% - 10px);
   width: calc(100% + 10px);

--- a/components/menu/WhiskerMenu.module.css
+++ b/components/menu/WhiskerMenu.module.css
@@ -1,0 +1,42 @@
+.menuContainer {
+  background-color: color-mix(in srgb, var(--color-ub-grey) calc(var(--window-opacity) * 100%), transparent);
+  color: var(--color-text);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--color-text), transparent 85%);
+  overflow: hidden;
+}
+
+.menuSidebar {
+  background-color: color-mix(in srgb, var(--color-ub-window-title) calc(var(--window-opacity) * 100%), transparent);
+  border-right: 1px solid color-mix(in srgb, var(--color-text), transparent 80%);
+}
+
+.menuContent {
+  color: inherit;
+}
+
+.menuSearch {
+  background-color: color-mix(in srgb, var(--color-text) 12%, transparent);
+  color: inherit;
+  border: 1px solid color-mix(in srgb, var(--color-text), transparent 80%);
+}
+
+.menuSearch::placeholder {
+  color: color-mix(in srgb, var(--color-text), transparent 40%);
+}
+
+.menuButton {
+  color: inherit;
+  transition: background-color var(--motion-fast) ease;
+}
+
+.menuButtonActive {
+  background-color: color-mix(in srgb, var(--color-text), transparent 85%);
+}
+
+.menuButton:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--color-text), transparent 60%);
+  outline-offset: 1px;
+}

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import styles from './WhiskerMenu.module.css';
 
 type AppMeta = {
   id: string;
@@ -134,7 +135,7 @@ const WhiskerMenu: React.FC = () => {
       {open && (
         <div
           ref={menuRef}
-          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
+          className={`absolute left-0 mt-1 z-50 flex shadow-lg ${styles.menuContainer}`}
           tabIndex={-1}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node)) {
@@ -142,20 +143,20 @@ const WhiskerMenu: React.FC = () => {
             }
           }}
         >
-          <div className="flex flex-col bg-gray-800 p-2">
+          <div className={`flex flex-col p-2 ${styles.menuSidebar}`}>
             {CATEGORIES.map(cat => (
               <button
                 key={cat.id}
-                className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
+                className={`${styles.menuButton} text-left px-2 py-1 rounded mb-1 ${category === cat.id ? styles.menuButtonActive : ''}`}
                 onClick={() => setCategory(cat.id)}
               >
                 {cat.label}
               </button>
             ))}
           </div>
-          <div className="p-3">
+          <div className={`p-3 ${styles.menuContent}`}>
             <input
-              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+              className={`mb-3 w-64 px-2 py-1 rounded focus:outline-none ${styles.menuSearch}`}
               placeholder="Search"
               value={query}
               onChange={e => setQuery(e.target.value)}

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -25,7 +25,8 @@
   --color-ub-dark-grey: #2a2e36;
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
-  --kali-bg: rgba(15, 19, 23, 0.85);
+  --window-opacity: 0.85;
+  --kali-bg: rgb(15 19 23 / var(--window-opacity));
 
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
@@ -77,6 +78,7 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --window-opacity: 1;
 }
 
 /* Dyslexia-friendly fonts */
@@ -116,5 +118,6 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+    --window-opacity: 1;
   }
 }


### PR DESCRIPTION
## Summary
- introduce a reusable `--window-opacity` design token and ensure high-contrast themes override it for solid fills
- wrap window shells with CSS-module glassmorphism backgrounds and share the style with the settings screen
- add a translucent backdrop-filtered shell for the whisker menu via a dedicated CSS module to preserve legibility

## Testing
- [ ] yarn lint *(fails: repository has pre-existing accessibility and browser globals violations)*

------
https://chatgpt.com/codex/tasks/task_e_68ca94ca48ac8328b109e9508ae758da