### PR TITLE
[spotlight] add quick action registry

### DIFF
--- a/__tests__/components/spotlight-actions.test.tsx
+++ b/__tests__/components/spotlight-actions.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import WhiskerMenu from '../../components/menu/WhiskerMenu';
+import {
+  executeSpotlightAction,
+  registerSpotlightAction,
+  __TEST_ONLY__resetSpotlightRegistry,
+} from '../../components/screen/spotlight-actions';
+
+describe('spotlight actions registry', () => {
+  afterEach(() => {
+    __TEST_ONLY__resetSpotlightRegistry();
+  });
+
+  it('executes a registered action and returns success metadata', async () => {
+    registerSpotlightAction({
+      id: 'test-action',
+      title: 'Test Action',
+      description: 'Verify registry execution',
+      run: () => ({ status: 'success', message: 'all good' }),
+    });
+
+    const result = await executeSpotlightAction('test-action');
+    expect(result.status).toBe('success');
+    expect(result.message).toBe('all good');
+  });
+
+  it('converts thrown errors into error results', async () => {
+    registerSpotlightAction({
+      id: 'error-action',
+      title: 'Throwing Action',
+      run: () => {
+        throw new Error('boom');
+      },
+    });
+
+    const result = await executeSpotlightAction('error-action');
+    expect(result.status).toBe('error');
+    expect(result.message).toContain('boom');
+  });
+});
+
+describe('Spotlight quick actions UI', () => {
+  afterEach(() => {
+    __TEST_ONLY__resetSpotlightRegistry();
+  });
+
+  it('shows success feedback when an action completes', async () => {
+    const unregister = registerSpotlightAction({
+      id: 'diagnostics-action',
+      title: 'Run Diagnostics',
+      description: 'Check system health',
+      keywords: ['diagnostics'],
+      run: () => ({ status: 'success', message: 'Diagnostics complete' }),
+    });
+
+    render(<WhiskerMenu />);
+    fireEvent.click(screen.getByRole('button', { name: /applications/i }));
+
+    const input = await screen.findByPlaceholderText('Search');
+    fireEvent.change(input, { target: { value: 'diagnostics' } });
+
+    const actionLabel = await screen.findByText('Run Diagnostics');
+    fireEvent.click(actionLabel.closest('button') as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(screen.getByText('Diagnostics complete')).toBeInTheDocument();
+    });
+
+    unregister();
+  });
+
+  it('surfaces error feedback when an action fails', async () => {
+    const unregister = registerSpotlightAction({
+      id: 'cache-failure',
+      title: 'Failing Action',
+      description: 'Always fails',
+      keywords: ['fail-case'],
+      run: () => ({ status: 'error', message: 'Operation failed' }),
+    });
+
+    render(<WhiskerMenu />);
+    fireEvent.click(screen.getByRole('button', { name: /applications/i }));
+
+    const input = await screen.findByPlaceholderText('Search');
+    fireEvent.change(input, { target: { value: 'fail-case' } });
+
+    const actionLabel = await screen.findByText('Failing Action');
+    fireEvent.click(actionLabel.closest('button') as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(screen.getByText('Operation failed')).toBeInTheDocument();
+    });
+
+    unregister();
+  });
+});

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -3,6 +3,12 @@ import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import {
+  executeSpotlightAction,
+  searchSpotlightActions,
+  SpotlightActionDefinition,
+  SpotlightActionResult,
+} from '../screen/spotlight-actions';
 
 type AppMeta = {
   id: string;
@@ -25,6 +31,10 @@ const WhiskerMenu: React.FC = () => {
   const [category, setCategory] = useState('all');
   const [query, setQuery] = useState('');
   const [highlight, setHighlight] = useState(0);
+  const [actionResult, setActionResult] = useState<
+    { id: string; result: SpotlightActionResult }
+  | null>(null);
+  const [runningActionId, setRunningActionId] = useState<string | null>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -66,14 +76,80 @@ const WhiskerMenu: React.FC = () => {
     return list;
   }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps]);
 
+  const quickActions = useMemo<SpotlightActionDefinition[]>(() => {
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+    return searchSpotlightActions(trimmed);
+  }, [query]);
+
+  const combinedItems = useMemo(() => {
+    const actions = quickActions.map((action) => ({
+      type: 'action' as const,
+      action,
+    }));
+    const apps = currentApps.map((app) => ({
+      type: 'app' as const,
+      app,
+    }));
+    return [...actions, ...apps];
+  }, [quickActions, currentApps]);
+
   useEffect(() => {
     if (!open) return;
     setHighlight(0);
-  }, [open, category, query]);
+  }, [open, category, query, quickActions.length]);
+
+  useEffect(() => {
+    if (!combinedItems.length) {
+      setHighlight(0);
+      return;
+    }
+    setHighlight((h) => Math.min(h, combinedItems.length - 1));
+  }, [combinedItems.length]);
+
+  useEffect(() => {
+    if (!open) {
+      setActionResult(null);
+      setRunningActionId(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!actionResult) return;
+    const timeout = window.setTimeout(() => setActionResult(null), 3000);
+    return () => window.clearTimeout(timeout);
+  }, [actionResult]);
 
   const openSelectedApp = (id: string) => {
     window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
     setOpen(false);
+  };
+
+  const runAction = async (action: SpotlightActionDefinition) => {
+    setRunningActionId(action.id);
+    const result = await executeSpotlightAction(action.id);
+    const message =
+      result.message ||
+      (result.status === 'success' ? 'Action completed.' : 'Action failed.');
+    const finalResult: SpotlightActionResult = { ...result, message };
+    setActionResult({ id: action.id, result: finalResult });
+    setRunningActionId(null);
+    if (
+      finalResult.status === 'success' &&
+      (finalResult.closeMenu ?? action.closeOnSuccess ?? false)
+    ) {
+      setOpen(false);
+    }
+  };
+
+  const handleSelect = (index: number) => {
+    const item = combinedItems[index];
+    if (!item) return;
+    if (item.type === 'app') {
+      openSelectedApp(item.app.id);
+    } else {
+      runAction(item.action);
+    }
   };
 
   useEffect(() => {
@@ -88,19 +164,19 @@ const WhiskerMenu: React.FC = () => {
         setOpen(false);
       } else if (e.key === 'ArrowDown') {
         e.preventDefault();
-        setHighlight(h => Math.min(h + 1, currentApps.length - 1));
+        if (!combinedItems.length) return;
+        setHighlight((h) => Math.min(h + 1, combinedItems.length - 1));
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
         setHighlight(h => Math.max(h - 1, 0));
       } else if (e.key === 'Enter') {
         e.preventDefault();
-        const app = currentApps[highlight];
-        if (app) openSelectedApp(app.id);
+        handleSelect(highlight);
       }
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [open, currentApps, highlight]);
+  }, [open, combinedItems, highlight]);
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
@@ -161,19 +237,78 @@ const WhiskerMenu: React.FC = () => {
               onChange={e => setQuery(e.target.value)}
               autoFocus
             />
-            <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
-              {currentApps.map((app, idx) => (
-                <div key={app.id} className={idx === highlight ? 'ring-2 ring-ubb-orange' : ''}>
-                  <UbuntuApp
-                    id={app.id}
-                    icon={app.icon}
-                    name={app.title}
-                    openApp={() => openSelectedApp(app.id)}
-                    disabled={app.disabled}
-                  />
+            {actionResult && (
+              <div
+                className={`mb-2 text-xs ${
+                  actionResult.result.status === 'success'
+                    ? 'text-green-300'
+                    : 'text-red-300'
+                }`}
+                role="status"
+              >
+                {actionResult.result.message}
+              </div>
+            )}
+            {quickActions.length > 0 && (
+              <div className="mb-3">
+                <div className="text-xs uppercase tracking-wide text-gray-300 mb-1">
+                  Quick Actions
                 </div>
-              ))}
-            </div>
+                <ul className="space-y-1">
+                  {quickActions.map((action, idx) => {
+                    const isHighlighted = highlight === idx;
+                    const isRunning = runningActionId === action.id;
+                    return (
+                      <li key={action.id}>
+                        <button
+                          type="button"
+                          onClick={() => runAction(action)}
+                          disabled={isRunning}
+                          className={`w-full text-left px-3 py-2 rounded transition-colors duration-100 ${
+                            isHighlighted
+                              ? 'bg-ub-orange text-black'
+                              : 'bg-black bg-opacity-20 hover:bg-opacity-30'
+                          } ${isRunning ? 'opacity-70' : ''}`}
+                        >
+                          <div className="flex justify-between items-center">
+                            <span className="font-semibold">{action.title}</span>
+                            {isRunning && (
+                              <span className="text-xs opacity-80">Running…</span>
+                            )}
+                          </div>
+                          {action.description && (
+                            <div className="text-xs opacity-80">
+                              {action.description}
+                            </div>
+                          )}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
+            {currentApps.length > 0 ? (
+              <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
+                {currentApps.map((app, idx) => {
+                  const globalIndex = quickActions.length + idx;
+                  const isHighlighted = highlight === globalIndex;
+                  return (
+                    <div key={app.id} className={isHighlighted ? 'ring-2 ring-ubb-orange' : ''}>
+                      <UbuntuApp
+                        id={app.id}
+                        icon={app.icon}
+                        name={app.title}
+                        openApp={() => openSelectedApp(app.id)}
+                        disabled={app.disabled}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            ) : combinedItems.length === 0 ? (
+              <div className="text-xs text-gray-300">No results found.</div>
+            ) : null}
           </div>
         </div>
       )}

--- a/components/screen/spotlight-actions.ts
+++ b/components/screen/spotlight-actions.ts
@@ -1,0 +1,227 @@
+import { getTheme, isDarkTheme, setTheme } from '../../utils/theme';
+
+export type SpotlightActionStatus = 'success' | 'error';
+
+export interface SpotlightActionResult {
+  status: SpotlightActionStatus;
+  message?: string;
+  closeMenu?: boolean;
+}
+
+export interface SpotlightActionMetadata {
+  /**
+   * Stable identifier used for lookup and plugin registration.
+   */
+  id: string;
+  /**
+   * Primary label shown in spotlight results.
+   */
+  title: string;
+  /**
+   * Short helper text displayed under the title.
+   */
+  description?: string;
+  /**
+   * Extra search keywords to improve discoverability.
+   */
+  keywords?: string[];
+  /**
+   * Optional icon URL when rendering custom results.
+   */
+  icon?: string;
+  /**
+   * When true, close the spotlight menu automatically after a successful run.
+   */
+  closeOnSuccess?: boolean;
+}
+
+export interface SpotlightActionDefinition extends SpotlightActionMetadata {
+  /**
+   * Execute the action. Returning {@link SpotlightActionResult} controls
+   * the success state surfaced to the user.
+   */
+  run: () => Promise<SpotlightActionResult | void> | SpotlightActionResult | void;
+}
+
+const registry = new Map<string, SpotlightActionDefinition>();
+
+export const registerSpotlightAction = (
+  action: SpotlightActionDefinition,
+): (() => void) => {
+  if (registry.has(action.id)) {
+    throw new Error(`Spotlight action with id "${action.id}" already registered`);
+  }
+  registry.set(action.id, action);
+  return () => {
+    registry.delete(action.id);
+  };
+};
+
+export const unregisterSpotlightAction = (id: string): void => {
+  registry.delete(id);
+};
+
+export const listSpotlightActions = (): SpotlightActionDefinition[] =>
+  Array.from(registry.values());
+
+export const searchSpotlightActions = (query: string): SpotlightActionDefinition[] => {
+  const normalised = query.trim().toLowerCase();
+  if (!normalised) return listSpotlightActions();
+  return listSpotlightActions().filter((action) => {
+    const haystack = [
+      action.title,
+      action.description,
+      ...(action.keywords ?? []),
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(normalised);
+  });
+};
+
+export const executeSpotlightAction = async (
+  id: string,
+): Promise<SpotlightActionResult> => {
+  const action = registry.get(id);
+  if (!action) {
+    return {
+      status: 'error',
+      message: `Action \"${id}\" not found`,
+    };
+  }
+  try {
+    const result = await action.run();
+    if (!result) {
+      return { status: 'success' };
+    }
+    return result;
+  } catch (error) {
+    return {
+      status: 'error',
+      message: error instanceof Error ? error.message : 'Action failed',
+    };
+  }
+};
+
+const persistQuickSettingsTheme = (theme: 'dark' | 'light') => {
+  try {
+    window.localStorage.setItem('qs-theme', JSON.stringify(theme));
+  } catch {
+    // ignore persistence errors
+  }
+};
+
+const toggleTheme: SpotlightActionDefinition = {
+  id: 'toggle-theme',
+  title: 'Toggle Theme',
+  description: 'Switch between light and dark appearance.',
+  keywords: ['dark mode', 'light mode'],
+  run: () => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return {
+        status: 'error',
+        message: 'Theme toggle requires a browser environment.',
+      };
+    }
+    const current = getTheme();
+    const next = isDarkTheme(current) ? 'default' : 'dark';
+    setTheme(next);
+    persistQuickSettingsTheme(next === 'dark' ? 'dark' : 'light');
+    window.document.documentElement.dataset.theme = next;
+    window.dispatchEvent(
+      new CustomEvent('settings:theme-change', { detail: next }),
+    );
+    return {
+      status: 'success',
+      message: `Theme set to ${next === 'dark' ? 'dark' : 'light'} mode`,
+    };
+  },
+};
+
+const openTerminal: SpotlightActionDefinition = {
+  id: 'open-terminal',
+  title: 'Open Terminal',
+  description: 'Launch the terminal application.',
+  keywords: ['shell', 'console', 'command'],
+  closeOnSuccess: true,
+  run: () => {
+    if (typeof window === 'undefined') {
+      return {
+        status: 'error',
+        message: 'Terminal can only be opened in the browser.',
+      };
+    }
+    window.dispatchEvent(new CustomEvent('open-app', { detail: 'terminal' }));
+    return {
+      status: 'success',
+      message: 'Opening Terminal…',
+      closeMenu: true,
+    };
+  },
+};
+
+const LOCAL_STORAGE_CACHE_KEYS = [
+  'recentApps',
+  'lastPluginRun',
+  'installedPlugins',
+];
+
+const clearCache: SpotlightActionDefinition = {
+  id: 'clear-cache',
+  title: 'Clear Cache',
+  description: 'Remove cached data and stored plugin results.',
+  keywords: ['storage', 'offline', 'reset'],
+  run: async () => {
+    if (typeof window === 'undefined') {
+      return {
+        status: 'error',
+        message: 'Cache clearing requires a browser context.',
+      };
+    }
+    const cleared: string[] = [];
+    if ('caches' in window) {
+      try {
+        const keys = await window.caches.keys();
+        await Promise.all(keys.map((key) => window.caches.delete(key)));
+        if (keys.length) cleared.push('offline caches');
+      } catch (error) {
+        return {
+          status: 'error',
+          message: error instanceof Error ? error.message : 'Failed to clear caches',
+        };
+      }
+    }
+    try {
+      LOCAL_STORAGE_CACHE_KEYS.forEach((key) => {
+        window.localStorage.removeItem(key);
+      });
+      if (LOCAL_STORAGE_CACHE_KEYS.length) {
+        cleared.push('stored results');
+      }
+    } catch {
+      // ignore storage errors, user may have disabled access
+    }
+    const message = cleared.length
+      ? `Cleared ${cleared.join(' and ')}`
+      : 'Nothing to clear';
+    return {
+      status: 'success',
+      message,
+    };
+  },
+};
+
+const builtins = [toggleTheme, openTerminal, clearCache];
+
+builtins.forEach((action) => {
+  if (!registry.has(action.id)) {
+    registry.set(action.id, action);
+  }
+});
+
+export const __TEST_ONLY__resetSpotlightRegistry = () => {
+  registry.clear();
+  builtins.forEach((action) => registry.set(action.id, action));
+};
+


### PR DESCRIPTION
## Summary
- add a reusable spotlight quick-action registry with built-in commands and plugin API
- surface quick actions inside the spotlight search menu with feedback and keyboard support
- add tests covering registry execution and spotlight UI success/error states

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window issues in unrelated files)*
- yarn test spotlight-actions

------
https://chatgpt.com/codex/tasks/task_e_68cc38c9735c8328b21ead92963d6bb1