### PR TITLE
[wireshark] add coloring context and regression test

### DIFF
--- a/__tests__/apps/wireshark/coloring-rules.test.tsx
+++ b/__tests__/apps/wireshark/coloring-rules.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ColoringProvider } from '../../../components/apps/wireshark/coloringContext';
+import ColorRuleEditor from '../../../apps/wireshark/components/ColorRuleEditor';
+import PcapViewer from '../../../apps/wireshark/components/PcapViewer';
+
+describe('Coloring rules integration', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.style.cssText = '';
+  });
+
+  it('loads default palette and updates rows when importing new rules', async () => {
+    const packets = [
+      {
+        timestamp: '1',
+        src: '1.1.1.1',
+        dest: '2.2.2.2',
+        protocol: 6,
+        info: 'tcp packet',
+        data: new Uint8Array(),
+      },
+    ];
+
+    render(
+      <ColoringProvider>
+        <ColorRuleEditor />
+        <PcapViewer showLegend={false} initialPackets={packets} />
+      </ColoringProvider>
+    );
+
+    const row = await screen.findByText('tcp packet');
+    const initial = row.closest('tr') as HTMLTableRowElement;
+    expect(initial).toHaveClass('ws-colored');
+    expect(initial.style.getPropertyValue('--ws-row-bg')).toBe(
+      'var(--wireshark-color-red-bg)'
+    );
+    expect(
+      document.documentElement.style.getPropertyValue(
+        '--wireshark-color-red-bg'
+      )
+    ).toBe('#7f1d1d');
+
+    const file = new File(
+      [JSON.stringify([{ expression: 'tcp', color: '#123456' }])],
+      'rules.json',
+      { type: 'application/json' }
+    );
+    const input = screen.getByLabelText(/color rules json file/i);
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      const updated = screen.getByText('tcp packet').closest(
+        'tr'
+      ) as HTMLTableRowElement;
+      expect(updated.style.getPropertyValue('--ws-row-bg')).toBe('#123456');
+      expect(updated.className).toContain('ws-colored');
+    });
+  });
+});

--- a/apps/wireshark/index.tsx
+++ b/apps/wireshark/index.tsx
@@ -2,22 +2,25 @@
 
 import React, { useState } from 'react';
 import PcapViewer from './components/PcapViewer';
+import { ColoringProvider } from '../../components/apps/wireshark/coloringContext';
 
 const WiresharkPage: React.FC = () => {
   const [showLegend, setShowLegend] = useState(true);
 
   return (
-    <div className="h-full w-full flex flex-col">
-      <button
-        onClick={() => setShowLegend((v) => !v)}
-        className="ml-4 mt-2 mb-2 w-max px-2 py-1 text-xs bg-gray-700 text-white rounded"
-        aria-pressed={showLegend}
-        aria-label="Toggle protocol color legend"
-      >
-        {showLegend ? 'Hide' : 'Show'} Legend
-      </button>
-      <PcapViewer showLegend={showLegend} />
-    </div>
+    <ColoringProvider>
+      <div className="h-full w-full flex flex-col">
+        <button
+          onClick={() => setShowLegend((v) => !v)}
+          className="ml-4 mt-2 mb-2 w-max px-2 py-1 text-xs bg-gray-700 text-white rounded"
+          aria-pressed={showLegend}
+          aria-label="Toggle protocol color legend"
+        >
+          {showLegend ? 'Hide' : 'Show'} Legend
+        </button>
+        <PcapViewer showLegend={showLegend} />
+      </div>
+    </ColoringProvider>
   );
 };
 

--- a/components/apps/wireshark/colorDefs.js
+++ b/components/apps/wireshark/colorDefs.js
@@ -1,6 +1,30 @@
 export const colorDefinitions = [
-  { name: 'Red', className: 'text-red-500' },
-  { name: 'Blue', className: 'text-blue-500' },
-  { name: 'Green', className: 'text-green-500' },
-  { name: 'Yellow', className: 'text-yellow-500' },
+  {
+    name: 'Red',
+    className: 'text-red-500',
+    text: '#fca5a5',
+    background: '#7f1d1d',
+    hover: '#991b1b',
+  },
+  {
+    name: 'Blue',
+    className: 'text-blue-500',
+    text: '#bfdbfe',
+    background: '#1e3a8a',
+    hover: '#1d4ed8',
+  },
+  {
+    name: 'Green',
+    className: 'text-green-500',
+    text: '#bbf7d0',
+    background: '#14532d',
+    hover: '#15803d',
+  },
+  {
+    name: 'Yellow',
+    className: 'text-yellow-500',
+    text: '#fef08a',
+    background: '#713f12',
+    hover: '#b45309',
+  },
 ];

--- a/components/apps/wireshark/coloringContext.tsx
+++ b/components/apps/wireshark/coloringContext.tsx
@@ -1,0 +1,280 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import type { ReactNode } from 'react';
+import defaultRuleSet from '../../../filters/colorRules.json';
+import { colorDefinitions } from './colorDefs';
+
+export interface ColorRule {
+  expression: string;
+  color: string;
+}
+
+export interface PaletteColor {
+  text: string;
+  background: string;
+  hover: string;
+}
+
+export interface RuleEvaluationPacket {
+  protocol: number;
+  src: string;
+  dest: string;
+  info?: string;
+  sport?: number;
+  dport?: number;
+  plaintext?: string;
+  decrypted?: string;
+}
+
+interface CompiledRule {
+  rule: ColorRule;
+  predicate: (packet: RuleEvaluationPacket) => boolean;
+}
+
+interface ColoringContextValue {
+  rules: ColorRule[];
+  setRules: (rules: ColorRule[]) => void;
+  importRules: (rules: unknown) => ColorRule[];
+  exportRules: () => string;
+  getRuleForPacket: (packet: RuleEvaluationPacket) => ColorRule | undefined;
+  palette: Record<string, PaletteColor>;
+  isProvided: boolean;
+}
+
+const slugifyColor = (name: string) =>
+  name.trim().toLowerCase().replace(/\s+/g, '-');
+
+type ColorDefinition = {
+  name: string;
+  className: string;
+  text?: string;
+  background?: string;
+  hover?: string;
+};
+
+const buildPalette = () => {
+  const palette: Record<string, PaletteColor> = {};
+  (colorDefinitions as ColorDefinition[]).forEach((definition) => {
+    const slug = slugifyColor(definition.name);
+    palette[slug] = {
+      text: definition.text ?? '#f9fafb',
+      background: definition.background ?? '#1f2937',
+      hover: definition.hover ?? definition.background ?? '#374151',
+    };
+  });
+  return palette;
+};
+
+const filterCache = new Map<string, (packet: RuleEvaluationPacket) => boolean>();
+
+export const sanitizeRuleSet = (input: unknown): ColorRule[] => {
+  if (!Array.isArray(input)) return [];
+  return input
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') return null;
+      const record = entry as Record<string, unknown>;
+      const expression =
+        typeof record.expression === 'string'
+          ? record.expression.trim()
+          : '';
+      const color =
+        typeof record.color === 'string' ? record.color.trim() : '';
+      return { expression, color };
+    })
+    .filter((rule): rule is ColorRule => rule !== null);
+};
+
+const defaultRules = sanitizeRuleSet(defaultRuleSet);
+const defaultPalette = buildPalette();
+const storageKey = 'wireshark:color-rules';
+
+const compileFilter = (expression: string) => {
+  const normalized = expression.trim().toLowerCase();
+  if (!normalized) {
+    return () => true;
+  }
+  const cached = filterCache.get(normalized);
+  if (cached) return cached;
+
+  let predicate: (packet: RuleEvaluationPacket) => boolean;
+  if (normalized === 'tcp') {
+    predicate = (packet) => packet.protocol === 6;
+  } else if (normalized === 'udp') {
+    predicate = (packet) => packet.protocol === 17;
+  } else if (normalized === 'icmp') {
+    predicate = (packet) => packet.protocol === 1;
+  } else {
+    let match = normalized.match(/^ip\.addr\s*==\s*(\d+\.\d+\.\d+\.\d+)$/);
+    if (match) {
+      const ip = match[1];
+      predicate = (packet) => packet.src === ip || packet.dest === ip;
+    } else if ((match = normalized.match(/^tcp\.port\s*==\s*(\d+)$/))) {
+      const port = parseInt(match[1], 10);
+      predicate = (packet) =>
+        packet.protocol === 6 &&
+        (packet.sport === port || packet.dport === port);
+    } else if ((match = normalized.match(/^udp\.port\s*==\s*(\d+)$/))) {
+      const port = parseInt(match[1], 10);
+      predicate = (packet) =>
+        packet.protocol === 17 &&
+        (packet.sport === port || packet.dport === port);
+    } else {
+      predicate = (packet) => {
+        const term = normalized;
+        const info = (packet.info || '').toLowerCase();
+        const src = (packet.src || '').toLowerCase();
+        const dest = (packet.dest || '').toLowerCase();
+        const plaintext =
+          (packet.plaintext || packet.decrypted || '').toLowerCase();
+        const sport = packet.sport?.toString() ?? '';
+        const dport = packet.dport?.toString() ?? '';
+        const proto =
+          typeof packet.protocol === 'number'
+            ? packet.protocol.toString()
+            : `${packet.protocol ?? ''}`;
+        return (
+          src.includes(term) ||
+          dest.includes(term) ||
+          info.includes(term) ||
+          plaintext.includes(term) ||
+          sport.includes(term) ||
+          dport.includes(term) ||
+          proto.toLowerCase().includes(term)
+        );
+      };
+    }
+  }
+
+  filterCache.set(normalized, predicate);
+  return predicate;
+};
+
+const compileRules = (rules: ColorRule[]): CompiledRule[] =>
+  rules
+    .filter((rule) => rule.expression.trim())
+    .map((rule) => ({ rule, predicate: compileFilter(rule.expression) }));
+
+const defaultContextValue: ColoringContextValue = {
+  rules: defaultRules,
+  setRules: () => {},
+  importRules: () => defaultRules,
+  exportRules: () => JSON.stringify(defaultRules, null, 2),
+  getRuleForPacket: () => undefined,
+  palette: defaultPalette,
+  isProvided: false,
+};
+
+const ColoringContext = createContext<ColoringContextValue>(defaultContextValue);
+
+interface ColoringProviderProps {
+  children: ReactNode;
+  initialRules?: ColorRule[];
+}
+
+export const ColoringProvider: React.FC<ColoringProviderProps> = ({
+  children,
+  initialRules,
+}) => {
+  const [rules, setRulesState] = useState<ColorRule[]>(() =>
+    initialRules ? sanitizeRuleSet(initialRules) : defaultRules
+  );
+  const palette = defaultPalette;
+  const shouldLoadFromStorage = initialRules === undefined;
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+    const root = document.documentElement;
+    const entries = Object.entries(palette);
+    entries.forEach(([slug, token]) => {
+      root.style.setProperty(`--wireshark-color-${slug}-text`, token.text);
+      root.style.setProperty(`--wireshark-color-${slug}-bg`, token.background);
+      root.style.setProperty(
+        `--wireshark-color-${slug}-hover`,
+        token.hover ?? token.background
+      );
+    });
+    return () => {
+      entries.forEach(([slug]) => {
+        root.style.removeProperty(`--wireshark-color-${slug}-text`);
+        root.style.removeProperty(`--wireshark-color-${slug}-bg`);
+        root.style.removeProperty(`--wireshark-color-${slug}-hover`);
+      });
+    };
+  }, [palette]);
+
+  useEffect(() => {
+    if (!shouldLoadFromStorage || typeof window === 'undefined') return;
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      if (!stored) return;
+      const parsed = JSON.parse(stored);
+      const sanitized = sanitizeRuleSet(parsed);
+      setRulesState(sanitized);
+    } catch {
+      // ignore malformed storage
+    }
+  }, [shouldLoadFromStorage]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(rules));
+    } catch {
+      // ignore storage quota issues
+    }
+  }, [rules]);
+
+  const compiledRules = useMemo(() => compileRules(rules), [rules]);
+
+  const setRules = useCallback((next: ColorRule[]) => {
+    setRulesState(sanitizeRuleSet(next));
+  }, []);
+
+  const importRules = useCallback((input: unknown) => {
+    const sanitized = sanitizeRuleSet(input);
+    setRulesState(sanitized);
+    return sanitized;
+  }, []);
+
+  const exportRules = useCallback(
+    () => JSON.stringify(rules, null, 2),
+    [rules]
+  );
+
+  const getRuleForPacket = useCallback(
+    (packet: RuleEvaluationPacket) => {
+      for (const { rule, predicate } of compiledRules) {
+        if (predicate(packet)) {
+          return rule;
+        }
+      }
+      return undefined;
+    },
+    [compiledRules]
+  );
+
+  const value = useMemo<ColoringContextValue>(
+    () => ({
+      rules,
+      setRules,
+      importRules,
+      exportRules,
+      getRuleForPacket,
+      palette,
+      isProvided: true,
+    }),
+    [rules, setRules, importRules, exportRules, getRuleForPacket, palette]
+  );
+
+  return (
+    <ColoringContext.Provider value={value}>{children}</ColoringContext.Provider>
+  );
+};
+
+export const useColoring = () => useContext(ColoringContext);

--- a/filters/colorRules.json
+++ b/filters/colorRules.json
@@ -1,0 +1,5 @@
+[
+  { "expression": "tcp", "color": "Red" },
+  { "expression": "udp", "color": "Blue" },
+  { "expression": "icmp", "color": "Yellow" }
+]


### PR DESCRIPTION
## Summary
- create a Wireshark coloring provider that loads default JSON rules, syncs palette variables, and caches compiled filters
- connect the rule editor and packet viewer to the context so importing/exporting JSON updates row colors without flicker
- wrap the Wireshark app with the provider, add default rule JSON, and cover the flow with a regression test

## Testing
- yarn test __tests__/apps/wireshark/coloring-rules.test.tsx
- yarn lint *(fails: pre-existing accessibility and no-top-level-window issues)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2836b92c8328867d735db5b0d9ef