### PR TITLE
[reaver] simulate staggered ap discovery

### DIFF
--- a/__tests__/apps/reaver/ap-discovery.test.tsx
+++ b/__tests__/apps/reaver/ap-discovery.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import APList from '../../../apps/reaver/components/APList';
+
+describe('Reaver access point discovery', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('paces discovered entries according to the interval', async () => {
+    render(<APList intervalMs={1000} maxEntries={4} />);
+
+    expect(screen.getAllByTestId('ap-skeleton').length).toBeGreaterThan(0);
+
+    await act(async () => {
+      jest.advanceTimersByTime(900);
+      await Promise.resolve();
+    });
+    expect(screen.queryAllByTestId('ap-entry')).toHaveLength(0);
+
+    await act(async () => {
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+    });
+    let entries = await screen.findAllByTestId('ap-entry');
+    expect(entries).toHaveLength(1);
+    expect(screen.getAllByTestId('ap-skeleton').length).toBeGreaterThan(0);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+    entries = await screen.findAllByTestId('ap-entry');
+    expect(entries).toHaveLength(2);
+  });
+
+  it('resets discovered access points when the interval changes', async () => {
+    const { rerender } = render(
+      <APList intervalMs={1000} maxEntries={4} />
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+    expect((await screen.findAllByTestId('ap-entry')).length).toBe(1);
+
+    rerender(<APList intervalMs={500} maxEntries={4} />);
+    expect(screen.queryAllByTestId('ap-entry')).toHaveLength(0);
+    expect(screen.getAllByTestId('ap-skeleton').length).toBeGreaterThan(0);
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+    expect((await screen.findAllByTestId('ap-entry')).length).toBe(1);
+  });
+});

--- a/apps/reaver/components/APList.tsx
+++ b/apps/reaver/components/APList.tsx
@@ -1,10 +1,120 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 export interface AccessPoint {
+  id: string;
   ssid: string;
   bssid: string;
+  channel: number;
+  security: 'Open' | 'WPA2' | 'WPA3' | 'WPA2/WPA3';
   wps: 'enabled' | 'locked' | 'disabled';
 }
+
+const MAX_APS = 12;
+
+const ssidPrefixes = [
+  'Home',
+  'Office',
+  'Corp',
+  'Secure',
+  'Guest',
+  'IoT',
+  'Lab',
+  'Campus',
+];
+
+const ssidSuffixes = [
+  'Net',
+  'WLAN',
+  'Mesh',
+  'AP',
+  'Zone',
+  'Link',
+  'Portal',
+  'Bridge',
+];
+
+const securityModes: AccessPoint['security'][] = [
+  'Open',
+  'WPA2',
+  'WPA3',
+  'WPA2/WPA3',
+];
+
+const wpsStatuses: AccessPoint['wps'][] = ['enabled', 'locked', 'disabled'];
+
+const randomFrom = <T,>(values: readonly T[]): T => {
+  const idx = Math.floor(Math.random() * values.length);
+  return values[idx];
+};
+
+const randomByte = () => Math.floor(Math.random() * 256)
+  .toString(16)
+  .padStart(2, '0');
+
+let sequence = 0;
+
+const generateBssid = () =>
+  `${randomByte()}:${randomByte()}:${randomByte()}:${randomByte()}:${randomByte()}:${randomByte()}`;
+
+const generateSsid = () =>
+  `${randomFrom(ssidPrefixes)}-${randomFrom(ssidSuffixes)}-${
+    10 + Math.floor(Math.random() * 90)
+  }`;
+
+const createAccessPoint = (): AccessPoint => ({
+  id: `ap-${Date.now()}-${sequence++}`,
+  ssid: generateSsid(),
+  bssid: generateBssid(),
+  channel: 1 + Math.floor(Math.random() * 11),
+  security: randomFrom(securityModes),
+  wps: randomFrom(wpsStatuses),
+});
+
+const waitForInterval = (delay: number, signal: AbortSignal) =>
+  new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timeout = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, delay);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    };
+    signal.addEventListener('abort', onAbort);
+  });
+
+const createAPGenerator = (
+  intervalMs: number,
+  signal: AbortSignal,
+): AsyncGenerator<AccessPoint, void, void> => {
+  const generator: AsyncGenerator<AccessPoint, void, void> = {
+    async next(): Promise<IteratorResult<AccessPoint>> {
+      if (signal.aborted) {
+        return { value: undefined as unknown as AccessPoint, done: true };
+      }
+      await waitForInterval(intervalMs, signal);
+      if (signal.aborted) {
+        return { value: undefined as unknown as AccessPoint, done: true };
+      }
+      return { value: createAccessPoint(), done: false };
+    },
+    async return(): Promise<IteratorResult<AccessPoint>> {
+      return { value: undefined as unknown as AccessPoint, done: true };
+    },
+    async throw(): Promise<IteratorResult<AccessPoint>> {
+      return { value: undefined as unknown as AccessPoint, done: true };
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  };
+  return generator;
+};
 
 const LockOpen = (props: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 20 20" fill="currentColor" {...props}>
@@ -44,28 +154,96 @@ const statusIcon = (status: AccessPoint['wps']) => {
   }
 };
 
-const APList: React.FC = () => {
+const formatWpsStatus = (status: AccessPoint['wps']) =>
+  status.charAt(0).toUpperCase() + status.slice(1);
+
+interface APListProps {
+  intervalMs: number;
+  maxEntries?: number;
+}
+
+const APList: React.FC<APListProps> = ({ intervalMs, maxEntries = MAX_APS }) => {
   const [aps, setAps] = useState<AccessPoint[]>([]);
+  const [scanning, setScanning] = useState(false);
 
   useEffect(() => {
-    fetch('/demo-data/reaver/aps.json')
-      .then((r) => r.json())
-      .then(setAps)
-      .catch(() => setAps([]));
-  }, []);
+    const controller = new AbortController();
+    let cancelled = false;
+    const generator = createAPGenerator(intervalMs, controller.signal);
+
+    setAps([]);
+    setScanning(true);
+
+    const consume = async () => {
+      while (!cancelled && !controller.signal.aborted) {
+        const { value, done } = await generator.next();
+        if (cancelled || controller.signal.aborted || done || !value) {
+          break;
+        }
+        setAps((prev) => {
+          if (cancelled) {
+            return prev;
+          }
+          const next = [...prev, value];
+          if (next.length > maxEntries) {
+            next.shift();
+          }
+          return next;
+        });
+      }
+      if (!cancelled) {
+        setScanning(false);
+      }
+    };
+
+    consume();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [intervalMs, maxEntries]);
+
+  const placeholderCount = useMemo(() => {
+    if (!scanning) {
+      return 0;
+    }
+    const remaining = maxEntries - aps.length;
+    return Math.max(1, Math.min(3, remaining));
+  }, [aps.length, maxEntries, scanning]);
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-4">
       {aps.map((ap) => (
         <div
-          key={ap.bssid}
-          className="flex items-center justify-between bg-gray-800 rounded p-3"
+          key={ap.id}
+          data-testid="ap-entry"
+          className="flex items-center justify-between bg-gray-800 rounded p-3 border border-gray-700"
         >
           <div>
-            <div className="font-semibold">{ap.ssid}</div>
+            <div className="font-semibold flex items-center gap-2">
+              <span>{ap.ssid}</span>
+              <span className="text-xs uppercase text-gray-400">{ap.security}</span>
+            </div>
             <div className="text-xs font-mono text-gray-400">{ap.bssid}</div>
+            <div className="text-xs text-gray-400">Channel {ap.channel}</div>
           </div>
-          {statusIcon(ap.wps)}
+          <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-gray-300">
+            {statusIcon(ap.wps)}
+            <span>WPS {formatWpsStatus(ap.wps)}</span>
+          </div>
+        </div>
+      ))}
+      {Array.from({ length: placeholderCount }).map((_, index) => (
+        <div
+          key={`skeleton-${index}`}
+          data-testid="ap-skeleton"
+          className="bg-gray-800 rounded p-3 border border-dashed border-gray-700 animate-pulse"
+          aria-hidden="true"
+        >
+          <div className="h-4 bg-gray-700 rounded w-3/4 mb-2" />
+          <div className="h-3 bg-gray-700 rounded w-2/3 mb-2" />
+          <div className="h-3 bg-gray-700 rounded w-1/2" />
         </div>
       ))}
     </div>

--- a/apps/reaver/index.tsx
+++ b/apps/reaver/index.tsx
@@ -70,6 +70,7 @@ const ReaverPanel: React.FC = () => {
   const [routers, setRouters] = useState<RouterMeta[]>([]);
   const [routerIdx, setRouterIdx] = useState(0);
   const [rate, setRate] = useState(1);
+  const [scanInterval, setScanInterval] = useState(1000);
   const [profile, setProfile] = useState<RouterProfile>(ROUTER_PROFILES[0]);
   const [attempts, setAttempts] = useState(0);
   const [running, setRunning] = useState(false);
@@ -209,8 +210,27 @@ const ReaverPanel: React.FC = () => {
       </p>
 
       <div className="mb-6">
-        <h2 className="text-lg mb-2">Access Points</h2>
-        <APList />
+        <div className="flex items-center justify-between mb-2 flex-wrap gap-2">
+          <h2 className="text-lg">Access Points</h2>
+          <label
+            htmlFor="ap-refresh-interval"
+            className="text-xs uppercase tracking-wider text-gray-300 flex items-center gap-2"
+          >
+            Refresh every
+            <select
+              id="ap-refresh-interval"
+              className="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-white text-xs"
+              value={scanInterval}
+              onChange={(event) => setScanInterval(Number(event.target.value))}
+            >
+              <option value={500}>0.5s</option>
+              <option value={1000}>1s</option>
+              <option value={2000}>2s</option>
+              <option value={5000}>5s</option>
+            </select>
+          </label>
+        </div>
+        <APList intervalMs={scanInterval} />
       </div>
 
       <div className="mb-6">


### PR DESCRIPTION
## Summary
- replace the static AP fetch with a simulated generator that emits randomized access points and keeps skeleton placeholders while scanning
- add a refresh interval selector so the Reaver app can adjust discovery cadence on the fly
- cover discovery pacing and reset behaviour with dedicated Jest tests

## Testing
- yarn test --runTestsByPath __tests__/apps/reaver/ap-discovery.test.tsx
- npx eslint apps/reaver/components/APList.tsx __tests__/apps/reaver/ap-discovery.test.tsx
- yarn lint *(fails: repository has longstanding accessibility and browser global lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2830454c83289be54a1ff6f42ee5