### PR TITLE
[desktop] Enhance window snapping interactions

### DIFF
--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -7,3 +7,16 @@
   height: calc(100% + 10px);
   width: calc(100% - 10px);
 }
+
+.windowFrame {
+  transition: transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    width 240ms ease,
+    height 240ms ease;
+  will-change: transform, width, height;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .windowFrame {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- track snap targets and target rectangles in the window manager so snaps persist across resizes
- add pointer/touch release handlers and guarded keyboard shortcuts to finalize snaps without duplicate events
- apply CSS transitions to the window frame for animated snapping with reduced-motion support

## Testing
- yarn lint *(fails: repository has pre-existing accessibility and browser globals violations)*
- yarn test __tests__/window.test.tsx --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ca94c062c08328ab8a2412605153a8