### PR TITLE
[spotify] add library search

### DIFF
--- a/__tests__/apps/spotify/library.test.tsx
+++ b/__tests__/apps/spotify/library.test.tsx
@@ -1,0 +1,76 @@
+import { act, renderHook } from "@testing-library/react";
+import useLibrary from "../../../apps/spotify/utils/useLibrary";
+
+describe("useLibrary", () => {
+  it("exposes the full library without a query", () => {
+    const { result } = renderHook(() => useLibrary());
+
+    expect(result.current.counts.tracks).toBe(6);
+    expect(result.current.counts.albums).toBe(3);
+    expect(result.current.counts.playlists).toBe(3);
+    expect(result.current.counts.all).toBe(12);
+    expect(result.current.getTrack("soundhelix-song-2")?.title).toBe(
+      "Dynamic Sweep",
+    );
+  });
+
+  it("filters by multi-word queries across categories", () => {
+    const { result } = renderHook(() => useLibrary());
+
+    act(() => {
+      result.current.setQuery("focus electronic");
+    });
+
+    const trackIds = result.current.results.tracks.map((track) => track.id);
+    const albumIds = result.current.results.albums.map((album) => album.id);
+    const playlistIds = result.current.results.playlists.map(
+      (playlist) => playlist.id,
+    );
+
+    expect(trackIds).toEqual(["soundhelix-song-2"]);
+    expect(albumIds).toEqual(["pulse-cascade"]);
+    expect(playlistIds).toEqual(["focus-scan"]);
+    expect(result.current.counts.tracks).toBe(1);
+    expect(result.current.counts.albums).toBe(1);
+    expect(result.current.counts.playlists).toBe(1);
+    expect(result.current.counts.all).toBe(3);
+  });
+
+  it("narrows visible collections when the category changes", () => {
+    const { result } = renderHook(() => useLibrary());
+
+    act(() => {
+      result.current.setQuery("quiet");
+    });
+
+    expect(result.current.results.tracks.map((track) => track.id)).toEqual([
+      "soundhelix-song-6",
+    ]);
+    expect(result.current.results.albums.map((album) => album.id)).toEqual([
+      "night-watch",
+    ]);
+    expect(result.current.results.playlists.map((playlist) => playlist.id)).toEqual(
+      ["after-hours"],
+    );
+
+    act(() => {
+      result.current.setCategory("albums");
+    });
+
+    expect(result.current.visible.tracks).toHaveLength(0);
+    expect(result.current.visible.albums.map((album) => album.id)).toEqual([
+      "night-watch",
+    ]);
+    expect(result.current.visible.playlists).toHaveLength(0);
+
+    act(() => {
+      result.current.setCategory("playlists");
+    });
+
+    expect(result.current.visible.tracks).toHaveLength(0);
+    expect(result.current.visible.albums).toHaveLength(0);
+    expect(result.current.visible.playlists.map((playlist) => playlist.id)).toEqual(
+      ["after-hours"],
+    );
+  });
+});

--- a/apps/spotify/index.tsx
+++ b/apps/spotify/index.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import usePersistentState from "../../hooks/usePersistentState";
 import CrossfadePlayer from "./utils/crossfade";
 import Visualizer from "./Visualizer";
 import Lyrics from "./Lyrics";
+import useLibrary, {
+  LibraryAlbum,
+  LibraryPlaylist,
+  LibraryTrack,
+  LibraryFilter,
+} from "./utils/useLibrary";
 
 interface Track {
   title: string;
@@ -67,6 +73,15 @@ const SpotifyApp = () => {
     false,
     (v): v is boolean => typeof v === "boolean",
   );
+  const {
+    query: libraryQuery,
+    setQuery: setLibraryQuery,
+    category: libraryCategory,
+    setCategory: setLibraryCategory,
+    visible: visibleLibrary,
+    counts: libraryCounts,
+    getTrack: getLibraryTrack,
+  } = useLibrary();
   const playerRef = useRef<CrossfadePlayer | null>(null);
   const [analyser, setAnalyser] = useState<AnalyserNode | null>(null);
   const [progress, setProgress] = useState(0);
@@ -114,9 +129,52 @@ const SpotifyApp = () => {
       setProgress(playerRef.current?.getCurrentTime() ?? 0);
       raf = requestAnimationFrame(tick);
     };
-    raf = requestAnimationFrame(tick);
+      raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
   }, []);
+
+  const queueLibraryTracks = (ids: string[]) => {
+    setQueue((prev) => {
+      const additions = ids
+        .map((id) => getLibraryTrack(id))
+        .filter((track): track is LibraryTrack => Boolean(track))
+        .map((track) => ({
+          title: track.title,
+          url: track.url,
+          cover: track.cover,
+        }));
+
+      if (!additions.length) {
+        return prev;
+      }
+
+      const existing = new Set(prev.map((track) => track.url));
+      const nextQueue = [...prev];
+      let added = false;
+
+      for (const track of additions) {
+        if (existing.has(track.url)) continue;
+        nextQueue.push(track);
+        existing.add(track.url);
+        added = true;
+      }
+
+      if (!added) {
+        return prev;
+      }
+
+      setPlaylistText(serialize(nextQueue));
+      if (!prev.length) {
+        setCurrent(0);
+      }
+
+      return nextQueue;
+    });
+  };
+
+  const queueCollection = (collection: LibraryAlbum | LibraryPlaylist) => {
+    queueLibraryTracks(collection.tracks);
+  };
 
   const next = () => {
     if (!queue.length) return;
@@ -144,6 +202,22 @@ const SpotifyApp = () => {
   };
 
   const currentTrack = queue[current];
+
+  const libraryFilters: { key: LibraryFilter; label: string }[] = useMemo(
+    () => [
+      { key: "all", label: `All (${libraryCounts.all})` },
+      { key: "tracks", label: `Tracks (${libraryCounts.tracks})` },
+      { key: "albums", label: `Albums (${libraryCounts.albums})` },
+      { key: "playlists", label: `Playlists (${libraryCounts.playlists})` },
+    ],
+    [libraryCounts],
+  );
+
+  const hasVisibleLibraryResults =
+    visibleLibrary.tracks.length +
+      visibleLibrary.albums.length +
+      visibleLibrary.playlists.length >
+    0;
 
   return (
     <div
@@ -242,7 +316,7 @@ const SpotifyApp = () => {
         </div>
       )}
       {!mini && (
-        <div className="flex-1 overflow-auto mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="flex-1 overflow-auto mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
           <div className="hidden md:block">
             <h2 className="mb-2 text-lg">Playlist JSON</h2>
             <textarea
@@ -282,6 +356,153 @@ const SpotifyApp = () => {
                 </li>
               ))}
             </ul>
+          </div>
+          <div>
+            <h2 className="mb-2 text-lg">Library Search</h2>
+            <div className="space-y-2">
+              <input
+                type="search"
+                value={libraryQuery}
+                onChange={(e) => setLibraryQuery(e.target.value)}
+                placeholder="Search tracks, albums, playlists"
+                className="w-full rounded border border-gray-700 bg-[var(--color-bg)] px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+              <div className="flex flex-wrap gap-2 text-xs">
+                {libraryFilters.map((filter) => (
+                  <button
+                    key={filter.key}
+                    onClick={() => setLibraryCategory(filter.key)}
+                    className={`rounded px-2 py-1 border ${
+                      libraryCategory === filter.key
+                        ? "border-blue-500 bg-blue-500/10"
+                        : "border-gray-700"
+                    }`}
+                  >
+                    {filter.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="mt-3 space-y-3 max-h-72 overflow-auto border border-gray-700 rounded p-2">
+              {libraryCounts.all === 0 ? (
+                <p className="text-sm text-gray-300">No matches found.</p>
+              ) : hasVisibleLibraryResults ? (
+                <>
+                  {visibleLibrary.tracks.length > 0 && (
+                    <div>
+                      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300">
+                        Tracks
+                      </h3>
+                      <ul className="mt-1 space-y-1">
+                        {visibleLibrary.tracks.map((track) => (
+                          <li
+                            key={track.id}
+                            className="flex items-center justify-between gap-2 rounded border border-gray-700 px-2 py-1"
+                          >
+                            <div>
+                              <p className="text-sm font-medium">{track.title}</p>
+                              <p className="text-xs text-gray-400">
+                                {track.artist} · {track.album}
+                              </p>
+                            </div>
+                            <button
+                              className="rounded bg-blue-600 px-2 py-1 text-xs"
+                              onClick={() => queueLibraryTracks([track.id])}
+                            >
+                              Add
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {visibleLibrary.albums.length > 0 && (
+                    <div>
+                      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300">
+                        Albums
+                      </h3>
+                      <ul className="mt-1 space-y-2">
+                        {visibleLibrary.albums.map((album) => (
+                          <li
+                            key={album.id}
+                            className="rounded border border-gray-700 p-2"
+                          >
+                            <div className="flex items-start justify-between gap-2">
+                              <div>
+                                <p className="text-sm font-medium">{album.title}</p>
+                                <p className="text-xs text-gray-400">
+                                  {album.artist} · {album.year}
+                                </p>
+                              </div>
+                              <button
+                                className="rounded bg-blue-600 px-2 py-1 text-xs"
+                                onClick={() => queueCollection(album)}
+                              >
+                                Queue Album
+                              </button>
+                            </div>
+                            <ul className="mt-2 space-y-0.5 text-xs text-gray-400">
+                              {album.tracks.map((trackId) => {
+                                const track = getLibraryTrack(trackId);
+                                return (
+                                  <li key={trackId}>
+                                    {track ? track.title : trackId}
+                                  </li>
+                                );
+                              })}
+                            </ul>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {visibleLibrary.playlists.length > 0 && (
+                    <div>
+                      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300">
+                        Playlists
+                      </h3>
+                      <ul className="mt-1 space-y-2">
+                        {visibleLibrary.playlists.map((playlist) => (
+                          <li
+                            key={playlist.id}
+                            className="rounded border border-gray-700 p-2"
+                          >
+                            <div className="flex items-start justify-between gap-2">
+                              <div>
+                                <p className="text-sm font-medium">{playlist.title}</p>
+                                <p className="text-xs text-gray-400">
+                                  {playlist.description}
+                                </p>
+                              </div>
+                              <button
+                                className="rounded bg-blue-600 px-2 py-1 text-xs"
+                                onClick={() => queueCollection(playlist)}
+                              >
+                                Queue Playlist
+                              </button>
+                            </div>
+                            <ul className="mt-2 space-y-0.5 text-xs text-gray-400">
+                              {playlist.tracks.map((trackId) => {
+                                const track = getLibraryTrack(trackId);
+                                return (
+                                  <li key={trackId}>
+                                    {track ? `${track.title} · ${track.artist}` : trackId}
+                                  </li>
+                                );
+                              })}
+                            </ul>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </>
+              ) : (
+                <p className="text-sm text-gray-300">
+                  No matches for the selected filter.
+                </p>
+              )}
+            </div>
           </div>
         </div>
       )}

--- a/apps/spotify/utils/library.json
+++ b/apps/spotify/utils/library.json
@@ -1,0 +1,129 @@
+{
+  "tracks": [
+    {
+      "id": "soundhelix-song-1",
+      "title": "Signal Drift",
+      "artist": "SoundHelix Collective",
+      "album": "Signal Drift",
+      "duration": 378,
+      "tags": ["ambient", "intro"],
+      "url": "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3"
+    },
+    {
+      "id": "soundhelix-song-2",
+      "title": "Dynamic Sweep",
+      "artist": "SoundHelix Collective",
+      "album": "Signal Drift",
+      "duration": 412,
+      "tags": ["electronic", "focus"],
+      "url": "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3"
+    },
+    {
+      "id": "soundhelix-song-3",
+      "title": "Night Watch",
+      "artist": "SoundHelix Collective",
+      "album": "Signal Drift",
+      "duration": 389,
+      "tags": ["synth", "nocturnal"],
+      "url": "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3"
+    },
+    {
+      "id": "soundhelix-song-4",
+      "title": "Pulse Cascade",
+      "artist": "SoundHelix Collective",
+      "album": "Pulse Cascade",
+      "duration": 366,
+      "tags": ["uplifting", "scan"],
+      "url": "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-4.mp3"
+    },
+    {
+      "id": "soundhelix-song-5",
+      "title": "Parallel Signals",
+      "artist": "SoundHelix Collective",
+      "album": "Pulse Cascade",
+      "duration": 401,
+      "tags": ["focus", "instrumental"],
+      "url": "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-5.mp3"
+    },
+    {
+      "id": "soundhelix-song-6",
+      "title": "Quiet Recon",
+      "artist": "SoundHelix Collective",
+      "album": "Night Watch",
+      "duration": 355,
+      "tags": ["downtempo", "late-night"],
+      "url": "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-6.mp3"
+    }
+  ],
+  "albums": [
+    {
+      "id": "signal-drift",
+      "title": "Signal Drift",
+      "artist": "SoundHelix Collective",
+      "year": 2023,
+      "tags": ["ambient", "synth"],
+      "tracks": [
+        "soundhelix-song-1",
+        "soundhelix-song-2",
+        "soundhelix-song-3"
+      ]
+    },
+    {
+      "id": "pulse-cascade",
+      "title": "Pulse Cascade",
+      "artist": "SoundHelix Collective",
+      "year": 2022,
+      "tags": ["electronic", "focus"],
+      "tracks": [
+        "soundhelix-song-4",
+        "soundhelix-song-5",
+        "soundhelix-song-2"
+      ]
+    },
+    {
+      "id": "night-watch",
+      "title": "Night Watch",
+      "artist": "SoundHelix Collective",
+      "year": 2021,
+      "tags": ["downtempo", "nocturnal"],
+      "tracks": [
+        "soundhelix-song-3",
+        "soundhelix-song-6"
+      ]
+    }
+  ],
+  "playlists": [
+    {
+      "id": "focus-scan",
+      "title": "Focus Scan",
+      "description": "Bright electronic cuts to keep recon sessions rolling.",
+      "tags": ["focus", "electronic"],
+      "tracks": [
+        "soundhelix-song-2",
+        "soundhelix-song-4",
+        "soundhelix-song-5"
+      ]
+    },
+    {
+      "id": "after-hours",
+      "title": "After Hours",
+      "description": "Downtempo ambience for late-night log reviews.",
+      "tags": ["downtempo", "night"],
+      "tracks": [
+        "soundhelix-song-3",
+        "soundhelix-song-6",
+        "soundhelix-song-1"
+      ]
+    },
+    {
+      "id": "launch-sequence",
+      "title": "Launch Sequence",
+      "description": "High-energy intros to kick off a new engagement.",
+      "tags": ["uplifting", "intro"],
+      "tracks": [
+        "soundhelix-song-1",
+        "soundhelix-song-4"
+      ]
+    }
+  ]
+}

--- a/apps/spotify/utils/useLibrary.ts
+++ b/apps/spotify/utils/useLibrary.ts
@@ -1,0 +1,181 @@
+import { useCallback, useMemo, useState } from "react";
+import rawLibrary from "./library.json";
+
+export interface LibraryTrack {
+  id: string;
+  title: string;
+  artist: string;
+  album: string;
+  duration: number;
+  tags: string[];
+  url: string;
+  cover?: string;
+}
+
+export interface LibraryAlbum {
+  id: string;
+  title: string;
+  artist: string;
+  year: number;
+  tags: string[];
+  tracks: string[];
+}
+
+export interface LibraryPlaylist {
+  id: string;
+  title: string;
+  description: string;
+  tags: string[];
+  tracks: string[];
+}
+
+export type LibraryFilter = "all" | "tracks" | "albums" | "playlists";
+
+interface LibraryData {
+  tracks: LibraryTrack[];
+  albums: LibraryAlbum[];
+  playlists: LibraryPlaylist[];
+}
+
+interface LibraryCounts {
+  all: number;
+  tracks: number;
+  albums: number;
+  playlists: number;
+}
+
+export interface UseLibraryResult {
+  query: string;
+  setQuery: (value: string) => void;
+  category: LibraryFilter;
+  setCategory: (value: LibraryFilter) => void;
+  results: LibraryData;
+  visible: LibraryData;
+  counts: LibraryCounts;
+  getTrack: (id: string) => LibraryTrack | undefined;
+}
+
+const libraryData = rawLibrary as LibraryData;
+
+const normalize = (value: string | number | undefined | null) =>
+  (value ?? "").toString().toLowerCase();
+
+const useLibrary = (
+  initialQuery = "",
+  initialCategory: LibraryFilter = "all",
+): UseLibraryResult => {
+  const [query, setQuery] = useState(initialQuery);
+  const [category, setCategory] = useState<LibraryFilter>(initialCategory);
+
+  const trackIndex = useMemo(() => {
+    const map = new Map<string, LibraryTrack>();
+    for (const track of libraryData.tracks) {
+      map.set(track.id, track);
+    }
+    return map;
+  }, []);
+
+  const tokens = useMemo(
+    () =>
+      query
+        .trim()
+        .toLowerCase()
+        .split(/\s+/)
+        .filter(Boolean),
+    [query],
+  );
+
+  const filtered = useMemo(() => {
+    if (!tokens.length) {
+      return libraryData;
+    }
+
+    const matchesQuery = (fields: string[]) =>
+      tokens.every((token) =>
+        fields.some((field) => field.includes(token)),
+      );
+
+    const tracks = libraryData.tracks.filter((track) =>
+      matchesQuery([
+        normalize(track.title),
+        normalize(track.artist),
+        normalize(track.album),
+        normalize(track.duration),
+        normalize(track.tags.join(" ")),
+      ]),
+    );
+
+    const albums = libraryData.albums.filter((album) =>
+      matchesQuery([
+        normalize(album.title),
+        normalize(album.artist),
+        normalize(album.year),
+        normalize(album.tags.join(" ")),
+        ...album.tracks
+          .map((id) => trackIndex.get(id))
+          .filter(Boolean)
+          .map((track) => normalize(track.title)),
+      ]),
+    );
+
+    const playlists = libraryData.playlists.filter((playlist) =>
+      matchesQuery([
+        normalize(playlist.title),
+        normalize(playlist.description),
+        normalize(playlist.tags.join(" ")),
+        ...playlist.tracks
+          .map((id) => trackIndex.get(id))
+          .filter(Boolean)
+          .map((track) => normalize(track.title)),
+      ]),
+    );
+
+    return { tracks, albums, playlists };
+  }, [tokens, trackIndex]);
+
+  const counts = useMemo(() => {
+    const allCount =
+      filtered.tracks.length +
+      filtered.albums.length +
+      filtered.playlists.length;
+
+    return {
+      all: allCount,
+      tracks: filtered.tracks.length,
+      albums: filtered.albums.length,
+      playlists: filtered.playlists.length,
+    };
+  }, [filtered]);
+
+  const visible = useMemo(() => {
+    switch (category) {
+      case "tracks":
+        return { tracks: filtered.tracks, albums: [], playlists: [] };
+      case "albums":
+        return { tracks: [], albums: filtered.albums, playlists: [] };
+      case "playlists":
+        return { tracks: [], albums: [], playlists: filtered.playlists };
+      case "all":
+      default:
+        return filtered;
+    }
+  }, [category, filtered]);
+
+  const getTrack = useCallback(
+    (id: string) => trackIndex.get(id),
+    [trackIndex],
+  );
+
+  return {
+    query,
+    setQuery,
+    category,
+    setCategory,
+    results: filtered,
+    visible,
+    counts,
+    getTrack,
+  };
+};
+
+export default useLibrary;


### PR DESCRIPTION
## Summary
- add a curated Spotify library dataset with tracks, albums, and playlists
- implement a memoized `useLibrary` hook and expose filtered results to the app
- integrate search and queue controls in the Spotify app and cover filtering logic with tests

## Testing
- yarn lint *(fails: existing jsx-a11y/no-top-level-window violations in unrelated apps and legacy public assets)*
- yarn test library

------
https://chatgpt.com/codex/tasks/task_e_68cc28184da883289352a106897c25f9