### PR TITLE
[tests] add Wireshark Playwright perf gate

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,27 @@
+# Testing notes
+
+## Playwright desktop suites
+
+The Playwright configuration now exposes two groups:
+
+- **`apps-smoke`** – legacy smoke checks under `tests/` that ensure every `/apps/*` route renders.
+- **`desktop-e2e`** – interaction-heavy specs in `playwright/` that simulate desktop workflows.
+
+Run one or both projects with:
+
+```bash
+npx playwright test --project=desktop-e2e
+npx playwright test --project=apps-smoke
+```
+
+## Wireshark performance gate
+
+`playwright/wireshark.spec.ts` exercises the Wireshark simulation end to end:
+
+1. Opens `/apps/wireshark` and loads the bundled HTTP capture from `public/samples/wireshark`.
+2. Applies the HTTP preset filter, selects the first packet to “follow” the stream, and exports the active display filter via the Copy control.
+3. Captures a Playwright trace and samples `window.performance.memory` before launching the capture and after navigating away. The test fails if the used JS heap grows by more than **5 MB**.
+4. Scrolls the packet table while logging the measured frames-per-second as a test annotation to track UI responsiveness.
+5. Fails on any browser console errors so regressions are caught quickly.
+
+Keep these behaviours in mind when modifying the Wireshark app: memory, console hygiene, and scroll performance are now part of the automated acceptance criteria.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,19 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },
+  projects: [
+    {
+      name: 'apps-smoke',
+      testDir: './tests',
+      testMatch: /.*\.spec\.ts/,
+    },
+    {
+      name: 'desktop-e2e',
+      testDir: './playwright',
+      testMatch: /.*\.spec\.ts/,
+    },
+  ],
 });

--- a/playwright/wireshark.spec.ts
+++ b/playwright/wireshark.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Wireshark capture workflow', () => {
+  test('loads HTTP sample, follows stream, exports filter, and stays within memory budget', async ({
+    page,
+    context,
+  }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.addInitScript(() => {
+      const globalWindow = window as typeof window & { __clipboardWrites?: string[] };
+      globalWindow.__clipboardWrites = [];
+
+      const original = navigator.clipboard?.writeText?.bind(navigator.clipboard);
+      const stub = async (text: string) => {
+        globalWindow.__clipboardWrites?.push(text);
+        if (original) {
+          try {
+            await original(text);
+          } catch {
+            // Ignore clipboard permission issues during automated tests
+          }
+        }
+      };
+
+      if (navigator.clipboard) {
+        (navigator.clipboard as Clipboard & { writeText: typeof stub }).writeText = stub;
+      } else {
+        Object.defineProperty(navigator, 'clipboard', {
+          value: { writeText: stub },
+          configurable: true,
+        });
+      }
+    });
+
+    const tracePath = test.info().outputPath('wireshark-trace.zip');
+    await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
+
+    try {
+      await page.goto('/apps/wireshark');
+      await expect(page.getByRole('button', { name: /Legend/i })).toBeVisible();
+
+      const baselineMemory = await page.evaluate(() => {
+        const memory = (window.performance as Performance & {
+          memory?: { usedJSHeapSize: number };
+        }).memory;
+        return memory?.usedJSHeapSize ?? null;
+      });
+
+      if (baselineMemory === null) {
+        test.skip('window.performance.memory is not available in this browser');
+      }
+
+      const sampleSelect = page.locator('select').first();
+      await sampleSelect.selectOption('/samples/wireshark/http.pcap');
+
+      const packetRows = page.locator('table tbody tr');
+      await expect(packetRows.first()).toBeVisible();
+
+      await page.getByRole('button', { name: 'HTTP(S)' }).click();
+      const filterInput = page.getByLabel('Quick search');
+      await expect(filterInput).toHaveValue('tcp.port == 80 || tcp.port == 443');
+
+      await packetRows.first().click();
+      await expect(page.getByText('Ethernet')).toBeVisible();
+
+      await page.getByRole('button', { name: 'Copy' }).click();
+      await expect.poll(async () =>
+        page.evaluate(() => {
+          const globalWindow = window as typeof window & { __clipboardWrites?: string[] };
+          const history = globalWindow.__clipboardWrites ?? [];
+          return history[history.length - 1] ?? null;
+        }),
+      ).toBe('tcp.port == 80 || tcp.port == 443');
+
+      const fps = await page.evaluate(async () => {
+        const table = document.querySelector('table');
+        const container = table?.closest('div');
+        if (!table || !container) return null;
+        const scrollContainer = container as HTMLElement;
+        scrollContainer.scrollTop = 0;
+
+        return await new Promise<number>((resolve) => {
+          const start = performance.now();
+          let frames = 0;
+
+          const tick = (timestamp: number) => {
+            frames += 1;
+            scrollContainer.scrollTop = (scrollContainer.scrollTop + 60) % Math.max(scrollContainer.scrollHeight, 1);
+            if (timestamp - start >= 500) {
+              const elapsed = timestamp - start;
+              resolve((frames * 1000) / elapsed);
+              return;
+            }
+            requestAnimationFrame(tick);
+          };
+
+          requestAnimationFrame(tick);
+        });
+      });
+
+      if (fps !== null) {
+        test.info().annotations.push({
+          type: 'perf',
+          description: `Wireshark scroll FPS ≈ ${fps.toFixed(1)}`,
+        });
+      }
+
+      await page.goto('/');
+      const postMemory = await page.evaluate(() => {
+        const memory = (window.performance as Performance & {
+          memory?: { usedJSHeapSize: number };
+        }).memory;
+        return memory?.usedJSHeapSize ?? null;
+      });
+
+      expect(postMemory).not.toBeNull();
+      const deltaMb = ((postMemory! - baselineMemory!) / (1024 * 1024));
+      expect(deltaMb).toBeLessThanOrEqual(5);
+
+      expect(consoleErrors).toEqual([]);
+    } finally {
+      await context.tracing.stop({ path: tracePath });
+      test.info().attach('wireshark-trace', {
+        path: tracePath,
+        contentType: 'application/zip',
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a desktop-e2e Playwright project that opens the Wireshark app, loads the bundled capture, applies the HTTP preset, and asserts no console errors while recording trace, FPS, and heap growth (<=5 MB)
- update the Playwright configuration so tests are split into smoke and desktop suites
- document the new Wireshark performance gate and the Playwright project layout in docs/testing.md

## Testing
- yarn lint *(fails: repository currently reports numerous pre-existing accessibility lint violations)*
- yarn test *(fails: existing suites such as window, nmap NSE, and modal tests fail under jsdom setup)*

------
https://chatgpt.com/codex/tasks/task_e_68cc283551fc8328aa064daf631352eb