### PR TITLE
[qr] add camera streaming toggle and tests

### DIFF
--- a/__tests__/apps/qr/scan.test.tsx
+++ b/__tests__/apps/qr/scan.test.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import Scan from '../../../apps/qr/components/Scan';
+
+describe('Scan camera toggle', () => {
+  const originalMediaDevices = navigator.mediaDevices;
+  const originalBarcodeDetector = (window as any).BarcodeDetector;
+  const originalRequestAnimationFrame = window.requestAnimationFrame;
+  const originalCancelAnimationFrame = window.cancelAnimationFrame;
+  const playDescriptor = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'play');
+  const pauseDescriptor = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'pause');
+  const srcObjectDescriptor = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'srcObject');
+  const readyStateDescriptor = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'readyState');
+
+  let stopTrack: jest.Mock;
+  let getUserMedia: jest.Mock;
+
+  beforeEach(() => {
+    stopTrack = jest.fn();
+    getUserMedia = jest.fn().mockResolvedValue({
+      getTracks: () => [
+        {
+          stop: stopTrack,
+        },
+      ],
+    });
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getUserMedia,
+      },
+    });
+
+    class MockBarcodeDetector {
+      public detect = jest.fn().mockResolvedValue([]);
+    }
+
+    (window as any).BarcodeDetector = MockBarcodeDetector;
+
+    let rafHandle = 1;
+    const rafTimers = new Map<number, ReturnType<typeof setTimeout>>();
+
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      value: jest.fn().mockImplementation((cb: FrameRequestCallback) => {
+        const handle = setTimeout(() => cb(0), 0);
+        const id = rafHandle++;
+        rafTimers.set(id, handle);
+        return id;
+      }),
+    });
+
+    Object.defineProperty(window, 'cancelAnimationFrame', {
+      configurable: true,
+      value: jest.fn().mockImplementation((id: number) => {
+        const handle = rafTimers.get(id);
+        if (handle) {
+          clearTimeout(handle);
+          rafTimers.delete(id);
+        }
+      }),
+    });
+
+    Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+      configurable: true,
+      value: jest.fn().mockResolvedValue(undefined),
+    });
+
+    Object.defineProperty(HTMLMediaElement.prototype, 'pause', {
+      configurable: true,
+      value: jest.fn(),
+    });
+
+    Object.defineProperty(HTMLMediaElement.prototype, 'srcObject', {
+      configurable: true,
+      get() {
+        return (this as any)._srcObject ?? null;
+      },
+      set(value) {
+        (this as any)._srcObject = value;
+      },
+    });
+
+    Object.defineProperty(HTMLMediaElement.prototype, 'readyState', {
+      configurable: true,
+      get() {
+        return HTMLMediaElement.HAVE_ENOUGH_DATA;
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (originalMediaDevices) {
+      Object.defineProperty(navigator, 'mediaDevices', {
+        configurable: true,
+        value: originalMediaDevices,
+      });
+    } else {
+      delete (navigator as any).mediaDevices;
+    }
+
+    if (originalBarcodeDetector) {
+      (window as any).BarcodeDetector = originalBarcodeDetector;
+    } else {
+      delete (window as any).BarcodeDetector;
+    }
+
+    if (originalRequestAnimationFrame) {
+      Object.defineProperty(window, 'requestAnimationFrame', {
+        configurable: true,
+        value: originalRequestAnimationFrame,
+      });
+    } else {
+      delete (window as any).requestAnimationFrame;
+    }
+
+    if (originalCancelAnimationFrame) {
+      Object.defineProperty(window, 'cancelAnimationFrame', {
+        configurable: true,
+        value: originalCancelAnimationFrame,
+      });
+    } else {
+      delete (window as any).cancelAnimationFrame;
+    }
+
+    if (playDescriptor) {
+      Object.defineProperty(HTMLMediaElement.prototype, 'play', playDescriptor);
+    }
+    if (pauseDescriptor) {
+      Object.defineProperty(HTMLMediaElement.prototype, 'pause', pauseDescriptor);
+    }
+    if (srcObjectDescriptor) {
+      Object.defineProperty(HTMLMediaElement.prototype, 'srcObject', srcObjectDescriptor);
+    } else {
+      delete (HTMLMediaElement.prototype as any).srcObject;
+    }
+    if (readyStateDescriptor) {
+      Object.defineProperty(HTMLMediaElement.prototype, 'readyState', readyStateDescriptor);
+    }
+
+    delete (HTMLMediaElement.prototype as any)._srcObject;
+
+    jest.clearAllMocks();
+  });
+
+  it('stops media tracks when the camera toggle is switched off', async () => {
+    render(<Scan onResult={jest.fn()} />);
+
+    const startButton = await screen.findByRole('button', { name: /start camera/i });
+
+    await act(async () => {
+      fireEvent.click(startButton);
+    });
+
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(1));
+
+    const stopButton = await screen.findByRole('button', { name: /stop camera/i });
+
+    await act(async () => {
+      fireEvent.click(stopButton);
+    });
+
+    await waitFor(() => expect(stopTrack).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/qr/components/Scan.tsx
+++ b/apps/qr/components/Scan.tsx
@@ -1,100 +1,449 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 interface Props {
   onResult: (text: string) => void;
 }
 
+type ScanStatus = 'idle' | 'requesting' | 'scanning';
+
 const Scan: React.FC<Props> = ({ onResult }) => {
   const [preview, setPreview] = useState('');
   const [error, setError] = useState('');
+  const [isScanning, setIsScanning] = useState(false);
+  const [status, setStatus] = useState<ScanStatus>('idle');
+  const [cameraAvailable, setCameraAvailable] = useState<boolean>(() => {
+    if (typeof navigator === 'undefined') return false;
+    return Boolean(navigator.mediaDevices?.getUserMedia);
+  });
 
-  const handleDrop = useCallback(
-    async (e: React.DragEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      const file = e.dataTransfer.files[0];
-      if (!file || !file.type.startsWith('image/')) {
-        setError('');
-        return;
-      }
-      const url = URL.createObjectURL(file);
-      setPreview(url);
-      setError('');
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const animationRef = useRef<number>();
+  const barcodeDetectorRef = useRef<any>();
+  const zxingControlsRef = useRef<{ stop: () => void } | null>(null);
+  const objectUrlRef = useRef<string>();
+  const scanningRef = useRef(false);
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined') {
+      return;
+    }
+    setCameraAvailable(Boolean(navigator.mediaDevices?.getUserMedia));
+  }, []);
+
+  const revokePreviewUrl = useCallback(() => {
+    if (objectUrlRef.current) {
+      URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = undefined;
+    }
+  }, []);
+
+  const clearPreview = useCallback(() => {
+    revokePreviewUrl();
+    setPreview('');
+  }, [revokePreviewUrl]);
+
+  const stopCamera = useCallback(() => {
+    scanningRef.current = false;
+
+    if (typeof cancelAnimationFrame === 'function' && animationRef.current !== undefined) {
+      cancelAnimationFrame(animationRef.current);
+      animationRef.current = undefined;
+    }
+
+    if (zxingControlsRef.current) {
       try {
-        if ('BarcodeDetector' in window) {
-          const img = new Image();
-          img.src = url;
-          await img.decode();
-          const detector = new (window as any).BarcodeDetector({
-            formats: ['qr_code'],
-          });
-          const codes = await detector.detect(img);
-          if (codes[0]) onResult(codes[0].rawValue);
-        } else {
-          const { BrowserQRCodeReader } = await import('@zxing/browser');
-          const reader = new BrowserQRCodeReader();
-          const res = await reader.decodeFromImageUrl(url);
-          onResult(res.getText());
-        }
+        zxingControlsRef.current.stop();
       } catch {
-        setError('No QR code found');
+        // ignore errors stopping the ZXing controls
       }
+      zxingControlsRef.current = null;
+    }
+
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => {
+        try {
+          track.stop();
+        } catch {
+          // ignore stop errors
+        }
+      });
+      streamRef.current = null;
+    }
+
+    if (videoRef.current) {
+      try {
+        videoRef.current.pause();
+      } catch {
+        // ignore pause failures
+      }
+      try {
+        videoRef.current.srcObject = null;
+      } catch {
+        // ignore cleanup failures
+      }
+    }
+  }, []);
+
+  useEffect(() => stopCamera, [stopCamera]);
+
+  useEffect(() => () => revokePreviewUrl(), [revokePreviewUrl]);
+
+  const finishScan = useCallback(
+    (value: string) => {
+      setError('');
+      onResult(value);
+      setIsScanning(false);
     },
     [onResult],
   );
 
+  const startBarcodeLoop = useCallback(() => {
+    if (typeof window === 'undefined' || !(window as any).BarcodeDetector || typeof requestAnimationFrame !== 'function') {
+      return false;
+    }
+
+    try {
+      const detector =
+        barcodeDetectorRef.current ||
+        new (window as any).BarcodeDetector({
+          formats: ['qr_code'],
+        });
+      barcodeDetectorRef.current = detector;
+
+      const runDetection = async () => {
+        if (!scanningRef.current) return;
+        if (!videoRef.current || videoRef.current.readyState < HTMLMediaElement.HAVE_ENOUGH_DATA) {
+          animationRef.current = requestAnimationFrame(runDetection);
+          return;
+        }
+
+        try {
+          const codes = await detector.detect(videoRef.current);
+          const match = codes?.[0]?.rawValue;
+          if (match) {
+            finishScan(match);
+            return;
+          }
+        } catch {
+          // ignore frame detection errors
+        }
+
+        animationRef.current = requestAnimationFrame(runDetection);
+      };
+
+      animationRef.current = requestAnimationFrame(runDetection);
+      return true;
+    } catch {
+      return false;
+    }
+  }, [finishScan]);
+
+  const startZxingLoop = useCallback(async () => {
+    if (!videoRef.current || !scanningRef.current) {
+      return false;
+    }
+
+    try {
+      const { BrowserQRCodeReader } = await import('@zxing/browser');
+      if (!scanningRef.current) {
+        return false;
+      }
+
+      const reader = new BrowserQRCodeReader();
+      const controls = await reader.decodeFromVideoDevice(
+        undefined,
+        videoRef.current,
+        (result) => {
+          const text = result?.getText();
+          if (text) {
+            finishScan(text);
+          }
+        },
+      );
+
+      if (!scanningRef.current) {
+        controls.stop();
+        return false;
+      }
+
+      zxingControlsRef.current = controls;
+      return true;
+    } catch {
+      if (scanningRef.current) {
+        setError('Unable to start QR reader');
+        setStatus('idle');
+        setIsScanning(false);
+      }
+      return false;
+    }
+  }, [finishScan]);
+
+  useEffect(() => {
+    if (!isScanning) {
+      setStatus('idle');
+      stopCamera();
+      return;
+    }
+
+    clearPreview();
+    setError('');
+
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+      setStatus('idle');
+      setError('Camera access is not available in this browser');
+      setIsScanning(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const start = async () => {
+      setStatus('requesting');
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: 'environment' },
+        });
+
+        if (cancelled) {
+          stream.getTracks().forEach((track) => track.stop());
+          return;
+        }
+
+        streamRef.current = stream;
+        scanningRef.current = true;
+
+        if (videoRef.current) {
+          try {
+            videoRef.current.srcObject = stream;
+          } catch {
+            // ignore assignment errors
+          }
+
+          try {
+            await videoRef.current.play();
+          } catch {
+            // ignore autoplay failures
+          }
+        }
+
+        if (!scanningRef.current) {
+          stopCamera();
+          return;
+        }
+
+        setStatus('scanning');
+
+        const barcodeStarted = startBarcodeLoop();
+        if (!barcodeStarted) {
+          const fallbackStarted = await startZxingLoop();
+          if (!fallbackStarted && scanningRef.current) {
+            setError('Unable to scan from camera feed');
+            setStatus('idle');
+            setIsScanning(false);
+          }
+        }
+      } catch {
+        if (!cancelled) {
+          setStatus('idle');
+          setError('Unable to access camera');
+          setIsScanning(false);
+        }
+      }
+    };
+
+    start();
+
+    return () => {
+      cancelled = true;
+      stopCamera();
+    };
+  }, [clearPreview, isScanning, startBarcodeLoop, startZxingLoop, stopCamera]);
+
+  const processImageFile = useCallback(
+    async (file: File) => {
+      if (!file) {
+        return;
+      }
+
+      if (!file.type.startsWith('image/')) {
+        setError('Unsupported file type');
+        return;
+      }
+
+      setIsScanning(false);
+      setStatus('idle');
+      stopCamera();
+      setError('');
+
+      clearPreview();
+      const url = URL.createObjectURL(file);
+      objectUrlRef.current = url;
+      setPreview(url);
+
+      try {
+        if (typeof window !== 'undefined' && (window as any).BarcodeDetector) {
+          try {
+            const detector =
+              barcodeDetectorRef.current ||
+              new (window as any).BarcodeDetector({
+                formats: ['qr_code'],
+              });
+            barcodeDetectorRef.current = detector;
+
+            const img = new Image();
+            img.src = url;
+            await img.decode();
+            const codes = await detector.detect(img);
+            const match = codes?.[0]?.rawValue;
+            if (match) {
+              finishScan(match);
+              return;
+            }
+          } catch {
+            // fall back to ZXing
+          }
+        }
+
+        const { BrowserQRCodeReader } = await import('@zxing/browser');
+        const reader = new BrowserQRCodeReader();
+        const res = await reader.decodeFromImageUrl(url);
+        finishScan(res.getText());
+      } catch {
+        setError('No QR code found');
+      }
+    },
+    [clearPreview, finishScan, stopCamera],
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const file = e.dataTransfer.files?.[0];
+      if (!file) {
+        return;
+      }
+      void processImageFile(file);
+    },
+    [processImageFile],
+  );
+
+  const handleFileInput = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) {
+        return;
+      }
+      void processImageFile(file);
+      e.target.value = '';
+    },
+    [processImageFile],
+  );
+
+  const statusMessage = useMemo(() => {
+    switch (status) {
+      case 'requesting':
+        return 'Requesting camera access...';
+      case 'scanning':
+        return 'Scanning for QR codes...';
+      default:
+        return 'Camera idle';
+    }
+  }, [status]);
+
   return (
-    <div
-      onDragOver={(e) => e.preventDefault()}
-      onDrop={handleDrop}
-      className="w-full h-full relative flex items-center justify-center border-2 border-dashed border-gray-500 text-gray-400"
-    >
-      {preview ? (
-        <img src={preview} alt="Dropped" className="max-w-full max-h-full" />
+    <div className="flex h-full flex-col gap-4 text-gray-200">
+      {cameraAvailable ? (
+        <div className="flex items-center justify-between gap-2">
+          <button
+            type="button"
+            onClick={() => setIsScanning((prev) => !prev)}
+            className="rounded border border-gray-600 px-3 py-1 text-sm hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2 focus:ring-offset-gray-900"
+            aria-pressed={isScanning}
+          >
+            {isScanning ? 'Stop camera' : 'Start camera'}
+          </button>
+          <span className="text-xs text-gray-400" aria-live="polite">
+            {statusMessage}
+          </span>
+        </div>
       ) : (
-        <p>Drop image</p>
-      )}
-      {/* corner anchors */}
-      <svg
-        className="w-6 h-6 absolute top-0 left-0"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-      >
-        <path d="M3 9V3h6" />
-      </svg>
-      <svg
-        className="w-6 h-6 absolute top-0 right-0"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-      >
-        <path d="M21 9V3h-6" />
-      </svg>
-      <svg
-        className="w-6 h-6 absolute bottom-0 left-0"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-      >
-        <path d="M3 15v6h6" />
-      </svg>
-      <svg
-        className="w-6 h-6 absolute bottom-0 right-0"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-      >
-        <path d="M21 15v6h-6" />
-      </svg>
-      {error && (
-        <p className="absolute bottom-2 left-1/2 -translate-x-1/2 text-xs text-red-500">
-          {error}
+        <p className="text-xs text-gray-400" aria-live="polite">
+          Live camera scanning isn&apos;t available here. Upload an image below instead.
         </p>
       )}
+
+      <div
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={handleDrop}
+        className="relative flex flex-1 items-center justify-center overflow-hidden rounded border-2 border-dashed border-gray-500 text-gray-400"
+      >
+        {isScanning ? (
+          <video
+            ref={videoRef}
+            data-testid="qr-video"
+            className="absolute inset-0 h-full w-full object-cover"
+            autoPlay
+            playsInline
+            muted
+          />
+        ) : preview ? (
+          <img src={preview} alt="QR preview" className="max-h-full max-w-full object-contain" />
+        ) : (
+          <p className="px-4 text-center text-sm">Drop an image or start the camera to scan a QR code.</p>
+        )}
+
+        <svg
+          className="pointer-events-none absolute top-0 left-0 h-6 w-6 text-gray-500"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M3 9V3h6" />
+        </svg>
+        <svg
+          className="pointer-events-none absolute top-0 right-0 h-6 w-6 text-gray-500"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M21 9V3h-6" />
+        </svg>
+        <svg
+          className="pointer-events-none absolute bottom-0 left-0 h-6 w-6 text-gray-500"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M3 15v6h6" />
+        </svg>
+        <svg
+          className="pointer-events-none absolute bottom-0 right-0 h-6 w-6 text-gray-500"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M21 15v6h-6" />
+        </svg>
+
+        {error && (
+          <p className="pointer-events-none absolute bottom-2 left-1/2 -translate-x-1/2 rounded bg-gray-900/70 px-2 py-1 text-xs text-red-500">
+            {error}
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-col items-center gap-2 text-xs text-gray-400">
+        <label className="cursor-pointer rounded border border-gray-600 px-3 py-1 text-sm text-gray-200 hover:border-gray-400 focus-within:outline-none focus-within:ring-2 focus-within:ring-indigo-400 focus-within:ring-offset-2 focus-within:ring-offset-gray-900">
+          <span>Upload image</span>
+          <input type="file" accept="image/*" onChange={handleFileInput} className="sr-only" />
+        </label>
+        <p>Drop an image above to scan without camera access.</p>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- request camera access when toggled on, stream through BarcodeDetector/ZXing, and tear down tracks and timers when scanning stops
- surface progressive enhancement UI with live status, drag-and-drop upload, and labeled fallback file picker for browsers without camera access
- add a focused unit test that mocks media devices and asserts stream cleanup when the camera toggle is switched off

## Testing
- `yarn lint` *(fails: pre-existing repository lint errors unrelated to this change)*
- `yarn test __tests__/apps/qr/scan.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68cc38e0bf808328b0dbabafec606098