### PR TITLE
[ui] Animate desktop and file drag feedback

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -7,12 +7,56 @@ export class UbuntuApp extends Component {
         this.state = { launching: false, dragging: false, prefetched: false };
     }
 
-    handleDragStart = () => {
+    handleDragStart = (event) => {
+        if (this.props.disabled) {
+            event?.preventDefault();
+            return;
+        }
+
         this.setState({ dragging: true });
+
+        if (event?.dataTransfer) {
+            try {
+                event.dataTransfer.setData('text/plain', this.props.id);
+            } catch { }
+            event.dataTransfer.effectAllowed = 'move';
+        }
+
+        if (typeof this.props.onDragStart === 'function') {
+            this.props.onDragStart(this.props.id, event);
+        }
     }
 
-    handleDragEnd = () => {
+    handleDragEnd = (event) => {
         this.setState({ dragging: false });
+
+        if (typeof this.props.onDragEnd === 'function') {
+            this.props.onDragEnd(this.props.id, event);
+        }
+    }
+
+    handleDragEnter = (event) => {
+        if (typeof this.props.onDragEnter === 'function') {
+            this.props.onDragEnter(this.props.id, event);
+        }
+    }
+
+    handleDragLeave = (event) => {
+        if (typeof this.props.onDragLeave === 'function') {
+            this.props.onDragLeave(this.props.id, event);
+        }
+    }
+
+    handleDrop = (event) => {
+        if (typeof this.props.onDrop === 'function') {
+            this.props.onDrop(this.props.id, event);
+        }
+    }
+
+    handleDragOver = (event) => {
+        if (typeof this.props.onDragOver === 'function') {
+            this.props.onDragOver(this.props.id, event);
+        }
     }
 
     openApp = () => {
@@ -31,18 +75,33 @@ export class UbuntuApp extends Component {
     }
 
     render() {
+        const classNames = [
+            "drag-animate",
+            "cursor-grab active:cursor-grabbing",
+            "p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active",
+        ];
+
+        if (this.state.launching) classNames.push("app-icon-launch");
+        if (this.state.dragging) classNames.push("drag-animate-active", "cursor-grabbing");
+        if (this.props.dropTargetReady) classNames.push("drop-target-ready");
+        if (this.props.dropTargetActive) classNames.push("drop-target-active");
+
         return (
             <div
                 role="button"
                 aria-label={this.props.name}
                 aria-disabled={this.props.disabled}
+                aria-grabbed={this.state.dragging}
                 data-context="app"
                 data-app-id={this.props.id}
                 draggable
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
-                className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                onDragEnter={this.handleDragEnter}
+                onDragLeave={this.handleDragLeave}
+                onDrop={this.handleDrop}
+                onDragOver={this.handleDragOver}
+                className={classNames.join(' ')}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}

--- a/styles/index.css
+++ b/styles/index.css
@@ -253,6 +253,47 @@ dialog {
     }
 }
 
+/* Drag and drop affordances */
+.drag-animate {
+    transition: transform 150ms ease, box-shadow 150ms ease, opacity 150ms ease;
+    will-change: transform, box-shadow, opacity;
+}
+
+.drag-animate-active {
+    transform: translate3d(0, -4px, 0) scale(1.05);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+    opacity: 0.95;
+}
+
+.drop-target-ready {
+    box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.45);
+    border-radius: 0.5rem;
+}
+
+.drop-target-active {
+    box-shadow: 0 0 0 2px rgba(147, 197, 253, 0.85), 0 12px 28px rgba(59, 130, 246, 0.55);
+    transform: translate3d(0, -2px, 0) scale(1.03);
+}
+
+.desktop-dragging {
+    cursor: grabbing;
+}
+
+.desktop-dragging .drop-target-ready {
+    animation: dropTargetPulse 1.2s ease-in-out infinite;
+}
+
+@keyframes dropTargetPulse {
+    0%,
+    100% {
+        box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.35);
+    }
+
+    50% {
+        box-shadow: 0 0 0 4px rgba(191, 219, 254, 0.75);
+    }
+}
+
 /* Blackjack animations */
 .card {
     position: relative;


### PR DESCRIPTION
## Summary
- add drag state callbacks to desktop shortcuts so trash can animate as a drop target
- update the file explorer to animate draggable entries and highlight directory drop zones
- introduce shared CSS transforms and drop target effects for drag affordances

## Testing
- yarn lint *(fails: repository has pre-existing accessibility and no-top-level-window violations)*
- yarn test *(fails: existing suites still break without browser APIs and Supabase configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68caa27100dc8328984ffab869e533f9