### PR TITLE
[ui] Add XFCE-style shortcut overlay

### DIFF
--- a/__tests__/ShortcutOverlay.ui.test.tsx
+++ b/__tests__/ShortcutOverlay.ui.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ShortcutOverlay from '../components/ui/ShortcutOverlay';
+
+describe('ShortcutOverlay (XFCE style)', () => {
+  it('renders shortcuts from the central config', () => {
+    render(<ShortcutOverlay open onClose={() => {}} />);
+
+    expect(
+      screen.getByRole('dialog', { name: /keyboard shortcuts/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Open the application menu')).toBeInTheDocument();
+    expect(screen.getByText('Open the clipboard manager')).toBeInTheDocument();
+  });
+
+  it('invokes onClose when pressing Escape', () => {
+    const handleClose = jest.fn();
+    render(<ShortcutOverlay open onClose={handleClose} />);
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('invokes onClose when clicking outside the panel', () => {
+    const handleClose = jest.fn();
+    render(<ShortcutOverlay open onClose={handleClose} />);
+
+    fireEvent.click(screen.getByRole('presentation'));
+    expect(handleClose).toHaveBeenCalled();
+  });
+});

--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -1,5 +1,5 @@
 import React, { act } from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import Ubuntu from '../components/ubuntu';
 
 jest.mock('../components/screen/desktop', () => function DesktopMock() {
@@ -56,5 +56,23 @@ describe('Ubuntu component', () => {
       instance!.shutDown();
     });
     expect(instance!.state.shutDownScreen).toBe(true);
+  });
+
+  it('toggles shortcut overlay with Super+/', () => {
+    let instance: Ubuntu | null = null;
+    render(<Ubuntu ref={(c) => (instance = c)} />);
+    expect(instance).not.toBeNull();
+
+    act(() => {
+      fireEvent.keyDown(window, { key: '/', code: 'Slash', metaKey: true });
+    });
+
+    expect(instance!.state.showShortcutOverlay).toBe(true);
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Escape' });
+    });
+
+    expect(instance!.state.showShortcutOverlay).toBe(false);
   });
 });

--- a/components/ui/ShortcutOverlay.tsx
+++ b/components/ui/ShortcutOverlay.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { Fragment, useEffect, useId, useRef } from "react";
+import shortcutsData from "../../data/shortcuts.json";
+
+interface ShortcutConfig {
+  id: string;
+  category: string;
+  keys: string;
+  description: string;
+  note?: string;
+}
+
+interface ShortcutOverlayProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const shortcuts = shortcutsData.shortcuts as ShortcutConfig[];
+
+const groupedShortcuts = shortcuts.reduce<
+  { title: string; shortcuts: ShortcutConfig[] }[]
+>((acc, shortcut) => {
+  const existing = acc.find((entry) => entry.title === shortcut.category);
+  if (existing) {
+    existing.shortcuts.push(shortcut);
+  } else {
+    acc.push({ title: shortcut.category, shortcuts: [shortcut] });
+  }
+  return acc;
+}, []);
+
+const formatKey = (part: string) => {
+  const normalized = part.trim();
+  switch (normalized.toLowerCase()) {
+    case "arrow left":
+      return "\u2190";
+    case "arrow right":
+      return "\u2192";
+    case "arrow up":
+      return "\u2191";
+    case "arrow down":
+      return "\u2193";
+    default:
+      return normalized;
+  }
+};
+
+const keyClasses =
+  "inline-flex min-w-[2.5rem] justify-center rounded-sm border border-[#d0c877] bg-[#fffce6] px-2 py-0.5 text-xs font-semibold text-[#3f3a28] shadow-inner";
+
+const joinerClasses = "text-[11px] font-semibold text-[#8c8353]";
+
+const ShortcutOverlay = ({ open, onClose }: ShortcutOverlayProps) => {
+  const titleId = useId();
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (open) {
+      closeButtonRef.current?.focus();
+    }
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[200] flex items-start justify-center bg-transparent pt-20"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        className="pointer-events-auto relative w-[min(90vw,560px)]"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div
+          className="absolute left-16 -top-2 h-4 w-4 rotate-45 border-l border-t border-[#d0c877] bg-[#fcf7c2] shadow-[-2px_-2px_4px_rgba(0,0,0,0.05)]"
+          aria-hidden="true"
+        />
+        <div className="overflow-hidden rounded-md border border-[#d0c877] bg-[#fcf7c2] text-[#2f2b1f] shadow-[0_20px_45px_rgba(0,0,0,0.45)]">
+          <div className="flex items-center justify-between border-b border-[#e5da9d] px-4 py-2">
+            <h2 id={titleId} className="text-sm font-semibold uppercase tracking-[0.15em] text-[#5c5230]">
+              Keyboard Shortcuts
+            </h2>
+            <button
+              ref={closeButtonRef}
+              type="button"
+              onClick={onClose}
+              className="rounded px-2 py-1 text-xs font-semibold text-[#5c5230] transition hover:text-[#2f2b1f] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d0c877] focus-visible:ring-offset-2 focus-visible:ring-offset-[#fcf7c2]"
+            >
+              Close
+            </button>
+          </div>
+          <div className="space-y-4 px-4 py-3 text-sm">
+            {groupedShortcuts.map((group) => (
+              <section key={group.title}>
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-[#6d6336]">
+                  {group.title}
+                </h3>
+                <ul className="space-y-2">
+                  {group.shortcuts.map((shortcut) => {
+                    const parts = shortcut.keys.split("+");
+                    return (
+                      <li
+                        key={shortcut.id}
+                        className="grid grid-cols-[auto_1fr] items-start gap-x-4 gap-y-1"
+                      >
+                        <div className="flex flex-wrap items-center gap-1">
+                          {parts.map((part, index) => (
+                            <Fragment key={`${shortcut.id}-${part}-${index}`}>
+                              <kbd className={keyClasses}>{formatKey(part)}</kbd>
+                              {index < parts.length - 1 && <span className={joinerClasses}>+</span>}
+                            </Fragment>
+                          ))}
+                        </div>
+                        <div className="text-sm leading-snug">
+                          <p>{shortcut.description}</p>
+                          {shortcut.note && (
+                            <p className="mt-1 text-xs text-[#6d6336]">{shortcut.note}</p>
+                          )}
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShortcutOverlay;

--- a/data/shortcuts.json
+++ b/data/shortcuts.json
@@ -1,0 +1,60 @@
+{
+  "shortcuts": [
+    {
+      "id": "toggle-menu",
+      "category": "System",
+      "keys": "Super",
+      "description": "Open the application menu"
+    },
+    {
+      "id": "toggle-shortcut-overlay",
+      "category": "System",
+      "keys": "Super+/",
+      "description": "Show keyboard shortcut overlay"
+    },
+    {
+      "id": "switch-apps",
+      "category": "Window Management",
+      "keys": "Alt+Tab",
+      "description": "Switch between running applications",
+      "note": "Hold Shift to reverse the direction."
+    },
+    {
+      "id": "cycle-app-windows",
+      "category": "Window Management",
+      "keys": "Alt+`",
+      "description": "Cycle windows of the focused application",
+      "note": "Hold Shift to reverse the direction."
+    },
+    {
+      "id": "snap-left",
+      "category": "Window Management",
+      "keys": "Super+Arrow Left",
+      "description": "Snap window to the left half of the screen"
+    },
+    {
+      "id": "snap-right",
+      "category": "Window Management",
+      "keys": "Super+Arrow Right",
+      "description": "Snap window to the right half of the screen"
+    },
+    {
+      "id": "maximize-window",
+      "category": "Window Management",
+      "keys": "Super+Arrow Up",
+      "description": "Maximize the active window"
+    },
+    {
+      "id": "restore-window",
+      "category": "Window Management",
+      "keys": "Super+Arrow Down",
+      "description": "Restore or unsnap the active window"
+    },
+    {
+      "id": "clipboard-manager",
+      "category": "Utilities",
+      "keys": "Ctrl+Shift+V",
+      "description": "Open the clipboard manager"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a shortcuts.json config so desktop hotkeys live in one source of truth
- build an XFCE-styled ShortcutOverlay component that reads from the shared config
- register the Super+/ global hotkey in the Ubuntu shell and cover it with unit tests

## Testing
- yarn lint *(fails: repo has existing accessibility + lint violations in unrelated apps)*
- yarn test --watch=false *(fails: existing suites such as __tests__/nmapNse.test.tsx expect alerts and fail without additional setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ca94e29af08328b9543a1ae2f6c6ba