### PR TITLE
feat(autopsy): add bloom filter hash lookup

### DIFF
--- a/__tests__/apps/autopsy/bloom-filter.test.ts
+++ b/__tests__/apps/autopsy/bloom-filter.test.ts
@@ -1,0 +1,39 @@
+import { BloomFilter } from '../../../apps/autopsy/utils/bloom';
+
+describe('BloomFilter', () => {
+  it('stores values without false negatives', () => {
+    const values = ['alpha', 'beta', 'gamma'];
+    const filter = BloomFilter.from(values, 0.01);
+
+    values.forEach((value) => {
+      expect(filter.has(value)).toBe(true);
+    });
+
+    expect(filter.has('delta')).toBe(false);
+  });
+
+  it('keeps false positive rate below 1% for random misses', () => {
+    const dataset = Array.from({ length: 1000 }, (_, index) => `item-${index}`);
+    const filter = BloomFilter.from(dataset, 0.01);
+
+    dataset.forEach((value) => expect(filter.has(value)).toBe(true));
+
+    let seed = 123456789;
+    const nextRandom = () => {
+      seed = (Math.imul(seed, 1103515245) + 12345) & 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+
+    const trials = 10_000;
+    let falsePositives = 0;
+    for (let i = 0; i < trials; i += 1) {
+      const missValue = `miss-${Math.floor(nextRandom() * 1e9)}`;
+      if (filter.has(missValue)) {
+        falsePositives += 1;
+      }
+    }
+
+    const rate = falsePositives / trials;
+    expect(rate).toBeLessThan(0.01);
+  });
+});

--- a/apps/autopsy/components/KeywordTester.tsx
+++ b/apps/autopsy/components/KeywordTester.tsx
@@ -1,7 +1,51 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import events from '../events.json';
+import nsrl from '../data/nsrl.json';
+import { BloomFilter } from '../utils/bloom';
+
+type NsrlEntry = {
+  fileName: string;
+  product: string;
+  version: string;
+  os: string;
+  sha1: string;
+  sha256: string;
+};
+
+type NsrlDataset = {
+  metadata: {
+    source: string;
+    generated: string;
+    count: number;
+    notes: string;
+  };
+  entries: NsrlEntry[];
+};
+
+const nsrlData = nsrl as NsrlDataset;
+const nsrlEntries = nsrlData.entries;
+const nsrlHashes = nsrlEntries.flatMap((entry) => [entry.sha1, entry.sha256]);
+
+type LookupState = 'idle' | 'hit' | 'miss' | 'probable';
+
+type Telemetry = {
+  datasetSize: number;
+  filterSize: number;
+  hashCount: number;
+  insertedItems: number;
+  estimatedFalsePositiveRate: number;
+  benchmark: {
+    lookups: number;
+    duration: number;
+    perLookup: number;
+    meetsTarget: boolean;
+  };
+};
+
+const LOOKUP_TARGET_MS = 50;
+const BENCHMARK_LOOKUPS = 10_000;
 
 const escapeHtml = (str: string = '') =>
   str
@@ -13,6 +57,54 @@ const escapeHtml = (str: string = '') =>
 
 function KeywordTester() {
   const [keywords, setKeywords] = useState<string[]>([]);
+  const [lookupHash, setLookupHash] = useState('');
+  const [lookupState, setLookupState] = useState<LookupState>('idle');
+  const [lookupResult, setLookupResult] = useState<NsrlEntry | null>(null);
+  const [telemetry, setTelemetry] = useState<Telemetry | null>(null);
+  const filterRef = useRef<BloomFilter | null>(null);
+
+  useEffect(() => {
+    const filter = BloomFilter.from(nsrlHashes, 0.005);
+    filterRef.current = filter;
+
+    // Deterministic pseudo-random generator for repeatable benchmark runs.
+    let seed = 0xdeadbeef;
+    const nextValue = () => {
+      seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+      return `miss-${seed.toString(16)}`;
+    };
+
+    const queries: string[] = new Array(BENCHMARK_LOOKUPS);
+    for (let i = 0; i < BENCHMARK_LOOKUPS; i += 1) {
+      if (i % 10 === 0) {
+        queries[i] = nsrlHashes[i % nsrlHashes.length];
+      } else {
+        queries[i] = nextValue();
+      }
+    }
+
+    const start = performance.now();
+    queries.forEach((value) => {
+      filter.has(value);
+    });
+    const duration = performance.now() - start;
+
+    setTelemetry({
+      datasetSize: nsrlHashes.length,
+      filterSize: filter.size,
+      hashCount: filter.hashCount,
+      insertedItems: filter.insertedItems,
+      estimatedFalsePositiveRate: filter.estimateFalsePositiveRate(
+        nsrlHashes.length
+      ),
+      benchmark: {
+        lookups: BENCHMARK_LOOKUPS,
+        duration,
+        perLookup: duration / BENCHMARK_LOOKUPS,
+        meetsTarget: duration < LOOKUP_TARGET_MS,
+      },
+    });
+  }, []);
 
   const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -50,8 +142,141 @@ function KeywordTester() {
     return keywords.some((k) => content.includes(k.toLowerCase()));
   });
 
+  const handleLookup = (event: React.FormEvent) => {
+    event.preventDefault();
+    const value = lookupHash.trim().toLowerCase();
+    if (!value) {
+      setLookupState('idle');
+      setLookupResult(null);
+      return;
+    }
+
+    const filter = filterRef.current;
+    if (!filter) {
+      return;
+    }
+
+    const isKnown = filter.has(value);
+    const match = nsrlEntries.find(
+      (entry) => entry.sha1 === value || entry.sha256 === value
+    );
+
+    if (match) {
+      setLookupState('hit');
+      setLookupResult(match);
+    } else if (isKnown) {
+      setLookupState('probable');
+      setLookupResult(null);
+    } else {
+      setLookupState('miss');
+      setLookupResult(null);
+    }
+  };
+
   return (
     <div className="space-y-4">
+      <div className="bg-ub-grey/80 rounded p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-white">NSRL Hash Lookup</h3>
+          {telemetry && (
+            <span
+              className={`text-xs font-mono ${
+                telemetry.benchmark.meetsTarget
+                  ? 'text-green-300'
+                  : 'text-yellow-300'
+              }`}
+            >
+              {telemetry.benchmark.duration.toFixed(2)} ms / {BENCHMARK_LOOKUPS}
+            </span>
+          )}
+        </div>
+        <p className="text-xs text-gray-300">
+          Paste a SHA-1 or SHA-256 hash to see if it appears in the simulated
+          NSRL reference set. Bloom filter lookups run locally so false
+          positives are possible but false negatives are not.
+        </p>
+        <form className="flex flex-col gap-2 sm:flex-row" onSubmit={handleLookup}>
+          <input
+            className="flex-1 rounded border border-ub-grey-dark bg-black/40 p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-cyan-400"
+            placeholder="e.g. 99a06053205a3436542bfa61d19c557032a1d28c"
+            value={lookupHash}
+            onChange={(event) => setLookupHash(event.target.value)}
+          />
+          <button
+            type="submit"
+            className="rounded bg-cyan-600 px-3 py-2 text-sm font-semibold text-white hover:bg-cyan-500"
+          >
+            Lookup
+          </button>
+        </form>
+        {lookupState !== 'idle' && (
+          <div
+            className={`rounded border p-3 text-sm ${
+              lookupState === 'hit'
+                ? 'border-green-600 bg-green-900/30 text-green-200'
+                : lookupState === 'probable'
+                ? 'border-yellow-600 bg-yellow-900/30 text-yellow-200'
+                : 'border-red-600 bg-red-900/30 text-red-200'
+            }`}
+          >
+            {lookupState === 'hit' && lookupResult && (
+              <div className="space-y-1">
+                <p className="font-semibold">Known good file identified.</p>
+                <div className="grid gap-x-4 gap-y-1 text-xs sm:grid-cols-2">
+                  <span>
+                    <strong>File:</strong> {lookupResult.fileName}
+                  </span>
+                  <span>
+                    <strong>Product:</strong> {lookupResult.product}
+                  </span>
+                  <span>
+                    <strong>Version:</strong> {lookupResult.version}
+                  </span>
+                  <span>
+                    <strong>OS:</strong> {lookupResult.os}
+                  </span>
+                </div>
+              </div>
+            )}
+            {lookupState === 'probable' && (
+              <p>
+                Bloom filter suggests a match, but the hash is not in the mock
+                dataset. Treat as a potential false positive.
+              </p>
+            )}
+            {lookupState === 'miss' && (
+              <p>No match found in the mock NSRL dataset.</p>
+            )}
+          </div>
+        )}
+        {telemetry && (
+          <div className="grid gap-2 rounded border border-ub-grey-dark p-3 text-xs text-gray-300 sm:grid-cols-2">
+            <div>
+              <strong>Hashes indexed:</strong> {telemetry.datasetSize}
+            </div>
+            <div>
+              <strong>Bloom size:</strong> {telemetry.filterSize.toLocaleString()} bits
+            </div>
+            <div>
+              <strong>Hash functions:</strong> {telemetry.hashCount}
+            </div>
+            <div>
+              <strong>Inserted items:</strong> {telemetry.insertedItems}
+            </div>
+            <div className="sm:col-span-2">
+              <strong>Estimated FPR:</strong>{' '}
+              {(telemetry.estimatedFalsePositiveRate * 100).toFixed(2)}%
+            </div>
+            <div className="sm:col-span-2">
+              <strong>Avg lookup:</strong>{' '}
+              {telemetry.benchmark.perLookup.toFixed(4)} ms ({
+                telemetry.benchmark.meetsTarget ? '✓' : '⚠'
+              }{' '}
+              target &lt; {LOOKUP_TARGET_MS} ms for {BENCHMARK_LOOKUPS} ops)
+            </div>
+          </div>
+        )}
+      </div>
       <div>
         <input
           type="file"

--- a/apps/autopsy/data/nsrl.json
+++ b/apps/autopsy/data/nsrl.json
@@ -1,0 +1,170 @@
+{
+  "metadata": {
+    "source": "Mock NSRL reference dataset for Autopsy demo",
+    "generated": "2025-09-18T15:45:19.629Z",
+    "count": 20,
+    "notes": "Hashes derived from deterministic fingerprints for repeatable demos. Not real NSRL data."
+  },
+  "entries": [
+    {
+      "fileName": "calc.exe",
+      "product": "Microsoft Calculator",
+      "version": "10.0.19041.1",
+      "os": "Windows 10",
+      "sha1": "99a06053205a3436542bfa61d19c557032a1d28c",
+      "sha256": "9162fab717bf3a31298744beec253f8cfd7a064cbb75f9d80f0906380eca4635"
+    },
+    {
+      "fileName": "notepad.exe",
+      "product": "Microsoft Notepad",
+      "version": "10.0.19041.1",
+      "os": "Windows 10",
+      "sha1": "9493759fe458605e65aa02387661422d17c7a0b3",
+      "sha256": "4b3e590843988d2df90e6a7579eeb113b95088f988e40f007a129e2407118dcc"
+    },
+    {
+      "fileName": "winword.exe",
+      "product": "Microsoft Word",
+      "version": "16.0.17029.20108",
+      "os": "Windows 11",
+      "sha1": "e977d00d6cee4f2e1edf67254b7a0dce58faade6",
+      "sha256": "74016f855bde2a941fa1d59d9bca8ed4ea3a3931fe3b93f8d5e7a609b58db06c"
+    },
+    {
+      "fileName": "excel.exe",
+      "product": "Microsoft Excel",
+      "version": "16.0.17029.20108",
+      "os": "Windows 11",
+      "sha1": "e73210d45ad14f7e6100780e3931c50209148b87",
+      "sha256": "de3ead3ebe0f86b8d5ebb1fe06aafb4dcb32dfd67ee32961bdcf449802241378"
+    },
+    {
+      "fileName": "powershell.exe",
+      "product": "Windows PowerShell",
+      "version": "7.3.0",
+      "os": "Windows 10",
+      "sha1": "6a97e2ea8a77d7719f50446fb853e418356ba050",
+      "sha256": "7c330a1155116118e6fea453e5f80dd9df5223c50d53b6e331c8f81df78f4ebe"
+    },
+    {
+      "fileName": "cmd.exe",
+      "product": "Windows Command Processor",
+      "version": "10.0.19041.1",
+      "os": "Windows 10",
+      "sha1": "6ef3cdf431fbb44f3da1e522bd0b7dbc1d9e7d8e",
+      "sha256": "bfc095b15a73729a83aca83d23e7bb9345ecbe960d6a0e1cf4bf51285f88a873"
+    },
+    {
+      "fileName": "explorer.exe",
+      "product": "Windows Explorer",
+      "version": "10.0.22000.120",
+      "os": "Windows 11",
+      "sha1": "3e786dafaa8e59a489047bd73d694302c0a05259",
+      "sha256": "28a5975d991b5b64e766cd3100cae36c874c3aabfc55f03114d497b9a7c08614"
+    },
+    {
+      "fileName": "mspaint.exe",
+      "product": "Microsoft Paint",
+      "version": "10.0.22000.120",
+      "os": "Windows 11",
+      "sha1": "0f7c96ee471661d70be34a95c677b288fcd79d8c",
+      "sha256": "721915bebe4f1563b79819f3d86db6a6a7240eeaf7d3d29e32fc934c417b91b2"
+    },
+    {
+      "fileName": "taskmgr.exe",
+      "product": "Windows Task Manager",
+      "version": "10.0.22621.1",
+      "os": "Windows 11",
+      "sha1": "6c1f37a1efebed06b0ce5be9141fa7e37bf162c7",
+      "sha256": "feed73a7408d8187e8882d195ac7d387532f3ae4227b765a3c0ab5d76ead5735"
+    },
+    {
+      "fileName": "wordpad.exe",
+      "product": "WordPad",
+      "version": "10.0.19041.1",
+      "os": "Windows 10",
+      "sha1": "0c99c9cc9f5b61e4445c846f11ed00125edf159b",
+      "sha256": "d3854f626eee6af37db604f08278dd2c69e1296bcd745eac39bde4884631de5c"
+    },
+    {
+      "fileName": "regedit.exe",
+      "product": "Registry Editor",
+      "version": "10.0.19041.1",
+      "os": "Windows 10",
+      "sha1": "0f5e24b8dce84bdaeb6bf1bd711c1b5297285ff2",
+      "sha256": "22993e91a09aca3b7394767b7550bc95f7f6fd6e16e679248d46a32c0f2f5441"
+    },
+    {
+      "fileName": "wscript.exe",
+      "product": "Windows Script Host",
+      "version": "5.812.10240",
+      "os": "Windows 10",
+      "sha1": "2806b596522278a0d9ceade481e82a9a2a5f519e",
+      "sha256": "c4aff43240f96b519f722bc7e572ddd1dac80e0fbcced50f2f314bb7d3b0a89e"
+    },
+    {
+      "fileName": "bash",
+      "product": "GNU Bash",
+      "version": "5.2.15",
+      "os": "Ubuntu 22.04",
+      "sha1": "a4307f8e0d9f46985c100d05758a05eb93a565da",
+      "sha256": "2f27918e0babdb203b60b980525bcaa2c983c0b6810220449b3892e6b7ea0545"
+    },
+    {
+      "fileName": "python3.10",
+      "product": "Python",
+      "version": "3.10.8",
+      "os": "Ubuntu 22.04",
+      "sha1": "92eb9f8c88c8fa146d087d7e9293fedc7c097b4b",
+      "sha256": "1e495a513f6e3d993ef2393ca891de40d9b156aa5572f0fbab0a80c559f0781f"
+    },
+    {
+      "fileName": "zsh",
+      "product": "Z shell",
+      "version": "5.9",
+      "os": "macOS 13",
+      "sha1": "4d188280daef2427f55725c7fe23d2e6d932c6c5",
+      "sha256": "4d9accf747502d052aaece6ee50e9e547cf25d045a89b969f62da167cad252b7"
+    },
+    {
+      "fileName": "Finder",
+      "product": "Finder",
+      "version": "13.0",
+      "os": "macOS 13",
+      "sha1": "256e22772abd56a32b94931972f8515ea1f048ac",
+      "sha256": "f24d6cccd3f8f6d2df598aa124ebc330ed658866d6178635ef619aefb2baa858"
+    },
+    {
+      "fileName": "Terminal",
+      "product": "Terminal",
+      "version": "2.13",
+      "os": "macOS 13",
+      "sha1": "3f300d796160001b8ad1d6e81d9d0d75d2d4c9b8",
+      "sha256": "d2b04fa58c3f224e5ae3f76af2a873ee6fb12c0b57abab17cedf3bcfee7dab5a"
+    },
+    {
+      "fileName": "Safari",
+      "product": "Safari",
+      "version": "16.0",
+      "os": "macOS 13",
+      "sha1": "55188edf9ff1a66591f7ddd6cad8e3043a2dd8bc",
+      "sha256": "42976db8b043ebf1404380e18820baccdc918d2994ca7abfefdcaf1ca5de0edb"
+    },
+    {
+      "fileName": "chrome.exe",
+      "product": "Google Chrome",
+      "version": "117.0.5938.92",
+      "os": "Windows 11",
+      "sha1": "1f1b11b915d8f3ee4c1149a452e4a06c373f9d11",
+      "sha256": "2c42c4b483748c615be3b435112d464ab3b29047399d4ab994ab51df150f8117"
+    },
+    {
+      "fileName": "firefox.exe",
+      "product": "Mozilla Firefox",
+      "version": "118.0.1",
+      "os": "Windows 11",
+      "sha1": "b6e52204a4bdb890b41c76c9796b8914191928de",
+      "sha256": "79fc07e71fa37709b8a7e7b6952c5293451f215c18c215a9271c62f41fcc673e"
+    }
+  ]
+}

--- a/apps/autopsy/utils/bloom.ts
+++ b/apps/autopsy/utils/bloom.ts
@@ -1,0 +1,148 @@
+export interface BloomFilterOptions {
+  /** Number of bits in the Bloom filter bitset */
+  size: number;
+  /** Number of hash functions to apply to each value */
+  hashCount: number;
+}
+
+/**
+ * Lightweight Bloom filter implementation used to simulate NSRL lookups.
+ * The filter works entirely in memory and avoids async APIs so it can run in
+ * both Node (tests) and the browser (Next.js client components).
+ */
+export class BloomFilter {
+  public readonly size: number;
+  public readonly hashCount: number;
+  private readonly bits: Uint8Array;
+  private items = 0;
+
+  constructor(options: BloomFilterOptions) {
+    if (!Number.isInteger(options.size) || options.size <= 0) {
+      throw new Error('BloomFilter size must be a positive integer');
+    }
+    if (!Number.isInteger(options.hashCount) || options.hashCount <= 0) {
+      throw new Error('BloomFilter hash count must be a positive integer');
+    }
+    this.size = options.size;
+    this.hashCount = options.hashCount;
+    this.bits = new Uint8Array(Math.ceil(this.size / 8));
+  }
+
+  /** Number of values that have been inserted. */
+  get insertedItems(): number {
+    return this.items;
+  }
+
+  /**
+   * Adds a string value to the Bloom filter.
+   */
+  add(value: string): void {
+    this.hashIndices(value).forEach((index) => this.setBit(index));
+    this.items += 1;
+  }
+
+  /**
+   * Checks if a string value *might* exist in the filter. False positives are
+   * possible, but false negatives are not.
+   */
+  has(value: string): boolean {
+    return this.hashIndices(value).every((index) => this.getBit(index));
+  }
+
+  /**
+   * Estimates the theoretical false positive rate based on the number of
+   * values inserted so far.
+   */
+  estimateFalsePositiveRate(inserted: number = this.items): number {
+    if (inserted <= 0) {
+      return 0;
+    }
+    const exponent = -((this.hashCount * inserted) / this.size);
+    const probability = Math.pow(1 - Math.exp(exponent), this.hashCount);
+    return probability;
+  }
+
+  /**
+   * Serialises the Bloom filter state to an object that can be stored or
+   * inspected. Primarily used for debugging/telemetry in the UI layer.
+   */
+  toJSON() {
+    return {
+      size: this.size,
+      hashCount: this.hashCount,
+      bits: Array.from(this.bits),
+      items: this.items,
+    };
+  }
+
+  /**
+   * Builds a Bloom filter pre-populated with the provided values.
+   */
+  static from(values: string[], errorRate = 0.01): BloomFilter {
+    const { size, hashCount } = BloomFilter.optimalParameters(
+      Math.max(values.length, 1),
+      errorRate
+    );
+    const filter = new BloomFilter({ size, hashCount });
+    values.forEach((value) => filter.add(value));
+    return filter;
+  }
+
+  /**
+   * Calculates optimal Bloom filter parameters for a target dataset size and
+   * false positive rate.
+   */
+  static optimalParameters(
+    expectedItems: number,
+    falsePositiveRate = 0.01
+  ): BloomFilterOptions {
+    if (expectedItems <= 0) {
+      throw new Error('expectedItems must be greater than zero');
+    }
+    if (falsePositiveRate <= 0 || falsePositiveRate >= 1) {
+      throw new Error('falsePositiveRate must be between 0 and 1');
+    }
+    const ln2 = Math.log(2);
+    const size = Math.ceil(
+      (-expectedItems * Math.log(falsePositiveRate)) / (ln2 * ln2)
+    );
+    const hashCount = Math.max(1, Math.round((size / expectedItems) * ln2));
+    return { size, hashCount };
+  }
+
+  private hashIndices(value: string): number[] {
+    const indices: number[] = new Array(this.hashCount);
+    const hashA = BloomFilter.fnv1a(value, 0x811c9dc5);
+    let hashB = BloomFilter.fnv1a(value, 0x9e3779b9);
+    if (hashB === 0) {
+      hashB = 0x9e3779b9;
+    }
+    for (let i = 0; i < this.hashCount; i += 1) {
+      const combined = (hashA + Math.imul(i, hashB)) >>> 0;
+      indices[i] = combined % this.size;
+    }
+    return indices;
+  }
+
+  private setBit(index: number): void {
+    const byteIndex = index >> 3;
+    const bitMask = 1 << (index & 7);
+    this.bits[byteIndex] |= bitMask;
+  }
+
+  private getBit(index: number): boolean {
+    const byteIndex = index >> 3;
+    const bitMask = 1 << (index & 7);
+    return (this.bits[byteIndex] & bitMask) !== 0;
+  }
+
+  private static fnv1a(value: string, seed: number): number {
+    let hash = seed >>> 0;
+    for (let i = 0; i < value.length; i += 1) {
+      hash ^= value.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193);
+      hash >>>= 0;
+    }
+    return hash >>> 0;
+  }
+}


### PR DESCRIPTION
## Summary
- add a deterministic mock NSRL dataset with paired SHA-1 and SHA-256 hashes
- build a reusable BloomFilter utility for seeding hash lookups in the Autopsy demo
- extend the Keyword Tester with an NSRL hash lookup panel, telemetry, and benchmarking
- cover the Bloom filter with unit tests that enforce a <1% false positive rate

## Testing
- yarn lint *(fails: long-standing jsx-a11y/control-has-associated-label errors across unrelated apps)*
- yarn test --runTestsByPath __tests__/apps/autopsy/bloom-filter.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc2833aea08328b8243178d20e4490