### PR TITLE
[ui] Compact window header redesign

### DIFF
--- a/__tests__/window-layout.test.tsx
+++ b/__tests__/window-layout.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import WindowHeader from '../components/ubuntu/window/Header';
+import { WindowEditButtons } from '../components/base/window';
+import TabbedWindow, { TabDefinition } from '../components/ui/TabbedWindow';
+
+describe('Window layout tokens', () => {
+  it('applies spacing tokens to the window header', () => {
+    render(<WindowHeader title="Alignment Check" />);
+    const header = screen.getByRole('button', { name: 'Alignment Check' });
+    expect(header.style.getPropertyValue('--window-header-padding')).toBe(
+      'calc(var(--space-2) * 2)',
+    );
+    expect(header.style.getPropertyValue('--window-header-padding-sm')).toBe('var(--space-2)');
+    expect(header.style.getPropertyValue('--window-header-min-height')).toBe(
+      'calc(var(--hit-area) + var(--space-2))',
+    );
+  });
+
+  it('applies spacing tokens to window control buttons', () => {
+    const { container } = render(
+      <WindowEditButtons
+        minimize={() => undefined}
+        maximize={() => undefined}
+        isMaximised={false}
+        close={() => undefined}
+        id="tokens"
+        allowMaximize
+      />,
+    );
+    const controls = container.firstChild as HTMLElement;
+    expect(controls.style.getPropertyValue('--window-controls-gap')).toBe('var(--space-2)');
+    expect(controls.style.getPropertyValue('--window-control-size')).toBe('var(--hit-area)');
+    expect(controls.style.getPropertyValue('--window-control-size-sm')).toBe(
+      'calc(var(--hit-area) - var(--space-2))',
+    );
+  });
+});
+
+describe('TabbedWindow layout tokens', () => {
+  const tabs: TabDefinition[] = [
+    { id: 'one', title: 'First Tab', content: <div>One</div> },
+    { id: 'two', title: 'Second Tab', content: <div>Two</div> },
+  ];
+
+  it('exposes spacing custom properties on the tab bar', () => {
+    render(<TabbedWindow initialTabs={tabs} />);
+    const tablist = screen.getByRole('tablist');
+    expect(tablist.style.getPropertyValue('--tab-bar-gap')).toBe('var(--space-2)');
+    expect(tablist.style.getPropertyValue('--tab-height')).toBe('var(--hit-area)');
+    expect(tablist.style.getPropertyValue('--tab-padding-inline')).toBe('calc(var(--space-2) * 2)');
+    const firstTab = screen.getByRole('tab', { name: /First Tab/ });
+    expect(firstTab.getAttribute('aria-selected')).toBe('true');
+    const closeButtons = screen.getAllByRole('button', { name: 'Close Tab' });
+    expect(closeButtons.length).toBeGreaterThan(0);
+    expect(tablist.style.getPropertyValue('--tab-close-size')).toBe('calc(var(--hit-area) / 2)');
+  });
+
+  it('renders a new tab button with aligned hit area when provided', () => {
+    const createTab = () => ({ id: 'three', title: 'Third Tab', content: <div>Three</div> });
+    render(<TabbedWindow initialTabs={tabs} onNewTab={createTab} />);
+    const newTabButton = screen.getByRole('button', { name: 'New Tab' });
+    expect(newTabButton).toBeInTheDocument();
+    const tablist = screen.getByRole('tablist');
+    expect(tablist.style.getPropertyValue('--new-tab-size')).toBe('var(--hit-area)');
+  });
+});

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -7,6 +7,8 @@ import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
 import styles from './window.module.css';
+import WindowHeader from '../ubuntu/window/Header';
+import headerStyles from '../ubuntu/window/Header.module.css';
 
 export class Window extends Component {
     constructor(props) {
@@ -676,16 +678,12 @@ export default Window
 // Window's title bar
 export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
     return (
-        <div
-            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
-            tabIndex={0}
-            role="button"
-            aria-grabbed={grabbed}
+        <WindowHeader
+            title={title}
+            grabbed={grabbed}
             onKeyDown={onKeyDown}
             onBlur={onBlur}
-        >
-            <div className="flex justify-center w-full text-sm font-bold">{title}</div>
-        </div>
+        />
     )
 }
 
@@ -733,13 +731,22 @@ export class WindowXBorder extends Component {
 export function WindowEditButtons(props) {
     const { togglePin } = useDocPiP(props.pip || (() => null));
     const pipSupported = typeof window !== 'undefined' && !!window.documentPictureInPicture;
+    const controlTokens = {
+        '--window-controls-offset': 'var(--space-2)',
+        '--window-controls-gap': 'var(--space-2)',
+        '--window-control-size': 'var(--hit-area)',
+        '--window-control-size-sm': 'calc(var(--hit-area) - var(--space-2))',
+        '--window-control-radius': 'var(--radius-lg)',
+    };
+    const secondaryButtonClass = `${headerStyles.controlButton} ${headerStyles.controlButtonSecondary}`;
+    const closeButtonClass = `${headerStyles.controlButton} ${headerStyles.controlButtonClose}`;
     return (
-        <div className="absolute select-none right-0 top-0 mt-1 mr-1 flex justify-center items-center h-11 min-w-[8.25rem]">
+        <div className={headerStyles.controls} style={controlTokens}>
             {pipSupported && props.pip && (
                 <button
                     type="button"
                     aria-label="Window pin"
-                    className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                    className={secondaryButtonClass}
                     onClick={togglePin}
                 >
                     <NextImage
@@ -755,7 +762,7 @@ export function WindowEditButtons(props) {
             <button
                 type="button"
                 aria-label="Window minimize"
-                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                className={secondaryButtonClass}
                 onClick={props.minimize}
             >
                 <NextImage
@@ -773,7 +780,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window restore"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className={secondaryButtonClass}
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -789,7 +796,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window maximize"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className={secondaryButtonClass}
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -807,7 +814,7 @@ export function WindowEditButtons(props) {
                 type="button"
                 id={`close-${props.id}`}
                 aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
+                className={closeButtonClass}
                 onClick={props.close}
             >
                 <NextImage

--- a/components/ubuntu/window/Header.module.css
+++ b/components/ubuntu/window/Header.module.css
@@ -1,0 +1,94 @@
+.header {
+  --window-header-padding: calc(var(--space-2) * 2);
+  --window-header-padding-sm: var(--space-2);
+  --window-header-min-height: calc(var(--hit-area) + var(--space-2));
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding-inline: var(--window-header-padding);
+  min-height: var(--window-header-min-height);
+  color: var(--color-text);
+  background-color: var(--color-ub-window-title);
+  border-top-left-radius: var(--radius-lg);
+  border-top-right-radius: var(--radius-lg);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  user-select: none;
+  text-transform: none;
+  letter-spacing: 0.01em;
+}
+
+.title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  line-height: 1.2;
+  max-width: calc(100% - var(--hit-area));
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-inline: var(--space-2);
+}
+
+.controls {
+  position: absolute;
+  top: var(--window-controls-offset, var(--space-2));
+  right: var(--window-controls-offset, var(--space-2));
+  display: flex;
+  align-items: center;
+  gap: var(--window-controls-gap, var(--space-2));
+  user-select: none;
+}
+
+.controlButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--window-control-size, var(--hit-area));
+  height: var(--window-control-size, var(--hit-area));
+  border-radius: var(--window-control-radius, var(--radius-lg));
+  border: 1px solid transparent;
+  background-color: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  padding: 0;
+  cursor: pointer;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease,
+    transform var(--motion-fast) ease;
+}
+
+.controlButton:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.controlButton:focus-visible {
+  outline: var(--focus-outline-width) solid var(--focus-outline-color);
+  outline-offset: 2px;
+}
+
+.controlButtonSecondary {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.controlButtonClose {
+  background-color: var(--color-ub-cool-grey);
+  border-color: rgba(255, 255, 255, 0.24);
+}
+
+.controlButtonClose:hover {
+  background-color: var(--color-ub-cool-grey);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+@media (max-width: 640px) {
+  .header {
+    padding-inline: var(--window-header-padding-sm);
+  }
+
+  .controlButton {
+    width: var(--window-control-size-sm, calc(var(--hit-area) - var(--space-2)));
+    height: var(--window-control-size-sm, calc(var(--hit-area) - var(--space-2)));
+  }
+}

--- a/components/ubuntu/window/Header.tsx
+++ b/components/ubuntu/window/Header.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import clsx from 'clsx';
+import styles from './Header.module.css';
+
+type WindowHeaderProps = {
+  title: string;
+  grabbed?: boolean;
+  onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
+  onBlur?: React.FocusEventHandler<HTMLDivElement>;
+  className?: string;
+};
+
+const headerStyle: React.CSSProperties = {
+  '--window-header-padding': 'calc(var(--space-2) * 2)',
+  '--window-header-padding-sm': 'var(--space-2)',
+  '--window-header-min-height': 'calc(var(--hit-area) + var(--space-2))',
+};
+
+const WindowHeader: React.FC<WindowHeaderProps> = ({
+  title,
+  grabbed = false,
+  onKeyDown,
+  onBlur,
+  className,
+}) => {
+  return (
+    <div
+      className={clsx(styles.header, 'bg-ub-window-title', className)}
+      tabIndex={0}
+      role="button"
+      aria-grabbed={grabbed}
+      onKeyDown={onKeyDown}
+      onBlur={onBlur}
+      style={headerStyle}
+    >
+      <span className={styles.title} title={title}>
+        {title}
+      </span>
+    </div>
+  );
+};
+
+WindowHeader.displayName = 'WindowHeader';
+
+export default WindowHeader;

--- a/components/ui/TabbedWindow.module.css
+++ b/components/ui/TabbedWindow.module.css
@@ -1,0 +1,161 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+}
+
+.tabBar {
+  --tab-bar-gap: var(--space-2);
+  --tab-bar-padding-inline: calc(var(--space-2) * 2);
+  --tab-bar-padding-inline-sm: var(--space-2);
+  --tab-bar-padding-block: var(--space-2);
+  --tab-gap: var(--space-2);
+  --tab-height: var(--hit-area);
+  --tab-radius: var(--radius-lg);
+  --tab-padding-inline: calc(var(--space-2) * 2);
+  --tab-padding-inline-sm: var(--space-2);
+  --tab-close-size: calc(var(--hit-area) / 2);
+  --new-tab-size: var(--hit-area);
+  display: flex;
+  align-items: center;
+  gap: var(--tab-bar-gap);
+  padding: var(--tab-bar-padding-block) var(--tab-bar-padding-inline);
+  background-color: var(--color-ub-lite-abrgn);
+  color: var(--color-text);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  overflow-x: auto;
+}
+
+.tabsScroll {
+  display: flex;
+  align-items: center;
+  gap: var(--tab-bar-gap);
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--tab-gap);
+  padding-inline: var(--tab-padding-inline);
+  min-height: var(--tab-height);
+  border-radius: var(--tab-radius);
+  border: 1px solid transparent;
+  background-color: transparent;
+  color: inherit;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease;
+  white-space: nowrap;
+}
+
+.tabActive {
+  background-color: var(--color-ub-med-abrgn);
+  border-color: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
+.tab:focus-visible {
+  outline: var(--focus-outline-width) solid var(--focus-outline-color);
+  outline-offset: 2px;
+}
+
+.tabLabel {
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tabCloseButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--tab-close-size);
+  height: var(--tab-close-size);
+  border-radius: var(--radius-md);
+  background-color: transparent;
+  border: 1px solid transparent;
+  color: inherit;
+  font-size: 0.875rem;
+  line-height: 1;
+  padding: 0;
+  cursor: pointer;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease;
+}
+
+.tabCloseButton:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.tabCloseButton:focus-visible {
+  outline: var(--focus-outline-width) solid var(--focus-outline-color);
+  outline-offset: 1px;
+}
+
+.newTabButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--new-tab-size);
+  height: var(--new-tab-size);
+  border-radius: var(--tab-radius);
+  border: 1px dashed rgba(255, 255, 255, 0.24);
+  background-color: transparent;
+  color: inherit;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease;
+}
+
+.newTabButton:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+  border-style: solid;
+}
+
+.newTabButton:focus-visible {
+  outline: var(--focus-outline-width) solid var(--focus-outline-color);
+  outline-offset: 1px;
+}
+
+.panelContainer {
+  position: relative;
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
+.panel {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.panelHidden {
+  display: none;
+}
+
+@media (max-width: 640px) {
+  .tabBar {
+    padding-inline: var(--tab-bar-padding-inline-sm);
+    gap: var(--space-1);
+  }
+
+  .tabsScroll {
+    gap: var(--space-1);
+  }
+
+  .tab {
+    padding-inline: var(--tab-padding-inline-sm);
+  }
+
+  .tabLabel {
+    max-width: 9rem;
+  }
+}


### PR DESCRIPTION
## Summary
- implement a dedicated Ubuntu window header component that consumes spacing tokens and applies the compact styling
- refresh the window controls and tabbed window bar to follow the 8px grid, updated radii, and responsive breakpoints
- add Jest coverage that asserts the spacing token usage for the header, controls, and tab bar

## Testing
- yarn lint *(fails: pre-existing accessibility violations across apps)*
- yarn test __tests__/window-layout.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68caa9cd42ac832895dc6aeeb5f2f9a1