### PR TITLE
[test] add metasploit e2e coverage

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -19,3 +19,4 @@ jobs:
           npx wait-on http://localhost:3000
       - run: npx pa11y-ci --config pa11yci.json
       - run: npx playwright test playwright/a11y.spec.ts
+      - run: npx playwright test playwright/metasploit.spec.ts

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,30 @@
+# Testing overview
+
+This project relies on automated end-to-end scenarios in addition to the Jest
+and lint suites already documented elsewhere. The Playwright specs simulate how
+the desktop shell behaves and help catch regressions in interactive apps.
+
+## Playwright scenarios
+
+- `playwright/metasploit.spec.ts`
+  - Opens the Metasploit desktop window through the internal `open-app` event
+    so the test mirrors the real user flow of launching the tool from the dock.
+  - Clicks the first 20 module cards to verify their detail panes render without
+    throwing console errors.
+  - Cycles through the severity filters (treated as tabs) to confirm state
+    changes and badge updates even when certain severities have no data.
+  - Runs a module search, records the latency of the generated `Enter`
+    keystroke, and asserts it stays within 100&nbsp;ms.
+  - Closes the window and compares DOM node counts via `getNodeCount` to make
+    sure no detached nodes remain.
+
+## Running locally
+
+1. Start the development server: `yarn dev`.
+2. In another terminal execute: `npx playwright test playwright/metasploit.spec.ts`.
+3. Watch the logs for console errors reported by the spec and confirm the final
+   DOM node counts return to their baseline after the window closes.
+
+The CI workflow (`.github/workflows/a11y.yml`) runs this scenario alongside the
+accessibility checks so every pull request validates the desktop Metasploit
+experience.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testDir: '.',
+  testMatch: ['tests/**/*.spec.ts', 'playwright/**/*.spec.ts'],
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/playwright/metasploit.spec.ts
+++ b/playwright/metasploit.spec.ts
@@ -1,0 +1,132 @@
+import { expect, Page, test } from '@playwright/test';
+
+const MODULES_TO_OPEN = 20;
+const DOM_TOLERANCE = 20;
+
+const getNodeCount = (page: Page) =>
+  page.evaluate(() => {
+    const walker = document.createTreeWalker(
+      document.body,
+      NodeFilter.SHOW_ELEMENT,
+    );
+    let count = 0;
+    while (walker.nextNode()) {
+      count += 1;
+    }
+    return count;
+  });
+
+test.describe('Metasploit desktop integration', () => {
+  test('opens modules, filters, searches, and closes without leaks', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        consoleErrors.push(message.text());
+      }
+    });
+
+    await page.goto('/');
+    await page.waitForTimeout(2500);
+    await page.waitForSelector('#window-area');
+
+    const baselineNodeCount = await getNodeCount(page);
+
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent('open-app', { detail: 'metasploit' }));
+    });
+
+    const metasploitWindow = page.locator('#metasploit');
+    await expect(metasploitWindow).toBeVisible();
+
+    const moduleButtons = metasploitWindow.locator(
+      '.grid.grid-cols-2 button:has(.font-mono)',
+    );
+    const moduleCount = await moduleButtons.count();
+    expect(moduleCount).toBeGreaterThanOrEqual(MODULES_TO_OPEN);
+
+    const moduleHeading = metasploitWindow.locator('aside.bg-ub-grey h3');
+    const openedModules = new Set<string>();
+    for (let index = 0; index < MODULES_TO_OPEN; index += 1) {
+      const button = moduleButtons.nth(index);
+      const name = (await button.locator('.font-mono').innerText()).trim();
+      await button.scrollIntoViewIfNeeded();
+      await button.click();
+      await expect(moduleHeading).toContainText(name);
+      openedModules.add(name);
+    }
+    expect(openedModules.size).toBeGreaterThanOrEqual(MODULES_TO_OPEN);
+
+    const severityButtons = metasploitWindow.locator('button[aria-pressed]');
+    const severityCount = await severityButtons.count();
+    expect(severityCount).toBeGreaterThan(0);
+
+    let hadModulesWhileSwitching = false;
+    for (let i = 0; i < severityCount; i += 1) {
+      const button = severityButtons.nth(i);
+      const label = (await button.innerText()).trim();
+      await button.click();
+      await expect(button).toHaveAttribute('aria-pressed', 'true');
+
+      for (let j = 0; j < severityCount; j += 1) {
+        const otherButton = severityButtons.nth(j);
+        if (j === i) continue;
+        await expect(otherButton).toHaveAttribute('aria-pressed', 'false');
+      }
+
+      const countForSeverity = await moduleButtons.count();
+      if (countForSeverity > 0) {
+        hadModulesWhileSwitching = true;
+        const severityBadge = moduleButtons
+          .first()
+          .locator('span')
+          .first();
+        await expect(severityBadge).toHaveText(new RegExp(label, 'i'));
+      }
+    }
+    expect(hadModulesWhileSwitching).toBeTruthy();
+
+    const searchInput = metasploitWindow.locator(
+      'input[placeholder="Search modules"]',
+    ).first();
+    await searchInput.fill('2wire');
+    const searchResults = metasploitWindow.locator('ul.max-h-40 li');
+    expect(await searchResults.count()).toBeGreaterThan(0);
+    await expect(searchResults.first()).toContainText(/2wire/i);
+
+    await searchInput.focus();
+    const latencyPromise = page.evaluate(() => {
+      const input = document.querySelector<HTMLInputElement>(
+        'input[placeholder="Search modules"]',
+      );
+      if (!input) {
+        throw new Error('Search input not found');
+      }
+      return new Promise<number>((resolve) => {
+        const start = performance.now();
+        const handler = (event: KeyboardEvent) => {
+          if (event.key === 'Enter') {
+            resolve(performance.now() - start);
+          }
+        };
+        input.addEventListener('keydown', handler, { once: true });
+      });
+    });
+
+    await page.keyboard.press('Enter');
+    const inputLatency = await latencyPromise;
+    expect(inputLatency).toBeLessThanOrEqual(100);
+
+    const nodeCountBeforeClose = await getNodeCount(page);
+
+    await metasploitWindow.locator('button[aria-label="Window close"]').click();
+    await expect(page.locator('#metasploit')).toHaveCount(0);
+
+    const finalNodeCount = await getNodeCount(page);
+    expect(finalNodeCount).toBeLessThanOrEqual(nodeCountBeforeClose);
+    expect(Math.abs(finalNodeCount - baselineNodeCount)).toBeLessThanOrEqual(
+      DOM_TOLERANCE,
+    );
+
+    expect(consoleErrors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Playwright scenario that drives the Metasploit desktop window, opens 20 modules, switches severity filters, records search latency, and checks for DOM leaks
- update the Playwright config and accessibility workflow so specs in the `playwright/` folder run in CI
- document how to run the new scenario in `docs/testing.md`

## Testing
- yarn lint *(fails: existing accessibility lint violations across legacy files)*
- npx playwright test playwright/metasploit.spec.ts *(fails: missing Playwright system dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc28291e5c8328b813c6c3a4dec99e