### PR TITLE
[http] add session auth panel

### DIFF
--- a/__tests__/apps/http/auth-panel.test.tsx
+++ b/__tests__/apps/http/auth-panel.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import AuthPanel, { AUTH_SESSION_STORAGE_KEY } from '@/apps/http/components/AuthPanel';
+import { HTTPBuilder } from '@/apps/http';
+
+describe('HTTP AuthPanel', () => {
+  const originalClipboard = navigator.clipboard;
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: originalClipboard,
+      });
+    } else {
+      delete (navigator as { clipboard?: unknown }).clipboard;
+    }
+  });
+
+  test('persists basic credentials within the session', async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<AuthPanel />);
+
+    const typeSelect = screen.getByLabelText(/authorization type/i);
+    await user.selectOptions(typeSelect, 'basic');
+
+    const usernameInput = await screen.findByLabelText(/username/i);
+    const passwordInput = screen.getByLabelText(/password/i);
+
+    await user.type(usernameInput, 'alice');
+    await user.type(passwordInput, 'pa55w0rd');
+
+    await waitFor(() =>
+      expect(window.sessionStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toContain('alice'),
+    );
+
+    unmount();
+    render(<AuthPanel />);
+
+    expect(screen.getByLabelText(/authorization type/i)).toHaveValue('basic');
+    expect(screen.getByLabelText(/username/i)).toHaveValue('alice');
+    expect(screen.getByLabelText(/password/i)).toHaveValue('pa55w0rd');
+  });
+
+  test('redacts secrets when exporting the request JSON', async () => {
+    const user = userEvent.setup();
+    const writeText = jest.fn();
+
+    if (navigator.clipboard) {
+      jest.spyOn(navigator.clipboard, 'writeText').mockImplementation(writeText);
+    } else {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      });
+    }
+
+    render(<HTTPBuilder />);
+
+    const typeSelect = screen.getByLabelText(/authorization type/i);
+    await user.selectOptions(typeSelect, 'bearer');
+
+    const tokenField = await screen.findByLabelText(/bearer token/i);
+    await user.type(tokenField, 'super-secret-token');
+
+    await waitFor(() =>
+      expect(window.sessionStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toContain('super-secret-token'),
+    );
+
+    const exportButton = screen.getByRole('button', { name: /export json/i });
+    await user.click(exportButton);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    const serialized = writeText.mock.calls[0][0];
+
+    expect(serialized).not.toContain('super-secret-token');
+
+    const payload = JSON.parse(serialized);
+    expect(payload.auth).toEqual({
+      type: 'bearer',
+      token: '***redacted***',
+      hasCredentials: true,
+    });
+  });
+
+  test('reset session clears sessionStorage', async () => {
+    const user = userEvent.setup();
+    render(<AuthPanel />);
+
+    const typeSelect = screen.getByLabelText(/authorization type/i);
+    await user.selectOptions(typeSelect, 'bearer');
+
+    const tokenField = await screen.findByLabelText(/bearer token/i);
+    await user.type(tokenField, 'temporary-token');
+
+    await waitFor(() =>
+      expect(window.sessionStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toContain('temporary-token'),
+    );
+
+    const resetButton = screen.getByRole('button', { name: /reset session/i });
+    await user.click(resetButton);
+
+    await waitFor(() =>
+      expect(window.sessionStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toBeNull(),
+    );
+    expect(screen.getByLabelText(/authorization type/i)).toHaveValue('none');
+  });
+});

--- a/apps/http/components/AuthPanel.tsx
+++ b/apps/http/components/AuthPanel.tsx
@@ -1,0 +1,281 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { safeSessionStorage } from '@/utils/safeSessionStorage';
+
+export type AuthType = 'none' | 'basic' | 'bearer';
+
+export interface AuthState {
+  type: AuthType;
+  username?: string;
+  password?: string;
+  token?: string;
+}
+
+export interface AuthExportState {
+  type: AuthType;
+  username?: string;
+  password?: string;
+  token?: string;
+  hasCredentials?: boolean;
+}
+
+export interface AuthChangePayload {
+  state: AuthState;
+  header: string | null;
+  exportData: AuthExportState;
+}
+
+interface AuthPanelProps {
+  onAuthChange?: (payload: AuthChangePayload) => void;
+}
+
+const STORAGE_KEY = 'http-auth-session';
+const REDACTED = '***redacted***';
+
+const createDefaultState = (): AuthState => ({
+  type: 'none',
+  username: '',
+  password: '',
+  token: '',
+});
+
+const loadInitialState = (): AuthState => {
+  if (!safeSessionStorage) {
+    return createDefaultState();
+  }
+  try {
+    const raw = safeSessionStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return createDefaultState();
+    }
+    const parsed = JSON.parse(raw) as Partial<AuthState>;
+    const type: AuthType = parsed.type === 'basic' || parsed.type === 'bearer' ? parsed.type : 'none';
+    return {
+      type,
+      username: parsed.username ?? '',
+      password: parsed.password ?? '',
+      token: parsed.token ?? '',
+    };
+  } catch {
+    return createDefaultState();
+  }
+};
+
+const base64Encode = (value: string): string => {
+  const globalScope = globalThis as typeof globalThis & {
+    btoa?: (data: string) => string;
+    Buffer?: {
+      from?: (input: string, encoding?: string) => { toString: (encoding: string) => string };
+    };
+  };
+
+  if (typeof globalScope.btoa === 'function') {
+    return globalScope.btoa(value);
+  }
+
+  const bufferCtor = globalScope.Buffer;
+  if (bufferCtor && typeof bufferCtor.from === 'function') {
+    return bufferCtor.from(value, 'utf-8').toString('base64');
+  }
+
+  return value;
+};
+
+export const buildAuthHeader = (state: AuthState): string | null => {
+  if (state.type === 'basic') {
+    const username = state.username ?? '';
+    const password = state.password ?? '';
+    if (!username && !password) {
+      return null;
+    }
+    const encoded = base64Encode(`${username}:${password}`);
+    return `Basic ${encoded}`;
+  }
+  if (state.type === 'bearer') {
+    const token = state.token?.trim();
+    if (!token) {
+      return null;
+    }
+    return `Bearer ${token}`;
+  }
+  return null;
+};
+
+export const redactAuthForExport = (state: AuthState): AuthExportState => {
+  if (state.type === 'basic') {
+    return {
+      type: 'basic',
+      username: state.username ?? '',
+      password: state.password ? REDACTED : undefined,
+      hasCredentials: Boolean((state.username ?? '').length || (state.password ?? '').length),
+    };
+  }
+  if (state.type === 'bearer') {
+    return {
+      type: 'bearer',
+      token: state.token ? REDACTED : undefined,
+      hasCredentials: Boolean(state.token?.length),
+    };
+  }
+  return { type: 'none', hasCredentials: false };
+};
+
+const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthChange }) => {
+  const [state, setState] = useState<AuthState>(() => loadInitialState());
+
+  const notifyChange = useCallback(
+    (nextState: AuthState) => {
+      const header = buildAuthHeader(nextState);
+      const exportData = redactAuthForExport(nextState);
+      onAuthChange?.({ state: nextState, header, exportData });
+    },
+    [onAuthChange],
+  );
+
+  useEffect(() => {
+    notifyChange(state);
+
+    if (!safeSessionStorage) {
+      return;
+    }
+
+    try {
+      if (state.type === 'none') {
+        safeSessionStorage.removeItem(STORAGE_KEY);
+        return;
+      }
+      const payload: AuthState = { type: state.type };
+      if (state.type === 'basic') {
+        payload.username = state.username ?? '';
+        payload.password = state.password ?? '';
+      } else if (state.type === 'bearer') {
+        payload.token = state.token ?? '';
+      }
+      safeSessionStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    } catch {
+      // Ignore storage errors
+    }
+  }, [state, notifyChange]);
+
+  const handleTypeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextType = event.target.value as AuthType;
+    setState((prev) => {
+      if (nextType === 'none') {
+        return createDefaultState();
+      }
+      return { ...prev, type: nextType };
+    });
+  };
+
+  const handleUsernameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setState((prev) => ({ ...prev, username: value }));
+  };
+
+  const handlePasswordChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setState((prev) => ({ ...prev, password: value }));
+  };
+
+  const handleTokenChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = event.target.value;
+    setState((prev) => ({ ...prev, token: value }));
+  };
+
+  const handleReset = () => {
+    setState(createDefaultState());
+  };
+
+  const hasStoredSecret = useMemo(() => Boolean(buildAuthHeader(state)), [state]);
+
+  return (
+    <section className="space-y-4 rounded border border-gray-700 bg-gray-900 p-4" aria-label="Authentication panel">
+      <header className="flex items-center justify-between gap-2">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Authentication</h2>
+          <p className="text-xs text-gray-300">
+            Secrets are kept in sessionStorage. Reset the session when you are done on shared devices.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleReset}
+          className="rounded border border-gray-600 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-gray-200 hover:bg-gray-800"
+        >
+          Reset session
+        </button>
+      </header>
+
+      <div className="space-y-2">
+        <label htmlFor="auth-type" className="block text-sm font-medium text-gray-200">
+          Authorization type
+        </label>
+        <select
+          id="auth-type"
+          value={state.type}
+          onChange={handleTypeChange}
+          className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-sm text-white"
+        >
+          <option value="none">No auth</option>
+          <option value="basic">Basic (username &amp; password)</option>
+          <option value="bearer">Bearer token</option>
+        </select>
+      </div>
+
+      {state.type === 'basic' && (
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <label htmlFor="auth-username" className="block text-sm font-medium text-gray-200">
+              Username
+            </label>
+            <input
+              id="auth-username"
+              type="text"
+              aria-label="Basic auth username"
+              value={state.username ?? ''}
+              onChange={handleUsernameChange}
+              className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-sm text-white"
+            />
+          </div>
+          <div className="space-y-2">
+            <label htmlFor="auth-password" className="block text-sm font-medium text-gray-200">
+              Password
+            </label>
+            <input
+              id="auth-password"
+              type="password"
+              aria-label="Basic auth password"
+              value={state.password ?? ''}
+              onChange={handlePasswordChange}
+              className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-sm text-white"
+            />
+          </div>
+        </div>
+      )}
+
+      {state.type === 'bearer' && (
+        <div className="space-y-2">
+          <label htmlFor="auth-token" className="block text-sm font-medium text-gray-200">
+            Bearer token
+          </label>
+          <textarea
+            id="auth-token"
+            aria-label="Bearer token value"
+            value={state.token ?? ''}
+            onChange={handleTokenChange}
+            className="h-24 w-full rounded border border-gray-700 bg-gray-800 p-2 text-sm text-white"
+          />
+        </div>
+      )}
+
+      {hasStoredSecret && (
+        <p className="text-xs text-green-400">Authorization headers will be added to generated curl commands.</p>
+      )}
+    </section>
+  );
+};
+
+export default AuthPanel;
+export { STORAGE_KEY as AUTH_SESSION_STORAGE_KEY };

--- a/apps/http/index.tsx
+++ b/apps/http/index.tsx
@@ -1,58 +1,136 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import AuthPanel, {
+  AuthChangePayload,
+  AuthExportState,
+  AuthState,
+  redactAuthForExport,
+} from './components/AuthPanel';
+
+const emptyAuthState: AuthState = { type: 'none' };
 
 const HTTPBuilder: React.FC = () => {
   const [method, setMethod] = useState('GET');
   const [url, setUrl] = useState('');
-  const command = `curl -X ${method} ${url}`.trim();
+  const [authHeader, setAuthHeader] = useState<string | null>(null);
+  const [authExport, setAuthExport] = useState<AuthExportState>(() =>
+    redactAuthForExport(emptyAuthState),
+  );
+
+  const handleAuthChange = useCallback(({ header, exportData }: AuthChangePayload) => {
+    setAuthHeader(header);
+    setAuthExport(exportData);
+  }, []);
+
+  const command = useMemo(() => {
+    const parts = [`curl -X ${method}`];
+    if (authHeader) {
+      parts.push(`-H 'Authorization: ${authHeader}'`);
+    }
+    if (url) {
+      parts.push(url);
+    }
+    return parts.join(' ');
+  }, [method, url, authHeader]);
+
+  const handleExportRequest = async () => {
+    const payload = {
+      method,
+      url,
+      auth: authExport,
+    };
+    const serialized = JSON.stringify(payload, null, 2);
+
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(serialized);
+        return;
+      }
+    } catch {
+      // fall through to file download fallback
+    }
+
+    try {
+      const blob = new Blob([serialized], { type: 'application/json' });
+      const href = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = href;
+      anchor.download = 'http-request.json';
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(href);
+    } catch {
+      // ignore download errors in environments without DOM access
+    }
+  };
 
   return (
-    <div className="h-full bg-gray-900 p-4 text-white overflow-auto">
-      <h1 className="mb-4 text-2xl">HTTP Request Builder</h1>
-      <p className="mb-4 text-sm text-yellow-300">
-        Build a curl command without sending any requests. Learn more at{' '}
-        <a
-          href="https://curl.se/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline text-blue-400"
+    <div className="h-full space-y-6 overflow-auto bg-gray-900 p-4 text-white">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl">HTTP Request Builder</h1>
+          <p className="text-sm text-yellow-300">
+            Build a curl command without sending any requests. Learn more at{' '}
+            <a
+              href="https://curl.se/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline text-blue-400"
+            >
+              the curl project page
+            </a>
+            .
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleExportRequest}
+          className="h-10 rounded border border-gray-600 px-4 text-sm font-semibold uppercase tracking-wide text-gray-100 hover:bg-gray-800"
         >
-          the curl project page
-        </a>
-        .
-      </p>
-      <form onSubmit={(e) => e.preventDefault()} className="mb-4 space-y-4">
-        <div>
-          <label htmlFor="http-method" className="mb-1 block text-sm font-medium">
-            Method
-          </label>
-          <select
-            id="http-method"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            value={method}
-            onChange={(e) => setMethod(e.target.value)}
-          >
-            <option value="GET">GET</option>
-            <option value="POST">POST</option>
-            <option value="PUT">PUT</option>
-            <option value="DELETE">DELETE</option>
-          </select>
-        </div>
-        <div>
-          <label htmlFor="http-url" className="mb-1 block text-sm font-medium">
-            URL
-          </label>
-          <input
-            id="http-url"
-            type="text"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-          />
-        </div>
-      </form>
+          Export JSON
+        </button>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+        <form onSubmit={(e) => e.preventDefault()} className="space-y-4">
+          <div>
+            <label htmlFor="http-method" className="mb-1 block text-sm font-medium">
+              Method
+            </label>
+            <select
+              id="http-method"
+              aria-label="HTTP method"
+              className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+              value={method}
+              onChange={(e) => setMethod(e.target.value)}
+            >
+              <option value="GET">GET</option>
+              <option value="POST">POST</option>
+              <option value="PUT">PUT</option>
+              <option value="DELETE">DELETE</option>
+            </select>
+          </div>
+          <div>
+            <label htmlFor="http-url" className="mb-1 block text-sm font-medium">
+              URL
+            </label>
+            <input
+              id="http-url"
+              type="text"
+              aria-label="Request URL"
+              className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+            />
+          </div>
+        </form>
+        <AuthPanel onAuthChange={handleAuthChange} />
+      </div>
+
       <div>
         <h2 className="mb-2 text-lg">Command Preview</h2>
         <pre className="overflow-auto rounded bg-black p-2 font-mono text-green-400">
@@ -80,4 +158,5 @@ const HTTPPreview: React.FC = () => {
   );
 };
 
+export { HTTPBuilder };
 export default HTTPPreview;

--- a/utils/safeSessionStorage.ts
+++ b/utils/safeSessionStorage.ts
@@ -1,0 +1,16 @@
+import { isBrowser } from './isBrowser';
+
+const getSessionStorage = (): Storage | undefined => {
+  if (!isBrowser) return undefined;
+  try {
+    const storage = window.sessionStorage;
+    const testKey = '__session_test__';
+    storage.setItem(testKey, '1');
+    storage.removeItem(testKey);
+    return storage;
+  } catch {
+    return undefined;
+  }
+};
+
+export const safeSessionStorage: Storage | undefined = getSessionStorage();


### PR DESCRIPTION
## Summary
- add an AuthPanel component that persists Basic and Bearer secrets in sessionStorage with a reset action and redacted export data
- integrate the auth panel into the HTTP request builder so Authorization headers are previewed and excluded from exported JSON
- introduce a safeSessionStorage helper and Jest coverage for session persistence plus export redaction

## Testing
- yarn test __tests__/apps/http/auth-panel.test.tsx
- yarn lint *(fails: repository already has numerous jsx-a11y/control-has-associated-label violations outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cc38efa7dc83289fc9328184b40f84