### PR TITLE
[apps] Add HS256 JWT debugger

### DIFF
--- a/__tests__/apps/crypto-toolkit/jwt-debugger.test.tsx
+++ b/__tests__/apps/crypto-toolkit/jwt-debugger.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { webcrypto } from 'crypto';
+import JwtDebugger from '@/apps/crypto-toolkit/components/JwtDebugger';
+
+describe('JwtDebugger', () => {
+  beforeAll(() => {
+    Object.defineProperty(global, 'crypto', {
+      value: webcrypto,
+      configurable: true,
+    });
+  });
+
+  const validToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' +
+    'eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.' +
+    'TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ';
+
+  const tamperedToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' +
+    'eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOmZhbHNlfQ.' +
+    'TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ';
+
+  it('verifies valid HS256 signatures', async () => {
+    render(<JwtDebugger />);
+
+    fireEvent.change(screen.getByLabelText(/jwt token/i), {
+      target: { value: validToken },
+    });
+
+    fireEvent.change(screen.getByLabelText(/shared secret/i), {
+      target: { value: 'secret' },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent(
+        'Signature verified with HS256.'
+      )
+    );
+
+    expect(screen.getByText(/Computed Signature/i)).toBeInTheDocument();
+    expect(screen.getByText(/Token Signature/i)).toBeInTheDocument();
+  });
+
+  it('flags tampered tokens', async () => {
+    render(<JwtDebugger />);
+
+    fireEvent.change(screen.getByLabelText(/jwt token/i), {
+      target: { value: tamperedToken },
+    });
+
+    fireEvent.change(screen.getByLabelText(/shared secret/i), {
+      target: { value: 'secret' },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent(
+        'Signature mismatch for HS256 verification.'
+      )
+    );
+  });
+});

--- a/apps/crypto-toolkit/components/JwtDebugger.tsx
+++ b/apps/crypto-toolkit/components/JwtDebugger.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import React, { useEffect, useId, useMemo, useState } from 'react';
+import {
+  base64UrlToUint8Array,
+  createVerificationMessage,
+  VerificationResult,
+  verifyHs256Signature,
+} from '@/utils/jwt';
+
+interface DecodedSegment {
+  formatted: string;
+  error?: string;
+}
+
+let sharedDecoder: TextDecoder | undefined;
+
+const decodeUtf8 = (bytes: Uint8Array): string => {
+  if (typeof TextDecoder !== 'undefined') {
+    if (!sharedDecoder) {
+      sharedDecoder = new TextDecoder();
+    }
+    return sharedDecoder.decode(bytes);
+  }
+
+  let result = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    result += String.fromCharCode(bytes[i]);
+  }
+  return result;
+};
+
+const decodeSegment = (segment: string): DecodedSegment => {
+  if (!segment) {
+    return { formatted: '' };
+  }
+
+  try {
+    const decoded = decodeUtf8(base64UrlToUint8Array(segment));
+    try {
+      const parsed = JSON.parse(decoded);
+      return { formatted: JSON.stringify(parsed, null, 2) };
+    } catch {
+      return { formatted: decoded };
+    }
+  } catch (error) {
+    return {
+      formatted: '',
+      error:
+        error instanceof Error ? error.message : 'Unable to decode segment.',
+    };
+  }
+};
+
+const JwtDebugger: React.FC = () => {
+  const [token, setToken] = useState('');
+  const [secret, setSecret] = useState('');
+  const [verification, setVerification] = useState<VerificationResult>({
+    status: 'idle',
+    message: createVerificationMessage('idle'),
+  });
+  const tokenInputId = useId();
+  const secretInputId = useId();
+
+  const headerSegment = useMemo(() => token.split('.')[0] ?? '', [token]);
+  const payloadSegment = useMemo(() => token.split('.')[1] ?? '', [token]);
+
+  const header = useMemo(() => decodeSegment(headerSegment), [headerSegment]);
+  const payload = useMemo(() => decodeSegment(payloadSegment), [payloadSegment]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const runVerification = async () => {
+      const result = await verifyHs256Signature(token, secret);
+      if (!cancelled) {
+        setVerification(result);
+      }
+    };
+
+    void runVerification();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [secret, token]);
+
+  return (
+    <div className="flex h-full flex-col gap-4 bg-gray-900 p-4 text-sm text-gray-100">
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor={tokenInputId}
+            className="text-xs font-semibold uppercase tracking-wider text-gray-400"
+          >
+            JWT Token
+          </label>
+          <textarea
+            id={tokenInputId}
+            aria-label="JWT Token"
+            value={token}
+            onChange={(event) => setToken(event.target.value)}
+            className="min-h-[120px] rounded border border-gray-700 bg-black/60 p-3 font-mono text-green-200 focus:border-cyan-400 focus:outline-none"
+            placeholder="Paste a JWT (header.payload.signature)"
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor={secretInputId}
+            className="text-xs font-semibold uppercase tracking-wider text-gray-400"
+          >
+            Shared Secret
+          </label>
+          <input
+            id={secretInputId}
+            aria-label="Shared Secret"
+            type="text"
+            value={secret}
+            onChange={(event) => setSecret(event.target.value)}
+            className="rounded border border-gray-700 bg-black/60 p-3 font-mono text-green-200 focus:border-cyan-400 focus:outline-none"
+            placeholder="Secret used for HS256"
+          />
+        </div>
+      </div>
+
+      <section className="rounded border border-gray-800 bg-black/40 p-4">
+        <h2 className="text-lg font-semibold text-cyan-300">Verification</h2>
+        <p role="status" className="mt-2 text-sm">
+          {verification.message}
+        </p>
+        {verification.expectedSignature && (
+          <div className="mt-3">
+            <span className="block text-xs uppercase tracking-wider text-gray-500">
+              Computed Signature
+            </span>
+            <code className="mt-1 block break-all rounded bg-gray-800/60 p-2 text-[13px] text-green-200">
+              {verification.expectedSignature}
+            </code>
+          </div>
+        )}
+        {verification.receivedSignature && (
+          <div className="mt-3">
+            <span className="block text-xs uppercase tracking-wider text-gray-500">
+              Token Signature
+            </span>
+            <code className="mt-1 block break-all rounded bg-gray-800/60 p-2 text-[13px] text-green-200">
+              {verification.receivedSignature}
+            </code>
+          </div>
+        )}
+      </section>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <section className="rounded border border-gray-800 bg-black/40 p-4">
+          <h3 className="text-base font-semibold text-cyan-200">Header</h3>
+          {header.error ? (
+            <p className="mt-2 text-amber-400">{header.error}</p>
+          ) : (
+            <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words rounded bg-gray-950/80 p-3 font-mono text-[13px] text-green-200">
+              {header.formatted || 'Decoded header will appear here.'}
+            </pre>
+          )}
+        </section>
+        <section className="rounded border border-gray-800 bg-black/40 p-4">
+          <h3 className="text-base font-semibold text-cyan-200">Payload</h3>
+          {payload.error ? (
+            <p className="mt-2 text-amber-400">{payload.error}</p>
+          ) : (
+            <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words rounded bg-gray-950/80 p-3 font-mono text-[13px] text-green-200">
+              {payload.formatted || 'Decoded payload will appear here.'}
+            </pre>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default JwtDebugger;

--- a/utils/jwt.ts
+++ b/utils/jwt.ts
@@ -1,0 +1,199 @@
+const textEncoder = new TextEncoder();
+
+const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer);
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64');
+  }
+
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+
+  if (typeof btoa === 'function') {
+    return btoa(binary);
+  }
+
+  throw new Error('No base64 encoder available in this environment.');
+};
+
+export const base64UrlEncode = (buffer: ArrayBuffer): string => {
+  const base64 = arrayBufferToBase64(buffer);
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
+};
+
+export const base64UrlToUint8Array = (input: string): Uint8Array => {
+  if (!input) {
+    return new Uint8Array();
+  }
+
+  const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+
+  try {
+    if (typeof atob === 'function') {
+      const binary = atob(padded);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i += 1) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+      return bytes;
+    }
+
+    if (typeof Buffer !== 'undefined') {
+      return Uint8Array.from(Buffer.from(padded, 'base64'));
+    }
+  } catch (error) {
+    throw new Error(
+      error instanceof Error ? error.message : 'Invalid base64url encoding.'
+    );
+  }
+
+  throw new Error('No base64 decoder available in this environment.');
+};
+
+const timingSafeEqual = (a: string, b: string): boolean => {
+  const aBytes = textEncoder.encode(a);
+  const bBytes = textEncoder.encode(b);
+
+  if (aBytes.length !== bBytes.length) {
+    return false;
+  }
+
+  let result = 0;
+  for (let i = 0; i < aBytes.length; i += 1) {
+    result |= aBytes[i] ^ bBytes[i];
+  }
+
+  return result === 0;
+};
+
+export const computeHs256Signature = async (
+  signingInput: string,
+  secret: string
+): Promise<string> => {
+  const cryptoImpl = typeof globalThis.crypto !== 'undefined' ? globalThis.crypto : undefined;
+
+  if (!cryptoImpl?.subtle) {
+    throw new Error('Web Crypto API is unavailable.');
+  }
+
+  const key = await cryptoImpl.subtle.importKey(
+    'raw',
+    textEncoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+
+  const signature = await cryptoImpl.subtle.sign(
+    'HMAC',
+    key,
+    textEncoder.encode(signingInput)
+  );
+
+  return base64UrlEncode(signature);
+};
+
+export type VerificationMessageKey =
+  | 'idle'
+  | 'malformed'
+  | 'missing-secret'
+  | 'valid'
+  | 'invalid'
+  | 'error';
+
+export interface VerificationMessageOptions {
+  error?: string;
+}
+
+export const createVerificationMessage = (
+  key: VerificationMessageKey,
+  options: VerificationMessageOptions = {}
+): string => {
+  switch (key) {
+    case 'idle':
+      return 'Enter a JWT to inspect.';
+    case 'malformed':
+      return 'JWT must include header, payload, and signature segments separated by dots.';
+    case 'missing-secret':
+      return 'Provide a secret to verify the signature.';
+    case 'valid':
+      return 'Signature verified with HS256.';
+    case 'invalid':
+      return 'Signature mismatch for HS256 verification.';
+    case 'error':
+    default:
+      return `Unable to compute HS256 signature${options.error ? `: ${options.error}` : '.'}`;
+  }
+};
+
+export interface VerificationResult {
+  status: VerificationMessageKey;
+  message: string;
+  expectedSignature?: string;
+  receivedSignature?: string;
+}
+
+export const verifyHs256Signature = async (
+  token: string,
+  secret: string
+): Promise<VerificationResult> => {
+  const trimmedToken = token.trim();
+
+  if (!trimmedToken) {
+    return {
+      status: 'idle',
+      message: createVerificationMessage('idle'),
+    };
+  }
+
+  const segments = trimmedToken.split('.');
+
+  if (segments.length !== 3) {
+    return {
+      status: 'malformed',
+      message: createVerificationMessage('malformed'),
+    };
+  }
+
+  const [header, payload, signature] = segments;
+
+  if (!secret) {
+    return {
+      status: 'missing-secret',
+      message: createVerificationMessage('missing-secret'),
+      receivedSignature: signature,
+    };
+  }
+
+  try {
+    const expected = await computeHs256Signature(`${header}.${payload}`, secret);
+    const valid = timingSafeEqual(signature, expected);
+
+    if (valid) {
+      return {
+        status: 'valid',
+        message: createVerificationMessage('valid'),
+        expectedSignature: expected,
+        receivedSignature: signature,
+      };
+    }
+
+    return {
+      status: 'invalid',
+      message: createVerificationMessage('invalid'),
+      expectedSignature: expected,
+      receivedSignature: signature,
+    };
+  } catch (error) {
+    return {
+      status: 'error',
+      message: createVerificationMessage('error', {
+        error: error instanceof Error ? error.message : String(error),
+      }),
+      receivedSignature: signature,
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- add a JWT debugger component for the crypto toolkit that decodes claims and shows signature verification status
- introduce jwt utilities to handle base64url conversion, HS256 signature computation, and user-facing messages
- cover the debugger with unit tests that assert messaging for valid and tampered tokens

## Testing
- yarn lint *(fails: repository already reports many unlabeled controls and legacy window/document usage)*
- yarn test --runTestsByPath __tests__/apps/crypto-toolkit/jwt-debugger.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc38f1edf08328a791b4621bd04779