### PR TITLE
[ui] unify button tokens

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -12,11 +12,7 @@ export default function Error({ error, reset }: { error: Error; reset: () => voi
   return (
     <div className="flex flex-col items-center justify-center gap-4 p-4">
       <h2 className="text-xl font-semibold">Something went wrong!</h2>
-      <button
-        type="button"
-        onClick={() => reset()}
-        className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
-      >
+      <button type="button" onClick={() => reset()} className="btn btn--primary">
         Try again
       </button>
     </div>

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -19,11 +19,7 @@ export default function GlobalError({
       <body>
         <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4">
           <h2 className="text-xl font-semibold">Something went wrong!</h2>
-          <button
-            type="button"
-            onClick={() => reset()}
-            className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
-          >
+          <button type="button" onClick={() => reset()} className="btn btn--primary">
             Try again
           </button>
         </div>

--- a/components/BetaBadge.jsx
+++ b/components/BetaBadge.jsx
@@ -3,7 +3,7 @@ export default function BetaBadge() {
   return (
     <button
       type="button"
-      className="fixed bottom-4 right-4 rounded bg-yellow-500/90 px-2 py-1 text-xs font-semibold text-black"
+      className="btn btn--warning btn--dense fixed bottom-4 right-4 text-xs font-semibold"
     >
       Beta
     </button>

--- a/components/FixturesLoader.tsx
+++ b/components/FixturesLoader.tsx
@@ -49,14 +49,14 @@ export default function FixturesLoader({ onData }: LoaderProps) {
   return (
     <div className="text-xs" aria-label="fixtures loader">
       <div className="mb-2 flex items-center">
-        <button onClick={loadSample} className="px-2 py-1 bg-ub-cool-grey text-white mr-2" type="button">
+        <button onClick={loadSample} className="btn btn--ghost btn--dense mr-2" type="button">
           Load Sample
         </button>
-        <label className="px-2 py-1 bg-ub-cool-grey text-white mr-2 cursor-pointer">
+        <label className="btn btn--primary btn--dense mr-2 cursor-pointer">
           Import
           <input type="file" onChange={onFile} className="hidden" aria-label="import fixture" />
         </label>
-        <button onClick={cancel} className="px-2 py-1 bg-ub-red text-white" type="button">
+        <button onClick={cancel} className="btn btn--danger btn--dense" type="button">
           Cancel
         </button>
       </div>

--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -26,7 +26,8 @@ const InstallButton: React.FC = () => {
   return (
     <button
       onClick={handleInstall}
-      className="fixed bottom-4 right-4 bg-ubt-blue text-white px-3 py-1 rounded"
+      type="button"
+      className="btn btn--primary fixed bottom-4 right-4"
     >
       Install
     </button>

--- a/components/LabMode.tsx
+++ b/components/LabMode.tsx
@@ -32,7 +32,7 @@ export default function LabMode({ children }: Props) {
     <div className="w-full h-full">
       <div className="bg-ub-yellow text-black p-2 text-xs flex justify-between items-center" aria-label="training banner">
         <span>{enabled ? 'Lab Mode enabled: all actions are simulated.' : 'Lab Mode disabled: enable to use training features.'}</span>
-        <button onClick={toggle} className="px-2 py-1 bg-ub-green text-black" type="button">
+        <button onClick={toggle} className="btn btn--success btn--dense" type="button">
           {enabled ? 'Disable' : 'Enable'}
         </button>
       </div>

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -13,7 +13,14 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
 
   return (
     <div>
-      <button aria-label="settings" onClick={() => setOpen(!open)}>
+      <button
+        type="button"
+        aria-label="settings"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen(!open)}
+        className="btn btn--ghost btn--dense"
+      >
         Settings
       </button>
       {open && (

--- a/components/TerminalOutput.tsx
+++ b/components/TerminalOutput.tsx
@@ -23,7 +23,8 @@ export default function TerminalOutput({ text, ariaLabel }: TerminalOutputProps)
         <div key={idx} className="flex items-start">
           <span className="flex-1 whitespace-pre-wrap">{line}</span>
           <button
-            className="ml-2 text-gray-400 hover:text-white"
+            type="button"
+            className="btn btn--ghost btn--icon ml-2"
             onClick={() => copyLine(line)}
             aria-label="copy line"
           >

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -119,8 +119,9 @@ const WhiskerMenu: React.FC = () => {
       <button
         ref={buttonRef}
         type="button"
+        aria-expanded={open}
         onClick={() => setOpen(o => !o)}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        className={`btn btn--ghost btn--toolbar ${open ? 'is-active' : ''}`}
       >
         <Image
           src="/themes/Yaru/status/decompiler-symbolic.svg"
@@ -146,7 +147,9 @@ const WhiskerMenu: React.FC = () => {
             {CATEGORIES.map(cat => (
               <button
                 key={cat.id}
-                className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
+                type="button"
+                aria-pressed={category === cat.id}
+                className={`btn btn--ghost btn--dense w-full justify-start text-left mb-1 ${category === cat.id ? 'is-active' : ''}`}
                 onClick={() => setCategory(cat.id)}
               >
                 {cat.label}

--- a/docs/design-buttons.md
+++ b/docs/design-buttons.md
@@ -1,0 +1,48 @@
+# Button system
+
+The desktop shell now exposes a shared button system that maps design tokens to reusable CSS
+variants. Use these classes in place of ad-hoc Tailwind mixes so control states remain
+consistent across apps.
+
+## Tokens
+
+The following custom properties are available globally (see `styles/tokens.css`). The base
+`--control-*` tokens map to the neutral surface style while the suffixes switch colours and
+shadows for emphasised actions.
+
+- `--control-transition-duration`, `--control-transition-easing`, `--control-transform-active`
+- `--control-surface*` – neutral surface background, border, text and shadow states
+- `--control-primary*`, `--control-success*`, `--control-warning*`, `--control-danger*` – accent
+  palettes for major CTAs, success/confirmation, warning and destructive actions
+- `--control-ghost*` – transparent background controls for toolbars or secondary actions
+- `--control-disabled-*` – muted palette for disabled controls
+
+Each group includes `surface`, `hover`, `active`, `border`, `foreground`, `shadow` and focus ring
+values. High contrast, reduced motion and media query overrides are wired up so the same token
+names work across accessibility modes.
+
+## Classes
+
+Buttons use a `.btn` base class with optional modifiers. The base class wires up padding,
+minimum hit area, font weight, transitions and disabled handling. Variants override the
+custom properties exposed above:
+
+- `.btn--primary`, `.btn--success`, `.btn--warning`, `.btn--danger` – map to the accent tokens
+- `.btn--ghost` – transparent chrome, toggles to the active colours when `.is-active`,
+  `aria-pressed="true"` or `aria-current="page"`
+- `.btn--dense` – reduced vertical padding for tight layouts
+- `.btn--icon` – circular icon buttons that maintain the minimum hit area
+- `.btn--toolbar` – ghost treatment tuned for the top navigation with inset focus/active bars
+
+The system also sets shared focus rings through `--control-ring-*` tokens so buttons and other
+controls reuse the same feedback. Apply the `.btn` class to `<button>`, `<a>`, or semantic
+controls with `role="button"` as needed.
+
+## Reference gallery
+
+Visit `/ui/button-gallery` to preview the current variants. The Playwright spec
+`tests/button-visual.spec.ts` captures a screenshot of this gallery to guard against regression.
+
+When adding a new variant, extend the token set in `styles/tokens.css`, add a modifier under the
+`@layer components` block in `styles/tailwind.css`, update this document, and include an example
+in the gallery page.

--- a/pages/ui/button-gallery.tsx
+++ b/pages/ui/button-gallery.tsx
@@ -1,0 +1,88 @@
+import Head from 'next/head';
+import type { ReactNode } from 'react';
+
+const Section = ({ title, children }: { title: string; children: ReactNode }) => (
+  <section className="space-y-3">
+    <h2 className="text-lg font-semibold">{title}</h2>
+    <div className="flex flex-wrap items-start gap-3">{children}</div>
+  </section>
+);
+
+export default function ButtonGallery() {
+  return (
+    <>
+      <Head>
+        <title>Button Tokens</title>
+      </Head>
+      <main
+        className="min-h-screen bg-ub-grey/95 p-6 text-sm text-white"
+        data-testid="button-gallery"
+      >
+        <div className="max-w-3xl space-y-6">
+          <header className="space-y-2">
+            <h1 className="text-2xl font-bold">Button variants</h1>
+            <p className="text-ubt-grey">
+              This gallery exercises the shared button tokens. Each sample uses the <code>btn</code> base
+              class and applies variants to demonstrate hover, pressed, and disabled states.
+            </p>
+          </header>
+          <Section title="Neutral actions">
+            <button type="button" className="btn">
+              Default surface
+            </button>
+            <button type="button" className="btn" disabled>
+              Disabled surface
+            </button>
+            <button type="button" className="btn btn--dense">
+              Dense surface
+            </button>
+          </Section>
+          <Section title="Emphasised actions">
+            <button type="button" className="btn btn--primary">
+              Primary
+            </button>
+            <button type="button" className="btn btn--success">
+              Success
+            </button>
+            <button type="button" className="btn btn--warning">
+              Warning
+            </button>
+            <button type="button" className="btn btn--danger">
+              Danger
+            </button>
+          </Section>
+          <Section title="Ghost and toolbar buttons">
+            <button type="button" className="btn btn--ghost">
+              Ghost
+            </button>
+            <button type="button" className="btn btn--ghost" aria-pressed="true">
+              Pressed ghost
+            </button>
+            <button type="button" className="btn btn--ghost btn--toolbar" aria-expanded="false">
+              Toolbar
+            </button>
+            <button type="button" className="btn btn--ghost btn--toolbar is-active" aria-expanded="true">
+              Toolbar active
+            </button>
+          </Section>
+          <Section title="Icon buttons">
+            <button type="button" className="btn btn--ghost btn--icon" aria-label="Copy">
+              📋
+            </button>
+            <button type="button" className="btn btn--primary btn--icon" aria-label="Confirm">
+              ✓
+            </button>
+            <button
+              type="button"
+              className="btn btn--danger btn--icon"
+              aria-label="Delete"
+              disabled
+            >
+              ✕
+            </button>
+          </Section>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -18,7 +18,7 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
 
 a:focus-visible,
 button:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
     outline-offset: 2px;
 }
 

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -11,9 +11,216 @@
   }
 }
 
+@layer components {
+  .btn {
+    --button-bg: var(--control-surface);
+    --button-bg-hover: var(--control-surface-hover);
+    --button-bg-active: var(--control-surface-active);
+    --button-border: var(--control-surface-border);
+    --button-border-hover: var(--control-surface-border-hover);
+    --button-border-active: var(--control-surface-border-active);
+    --button-border-width: 1px;
+    --button-fg: var(--control-surface-foreground);
+    --button-fg-hover: var(--control-surface-foreground);
+    --button-fg-active: var(--control-surface-foreground);
+    --button-shadow: var(--control-surface-shadow);
+    --button-shadow-hover: var(--control-surface-shadow-hover);
+    --button-shadow-active: var(--control-surface-shadow-active);
+    --button-shadow-focus: var(--control-surface-shadow-focus);
+    --button-bg-disabled: var(--control-disabled-surface);
+    --button-fg-disabled: var(--control-disabled-foreground);
+    --button-border-disabled: var(--control-disabled-border);
+    --button-disabled-opacity: var(--control-disabled-opacity);
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    padding-inline: var(--space-4);
+    padding-block: calc(var(--space-2) + 0.125rem);
+    min-height: var(--hit-area);
+    min-width: var(--hit-area);
+    border-radius: var(--radius-md);
+    border-style: solid;
+    border-width: var(--button-border-width);
+    background: var(--button-bg);
+    color: var(--button-fg);
+    border-color: var(--button-border);
+    box-shadow: var(--button-shadow);
+    font: inherit;
+    font-weight: 500;
+    line-height: 1.4;
+    text-decoration: none;
+    user-select: none;
+    cursor: pointer;
+    transition-property: background-color, color, border-color, box-shadow, transform;
+    transition-duration: var(--control-transition-duration);
+    transition-timing-function: var(--control-transition-easing);
+  }
+
+  .btn:hover:not(:disabled):not([aria-disabled="true"]) {
+    background: var(--button-bg-hover);
+    color: var(--button-fg-hover);
+    border-color: var(--button-border-hover);
+    box-shadow: var(--button-shadow-hover);
+  }
+
+  .btn:active:not(:disabled):not([aria-disabled="true"]) {
+    background: var(--button-bg-active);
+    color: var(--button-fg-active);
+    border-color: var(--button-border-active);
+    box-shadow: var(--button-shadow-active);
+    transform: var(--button-transform-active, var(--control-transform-active));
+  }
+
+  .btn:focus-visible {
+    outline: none;
+    box-shadow: var(--button-shadow-focus);
+  }
+
+  .btn:disabled,
+  .btn[aria-disabled="true"] {
+    background: var(--button-bg-disabled);
+    color: var(--button-fg-disabled);
+    border-color: var(--button-border-disabled);
+    box-shadow: none;
+    cursor: not-allowed;
+    opacity: var(--button-disabled-opacity);
+    transform: none;
+  }
+
+  .btn--primary {
+    --button-bg: var(--control-primary-surface);
+    --button-bg-hover: var(--control-primary-hover);
+    --button-bg-active: var(--control-primary-active);
+    --button-border: var(--control-primary-border);
+    --button-border-hover: var(--control-primary-border-hover);
+    --button-border-active: var(--control-primary-border-active);
+    --button-fg: var(--control-primary-foreground);
+    --button-fg-hover: var(--control-primary-foreground);
+    --button-fg-active: var(--control-primary-foreground);
+    --button-shadow: var(--control-primary-shadow);
+    --button-shadow-hover: var(--control-primary-shadow-hover);
+    --button-shadow-active: var(--control-primary-shadow-active);
+    --button-shadow-focus: var(--control-primary-shadow-hover),
+      0 0 0 var(--control-ring-width) var(--control-ring-color);
+  }
+
+  .btn--success {
+    --button-bg: var(--control-success-surface);
+    --button-bg-hover: var(--control-success-hover);
+    --button-bg-active: var(--control-success-active);
+    --button-border: var(--control-success-border);
+    --button-border-hover: var(--control-success-border-hover);
+    --button-border-active: var(--control-success-border-active);
+    --button-fg: var(--control-success-foreground);
+    --button-fg-hover: var(--control-success-foreground);
+    --button-fg-active: var(--control-success-foreground);
+    --button-shadow: var(--control-success-shadow);
+    --button-shadow-hover: var(--control-success-shadow-hover);
+    --button-shadow-active: var(--control-success-shadow-active);
+    --button-shadow-focus: var(--control-success-shadow-hover),
+      0 0 0 var(--control-ring-width) var(--control-ring-color);
+  }
+
+  .btn--warning {
+    --button-bg: var(--control-warning-surface);
+    --button-bg-hover: var(--control-warning-hover);
+    --button-bg-active: var(--control-warning-active);
+    --button-border: var(--control-warning-border);
+    --button-border-hover: var(--control-warning-border-hover);
+    --button-border-active: var(--control-warning-border-active);
+    --button-fg: var(--control-warning-foreground);
+    --button-fg-hover: var(--control-warning-foreground);
+    --button-fg-active: var(--control-warning-foreground);
+    --button-shadow: var(--control-warning-shadow);
+    --button-shadow-hover: var(--control-warning-shadow-hover);
+    --button-shadow-active: var(--control-warning-shadow-active);
+    --button-shadow-focus: var(--control-warning-shadow-hover),
+      0 0 0 var(--control-ring-width) var(--control-ring-color);
+  }
+
+  .btn--danger {
+    --button-bg: var(--control-danger-surface);
+    --button-bg-hover: var(--control-danger-hover);
+    --button-bg-active: var(--control-danger-active);
+    --button-border: var(--control-danger-border);
+    --button-border-hover: var(--control-danger-border-hover);
+    --button-border-active: var(--control-danger-border-active);
+    --button-fg: var(--control-danger-foreground);
+    --button-fg-hover: var(--control-danger-foreground);
+    --button-fg-active: var(--control-danger-foreground);
+    --button-shadow: var(--control-danger-shadow);
+    --button-shadow-hover: var(--control-danger-shadow-hover);
+    --button-shadow-active: var(--control-danger-shadow-active);
+    --button-shadow-focus: var(--control-danger-shadow-hover),
+      0 0 0 var(--control-ring-width) var(--control-ring-color);
+  }
+
+  .btn--ghost {
+    --button-bg: var(--control-ghost-surface);
+    --button-bg-hover: var(--control-ghost-hover);
+    --button-bg-active: var(--control-ghost-active);
+    --button-border: var(--control-ghost-border);
+    --button-border-hover: var(--control-ghost-border-hover);
+    --button-border-active: var(--control-ghost-border-active);
+    --button-shadow: var(--control-ghost-shadow);
+    --button-shadow-hover: var(--control-ghost-shadow);
+    --button-shadow-active: var(--control-ghost-shadow);
+    --button-shadow-focus: var(--control-ghost-focus);
+  }
+
+  .btn--ghost.is-active,
+  .btn--ghost[aria-pressed='true'],
+  .btn--ghost[aria-current='true'],
+  .btn--ghost[aria-current='page'] {
+    --button-bg: var(--control-ghost-active);
+    --button-border: var(--control-ghost-border-active);
+  }
+
+  .btn--dense {
+    padding-block: var(--space-2);
+    font-size: 0.8125rem;
+  }
+
+  .btn--icon {
+    padding-inline: var(--space-2);
+    padding-block: var(--space-2);
+    border-radius: var(--radius-round);
+    min-width: var(--hit-area);
+  }
+
+  .btn--toolbar {
+    --button-border-width: 0px;
+    padding-inline: calc(var(--space-3) + 0.25rem);
+    padding-block: var(--space-2);
+    font-weight: 600;
+    box-shadow: none;
+    --button-shadow-focus: 0 0 0 var(--control-ring-width) var(--control-ring-color);
+  }
+
+  .btn--toolbar:hover:not(:disabled):not([aria-disabled="true"]) {
+    box-shadow: inset 0 -2px 0 var(--color-accent);
+  }
+
+  .btn--toolbar[aria-expanded='true'],
+  .btn--toolbar.is-active {
+    --button-bg: var(--control-ghost-active);
+    --button-border-width: 0px;
+    box-shadow: inset 0 -2px 0 var(--color-accent);
+  }
+}
+
 @layer base {
   button {
-    @apply transition-hover transition-active;
+    font-family: inherit;
+    transition-property: background-color, color, border-color, box-shadow, transform;
+    transition-duration: var(--control-transition-duration);
+    transition-timing-function: var(--control-transition-easing);
+  }
+
+  button:disabled {
+    cursor: not-allowed;
   }
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -60,6 +60,85 @@
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;
+
+  /* Control + button states */
+  --control-transition-duration: var(--motion-fast);
+  --control-transition-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --control-transform-active: translateY(1px) scale(0.99);
+  --control-ring-width: 3px;
+  --control-ring-color: color-mix(in srgb, var(--color-accent) 55%, transparent 45%);
+  --control-ring-offset: color-mix(in srgb, var(--color-bg) 85%, transparent 15%);
+
+  --control-surface: color-mix(in srgb, var(--color-surface) 80%, white 20%);
+  --control-surface-hover: color-mix(in srgb, var(--color-surface) 70%, white 30%);
+  --control-surface-active: color-mix(in srgb, var(--color-surface) 60%, white 40%);
+  --control-surface-border: color-mix(in srgb, var(--color-border) 80%, transparent 20%);
+  --control-surface-border-hover: color-mix(in srgb, var(--color-border) 60%, var(--color-accent) 40%);
+  --control-surface-border-active: var(--color-accent);
+  --control-surface-foreground: var(--color-text);
+  --control-surface-shadow: 0 1px 2px color-mix(in srgb, var(--color-inverse) 20%, transparent 80%);
+  --control-surface-shadow-hover: 0 6px 18px color-mix(in srgb, var(--color-inverse) 25%, transparent 75%);
+  --control-surface-shadow-active: inset 0 1px 1px color-mix(in srgb, var(--color-inverse) 30%, transparent 70%);
+  --control-surface-shadow-focus: 0 0 0 var(--control-ring-width) var(--control-ring-color), var(--control-surface-shadow);
+
+  --control-primary-surface: var(--color-primary);
+  --control-primary-hover: color-mix(in srgb, var(--color-primary) 88%, white 12%);
+  --control-primary-active: color-mix(in srgb, var(--color-primary) 78%, black 22%);
+  --control-primary-border: color-mix(in srgb, var(--color-primary) 70%, black 30%);
+  --control-primary-border-hover: color-mix(in srgb, var(--color-primary) 85%, black 15%);
+  --control-primary-border-active: color-mix(in srgb, var(--color-primary) 72%, black 28%);
+  --control-primary-foreground: #f5f5f5;
+  --control-primary-shadow: 0 6px 20px color-mix(in srgb, var(--color-primary) 40%, transparent 60%);
+  --control-primary-shadow-hover: 0 10px 28px color-mix(in srgb, var(--color-primary) 45%, transparent 55%);
+  --control-primary-shadow-active: inset 0 1px 0 color-mix(in srgb, white 45%, transparent 55%);
+
+  --control-success-surface: var(--game-color-success);
+  --control-success-hover: color-mix(in srgb, var(--game-color-success) 88%, white 12%);
+  --control-success-active: color-mix(in srgb, var(--game-color-success) 75%, black 25%);
+  --control-success-border: color-mix(in srgb, var(--game-color-success) 70%, black 30%);
+  --control-success-border-hover: color-mix(in srgb, var(--game-color-success) 85%, black 15%);
+  --control-success-border-active: color-mix(in srgb, var(--game-color-success) 72%, black 28%);
+  --control-success-foreground: #041b0b;
+  --control-success-shadow: 0 6px 16px color-mix(in srgb, var(--game-color-success) 45%, transparent 55%);
+  --control-success-shadow-hover: 0 10px 24px color-mix(in srgb, var(--game-color-success) 50%, transparent 50%);
+  --control-success-shadow-active: inset 0 1px 0 color-mix(in srgb, white 45%, transparent 55%);
+
+  --control-warning-surface: var(--game-color-warning);
+  --control-warning-hover: color-mix(in srgb, var(--game-color-warning) 88%, white 12%);
+  --control-warning-active: color-mix(in srgb, var(--game-color-warning) 75%, black 25%);
+  --control-warning-border: color-mix(in srgb, var(--game-color-warning) 65%, black 35%);
+  --control-warning-border-hover: color-mix(in srgb, var(--game-color-warning) 82%, black 18%);
+  --control-warning-border-active: color-mix(in srgb, var(--game-color-warning) 70%, black 30%);
+  --control-warning-foreground: #1f1300;
+  --control-warning-shadow: 0 6px 18px color-mix(in srgb, var(--game-color-warning) 45%, transparent 55%);
+  --control-warning-shadow-hover: 0 10px 26px color-mix(in srgb, var(--game-color-warning) 50%, transparent 50%);
+  --control-warning-shadow-active: inset 0 1px 0 color-mix(in srgb, white 45%, transparent 55%);
+
+  --control-danger-surface: var(--game-color-danger);
+  --control-danger-hover: color-mix(in srgb, var(--game-color-danger) 88%, white 12%);
+  --control-danger-active: color-mix(in srgb, var(--game-color-danger) 76%, black 24%);
+  --control-danger-border: color-mix(in srgb, var(--game-color-danger) 70%, black 30%);
+  --control-danger-border-hover: color-mix(in srgb, var(--game-color-danger) 85%, black 15%);
+  --control-danger-border-active: color-mix(in srgb, var(--game-color-danger) 72%, black 28%);
+  --control-danger-foreground: #fef2f2;
+  --control-danger-shadow: 0 6px 20px color-mix(in srgb, var(--game-color-danger) 45%, transparent 55%);
+  --control-danger-shadow-hover: 0 10px 28px color-mix(in srgb, var(--game-color-danger) 50%, transparent 50%);
+  --control-danger-shadow-active: inset 0 1px 0 color-mix(in srgb, white 40%, transparent 60%);
+
+  --control-ghost-surface: transparent;
+  --control-ghost-hover: color-mix(in srgb, var(--color-primary) 18%, transparent 82%);
+  --control-ghost-active: color-mix(in srgb, var(--color-primary) 26%, transparent 74%);
+  --control-ghost-border: color-mix(in srgb, var(--color-primary) 45%, transparent 55%);
+  --control-ghost-border-hover: color-mix(in srgb, var(--color-primary) 65%, transparent 35%);
+  --control-ghost-border-active: color-mix(in srgb, var(--color-primary) 75%, transparent 25%);
+  --control-ghost-foreground: var(--color-text);
+  --control-ghost-shadow: none;
+  --control-ghost-focus: 0 0 0 var(--control-ring-width) var(--control-ring-color);
+
+  --control-disabled-surface: color-mix(in srgb, var(--color-muted) 85%, transparent 15%);
+  --control-disabled-foreground: color-mix(in srgb, var(--color-text) 50%, transparent 50%);
+  --control-disabled-border: color-mix(in srgb, var(--color-border) 70%, transparent 30%);
+  --control-disabled-opacity: 1;
 }
 
 /* High contrast theme */
@@ -77,6 +156,77 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+
+  --control-surface: #000000;
+  --control-surface-hover: #222222;
+  --control-surface-active: #444444;
+  --control-surface-border: #ffffff;
+  --control-surface-border-hover: #ffff00;
+  --control-surface-border-active: #ffbf00;
+  --control-surface-foreground: #ffffff;
+  --control-surface-shadow: none;
+  --control-surface-shadow-hover: none;
+  --control-surface-shadow-active: none;
+  --control-surface-shadow-focus: 0 0 0 var(--control-ring-width) #ffff00;
+
+  --control-primary-surface: #ffff00;
+  --control-primary-hover: #ffff33;
+  --control-primary-active: #ffbf00;
+  --control-primary-border: #000000;
+  --control-primary-border-hover: #000000;
+  --control-primary-border-active: #000000;
+  --control-primary-foreground: #000000;
+  --control-primary-shadow: none;
+  --control-primary-shadow-hover: none;
+  --control-primary-shadow-active: none;
+
+  --control-success-surface: #00ffff;
+  --control-success-hover: #33ffff;
+  --control-success-active: #00bfbf;
+  --control-success-border: #ffffff;
+  --control-success-border-hover: #ffff00;
+  --control-success-border-active: #ffbf00;
+  --control-success-foreground: #000000;
+  --control-success-shadow: none;
+  --control-success-shadow-hover: none;
+  --control-success-shadow-active: none;
+
+  --control-warning-surface: #ff00ff;
+  --control-warning-hover: #ff33ff;
+  --control-warning-active: #bf00bf;
+  --control-warning-border: #ffffff;
+  --control-warning-border-hover: #ffff00;
+  --control-warning-border-active: #ffbf00;
+  --control-warning-foreground: #000000;
+  --control-warning-shadow: none;
+  --control-warning-shadow-hover: none;
+  --control-warning-shadow-active: none;
+
+  --control-danger-surface: #ff0000;
+  --control-danger-hover: #ff3333;
+  --control-danger-active: #bf0000;
+  --control-danger-border: #ffffff;
+  --control-danger-border-hover: #ffff00;
+  --control-danger-border-active: #ffbf00;
+  --control-danger-foreground: #000000;
+  --control-danger-shadow: none;
+  --control-danger-shadow-hover: none;
+  --control-danger-shadow-active: none;
+
+  --control-ghost-surface: transparent;
+  --control-ghost-hover: #ffff00;
+  --control-ghost-active: #ffbf00;
+  --control-ghost-border: #ffffff;
+  --control-ghost-border-hover: #ffff00;
+  --control-ghost-border-active: #ffbf00;
+  --control-ghost-foreground: #ffffff;
+  --control-ghost-shadow: none;
+  --control-ghost-focus: 0 0 0 var(--control-ring-width) #ffff00;
+
+  --control-disabled-surface: #2b2b2b;
+  --control-disabled-foreground: #cccccc;
+  --control-disabled-border: #f5f5f5;
+  --control-ring-color: #ffff00;
 }
 
 /* Dyslexia-friendly fonts */
@@ -94,6 +244,8 @@
   --motion-fast: 0ms;
   --motion-medium: 0ms;
   --motion-slow: 0ms;
+  --control-transition-duration: 0ms;
+  --control-transform-active: none;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -101,6 +253,8 @@
     --motion-fast: 0ms;
     --motion-medium: 0ms;
     --motion-slow: 0ms;
+    --control-transition-duration: 0ms;
+    --control-transform-active: none;
   }
 }
 
@@ -116,5 +270,17 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+    --control-surface: #000000;
+    --control-surface-hover: #222222;
+    --control-surface-active: #444444;
+    --control-surface-border: #ffffff;
+    --control-surface-border-hover: #ffff00;
+    --control-surface-border-active: #ffbf00;
+    --control-surface-foreground: #ffffff;
+    --control-surface-shadow: none;
+    --control-surface-shadow-hover: none;
+    --control-surface-shadow-active: none;
+    --control-surface-shadow-focus: 0 0 0 var(--control-ring-width) #ffff00;
+    --control-ring-color: #ffff00;
   }
 }

--- a/tests/button-visual.spec.ts
+++ b/tests/button-visual.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test.use({ viewport: { width: 1200, height: 900 } });
+
+test.describe('Button tokens', () => {
+  test('renders button variants consistently', async ({ page }) => {
+    await page.goto('/ui/button-gallery');
+    const gallery = page.getByTestId('button-gallery');
+    await expect(gallery).toBeVisible();
+    await expect(gallery).toHaveScreenshot('button-gallery.png', {
+      animations: 'disabled',
+      caret: 'hide',
+      scale: 'css',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add shared control state tokens and `.btn` variants to the design system CSS
- migrate prominent shell controls to the new button styles and publish a `/ui/button-gallery` reference page
- document the token/class contract and add a Playwright visual regression test for the gallery

## Testing
- `yarn lint` *(fails: repository already has hundreds of jsx-a11y/no-top-level-window violations across legacy apps)*
- `yarn test` *(fails: existing suites such as window focus handling and Nmap NSE crash under jsdom; run aborted after repeated failures)*
- `npx playwright test` *(fails: browsers not installed in container; Playwright requests running `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68caa9adf1048328bd09ec5ac7b5d146