### PR TITLE
[apps] Add YAML data converter UI

### DIFF
--- a/__tests__/apps/data-converter/yaml-bridge.test.tsx
+++ b/__tests__/apps/data-converter/yaml-bridge.test.tsx
@@ -1,0 +1,136 @@
+import { parseDocument } from 'yaml';
+import {
+  convertJsonToYaml,
+  convertYamlToJson,
+} from '../../../apps/data-converter/components/YamlBridge';
+
+type KeyOrder = string[][];
+
+const collectObjectKeyOrders = (value: unknown): KeyOrder => {
+  const orders: KeyOrder = [];
+
+  const visit = (node: unknown) => {
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+
+    if (node && typeof node === 'object') {
+      const entries = Object.entries(node as Record<string, unknown>);
+      if (entries.length) {
+        orders.push(entries.map(([key]) => key));
+      }
+      entries.forEach(([, child]) => visit(child));
+    }
+  };
+
+  visit(value);
+  return orders;
+};
+
+const collectMapKeyOrders = (value: unknown): KeyOrder => {
+  const orders: KeyOrder = [];
+
+  const visit = (node: unknown) => {
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+
+    if (node instanceof Map) {
+      const keys = Array.from(node.keys()).map((key) => String(key));
+      if (keys.length) {
+        orders.push(keys);
+      }
+      for (const child of node.values()) {
+        visit(child);
+      }
+      return;
+    }
+
+    if (node && typeof node === 'object') {
+      const entries = Object.entries(node as Record<string, unknown>);
+      if (entries.length) {
+        orders.push(entries.map(([key]) => key));
+      }
+      entries.forEach(([, child]) => visit(child));
+    }
+  };
+
+  visit(value);
+  return orders;
+};
+
+describe('YamlBridge conversions', () => {
+  it('round-trips JSON to YAML and back while keeping key order', () => {
+    const jsonText = `{
+  "one": 1,
+  "two": {
+    "alpha": true,
+    "beta": "value",
+    "gamma": {
+      "inner": [
+        { "label": "first", "score": 1 },
+        { "label": "second", "score": 2 }
+      ]
+    }
+  },
+  "three": [
+    { "a": 1, "b": 2 },
+    { "c": 3, "d": 4 }
+  ]
+}`;
+
+    const { output: yamlFromJson } = convertJsonToYaml(jsonText);
+    const { output: jsonRoundTrip } = convertYamlToJson(yamlFromJson);
+
+    const original = JSON.parse(jsonText);
+    const roundTripped = JSON.parse(jsonRoundTrip);
+
+    expect(roundTripped).toEqual(original);
+    expect(collectObjectKeyOrders(roundTripped)).toEqual(
+      collectObjectKeyOrders(original),
+    );
+  });
+
+  it('round-trips YAML to JSON and back while keeping map ordering', () => {
+    const yamlText = `service: api
+metadata:
+  owner: ops
+  teams:
+    - name: response
+      pager: true
+    - name: platform
+      pager: false
+pipelines:
+  build:
+    steps:
+      - checkout
+      - test
+      - package
+  deploy:
+    strategy: rolling
+    regions:
+      - us-east-1
+      - eu-central-1
+`;
+
+    const { output: jsonFromYaml } = convertYamlToJson(yamlText);
+    const { output: yamlRoundTrip } = convertJsonToYaml(jsonFromYaml);
+
+    const originalDoc = parseDocument(yamlText);
+    const roundTripDoc = parseDocument(yamlRoundTrip);
+
+    const originalOrders = collectMapKeyOrders(
+      originalDoc.toJS({ mapAsMap: true }),
+    );
+    const roundTripOrders = collectMapKeyOrders(
+      roundTripDoc.toJS({ mapAsMap: true }),
+    );
+
+    expect(JSON.parse(jsonFromYaml)).toEqual(
+      JSON.parse(convertYamlToJson(yamlRoundTrip).output),
+    );
+    expect(roundTripOrders).toEqual(originalOrders);
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -26,6 +26,7 @@ const VsCodeApp = createDynamicApp('vscode', 'VsCode');
 const YouTubeApp = createDynamicApp('youtube', 'YouTube');
 const CalculatorApp = createDynamicApp('calculator', 'Calculator');
 const ConverterApp = createDynamicApp('converter', 'Converter');
+const DataConverterApp = createDynamicApp('data-converter', 'Data Converter');
 const TicTacToeApp = createDynamicApp('tictactoe', 'Tic Tac Toe');
 const ChessApp = createDynamicApp('chess', 'Chess');
 // Classic four-in-a-row game
@@ -120,6 +121,7 @@ const displayVsCode = createDisplay(VsCodeApp);
 const displayYouTube = createDisplay(YouTubeApp);
 const displayCalculator = createDisplay(CalculatorApp);
 const displayConverter = createDisplay(ConverterApp);
+const displayDataConverter = createDisplay(DataConverterApp);
 const displayTicTacToe = createDisplay(TicTacToeApp);
 const displayChess = createDisplay(ChessApp);
 const displayConnectFour = createDisplay(ConnectFourApp);
@@ -230,6 +232,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayClipboardManager,
+  },
+  {
+    id: 'data-converter',
+    title: 'Data Converter',
+    icon: '/themes/Yaru/apps/gedit.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayDataConverter,
   },
   {
     id: 'figlet',
@@ -799,6 +810,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayConverter,
+  },
+  {
+    id: 'data-converter',
+    title: 'Data Converter',
+    icon: '/themes/Yaru/apps/gedit.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayDataConverter,
   },
   {
     id: 'kismet',

--- a/apps/data-converter/components/YamlBridge.tsx
+++ b/apps/data-converter/components/YamlBridge.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { diffLines, type Change } from 'diff';
+import { Document, parseDocument } from 'yaml';
+
+export interface ConversionResult<TValue = unknown> {
+  doc: Document.Parsed<TValue>;
+  output: string;
+  value: TValue;
+}
+
+const mapLikeToObject = (value: unknown): unknown => {
+  if (value instanceof Map) {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of value.entries()) {
+      const stringKey = typeof key === 'string' ? key : String(key);
+      result[stringKey] = mapLikeToObject(val);
+    }
+    return result;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => mapLikeToObject(item));
+  }
+
+  if (value && typeof value === 'object') {
+    const proto = Object.getPrototypeOf(value);
+    if (proto === Object.prototype || proto === null) {
+      const result: Record<string, unknown> = {};
+      for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+        result[key] = mapLikeToObject(val);
+      }
+      return result;
+    }
+  }
+
+  return value;
+};
+
+export const convertJsonToYaml = (jsonText: string): ConversionResult<unknown> => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (error) {
+    throw new Error(`Invalid JSON: ${(error as Error).message}`);
+  }
+
+  const doc = new Document();
+  doc.contents = doc.createNode(parsed, { keepUndefined: false });
+  return {
+    doc,
+    output: doc.toString(),
+    value: parsed,
+  };
+};
+
+export const convertYamlToJson = (yamlText: string): ConversionResult<unknown> => {
+  const doc = parseDocument(yamlText, { keepSourceTokens: true });
+
+  if (doc.errors.length) {
+    const [firstError] = doc.errors;
+    throw new Error(`Invalid YAML: ${firstError.message}`);
+  }
+
+  const value = doc.toJS({ mapAsMap: true });
+  const normalized = mapLikeToObject(value);
+
+  return {
+    doc,
+    output: JSON.stringify(normalized, null, 2),
+    value: normalized,
+  };
+};
+
+export const canonicalizeJson = (jsonText: string): string => {
+  const { output } = convertJsonToYaml(jsonText);
+  const roundTrip = convertYamlToJson(output);
+  return roundTrip.output;
+};
+
+export const canonicalizeYaml = (yamlText: string): string => {
+  const { doc } = convertYamlToJson(yamlText);
+  return doc.toString();
+};
+
+const DEFAULT_JSON = `{
+  "service": "demo",
+  "metadata": {
+    "owner": "ops",
+    "tier": "gold"
+  },
+  "env": [
+    { "name": "HOST", "value": "localhost" },
+    { "name": "PORT", "value": 8080 }
+  ]
+}`;
+
+const DEFAULT_YAML = convertJsonToYaml(DEFAULT_JSON).output;
+
+const DiffViewer = ({ diff }: { diff: Change[] }) => {
+  const hasChanges = useMemo(
+    () => diff.some((part) => part.added || part.removed),
+    [diff],
+  );
+
+  return (
+    <div className="space-y-2">
+      <pre className="whitespace-pre-wrap rounded bg-gray-800 p-3 text-sm overflow-auto">
+        {diff.map((part, idx) => (
+          <span
+            key={idx}
+            className={
+              part.added
+                ? 'bg-green-900/60'
+                : part.removed
+                  ? 'bg-red-900/70 line-through'
+                  : ''
+            }
+          >
+            {part.value}
+          </span>
+        ))}
+      </pre>
+      {!hasChanges && <p className="text-xs text-gray-400">No differences detected.</p>}
+    </div>
+  );
+};
+
+const buttonBase =
+  'rounded bg-blue-600 px-3 py-1 text-sm font-medium text-white transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-1 focus:ring-offset-gray-900 disabled:cursor-not-allowed disabled:bg-gray-600';
+
+const secondaryButton =
+  'rounded bg-gray-700 px-3 py-1 text-sm font-medium text-white transition hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-1 focus:ring-offset-gray-900 disabled:cursor-not-allowed disabled:bg-gray-600';
+
+const YamlBridge = () => {
+  const [jsonText, setJsonText] = useState(DEFAULT_JSON);
+  const [yamlText, setYamlText] = useState(DEFAULT_YAML);
+  const [diff, setDiff] = useState<Change[] | null>(null);
+  const [diffLabel, setDiffLabel] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateYaml = (commit: boolean) => {
+    try {
+      const { output } = convertJsonToYaml(jsonText);
+      let baseline = yamlText;
+      try {
+        baseline = canonicalizeYaml(yamlText);
+      } catch (err) {
+        if (!commit) {
+          throw err;
+        }
+      }
+
+      setDiff(diffLines(baseline, output));
+      setDiffLabel(commit ? 'YAML diff (after converting JSON → YAML)' : 'YAML diff preview');
+      setError(null);
+      if (commit) {
+        setYamlText(output);
+      }
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const updateJson = (commit: boolean) => {
+    try {
+      const { output } = convertYamlToJson(yamlText);
+      let baseline = jsonText;
+      try {
+        baseline = canonicalizeJson(jsonText);
+      } catch (err) {
+        if (!commit) {
+          throw err;
+        }
+      }
+
+      setDiff(diffLines(baseline, output));
+      setDiffLabel(commit ? 'JSON diff (after converting YAML → JSON)' : 'JSON diff preview');
+      setError(null);
+      if (commit) {
+        setJsonText(output);
+      }
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-4 overflow-hidden bg-ub-cool-grey p-4 text-white">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Data Converter</h1>
+        <p className="text-sm text-gray-300">
+          Convert JSON and YAML using yaml&apos;s Document API. Order of keys is preserved whenever possible so round-trips stay predictable.
+        </p>
+      </header>
+      <div className="flex flex-1 flex-col gap-4 overflow-hidden md:flex-row">
+        <label className="flex flex-1 flex-col gap-2">
+          <span className="text-sm font-medium text-gray-200">JSON</span>
+          <textarea
+            className="min-h-[200px] flex-1 rounded bg-gray-900 p-3 font-mono text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={jsonText}
+            onChange={(event) => setJsonText(event.target.value)}
+          />
+        </label>
+        <label className="flex flex-1 flex-col gap-2">
+          <span className="text-sm font-medium text-gray-200">YAML</span>
+          <textarea
+            className="min-h-[200px] flex-1 rounded bg-gray-900 p-3 font-mono text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={yamlText}
+            onChange={(event) => setYamlText(event.target.value)}
+          />
+        </label>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          aria-label="Convert JSON to YAML"
+          className={buttonBase}
+          onClick={() => updateYaml(true)}
+        >
+          Convert JSON → YAML
+        </button>
+        <button
+          type="button"
+          aria-label="Diff JSON to YAML"
+          className={secondaryButton}
+          onClick={() => updateYaml(false)}
+        >
+          Diff JSON → YAML
+        </button>
+        <button
+          type="button"
+          aria-label="Convert YAML to JSON"
+          className={buttonBase}
+          onClick={() => updateJson(true)}
+        >
+          Convert YAML → JSON
+        </button>
+        <button
+          type="button"
+          aria-label="Diff YAML to JSON"
+          className={secondaryButton}
+          onClick={() => updateJson(false)}
+        >
+          Diff YAML → JSON
+        </button>
+      </div>
+      {error && (
+        <p className="text-sm text-red-300" role="alert">
+          {error}
+        </p>
+      )}
+      {diff && diffLabel && (
+        <section className="space-y-2">
+          <h2 className="text-lg font-semibold">{diffLabel}</h2>
+          <DiffViewer diff={diff} />
+        </section>
+      )}
+    </div>
+  );
+};
+
+export default YamlBridge;

--- a/apps/data-converter/index.tsx
+++ b/apps/data-converter/index.tsx
@@ -1,0 +1,3 @@
+'use client';
+
+export { default } from './components/YamlBridge';

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "tailwindcss": "^3.2.4",
     "three": "^0.179.1",
     "turndown": "^7.2.1",
+    "yaml": "^2.8.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pages/apps/data-converter.jsx
+++ b/pages/apps/data-converter.jsx
@@ -1,0 +1,10 @@
+import dynamic from "next/dynamic";
+
+const DataConverter = dynamic(() => import("../../apps/data-converter"), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function DataConverterPage() {
+  return <DataConverter />;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13967,6 +13967,7 @@ __metadata:
     webpack: "npm:^5.92.0"
     workbox-build: "npm:7.1.1"
     ws: "npm:^8.18.0"
+    yaml: "npm:^2.8.1"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -14774,7 +14775,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.3.4":
+"yaml@npm:^2.3.4, yaml@npm:^2.8.1":
   version: 2.8.1
   resolution: "yaml@npm:2.8.1"
   bin:


### PR DESCRIPTION
## Summary
- add a YAML/JSON bridge that uses yaml's Document API to preserve map order and expose conversion + diff controls in the data converter app
- register the new utility with the desktop configuration and add a Next.js page for it
- cover round-trip fidelity between YAML and JSON with focused unit tests

## Testing
- yarn lint *(fails: repository already has widespread jsx-a11y/control-has-associated-label and no-top-level-window violations in existing apps)*
- yarn test --watch=false --runInBand __tests__/apps/data-converter/yaml-bridge.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc38e7d6008328a2259eda14f2e7c0