### PR TITLE
[screen] refresh lock screen experience

### DIFF
--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -1,37 +1,126 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
 
-export default function LockScreen(props) {
+const DUMMY_PASSWORD = 'toor';
+const DISPLAY_NAME = 'kali';
 
+export default function LockScreen({ isLocked, unLockScreen }) {
     const { wallpaper } = useSettings();
+    const passwordRef = useRef(null);
+    const [password, setPassword] = useState('');
+    const [authError, setAuthError] = useState('');
 
-    if (props.isLocked) {
-        window.addEventListener('click', props.unLockScreen);
-        window.addEventListener('keypress', props.unLockScreen);
+    useEffect(() => {
+        if (!isLocked) {
+            setPassword('');
+            setAuthError('');
+            return undefined;
+        }
+
+        const timer = setTimeout(() => {
+            passwordRef.current?.focus();
+        }, 120);
+
+        return () => clearTimeout(timer);
+    }, [isLocked]);
+
+    const handleSubmit = (event) => {
+        event.preventDefault();
+
+        if (password === DUMMY_PASSWORD) {
+            setPassword('');
+            setAuthError('');
+            unLockScreen?.();
+            return;
+        }
+
+        setAuthError('Incorrect password. Try again.');
+        setPassword('');
+        passwordRef.current?.focus();
     };
+
+    const handleContainerInteraction = () => {
+        if (isLocked) {
+            passwordRef.current?.focus();
+        }
+    };
+
+    const handleInputKeyDown = (event) => {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            setPassword('');
+            setAuthError('');
+        }
+    };
+
+    const avatarInitial = DISPLAY_NAME.charAt(0).toUpperCase();
 
     return (
         <div
             id="ubuntu-lock-screen"
-            style={{ zIndex: "100", contentVisibility: 'auto' }}
-            className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
-            <img
-                src={`/wallpapers/${wallpaper}.webp`}
-                alt=""
-                className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
-            />
-            <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
-                <div className=" text-7xl">
-                    <Clock onlyTime={true} />
+            role="dialog"
+            aria-modal={isLocked ? 'true' : 'false'}
+            aria-hidden={isLocked ? 'false' : 'true'}
+            style={{ zIndex: '100', contentVisibility: 'auto' }}
+            className={`lock-screen ${isLocked ? 'lock-screen--visible' : 'lock-screen--hidden'}`}
+            onClick={handleContainerInteraction}
+            tabIndex={-1}
+        >
+            <div className="lock-screen__background" aria-hidden="true">
+                <img
+                    src={`/wallpapers/${wallpaper}.webp`}
+                    alt=""
+                    className="lock-screen__wallpaper"
+                />
+                <div className="lock-screen__overlay" />
+            </div>
+
+            <div className="lock-screen__content">
+                <div className="lock-screen__time">
+                    <span className="lock-screen__time-display">
+                        <Clock onlyTime={true} />
+                    </span>
+                    <span className="lock-screen__date-display">
+                        <Clock onlyDay={true} />
+                    </span>
                 </div>
-                <div className="mt-4 text-xl font-medium">
-                    <Clock onlyDay={true} />
-                </div>
-                <div className=" mt-16 text-base">
-                    Click or Press a key to unlock
-                </div>
+
+                <section className="lock-screen__auth" aria-label="Unlock session">
+                    <div className="lock-screen__avatar" aria-hidden="true">
+                        {avatarInitial}
+                    </div>
+                    <h2 className="lock-screen__user-name">{DISPLAY_NAME}</h2>
+                    <form className="lock-screen__form" onSubmit={handleSubmit}>
+                        <label className="lock-screen__label" htmlFor="lock-screen-password">
+                            Password
+                        </label>
+                        <input
+                            id="lock-screen-password"
+                            ref={passwordRef}
+                            className="lock-screen__input"
+                            type="password"
+                            value={password}
+                            onChange={(event) => setPassword(event.target.value)}
+                            onKeyDown={handleInputKeyDown}
+                            autoComplete="current-password"
+                            placeholder="Enter password"
+                            aria-invalid={authError ? 'true' : 'false'}
+                        />
+                        <button type="submit" className="lock-screen__button">
+                            Unlock
+                        </button>
+                        <p className="lock-screen__hint" aria-live="polite">
+                            Hint: try "toor"
+                        </p>
+                        {authError ? (
+                            <p role="alert" className="lock-screen__error">
+                                {authError}
+                            </p>
+                        ) : null}
+                    </form>
+                </section>
             </div>
         </div>
-    )
+    );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -77,3 +77,206 @@ html[data-theme='matrix'] {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
+
+.lock-screen {
+  position: absolute;
+  inset: 0;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+  color: var(--color-text);
+  font-family: var(--font-family-base);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity var(--motion-medium) ease,
+    transform var(--motion-medium) ease;
+  background-color: transparent;
+}
+
+.lock-screen--hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(-100%);
+}
+
+.lock-screen--visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.lock-screen__background {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
+.lock-screen__wallpaper {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: blur(18px);
+  transform: scale(1.05);
+  transition: filter var(--motion-medium) ease;
+}
+
+.lock-screen__overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    135deg,
+    var(--color-ub-lite-abrgn) 0%,
+    var(--kali-bg) 60%,
+    var(--color-ub-grey) 100%
+  );
+  opacity: 0.92;
+  pointer-events: none;
+}
+
+@supports ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
+  .lock-screen__overlay {
+    -webkit-backdrop-filter: blur(18px);
+    backdrop-filter: blur(18px);
+  }
+}
+
+.lock-screen__content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-6);
+  padding: var(--space-6);
+  width: min(420px, 90vw);
+  text-align: center;
+}
+
+.lock-screen__time {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.lock-screen__time-display {
+  font-size: clamp(3rem, 8vw, 5rem);
+  letter-spacing: 0.04em;
+}
+
+.lock-screen__date-display {
+  font-size: clamp(1rem, 3vw, 1.25rem);
+  color: var(--color-ubt-grey);
+  text-transform: capitalize;
+}
+
+.lock-screen__auth {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
+  width: 100%;
+  padding: var(--space-5) var(--space-6);
+  background: linear-gradient(
+    160deg,
+    var(--color-ub-lite-abrgn) 0%,
+    var(--color-ub-med-abrgn) 60%,
+    var(--color-ub-drk-abrgn) 100%
+  );
+  border-radius: var(--radius-lg);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.lock-screen__avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: var(--radius-round);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--color-text);
+  background: linear-gradient(
+    140deg,
+    var(--color-ub-orange) 0%,
+    var(--color-ub-lite-abrgn) 100%
+  );
+  box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.35);
+}
+
+.lock-screen__user-name {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+  text-transform: lowercase;
+}
+
+.lock-screen__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  width: 100%;
+}
+
+.lock-screen__label {
+  align-self: flex-start;
+  font-size: 0.875rem;
+  color: var(--color-ubt-warm-grey);
+}
+
+.lock-screen__input {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-lg);
+  border: 1px solid transparent;
+  background-color: var(--color-ub-med-abrgn);
+  color: var(--color-text);
+  transition: border-color var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease;
+}
+
+.lock-screen__input::placeholder {
+  color: var(--color-ubt-warm-grey);
+}
+
+.lock-screen__input:focus {
+  border-color: var(--color-ub-border-orange);
+  box-shadow: 0 0 0 2px rgba(23, 147, 209, 0.35);
+  outline: none;
+}
+
+.lock-screen__button {
+  width: 100%;
+  padding: var(--space-3);
+  border-radius: var(--radius-lg);
+  border: 0;
+  background-color: var(--color-ub-orange);
+  color: var(--color-text);
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter var(--motion-fast) ease;
+}
+
+.lock-screen__button:hover,
+.lock-screen__button:focus-visible {
+  filter: brightness(1.05);
+}
+
+.lock-screen__hint {
+  font-size: 0.875rem;
+  color: var(--color-ubt-warm-grey);
+  margin: 0;
+}
+
+.lock-screen__error {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--game-color-danger);
+}


### PR DESCRIPTION
## Summary
- replace the lock screen overlay with a Kali-inspired layout featuring a blurred wallpaper, avatar, clock, and password prompt
- add global lock-screen styles that reuse the design tokens for gradients, blur, spacing, and state colors
- simulate authentication with the "toor" password, autofocus the field on lock, and surface inline validation feedback

## Testing
- yarn lint *(fails: repository has numerous pre-existing a11y lint errors across app fixtures and public demos)*
- yarn test *(fails: repository already contains failing suites such as window.test.tsx and nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ca94b60f34832895a241058d999221