### PR TITLE
[reaver] Add AP lockout handling

### DIFF
--- a/__tests__/apps/reaver/lockout.test.tsx
+++ b/__tests__/apps/reaver/lockout.test.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import RouterProfiles from '../../../apps/reaver/components/RouterProfiles';
+
+describe('RouterProfiles lockout behaviour', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('displays a cooldown banner and re-enables attempts after the timer expires', async () => {
+    jest.useFakeTimers();
+    let now = 0;
+    jest.spyOn(performance, 'now').mockImplementation(() => now);
+
+    const onChange = jest.fn();
+    const onLockStateChange = jest.fn();
+
+    const { rerender } = render(
+      <RouterProfiles
+        attempts={0}
+        activeApId="ap-1"
+        activeApLabel="AP One"
+        onChange={onChange}
+        onLockStateChange={onLockStateChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Router Vendor Profile'), {
+      target: { value: 'netgear' },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ id: 'netgear' }),
+      );
+    });
+
+    onLockStateChange.mockClear();
+
+    rerender(
+      <RouterProfiles
+        attempts={5}
+        activeApId="ap-1"
+        activeApLabel="AP One"
+        onChange={onChange}
+        onLockStateChange={onLockStateChange}
+      />,
+    );
+
+    expect(await screen.findByText(/Cooldown: 60s/)).toBeInTheDocument();
+
+    expect(onLockStateChange).toHaveBeenCalledWith({
+      locked: true,
+      remainingSeconds: 60,
+      apId: 'ap-1::netgear',
+    });
+
+    const advance = async (ms: number) => {
+      await act(async () => {
+        const step = 250;
+        let remaining = ms;
+        while (remaining > 0) {
+          const delta = Math.min(step, remaining);
+          now += delta;
+          jest.advanceTimersByTime(delta);
+          remaining -= delta;
+        }
+      });
+    };
+
+    await advance(1000);
+    expect(await screen.findByText(/Cooldown: 59s/)).toBeInTheDocument();
+
+    onLockStateChange.mockClear();
+    await advance(59000);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Cooldown:/)).not.toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/Attempts on AP One: 0 \/ 5/),
+    ).toBeInTheDocument();
+
+    const lastCall =
+      onLockStateChange.mock.calls[onLockStateChange.mock.calls.length - 1];
+    expect(lastCall?.[0]).toEqual({
+      locked: false,
+      remainingSeconds: 0,
+      apId: 'ap-1::netgear',
+    });
+  });
+
+  it('maintains attempt counts separately for each AP', async () => {
+    const onChange = jest.fn();
+
+    const { rerender } = render(
+      <RouterProfiles
+        attempts={0}
+        activeApId="ap-1"
+        activeApLabel="AP One"
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Router Vendor Profile'), {
+      target: { value: 'netgear' },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ id: 'netgear' }),
+      );
+    });
+
+    rerender(
+      <RouterProfiles
+        attempts={2}
+        activeApId="ap-1"
+        activeApLabel="AP One"
+        onChange={onChange}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Attempts on AP One: 2 \/ 5/),
+    ).toBeInTheDocument();
+
+    rerender(
+      <RouterProfiles
+        attempts={2}
+        activeApId="ap-2"
+        activeApLabel="AP Two"
+        onChange={onChange}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Attempts on AP Two: 0 \/ 5/),
+    ).toBeInTheDocument();
+
+    rerender(
+      <RouterProfiles
+        attempts={3}
+        activeApId="ap-2"
+        activeApLabel="AP Two"
+        onChange={onChange}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Attempts on AP Two: 1 \/ 5/),
+    ).toBeInTheDocument();
+
+    rerender(
+      <RouterProfiles
+        attempts={3}
+        activeApId="ap-1"
+        activeApLabel="AP One"
+        onChange={onChange}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Attempts on AP One: 2 \/ 5/),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/reaver/components/RouterProfiles.tsx
+++ b/apps/reaver/components/RouterProfiles.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 export interface RouterProfile {
   id: string;
@@ -35,23 +41,223 @@ export const ROUTER_PROFILES: RouterProfile[] = [
   },
 ];
 
+export interface LockState {
+  locked: boolean;
+  remainingSeconds: number;
+  apId: string | null;
+}
+
 interface RouterProfilesProps {
+  attempts: number;
+  activeApId?: string;
+  activeApLabel?: string;
   onChange: (profile: RouterProfile) => void;
+  onLockStateChange?: (state: LockState) => void;
 }
 
 const STORAGE_KEY = 'reaver-router-profile';
+const DEFAULT_AP_ID = 'global-ap';
 
-const RouterProfiles: React.FC<RouterProfilesProps> = ({ onChange }) => {
+interface LockDisplayState {
+  locked: boolean;
+  remainingSeconds: number;
+  key: string | null;
+}
+
+const RouterProfiles: React.FC<RouterProfilesProps> = ({
+  attempts,
+  activeApId,
+  activeApLabel,
+  onChange,
+  onLockStateChange,
+}) => {
   const [selected, setSelected] = useState<RouterProfile>(ROUTER_PROFILES[0]);
+  const [attemptsByKey, setAttemptsByKey] = useState<Record<string, number>>({});
+  const attemptsRef = useRef<Record<string, number>>({});
+  const prevAttemptsRef = useRef(attempts);
+  const lockoutsRef = useRef<Record<string, number>>({});
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [lockDisplay, setLockDisplay] = useState<LockDisplayState>({
+    locked: false,
+    remainingSeconds: 0,
+    key: null,
+  });
+  const lastNotificationRef = useRef<LockState>({
+    locked: false,
+    remainingSeconds: 0,
+    apId: null,
+  });
+
+  const apIdentifier = useMemo(
+    () => `${activeApId ?? DEFAULT_AP_ID}::${selected.id}`,
+    [activeApId, selected.id],
+  );
+
+  const apLabel = activeApLabel ?? 'the selected access point';
+
+  const setAttemptValue = useCallback((key: string, value: number) => {
+    setAttemptsByKey((prev) => {
+      if (prev[key] === value) {
+        return prev;
+      }
+      const next = { ...prev, [key]: value };
+      attemptsRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const updateDisplay = useCallback(
+    (locked: boolean, seconds: number, key: string | null) => {
+      setLockDisplay((prev) => {
+        const normalizedKey = locked ? key : null;
+        if (
+          prev.locked === locked &&
+          prev.remainingSeconds === seconds &&
+          prev.key === normalizedKey
+        ) {
+          return prev;
+        }
+        return {
+          locked,
+          remainingSeconds: seconds,
+          key: normalizedKey,
+        };
+      });
+
+      const last = lastNotificationRef.current;
+      if (
+        last.locked !== locked ||
+        last.remainingSeconds !== seconds ||
+        last.apId !== key
+      ) {
+        const nextState: LockState = {
+          locked,
+          remainingSeconds: seconds,
+          apId: key,
+        };
+        lastNotificationRef.current = nextState;
+        onLockStateChange?.(nextState);
+      }
+    },
+    [onLockStateChange],
+  );
+
+  const startTimerForKey = useCallback(
+    (key: string, unlockAt: number) => {
+      clearTimer();
+
+      const tick = () => {
+        const now =
+          typeof performance !== 'undefined' ? performance.now() : Date.now();
+        const remainingMs = unlockAt - now;
+        if (remainingMs <= 0) {
+          clearTimer();
+          delete lockoutsRef.current[key];
+          updateDisplay(false, 0, key);
+          setAttemptValue(key, 0);
+          return;
+        }
+
+        const seconds = Math.ceil(remainingMs / 1000);
+        updateDisplay(true, seconds, key);
+      };
+
+      tick();
+      timerRef.current = setInterval(tick, 250);
+    },
+    [clearTimer, setAttemptValue, updateDisplay],
+  );
 
   // Load persisted profile on mount
   useEffect(() => {
     const stored = window.localStorage.getItem(STORAGE_KEY);
-    const profile = ROUTER_PROFILES.find((p) => p.id === stored) || ROUTER_PROFILES[0];
+    const profile =
+      ROUTER_PROFILES.find((p) => p.id === stored) || ROUTER_PROFILES[0];
     setSelected(profile);
     onChange(profile);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => () => clearTimer(), [clearTimer]);
+
+  useEffect(() => {
+    const prev = prevAttemptsRef.current;
+    const delta = attempts - prev;
+    prevAttemptsRef.current = attempts;
+
+    const key = apIdentifier;
+
+    if (delta < 0) {
+      setAttemptValue(key, Math.max(0, attempts));
+      return;
+    }
+
+    if (delta === 0) {
+      return;
+    }
+
+    const now =
+      typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const unlockAt = lockoutsRef.current[key];
+    if (unlockAt && unlockAt > now) {
+      // Locked - ignore new attempts during cooldown
+      return;
+    }
+
+    if (selected.lockAttempts === Infinity) {
+      setAttemptValue(key, (attemptsRef.current[key] ?? 0) + delta);
+      return;
+    }
+
+    const current = attemptsRef.current[key] ?? 0;
+    const next = current + delta;
+
+    if (next >= selected.lockAttempts) {
+      const limited = selected.lockAttempts;
+      setAttemptValue(key, limited);
+      if (selected.lockDuration > 0) {
+        const cooldownUntil = now + selected.lockDuration * 1000;
+        lockoutsRef.current[key] = cooldownUntil;
+        startTimerForKey(key, cooldownUntil);
+      } else {
+        delete lockoutsRef.current[key];
+        updateDisplay(false, 0, key);
+        setAttemptValue(key, 0);
+      }
+    } else {
+      setAttemptValue(key, next);
+    }
+  }, [
+    attempts,
+    apIdentifier,
+    selected.lockAttempts,
+    selected.lockDuration,
+    setAttemptValue,
+    startTimerForKey,
+    updateDisplay,
+  ]);
+
+  useEffect(() => {
+    const unlockAt = lockoutsRef.current[apIdentifier];
+    const now =
+      typeof performance !== 'undefined' ? performance.now() : Date.now();
+    if (unlockAt && unlockAt > now) {
+      startTimerForKey(apIdentifier, unlockAt);
+    } else {
+      if (unlockAt) {
+        delete lockoutsRef.current[apIdentifier];
+      }
+      clearTimer();
+      updateDisplay(false, 0, apIdentifier);
+    }
+  }, [apIdentifier, clearTimer, startTimerForKey, updateDisplay]);
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const profile = ROUTER_PROFILES.find((p) => p.id === e.target.value)!;
@@ -59,6 +265,9 @@ const RouterProfiles: React.FC<RouterProfilesProps> = ({ onChange }) => {
     window.localStorage.setItem(STORAGE_KEY, profile.id);
     onChange(profile);
   };
+
+  const currentAttempts = attemptsByKey[apIdentifier] ?? 0;
+  const totalAttempts = selected.lockAttempts;
 
   return (
     <div className="mb-4">
@@ -79,15 +288,26 @@ const RouterProfiles: React.FC<RouterProfilesProps> = ({ onChange }) => {
       </select>
       {selected.lockAttempts !== Infinity && (
         <p className="text-xs text-gray-400 mt-1">
-          Locks after {selected.lockAttempts} failed attempts for {selected.lockDuration}s
+          Locks after {selected.lockAttempts} failed attempts for{' '}
+          {selected.lockDuration}s
+        </p>
+      )}
+      {selected.lockAttempts !== Infinity && (
+        <p className="text-xs text-gray-400 mt-1">
+          Attempts on {apLabel}: {currentAttempts} / {totalAttempts}
         </p>
       )}
       {selected.lockAttempts === Infinity && (
         <p className="text-xs text-gray-400 mt-1">No WPS lockout behaviour</p>
+      )}
+      {lockDisplay.locked && lockDisplay.key === apIdentifier && (
+        <div className="mt-2 rounded border border-yellow-600 bg-yellow-900/40 px-3 py-2 text-xs text-yellow-200">
+          WPS temporarily locked on {apLabel}. Cooldown:{' '}
+          {lockDisplay.remainingSeconds}s
+        </div>
       )}
     </div>
   );
 };
 
 export default RouterProfiles;
-


### PR DESCRIPTION
## Summary
- track per-access-point attempt counts in the router profile picker, showing a lockout banner with a countdown when thresholds are exceeded
- notify the simulator about lock-state changes so brute-force attempts pause during cooldowns, resuming once the timer expires
- add focused Jest coverage for the lockout countdown and per-AP attempt tracking logic

## Testing
- yarn lint *(fails: existing accessibility and tooling violations across legacy apps)*
- yarn test __tests__/apps/reaver/lockout.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc282eb3148328b501670013595772