### PR TITLE
[metasploit] Wire docs viewer markdown and anchors

### DIFF
--- a/__tests__/apps/metasploit/docs-viewer.test.tsx
+++ b/__tests__/apps/metasploit/docs-viewer.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { DocsViewer } from '../../../apps/metasploit';
+
+jest.mock('next/router', () => {
+  const replace = jest.fn();
+  const events = {
+    on: jest.fn(),
+    off: jest.fn(),
+  };
+  const routerState = {
+    asPath: '/apps/metasploit',
+    pathname: '/apps/metasploit',
+    replace,
+    events,
+  };
+  return {
+    useRouter: () => routerState,
+    __mockRouter: routerState,
+  };
+});
+
+const { __mockRouter } = jest.requireMock('next/router') as {
+  __mockRouter: {
+    asPath: string;
+    pathname: string;
+    replace: jest.Mock;
+    events: { on: jest.Mock; off: jest.Mock };
+  };
+};
+
+const htmlFixture = [
+  '<h1 id="demo">Demo</h1>',
+  '<h2 id="options">Options</h2><p>Details here.</p>',
+  '<h2 id="usage">Usage</h2><p>More details.</p>',
+].join('');
+
+const headingsFixture = [
+  { id: 'options', text: 'Options', depth: 2 },
+  { id: 'usage', text: 'Usage', depth: 2 },
+];
+
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+const scrollIntoViewMock = jest.fn();
+
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: scrollIntoViewMock,
+  });
+});
+
+afterAll(() => {
+  if (originalScrollIntoView) {
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: originalScrollIntoView,
+    });
+  } else {
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: undefined,
+    });
+  }
+});
+
+describe('DocsViewer anchor navigation', () => {
+  beforeEach(() => {
+    __mockRouter.asPath = '/apps/metasploit';
+    __mockRouter.pathname = '/apps/metasploit';
+    __mockRouter.replace.mockClear();
+    __mockRouter.events.on.mockClear();
+    __mockRouter.events.off.mockClear();
+    scrollIntoViewMock.mockClear();
+  });
+
+  it('scrolls to headings when selecting entries from the table of contents', async () => {
+    const markdown = '# Demo\n\n## Options\nDetails here.\n\n## Usage\nMore details.';
+    const loader = jest.fn().mockResolvedValue(markdown);
+    const markdownRenderer = jest
+      .fn()
+      .mockImplementation(async () => ({
+        html: htmlFixture,
+        headings: headingsFixture.map((heading) => ({ ...heading })),
+      }));
+
+    render(
+      <DocsViewer
+        moduleName="auxiliary/admin/example"
+        docTitle="Example"
+        docLoader={loader}
+        markdownRenderer={markdownRenderer}
+      />,
+    );
+
+    await waitFor(() => expect(markdownRenderer).toHaveBeenCalledWith(markdown));
+
+    const tocButton = await screen.findByRole('button', { name: 'Options' });
+    fireEvent.click(tocButton);
+
+    await waitFor(() => expect(scrollIntoViewMock).toHaveBeenCalled());
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'start',
+    });
+    expect(__mockRouter.replace).toHaveBeenCalledWith(
+      '/apps/metasploit#options',
+      undefined,
+      { shallow: true, scroll: false },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Back to top/i }));
+    const lastCall = __mockRouter.replace.mock.calls.at(-1);
+    expect(lastCall).toEqual([
+      '/apps/metasploit',
+      undefined,
+      { shallow: true, scroll: false },
+    ]);
+  });
+
+  it('honors hash fragments by jumping to the matching section on load', async () => {
+    const markdown = '# Demo\n\n## Options\nDetails here.\n\n## Usage\nMore details.';
+    const loader = jest.fn().mockResolvedValue(markdown);
+    const markdownRenderer = jest
+      .fn()
+      .mockImplementation(async () => ({
+        html: htmlFixture,
+        headings: headingsFixture.map((heading) => ({ ...heading })),
+      }));
+
+    __mockRouter.asPath = '/apps/metasploit#usage';
+
+    render(
+      <DocsViewer
+        moduleName="auxiliary/admin/example"
+        docLoader={loader}
+        markdownRenderer={markdownRenderer}
+      />,
+    );
+
+    await waitFor(() => expect(loader).toHaveBeenCalled());
+    await waitFor(() => expect(markdownRenderer).toHaveBeenCalledWith(markdown));
+    await waitFor(() => expect(scrollIntoViewMock).toHaveBeenCalled());
+    const firstCallArgs = scrollIntoViewMock.mock.calls[0][0];
+    expect(firstCallArgs).toMatchObject({ behavior: 'auto', block: 'start' });
+  });
+});

--- a/components/apps/metasploit/docs/auxiliary__admin__2wire__xslt_password_reset.md
+++ b/components/apps/metasploit/docs/auxiliary__admin__2wire__xslt_password_reset.md
@@ -1,0 +1,39 @@
+# 2Wire XSLT Password Reset (Simulated)
+
+This simulated README walks through the high-level workflow of the Metasploit module.
+It is designed for educational purposes only.
+
+## Overview
+
+The auxiliary module triggers the administrative password reset form exposed on
+legacy 2Wire gateways. The simulated exploit highlights:
+
+- Discovering the management endpoint at `http://192.168.0.1/xslt`.
+- Issuing a crafted POST request that resets credentials without prior auth.
+- Reviewing logs to understand what changes were applied.
+
+## Options
+
+| Option  | Required | Default     | Description                              |
+| ------- | -------- | ----------- | ---------------------------------------- |
+| RHOSTS  | Yes      | 192.168.0.1 | Address range that will be enumerated.   |
+| RPORT   | No       | 80          | HTTP service port.                       |
+| SSL     | No       | false       | Toggle HTTPS when the gateway supports it. |
+
+## Usage walkthrough
+
+1. Enumerate the network to locate 2Wire devices.
+2. Launch the module with valid `RHOSTS` targets.
+3. Verify the console output for `[*] Password reset scheduled`.
+4. Notify impacted stakeholders that credentials were reset.
+
+### Post exploitation tips
+
+- Update the firmware immediately after regaining access.
+- Replace default passwords with randomly generated phrases.
+- Audit the gateway for additional misconfigurations.
+
+## Further reading
+
+For real-world guidance review the vendor advisory and the
+[Metasploit module documentation](https://docs.metasploit.com/docs/modules/).


### PR DESCRIPTION
## Summary
- finish the Metasploit docs viewer by defaulting to the async markdown renderer, sanitising output, and wiring table-of-contents navigation with hash syncing and back-to-top support
- add the first module README for the auxiliary/admin/2wire/xslt_password_reset simulation
- cover anchor jumps and hash-handling with a DocsViewer unit test that injects a mock markdown renderer

## Testing
- yarn test __tests__/apps/metasploit/docs-viewer.test.tsx
- yarn lint *(fails: repository already has hundreds of jsx-a11y/control-has-associated-label and no-top-level-window violations unrelated to this change)*
- yarn test *(fails: existing suites such as __tests__/window.test.tsx, __tests__/nmapNse.test.tsx, settings store, and accessibility suites already error under jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68cc282fff088328abb5cda65d7c563b