### PR TITLE
ssh: add mock sftp sidecar and tests

### DIFF
--- a/__tests__/apps/ssh/sftp-adapter.test.ts
+++ b/__tests__/apps/ssh/sftp-adapter.test.ts
@@ -1,0 +1,103 @@
+import {
+  SftpEntry,
+  SftpSnapshot,
+  createSftpAdapter,
+} from '../../../apps/ssh/mocks/sftpAdapter';
+import localSeed from '../../../data/ssh/sftp/local.json';
+import remoteSeed from '../../../data/ssh/sftp/remote.json';
+
+type Pane = 'local' | 'remote';
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const findEntry = (entries: SftpEntry[], path: string[]): SftpEntry | null => {
+  if (path.length === 0) return null;
+  let currentEntries = entries;
+  let current: SftpEntry | undefined;
+  for (let i = 0; i < path.length; i += 1) {
+    current = currentEntries.find((entry) => entry.name === path[i]);
+    if (!current) return null;
+    if (i < path.length - 1) {
+      if (current.type !== 'directory' || !current.children) return null;
+      currentEntries = current.children;
+    }
+  }
+  return current ?? null;
+};
+
+const getLatest = (updates: SftpSnapshot[]) => updates[updates.length - 1];
+
+const createAdapter = () =>
+  createSftpAdapter(clone(localSeed as SftpEntry[]), clone(remoteSeed as SftpEntry[]));
+
+describe('SFTP adapter', () => {
+  it('copies files from local to remote and notifies listeners', () => {
+    const adapter = createAdapter();
+    const updates: SftpSnapshot[] = [];
+    const unsubscribe = adapter.subscribe((snapshot) => updates.push(snapshot));
+
+    const result = adapter.copy({
+      from: 'local',
+      to: 'remote',
+      path: ['notes.txt'],
+      targetPath: [],
+    });
+
+    expect(result.success).toBe(true);
+    const latest = getLatest(updates);
+    expect(findEntry(latest.remote, ['notes.txt'])).not.toBeNull();
+    expect(findEntry(latest.local, ['notes.txt'])).not.toBeNull();
+
+    unsubscribe();
+  });
+
+  it('moves files between panes and removes the original entry', () => {
+    const adapter = createAdapter();
+    const updates: SftpSnapshot[] = [];
+    const unsubscribe = adapter.subscribe((snapshot) => updates.push(snapshot));
+
+    const result = adapter.move({
+      from: 'remote',
+      to: 'local',
+      path: ['motd.txt'],
+      targetPath: [],
+    });
+
+    expect(result.success).toBe(true);
+    const latest = getLatest(updates);
+    expect(findEntry(latest.local, ['motd.txt'])).not.toBeNull();
+    expect(findEntry(latest.remote, ['motd.txt'])).toBeNull();
+
+    unsubscribe();
+  });
+
+  it('deletes files from a pane and emits an updated snapshot', () => {
+    const adapter = createAdapter();
+    const updates: SftpSnapshot[] = [];
+    const unsubscribe = adapter.subscribe((snapshot) => updates.push(snapshot));
+
+    const result = adapter.delete({ side: 'local', path: ['inventory.csv'] });
+
+    expect(result.success).toBe(true);
+    const latest = getLatest(updates);
+    expect(findEntry(latest.local, ['inventory.csv'])).toBeNull();
+
+    unsubscribe();
+  });
+
+  it('prevents directory operations for copy, move, and delete', () => {
+    const adapter = createAdapter();
+    const directories: Record<Pane, string[]> = {
+      local: ['Documents'],
+      remote: ['reports'],
+    };
+
+    const copyDir = adapter.copy({ from: 'local', to: 'remote', path: directories.local });
+    const moveDir = adapter.move({ from: 'remote', to: 'local', path: directories.remote });
+    const deleteDir = adapter.delete({ side: 'local', path: directories.local });
+
+    expect(copyDir.success).toBe(false);
+    expect(moveDir.success).toBe(false);
+    expect(deleteDir.success).toBe(false);
+  });
+});

--- a/apps/ssh/components/SftpSidecar.tsx
+++ b/apps/ssh/components/SftpSidecar.tsx
@@ -1,0 +1,463 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  SftpAdapter,
+  SftpEntry,
+  SftpOperationResult,
+  SftpSide,
+  SftpSnapshot,
+  createSftpAdapter,
+} from '../mocks/sftpAdapter';
+import localSeed from '../../../data/ssh/sftp/local.json';
+import remoteSeed from '../../../data/ssh/sftp/remote.json';
+
+type PaneSide = SftpSide;
+
+interface SftpSidecarProps {
+  className?: string;
+}
+
+interface PaneProps {
+  side: PaneSide;
+  title: string;
+  path: string[];
+  entries: SftpEntry[];
+  selection: string[] | null;
+  onSelect: (path: string[]) => void;
+  onEnterDirectory: (path: string[]) => void;
+  onNavigate: (path: string[]) => void;
+  selectedEntry: SftpEntry | null;
+}
+
+const SIDES: PaneSide[] = ['local', 'remote'];
+
+const formatSize = (size?: number) => {
+  if (!size) return '—';
+  if (size < 1024) return `${size} B`;
+  const kb = size / 1024;
+  if (kb < 1024) return `${kb.toFixed(kb < 10 ? 1 : 0)} KB`;
+  const mb = kb / 1024;
+  return `${mb.toFixed(mb < 10 ? 1 : 0)} MB`;
+};
+
+const formatModified = (modified?: string) => {
+  if (!modified) return 'Unknown';
+  const date = new Date(modified);
+  if (Number.isNaN(date.getTime())) return modified;
+  return date.toLocaleString();
+};
+
+const findEntry = (entries: SftpEntry[], path: string[]): SftpEntry | null => {
+  if (path.length === 0) return null;
+  let currentEntries = entries;
+  let current: SftpEntry | undefined;
+  for (let i = 0; i < path.length; i += 1) {
+    const segment = path[i];
+    current = currentEntries.find((entry) => entry.name === segment);
+    if (!current) return null;
+    if (i < path.length - 1) {
+      if (current.type !== 'directory' || !current.children) return null;
+      currentEntries = current.children;
+    }
+  }
+  return current ?? null;
+};
+
+const getDirectoryEntries = (entries: SftpEntry[], path: string[]): SftpEntry[] | null => {
+  if (path.length === 0) return entries;
+  const directory = findEntry(entries, path);
+  if (!directory || directory.type !== 'directory') return null;
+  return directory.children ?? [];
+};
+
+const Pane: React.FC<PaneProps> = ({
+  side,
+  title,
+  path,
+  entries,
+  selection,
+  onSelect,
+  onEnterDirectory,
+  onNavigate,
+  selectedEntry,
+}) => {
+  const breadcrumbs = useMemo(() => {
+    const base = [{ label: 'home', path: [] as string[] }];
+    const crumbs = path.map((segment, index) => ({
+      label: segment,
+      path: path.slice(0, index + 1),
+    }));
+    return [...base, ...crumbs];
+  }, [path]);
+
+  return (
+    <div className="flex h-full flex-col rounded border border-gray-800 bg-gray-900 shadow-inner">
+      <div className="border-b border-gray-800 px-3 py-2">
+        <div className="flex items-center justify-between text-xs uppercase tracking-wide text-gray-400">
+          <span>{title}</span>
+          <span className="text-[11px] text-gray-600">{side}</span>
+        </div>
+        <nav className="mt-1 flex flex-wrap items-center gap-1 text-[11px] text-gray-500">
+          {breadcrumbs.map((crumb, index) => {
+            const isLast = index === breadcrumbs.length - 1;
+            return (
+              <React.Fragment key={`${side}-crumb-${crumb.label}-${index}`}>
+                <button
+                  type="button"
+                  className={`rounded px-1 py-0.5 ${
+                    isLast
+                      ? 'bg-gray-800 text-gray-300'
+                      : 'hover:bg-gray-800 hover:text-gray-200'
+                  }`}
+                  onClick={() => onNavigate(crumb.path)}
+                  disabled={isLast}
+                >
+                  {crumb.label}
+                </button>
+                {index < breadcrumbs.length - 1 && <span className="text-gray-700">/</span>}
+              </React.Fragment>
+            );
+          })}
+        </nav>
+      </div>
+      <ul className="flex-1 overflow-auto text-sm">
+        {entries.length === 0 && (
+          <li className="px-3 py-6 text-center text-xs text-gray-500">This folder is empty.</li>
+        )}
+        {entries.map((entry) => {
+          const nextPath = [...path, entry.name];
+          const isSelected =
+            selection !== null && selection.join('/') === nextPath.join('/');
+          return (
+            <li key={`${side}-${nextPath.join('/')}`} className="border-b border-gray-800 last:border-b-0">
+              <button
+                type="button"
+                className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left transition-colors ${
+                  isSelected ? 'bg-gray-800/70 text-white' : 'hover:bg-gray-800/70'
+                }`}
+                onClick={() =>
+                  entry.type === 'directory' ? onEnterDirectory(nextPath) : onSelect(nextPath)
+                }
+              >
+                <span className="flex items-center gap-2">
+                  <span aria-hidden className="text-lg">
+                    {entry.type === 'directory' ? '📁' : '📄'}
+                  </span>
+                  <span>{entry.name}</span>
+                </span>
+                <span className="text-xs text-gray-400">
+                  {entry.type === 'file' ? formatSize(entry.size) : 'dir'}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      {selectedEntry && (
+        <dl className="grid grid-cols-2 gap-x-2 gap-y-1 border-t border-gray-800 bg-gray-950 px-3 py-2 text-[11px] text-gray-400">
+          <dt className="uppercase tracking-wide text-gray-500">Name</dt>
+          <dd className="text-right text-gray-300">{selectedEntry.name}</dd>
+          <dt className="uppercase tracking-wide text-gray-500">Size</dt>
+          <dd className="text-right text-gray-300">{formatSize(selectedEntry.size)}</dd>
+          <dt className="uppercase tracking-wide text-gray-500">Modified</dt>
+          <dd className="text-right text-gray-300">{formatModified(selectedEntry.modified)}</dd>
+        </dl>
+      )}
+    </div>
+  );
+};
+
+const SftpSidecar: React.FC<SftpSidecarProps> = ({ className = '' }) => {
+  const adapterRef = useRef<SftpAdapter | null>(null);
+  if (!adapterRef.current) {
+    adapterRef.current = createSftpAdapter(
+      localSeed as SftpEntry[],
+      remoteSeed as SftpEntry[],
+    );
+  }
+  const adapter = adapterRef.current;
+
+  const [snapshot, setSnapshot] = useState<SftpSnapshot>(() => adapter.getSnapshot());
+  const [paths, setPaths] = useState<Record<PaneSide, string[]>>({ local: [], remote: [] });
+  const [selection, setSelection] = useState<Record<PaneSide, string[] | null>>({
+    local: null,
+    remote: null,
+  });
+  const [status, setStatus] = useState<SftpOperationResult | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = adapter.subscribe(setSnapshot);
+    return () => unsubscribe();
+  }, [adapter]);
+
+  useEffect(() => {
+    setPaths((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      SIDES.forEach((side) => {
+        if (!getDirectoryEntries(snapshot[side], prev[side])) {
+          next[side] = [];
+          changed = true;
+        }
+      });
+      return changed ? next : prev;
+    });
+  }, [snapshot]);
+
+  useEffect(() => {
+    setSelection((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      SIDES.forEach((side) => {
+        const current = prev[side];
+        if (current && !findEntry(snapshot[side], current)) {
+          next[side] = null;
+          changed = true;
+        }
+      });
+      return changed ? next : prev;
+    });
+  }, [snapshot]);
+
+  const entries = useMemo(
+    () => ({
+      local: getDirectoryEntries(snapshot.local, paths.local) ?? [],
+      remote: getDirectoryEntries(snapshot.remote, paths.remote) ?? [],
+    }),
+    [paths.local, paths.remote, snapshot.local, snapshot.remote],
+  );
+
+  const selectedEntries = useMemo(
+    () => ({
+      local: selection.local ? findEntry(snapshot.local, selection.local) : null,
+      remote: selection.remote ? findEntry(snapshot.remote, selection.remote) : null,
+    }),
+    [selection.local, selection.remote, snapshot.local, snapshot.remote],
+  );
+
+  const selectFile = (side: PaneSide, pathValue: string[]) => {
+    setSelection((prev) => ({ ...prev, [side]: pathValue }));
+    setStatus(null);
+  };
+
+  const enterDirectory = (side: PaneSide, pathValue: string[]) => {
+    setPaths((prev) => ({ ...prev, [side]: pathValue }));
+    setStatus(null);
+  };
+
+  const navigateTo = (side: PaneSide, pathValue: string[]) => {
+    setPaths((prev) => ({ ...prev, [side]: pathValue }));
+    setStatus(null);
+  };
+
+  const ensureFileSelected = (side: PaneSide): string[] | null => {
+    const current = selection[side];
+    const entry = current ? findEntry(snapshot[side], current) : null;
+    if (!entry || entry.type !== 'file') {
+      return null;
+    }
+    return current;
+  };
+
+  const runOperation = (result: SftpOperationResult | null) => {
+    if (result) {
+      setStatus(result);
+    }
+  };
+
+  const handleCopyLocalToRemote = () => {
+    const sourcePath = ensureFileSelected('local');
+    if (!sourcePath) {
+      runOperation({ success: false, message: 'Select a local file to copy.' });
+      return;
+    }
+    const fileName = sourcePath[sourcePath.length - 1];
+    const result = adapter.copy({
+      from: 'local',
+      to: 'remote',
+      path: sourcePath,
+      targetPath: paths.remote,
+    });
+    runOperation(result);
+    if (result.success) {
+      setSelection((prev) => ({ ...prev, remote: [...paths.remote, fileName] }));
+    }
+  };
+
+  const handleCopyRemoteToLocal = () => {
+    const sourcePath = ensureFileSelected('remote');
+    if (!sourcePath) {
+      runOperation({ success: false, message: 'Select a remote file to copy.' });
+      return;
+    }
+    const fileName = sourcePath[sourcePath.length - 1];
+    const result = adapter.copy({
+      from: 'remote',
+      to: 'local',
+      path: sourcePath,
+      targetPath: paths.local,
+    });
+    runOperation(result);
+    if (result.success) {
+      setSelection((prev) => ({ ...prev, local: [...paths.local, fileName] }));
+    }
+  };
+
+  const handleMoveLocalToRemote = () => {
+    const sourcePath = ensureFileSelected('local');
+    if (!sourcePath) {
+      runOperation({ success: false, message: 'Select a local file to move.' });
+      return;
+    }
+    const fileName = sourcePath[sourcePath.length - 1];
+    const result = adapter.move({
+      from: 'local',
+      to: 'remote',
+      path: sourcePath,
+      targetPath: paths.remote,
+    });
+    runOperation(result);
+    if (result.success) {
+      setSelection((prev) => ({ ...prev, local: null, remote: [...paths.remote, fileName] }));
+    }
+  };
+
+  const handleMoveRemoteToLocal = () => {
+    const sourcePath = ensureFileSelected('remote');
+    if (!sourcePath) {
+      runOperation({ success: false, message: 'Select a remote file to move.' });
+      return;
+    }
+    const fileName = sourcePath[sourcePath.length - 1];
+    const result = adapter.move({
+      from: 'remote',
+      to: 'local',
+      path: sourcePath,
+      targetPath: paths.local,
+    });
+    runOperation(result);
+    if (result.success) {
+      setSelection((prev) => ({ ...prev, remote: null, local: [...paths.local, fileName] }));
+    }
+  };
+
+  const handleDeleteLocal = () => {
+    const sourcePath = ensureFileSelected('local');
+    if (!sourcePath) {
+      runOperation({ success: false, message: 'Select a local file to delete.' });
+      return;
+    }
+    const result = adapter.delete({ side: 'local', path: sourcePath });
+    runOperation(result);
+    if (result.success) {
+      setSelection((prev) => ({ ...prev, local: null }));
+    }
+  };
+
+  const handleDeleteRemote = () => {
+    const sourcePath = ensureFileSelected('remote');
+    if (!sourcePath) {
+      runOperation({ success: false, message: 'Select a remote file to delete.' });
+      return;
+    }
+    const result = adapter.delete({ side: 'remote', path: sourcePath });
+    runOperation(result);
+    if (result.success) {
+      setSelection((prev) => ({ ...prev, remote: null }));
+    }
+  };
+
+  return (
+    <aside
+      className={`flex h-full min-h-[22rem] flex-col gap-4 border-t border-gray-800 bg-gray-950 p-4 text-sm text-gray-200 shadow-lg lg:border-l lg:border-t-0 ${className}`.trim()}
+    >
+      <div className="grid h-full grid-cols-1 gap-4 xl:grid-cols-2">
+        <Pane
+          side="local"
+          title="Local Files"
+          path={paths.local}
+          entries={entries.local}
+          selection={selection.local}
+          selectedEntry={selectedEntries.local}
+          onSelect={(pathValue) => selectFile('local', pathValue)}
+          onEnterDirectory={(pathValue) => enterDirectory('local', pathValue)}
+          onNavigate={(pathValue) => navigateTo('local', pathValue)}
+        />
+        <Pane
+          side="remote"
+          title="Remote Files"
+          path={paths.remote}
+          entries={entries.remote}
+          selection={selection.remote}
+          selectedEntry={selectedEntries.remote}
+          onSelect={(pathValue) => selectFile('remote', pathValue)}
+          onEnterDirectory={(pathValue) => enterDirectory('remote', pathValue)}
+          onNavigate={(pathValue) => navigateTo('remote', pathValue)}
+        />
+      </div>
+      <div className="flex flex-col gap-3 rounded border border-gray-800 bg-gray-900 p-3 text-xs text-gray-300">
+        {status ? (
+          <p className={status.success ? 'text-emerald-400' : 'text-red-400'}>{status.message}</p>
+        ) : (
+          <p className="text-gray-400">Select a file to copy, move, or delete.</p>
+        )}
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            className="rounded bg-sky-600 px-3 py-1 text-xs font-semibold text-white transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:bg-gray-700"
+            onClick={handleCopyLocalToRemote}
+            disabled={!selectedEntries.local || selectedEntries.local.type !== 'file'}
+          >
+            Copy → Remote
+          </button>
+          <button
+            type="button"
+            className="rounded bg-sky-600 px-3 py-1 text-xs font-semibold text-white transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:bg-gray-700"
+            onClick={handleCopyRemoteToLocal}
+            disabled={!selectedEntries.remote || selectedEntries.remote.type !== 'file'}
+          >
+            Copy → Local
+          </button>
+          <button
+            type="button"
+            className="rounded bg-amber-600 px-3 py-1 text-xs font-semibold text-white transition hover:bg-amber-500 disabled:cursor-not-allowed disabled:bg-gray-700"
+            onClick={handleMoveLocalToRemote}
+            disabled={!selectedEntries.local || selectedEntries.local.type !== 'file'}
+          >
+            Move → Remote
+          </button>
+          <button
+            type="button"
+            className="rounded bg-amber-600 px-3 py-1 text-xs font-semibold text-white transition hover:bg-amber-500 disabled:cursor-not-allowed disabled:bg-gray-700"
+            onClick={handleMoveRemoteToLocal}
+            disabled={!selectedEntries.remote || selectedEntries.remote.type !== 'file'}
+          >
+            Move → Local
+          </button>
+          <button
+            type="button"
+            className="rounded bg-rose-600 px-3 py-1 text-xs font-semibold text-white transition hover:bg-rose-500 disabled:cursor-not-allowed disabled:bg-gray-700"
+            onClick={handleDeleteLocal}
+            disabled={!selectedEntries.local || selectedEntries.local.type !== 'file'}
+          >
+            Delete Local
+          </button>
+          <button
+            type="button"
+            className="rounded bg-rose-600 px-3 py-1 text-xs font-semibold text-white transition hover:bg-rose-500 disabled:cursor-not-allowed disabled:bg-gray-700"
+            onClick={handleDeleteRemote}
+            disabled={!selectedEntries.remote || selectedEntries.remote.type !== 'file'}
+          >
+            Delete Remote
+          </button>
+        </div>
+        <p className="text-[11px] text-gray-500">
+          Transfers are simulated and limited to small files in this mock sidecar.
+        </p>
+      </div>
+    </aside>
+  );
+};
+
+export default SftpSidecar;

--- a/apps/ssh/index.tsx
+++ b/apps/ssh/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import SftpSidecar from './components/SftpSidecar';
 
 const SSHBuilder: React.FC = () => {
   const [user, setUser] = useState('');
@@ -10,61 +11,71 @@ const SSHBuilder: React.FC = () => {
   const command = `ssh ${user ? `${user}@` : ''}${host}${port ? ` -p ${port}` : ''}`.trim();
 
   return (
-    <div className="h-full bg-gray-900 p-4 text-white overflow-auto">
-      <h1 className="mb-4 text-2xl">SSH Command Builder</h1>
-      <p className="mb-4 text-sm text-yellow-300">
-        Generate an SSH command without executing it. Learn more at{' '}
-        <a
-          href="https://www.openssh.com/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline text-blue-400"
-        >
-          the OpenSSH project page
-        </a>
-        .
-      </p>
-      <form onSubmit={(e) => e.preventDefault()} className="mb-4 space-y-4">
-        <div>
-          <label htmlFor="ssh-user" className="mb-1 block text-sm font-medium">
-            Username
-          </label>
-          <input
-            id="ssh-user"
-            type="text"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            value={user}
-            onChange={(e) => setUser(e.target.value)}
-          />
+    <div className="flex h-full flex-col bg-gray-900 text-white">
+      <div className="flex-1 overflow-auto p-4">
+        <h1 className="mb-4 text-2xl">SSH Command Builder</h1>
+        <p className="mb-4 text-sm text-yellow-300">
+          Generate an SSH command without executing it. Learn more at{' '}
+          <a
+            href="https://www.openssh.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline text-blue-400"
+          >
+            the OpenSSH project page
+          </a>
+          .
+        </p>
+        <form onSubmit={(e) => e.preventDefault()} className="mb-4 space-y-4">
+          <div>
+            <label htmlFor="ssh-user" className="mb-1 block text-sm font-medium">
+              Username
+            </label>
+            <input
+              id="ssh-user"
+              type="text"
+              className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+              value={user}
+              onChange={(e) => setUser(e.target.value)}
+            />
+          </div>
+          <div>
+            <label htmlFor="ssh-host" className="mb-1 block text-sm font-medium">
+              Host
+            </label>
+            <input
+              id="ssh-host"
+              type="text"
+              className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+              value={host}
+              onChange={(e) => setHost(e.target.value)}
+            />
+          </div>
+          <div>
+            <label htmlFor="ssh-port" className="mb-1 block text-sm font-medium">
+              Port (optional)
+            </label>
+            <input
+              id="ssh-port"
+              type="number"
+              className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+              value={port}
+              onChange={(e) => setPort(e.target.value)}
+            />
+          </div>
+        </form>
+        <div className="rounded border border-gray-800 bg-gray-950 p-4 text-xs text-gray-300">
+          <p className="mb-1 font-semibold uppercase tracking-wide text-gray-400">Tips</p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>Populate the username and host to build the basic command.</li>
+            <li>Add a port when connecting to non-standard SSH services.</li>
+            <li>Use the SFTP sidecar to stage files before running the command.</li>
+          </ul>
         </div>
-        <div>
-          <label htmlFor="ssh-host" className="mb-1 block text-sm font-medium">
-            Host
-          </label>
-          <input
-            id="ssh-host"
-            type="text"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            value={host}
-            onChange={(e) => setHost(e.target.value)}
-          />
-        </div>
-        <div>
-          <label htmlFor="ssh-port" className="mb-1 block text-sm font-medium">
-            Port (optional)
-          </label>
-          <input
-            id="ssh-port"
-            type="number"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            value={port}
-            onChange={(e) => setPort(e.target.value)}
-          />
-        </div>
-      </form>
-      <div>
+      </div>
+      <div className="border-t border-gray-800 bg-black/70 p-4">
         <h2 className="mb-2 text-lg">Command Preview</h2>
-        <pre className="overflow-auto rounded bg-black p-2 font-mono text-green-400">
+        <pre className="overflow-auto rounded bg-black/80 p-3 font-mono text-green-400">
           {command || '# Fill in the form to generate a command'}
         </pre>
       </div>
@@ -72,17 +83,26 @@ const SSHBuilder: React.FC = () => {
   );
 };
 
+const SSHSessionPane: React.FC = () => (
+  <div className="flex h-full flex-col bg-gray-950 text-white lg:flex-row">
+    <div className="flex flex-1 flex-col overflow-hidden border-b border-gray-800 lg:border-b-0 lg:border-r">
+      <SSHBuilder />
+    </div>
+    <SftpSidecar className="lg:w-[26rem] xl:w-[30rem]" />
+  </div>
+);
+
 const SSHPreview: React.FC = () => {
   const countRef = useRef(1);
 
   const createTab = (): TabDefinition => {
     const id = Date.now().toString();
-    return { id, title: `Session ${countRef.current++}`, content: <SSHBuilder /> };
+    return { id, title: `Session ${countRef.current++}`, content: <SSHSessionPane /> };
   };
 
   return (
     <TabbedWindow
-      className="min-h-screen bg-gray-900 text-white"
+      className="min-h-screen bg-gray-950 text-white"
       initialTabs={[createTab()]}
       onNewTab={createTab}
     />

--- a/apps/ssh/mocks/sftpAdapter.ts
+++ b/apps/ssh/mocks/sftpAdapter.ts
@@ -1,0 +1,203 @@
+export type SftpSide = 'local' | 'remote';
+
+export interface SftpEntry {
+  name: string;
+  type: 'file' | 'directory';
+  size?: number;
+  modified?: string;
+  children?: SftpEntry[];
+}
+
+export interface SftpSnapshot {
+  local: SftpEntry[];
+  remote: SftpEntry[];
+}
+
+export interface SftpOperationResult {
+  success: boolean;
+  message: string;
+}
+
+export interface SftpCopyOptions {
+  from: SftpSide;
+  to: SftpSide;
+  path: string[];
+  targetPath?: string[];
+  newName?: string;
+}
+
+export interface SftpMoveOptions extends SftpCopyOptions {}
+
+export interface SftpDeleteOptions {
+  side: SftpSide;
+  path: string[];
+}
+
+export interface SftpAdapter {
+  getSnapshot(): SftpSnapshot;
+  subscribe(listener: (snapshot: SftpSnapshot) => void): () => void;
+  list(side: SftpSide, path?: string[]): SftpEntry[] | null;
+  pathExists(side: SftpSide, path: string[]): boolean;
+  entryExists(side: SftpSide, path: string[]): boolean;
+  copy(options: SftpCopyOptions): SftpOperationResult;
+  move(options: SftpMoveOptions): SftpOperationResult;
+  delete(options: SftpDeleteOptions): SftpOperationResult;
+}
+
+const cloneEntries = (entries: SftpEntry[]): SftpEntry[] =>
+  entries.map((entry) => ({
+    ...entry,
+    children: entry.children ? cloneEntries(entry.children) : undefined,
+  }));
+
+const cloneEntry = (entry: SftpEntry): SftpEntry => ({
+  ...entry,
+  children: entry.children ? cloneEntries(entry.children) : undefined,
+});
+
+class InMemorySftpAdapter implements SftpAdapter {
+  private tree: Record<SftpSide, SftpEntry[]>;
+
+  private listeners = new Set<(snapshot: SftpSnapshot) => void>();
+
+  constructor(local: SftpEntry[], remote: SftpEntry[]) {
+    this.tree = {
+      local: cloneEntries(local),
+      remote: cloneEntries(remote),
+    };
+  }
+
+  getSnapshot(): SftpSnapshot {
+    return {
+      local: cloneEntries(this.tree.local),
+      remote: cloneEntries(this.tree.remote),
+    };
+  }
+
+  subscribe(listener: (snapshot: SftpSnapshot) => void): () => void {
+    this.listeners.add(listener);
+    listener(this.getSnapshot());
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  list(side: SftpSide, path: string[] = []): SftpEntry[] | null {
+    const container = this.getContainer(side, path);
+    if (!container) return null;
+    return cloneEntries(container);
+  }
+
+  pathExists(side: SftpSide, path: string[]): boolean {
+    return this.getContainer(side, path) !== null;
+  }
+
+  entryExists(side: SftpSide, path: string[]): boolean {
+    return this.findEntry(side, path) !== null;
+  }
+
+  copy({ from, to, path, targetPath = [], newName }: SftpCopyOptions): SftpOperationResult {
+    const source = this.findEntry(from, path);
+    if (!source) {
+      return { success: false, message: 'File not found.' };
+    }
+    if (source.entry.type !== 'file') {
+      return { success: false, message: 'Only files can be copied in this demo.' };
+    }
+    const destination = this.getContainer(to, targetPath);
+    if (!destination) {
+      return { success: false, message: 'Target folder not found.' };
+    }
+    const duplicated = cloneEntry(source.entry);
+    duplicated.name = newName ?? duplicated.name;
+    const existingIndex = destination.findIndex((entry) => entry.name === duplicated.name);
+    if (existingIndex !== -1) destination.splice(existingIndex, 1);
+    destination.push(duplicated);
+    this.emit();
+    return {
+      success: true,
+      message: `Copied ${source.entry.name} to ${to}.`,
+    };
+  }
+
+  move({ from, to, path, targetPath = [], newName }: SftpMoveOptions): SftpOperationResult {
+    const source = this.findEntry(from, path);
+    if (!source) {
+      return { success: false, message: 'File not found.' };
+    }
+    if (source.entry.type !== 'file') {
+      return { success: false, message: 'Only files can be moved in this demo.' };
+    }
+    const destination = this.getContainer(to, targetPath);
+    if (!destination) {
+      return { success: false, message: 'Target folder not found.' };
+    }
+    const moved = cloneEntry(source.entry);
+    moved.name = newName ?? moved.name;
+    const originalName = source.entry.name;
+    const existingIndex = destination.findIndex((entry) => entry.name === moved.name);
+    if (existingIndex !== -1) destination.splice(existingIndex, 1);
+    destination.push(moved);
+    source.parent.splice(source.index, 1);
+    this.emit();
+    return {
+      success: true,
+      message: `Moved ${originalName} to ${to}.`,
+    };
+  }
+
+  delete({ side, path }: SftpDeleteOptions): SftpOperationResult {
+    const target = this.findEntry(side, path);
+    if (!target) {
+      return { success: false, message: 'File not found.' };
+    }
+    if (target.entry.type !== 'file') {
+      return { success: false, message: 'Only files can be deleted in this demo.' };
+    }
+    const [removed] = target.parent.splice(target.index, 1);
+    this.emit();
+    return {
+      success: true,
+      message: `Deleted ${removed.name} from ${side}.`,
+    };
+  }
+
+  private emit() {
+    const snapshot = this.getSnapshot();
+    for (const listener of this.listeners) {
+      listener(snapshot);
+    }
+  }
+
+  private getContainer(side: SftpSide, path: string[]): SftpEntry[] | null {
+    let entries = this.tree[side];
+    if (path.length === 0) return entries;
+    for (const segment of path) {
+      const directory = entries.find((entry) => entry.name === segment && entry.type === 'directory');
+      if (!directory) return null;
+      if (!directory.children) {
+        directory.children = [];
+      }
+      entries = directory.children;
+    }
+    return entries;
+  }
+
+  private findEntry(side: SftpSide, path: string[]):
+    | { entry: SftpEntry; parent: SftpEntry[]; index: number }
+    | null {
+    if (path.length === 0) return null;
+    const parentPath = path.slice(0, -1);
+    const container = this.getContainer(side, parentPath);
+    if (!container) return null;
+    const name = path[path.length - 1];
+    const index = container.findIndex((entry) => entry.name === name);
+    if (index === -1) return null;
+    return { entry: container[index], parent: container, index };
+  }
+}
+
+export const createSftpAdapter = (local: SftpEntry[], remote: SftpEntry[]): SftpAdapter =>
+  new InMemorySftpAdapter(local, remote);
+
+export default InMemorySftpAdapter;

--- a/data/ssh/sftp/local.json
+++ b/data/ssh/sftp/local.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "Documents",
+    "type": "directory",
+    "children": [
+      {
+        "name": "ssh_cheatsheet.txt",
+        "type": "file",
+        "size": 2048,
+        "modified": "2024-02-15T10:30:00Z"
+      },
+      {
+        "name": "payloads",
+        "type": "directory",
+        "children": [
+          {
+            "name": "passwords.lst",
+            "type": "file",
+            "size": 512,
+            "modified": "2024-01-18T15:10:00Z"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "notes.txt",
+    "type": "file",
+    "size": 1024,
+    "modified": "2024-01-20T08:15:00Z"
+  },
+  {
+    "name": "inventory.csv",
+    "type": "file",
+    "size": 1536,
+    "modified": "2023-12-28T20:45:00Z"
+  }
+]

--- a/data/ssh/sftp/remote.json
+++ b/data/ssh/sftp/remote.json
@@ -1,0 +1,31 @@
+[
+  {
+    "name": "reports",
+    "type": "directory",
+    "children": [
+      {
+        "name": "audit.log",
+        "type": "file",
+        "size": 4096,
+        "modified": "2024-02-01T09:00:00Z"
+      },
+      {
+        "name": "findings.txt",
+        "type": "file",
+        "size": 3072,
+        "modified": "2024-01-29T18:30:00Z"
+      }
+    ]
+  },
+  {
+    "name": "motd.txt",
+    "type": "file",
+    "size": 512,
+    "modified": "2024-01-10T12:00:00Z"
+  },
+  {
+    "name": "uploads",
+    "type": "directory",
+    "children": []
+  }
+]


### PR DESCRIPTION
## Summary
- add an SFTP sidecar beside SSH sessions with synchronized local/remote panes and basic file actions
- implement an in-memory SFTP adapter seeded from local/remote fixtures to drive the UI
- cover the adapter with Jest tests for copy, move, and delete operations

## Testing
- yarn lint *(fails: repo-wide accessibility rules on unrelated files)*
- yarn test __tests__/apps/ssh/sftp-adapter.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc38ff62b483289b411e57d2013cb9