### PR TITLE
[metasploit] add payload builder form

### DIFF
--- a/__tests__/apps/metasploit/payload-builder.test.tsx
+++ b/__tests__/apps/metasploit/payload-builder.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import PayloadBuilderForm from '../../../apps/metasploit/components/PayloadBuilderForm';
+
+describe('PayloadBuilderForm', () => {
+  const writeText = jest.fn<Promise<void>, [string]>();
+
+  beforeEach(() => {
+    writeText.mockReset();
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('updates dependent fields and preview when payload type changes', () => {
+    render(<PayloadBuilderForm />);
+
+    fireEvent.change(screen.getByLabelText(/Payload Type/i), {
+      target: { value: 'linux/x64/meterpreter_reverse_tcp' },
+    });
+
+    expect(screen.getByLabelText(/Architecture/i)).toHaveValue('x64');
+
+    const hostInput = screen.getByLabelText('LHOST');
+    fireEvent.change(hostInput, { target: { value: '10.10.14.5' } });
+
+    const preview = screen.getByTestId('payload-preview');
+    expect(preview.textContent).toContain('"payload": "linux/x64/meterpreter_reverse_tcp"');
+    expect(preview.textContent).toContain('"LHOST": "10.10.14.5"');
+  });
+
+  it('shows validation errors and disables submit for invalid configuration', async () => {
+    render(<PayloadBuilderForm />);
+
+    const hostInput = screen.getByLabelText('LHOST');
+    const submitButton = screen.getByRole('button', { name: /Generate Payload/i });
+
+    fireEvent.change(hostInput, { target: { value: '192.168.56.1' } });
+    await waitFor(() => expect(submitButton).not.toBeDisabled());
+
+    fireEvent.change(hostInput, { target: { value: '' } });
+
+    expect(await screen.findByText('LHOST is required.')).toBeInTheDocument();
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('copies payload script to clipboard when configuration is valid', async () => {
+    render(<PayloadBuilderForm />);
+
+    const hostInput = screen.getByLabelText('LHOST');
+    const submitButton = screen.getByRole('button', { name: /Generate Payload/i });
+
+    fireEvent.change(hostInput, { target: { value: '192.168.56.1' } });
+    await waitFor(() => expect(submitButton).not.toBeDisabled());
+
+    fireEvent.submit(screen.getByTestId('payload-builder-form'));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const payloadScript = writeText.mock.calls[0][0];
+    expect(payloadScript).toContain('use payload/windows/meterpreter_reverse_tcp');
+    expect(payloadScript).toContain('set LHOST 192.168.56.1');
+    expect(payloadScript).toContain('generate -f raw');
+    expect(screen.getByText(/Payload copied to clipboard/i)).toBeInTheDocument();
+  });
+});

--- a/apps/metasploit/components/PayloadBuilderForm.tsx
+++ b/apps/metasploit/components/PayloadBuilderForm.tsx
@@ -1,0 +1,299 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import type { ZodIssue } from 'zod';
+import {
+  buildPayloadScript,
+  getPayloadDefinition,
+  payloadDefinitions,
+  payloadSelectionSchema,
+  type PayloadDefinition,
+  type PayloadSelection,
+} from '../../../components/apps/metasploit/payloads';
+
+interface PayloadBuilderFormProps {
+  onCopy?: (result: { success: boolean; payload: string }) => void;
+}
+
+type OptionErrorMap = Record<string, string>;
+
+interface FormErrors {
+  type?: string;
+  architecture?: string;
+  encoder?: string;
+  options?: OptionErrorMap;
+}
+
+const buildInitialState = (definition: PayloadDefinition): PayloadSelection => ({
+  type: definition.id,
+  architecture: definition.architectures[0],
+  encoder: definition.encoders[0],
+  options: definition.options.reduce<Record<string, string>>((acc, option) => {
+    acc[option.name] = option.defaultValue ?? '';
+    return acc;
+  }, {}),
+});
+
+const toErrorMap = (issues: ZodIssue[]): FormErrors => {
+  const errors: FormErrors = {};
+  issues.forEach((issue) => {
+    const [first, second] = issue.path;
+    if (first === 'options' && typeof second === 'string') {
+      if (!errors.options) errors.options = {};
+      errors.options[second] = issue.message;
+    } else if (typeof first === 'string') {
+      errors[first as keyof FormErrors] = issue.message;
+    }
+  });
+  return errors;
+};
+
+const PayloadBuilderForm: React.FC<PayloadBuilderFormProps> = ({ onCopy }) => {
+  const defaultDefinition = payloadDefinitions[0];
+  const [formState, setFormState] = useState<PayloadSelection>(() =>
+    buildInitialState(defaultDefinition),
+  );
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [isValid, setIsValid] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [status, setStatus] = useState<{ success: boolean; message: string } | null>(null);
+
+  const selectedDefinition = useMemo(
+    () => getPayloadDefinition(formState.type) ?? defaultDefinition,
+    [formState.type, defaultDefinition],
+  );
+
+  useEffect(() => {
+    const result = payloadSelectionSchema.safeParse(formState);
+    if (result.success) {
+      setErrors({});
+      setIsValid(true);
+    } else {
+      setErrors(toErrorMap(result.error.issues));
+      setIsValid(false);
+    }
+  }, [formState]);
+
+  const handleTypeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextType = event.target.value;
+    const definition = getPayloadDefinition(nextType);
+    if (!definition) {
+      setFormState((prev) => ({ ...prev, type: nextType }));
+      return;
+    }
+
+    setFormState((prev) => {
+      const nextArchitecture = definition.architectures.includes(prev.architecture)
+        ? prev.architecture
+        : definition.architectures[0];
+      const nextEncoder = definition.encoders.includes(prev.encoder)
+        ? prev.encoder
+        : definition.encoders[0];
+
+      const optionState = definition.options.reduce<Record<string, string>>((acc, option) => {
+        const prior = prev.options?.[option.name];
+        acc[option.name] = prior !== undefined ? prior : option.defaultValue ?? '';
+        return acc;
+      }, {});
+
+      return {
+        type: definition.id,
+        architecture: nextArchitecture,
+        encoder: nextEncoder,
+        options: optionState,
+      };
+    });
+  };
+
+  const handleArchitectureChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setFormState((prev) => ({ ...prev, architecture: event.target.value }));
+  };
+
+  const handleEncoderChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setFormState((prev) => ({ ...prev, encoder: event.target.value }));
+  };
+
+  const handleOptionChange = (name: string, value: string) => {
+    setFormState((prev) => ({
+      ...prev,
+      options: {
+        ...prev.options,
+        [name]: value,
+      },
+    }));
+  };
+
+  const preview = useMemo(() => {
+    return JSON.stringify(
+      {
+        payload: formState.type,
+        architecture: formState.architecture,
+        encoder: formState.encoder,
+        options: formState.options,
+      },
+      null,
+      2,
+    );
+  }, [formState]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const result = payloadSelectionSchema.safeParse(formState);
+    if (!result.success) {
+      setErrors(toErrorMap(result.error.issues));
+      setIsValid(false);
+      setStatus({ success: false, message: 'Resolve validation errors before generating.' });
+      return;
+    }
+
+    const payloadScript = buildPayloadScript(result.data);
+
+    setIsSubmitting(true);
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(payloadScript);
+        setStatus({ success: true, message: 'Payload copied to clipboard.' });
+        onCopy?.({ success: true, payload: payloadScript });
+      } else {
+        setStatus({ success: false, message: 'Clipboard API is not available.' });
+        onCopy?.({ success: false, payload: payloadScript });
+      }
+    } catch (error) {
+      setStatus({ success: false, message: 'Failed to copy payload to clipboard.' });
+      onCopy?.({ success: false, payload: payloadScript });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <form className="space-y-4" onSubmit={handleSubmit} data-testid="payload-builder-form">
+        <div>
+          <label className="block text-sm font-medium text-gray-200" htmlFor="payload-type">
+            Payload Type
+          </label>
+          <select
+            id="payload-type"
+            className="mt-1 w-full rounded border border-gray-600 bg-gray-900 p-2 text-sm text-gray-100"
+            value={formState.type}
+            onChange={handleTypeChange}
+          >
+            {payloadDefinitions.map((definition) => (
+              <option key={definition.id} value={definition.id}>
+                {definition.name}
+              </option>
+            ))}
+          </select>
+          {errors.type && <p className="mt-1 text-xs text-red-400">{errors.type}</p>}
+          <p className="mt-1 text-xs text-gray-400">{selectedDefinition.description}</p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label
+              className="block text-sm font-medium text-gray-200"
+              htmlFor="payload-architecture"
+            >
+              Architecture
+            </label>
+            <select
+              id="payload-architecture"
+              className="mt-1 w-full rounded border border-gray-600 bg-gray-900 p-2 text-sm text-gray-100"
+              value={formState.architecture}
+              onChange={handleArchitectureChange}
+            >
+              {selectedDefinition.architectures.map((arch) => (
+                <option key={arch} value={arch}>
+                  {arch}
+                </option>
+              ))}
+            </select>
+            {errors.architecture && (
+              <p className="mt-1 text-xs text-red-400">{errors.architecture}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-200" htmlFor="payload-encoder">
+              Encoder
+            </label>
+            <select
+              id="payload-encoder"
+              className="mt-1 w-full rounded border border-gray-600 bg-gray-900 p-2 text-sm text-gray-100"
+              value={formState.encoder}
+              onChange={handleEncoderChange}
+            >
+              {selectedDefinition.encoders.map((enc) => (
+                <option key={enc} value={enc}>
+                  {enc}
+                </option>
+              ))}
+            </select>
+            {errors.encoder && <p className="mt-1 text-xs text-red-400">{errors.encoder}</p>}
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          {selectedDefinition.options.map((option) => {
+            const fieldId = `payload-option-${option.name.toLowerCase()}`;
+            const labelId = `${fieldId}-label`;
+            return (
+              <div key={option.name}>
+                <label
+                  id={labelId}
+                  className="block text-sm font-medium text-gray-200"
+                  htmlFor={fieldId}
+                >
+                  {option.label}
+                </label>
+                <input
+                  id={fieldId}
+                  name={option.name}
+                  type="text"
+                  className="mt-1 w-full rounded border border-gray-600 bg-gray-900 p-2 text-sm text-gray-100"
+                  placeholder={option.placeholder}
+                  value={formState.options?.[option.name] ?? ''}
+                  aria-labelledby={labelId}
+                  onChange={(event) => handleOptionChange(option.name, event.target.value)}
+                />
+                {option.description && (
+                  <p className="mt-1 text-xs text-gray-400">{option.description}</p>
+                )}
+                {errors.options?.[option.name] && (
+                  <p className="mt-1 text-xs text-red-400">{errors.options[option.name]}</p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
+          <button
+            type="submit"
+            className="rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:bg-blue-600/50"
+            disabled={!isValid || isSubmitting}
+          >
+            {isSubmitting ? 'Copying…' : 'Generate Payload'}
+          </button>
+          {status && (
+            <p
+              className={`text-sm ${status.success ? 'text-green-400' : 'text-red-400'}`}
+              role="status"
+              aria-live="polite"
+            >
+              {status.message}
+            </p>
+          )}
+        </div>
+      </form>
+
+      <div className="rounded border border-gray-700 bg-black/70 p-3 text-xs text-green-300">
+        <div className="mb-2 text-sm font-semibold text-gray-200">Payload Preview</div>
+        <pre data-testid="payload-preview" className="whitespace-pre-wrap break-words">{preview}</pre>
+      </div>
+    </div>
+  );
+};
+
+export default PayloadBuilderForm;

--- a/apps/metasploit/index.tsx
+++ b/apps/metasploit/index.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import modulesData from '../../components/apps/metasploit/modules.json';
 import MetasploitApp from '../../components/apps/metasploit';
+import PayloadBuilderForm from './components/PayloadBuilderForm';
 import Toast from '../../components/ui/Toast';
 
 interface Module {
@@ -99,7 +100,9 @@ const MetasploitPage: React.FC = () => {
     };
   }, []);
 
-  const handleGenerate = () => setToast('Payload generated');
+  const handlePayloadCopy = (result: { success: boolean }) => {
+    setToast(result.success ? 'Payload copied to clipboard' : 'Failed to copy payload');
+  };
 
   const renderTree = (node: TreeNode) => (
     <ul className="ml-2">
@@ -192,20 +195,10 @@ const MetasploitPage: React.FC = () => {
           />
           <div
             style={{ height: `calc(${100 - split}% - 2px)` }}
-            className="overflow-auto p-2 space-y-2"
+            className="overflow-auto p-2"
           >
-            <h3 className="font-semibold">Generate Payload</h3>
-            <input
-              type="text"
-              placeholder="Payload options..."
-              className="border p-1 w-full"
-            />
-            <button
-              onClick={handleGenerate}
-              className="px-2 py-1 bg-blue-500 text-white rounded"
-            >
-              Generate
-            </button>
+            <h3 className="mb-3 font-semibold">Generate Payload</h3>
+            <PayloadBuilderForm onCopy={handlePayloadCopy} />
           </div>
         </div>
       </div>

--- a/components/apps/metasploit/payloads.ts
+++ b/components/apps/metasploit/payloads.ts
@@ -1,0 +1,230 @@
+import { z } from 'zod';
+
+export interface PayloadOptionDefinition {
+  name: string;
+  label: string;
+  description?: string;
+  required?: boolean;
+  placeholder?: string;
+  defaultValue?: string;
+  validator?: (value: string) => boolean;
+  validationMessage?: string;
+}
+
+export interface PayloadDefinition {
+  id: string;
+  name: string;
+  description: string;
+  architectures: string[];
+  encoders: string[];
+  options: PayloadOptionDefinition[];
+}
+
+const ipRegex = /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)){3}$/;
+
+const isIpAddress = (value: string): boolean => ipRegex.test(value.trim());
+
+const isPort = (value: string): boolean => {
+  const port = Number(value.trim());
+  return Number.isInteger(port) && port >= 1 && port <= 65535;
+};
+
+const hasLeadingSlash = (value: string): boolean => value.trim().startsWith('/');
+
+export const payloadDefinitions: PayloadDefinition[] = [
+  {
+    id: 'windows/meterpreter_reverse_tcp',
+    name: 'Windows Meterpreter Reverse TCP',
+    description:
+      'Classic Meterpreter reverse TCP payload for Windows hosts with staged connection.',
+    architectures: ['x86', 'x64'],
+    encoders: ['generic/none', 'x86/shikata_ga_nai', 'x64/xor_dynamic'],
+    options: [
+      {
+        name: 'LHOST',
+        label: 'LHOST',
+        description: 'Local interface to receive the incoming session.',
+        placeholder: '192.168.56.1',
+        required: true,
+        validator: isIpAddress,
+        validationMessage: 'Enter a valid IPv4 address.',
+      },
+      {
+        name: 'LPORT',
+        label: 'LPORT',
+        description: 'Local port for the handler (1-65535).',
+        defaultValue: '4444',
+        required: true,
+        validator: isPort,
+        validationMessage: 'Enter a port number between 1 and 65535.',
+      },
+      {
+        name: 'EXITFUNC',
+        label: 'EXITFUNC',
+        description: 'Method the payload should use to exit.',
+        defaultValue: 'thread',
+      },
+    ],
+  },
+  {
+    id: 'linux/x64/meterpreter_reverse_tcp',
+    name: 'Linux Meterpreter Reverse TCP',
+    description:
+      'Staged reverse TCP meterpreter for Linux with optional SSL negotiation.',
+    architectures: ['x64'],
+    encoders: ['generic/none', 'x64/xor_dynamic'],
+    options: [
+      {
+        name: 'LHOST',
+        label: 'LHOST',
+        description: 'Callback interface for the payload.',
+        placeholder: '10.10.14.1',
+        required: true,
+        validator: isIpAddress,
+        validationMessage: 'Enter a valid IPv4 address.',
+      },
+      {
+        name: 'LPORT',
+        label: 'LPORT',
+        description: 'Listener port for the payload connection.',
+        defaultValue: '4444',
+        required: true,
+        validator: isPort,
+        validationMessage: 'Enter a port number between 1 and 65535.',
+      },
+      {
+        name: 'SSL',
+        label: 'SSL',
+        description: 'Enable SSL for transport (true/false).',
+        defaultValue: 'false',
+      },
+    ],
+  },
+  {
+    id: 'python/meterpreter_reverse_https',
+    name: 'Python Meterpreter Reverse HTTPS',
+    description:
+      'Python reverse HTTPS meterpreter payload with URI customisation.',
+    architectures: ['python'],
+    encoders: ['generic/none'],
+    options: [
+      {
+        name: 'LHOST',
+        label: 'LHOST',
+        description: 'Callback interface for the payload.',
+        placeholder: '10.0.0.5',
+        required: true,
+        validator: isIpAddress,
+        validationMessage: 'Enter a valid IPv4 address.',
+      },
+      {
+        name: 'LPORT',
+        label: 'LPORT',
+        description: 'Listener port for the payload connection.',
+        defaultValue: '8443',
+        required: true,
+        validator: isPort,
+        validationMessage: 'Enter a port number between 1 and 65535.',
+      },
+      {
+        name: 'URIPATH',
+        label: 'URI Path',
+        description: 'Endpoint path for staging, must start with a slash.',
+        defaultValue: '/metasploit',
+        validator: hasLeadingSlash,
+        validationMessage: 'Provide a relative URI path that begins with /.',
+      },
+    ],
+  },
+];
+
+const payloadDefinitionMap = new Map(payloadDefinitions.map((definition) => [definition.id, definition]));
+
+export const getPayloadDefinition = (type: string): PayloadDefinition | undefined =>
+  payloadDefinitionMap.get(type);
+
+export const payloadSelectionSchema = z
+  .object({
+    type: z.string(),
+    architecture: z.string(),
+    encoder: z.string(),
+    options: z.record(z.string(), z.string()).default({}),
+  })
+  .superRefine((value, ctx) => {
+    const definition = payloadDefinitionMap.get(value.type);
+    if (!definition) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['type'],
+        message: 'Select a valid payload type.',
+      });
+      return;
+    }
+
+    if (!definition.architectures.includes(value.architecture)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['architecture'],
+        message: 'Architecture is not supported by this payload.',
+      });
+    }
+
+    if (!definition.encoders.includes(value.encoder)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['encoder'],
+        message: 'Encoder is not compatible with this payload.',
+      });
+    }
+
+    definition.options.forEach((option) => {
+      const rawValue = value.options?.[option.name] ?? '';
+      const trimmed = rawValue.trim();
+
+      if (option.required && !trimmed) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['options', option.name],
+          message: `${option.label} is required.`,
+        });
+        return;
+      }
+
+      if (trimmed && option.validator && !option.validator(trimmed)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['options', option.name],
+          message: option.validationMessage || `${option.label} is invalid.`,
+        });
+      }
+    });
+  });
+
+export type PayloadSelection = z.infer<typeof payloadSelectionSchema>;
+
+export const buildPayloadScript = (selection: PayloadSelection): string => {
+  const definition = payloadDefinitionMap.get(selection.type);
+  const lines = [`use payload/${selection.type}`];
+  lines.push(`set ARCH ${selection.architecture}`);
+  lines.push(`set ENCODER ${selection.encoder}`);
+
+  if (definition) {
+    definition.options.forEach((option) => {
+      const value = selection.options?.[option.name]?.trim();
+      if (value) {
+        lines.push(`set ${option.name} ${value}`);
+      } else if (option.defaultValue) {
+        lines.push(`set ${option.name} ${option.defaultValue}`);
+      }
+    });
+  } else {
+    Object.entries(selection.options || {}).forEach(([key, value]) => {
+      if (value?.trim()) {
+        lines.push(`set ${key} ${value.trim()}`);
+      }
+    });
+  }
+
+  lines.push('generate -f raw');
+  return lines.join('\n');
+};


### PR DESCRIPTION
## Summary
- add reusable payload metadata, validation schema, and script builder helpers
- add a metasploit payload builder form with live validation, preview, and clipboard copy handling
- integrate the payload builder into the Metasploit page and cover the form with unit tests

## Testing
- yarn lint *(fails: repository has pre-existing accessibility lint violations outside this change)*
- yarn test payload-builder

------
https://chatgpt.com/codex/tasks/task_e_68cc282c25f08328a2ebb37ffaf42661