### PR TITLE
test: add BeEF lab stability scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,30 @@ yarn test:watch
 yarn lint
 ```
 
+### Playwright BeEF lab stability scenario
+
+The reusable flow in [`playwright/beefLabScenario.ts`](./playwright/beefLabScenario.ts) drives the BeEF lab demo five times, checks for console warnings, and tracks heap growth. Run it locally with Playwright (Chromium only):
+
+```bash
+# In one terminal start the dev server
+yarn dev
+
+# Install browser binaries once (if you haven't already)
+npx playwright install chromium
+
+# In another terminal run the scenario
+npx playwright test tests/beef-lab.spec.ts --browser=chromium
+
+```
+
+If you're running in a fresh Linux container without GUI libraries, install Playwright's Chromium dependencies first:
+
+```bash
+npx playwright install-deps chromium
+```
+
+The assertion fails if heap usage grows by more than **7 MB** across the run or if any browser warnings are logged.
+
 ---
 
 ## Feature Overview

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
   testMatch: /.*\.spec\.ts/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    bypassCSP: true,
   },
 });

--- a/playwright/beefLabScenario.ts
+++ b/playwright/beefLabScenario.ts
@@ -1,0 +1,140 @@
+import { expect, Page } from '@playwright/test';
+
+export interface BeefLabScenarioOptions {
+  runs?: number;
+}
+
+export interface BeefLabScenarioResult {
+  warnings: string[];
+  memoryReadings: number[];
+  maxDeltaBytes: number | null;
+}
+
+async function readUsedHeap(page: Page): Promise<number | null> {
+  try {
+    const value = await page.evaluate(() => {
+      const perf = performance as Performance & { memory?: { usedJSHeapSize?: number } };
+      if (!perf.memory || typeof perf.memory.usedJSHeapSize !== 'number') {
+        return null;
+      }
+      return perf.memory.usedJSHeapSize;
+    });
+    return typeof value === 'number' ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+async function ensureAtDisclaimer(page: Page) {
+  await expect(page.getByRole('heading', { name: /Disclaimer/i })).toBeVisible();
+}
+
+async function connectToLab(page: Page) {
+  await ensureAtDisclaimer(page);
+  const beginButton = page.getByRole('button', { name: /Begin/i });
+  await expect(beginButton).toBeEnabled();
+  await beginButton.click();
+  await expect(page.getByRole('heading', { name: /Sandboxed Target/i })).toBeVisible();
+}
+
+async function advanceToDemo(page: Page) {
+  await expect(page.getByRole('heading', { name: /Sandboxed Target/i })).toBeVisible();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+  await expect(page.getByRole('heading', { name: /Simulated Hook/i })).toBeVisible();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+  await expect(page.getByRole('heading', { name: /Run Demo Module/i })).toBeVisible();
+  const output = page.locator('pre');
+  await expect(output).toContainText('Demo module executed');
+  await expect(output).toContainText('Result: success');
+}
+
+async function interactWithPayloadBuilder(page: Page, iteration: number) {
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
+  await expect(page.getByRole('heading', { name: /Payload Builder/i })).toBeVisible();
+
+  const payloadSelect = page.getByLabel('Payload:');
+  if (await payloadSelect.isVisible()) {
+    const options = await payloadSelect.locator('option').all();
+    if (options.length > 0) {
+      const option = options[iteration % options.length];
+      const value = (await option.getAttribute('value')) ?? (await option.textContent()) ?? undefined;
+      if (value) {
+        await payloadSelect.selectOption(value);
+      }
+    }
+  }
+
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
+  await expect(page.getByRole('heading', { name: /Complete/i })).toBeVisible();
+}
+
+async function resetLab(page: Page) {
+  const resetButton = page.getByRole('button', { name: /Reset Lab/i });
+  await expect(resetButton).toBeVisible();
+  await resetButton.click();
+  await ensureAtDisclaimer(page);
+}
+
+export async function runBeefLabScenario(
+  page: Page,
+  options: BeefLabScenarioOptions = {},
+): Promise<BeefLabScenarioResult> {
+  const runs = Math.max(1, options.runs ?? 5);
+  const warnings: string[] = [];
+  const memoryReadings: number[] = [];
+
+  const warningListener = (msg: { type(): string; text(): string }) => {
+    if (msg.type() === 'warning') {
+      warnings.push(msg.text());
+    }
+  };
+
+  page.on('console', warningListener);
+
+  try {
+    await page.goto('/apps/beef', { waitUntil: 'networkidle' });
+    await expect(page.getByRole('heading', { name: /BeEF Demo/i })).toBeVisible({ timeout: 45_000 });
+    const initialMemory = await readUsedHeap(page);
+    if (initialMemory !== null) {
+      memoryReadings.push(initialMemory);
+    }
+
+    for (let i = 0; i < runs; i += 1) {
+      await connectToLab(page);
+      await advanceToDemo(page);
+      await interactWithPayloadBuilder(page, i);
+      const reading = await readUsedHeap(page);
+      if (reading !== null) {
+        memoryReadings.push(reading);
+      }
+      await resetLab(page);
+    }
+
+    await connectToLab(page);
+    const finalReading = await readUsedHeap(page);
+    if (finalReading !== null) {
+      memoryReadings.push(finalReading);
+    }
+    await page.goto('/apps/beef', { waitUntil: 'networkidle' });
+    await ensureAtDisclaimer(page);
+  } finally {
+    page.off('console', warningListener);
+  }
+
+  let maxDelta: number | null = null;
+  if (memoryReadings.length > 1) {
+    const baseline = memoryReadings[0];
+    maxDelta = memoryReadings.reduce((max, value) => {
+      const delta = value - baseline;
+      return delta > max ? delta : max;
+    }, 0);
+  }
+
+  return {
+    warnings,
+    memoryReadings,
+    maxDeltaBytes: maxDelta,
+  };
+}

--- a/tests/beef-lab.spec.ts
+++ b/tests/beef-lab.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+import { runBeefLabScenario } from '../playwright/beefLabScenario';
+
+const MEMORY_LIMIT_MB = 7;
+
+test.describe('BeEF lab demo stability', () => {
+  test.setTimeout(120_000);
+  test.skip(({ browserName }) => browserName !== 'chromium', 'Memory metrics require Chromium');
+
+  test('runs five demos without warnings or memory spikes', async ({ page }) => {
+    const memorySupported = await page.evaluate(() => {
+      const perf = performance as Performance & { memory?: { usedJSHeapSize?: number } };
+      return Boolean(perf.memory && typeof perf.memory.usedJSHeapSize === 'number');
+    });
+
+    test.skip(!memorySupported, 'performance.memory is unavailable in this browser');
+
+    const result = await runBeefLabScenario(page, { runs: 5 });
+
+    expect(result.warnings, 'Console warnings were emitted during the demo runs').toEqual([]);
+
+    expect(result.maxDeltaBytes).not.toBeNull();
+    const deltaMb = (result.maxDeltaBytes ?? 0) / (1024 * 1024);
+    expect(deltaMb).toBeLessThan(MEMORY_LIMIT_MB);
+
+    await expect(page.getByRole('heading', { name: /Disclaimer/i })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable Playwright helper that runs the BeEF lab flow, tracks heap deltas, and collects browser warnings
- create a Chromium-only Playwright spec that asserts warning-free runs and enforces the <7 MB memory ceiling
- update the Playwright config to bypass CSP in dev and document how to run the scenario locally

## Testing
- yarn lint *(fails: hundreds of pre-existing jsx-a11y and no-top-level-window violations across the repo)*
- yarn test *(fails: multiple legacy suites such as window, nmapNse, and Modal remain red)*
- npx playwright test tests/beef-lab.spec.ts --browser=chromium

------
https://chatgpt.com/codex/tasks/task_e_68cc1e356c208328b9bf71e6e5776add