### PR TITLE
[http] environment store and template substitutions

### DIFF
--- a/__mocks__/idb-keyval.ts
+++ b/__mocks__/idb-keyval.ts
@@ -1,0 +1,47 @@
+const stores = new Map<string, Map<IDBValidKey, unknown>>();
+
+interface MockStore {
+  namespace: string;
+}
+
+const namespaceFor = (store?: MockStore) => store?.namespace ?? 'default';
+
+const ensureStore = (store?: MockStore) => {
+  const namespace = namespaceFor(store);
+  if (!stores.has(namespace)) {
+    stores.set(namespace, new Map());
+  }
+  return stores.get(namespace)!;
+};
+
+export const createStore = (dbName: string, storeName: string): MockStore => ({
+  namespace: `${dbName || 'db'}:${storeName || 'store'}`,
+});
+
+export const get = async <T = unknown>(key: IDBValidKey, store?: MockStore): Promise<T | undefined> =>
+  ensureStore(store).get(key) as T | undefined;
+
+export const set = async (key: IDBValidKey, value: unknown, store?: MockStore): Promise<void> => {
+  ensureStore(store).set(key, value);
+};
+
+export const del = async (key: IDBValidKey, store?: MockStore): Promise<void> => {
+  ensureStore(store).delete(key);
+};
+
+export const update = async <T = unknown>(
+  key: IDBValidKey,
+  updater: (value: T | undefined) => T,
+  store?: MockStore,
+): Promise<void> => {
+  const map = ensureStore(store);
+  const next = updater(map.get(key) as T | undefined);
+  map.set(key, next);
+};
+
+export const keys = async (store?: MockStore): Promise<IDBValidKey[]> =>
+  Array.from(ensureStore(store).keys());
+
+export const __resetStore = (): void => {
+  stores.clear();
+};

--- a/__tests__/apps/http/environments.test.ts
+++ b/__tests__/apps/http/environments.test.ts
@@ -1,0 +1,88 @@
+jest.mock('idb-keyval');
+
+import httpEnvironmentStore, {
+  __dangerous__resetHttpEnvironmentStoreForTests,
+  extractPlaceholders,
+  HttpEnvironment,
+  resolveTemplate,
+} from '../../../apps/http/state/environments';
+
+const idb = require('idb-keyval') as { __resetStore?: () => void };
+
+beforeEach(async () => {
+  idb.__resetStore?.();
+  await __dangerous__resetHttpEnvironmentStoreForTests();
+  await httpEnvironmentStore.ready();
+});
+
+describe('template parsing', () => {
+  test('replaces placeholders while leaving unknown tokens intact', () => {
+    const environment: HttpEnvironment = {
+      id: 'env-test',
+      name: 'Test',
+      variables: {
+        token: 'abc123',
+        version: 'v2',
+        'dashed-name': 'dash',
+      },
+    };
+
+    const template =
+      'https://api.example.com/{{ version }}/users/{{token}}?missing={{ missing }}&dash={{dashed-name}}';
+
+    expect(resolveTemplate(template, environment)).toBe(
+      'https://api.example.com/v2/users/abc123?missing={{ missing }}&dash=dash',
+    );
+  });
+
+  test('ignores malformed placeholders and de-duplicates extracted names', () => {
+    const environment: HttpEnvironment = {
+      id: 'env-mixed',
+      name: 'Mixed',
+      variables: { token: 'value' },
+    };
+    const template =
+      'start {{ }} repeat {{ token }} + {{token}} literal {{{token}}} tail {{token';
+
+    expect(resolveTemplate(template, environment)).toBe(
+      'start {{ }} repeat value + value literal {{{token}}} tail {{token',
+    );
+
+    expect(extractPlaceholders(template)).toEqual(['token']);
+  });
+});
+
+describe('environment switching', () => {
+  test('notifies subscribers with updated substitutions when active environment changes', async () => {
+    const defaultEnv = httpEnvironmentStore.getActiveEnvironment();
+    if (defaultEnv) {
+      await httpEnvironmentStore.setEnvironmentVariable(defaultEnv.id, 'token', 'default');
+    }
+
+    const staging = await httpEnvironmentStore.createEnvironment('Staging');
+    await httpEnvironmentStore.setEnvironmentVariable(staging.id, 'token', 'staging-token');
+
+    const production = await httpEnvironmentStore.createEnvironment('Production');
+    await httpEnvironmentStore.setEnvironmentVariable(production.id, 'token', 'prod-token');
+
+    const observed: string[] = [];
+    const template = 'Authorization: Bearer {{token}}';
+
+    const unsubscribe = httpEnvironmentStore.subscribe((snapshot) => {
+      const active =
+        snapshot.environments.find((env) => env.id === snapshot.activeEnvironmentId) ??
+        snapshot.environments[0];
+      observed.push(resolveTemplate(template, active ?? null));
+    });
+
+    await httpEnvironmentStore.setActiveEnvironment(staging.id);
+    await httpEnvironmentStore.setActiveEnvironment(production.id);
+
+    unsubscribe();
+
+    expect(observed).toEqual([
+      'Authorization: Bearer staging-token',
+      'Authorization: Bearer prod-token',
+    ]);
+  });
+});

--- a/apps/http/index.tsx
+++ b/apps/http/index.tsx
@@ -1,63 +1,332 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import httpEnvironmentStore, {
+  extractPlaceholders,
+  HttpEnvironment,
+  HttpEnvironmentState,
+  resolveTemplate,
+} from './state/environments';
+
+const escapeSingleQuotes = (value: string) => value.replace(/'/g, "'\\''");
 
 const HTTPBuilder: React.FC = () => {
   const [method, setMethod] = useState('GET');
-  const [url, setUrl] = useState('');
-  const command = `curl -X ${method} ${url}`.trim();
+  const [urlTemplate, setUrlTemplate] = useState('');
+  const [bodyTemplate, setBodyTemplate] = useState('');
+  const [environmentState, setEnvironmentState] = useState<HttpEnvironmentState>(
+    () => httpEnvironmentStore.getState(),
+  );
+  const [newVariableKey, setNewVariableKey] = useState('');
+  const [newVariableValue, setNewVariableValue] = useState('');
+
+  useEffect(() => {
+    httpEnvironmentStore.ready();
+    const unsubscribe = httpEnvironmentStore.subscribe(setEnvironmentState);
+    return () => unsubscribe();
+  }, []);
+
+  const activeEnvironment: HttpEnvironment | undefined = useMemo(() => {
+    const { environments, activeEnvironmentId } = environmentState;
+    return (
+      environments.find((env) => env.id === activeEnvironmentId) ?? environments[0]
+    );
+  }, [environmentState]);
+
+  useEffect(() => {
+    if (!environmentState.activeEnvironmentId && activeEnvironment) {
+      void httpEnvironmentStore.setActiveEnvironment(activeEnvironment.id);
+    }
+  }, [environmentState.activeEnvironmentId, activeEnvironment]);
+
+  const resolvedUrl = useMemo(
+    () => resolveTemplate(urlTemplate, activeEnvironment ?? null),
+    [urlTemplate, activeEnvironment],
+  );
+  const resolvedBody = useMemo(
+    () => resolveTemplate(bodyTemplate, activeEnvironment ?? null),
+    [bodyTemplate, activeEnvironment],
+  );
+
+  const variableEntries = useMemo(() => {
+    if (!activeEnvironment) return [] as Array<[string, string]>;
+    return Object.entries(activeEnvironment.variables).sort((a, b) =>
+      a[0].localeCompare(b[0]),
+    );
+  }, [activeEnvironment]);
+
+  const missingVariables = useMemo(() => {
+    if (!activeEnvironment) return [] as string[];
+    const required = new Set<string>();
+    for (const name of extractPlaceholders(urlTemplate)) required.add(name);
+    for (const name of extractPlaceholders(bodyTemplate)) required.add(name);
+    return Array.from(required).filter(
+      (name) => activeEnvironment.variables[name] === undefined,
+    );
+  }, [activeEnvironment, urlTemplate, bodyTemplate]);
+
+  const commandPreview = useMemo(() => {
+    if (!resolvedUrl) return '# Fill in the form to generate a command';
+    const parts = [`curl -X ${method}`, `'${escapeSingleQuotes(resolvedUrl)}'`];
+    if (resolvedBody) {
+      parts.push(`-d '${escapeSingleQuotes(resolvedBody)}'`);
+    }
+    return parts.join(' ');
+  }, [method, resolvedUrl, resolvedBody]);
+
+  const handleEnvironmentChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    void httpEnvironmentStore.setActiveEnvironment(event.target.value);
+  };
+
+  const handleAddEnvironment = async () => {
+    const created = await httpEnvironmentStore.createEnvironment();
+    await httpEnvironmentStore.setActiveEnvironment(created.id);
+  };
+
+  const handleRenameEnvironment = () => {
+    if (!activeEnvironment) return;
+    const nextName = window.prompt('Environment name', activeEnvironment.name);
+    if (nextName && nextName.trim()) {
+      void httpEnvironmentStore.renameEnvironment(activeEnvironment.id, nextName);
+    }
+  };
+
+  const handleRemoveEnvironment = () => {
+    if (!activeEnvironment) return;
+    if (environmentState.environments.length <= 1) return;
+    void httpEnvironmentStore.removeEnvironment(activeEnvironment.id);
+  };
+
+  const handleVariableValueChange = (key: string, value: string) => {
+    if (!activeEnvironment) return;
+    void httpEnvironmentStore.setEnvironmentVariable(activeEnvironment.id, key, value);
+  };
+
+  const handleVariableRename = (key: string) => {
+    if (!activeEnvironment) return;
+    const next = window.prompt('Variable name', key);
+    if (next && next.trim() && next.trim() !== key) {
+      void httpEnvironmentStore.renameEnvironmentVariable(activeEnvironment.id, key, next);
+    }
+  };
+
+  const handleVariableDelete = (key: string) => {
+    if (!activeEnvironment) return;
+    void httpEnvironmentStore.deleteEnvironmentVariable(activeEnvironment.id, key);
+  };
+
+  const handleAddVariable = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!activeEnvironment) return;
+    const key = newVariableKey.trim();
+    if (!key) return;
+    void httpEnvironmentStore.setEnvironmentVariable(activeEnvironment.id, key, newVariableValue);
+    setNewVariableKey('');
+    setNewVariableValue('');
+  };
 
   return (
-    <div className="h-full bg-gray-900 p-4 text-white overflow-auto">
-      <h1 className="mb-4 text-2xl">HTTP Request Builder</h1>
-      <p className="mb-4 text-sm text-yellow-300">
-        Build a curl command without sending any requests. Learn more at{' '}
-        <a
-          href="https://curl.se/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline text-blue-400"
-        >
-          the curl project page
-        </a>
-        .
-      </p>
-      <form onSubmit={(e) => e.preventDefault()} className="mb-4 space-y-4">
-        <div>
-          <label htmlFor="http-method" className="mb-1 block text-sm font-medium">
-            Method
-          </label>
-          <select
-            id="http-method"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            value={method}
-            onChange={(e) => setMethod(e.target.value)}
-          >
-            <option value="GET">GET</option>
-            <option value="POST">POST</option>
-            <option value="PUT">PUT</option>
-            <option value="DELETE">DELETE</option>
-          </select>
-        </div>
-        <div>
-          <label htmlFor="http-url" className="mb-1 block text-sm font-medium">
-            URL
-          </label>
-          <input
-            id="http-url"
-            type="text"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-          />
-        </div>
-      </form>
-      <div>
-        <h2 className="mb-2 text-lg">Command Preview</h2>
-        <pre className="overflow-auto rounded bg-black p-2 font-mono text-green-400">
-          {command || '# Fill in the form to generate a command'}
-        </pre>
+    <div className="h-full overflow-auto bg-gray-900 p-4 text-white">
+      <div className="space-y-6">
+        <header>
+          <h1 className="text-2xl font-semibold">HTTP Request Composer</h1>
+          <p className="mt-2 text-sm text-gray-300">
+            Craft mock HTTP requests and curl commands without sending traffic. Use{' '}
+            <span className="font-mono text-yellow-300">{'{{variable}}'}</span> placeholders
+            in your URL or body to substitute values from the active environment.
+          </p>
+        </header>
+
+        <section className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <label htmlFor="http-environment" className="text-sm font-medium">
+              Active environment
+            </label>
+            <select
+              id="http-environment"
+              className="rounded border border-gray-700 bg-gray-800 p-2 text-sm"
+              value={activeEnvironment?.id ?? ''}
+              onChange={handleEnvironmentChange}
+            >
+              {environmentState.environments.map((env) => (
+                <option key={env.id} value={env.id}>
+                  {env.name}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              className="rounded bg-blue-600 px-3 py-1 text-sm font-medium hover:bg-blue-500"
+              onClick={handleAddEnvironment}
+            >
+              New environment
+            </button>
+            <button
+              type="button"
+              className="rounded border border-gray-700 px-3 py-1 text-sm hover:bg-gray-800"
+              onClick={handleRenameEnvironment}
+              disabled={!activeEnvironment}
+            >
+              Rename
+            </button>
+            <button
+              type="button"
+              className="rounded border border-red-600 px-3 py-1 text-sm text-red-300 hover:bg-red-900/40 disabled:opacity-40"
+              onClick={handleRemoveEnvironment}
+              disabled={environmentState.environments.length <= 1}
+            >
+              Delete
+            </button>
+          </div>
+
+          {activeEnvironment && (
+            <div className="rounded border border-gray-800 bg-gray-950 p-4">
+              <div className="mb-3 flex items-center justify-between">
+                <h2 className="text-lg font-semibold">Variables</h2>
+                <span className="text-xs text-gray-400">
+                  {variableEntries.length} defined
+                </span>
+              </div>
+              <div className="space-y-2">
+                {variableEntries.length === 0 && (
+                  <p className="text-sm text-gray-400">
+                    No variables yet. Add key/value pairs to reuse them in requests.
+                  </p>
+                )}
+                {variableEntries.map(([key, value]) => (
+                  <div
+                    key={key}
+                    className="flex flex-wrap items-center gap-2 rounded border border-gray-800 bg-gray-900 p-2"
+                  >
+                    <button
+                      type="button"
+                      className="rounded bg-gray-800 px-2 py-1 text-xs font-mono text-blue-300 hover:bg-gray-700"
+                      onClick={() => handleVariableRename(key)}
+                      title="Rename variable"
+                    >
+                      {key}
+                    </button>
+                    <input
+                      className="min-w-[140px] flex-1 rounded border border-gray-700 bg-gray-950 p-2 text-sm text-white"
+                      value={value}
+                      onChange={(event) => handleVariableValueChange(key, event.target.value)}
+                      placeholder="Value"
+                      aria-label={`Value for ${key}`}
+                    />
+                    <button
+                      type="button"
+                      className="rounded border border-red-500 px-2 py-1 text-xs text-red-300 hover:bg-red-900/40"
+                      onClick={() => handleVariableDelete(key)}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                ))}
+              </div>
+              <form className="mt-4 flex flex-wrap gap-2" onSubmit={handleAddVariable}>
+                <input
+                  className="min-w-[160px] flex-1 rounded border border-gray-700 bg-gray-900 p-2 text-sm text-white"
+                  placeholder="Variable name"
+                  value={newVariableKey}
+                  onChange={(event) => setNewVariableKey(event.target.value)}
+                  aria-label="New variable name"
+                />
+                <input
+                  className="min-w-[160px] flex-1 rounded border border-gray-700 bg-gray-900 p-2 text-sm text-white"
+                  placeholder="Value"
+                  value={newVariableValue}
+                  onChange={(event) => setNewVariableValue(event.target.value)}
+                  aria-label="New variable value"
+                />
+                <button
+                  type="submit"
+                  className="rounded bg-emerald-600 px-3 py-1 text-sm font-medium hover:bg-emerald-500"
+                  disabled={!newVariableKey.trim()}
+                >
+                  Add variable
+                </button>
+              </form>
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-4">
+          <form onSubmit={(event) => event.preventDefault()} className="space-y-4">
+            <div>
+              <label htmlFor="http-method" className="mb-1 block text-sm font-medium">
+                Method
+              </label>
+              <select
+                id="http-method"
+                className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+                value={method}
+                onChange={(event) => setMethod(event.target.value)}
+              >
+                <option value="GET">GET</option>
+                <option value="POST">POST</option>
+                <option value="PUT">PUT</option>
+                <option value="PATCH">PATCH</option>
+                <option value="DELETE">DELETE</option>
+              </select>
+            </div>
+            <div>
+              <label htmlFor="http-url" className="mb-1 block text-sm font-medium">
+                URL template
+              </label>
+              <input
+                id="http-url"
+                type="text"
+                className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+                value={urlTemplate}
+                onChange={(event) => setUrlTemplate(event.target.value)}
+                placeholder="https://api.example.com/{{version}}/users"
+                spellCheck={false}
+              />
+            </div>
+            <div>
+              <label htmlFor="http-body" className="mb-1 block text-sm font-medium">
+                Body template
+              </label>
+              <textarea
+                id="http-body"
+                className="min-h-[120px] w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+                value={bodyTemplate}
+                onChange={(event) => setBodyTemplate(event.target.value)}
+                placeholder='{"token": "{{api_token}}"}'
+                spellCheck={false}
+              />
+            </div>
+          </form>
+          {missingVariables.length > 0 && (
+            <div className="rounded border border-yellow-600 bg-yellow-900/40 p-3 text-sm text-yellow-200">
+              Missing values for: {missingVariables.join(', ')}
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <h2 className="mb-2 text-lg font-semibold">Resolved URL</h2>
+              <pre className="min-h-[72px] overflow-auto rounded bg-black p-3 font-mono text-green-300">
+                {resolvedUrl || '# Provide a URL template'}
+              </pre>
+            </div>
+            <div>
+              <h2 className="mb-2 text-lg font-semibold">Resolved Body</h2>
+              <pre className="min-h-[72px] overflow-auto rounded bg-black p-3 font-mono text-green-300">
+                {resolvedBody || '# Provide a body template'}
+              </pre>
+            </div>
+          </div>
+          <div>
+            <h2 className="mb-2 text-lg font-semibold">Command Preview</h2>
+            <pre className="overflow-auto rounded bg-black p-3 font-mono text-green-400">
+              {commandPreview}
+            </pre>
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/apps/http/state/environments.ts
+++ b/apps/http/state/environments.ts
@@ -1,0 +1,382 @@
+import { get, set } from 'idb-keyval';
+
+export interface HttpEnvironment {
+  id: string;
+  name: string;
+  variables: Record<string, string>;
+}
+
+export interface HttpEnvironmentState {
+  environments: HttpEnvironment[];
+  activeEnvironmentId: string | null;
+}
+
+export type HttpEnvironmentListener = (state: HttpEnvironmentState) => void;
+
+const ENVIRONMENTS_KEY = 'http:environments';
+const ACTIVE_ENVIRONMENT_KEY = 'http:active-environment';
+const DEFAULT_ENVIRONMENT_ID = 'http-env-default';
+const PLACEHOLDER_PATTERN = /{{\s*([A-Za-z0-9_.-]+)\s*}}/g;
+
+type UpdateResult<T = void> = {
+  state: HttpEnvironmentState;
+  value?: T;
+};
+
+const listeners = new Set<HttpEnvironmentListener>();
+let loadPromise: Promise<void> | null = null;
+let state: HttpEnvironmentState = createInitialState();
+
+function isClient() {
+  return typeof window !== 'undefined';
+}
+
+function createDefaultEnvironment(): HttpEnvironment {
+  return { id: DEFAULT_ENVIRONMENT_ID, name: 'Default', variables: {} };
+}
+
+function createInitialState(): HttpEnvironmentState {
+  const env = createDefaultEnvironment();
+  return { environments: [env], activeEnvironmentId: env.id };
+}
+
+function generateEnvironmentId(): string {
+  return `env-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function sanitizeVariables(input: unknown): Record<string, string> {
+  if (!input || typeof input !== 'object') return {};
+
+  const result: Record<string, string> = {};
+  for (const [rawKey, rawValue] of Object.entries(input as Record<string, unknown>)) {
+    if (typeof rawKey !== 'string') continue;
+    const trimmedKey = rawKey.trim();
+    if (!trimmedKey) continue;
+    if (rawValue === undefined) continue;
+    result[trimmedKey] = typeof rawValue === 'string' ? rawValue : String(rawValue);
+  }
+  return result;
+}
+
+function sanitizeEnvironments(input: unknown): HttpEnvironment[] {
+  if (!Array.isArray(input)) return createInitialState().environments;
+
+  const sanitized: HttpEnvironment[] = [];
+  const seenIds = new Set<string>();
+
+  for (const raw of input) {
+    if (!raw || typeof raw !== 'object') continue;
+    const candidate = raw as Partial<HttpEnvironment>;
+    let id = typeof candidate.id === 'string' && candidate.id.trim() ? candidate.id : generateEnvironmentId();
+    while (seenIds.has(id)) {
+      id = generateEnvironmentId();
+    }
+    seenIds.add(id);
+    const name = typeof candidate.name === 'string' && candidate.name.trim() ? candidate.name.trim() : 'Environment';
+    const variables = sanitizeVariables(candidate.variables);
+    sanitized.push({ id, name, variables });
+  }
+
+  if (!sanitized.length) {
+    return createInitialState().environments;
+  }
+
+  return sanitized;
+}
+
+function ensureActiveEnvironmentId(
+  environments: HttpEnvironment[],
+  preferredId: string | null | undefined,
+): string | null {
+  if (!environments.length) return null;
+  if (preferredId && environments.some((env) => env.id === preferredId)) {
+    return preferredId;
+  }
+  return environments[0].id;
+}
+
+async function loadFromStorage(): Promise<void> {
+  if (!isClient()) return;
+  try {
+    const [storedEnvironments, storedActiveId] = await Promise.all([
+      get<HttpEnvironment[]>(ENVIRONMENTS_KEY),
+      get<string | null>(ACTIVE_ENVIRONMENT_KEY),
+    ]);
+    const environments = sanitizeEnvironments(storedEnvironments);
+    const activeEnvironmentId = ensureActiveEnvironmentId(
+      environments,
+      typeof storedActiveId === 'string' ? storedActiveId : null,
+    );
+    state = { environments, activeEnvironmentId };
+  } catch {
+    state = createInitialState();
+  }
+  notify();
+}
+
+async function ensureReady(): Promise<void> {
+  if (!loadPromise) {
+    loadPromise = loadFromStorage();
+  }
+  await loadPromise;
+}
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener(state);
+  }
+}
+
+async function persistState(): Promise<void> {
+  if (!isClient()) return;
+  try {
+    await Promise.all([
+      set(ENVIRONMENTS_KEY, state.environments),
+      set(ACTIVE_ENVIRONMENT_KEY, state.activeEnvironmentId),
+    ]);
+  } catch {
+    // Ignore persistence errors in environments where IndexedDB is unavailable
+  }
+}
+
+function updateEnvironmentState(
+  current: HttpEnvironmentState,
+  envId: string,
+  updater: (environment: HttpEnvironment) => HttpEnvironment | null | undefined,
+): HttpEnvironmentState | null {
+  const index = current.environments.findIndex((env) => env.id === envId);
+  if (index === -1) return null;
+  const environment = current.environments[index];
+  const updated = updater(environment);
+  if (!updated || updated === environment) return null;
+  const environments = current.environments.slice();
+  environments[index] = updated;
+  return { environments, activeEnvironmentId: current.activeEnvironmentId };
+}
+
+async function applyUpdate<T>(
+  mutator: (current: HttpEnvironmentState) => UpdateResult<T> | null | undefined,
+): Promise<T | undefined> {
+  await ensureReady();
+  const result = mutator(state);
+  if (!result) return undefined;
+  const { state: nextState, value } = result;
+  if (
+    nextState.environments === state.environments &&
+    nextState.activeEnvironmentId === state.activeEnvironmentId
+  ) {
+    return value;
+  }
+  state = nextState;
+  notify();
+  await persistState();
+  return value;
+}
+
+function getActiveEnvironmentFromState(
+  snapshot: HttpEnvironmentState,
+): HttpEnvironment | undefined {
+  const { environments, activeEnvironmentId } = snapshot;
+  return (
+    environments.find((env) => env.id === activeEnvironmentId) ??
+    environments[0]
+  );
+}
+
+export const httpEnvironmentStore = {
+  ready: ensureReady,
+  subscribe(listener: HttpEnvironmentListener) {
+    listeners.add(listener);
+    void ensureReady();
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+  getState(): HttpEnvironmentState {
+    return state;
+  },
+  getActiveEnvironment(): HttpEnvironment | undefined {
+    return getActiveEnvironmentFromState(state);
+  },
+  async createEnvironment(
+    name?: string,
+    variables: Record<string, string> = {},
+  ): Promise<HttpEnvironment> {
+    const created = await applyUpdate<HttpEnvironment>((current) => {
+      const environment: HttpEnvironment = {
+        id: generateEnvironmentId(),
+        name:
+          name && name.trim()
+            ? name.trim()
+            : defaultEnvironmentName(current.environments),
+        variables: sanitizeVariables(variables),
+      };
+      return {
+        state: {
+          environments: [...current.environments, environment],
+          activeEnvironmentId: current.activeEnvironmentId ?? environment.id,
+        },
+        value: environment,
+      };
+    });
+    return created ?? getActiveEnvironmentFromState(state)!;
+  },
+  async removeEnvironment(envId: string): Promise<void> {
+    await applyUpdate((current) => {
+      const environments = current.environments.filter((env) => env.id !== envId);
+      if (environments.length === current.environments.length) return null;
+      if (!environments.length) {
+        const initial = createInitialState();
+        return { state: initial };
+      }
+      const activeEnvironmentId =
+        current.activeEnvironmentId === envId
+          ? ensureActiveEnvironmentId(environments, null)
+          : current.activeEnvironmentId;
+      return { state: { environments, activeEnvironmentId } };
+    });
+  },
+  async renameEnvironment(envId: string, name: string): Promise<void> {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    await applyUpdate((current) => {
+      const next = updateEnvironmentState(current, envId, (environment) => {
+        if (environment.name === trimmed) return environment;
+        return { ...environment, name: trimmed };
+      });
+      return next ? { state: next } : null;
+    });
+  },
+  async setActiveEnvironment(envId: string): Promise<void> {
+    await applyUpdate((current) => {
+      if (!current.environments.length) {
+        const initial = createInitialState();
+        return { state: initial };
+      }
+      const nextId = ensureActiveEnvironmentId(current.environments, envId);
+      if (nextId === current.activeEnvironmentId) return null;
+      return { state: { environments: current.environments, activeEnvironmentId: nextId } };
+    });
+  },
+  async setEnvironmentVariable(envId: string, key: string, value: string): Promise<void> {
+    const normalizedKey = key.trim();
+    if (!normalizedKey) return;
+    await applyUpdate((current) => {
+      const next = updateEnvironmentState(current, envId, (environment) => {
+        const existing = environment.variables[normalizedKey];
+        if (existing === value && normalizedKey in environment.variables) {
+          return environment;
+        }
+        return {
+          ...environment,
+          variables: { ...environment.variables, [normalizedKey]: value },
+        };
+      });
+      return next ? { state: next } : null;
+    });
+  },
+  async renameEnvironmentVariable(envId: string, fromKey: string, toKey: string): Promise<void> {
+    const trimmed = toKey.trim();
+    if (!trimmed) return;
+    await applyUpdate((current) => {
+      const next = updateEnvironmentState(current, envId, (environment) => {
+        if (!(fromKey in environment.variables)) return environment;
+        if (trimmed === fromKey) return environment;
+        const value = environment.variables[fromKey];
+        const variables = { ...environment.variables };
+        delete variables[fromKey];
+        variables[trimmed] = value;
+        return { ...environment, variables };
+      });
+      return next ? { state: next } : null;
+    });
+  },
+  async deleteEnvironmentVariable(envId: string, key: string): Promise<void> {
+    await applyUpdate((current) => {
+      const next = updateEnvironmentState(current, envId, (environment) => {
+        if (!(key in environment.variables)) return environment;
+        const variables = { ...environment.variables };
+        delete variables[key];
+        return { ...environment, variables };
+      });
+      return next ? { state: next } : null;
+    });
+  },
+};
+
+function defaultEnvironmentName(environments: HttpEnvironment[]): string {
+  const base = 'Environment';
+  const existingNames = new Set(environments.map((env) => env.name));
+  let index = environments.length + 1;
+  let candidate = `${base} ${index}`;
+  while (existingNames.has(candidate)) {
+    index += 1;
+    candidate = `${base} ${index}`;
+  }
+  return candidate;
+}
+
+export function resolveTemplateWithVariables(
+  template: string,
+  variables: Record<string, string>,
+): string {
+  if (!template) return template;
+  PLACEHOLDER_PATTERN.lastIndex = 0;
+  return template.replace(
+    PLACEHOLDER_PATTERN,
+    (match, rawName: string, offset: number, original: string) => {
+      const key = rawName.trim();
+      if (!key) return match;
+      const before = offset > 0 ? original[offset - 1] : undefined;
+      const after = original[offset + match.length];
+      if (before === '{' || after === '}') {
+        return match;
+      }
+      return Object.prototype.hasOwnProperty.call(variables, key)
+        ? variables[key]
+        : match;
+    },
+  );
+}
+
+export function resolveTemplate(
+  template: string,
+  environment?: HttpEnvironment | null,
+): string {
+  return resolveTemplateWithVariables(template, environment?.variables ?? {});
+}
+
+export function extractPlaceholders(template: string): string[] {
+  if (!template) return [];
+  PLACEHOLDER_PATTERN.lastIndex = 0;
+  const found = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = PLACEHOLDER_PATTERN.exec(template))) {
+    const [fullMatch, rawName] = match;
+    const key = rawName?.trim();
+    if (!key) continue;
+    const before = match.index > 0 ? template[match.index - 1] : undefined;
+    const after = template[match.index + fullMatch.length];
+    if (before === '{' || after === '}') continue;
+    found.add(key);
+  }
+  return Array.from(found);
+}
+
+export async function __dangerous__resetHttpEnvironmentStoreForTests(): Promise<void> {
+  state = createInitialState();
+  loadPromise = null;
+  notify();
+  if (isClient()) {
+    try {
+      await Promise.all([
+        set(ENVIRONMENTS_KEY, state.environments),
+        set(ACTIVE_ENVIRONMENT_KEY, state.activeEnvironmentId),
+      ]);
+    } catch {
+      // ignore reset errors in non-indexedDB environments
+    }
+  }
+}
+
+export default httpEnvironmentStore;


### PR DESCRIPTION
## Summary
- add an IndexedDB-backed HTTP environment store with placeholder resolution helpers
- expand the HTTP composer UI to manage environments and substitute {{variable}} tokens
- cover parsing edge cases and environment switching with new Jest tests

## Testing
- yarn test environments --runInBand
- yarn lint *(fails: repo has pre-existing accessibility and window/document lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cc38eed078832885f3a0265dd3bf48