### PR TITLE
[ssh] Add heartbeat hook and reconnection tests

### DIFF
--- a/__tests__/apps/ssh/reconnect.test.tsx
+++ b/__tests__/apps/ssh/reconnect.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, act, waitFor } from '@testing-library/react';
+import React from 'react';
+import SSHPreview from '../../../apps/ssh';
+
+describe('SSH pseudo session reconnect flow', () => {
+  const originalOnLine = Object.getOwnPropertyDescriptor(window.navigator, 'onLine');
+  let online = true;
+
+  const updateOnline = (value: boolean) => {
+    online = value;
+    window.dispatchEvent(new Event(value ? 'online' : 'offline'));
+  };
+
+  beforeEach(() => {
+    online = true;
+    Object.defineProperty(window.navigator, 'onLine', {
+      configurable: true,
+      get: () => online,
+    });
+  });
+
+  afterAll(() => {
+    if (originalOnLine) {
+      Object.defineProperty(window.navigator, 'onLine', originalOnLine);
+    }
+  });
+
+  it('shows a banner, countdown, and reopens the session after recovery', async () => {
+    render(<SSHPreview />);
+
+    expect(screen.queryByTestId('ssh-connection-banner')).not.toBeInTheDocument();
+    expect(screen.getByTestId('ssh-session-status')).toHaveTextContent(/connected/i);
+
+    await act(async () => {
+      updateOnline(false);
+      await Promise.resolve();
+    });
+
+    const disconnectBanner = await screen.findByTestId('ssh-connection-banner');
+    expect(disconnectBanner).toHaveTextContent(/connection lost/i);
+    expect(screen.getByTestId('ssh-session-status')).toHaveTextContent(/paused/i);
+    expect(screen.getByTestId('ssh-session-message')).toHaveTextContent(/paused until the connection returns/i);
+
+    await act(async () => {
+      updateOnline(true);
+      await Promise.resolve();
+    });
+
+    const reconnectBanner = await screen.findByTestId('ssh-connection-banner');
+    expect(reconnectBanner).toHaveTextContent(/reopening session in 3/i);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('ssh-connection-banner')).toHaveTextContent(/in 2/i);
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('ssh-connection-banner')).toHaveTextContent(/in 1/i);
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+    });
+
+    expect(screen.queryByTestId('ssh-connection-banner')).not.toBeInTheDocument();
+    expect(screen.getByTestId('ssh-session-status')).toHaveTextContent(/connected/i);
+    await waitFor(() => {
+      expect(screen.getByTestId('ssh-session-message')).toHaveTextContent(/session reconnected/i);
+    });
+  });
+});

--- a/apps/ssh/hooks/useHeartbeat.ts
+++ b/apps/ssh/hooks/useHeartbeat.ts
@@ -1,0 +1,199 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type HeartbeatStatus = 'connected' | 'disconnected' | 'reconnecting';
+
+interface PromiseController {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+export interface UseHeartbeatOptions {
+  intervalMs?: number;
+  countdownSeconds?: number;
+  onDisconnect?: () => void;
+}
+
+export interface HeartbeatState {
+  status: HeartbeatStatus;
+  countdown: number | null;
+  lastPingAt: number | null;
+  waitForReconnect: () => Promise<void>;
+}
+
+const DEFAULT_INTERVAL = 4000;
+const DEFAULT_COUNTDOWN = 3;
+
+export function useHeartbeat({
+  intervalMs = DEFAULT_INTERVAL,
+  countdownSeconds = DEFAULT_COUNTDOWN,
+  onDisconnect,
+}: UseHeartbeatOptions = {}): HeartbeatState {
+  const [status, setStatus] = useState<HeartbeatStatus>('connected');
+  const statusRef = useRef<HeartbeatStatus>('connected');
+  const [lastPingAt, setLastPingAt] = useState<number | null>(null);
+  const [countdown, setCountdown] = useState<number | null>(null);
+  const countdownRef = useRef<number | null>(null);
+  const promiseRef = useRef<PromiseController | null>(null);
+  const disconnectRef = useRef<(() => void) | undefined>(onDisconnect);
+
+  useEffect(() => {
+    disconnectRef.current = onDisconnect;
+  }, [onDisconnect]);
+
+  const ensurePromise = useCallback(() => {
+    if (promiseRef.current) return promiseRef.current;
+    let resolve: () => void = () => {};
+    const promise = new Promise<void>((res) => {
+      resolve = res;
+    });
+    promiseRef.current = { promise, resolve };
+    return promiseRef.current;
+  }, []);
+
+  const waitForReconnect = useCallback(() => {
+    if (statusRef.current === 'connected' && countdownRef.current === null) {
+      return Promise.resolve();
+    }
+    return ensurePromise().promise;
+  }, [ensurePromise]);
+
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
+
+  useEffect(() => {
+    countdownRef.current = countdown;
+  }, [countdown]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    let heartbeatTimer: number | undefined;
+    let countdownTimer: number | undefined;
+
+    const resolvePromise = () => {
+      if (promiseRef.current) {
+        const { resolve } = promiseRef.current;
+        promiseRef.current = null;
+        resolve();
+      }
+    };
+
+    const stopCountdown = () => {
+      if (countdownTimer !== undefined) {
+        window.clearTimeout(countdownTimer);
+        countdownTimer = undefined;
+      }
+      countdownRef.current = null;
+      setCountdown(null);
+    };
+
+    const transitionToConnected = () => {
+      stopCountdown();
+      statusRef.current = 'connected';
+      setStatus('connected');
+      resolvePromise();
+    };
+
+    const startReconnectCountdown = () => {
+      if (statusRef.current === 'reconnecting' && countdownRef.current !== null) {
+        return;
+      }
+      stopCountdown();
+      ensurePromise();
+      const start = Math.max(0, Math.floor(countdownSeconds));
+      if (start <= 0) {
+        transitionToConnected();
+        return;
+      }
+      statusRef.current = 'reconnecting';
+      setStatus('reconnecting');
+      countdownRef.current = start;
+      setCountdown(start);
+      const scheduleNextTick = () => {
+        countdownTimer = window.setTimeout(() => {
+          if (countdownRef.current === null) {
+            return;
+          }
+          const next = countdownRef.current - 1;
+          countdownRef.current = next;
+          setCountdown(next >= 0 ? next : 0);
+          if (next <= 0) {
+            transitionToConnected();
+          } else {
+            scheduleNextTick();
+          }
+        }, 1000);
+      };
+
+      scheduleNextTick();
+    };
+
+    const setDisconnected = () => {
+      if (statusRef.current === 'disconnected') {
+        return;
+      }
+      stopCountdown();
+      promiseRef.current = null;
+      statusRef.current = 'disconnected';
+      setStatus('disconnected');
+      disconnectRef.current?.();
+    };
+
+    const isOnline = () => {
+      if (typeof navigator === 'undefined' || typeof navigator.onLine === 'undefined') {
+        return true;
+      }
+      return navigator.onLine;
+    };
+
+    const checkHeartbeat = () => {
+      setLastPingAt(Date.now());
+      if (!isOnline()) {
+        setDisconnected();
+      } else if (statusRef.current === 'disconnected') {
+        startReconnectCountdown();
+      }
+    };
+
+    const handleOffline = () => {
+      setLastPingAt(Date.now());
+      setDisconnected();
+    };
+
+    const handleOnline = () => {
+      setLastPingAt(Date.now());
+      if (statusRef.current !== 'connected') {
+        startReconnectCountdown();
+      }
+    };
+
+    heartbeatTimer = window.setInterval(checkHeartbeat, intervalMs);
+    checkHeartbeat();
+
+    window.addEventListener('offline', handleOffline);
+    window.addEventListener('online', handleOnline);
+
+    return () => {
+      if (heartbeatTimer !== undefined) {
+        window.clearInterval(heartbeatTimer);
+      }
+      if (countdownTimer !== undefined) {
+        window.clearTimeout(countdownTimer);
+      }
+      window.removeEventListener('offline', handleOffline);
+      window.removeEventListener('online', handleOnline);
+    };
+  }, [countdownSeconds, ensurePromise, intervalMs]);
+
+  return {
+    status,
+    countdown,
+    lastPingAt,
+    waitForReconnect,
+  };
+}

--- a/apps/ssh/index.tsx
+++ b/apps/ssh/index.tsx
@@ -1,16 +1,67 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import { useHeartbeat } from './hooks/useHeartbeat';
 
 const SSHBuilder: React.FC = () => {
   const [user, setUser] = useState('');
   const [host, setHost] = useState('');
   const [port, setPort] = useState('');
+  const [sessionActive, setSessionActive] = useState(true);
+  const [recoveryMessage, setRecoveryMessage] = useState<string | null>(null);
+
+  const { status, countdown, waitForReconnect } = useHeartbeat({
+    onDisconnect: () => {
+      setSessionActive(false);
+      setRecoveryMessage('Pseudo session paused until the connection returns.');
+    },
+  });
+
+  useEffect(() => {
+    if (status === 'reconnecting') {
+      let cancelled = false;
+      setRecoveryMessage('Network recovered. Restoring pseudo session...');
+      waitForReconnect().then(() => {
+        if (!cancelled) {
+          setSessionActive(true);
+          setRecoveryMessage('Session reconnected after network recovery.');
+        }
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+    return undefined;
+  }, [status, waitForReconnect]);
+
   const command = `ssh ${user ? `${user}@` : ''}${host}${port ? ` -p ${port}` : ''}`.trim();
+
+  const bannerMessage =
+    status === 'disconnected'
+      ? 'Connection lost. Trying to reconnect…'
+      : status === 'reconnecting'
+      ? `Network restored. Reopening session in ${Math.max(countdown ?? 0, 0)}s…`
+      : null;
+
+  const defaultSessionMessage = sessionActive
+    ? command
+      ? `Pseudo session ready. Command preview: ${command}`
+      : 'Pseudo session ready. Fill in the form to generate a command.'
+    : 'Pseudo session paused until the connection returns.';
+
+  const sessionMessage = recoveryMessage ?? defaultSessionMessage;
 
   return (
     <div className="h-full bg-gray-900 p-4 text-white overflow-auto">
+      {bannerMessage && (
+        <div
+          data-testid="ssh-connection-banner"
+          className="mb-4 rounded border border-yellow-400 bg-yellow-500/10 px-3 py-2 text-yellow-300"
+        >
+          {bannerMessage}
+        </div>
+      )}
       <h1 className="mb-4 text-2xl">SSH Command Builder</h1>
       <p className="mb-4 text-sm text-yellow-300">
         Generate an SSH command without executing it. Learn more at{' '}
@@ -33,6 +84,7 @@ const SSHBuilder: React.FC = () => {
             id="ssh-user"
             type="text"
             className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+            aria-label="SSH username"
             value={user}
             onChange={(e) => setUser(e.target.value)}
           />
@@ -45,6 +97,7 @@ const SSHBuilder: React.FC = () => {
             id="ssh-host"
             type="text"
             className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+            aria-label="SSH host"
             value={host}
             onChange={(e) => setHost(e.target.value)}
           />
@@ -57,16 +110,30 @@ const SSHBuilder: React.FC = () => {
             id="ssh-port"
             type="number"
             className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+            aria-label="SSH port"
             value={port}
             onChange={(e) => setPort(e.target.value)}
           />
         </div>
       </form>
       <div>
-        <h2 className="mb-2 text-lg">Command Preview</h2>
-        <pre className="overflow-auto rounded bg-black p-2 font-mono text-green-400">
-          {command || '# Fill in the form to generate a command'}
-        </pre>
+        <h2 className="mb-2 text-lg">Pseudo Session</h2>
+        <div className="rounded border border-gray-700 bg-black p-3">
+          <div className="mb-2 flex items-center justify-between text-xs uppercase tracking-wide text-gray-400">
+            <span>Status</span>
+            <span data-testid="ssh-session-status" className="font-semibold text-white">
+              {sessionActive ? 'Connected' : 'Paused'}
+            </span>
+          </div>
+          <p data-testid="ssh-session-message" className="text-sm text-gray-300">
+            {sessionMessage}
+          </p>
+          <pre className="mt-3 overflow-auto rounded bg-gray-900 p-3 font-mono text-green-400">
+            {sessionActive
+              ? command || '# Fill in the form to generate a command'
+              : '# Session paused - waiting for the network to recover'}
+          </pre>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a heartbeat hook that simulates connectivity, drives a countdown, and notifies reconnection listeners
- update the SSH builder UI to surface connection banners, resume the session after the countdown, and improve input labels
- create a reconnect unit test that stubs navigator.onLine and verifies countdown text and session recovery

## Testing
- yarn test --runTestsByPath __tests__/apps/ssh/reconnect.test.tsx
- yarn eslint apps/ssh/index.tsx apps/ssh/hooks/useHeartbeat.ts __tests__/apps/ssh/reconnect.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc39000b7c832885d02c24edbe98eb