### PR TITLE
[qr] add styling controls with persistence

### DIFF
--- a/__tests__/apps/qr/styling.test.tsx
+++ b/__tests__/apps/qr/styling.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import QR from '../../../apps/qr';
+
+jest.mock('qrcode', () => ({
+  __esModule: true,
+  default: {
+    toCanvas: jest.fn(() => Promise.resolve()),
+    toString: jest.fn(() => Promise.resolve('<svg></svg>')),
+  },
+}));
+
+
+beforeAll(() => {
+  Object.defineProperty(window.HTMLCanvasElement.prototype, 'getContext', {
+    value: jest.fn(() => ({
+      clearRect: jest.fn(),
+      drawImage: jest.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+});
+
+describe('QR styling controls', () => {
+  it('shows a warning when the contrast ratio falls below WCAG guidance', async () => {
+    render(<QR />);
+
+    const foregroundInput = screen.getByLabelText('Foreground color') as HTMLInputElement;
+    const backgroundInput = screen.getByLabelText('Background color') as HTMLInputElement;
+
+    expect(foregroundInput.value).toBe('#000000');
+    expect(backgroundInput.value).toBe('#ffffff');
+
+    fireEvent.change(foregroundInput, { target: { value: '#ffffff' } });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Warning: Low contrast may impact scanning/i),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Contrast ratio 1.00:1/i)).toBeInTheDocument();
+  });
+
+  it('persists styling preferences via safeLocalStorage and hydrates on load', async () => {
+    const { unmount } = render(<QR />);
+
+    fireEvent.change(screen.getByLabelText('Size'), { target: { value: '512' } });
+    fireEvent.change(screen.getByLabelText('Margin'), { target: { value: '4' } });
+    fireEvent.change(screen.getByLabelText('ECC'), { target: { value: 'H' } });
+    fireEvent.change(screen.getByLabelText('Foreground color'), {
+      target: { value: '#ff0000' },
+    });
+    fireEvent.change(screen.getByLabelText('Background color'), {
+      target: { value: '#00ff00' },
+    });
+
+    await waitFor(() => {
+      const storedRaw = localStorage.getItem('qr-style-preferences');
+      expect(storedRaw).not.toBeNull();
+      const stored = JSON.parse(storedRaw ?? '{}');
+      expect(stored).toMatchObject({
+        size: 512,
+        margin: 4,
+        ecc: 'H',
+        foregroundColor: '#ff0000',
+        backgroundColor: '#00ff00',
+      });
+    });
+
+    unmount();
+
+    render(<QR />);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Size') as HTMLSelectElement).value).toBe('512');
+    });
+
+    expect((screen.getByLabelText('Margin') as HTMLSelectElement).value).toBe('4');
+    expect((screen.getByLabelText('ECC') as HTMLSelectElement).value).toBe('H');
+    expect((screen.getByLabelText('Foreground color') as HTMLInputElement).value).toBe(
+      '#ff0000',
+    );
+    expect((screen.getByLabelText('Background color') as HTMLInputElement).value).toBe(
+      '#00ff00',
+    );
+  });
+});

--- a/apps/qr/components/Presets.tsx
+++ b/apps/qr/components/Presets.tsx
@@ -16,6 +16,8 @@ interface Props {
   margin: number;
   ecc: 'L' | 'M' | 'Q' | 'H';
   logo?: string | null;
+  foregroundColor: string;
+  backgroundColor: string;
 }
 
 const Presets: React.FC<Props> = ({
@@ -25,6 +27,8 @@ const Presets: React.FC<Props> = ({
   margin,
   ecc,
   logo,
+  foregroundColor,
+  backgroundColor,
 }) => {
   const [preset, setPreset] = useState<Preset>('text');
   const [text, setText] = useState('');
@@ -59,6 +63,10 @@ const Presets: React.FC<Props> = ({
       margin,
       width: size,
       errorCorrectionLevel: ecc,
+      color: {
+        dark: foregroundColor,
+        light: backgroundColor,
+      },
     })
       .then(() => {
         if (logo) {
@@ -79,7 +87,16 @@ const Presets: React.FC<Props> = ({
         const ctx = canvas.getContext('2d');
         if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
       });
-  }, [payload, canvasRef, size, margin, ecc, logo]);
+  }, [
+    payload,
+    canvasRef,
+    size,
+    margin,
+    ecc,
+    logo,
+    foregroundColor,
+    backgroundColor,
+  ]);
 
   const copyPayload = async () => {
     if (!payload) return;


### PR DESCRIPTION
## Summary
- add configurable foreground and background pickers to the QR generator, persisting selections and surfacing WCAG contrast warnings
- propagate color configuration into QR rendering so canvases and SVG exports respect the chosen palette
- cover contrast messaging and preference hydration with targeted unit tests

## Testing
- yarn lint *(fails: repository has pre-existing accessibility rule violations unrelated to this change)*
- yarn test __tests__/apps/qr/styling.test.tsx --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cc38df2dac83288013b56e7289e048