### PR TITLE
apps: add zxcvbn-powered password strength analysis

### DIFF
--- a/__tests__/apps/crypto-toolkit/password-strength.test.tsx
+++ b/__tests__/apps/crypto-toolkit/password-strength.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PasswordStrength from '../../../apps/crypto-toolkit/components/PasswordStrength';
+
+describe('PasswordStrength component', () => {
+  it('updates entropy and guess metrics on every keystroke within 50ms', async () => {
+    const user = userEvent.setup();
+    render(<PasswordStrength />);
+
+    const input = screen.getByTestId('password-input') as HTMLInputElement;
+
+    await user.type(input, 'a');
+    const firstEntropy = parseFloat(screen.getByTestId('entropy-value').getAttribute('data-raw') ?? '0');
+    const firstGuesses = parseFloat(screen.getByTestId('guesses-value').getAttribute('data-raw') ?? '0');
+
+    await user.type(input, 'b');
+    const secondEntropy = parseFloat(screen.getByTestId('entropy-value').getAttribute('data-raw') ?? '0');
+    const secondGuesses = parseFloat(screen.getByTestId('guesses-value').getAttribute('data-raw') ?? '0');
+
+    await user.type(input, 'c');
+    const thirdEntropy = parseFloat(screen.getByTestId('entropy-value').getAttribute('data-raw') ?? '0');
+    const thirdGuesses = parseFloat(screen.getByTestId('guesses-value').getAttribute('data-raw') ?? '0');
+
+    expect(firstEntropy).toBeGreaterThanOrEqual(0);
+    expect(secondEntropy).not.toBe(firstEntropy);
+    expect(thirdEntropy).not.toBe(secondEntropy);
+
+    expect(firstGuesses).toBeGreaterThanOrEqual(0);
+    expect(secondGuesses).not.toBe(firstGuesses);
+    expect(thirdGuesses).not.toBe(secondGuesses);
+
+    const analysisRuntime = parseFloat(screen.getByTestId('analysis-time').getAttribute('data-raw') ?? '0');
+    expect(analysisRuntime).toBeLessThan(50);
+  });
+
+  it('never performs network fetches during analysis', async () => {
+    const user = userEvent.setup();
+    const fetchSpy = jest.spyOn(global, 'fetch');
+
+    render(<PasswordStrength />);
+
+    const input = screen.getByTestId('password-input') as HTMLInputElement;
+    await user.type(input, 'Complex#Pass123!');
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+});

--- a/apps/crypto-toolkit/components/PasswordStrength.tsx
+++ b/apps/crypto-toolkit/components/PasswordStrength.tsx
@@ -1,0 +1,234 @@
+import React, { useMemo, useState } from 'react';
+import { zxcvbn, zxcvbnOptions, ZxcvbnResult } from '@zxcvbn-ts/core';
+import { adjacencyGraphs, dictionary } from '@zxcvbn-ts/language-common';
+
+const translations = {
+  warnings: {
+    straightRow: 'Straight rows of keys on your keyboard are easy to guess.',
+    keyPattern: 'Short keyboard patterns are easy to guess.',
+    simpleRepeat: 'Repeated characters like "aaa" are easy to guess.',
+    extendedRepeat: 'Repeated character patterns like "abcabcabc" are easy to guess.',
+    sequences: 'Common character sequences like "abc" are easy to guess.',
+    recentYears: 'Recent years are easy to guess.',
+    dates: 'Dates are easy to guess.',
+    topTen: 'This is a heavily used password.',
+    topHundred: 'This is a frequently used password.',
+    common: 'This is a commonly used password.',
+    similarToCommon: 'This is similar to a commonly used password.',
+    wordByItself: 'Single words are easy to guess.',
+    namesByThemselves: 'Single names or surnames are easy to guess.',
+    commonNames: 'Common names and surnames are easy to guess.',
+    userInputs: 'There should not be any personal or page related data.',
+    pwned: 'Your password was exposed by a data breach on the Internet.',
+  },
+  suggestions: {
+    l33t: "Avoid predictable letter substitutions like '@' for 'a'.",
+    reverseWords: 'Avoid reversed spellings of common words.',
+    allUppercase: 'Capitalize some, but not all letters.',
+    capitalization: 'Capitalize more than the first letter.',
+    dates: 'Avoid dates and years that are associated with you.',
+    recentYears: 'Avoid recent years.',
+    associatedYears: 'Avoid years that are associated with you.',
+    sequences: 'Avoid common character sequences.',
+    repeated: 'Avoid repeated words and characters.',
+    longerKeyboardPattern: 'Use longer keyboard patterns and change typing direction multiple times.',
+    anotherWord: 'Add more words that are less common.',
+    useWords: 'Use multiple words, but avoid common phrases.',
+    noNeed: 'You can create strong passwords without using symbols, numbers, or uppercase letters.',
+    pwned: 'If you use this password elsewhere, you should change it.',
+  },
+  timeEstimation: {
+    ltSecond: 'less than a second',
+    second: '{base} second',
+    seconds: '{base} seconds',
+    minute: '{base} minute',
+    minutes: '{base} minutes',
+    hour: '{base} hour',
+    hours: '{base} hours',
+    day: '{base} day',
+    days: '{base} days',
+    month: '{base} month',
+    months: '{base} months',
+    year: '{base} year',
+    years: '{base} years',
+    centuries: 'centuries',
+  },
+} as const;
+
+type StrengthScale = 0 | 1 | 2 | 3 | 4;
+
+const STRENGTH_STATES: Record<StrengthScale, { label: string; description: string; bar: string; text: string }> = {
+  0: {
+    label: 'Very weak',
+    description: 'This password can be cracked almost instantly. Try mixing uncommon words and symbols.',
+    bar: 'bg-red-600',
+    text: 'text-red-400',
+  },
+  1: {
+    label: 'Weak',
+    description: 'Add more variety and length to slow down basic attacks.',
+    bar: 'bg-orange-500',
+    text: 'text-orange-300',
+  },
+  2: {
+    label: 'Fair',
+    description: 'Better, but still susceptible to targeted guesses. Add another uncommon word.',
+    bar: 'bg-yellow-500',
+    text: 'text-yellow-300',
+  },
+  3: {
+    label: 'Strong',
+    description: 'Resists common attacks. Consider unique substitutions to harden further.',
+    bar: 'bg-emerald-500',
+    text: 'text-emerald-300',
+  },
+  4: {
+    label: 'Very strong',
+    description: 'Great job! Keep this password unique across accounts.',
+    bar: 'bg-emerald-600',
+    text: 'text-emerald-200',
+  },
+};
+
+const CRACK_TIME_LABELS: Array<{
+  key: keyof ZxcvbnResult['crackTimesDisplay'];
+  label: string;
+}> = [
+  { key: 'onlineThrottling100PerHour', label: 'Online attack (100/h)' },
+  { key: 'onlineNoThrottling10PerSecond', label: 'Online attack (10/s)' },
+  { key: 'offlineSlowHashing1e4PerSecond', label: 'Offline slow hashing (10⁴/s)' },
+  { key: 'offlineFastHashing1e10PerSecond', label: 'Offline fast hashing (10¹⁰/s)' },
+];
+
+const numberFormatter = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+});
+
+let configured = false;
+
+const configureZxcvbn = () => {
+  if (configured) return;
+  // Trim the bundled dictionaries so each evaluation stays under the 50 ms budget.
+  const trimmedDictionary: typeof dictionary = {
+    passwords: dictionary.passwords.slice(0, 3500),
+    diceware: dictionary.diceware.slice(0, 3500),
+  };
+
+  zxcvbnOptions.setOptions({
+    dictionary: trimmedDictionary,
+    graphs: adjacencyGraphs,
+    translations,
+  });
+  configured = true;
+};
+
+const computeEntropy = (guesses: number, hasInput: boolean) => {
+  if (!hasInput) return 0;
+  return Math.max(0, Math.log2(Math.max(guesses, 1)));
+};
+
+const PasswordStrength: React.FC = () => {
+  configureZxcvbn();
+  const [password, setPassword] = useState('');
+
+  const analysis = useMemo(() => {
+    const result = zxcvbn(password);
+    const entropy = computeEntropy(result.guesses, Boolean(password));
+    return {
+      ...result,
+      entropy,
+    };
+  }, [password]);
+
+  const state = STRENGTH_STATES[analysis.score];
+  const progressValues = [0, 25, 50, 75, 100];
+  const progress = password ? progressValues[analysis.score] : 0;
+  const warning = analysis.feedback.warning;
+  const suggestions = analysis.feedback.suggestions;
+
+  return (
+    <section className="flex h-full flex-col gap-4 rounded-lg bg-slate-900 p-4 text-slate-100" aria-live="polite">
+      <div>
+        <label htmlFor="password-strength-input" className="block text-sm font-medium text-slate-300">
+          Test a password
+        </label>
+        <input
+          id="password-strength-input"
+          data-testid="password-input"
+          type="password"
+          autoComplete="off"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          className="mt-1 w-full rounded border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-base text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+        />
+      </div>
+      <div>
+        <div className="h-3 rounded-full bg-slate-800" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={progress}>
+          <div
+            className={`h-full rounded-full transition-[width] duration-150 ease-out ${state.bar}`}
+            style={{ width: `${progress}%` }}
+            data-testid="strength-meter"
+          />
+        </div>
+        <div className={`mt-2 text-sm font-semibold ${password ? state.text : 'text-slate-400'}`} data-testid="strength-label">
+          {password ? state.label : 'Start typing to analyze strength'}
+        </div>
+        <p className="mt-1 text-xs text-slate-400" data-testid="strength-description">
+          {password ? state.description : 'We never send your password anywhere. Analysis runs entirely in your browser.'}
+        </p>
+      </div>
+      <dl className="grid gap-2 rounded-md bg-slate-800/60 p-3 text-xs sm:grid-cols-2">
+        <div>
+          <dt className="font-semibold text-slate-300">Entropy</dt>
+          <dd data-testid="entropy-value" data-raw={analysis.entropy.toString()}>
+            {analysis.entropy.toFixed(2)} bits
+          </dd>
+        </div>
+        <div>
+          <dt className="font-semibold text-slate-300">Estimated guesses</dt>
+          <dd data-testid="guesses-value" data-raw={analysis.guesses.toString()}>
+            {numberFormatter.format(Math.max(analysis.guesses, 0))}
+          </dd>
+        </div>
+        <div>
+          <dt className="font-semibold text-slate-300">Analysis time</dt>
+          <dd data-testid="analysis-time" data-raw={analysis.calcTime.toString()}>
+            {analysis.calcTime.toFixed(1)} ms
+          </dd>
+        </div>
+        <div>
+          <dt className="font-semibold text-slate-300">Score</dt>
+          <dd data-testid="score-value">{analysis.score} / 4</dd>
+        </div>
+      </dl>
+      <div className="grid gap-2 rounded-md bg-slate-800/40 p-3 text-xs">
+        {CRACK_TIME_LABELS.map(({ key, label }) => (
+          <div key={key} className="flex justify-between gap-2" data-testid={`crack-${key}`}>
+            <span className="font-semibold text-slate-300">{label}</span>
+            <span className="text-right text-slate-200">{analysis.crackTimesDisplay[key]}</span>
+          </div>
+        ))}
+      </div>
+      <div className="rounded-md bg-slate-800/30 p-3 text-xs">
+        <p className="font-semibold text-slate-300">Feedback</p>
+        {password ? (
+          <ul className="mt-2 space-y-1 text-slate-200" data-testid="feedback-list">
+            {warning && <li className="text-amber-300">⚠️ {warning}</li>}
+            {suggestions.length > 0 ? (
+              suggestions.map((suggestion) => (
+                <li key={suggestion}>{suggestion}</li>
+              ))
+            ) : (
+              !warning && <li>Your password looks solid. Just keep it unique.</li>
+            )}
+          </ul>
+        ) : (
+          <p className="mt-2 text-slate-400">Enter a password to receive guidance.</p>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default PasswordStrength;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-search": "^0.15.0",
     "@xterm/xterm": "^5.5.0",
+    "@zxcvbn-ts/core": "^3.0.4",
+    "@zxcvbn-ts/language-common": "^3.0.4",
     "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.3",
     "aframe": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4411,6 +4411,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@zxcvbn-ts/core@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@zxcvbn-ts/core@npm:3.0.4"
+  dependencies:
+    fastest-levenshtein: "npm:1.0.16"
+  checksum: 10c0/afe266635651303b9dbd0dad73ac9c76261b1d4d6fbb1d657a4d84d5552531346030d483e41b2a349940e11afdf439dcea94c5793faba8f9a9910eff104859e4
+  languageName: node
+  linkType: hard
+
+"@zxcvbn-ts/language-common@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@zxcvbn-ts/language-common@npm:3.0.4"
+  checksum: 10c0/0dc6185c4289a876a236e498c4b1b4bd181a56f14068fb5610d7238918cab5ce56e08d5e8c7fe980cd28dbed57650defc202bc57bd1bffc302bb600aec4769c8
+  languageName: node
+  linkType: hard
+
 "@zxing/browser@npm:^0.1.5":
   version: 0.1.5
   resolution: "@zxing/browser@npm:0.1.5"
@@ -7327,6 +7343,13 @@ __metadata:
   bin:
     fxparser: src/cli/cli.js
   checksum: 10c0/bf9ccadacfadc95f6e3f0e7882a380a7f219cf0a6f96575149f02cb62bf44c3b7f0daee75b8ff3847bcfd7fbcb201e402c71045936c265cf6d94b141ec4e9327
+  languageName: node
+  linkType: hard
+
+"fastest-levenshtein@npm:1.0.16":
+  version: 1.0.16
+  resolution: "fastest-levenshtein@npm:1.0.16"
+  checksum: 10c0/7e3d8ae812a7f4fdf8cad18e9cde436a39addf266a5986f653ea0d81e0de0900f50c0f27c6d5aff3f686bcb48acbd45be115ae2216f36a6a13a7dbbf5cad878b
   languageName: node
   linkType: hard
 
@@ -13889,6 +13912,8 @@ __metadata:
     "@xterm/addon-fit": "npm:^0.10.0"
     "@xterm/addon-search": "npm:^0.15.0"
     "@xterm/xterm": "npm:^5.5.0"
+    "@zxcvbn-ts/core": "npm:^3.0.4"
+    "@zxcvbn-ts/language-common": "npm:^3.0.4"
     "@zxing/browser": "npm:^0.1.5"
     "@zxing/library": "npm:^0.21.3"
     aframe: "npm:^1.5.0"


### PR DESCRIPTION
## Summary
- integrate @zxcvbn-ts core with trimmed dictionaries to keep local password analysis under 50ms
- render entropy, guess estimates, crack times, and feedback inside the PasswordStrength component without network calls
- add Jest coverage for per-keystroke metric updates and the absence of fetch activity

## Testing
- yarn test __tests__/apps/crypto-toolkit/password-strength.test.tsx
- yarn lint *(fails: repository has pre-existing jsx-a11y/control-has-associated-label errors across many apps)*

------
https://chatgpt.com/codex/tasks/task_e_68cc38f1654483288a6511a29f9f23b8