### PR TITLE
[qr] add batch mode component

### DIFF
--- a/__tests__/apps/qr/batch-mode.test.tsx
+++ b/__tests__/apps/qr/batch-mode.test.tsx
@@ -1,0 +1,60 @@
+import JSZip from 'jszip';
+import {
+  BatchResult,
+  createZipFromBatch,
+  parseCsvRows,
+  templateFilename,
+} from '../../../apps/qr/components/BatchMode';
+
+describe('BatchMode helpers', () => {
+  it('parses CSV rows with headers and quoted values', () => {
+    const csv = ['text,name,category', '"https://example.com","Example","Primary"', '"Hello, world","Greeting","Secondary"'].join('\n');
+    const rows = parseCsvRows(csv);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].text).toBe('https://example.com');
+    expect(rows[0].columns.name).toBe('Example');
+    expect(rows[1].text).toBe('Hello, world');
+    expect(rows[1].columns.category).toBe('Secondary');
+  });
+
+  it('falls back to positional columns when no header is present', () => {
+    const csv = ['first row,alpha', 'second row,beta'].join('\n');
+    const rows = parseCsvRows(csv);
+
+    expect(rows.map((row) => row.text)).toEqual(['first row', 'second row']);
+    expect(rows[0].columns.column2).toBe('alpha');
+  });
+
+  it('creates a ZIP archive with PNG and SVG entries', async () => {
+    const pngData = Buffer.from('png-data');
+    const dataUrl = `data:image/png;base64,${pngData.toString('base64')}`;
+
+    const batch: BatchResult[] = [
+      {
+        filename: templateFilename('{{row}}-{{column2}}', {
+          columns: { column1: 'value', column2: 'alpha' },
+          rowNumber: 1,
+          text: 'value',
+        }, 0),
+        png: dataUrl,
+        svg: '<svg>alpha</svg>',
+        rowNumber: 1,
+        columns: { column1: 'value', column2: 'alpha' },
+      },
+    ];
+
+    const zip = createZipFromBatch(batch);
+    expect(zip).toBeInstanceOf(JSZip);
+
+    const files = Object.keys(zip.files);
+    expect(files).toEqual(expect.arrayContaining(['1-alpha.png', '1-alpha.svg']));
+
+    const pngBytes = await zip.file('1-alpha.png')?.async('uint8array');
+    expect(pngBytes).toBeDefined();
+    expect(Buffer.from(pngBytes as Uint8Array).toString()).toBe('png-data');
+
+    const svg = await zip.file('1-alpha.svg')?.async('string');
+    expect(svg).toBe('<svg>alpha</svg>');
+  });
+});

--- a/apps/qr/components/BatchMode.tsx
+++ b/apps/qr/components/BatchMode.tsx
@@ -1,0 +1,474 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import JSZip from 'jszip';
+
+const HEADER_SIGNALS = [
+  'text',
+  'value',
+  'name',
+  'filename',
+  'label',
+  'url',
+  'payload',
+  'data',
+  'content',
+  'code',
+];
+
+const INVALID_FILENAME_CHARS = /[<>:"/\\|?*\x00-\x1f]/g;
+
+export interface ParsedCsvRow {
+  columns: Record<string, string>;
+  rowNumber: number;
+  text: string;
+}
+
+export interface BatchResult {
+  filename: string;
+  png: string;
+  svg: string;
+  rowNumber: number;
+  columns: Record<string, string>;
+}
+
+const splitCsv = (input: string): string[][] => {
+  const rows: string[][] = [];
+  let current = '';
+  let row: string[] = [];
+  let inQuotes = false;
+
+  const pushCell = () => {
+    row.push(current.trim());
+    current = '';
+  };
+
+  const pushRow = () => {
+    if (row.length > 0 || current.trim()) {
+      pushCell();
+      rows.push(row);
+    }
+    row = [];
+  };
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+
+    if (char === '"') {
+      if (inQuotes && input[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (!inQuotes && (char === '\n' || char === '\r')) {
+      if (char === '\r' && input[i + 1] === '\n') i += 1;
+      pushRow();
+      continue;
+    }
+
+    if (!inQuotes && char === ',') {
+      pushCell();
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current || row.length) {
+    pushCell();
+    rows.push(row);
+  }
+
+  return rows.filter((cols) => cols.some((cell) => cell.trim() !== ''));
+};
+
+export const parseCsvRows = (input: string): ParsedCsvRow[] => {
+  const matrix = splitCsv(input);
+  if (!matrix.length) return [];
+
+  const headerCandidates = matrix[0].map((cell, index) => cell.trim() || `column${index + 1}`);
+  const hasHeaderSignals = headerCandidates.some((cell) =>
+    HEADER_SIGNALS.some((signal) => cell.toLowerCase().includes(signal)),
+  );
+
+  const headers = hasHeaderSignals
+    ? headerCandidates
+    : headerCandidates.map((_, index) => `column${index + 1}`);
+  const dataRows = hasHeaderSignals ? matrix.slice(1) : matrix;
+
+  return dataRows
+    .map((cells, rowIndex) => {
+      const columns: Record<string, string> = {};
+      headers.forEach((header, colIndex) => {
+        columns[header] = cells[colIndex]?.trim() ?? '';
+      });
+
+      const preferredKeys = [
+        'text',
+        'value',
+        'payload',
+        'data',
+        'url',
+        'content',
+        headers[0],
+      ];
+
+      let text = '';
+      for (const key of preferredKeys) {
+        if (key && columns[key]) {
+          text = columns[key];
+          break;
+        }
+      }
+      if (!text) {
+        const values = Object.values(columns);
+        text = values[0] ?? '';
+      }
+
+      return {
+        columns,
+        rowNumber: rowIndex + 1,
+        text,
+      } satisfies ParsedCsvRow;
+    })
+    .filter((row) => row.text !== '');
+};
+
+export const templateFilename = (
+  template: string,
+  row: ParsedCsvRow,
+  fallbackIndex: number,
+): string => {
+  const tokens = new Map<string, string>();
+  tokens.set('row', String(row.rowNumber));
+
+  Object.entries(row.columns).forEach(([key, value]) => {
+    const trimmedKey = key.trim();
+    const normalizedKey = trimmedKey.replace(/\s+/g, '_');
+    tokens.set(trimmedKey, value);
+    tokens.set(trimmedKey.toLowerCase(), value);
+    tokens.set(normalizedKey, value);
+    tokens.set(normalizedKey.toLowerCase(), value);
+  });
+
+  const resolved = template.replace(/{{\s*([^}]+)\s*}}/g, (_, rawKey: string) => {
+    const key = rawKey.trim();
+    return (
+      tokens.get(key) ??
+      tokens.get(key.toLowerCase()) ??
+      tokens.get(key.replace(/\s+/g, '_')) ??
+      tokens.get(key.replace(/\s+/g, '_').toLowerCase()) ??
+      ''
+    );
+  });
+
+  const sanitized = resolved
+    .trim()
+    .replace(INVALID_FILENAME_CHARS, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^\.+/, '')
+    .replace(/\.+$/, '')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '');
+
+  if (sanitized) return sanitized;
+  return `code-${fallbackIndex + 1}`;
+};
+
+export const dataUrlToUint8Array = (dataUrl: string): Uint8Array => {
+  const base64 = dataUrl.split(',')[1] ?? '';
+  if (!base64) return new Uint8Array();
+
+  if (typeof globalThis.atob === 'function') {
+    const binary = globalThis.atob(base64);
+    const len = binary.length;
+    const bytes = new Uint8Array(len);
+    for (let i = 0; i < len; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+
+  if (typeof Buffer === 'function') {
+    const buffer = Buffer.from(base64, 'base64');
+    return new Uint8Array(buffer);
+  }
+
+  return new Uint8Array();
+};
+
+export const createZipFromBatch = (items: BatchResult[]): JSZip => {
+  const zip = new JSZip();
+  items.forEach((item) => {
+    if (item.png) {
+      zip.file(`${item.filename}.png`, dataUrlToUint8Array(item.png), { binary: true });
+    }
+    if (item.svg) {
+      zip.file(`${item.filename}.svg`, item.svg);
+    }
+  });
+  return zip;
+};
+
+interface BatchModeProps {
+  size?: number;
+  margin?: number;
+  ecc?: 'L' | 'M' | 'Q' | 'H';
+}
+
+const PreviewCanvas: React.FC<{ dataUrl: string; size: number; label: string }> = ({
+  dataUrl,
+  size,
+  label,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    if (!dataUrl) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      return;
+    }
+
+    const img = new Image();
+    img.src = dataUrl;
+    img.onload = () => {
+      canvas.width = size;
+      canvas.height = size;
+      ctx.clearRect(0, 0, size, size);
+      ctx.drawImage(img, 0, 0, size, size);
+    };
+
+    return () => {
+      img.onload = null;
+    };
+  }, [dataUrl, size]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={size}
+      height={size}
+      aria-label={label}
+      className="w-32 h-32 bg-white"
+    />
+  );
+};
+
+const BatchMode: React.FC<BatchModeProps> = ({ size = 256, margin = 1, ecc = 'M' }) => {
+  const [csvInput, setCsvInput] = useState('');
+  const [template, setTemplate] = useState('{{name}}');
+  const [results, setResults] = useState<BatchResult[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [progress, setProgress] = useState({ current: 0, total: 0 });
+  const [error, setError] = useState('');
+
+  const workerRef = useRef<Worker | null>(null);
+  const cancelledRef = useRef(false);
+
+  const initWorker = useCallback(() => {
+    if (typeof window === 'undefined' || typeof Worker === 'undefined') return null;
+    if (!workerRef.current) {
+      workerRef.current = new Worker(
+        new URL('../../../workers/qrEncode.worker.ts', import.meta.url),
+      );
+    }
+    return workerRef.current;
+  }, []);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    return () => {
+      cancelledRef.current = true;
+      workerRef.current?.terminate();
+    };
+  }, []);
+
+  const encodeWithWorker = useCallback(
+    (text: string) =>
+      new Promise<{ png: string; svg: string }>((resolve) => {
+        const worker = initWorker();
+        if (!worker) {
+          resolve({ png: '', svg: '' });
+          return;
+        }
+
+        const handleMessage = (event: MessageEvent<{ png: string; svg: string }>) => {
+          worker.removeEventListener('message', handleMessage as EventListener);
+          resolve(event.data);
+        };
+
+        worker.addEventListener('message', handleMessage as EventListener);
+        worker.postMessage({
+          text,
+          opts: {
+            margin,
+            width: size,
+            errorCorrectionLevel: ecc,
+          },
+        });
+      }),
+    [ecc, initWorker, margin, size],
+  );
+
+  const handleGenerate = useCallback(async () => {
+    const parsedRows = parseCsvRows(csvInput);
+    setError('');
+    setResults([]);
+
+    if (!parsedRows.length) {
+      setProgress({ current: 0, total: 0 });
+      setError('No rows detected in CSV input.');
+      return;
+    }
+
+    const worker = initWorker();
+    if (!worker) {
+      setError('Batch mode requires Web Worker support.');
+      return;
+    }
+
+    setIsGenerating(true);
+    setProgress({ current: 0, total: parsedRows.length });
+
+    const generated: BatchResult[] = [];
+    for (let i = 0; i < parsedRows.length; i += 1) {
+      if (cancelledRef.current) break;
+      const row = parsedRows[i];
+      if (!row.text) {
+        setProgress({ current: i + 1, total: parsedRows.length });
+        continue;
+      }
+
+      const filename = templateFilename(template, row, i);
+      try {
+        const { png, svg } = await encodeWithWorker(row.text);
+        generated.push({
+          filename,
+          png,
+          svg,
+          rowNumber: row.rowNumber,
+          columns: row.columns,
+        });
+      } catch {
+        // ignore encoding errors for individual rows
+      }
+      setProgress({ current: i + 1, total: parsedRows.length });
+    }
+
+    if (!cancelledRef.current) {
+      setResults(generated);
+    }
+
+    setIsGenerating(false);
+  }, [cancelledRef, csvInput, encodeWithWorker, initWorker, template]);
+
+  const downloadZip = useCallback(async () => {
+    if (!results.length) return;
+    const zip = createZipFromBatch(results);
+    const blob = await zip.generateAsync({ type: 'blob' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'qr-batch.zip';
+    link.click();
+    URL.revokeObjectURL(url);
+  }, [results]);
+
+  const { current: progressCurrent, total: progressTotal } = progress;
+  const progressLabel = useMemo(() => {
+    if (!progressTotal) return '';
+    const percent = Math.round((progressCurrent / progressTotal) * 100);
+    return `${progressCurrent}/${progressTotal} (${percent}%)`;
+  }, [progressCurrent, progressTotal]);
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <label htmlFor="batch-csv" className="block text-sm">
+          CSV rows
+          <textarea
+            id="batch-csv"
+            className="w-full mt-1 rounded p-2 text-black"
+            rows={6}
+            placeholder="text,name\nhttps://example.com,Homepage"
+            value={csvInput}
+            onChange={(event) => setCsvInput(event.target.value)}
+            aria-label="Batch CSV rows"
+          />
+        </label>
+        <label htmlFor="batch-template" className="block text-sm">
+          Filename template
+          <input
+            id="batch-template"
+            type="text"
+            className="w-full mt-1 rounded p-1 text-black"
+            value={template}
+            onChange={(event) => setTemplate(event.target.value)}
+            placeholder="{{name}}"
+            aria-label="Filename template"
+          />
+        </label>
+        <p className="text-xs text-gray-300">
+          Use placeholders like {'{{name}}'}, {'{{url}}'} or {'{{row}}'} to build filenames.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={handleGenerate}
+          disabled={isGenerating}
+          className="px-3 py-1 bg-blue-600 rounded disabled:opacity-60"
+        >
+          {isGenerating ? 'Generating…' : 'Preview batch'}
+        </button>
+        <button
+          type="button"
+          onClick={downloadZip}
+          disabled={!results.length || isGenerating}
+          className="px-3 py-1 bg-green-600 rounded disabled:opacity-60"
+        >
+          Download ZIP
+        </button>
+        {progressLabel && (
+          <span className="text-xs text-gray-200 self-center">{progressLabel}</span>
+        )}
+      </div>
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+
+      {isGenerating && (
+        <div role="status" className="text-sm text-gray-200">
+          Processing batch… {progressLabel}
+        </div>
+      )}
+
+      {results.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-xs text-gray-300">Preview ({results.length} items)</p>
+          <div className="grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-4">
+            {results.map((item) => (
+              <div key={`${item.filename}-${item.rowNumber}`} className="space-y-1 text-center">
+                <PreviewCanvas
+                  dataUrl={item.png}
+                  size={size}
+                  label={`QR code for row ${item.rowNumber}`}
+                />
+                <div className="text-xs break-all text-gray-100">{item.filename}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BatchMode;

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "idb": "7.1.1",
     "idb-keyval": "^6.2.1",
     "jspdf": "^3.0.2",
+    "jszip": "^3.10.1",
     "kaitai-struct": "^0.10.0",
     "leaflet": "^1.9.4",
     "marked": "^16.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5791,6 +5791,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-util-is@npm:~1.0.0":
+  version: 1.0.3
+  resolution: "core-util-is@npm:1.0.3"
+  checksum: 10c0/90a0e40abbddfd7618f8ccd63a74d88deea94e77d0e8dbbea059fa7ebebb8fbb4e2909667fe26f3a467073de1a542ebe6ae4c73a73745ac5833786759cd906c9
+  languageName: node
+  linkType: hard
+
 "cose-base@npm:^1.0.0":
   version: 1.0.3
   resolution: "cose-base@npm:1.0.3"
@@ -8095,6 +8102,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immediate@npm:~3.0.5":
+  version: 3.0.6
+  resolution: "immediate@npm:3.0.6"
+  checksum: 10c0/f8ba7ede69bee9260241ad078d2d535848745ff5f6995c7c7cb41cfdc9ccc213f66e10fa5afb881f90298b24a3f7344b637b592beb4f54e582770cdce3f1f039
+  languageName: node
+  linkType: hard
+
 "import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
   version: 3.3.1
   resolution: "import-fresh@npm:3.3.1"
@@ -8135,6 +8149,13 @@ __metadata:
   version: 1.4.2
   resolution: "index-array-by@npm:1.4.2"
   checksum: 10c0/70cfb089148678236c620f471f75b3bec85da65f24cd44ea601c1eae8f6e0da5e1899cee08ed3a276bea1943b6f910fe6fa388276bca4667c6738bb44eae08cb
+  languageName: node
+  linkType: hard
+
+"inherits@npm:~2.0.3":
+  version: 2.0.4
+  resolution: "inherits@npm:2.0.4"
+  checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
   languageName: node
   linkType: hard
 
@@ -8531,6 +8552,13 @@ __metadata:
   version: 2.0.5
   resolution: "isarray@npm:2.0.5"
   checksum: 10c0/4199f14a7a13da2177c66c31080008b7124331956f47bca57dd0b6ea9f11687aa25e565a2c7a2b519bc86988d10398e3049a1f5df13c9f6b7664154690ae79fd
+  languageName: node
+  linkType: hard
+
+"isarray@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "isarray@npm:1.0.0"
+  checksum: 10c0/18b5be6669be53425f0b84098732670ed4e727e3af33bc7f948aac01782110eb9a18b3b329c5323bcdd3acdaae547ee077d3951317e7f133bff7105264b3003d
   languageName: node
   linkType: hard
 
@@ -9417,6 +9445,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jszip@npm:^3.10.1":
+  version: 3.10.1
+  resolution: "jszip@npm:3.10.1"
+  dependencies:
+    lie: "npm:~3.3.0"
+    pako: "npm:~1.0.2"
+    readable-stream: "npm:~2.3.6"
+    setimmediate: "npm:^1.0.5"
+  checksum: 10c0/58e01ec9c4960383fb8b38dd5f67b83ccc1ec215bf74c8a5b32f42b6e5fb79fada5176842a11409c4051b5b94275044851814a31076bf49e1be218d3ef57c863
+  languageName: node
+  linkType: hard
+
 "kaitai-struct@npm:^0.10.0":
   version: 0.10.0
   resolution: "kaitai-struct@npm:0.10.0"
@@ -9523,6 +9563,15 @@ __metadata:
     prelude-ls: "npm:~1.1.2"
     type-check: "npm:~0.3.2"
   checksum: 10c0/e440df9de4233da0b389cd55bd61f0f6aaff766400bebbccd1231b81801f6dbc1d816c676ebe8d70566394b749fa624b1ed1c68070e9c94999f0bdecc64cb676
+  languageName: node
+  linkType: hard
+
+"lie@npm:~3.3.0":
+  version: 3.3.0
+  resolution: "lie@npm:3.3.0"
+  dependencies:
+    immediate: "npm:~3.0.5"
+  checksum: 10c0/56dd113091978f82f9dc5081769c6f3b947852ecf9feccaf83e14a123bc630c2301439ce6182521e5fbafbde88e88ac38314327a4e0493a1bea7e0699a7af808
   languageName: node
   linkType: hard
 
@@ -10663,6 +10712,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pako@npm:~1.0.2":
+  version: 1.0.11
+  resolution: "pako@npm:1.0.11"
+  checksum: 10c0/86dd99d8b34c3930345b8bbeb5e1cd8a05f608eeb40967b293f72fe469d0e9c88b783a8777e4cc7dc7c91ce54c5e93d88ff4b4f060e6ff18408fd21030d9ffbe
+  languageName: node
+  linkType: hard
+
 "parent-module@npm:^1.0.0":
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
@@ -11080,6 +11136,13 @@ __metadata:
   version: 5.0.0
   resolution: "proc-log@npm:5.0.0"
   checksum: 10c0/bbe5edb944b0ad63387a1d5b1911ae93e05ce8d0f60de1035b218cdcceedfe39dbd2c697853355b70f1a090f8f58fe90da487c85216bf9671f9499d1a897e9e3
+  languageName: node
+  linkType: hard
+
+"process-nextick-args@npm:~2.0.0":
+  version: 2.0.1
+  resolution: "process-nextick-args@npm:2.0.1"
+  checksum: 10c0/bec089239487833d46b59d80327a1605e1c5287eaad770a291add7f45fda1bb5e28b38e0e061add0a1d0ee0984788ce74fa394d345eed1c420cacf392c554367
   languageName: node
   linkType: hard
 
@@ -12009,6 +12072,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readable-stream@npm:~2.3.6":
+  version: 2.3.8
+  resolution: "readable-stream@npm:2.3.8"
+  dependencies:
+    core-util-is: "npm:~1.0.0"
+    inherits: "npm:~2.0.3"
+    isarray: "npm:~1.0.0"
+    process-nextick-args: "npm:~2.0.0"
+    safe-buffer: "npm:~5.1.1"
+    string_decoder: "npm:~1.1.1"
+    util-deprecate: "npm:~1.0.1"
+  checksum: 10c0/7efdb01f3853bc35ac62ea25493567bf588773213f5f4a79f9c365e1ad13bab845ac0dae7bc946270dc40c3929483228415e92a3fc600cc7e4548992f41ee3fa
+  languageName: node
+  linkType: hard
+
 "readdirp@npm:~3.6.0":
   version: 3.6.0
   resolution: "readdirp@npm:3.6.0"
@@ -12335,6 +12413,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
+  version: 5.1.2
+  resolution: "safe-buffer@npm:5.1.2"
+  checksum: 10c0/780ba6b5d99cc9a40f7b951d47152297d0e260f0df01472a1b99d4889679a4b94a13d644f7dbc4f022572f09ae9005fa2fbb93bbbd83643316f365a3e9a45b21
+  languageName: node
+  linkType: hard
+
 "safe-push-apply@npm:^1.0.0":
   version: 1.0.0
   resolution: "safe-push-apply@npm:1.0.0"
@@ -12491,6 +12576,13 @@ __metadata:
     es-errors: "npm:^1.3.0"
     es-object-atoms: "npm:^1.0.0"
   checksum: 10c0/ca5c3ccbba479d07c30460e367e66337cec825560b11e8ba9c5ebe13a2a0d6021ae34eddf94ff3dfe17a3104dc1f191519cb6c48378b503e5c3f36393938776a
+  languageName: node
+  linkType: hard
+
+"setimmediate@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "setimmediate@npm:1.0.5"
+  checksum: 10c0/5bae81bfdbfbd0ce992893286d49c9693c82b1bcc00dcaaf3a09c8f428fdeacf4190c013598b81875dfac2b08a572422db7df779a99332d0fce186d15a3e4d49
   languageName: node
   linkType: hard
 
@@ -12964,6 +13056,15 @@ __metadata:
     define-properties: "npm:^1.2.1"
     es-object-atoms: "npm:^1.0.0"
   checksum: 10c0/d53af1899959e53c83b64a5fd120be93e067da740e7e75acb433849aa640782fb6c7d4cd5b84c954c84413745a3764df135a8afeb22908b86a835290788d8366
+  languageName: node
+  linkType: hard
+
+"string_decoder@npm:~1.1.1":
+  version: 1.1.1
+  resolution: "string_decoder@npm:1.1.1"
+  dependencies:
+    safe-buffer: "npm:~5.1.0"
+  checksum: 10c0/b4f89f3a92fd101b5653ca3c99550e07bdf9e13b35037e9e2a1c7b47cec4e55e06ff3fc468e314a0b5e80bfbaf65c1ca5a84978764884ae9413bec1fc6ca924e
   languageName: node
   linkType: hard
 
@@ -13920,6 +14021,7 @@ __metadata:
     jest: "npm:30.0.5"
     jest-environment-jsdom: "npm:30.0.5"
     jspdf: "npm:^3.0.2"
+    jszip: "npm:^3.10.1"
     kaitai-struct: "npm:^0.10.0"
     leaflet: "npm:^1.9.4"
     magic-string: "npm:0.30.18"
@@ -14086,7 +14188,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util-deprecate@npm:^1.0.2":
+"util-deprecate@npm:^1.0.2, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942


### PR DESCRIPTION
## Summary
- add a QR batch mode component that parses CSV rows, generates previews with the encoder worker, and streams zip downloads with templated filenames
- add JSZip to bundle the generated PNG/SVG assets into a ZIP archive
- cover the CSV parsing helpers and ZIP bundling logic with new unit tests

## Testing
- yarn eslint apps/qr/components/BatchMode.tsx __tests__/apps/qr/batch-mode.test.tsx --max-warnings=0
- yarn test batch-mode

------
https://chatgpt.com/codex/tasks/task_e_68cc38dff0788328aa7bd94ecb71047e