### PR TITLE
[style] unify scrollbar styling

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,6 +20,9 @@
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   accent-color: var(--color-control-accent);
+  --scrollbar-track-color: var(--color-ub-cool-grey);
+  --scrollbar-thumb-color: var(--color-ub-dark-grey);
+  --scrollbar-thumb-hover-color: var(--color-primary);
 }
 
 /* Dark theme */
@@ -76,4 +79,34 @@ html[data-theme='matrix'] {
 *:focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
+}
+
+/* Global scrollbar styling */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb-color) var(--scrollbar-track-color);
+}
+
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+*::-webkit-scrollbar-track {
+  background-color: var(--scrollbar-track-color);
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb-color);
+  border-radius: var(--radius-md);
+  border: 2px solid var(--scrollbar-track-color);
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: var(--scrollbar-thumb-hover-color);
+}
+
+*::-webkit-scrollbar-corner {
+  background-color: var(--scrollbar-track-color);
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -132,21 +132,6 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     container-type: inline-size;
 }
 
-.windowMainScreen::-webkit-scrollbar-track {
-    -webkit-box-shadow: inset 0 0 6px color-mix(in srgb, var(--color-inverse), transparent 70%);
-    background-color: transparent;
-}
-
-.windowMainScreen::-webkit-scrollbar {
-    width: 6px;
-    background-color: transparent;
-}
-
-.windowMainScreen::-webkit-scrollbar-thumb {
-    background-color: var(--color-border);
-    border-radius: 5px;
-}
-
 /* SideBarApp Scale image onClick */
 .scalable-app-icon {
     visibility: hidden;


### PR DESCRIPTION
## Summary
- add global scrollbar CSS variables and styling aligned with the Kali palette
- remove window-specific scrollbar overrides so components inherit the global theme

## Testing
- [ ] `yarn lint` *(fails: pre-existing accessibility and browser global lint errors)*
- [ ] `yarn test` *(fails: pre-existing window keyboard handling and environment-dependent tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ca94bab1108328818ac6da6079860f