### PR TITLE
[beef] add queue monitor

### DIFF
--- a/__tests__/apps/beef/queue-monitor.test.tsx
+++ b/__tests__/apps/beef/queue-monitor.test.tsx
@@ -1,0 +1,70 @@
+import { queueActions, queueStore } from '../../../apps/beef/state/queueStore';
+
+describe('BeEF queue store', () => {
+  beforeEach(() => {
+    queueActions.resetQueue();
+  });
+
+  test('enqueues commands with default state', () => {
+    const item = queueActions.enqueueCommand('Collect DOM snapshot');
+    const { items } = queueStore.getState();
+
+    expect(items).toHaveLength(1);
+    expect(item.status).toBe('queued');
+    expect(item.retries).toBe(0);
+    expect(item.failures).toHaveLength(0);
+  });
+
+  test('tracks failures with retry counters and logs', () => {
+    const item = queueActions.enqueueCommand('Deploy payload', { maxRetries: 3 });
+    queueActions.markCommandRunning(item.id);
+
+    queueActions.markCommandFailure(item.id, 'Sandbox refused inline script execution.');
+    queueActions.markCommandFailure(item.id, 'Content-Security-Policy blocked injection.');
+
+    const [stored] = queueStore.getState().items;
+    expect(stored.status).toBe('failed');
+    expect(stored.retries).toBe(2);
+    expect(stored.failures).toHaveLength(2);
+    expect(stored.failures[0].attempt).toBe(1);
+    expect(stored.failures[1].message).toContain('Content-Security-Policy');
+  });
+
+  test('retry only succeeds while attempts remain', () => {
+    const item = queueActions.enqueueCommand('Escalate privileges', { maxRetries: 2 });
+    queueActions.markCommandFailure(item.id, 'First failure');
+
+    const retried = queueActions.retryCommand(item.id);
+    expect(retried?.status).toBe('queued');
+
+    queueActions.markCommandFailure(item.id, 'Second failure');
+    const rejected = queueActions.retryCommand(item.id);
+
+    expect(rejected).toBeUndefined();
+    const [stored] = queueStore.getState().items;
+    expect(stored.retries).toBe(2);
+    expect(stored.status).toBe('failed');
+  });
+
+  test('remove command clears it from the queue', () => {
+    const first = queueActions.enqueueCommand('Stage hook');
+    const second = queueActions.enqueueCommand('Await callbacks');
+
+    queueActions.removeCommand(first.id);
+    const { items } = queueStore.getState();
+
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe(second.id);
+  });
+
+  test('success clears any last error', () => {
+    const item = queueActions.enqueueCommand('Collect screenshot');
+    queueActions.markCommandFailure(item.id, 'DOM snapshot timed out.');
+
+    queueActions.markCommandSuccess(item.id);
+    const [stored] = queueStore.getState().items;
+
+    expect(stored.status).toBe('success');
+    expect(stored.lastError).toBeUndefined();
+  });
+});

--- a/apps/beef/components/QueueLogModal.tsx
+++ b/apps/beef/components/QueueLogModal.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React from 'react';
+import type { QueueItem } from '../state/queueStore';
+
+interface QueueLogModalProps {
+  item: QueueItem;
+  onClose: () => void;
+}
+
+const formatTimestamp = (value: number) => {
+  try {
+    return new Date(value).toLocaleString();
+  } catch (error) {
+    return `${value}`;
+  }
+};
+
+export default function QueueLogModal({ item, onClose }: QueueLogModalProps) {
+  return (
+    <div
+      role="presentation"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Failure details for ${item.command}`}
+        className="w-[min(32rem,90vw)] rounded border border-gray-700 bg-ub-cool-grey shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="flex items-center justify-between border-b border-gray-700 px-4 py-3">
+          <h2 className="text-lg font-semibold">Failure log</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded px-2 py-1 text-sm text-gray-300 transition hover:bg-black/30 hover:text-white"
+          >
+            Close
+          </button>
+        </header>
+        <div className="max-h-[60vh] overflow-y-auto px-4 py-3 text-sm">
+          {item.failures.length === 0 ? (
+            <p className="text-gray-300">No failures recorded for this command.</p>
+          ) : (
+            <ul className="space-y-3">
+              {item.failures.map((failure) => (
+                <li
+                  key={failure.id}
+                  className="rounded border border-gray-700 bg-black/30 p-3"
+                >
+                  <div className="flex items-center justify-between text-xs text-gray-400">
+                    <span>Attempt {failure.attempt}</span>
+                    <span>{formatTimestamp(failure.timestamp)}</span>
+                  </div>
+                  <p className="mt-2 text-gray-100">{failure.message}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/beef/index.tsx
+++ b/apps/beef/index.tsx
@@ -1,29 +1,80 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import BeefApp from '../../components/apps/beef';
+import QueueLogModal from './components/QueueLogModal';
+import {
+  queueActions,
+  useQueueStore,
+  type QueueItem,
+  type QueueStatus,
+} from './state/queueStore';
 
-type Severity = 'Low' | 'Medium' | 'High';
+const statusStyles: Record<QueueStatus, string> = {
+  queued: 'bg-slate-600 text-white',
+  running: 'bg-blue-700 text-white',
+  success: 'bg-green-700 text-white',
+  failed: 'bg-red-700 text-white',
+};
 
-interface LogEntry {
-  time: string;
-  severity: Severity;
-  message: string;
-}
-
-const severityStyles: Record<Severity, { icon: string; color: string }> = {
-  Low: { icon: '🟢', color: 'bg-green-700' },
-  Medium: { icon: '🟡', color: 'bg-yellow-700' },
-  High: { icon: '🔴', color: 'bg-red-700' },
+const statusLabels: Record<QueueStatus, string> = {
+  queued: 'Queued',
+  running: 'Running',
+  success: 'Completed',
+  failed: 'Failed',
 };
 
 const BeefPage: React.FC = () => {
-  const [logs] = useState<LogEntry[]>([
-    { time: '10:00:00', severity: 'Low', message: 'Hook initialized' },
-    { time: '10:00:02', severity: 'Medium', message: 'Payload delivered' },
-    { time: '10:00:03', severity: 'High', message: 'Sensitive data exfil attempt' },
-  ]);
+  const queueItems = useQueueStore((state) => state.items);
+  const [selectedItem, setSelectedItem] = useState<QueueItem | null>(null);
+  const seededRef = useRef(false);
+
+  useEffect(() => {
+    if (seededRef.current || queueItems.length > 0) {
+      return;
+    }
+    seededRef.current = true;
+
+    const stageHook = queueActions.enqueueCommand('Stage harmless hook', { maxRetries: 3 });
+    queueActions.markCommandRunning(stageHook.id);
+    queueActions.markCommandFailure(
+      stageHook.id,
+      'Initial hook blocked by sandboxed iframe.',
+    );
+    queueActions.retryCommand(stageHook.id);
+    queueActions.markCommandRunning(stageHook.id);
+    queueActions.markCommandFailure(
+      stageHook.id,
+      'Content Security Policy prevented inline script execution.',
+    );
+
+    const deliverPayload = queueActions.enqueueCommand('Deliver demo payload');
+    queueActions.markCommandRunning(deliverPayload.id);
+    queueActions.markCommandSuccess(deliverPayload.id);
+
+    const domSnapshot = queueActions.enqueueCommand('Collect DOM snapshot', { maxRetries: 2 });
+    queueActions.markCommandRunning(domSnapshot.id);
+
+    queueActions.enqueueCommand('Await callbacks from demo clients');
+
+    const privilegeAttempt = queueActions.enqueueCommand(
+      'Escalate privileges (simulated)',
+      { maxRetries: 1 },
+    );
+    queueActions.markCommandRunning(privilegeAttempt.id);
+    queueActions.markCommandFailure(
+      privilegeAttempt.id,
+      'Privilege escalation blocked by lab guard rails.',
+    );
+  }, [queueItems.length]);
+
+  const handleRetry = (item: QueueItem) => {
+    const retried = queueActions.retryCommand(item.id);
+    if (retried) {
+      queueActions.markCommandRunning(item.id);
+    }
+  };
 
   return (
     <div className="bg-ub-cool-grey text-white h-full w-full flex flex-col">
@@ -55,20 +106,68 @@ const BeefPage: React.FC = () => {
         <BeefApp />
       </div>
 
-      <div className="border-t border-gray-700 font-mono text-sm">
-        {logs.map((log, idx) => (
-          <div key={idx} className="flex items-center gap-2 px-2 py-1.5">
-            <span
-              className={`flex items-center px-2 py-0.5 rounded-full text-xs ${severityStyles[log.severity].color}`}
-            >
-              <span className="mr-1">{severityStyles[log.severity].icon}</span>
-              {log.severity}
-            </span>
-            <span className="text-gray-400">{log.time}</span>
-            <span>{log.message}</span>
-          </div>
-        ))}
-      </div>
+      <section className="border-t border-gray-700 bg-black/20">
+        <div className="px-4 py-3">
+          <h2 className="text-lg font-semibold">Command queue</h2>
+          <p className="text-xs text-gray-300">
+            Commands execute locally in this demo. Failures simply document simulated guard rails.
+          </p>
+        </div>
+        <div className="divide-y divide-gray-800">
+          {queueItems.length === 0 && (
+            <p className="px-4 py-6 text-sm text-gray-300">No commands queued.</p>
+          )}
+          {queueItems.map((item) => {
+            const attemptsRemaining = item.maxRetries - item.retries;
+            const canRetry = item.status === 'failed' && attemptsRemaining > 0;
+            const showLog = item.failures.length > 0;
+            const statusLabel =
+              item.status === 'failed' && item.retries >= item.maxRetries
+                ? 'Failed (limit reached)'
+                : statusLabels[item.status];
+            return (
+              <div
+                key={item.id}
+                className="flex flex-wrap items-center gap-3 px-4 py-3 text-sm"
+              >
+                <div className="min-w-[16rem] flex-1">
+                  <p className="font-mono text-sm leading-5">{item.command}</p>
+                  <p className="mt-1 text-xs text-gray-400">
+                    Attempts used {item.retries} / {item.maxRetries}
+                    {item.lastError ? ` · Last error: ${item.lastError}` : ''}
+                  </p>
+                </div>
+                <span
+                  className={`rounded-full px-2 py-1 text-xs font-semibold ${statusStyles[item.status]}`}
+                >
+                  {statusLabel}
+                </span>
+                {showLog && (
+                  <button
+                    type="button"
+                    onClick={() => setSelectedItem(item)}
+                    className="rounded border border-gray-600 px-2 py-1 text-xs transition hover:bg-gray-700"
+                  >
+                    View log
+                  </button>
+                )}
+                {canRetry && (
+                  <button
+                    type="button"
+                    onClick={() => handleRetry(item)}
+                    className="rounded bg-ub-primary px-3 py-1 text-xs font-semibold text-white transition hover:bg-ub-primary-dark"
+                  >
+                    Retry ({attemptsRemaining} left)
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </section>
+      {selectedItem && (
+        <QueueLogModal item={selectedItem} onClose={() => setSelectedItem(null)} />
+      )}
     </div>
   );
 };

--- a/apps/beef/state/queueStore.ts
+++ b/apps/beef/state/queueStore.ts
@@ -1,0 +1,188 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+export type QueueStatus = 'queued' | 'running' | 'success' | 'failed';
+
+export interface FailureLogEntry {
+  id: string;
+  message: string;
+  timestamp: number;
+  attempt: number;
+}
+
+export interface QueueItem {
+  id: string;
+  command: string;
+  status: QueueStatus;
+  retries: number;
+  maxRetries: number;
+  failures: FailureLogEntry[];
+  lastError?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface QueueState {
+  items: QueueItem[];
+}
+
+const DEFAULT_MAX_RETRIES = 3;
+
+const listeners = new Set<() => void>();
+let state: QueueState = { items: [] };
+
+const getSnapshot = () => state;
+
+const notify = () => {
+  listeners.forEach((listener) => listener());
+};
+
+const setState = (updater: (state: QueueState) => QueueState) => {
+  state = updater(state);
+  notify();
+};
+
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+const createId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+const createQueueItem = (
+  command: string,
+  maxRetries: number,
+  id?: string,
+): QueueItem => {
+  const now = Date.now();
+  return {
+    id: id ?? createId(),
+    command,
+    status: 'queued',
+    retries: 0,
+    maxRetries,
+    failures: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+};
+
+const updateQueueItem = (
+  id: string,
+  updater: (item: QueueItem) => QueueItem,
+): QueueItem | undefined => {
+  let updated: QueueItem | undefined;
+  setState((prev) => {
+    const index = prev.items.findIndex((item) => item.id === id);
+    if (index === -1) {
+      return prev;
+    }
+    const nextItem = updater(prev.items[index]);
+    const items = [...prev.items];
+    items[index] = nextItem;
+    updated = nextItem;
+    return { ...prev, items };
+  });
+  return updated;
+};
+
+const enqueueCommand = (
+  command: string,
+  options?: { id?: string; maxRetries?: number },
+): QueueItem => {
+  const item = createQueueItem(command, options?.maxRetries ?? DEFAULT_MAX_RETRIES, options?.id);
+  setState((prev) => ({ ...prev, items: [...prev.items, item] }));
+  return item;
+};
+
+const markCommandRunning = (id: string) =>
+  updateQueueItem(id, (item) => ({ ...item, status: 'running', updatedAt: Date.now() }));
+
+const markCommandSuccess = (id: string) =>
+  updateQueueItem(id, (item) => ({
+    ...item,
+    status: 'success',
+    lastError: undefined,
+    updatedAt: Date.now(),
+  }));
+
+const markCommandFailure = (id: string, message: string) =>
+  updateQueueItem(id, (item) => {
+    const attempt = item.retries + 1;
+    const timestamp = Date.now();
+    const failure: FailureLogEntry = {
+      id: `${id}-failure-${attempt}-${timestamp}`,
+      attempt,
+      message,
+      timestamp,
+    };
+    return {
+      ...item,
+      status: 'failed',
+      retries: attempt,
+      lastError: message,
+      failures: [...item.failures, failure],
+      updatedAt: timestamp,
+    };
+  });
+
+const retryCommand = (id: string) => {
+  let retried: QueueItem | undefined;
+  setState((prev) => {
+    const index = prev.items.findIndex((item) => item.id === id);
+    if (index === -1) {
+      return prev;
+    }
+    const current = prev.items[index];
+    if (current.retries >= current.maxRetries) {
+      retried = undefined;
+      return prev;
+    }
+    const next: QueueItem = {
+      ...current,
+      status: 'queued',
+      updatedAt: Date.now(),
+    };
+    const items = [...prev.items];
+    items[index] = next;
+    retried = next;
+    return { ...prev, items };
+  });
+  return retried;
+};
+
+const removeCommand = (id: string) => {
+  setState((prev) => ({
+    ...prev,
+    items: prev.items.filter((item) => item.id !== id),
+  }));
+};
+
+const resetQueue = () => {
+  state = { items: [] };
+  notify();
+};
+
+export function useQueueStore<T>(selector: (state: QueueState) => T): T {
+  return useSyncExternalStore(subscribe, () => selector(getSnapshot()), () => selector(getSnapshot()));
+}
+
+export const queueStore = {
+  subscribe,
+  getState: getSnapshot,
+};
+
+export const queueActions = {
+  enqueueCommand,
+  markCommandRunning,
+  markCommandSuccess,
+  markCommandFailure,
+  retryCommand,
+  removeCommand,
+  resetQueue,
+};
+
+export type { QueueState };


### PR DESCRIPTION
## Summary
- add a dedicated queue store for BeEF with retry tracking and failure logs
- render the queue state in the BeEF app with manual retry controls and a modal for log details
- cover the queue store behaviors with focused unit tests

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window violations in unrelated files)*
- yarn test __tests__/apps/beef/queue-monitor.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc2819dac48328b0e2cc3ed4f37203