### PR TITLE
[design] apply elevation tokens to shell surfaces

### DIFF
--- a/__tests__/Modal.test.tsx
+++ b/__tests__/Modal.test.tsx
@@ -29,6 +29,7 @@ test('modal traps focus, disables background, and restores opener focus', async 
   const first = await screen.findByText('first');
   const second = await screen.findByText('second');
   expect(first).toHaveFocus();
+  expect(first.closest('[role="dialog"]')).toHaveClass('shadow-elevation-6');
   expect(root).toHaveAttribute('inert');
 
   second.focus();

--- a/__tests__/Popover.test.tsx
+++ b/__tests__/Popover.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Popover from '../components/base/Popover';
+
+test('popover applies elevation token and closes on outside interaction', () => {
+  const anchor = document.createElement('button');
+  document.body.appendChild(anchor);
+  const anchorRef = { current: anchor } as React.RefObject<HTMLElement>;
+  const onClose = jest.fn();
+
+  const { getByRole, unmount } = render(
+    <Popover open anchorRef={anchorRef} onClose={onClose} ariaLabel="Test popover">
+      <button type="button">Action</button>
+    </Popover>,
+  );
+
+  const dialog = getByRole('dialog', { name: 'Test popover' });
+  expect(dialog).toBeInTheDocument();
+  expect(dialog).toHaveClass('shadow-elevation-3');
+
+  fireEvent.mouseDown(document.body);
+  fireEvent.keyDown(document, { key: 'Escape' });
+  expect(onClose).toHaveBeenCalledTimes(2);
+
+  unmount();
+  document.body.removeChild(anchor);
+});
+
+test('popover does not render when closed', () => {
+  const { queryByRole } = render(
+    <Popover open={false} ariaLabel="Hidden popover">
+      <div>hidden</div>
+    </Popover>,
+  );
+
+  expect(queryByRole('dialog')).toBeNull();
+});

--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -11,6 +11,8 @@ interface ModalProps {
      * Defaults to the Next.js root (`__next`).
      */
     overlayRoot?: string | HTMLElement;
+    /** Additional class names for the modal container. */
+    className?: string;
 }
 
 const FOCUSABLE_SELECTORS = [
@@ -27,7 +29,7 @@ const FOCUSABLE_SELECTORS = [
     '[contenteditable]'
 ].join(',');
 
-const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot }) => {
+const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot, className }) => {
     const modalRef = useRef<HTMLDivElement>(null);
     const triggerRef = useRef<HTMLElement | null>(null);
     const portalRef = useRef<HTMLDivElement | null>(null);
@@ -116,6 +118,8 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
             ref={modalRef}
             onKeyDown={handleKeyDown}
             tabIndex={-1}
+            className={`shadow-elevation-6 focus:outline-none ${className ?? ''}`.trim()}
+            data-elevation="modal"
         >
             {children}
         </div>,

--- a/components/base/Popover.tsx
+++ b/components/base/Popover.tsx
@@ -1,0 +1,151 @@
+import React, { forwardRef, useEffect, useRef } from 'react';
+
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable="true"]',
+].join(',');
+
+export interface PopoverProps {
+  /** Whether the popover should be rendered. */
+  open: boolean;
+  /** Anchor element used to ignore outside-click detection. */
+  anchorRef?: React.RefObject<HTMLElement> | null;
+  /** Called when the popover requests to close (outside click or Escape). */
+  onClose?: () => void;
+  /** ARIA role applied to the popover container. */
+  role?: 'dialog' | 'menu' | 'listbox';
+  /** Additional class names applied to the container. */
+  className?: string;
+  /** Optional inline style overrides. */
+  style?: React.CSSProperties;
+  /** Whether to focus the first focusable element when opening. */
+  focusOnOpen?: boolean;
+  /** Accessible label for assistive technology. */
+  ariaLabel?: string;
+  /** Id of an element that labels the popover. */
+  ariaLabelledBy?: string;
+  children: React.ReactNode;
+}
+
+function setRef<T>(target: React.Ref<T> | undefined, value: T) {
+  if (!target) return;
+  if (typeof target === 'function') {
+    target(value);
+    return;
+  }
+  try {
+    // eslint-disable-next-line no-param-reassign
+    (target as React.MutableRefObject<T>).current = value;
+  } catch {
+    // noop – the consumer provided a readonly ref
+  }
+}
+
+const Popover = forwardRef<HTMLDivElement, PopoverProps>(function Popover(
+  {
+    open,
+    anchorRef,
+    onClose,
+    role = 'dialog',
+    className = '',
+    style,
+    focusOnOpen = true,
+    ariaLabel,
+    ariaLabelledBy,
+    children,
+  },
+  forwardedRef,
+) {
+  const localRef = useRef<HTMLDivElement | null>(null);
+  const previousFocus = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const node = localRef.current;
+    if (!node) return;
+
+    previousFocus.current = document.activeElement as HTMLElement | null;
+
+    if (focusOnOpen) {
+      const focusable = node.querySelector<HTMLElement>(FOCUSABLE_SELECTORS);
+      (focusable || node).focus({ preventScroll: true });
+    }
+
+    const handlePointer = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node;
+      if (!node.contains(target) && !anchorRef?.current?.contains(target)) {
+        onClose?.();
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        onClose?.();
+      }
+    };
+
+    document.addEventListener('mousedown', handlePointer, true);
+    document.addEventListener('touchstart', handlePointer, true);
+    document.addEventListener('keydown', handleKeyDown, true);
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointer, true);
+      document.removeEventListener('touchstart', handlePointer, true);
+      document.removeEventListener('keydown', handleKeyDown, true);
+      if (focusOnOpen) {
+        const focusTarget = previousFocus.current;
+        if (focusTarget && typeof focusTarget.focus === 'function') {
+          focusTarget.focus();
+        }
+        previousFocus.current = null;
+      }
+    };
+  }, [open, onClose, anchorRef, focusOnOpen]);
+
+  if (!open) {
+    return null;
+  }
+
+  const classes = [
+    'shadow-elevation-3',
+    'rounded-md',
+    'border',
+    'border-black/40',
+    'bg-ub-cool-grey',
+    'focus:outline-none',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .trim();
+
+  return (
+    <div
+      ref={(node) => {
+        localRef.current = node;
+        setRef(forwardedRef, node);
+      }}
+      role={role}
+      aria-modal={role === 'dialog' ? true : undefined}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      tabIndex={-1}
+      className={classes}
+      style={style}
+      data-elevation="popover"
+    >
+      {children}
+    </div>
+  );
+});
+
+Popover.displayName = 'Popover';
+
+export default Popover;

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -612,6 +612,7 @@ export class Window extends Component {
     }
 
     render() {
+        const elevationClass = this.props.isFocused ? " shadow-elevation-5 " : " shadow-elevation-4 ";
         return (
             <>
                 {this.state.snapPreview && (
@@ -635,7 +636,18 @@ export class Window extends Component {
                 >
                     <div
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        className={
+                            this.state.cursorType +
+                            " " +
+                            (this.state.closed ? " closed-window " : "") +
+                            (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") +
+                            (this.props.minimized ? " opacity-0 invisible duration-200 " : "") +
+                            (this.state.grabbed ? " opacity-70 " : "") +
+                            (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") +
+                            (this.props.isFocused ? " z-30 " : " z-20 notFocused") +
+                            elevationClass +
+                            " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute border-black border-opacity-40 border border-t-0 flex flex-col"
+                        }
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -134,7 +134,7 @@ const WhiskerMenu: React.FC = () => {
       {open && (
         <div
           ref={menuRef}
-          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
+          className="absolute left-0 mt-1 z-50 flex rounded-md border border-black/40 bg-ub-grey text-white shadow-elevation-3"
           tabIndex={-1}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node)) {

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -6,16 +6,17 @@ import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+        constructor() {
+                super();
+                this.state = {
+                        status_card: false
+                };
+                this.statusButtonRef = React.createRef();
+        }
 
-	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+        render() {
+                return (
+                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-elevation-2 flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
@@ -37,11 +38,16 @@ export default class Navbar extends Component {
                                         className={
                                                 'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
                                         }
+                                        ref={this.statusButtonRef}
                                 >
                                         <Status />
-                                        <QuickSettings open={this.state.status_card} />
+                                        <QuickSettings
+                                                open={this.state.status_card}
+                                                anchorRef={this.statusButtonRef}
+                                                onClose={() => this.setState({ status_card: false })}
+                                        />
                                 </button>
-			</div>
-		);
-	}
+                        </div>
+                );
+        }
 }

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -16,7 +16,7 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 shadow-elevation-1 flex items-center z-40" role="toolbar">
             {runningApps.map(app => (
                 <button
                     key={app.id}

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,13 +1,17 @@
 "use client";
 
-import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import type { RefObject } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+import Popover from '../base/Popover';
 
 interface Props {
   open: boolean;
+  anchorRef: RefObject<HTMLElement> | null;
+  onClose: () => void;
 }
 
-const QuickSettings = ({ open }: Props) => {
+const QuickSettings = ({ open, anchorRef, onClose }: Props) => {
   const [theme, setTheme] = usePersistentState('qs-theme', 'light');
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
@@ -21,38 +25,43 @@ const QuickSettings = ({ open }: Props) => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
 
+  if (!open) {
+    return null;
+  }
+
   return (
-    <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
-        open ? '' : 'hidden'
-      }`}
+    <Popover
+      open={open}
+      anchorRef={anchorRef}
+      onClose={onClose}
+      ariaLabel="Quick settings"
+      className="absolute top-9 right-3 w-60 space-y-3 p-4 text-sm text-ubt-grey"
     >
-      <div className="px-4 pb-2">
-        <button
-          className="w-full flex justify-between"
-          onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-        >
-          <span>Theme</span>
-          <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
-        </button>
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
+      <button
+        className="flex w-full items-center justify-between"
+        onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+        type="button"
+      >
+        <span>Theme</span>
+        <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
+      </button>
+      <label className="flex w-full items-center justify-between">
         <span>Sound</span>
         <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
+      </label>
+      <label className="flex w-full items-center justify-between">
         <span>Network</span>
         <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
+      </label>
+      <label className="flex w-full items-center justify-between">
         <span>Reduced motion</span>
         <input
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
         />
-      </div>
-    </div>
+      </label>
+    </Popover>
   );
 };
 

--- a/docs/elevation-scale.md
+++ b/docs/elevation-scale.md
@@ -1,0 +1,27 @@
+# Elevation scale
+
+The Kali desktop shell now exposes a six-tier elevation scale that mirrors the surfaces in the UI.  
+Design tokens live in [`styles/tokens.css`](../styles/tokens.css) and are surfaced as Tailwind utilities via
+`shadow-elevation-{0..6}` in [`tailwind.config.js`](../tailwind.config.js).
+
+## Token mapping
+
+| Token / utility | Typical surfaces | Notes |
+| --- | --- | --- |
+| `--shadow-elevation-0` (`shadow-elevation-0`) | Flat panels embedded in layouts | No drop shadow; used when a surface is flush with the background. |
+| `--shadow-elevation-1` (`shadow-elevation-1`) | Dock / taskbar (`components/screen/taskbar.js`) | Keeps the dock readable while sitting close to wallpaper content. |
+| `--shadow-elevation-2` (`shadow-elevation-2`) | Global top bar (`components/screen/navbar.js`) | Slight lift over the dock to prioritise status controls. |
+| `--shadow-elevation-3` (`shadow-elevation-3`) | Popovers & context menus (shared `Popover` base, Whisker menu) | Applies to quick settings, context menus, and other transient surfaces. |
+| `--shadow-elevation-4` (`shadow-elevation-4`) | Inactive application windows | Matches legacy `.window-shadow` styling while signalling the window is on the desktop plane. |
+| `--shadow-elevation-5` (`shadow-elevation-5`) | Active/focused windows | Adds separation so the focused window stands above inactive ones. |
+| `--shadow-elevation-6` (`shadow-elevation-6`) | System modals (`components/base/Modal.tsx`) and blocking overlays | Highest contrast layer for dialogs that must sit above the desktop stack. |
+
+## Verification
+
+Visual hierarchy is covered by automated snapshots:
+
+- `__tests__/Popover.test.tsx` asserts the shared popover wrapper renders with `shadow-elevation-3` and responds to outside
+  interactions.
+- `__tests__/Modal.test.tsx` now checks the modal container carries the `shadow-elevation-6` class.
+
+Run `yarn test` to exercise the assertions before shipping visual changes.

--- a/styles/index.css
+++ b/styles/index.css
@@ -105,9 +105,9 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .window-shadow {
-    box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -webkit-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -moz-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+    box-shadow: var(--shadow-elevation-4);
+    -webkit-box-shadow: var(--shadow-elevation-4);
+    -moz-box-shadow: var(--shadow-elevation-4);
 }
 
 .closed-window {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -52,6 +52,21 @@
   --motion-medium: 300ms;
   --motion-slow: 500ms;
 
+  /* Elevation shadows */
+  --shadow-elevation-0: none;
+  --shadow-elevation-1: 0 1px 1px 0 color-mix(in srgb, var(--color-inverse) 16%, transparent),
+    0 1px 2px 0 color-mix(in srgb, var(--color-inverse) 12%, transparent);
+  --shadow-elevation-2: 0 2px 4px 0 color-mix(in srgb, var(--color-inverse) 18%, transparent),
+    0 1px 2px 0 color-mix(in srgb, var(--color-inverse) 10%, transparent);
+  --shadow-elevation-3: 0 4px 8px 0 color-mix(in srgb, var(--color-inverse) 20%, transparent),
+    0 1px 3px 0 color-mix(in srgb, var(--color-inverse) 12%, transparent);
+  --shadow-elevation-4: 0 6px 16px 0 color-mix(in srgb, var(--color-inverse) 22%, transparent),
+    0 2px 6px 0 color-mix(in srgb, var(--color-inverse) 14%, transparent);
+  --shadow-elevation-5: 0 10px 24px 0 color-mix(in srgb, var(--color-inverse) 24%, transparent),
+    0 4px 12px 0 color-mix(in srgb, var(--color-inverse) 16%, transparent);
+  --shadow-elevation-6: 0 16px 32px 0 color-mix(in srgb, var(--color-inverse) 26%, transparent),
+    0 6px 20px 0 color-mix(in srgb, var(--color-inverse) 18%, transparent);
+
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
   --font-multiplier: 1;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -37,6 +37,15 @@ module.exports = {
         'ub-border-orange': 'var(--color-ub-border-orange)',
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
       },
+      boxShadow: {
+        'elevation-0': 'var(--shadow-elevation-0)',
+        'elevation-1': 'var(--shadow-elevation-1)',
+        'elevation-2': 'var(--shadow-elevation-2)',
+        'elevation-3': 'var(--shadow-elevation-3)',
+        'elevation-4': 'var(--shadow-elevation-4)',
+        'elevation-5': 'var(--shadow-elevation-5)',
+        'elevation-6': 'var(--shadow-elevation-6)',
+      },
       fontFamily: {
         ubuntu: ['Ubuntu', 'sans-serif'],
       },


### PR DESCRIPTION
## Summary
- introduce six-level elevation design tokens and surface them as Tailwind shadow utilities
- update windows, the top bar, taskbar, and shared popover wrapper so shell surfaces map to the new elevation scale
- document the mapping and add modal/popover tests that verify the expected shadow classes

## Testing
- yarn lint *(fails: repository has pre-existing jsx-a11y and no-top-level-window violations)*
- yarn test *(fails: existing suites such as window and nmap NSE tests already red; aborted watch mode after capturing failures)*

------
https://chatgpt.com/codex/tasks/task_e_68caa9c4b15483288346dfd60f912382