### PR TITLE
feat(theme): add dynamic theme provider and settings UI

### DIFF
--- a/__tests__/radare2Guide.test.tsx
+++ b/__tests__/radare2Guide.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '../components/providers/ThemeProvider';
 import Radare2 from '../components/apps/radare2';
 import sample from '../apps/radare2/sample.json';
 
@@ -9,7 +10,11 @@ describe('Radare2 tutorial', () => {
   });
 
   it('opens tutorial from help menu', () => {
-    render(<Radare2 initialData={sample} />);
+    render(
+      <ThemeProvider>
+        <Radare2 initialData={sample} />
+      </ThemeProvider>,
+    );
     expect(screen.queryByText('Radare2 Tutorial')).toBeNull();
     fireEvent.click(screen.getByText('Help'));
     expect(screen.getByText('Radare2 Tutorial')).toBeInTheDocument();

--- a/__tests__/theme.test.tsx
+++ b/__tests__/theme.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, fireEvent, renderHook, act } from '@testing-library/react';
+import { ThemeProvider } from '../components/providers/ThemeProvider';
+import { useTheme } from '../hooks/useTheme';
+import AppearancePanel from '../components/apps/settings/AppearancePanel';
+import { THEME_KEY } from '../utils/theme';
+import { THEME_DEFINITIONS } from '../lib/theme/tokens';
+
+type WrapperProps = { children: React.ReactNode };
+
+const Wrapper: React.FC<WrapperProps> = ({ children }) => (
+  <ThemeProvider>{children}</ThemeProvider>
+);
+
+beforeEach(() => {
+  window.localStorage.clear();
+  document.documentElement.dataset.theme = '';
+  document.documentElement.className = '';
+  document.documentElement.style.cssText = '';
+});
+
+describe('ThemeProvider', () => {
+  test('exposes default theme tokens', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper: Wrapper });
+    expect(result.current.theme).toBe('default');
+    expect(result.current.tokens).toBe(THEME_DEFINITIONS.default.tokens);
+  });
+
+  test('setTheme persists selection and updates CSS variables', async () => {
+    const { result } = renderHook(() => useTheme(), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.setTheme('dark');
+    });
+
+    expect(result.current.theme).toBe('dark');
+    expect(window.localStorage.getItem(THEME_KEY)).toBe('dark');
+    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(
+      document.documentElement.style.getPropertyValue('--color-bg').trim(),
+    ).toBe(THEME_DEFINITIONS.dark.tokens.background);
+  });
+
+  test('responds to storage events from other tabs', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper: Wrapper });
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', { key: THEME_KEY, newValue: 'neon' }),
+      );
+    });
+
+    expect(result.current.theme).toBe('neon');
+  });
+});
+
+describe('AppearancePanel', () => {
+  test('clicking a theme option updates the active theme', () => {
+    const { getByRole } = render(<AppearancePanel />, { wrapper: Wrapper });
+
+    const neonOption = getByRole('radio', { name: /neon/i });
+    fireEvent.click(neonOption);
+
+    expect(document.documentElement.dataset.theme).toBe('neon');
+    expect(neonOption).toHaveAttribute('aria-checked', 'true');
+  });
+});

--- a/apps/radare2/components/GraphView.tsx
+++ b/apps/radare2/components/GraphView.tsx
@@ -8,9 +8,17 @@ interface Block {
   edges?: string[];
 }
 
+interface ThemePalette {
+  bg: string;
+  surface: string;
+  text: string;
+  accent: string;
+  border: string;
+}
+
 interface GraphViewProps {
   blocks: Block[];
-  theme: string;
+  palette: ThemePalette;
 }
 
 const ForceGraph2D = dynamic(
@@ -18,17 +26,11 @@ const ForceGraph2D = dynamic(
   { ssr: false },
 );
 
-const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
+const GraphView: React.FC<GraphViewProps> = ({ blocks, palette }) => {
   const fgRef = useRef<any | null>(null);
   const [center, setCenter] = useState({ x: 0, y: 0 });
   const [selected, setSelected] = useState<Block | null>(null);
-  const [colors, setColors] = useState({
-    bg: "#000",
-    surface: "#374151",
-    text: "#fff",
-    accent: "#fbbf24",
-    border: "#4b5563",
-  });
+  const colors = palette;
 
   const graphData = useMemo(() => {
     const nodes = blocks.map((b) => ({ id: b.addr }));
@@ -38,18 +40,6 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
     );
     return { nodes, links };
   }, [blocks]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const style = getComputedStyle(document.documentElement);
-    setColors({
-      bg: style.getPropertyValue("--r2-bg").trim() || "#000",
-      surface: style.getPropertyValue("--r2-surface").trim() || "#374151",
-      text: style.getPropertyValue("--r2-text").trim() || "#fff",
-      accent: style.getPropertyValue("--r2-accent").trim() || "#fbbf24",
-      border: style.getPropertyValue("--r2-border").trim() || "#4b5563",
-    });
-  }, [theme]);
 
   useEffect(() => {
     const fg = fgRef.current;
@@ -187,8 +177,8 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
           onClick={zoomIn}
           className="px-2 py-1 rounded"
           style={{
-            backgroundColor: "var(--r2-surface)",
-            border: "1px solid var(--r2-border)",
+            backgroundColor: colors.surface,
+            border: `1px solid ${colors.border}`,
           }}
         >
           +
@@ -197,8 +187,8 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
           onClick={zoomOut}
           className="px-2 py-1 rounded"
           style={{
-            backgroundColor: "var(--r2-surface)",
-            border: "1px solid var(--r2-border)",
+            backgroundColor: colors.surface,
+            border: `1px solid ${colors.border}`,
           }}
         >
           -
@@ -207,8 +197,8 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
           onClick={() => pan(0, -20)}
           className="px-2 py-1 rounded"
           style={{
-            backgroundColor: "var(--r2-surface)",
-            border: "1px solid var(--r2-border)",
+            backgroundColor: colors.surface,
+            border: `1px solid ${colors.border}`,
           }}
         >
           ↑
@@ -217,8 +207,8 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
           onClick={() => pan(0, 20)}
           className="px-2 py-1 rounded"
           style={{
-            backgroundColor: "var(--r2-surface)",
-            border: "1px solid var(--r2-border)",
+            backgroundColor: colors.surface,
+            border: `1px solid ${colors.border}`,
           }}
         >
           ↓
@@ -227,8 +217,8 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
           onClick={() => pan(-20, 0)}
           className="px-2 py-1 rounded"
           style={{
-            backgroundColor: "var(--r2-surface)",
-            border: "1px solid var(--r2-border)",
+            backgroundColor: colors.surface,
+            border: `1px solid ${colors.border}`,
           }}
         >
           ←
@@ -237,8 +227,8 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
           onClick={() => pan(20, 0)}
           className="px-2 py-1 rounded"
           style={{
-            backgroundColor: "var(--r2-surface)",
-            border: "1px solid var(--r2-border)",
+            backgroundColor: colors.surface,
+            border: `1px solid ${colors.border}`,
           }}
         >
           →
@@ -246,7 +236,7 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
       </div>
       <div
         className="h-64 rounded"
-        style={{ backgroundColor: "var(--r2-surface)" }}
+        style={{ backgroundColor: colors.surface }}
       >
         <ForceGraph2D
           ref={fgRef}
@@ -266,8 +256,8 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
         <div
           className="mt-2 p-2 rounded text-sm"
           style={{
-            backgroundColor: "var(--r2-surface)",
-            border: "1px solid var(--r2-border)",
+            backgroundColor: colors.surface,
+            border: `1px solid ${colors.border}`,
           }}
         >
           <div>Block: {selected.addr}</div>

--- a/components/apps/radare2/HexEditor.js
+++ b/components/apps/radare2/HexEditor.js
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 const BYTES_PER_ROW = 16;
 
-const HexEditor = ({ hex, theme }) => {
+const HexEditor = ({ hex, palette }) => {
   const [bytes, setBytes] = useState([]);
   const [patches, setPatches] = useState([]);
   const [selection, setSelection] = useState([null, null]);
@@ -13,22 +13,20 @@ const HexEditor = ({ hex, theme }) => {
   const prefersReduced = useRef(false);
   const visibleRef = useRef(true);
   const colorsRef = useRef({
-    surface: '#374151',
-    accent: '#fbbf24',
-    text: '#ffffff',
-    border: '#4b5563',
+    surface: palette.surface,
+    accent: palette.accent,
+    text: palette.text,
+    border: palette.border,
   });
 
   useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const style = getComputedStyle(document.documentElement);
     colorsRef.current = {
-      surface: style.getPropertyValue('--r2-surface').trim() || '#374151',
-      accent: style.getPropertyValue('--r2-accent').trim() || '#fbbf24',
-      text: style.getPropertyValue('--r2-text').trim() || '#ffffff',
-      border: style.getPropertyValue('--r2-border').trim() || '#4b5563',
+      surface: palette.surface,
+      accent: palette.accent,
+      text: palette.text,
+      border: palette.border,
     };
-  }, [theme]);
+  }, [palette.accent, palette.border, palette.surface, palette.text]);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -162,8 +160,8 @@ const HexEditor = ({ hex, theme }) => {
           ref={containerRef}
           className="overflow-auto p-2 rounded max-h-64 flex-1"
           style={{
-            backgroundColor: 'var(--r2-surface)',
-            border: '1px solid var(--r2-border)',
+            backgroundColor: palette.surface,
+            border: `1px solid ${palette.border}`,
           }}
         >
           <div className="text-xs font-mono">
@@ -184,10 +182,10 @@ const HexEditor = ({ hex, theme }) => {
                       className="w-6 h-6 flex items-center justify-center rounded focus:outline-none focus-visible:ring-2"
                       style={{
                         backgroundColor: selected
-                          ? 'var(--r2-accent)'
-                          : 'var(--r2-surface)',
-                        color: selected ? '#000' : 'var(--r2-text)',
-                        '--tw-ring-color': 'var(--r2-accent)',
+                          ? palette.accent
+                          : palette.surface,
+                        color: selected ? '#000' : palette.text,
+                        '--tw-ring-color': palette.accent,
                         marginLeft: colIdx === 8 ? '0.5rem' : undefined,
                       }}
                     >
@@ -206,8 +204,8 @@ const HexEditor = ({ hex, theme }) => {
           onClick={handleMiniMapClick}
           className="rounded cursor-pointer"
           style={{
-            backgroundColor: 'var(--r2-surface)',
-            border: '1px solid var(--r2-border)',
+            backgroundColor: palette.surface,
+            border: `1px solid ${palette.border}`,
           }}
           aria-label="hex mini map"
         />
@@ -217,8 +215,8 @@ const HexEditor = ({ hex, theme }) => {
           onClick={() => workerRef.current?.postMessage({ type: 'export' })}
           className="px-3 py-1 rounded"
           style={{
-            backgroundColor: 'var(--r2-surface)',
-            border: '1px solid var(--r2-border)',
+            backgroundColor: palette.surface,
+            border: `1px solid ${palette.border}`,
           }}
         >
           Export Patches

--- a/components/apps/radare2/index.js
+++ b/components/apps/radare2/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import HexEditor from "./HexEditor";
 import {
   loadNotes,
@@ -29,7 +29,18 @@ const Radare2 = ({ initialData = {} }) => {
   const [showGuide, setShowGuide] = useState(false);
   const [strings, setStrings] = useState([]);
   const disasmRef = useRef(null);
-  const { theme } = useTheme();
+  const { theme, tokens } = useTheme();
+
+  const palette = useMemo(
+    () => ({
+      bg: tokens.background,
+      surface: tokens.surface,
+      text: tokens.text,
+      accent: tokens.accent,
+      border: tokens.border,
+    }),
+    [tokens],
+  );
 
   useEffect(() => {
     if (typeof window !== "undefined") {
@@ -178,10 +189,10 @@ const Radare2 = ({ initialData = {} }) => {
       </div>
 
       {mode === "graph" ? (
-        <GraphView blocks={blocks} theme={theme} />
+        <GraphView blocks={blocks} palette={palette} />
       ) : (
         <div className="grid md:grid-cols-2 gap-4">
-          <HexEditor hex={hex} theme={theme} />
+          <HexEditor hex={hex} palette={palette} />
           <div
             ref={disasmRef}
             className="overflow-auto rounded max-h-64 p-1.5 font-mono"

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,9 +1,10 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
+import AppearancePanel from './settings/AppearancePanel';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -59,19 +60,7 @@ export function Settings() {
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
             <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Theme:</label>
-                <select
-                    value={theme}
-                    onChange={(e) => setTheme(e.target.value)}
-                    className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-                >
-                    <option value="default">Default</option>
-                    <option value="dark">Dark</option>
-                    <option value="neon">Neon</option>
-                    <option value="matrix">Matrix</option>
-                </select>
-            </div>
+            <AppearancePanel />
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Accent:</label>
                 <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">

--- a/components/apps/settings/AppearancePanel.tsx
+++ b/components/apps/settings/AppearancePanel.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { useTheme } from '../../../hooks/useTheme';
+
+const AppearancePanel: React.FC = () => {
+  const { theme, setTheme, themes } = useTheme();
+
+  return (
+    <section aria-labelledby="appearance-heading" className="w-full px-6 mb-6">
+      <div className="mb-4 text-ubt-grey">
+        <h2 id="appearance-heading" className="text-lg font-semibold">
+          Themes
+        </h2>
+        <p className="text-sm text-ubt-warm-grey">
+          Switch between curated palettes. Changes apply instantly across the desktop.
+        </p>
+      </div>
+      <div
+        role="radiogroup"
+        aria-label="Theme selection"
+        className="grid gap-4 sm:grid-cols-2"
+      >
+        {themes.map((definition) => {
+          const selected = definition.id === theme;
+          const { background, surface, accent, text, border } = definition.tokens;
+          return (
+            <button
+              key={definition.id}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              onClick={() => setTheme(definition.id)}
+              className={`rounded-lg border p-4 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${
+                selected
+                  ? 'border-ubt-blue ring-2 ring-ubt-blue ring-offset-gray-900'
+                  : 'border-gray-700 hover:border-ubt-blue/70'
+              }`}
+              style={{
+                backgroundColor: 'rgba(26, 31, 38, 0.6)',
+                color: '#f5f5f5',
+              }}
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-base font-medium">{definition.label}</p>
+                  <p className="mt-1 text-xs text-ubt-warm-grey">{definition.description}</p>
+                </div>
+                {selected && (
+                  <span className="text-xs uppercase tracking-wide text-ubt-blue">
+                    Active
+                  </span>
+                )}
+              </div>
+              <div className="mt-4 flex items-center gap-3">
+                <div className="flex-1 rounded-md border" style={{ borderColor: border }}>
+                  <div className="h-10 w-full rounded-t-md" style={{ backgroundColor: background }} />
+                  <div
+                    className="h-10 w-full rounded-b-md border-t"
+                    style={{
+                      backgroundColor: surface,
+                      borderColor: border,
+                    }}
+                  />
+                </div>
+                <div
+                  className="flex h-12 w-12 items-center justify-center rounded-full border"
+                  style={{
+                    backgroundColor: accent,
+                    borderColor: border,
+                    color: text,
+                  }}
+                  aria-hidden="true"
+                >
+                  Aa
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+};
+
+export default AppearancePanel;

--- a/components/providers/ThemeProvider.tsx
+++ b/components/providers/ThemeProvider.tsx
@@ -1,0 +1,77 @@
+import React, { createContext, useCallback, useEffect, useMemo, useState, ReactNode } from 'react';
+import {
+  THEME_DEFINITIONS,
+  THEME_ORDER,
+  ThemeDefinition,
+  ThemeName,
+  ThemeTokens,
+  ensureThemeName,
+  themeToCssVars,
+} from '../../lib/theme/tokens';
+import { THEME_KEY, getTheme, setTheme as persistTheme } from '../../utils/theme';
+
+export interface ThemeContextValue {
+  theme: ThemeName;
+  definition: ThemeDefinition;
+  tokens: ThemeTokens;
+  themes: ThemeDefinition[];
+  setTheme: (theme: ThemeName | string) => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [theme, setThemeState] = useState<ThemeName>(() => ensureThemeName(getTheme()));
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const definition = THEME_DEFINITIONS[theme] ?? THEME_DEFINITIONS.default;
+    const vars = themeToCssVars(definition.tokens);
+    const root = document.documentElement;
+    Object.entries(vars).forEach(([key, value]) => {
+      root.style.setProperty(key, value);
+    });
+    persistTheme(theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === THEME_KEY) {
+        setThemeState(ensureThemeName(event.newValue));
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
+
+  const themeOptions = useMemo(
+    () => THEME_ORDER.map((id) => THEME_DEFINITIONS[id]),
+    [],
+  );
+
+  const definition = THEME_DEFINITIONS[theme] ?? THEME_DEFINITIONS.default;
+
+  const handleSetTheme = useCallback(
+    (next: ThemeName | string) => {
+      setThemeState((current) => {
+        const resolved = ensureThemeName(next);
+        return current === resolved ? current : resolved;
+      });
+    },
+    [],
+  );
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      theme,
+      definition,
+      tokens: definition.tokens,
+      themes: themeOptions,
+      setTheme: handleSetTheme,
+    }),
+    [definition, handleSetTheme, theme, themeOptions],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -22,7 +22,8 @@ import {
   setHaptics as saveHaptics,
   defaults,
 } from '../utils/settingsStore';
-import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+import { ThemeName } from '../lib/theme/tokens';
+import { useTheme } from './useTheme';
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
@@ -62,7 +63,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
-  theme: string;
+  theme: ThemeName;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -73,7 +74,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
-  setTheme: (value: string) => void;
+  setTheme: (value: ThemeName | string) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -102,6 +103,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
+  const { theme, setTheme } = useTheme();
   const [accent, setAccent] = useState<string>(defaults.accent);
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
   const [density, setDensity] = useState<Density>(defaults.density as Density);
@@ -112,7 +114,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
-  const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -127,13 +128,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
-      setTheme(loadTheme());
     })();
   }, []);
-
-  useEffect(() => {
-    saveTheme(theme);
-  }, [theme]);
 
   useEffect(() => {
     const border = shadeColor(accent, -0.2);

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,28 +1,10 @@
-import { useEffect, useState } from 'react';
-import { THEME_KEY, getTheme, setTheme as applyTheme } from '../utils/theme';
+import { useContext } from 'react';
+import { ThemeContext } from '../components/providers/ThemeProvider';
 
 export const useTheme = () => {
-  const [theme, setThemeState] = useState<string>(() => getTheme());
-
-  useEffect(() => {
-    const handleStorage = (e: StorageEvent) => {
-      if (e.key === THEME_KEY) {
-        const next = getTheme();
-        setThemeState(next);
-        applyTheme(next);
-
-      }
-    };
-    window.addEventListener('storage', handleStorage);
-    return () => window.removeEventListener('storage', handleStorage);
-  }, []);
-
-  const setTheme = (next: string) => {
-    setThemeState(next);
-    applyTheme(next);
-
-  };
-
-  return { theme, setTheme };
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
 };
-

--- a/lib/theme/tokens.ts
+++ b/lib/theme/tokens.ts
@@ -1,0 +1,134 @@
+export type ThemeName = 'default' | 'dark' | 'neon' | 'matrix';
+
+export interface ThemeTokens {
+  /** Primary background color for the shell */
+  background: string;
+  /** Default text color used on backgrounds */
+  text: string;
+  /** Accent/brand color used for buttons and focus rings */
+  primary: string;
+  /** Secondary background used for panels */
+  secondary: string;
+  /** Accent color applied to highlights */
+  accent: string;
+  /** Muted surfaces for subdued UI */
+  muted: string;
+  /** Elevated surfaces like panels */
+  surface: string;
+  /** Border color for separators */
+  border: string;
+  /** Inverse text color when needed */
+  inverse: string;
+  /** Terminal text color */
+  terminal: string;
+  /** Deep background color for cards */
+  dark: string;
+}
+
+export interface ThemeDefinition {
+  id: ThemeName;
+  label: string;
+  description: string;
+  tokens: ThemeTokens;
+}
+
+export const THEME_DEFINITIONS: Record<ThemeName, ThemeDefinition> = {
+  default: {
+    id: 'default',
+    label: 'Default',
+    description: 'Kali inspired dark shell with electric blue accents.',
+    tokens: {
+      background: '#0f1317',
+      text: '#f5f5f5',
+      primary: '#1793d1',
+      secondary: '#1a1f26',
+      accent: '#1793d1',
+      muted: '#2a2e36',
+      surface: '#1a1f26',
+      border: '#2a2e36',
+      inverse: '#000000',
+      terminal: '#00ff00',
+      dark: '#0c0f12',
+    },
+  },
+  dark: {
+    id: 'dark',
+    label: 'Dark',
+    description: 'High contrast midnight palette tuned for low-light.',
+    tokens: {
+      background: '#000000',
+      text: '#e5e5e5',
+      primary: '#1e88e5',
+      secondary: '#121212',
+      accent: '#bb86fc',
+      muted: '#1f1f1f',
+      surface: '#121212',
+      border: '#333333',
+      inverse: '#ffffff',
+      terminal: '#00ff00',
+      dark: '#0a0a0a',
+    },
+  },
+  neon: {
+    id: 'neon',
+    label: 'Neon',
+    description: 'Cyberpunk glow with magenta highlights on black.',
+    tokens: {
+      background: '#000000',
+      text: '#ffffff',
+      primary: '#39ff14',
+      secondary: '#1a1a1a',
+      accent: '#ff00ff',
+      muted: '#222222',
+      surface: '#111111',
+      border: '#333333',
+      inverse: '#ffffff',
+      terminal: '#39ff14',
+      dark: '#000000',
+    },
+  },
+  matrix: {
+    id: 'matrix',
+    label: 'Matrix',
+    description: 'Terminal green cascading code aesthetic.',
+    tokens: {
+      background: '#000000',
+      text: '#00ff00',
+      primary: '#00ff00',
+      secondary: '#001100',
+      accent: '#00ff00',
+      muted: '#003300',
+      surface: '#001100',
+      border: '#003300',
+      inverse: '#ffffff',
+      terminal: '#00ff00',
+      dark: '#000000',
+    },
+  },
+};
+
+export const THEME_ORDER: ThemeName[] = ['default', 'dark', 'neon', 'matrix'];
+
+export const themeToCssVars = (tokens: ThemeTokens): Record<string, string> => ({
+  '--color-bg': tokens.background,
+  '--color-text': tokens.text,
+  '--color-primary': tokens.primary,
+  '--color-secondary': tokens.secondary,
+  '--color-accent': tokens.accent,
+  '--color-muted': tokens.muted,
+  '--color-surface': tokens.surface,
+  '--color-border': tokens.border,
+  '--color-inverse': tokens.inverse,
+  '--color-terminal': tokens.terminal,
+  '--color-dark': tokens.dark,
+  '--color-focus-ring': tokens.accent,
+  '--color-selection': tokens.accent,
+  '--color-control-accent': tokens.accent,
+});
+
+export const ensureThemeName = (value: string | null | undefined): ThemeName => {
+  if (!value) return 'default';
+  return Object.prototype.hasOwnProperty.call(THEME_DEFINITIONS, value)
+    ? (value as ThemeName)
+    : 'default';
+};

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -10,6 +10,7 @@ import '../styles/resume-print.css';
 import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
+import { ThemeProvider } from '../components/providers/ThemeProvider';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
@@ -156,23 +157,25 @@ function MyApp(props) {
         >
           Skip to app grid
         </a>
-        <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+        <ThemeProvider>
+          <SettingsProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
-        </SettingsProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </SettingsProvider>
+        </ThemeProvider>
       </div>
     </ErrorBoundary>
 

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -1,23 +1,31 @@
+import {
+  THEME_DEFINITIONS,
+  THEME_ORDER,
+  ThemeName,
+  ensureThemeName,
+  themeToCssVars,
+} from '../lib/theme/tokens';
+
 export const THEME_KEY = 'app:theme';
 
+const DARK_THEMES: ThemeName[] = ['dark', 'neon', 'matrix'];
+
 // Score required to unlock each theme
-export const THEME_UNLOCKS: Record<string, number> = {
+export const THEME_UNLOCKS: Partial<Record<ThemeName, number>> = {
   default: 0,
   neon: 100,
   dark: 500,
   matrix: 1000,
 };
 
-const DARK_THEMES = ['dark', 'neon', 'matrix'] as const;
-
 export const isDarkTheme = (theme: string): boolean =>
-  DARK_THEMES.includes(theme as (typeof DARK_THEMES)[number]);
+  DARK_THEMES.includes(ensureThemeName(theme));
 
-export const getTheme = (): string => {
+export const getTheme = (): ThemeName => {
   if (typeof window === 'undefined') return 'default';
   try {
     const stored = window.localStorage.getItem(THEME_KEY);
-    if (stored) return stored;
+    if (stored) return ensureThemeName(stored);
     const prefersDark = window.matchMedia?.(
       '(prefers-color-scheme: dark)'
     ).matches;
@@ -29,19 +37,29 @@ export const getTheme = (): string => {
 
 export const setTheme = (theme: string): void => {
   if (typeof window === 'undefined') return;
+  const resolved = ensureThemeName(theme);
   try {
-    window.localStorage.setItem(THEME_KEY, theme);
-    document.documentElement.dataset.theme = theme;
-    document.documentElement.classList.toggle('dark', isDarkTheme(theme));
+    window.localStorage.setItem(THEME_KEY, resolved);
+    const root = document.documentElement;
+    root.dataset.theme = resolved;
+    root.classList.toggle('dark', isDarkTheme(resolved));
+    const vars = themeToCssVars(THEME_DEFINITIONS[resolved].tokens);
+    Object.entries(vars).forEach(([key, value]) => {
+      root.style.setProperty(key, value);
+    });
   } catch {
     /* ignore storage errors */
   }
 };
 
-export const getUnlockedThemes = (highScore: number): string[] =>
-  Object.entries(THEME_UNLOCKS)
-    .filter(([, score]) => highScore >= score)
-    .map(([theme]) => theme);
+export const getUnlockedThemes = (highScore: number): ThemeName[] =>
+  THEME_ORDER.filter((theme) => {
+    const required = THEME_UNLOCKS[theme] ?? Number.POSITIVE_INFINITY;
+    return highScore >= required;
+  });
 
-export const isThemeUnlocked = (theme: string, highScore: number): boolean =>
-  highScore >= (THEME_UNLOCKS[theme] ?? Infinity);
+export const isThemeUnlocked = (theme: string, highScore: number): boolean => {
+  const resolved = ensureThemeName(theme);
+  const required = THEME_UNLOCKS[resolved] ?? Number.POSITIVE_INFINITY;
+  return highScore >= required;
+};


### PR DESCRIPTION
## Summary
- define typed theme token metadata and a ThemeProvider that syncs CSS variables from those tokens
- expose the provider through useTheme/useSettings, replace the settings dropdown with the new AppearancePanel, and wire the provider into _app
- refresh Radare2 rendering to consume the shared palette and add unit tests for theme switching and persistence

## Testing
- ⚠️ `yarn lint` *(fails due to pre-existing accessibility/no-top-level-window violations in unrelated modules)*
- ⚠️ `yarn test` *(fails due to pre-existing window snapping and act warnings in unrelated suites)*
- ✅ `yarn test --runTestsByPath __tests__/themePersistence.test.tsx __tests__/radare2Guide.test.tsx __tests__/theme.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68caa9c8d15c83288a899a39fe041dc9