### PR TITLE
[beef] Add sandboxed hook lab

### DIFF
--- a/__tests__/apps/beef/hook-lab.test.tsx
+++ b/__tests__/apps/beef/hook-lab.test.tsx
@@ -1,0 +1,70 @@
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import BeefPage from '../../../apps/beef';
+
+describe('BeEF sandbox hook lab', () => {
+  const dispatchHookMessage = (stage: string, message?: string) => {
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { source: 'beef-demo', type: 'hook-status', stage, message },
+        })
+      );
+    });
+  };
+
+  it('activates the sandbox iframe and records hook progress', () => {
+    render(<BeefPage />);
+
+    const launchButton = screen.getByRole('button', { name: /launch sandbox/i });
+    fireEvent.click(launchButton);
+
+    const status = screen.getByTestId('hook-status');
+    const statusMessage = screen.getByTestId('hook-status-message');
+    const logs = screen.getByTestId('hook-log');
+    expect(status).toHaveTextContent(/initializing/i);
+    expect(statusMessage).toHaveTextContent(/launching sandboxed target iframe/i);
+
+    const iframe = screen.getByTitle('BeEF sandbox target');
+    fireEvent.load(iframe);
+
+    expect(statusMessage).toHaveTextContent(/waiting for hook signal/i);
+    expect(within(logs).getByText(/Sandboxed target loaded locally\./i)).toBeInTheDocument();
+
+    dispatchHookMessage('ready', 'Sandbox handshake acknowledged. Deploying local hook.');
+    expect(status).toHaveTextContent(/initializing/i);
+    expect(statusMessage).toHaveTextContent(/deploying local hook/i);
+    expect(
+      within(logs).getByText(/Sandbox handshake acknowledged\. Deploying local hook\./i)
+    ).toBeInTheDocument();
+
+    dispatchHookMessage('hooked', 'Simulated BeEF hook established locally.');
+    expect(status).toHaveTextContent(/hooked/i);
+    expect(within(logs).getByText(/Simulated BeEF hook established locally\./i)).toBeInTheDocument();
+  });
+
+  it('disconnect button removes the iframe and stops listening', () => {
+    render(<BeefPage />);
+
+    const launchButton = screen.getByRole('button', { name: /launch sandbox/i });
+    const disconnectButton = screen.getByRole('button', { name: /disconnect/i });
+    expect(disconnectButton).toBeDisabled();
+
+    fireEvent.click(launchButton);
+    const iframe = screen.getByTitle('BeEF sandbox target');
+    fireEvent.load(iframe);
+    expect(disconnectButton).not.toBeDisabled();
+
+    fireEvent.click(disconnectButton);
+
+    expect(screen.queryByTitle('BeEF sandbox target')).not.toBeInTheDocument();
+    const status = screen.getByTestId('hook-status');
+    const statusMessage = screen.getByTestId('hook-status-message');
+    expect(status).toHaveTextContent(/disconnected/i);
+    expect(statusMessage).toHaveTextContent(/ready to reconnect/i);
+    expect(disconnectButton).toBeDisabled();
+
+    dispatchHookMessage('hooked', 'Message should be ignored');
+    expect(status).toHaveTextContent(/disconnected/i);
+    expect(statusMessage).toHaveTextContent(/ready to reconnect/i);
+  });
+});

--- a/apps/beef/index.tsx
+++ b/apps/beef/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import BeefApp from '../../components/apps/beef';
 
@@ -12,18 +12,153 @@ interface LogEntry {
   message: string;
 }
 
+type HookStage = 'disconnected' | 'initializing' | 'hooked' | 'error';
+
+interface HookMessage {
+  source: 'beef-demo';
+  type: 'hook-status';
+  stage?: string;
+  message?: string;
+}
+
 const severityStyles: Record<Severity, { icon: string; color: string }> = {
   Low: { icon: '🟢', color: 'bg-green-700' },
   Medium: { icon: '🟡', color: 'bg-yellow-700' },
   High: { icon: '🔴', color: 'bg-red-700' },
 };
 
+const statusLabels: Record<HookStage, string> = {
+  disconnected: 'Disconnected',
+  initializing: 'Initializing',
+  hooked: 'Hooked',
+  error: 'Error',
+};
+
+const statusColors: Record<HookStage, string> = {
+  disconnected: 'text-red-400',
+  initializing: 'text-yellow-300',
+  hooked: 'text-green-400',
+  error: 'text-orange-400',
+};
+
+const defaultMessages: Record<string, string> = {
+  loading: 'Sandboxed page loaded in isolated environment.',
+  ready: 'Sandbox handshake acknowledged. Deploying local hook.',
+  probe: 'Local recon telemetry received.',
+  hooked: 'Simulated BeEF hook established locally.',
+  disconnected: 'Sandbox target closed the connection.',
+  error: 'Sandbox reported an error state.',
+};
+
+const severityByStage: Record<string, Severity> = {
+  loading: 'Low',
+  ready: 'Medium',
+  probe: 'Medium',
+  hooked: 'High',
+  disconnected: 'Low',
+  error: 'High',
+};
+
+const isHookMessage = (data: unknown): data is HookMessage => {
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+
+  const payload = data as Record<string, unknown>;
+  return payload.source === 'beef-demo' && payload.type === 'hook-status';
+};
+
+const timeStamp = () => new Date().toLocaleTimeString('en-GB', { hour12: false });
+
 const BeefPage: React.FC = () => {
-  const [logs] = useState<LogEntry[]>([
+  const [logs, setLogs] = useState<LogEntry[]>([
     { time: '10:00:00', severity: 'Low', message: 'Hook initialized' },
     { time: '10:00:02', severity: 'Medium', message: 'Payload delivered' },
     { time: '10:00:03', severity: 'High', message: 'Sensitive data exfil attempt' },
   ]);
+  const [hookStage, setHookStage] = useState<HookStage>('disconnected');
+  const [statusDetail, setStatusDetail] = useState<string>(
+    'No target connected. Launch the sandbox to begin.'
+  );
+  const [frameActive, setFrameActive] = useState(false);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+
+  const addLog = useCallback((message: string, severity: Severity) => {
+    setLogs((prev) => [...prev, { time: timeStamp(), severity, message }]);
+  }, []);
+
+  const handleConnect = useCallback(() => {
+    if (frameActive) {
+      return;
+    }
+    setFrameActive(true);
+    setHookStage('initializing');
+    setStatusDetail('Launching sandboxed target iframe...');
+    addLog('Launching sandboxed target iframe.', 'Low');
+  }, [addLog, frameActive]);
+
+  const handleDisconnect = useCallback(() => {
+    if (!frameActive) {
+      return;
+    }
+    setFrameActive(false);
+    setHookStage('disconnected');
+    setStatusDetail('Sandbox target removed. Ready to reconnect.');
+    addLog('Disconnected from sandbox target.', 'Low');
+    iframeRef.current = null;
+  }, [addLog, frameActive]);
+
+  const handleSandboxLoad = useCallback(() => {
+    setStatusDetail('Sandbox target loaded. Waiting for hook signal.');
+    addLog('Sandboxed target loaded locally.', 'Low');
+    iframeRef.current?.contentWindow?.postMessage(
+      { source: 'beef-console', type: 'beef-demo:init' },
+      '*'
+    );
+  }, [addLog]);
+
+  useEffect(() => {
+    if (!frameActive) {
+      return undefined;
+    }
+
+    const handleMessage = (event: MessageEvent) => {
+      if (!isHookMessage(event.data)) {
+        return;
+      }
+
+      const stage = typeof event.data.stage === 'string' ? event.data.stage : undefined;
+      const incoming =
+        typeof event.data.message === 'string'
+          ? event.data.message
+          : undefined;
+      const detail = incoming ?? (stage ? defaultMessages[stage] : undefined) ?? 'Sandbox update received.';
+      const severity = (stage && severityByStage[stage]) || 'Low';
+
+      if (stage === 'hooked') {
+        setHookStage('hooked');
+      } else if (stage === 'error') {
+        setHookStage('error');
+      } else if (stage === 'disconnected') {
+        setHookStage('disconnected');
+        setFrameActive(false);
+        iframeRef.current = null;
+      } else if (stage) {
+        setHookStage('initializing');
+      }
+
+      setStatusDetail(detail);
+      addLog(detail, severity);
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, [frameActive, addLog]);
+
+  const statusColor = statusColors[hookStage];
+  const statusLabel = statusLabels[hookStage];
 
   return (
     <div className="bg-ub-cool-grey text-white h-full w-full flex flex-col">
@@ -52,10 +187,65 @@ const BeefPage: React.FC = () => {
       </header>
 
       <div className="p-4 flex-1 overflow-auto">
-        <BeefApp />
+        <div className="grid gap-6 lg:grid-cols-2">
+          <section className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold">Hook Lab</h2>
+              <span
+                data-testid="hook-status"
+                className={`text-sm font-semibold ${statusColor}`}
+              >
+                {statusLabel}
+              </span>
+            </div>
+            <p data-testid="hook-status-message" className="text-sm text-gray-300">
+              {statusDetail}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={handleConnect}
+                disabled={frameActive}
+                className="px-3 py-1 rounded bg-ub-primary text-white disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                Launch Sandbox
+              </button>
+              <button
+                type="button"
+                onClick={handleDisconnect}
+                disabled={!frameActive}
+                className="px-3 py-1 rounded bg-ub-orange text-black disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                Disconnect
+              </button>
+            </div>
+            <div className="border border-gray-700 rounded bg-black/30 h-64 flex items-center justify-center">
+              {frameActive ? (
+                <iframe
+                  ref={iframeRef}
+                  title="BeEF sandbox target"
+                  src="/beef-demo/index.html"
+                  sandbox="allow-scripts"
+                  className="w-full h-full rounded"
+                  onLoad={handleSandboxLoad}
+                />
+              ) : (
+                <p className="text-sm text-gray-400 text-center px-4">
+                  The sandboxed target loads entirely from local files. Launch it to
+                  simulate a BeEF hook without any external traffic.
+                </p>
+              )}
+            </div>
+          </section>
+          <section className="min-h-[16rem]">
+            <div className="border border-gray-700 rounded bg-black/20 h-full overflow-hidden">
+              <BeefApp />
+            </div>
+          </section>
+        </div>
       </div>
 
-      <div className="border-t border-gray-700 font-mono text-sm">
+      <div className="border-t border-gray-700 font-mono text-sm" data-testid="hook-log">
         {logs.map((log, idx) => (
           <div key={idx} className="flex items-center gap-2 px-2 py-1.5">
             <span

--- a/public/beef-demo/index.html
+++ b/public/beef-demo/index.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BeEF Demo Target</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      body {
+        margin: 0;
+        font-family: 'Ubuntu', 'Segoe UI', sans-serif;
+        background: radial-gradient(circle at top, #1f2933 0%, #111827 60%, #0b1220 100%);
+        color: #f9fafb;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      main {
+        background: rgba(15, 23, 42, 0.85);
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        border-radius: 12px;
+        padding: 24px;
+        max-width: 520px;
+        box-shadow: 0 16px 32px rgba(0, 0, 0, 0.45);
+      }
+      h1 {
+        margin: 0 0 12px;
+        font-size: 1.5rem;
+      }
+      p {
+        margin: 0 0 12px;
+        font-size: 0.95rem;
+        line-height: 1.5;
+      }
+      .status {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        margin-bottom: 16px;
+        padding: 8px 12px;
+        border-radius: 8px;
+        background: rgba(34, 197, 94, 0.15);
+        border: 1px solid rgba(34, 197, 94, 0.3);
+        font-size: 0.9rem;
+      }
+      .status span:first-child {
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+      }
+      code {
+        font-family: 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+        background: rgba(30, 41, 59, 0.8);
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-size: 0.85rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Local BeEF Hook Target</h1>
+      <p>
+        This lab target is fully sandboxed. It cannot reach the network and only
+        talks to its parent window via <code>postMessage</code>.
+      </p>
+      <div class="status" aria-live="polite">
+        <span>Status</span>
+        <span id="statusMessage">Awaiting sandbox initialization…</span>
+      </div>
+      <p class="hint">
+        Watch the command console in the main window to see simulated hook
+        events stream in real time.
+      </p>
+    </main>
+    <script>
+      (function () {
+        const defaultMessages = {
+          loading: 'Sandboxed page loaded in isolated environment.',
+          ready: 'Sandbox handshake acknowledged. Deploying local hook.',
+          probe: 'Local recon telemetry received.',
+          hooked: 'Simulated BeEF hook established locally.',
+          disconnected: 'Sandbox target closed the connection.',
+          error: 'Sandbox reported an error state.',
+        };
+
+        const statusEl = document.getElementById('statusMessage');
+
+        const updateStatus = (text) => {
+          if (statusEl) {
+            statusEl.textContent = text;
+          }
+        };
+
+        const notify = (stage, message) => {
+          const target = window.parent;
+          if (!target || typeof target.postMessage !== 'function') {
+            return;
+          }
+          target.postMessage(
+            {
+              source: 'beef-demo',
+              type: 'hook-status',
+              stage,
+              message,
+            },
+            '*'
+          );
+        };
+
+        window.addEventListener('load', () => {
+          updateStatus('Client bootstrap complete. Awaiting controller.');
+          notify('loading', defaultMessages.loading);
+          setTimeout(() => {
+            updateStatus('Enumerating local environment…');
+            notify('probe', defaultMessages.probe);
+          }, 450);
+        });
+
+        window.addEventListener('message', (event) => {
+          const data = event.data;
+          if (!data || typeof data !== 'object') {
+            return;
+          }
+          if (data.type === 'beef-demo:init') {
+            updateStatus('Control channel received. Simulating hook.');
+            notify('ready', defaultMessages.ready);
+            setTimeout(() => {
+              updateStatus('Hook established locally.');
+              notify('hooked', defaultMessages.hooked);
+            }, 600);
+          } else if (data.type === 'beef-demo:disconnect') {
+            updateStatus('Controller requested shutdown.');
+            notify('disconnected', defaultMessages.disconnected);
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a sandboxed BeEF hook lab iframe that reports status via postMessage
- serve a local `public/beef-demo/index.html` target for the lab
- cover sandbox connect/disconnect behavior with new tests

## Testing
- yarn lint *(fails: existing repo accessibility and browser global lint errors)*
- yarn test --watch=false *(fails: existing suites around window focus and Supabase mocks)*
- yarn test hook-lab --watch=false


------
https://chatgpt.com/codex/tasks/task_e_68cc281c1c30832893aa11b32b58ad52