### PR TITLE
wireshark: add persistent color rules to pcap viewer

### DIFF
--- a/__tests__/colorRuleUtils.test.ts
+++ b/__tests__/colorRuleUtils.test.ts
@@ -1,0 +1,75 @@
+import {
+  buildPacketRowMetadata,
+  parseColorRules,
+  serializeColorRules,
+} from '../apps/wireshark/components/colorRuleUtils';
+
+const samplePackets = [
+  {
+    timestamp: '1',
+    src: '1.1.1.1',
+    dest: '2.2.2.2',
+    protocol: 6,
+    info: 'tcp packet',
+  },
+  {
+    timestamp: '2',
+    src: '3.3.3.3',
+    dest: '4.4.4.4',
+    protocol: 17,
+    info: 'udp packet',
+  },
+];
+
+describe('colorRuleUtils', () => {
+  it('serializes color rules with trimming', () => {
+    const json = serializeColorRules([
+      { expression: ' tcp ', color: ' Red ' },
+      { expression: 'ip.addr == 4.4.4.4', color: 'Blue' },
+    ]);
+
+    expect(json).toBe(
+      JSON.stringify(
+        [
+          { expression: 'tcp', color: 'Red' },
+          { expression: 'ip.addr == 4.4.4.4', color: 'Blue' },
+        ],
+        null,
+        2,
+      ),
+    );
+  });
+
+  it('parses rule JSON safely', () => {
+    const parsed = parseColorRules(
+      JSON.stringify([
+        { expression: 'udp', color: 'Green' },
+        { expression: 123, color: null },
+        'not-a-rule',
+      ]),
+    );
+
+    expect(parsed).toEqual([
+      { expression: 'udp', color: 'Green' },
+      { expression: '', color: '' },
+      { expression: '', color: '' },
+    ]);
+  });
+
+  it('returns empty array for malformed JSON', () => {
+    expect(parseColorRules('{ not valid json }')).toEqual([]);
+    expect(parseColorRules(JSON.stringify({ foo: 'bar' }))).toEqual([]);
+  });
+
+  it('builds row metadata using display filters and rules', () => {
+    const metadata = buildPacketRowMetadata(samplePackets, 'udp', [
+      { expression: 'tcp', color: 'Red' },
+    ]);
+
+    expect(metadata).toHaveLength(2);
+    expect(metadata[0].matchesFilter).toBe(false);
+    expect(metadata[0].colorClass).toBe('text-red-500');
+    expect(metadata[1].matchesFilter).toBe(true);
+    expect(metadata[1].colorClass).toBe('');
+  });
+});

--- a/apps/wireshark/components/colorRuleUtils.ts
+++ b/apps/wireshark/components/colorRuleUtils.ts
@@ -1,0 +1,73 @@
+import { getRowColor, matchesDisplayFilter } from '../../../components/apps/wireshark/utils';
+
+export interface ColorRule {
+  expression: string;
+  color: string;
+}
+
+export interface PacketLike {
+  src: string;
+  dest: string;
+  protocol: number;
+  info?: string;
+  sport?: number;
+  dport?: number;
+  plaintext?: string;
+  decrypted?: string;
+  [key: string]: unknown;
+}
+
+export interface PacketRowMetadata<T extends PacketLike> {
+  packet: T;
+  matchesFilter: boolean;
+  colorClass: string;
+}
+
+const toColorRule = (value: unknown): ColorRule => {
+  if (typeof value !== 'object' || value === null) {
+    return { expression: '', color: '' };
+  }
+  const record = value as Record<string, unknown>;
+  const expression = typeof record.expression === 'string' ? record.expression.trim() : '';
+  const color = typeof record.color === 'string' ? record.color.trim() : '';
+  return { expression, color };
+};
+
+export const isColorRuleArray = (value: unknown): value is ColorRule[] => {
+  if (!Array.isArray(value)) return false;
+  return value.every((rule) => {
+    if (typeof rule !== 'object' || rule === null) return false;
+    const record = rule as Record<string, unknown>;
+    return typeof record.expression === 'string' && typeof record.color === 'string';
+  });
+};
+
+export const sanitizeColorRules = (value: ColorRule[]): ColorRule[] =>
+  value.map((rule) => ({
+    expression: rule.expression?.trim?.() ?? '',
+    color: rule.color?.trim?.() ?? '',
+  }));
+
+export const parseColorRules = (input: string): ColorRule[] => {
+  try {
+    const parsed = JSON.parse(input);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map(toColorRule);
+  } catch {
+    return [];
+  }
+};
+
+export const serializeColorRules = (rules: ColorRule[]): string =>
+  JSON.stringify(sanitizeColorRules(rules), null, 2);
+
+export const buildPacketRowMetadata = <T extends PacketLike>(
+  packets: T[],
+  filter: string,
+  rules: ColorRule[],
+): PacketRowMetadata<T>[] =>
+  packets.map((packet) => ({
+    packet,
+    matchesFilter: matchesDisplayFilter(packet, filter),
+    colorClass: getRowColor(packet, rules),
+  }));


### PR DESCRIPTION
## Summary
- add shared color rule utilities for serialization and packet styling
- integrate the color rule editor into the Pcap viewer with persistent storage and memoized rendering
- harden the Wireshark row-color helper and add dedicated unit coverage for rules

## Testing
- yarn lint *(fails: existing accessibility and window globals violations across unrelated apps)*
- yarn test --watch=false *(fails: existing suites such as window, nmapNse, Modal; run interrupted after repeated hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1e4b156c83288bd4db50a7071f00