### PR TITLE
[screen] improve spotlight accessibility

### DIFF
--- a/__tests__/components/spotlight-accessibility.test.tsx
+++ b/__tests__/components/spotlight-accessibility.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ShortcutSelector from '../../components/screen/shortcut-selector';
+import { Desktop } from '../../components/screen/desktop';
+
+describe('Spotlight overlay accessibility', () => {
+  const apps = [
+    { id: 'terminal', title: 'Terminal', icon: '/terminal.png' },
+    { id: 'notes', title: 'Notes', icon: '/notes.png' },
+    { id: 'settings', title: 'Settings', icon: '/settings.png' },
+  ];
+
+  const renderOverlay = (onSelect = jest.fn()) =>
+    render(
+      <ShortcutSelector
+        apps={apps}
+        games={[]}
+        onSelect={onSelect}
+        onClose={jest.fn()}
+      />
+    );
+
+  it('announces result counts as the user filters', async () => {
+    renderOverlay();
+    const status = screen.getByRole('status');
+    await waitFor(() => expect(status).toHaveTextContent('3 results available.'));
+
+    const input = screen.getByLabelText('Search applications');
+    fireEvent.change(input, { target: { value: 'Term' } });
+    await waitFor(() => expect(status).toHaveTextContent('1 result available.'));
+
+    fireEvent.change(input, { target: { value: 'zzz' } });
+    await waitFor(() => expect(status).toHaveTextContent('No results found.'));
+  });
+
+  it('cycles search results with arrow keys and roving tabindex', async () => {
+    const onSelect = jest.fn();
+    const { container } = renderOverlay(onSelect);
+    const input = screen.getByLabelText('Search applications');
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    const resultButtons = Array.from(container.querySelectorAll('[data-app-id]'));
+    expect(resultButtons).toHaveLength(3);
+
+    await waitFor(() => expect(document.activeElement).toBe(resultButtons[0]));
+    expect(resultButtons[0].getAttribute('tabindex')).toBe('0');
+    expect(resultButtons[1].getAttribute('tabindex')).toBe('-1');
+
+    fireEvent.keyDown(resultButtons[0], { key: 'ArrowDown' });
+    await waitFor(() => expect(document.activeElement).toBe(resultButtons[1]));
+    expect(resultButtons[1].getAttribute('tabindex')).toBe('0');
+
+    fireEvent.keyDown(resultButtons[1], { key: 'ArrowUp' });
+    await waitFor(() => expect(document.activeElement).toBe(resultButtons[0]));
+
+    fireEvent.keyDown(resultButtons[0], { key: 'ArrowUp' });
+    const last = resultButtons[resultButtons.length - 1];
+    await waitFor(() => expect(document.activeElement).toBe(last));
+
+    fireEvent.keyDown(last, { key: 'Enter' });
+    expect(onSelect).toHaveBeenCalledWith(last.getAttribute('data-app-id'));
+  });
+
+  it('opens the spotlight overlay when Alt+Space is pressed', () => {
+    const desktop = new Desktop({});
+    const openShortcutSelector = jest.fn();
+    desktop.openShortcutSelector = openShortcutSelector;
+
+    const preventDefault = jest.fn();
+    desktop.handleGlobalShortcut({
+      altKey: true,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      code: 'Space',
+      key: ' ',
+      target: document.createElement('div'),
+      preventDefault,
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(openShortcutSelector).toHaveBeenCalled();
+  });
+});

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -30,6 +30,30 @@ export class UbuntuApp extends Component {
         }
     }
 
+    setNodeRef = (node) => {
+        this.node = node;
+        if (this.props.buttonRef) {
+            if (typeof this.props.buttonRef === 'function') {
+                this.props.buttonRef(node);
+            } else if (typeof this.props.buttonRef === 'object') {
+                this.props.buttonRef.current = node;
+            }
+        }
+    }
+
+    handleKeyDown = (e) => {
+        if (typeof this.props.onKeyDown === 'function') {
+            this.props.onKeyDown(e);
+            if (e.defaultPrevented) {
+                return;
+            }
+        }
+        if ((e.key === 'Enter' || e.key === ' ') && !this.props.disabled) {
+            e.preventDefault();
+            this.openApp();
+        }
+    }
+
     render() {
         return (
             <div
@@ -45,10 +69,11 @@ export class UbuntuApp extends Component {
                     " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
-                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
-                tabIndex={this.props.disabled ? -1 : 0}
+                onKeyDown={this.handleKeyDown}
+                tabIndex={this.props.disabled ? -1 : (typeof this.props.tabIndex === 'number' ? this.props.tabIndex : 0)}
                 onMouseEnter={this.handlePrefetch}
                 onFocus={this.handlePrefetch}
+                ref={this.setNodeRef}
             >
                 <Image
                     width={40}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -147,7 +147,16 @@ export class Desktop extends Component {
     }
 
     handleGlobalShortcut = (e) => {
-        if (e.altKey && e.key === 'Tab') {
+        if (e.altKey && !e.ctrlKey && !e.metaKey && (e.code === 'Space' || e.key === ' ' || e.key === 'Spacebar')) {
+            const target = e.target;
+            const tagName = target && target.tagName ? target.tagName.toLowerCase() : '';
+            if (tagName === 'input' || tagName === 'textarea' || target?.isContentEditable) {
+                return;
+            }
+            e.preventDefault();
+            this.openShortcutSelector();
+        }
+        else if (e.altKey && e.key === 'Tab') {
             e.preventDefault();
             if (!this.state.showWindowSwitcher) {
                 this.openWindowSwitcher();

--- a/components/screen/shortcut-selector.js
+++ b/components/screen/shortcut-selector.js
@@ -8,7 +8,11 @@ class ShortcutSelector extends React.Component {
             query: '',
             apps: [],
             unfilteredApps: [],
+            activeIndex: -1,
+            liveMessage: '',
         };
+        this.searchRef = React.createRef();
+        this.skipFocusOnce = false;
     }
 
     componentDidMount() {
@@ -17,7 +21,54 @@ class ShortcutSelector extends React.Component {
         games.forEach((game) => {
             if (!combined.some((app) => app.id === game.id)) combined.push(game);
         });
-        this.setState({ apps: combined, unfilteredApps: combined });
+        const message = this.getResultsMessage(combined.length);
+        const activeIndex = combined.length ? 0 : -1;
+        this.skipFocusOnce = true;
+        this.setState(
+            {
+                apps: combined,
+                unfilteredApps: combined,
+                activeIndex,
+                liveMessage: message,
+            },
+            () => {
+                this.focusSearch();
+            }
+        );
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        if (prevState.activeIndex !== this.state.activeIndex) {
+            if (this.skipFocusOnce) {
+                this.skipFocusOnce = false;
+            } else if (this.state.activeIndex !== -1) {
+                this.focusResult(this.state.activeIndex);
+            }
+        } else if (this.skipFocusOnce) {
+            this.skipFocusOnce = false;
+        }
+    }
+
+    focusSearch = () => {
+        if (this.searchRef && typeof this.searchRef.current?.focus === 'function') {
+            this.searchRef.current.focus();
+        }
+    }
+
+    getResultsMessage = (count) => {
+        if (count === 0) {
+            return 'No results found.';
+        }
+        return `${count} result${count === 1 ? '' : 's'} available.`;
+    }
+
+    focusResult = (index) => {
+        const app = this.state.apps[index];
+        if (!app) return;
+        const node = typeof document !== 'undefined' ? document.getElementById(`app-${app.id}`) : null;
+        if (node && typeof node.focus === 'function') {
+            node.focus();
+        }
     }
 
     handleChange = (e) => {
@@ -29,8 +80,87 @@ class ShortcutSelector extends React.Component {
                 : unfilteredApps.filter((app) =>
                       app.title.toLowerCase().includes(value.toLowerCase())
                   );
-        this.setState({ query: value, apps });
+        const activeIndex = apps.length ? 0 : -1;
+        this.skipFocusOnce = true;
+        this.setState({ query: value, apps, activeIndex, liveMessage: this.getResultsMessage(apps.length) });
     };
+
+    handleInputKeyDown = (e) => {
+        if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            if (this.state.apps.length) {
+                if (this.state.activeIndex === 0) {
+                    this.focusResult(0);
+                } else {
+                    this.setState({ activeIndex: 0 });
+                }
+            }
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            if (this.state.apps.length) {
+                const last = this.state.apps.length - 1;
+                if (this.state.activeIndex === last) {
+                    this.focusResult(last);
+                } else {
+                    this.setState({ activeIndex: last });
+                }
+            }
+        } else if (e.key === 'Escape') {
+            if (typeof this.props.onClose === 'function') {
+                e.preventDefault();
+                this.props.onClose();
+            }
+        }
+    }
+
+    handleResultsKeyDown = (e) => {
+        if (['ArrowDown', 'ArrowRight'].includes(e.key)) {
+            e.preventDefault();
+            this.moveActive(1);
+        } else if (['ArrowUp', 'ArrowLeft'].includes(e.key)) {
+            e.preventDefault();
+            this.moveActive(-1);
+        } else if (e.key === 'Home') {
+            e.preventDefault();
+            if (this.state.apps.length) {
+                if (this.state.activeIndex === 0) {
+                    this.focusResult(0);
+                } else {
+                    this.setState({ activeIndex: 0 });
+                }
+            }
+        } else if (e.key === 'End') {
+            e.preventDefault();
+            if (this.state.apps.length) {
+                const last = this.state.apps.length - 1;
+                if (this.state.activeIndex === last) {
+                    this.focusResult(last);
+                } else {
+                    this.setState({ activeIndex: last });
+                }
+            }
+        } else if (e.key === 'Escape') {
+            if (typeof this.props.onClose === 'function') {
+                e.preventDefault();
+                this.props.onClose();
+            }
+        }
+    }
+
+    moveActive = (direction) => {
+        this.setState((state) => {
+            if (!state.apps.length) return null;
+            const count = state.apps.length;
+            const current = state.activeIndex;
+            let next;
+            if (current === -1) {
+                next = direction > 0 ? 0 : count - 1;
+            } else {
+                next = (current + direction + count) % count;
+            }
+            return { activeIndex: next };
+        });
+    }
 
     selectApp = (id) => {
         if (typeof this.props.onSelect === 'function') {
@@ -40,7 +170,8 @@ class ShortcutSelector extends React.Component {
 
     renderApps = () => {
         const apps = this.state.apps || [];
-        return apps.map((app) => (
+        const activeIndex = this.state.activeIndex;
+        return apps.map((app, index) => (
             <UbuntuApp
                 key={app.id}
                 name={app.title}
@@ -49,6 +180,7 @@ class ShortcutSelector extends React.Component {
                 openApp={() => this.selectApp(app.id)}
                 disabled={app.disabled}
                 prefetch={app.screen?.prefetch}
+                tabIndex={index === activeIndex ? 0 : -1}
             />
         ));
     };
@@ -59,10 +191,20 @@ class ShortcutSelector extends React.Component {
                 <input
                     className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
                     placeholder="Search"
+                    aria-label="Search applications"
                     value={this.state.query}
                     onChange={this.handleChange}
+                    onKeyDown={this.handleInputKeyDown}
+                    ref={this.searchRef}
                 />
-                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
+                <div className="sr-only" aria-live="polite" role="status" aria-atomic="true">
+                    {this.state.liveMessage}
+                </div>
+                <div
+                    className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center"
+                    aria-label="Search results"
+                    onKeyDown={this.handleResultsKeyDown}
+                >
                     {this.renderApps()}
                 </div>
                 <button


### PR DESCRIPTION
## Summary
- handle Alt+Space in the desktop global shortcut handler to launch the spotlight overlay
- update the shortcut selector to support roving focus, live result announcements, and richer keyboard control
- add spotlight accessibility tests that exercise keyboard navigation and announcements

## Testing
- yarn lint *(fails: repo contains pre-existing accessibility lint violations in unrelated apps)*
- yarn test spotlight-accessibility

------
https://chatgpt.com/codex/tasks/task_e_68cc38c95d288328b55cb6b4b588a0de