### PR TITLE
[accessibility] improve focus indicators

### DIFF
--- a/__tests__/components/focus-layering.test.tsx
+++ b/__tests__/components/focus-layering.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Window from '../../components/base/window';
+import Taskbar from '../../components/screen/taskbar';
+
+jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+jest.mock('react-draggable', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const testApps = [
+  {
+    id: 'app1',
+    title: 'App One',
+    icon: '/icons/app-one.png',
+    screen: () => <div>App One Body</div>,
+  },
+  {
+    id: 'app2',
+    title: 'App Two',
+    icon: '/icons/app-two.png',
+    screen: () => <div>App Two Body</div>,
+  },
+];
+
+const createStateMap = (value: (id: string) => boolean) =>
+  Object.fromEntries(testApps.map((app) => [app.id, value(app.id)]));
+
+const layerForFocus = (focusedId: string) => {
+  const focused = createStateMap((id) => id === focusedId);
+  const minimized = createStateMap(() => false);
+  const closed = createStateMap(() => false);
+
+  return (
+    <>
+      {testApps.map((app) => (
+        <Window
+          key={app.id}
+          id={app.id}
+          title={app.title}
+          screen={app.screen}
+          focus={() => {}}
+          openApp={() => {}}
+          addFolder={() => {}}
+          closed={() => {}}
+          hideSideBar={() => {}}
+          hasMinimised={() => {}}
+          isFocused={focused[app.id]}
+          minimized={minimized[app.id]}
+        />
+      ))}
+      <Taskbar
+        apps={testApps}
+        closed_windows={closed}
+        minimized_windows={minimized}
+        focused_windows={focused}
+        openApp={() => {}}
+        minimize={() => {}}
+      />
+    </>
+  );
+};
+
+describe('Focus layering indicators', () => {
+  it('update when active window changes', () => {
+    const { rerender } = render(layerForFocus('app1'));
+
+    const assertState = (activeId: string) => {
+      testApps.forEach((app) => {
+        const dialog = screen.getByRole('dialog', { name: new RegExp(app.title, 'i') });
+        const taskbarButton = screen
+          .getAllByRole('button', { name: new RegExp(app.title, 'i') })
+          .find((node) => node.getAttribute('data-context') === 'taskbar');
+        expect(taskbarButton).toBeDefined();
+        const button = taskbarButton!;
+        const indicator = button.querySelector('[data-indicator="window-state"]');
+        const isActive = app.id === activeId;
+
+        if (isActive) {
+          expect(dialog).toHaveAttribute('aria-current', 'true');
+          expect(dialog).toHaveAttribute('data-focused', 'true');
+          expect(button).toHaveAttribute('aria-current', 'true');
+          expect(button).toHaveAttribute('data-active', 'true');
+          expect(indicator).not.toBeNull();
+          expect(indicator).toHaveAttribute('data-active', 'true');
+        } else {
+          expect(dialog).not.toHaveAttribute('aria-current');
+          expect(dialog).toHaveAttribute('data-focused', 'false');
+          expect(button).not.toHaveAttribute('aria-current');
+          expect(button).toHaveAttribute('data-active', 'false');
+          expect(indicator).not.toBeNull();
+          expect(indicator).toHaveAttribute('data-active', 'false');
+        }
+      });
+    };
+
+    assertState('app1');
+    rerender(layerForFocus('app2'));
+    assertState('app2');
+  });
+});

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -612,6 +612,18 @@ export class Window extends Component {
     }
 
     render() {
+        const isActive = this.props.isFocused && !this.props.minimized;
+        const windowClassNames = [
+            this.state.cursorType,
+            this.state.closed ? "closed-window" : "",
+            this.state.maximized ? "duration-300 rounded-none" : "rounded-lg rounded-b-none",
+            this.props.minimized ? "opacity-0 invisible duration-200" : "",
+            this.state.grabbed ? "opacity-70" : "",
+            this.state.snapPreview ? "ring-2 ring-blue-400" : "",
+            isActive ? "z-30" : "z-20 notFocused",
+            "opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col",
+        ].filter(Boolean).join(" ");
+
         return (
             <>
                 {this.state.snapPreview && (
@@ -635,10 +647,12 @@ export class Window extends Component {
                 >
                     <div
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        className={windowClassNames + (isActive ? " focus:outline-none focus-visible:outline-none" : "")}
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}
+                        aria-current={isActive ? "true" : undefined}
+                        data-focused={isActive ? "true" : "false"}
                         tabIndex={0}
                         onKeyDown={this.handleKeyDown}
                     >

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -17,31 +17,46 @@ export default function Taskbar(props) {
 
     return (
         <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => (
-                <button
-                    key={app.id}
-                    type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
-                    onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
-                    />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
-                </button>
-            ))}
+            {runningApps.map(app => {
+                const isMinimized = props.minimized_windows[app.id];
+                const isActive = props.focused_windows[app.id] && !isMinimized;
+                const buttonClasses = [
+                    'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10',
+                    isActive ? 'bg-white bg-opacity-20' : '',
+                ].filter(Boolean).join(' ');
+
+                return (
+                    <button
+                        key={app.id}
+                        type="button"
+                        aria-label={app.title}
+                        aria-current={isActive ? 'true' : undefined}
+                        data-context="taskbar"
+                        data-app-id={app.id}
+                        data-active={isActive ? 'true' : 'false'}
+                        onClick={() => handleClick(app)}
+                        className={buttonClasses}
+                    >
+                        <Image
+                            width={24}
+                            height={24}
+                            className="w-5 h-5"
+                            src={app.icon.replace('./', '/')}
+                            alt=""
+                            sizes="24px"
+                        />
+                        <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                        {!isMinimized && (
+                            <span
+                                aria-hidden="true"
+                                data-indicator="window-state"
+                                data-active={isActive ? 'true' : 'false'}
+                                className={`absolute bottom-0 left-1/2 -translate-x-1/2 rounded transition-all ${isActive ? 'w-3 h-1 bg-white opacity-100' : 'w-2 h-0.5 bg-white opacity-70'}`}
+                            />
+                        )}
+                    </button>
+                );
+            })}
         </div>
     );
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -97,6 +97,11 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     filter: brightness(90%);
 }
 
+.main-window[data-focused="true"] {
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline-offset: 0;
+}
+
 .root,
 #root,
 #docs-root {


### PR DESCRIPTION
## Summary
- add explicit focus metadata and highlight styling to desktop windows, including aria-current wiring
- update the taskbar buttons to expose an accessible active indicator with synchronized state
- cover focus state changes with a new focus-layering unit test

## Testing
- yarn lint *(fails: numerous pre-existing jsx-a11y label violations in unrelated apps)*
- yarn test focus-layering
- yarn test taskbar

------
https://chatgpt.com/codex/tasks/task_e_68cc38cfc0908328a22ca4d31d29c895