### PR TITLE
[apps/kismet] add CSV export support

### DIFF
--- a/__tests__/apps/kismet/csv-export.test.tsx
+++ b/__tests__/apps/kismet/csv-export.test.tsx
@@ -1,0 +1,101 @@
+import {
+  escapeCsvValue,
+  KismetCsvColumn,
+  serializeVisibleSnapshotToCsv,
+} from '../../../components/apps/kismet/export';
+
+type TestRow = {
+  ssid: string;
+  bssid: string;
+  channel: number | string;
+  frames: number;
+};
+
+const createColumns = (): KismetCsvColumn<TestRow>[] => [
+  {
+    id: 'ssid',
+    label: 'SSID',
+    getValue: (row) => row.ssid,
+  },
+  {
+    id: 'bssid',
+    label: 'BSSID',
+    getValue: (row) => row.bssid,
+  },
+  {
+    id: 'channel',
+    label: 'Channel',
+    getValue: (row) => row.channel,
+  },
+  {
+    id: 'frames',
+    label: 'Frames',
+    getValue: (row) => row.frames,
+  },
+];
+
+describe('kismet CSV export', () => {
+  it('serializes visible rows in their current order', () => {
+    const columns = createColumns().slice(0, 3);
+    const rows: TestRow[] = [
+      { ssid: 'Cafe', bssid: '00:11:22:33:44:55', channel: 6, frames: 10 },
+      { ssid: 'Home', bssid: 'aa:bb:cc:dd:ee:ff', channel: 11, frames: 20 },
+    ];
+
+    const csv = serializeVisibleSnapshotToCsv({ columns, rows });
+
+    expect(csv).toBe('SSID,BSSID,Channel\nCafe,00:11:22:33:44:55,6\nHome,aa:bb:cc:dd:ee:ff,11');
+  });
+
+  it('escapes values containing commas, quotes or new lines', () => {
+    const columns = createColumns();
+    const rows: TestRow[] = [
+      {
+        ssid: 'Office, WiFi',
+        bssid: '"escaped"',
+        channel: '10\n11',
+        frames: 42,
+      },
+    ];
+
+    const csv = serializeVisibleSnapshotToCsv({ columns, rows });
+
+    expect(csv).toBe(
+      'SSID,BSSID,Channel,Frames\n"Office, WiFi","""escaped""","10\n11",42',
+    );
+  });
+
+  it('returns an empty string when no columns are visible', () => {
+    const csv = serializeVisibleSnapshotToCsv({ columns: [], rows: [] });
+    expect(csv).toBe('');
+  });
+
+  it('handles null and undefined values', () => {
+    const columns: KismetCsvColumn<TestRow>[] = [
+      {
+        id: 'ssid',
+        label: 'SSID',
+        getValue: () => undefined,
+      },
+      {
+        id: 'frames',
+        label: 'Frames',
+        getValue: () => null,
+      },
+    ];
+
+    const csv = serializeVisibleSnapshotToCsv({
+      columns,
+      rows: [{ ssid: '', bssid: '', channel: '-', frames: 0 }],
+    });
+
+    expect(csv).toBe('SSID,Frames\n,');
+  });
+});
+
+describe('escapeCsvValue', () => {
+  it('stringifies arrays and nested objects', () => {
+    expect(escapeCsvValue(['a', 'b'])).toBe('a; b');
+    expect(escapeCsvValue({ nested: true })).toBe('"{""nested"":true}"');
+  });
+});

--- a/apps/kismet/index.tsx
+++ b/apps/kismet/index.tsx
@@ -1,11 +1,28 @@
 'use client';
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import KismetApp from '../../components/apps/kismet.jsx';
 import DeauthWalkthrough from './components/DeauthWalkthrough';
 import { createLogger } from '../../lib/logger';
+import {
+  KismetCsvColumn,
+  KismetCsvSnapshot,
+  serializeVisibleSnapshotToCsv,
+} from '../../components/apps/kismet/export';
+
+type DeviceRow = {
+  ssid: string;
+  bssid: string;
+  channel?: number;
+  frames: number;
+};
 
 const KismetPage: React.FC = () => {
+  const [visibleSnapshot, setVisibleSnapshot] = useState<KismetCsvSnapshot<DeviceRow>>({
+    columns: [] as KismetCsvColumn<DeviceRow>[],
+    rows: [],
+  });
+
   const handleNetworkDiscovered = useCallback(
     (net?: { ssid: string; bssid: string; discoveredAt: number }) => {
       if (!net) return;
@@ -18,9 +35,50 @@ const KismetPage: React.FC = () => {
     [],
   );
 
+  const handleVisibleDataChange = useCallback(
+    (snapshot: KismetCsvSnapshot<DeviceRow>) => {
+      setVisibleSnapshot(snapshot);
+    },
+    [],
+  );
+
+  const handleExportCsv = useCallback(() => {
+    if (!visibleSnapshot.columns.length || !visibleSnapshot.rows.length) {
+      return;
+    }
+
+    const csv = serializeVisibleSnapshotToCsv(visibleSnapshot);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'kismet-devices.csv';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [visibleSnapshot]);
+
+  const exportDisabled =
+    !visibleSnapshot.columns.length || !visibleSnapshot.rows.length;
+
   return (
     <>
-      <KismetApp onNetworkDiscovered={handleNetworkDiscovered} />
+      <KismetApp
+        onNetworkDiscovered={handleNetworkDiscovered}
+        onVisibleDataChange={handleVisibleDataChange}
+        exportToolbar={
+          <button
+            type="button"
+            onClick={handleExportCsv}
+            disabled={exportDisabled}
+            className="px-3 py-1 text-sm bg-gray-800 border border-gray-700 rounded hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            aria-label="Export visible devices as CSV"
+          >
+            Export CSV
+          </button>
+        }
+      />
       <DeauthWalkthrough />
     </>
   );

--- a/components/apps/kismet.jsx
+++ b/components/apps/kismet.jsx
@@ -1,4 +1,30 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+
+const DEVICE_COLUMNS = [
+  {
+    id: 'ssid',
+    label: 'SSID',
+    getValue: (network) => network.ssid || '(hidden)',
+    cellClassName: 'pr-2',
+  },
+  {
+    id: 'bssid',
+    label: 'BSSID',
+    getValue: (network) => network.bssid,
+    cellClassName: 'pr-2',
+  },
+  {
+    id: 'channel',
+    label: 'Channel',
+    getValue: (network) => (network.channel ?? '-').toString(),
+    cellClassName: 'pr-2',
+  },
+  {
+    id: 'frames',
+    label: 'Frames',
+    getValue: (network) => network.frames,
+  },
+];
 
 // Helper to convert bytes to MAC address string
 const macToString = (bytes) =>
@@ -132,10 +158,14 @@ const TimeChart = ({ data }) => {
   );
 };
 
-const KismetApp = ({ onNetworkDiscovered }) => {
+const KismetApp = ({ onNetworkDiscovered, onVisibleDataChange, exportToolbar }) => {
   const [networks, setNetworks] = useState([]);
   const [channels, setChannels] = useState({});
   const [times, setTimes] = useState({});
+
+  useEffect(() => {
+    onVisibleDataChange?.({ columns: DEVICE_COLUMNS, rows: networks });
+  }, [networks, onVisibleDataChange]);
 
   const handleFile = async (e) => {
     const file = e.target.files?.[0];
@@ -162,22 +192,27 @@ const KismetApp = ({ onNetworkDiscovered }) => {
 
       {networks.length > 0 && (
         <>
+          {exportToolbar ? (
+            <div className="flex justify-end mb-2">{exportToolbar}</div>
+          ) : null}
           <table className="text-sm w-full" aria-label="Networks">
             <thead>
               <tr className="text-left">
-                <th className="pr-2">SSID</th>
-                <th className="pr-2">BSSID</th>
-                <th className="pr-2">Channel</th>
-                <th>Frames</th>
+                {DEVICE_COLUMNS.map((column) => (
+                  <th key={column.id} className={column.cellClassName || ''}>
+                    {column.label}
+                  </th>
+                ))}
               </tr>
             </thead>
             <tbody>
               {networks.map((n) => (
                 <tr key={n.bssid} className="odd:bg-gray-800">
-                  <td className="pr-2">{n.ssid || '(hidden)'}</td>
-                  <td className="pr-2">{n.bssid}</td>
-                  <td className="pr-2">{n.channel ?? '-'}</td>
-                  <td>{n.frames}</td>
+                  {DEVICE_COLUMNS.map((column) => (
+                    <td key={column.id} className={column.cellClassName || ''}>
+                      {column.getValue(n)}
+                    </td>
+                  ))}
                 </tr>
               ))}
             </tbody>

--- a/components/apps/kismet/export.ts
+++ b/components/apps/kismet/export.ts
@@ -1,0 +1,73 @@
+export interface KismetCsvColumn<T> {
+  /** Unique identifier for the column */
+  id: string;
+  /** Header label shown in the table / CSV */
+  label: string;
+  /**
+   * Returns the value that should be written to the CSV for the provided row.
+   * The value is converted to a string during serialization.
+   */
+  getValue: (row: T) => unknown;
+}
+
+export interface KismetCsvSnapshot<T> {
+  /** Columns that are currently visible in the table */
+  columns: KismetCsvColumn<T>[];
+  /** Rows in the order they are currently displayed */
+  rows: T[];
+}
+
+const needsQuoting = (value: string) => /[",\n]/.test(value);
+
+const normaliseValue = (value: unknown): string => {
+  if (value == null) {
+    return '';
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => normaliseValue(item)).join('; ');
+  }
+
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch (error) {
+      return '';
+    }
+  }
+
+  return String(value);
+};
+
+export const escapeCsvValue = (value: unknown): string => {
+  const stringValue = normaliseValue(value);
+  if (stringValue === '') {
+    return '';
+  }
+
+  if (needsQuoting(stringValue)) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+
+  return stringValue;
+};
+
+export const serializeVisibleSnapshotToCsv = <T,>({
+  columns,
+  rows,
+}: KismetCsvSnapshot<T>): string => {
+  if (!columns.length) {
+    return '';
+  }
+
+  const header = columns.map((column) => escapeCsvValue(column.label)).join(',');
+  const lines = rows.map((row) =>
+    columns.map((column) => escapeCsvValue(column.getValue(row))).join(','),
+  );
+
+  return [header, ...lines].join('\n');
+};


### PR DESCRIPTION
## Summary
- add a CSV serialization helper for the Kismet device table
- surface visible device data from the Kismet app and render an export toolbar near the table
- cover the CSV formatting logic with dedicated tests

## Testing
- yarn lint *(fails: repository has numerous pre-existing accessibility and window globals errors)*
- yarn test --watch=false *(fails: existing window/Nmap suites fail to locate expected UI state)*
- yarn test --watch=false --runTestsByPath __tests__/apps/kismet/csv-export.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc2824082883288b4b33040c9e87a7