### PR TITLE
[nikto] add rule category toggles

### DIFF
--- a/__tests__/apps/nikto/rule-categories.test.tsx
+++ b/__tests__/apps/nikto/rule-categories.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NiktoApp from '../../../components/apps/nikto';
+
+describe('Nikto rule categories', () => {
+  it('updates pending checks when categories are toggled', async () => {
+    const user = userEvent.setup();
+    render(<NiktoApp />);
+
+    const pendingList = within(await screen.findByTestId('pending-checks'));
+    expect(
+      pendingList.getByText(/Server banner disclosure/i)
+    ).toBeInTheDocument();
+    expect(
+      pendingList.getByText(/Missing security headers/i)
+    ).toBeInTheDocument();
+
+    const headersCheckbox = screen.getByLabelText(/Headers/i);
+    await user.click(headersCheckbox);
+
+    expect(
+      screen.queryByText(/Missing security headers/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Admin console discovery/i)
+    ).toBeInTheDocument();
+
+    await user.click(headersCheckbox);
+    expect(
+      screen.getByText(/Missing security headers/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/components/apps/nikto/rules.json
+++ b/components/apps/nikto/rules.json
@@ -1,0 +1,38 @@
+{
+  "info leak": [
+    {
+      "id": "server-banner",
+      "title": "Server banner disclosure",
+      "description": "Check for verbose Server and X-Powered-By headers that reveal software versions."
+    },
+    {
+      "id": "robots-review",
+      "title": "Robots.txt secrets",
+      "description": "Review robots.txt for disallowed entries that may expose sensitive directories."
+    }
+  ],
+  "default files": [
+    {
+      "id": "admin-console",
+      "title": "Admin console discovery",
+      "description": "Probe for default admin panels and dashboards left accessible."
+    },
+    {
+      "id": "cgi-leftovers",
+      "title": "Legacy CGI scripts",
+      "description": "Check for leftover CGI scripts such as /cgi-bin/test that leak system info."
+    }
+  ],
+  "headers": [
+    {
+      "id": "security-headers",
+      "title": "Missing security headers",
+      "description": "Verify presence of CSP, HSTS, and X-Frame-Options defensive headers."
+    },
+    {
+      "id": "etag-audit",
+      "title": "ETag fingerprinting",
+      "description": "Inspect ETag responses that may disclose inode values or deployment details."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add categorized rule metadata for the Nikto simulation
- update the scan configuration to toggle categories and show pending checks instantly
- add a Jest test covering pending check updates when categories change

## Testing
- yarn lint *(fails: existing jsx-a11y labeling errors in unrelated apps)*
- CI=1 yarn test __tests__/apps/nikto/rule-categories.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc281f9c0483288b556add069b2748