### PR TITLE
[ssh] add port forwarding panel

### DIFF
--- a/__tests__/apps/ssh/__snapshots__/port-forward-panel.test.tsx.snap
+++ b/__tests__/apps/ssh/__snapshots__/port-forward-panel.test.tsx.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`PortForwardPanel matches the snapshot for an empty profile 1`] = `
+<DocumentFragment>
+  <section
+    class="mt-6 rounded border border-gray-700 bg-gray-900 p-4"
+  >
+    <div
+      class="mb-4 flex flex-col gap-2 md:flex-row md:items-center md:justify-between"
+    >
+      <div>
+        <h2
+          class="text-lg font-semibold text-white"
+        >
+          Port Forwarding
+        </h2>
+        <p
+          class="text-sm text-gray-300"
+        >
+          Define local and remote forwards. This panel simulates SSH listeners and does not open real sockets.
+        </p>
+      </div>
+    </div>
+    <form
+      class="mb-4 grid gap-4 md:grid-cols-[auto,1fr,1fr,auto] md:items-end"
+    >
+      <div
+        class="flex flex-col"
+      >
+        <span
+          class="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-400"
+        >
+          Type
+        </span>
+        <button
+          aria-label="Toggle forward direction"
+          class="rounded border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-white hover:border-gray-400"
+          type="button"
+        >
+          Local → Remote
+        </button>
+      </div>
+      <label
+        class="flex flex-col"
+        for="«r0»-source-port"
+      >
+        <span
+          class="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-400"
+        >
+          Source port
+        </span>
+        <input
+          class="rounded border border-gray-600 bg-gray-800 p-2 text-white focus:border-blue-500 focus:outline-none"
+          id="«r0»-source-port"
+          min="1"
+          type="number"
+          value="8080"
+        />
+      </label>
+      <label
+        class="flex flex-col"
+        for="«r0»-destination-host"
+      >
+        <span
+          class="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-400"
+        >
+          Destination host
+        </span>
+        <input
+          class="rounded border border-gray-600 bg-gray-800 p-2 text-white focus:border-blue-500 focus:outline-none"
+          id="«r0»-destination-host"
+          type="text"
+          value="127.0.0.1"
+        />
+      </label>
+      <label
+        class="flex flex-col"
+        for="«r0»-destination-port"
+      >
+        <span
+          class="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-400"
+        >
+          Destination port
+        </span>
+        <div
+          class="flex gap-2"
+        >
+          <input
+            class="w-full rounded border border-gray-600 bg-gray-800 p-2 text-white focus:border-blue-500 focus:outline-none"
+            id="«r0»-destination-port"
+            min="1"
+            type="number"
+            value="80"
+          />
+          <button
+            class="whitespace-nowrap rounded bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+            type="submit"
+          >
+            Add Forward
+          </button>
+        </div>
+      </label>
+    </form>
+    <p
+      class="text-sm text-gray-400"
+    >
+      No forwards defined yet. Add one above to start listening.
+    </p>
+  </section>
+</DocumentFragment>
+`;

--- a/__tests__/apps/ssh/port-forward-panel.test.tsx
+++ b/__tests__/apps/ssh/port-forward-panel.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import PortForwardPanel from '@/apps/ssh/components/PortForwardPanel';
+import { __testing as profileTesting } from '@/apps/ssh/state/profiles';
+
+describe('PortForwardPanel', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    profileTesting.reset();
+  });
+
+  it('matches the snapshot for an empty profile', () => {
+    const { asFragment } = render(<PortForwardPanel profileId="snapshot-profile" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('updates status chip when activating a forward', async () => {
+    render(<PortForwardPanel profileId="profile-1" />);
+
+    fireEvent.change(screen.getByLabelText('Source port'), { target: { value: '3000' } });
+    fireEvent.change(screen.getByLabelText('Destination host'), {
+      target: { value: 'internal.service' },
+    });
+    fireEvent.change(screen.getByLabelText('Destination port'), { target: { value: '8080' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add Forward' }));
+
+    const item = screen.getByRole('listitem');
+    expect(within(item).getByText('Stopped')).toBeInTheDocument();
+
+    const toggle = within(item).getByLabelText('Activate forward 3000 to internal.service:8080');
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(toggle).toBeChecked());
+    await waitFor(() => expect(within(item).getByText('Listening')).toBeInTheDocument());
+
+    const events = profileTesting.getEvents();
+    expect(events).toEqual([
+      expect.objectContaining({ type: 'started', profileId: 'profile-1' }),
+    ]);
+  });
+
+  it('tears down active listeners on unmount', async () => {
+    const { unmount } = render(<PortForwardPanel profileId="cleanup" />);
+
+    fireEvent.change(screen.getByLabelText('Source port'), { target: { value: '4000' } });
+    fireEvent.change(screen.getByLabelText('Destination host'), {
+      target: { value: 'db.internal' },
+    });
+    fireEvent.change(screen.getByLabelText('Destination port'), { target: { value: '5432' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add Forward' }));
+
+    const item = screen.getByRole('listitem');
+    const toggle = within(item).getByLabelText('Activate forward 4000 to db.internal:5432');
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(toggle).toBeChecked());
+
+    unmount();
+
+    const events = profileTesting.getEvents();
+    expect(events).toEqual([
+      expect.objectContaining({ type: 'started', profileId: 'cleanup' }),
+      expect.objectContaining({ type: 'stopped', profileId: 'cleanup' }),
+    ]);
+  });
+});
+

--- a/apps/ssh/components/PortForwardPanel.tsx
+++ b/apps/ssh/components/PortForwardPanel.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import React, { useEffect, useMemo, useState, useId } from 'react';
+import {
+  PortForwardDefinition,
+  ForwardDirection,
+  PortForwardInput,
+  ensureActiveForwards,
+  getForwardStatus,
+  subscribeListenerRegistry,
+  useSshProfile,
+  deactivateProfile,
+} from '../state/profiles';
+
+interface PortForwardPanelProps {
+  profileId: string;
+}
+
+const directionLabel = (direction: ForwardDirection) =>
+  direction === 'local' ? 'Local Forward' : 'Remote Forward';
+
+const directionFlow = (forward: PortForwardDefinition) =>
+  forward.direction === 'local'
+    ? `localhost:${forward.sourcePort} → ${forward.destinationHost}:${forward.destinationPort}`
+    : `${forward.destinationHost}:${forward.destinationPort} → localhost:${forward.sourcePort}`;
+
+const statusChip = (status: 'listening' | 'stopped') => ({
+  label: status === 'listening' ? 'Listening' : 'Stopped',
+  className:
+    status === 'listening'
+      ? 'bg-green-700 text-green-100 border border-green-500'
+      : 'bg-gray-700 text-gray-200 border border-gray-600',
+});
+
+const DEFAULT_SOURCE_PORT = '8080';
+const DEFAULT_DEST_PORT = '80';
+const DEFAULT_HOST = '127.0.0.1';
+
+const PortForwardPanel: React.FC<PortForwardPanelProps> = ({ profileId }) => {
+  const { profile, addForward, updateForward, removeForward, setForwardEnabled } = useSshProfile(profileId);
+  const [direction, setDirection] = useState<ForwardDirection>('local');
+  const [sourcePort, setSourcePort] = useState(DEFAULT_SOURCE_PORT);
+  const [destinationHost, setDestinationHost] = useState(DEFAULT_HOST);
+  const [destinationPort, setDestinationPort] = useState(DEFAULT_DEST_PORT);
+  const [error, setError] = useState<string | null>(null);
+  const [, forceUpdate] = useState(0);
+
+  const formId = useId();
+  const sourceId = `${formId}-source-port`;
+  const hostId = `${formId}-destination-host`;
+  const destPortId = `${formId}-destination-port`;
+
+  useEffect(() => {
+    ensureActiveForwards(profileId, profile.forwards);
+  }, [profileId, profile.forwards]);
+
+  useEffect(() => {
+    const unsubscribe = subscribeListenerRegistry(() => {
+      forceUpdate((value) => value + 1);
+    });
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      deactivateProfile(profileId);
+    };
+  }, [profileId]);
+
+  const handleAdd = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    const parsedSource = Number(sourcePort);
+    const parsedDest = Number(destinationPort);
+    const trimmedHost = destinationHost.trim();
+
+    if (!Number.isInteger(parsedSource) || parsedSource <= 0) {
+      setError('Enter a valid source port.');
+      return;
+    }
+    if (!Number.isInteger(parsedDest) || parsedDest <= 0) {
+      setError('Enter a valid destination port.');
+      return;
+    }
+    if (!trimmedHost) {
+      setError('Destination host is required.');
+      return;
+    }
+
+    const payload: PortForwardInput = {
+      direction,
+      sourcePort: parsedSource,
+      destinationHost: trimmedHost,
+      destinationPort: parsedDest,
+    };
+    addForward(payload);
+
+    setSourcePort(DEFAULT_SOURCE_PORT);
+    setDestinationPort(DEFAULT_DEST_PORT);
+    setDestinationHost(trimmedHost);
+  };
+
+  const forwards = useMemo(() => profile.forwards, [profile.forwards]);
+
+  return (
+    <section className="mt-6 rounded border border-gray-700 bg-gray-900 p-4">
+      <div className="mb-4 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Port Forwarding</h2>
+          <p className="text-sm text-gray-300">
+            Define local and remote forwards. This panel simulates SSH listeners and does not open real sockets.
+          </p>
+        </div>
+      </div>
+      <form onSubmit={handleAdd} className="mb-4 grid gap-4 md:grid-cols-[auto,1fr,1fr,auto] md:items-end">
+        <div className="flex flex-col">
+          <span className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-400">Type</span>
+          <button
+            type="button"
+            onClick={() => setDirection((current) => (current === 'local' ? 'remote' : 'local'))}
+            className="rounded border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-white hover:border-gray-400"
+            aria-label="Toggle forward direction"
+          >
+            {direction === 'local' ? 'Local → Remote' : 'Remote → Local'}
+          </button>
+        </div>
+        <label htmlFor={sourceId} className="flex flex-col">
+          <span className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-400">Source port</span>
+          <input
+            id={sourceId}
+            type="number"
+            min={1}
+            className="rounded border border-gray-600 bg-gray-800 p-2 text-white focus:border-blue-500 focus:outline-none"
+            value={sourcePort}
+            onChange={(event) => setSourcePort(event.target.value)}
+          />
+        </label>
+        <label htmlFor={hostId} className="flex flex-col">
+          <span className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-400">Destination host</span>
+          <input
+            id={hostId}
+            type="text"
+            className="rounded border border-gray-600 bg-gray-800 p-2 text-white focus:border-blue-500 focus:outline-none"
+            value={destinationHost}
+            onChange={(event) => setDestinationHost(event.target.value)}
+          />
+        </label>
+        <label htmlFor={destPortId} className="flex flex-col">
+          <span className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-400">Destination port</span>
+          <div className="flex gap-2">
+            <input
+              id={destPortId}
+              type="number"
+              min={1}
+              className="w-full rounded border border-gray-600 bg-gray-800 p-2 text-white focus:border-blue-500 focus:outline-none"
+              value={destinationPort}
+              onChange={(event) => setDestinationPort(event.target.value)}
+            />
+            <button
+              type="submit"
+              className="whitespace-nowrap rounded bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+            >
+              Add Forward
+            </button>
+          </div>
+        </label>
+      </form>
+      {error && <p className="mb-4 text-sm text-red-400" role="alert">{error}</p>}
+      {forwards.length === 0 ? (
+        <p className="text-sm text-gray-400">No forwards defined yet. Add one above to start listening.</p>
+      ) : (
+        <ul className="space-y-3">
+          {forwards.map((forward) => {
+            const status = getForwardStatus(forward.id);
+            const chip = statusChip(status);
+            const nextDirection = forward.direction === 'local' ? 'remote' : 'local';
+
+            return (
+              <li
+                key={forward.id}
+                className="rounded border border-gray-700 bg-gray-800 p-3 text-sm text-white"
+              >
+                <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                  <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-4">
+                    <button
+                      type="button"
+                      onClick={() => updateForward(forward.id, { direction: nextDirection })}
+                      className="rounded border border-gray-600 bg-gray-700 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-gray-200 hover:border-gray-400"
+                      aria-label={`Switch to ${directionLabel(nextDirection)}`}
+                    >
+                      {directionLabel(forward.direction)}
+                    </button>
+                    <span className="font-mono text-gray-100">{directionFlow(forward)}</span>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <span
+                      className={`rounded-full px-2 py-1 text-xs font-semibold ${chip.className}`}
+                    >
+                      {chip.label}
+                    </span>
+                    <label className="flex items-center gap-2 text-xs uppercase tracking-wide text-gray-300">
+                      <input
+                        type="checkbox"
+                        checked={forward.enabled}
+                        onChange={(event) => setForwardEnabled(forward.id, event.target.checked)}
+                        className="h-4 w-4 accent-blue-500"
+                        aria-label={`Activate forward ${forward.sourcePort} to ${forward.destinationHost}:${forward.destinationPort}`}
+                      />
+                      Active
+                    </label>
+                    <button
+                      type="button"
+                      onClick={() => removeForward(forward.id)}
+                      className="rounded border border-red-600 px-2 py-1 text-xs font-semibold uppercase tracking-wide text-red-200 hover:bg-red-600/20"
+                      aria-label={`Remove forward ${forward.sourcePort} to ${forward.destinationHost}:${forward.destinationPort}`}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+export default PortForwardPanel;
+

--- a/apps/ssh/index.tsx
+++ b/apps/ssh/index.tsx
@@ -2,8 +2,16 @@
 
 import React, { useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import PortForwardPanel from './components/PortForwardPanel';
 
-const SSHBuilder: React.FC = () => {
+const createProfileId = () =>
+  `ssh-session-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+interface SSHBuilderProps {
+  profileId: string;
+}
+
+const SSHBuilder: React.FC<SSHBuilderProps> = ({ profileId }) => {
   const [user, setUser] = useState('');
   const [host, setHost] = useState('');
   const [port, setPort] = useState('');
@@ -68,6 +76,7 @@ const SSHBuilder: React.FC = () => {
           {command || '# Fill in the form to generate a command'}
         </pre>
       </div>
+      <PortForwardPanel profileId={profileId} />
     </div>
   );
 };
@@ -76,8 +85,8 @@ const SSHPreview: React.FC = () => {
   const countRef = useRef(1);
 
   const createTab = (): TabDefinition => {
-    const id = Date.now().toString();
-    return { id, title: `Session ${countRef.current++}`, content: <SSHBuilder /> };
+    const id = createProfileId();
+    return { id, title: `Session ${countRef.current++}`, content: <SSHBuilder profileId={id} /> };
   };
 
   return (

--- a/apps/ssh/state/profiles.ts
+++ b/apps/ssh/state/profiles.ts
@@ -1,0 +1,235 @@
+import { useCallback, useMemo } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+export type ForwardDirection = 'local' | 'remote';
+
+export interface PortForwardInput {
+  direction: ForwardDirection;
+  sourcePort: number;
+  destinationHost: string;
+  destinationPort: number;
+}
+
+export interface PortForwardDefinition extends PortForwardInput {
+  id: string;
+  enabled: boolean;
+}
+
+interface ProfileRecord {
+  forwards: PortForwardDefinition[];
+}
+
+type ProfileStore = Record<string, ProfileRecord>;
+
+const STORAGE_KEY = 'ssh:profiles';
+
+const createProfileRecord = (): ProfileRecord => ({ forwards: [] });
+
+const createForwardId = () =>
+  `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+type ListenerStatus = 'listening' | 'stopped';
+
+type ListenerEventType = 'started' | 'stopped';
+
+interface ListenerEvent {
+  type: ListenerEventType;
+  profileId: string;
+  forwardId: string;
+}
+
+interface ListenerEntry {
+  profileId: string;
+}
+
+const listeners = new Map<string, ListenerEntry>();
+const listenerSubscribers = new Set<() => void>();
+const listenerEvents: ListenerEvent[] = [];
+
+const notifyListeners = () => {
+  listenerSubscribers.forEach((cb) => cb());
+};
+
+const recordEvent = (event: ListenerEvent) => {
+  listenerEvents.push(event);
+};
+
+const startListening = (profileId: string, forward: PortForwardDefinition) => {
+  listeners.set(forward.id, { profileId });
+  recordEvent({ type: 'started', profileId, forwardId: forward.id });
+  notifyListeners();
+};
+
+const stopListening = (profileId: string, forwardId: string) => {
+  if (listeners.delete(forwardId)) {
+    recordEvent({ type: 'stopped', profileId, forwardId });
+    notifyListeners();
+  }
+};
+
+export const getForwardStatus = (forwardId: string): ListenerStatus =>
+  listeners.has(forwardId) ? 'listening' : 'stopped';
+
+export const subscribeListenerRegistry = (callback: () => void) => {
+  listenerSubscribers.add(callback);
+  return () => {
+    listenerSubscribers.delete(callback);
+  };
+};
+
+export const ensureActiveForwards = (
+  profileId: string,
+  forwards: PortForwardDefinition[],
+) => {
+  forwards.forEach((forward) => {
+    if (forward.enabled && !listeners.has(forward.id)) {
+      startListening(profileId, forward);
+    }
+  });
+};
+
+export const deactivateProfile = (profileId: string) => {
+  const ids = Array.from(listeners.entries())
+    .filter(([, entry]) => entry.profileId === profileId)
+    .map(([forwardId]) => forwardId);
+  ids.forEach((forwardId) => {
+    stopListening(profileId, forwardId);
+  });
+};
+
+export const useSshProfile = (profileId: string) => {
+  const [profiles, setProfiles] = usePersistentState<ProfileStore>(STORAGE_KEY, {});
+
+  const profile = useMemo(() => {
+    const entry = profiles[profileId];
+    if (!entry) return createProfileRecord();
+    return {
+      forwards: entry.forwards.map((forward) => ({ ...forward })),
+    };
+  }, [profiles, profileId]);
+
+  const addForward = useCallback(
+    (input: PortForwardInput) => {
+      const forward: PortForwardDefinition = {
+        id: createForwardId(),
+        enabled: false,
+        ...input,
+      };
+      setProfiles((prev) => {
+        const current = prev[profileId] ?? createProfileRecord();
+        const nextProfile: ProfileRecord = {
+          forwards: [...current.forwards, forward],
+        };
+        return { ...prev, [profileId]: nextProfile };
+      });
+    },
+    [profileId, setProfiles],
+  );
+
+  const updateForward = useCallback(
+    (forwardId: string, patch: Partial<PortForwardInput>) => {
+      let effect: (() => void) | undefined;
+      setProfiles((prev) => {
+        const current = prev[profileId] ?? createProfileRecord();
+        let updated: PortForwardDefinition | undefined;
+        let previous: PortForwardDefinition | undefined;
+        const forwards = current.forwards.map((forward) => {
+          if (forward.id !== forwardId) return forward;
+          previous = forward;
+          updated = { ...forward, ...patch };
+          return updated;
+        });
+        if (!updated || !previous) return prev;
+        effect = () => {
+          if (updated && updated.enabled) {
+            startListening(profileId, updated);
+          } else if (previous?.enabled) {
+            stopListening(profileId, forwardId);
+          }
+        };
+        return { ...prev, [profileId]: { forwards } };
+      });
+      effect?.();
+    },
+    [profileId, setProfiles],
+  );
+
+  const removeForward = useCallback(
+    (forwardId: string) => {
+      let effect: (() => void) | undefined;
+      setProfiles((prev) => {
+        const current = prev[profileId] ?? createProfileRecord();
+        const forward = current.forwards.find((item) => item.id === forwardId);
+        if (!forward) return prev;
+        const nextProfile: ProfileRecord = {
+          forwards: current.forwards.filter((item) => item.id !== forwardId),
+        };
+        if (forward.enabled) {
+          effect = () => stopListening(profileId, forwardId);
+        }
+        return { ...prev, [profileId]: nextProfile };
+      });
+      effect?.();
+    },
+    [profileId, setProfiles],
+  );
+
+  const setForwardEnabled = useCallback(
+    (forwardId: string, enabled: boolean) => {
+      let effect: (() => void) | undefined;
+      setProfiles((prev) => {
+        const current = prev[profileId] ?? createProfileRecord();
+        let changed = false;
+        let updatedForward: PortForwardDefinition | undefined;
+        let previousForward: PortForwardDefinition | undefined;
+        const forwards = current.forwards.map((forward) => {
+          if (forward.id !== forwardId) return forward;
+          if (forward.enabled === enabled) return forward;
+          changed = true;
+          previousForward = forward;
+          updatedForward = { ...forward, enabled };
+          return updatedForward;
+        });
+        if (!changed || !previousForward || !updatedForward) return prev;
+        effect = () => {
+          if (enabled) {
+            startListening(profileId, updatedForward!);
+          } else {
+            stopListening(profileId, forwardId);
+          }
+        };
+        return { ...prev, [profileId]: { forwards } };
+      });
+      effect?.();
+    },
+    [profileId, setProfiles],
+  );
+
+  const clearProfile = useCallback(() => {
+    setProfiles((prev) => {
+      if (!(profileId in prev)) return prev;
+      const next = { ...prev };
+      delete next[profileId];
+      return next;
+    });
+    deactivateProfile(profileId);
+  }, [profileId, setProfiles]);
+
+  return {
+    profile,
+    addForward,
+    updateForward,
+    removeForward,
+    setForwardEnabled,
+    clearProfile,
+  } as const;
+};
+
+export const __testing = {
+  getEvents: () => [...listenerEvents],
+  reset: () => {
+    listeners.clear();
+    listenerEvents.length = 0;
+  },
+};
+


### PR DESCRIPTION
## Summary
- add a port forwarding panel to SSH sessions with local/remote toggles and simulated listener status chips
- persist port-forward definitions per session profile and synchronize listener lifecycle events
- cover the new panel with snapshot and interaction tests to assert status updates and cleanup

## Testing
- yarn test port-forward-panel
- yarn lint *(fails: repository has pre-existing accessibility and no-top-level-window violations)*

------
https://chatgpt.com/codex/tasks/task_e_68cc38fe70a883288f0ecb8d4f732657