### PR TITLE
[beef] add fingerprint panel with postMessage

### DIFF
--- a/__tests__/apps/beef/fingerprint.test.tsx
+++ b/__tests__/apps/beef/fingerprint.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import BeefPage from '../../../apps/beef';
+
+jest.mock('next/image', () => {
+  const MockedImage = (props: any) => <img {...props} alt={props.alt || ''} />;
+  MockedImage.displayName = 'MockedImage';
+  return MockedImage;
+});
+
+describe('BeEF fingerprint panel', () => {
+  const renderBeef = () => render(<BeefPage />);
+
+  test('updates fingerprint values when the iframe posts data', () => {
+    renderBeef();
+
+    const payload = {
+      userAgent: 'Mozilla/5.0 (Test Agent)',
+      language: 'fr-FR',
+      timezone: 'Europe/Paris',
+    };
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            source: 'beef-demo',
+            type: 'beef:fingerprint',
+            payload,
+          },
+        })
+      );
+    });
+
+    expect(screen.getByTestId('fingerprint-userAgent')).toHaveTextContent(payload.userAgent);
+    expect(screen.getByTestId('fingerprint-language')).toHaveTextContent(payload.language);
+    expect(screen.getByTestId('fingerprint-timezone')).toHaveTextContent(payload.timezone);
+  });
+
+  test('copy buttons write fingerprint values to the clipboard', async () => {
+    const originalClipboard = (navigator as any).clipboard;
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText,
+      },
+    });
+
+    renderBeef();
+
+    const payload = {
+      userAgent: 'Test UA',
+      language: 'de-DE',
+      timezone: 'Europe/Berlin',
+    };
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            source: 'beef-demo',
+            type: 'beef:fingerprint',
+            payload,
+          },
+        })
+      );
+    });
+
+    const copyButton = screen.getByRole('button', { name: /copy user agent/i });
+
+    await act(async () => {
+      fireEvent.click(copyButton);
+    });
+
+    expect(writeText).toHaveBeenCalledWith(payload.userAgent);
+    expect(copyButton).toHaveTextContent(/copied!/i);
+
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: originalClipboard,
+      });
+    } else {
+      delete (navigator as any).clipboard;
+    }
+  });
+
+  test('sends emulator settings to the demo iframe when profile changes', () => {
+    renderBeef();
+
+    const iframe = screen.getByTitle(/demo target/i) as HTMLIFrameElement;
+    const postMessage = jest.fn();
+    Object.defineProperty(iframe, 'contentWindow', {
+      configurable: true,
+      value: { postMessage },
+    });
+
+    act(() => {
+      fireEvent.load(iframe);
+    });
+
+    postMessage.mockClear();
+
+    const profileSelect = screen.getByLabelText(/emulator profile/i);
+    fireEvent.change(profileSelect, { target: { value: 'mobile-safari' } });
+
+    expect(postMessage).toHaveBeenCalled();
+    const [message, target] = postMessage.mock.calls[0];
+    expect(target).toBe('*');
+    expect(message).toMatchObject({
+      type: 'beef:apply-emulator',
+      payload: expect.objectContaining({
+        userAgent: expect.any(String),
+        language: expect.any(String),
+        timezone: expect.any(String),
+      }),
+    });
+  });
+});

--- a/apps/beef/index.tsx
+++ b/apps/beef/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import BeefApp from '../../components/apps/beef';
 
@@ -12,11 +12,66 @@ interface LogEntry {
   message: string;
 }
 
+type FingerprintField = 'userAgent' | 'language' | 'timezone';
+
+interface FingerprintData {
+  userAgent: string;
+  language: string;
+  timezone: string;
+}
+
+interface EmulatorProfile {
+  id: string;
+  label: string;
+  settings: FingerprintData;
+}
+
 const severityStyles: Record<Severity, { icon: string; color: string }> = {
   Low: { icon: '🟢', color: 'bg-green-700' },
   Medium: { icon: '🟡', color: 'bg-yellow-700' },
   High: { icon: '🔴', color: 'bg-red-700' },
 };
+
+const FINGERPRINT_FIELDS: { key: FingerprintField; label: string }[] = [
+  { key: 'userAgent', label: 'User Agent' },
+  { key: 'language', label: 'Language' },
+  { key: 'timezone', label: 'Timezone' },
+];
+
+const EMULATOR_PROFILES: EmulatorProfile[] = [
+  {
+    id: 'desktop-chrome',
+    label: 'Chrome on macOS',
+    settings: {
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      language: 'en-US',
+      timezone: 'America/New_York',
+    },
+  },
+  {
+    id: 'mobile-safari',
+    label: 'Safari on iPhone',
+    settings: {
+      userAgent:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      language: 'en-GB',
+      timezone: 'Europe/London',
+    },
+  },
+  {
+    id: 'android-firefox',
+    label: 'Firefox on Android',
+    settings: {
+      userAgent:
+        'Mozilla/5.0 (Android 14; Mobile; rv:120.0) Gecko/120.0 Firefox/120.0',
+      language: 'de-DE',
+      timezone: 'Europe/Berlin',
+    },
+  },
+];
+
+const defaultProfile = EMULATOR_PROFILES[0];
 
 const BeefPage: React.FC = () => {
   const [logs] = useState<LogEntry[]>([
@@ -24,6 +79,115 @@ const BeefPage: React.FC = () => {
     { time: '10:00:02', severity: 'Medium', message: 'Payload delivered' },
     { time: '10:00:03', severity: 'High', message: 'Sensitive data exfil attempt' },
   ]);
+  const [selectedProfileId, setSelectedProfileId] = useState<string>(defaultProfile.id);
+  const [emulatorSettings, setEmulatorSettings] = useState<FingerprintData>({
+    ...defaultProfile.settings,
+  });
+  const [fingerprint, setFingerprint] = useState<FingerprintData>({
+    ...defaultProfile.settings,
+  });
+  const [copiedField, setCopiedField] = useState<FingerprintField | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [iframeReady, setIframeReady] = useState(false);
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      const data = event.data as
+        | { source?: string; type?: string; payload?: Partial<FingerprintData> }
+        | undefined;
+      if (!data || data.source !== 'beef-demo' || data.type !== 'beef:fingerprint') {
+        return;
+      }
+      const payload = data.payload ?? {};
+      setFingerprint((prev) => ({
+        userAgent: typeof payload.userAgent === 'string' && payload.userAgent.length > 0
+          ? payload.userAgent
+          : prev.userAgent,
+        language: typeof payload.language === 'string' && payload.language.length > 0
+          ? payload.language
+          : prev.language,
+        timezone: typeof payload.timezone === 'string' && payload.timezone.length > 0
+          ? payload.timezone
+          : prev.timezone,
+      }));
+    };
+
+    window.addEventListener('message', handler);
+    return () => {
+      window.removeEventListener('message', handler);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (copyTimer.current) {
+      clearTimeout(copyTimer.current);
+      copyTimer.current = null;
+    }
+    if (copiedField) {
+      copyTimer.current = setTimeout(() => {
+        setCopiedField(null);
+        copyTimer.current = null;
+      }, 2000);
+    }
+
+    return () => {
+      if (copyTimer.current) {
+        clearTimeout(copyTimer.current);
+        copyTimer.current = null;
+      }
+    };
+  }, [copiedField]);
+
+  useEffect(() => {
+    if (!iframeReady || !iframeRef.current?.contentWindow) {
+      return;
+    }
+    iframeRef.current.contentWindow.postMessage(
+      {
+        source: 'beef-control',
+        type: 'beef:apply-emulator',
+        payload: emulatorSettings,
+      },
+      '*'
+    );
+  }, [emulatorSettings, iframeReady]);
+
+  useEffect(() => {
+    if (!iframeReady || !iframeRef.current?.contentWindow) {
+      return;
+    }
+    iframeRef.current.contentWindow.postMessage(
+      {
+        source: 'beef-control',
+        type: 'beef:request-fingerprint',
+      },
+      '*'
+    );
+  }, [iframeReady]);
+
+  const handleProfileChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextProfile =
+      EMULATOR_PROFILES.find((profile) => profile.id === event.target.value) ?? defaultProfile;
+    setSelectedProfileId(nextProfile.id);
+    setEmulatorSettings({ ...nextProfile.settings });
+    setFingerprint({ ...nextProfile.settings });
+  };
+
+  const handleCopy = async (field: FingerprintField) => {
+    const value = fingerprint[field];
+    if (!value) {
+      return;
+    }
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+        await navigator.clipboard.writeText(value);
+      }
+    } catch {
+      // ignore copy errors but still show feedback so the UI feels responsive
+    }
+    setCopiedField(field);
+  };
 
   return (
     <div className="bg-ub-cool-grey text-white h-full w-full flex flex-col">
@@ -35,7 +199,10 @@ const BeefPage: React.FC = () => {
             width={48}
             height={48}
           />
-          <h1 className="text-xl">BeEF Demo</h1>
+          <div>
+            <h1 className="text-xl">BeEF Demo</h1>
+            <p className="text-xs text-gray-300">Browser Exploitation Framework — safe training mode</p>
+          </div>
         </div>
         <div className="flex gap-2">
           <img
@@ -51,8 +218,78 @@ const BeefPage: React.FC = () => {
         </div>
       </header>
 
-      <div className="p-4 flex-1 overflow-auto">
-        <BeefApp />
+      <div className="p-4 flex-1 overflow-hidden flex flex-col lg:flex-row gap-4">
+        <div className="flex-1 overflow-auto rounded border border-gray-700 bg-black/20">
+          <BeefApp />
+        </div>
+        <aside
+          className="w-full lg:w-80 flex-shrink-0 border border-gray-700/80 rounded bg-black/30 p-4 text-sm flex flex-col gap-4"
+          aria-labelledby="fingerprint-heading"
+        >
+          <div className="flex items-center justify-between">
+            <h2 id="fingerprint-heading" className="text-base font-semibold">
+              Fingerprint
+            </h2>
+            <span className="text-xs text-emerald-300">Live</span>
+          </div>
+          <div className="flex flex-col gap-2">
+            <label htmlFor="emulatorProfile" className="text-xs uppercase text-gray-300 tracking-wide">
+              Emulator profile
+            </label>
+            <select
+              id="emulatorProfile"
+              value={selectedProfileId}
+              onChange={handleProfileChange}
+              className="text-black rounded px-2 py-1 text-sm"
+            >
+              {EMULATOR_PROFILES.map((profile) => (
+                <option key={profile.id} value={profile.id}>
+                  {profile.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <dl className="space-y-3">
+            {FINGERPRINT_FIELDS.map((field) => (
+              <div
+                key={field.key}
+                className="flex items-start justify-between gap-2 border border-gray-700/60 rounded bg-black/40 p-3"
+              >
+                <div className="flex-1">
+                  <dt className="text-xs uppercase text-gray-300 tracking-wide">{field.label}</dt>
+                  <dd
+                    className="text-sm break-all"
+                    data-testid={`fingerprint-${field.key}`}
+                    aria-live="polite"
+                  >
+                    {fingerprint[field.key] || '—'}
+                  </dd>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleCopy(field.key)}
+                  className="self-start px-2 py-1 bg-ub-primary text-white text-xs rounded"
+                  aria-label={`Copy ${field.label}`}
+                >
+                  {copiedField === field.key ? 'Copied!' : 'Copy'}
+                </button>
+              </div>
+            ))}
+          </dl>
+          <div className="flex flex-col gap-2">
+            <iframe
+              ref={iframeRef}
+              title="Demo Target"
+              src="/beef-demo/index.html"
+              className="w-full h-40 border border-gray-700/60 rounded"
+              sandbox="allow-scripts"
+              onLoad={() => setIframeReady(true)}
+            />
+            <p className="text-xs text-gray-300">
+              The sandboxed target only echoes emulator preferences. No network calls ever leave this demo.
+            </p>
+          </div>
+        </aside>
       </div>
 
       <div className="border-t border-gray-700 font-mono text-sm">

--- a/public/beef-demo/index.html
+++ b/public/beef-demo/index.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>BeEF Demo Target</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: "Fira Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #121212;
+        color: #f5f5f5;
+      }
+      body {
+        margin: 0;
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      h1 {
+        font-size: 18px;
+        margin: 0;
+      }
+      p {
+        margin: 0;
+        font-size: 14px;
+        line-height: 1.4;
+      }
+      dl {
+        margin: 0;
+        display: grid;
+        grid-template-columns: minmax(120px, 1fr) 2fr;
+        gap: 6px 12px;
+        font-size: 13px;
+      }
+      dt {
+        font-weight: 600;
+        color: #9ca3af;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        font-size: 11px;
+      }
+      dd {
+        margin: 0;
+        word-break: break-all;
+      }
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 11px;
+        padding: 4px 8px;
+        border-radius: 9999px;
+        background: rgba(56, 189, 248, 0.15);
+        color: #38bdf8;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="badge" id="status">Awaiting profile…</div>
+    <h1>Sandboxed Target Page</h1>
+    <p>
+      This page never leaves your browser. It mirrors emulator preferences and reports them back to the
+      desktop over <code>postMessage</code> so you can observe how the control channel works.
+    </p>
+    <dl>
+      <dt>User agent</dt>
+      <dd id="fingerprint-userAgent">Loading…</dd>
+      <dt>Language</dt>
+      <dd id="fingerprint-language">Loading…</dd>
+      <dt>Timezone</dt>
+      <dd id="fingerprint-timezone">Loading…</dd>
+    </dl>
+    <script>
+      (function () {
+        var state = {
+          userAgent: navigator.userAgent || '',
+          language: navigator.language || (navigator.languages && navigator.languages[0]) || 'en-US',
+          timezone: (Intl.DateTimeFormat().resolvedOptions().timeZone) || 'UTC',
+        };
+
+        var statusEl = document.getElementById('status');
+        var userAgentEl = document.getElementById('fingerprint-userAgent');
+        var languageEl = document.getElementById('fingerprint-language');
+        var timezoneEl = document.getElementById('fingerprint-timezone');
+
+        function updateDisplay() {
+          if (statusEl) {
+            statusEl.textContent = 'Profile active';
+          }
+          if (userAgentEl) {
+            userAgentEl.textContent = state.userAgent || '—';
+          }
+          if (languageEl) {
+            languageEl.textContent = state.language || '—';
+          }
+          if (timezoneEl) {
+            timezoneEl.textContent = state.timezone || '—';
+          }
+        }
+
+        function sendFingerprint() {
+          if (window.parent && window.parent !== window) {
+            window.parent.postMessage(
+              {
+                source: 'beef-demo',
+                type: 'beef:fingerprint',
+                payload: {
+                  userAgent: state.userAgent,
+                  language: state.language,
+                  timezone: state.timezone,
+                },
+              },
+              '*'
+            );
+          }
+        }
+
+        function applySettings(payload) {
+          if (!payload || typeof payload !== 'object') {
+            return;
+          }
+          if (typeof payload.userAgent === 'string') {
+            state.userAgent = payload.userAgent;
+          }
+          if (typeof payload.language === 'string') {
+            state.language = payload.language;
+          }
+          if (typeof payload.timezone === 'string') {
+            state.timezone = payload.timezone;
+          }
+          updateDisplay();
+          sendFingerprint();
+        }
+
+        window.addEventListener('message', function (event) {
+          var data = event.data;
+          if (!data || typeof data !== 'object') {
+            return;
+          }
+          if (data.type === 'beef:apply-emulator') {
+            applySettings(data.payload);
+          } else if (data.type === 'beef:request-fingerprint') {
+            sendFingerprint();
+          }
+        });
+
+        document.addEventListener('DOMContentLoaded', function () {
+          updateDisplay();
+          sendFingerprint();
+        });
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a sandboxed beef-demo page that echoes emulator preferences back to the desktop via postMessage
- render a live fingerprint panel with copy actions alongside the BeEF training flow
- cover the new postMessage wiring with targeted Jest tests

## Testing
- yarn lint *(fails: repository-wide accessibility and top-level window lint violations present before this change)*
- yarn test --watch=false --runInBand *(terminated after encountering existing failing suites to avoid an extremely long run)*
- yarn test __tests__/apps/beef/fingerprint.test.tsx --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68cc281a919083288f9f6ce562887505