### PR TITLE
[context-menu] align highlight tokens

### DIFF
--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -2,6 +2,8 @@ import React, { useRef } from 'react'
 import useFocusTrap from '../../hooks/useFocusTrap'
 import useRovingTabIndex from '../../hooks/useRovingTabIndex'
 
+const interactiveItemClasses = 'w-full text-left cursor-default py-0.5 mb-1.5 transition-hover transition-active hover:bg-[var(--interactive-hover)] focus:bg-[var(--interactive-hover)] focus-visible:bg-[var(--interactive-hover)] active:bg-[var(--interactive-active)]'
+
 function AppMenu(props) {
     const menuRef = useRef(null)
     useFocusTrap(menuRef, props.active)
@@ -28,14 +30,14 @@ function AppMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
-            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+            className={`${props.active ? 'block' : 'hidden'} cursor-default w-52 context-menu-bg border text-left border-[color:var(--color-border)] text-[color:var(--color-text)] py-4 absolute z-50 text-sm`}
         >
             <button
                 type="button"
                 onClick={handlePin}
                 role="menuitem"
                 aria-label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className={interactiveItemClasses}
             >
                 <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
             </button>

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -2,6 +2,8 @@ import React, { useRef } from 'react'
 import useFocusTrap from '../../hooks/useFocusTrap'
 import useRovingTabIndex from '../../hooks/useRovingTabIndex'
 
+const interactiveItemClasses = 'w-full text-left cursor-default py-0.5 mb-1.5 transition-hover transition-active hover:bg-[var(--interactive-hover)] focus:bg-[var(--interactive-hover)] focus-visible:bg-[var(--interactive-hover)] active:bg-[var(--interactive-active)]'
+
 function DefaultMenu(props) {
     const menuRef = useRef(null)
     useFocusTrap(menuRef, props.active)
@@ -20,7 +22,7 @@ function DefaultMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
-            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+            className={`${props.active ? 'block' : 'hidden'} cursor-default w-52 context-menu-bg border text-left border-[color:var(--color-border)] text-[color:var(--color-text)] py-4 absolute z-50 text-sm`}
         >
 
             <Devider />
@@ -30,7 +32,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Linkedin"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className={`block ${interactiveItemClasses}`}
             >
                 <span className="ml-5">🙋‍♂️</span> <span className="ml-2">Follow on <strong>Linkedin</strong></span>
             </a>
@@ -40,7 +42,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Github"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className={`block ${interactiveItemClasses}`}
             >
                 <span className="ml-5">🤝</span> <span className="ml-2">Follow on <strong>Github</strong></span>
             </a>
@@ -50,7 +52,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Contact Me"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className={`block ${interactiveItemClasses}`}
             >
                 <span className="ml-5">📥</span> <span className="ml-2">Contact Me</span>
             </a>
@@ -60,7 +62,7 @@ function DefaultMenu(props) {
                 onClick={() => { localStorage.clear(); window.location.reload() }}
                 role="menuitem"
                 aria-label="Reset Kali Linux"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className={interactiveItemClasses}
             >
                 <span className="ml-5">🧹</span> <span className="ml-2">Reset Kali Linux</span>
             </button>
@@ -71,7 +73,7 @@ function DefaultMenu(props) {
 function Devider() {
     return (
         <div className="flex justify-center w-full">
-            <div className=" border-t border-gray-900 py-1 w-2/5"></div>
+            <div className="border-t border-[color:color-mix(in_srgb,_var(--color-border),_transparent_25%)] py-1 w-2/5"></div>
         </div>
     );
 }

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,6 +1,9 @@
 import React, { useState, useEffect } from 'react'
 import logger from '../../utils/logger'
 
+const interactiveItemClasses = 'w-full text-left py-0.5 mb-1.5 cursor-default transition-hover transition-active hover:bg-[var(--interactive-hover)] focus:bg-[var(--interactive-hover)] focus-visible:bg-[var(--interactive-hover)] active:bg-[var(--interactive-active)]'
+const disabledItemClasses = 'w-full py-0.5 mb-1.5 text-left cursor-not-allowed text-[color:color-mix(in_srgb,_var(--color-text),_transparent_45%)]'
+
 function DesktopMenu(props) {
 
     const [isFullScreen, setIsFullScreen] = useState(false)
@@ -48,14 +51,14 @@ function DesktopMenu(props) {
             id="desktop-menu"
             role="menu"
             aria-label="Desktop context menu"
-            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+            className={`${props.active ? 'block' : 'hidden'} cursor-default w-52 context-menu-bg border text-left font-light border-[color:var(--color-border)] text-[color:var(--color-text)] py-4 absolute z-50 text-sm`}
         >
             <button
                 onClick={props.addNewFolder}
                 type="button"
                 role="menuitem"
                 aria-label="New Folder"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className={interactiveItemClasses}
             >
                 <span className="ml-5">New Folder</span>
             </button>
@@ -64,16 +67,16 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Create Shortcut"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className={interactiveItemClasses}
             >
                 <span className="ml-5">Create Shortcut...</span>
             </button>
             <Devider />
-            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <div role="menuitem" aria-label="Paste" aria-disabled="true" className={disabledItemClasses}>
                 <span className="ml-5">Paste</span>
             </div>
             <Devider />
-            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className={disabledItemClasses}>
                 <span className="ml-5">Show Desktop in Files</span>
             </div>
             <button
@@ -81,7 +84,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Open in Terminal"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className={interactiveItemClasses}
             >
                 <span className="ml-5">Open in Terminal</span>
             </button>
@@ -91,12 +94,12 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Change Background"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className={interactiveItemClasses}
             >
                 <span className="ml-5">Change Background...</span>
             </button>
             <Devider />
-            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className={disabledItemClasses}>
                 <span className="ml-5">Display Settings</span>
             </div>
             <button
@@ -104,7 +107,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Settings"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className={interactiveItemClasses}
             >
                 <span className="ml-5">Settings</span>
             </button>
@@ -114,7 +117,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label={isFullScreen ? "Exit Full Screen" : "Enter Full Screen"}
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className={interactiveItemClasses}
             >
                 <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
             </button>
@@ -124,7 +127,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Clear Session"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className={interactiveItemClasses}
             >
                 <span className="ml-5">Clear Session</span>
             </button>
@@ -135,7 +138,7 @@ function DesktopMenu(props) {
 function Devider() {
     return (
         <div className="flex justify-center w-full">
-            <div className=" border-t border-gray-900 py-1 w-2/5"></div>
+            <div className="border-t border-[color:color-mix(in_srgb,_var(--color-border),_transparent_25%)] py-1 w-2/5"></div>
         </div>
     );
 }

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -2,6 +2,8 @@ import React, { useRef } from 'react';
 import useFocusTrap from '../../hooks/useFocusTrap';
 import useRovingTabIndex from '../../hooks/useRovingTabIndex';
 
+const interactiveItemClasses = 'w-full text-left cursor-default py-0.5 mb-1.5 transition-hover transition-active hover:bg-[var(--interactive-hover)] focus:bg-[var(--interactive-hover)] focus-visible:bg-[var(--interactive-hover)] active:bg-[var(--interactive-active)]';
+
 function TaskbarMenu(props) {
     const menuRef = useRef(null);
     useFocusTrap(menuRef, props.active);
@@ -30,14 +32,14 @@ function TaskbarMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
-            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-40 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm'}
+            className={`${props.active ? 'block' : 'hidden'} cursor-default w-40 context-menu-bg border text-left border-[color:var(--color-border)] text-[color:var(--color-text)] py-2 absolute z-50 text-sm`}
         >
             <button
                 type="button"
                 onClick={handleMinimize}
                 role="menuitem"
                 aria-label={props.minimized ? 'Restore Window' : 'Minimize Window'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className={interactiveItemClasses}
             >
                 <span className="ml-5">{props.minimized ? 'Restore' : 'Minimize'}</span>
             </button>
@@ -46,7 +48,7 @@ function TaskbarMenu(props) {
                 onClick={handleClose}
                 role="menuitem"
                 aria-label="Close Window"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className={interactiveItemClasses}
             >
                 <span className="ml-5">Close</span>
             </button>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,6 +19,8 @@
   --color-focus-ring: var(--color-accent);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
+  --interactive-hover: color-mix(in srgb, var(--color-primary) 18%, transparent);
+  --interactive-active: color-mix(in srgb, var(--color-primary) 30%, transparent);
   accent-color: var(--color-control-accent);
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -77,6 +77,8 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --interactive-hover: color-mix(in srgb, var(--color-ub-border-orange) 40%, transparent);
+  --interactive-active: color-mix(in srgb, var(--color-ub-border-orange) 60%, transparent);
 }
 
 /* Dyslexia-friendly fonts */


### PR DESCRIPTION
## Summary
- remove rounded corners from context menu surfaces and switch them to Kali accent-driven hover/active states
- apply the new interaction tokens across default, app, desktop, and taskbar context menu entries (including disabled styling)
- introduce reusable interactive hover/active tokens in the global theme with a high-contrast override

## Testing
- yarn lint *(fails: repository contains pre-existing accessibility and no-top-level-window lint errors in unrelated apps)*

------
https://chatgpt.com/codex/tasks/task_e_68ca94cb8acc8328b516803e2863763f