### PR TITLE
[networking] add IPv6 utilities and UI breakdown

### DIFF
--- a/__tests__/modules/subnet-ipv6.test.ts
+++ b/__tests__/modules/subnet-ipv6.test.ts
@@ -1,0 +1,24 @@
+import { macToEui64 } from '../../modules/networking/subnet';
+
+describe('macToEui64', () => {
+  const vectors: Array<{ mac: string; expected: string }> = [
+    // Examples appear in vendor training guides (e.g. Cisco) and IPv6 primers referencing IEEE EUI-64 derivation.
+    { mac: '00:25:96:12:34:56', expected: '0225:96FF:FE12:3456' },
+    { mac: 'a0-ce-c8-30-04-7d', expected: 'A2CE:C8FF:FE30:047D' },
+    { mac: 'F0.9F.C2.8D.12.34', expected: 'F29F:C2FF:FE8D:1234' },
+  ];
+
+  it.each(vectors)('derives %s to %s using the EUI-64 algorithm', ({ mac, expected }) => {
+    expect(macToEui64(mac).value).toBe(expected);
+  });
+
+  it('normalizes lowercase MAC addresses before processing', () => {
+    expect(macToEui64('d4:5d:64:7f:fe:21').value).toBe('D65D:64FF:FE7F:FE21');
+  });
+
+  it('rejects inputs that do not contain 48 bits worth of hex characters', () => {
+    expect(() => macToEui64('00:11:22:33')).toThrow(
+      'MAC address must contain exactly 12 hexadecimal characters.',
+    );
+  });
+});

--- a/apps/subnet-calculator/index.tsx
+++ b/apps/subnet-calculator/index.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  IdentifierBreakdown,
+  NibbleMatrix,
+  expandIpv6,
+  interfaceIdentifierFromIpv6,
+  macToEui64,
+  nibbleMatrixFromHextets,
+} from '../../modules/networking/subnet';
+
+type IdentifierResult = IdentifierBreakdown | { error: string };
+
+type IPv6BreakdownResult =
+  | {
+      normalized: string;
+      nibbleMatrix: NibbleMatrix;
+      interfaceId: IdentifierBreakdown;
+    }
+  | { error: string };
+
+const DEFAULT_IPV6 = '2001:db8::1428:57ab';
+const DEFAULT_MAC = '00:25:96:12:34:56';
+
+function NibbleGrid({ matrix, title }: { matrix: NibbleMatrix; title: string }) {
+  if (!matrix.length) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-sky-300">{title}</h3>
+      <div className="flex flex-wrap gap-2 font-mono text-sm">
+        {matrix.map((group, hextetIndex) => (
+          <div
+            key={`hextet-${hextetIndex}`}
+            className="rounded border border-slate-700 bg-slate-900/60 px-2 py-2"
+          >
+            <div className="flex items-center justify-between text-[10px] uppercase text-slate-300">
+              <span>H{hextetIndex + 1}</span>
+              <span>{group.join('')}</span>
+            </div>
+            <div className="mt-1 grid grid-cols-4 gap-1 text-center">
+              {group.map((nibble, nibbleIndex) => (
+                <span
+                  key={`n-${hextetIndex}-${nibbleIndex}`}
+                  className="rounded bg-black/60 px-2 py-1 text-xs text-cyan-100"
+                >
+                  {nibble}
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function BinaryStrip({ groups, title }: { groups: string[]; title: string }) {
+  if (!groups.length) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <h4 className="text-sm font-semibold uppercase tracking-wide text-sky-300">{title}</h4>
+      <div className="flex flex-wrap gap-1 font-mono text-xs">
+        {groups.map((group, index) => (
+          <span
+            key={`binary-${group}-${index}`}
+            className="rounded border border-slate-700 bg-black/60 px-2 py-1 text-cyan-100"
+          >
+            {group}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function SubnetCalculator() {
+  const [ipv6Input, setIpv6Input] = useState(DEFAULT_IPV6);
+  const [macInput, setMacInput] = useState(DEFAULT_MAC);
+
+  const ipv6Breakdown = useMemo<IPv6BreakdownResult>(() => {
+    try {
+      const hextets = expandIpv6(ipv6Input);
+      return {
+        normalized: hextets.join(':'),
+        nibbleMatrix: nibbleMatrixFromHextets(hextets),
+        interfaceId: interfaceIdentifierFromIpv6(ipv6Input),
+      };
+    } catch (error) {
+      return { error: (error as Error).message };
+    }
+  }, [ipv6Input]);
+
+  const eui64 = useMemo<IdentifierResult>(() => {
+    try {
+      return macToEui64(macInput);
+    } catch (error) {
+      return { error: (error as Error).message };
+    }
+  }, [macInput]);
+
+  const matchingIdentifier =
+    !('error' in ipv6Breakdown) && !('error' in eui64)
+      ? ipv6Breakdown.interfaceId.value === eui64.value
+      : false;
+
+  return (
+    <div className="flex h-full flex-col gap-6 overflow-y-auto bg-gray-900 p-4 text-white">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-sky-200">Subnet Calculator – IPv6 Focus</h1>
+        <p className="text-sm text-slate-300">
+          Expand IPv6 literals, inspect their nibble boundaries, and derive interface identifiers
+          using the EUI-64 algorithm. Calculations are performed locally and never leave this
+          browser window.
+        </p>
+      </header>
+
+      <section className="space-y-4 rounded border border-slate-800 bg-slate-950/60 p-4 shadow">
+        <h2 className="text-lg font-semibold text-sky-200">IPv6 Interface Identifier</h2>
+        <label className="block text-sm">
+          <span className="mb-1 block font-medium text-slate-200">IPv6 address</span>
+          <input
+            className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono text-white focus:border-sky-500 focus:outline-none"
+            value={ipv6Input}
+            onChange={(event) => setIpv6Input(event.target.value)}
+            placeholder="2001:db8::1/64"
+            aria-label="IPv6 address"
+          />
+        </label>
+
+        {'error' in ipv6Breakdown ? (
+          <p className="rounded border border-red-700 bg-red-900/60 p-3 text-sm text-red-200">
+            {ipv6Breakdown.error}
+          </p>
+        ) : (
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-sky-300">
+                Normalized address
+              </h3>
+              <pre className="mt-1 overflow-auto rounded bg-black/70 p-2 font-mono text-cyan-200">
+                {ipv6Breakdown.normalized}
+              </pre>
+            </div>
+
+            <NibbleGrid matrix={ipv6Breakdown.nibbleMatrix} title="Nibble groups" />
+
+            <div className="space-y-3">
+              <div>
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-sky-300">
+                  Interface identifier (last 64 bits)
+                </h3>
+                <pre className="mt-1 overflow-auto rounded bg-black/70 p-2 font-mono text-cyan-200">
+                  {ipv6Breakdown.interfaceId.value}
+                </pre>
+              </div>
+              <NibbleGrid
+                matrix={ipv6Breakdown.interfaceId.nibbleMatrix}
+                title="Interface identifier nibble groups"
+              />
+              <BinaryStrip
+                groups={ipv6Breakdown.interfaceId.binaryGroups}
+                title="Binary (grouped by nibble)"
+              />
+            </div>
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-4 rounded border border-slate-800 bg-slate-950/60 p-4 shadow">
+        <h2 className="text-lg font-semibold text-sky-200">EUI-64 from MAC address</h2>
+        <label className="block text-sm">
+          <span className="mb-1 block font-medium text-slate-200">MAC address</span>
+          <input
+            className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono text-white focus:border-sky-500 focus:outline-none"
+            value={macInput}
+            onChange={(event) => setMacInput(event.target.value)}
+            placeholder="00:00:5e:00:53:af"
+            aria-label="MAC address"
+          />
+        </label>
+
+        {'error' in eui64 ? (
+          <p className="rounded border border-red-700 bg-red-900/60 p-3 text-sm text-red-200">
+            {eui64.error}
+          </p>
+        ) : (
+          <div className="space-y-3">
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-sky-300">
+                Derived EUI-64 identifier
+              </h3>
+              <pre className="mt-1 overflow-auto rounded bg-black/70 p-2 font-mono text-cyan-200">
+                {eui64.value}
+              </pre>
+            </div>
+            <NibbleGrid matrix={eui64.nibbleMatrix} title="EUI-64 nibble groups" />
+            <BinaryStrip groups={eui64.binaryGroups} title="Binary (grouped by nibble)" />
+          </div>
+        )}
+
+        {!('error' in ipv6Breakdown) && !('error' in eui64) ? (
+          <p className="text-xs text-slate-400">
+            Interface identifier {matchingIdentifier ? 'matches' : 'does not match'} the derived
+            EUI-64 value for the provided inputs.
+          </p>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/modules/networking/subnet.ts
+++ b/modules/networking/subnet.ts
@@ -1,0 +1,177 @@
+const TOTAL_HEXTETS = 8;
+const HEX_DIGITS_PER_HEXTET = 4;
+const INTERFACE_IDENTIFIER_BITS = 64;
+const HEXTET_BIT_WIDTH = 16n;
+const NIBBLE_SIZE = 4;
+const INTERFACE_MASK = (1n << BigInt(INTERFACE_IDENTIFIER_BITS)) - 1n;
+
+export type NibbleMatrix = string[][];
+
+export interface IdentifierBreakdown {
+  value: string;
+  hextets: string[];
+  nibbleMatrix: NibbleMatrix;
+  binaryGroups: string[];
+}
+
+const HEX_PATTERN = /^[0-9a-fA-F]{1,4}$/;
+const MAC_SANITIZE = /[^0-9a-fA-F]/g;
+
+function ipv4SegmentToHextets(segment: string): string[] {
+  const octets = segment.split('.');
+  if (octets.length !== 4) {
+    throw new Error('Invalid embedded IPv4 address in IPv6 literal.');
+  }
+  const bytes = octets.map((part) => {
+    const value = Number(part);
+    if (!Number.isInteger(value) || value < 0 || value > 255) {
+      throw new Error('Invalid IPv4 octet inside IPv6 address.');
+    }
+    return value;
+  });
+  const high = ((bytes[0] << 8) | bytes[1]).toString(16).padStart(HEX_DIGITS_PER_HEXTET, '0');
+  const low = ((bytes[2] << 8) | bytes[3]).toString(16).padStart(HEX_DIGITS_PER_HEXTET, '0');
+  return [high.toUpperCase(), low.toUpperCase()];
+}
+
+function sanitizeHextet(segment: string): string {
+  if (!segment) return '0000';
+  if (!HEX_PATTERN.test(segment)) {
+    throw new Error(`Invalid hextet segment "${segment}".`);
+  }
+  return segment.toUpperCase().padStart(HEX_DIGITS_PER_HEXTET, '0');
+}
+
+export function expandIpv6(address: string): string[] {
+  if (!address) {
+    throw new Error('IPv6 address is required.');
+  }
+
+  const trimmed = address.trim();
+  if (!trimmed) {
+    throw new Error('IPv6 address is required.');
+  }
+
+  const zoneStripped = trimmed.split('%')[0];
+  const [addrPart] = zoneStripped.split('/');
+  const lowercase = addrPart.toLowerCase();
+  const doubleColonParts = lowercase.split('::');
+
+  if (doubleColonParts.length > 2) {
+    throw new Error('IPv6 address may contain at most one double colon.');
+  }
+
+  const headSegments = doubleColonParts[0]
+    .split(':')
+    .filter(Boolean)
+    .flatMap((segment) => (segment.includes('.') ? ipv4SegmentToHextets(segment) : [segment]));
+
+  const tailSegments = (doubleColonParts[1] ?? '')
+    .split(':')
+    .filter(Boolean)
+    .flatMap((segment) => (segment.includes('.') ? ipv4SegmentToHextets(segment) : [segment]));
+
+  const missing = TOTAL_HEXTETS - (headSegments.length + tailSegments.length);
+  if (doubleColonParts.length === 1 && missing !== 0) {
+    throw new Error('IPv6 address has incorrect number of hextets.');
+  }
+  if (missing < 0) {
+    throw new Error('IPv6 address has too many hextets.');
+  }
+
+  const hextets = [
+    ...headSegments.map(sanitizeHextet),
+    ...Array(Math.max(missing, 0)).fill('0000'),
+    ...tailSegments.map(sanitizeHextet),
+  ];
+
+  if (hextets.length !== TOTAL_HEXTETS) {
+    throw new Error('Expanded IPv6 address must contain eight hextets.');
+  }
+
+  return hextets;
+}
+
+function hextetsToBigInt(hextets: string[]): bigint {
+  return hextets.reduce((acc, segment) => {
+    const value = BigInt(`0x${segment}`);
+    return (acc << HEXTET_BIT_WIDTH) | value;
+  }, 0n);
+}
+
+function bigIntToHextets(value: bigint, groups: number): string[] {
+  const mask = 0xffffn;
+  const hextets = new Array<string>(groups);
+  let working = value;
+  for (let index = groups - 1; index >= 0; index -= 1) {
+    const segment = Number(working & mask);
+    hextets[index] = segment.toString(16).toUpperCase().padStart(HEX_DIGITS_PER_HEXTET, '0');
+    working >>= HEXTET_BIT_WIDTH;
+  }
+  return hextets;
+}
+
+export function nibbleMatrixFromHextets(hextets: string[]): NibbleMatrix {
+  return hextets.map((segment) => segment.toUpperCase().padStart(HEX_DIGITS_PER_HEXTET, '0').split(''));
+}
+
+function binaryNibbleGroups(value: bigint, width: number): string[] {
+  const binary = value.toString(2).padStart(width, '0');
+  const groups: string[] = [];
+  for (let index = 0; index < binary.length; index += NIBBLE_SIZE) {
+    groups.push(binary.slice(index, index + NIBBLE_SIZE));
+  }
+  return groups;
+}
+
+export function ipv6NibbleMatrix(address: string): NibbleMatrix {
+  return nibbleMatrixFromHextets(expandIpv6(address));
+}
+
+export function interfaceIdentifierFromIpv6(address: string): IdentifierBreakdown {
+  const hextets = expandIpv6(address);
+  const numeric = hextetsToBigInt(hextets);
+  const identifier = numeric & INTERFACE_MASK;
+  const identifierHextets = bigIntToHextets(identifier, 4);
+  const value = identifierHextets.join(':');
+
+  return {
+    value,
+    hextets: identifierHextets,
+    nibbleMatrix: nibbleMatrixFromHextets(identifierHextets),
+    binaryGroups: binaryNibbleGroups(identifier, INTERFACE_IDENTIFIER_BITS),
+  };
+}
+
+export function macToEui64(mac: string): IdentifierBreakdown {
+  if (!mac) {
+    throw new Error('MAC address is required.');
+  }
+
+  const sanitized = mac.replace(MAC_SANITIZE, '').toLowerCase();
+  if (sanitized.length !== 12) {
+    throw new Error('MAC address must contain exactly 12 hexadecimal characters.');
+  }
+
+  const macValue = BigInt(`0x${sanitized}`);
+  const upper24 = macValue >> 24n;
+  const lower24 = macValue & ((1n << 24n) - 1n);
+
+  const firstOctet = Number((upper24 >> 16n) & 0xffn) ^ 0x02;
+  const secondOctet = Number((upper24 >> 8n) & 0xffn);
+  const thirdOctet = Number(upper24 & 0xffn);
+
+  const flippedUpper =
+    (BigInt(firstOctet) << 16n) | (BigInt(secondOctet) << 8n) | BigInt(thirdOctet);
+
+  const eui64 = (flippedUpper << 40n) | (0xfffen << 24n) | lower24;
+  const hextets = bigIntToHextets(eui64, 4);
+  const value = hextets.join(':');
+
+  return {
+    value,
+    hextets,
+    nibbleMatrix: nibbleMatrixFromHextets(hextets),
+    binaryGroups: binaryNibbleGroups(eui64, INTERFACE_IDENTIFIER_BITS),
+  };
+}


### PR DESCRIPTION
## Summary
- add networking subnet helpers to expand IPv6, derive interface identifiers, and build EUI-64 values
- create an IPv6-focused section in the subnet calculator that surfaces nibble groups and binary groupings
- add Jest vectors covering published MAC-to-EUI-64 conversions

## Testing
- yarn lint *(fails: repository has pre-existing accessibility lint violations unrelated to this change)*
- yarn test subnet-ipv6

------
https://chatgpt.com/codex/tasks/task_e_68cc38f589988328b6b5b0177a4fce85