### PR TITLE
[desktop] add cross-app drag and drop

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -1,17 +1,31 @@
 import React, { Component } from 'react'
 import Image from 'next/image'
+import { beginDesktopDrag, endDesktopDrag } from '../../utils/desktopDrag.js'
 
 export class UbuntuApp extends Component {
     constructor() {
         super();
         this.state = { launching: false, dragging: false, prefetched: false };
+        this.dragToken = null;
     }
 
-    handleDragStart = () => {
+    handleDragStart = (event) => {
         this.setState({ dragging: true });
+        if (this.dragToken) {
+            endDesktopDrag(this.dragToken);
+        }
+        this.dragToken = beginDesktopDrag(event, {
+            type: 'app',
+            appId: this.props.id,
+            title: this.props.displayName || this.props.name,
+        });
     }
 
     handleDragEnd = () => {
+        if (this.dragToken) {
+            endDesktopDrag(this.dragToken);
+            this.dragToken = null;
+        }
         this.setState({ dragging: false });
     }
 

--- a/public/samples/nikto/demo.txt
+++ b/public/samples/nikto/demo.txt
@@ -1,0 +1,4 @@
+Host: demo.local
+/login.php High
+/phpinfo.php Medium
+/admin/robots.txt Low

--- a/tests/desktop-dnd.spec.ts
+++ b/tests/desktop-dnd.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '@playwright/test';
+
+async function bootDesktop(page) {
+  await page.goto('/');
+  await page.waitForSelector('#desktop');
+  await page.evaluate(() => {
+    const win =
+      document.getElementById('about-alex') || document.getElementById('about');
+    if (win) {
+      win.style.transform = 'translate(620px, 40px)';
+    }
+  });
+}
+
+async function openApp(page, appId: string) {
+  await page.evaluate((id) => {
+    window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
+  }, appId);
+  await page.waitForSelector(`#${appId}`, { state: 'visible' });
+}
+
+test.describe('cross-application drag-and-drop', () => {
+  test('drags demo text file to Hash Converter', async ({ page }) => {
+    await bootDesktop(page);
+    await openApp(page, 'files');
+    await openApp(page, 'converter');
+
+    await page.waitForSelector('[data-testid="file-explorer-demo"][data-name="common.txt"]');
+    await page.evaluate(() => {
+      const files = document.getElementById('files');
+      const converter = document.getElementById('converter');
+      if (files) files.style.transform = 'translate(80px, 140px)';
+      if (converter) converter.style.transform = 'translate(460px, 120px)';
+    });
+
+    const source = page.locator('[data-testid="file-explorer-demo"][data-name="common.txt"]');
+    const target = page.locator('#converter [data-testid="hash-dropzone"]');
+    await source.dragTo(target);
+
+    await expect(page.locator('#converter').getByText('File: common.txt')).toBeVisible();
+  });
+
+  test('drags demo pcap file to Wireshark', async ({ page }) => {
+    await bootDesktop(page);
+    await openApp(page, 'files');
+    await openApp(page, 'wireshark');
+
+    await page.waitForSelector('[data-testid="file-explorer-demo"][data-name="dns.pcap"]');
+    await page.evaluate(() => {
+      const files = document.getElementById('files');
+      const wireshark = document.getElementById('wireshark');
+      if (files) files.style.transform = 'translate(40px, 140px)';
+      if (wireshark) wireshark.style.transform = 'translate(420px, 60px)';
+    });
+
+    const source = page.locator('[data-testid="file-explorer-demo"][data-name="dns.pcap"]');
+    const target = page.locator('[data-testid="wireshark-app"]');
+    await source.dragTo(target);
+
+    await expect(page.locator('#wireshark tbody tr').first()).toBeVisible();
+  });
+
+  test('drops app icon into clipboard manager', async ({ page }) => {
+    await bootDesktop(page);
+    await openApp(page, 'clipboard-manager');
+
+    await page.evaluate(() => {
+      const clipboard = document.getElementById('clipboard-manager');
+      if (clipboard) clipboard.style.transform = 'translate(420px, 180px)';
+    });
+
+    const appIcon = page.locator('#app-chrome');
+    await expect(appIcon).toBeVisible();
+
+    const dropzone = page.locator('#clipboard-manager [data-testid="clipboard-dropzone"]');
+    await appIcon.dragTo(dropzone);
+
+    await expect(
+      page.locator('#clipboard-manager').getByText('[App] Google Chrome (chrome)'),
+    ).toBeVisible();
+  });
+});

--- a/utils/desktopDrag.d.ts
+++ b/utils/desktopDrag.d.ts
@@ -1,0 +1,45 @@
+export type DesktopFileDrag = {
+  type: 'file';
+  name: string;
+  getFile: () => Promise<File>;
+  label?: string;
+};
+
+export type DesktopAppDrag = {
+  type: 'app';
+  appId: string;
+  title: string;
+  label?: string;
+};
+
+export type DesktopDragPayload = DesktopFileDrag | DesktopAppDrag;
+
+export type BeginDesktopDragOptions = {
+  ttl?: number;
+  effectAllowed?: DataTransfer['effectAllowed'];
+};
+
+export function beginDesktopDrag(
+  event: Pick<DragEvent, 'dataTransfer'>,
+  payload: DesktopDragPayload,
+  options?: BeginDesktopDragOptions,
+): string | null;
+
+export function endDesktopDrag(id: string | null | undefined): void;
+
+export function peekDesktopDrag(
+  dataTransfer: DataTransfer | null,
+): DesktopDragPayload | null;
+
+export function consumeDesktopDrag(
+  dataTransfer: DataTransfer | null,
+): DesktopDragPayload | null;
+
+export function isDesktopDragEvent(dataTransfer: DataTransfer | null): boolean;
+
+declare const desktopDragInternal: {
+  _store: Map<string, { payload: DesktopDragPayload; expires: number }>;
+  _mime: string;
+};
+
+export { desktopDragInternal };

--- a/utils/desktopDrag.js
+++ b/utils/desktopDrag.js
@@ -1,0 +1,158 @@
+const DESKTOP_DRAG_MIME = 'application/x-kali-desktop-drag';
+const DEFAULT_TTL = 30_000; // 30 seconds
+
+/**
+ * @typedef {Object} DesktopFileDrag
+ * @property {'file'} type
+ * @property {string} name
+ * @property {() => Promise<File>} getFile
+ * @property {string} [label]
+ */
+
+/**
+ * @typedef {Object} DesktopAppDrag
+ * @property {'app'} type
+ * @property {string} appId
+ * @property {string} title
+ * @property {string} [label]
+ */
+
+/** @typedef {DesktopFileDrag | DesktopAppDrag} DesktopDragPayload */
+
+/**
+ * @typedef {Object} BeginDesktopDragOptions
+ * @property {number} [ttl]
+ * @property {DataTransfer['effectAllowed']} [effectAllowed]
+ */
+
+const dragStore = new Map();
+
+function createId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `drag-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function cleanupStore(now = Date.now()) {
+  for (const [id, entry] of dragStore.entries()) {
+    if (entry.expires <= now) {
+      dragStore.delete(id);
+    }
+  }
+}
+
+/**
+ * @param {DataTransfer} dataTransfer
+ * @param {string} id
+ * @param {DesktopDragPayload} payload
+ */
+function setTransferData(dataTransfer, id, payload) {
+  try {
+    dataTransfer.setData(
+      DESKTOP_DRAG_MIME,
+      JSON.stringify({ id, type: payload.type }),
+    );
+  } catch {
+    // ignore DataTransfer errors (e.g. during tests)
+  }
+  const label =
+    payload.type === 'file'
+      ? payload.name
+      : payload.label || `${payload.title} (${payload.appId})`;
+  if (label) {
+    try {
+      dataTransfer.setData('text/plain', label);
+    } catch {
+      // ignore clipboard errors
+    }
+  }
+}
+
+/**
+ * Serialize a drag payload and attach it to the provided event.
+ * Returns a token that can later be cleared via {@link endDesktopDrag}.
+ *
+ * @param {{ dataTransfer: DataTransfer | null }} event
+ * @param {DesktopDragPayload} payload
+ * @param {BeginDesktopDragOptions} [options]
+ * @returns {string | null}
+ */
+export function beginDesktopDrag(event, payload, options = {}) {
+  const { dataTransfer } = event;
+  if (!dataTransfer) return null;
+  cleanupStore();
+  const id = createId();
+  dragStore.set(id, {
+    payload,
+    expires: Date.now() + (options.ttl ?? DEFAULT_TTL),
+  });
+  setTransferData(dataTransfer, id, payload);
+  dataTransfer.effectAllowed = options.effectAllowed ?? 'copy';
+  return id;
+}
+
+/** Remove a serialized payload once a drag concludes. */
+export function endDesktopDrag(id) {
+  if (!id) return;
+  dragStore.delete(id);
+}
+
+function lookupPayload(dataTransfer) {
+  if (!dataTransfer) return null;
+  let raw = '';
+  try {
+    raw = dataTransfer.getData(DESKTOP_DRAG_MIME);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+  try {
+    const meta = JSON.parse(raw);
+    if (!meta?.id) return null;
+    const entry = dragStore.get(meta.id);
+    if (!entry) return null;
+    return { id: meta.id, payload: entry.payload };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the payload for the current drag without clearing it.
+ * @param {DataTransfer | null} dataTransfer
+ * @returns {DesktopDragPayload | null}
+ */
+export function peekDesktopDrag(dataTransfer) {
+  const entry = lookupPayload(dataTransfer);
+  return entry?.payload ?? null;
+}
+
+/**
+ * Retrieve and clear the payload associated with a drop event.
+ * @param {DataTransfer | null} dataTransfer
+ * @returns {DesktopDragPayload | null}
+ */
+export function consumeDesktopDrag(dataTransfer) {
+  const entry = lookupPayload(dataTransfer);
+  if (!entry) return null;
+  dragStore.delete(entry.id);
+  return entry.payload;
+}
+
+/**
+ * Determine if the provided event contains serialized desktop drag data.
+ * @param {DataTransfer | null} dataTransfer
+ * @returns {boolean}
+ */
+export function isDesktopDragEvent(dataTransfer) {
+  if (!dataTransfer?.types) return false;
+  const types = Array.from(dataTransfer.types);
+  return types.includes(DESKTOP_DRAG_MIME);
+}
+
+export const desktopDragInternal = {
+  /** Primarily for tests */
+  _store: dragStore,
+  _mime: DESKTOP_DRAG_MIME,
+};


### PR DESCRIPTION
## Summary
- add a desktop drag registry to serialize file handles and app references
- update desktop icons, File Explorer, and key apps to participate in cross-app drag-and-drop with validation and visual feedback
- seed demo assets and add Playwright coverage for dragging between apps

## Testing
- yarn lint *(fails: numerous pre-existing accessibility errors reported)*
- yarn test *(fails: suite failures unrelated to this change, e.g. jsdom localStorage issues)*
- npx playwright test *(fails: browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caa9ae8458832889c0da30c32c18fb