### PR TITLE
[minesweeper] add per-difficulty leaderboards

### DIFF
--- a/__tests__/minesweeper.leaderboard.test.ts
+++ b/__tests__/minesweeper.leaderboard.test.ts
@@ -1,0 +1,73 @@
+import {
+  LEADERBOARD_LIMIT,
+  clearLeaderboard,
+  loadLeaderboards,
+  recordTime,
+  shouldRecordTime,
+} from '../games/minesweeper/leaderboard';
+
+describe('minesweeper leaderboard storage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('records times in ascending order with enforced limit', () => {
+    recordTime('beginner', 'Alice', 12.5);
+    recordTime('beginner', 'Bob', 8.2);
+    recordTime('beginner', 'Carol', 15.1);
+
+    const board = loadLeaderboards().beginner;
+    expect(board).toHaveLength(3);
+    expect(board.map((entry) => entry.name)).toEqual(['Bob', 'Alice', 'Carol']);
+    expect(board[0].time).toBeCloseTo(8.2);
+  });
+
+  test('applies leaderboard size limit', () => {
+    for (let i = 0; i < LEADERBOARD_LIMIT + 2; i += 1) {
+      recordTime('intermediate', `Player${i}`, 10 + i);
+    }
+
+    const board = loadLeaderboards().intermediate;
+    expect(board).toHaveLength(LEADERBOARD_LIMIT);
+    expect(board[board.length - 1].time).toBeCloseTo(10 + LEADERBOARD_LIMIT - 1);
+  });
+
+  test('shouldRecordTime validates qualification rules', () => {
+    expect(shouldRecordTime([], 25)).toBe(true);
+
+    const filled = Array.from({ length: LEADERBOARD_LIMIT }, (_, i) => ({
+      name: `P${i}`,
+      time: 10 + i,
+      createdAt: i,
+    }));
+
+    expect(shouldRecordTime(filled, 9)).toBe(true);
+    expect(shouldRecordTime(filled, 10 + LEADERBOARD_LIMIT - 1)).toBe(false);
+    expect(shouldRecordTime(filled, Infinity)).toBe(false);
+  });
+
+  test('clearLeaderboard removes entries for the requested difficulty', () => {
+    recordTime('expert', 'A', 20);
+    expect(loadLeaderboards().expert).toHaveLength(1);
+    clearLeaderboard('expert');
+    expect(loadLeaderboards().expert).toHaveLength(0);
+  });
+
+  test('loadLeaderboards sanitizes invalid stored data', () => {
+    window.localStorage.setItem(
+      'minesweeper:leaderboards',
+      JSON.stringify({
+        beginner: [
+          { name: 'Bad', time: -5, createdAt: 'nope' },
+          { name: 'Good', time: 9, createdAt: 0 },
+        ],
+      }),
+    );
+
+    const board = loadLeaderboards().beginner;
+    expect(board).toHaveLength(1);
+    expect(board[0].name).toBe('Good');
+    expect(board[0].time).toBe(9);
+  });
+});
+

--- a/games/minesweeper/leaderboard.ts
+++ b/games/minesweeper/leaderboard.ts
@@ -1,0 +1,143 @@
+export type MinesweeperDifficulty = 'beginner' | 'intermediate' | 'expert';
+
+export interface MinesweeperLeaderboardEntry {
+  name: string;
+  time: number;
+  createdAt: number;
+}
+
+export type MinesweeperLeaderboards = Record<
+  MinesweeperDifficulty,
+  MinesweeperLeaderboardEntry[]
+>;
+
+export const LEADERBOARD_LIMIT = 5;
+
+export const DIFFICULTY_IDS: MinesweeperDifficulty[] = [
+  'beginner',
+  'intermediate',
+  'expert',
+];
+
+const STORAGE_KEY = 'minesweeper:leaderboards';
+
+const clampName = (name: string): string => {
+  const trimmed = name.trim();
+  if (!trimmed) return 'Anonymous';
+  return trimmed.slice(0, 40);
+};
+
+export const createEmptyLeaderboards = (): MinesweeperLeaderboards => ({
+  beginner: [],
+  intermediate: [],
+  expert: [],
+});
+
+const isFiniteTime = (time: number): boolean =>
+  typeof time === 'number' && Number.isFinite(time) && time > 0;
+
+const parseLeaderboards = (raw: unknown): MinesweeperLeaderboards => {
+  const fallback = createEmptyLeaderboards();
+  if (!raw || typeof raw !== 'object') return fallback;
+  const data = raw as Record<string, unknown>;
+  const result: MinesweeperLeaderboards = createEmptyLeaderboards();
+
+  for (const difficulty of DIFFICULTY_IDS) {
+    const list = data[difficulty];
+    if (!Array.isArray(list)) continue;
+    const entries: MinesweeperLeaderboardEntry[] = [];
+    for (const item of list) {
+      if (!item || typeof item !== 'object') continue;
+      const entry = item as Partial<MinesweeperLeaderboardEntry>;
+      if (!isFiniteTime(entry.time ?? NaN)) continue;
+      const createdAt =
+        typeof entry.createdAt === 'number' && Number.isFinite(entry.createdAt)
+          ? entry.createdAt
+          : Date.now();
+      const name =
+        typeof entry.name === 'string' ? clampName(entry.name) : 'Anonymous';
+      entries.push({ name, time: entry.time as number, createdAt });
+    }
+    entries.sort(
+      (a, b) => a.time - b.time || a.createdAt - b.createdAt,
+    );
+    result[difficulty] = entries.slice(0, LEADERBOARD_LIMIT);
+  }
+
+  return result;
+};
+
+const readStorage = (): MinesweeperLeaderboards => {
+  if (typeof window === 'undefined') {
+    return createEmptyLeaderboards();
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return createEmptyLeaderboards();
+    return parseLeaderboards(JSON.parse(raw));
+  } catch {
+    return createEmptyLeaderboards();
+  }
+};
+
+const writeStorage = (data: MinesweeperLeaderboards): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch {
+    /* ignore storage errors */
+  }
+};
+
+export const loadLeaderboards = (): MinesweeperLeaderboards => readStorage();
+
+export const getLeaderboard = (
+  difficulty: MinesweeperDifficulty,
+): MinesweeperLeaderboardEntry[] => readStorage()[difficulty] ?? [];
+
+export const shouldRecordTime = (
+  entries: MinesweeperLeaderboardEntry[],
+  time: number,
+  limit: number = LEADERBOARD_LIMIT,
+): boolean => {
+  if (!isFiniteTime(time)) return false;
+  if (entries.length < limit) return true;
+  const worst = entries[entries.length - 1];
+  return time < worst.time;
+};
+
+export const recordTime = (
+  difficulty: MinesweeperDifficulty,
+  name: string,
+  time: number,
+  limit: number = LEADERBOARD_LIMIT,
+): MinesweeperLeaderboardEntry[] => {
+  if (!isFiniteTime(time)) return getLeaderboard(difficulty);
+  const leaderboards = readStorage();
+  const entries = leaderboards[difficulty]
+    ? [...leaderboards[difficulty]]
+    : [];
+  entries.push({ name: clampName(name), time, createdAt: Date.now() });
+  entries.sort((a, b) => a.time - b.time || a.createdAt - b.createdAt);
+  leaderboards[difficulty] = entries.slice(0, limit);
+  writeStorage(leaderboards);
+  return leaderboards[difficulty];
+};
+
+export const qualifiesForLeaderboard = (
+  difficulty: MinesweeperDifficulty,
+  time: number,
+  limit: number = LEADERBOARD_LIMIT,
+): boolean => {
+  const entries = getLeaderboard(difficulty);
+  return shouldRecordTime(entries, time, limit);
+};
+
+export const clearLeaderboard = (
+  difficulty: MinesweeperDifficulty,
+): void => {
+  const leaderboards = readStorage();
+  leaderboards[difficulty] = [];
+  writeStorage(leaderboards);
+};
+


### PR DESCRIPTION
## Summary
- add a Minesweeper leaderboard helper that stores per-difficulty top times in localStorage and enforces ordering/limits
- integrate dynamic difficulty selection, share-code parsing, best-time prompts, and a leaderboard modal into the Minesweeper UI
- cover leaderboard persistence and qualification logic with focused Jest tests

## Testing
- yarn eslint games/minesweeper/leaderboard.ts components/apps/minesweeper.js __tests__/minesweeper.leaderboard.test.ts
- yarn test __tests__/minesweeper.leaderboard.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68cc1e1f070c8328807589bbc8e34fd5