### PR TITLE
[reaver] add handshake visualizer

### DIFF
--- a/__tests__/apps/reaver/__snapshots__/handshake.test.tsx.snap
+++ b/__tests__/apps/reaver/__snapshots__/handshake.test.tsx.snap
@@ -1,0 +1,617 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`HandshakeVisualizer renders the handshake diagram 1`] = `
+<DocumentFragment>
+  <section
+    aria-labelledby="«r0»"
+    class="bg-gray-800 rounded p-4"
+  >
+    <h3
+      class="text-base font-semibold text-white mb-3"
+      id="«r0»"
+    >
+      WPA2 4-Way Handshake
+    </h3>
+    <div
+      class="relative"
+    >
+      <svg
+        aria-describedby="«r0»-desc"
+        class="w-full h-auto text-gray-200"
+        role="img"
+        viewBox="0 0 380 550"
+      >
+        <title>
+          WPA2 4-Way Handshake sequence diagram
+        </title>
+        <desc
+          id="«r0»-desc"
+        >
+          M1 from Access Point to Client. M2 from Client to Access Point. M3 from Access Point to Client. M4 from Client to Access Point
+        </desc>
+        <defs>
+          <marker
+            fill="currentColor"
+            id="arrow-head"
+            markerHeight="7"
+            markerWidth="10"
+            orient="auto"
+            refX="10"
+            refY="3.5"
+          >
+            <polygon
+              points="0 0, 10 3.5, 0 7"
+            />
+          </marker>
+        </defs>
+        <g>
+          <text
+            class="fill-gray-100 text-xs uppercase tracking-wide"
+            text-anchor="middle"
+            x="80"
+            y="18"
+          >
+            Access Point
+          </text>
+          <circle
+            class="fill-gray-200"
+            cx="80"
+            cy="40"
+            r="6"
+          />
+          <line
+            class="stroke-gray-600"
+            stroke-dasharray="6 6"
+            stroke-width="2"
+            x1="80"
+            x2="80"
+            y1="40"
+            y2="510"
+          />
+        </g>
+        <g>
+          <text
+            class="fill-gray-100 text-xs uppercase tracking-wide"
+            text-anchor="middle"
+            x="300"
+            y="18"
+          >
+            Client
+          </text>
+          <circle
+            class="fill-gray-200"
+            cx="300"
+            cy="40"
+            r="6"
+          />
+          <line
+            class="stroke-gray-600"
+            stroke-dasharray="6 6"
+            stroke-width="2"
+            x1="300"
+            x2="300"
+            y1="40"
+            y2="510"
+          />
+        </g>
+        <g>
+          <line
+            class="stroke-green-400"
+            marker-end="url(#arrow-head)"
+            stroke-width="3"
+            x1="80"
+            x2="300"
+            y1="80"
+            y2="80"
+          />
+          <text
+            class="fill-gray-200 text-xs font-semibold"
+            text-anchor="middle"
+            x="190"
+            y="70"
+          >
+            M1
+          </text>
+          <foreignobject
+            height="46"
+            width="200"
+            x="90"
+            y="49"
+          >
+            <div
+              class="pointer-events-auto flex items-center justify-center gap-2"
+              xmlns="http://www.w3.org/1999/xhtml"
+            >
+              <span
+                class="rounded bg-gray-900/80 px-2 py-1 text-xs text-gray-200 shadow"
+              >
+                Access Point → Client
+              </span>
+              <button
+                aria-label="Copy M1 details"
+                class="rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
+                type="button"
+              >
+                Copy
+              </button>
+            </div>
+          </foreignobject>
+        </g>
+        <g>
+          <line
+            class="stroke-green-400"
+            marker-end="url(#arrow-head)"
+            stroke-width="3"
+            x1="300"
+            x2="80"
+            y1="190"
+            y2="190"
+          />
+          <text
+            class="fill-gray-200 text-xs font-semibold"
+            text-anchor="middle"
+            x="190"
+            y="180"
+          >
+            M2
+          </text>
+          <foreignobject
+            height="46"
+            width="200"
+            x="90"
+            y="159"
+          >
+            <div
+              class="pointer-events-auto flex items-center justify-center gap-2"
+              xmlns="http://www.w3.org/1999/xhtml"
+            >
+              <span
+                class="rounded bg-gray-900/80 px-2 py-1 text-xs text-gray-200 shadow"
+              >
+                Client → Access Point
+              </span>
+              <button
+                aria-label="Copy M2 details"
+                class="rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
+                type="button"
+              >
+                Copy
+              </button>
+            </div>
+          </foreignobject>
+        </g>
+        <g>
+          <line
+            class="stroke-green-400"
+            marker-end="url(#arrow-head)"
+            stroke-width="3"
+            x1="80"
+            x2="300"
+            y1="300"
+            y2="300"
+          />
+          <text
+            class="fill-gray-200 text-xs font-semibold"
+            text-anchor="middle"
+            x="190"
+            y="290"
+          >
+            M3
+          </text>
+          <foreignobject
+            height="46"
+            width="200"
+            x="90"
+            y="269"
+          >
+            <div
+              class="pointer-events-auto flex items-center justify-center gap-2"
+              xmlns="http://www.w3.org/1999/xhtml"
+            >
+              <span
+                class="rounded bg-gray-900/80 px-2 py-1 text-xs text-gray-200 shadow"
+              >
+                Access Point → Client
+              </span>
+              <button
+                aria-label="Copy M3 details"
+                class="rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
+                type="button"
+              >
+                Copy
+              </button>
+            </div>
+          </foreignobject>
+        </g>
+        <g>
+          <line
+            class="stroke-green-400"
+            marker-end="url(#arrow-head)"
+            stroke-width="3"
+            x1="300"
+            x2="80"
+            y1="410"
+            y2="410"
+          />
+          <text
+            class="fill-gray-200 text-xs font-semibold"
+            text-anchor="middle"
+            x="190"
+            y="400"
+          >
+            M4
+          </text>
+          <foreignobject
+            height="46"
+            width="200"
+            x="90"
+            y="379"
+          >
+            <div
+              class="pointer-events-auto flex items-center justify-center gap-2"
+              xmlns="http://www.w3.org/1999/xhtml"
+            >
+              <span
+                class="rounded bg-gray-900/80 px-2 py-1 text-xs text-gray-200 shadow"
+              >
+                Client → Access Point
+              </span>
+              <button
+                aria-label="Copy M4 details"
+                class="rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
+                type="button"
+              >
+                Copy
+              </button>
+            </div>
+          </foreignobject>
+        </g>
+      </svg>
+    </div>
+    <ol
+      class="mt-4 space-y-3 text-sm text-gray-200"
+    >
+      <li>
+        <span
+          class="font-semibold text-white"
+        >
+          M1:
+        </span>
+         Authenticator sends ANonce and security parameters to start the handshake.
+      </li>
+      <li>
+        <span
+          class="font-semibold text-white"
+        >
+          M2:
+        </span>
+         Supplicant responds with SNonce and a MIC computed with the PTK.
+      </li>
+      <li>
+        <span
+          class="font-semibold text-white"
+        >
+          M3:
+        </span>
+         Authenticator sends the GTK and a MIC, instructing the client to install the PTK.
+      </li>
+      <li>
+        <span
+          class="font-semibold text-white"
+        >
+          M4:
+        </span>
+         Supplicant acknowledges installation of the PTK completing the handshake.
+      </li>
+    </ol>
+  </section>
+</DocumentFragment>
+`;
+
+exports[`HandshakeVisualizer shows feedback after copying a step: copied state 1`] = `
+<DocumentFragment>
+  <section
+    aria-labelledby="«r1»"
+    class="bg-gray-800 rounded p-4"
+  >
+    <h3
+      class="text-base font-semibold text-white mb-3"
+      id="«r1»"
+    >
+      WPA2 4-Way Handshake
+    </h3>
+    <div
+      class="relative"
+    >
+      <svg
+        aria-describedby="«r1»-desc"
+        class="w-full h-auto text-gray-200"
+        role="img"
+        viewBox="0 0 380 550"
+      >
+        <title>
+          WPA2 4-Way Handshake sequence diagram
+        </title>
+        <desc
+          id="«r1»-desc"
+        >
+          M1 from Access Point to Client. M2 from Client to Access Point. M3 from Access Point to Client. M4 from Client to Access Point
+        </desc>
+        <defs>
+          <marker
+            fill="currentColor"
+            id="arrow-head"
+            markerHeight="7"
+            markerWidth="10"
+            orient="auto"
+            refX="10"
+            refY="3.5"
+          >
+            <polygon
+              points="0 0, 10 3.5, 0 7"
+            />
+          </marker>
+        </defs>
+        <g>
+          <text
+            class="fill-gray-100 text-xs uppercase tracking-wide"
+            text-anchor="middle"
+            x="80"
+            y="18"
+          >
+            Access Point
+          </text>
+          <circle
+            class="fill-gray-200"
+            cx="80"
+            cy="40"
+            r="6"
+          />
+          <line
+            class="stroke-gray-600"
+            stroke-dasharray="6 6"
+            stroke-width="2"
+            x1="80"
+            x2="80"
+            y1="40"
+            y2="510"
+          />
+        </g>
+        <g>
+          <text
+            class="fill-gray-100 text-xs uppercase tracking-wide"
+            text-anchor="middle"
+            x="300"
+            y="18"
+          >
+            Client
+          </text>
+          <circle
+            class="fill-gray-200"
+            cx="300"
+            cy="40"
+            r="6"
+          />
+          <line
+            class="stroke-gray-600"
+            stroke-dasharray="6 6"
+            stroke-width="2"
+            x1="300"
+            x2="300"
+            y1="40"
+            y2="510"
+          />
+        </g>
+        <g>
+          <line
+            class="stroke-green-400"
+            marker-end="url(#arrow-head)"
+            stroke-width="3"
+            x1="80"
+            x2="300"
+            y1="80"
+            y2="80"
+          />
+          <text
+            class="fill-gray-200 text-xs font-semibold"
+            text-anchor="middle"
+            x="190"
+            y="70"
+          >
+            M1
+          </text>
+          <foreignobject
+            height="46"
+            width="200"
+            x="90"
+            y="49"
+          >
+            <div
+              class="pointer-events-auto flex items-center justify-center gap-2"
+              xmlns="http://www.w3.org/1999/xhtml"
+            >
+              <span
+                class="rounded bg-gray-900/80 px-2 py-1 text-xs text-gray-200 shadow"
+              >
+                Access Point → Client
+              </span>
+              <button
+                aria-label="Copy M1 details"
+                class="rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
+                type="button"
+              >
+                Copied!
+              </button>
+            </div>
+          </foreignobject>
+        </g>
+        <g>
+          <line
+            class="stroke-green-400"
+            marker-end="url(#arrow-head)"
+            stroke-width="3"
+            x1="300"
+            x2="80"
+            y1="190"
+            y2="190"
+          />
+          <text
+            class="fill-gray-200 text-xs font-semibold"
+            text-anchor="middle"
+            x="190"
+            y="180"
+          >
+            M2
+          </text>
+          <foreignobject
+            height="46"
+            width="200"
+            x="90"
+            y="159"
+          >
+            <div
+              class="pointer-events-auto flex items-center justify-center gap-2"
+              xmlns="http://www.w3.org/1999/xhtml"
+            >
+              <span
+                class="rounded bg-gray-900/80 px-2 py-1 text-xs text-gray-200 shadow"
+              >
+                Client → Access Point
+              </span>
+              <button
+                aria-label="Copy M2 details"
+                class="rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
+                type="button"
+              >
+                Copy
+              </button>
+            </div>
+          </foreignobject>
+        </g>
+        <g>
+          <line
+            class="stroke-green-400"
+            marker-end="url(#arrow-head)"
+            stroke-width="3"
+            x1="80"
+            x2="300"
+            y1="300"
+            y2="300"
+          />
+          <text
+            class="fill-gray-200 text-xs font-semibold"
+            text-anchor="middle"
+            x="190"
+            y="290"
+          >
+            M3
+          </text>
+          <foreignobject
+            height="46"
+            width="200"
+            x="90"
+            y="269"
+          >
+            <div
+              class="pointer-events-auto flex items-center justify-center gap-2"
+              xmlns="http://www.w3.org/1999/xhtml"
+            >
+              <span
+                class="rounded bg-gray-900/80 px-2 py-1 text-xs text-gray-200 shadow"
+              >
+                Access Point → Client
+              </span>
+              <button
+                aria-label="Copy M3 details"
+                class="rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
+                type="button"
+              >
+                Copy
+              </button>
+            </div>
+          </foreignobject>
+        </g>
+        <g>
+          <line
+            class="stroke-green-400"
+            marker-end="url(#arrow-head)"
+            stroke-width="3"
+            x1="300"
+            x2="80"
+            y1="410"
+            y2="410"
+          />
+          <text
+            class="fill-gray-200 text-xs font-semibold"
+            text-anchor="middle"
+            x="190"
+            y="400"
+          >
+            M4
+          </text>
+          <foreignobject
+            height="46"
+            width="200"
+            x="90"
+            y="379"
+          >
+            <div
+              class="pointer-events-auto flex items-center justify-center gap-2"
+              xmlns="http://www.w3.org/1999/xhtml"
+            >
+              <span
+                class="rounded bg-gray-900/80 px-2 py-1 text-xs text-gray-200 shadow"
+              >
+                Client → Access Point
+              </span>
+              <button
+                aria-label="Copy M4 details"
+                class="rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
+                type="button"
+              >
+                Copy
+              </button>
+            </div>
+          </foreignobject>
+        </g>
+      </svg>
+    </div>
+    <ol
+      class="mt-4 space-y-3 text-sm text-gray-200"
+    >
+      <li>
+        <span
+          class="font-semibold text-white"
+        >
+          M1:
+        </span>
+         Authenticator sends ANonce and security parameters to start the handshake.
+      </li>
+      <li>
+        <span
+          class="font-semibold text-white"
+        >
+          M2:
+        </span>
+         Supplicant responds with SNonce and a MIC computed with the PTK.
+      </li>
+      <li>
+        <span
+          class="font-semibold text-white"
+        >
+          M3:
+        </span>
+         Authenticator sends the GTK and a MIC, instructing the client to install the PTK.
+      </li>
+      <li>
+        <span
+          class="font-semibold text-white"
+        >
+          M4:
+        </span>
+         Supplicant acknowledges installation of the PTK completing the handshake.
+      </li>
+    </ol>
+  </section>
+</DocumentFragment>
+`;

--- a/__tests__/apps/reaver/handshake.test.tsx
+++ b/__tests__/apps/reaver/handshake.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import HandshakeVisualizer from '../../../apps/reaver/components/HandshakeVisualizer';
+
+describe('HandshakeVisualizer', () => {
+  const originalClipboard = navigator.clipboard;
+
+  beforeEach(() => {
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    if (originalClipboard) {
+      Object.defineProperty(window.navigator, 'clipboard', {
+        value: originalClipboard,
+        configurable: true,
+      });
+    } else {
+      delete (window.navigator as unknown as { clipboard?: unknown }).clipboard;
+    }
+  });
+
+  it('renders the handshake diagram', () => {
+    const { asFragment } = render(<HandshakeVisualizer />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('shows feedback after copying a step', () => {
+    const { asFragment, getAllByRole } = render(<HandshakeVisualizer />);
+    const copyButtons = getAllByRole('button', { name: /copy/i });
+    fireEvent.click(copyButtons[0]);
+
+    expect(asFragment()).toMatchSnapshot('copied state');
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining('M1')
+    );
+  });
+});

--- a/apps/reaver/components/HandshakeVisualizer.tsx
+++ b/apps/reaver/components/HandshakeVisualizer.tsx
@@ -1,0 +1,274 @@
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
+import handshakeSample from '../../../data/handshake.json';
+
+type HandshakeStep = {
+  step: string;
+  from: string;
+  to: string;
+  description: string;
+};
+
+type HandshakeDataset = {
+  title: string;
+  participants?: string[];
+  steps: HandshakeStep[];
+};
+
+type ParticipantLayout = {
+  name: string;
+  x: number;
+};
+
+type StepLayout = HandshakeStep & {
+  index: number;
+  fromX: number;
+  toX: number;
+  y: number;
+  labelX: number;
+  labelY: number;
+};
+
+type DiagramLayout = {
+  width: number;
+  height: number;
+  lineTop: number;
+  lineBottom: number;
+  labelWidth: number;
+  labelHeight: number;
+  participants: ParticipantLayout[];
+  steps: StepLayout[];
+};
+
+const HANDSHAKE_DATA = handshakeSample as HandshakeDataset;
+const DEFAULT_PARTICIPANTS = Array.from(
+  new Set(
+    HANDSHAKE_DATA.steps.flatMap((s) => [s.from, s.to])
+  )
+);
+
+const PARTICIPANTS =
+  HANDSHAKE_DATA.participants && HANDSHAKE_DATA.participants.length > 0
+    ? HANDSHAKE_DATA.participants
+    : DEFAULT_PARTICIPANTS;
+
+const HORIZONTAL_PADDING = 80;
+const LANE_GAP = 220;
+const STEP_GAP = 110;
+const STEP_VERTICAL_OFFSET = 80;
+const LINE_BOTTOM_PADDING = 60;
+const LABEL_WIDTH = 200;
+const LABEL_HEIGHT = 46;
+
+const computeLayout = (
+  participants: readonly string[],
+  steps: readonly HandshakeStep[]
+): DiagramLayout => {
+  const width =
+    HORIZONTAL_PADDING * 2 +
+    LANE_GAP * Math.max(participants.length - 1, 0);
+  const stepAreaTop = STEP_VERTICAL_OFFSET;
+  const height =
+    stepAreaTop + STEP_GAP * Math.max(steps.length - 1, 0) + LINE_BOTTOM_PADDING + 80;
+  const lineTop = 40;
+  const lineBottom = height - 40;
+
+  const participantPositions: ParticipantLayout[] = participants.map((name, index) => ({
+    name,
+    x: HORIZONTAL_PADDING + index * LANE_GAP,
+  }));
+
+  const positionLookup = new Map(participantPositions.map((p) => [p.name, p.x]));
+
+  const stepLayouts: StepLayout[] = steps.map((step, index) => {
+    const fromX = positionLookup.get(step.from) ?? participantPositions[0]?.x ?? HORIZONTAL_PADDING;
+    const toX = positionLookup.get(step.to) ?? participantPositions[participantPositions.length - 1]?.x ?? HORIZONTAL_PADDING;
+    const y = stepAreaTop + STEP_GAP * index;
+    const labelX = (fromX + toX) / 2;
+    const labelY = y - LABEL_HEIGHT / 2 - 8;
+
+    return {
+      ...step,
+      index,
+      fromX,
+      toX,
+      y,
+      labelX,
+      labelY,
+    };
+  });
+
+  return {
+    width,
+    height,
+    lineTop,
+    lineBottom,
+    labelWidth: LABEL_WIDTH,
+    labelHeight: LABEL_HEIGHT,
+    participants: participantPositions,
+    steps: stepLayouts,
+  };
+};
+
+const formatCopyText = (step: HandshakeStep) =>
+  `${step.step}: ${step.from} → ${step.to} — ${step.description}`;
+
+const HandshakeVisualizer: React.FC = () => {
+  const titleId = useId();
+  const layout = useMemo(
+    () => computeLayout(PARTICIPANTS, HANDSHAKE_DATA.steps),
+    []
+  );
+  const [copiedStep, setCopiedStep] = useState<string | null>(null);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimer.current) {
+        clearTimeout(resetTimer.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = (step: HandshakeStep) => {
+    const text = formatCopyText(step);
+    try {
+      if (
+        typeof navigator !== 'undefined' &&
+        navigator.clipboard &&
+        typeof navigator.clipboard.writeText === 'function'
+      ) {
+        void navigator.clipboard.writeText(text);
+      }
+    } catch (error) {
+      // Silently ignore clipboard failures in unsupported environments.
+    }
+
+    setCopiedStep(step.step);
+    if (resetTimer.current) {
+      clearTimeout(resetTimer.current);
+    }
+    resetTimer.current = setTimeout(() => {
+      setCopiedStep(null);
+    }, 1500);
+  };
+
+  const descId = `${titleId}-desc`;
+  const diagramDescription = layout.steps
+    .map((step) => `${step.step} from ${step.from} to ${step.to}`)
+    .join('. ');
+
+  return (
+    <section className="bg-gray-800 rounded p-4" aria-labelledby={titleId}>
+      <h3 id={titleId} className="text-base font-semibold text-white mb-3">
+        {HANDSHAKE_DATA.title}
+      </h3>
+      <div className="relative">
+        <svg
+          viewBox={`0 0 ${layout.width} ${layout.height}`}
+          className="w-full h-auto text-gray-200"
+          role="img"
+          aria-describedby={descId}
+        >
+          <title>{HANDSHAKE_DATA.title} sequence diagram</title>
+          <desc id={descId}>{diagramDescription}</desc>
+          <defs>
+            <marker
+              id="arrow-head"
+              markerWidth="10"
+              markerHeight="7"
+              refX="10"
+              refY="3.5"
+              orient="auto"
+              fill="currentColor"
+            >
+              <polygon points="0 0, 10 3.5, 0 7" />
+            </marker>
+          </defs>
+
+          {layout.participants.map((participant) => (
+            <g key={participant.name}>
+              <text
+                x={participant.x}
+                y={18}
+                textAnchor="middle"
+                className="fill-gray-100 text-xs uppercase tracking-wide"
+              >
+                {participant.name}
+              </text>
+              <circle
+                cx={participant.x}
+                cy={layout.lineTop}
+                r={6}
+                className="fill-gray-200"
+              />
+              <line
+                x1={participant.x}
+                x2={participant.x}
+                y1={layout.lineTop}
+                y2={layout.lineBottom}
+                strokeWidth={2}
+                className="stroke-gray-600"
+                strokeDasharray="6 6"
+              />
+            </g>
+          ))}
+
+          {layout.steps.map((step) => (
+            <g key={step.step}>
+              <line
+                x1={step.fromX}
+                x2={step.toX}
+                y1={step.y}
+                y2={step.y}
+                strokeWidth={3}
+                className="stroke-green-400"
+                markerEnd="url(#arrow-head)"
+              />
+              <text
+                x={step.labelX}
+                y={step.y - 10}
+                textAnchor="middle"
+                className="fill-gray-200 text-xs font-semibold"
+              >
+                {step.step}
+              </text>
+              <foreignObject
+                x={step.labelX - layout.labelWidth / 2}
+                y={step.labelY}
+                width={layout.labelWidth}
+                height={layout.labelHeight}
+              >
+                <div
+                  xmlns="http://www.w3.org/1999/xhtml"
+                  className="pointer-events-auto flex items-center justify-center gap-2"
+                >
+                  <span className="rounded bg-gray-900/80 px-2 py-1 text-xs text-gray-200 shadow">
+                    {step.from} → {step.to}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => handleCopy(step)}
+                    className="rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
+                    aria-label={`Copy ${step.step} details`}
+                  >
+                    {copiedStep === step.step ? 'Copied!' : 'Copy'}
+                  </button>
+                </div>
+              </foreignObject>
+            </g>
+          ))}
+        </svg>
+      </div>
+      <ol className="mt-4 space-y-3 text-sm text-gray-200">
+        {layout.steps.map((step) => (
+          <li key={step.step}>
+            <span className="font-semibold text-white">{step.step}:</span>{' '}
+            {step.description}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+};
+
+export default HandshakeVisualizer;

--- a/apps/reaver/index.tsx
+++ b/apps/reaver/index.tsx
@@ -8,6 +8,7 @@ import RouterProfiles, {
 } from './components/RouterProfiles';
 import APList from './components/APList';
 import ProgressDonut from './components/ProgressDonut';
+import HandshakeVisualizer from './components/HandshakeVisualizer';
 
 const PlayIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 20 20" fill="currentColor" {...props}>
@@ -242,6 +243,11 @@ const ReaverPanel: React.FC = () => {
             </li>
           ))}
         </ol>
+      </div>
+
+      <div className="mb-6">
+        <h2 className="text-lg mb-2">WPA2 Handshake Sequence</h2>
+        <HandshakeVisualizer />
       </div>
 
       <div className="mb-6">

--- a/data/handshake.json
+++ b/data/handshake.json
@@ -1,0 +1,30 @@
+{
+  "title": "WPA2 4-Way Handshake",
+  "participants": ["Access Point", "Client"],
+  "steps": [
+    {
+      "step": "M1",
+      "from": "Access Point",
+      "to": "Client",
+      "description": "Authenticator sends ANonce and security parameters to start the handshake."
+    },
+    {
+      "step": "M2",
+      "from": "Client",
+      "to": "Access Point",
+      "description": "Supplicant responds with SNonce and a MIC computed with the PTK."
+    },
+    {
+      "step": "M3",
+      "from": "Access Point",
+      "to": "Client",
+      "description": "Authenticator sends the GTK and a MIC, instructing the client to install the PTK."
+    },
+    {
+      "step": "M4",
+      "from": "Client",
+      "to": "Access Point",
+      "description": "Supplicant acknowledges installation of the PTK completing the handshake."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- render the WPA2 handshake as an SVG sequence diagram backed by the shared sample data
- memoize diagram layout, add copy controls for each step label, and expose the dataset
- embed the visualizer in the Reaver simulator with snapshot coverage for the new UI

## Testing
- yarn test __tests__/apps/reaver/handshake.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc282e2edc8328827c96926762e320