### PR TITLE
[weather] add geolocation modal with manual fallback

### DIFF
--- a/__tests__/weatherLocation.test.tsx
+++ b/__tests__/weatherLocation.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import WeatherApp from '../apps/weather';
+
+describe('Weather app location modal', () => {
+  const originalGeolocation = navigator.geolocation;
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (originalGeolocation) {
+      Object.defineProperty(navigator, 'geolocation', {
+        value: originalGeolocation,
+        configurable: true,
+      });
+    } else {
+      delete (navigator as any).geolocation;
+    }
+    localStorage.clear();
+  });
+
+  it('requests geolocation and stores a location when permission is granted', async () => {
+    const getCurrentPosition = jest.fn(
+      (
+        success: PositionCallback,
+        _error?: PositionErrorCallback | null,
+      ) => {
+        success({
+          coords: { latitude: 51.5, longitude: -0.12 },
+        } as unknown as GeolocationPosition);
+      },
+    );
+
+    Object.defineProperty(navigator, 'geolocation', {
+      value: { getCurrentPosition },
+      configurable: true,
+    });
+
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      json: async () => ({
+        current_weather: { temperature: 20, weathercode: 1 },
+        daily: { time: [], temperature_2m_max: [], weathercode: [] },
+      }),
+    } as unknown as Response);
+
+    render(<WeatherApp />);
+
+    await waitFor(() => expect(getCurrentPosition).toHaveBeenCalled());
+
+    await screen.findByText(
+      /Last location: Current Location \(51\.50, -0\.12\)/i,
+    );
+    expect(screen.getByText('Current Location')).toBeInTheDocument();
+
+    const stored = localStorage.getItem('weather-last-location');
+    expect(stored).toContain('51.5');
+  });
+
+  it('falls back to manual entry when geolocation is denied', async () => {
+    const getCurrentPosition = jest.fn(
+      (
+        _success: PositionCallback,
+        error?: PositionErrorCallback | null,
+      ) => {
+        error?.({ message: 'Permission denied' } as unknown as GeolocationPositionError);
+      },
+    );
+
+    Object.defineProperty(navigator, 'geolocation', {
+      value: { getCurrentPosition },
+      configurable: true,
+    });
+
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      json: async () => ({
+        current_weather: { temperature: 20, weathercode: 1 },
+        daily: { time: [], temperature_2m_max: [], weathercode: [] },
+      }),
+    } as unknown as Response);
+
+    render(<WeatherApp />);
+
+    const errorMessage = await screen.findByText(/permission denied/i);
+    expect(errorMessage).toBeInTheDocument();
+
+    const nameInput = screen.getByPlaceholderText(/city name/i);
+    fireEvent.change(nameInput, { target: { value: 'Testville' } });
+    fireEvent.change(screen.getByPlaceholderText(/latitude/i), {
+      target: { value: '10' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/longitude/i), {
+      target: { value: '20' },
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /save manual location/i }),
+    );
+
+    await screen.findByText(/Last location: Testville \(10\.00, 20\.00\)/i);
+    expect(screen.getByText('Testville')).toBeInTheDocument();
+
+    expect(localStorage.getItem('weather-manual-city-entry')).toContain(
+      'Testville',
+    );
+    expect(localStorage.getItem('weather-last-location')).toContain('Testville');
+  });
+});

--- a/apps/weather/index.tsx
+++ b/apps/weather/index.tsx
@@ -1,11 +1,20 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+} from 'react';
 import useWeatherState, {
   City,
   ForecastDay,
   useWeatherGroups,
   useCurrentGroup,
+  useGeolocationOptOut,
+  useLastLocation,
+  useManualCityEntry,
 } from './state';
 import Forecast from './components/Forecast';
 import CityDetail from './components/CityDetail';
@@ -34,6 +43,9 @@ export default function WeatherApp() {
   const [cities, setCities] = useWeatherState();
   const [groups, setGroups] = useWeatherGroups();
   const [currentGroup, setCurrentGroup] = useCurrentGroup();
+  const [manualEntry, setManualEntry] = useManualCityEntry();
+  const [optOut, setOptOut] = useGeolocationOptOut();
+  const [lastLocation, setLastLocation] = useLastLocation();
   const [name, setName] = useState('');
   const [lat, setLat] = useState('');
   const [lon, setLon] = useState('');
@@ -42,13 +54,105 @@ export default function WeatherApp() {
     typeof navigator !== 'undefined' ? !navigator.onLine : false,
   );
   const [selected, setSelected] = useState<City | null>(null);
+  const [showLocationModal, setShowLocationModal] = useState(false);
+  const [geoPending, setGeoPending] = useState(false);
+  const [locationError, setLocationError] = useState<string | null>(null);
   const dragSrc = useRef<number | null>(null);
+  const autoRequest = useRef(false);
+
+  const addOrUpdateLocation = useCallback(
+    (city: City) => {
+      setLastLocation(city);
+      setCities((prev) => {
+        const idx = prev.findIndex((c) => c.id === city.id);
+        if (idx >= 0) {
+          const next = [...prev];
+          next[idx] = { ...next[idx], ...city };
+          return next;
+        }
+        return [city, ...prev];
+      });
+    },
+    [setCities, setLastLocation],
+  );
+
+  const requestGeolocation = useCallback(() => {
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      setLocationError('Geolocation is not supported in this environment.');
+      setGeoPending(false);
+      return;
+    }
+    setGeoPending(true);
+    setLocationError(null);
+    navigator.geolocation.getCurrentPosition(
+      ({ coords }) => {
+        const { latitude, longitude } = coords;
+        addOrUpdateLocation({
+          id: 'last-location',
+          name: 'Current Location',
+          lat: latitude,
+          lon: longitude,
+        });
+        setOptOut(false);
+        setShowLocationModal(false);
+        setGeoPending(false);
+      },
+      (err) => {
+        setLocationError(err?.message || 'Unable to retrieve your location.');
+        setGeoPending(false);
+      },
+    );
+  }, [
+    addOrUpdateLocation,
+    setGeoPending,
+    setLocationError,
+    setOptOut,
+    setShowLocationModal,
+  ]);
+
+  const onManualChange = (field: 'name' | 'lat' | 'lon') =>
+    (event: ChangeEvent<HTMLInputElement>) =>
+      setManualEntry((prev) => ({ ...prev, [field]: event.target.value }));
+
+  const saveManualLocation = () => {
+    const manualName = manualEntry.name.trim() || 'Manual Location';
+    const latValue = manualEntry.lat.trim();
+    const lonValue = manualEntry.lon.trim();
+    const latNum = parseFloat(latValue);
+    const lonNum = parseFloat(lonValue);
+    if (Number.isNaN(latNum) || Number.isNaN(lonNum)) {
+      setLocationError('Enter a valid latitude and longitude.');
+      return;
+    }
+    setManualEntry({ name: manualName, lat: latValue, lon: lonValue });
+    addOrUpdateLocation({
+      id: 'last-location',
+      name: manualName,
+      lat: latNum,
+      lon: lonNum,
+    });
+    setLocationError(null);
+    setShowLocationModal(false);
+  };
 
   useEffect(() => {
     if (!currentGroup) return;
     const group = groups.find((g) => g.name === currentGroup);
     if (group) setCities(group.cities);
   }, [currentGroup, groups, setCities]);
+
+  useEffect(() => {
+    if (!lastLocation) return;
+    setCities((prev) => {
+      const exists = prev.some((city) => city.id === lastLocation.id);
+      if (exists) {
+        return prev.map((city) =>
+          city.id === lastLocation.id ? { ...city, ...lastLocation } : city,
+        );
+      }
+      return [lastLocation, ...prev];
+    });
+  }, [lastLocation, setCities]);
 
   useEffect(() => {
     const onOnline = () => setOffline(false);
@@ -92,7 +196,24 @@ export default function WeatherApp() {
           // ignore fetch errors
         });
     });
-    }, [offline, cities, setCities]);
+  }, [offline, cities, setCities]);
+
+  useEffect(() => {
+    if (!lastLocation && !optOut) {
+      setShowLocationModal(true);
+    }
+  }, [lastLocation, optOut]);
+
+  useEffect(() => {
+    if (!showLocationModal) {
+      autoRequest.current = false;
+      return;
+    }
+    if (!optOut && !autoRequest.current) {
+      autoRequest.current = true;
+      requestGeolocation();
+    }
+  }, [optOut, requestGeolocation, showLocationModal]);
 
   const addCity = () => {
     const latNum = parseFloat(lat);
@@ -144,6 +265,22 @@ export default function WeatherApp() {
 
   return (
     <div className="p-4 text-white">
+      <div className="flex items-center justify-between mb-4">
+        <div className="text-sm opacity-80">
+          {lastLocation
+            ? `Last location: ${lastLocation.name} (${lastLocation.lat.toFixed(2)}, ${lastLocation.lon.toFixed(2)})`
+            : 'No location selected'}
+        </div>
+        <button
+          className="bg-blue-600 px-2 rounded"
+          onClick={() => {
+            setShowLocationModal(true);
+            setLocationError(null);
+          }}
+        >
+          Set Location
+        </button>
+      </div>
       <div className="flex gap-2 mb-4">
         <input
           className="text-black px-1"
@@ -209,6 +346,69 @@ export default function WeatherApp() {
       )}
       {selected && (
         <CityDetail city={selected} onClose={() => setSelected(null)} />
+      )}
+      {showLocationModal && (
+        <div className="fixed inset-0 bg-black/70 flex items-center justify-center p-4">
+          <div className="bg-neutral-900 p-4 rounded w-full max-w-md text-white">
+            <div className="flex justify-between items-start gap-4 mb-2">
+              <h2 className="font-bold text-lg">Location Access</h2>
+              <button onClick={() => setShowLocationModal(false)} className="px-1.5">
+                Close
+              </button>
+            </div>
+            <p className="text-sm opacity-80 mb-3">
+              Allow the weather app to use your current location or enter a city manually.
+            </p>
+            {locationError && (
+              <div className="mb-3 text-sm text-red-400" role="alert">
+                {locationError}
+              </div>
+            )}
+            <div className="flex flex-col gap-2 mb-4">
+              <button
+                className="bg-blue-600 px-2 py-1 rounded disabled:opacity-60"
+                onClick={requestGeolocation}
+                disabled={geoPending}
+              >
+                {geoPending ? 'Locating…' : 'Use my current location'}
+              </button>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={optOut}
+                  onChange={(e) => setOptOut(e.target.checked)}
+                />
+                Skip automatic geolocation prompts
+              </label>
+            </div>
+            <div className="mb-4">
+              <div className="font-semibold mb-2">Manual city</div>
+              <input
+                className="text-black px-1 w-full mb-2"
+                placeholder="City name"
+                value={manualEntry.name}
+                onChange={onManualChange('name')}
+              />
+              <div className="flex gap-2 mb-2">
+                <input
+                  className="text-black px-1 w-full"
+                  placeholder="Latitude"
+                  value={manualEntry.lat}
+                  onChange={onManualChange('lat')}
+                />
+                <input
+                  className="text-black px-1 w-full"
+                  placeholder="Longitude"
+                  value={manualEntry.lon}
+                  onChange={onManualChange('lon')}
+                />
+              </div>
+              <button className="bg-white/20 px-2 py-1 rounded" onClick={saveManualLocation}>
+                Save manual location
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/apps/weather/state.ts
+++ b/apps/weather/state.ts
@@ -23,6 +23,12 @@ export interface City {
   forecast?: ForecastDay[];
 }
 
+export interface ManualCityEntry {
+  name: string;
+  lat: string;
+  lon: string;
+}
+
 export interface CityGroup {
   name: string;
   cities: City[];
@@ -51,6 +57,22 @@ export default function useWeatherState() {
   return usePersistentState<City[]>('weather-cities', [], isCityArray);
 }
 
+const isManualCityEntry = (v: unknown): v is ManualCityEntry =>
+  Boolean(
+    v &&
+      typeof (v as ManualCityEntry).name === 'string' &&
+      typeof (v as ManualCityEntry).lat === 'string' &&
+      typeof (v as ManualCityEntry).lon === 'string',
+  );
+
+export function useManualCityEntry() {
+  return usePersistentState<ManualCityEntry>(
+    'weather-manual-city-entry',
+    { name: '', lat: '', lon: '' },
+    isManualCityEntry,
+  );
+}
+
 const isCityGroup = (v: any): v is CityGroup =>
   v && typeof v.name === 'string' && isCityArray(v.cities);
 
@@ -66,5 +88,17 @@ const isStringOrNull = (v: unknown): v is string | null =>
 
 export function useCurrentGroup() {
   return usePersistentState<string | null>('weather-current-group', null, isStringOrNull);
+}
+
+const isBoolean = (v: unknown): v is boolean => typeof v === 'boolean';
+
+const isCityOrNull = (v: unknown): v is City | null => v === null || isCity(v);
+
+export function useGeolocationOptOut() {
+  return usePersistentState<boolean>('weather-geolocation-opt-out', false, isBoolean);
+}
+
+export function useLastLocation() {
+  return usePersistentState<City | null>('weather-last-location', null, isCityOrNull);
 }
 


### PR DESCRIPTION
## Summary
- add a location modal that requests geolocation, restores the last location, and allows opting out
- persist manual city entry values so the fallback flow can reuse stored input
- cover geolocation grant/deny scenarios with targeted Weather app tests

## Testing
- [ ] yarn lint *(fails: repository has existing accessibility lint errors unrelated to this change)*
- [x] yarn test --runTestsByPath __tests__/weatherLocation.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc0659d630832898dfdb2b3a2aa8a4