### PR TITLE
spotify: add media key indicator overlay

### DIFF
--- a/__tests__/apps/spotify/media-keys.test.tsx
+++ b/__tests__/apps/spotify/media-keys.test.tsx
@@ -1,0 +1,92 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import SpotifyApp from "../../../apps/spotify";
+
+describe("Spotify media key integration", () => {
+  const renderWithWindow = () => {
+    const windowRoot = document.createElement("div");
+    windowRoot.id = "spotify";
+    windowRoot.tabIndex = 0;
+    const container = document.createElement("div");
+    windowRoot.appendChild(container);
+    document.body.appendChild(windowRoot);
+    render(<SpotifyApp />, { container });
+    return { windowRoot };
+  };
+
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+  });
+
+  it("handles media track navigation when the window is focused", async () => {
+    const { windowRoot } = renderWithWindow();
+    const appRoot = windowRoot.querySelector('[tabindex="0"]') as HTMLElement | null;
+    expect(appRoot).toBeTruthy();
+    appRoot?.focus();
+
+    await act(async () => {
+      fireEvent.keyDown(window, { code: "MediaTrackNext", key: "MediaTrackNext" });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText("Song 2", { selector: "p" })).toBeInTheDocument(),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent("Next track"),
+    );
+
+    await act(async () => {
+      fireEvent.keyDown(window, { code: "MediaTrackPrevious", key: "MediaTrackPrevious" });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText("Song 1", { selector: "p" })).toBeInTheDocument(),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent("Previous track"),
+    );
+  });
+
+  it("ignores media keys when the Spotify window is not focused", async () => {
+    renderWithWindow();
+    const outsideButton = document.createElement("button");
+    outsideButton.textContent = "outside";
+    outsideButton.tabIndex = 0;
+    document.body.appendChild(outsideButton);
+    outsideButton.focus();
+
+    await act(async () => {
+      fireEvent.keyDown(window, { code: "MediaTrackNext", key: "MediaTrackNext" });
+    });
+
+    expect(screen.getByText("Song 1", { selector: "p" })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toBeEmptyDOMElement();
+    outsideButton.remove();
+  });
+
+  it("toggles playback state with the media play/pause key", async () => {
+    const { windowRoot } = renderWithWindow();
+    const appRoot = windowRoot.querySelector('[tabindex="0"]') as HTMLElement | null;
+    expect(appRoot).toBeTruthy();
+    appRoot?.focus();
+
+    const playButton = screen.getByRole("button", { name: "Play/Pause" });
+    expect(playButton).toHaveAttribute("aria-pressed", "false");
+
+    await act(async () => {
+      fireEvent.keyDown(window, { code: "MediaPlayPause", key: "MediaPlayPause" });
+    });
+
+    await waitFor(() => expect(playButton).toHaveAttribute("aria-pressed", "true"));
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent("Playing"),
+    );
+
+    await act(async () => {
+      fireEvent.keyDown(window, { code: "MediaPlayPause", key: "MediaPlayPause" });
+    });
+
+    await waitFor(() => expect(playButton).toHaveAttribute("aria-pressed", "false"));
+    await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent("Paused"));
+  });
+});

--- a/apps/spotify/MediaIndicator.tsx
+++ b/apps/spotify/MediaIndicator.tsx
@@ -1,0 +1,26 @@
+import type { FC } from "react";
+
+interface MediaIndicatorProps {
+  action: string | null;
+}
+
+const MediaIndicator: FC<MediaIndicatorProps> = ({ action }) => {
+  return (
+    <div className="pointer-events-none fixed inset-x-0 top-4 z-50 flex justify-center">
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className={`transition-opacity duration-200 ${action ? "opacity-100" : "opacity-0"}`}
+      >
+        {action && (
+          <span className="inline-block rounded-full bg-black/70 px-4 py-2 text-sm text-white shadow-lg">
+            {action}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MediaIndicator;


### PR DESCRIPTION
## Summary
- add Spotify playback indicator state and register global media key listeners when the window is focused
- render an aria-live MediaIndicator overlay and label existing transport controls for accessibility
- cover media key navigation, focus gating, and play/pause toggles with unit tests

## Testing
- yarn test __tests__/apps/spotify/media-keys.test.tsx
- npx eslint apps/spotify/index.tsx apps/spotify/MediaIndicator.tsx __tests__/apps/spotify/media-keys.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc28163468832898edff8d5ac04246