### PR TITLE
[apps] Add Minesweeper difficulty presets

### DIFF
--- a/__tests__/minesweeper.settings.test.tsx
+++ b/__tests__/minesweeper.settings.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import Minesweeper from '../components/apps/minesweeper';
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.matchMedia =
+    window.matchMedia ||
+    ((query: string) => ({
+      matches: false,
+      media: query,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+  window.requestAnimationFrame = jest.fn(() => 0);
+  window.cancelAnimationFrame = jest.fn();
+  HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+    clearRect: jest.fn(),
+    fillRect: jest.fn(),
+    strokeRect: jest.fn(),
+    fillText: jest.fn(),
+    save: jest.fn(),
+    restore: jest.fn(),
+    translate: jest.fn(),
+    scale: jest.fn(),
+    beginPath: jest.fn(),
+    arc: jest.fn(),
+    stroke: jest.fn(),
+  } as unknown as CanvasRenderingContext2D));
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test('allows selecting difficulty preset', async () => {
+  const { getByText, getByLabelText, getByRole, container } = render(
+    <Minesweeper />,
+  );
+
+  fireEvent.click(getByText('Settings'));
+  fireEvent.click(getByLabelText('Intermediate (16x16, 40 mines)'));
+  fireEvent.click(getByRole('button', { name: 'Apply' }));
+
+  await waitFor(() => {
+    expect(getByText(/Mines:/).textContent).toContain('40');
+  });
+
+  const canvas = container.querySelector('canvas');
+  expect(canvas?.width).toBe(16 * 32);
+});
+
+test('shows validation error for invalid custom configuration', () => {
+  const { getByText, getByLabelText, getByRole } = render(<Minesweeper />);
+
+  fireEvent.click(getByText('Settings'));
+  fireEvent.click(getByLabelText('Custom'));
+
+  const sizeInput = getByLabelText(/Board size/);
+  const minesInput = getByLabelText(/Mines/);
+
+  fireEvent.change(sizeInput, { target: { value: '3' } });
+  fireEvent.change(minesInput, { target: { value: '10' } });
+  fireEvent.click(getByRole('button', { name: 'Apply' }));
+
+  expect(getByText(/Board size must be between/)).toBeInTheDocument();
+  expect(getByText(/Mines:/).textContent).toContain('10');
+});


### PR DESCRIPTION
## Summary
- add Minesweeper difficulty presets with persisted custom configuration controls and validation
- generate boards, share codes, and canvas sizing from the selected preset or custom values
- cover preset selection and invalid custom dimensions with dedicated settings tests

## Testing
- yarn lint *(fails: pre-existing accessibility violations in unrelated apps and static assets)*
- yarn test *(fails: pre-existing act warnings/failures in window and Nmap NSE suites)*
- yarn test __tests__/minesweeper.settings.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc1e1fe8c08328b7986212db6cfb9e