### PR TITLE
[networking] add subnet summarization and VLSM planner

### DIFF
--- a/__tests__/subnet.summary.test.ts
+++ b/__tests__/subnet.summary.test.ts
@@ -1,0 +1,101 @@
+import fc from 'fast-check';
+import {
+  IPv4Cidr,
+  summarizeSubnets,
+  parseCidr,
+  ipv4ToNumber,
+} from '../modules/networking/subnet';
+
+type NumericRange = {
+  start: number;
+  end: number;
+};
+
+function cidrToRange(cidr: IPv4Cidr): NumericRange {
+  const start = ipv4ToNumber(cidr.network);
+  const size = Math.pow(2, 32 - cidr.prefix);
+  return { start, end: start + size - 1 };
+}
+
+function mergeRanges(ranges: NumericRange[]): NumericRange[] {
+  if (ranges.length === 0) return [];
+  const sorted = [...ranges].sort((a, b) => (a.start === b.start ? a.end - b.end : a.start - b.start));
+  const merged: NumericRange[] = [{ ...sorted[0] }];
+
+  for (let i = 1; i < sorted.length; i++) {
+    const current = sorted[i];
+    const last = merged[merged.length - 1];
+    if (current.start <= last.end + 1) {
+      if (current.end > last.end) {
+        last.end = current.end;
+      }
+    } else {
+      merged.push({ ...current });
+    }
+  }
+
+  return merged;
+}
+
+function deriveGaps(union: NumericRange[]): NumericRange[] {
+  const gaps: NumericRange[] = [];
+  for (let i = 0; i < union.length - 1; i++) {
+    const gapStart = union[i].end + 1;
+    const gapEnd = union[i + 1].start - 1;
+    if (gapStart <= gapEnd) {
+      gaps.push({ start: gapStart, end: gapEnd });
+    }
+  }
+  return gaps;
+}
+
+describe('summarizeSubnets', () => {
+  const cidrArb = fc.array(
+    fc
+      .tuple(
+        fc.integer({ min: 0, max: 255 }),
+        fc.integer({ min: 0, max: 255 }),
+        fc.integer({ min: 0, max: 255 }),
+        fc.integer({ min: 0, max: 255 }),
+        fc.integer({ min: 0, max: 32 }),
+      )
+      .map(([a, b, c, d, prefix]) => `${a}.${b}.${c}.${d}/${prefix}`),
+    { minLength: 1, maxLength: 5 },
+  );
+
+  it('produces gap-free coverage equivalent to the original ranges', () => {
+    fc.assert(
+      fc.property(cidrArb, (entries) => {
+        const cidrs = entries.map((entry) => parseCidr(entry));
+        const result = summarizeSubnets(cidrs);
+
+        const originalUnion = mergeRanges(cidrs.map(cidrToRange));
+        const summarizedRanges = result.subnets.map((subnet) =>
+          cidrToRange({ network: subnet.network, prefix: subnet.prefix }),
+        );
+        const summarizedUnion = mergeRanges(summarizedRanges);
+
+        const sortedSummaries = [...summarizedRanges].sort((a, b) => a.start - b.start);
+        for (let i = 1; i < sortedSummaries.length; i++) {
+          expect(sortedSummaries[i].start).toBeGreaterThan(sortedSummaries[i - 1].end);
+        }
+
+        expect(summarizedUnion).toEqual(originalUnion);
+
+        const expectedTotal = originalUnion.reduce(
+          (total, range) => total + (range.end - range.start + 1),
+          0,
+        );
+        expect(result.totalAddresses).toBe(expectedTotal);
+
+        const expectedGaps = deriveGaps(originalUnion);
+        const resultGaps = result.gaps.map((gap) => ({
+          start: ipv4ToNumber(gap.start),
+          end: ipv4ToNumber(gap.end),
+        }));
+        expect(resultGaps).toEqual(expectedGaps);
+        expect(result.isGapFree).toBe(expectedGaps.length === 0);
+      }),
+    );
+  });
+});

--- a/apps/subnet-calculator/index.tsx
+++ b/apps/subnet-calculator/index.tsx
@@ -1,0 +1,350 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  CoverageReport,
+  IPv4AddressRange,
+  IPv4Cidr,
+  IPv4Subnet,
+  VlsmAllocation,
+  VlsmPlan,
+  VlsmRequirement,
+  formatCidr,
+  parseCidr,
+  performVlsm,
+  summarizeSubnets,
+} from '../../modules/networking/subnet';
+
+interface SummaryState {
+  errors: string[];
+  result: CoverageReport<IPv4Subnet> | null;
+}
+
+interface VlsmState {
+  base: IPv4Cidr | null;
+  baseError: string | null;
+  requirementErrors: string[];
+  result: VlsmPlan | null;
+}
+
+const DEFAULT_SUMMARY = ['192.168.10.0/25', '192.168.10.128/25'].join('\n');
+const DEFAULT_BASE = '10.0.0.0/24';
+const DEFAULT_REQUIREMENTS = '90, 40, 20, 10';
+
+function parseSummaryInput(value: string): SummaryState {
+  const lines = value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const errors: string[] = [];
+  const cidrs: IPv4Cidr[] = [];
+
+  lines.forEach((line, index) => {
+    try {
+      cidrs.push(parseCidr(line));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Invalid CIDR';
+      errors.push(`Line ${index + 1}: ${message}`);
+    }
+  });
+
+  const result = cidrs.length > 0 && errors.length === 0 ? summarizeSubnets(cidrs) : null;
+
+  return { errors, result };
+}
+
+function parseHosts(value: string): { requirements: VlsmRequirement[]; errors: string[] } {
+  const requirements: VlsmRequirement[] = [];
+  const errors: string[] = [];
+
+  const entries = value
+    .split(/[,\n]+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+
+  entries.forEach((token, index) => {
+    const numeric = Number(token);
+    if (!Number.isFinite(numeric)) {
+      errors.push(`Entry ${index + 1} is not a number.`);
+      return;
+    }
+    const integer = Math.trunc(numeric);
+    if (integer !== numeric) {
+      errors.push(`Entry ${index + 1} must be an integer.`);
+      return;
+    }
+    if (integer < 0) {
+      errors.push(`Entry ${index + 1} must be zero or positive.`);
+      return;
+    }
+    requirements.push({ hosts: integer, label: `Subnet ${index + 1}` });
+  });
+
+  return { requirements, errors };
+}
+
+function formatGap(gap: IPv4AddressRange) {
+  return `${gap.start} – ${gap.end} (${gap.size.toLocaleString()} addresses)`;
+}
+
+function SummaryTable({ subnets }: { subnets: IPv4Subnet[] }) {
+  if (subnets.length === 0) {
+    return (
+      <p className="rounded border border-slate-700 bg-slate-900 p-3 text-sm text-slate-300">
+        Provide at least one subnet to view the summary.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-slate-700 text-sm">
+        <thead className="bg-slate-800">
+          <tr>
+            <th className="px-3 py-2 text-left font-semibold">CIDR</th>
+            <th className="px-3 py-2 text-left font-semibold">Network</th>
+            <th className="px-3 py-2 text-left font-semibold">Broadcast</th>
+            <th className="px-3 py-2 text-left font-semibold">Usable Hosts</th>
+            <th className="px-3 py-2 text-left font-semibold">Total Addresses</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-800">
+          {subnets.map((subnet) => (
+            <tr key={subnet.cidr}>
+              <td className="px-3 py-2 font-mono">{subnet.cidr}</td>
+              <td className="px-3 py-2 font-mono">{subnet.network}</td>
+              <td className="px-3 py-2 font-mono">{subnet.broadcast}</td>
+              <td className="px-3 py-2">{subnet.usableHosts.toLocaleString()}</td>
+              <td className="px-3 py-2">{subnet.totalAddresses.toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function VlsmTable({ allocations }: { allocations: VlsmAllocation[] }) {
+  if (allocations.length === 0) {
+    return (
+      <p className="rounded border border-slate-700 bg-slate-900 p-3 text-sm text-slate-300">
+        Add host requirements to build a VLSM plan.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-slate-700 text-sm">
+        <thead className="bg-slate-800">
+          <tr>
+            <th className="px-3 py-2 text-left font-semibold">Label</th>
+            <th className="px-3 py-2 text-left font-semibold">Hosts Requested</th>
+            <th className="px-3 py-2 text-left font-semibold">Allocated CIDR</th>
+            <th className="px-3 py-2 text-left font-semibold">Usable Hosts</th>
+            <th className="px-3 py-2 text-left font-semibold">Unused Capacity</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-800">
+          {allocations.map((allocation) => (
+            <tr key={`${allocation.cidr}-${allocation.requirement.originalIndex}`}>
+              <td className="px-3 py-2">
+                {allocation.requirement.label ?? `Subnet ${allocation.requirement.originalIndex + 1}`}
+              </td>
+              <td className="px-3 py-2">{allocation.requirement.hosts.toLocaleString()}</td>
+              <td className="px-3 py-2 font-mono">{allocation.cidr}</td>
+              <td className="px-3 py-2">{allocation.usableHosts.toLocaleString()}</td>
+              <td className="px-3 py-2">{allocation.wastedAddresses.toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function SubnetCalculator() {
+  const [summaryInput, setSummaryInput] = useState(DEFAULT_SUMMARY);
+  const [baseInput, setBaseInput] = useState(DEFAULT_BASE);
+  const [hostInput, setHostInput] = useState(DEFAULT_REQUIREMENTS);
+
+  const summaryState = useMemo(() => parseSummaryInput(summaryInput), [summaryInput]);
+
+  const vlsmState = useMemo(() => {
+    let base: IPv4Cidr | null = null;
+    let baseError: string | null = null;
+
+    try {
+      base = parseCidr(baseInput);
+    } catch (error) {
+      baseError = error instanceof Error ? error.message : 'Invalid CIDR';
+    }
+
+    const { requirements, errors: requirementErrors } = parseHosts(hostInput);
+    const result =
+      base && requirementErrors.length === 0
+        ? performVlsm({ base, requirements })
+        : null;
+
+    return { base, baseError, requirementErrors, result } satisfies VlsmState;
+  }, [baseInput, hostInput]);
+
+  return (
+    <div className="flex h-full flex-col gap-6 bg-slate-900 p-4 text-slate-100">
+      <header>
+        <h1 className="text-2xl font-semibold">Subnet Calculator</h1>
+        <p className="mt-1 text-sm text-slate-300">
+          Summarize IPv4 networks and build variable-length subnetting plans with automatic gap detection.
+        </p>
+      </header>
+
+      <section className="space-y-4 rounded-lg border border-slate-700 bg-slate-950/60 p-4 shadow">
+        <header className="space-y-1">
+          <h2 className="text-xl font-semibold">Subnet Summarization</h2>
+          <p className="text-sm text-slate-300">
+            Enter IPv4 networks in CIDR notation. The tool merges adjacent ranges and highlights uncovered gaps.
+          </p>
+        </header>
+        <div>
+          <label htmlFor="summary-input" className="mb-1 block text-sm font-medium text-slate-200">
+            CIDR ranges (one per line)
+          </label>
+          <textarea
+            id="summary-input"
+            value={summaryInput}
+            onChange={(event) => setSummaryInput(event.target.value)}
+            className="h-32 w-full resize-y rounded border border-slate-700 bg-slate-900 p-2 font-mono text-sm text-slate-100 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-500"
+            placeholder="192.168.0.0/24"
+          />
+          {summaryState.errors.length > 0 && (
+            <ul className="mt-2 space-y-1 text-sm text-red-400">
+              {summaryState.errors.map((error) => (
+                <li key={error}>{error}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+        {summaryState.result && (
+          <div className="space-y-3">
+            <SummaryTable subnets={summaryState.result.subnets} />
+            <div className="text-sm text-slate-300">
+              <p>
+                Total coverage: {summaryState.result.totalAddresses.toLocaleString()} addresses across{' '}
+                {summaryState.result.subnets.length} subnet{summaryState.result.subnets.length === 1 ? '' : 's'}.
+              </p>
+              {!summaryState.result.isGapFree && summaryState.result.gaps.length > 0 && (
+                <div className="mt-2 rounded border border-amber-500/60 bg-amber-500/10 p-3 text-amber-200">
+                  <p className="font-semibold">Gap detected</p>
+                  <ul className="mt-1 list-inside list-disc space-y-1">
+                    {summaryState.result.gaps.map((gap) => (
+                      <li key={gap.start}>{formatGap(gap)}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {summaryState.result.isGapFree && (
+                <p className="mt-2 rounded border border-emerald-500/50 bg-emerald-500/10 p-3 text-emerald-200">
+                  The supplied ranges provide continuous coverage without gaps.
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-4 rounded-lg border border-slate-700 bg-slate-950/60 p-4 shadow">
+        <header className="space-y-1">
+          <h2 className="text-xl font-semibold">VLSM Planner</h2>
+          <p className="text-sm text-slate-300">
+            Define a base network and host requirements. Allocations are made from largest to smallest and any gaps or
+            unallocated segments are reported.
+          </p>
+        </header>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label htmlFor="base-input" className="mb-1 block text-sm font-medium text-slate-200">
+              Base network (CIDR)
+            </label>
+            <input
+              id="base-input"
+              value={baseInput}
+              onChange={(event) => setBaseInput(event.target.value)}
+              className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono text-sm text-slate-100 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-500"
+              placeholder="10.0.0.0/24"
+            />
+            {vlsmState.baseError && (
+              <p className="mt-1 text-sm text-red-400">{vlsmState.baseError}</p>
+            )}
+          </div>
+          <div>
+            <label htmlFor="hosts-input" className="mb-1 block text-sm font-medium text-slate-200">
+              Host requirements (comma or newline separated)
+            </label>
+            <textarea
+              id="hosts-input"
+              value={hostInput}
+              onChange={(event) => setHostInput(event.target.value)}
+              className="h-32 w-full resize-y rounded border border-slate-700 bg-slate-900 p-2 text-sm text-slate-100 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-500"
+              placeholder="90, 40, 20, 10"
+            />
+            {vlsmState.requirementErrors.length > 0 && (
+              <ul className="mt-2 space-y-1 text-sm text-red-400">
+                {vlsmState.requirementErrors.map((error) => (
+                  <li key={error}>{error}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        {vlsmState.result && (
+          <div className="space-y-3">
+            <div className="rounded border border-slate-700 bg-slate-900 p-3 text-sm text-slate-200">
+              <p className="font-semibold">Base network: {formatCidr(vlsmState.result.base)}</p>
+              <p className="mt-1">
+                Total addresses: {vlsmState.result.base.totalAddresses.toLocaleString()} — usable hosts:{' '}
+                {vlsmState.result.base.usableHosts.toLocaleString()}
+              </p>
+            </div>
+            <VlsmTable allocations={vlsmState.result.subnets} />
+            <div className="text-sm text-slate-300">
+              <p>
+                Allocated coverage: {vlsmState.result.totalAddresses.toLocaleString()} addresses across{' '}
+                {vlsmState.result.subnets.length} subnet{vlsmState.result.subnets.length === 1 ? '' : 's'}.
+              </p>
+              {vlsmState.result.unallocated.length > 0 && (
+                <div className="mt-2 rounded border border-red-500/60 bg-red-500/10 p-3 text-red-200">
+                  <p className="font-semibold">Unallocated requirements</p>
+                  <ul className="mt-1 list-inside list-disc space-y-1">
+                    {vlsmState.result.unallocated.map((req) => (
+                      <li key={req.originalIndex}>
+                        {(req.label ?? `Subnet ${req.originalIndex + 1}`) + ': '}
+                        {req.hosts.toLocaleString()} hosts
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {vlsmState.result.gaps.length > 0 && (
+                <div className="mt-2 rounded border border-amber-500/60 bg-amber-500/10 p-3 text-amber-200">
+                  <p className="font-semibold">Unassigned address space</p>
+                  <ul className="mt-1 list-inside list-disc space-y-1">
+                    {vlsmState.result.gaps.map((gap) => (
+                      <li key={gap.start}>{formatGap(gap)}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {vlsmState.result.isGapFree && (
+                <p className="mt-2 rounded border border-emerald-500/50 bg-emerald-500/10 p-3 text-emerald-200">
+                  Plan covers the base network without gaps or leftover requirements.
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/modules/networking/subnet.ts
+++ b/modules/networking/subnet.ts
@@ -1,0 +1,352 @@
+export type IPv4Address = `${number}.${number}.${number}.${number}`;
+
+export interface IPv4Cidr {
+  network: IPv4Address;
+  prefix: number;
+}
+
+interface NormalizedSubnet {
+  start: number;
+  end: number;
+  prefix: number;
+}
+
+export interface IPv4Subnet {
+  cidr: string;
+  network: IPv4Address;
+  prefix: number;
+  broadcast: IPv4Address;
+  firstHost: IPv4Address | null;
+  lastHost: IPv4Address | null;
+  totalAddresses: number;
+  usableHosts: number;
+}
+
+export interface IPv4AddressRange {
+  start: IPv4Address;
+  end: IPv4Address;
+  size: number;
+}
+
+export interface CoverageReport<T extends IPv4Subnet> {
+  subnets: T[];
+  gaps: IPv4AddressRange[];
+  totalAddresses: number;
+  isGapFree: boolean;
+}
+
+export interface VlsmRequirement {
+  hosts: number;
+  label?: string;
+}
+
+export interface ResolvedVlsmRequirement extends VlsmRequirement {
+  originalIndex: number;
+}
+
+export interface VlsmAllocation extends IPv4Subnet {
+  requirement: ResolvedVlsmRequirement;
+  wastedAddresses: number;
+}
+
+export interface VlsmPlan extends CoverageReport<VlsmAllocation> {
+  base: IPv4Subnet;
+  unallocated: ResolvedVlsmRequirement[];
+}
+
+const MAX_IPV4 = 2 ** 32 - 1;
+
+function validatePrefix(prefix: number): number {
+  if (!Number.isInteger(prefix) || prefix < 0 || prefix > 32) {
+    throw new Error('Prefix length must be an integer between 0 and 32.');
+  }
+  return prefix;
+}
+
+export function ipv4ToNumber(address: string): number {
+  const parts = address.trim().split('.');
+  if (parts.length !== 4) {
+    throw new Error('IPv4 address must contain four octets.');
+  }
+
+  let value = 0;
+  for (const part of parts) {
+    if (part === '') {
+      throw new Error('IPv4 octets cannot be empty.');
+    }
+    if (!/^\d+$/.test(part)) {
+      throw new Error('IPv4 octets must be numeric.');
+    }
+    const octet = Number(part);
+    if (!Number.isInteger(octet) || octet < 0 || octet > 255) {
+      throw new Error('IPv4 octets must be in the range 0-255.');
+    }
+    value = value * 256 + octet;
+  }
+  return value;
+}
+
+export function numberToIpv4(value: number): IPv4Address {
+  if (!Number.isInteger(value) || value < 0 || value > MAX_IPV4) {
+    throw new Error('IPv4 numeric value must be between 0 and 2^32 - 1.');
+  }
+
+  const octets = [
+    Math.floor(value / 16777216) % 256,
+    Math.floor(value / 65536) % 256,
+    Math.floor(value / 256) % 256,
+    value % 256,
+  ];
+  return `${octets[0]}.${octets[1]}.${octets[2]}.${octets[3]}` as IPv4Address;
+}
+
+function subnetSize(prefix: number): number {
+  validatePrefix(prefix);
+  if (prefix === 32) return 1;
+  return 2 ** (32 - prefix);
+}
+
+function normalizeCidr({ network, prefix }: IPv4Cidr): NormalizedSubnet {
+  const validPrefix = validatePrefix(prefix);
+  const address = ipv4ToNumber(network);
+  const size = subnetSize(validPrefix);
+  const start = address - (address % size);
+  const end = start + size - 1;
+  return { start, end, prefix: validPrefix };
+}
+
+function largestAlignedBlock(start: number): number {
+  let block = 1;
+  while (block < 2 ** 32 && start % (block * 2) === 0) {
+    block *= 2;
+  }
+  return block;
+}
+
+function rangeToCidrs(start: number, end: number): Array<{ start: number; prefix: number }> {
+  const ranges: Array<{ start: number; prefix: number }> = [];
+  let current = start;
+  while (current <= end) {
+    let block = largestAlignedBlock(current);
+    const remaining = end - current + 1;
+    while (block > remaining) {
+      block /= 2;
+    }
+    const prefix = 32 - Math.floor(Math.log2(block));
+    ranges.push({ start: current, prefix });
+    current += block;
+  }
+  return ranges;
+}
+
+function createSubnet(start: number, prefix: number): IPv4Subnet {
+  const size = subnetSize(prefix);
+  const network = numberToIpv4(start);
+  const broadcast = numberToIpv4(start + size - 1);
+
+  if (prefix >= 31) {
+    return {
+      cidr: `${network}/${prefix}`,
+      network,
+      prefix,
+      broadcast,
+      firstHost: network,
+      lastHost: broadcast,
+      totalAddresses: size,
+      usableHosts: prefix === 32 ? 1 : 2,
+    };
+  }
+
+  return {
+    cidr: `${network}/${prefix}`,
+    network,
+    prefix,
+    broadcast,
+    firstHost: numberToIpv4(start + 1),
+    lastHost: numberToIpv4(start + size - 2),
+    totalAddresses: size,
+    usableHosts: Math.max(size - 2, 0),
+  };
+}
+
+function mergeRanges(ranges: NormalizedSubnet[]): Array<{ start: number; end: number }> {
+  if (ranges.length === 0) return [];
+  const sorted = [...ranges].sort((a, b) => {
+    if (a.start === b.start) return a.end - b.end;
+    return a.start - b.start;
+  });
+  const merged: Array<{ start: number; end: number }> = [
+    { start: sorted[0].start, end: sorted[0].end },
+  ];
+
+  for (let i = 1; i < sorted.length; i++) {
+    const current = sorted[i];
+    const last = merged[merged.length - 1];
+    if (current.start <= last.end + 1) {
+      if (current.end > last.end) {
+        last.end = current.end;
+      }
+    } else {
+      merged.push({ start: current.start, end: current.end });
+    }
+  }
+
+  return merged;
+}
+
+function calculateGaps(merged: Array<{ start: number; end: number }>): IPv4AddressRange[] {
+  const gaps: IPv4AddressRange[] = [];
+  for (let i = 0; i < merged.length - 1; i++) {
+    const gapStart = merged[i].end + 1;
+    const gapEnd = merged[i + 1].start - 1;
+    if (gapStart <= gapEnd) {
+      gaps.push({
+        start: numberToIpv4(gapStart),
+        end: numberToIpv4(gapEnd),
+        size: gapEnd - gapStart + 1,
+      });
+    }
+  }
+  return gaps;
+}
+
+export function parseCidr(input: string): IPv4Cidr {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error('CIDR notation cannot be empty.');
+  }
+  const parts = trimmed.split('/');
+  if (parts.length !== 2) {
+    throw new Error('CIDR must include a prefix length, e.g. 192.168.0.0/24.');
+  }
+  const prefix = Number(parts[1]);
+  if (!Number.isInteger(prefix)) {
+    throw new Error('Prefix length must be an integer.');
+  }
+  const address = ipv4ToNumber(parts[0]);
+  const size = subnetSize(prefix);
+  const networkValue = address - (address % size);
+  const network = numberToIpv4(networkValue);
+  return { network, prefix };
+}
+
+export function formatCidr({ network, prefix }: IPv4Cidr): string {
+  return `${network}/${prefix}`;
+}
+
+export function summarizeSubnets(cidrs: IPv4Cidr[]): CoverageReport<IPv4Subnet> {
+  if (cidrs.length === 0) {
+    return { subnets: [], gaps: [], totalAddresses: 0, isGapFree: true };
+  }
+
+  const normalized = cidrs.map(normalizeCidr);
+  const merged = mergeRanges(normalized);
+  const subnets = merged.flatMap((range) =>
+    rangeToCidrs(range.start, range.end).map((block) =>
+      createSubnet(block.start, block.prefix),
+    ),
+  );
+
+  const gaps = calculateGaps(merged);
+  const totalAddresses = subnets.reduce((sum, subnet) => sum + subnet.totalAddresses, 0);
+
+  return {
+    subnets,
+    gaps,
+    totalAddresses,
+    isGapFree: gaps.length === 0,
+  };
+}
+
+function requirementToPrefix(hosts: number): number {
+  if (!Number.isFinite(hosts) || hosts < 0) {
+    throw new Error('Host requirements must be zero or a positive number.');
+  }
+  if (hosts === 0) {
+    return 32;
+  }
+  let needed = hosts + 2;
+  if (needed < 2) needed = 2;
+  let prefix = 32;
+  while (2 ** (32 - prefix) < needed && prefix > 0) {
+    prefix -= 1;
+  }
+  return prefix;
+}
+
+export function performVlsm({
+  base,
+  requirements,
+}: {
+  base: IPv4Cidr;
+  requirements: VlsmRequirement[];
+}): VlsmPlan {
+  const normalizedBase = normalizeCidr(base);
+  const baseSubnet = createSubnet(normalizedBase.start, normalizedBase.prefix);
+
+  const resolvedRequirements: ResolvedVlsmRequirement[] = requirements.map(
+    (req, index) => ({
+      hosts: req.hosts,
+      label: req.label,
+      originalIndex: index,
+    }),
+  );
+
+  const sorted = [...resolvedRequirements].sort((a, b) => {
+    if (b.hosts === a.hosts) return a.originalIndex - b.originalIndex;
+    return b.hosts - a.hosts;
+  });
+
+  const allocations: VlsmAllocation[] = [];
+  const unallocated: ResolvedVlsmRequirement[] = [];
+  let cursor = normalizedBase.start;
+
+  for (const requirement of sorted) {
+    const prefix = requirementToPrefix(requirement.hosts);
+    const size = subnetSize(prefix);
+    if (cursor + size - 1 > normalizedBase.end) {
+      unallocated.push(requirement);
+      continue;
+    }
+    const subnet = createSubnet(cursor, prefix);
+    const wasted = Math.max(subnet.usableHosts - requirement.hosts, 0);
+    allocations.push({
+      ...subnet,
+      requirement,
+      wastedAddresses: wasted,
+    });
+    cursor += size;
+  }
+
+  allocations.sort(
+    (a, b) => ipv4ToNumber(a.network) - ipv4ToNumber(b.network),
+  );
+  unallocated.sort((a, b) => a.originalIndex - b.originalIndex);
+
+  const totalAddresses = allocations.reduce(
+    (sum, subnet) => sum + subnet.totalAddresses,
+    0,
+  );
+
+  const gaps: IPv4AddressRange[] = [];
+  if (cursor <= normalizedBase.end) {
+    const gapStart = cursor;
+    const gapEnd = normalizedBase.end;
+    if (gapStart <= gapEnd) {
+      gaps.push({
+        start: numberToIpv4(gapStart),
+        end: numberToIpv4(gapEnd),
+        size: gapEnd - gapStart + 1,
+      });
+    }
+  }
+
+  return {
+    base: baseSubnet,
+    subnets: allocations,
+    gaps,
+    totalAddresses,
+    unallocated,
+    isGapFree: gaps.length === 0 && unallocated.length === 0,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "eslint": "^9.13.0",
     "eslint-config-next": "15.5.2",
     "fake-indexeddb": "^6.1.0",
+    "fast-check": "^3.23.1",
     "fast-glob": "^3.3.3",
     "jest": "30.0.5",
     "jest-environment-jsdom": "30.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7234,6 +7234,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-check@npm:^3.23.1":
+  version: 3.23.2
+  resolution: "fast-check@npm:3.23.2"
+  dependencies:
+    pure-rand: "npm:^6.1.0"
+  checksum: 10c0/16fcff3c80321ee765e23c3aebd0f6427f175c9c6c1753104ec658970162365dc2d56bda046d815e8f2e90634c07ba7d6f0bcfd327fbd576d98c56a18a9765ed
+  languageName: node
+  linkType: hard
+
 "fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
@@ -11200,6 +11209,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pure-rand@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "pure-rand@npm:6.1.0"
+  checksum: 10c0/1abe217897bf74dcb3a0c9aba3555fe975023147b48db540aa2faf507aee91c03bf54f6aef0eb2bf59cc259a16d06b28eca37f0dc426d94f4692aeff02fb0e65
+  languageName: node
+  linkType: hard
+
 "pure-rand@npm:^7.0.0":
   version: 7.0.1
   resolution: "pure-rand@npm:7.0.1"
@@ -13908,6 +13924,7 @@ __metadata:
     eslint: "npm:^9.13.0"
     eslint-config-next: "npm:15.5.2"
     fake-indexeddb: "npm:^6.1.0"
+    fast-check: "npm:^3.23.1"
     fast-glob: "npm:^3.3.3"
     fast-xml-parser: "npm:^4.3.5"
     figlet: "npm:^1.8.2"


### PR DESCRIPTION
## Summary
- add a typed IPv4 subnet utility module with summarization and VLSM planning helpers
- create a subnet calculator UI that visualizes aggregated coverage, VLSM allocations, and gap warnings
- add property-based tests to ensure summarization output matches original coverage without overlaps

## Testing
- yarn test --runTestsByPath __tests__/subnet.summary.test.ts
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc38f6378c8328959ec262833e6ad5