### PR TITLE
[settings] Accent picker and theming tests

### DIFF
--- a/__tests__/accent.test.tsx
+++ b/__tests__/accent.test.tsx
@@ -1,0 +1,65 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { SettingsProvider, useSettings, ACCENT_OPTIONS } from '../hooks/useSettings';
+import { defaults } from '../utils/settingsStore';
+
+jest.mock('idb-keyval', () => ({
+  get: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn(),
+  del: jest.fn(),
+}));
+
+describe('accent theming', () => {
+  beforeEach(() => {
+    document.documentElement.style.cssText = '';
+    window.localStorage.clear();
+  });
+
+  it('updates CSS variables when accent changes', async () => {
+    const { result } = renderHook(() => useSettings(), {
+      wrapper: SettingsProvider,
+    });
+
+    const option = ACCENT_OPTIONS.find((entry) => entry.value !== defaults.accent);
+    expect(option).toBeDefined();
+
+    await waitFor(() => {
+      expect(result.current.accent).toBe(defaults.accent);
+    });
+
+    await act(async () => {
+      result.current.setAccent(option!.value);
+    });
+
+    await waitFor(() => {
+      expect(
+        document.documentElement.style.getPropertyValue('--color-accent')
+      ).toBe(option!.value);
+      expect(
+        document.documentElement.style.getPropertyValue('--color-focus-ring')
+      ).toBe(option!.value);
+      expect(
+        document.documentElement.style.getPropertyValue('--color-ub-orange')
+      ).toBe(option!.value);
+      expect(
+        document.documentElement.style.getPropertyValue('--focus-outline-color')
+      ).toBe(option!.value);
+    });
+  });
+
+  it('falls back to default accent when stored value is missing', async () => {
+    const { result } = renderHook(() => useSettings(), {
+      wrapper: SettingsProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.accent).toBe(defaults.accent);
+    });
+
+    expect(
+      document.documentElement.style.getPropertyValue('--color-accent')
+    ).toBe(defaults.accent);
+    expect(
+      document.documentElement.style.getPropertyValue('--color-ub-orange')
+    ).toBe(defaults.accent);
+  });
+});

--- a/apps/settings/components/AccentPicker.tsx
+++ b/apps/settings/components/AccentPicker.tsx
@@ -1,0 +1,61 @@
+import { ACCENT_OPTIONS } from "../../../hooks/useSettings";
+import { getAccessibleTextColor } from "../../../utils/color";
+
+type Props = {
+  value: string;
+  onChange: (accent: string) => void;
+};
+
+const AccentPicker = ({ value, onChange }: Props) => {
+  return (
+    <fieldset className="w-full max-w-xl">
+      <legend className="mb-3 text-sm font-semibold uppercase tracking-wide text-ubt-grey">
+        Accent color
+      </legend>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-6">
+        {ACCENT_OPTIONS.map((option) => {
+          const isSelected = option.value === value;
+          return (
+            <label
+              key={option.id}
+              className="flex cursor-pointer flex-col items-center gap-2 text-xs text-ubt-grey"
+            >
+              <input
+                type="radio"
+                name="accent-color"
+                value={option.value}
+                checked={isSelected}
+                onChange={() => onChange(option.value)}
+                className="peer sr-only"
+                aria-label={`select-accent-${option.id}`}
+              />
+              <span
+                aria-hidden="true"
+                className="flex h-12 w-12 items-center justify-center rounded-full border-2 border-transparent transition-all duration-200 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-[var(--color-focus-ring)] peer-focus-visible:outline-offset-2"
+                style={{
+                  backgroundColor: option.value,
+                  borderColor: isSelected ? "#ffffff" : "transparent",
+                  boxShadow: isSelected
+                    ? `0 0 0 4px ${option.value}40`
+                    : "none",
+                }}
+              >
+                {isSelected && (
+                  <span
+                    className="text-sm font-semibold"
+                    style={{ color: getAccessibleTextColor(option.value) }}
+                  >
+                    ✓
+                  </span>
+                )}
+              </span>
+              <span>{option.label}</span>
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+};
+
+export default AccentPicker;

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
-import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
+import { useSettings } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
   resetSettings,
@@ -9,9 +9,11 @@ import {
   exportSettings as exportSettingsData,
   importSettings as importSettingsData,
 } from "../../utils/settingsStore";
+import { getAccessibleTextColor } from "../../utils/color";
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import AccentPicker from "./components/AccentPicker";
 
 export default function Settings() {
   const {
@@ -134,20 +136,23 @@ export default function Settings() {
               <option value="matrix">Matrix</option>
             </select>
           </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Accent:</label>
-            <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
-              {ACCENT_OPTIONS.map((c) => (
+          <div className="flex justify-center my-4 px-4">
+            <AccentPicker value={accent} onChange={setAccent} />
+          </div>
+          <div className="flex justify-center my-4 px-4">
+            <div className="w-full max-w-md rounded-lg border border-[var(--color-border)] bg-[var(--color-ub-lite-abrgn)] p-4 text-center text-ubt-grey shadow" role="presentation">
+              <p className="text-sm font-semibold uppercase tracking-wide">Accent preview</p>
+              <div className="mt-3 flex flex-col items-center gap-2">
                 <button
-                  key={c}
-                  aria-label={`select-accent-${c}`}
-                  role="radio"
-                  aria-checked={accent === c}
-                  onClick={() => setAccent(c)}
-                  className={`w-8 h-8 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
-                  style={{ backgroundColor: c }}
-                />
-              ))}
+                  className="rounded-md px-4 py-2 font-medium shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+                  style={{ backgroundColor: accent, color: getAccessibleTextColor(accent) }}
+                >
+                  Accent button
+                </button>
+                <span className="text-xs text-ubt-grey">
+                  Buttons, sliders, and focus rings use this color.
+                </span>
+              </div>
             </div>
           </div>
           <div className="flex justify-center my-4">

--- a/apps/volatility/components/TriageFilters.tsx
+++ b/apps/volatility/components/TriageFilters.tsx
@@ -48,9 +48,9 @@ const TriageFilters: React.FC = () => {
           <label key={sev} className="flex items-center space-x-1">
             <input
               type="checkbox"
-              className="accent-blue-500"
               checked={activeFilters.includes(sev)}
               onChange={() => toggleFilter(sev)}
+              style={{ accentColor: 'var(--color-control-accent)' }}
             />
             <span className="capitalize">{sev}</span>
           </label>

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -39,15 +39,15 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
               role="radiogroup"
               className="flex gap-2 mt-1"
             >
-              {ACCENT_OPTIONS.map((c) => (
+              {ACCENT_OPTIONS.map((option) => (
                 <button
-                  key={c}
-                  aria-label={`select-accent-${c}`}
+                  key={option.id}
+                  aria-label={`select-accent-${option.id}`}
                   role="radio"
-                  aria-checked={accent === c}
-                  onClick={() => setAccent(c)}
-                  className={`w-6 h-6 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
-                  style={{ backgroundColor: c }}
+                  aria-checked={accent === option.value}
+                  onClick={() => setAccent(option.value)}
+                  className={`w-6 h-6 rounded-full border-2 ${accent === option.value ? 'border-white' : 'border-transparent'}`}
+                  style={{ backgroundColor: option.value }}
                 />
               ))}
             </div>

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -75,15 +75,15 @@ export function Settings() {
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Accent:</label>
                 <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
-                    {ACCENT_OPTIONS.map((c) => (
+                    {ACCENT_OPTIONS.map((option) => (
                         <button
-                            key={c}
-                            aria-label={`select-accent-${c}`}
+                            key={option.id}
+                            aria-label={`select-accent-${option.id}`}
                             role="radio"
-                            aria-checked={accent === c}
-                            onClick={() => setAccent(c)}
-                            className={`w-8 h-8 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
-                            style={{ backgroundColor: c }}
+                            aria-checked={accent === option.value}
+                            onClick={() => setAccent(option.value)}
+                            className={`w-8 h-8 rounded-full border-2 ${accent === option.value ? 'border-white' : 'border-transparent'}`}
+                            style={{ backgroundColor: option.value }}
                         />
                     ))}
                 </div>

--- a/components/apps/sokoban.js
+++ b/components/apps/sokoban.js
@@ -346,8 +346,9 @@ const move = ({ x, y }) => {
           max={historyRef.current.length - 1}
           value={historyIndex}
           onChange={handleRewind}
-          className="w-32 accent-blue-500 bg-gray-600"
+          className="w-32 bg-gray-600 ubuntu-slider"
           aria-label="Rewind moves"
+          style={{ accentColor: 'var(--color-control-accent)' }}
         />
         <div>Moves: {state.moves}</div>
         <div>Pushes: {state.pushes}</div>

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -27,13 +27,15 @@ type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
 export const ACCENT_OPTIONS = [
-  '#1793d1', // kali blue (default)
-  '#e53e3e', // red
-  '#d97706', // orange
-  '#38a169', // green
-  '#805ad5', // purple
-  '#ed64a6', // pink
-];
+  { id: 'kali-blue', label: 'Kali blue', value: '#1793d1' },
+  { id: 'signal-red', label: 'Signal red', value: '#e53e3e' },
+  { id: 'amber', label: 'Amber', value: '#d97706' },
+  { id: 'emerald', label: 'Emerald', value: '#38a169' },
+  { id: 'violet', label: 'Violet', value: '#805ad5' },
+  { id: 'magenta', label: 'Magenta', value: '#ed64a6' },
+] as const;
+
+export type AccentOption = (typeof ACCENT_OPTIONS)[number];
 
 // Utility to lighten or darken a hex color by a percentage
 const shadeColor = (color: string, percent: number): string => {
@@ -145,6 +147,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       '--color-focus-ring': accent,
       '--color-selection': accent,
       '--color-control-accent': accent,
+      '--focus-outline-color': accent,
     };
     Object.entries(vars).forEach(([key, value]) => {
       document.documentElement.style.setProperty(key, value);

--- a/styles/index.css
+++ b/styles/index.css
@@ -66,17 +66,36 @@ button:focus-visible {
 input[type=range].ubuntu-slider {
     outline: none;
     -webkit-appearance: none;
+    appearance: none;
     background: linear-gradient(
         to right,
-        color-mix(in srgb, var(--color-text), transparent 70%) 0%,
-        color-mix(in srgb, var(--color-text), transparent 70%) 100%
+        color-mix(in srgb, var(--color-control-accent), transparent 40%) 0%,
+        color-mix(in srgb, var(--color-control-accent), transparent 40%) 100%
     );
     background-position: center;
-    background-size: 99% 3px;
+    background-size: 100% 4px;
     background-repeat: no-repeat;
-    /* width: 65%; */
     height: 6px;
-    border-radius: 50%;
+    border-radius: 9999px;
+    accent-color: var(--color-control-accent);
+}
+
+input[type=range].ubuntu-slider::-webkit-slider-runnable-track {
+    height: 4px;
+    border-radius: 9999px;
+    background: color-mix(in srgb, var(--color-control-accent), transparent 45%);
+}
+
+input[type=range].ubuntu-slider::-moz-range-track {
+    height: 4px;
+    border-radius: 9999px;
+    background: color-mix(in srgb, var(--color-control-accent), transparent 45%);
+}
+
+input[type=range].ubuntu-slider::-moz-range-progress {
+    height: 4px;
+    border-radius: 9999px;
+    background-color: var(--color-control-accent);
 }
 
 input[type=range].ubuntu-slider::-webkit-slider-thumb {
@@ -85,12 +104,22 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
     -webkit-appearance: none;
-    background-color: var(--color-surface);
+    background-color: var(--color-control-accent);
+    border: 2px solid color-mix(in srgb, var(--color-control-accent), transparent 35%);
     pointer-events: none;
     border-radius: 50%;
-    width: 12px;
-    height: 12px;
+    width: 14px;
+    height: 14px;
     position: relative;
+}
+
+input[type=range].ubuntu-slider::-moz-range-thumb {
+    box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-inverse), transparent 80%);
+    background-color: var(--color-control-accent);
+    border: 2px solid color-mix(in srgb, var(--color-control-accent), transparent 35%);
+    border-radius: 50%;
+    width: 14px;
+    height: 14px;
 }
 
 .notFocused {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -58,7 +58,7 @@
   /* Minimum interactive target size */
   --hit-area: 32px;
   /* Focus outline */
-  --focus-outline-color: var(--color-ubt-blue);
+  --focus-outline-color: var(--color-focus-ring);
   --focus-outline-width: 2px;
 }
 

--- a/utils/color.ts
+++ b/utils/color.ts
@@ -1,0 +1,43 @@
+export type RGB = { r: number; g: number; b: number };
+
+export const hexToRgb = (hex: string): RGB | null => {
+  const normalized = hex.replace('#', '');
+  if (normalized.length !== 6) return null;
+  const value = parseInt(normalized, 16);
+  return {
+    r: (value >> 16) & 255,
+    g: (value >> 8) & 255,
+    b: value & 255,
+  };
+};
+
+const srgbToLinear = (value: number): number => {
+  const scaled = value / 255;
+  return scaled <= 0.03928
+    ? scaled / 12.92
+    : Math.pow((scaled + 0.055) / 1.055, 2.4);
+};
+
+export const relativeLuminance = ({ r, g, b }: RGB): number =>
+  0.2126 * srgbToLinear(r) +
+  0.7152 * srgbToLinear(g) +
+  0.0722 * srgbToLinear(b);
+
+export const contrastRatio = (a: RGB, b: RGB): number => {
+  const lumA = relativeLuminance(a);
+  const lumB = relativeLuminance(b);
+  const brighter = Math.max(lumA, lumB);
+  const darker = Math.min(lumA, lumB);
+  return (brighter + 0.05) / (darker + 0.05);
+};
+
+const WHITE: RGB = { r: 255, g: 255, b: 255 };
+const BLACK: RGB = { r: 0, g: 0, b: 0 };
+
+export const getAccessibleTextColor = (hex: string): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return '#ffffff';
+  return contrastRatio(rgb, BLACK) >= contrastRatio(rgb, WHITE)
+    ? '#000000'
+    : '#ffffff';
+};


### PR DESCRIPTION
## Summary
- add an accessible accent picker with preview to the settings appearance tab and share palette metadata
- bind the accent CSS token to interactive elements, including range sliders and smaller controls using CSS variables
- add regression coverage to ensure accent selections propagate and default values apply when storage is empty

## Testing
- yarn lint *(fails: existing accessibility label violations in unrelated apps)*
- yarn test __tests__/accent.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68caa9caedbc83288c1baf204ca0549a