### PR TITLE
[autopsy] high-performance timeline canvas

### DIFF
--- a/__tests__/apps/autopsy/timeline.test.tsx
+++ b/__tests__/apps/autopsy/timeline.test.tsx
@@ -1,0 +1,118 @@
+import {
+  createInitialTimelineState,
+  timelineReducer,
+  DEFAULT_MS_PER_PIXEL,
+} from '../../../apps/autopsy/components/timelineState';
+
+describe('timelineReducer', () => {
+  const totalDurationMs = 120_000;
+
+  it('sets active categories and resets offset', () => {
+    const initial = {
+      ...createInitialTimelineState(['docs']),
+      offsetMs: 45_000,
+      viewportWidth: 400,
+      msPerPixel: 300,
+      hasInteracted: true,
+    };
+
+    const next = timelineReducer(initial, {
+      type: 'SET_ACTIVE_CATEGORIES',
+      categoryIds: ['images', 'archives', 'images'],
+      totalDurationMs,
+    });
+
+    expect(next.activeCategoryIds).toEqual(['images', 'archives']);
+    expect(next.offsetMs).toBe(0);
+    expect(next.hasInteracted).toBe(false);
+  });
+
+  it('pans and clamps within the total duration', () => {
+    const base = {
+      ...createInitialTimelineState(['docs']),
+      viewportWidth: 400,
+      msPerPixel: 150,
+    };
+
+    const panned = timelineReducer(base, {
+      type: 'PAN',
+      deltaMs: 30_000,
+      totalDurationMs,
+    });
+
+    expect(panned.offsetMs).toBe(30_000);
+    expect(panned.hasInteracted).toBe(true);
+
+    const maxed = timelineReducer(panned, {
+      type: 'PAN',
+      deltaMs: 100_000,
+      totalDurationMs,
+    });
+
+    expect(maxed.offsetMs).toBeCloseTo(60_000); // total - viewport (120k - 60k)
+
+    const backToStart = timelineReducer(maxed, {
+      type: 'PAN',
+      deltaMs: -200_000,
+      totalDurationMs,
+    });
+
+    expect(backToStart.offsetMs).toBe(0);
+  });
+
+  it('zooms around the provided focus point', () => {
+    const state = {
+      ...createInitialTimelineState(['docs']),
+      viewportWidth: 800,
+      msPerPixel: 200,
+      offsetMs: 20_000,
+    };
+
+    const zoomed = timelineReducer(state, {
+      type: 'ZOOM_BY_FACTOR',
+      factor: 2,
+      focusRatio: 0.5,
+      totalDurationMs: 200_000,
+    });
+
+    expect(zoomed.msPerPixel).toBeCloseTo(100);
+    expect(zoomed.offsetMs).toBeCloseTo(60_000);
+    expect(zoomed.hasInteracted).toBe(true);
+  });
+
+  it('auto fits the timeline to the viewport when requested', () => {
+    const state = {
+      ...createInitialTimelineState(['docs']),
+      viewportWidth: 400,
+      msPerPixel: 500,
+      offsetMs: 10_000,
+    };
+
+    const fitted = timelineReducer(state, {
+      type: 'AUTO_FIT',
+      totalDurationMs,
+    });
+
+    expect(fitted.msPerPixel).toBeCloseTo(300);
+    expect(fitted.offsetMs).toBe(0);
+    expect(fitted.hasInteracted).toBe(false);
+  });
+
+  it('resets to the default zoom level', () => {
+    const state = {
+      ...createInitialTimelineState(['docs']),
+      msPerPixel: 500,
+      offsetMs: 25_000,
+      hasInteracted: true,
+    };
+
+    const reset = timelineReducer(state, {
+      type: 'RESET',
+      totalDurationMs,
+    });
+
+    expect(reset.msPerPixel).toBe(DEFAULT_MS_PER_PIXEL);
+    expect(reset.offsetMs).toBe(0);
+    expect(reset.hasInteracted).toBe(false);
+  });
+});

--- a/apps/autopsy/components/CaseWalkthrough.tsx
+++ b/apps/autopsy/components/CaseWalkthrough.tsx
@@ -1,21 +1,10 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import caseData from '../data/case.json';
+import type { CaseData, CaseFileNode } from '../types';
 
-interface TimelineEntry {
-  timestamp: string;
-  event: string;
-  thumbnail: string;
-}
-
-interface FileNode {
-  name: string;
-  thumbnail?: string;
-  children?: FileNode[];
-}
-
-const renderNode = (node: FileNode): React.ReactNode => {
+const renderNode = (node: CaseFileNode): React.ReactNode => {
   if (node.children && node.children.length > 0) {
     return (
       <div key={node.name} className="ml-4">
@@ -44,24 +33,63 @@ const renderNode = (node: FileNode): React.ReactNode => {
 };
 
 const CaseWalkthrough: React.FC = () => {
-  const { timeline, fileTree } = caseData as {
-    timeline: TimelineEntry[];
-    fileTree: FileNode;
-  };
+  const { timeline, fileTree } = caseData as CaseData;
+  const categories = useMemo(
+    () =>
+      new Map(
+        timeline.categories.map((category) => [category.id, category])
+      ),
+    [timeline.categories]
+  );
 
   return (
     <div className="space-y-6">
       <section>
         <h2 className="text-lg font-bold mb-2">Timeline</h2>
-        <ul className="space-y-2">
-          {timeline.map((item, idx) => (
-            <li key={idx} className="flex items-center text-sm">
-              <img src={item.thumbnail} alt="" className="w-6 h-6 mr-2" />
-              <span>
-                {new Date(item.timestamp).toLocaleString()} – {item.event}
-              </span>
-            </li>
-          ))}
+        <ul className="space-y-3">
+          {timeline.events.map((item) => {
+            const category = categories.get(item.categoryId);
+            return (
+              <li key={item.id} className="flex text-sm">
+                {item.thumbnail && (
+                  <img
+                    src={item.thumbnail}
+                    alt=""
+                    className="w-8 h-8 mr-2 rounded"
+                  />
+                )}
+                <div>
+                  <div className="font-semibold capitalize">{item.title}</div>
+                  <div className="text-xs text-ubt-muted">
+                    {new Date(item.timestamp).toLocaleString()}
+                    {item.endTimestamp && (
+                      <>
+                        {' '}
+                        –
+                        {' '}
+                        {new Date(item.endTimestamp).toLocaleTimeString([], {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                        })}
+                      </>
+                    )}
+                    {category && (
+                      <>
+                        {' '}
+                        · {category.label}
+                      </>
+                    )}
+                  </div>
+                  <div className="text-xs text-ubt-muted">{item.summary}</div>
+                  {item.sources && item.sources.length > 0 && (
+                    <div className="mt-1 text-[10px] uppercase tracking-wide text-ub-orange">
+                      Sources: {item.sources.join(', ')}
+                    </div>
+                  )}
+                </div>
+              </li>
+            );
+          })}
         </ul>
       </section>
       <section>

--- a/apps/autopsy/components/TimelineCanvas.tsx
+++ b/apps/autopsy/components/TimelineCanvas.tsx
@@ -1,0 +1,537 @@
+'use client';
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react';
+import type { TimelineCategory, TimelineEvent } from '../types';
+import {
+  createInitialTimelineState,
+  timelineReducer,
+} from './timelineState';
+
+interface TimelineCanvasProps {
+  events: TimelineEvent[];
+  categories: TimelineCategory[];
+  activeCategoryIds: string[];
+  height?: number;
+  onSelectEvent?: (event: TimelineEvent) => void;
+}
+
+interface LayoutPosition {
+  event: TimelineEvent;
+  x: number;
+}
+
+interface LayoutTick {
+  x: number;
+  label: string;
+}
+
+interface LayoutCache {
+  positions: LayoutPosition[];
+  ticks: LayoutTick[];
+  signature: string;
+}
+
+const TICK_STEPS = [
+  1_000,
+  5_000,
+  15_000,
+  30_000,
+  60_000,
+  5 * 60_000,
+  15 * 60_000,
+  30 * 60_000,
+  60 * 60_000,
+  2 * 60 * 60_000,
+  6 * 60 * 60_000,
+  12 * 60 * 60_000,
+  24 * 60 * 60_000,
+  3 * 24 * 60 * 60_000,
+  7 * 24 * 60 * 60_000,
+];
+
+const clampRatio = (value: number): number => Math.min(1, Math.max(0, value));
+
+const buildSignature = (events: TimelineEvent[]): string =>
+  events.map((event) => `${event.id}:${event.timestamp}`).join('|');
+
+const computeTickStep = (targetMs: number): number => {
+  for (const step of TICK_STEPS) {
+    if (step >= targetMs) {
+      return step;
+    }
+  }
+  return TICK_STEPS[TICK_STEPS.length - 1];
+};
+
+const formatTickLabel = (ms: number, granularityMs: number): string => {
+  const date = new Date(ms);
+  if (granularityMs >= 24 * 60 * 60_000) {
+    return date.toLocaleDateString();
+  }
+  if (granularityMs >= 60 * 60_000) {
+    return date.toLocaleTimeString([], { hour: '2-digit' });
+  }
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+};
+
+const computeTicks = (
+  viewportStartMs: number,
+  viewportMs: number,
+  width: number
+): LayoutTick[] => {
+  if (!Number.isFinite(viewportMs) || viewportMs <= 0 || width <= 0) {
+    return [];
+  }
+  const target = viewportMs / 6;
+  const step = computeTickStep(target);
+  const firstTick = Math.floor(viewportStartMs / step) * step;
+  const ticks: LayoutTick[] = [];
+  for (
+    let tick = firstTick;
+    tick <= viewportStartMs + viewportMs + step;
+    tick += step
+  ) {
+    const x = ((tick - viewportStartMs) / viewportMs) * width;
+    ticks.push({ x, label: formatTickLabel(tick, step) });
+  }
+  return ticks;
+};
+
+const TimelineCanvas: React.FC<TimelineCanvasProps> = ({
+  events,
+  categories,
+  activeCategoryIds,
+  height = 160,
+  onSelectEvent,
+}) => {
+  const [state, dispatch] = useReducer(
+    timelineReducer,
+    activeCategoryIds,
+    createInitialTimelineState
+  );
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const layoutCacheRef = useRef<Map<string, LayoutCache>>(new Map());
+  const pointerState = useRef<{ dragging: boolean; lastX: number }>(
+    { dragging: false, lastX: 0 }
+  );
+  const autoFitRef = useRef<number | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+
+  const sortedEvents = useMemo(
+    () =>
+      [...events].sort(
+        (a, b) =>
+          new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+      ),
+    [events]
+  );
+
+  const activeSet = useMemo(
+    () => new Set(activeCategoryIds),
+    [activeCategoryIds]
+  );
+
+  const filteredEvents = useMemo(() => {
+    if (activeSet.size === 0) {
+      return [];
+    }
+    return sortedEvents.filter((event) => activeSet.has(event.categoryId));
+  }, [activeSet, sortedEvents]);
+
+  const fallbackEvents = filteredEvents.length > 0 ? filteredEvents : sortedEvents;
+
+  const range = useMemo(() => {
+    if (fallbackEvents.length === 0) {
+      const now = Date.now();
+      return { start: now, end: now + 1 };
+    }
+    const first = new Date(fallbackEvents[0].timestamp).getTime();
+    const last = new Date(
+      fallbackEvents[fallbackEvents.length - 1].timestamp
+    ).getTime();
+    return { start: first, end: Math.max(last, first + 1) };
+  }, [fallbackEvents]);
+
+  const totalDurationMs = Math.max(1, range.end - range.start);
+
+  const categoryMap = useMemo(
+    () => new Map(categories.map((category) => [category.id, category])),
+    [categories]
+  );
+
+  const filteredSignature = useMemo(
+    () => buildSignature(filteredEvents),
+    [filteredEvents]
+  );
+  const eventsSignature = useMemo(
+    () => buildSignature(sortedEvents),
+    [sortedEvents]
+  );
+
+  useEffect(() => {
+    layoutCacheRef.current.clear();
+  }, [eventsSignature, filteredSignature]);
+
+  useEffect(() => {
+    dispatch({
+      type: 'SET_ACTIVE_CATEGORIES',
+      categoryIds: activeCategoryIds,
+      totalDurationMs,
+    });
+  }, [activeCategoryIds, totalDurationMs]);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const width = entry.contentRect.width;
+      dispatch({ type: 'SET_VIEWPORT_WIDTH', width, totalDurationMs });
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [totalDurationMs]);
+
+  useEffect(() => {
+    if (state.hasInteracted) {
+      autoFitRef.current = null;
+      return;
+    }
+    if (state.viewportWidth <= 0) return;
+    if (autoFitRef.current === totalDurationMs) return;
+    autoFitRef.current = totalDurationMs;
+    dispatch({ type: 'AUTO_FIT', totalDurationMs });
+  }, [state.viewportWidth, state.hasInteracted, totalDurationMs]);
+
+  const layout = useMemo(() => {
+    const width = Math.max(1, state.viewportWidth);
+    const cacheKey = `${width}:${state.msPerPixel}:${state.offsetMs}`;
+    const cached = layoutCacheRef.current.get(cacheKey);
+    if (cached && cached.signature === filteredSignature) {
+      return cached;
+    }
+    const viewportMs = state.msPerPixel * width;
+    const viewportStart = range.start + state.offsetMs;
+    const positions: LayoutPosition[] = [];
+    filteredEvents.forEach((event) => {
+      const time = new Date(event.timestamp).getTime();
+      const x = (time - viewportStart) / state.msPerPixel;
+      if (x >= -32 && x <= width + 32) {
+        positions.push({ event, x });
+      }
+    });
+    const ticks = computeTicks(viewportStart, viewportMs, width);
+    const computed: LayoutCache = {
+      positions,
+      ticks,
+      signature: filteredSignature,
+    };
+    layoutCacheRef.current.set(cacheKey, computed);
+    return computed;
+  }, [
+    filteredEvents,
+    filteredSignature,
+    range.start,
+    state.msPerPixel,
+    state.offsetMs,
+    state.viewportWidth,
+  ]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const width = state.viewportWidth;
+    if (width <= 0) return;
+    const context = canvas.getContext('2d');
+    if (!context) return;
+    const dpr = window.devicePixelRatio ?? 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+
+    context.setTransform(1, 0, 0, 1, 0, 0);
+    context.scale(dpr, dpr);
+
+    const gradient = context.createLinearGradient(0, 0, width, 0);
+    gradient.addColorStop(0, '#111827');
+    gradient.addColorStop(1, '#1f2937');
+    context.fillStyle = gradient;
+    context.fillRect(0, 0, width, height);
+
+    context.strokeStyle = '#9ca3af';
+    context.globalAlpha = 0.35;
+    context.beginPath();
+    context.moveTo(0, height - 32);
+    context.lineTo(width, height - 32);
+    context.stroke();
+    context.globalAlpha = 1;
+
+    context.font = '11px Inter, system-ui, sans-serif';
+    context.fillStyle = '#d1d5db';
+
+    layout.ticks.forEach((tick) => {
+      if (tick.x < -5 || tick.x > width + 5) return;
+      context.globalAlpha = 0.25;
+      context.fillRect(tick.x, 16, 1, height - 56);
+      context.globalAlpha = 1;
+      context.fillText(tick.label, tick.x + 4, height - 12);
+    });
+
+    layout.positions.forEach(({ event, x }) => {
+      const category = categoryMap.get(event.categoryId);
+      const color = category?.color ?? '#f97316';
+      if (x < -10 || x > width + 10) return;
+      context.fillStyle = color;
+      context.fillRect(x - 1, 24, 2, height - 64);
+      context.beginPath();
+      context.arc(x, 24, 4, 0, Math.PI * 2);
+      context.fill();
+    });
+
+    if (hoveredId) {
+      const hovered = layout.positions.find(
+        (position) => position.event.id === hoveredId
+      );
+      if (hovered) {
+        const category = categoryMap.get(hovered.event.categoryId);
+        const color = category?.color ?? '#fb923c';
+        context.strokeStyle = color;
+        context.lineWidth = 2;
+        context.beginPath();
+        context.arc(hovered.x, 24, 7, 0, Math.PI * 2);
+        context.stroke();
+      }
+    }
+  }, [categoryMap, height, hoveredId, layout, state.viewportWidth]);
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLCanvasElement>) => {
+      pointerState.current.dragging = true;
+      pointerState.current.lastX = event.clientX;
+      setIsDragging(true);
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    []
+  );
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLCanvasElement>) => {
+      if (!pointerState.current.dragging) return;
+      const deltaPx = pointerState.current.lastX - event.clientX;
+      pointerState.current.lastX = event.clientX;
+      if (deltaPx === 0) return;
+      dispatch({
+        type: 'PAN',
+        deltaMs: deltaPx * state.msPerPixel,
+        totalDurationMs,
+      });
+    },
+    [state.msPerPixel, totalDurationMs]
+  );
+
+  const handlePointerUp = useCallback(
+    (event: React.PointerEvent<HTMLCanvasElement>) => {
+      if (!pointerState.current.dragging) return;
+      pointerState.current.dragging = false;
+      setIsDragging(false);
+      event.currentTarget.releasePointerCapture?.(event.pointerId);
+    },
+    []
+  );
+
+  const handleWheel = useCallback(
+    (event: React.WheelEvent<HTMLDivElement>) => {
+      if (state.viewportWidth <= 0) return;
+      event.preventDefault();
+      const width = state.viewportWidth;
+      const rect = containerRef.current?.getBoundingClientRect();
+      const ratio = rect
+        ? clampRatio((event.clientX - rect.left) / width)
+        : 0.5;
+      if (event.ctrlKey || event.metaKey) {
+        const factor = event.deltaY < 0 ? 1.2 : 0.8333333333;
+        dispatch({
+          type: 'ZOOM_BY_FACTOR',
+          factor,
+          focusRatio: ratio,
+          totalDurationMs,
+        });
+      } else {
+        dispatch({
+          type: 'PAN',
+          deltaMs: event.deltaY * state.msPerPixel,
+          totalDurationMs,
+        });
+      }
+    },
+    [state.viewportWidth, state.msPerPixel, totalDurationMs]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === '+' || event.key === '=') {
+        event.preventDefault();
+        dispatch({
+          type: 'ZOOM_BY_FACTOR',
+          factor: 1.2,
+          focusRatio: 0.5,
+          totalDurationMs,
+        });
+        return;
+      }
+      if (event.key === '-' || event.key === '_') {
+        event.preventDefault();
+        dispatch({
+          type: 'ZOOM_BY_FACTOR',
+          factor: 0.8333333333,
+          focusRatio: 0.5,
+          totalDurationMs,
+        });
+        return;
+      }
+      if (event.key === '0') {
+        event.preventDefault();
+        autoFitRef.current = null;
+        dispatch({ type: 'AUTO_FIT', totalDurationMs });
+        return;
+      }
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        dispatch({
+          type: 'PAN',
+          deltaMs: -state.msPerPixel * 40,
+          totalDurationMs,
+        });
+        return;
+      }
+      if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        dispatch({
+          type: 'PAN',
+          deltaMs: state.msPerPixel * 40,
+          totalDurationMs,
+        });
+      }
+    },
+    [state.msPerPixel, totalDurationMs]
+  );
+
+  const hoveredEvent = useMemo(() => {
+    if (!hoveredId) return null;
+    return filteredEvents.find((event) => event.id === hoveredId) ?? null;
+  }, [filteredEvents, hoveredId]);
+
+  const hoveredCategory = hoveredEvent
+    ? categoryMap.get(hoveredEvent.categoryId)
+    : undefined;
+
+  const canvasClassName = `w-full rounded bg-ub-grey ${
+    isDragging ? 'cursor-grabbing' : 'cursor-grab'
+  }`;
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative select-none"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      onWheel={handleWheel}
+      style={{ touchAction: 'none' }}
+      aria-label="Forensic timeline"
+      onMouseLeave={() => setHoveredId(null)}
+    >
+      <canvas
+        ref={canvasRef}
+        role="img"
+        aria-hidden={filteredEvents.length === 0}
+        className={canvasClassName}
+        height={height}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerLeave={handlePointerUp}
+      />
+      <div className="pointer-events-none absolute inset-0">
+        {layout.positions.map(({ event, x }) => {
+          const category = categoryMap.get(event.categoryId);
+          const color = category?.color ?? '#f97316';
+          return (
+            <button
+              key={event.id}
+              type="button"
+              className="pointer-events-auto absolute top-3 h-3 w-3 -translate-x-1/2 rounded-full border border-white focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+              style={{ left: `${x}px`, backgroundColor: color }}
+              title={event.title}
+              onClick={() => onSelectEvent?.(event)}
+              onMouseEnter={() => setHoveredId(event.id)}
+              onMouseLeave={() =>
+                setHoveredId((current) => (current === event.id ? null : current))
+              }
+              onFocus={() => setHoveredId(event.id)}
+              onBlur={() =>
+                setHoveredId((current) => (current === event.id ? null : current))
+              }
+              aria-label={`${new Date(event.timestamp).toLocaleString()} – ${
+                event.title
+              }`}
+            />
+          );
+        })}
+      </div>
+      {filteredEvents.length === 0 && (
+        <p className="mt-2 text-xs text-ubt-muted">
+          No events matched the selected categories. Toggle a category to
+          repopulate the timeline.
+        </p>
+      )}
+      {hoveredEvent && (
+        <div className="mt-3 space-y-1 rounded border border-ub-cool-grey bg-ub-grey/80 px-3 py-2 text-xs">
+          <div className="flex items-center justify-between">
+            <span className="font-semibold text-sm">{hoveredEvent.title}</span>
+            {hoveredCategory && (
+              <span
+                className="text-[10px] uppercase tracking-wide"
+                style={{ color: hoveredCategory.color }}
+              >
+                {hoveredCategory.label}
+              </span>
+            )}
+          </div>
+          <div className="text-ubt-muted">
+            {new Date(hoveredEvent.timestamp).toLocaleString()}
+            {hoveredEvent.endTimestamp && (
+              <>
+                {' '}
+                –
+                {' '}
+                {new Date(hoveredEvent.endTimestamp).toLocaleTimeString([], {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+              </>
+            )}
+          </div>
+          <p className="text-ubt-muted">{hoveredEvent.summary}</p>
+          {hoveredEvent.sources && hoveredEvent.sources.length > 0 && (
+            <div className="text-[10px] uppercase tracking-wide text-ub-orange">
+              Sources: {hoveredEvent.sources.join(', ')}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TimelineCanvas;

--- a/apps/autopsy/components/timelineState.ts
+++ b/apps/autopsy/components/timelineState.ts
@@ -1,0 +1,144 @@
+export const DEFAULT_MS_PER_PIXEL = 60_000; // 1 minute per pixel
+export const MIN_MS_PER_PIXEL = 50; // 50 milliseconds per pixel when fully zoomed in
+export const MAX_MS_PER_PIXEL = 2_592_000_000; // 30 days per pixel when fully zoomed out
+
+export interface TimelineState {
+  msPerPixel: number;
+  offsetMs: number;
+  viewportWidth: number;
+  activeCategoryIds: string[];
+  hasInteracted: boolean;
+}
+
+export type TimelineAction =
+  | { type: 'SET_ACTIVE_CATEGORIES'; categoryIds: string[]; totalDurationMs: number }
+  | { type: 'SET_VIEWPORT_WIDTH'; width: number; totalDurationMs: number }
+  | { type: 'PAN'; deltaMs: number; totalDurationMs: number }
+  | {
+      type: 'ZOOM_BY_FACTOR';
+      factor: number;
+      focusRatio?: number;
+      totalDurationMs: number;
+    }
+  | { type: 'AUTO_FIT'; totalDurationMs: number }
+  | { type: 'RESET'; totalDurationMs: number };
+
+const normalizeCategoryIds = (categoryIds: string[]): string[] => [
+  ...new Set(categoryIds),
+];
+
+const clampMsPerPixel = (value: number): number => {
+  if (!Number.isFinite(value) || value <= 0) {
+    return DEFAULT_MS_PER_PIXEL;
+  }
+  return Math.min(MAX_MS_PER_PIXEL, Math.max(MIN_MS_PER_PIXEL, value));
+};
+
+const clampOffset = (
+  offsetMs: number,
+  totalDurationMs: number,
+  viewportMs: number
+): number => {
+  if (!Number.isFinite(offsetMs)) {
+    return 0;
+  }
+  const safeViewport = Math.max(1, viewportMs);
+  const maxOffset = Math.max(0, totalDurationMs - safeViewport);
+  if (maxOffset === 0) {
+    return 0;
+  }
+  return Math.min(Math.max(0, offsetMs), maxOffset);
+};
+
+export const createInitialTimelineState = (
+  categoryIds: string[]
+): TimelineState => ({
+  msPerPixel: DEFAULT_MS_PER_PIXEL,
+  offsetMs: 0,
+  viewportWidth: 0,
+  activeCategoryIds: normalizeCategoryIds(categoryIds),
+  hasInteracted: false,
+});
+
+export const timelineReducer = (
+  state: TimelineState,
+  action: TimelineAction
+): TimelineState => {
+  switch (action.type) {
+    case 'SET_ACTIVE_CATEGORIES': {
+      const viewportMs = state.msPerPixel * Math.max(1, state.viewportWidth);
+      return {
+        ...state,
+        activeCategoryIds: normalizeCategoryIds(action.categoryIds),
+        offsetMs: clampOffset(0, action.totalDurationMs, viewportMs),
+        hasInteracted: false,
+      };
+    }
+    case 'SET_VIEWPORT_WIDTH': {
+      const width = Math.max(0, action.width);
+      const viewportMs = state.msPerPixel * Math.max(1, width);
+      return {
+        ...state,
+        viewportWidth: width,
+        offsetMs: clampOffset(state.offsetMs, action.totalDurationMs, viewportMs),
+      };
+    }
+    case 'PAN': {
+      const viewportMs = state.msPerPixel * Math.max(1, state.viewportWidth);
+      return {
+        ...state,
+        offsetMs: clampOffset(
+          state.offsetMs + action.deltaMs,
+          action.totalDurationMs,
+          viewportMs
+        ),
+        hasInteracted: true,
+      };
+    }
+    case 'ZOOM_BY_FACTOR': {
+      const factor = Number.isFinite(action.factor) && action.factor > 0 ? action.factor : 1;
+      const width = Math.max(1, state.viewportWidth);
+      const viewportMs = state.msPerPixel * width;
+      const nextMsPerPixel = clampMsPerPixel(state.msPerPixel / factor);
+      const nextViewportMs = nextMsPerPixel * width;
+      const focusRatio = Math.min(
+        1,
+        Math.max(0, action.focusRatio ?? 0.5)
+      );
+      const focusPoint = state.offsetMs + focusRatio * viewportMs;
+      return {
+        ...state,
+        msPerPixel: nextMsPerPixel,
+        offsetMs: clampOffset(
+          focusPoint - focusRatio * nextViewportMs,
+          action.totalDurationMs,
+          nextViewportMs
+        ),
+        hasInteracted: true,
+      };
+    }
+    case 'AUTO_FIT': {
+      if (state.viewportWidth <= 0) {
+        return state;
+      }
+      const target = clampMsPerPixel(
+        action.totalDurationMs / Math.max(1, state.viewportWidth)
+      );
+      return {
+        ...state,
+        msPerPixel: target,
+        offsetMs: 0,
+        hasInteracted: false,
+      };
+    }
+    case 'RESET':
+      return {
+        ...state,
+        msPerPixel: DEFAULT_MS_PER_PIXEL,
+        offsetMs: 0,
+        hasInteracted: false,
+      };
+    default:
+      return state;
+  }
+};

--- a/apps/autopsy/data/case.json
+++ b/apps/autopsy/data/case.json
@@ -1,31 +1,85 @@
 {
-  "timeline": [
-    {
-      "timestamp": "2023-08-01T10:00:00Z",
-      "event": "resume.docx created on desktop",
-      "thumbnail": "/themes/Yaru/apps/gedit.png"
-    },
-    {
-      "timestamp": "2023-08-01T12:30:00Z",
-      "event": "photo.jpg taken on phone",
-      "thumbnail": "/themes/Yaru/apps/autopsy.svg"
-    },
-    {
-      "timestamp": "2023-08-01T14:45:00Z",
-      "event": "system.log updated",
-      "thumbnail": "/themes/Yaru/apps/autopsy.svg"
-    },
-    {
-      "timestamp": "2023-08-01T16:15:00Z",
-      "event": "run.exe executed",
-      "thumbnail": "/themes/Yaru/apps/autopsy.svg"
-    },
-    {
-      "timestamp": "2023-08-01T18:20:00Z",
-      "event": "Registry key modified",
-      "thumbnail": "/themes/Yaru/apps/autopsy.svg"
-    }
-  ],
+  "timeline": {
+    "categories": [
+      {
+        "id": "docs",
+        "label": "Documents",
+        "color": "#f97316",
+        "description": "Word processing files and exported reports",
+        "icon": "/themes/Yaru/apps/gedit.png"
+      },
+      {
+        "id": "images",
+        "label": "Images",
+        "color": "#38bdf8",
+        "description": "Photos, screenshots, and other media captures",
+        "icon": "/themes/Yaru/apps/autopsy.svg"
+      },
+      {
+        "id": "archives",
+        "label": "Archives",
+        "color": "#a855f7",
+        "description": "Compressed bundles and staging exports"
+      }
+    ],
+    "events": [
+      {
+        "id": "evt-resume-draft",
+        "categoryId": "docs",
+        "timestamp": "2023-08-01T10:00:00Z",
+        "title": "resume.docx drafted on desktop",
+        "summary": "User created resume.docx in the Documents folder using LibreOffice Writer.",
+        "thumbnail": "/themes/Yaru/apps/gedit.png",
+        "sources": ["Documents/resume.docx"]
+      },
+      {
+        "id": "evt-expense-export",
+        "categoryId": "docs",
+        "timestamp": "2023-08-01T10:22:00Z",
+        "title": "Expense report exported to PDF",
+        "summary": "Spreadsheet export saved as expense_report.pdf alongside the resume draft.",
+        "thumbnail": "/themes/Yaru/apps/gedit.png",
+        "sources": ["Documents/expense_report.pdf", "Documents/resume.docx"]
+      },
+      {
+        "id": "evt-photo-import",
+        "categoryId": "images",
+        "timestamp": "2023-08-01T12:30:00Z",
+        "title": "photo.jpg imported from mobile",
+        "summary": "High-resolution image synced from the user's phone into Pictures/Trips.",
+        "thumbnail": "/themes/Yaru/apps/autopsy.svg",
+        "sources": ["Pictures/Trips/photo.jpg"]
+      },
+      {
+        "id": "evt-screenshot",
+        "categoryId": "images",
+        "timestamp": "2023-08-01T13:05:00Z",
+        "title": "Screenshot captured for support ticket",
+        "summary": "Desktop screenshot saved to Pictures/Screenshots illustrating an error dialog.",
+        "thumbnail": "/themes/Yaru/apps/autopsy.svg",
+        "sources": ["Pictures/Screenshots/support.png"]
+      },
+      {
+        "id": "evt-log-archive",
+        "categoryId": "archives",
+        "timestamp": "2023-08-01T14:45:00Z",
+        "endTimestamp": "2023-08-01T14:47:00Z",
+        "title": "System logs compressed",
+        "summary": "Incident response script packaged system.log into logs-2023-08-01.tar.gz for transfer.",
+        "thumbnail": "/themes/Yaru/apps/autopsy.svg",
+        "sources": ["Archives/logs-2023-08-01.tar.gz", "Logs/system.log"]
+      },
+      {
+        "id": "evt-backup-bundle",
+        "categoryId": "archives",
+        "timestamp": "2023-08-01T16:15:00Z",
+        "title": "Evidence bundle encrypted",
+        "summary": "Collected artifacts zipped into incident-backup.zip and staged in Archives.",
+        "thumbnail": "/themes/Yaru/apps/autopsy.svg",
+        "sources": ["Archives/incident-backup.zip", "Documents/resume.docx", "Pictures/Trips/photo.jpg"]
+      }
+    ]
+  },
   "fileTree": {
     "name": "root",
     "children": [
@@ -35,6 +89,10 @@
           {
             "name": "resume.docx",
             "thumbnail": "/themes/Yaru/apps/gedit.png"
+          },
+          {
+            "name": "expense_report.pdf",
+            "thumbnail": "/themes/Yaru/apps/gedit.png"
           }
         ]
       },
@@ -42,7 +100,34 @@
         "name": "Pictures",
         "children": [
           {
-            "name": "photo.jpg",
+            "name": "Trips",
+            "children": [
+              {
+                "name": "photo.jpg",
+                "thumbnail": "/themes/Yaru/apps/autopsy.svg"
+              }
+            ]
+          },
+          {
+            "name": "Screenshots",
+            "children": [
+              {
+                "name": "support.png",
+                "thumbnail": "/themes/Yaru/apps/autopsy.svg"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Archives",
+        "children": [
+          {
+            "name": "logs-2023-08-01.tar.gz",
+            "thumbnail": "/themes/Yaru/apps/autopsy.svg"
+          },
+          {
+            "name": "incident-backup.zip",
             "thumbnail": "/themes/Yaru/apps/autopsy.svg"
           }
         ]

--- a/apps/autopsy/index.tsx
+++ b/apps/autopsy/index.tsx
@@ -1,12 +1,23 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import AutopsyAppComponent from '../../components/apps/autopsy';
 import KeywordTester from './components/KeywordTester';
+import TimelineCanvas from './components/TimelineCanvas';
+import caseData from './data/case.json';
+import type { CaseData } from './types';
+
+const timelineData = caseData as CaseData;
+const ALL_CATEGORY_IDS = timelineData.timeline.categories.map(
+  (category) => category.id
+);
 
 const AutopsyPage: React.FC = () => {
   // Track which view is active so we can restore UI state when toggling
   const [view, setView] = useState<'autopsy' | 'keywords'>('autopsy');
+  const [activeCategories, setActiveCategories] = useState<string[]>(() => [
+    ...ALL_CATEGORY_IDS,
+  ]);
 
   // Restore view from the URL hash on first load
   useEffect(() => {
@@ -26,6 +37,27 @@ const AutopsyPage: React.FC = () => {
     const newHash = params.toString();
     window.location.hash = newHash ? `#${newHash}` : '';
   }, [view]);
+
+  const selectedCount = activeCategories.length;
+  const allSelected = selectedCount === ALL_CATEGORY_IDS.length;
+  const categorySummary = useMemo(() => {
+    if (allSelected) return 'All categories visible';
+    if (selectedCount === 0) return 'No categories selected';
+    return `${selectedCount} of ${ALL_CATEGORY_IDS.length} categories visible`;
+  }, [allSelected, selectedCount]);
+
+  const toggleCategory = (categoryId: string) => {
+    setActiveCategories((current) => {
+      if (current.includes(categoryId)) {
+        return current.filter((id) => id !== categoryId);
+      }
+      return [...current, categoryId];
+    });
+  };
+
+  const resetCategories = () => {
+    setActiveCategories([...ALL_CATEGORY_IDS]);
+  };
 
   return (
     <div className="space-y-4">
@@ -47,7 +79,65 @@ const AutopsyPage: React.FC = () => {
           Keyword Tester
         </button>
       </div>
-      {view === 'autopsy' && <AutopsyAppComponent />}
+      {view === 'autopsy' && (
+        <>
+          <section className="space-y-4 rounded bg-ub-cool-grey/40 p-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h2 className="text-sm font-semibold uppercase tracking-wider text-ubt-muted">
+                  Case timeline
+                </h2>
+                <p className="text-xs text-ubt-muted">{categorySummary}</p>
+              </div>
+              <div className="flex items-center gap-3 text-[10px] uppercase tracking-wide text-ub-orange">
+                <span>Shortcuts: + / - / 0</span>
+                {!allSelected && (
+                  <button
+                    type="button"
+                    onClick={resetCategories}
+                    className="hover:underline"
+                  >
+                    Reset filters
+                  </button>
+                )}
+              </div>
+            </div>
+            <div
+              className="flex flex-wrap gap-3"
+              role="group"
+              aria-label="Filter timeline categories"
+            >
+              {timelineData.timeline.categories.map((category) => {
+                const checked = activeCategories.includes(category.id);
+                return (
+                  <label
+                    key={category.id}
+                    className={`flex items-center space-x-2 rounded border px-2 py-1 text-xs transition ${
+                      checked
+                        ? 'border-ub-orange bg-ub-grey text-white'
+                        : 'border-ub-cool-grey text-ubt-muted'
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      className="accent-ub-orange"
+                      checked={checked}
+                      onChange={() => toggleCategory(category.id)}
+                    />
+                    <span>{category.label}</span>
+                  </label>
+                );
+              })}
+            </div>
+            <TimelineCanvas
+              events={timelineData.timeline.events}
+              categories={timelineData.timeline.categories}
+              activeCategoryIds={activeCategories}
+            />
+          </section>
+          <AutopsyAppComponent />
+        </>
+      )}
       {view === 'keywords' && <KeywordTester />}
     </div>
   );

--- a/apps/autopsy/types.ts
+++ b/apps/autopsy/types.ts
@@ -7,3 +7,38 @@ export interface Artifact {
   timestamp: string;
   user?: string;
 }
+
+export interface TimelineCategory {
+  id: string;
+  label: string;
+  color: string;
+  description?: string;
+  icon?: string;
+}
+
+export interface TimelineEvent {
+  id: string;
+  categoryId: string;
+  timestamp: string;
+  endTimestamp?: string;
+  title: string;
+  summary: string;
+  thumbnail?: string;
+  sources?: string[];
+}
+
+export interface CaseFileNode {
+  name: string;
+  thumbnail?: string;
+  children?: CaseFileNode[];
+}
+
+export interface CaseTimeline {
+  categories: TimelineCategory[];
+  events: TimelineEvent[];
+}
+
+export interface CaseData {
+  timeline: CaseTimeline;
+  fileTree: CaseFileNode;
+}


### PR DESCRIPTION
## Summary
- expand the sample case data with timeline categories, timestamps, and metadata
't- expose the richer timeline through the CaseWalkthrough and page-level Autopsy view
't- add a performant TimelineCanvas with zoom/pan reducer and targeted unit tests

## Testing
- yarn test __tests__/apps/autopsy/timeline.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc28347054832889e4749b11b0d6ec