### PR TITLE
feat(dns-toolkit): add traceroute map animation

### DIFF
--- a/__tests__/apps/dns-toolkit/traceroute-map.test.tsx
+++ b/__tests__/apps/dns-toolkit/traceroute-map.test.tsx
@@ -1,0 +1,119 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import TracerouteMap from '@/apps/dns-toolkit/components/TracerouteMap';
+import { TRACEROUTE_HOPS } from '@/apps/dns-toolkit/mocks/traceroute';
+
+jest.mock('react-leaflet', () => ({
+  MapContainer: ({ children, className, style }: any) => (
+    <div data-testid="leaflet-map" className={className} style={style}>
+      {children}
+    </div>
+  ),
+  TileLayer: () => null,
+  Polyline: () => null,
+  CircleMarker: ({ children }: any) => <div data-testid="leaflet-circle">{children}</div>,
+  Tooltip: ({ children }: any) => <div data-testid="leaflet-tooltip">{children}</div>,
+}));
+
+describe('TracerouteMap animation controls', () => {
+  const callbacks = new Map<number, FrameRequestCallback>();
+  let rafId = 1;
+  let rafSpy: jest.SpyInstance<number, [FrameRequestCallback]>;
+  let cancelSpy: jest.SpyInstance<void, [number]>;
+
+  const flushFrame = (timestamp: number) => {
+    const pending = Array.from(callbacks.entries());
+    callbacks.clear();
+    pending.forEach(([, cb]) => cb(timestamp));
+  };
+
+  const getFrameIndex = () => Number((screen.getByTestId('frame-index').textContent ?? '0').trim());
+  const getAnimationState = () => (screen.getByTestId('animation-state').textContent ?? '').trim();
+  const getLatencyText = (index: number) =>
+    (screen.getByTestId(`hop-latency-${index}`).textContent ?? '').trim();
+
+  beforeEach(() => {
+    callbacks.clear();
+    rafId = 1;
+    rafSpy = jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+      const id = rafId++;
+      callbacks.set(id, cb);
+      return id;
+    });
+    cancelSpy = jest.spyOn(window, 'cancelAnimationFrame').mockImplementation((id: number) => {
+      callbacks.delete(id);
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    callbacks.clear();
+  });
+
+  test('pausing stops the animation loop and resume continues from the saved frame', async () => {
+    render(<TracerouteMap />);
+
+    await waitFor(() => expect(callbacks.size).toBeGreaterThan(0));
+
+    act(() => {
+      flushFrame(0);
+    });
+
+    await waitFor(() => expect(getFrameIndex()).toBeGreaterThan(0));
+
+    act(() => {
+      flushFrame(1600);
+    });
+
+    const frameBeforePause = getFrameIndex();
+    expect(frameBeforePause).toBeGreaterThan(0);
+
+    const pauseButton = screen.getByRole('button', { name: /pause animation/i });
+    fireEvent.click(pauseButton);
+
+    await waitFor(() => expect(getAnimationState()).toBe('paused'));
+    await waitFor(() => expect(cancelSpy).toHaveBeenCalled());
+    await waitFor(() => expect(callbacks.size).toBe(0));
+
+    act(() => {
+      flushFrame(2600);
+    });
+
+    expect(getFrameIndex()).toBe(frameBeforePause);
+
+    const resumeButton = screen.getByRole('button', { name: /resume animation/i });
+    fireEvent.click(resumeButton);
+
+    await waitFor(() => expect(callbacks.size).toBeGreaterThan(0));
+
+    act(() => {
+      flushFrame(4200);
+      flushFrame(5800);
+    });
+
+    expect(getFrameIndex()).toBeGreaterThan(frameBeforePause);
+    expect(rafSpy).toHaveBeenCalled();
+  });
+
+  test('renders hop list entries with generator-driven latency updates', async () => {
+    render(<TracerouteMap />);
+
+    const hopList = await screen.findByTestId('hop-list');
+    const items = within(hopList).getAllByRole('listitem');
+    expect(items).toHaveLength(TRACEROUTE_HOPS.length);
+
+    items.forEach((item, index) => {
+      const hop = TRACEROUTE_HOPS[index];
+      expect(within(item).getByText(hop.label)).toBeInTheDocument();
+      expect(within(item).getByText(hop.location)).toBeInTheDocument();
+    });
+
+    await waitFor(() => expect(getLatencyText(0)).toMatch(/ms$/));
+
+    act(() => {
+      flushFrame(0);
+      flushFrame(1800);
+    });
+
+    await waitFor(() => expect(getLatencyText(1)).toMatch(/ms$/));
+  });
+});

--- a/apps/dns-toolkit/components/TracerouteMap.tsx
+++ b/apps/dns-toolkit/components/TracerouteMap.tsx
@@ -1,0 +1,325 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { LatLngBoundsExpression, LatLngExpression } from 'leaflet';
+import { CircleMarker, MapContainer, Polyline, TileLayer, Tooltip } from 'react-leaflet';
+import {
+  TRACEROUTE_HOPS,
+  createTracerouteLatencyGenerator,
+  type TracerouteFrame,
+} from '../mocks/traceroute';
+
+const MAP_CENTER: LatLngExpression = [20, 10];
+const MAP_BOUNDS: LatLngBoundsExpression = [
+  [-75, -190],
+  [85, 190],
+];
+
+const SEGMENT_COLORS = {
+  active: '#38bdf8',
+  complete: '#22c55e',
+  pending: '#475569',
+} as const;
+
+const formatLatency = (latency: number) => (latency > 0 ? `${latency.toFixed(1)} ms` : '—');
+
+const latencyToDuration = (latency: number) => Math.max(900, Math.min(2200, latency * 18));
+
+export default function TracerouteMap() {
+  const [isClient, setIsClient] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(true);
+  const [currentFrame, setCurrentFrame] = useState<TracerouteFrame | null>(null);
+
+  const baseLatencies = useMemo(() => TRACEROUTE_HOPS.map(() => 0), []);
+  const latencies = currentFrame?.latencies ?? baseLatencies;
+  const activeHopIndex = currentFrame?.hopIndex ?? 0;
+  const frameNumber = currentFrame?.frame ?? 0;
+  const currentHop = TRACEROUTE_HOPS[activeHopIndex] ?? TRACEROUTE_HOPS[0];
+
+  const generatorRef = useRef(createTracerouteLatencyGenerator());
+  const frameRef = useRef<TracerouteFrame | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const lastTimestampRef = useRef<number | null>(null);
+  const elapsedRef = useRef(0);
+  const isPlayingRef = useRef(isPlaying);
+  const currentDurationRef = useRef(latencyToDuration(TRACEROUTE_HOPS[0].baseLatency));
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  useEffect(() => {
+    isPlayingRef.current = isPlaying;
+  }, [isPlaying]);
+
+  const applyFrame = useCallback((frame: TracerouteFrame) => {
+    frameRef.current = frame;
+    currentDurationRef.current = latencyToDuration(frame.latency);
+    setCurrentFrame(frame);
+  }, []);
+
+  useEffect(() => {
+    if (!isClient) {
+      return;
+    }
+    if (frameRef.current) {
+      return;
+    }
+
+    const initial = generatorRef.current.next();
+    if (!initial.done) {
+      elapsedRef.current = 0;
+      lastTimestampRef.current = null;
+      applyFrame(initial.value);
+    }
+  }, [applyFrame, isClient]);
+
+  const onFrame = useCallback(
+    (timestamp: number) => {
+      if (!isPlayingRef.current) {
+        return;
+      }
+
+      if (lastTimestampRef.current == null) {
+        lastTimestampRef.current = timestamp;
+      }
+
+      const delta = timestamp - lastTimestampRef.current;
+      lastTimestampRef.current = timestamp;
+      if (delta > 0) {
+        elapsedRef.current += delta;
+      }
+
+      const duration = currentDurationRef.current;
+      if (frameRef.current && elapsedRef.current >= duration) {
+        const overshoot = elapsedRef.current - duration;
+        const next = generatorRef.current.next();
+        if (!next.done) {
+          elapsedRef.current = overshoot;
+          applyFrame(next.value);
+        } else {
+          elapsedRef.current = 0;
+        }
+      }
+
+      if (isPlayingRef.current) {
+        rafRef.current = window.requestAnimationFrame(onFrame);
+      }
+    },
+    [applyFrame]
+  );
+
+  useEffect(() => {
+    if (!isClient) {
+      return;
+    }
+
+    if (isPlaying) {
+      if (rafRef.current != null) {
+        window.cancelAnimationFrame(rafRef.current);
+      }
+      lastTimestampRef.current = null;
+      rafRef.current = window.requestAnimationFrame(onFrame);
+    } else if (rafRef.current != null) {
+      window.cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+      lastTimestampRef.current = null;
+    }
+
+    return () => {
+      if (rafRef.current != null) {
+        window.cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [isClient, isPlaying, onFrame]);
+
+  const completedMap = useMemo(() => {
+    if (!currentFrame) {
+      return TRACEROUTE_HOPS.map(() => false);
+    }
+    if (currentFrame.hopIndex === 0) {
+      return TRACEROUTE_HOPS.map(() => false);
+    }
+    return TRACEROUTE_HOPS.map((_, index) => index < currentFrame.hopIndex);
+  }, [currentFrame]);
+
+  const animationStateLabel = isPlaying ? 'playing' : 'paused';
+  const buttonLabel = isPlaying ? 'Pause animation' : 'Resume animation';
+
+  const totalLatencyLabel = currentFrame ? `${currentFrame.cumulativeLatency.toFixed(1)} ms` : '—';
+  const currentLatencyLabel = formatLatency(currentFrame?.latency ?? 0);
+
+  return (
+    <div className="flex flex-col gap-4 text-slate-100">
+      <header className="flex flex-col gap-3 rounded-xl border border-slate-800 bg-slate-950/70 p-4 shadow-inner md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Traceroute visualizer</h2>
+          <p className="text-sm text-slate-400">
+            Synthetic route tracing across major internet exchange points with animated hop metrics.
+          </p>
+        </div>
+        <div className="flex flex-col gap-2 text-xs text-slate-300 sm:flex-row sm:items-center">
+          <div className="flex gap-4">
+            <div>
+              <div className="uppercase tracking-widest text-slate-500">Frame</div>
+              <div data-testid="frame-index" className="text-base font-semibold text-slate-100">
+                {frameNumber}
+              </div>
+            </div>
+            <div>
+              <div className="uppercase tracking-widest text-slate-500">Mode</div>
+              <div data-testid="animation-state" className="text-base font-semibold capitalize text-slate-100">
+                {animationStateLabel}
+              </div>
+            </div>
+          </div>
+          <div>
+            <div className="uppercase tracking-widest text-slate-500">Active hop</div>
+            <div className="text-sm font-medium text-slate-100">{currentHop.label}</div>
+            <div className="text-xs text-slate-400">
+              Hop latency: <span className="font-semibold text-slate-100">{currentLatencyLabel}</span>
+            </div>
+            <div className="text-xs text-slate-400">
+              Cumulative: <span className="font-semibold text-slate-100">{totalLatencyLabel}</span>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setIsPlaying((value) => !value)}
+            className="inline-flex items-center justify-center rounded-lg border border-slate-700 bg-slate-800 px-4 py-2 font-semibold text-slate-100 shadow hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+          >
+            {buttonLabel}
+          </button>
+        </div>
+      </header>
+      <div className="grid gap-4 lg:grid-cols-[1.35fr_1fr]">
+        <section className="overflow-hidden rounded-xl border border-slate-800 bg-slate-950/60 p-2">
+          {isClient ? (
+            <MapContainer
+              center={MAP_CENTER}
+              zoom={2}
+              minZoom={2}
+              maxZoom={5}
+              maxBounds={MAP_BOUNDS}
+              scrollWheelZoom={false}
+              worldCopyJump
+              className="h-[320px] w-full rounded-lg"
+              style={{ backgroundColor: '#020617' }}
+            >
+              <TileLayer
+                attribution="&copy; OpenStreetMap contributors"
+                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                noWrap
+              />
+              {TRACEROUTE_HOPS.map((hop, index) => {
+                if (index === 0) {
+                  return null;
+                }
+                const prev = TRACEROUTE_HOPS[index - 1];
+                const isActive = index === activeHopIndex;
+                const isComplete = completedMap[index];
+                const statusColor = isActive
+                  ? SEGMENT_COLORS.active
+                  : isComplete
+                    ? SEGMENT_COLORS.complete
+                    : SEGMENT_COLORS.pending;
+
+                return (
+                  <Polyline
+                    key={`segment-${prev.id}-${hop.id}`}
+                    positions={[prev.coordinates, hop.coordinates]}
+                    pathOptions={{
+                      color: statusColor,
+                      weight: isActive ? 4 : isComplete ? 3 : 2,
+                      opacity: isComplete || isActive ? 0.9 : 0.45,
+                      dashArray: isActive ? '10 8' : undefined,
+                    }}
+                  />
+                );
+              })}
+              {TRACEROUTE_HOPS.map((hop, index) => {
+                const isActive = index === activeHopIndex;
+                const isComplete = completedMap[index];
+                const markerColor = isActive
+                  ? SEGMENT_COLORS.active
+                  : isComplete
+                    ? SEGMENT_COLORS.complete
+                    : '#94a3b8';
+
+                return (
+                  <CircleMarker
+                    key={`marker-${hop.id}`}
+                    center={hop.coordinates as LatLngExpression}
+                    radius={isActive ? 8 : 6}
+                    pathOptions={{
+                      color: markerColor,
+                      weight: 2,
+                      fillColor: markerColor,
+                      fillOpacity: 1,
+                    }}
+                  >
+                    <Tooltip direction="top" offset={[0, -10]} opacity={0.9} permanent={false}>
+                      <div className="space-y-1">
+                        <div className="font-semibold">{hop.label}</div>
+                        <div className="text-xs text-slate-300">{hop.ip}</div>
+                        <div className="text-xs text-slate-300">{formatLatency(latencies[index])}</div>
+                      </div>
+                    </Tooltip>
+                  </CircleMarker>
+                );
+              })}
+            </MapContainer>
+          ) : (
+            <div className="flex h-[320px] items-center justify-center text-sm text-slate-400">
+              Initializing map…
+            </div>
+          )}
+        </section>
+        <section className="rounded-xl border border-slate-800 bg-slate-950/60 p-4">
+          <h3 className="text-base font-semibold text-slate-100">Simulated hops</h3>
+          <p className="mb-3 text-sm text-slate-400">
+            Values stream from a deterministic generator to keep the experience in demo mode while still showing realistic
+            latency jitter.
+          </p>
+          <ul data-testid="hop-list" className="space-y-2" aria-label="Traceroute hops">
+            {TRACEROUTE_HOPS.map((hop, index) => {
+              const isActive = index === activeHopIndex;
+              const isComplete = completedMap[index];
+              const borderColor = isActive
+                ? 'border-sky-500'
+                : isComplete
+                  ? 'border-emerald-500'
+                  : 'border-slate-800';
+              const backgroundColor = isActive
+                ? 'bg-sky-500/10'
+                : isComplete
+                  ? 'bg-emerald-500/10'
+                  : 'bg-slate-900/40';
+
+              return (
+                <li
+                  key={hop.id}
+                  className={`rounded-lg border ${borderColor} ${backgroundColor} p-3 transition-colors`}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="text-sm font-semibold text-slate-100">{hop.label}</div>
+                      <div className="text-xs text-slate-400">{hop.location}</div>
+                      <div className="text-xs text-slate-500">{hop.ip}</div>
+                    </div>
+                    <div
+                      className="text-sm font-semibold text-slate-100"
+                      data-testid={`hop-latency-${index}`}
+                      aria-label={`Latency for ${hop.label}`}
+                    >
+                      {formatLatency(latencies[index])}
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/dns-toolkit/mocks/traceroute.ts
+++ b/apps/dns-toolkit/mocks/traceroute.ts
@@ -1,0 +1,118 @@
+export type CoordinatePair = [number, number];
+
+export interface TracerouteHop {
+  id: number;
+  label: string;
+  location: string;
+  ip: string;
+  coordinates: CoordinatePair;
+  baseLatency: number;
+  jitter: number;
+}
+
+export interface TracerouteFrame {
+  frame: number;
+  hopIndex: number;
+  hop: TracerouteHop;
+  latency: number;
+  cumulativeLatency: number;
+  latencies: number[];
+}
+
+export const TRACEROUTE_HOPS: TracerouteHop[] = [
+  {
+    id: 1,
+    label: 'Gateway — Seattle',
+    location: 'Seattle, USA',
+    ip: '203.0.113.1',
+    coordinates: [47.6062, -122.3321],
+    baseLatency: 12,
+    jitter: 4.5,
+  },
+  {
+    id: 2,
+    label: 'Edge Router — Los Angeles',
+    location: 'Los Angeles, USA',
+    ip: '203.0.113.5',
+    coordinates: [34.0522, -118.2437],
+    baseLatency: 18,
+    jitter: 6,
+  },
+  {
+    id: 3,
+    label: 'Pacific Exchange — Honolulu',
+    location: 'Honolulu, USA',
+    ip: '198.51.100.12',
+    coordinates: [21.3069, -157.8583],
+    baseLatency: 62,
+    jitter: 9,
+  },
+  {
+    id: 4,
+    label: 'Transpacific Relay — Tokyo',
+    location: 'Tokyo, Japan',
+    ip: '198.51.100.42',
+    coordinates: [35.6762, 139.6503],
+    baseLatency: 124,
+    jitter: 14,
+  },
+  {
+    id: 5,
+    label: 'ASE Transit — Singapore',
+    location: 'Singapore',
+    ip: '203.0.113.78',
+    coordinates: [1.3521, 103.8198],
+    baseLatency: 178,
+    jitter: 16,
+  },
+  {
+    id: 6,
+    label: 'Oceania Uplink — Sydney',
+    location: 'Sydney, Australia',
+    ip: '203.0.113.102',
+    coordinates: [-33.8688, 151.2093],
+    baseLatency: 235,
+    jitter: 18,
+  },
+  {
+    id: 7,
+    label: 'European Exchange — Frankfurt',
+    location: 'Frankfurt, Germany',
+    ip: '198.51.100.200',
+    coordinates: [50.1109, 8.6821],
+    baseLatency: 305,
+    jitter: 22,
+  },
+];
+
+export function createTracerouteLatencyGenerator(seed = 0): Generator<TracerouteFrame, never, unknown> {
+  let frame = 0;
+  const latencies = new Array(TRACEROUTE_HOPS.length).fill(0);
+  const jitterSeed = Math.abs(seed % 997) / 997;
+
+  return (function* () {
+    while (true) {
+      const hopIndex = frame % TRACEROUTE_HOPS.length;
+      const hop = TRACEROUTE_HOPS[hopIndex];
+      const phase = frame + hopIndex + jitterSeed * 13;
+      const variation = Math.abs(Math.sin(phase * 0.9));
+      const latency = Number((hop.baseLatency + variation * hop.jitter).toFixed(1));
+      latencies[hopIndex] = latency;
+
+      const cumulativeLatency = Number(
+        latencies.slice(0, hopIndex + 1).reduce((sum, value) => sum + value, 0).toFixed(1)
+      );
+
+      frame += 1;
+
+      yield {
+        frame,
+        hopIndex,
+        hop,
+        latency,
+        cumulativeLatency,
+        latencies: [...latencies],
+      } satisfies TracerouteFrame;
+    }
+  })();
+}


### PR DESCRIPTION
## Summary
- add a traceroute map component that renders hop polylines with react-leaflet and playback controls
- expose a deterministic traceroute latency generator for the DNS toolkit
- cover animation pause/resume behaviour and hop list rendering with Jest

## Testing
- yarn test traceroute-map
- yarn lint *(fails: repository currently has existing accessibility violations in multiple apps)*

------
https://chatgpt.com/codex/tasks/task_e_68cc38fd40588328befcf0fb56ca28b2