### PR TITLE
[window] update controls to Kali XFCE style

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -28,7 +28,7 @@ describe('Window lifecycle', () => {
       />
     );
 
-    const closeButton = screen.getByRole('button', { name: /window close/i });
+    const closeButton = screen.getByRole('button', { name: /close window/i });
     fireEvent.click(closeButton);
 
     expect(hideSideBar).toHaveBeenCalledWith('test-window', false);
@@ -199,7 +199,12 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({
+        key: 'ArrowDown',
+        altKey: true,
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+      } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { Component } from 'react';
-import NextImage from 'next/image';
 import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
@@ -731,96 +730,134 @@ export class WindowXBorder extends Component {
 
 // Window's Edit Buttons
 export function WindowEditButtons(props) {
-    const { togglePin } = useDocPiP(props.pip || (() => null));
+    const { togglePin, isPinned } = useDocPiP(props.pip || (() => null));
     const pipSupported = typeof window !== 'undefined' && !!window.documentPictureInPicture;
+    const pinLabel = isPinned ? 'Unpin window' : 'Pin window';
     return (
-        <div className="absolute select-none right-0 top-0 mt-1 mr-1 flex justify-center items-center h-11 min-w-[8.25rem]">
+        <div className={styles.windowControls} role="group" aria-label="Window controls">
             {pipSupported && props.pip && (
                 <button
                     type="button"
-                    aria-label="Window pin"
-                    className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                    aria-label={pinLabel}
+                    aria-pressed={isPinned}
+                    className={`${styles.controlButton} ${styles.controlButtonSecondary}`}
                     onClick={togglePin}
                 >
-                    <NextImage
-                        src="/themes/Yaru/window/window-pin-symbolic.svg"
-                        alt="Kali window pin"
-                        className="h-4 w-4 inline"
-                        width={16}
-                        height={16}
-                        sizes="16px"
-                    />
+                    <PinIcon pinned={isPinned} />
                 </button>
             )}
             <button
                 type="button"
-                aria-label="Window minimize"
-                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                aria-label="Minimize window"
+                className={`${styles.controlButton} ${styles.controlButtonNeutral}`}
                 onClick={props.minimize}
             >
-                <NextImage
-                    src="/themes/Yaru/window/window-minimize-symbolic.svg"
-                    alt="Kali window minimize"
-                    className="h-4 w-4 inline"
-                    width={16}
-                    height={16}
-                    sizes="16px"
-                />
+                <MinimizeIcon />
             </button>
             {props.allowMaximize && (
-                props.isMaximised
-                    ? (
-                        <button
-                            type="button"
-                            aria-label="Window restore"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
-                            onClick={props.maximize}
-                        >
-                            <NextImage
-                                src="/themes/Yaru/window/window-restore-symbolic.svg"
-                                alt="Kali window restore"
-                                className="h-4 w-4 inline"
-                                width={16}
-                                height={16}
-                                sizes="16px"
-                            />
-                        </button>
-                    ) : (
-                        <button
-                            type="button"
-                            aria-label="Window maximize"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
-                            onClick={props.maximize}
-                        >
-                            <NextImage
-                                src="/themes/Yaru/window/window-maximize-symbolic.svg"
-                                alt="Kali window maximize"
-                                className="h-4 w-4 inline"
-                                width={16}
-                                height={16}
-                                sizes="16px"
-                            />
-                        </button>
-                    )
+                <button
+                    type="button"
+                    aria-label={props.isMaximised ? 'Restore window' : 'Maximize window'}
+                    className={`${styles.controlButton} ${styles.controlButtonNeutral}`}
+                    onClick={props.maximize}
+                >
+                    {props.isMaximised ? <RestoreIcon /> : <MaximizeIcon />}
+                </button>
             )}
             <button
                 type="button"
                 id={`close-${props.id}`}
-                aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
+                aria-label="Close window"
+                className={`${styles.controlButton} ${styles.controlButtonClose}`}
                 onClick={props.close}
             >
-                <NextImage
-                    src="/themes/Yaru/window/window-close-symbolic.svg"
-                    alt="Kali window close"
-                    className="h-4 w-4 inline"
-                    width={16}
-                    height={16}
-                    sizes="16px"
-                />
+                <CloseIcon />
             </button>
         </div>
     )
+}
+
+function MinimizeIcon() {
+    return (
+        <svg
+            className={styles.controlButtonIcon}
+            viewBox="0 0 12 12"
+            role="presentation"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <rect x="2" y="6.25" width="8" height="1.5" rx="0.75" fill="currentColor" />
+        </svg>
+    );
+}
+
+function MaximizeIcon() {
+    return (
+        <svg
+            className={styles.controlButtonIcon}
+            viewBox="0 0 12 12"
+            role="presentation"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <rect x="2.25" y="2.25" width="7.5" height="7.5" rx="1" fill="none" stroke="currentColor" strokeWidth="1.35" />
+        </svg>
+    );
+}
+
+function RestoreIcon() {
+    return (
+        <svg
+            className={styles.controlButtonIcon}
+            viewBox="0 0 12 12"
+            role="presentation"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <rect x="3.25" y="3.75" width="5.5" height="5.5" rx="0.9" fill="none" stroke="currentColor" strokeWidth="1.2" />
+            <path d="M4.25 3.25h4.5a.75.75 0 0 1 .75.75v4.5" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+        </svg>
+    );
+}
+
+function CloseIcon() {
+    return (
+        <svg
+            className={styles.controlButtonIcon}
+            viewBox="0 0 12 12"
+            role="presentation"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M3.2 3.2L8.8 8.8M8.8 3.2L3.2 8.8" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+        </svg>
+    );
+}
+
+function PinIcon({ pinned }) {
+    return (
+        <svg
+            className={styles.controlButtonIcon}
+            viewBox="0 0 12 12"
+            role="presentation"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path
+                d="M4.5 2.5h3l.35 2.2a1 1 0 0 1-.35.9l-.9.75.9 1.95-1.1.5-.8-2-.8 2-1.1-.5.9-1.95-.9-.75a1 1 0 0 1-.35-.9z"
+                fill="currentColor"
+            />
+            {pinned && (
+                <path
+                    d="M5.4 9.5l.6 1.8"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.1"
+                    strokeLinecap="round"
+                />
+            )}
+        </svg>
+    );
 }
 
 // Window's Main Screen

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -7,3 +7,94 @@
   height: calc(100% + 10px);
   width: calc(100% - 10px);
 }
+
+.windowControls {
+  position: absolute;
+  top: 0.45rem;
+  right: 0.45rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  height: 2.75rem;
+  padding: 0.25rem 0.4rem;
+  pointer-events: auto;
+  min-width: 8.25rem;
+}
+
+.controlButton {
+  appearance: none;
+  border: 1px solid rgba(103, 140, 178, 0.32);
+  background-color: rgba(27, 36, 49, 0.92);
+  color: #e7f1ff;
+  border-radius: 9999px;
+  min-width: 2.2rem;
+  height: 1.55rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.7rem;
+  cursor: pointer;
+  transition: background-color 140ms ease, border-color 140ms ease, color 140ms ease, box-shadow 140ms ease;
+}
+
+.controlButtonNeutral {
+  background-color: rgba(33, 47, 63, 0.9);
+  border-color: rgba(103, 140, 178, 0.35);
+}
+
+.controlButtonNeutral:hover {
+  background-color: #3d566e;
+  border-color: rgba(126, 169, 212, 0.6);
+}
+
+.controlButtonNeutral:active {
+  background-color: #31465d;
+}
+
+.controlButtonSecondary {
+  background-color: rgba(38, 53, 70, 0.85);
+  border-color: rgba(120, 160, 200, 0.3);
+}
+
+.controlButtonSecondary:hover,
+.controlButtonSecondary[aria-pressed="true"] {
+  background-color: #3c5976;
+  border-color: rgba(140, 184, 230, 0.6);
+}
+
+.controlButtonSecondary:active {
+  background-color: #324a61;
+}
+
+.controlButtonClose {
+  background-color: rgba(72, 22, 29, 0.85);
+  border-color: rgba(214, 87, 98, 0.45);
+  color: #ffe6ea;
+}
+
+.controlButtonClose:hover {
+  background-color: #d74c53;
+  border-color: rgba(255, 133, 141, 0.8);
+  color: #fff5f6;
+}
+
+.controlButtonClose:active {
+  background-color: #b63f45;
+}
+
+.controlButton:focus-visible {
+  outline: 2px solid #4da7ff;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px rgba(23, 93, 140, 0.35);
+}
+
+.controlButtonIcon {
+  width: 0.85rem;
+  height: 0.85rem;
+  pointer-events: none;
+}
+
+.controlButtonIcon path,
+.controlButtonIcon rect {
+  vector-effect: non-scaling-stroke;
+}


### PR DESCRIPTION
## Summary
- refactor the window control toolbar to use XFCE-style pill buttons with inline SVG icons and accessible labelling
- add Kali window manager spacing, hover, and focus styling for the control buttons in the CSS module
- adjust the window unit tests for the new labels and to stub preventDefault when simulating Alt+Arrow interactions

## Testing
- yarn lint *(fails: repository already contains hundreds of pre-existing jsx-a11y and no-top-level-window violations)*
- yarn test --watch=false window.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ca94d6cdb883288d33b328dd5a695b