### PR TITLE
[ui] unify progress bars

### DIFF
--- a/apps/hashcat/index.tsx
+++ b/apps/hashcat/index.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
 import RulesSandbox from './components/RulesSandbox';
 import StatsChart from '../../components/StatsChart';
+import ProgressBar from '@/components/ui/ProgressBar';
 
 interface Preset {
   value: string;
@@ -317,12 +318,12 @@ const Hashcat: React.FC = () => {
       </div>
 
       <div className="bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 p-2 rounded">
-        <div className="w-full bg-gray-400 dark:bg-gray-600 rounded h-2">
-          <div
-            className="h-2 bg-green-500 rounded"
-            style={{ width: `${progress}%` }}
-          />
-        </div>
+        <ProgressBar
+          value={progress}
+          className="h-2"
+          aria-label="Hashcat progress"
+          aria-valuetext={`${Math.round(progress)}%`}
+        />
         <div className="text-xs text-center mt-1">ETA: {eta}</div>
       </div>
       <div className="bg-black text-green-400 p-2 h-32 overflow-auto font-mono text-xs">

--- a/apps/john/index.tsx
+++ b/apps/john/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import AuditSimulator from './components/AuditSimulator';
+import ProgressBar from '@/components/ui/ProgressBar';
 
 interface HashItem {
   hash: string;
@@ -214,12 +215,12 @@ const JohnApp: React.FC = () => {
       </div>
 
       <div className="bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 p-2 rounded">
-        <div className="w-full bg-gray-400 dark:bg-gray-600 rounded h-2">
-          <div
-            className="h-2 bg-blue-500 rounded"
-            style={{ width: `${overallProgress}%` }}
-          />
-        </div>
+        <ProgressBar
+          value={overallProgress}
+          className="h-2"
+          aria-label="Overall cracking progress"
+          aria-valuetext={`${Math.round(overallProgress)}%`}
+        />
         <div className="text-xs text-center mt-1">ETA: {eta}</div>
       </div>
 

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -190,7 +190,11 @@ export class Gedit extends Component {
                     this.state.sending && (
                         <div className="flex justify-center items-center h-full w-full bg-gray-400 bg-opacity-30 absolute top-0 left-0">
                             {this.state.showProgress ? (
-                                <ProgressBar progress={this.state.progress} />
+                                <ProgressBar
+                                    value={this.state.progress}
+                                    className="w-48"
+                                    aria-label="Message send progress"
+                                />
                             ) : (
                                 <Image
                                     className="w-8 motion-safe:animate-spin"

--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import progressInfo from './progress.json';
 import StatsChart from '../../StatsChart';
+import ProgressBar from '../../ui/ProgressBar';
 
 export const hashTypes = [
   {
@@ -133,20 +134,17 @@ const ProgressGauge = ({ progress, info, reduceMotion }) => {
   return (
     <div
       className="w-48"
-      role="progressbar"
-      aria-label="Hash cracking progress"
-      aria-valuemin={0}
-      aria-valuemax={100}
-      aria-valuenow={progress}
-      aria-valuetext={`${progress}%`}
+      role="group"
+      aria-label="Hash cracking progress summary"
     >
       <div className="text-sm mb-1">Progress: {progress}%</div>
-      <div className="w-full h-4 bg-gray-700 rounded">
-        <div
-          className="h-4 bg-blue-600 rounded"
-          style={{ width: `${progress}%` }}
-        />
-      </div>
+      <ProgressBar
+        value={progress}
+        className="h-4"
+        aria-label="Hash cracking progress"
+        aria-valuetext={`${progress}%`}
+        reduceMotion={reduceMotion}
+      />
       <div role="status" aria-live="polite" className="text-sm mt-2">
         <div>Attempts/sec: {hashRates[index]}</div>
         <div>ETA: {etas[index]}</div>

--- a/components/apps/hydra/index.js
+++ b/components/apps/hydra/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState, useMemo } from 'react';
 import Stepper from './Stepper';
 import AttemptTimeline from './Timeline';
+import ProgressBar from '../../ui/ProgressBar';
 
 const baseServices = ['ssh', 'ftp', 'http-get', 'http-post-form', 'smtp'];
 const pluginServices = [];
@@ -652,12 +653,11 @@ const HydraApp = () => {
           alt="credentials"
           className="w-5 h-5"
         />
-        <div className="flex-1 bg-gray-700 h-2 rounded">
-          <div
-            className="bg-green-500 h-2 rounded"
-            style={{ width: `${progress}%` }}
-          ></div>
-        </div>
+        <ProgressBar
+          value={progress}
+          className="flex-1 h-2"
+          aria-label="Hydra spray progress"
+        />
       </div>
       <p className="mt-2 text-sm text-yellow-300">
         This demo slows after {BACKOFF_THRESHOLD} tries to mimic password spray

--- a/components/apps/john/index.js
+++ b/components/apps/john/index.js
@@ -8,6 +8,7 @@ import {
 } from './utils';
 import FormError from '../../ui/FormError';
 import StatsChart from '../../StatsChart';
+import ProgressBar from '../../ui/ProgressBar';
 
 // Enhanced John the Ripper interface that supports rule uploads,
 // basic hash analysis and mock distribution of cracking tasks.
@@ -27,7 +28,6 @@ const JohnApp = () => {
   const [progress, setProgress] = useState(0);
   const [phase, setPhase] = useState('wordlist');
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-  const [animOffset, setAnimOffset] = useState(0);
   const [mode, setMode] = useState('wordlist');
   const [candidates, setCandidates] = useState([]);
   const [potfileEntries, setPotfileEntries] = useState([]);
@@ -44,17 +44,6 @@ const JohnApp = () => {
     media.addEventListener('change', update);
     return () => media.removeEventListener('change', update);
   }, []);
-
-  useEffect(() => {
-    if (prefersReducedMotion) return undefined;
-    let frame;
-    const animate = () => {
-      setAnimOffset((o) => (o + 1) % 20);
-      frame = requestAnimationFrame(animate);
-    };
-    frame = requestAnimationFrame(animate);
-    return () => cancelAnimationFrame(frame);
-  }, [prefersReducedMotion]);
 
   useEffect(
     () => () => {
@@ -438,26 +427,14 @@ const JohnApp = () => {
         </div>
         {loading && (
           <>
-            <div className="w-full bg-gray-700 rounded h-4 overflow-hidden mt-2 relative">
-              <div
-                className="h-full"
-                style={{
-                  width: `${progress}%`,
-                  backgroundImage:
-                    phase === 'wordlist'
-                      ? 'repeating-linear-gradient(45deg,#065f46,#065f46 10px,#1e3a8a 10px,#1e3a8a 20px)'
-                      : 'repeating-linear-gradient(45deg,#1e3a8a,#1e3a8a 10px,#065f46 10px,#065f46 20px)',
-                  backgroundSize: '20px 20px',
-                  backgroundPosition: `${phase === 'wordlist' ? animOffset : -animOffset}px 0`,
-                  transition: prefersReducedMotion ? 'none' : 'width 0.2s ease-out',
-                }}
-                role="progressbar"
-                aria-valuenow={Math.round(progress)}
-                aria-valuemin={0}
-                aria-valuemax={100}
-              >
-                <span className="sr-only">{`Progress ${Math.round(progress)} percent`}</span>
-              </div>
+            <div className="relative mt-2">
+              <ProgressBar
+                value={progress}
+                className="h-4"
+                aria-label="John the Ripper cracking progress"
+                aria-valuetext={`${Math.round(progress)}%`}
+                reduceMotion={prefersReducedMotion}
+              />
               <span className="absolute inset-0 flex items-center justify-center text-xs font-bold text-white">
                 {`${Math.round(progress)}%`}
               </span>

--- a/components/apps/metasploit/metasploit.jsx
+++ b/components/apps/metasploit/metasploit.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import modules from './modules.json';
 import usePersistentState from '../../../hooks/usePersistentState';
 import ConsolePane from './ConsolePane';
+import ProgressBar from '../../ui/ProgressBar';
 
 const severities = ['critical', 'high', 'medium', 'low'];
 const severityStyles = {
@@ -477,15 +478,12 @@ const MetasploitApp = ({
                     <li key={i}>{t}</li>
                   ))}
                 </ul>
-                <div
-                  className="w-full bg-ub-grey h-2 mt-2"
-                  role="progressbar"
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                  aria-valuenow={Math.round(progress)}
-                >
-                  <div className="h-full bg-ub-orange" style={{ width: `${progress}%` }} />
-                </div>
+                <ProgressBar
+                  value={progress}
+                  className="mt-2 h-2"
+                  aria-label="Exploit replay progress"
+                  aria-valuetext={`${Math.round(progress)}%`}
+                />
               </>
             )}
           </div>

--- a/components/apps/mimikatz/CredentialLocator.js
+++ b/components/apps/mimikatz/CredentialLocator.js
@@ -1,5 +1,6 @@
 // Simulator: displays sample credential artifacts. For educational use only.
 import React, { useState, useEffect } from 'react';
+import ProgressBar from '../../ui/ProgressBar';
 
 const artifacts = [
   { label: 'SAM Database (sample)', found: true },
@@ -56,20 +57,13 @@ const CredentialArtifactLocator = () => {
       >
         Locate Artifacts
       </button>
-      <div className="w-full bg-gray-700 h-4 mb-2">
-        <div
-          className="bg-blue-500 h-4"
-          style={{
-            width: `${progress}%`,
-            transition: prefersReducedMotion ? 'none' : 'width 0.2s',
-          }}
-          role="progressbar"
-          aria-label="scan progress"
-          aria-valuenow={progress}
-          aria-valuemin={0}
-          aria-valuemax={100}
-        />
-      </div>
+      <ProgressBar
+        value={progress}
+        className="w-full h-4 mb-2"
+        aria-label="Scan progress"
+        aria-valuetext={`${progress}%`}
+        reduceMotion={prefersReducedMotion}
+      />
       <ul>
         {results.map((r, idx) => (
           <li

--- a/components/apps/openvas/index.js
+++ b/components/apps/openvas/index.js
@@ -3,6 +3,7 @@ import TaskOverview from './task-overview';
 import PolicySettings from './policy-settings';
 import pciProfile from './templates/pci.json';
 import hipaaProfile from './templates/hipaa.json';
+import ProgressBar from '../../ui/ProgressBar';
 
 const templates = { PCI: pciProfile, HIPAA: hipaaProfile };
 
@@ -411,12 +412,13 @@ const OpenVASApp = () => {
         </button>
       </div>
       {loading && (
-        <div className="w-full bg-gray-700 h-2 mb-4">
-          <div
-            style={{ width: `${progress}%` }}
-            className="h-2 bg-green-500 transition-all"
-          />
-        </div>
+        <ProgressBar
+          value={progress}
+          className="w-full h-2 mb-4"
+          aria-label="OpenVAS scan progress"
+          aria-valuetext={`${Math.round(progress)}%`}
+          reduceMotion={reduceMotion.current}
+        />
       )}
       <SeverityChart
         data={severityCounts}

--- a/components/ui/ProgressBar.tsx
+++ b/components/ui/ProgressBar.tsx
@@ -1,25 +1,99 @@
 import React from 'react';
+import clsx from 'clsx';
 
-interface ProgressBarProps {
-  progress: number;
-  className?: string;
+export interface ProgressBarProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: number;
+  min?: number;
+  max?: number;
+  indeterminate?: boolean;
+  reduceMotion?: boolean;
 }
 
-export default function ProgressBar({ progress, className = '' }: ProgressBarProps) {
-  const clamped = Math.max(0, Math.min(progress, 100));
+const FILL_GRADIENT =
+  'linear-gradient(90deg, rgba(15,154,216,1) 0%, rgba(70,209,255,1) 50%, rgba(15,154,216,1) 100%)';
+
+export default function ProgressBar({
+  value,
+  min = 0,
+  max = 100,
+  indeterminate = false,
+  reduceMotion = false,
+  className,
+  style,
+  ...rest
+}: ProgressBarProps) {
+  const range = Math.max(max - min, 1);
+  const numericValue =
+    typeof value === 'number' && Number.isFinite(value) ? value : min;
+  const clamped = Math.min(Math.max(numericValue, min), max);
+  const percent = ((clamped - min) / range) * 100;
+
+  const ariaProps = indeterminate
+    ? { 'aria-valuemin': min, 'aria-valuemax': max }
+    : {
+        'aria-valuenow': Math.round(percent),
+        'aria-valuemin': min,
+        'aria-valuemax': max,
+      };
+
+  const fillStyle: React.CSSProperties = {
+    width: indeterminate ? '40%' : `${percent}%`,
+    backgroundImage: FILL_GRADIENT,
+    backgroundSize: '200% 100%',
+    boxShadow: '0 0 12px rgba(70, 209, 255, 0.35)',
+    ...(indeterminate && reduceMotion ? { left: '30%' } : {}),
+  };
+
+  if (reduceMotion) {
+    fillStyle.transition = 'none';
+  }
+
   return (
     <div
-      className={`w-32 h-2 bg-gray-300 rounded ${className}`}
       role="progressbar"
-      aria-valuenow={Math.round(clamped)}
-      aria-valuemin={0}
-      aria-valuemax={100}
+      className={clsx(
+        'progress-bar relative h-2 w-full overflow-hidden rounded-sm border border-[#0d374d] bg-[#071520] shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]',
+        className
+      )}
+      style={style}
+      {...ariaProps}
+      {...rest}
     >
       <div
-        className="h-full bg-blue-500 transition-all duration-200"
-        style={{ width: `${clamped}%` }}
+        aria-hidden="true"
+        className={clsx(
+          'progress-bar__fill absolute left-0 top-0 h-full rounded-sm',
+          !indeterminate && !reduceMotion && 'transition-[width] duration-300 ease-out',
+          indeterminate && !reduceMotion && 'progress-bar__fill--indeterminate'
+        )}
+        style={fillStyle}
       />
+      <style jsx>{`
+        .progress-bar {
+          background-image: linear-gradient(
+            180deg,
+            rgba(255, 255, 255, 0.08),
+            rgba(0, 0, 0, 0.3)
+          );
+        }
+        .progress-bar__fill {
+          background-position: 0% 0%;
+        }
+        .progress-bar__fill--indeterminate {
+          animation: kali-progress-indeterminate 1.4s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+        }
+        @keyframes kali-progress-indeterminate {
+          0% {
+            transform: translateX(-60%);
+          }
+          50% {
+            transform: translateX(-5%);
+          }
+          100% {
+            transform: translateX(125%);
+          }
+        }
+      `}</style>
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- add a Kali-style ProgressBar component that supports determinate/indeterminate states and reduced-motion fallbacks
- swap gedit, Hydra, John, Metasploit, OpenVAS, Mimikatz, and Hashcat to use the shared progress bar
- update the Hashcat and John Next.js pages to match the new indicator

## Testing
- yarn lint *(fails: repository has pre-existing accessibility lint errors)*
- yarn test *(fails: repository has pre-existing test failures around accessibility and browser APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68ca94eaca948328b44f262668955454