### PR TITLE
apps: add regex tester explanation view

### DIFF
--- a/__tests__/apps/regex-tester/explain-view.test.tsx
+++ b/__tests__/apps/regex-tester/explain-view.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, within } from '@testing-library/react';
+import ExplainView from '../../../apps/regex-tester/components/ExplainView';
+
+describe('ExplainView', () => {
+  it('prompts for a pattern when empty', () => {
+    render(<ExplainView pattern="" flags="" />);
+
+    expect(screen.getByText(/enter a pattern/i)).toBeInTheDocument();
+    expect(screen.queryByRole('tree')).not.toBeInTheDocument();
+  });
+
+  it('shows parser errors without crashing', () => {
+    render(<ExplainView pattern="(" flags="" />);
+
+    expect(screen.getByText(/parser error/i)).toBeInTheDocument();
+    expect(screen.getByText(/unterminated group/i)).toBeInTheDocument();
+  });
+
+  it('renders nested groups with proper hierarchy', () => {
+    const pattern = String.raw`^(?<outer>(\w+)(?:-(?<inner>(?:foo|bar(?:baz|qux))))?)$`;
+
+    render(<ExplainView pattern={pattern} flags="" />);
+
+    expect(screen.getByRole('tree')).toBeInTheDocument();
+    expect(screen.getByText('Capturing group #1 <outer>')).toBeInTheDocument();
+    expect(screen.getByText('Capturing group #2')).toBeInTheDocument();
+    expect(screen.getByText('Capturing group #3 <inner>')).toBeInTheDocument();
+
+    // The optional hyphen and inner group should be represented as a quantifier.
+    expect(screen.getByText('Zero or one time')).toBeInTheDocument();
+    const literalNodes = screen.getAllByText('\\w+');
+    expect(literalNodes.length).toBeGreaterThan(0);
+
+    const optionHeaders = screen.getAllByText('Option 2');
+    const nestedOptionHeader = optionHeaders.find((header) => {
+      const treeItem = header.closest('li');
+      return treeItem ? within(treeItem).queryByText('bar(?:baz|qux)') : null;
+    });
+
+    expect(nestedOptionHeader).toBeDefined();
+    if (nestedOptionHeader) {
+      const treeItem = nestedOptionHeader.closest('li');
+      expect(treeItem).not.toBeNull();
+      if (treeItem) {
+        expect(within(treeItem).getByText('Non-capturing group')).toBeInTheDocument();
+        expect(within(treeItem).getByText('bar(?:baz|qux)')).toBeInTheDocument();
+      }
+    }
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -110,6 +110,7 @@ const ReconNGApp = createDynamicApp('reconng', 'Recon-ng');
 const SecurityToolsApp = createDynamicApp('security-tools', 'Security Tools');
 const SSHApp = createDynamicApp('ssh', 'SSH Command Builder');
 const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
+const RegexTesterApp = createDynamicApp('regex-tester', 'Regex Tester');
 const HtmlRewriteApp = createDynamicApp('html-rewriter', 'HTML Rewriter');
 const ContactApp = createDynamicApp('contact', 'Contact');
 
@@ -195,6 +196,7 @@ const displayReconNG = createDisplay(ReconNGApp);
 const displaySecurityTools = createDisplay(SecurityToolsApp);
 const displaySSH = createDisplay(SSHApp);
 const displayHTTP = createDisplay(HTTPApp);
+const displayRegexTester = createDisplay(RegexTesterApp);
 const displayHtmlRewrite = createDisplay(HtmlRewriteApp);
 const displayContact = createDisplay(ContactApp);
 
@@ -266,6 +268,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayInputLab,
+  },
+  {
+    id: 'regex-tester',
+    title: 'Regex Tester',
+    icon: '/themes/Yaru/apps/gedit.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayRegexTester,
   },
 ];
 
@@ -897,6 +908,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayHTTP,
+  },
+  {
+    id: 'regex-tester',
+    title: 'Regex Tester',
+    icon: '/themes/Yaru/apps/gedit.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayRegexTester,
   },
   {
     id: 'html-rewriter',

--- a/apps/regex-tester/components/ExplainView.tsx
+++ b/apps/regex-tester/components/ExplainView.tsx
@@ -1,0 +1,462 @@
+'use client';
+
+import { useMemo } from 'react';
+import { RegExpParser } from '@eslint-community/regexpp';
+import type { AST } from '@eslint-community/regexpp';
+
+interface ExplainViewProps {
+  pattern: string;
+  flags: string;
+}
+
+interface ExplanationNode {
+  id: string;
+  title: string;
+  description?: string;
+  snippet?: string;
+  children?: ExplanationNode[];
+}
+
+type AlternativeContext = 'pattern' | 'group' | 'lookaround';
+
+const CONTROL_NAMES: Record<number, string> = {
+  0: 'Null',
+  8: 'Backspace',
+  9: 'Tab',
+  10: 'Line feed',
+  11: 'Vertical tab',
+  12: 'Form feed',
+  13: 'Carriage return',
+  27: 'Escape',
+};
+
+const FLAG_LABELS: Record<string, string> = {
+  d: 'indices (d)',
+  g: 'global (g)',
+  i: 'ignore case (i)',
+  m: 'multiline (m)',
+  s: 'dotAll (s)',
+  u: 'unicode (u)',
+  v: 'unicode sets (v)',
+  y: 'sticky (y)',
+};
+
+function escapeSnippet(raw: string): string {
+  return raw
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t')
+    .replace(/\f/g, '\\f')
+    .replace(/\v/g, '\\v')
+    .replace(/\u0000/g, '\\0');
+}
+
+function formatCodePoint(value: number): string {
+  const hex = value.toString(16).toUpperCase();
+  const padded = hex.padStart(Math.max(4, hex.length), '0');
+  const char = value <= 0x10ffff ? String.fromCodePoint(value) : '';
+  const isPrintable = value >= 0x20 && value !== 0x7f;
+  const controlName = CONTROL_NAMES[value];
+
+  if (isPrintable) {
+    return `"${char}" (U+${padded})`;
+  }
+
+  if (controlName) {
+    return `${controlName} (U+${padded})`;
+  }
+
+  return `U+${padded}`;
+}
+
+function describeFlags(flags: string): string {
+  if (!flags) {
+    return 'Flags: none';
+  }
+
+  const labels = Array.from(new Set(flags.split('')))
+    .map((flag) => FLAG_LABELS[flag] ?? `${flag}`)
+    .join(', ');
+
+  return labels ? `Flags: ${labels}` : `Flags: ${flags}`;
+}
+
+function buildTree(pattern: AST.Pattern, flags: string): ExplanationNode {
+  let captureIndex = 1;
+  let nextId = 0;
+
+  const makeId = () => `regex-node-${nextId++}`;
+
+  const createNode = (
+    title: string,
+    {
+      description,
+      snippet,
+      children,
+    }: {
+      description?: string;
+      snippet?: string;
+      children?: ExplanationNode[];
+    } = {},
+  ): ExplanationNode => ({
+    id: makeId(),
+    title,
+    description,
+    snippet,
+    children: children?.filter(Boolean),
+  });
+
+  const buildAlternative = (
+    alternative: AST.Alternative,
+    index: number,
+    total: number,
+    context: AlternativeContext,
+  ): ExplanationNode => {
+    const rawSnippet = alternative.raw;
+    const hasContent = rawSnippet.length > 0;
+
+    let title: string;
+    if (total > 1) {
+      title = context === 'pattern' ? `Alternative ${index + 1}` : `Option ${index + 1}`;
+    } else {
+      title = 'Sequence';
+    }
+
+    return createNode(title, {
+      description: hasContent ? undefined : 'Matches the empty string',
+      snippet: hasContent ? escapeSnippet(rawSnippet) : 'ε',
+      children: alternative.elements.map((element) => buildElement(element)),
+    });
+  };
+
+  const describeModifierFlags = (flagsNode: AST.ModifierFlags | null): string | undefined => {
+    if (!flagsNode) {
+      return undefined;
+    }
+
+    const flagsDescriptions: string[] = [];
+    if (flagsNode.ignoreCase) flagsDescriptions.push('ignore case');
+    if (flagsNode.multiline) flagsDescriptions.push('multiline');
+    if (flagsNode.dotAll) flagsDescriptions.push('dotAll');
+
+    if (!flagsDescriptions.length) {
+      return undefined;
+    }
+
+    return `Applies modifiers: ${flagsDescriptions.join(', ')}`;
+  };
+
+  const buildCharacterSet = (set: AST.CharacterSet): ExplanationNode => {
+    if (set.kind === 'any') {
+      return createNode('Any character', {
+        description: 'Matches any character except line terminators',
+        snippet: escapeSnippet(set.raw),
+      });
+    }
+
+    if (set.kind === 'digit' || set.kind === 'space' || set.kind === 'word') {
+      const kindLabel =
+        set.kind === 'digit' ? 'digit' : set.kind === 'space' ? 'whitespace' : 'word';
+      const negate = set.negate ? 'non-' : '';
+      return createNode(`${set.negate ? 'Negated' : 'Character'} set`, {
+        description: `Matches ${negate}${kindLabel} characters`,
+        snippet: escapeSnippet(set.raw),
+      });
+    }
+
+    if (set.kind === 'property') {
+      const property = `${set.key}${set.value ? `=${set.value}` : ''}`;
+      const baseDescription = set.strings
+        ? `Matches ${set.negate ? 'strings without' : 'strings with'} property ${property}`
+        : `Matches ${set.negate ? 'characters without' : 'characters with'} property ${property}`;
+      return createNode(set.negate ? 'Negated Unicode property' : 'Unicode property', {
+        description: baseDescription,
+        snippet: escapeSnippet(set.raw),
+      });
+    }
+
+    return createNode('Character set', {
+      snippet: escapeSnippet(set.raw),
+    });
+  };
+
+  const buildCharacterRange = (range: AST.CharacterClassRange): ExplanationNode => {
+    return createNode('Range', {
+      description: `${formatCodePoint(range.min.value)} through ${formatCodePoint(range.max.value)}`,
+      snippet: escapeSnippet(range.raw),
+      children: [
+        createNode('Start', {
+          description: formatCodePoint(range.min.value),
+          snippet: escapeSnippet(range.min.raw),
+        }),
+        createNode('End', {
+          description: formatCodePoint(range.max.value),
+          snippet: escapeSnippet(range.max.raw),
+        }),
+      ],
+    });
+  };
+
+  const buildClassElement = (element: AST.CharacterClassElement): ExplanationNode => {
+    switch (element.type) {
+      case 'Character':
+        return createNode('Literal', {
+          description: formatCodePoint(element.value),
+          snippet: escapeSnippet(element.raw),
+        });
+      case 'CharacterClassRange':
+        return buildCharacterRange(element);
+      case 'CharacterSet':
+        return buildCharacterSet(element);
+      case 'CharacterClass':
+        return buildCharacterClass(element);
+      case 'ClassIntersection':
+        return createNode('Class intersection', {
+          snippet: escapeSnippet(element.raw),
+        });
+      case 'ClassSubtraction':
+        return createNode('Class subtraction', {
+          snippet: escapeSnippet(element.raw),
+        });
+      case 'ClassStringDisjunction':
+        return createNode('String alternatives', {
+          snippet: escapeSnippet(element.raw),
+        });
+      case 'ExpressionCharacterClass':
+        return createNode('Expression character class', {
+          snippet: escapeSnippet(element.raw),
+        });
+      default:
+        return createNode(element.type, {
+          snippet: escapeSnippet(element.raw),
+        });
+    }
+  };
+
+  const buildCharacterClass = (characterClass: AST.CharacterClass): ExplanationNode => {
+    return createNode(characterClass.negate ? 'Negated character class' : 'Character class', {
+      description: characterClass.negate
+        ? 'Matches characters that are not in this set'
+        : 'Matches one of the listed characters',
+      snippet: escapeSnippet(characterClass.raw),
+      children: characterClass.elements.map((element) => buildClassElement(element)),
+    });
+  };
+
+  const buildAssertion = (assertion: AST.Assertion): ExplanationNode => {
+    switch (assertion.kind) {
+      case 'start':
+        return createNode('Start assertion', {
+          description: 'Matches at the beginning of the input',
+          snippet: escapeSnippet(assertion.raw),
+        });
+      case 'end':
+        return createNode('End assertion', {
+          description: 'Matches at the end of the input',
+          snippet: escapeSnippet(assertion.raw),
+        });
+      case 'word':
+        return createNode(assertion.negate ? 'Non-word boundary' : 'Word boundary', {
+          description: assertion.negate
+            ? 'Position between word and non-word characters is not allowed'
+            : 'Position between word and non-word characters',
+          snippet: escapeSnippet(assertion.raw),
+        });
+      case 'lookahead':
+      case 'lookbehind': {
+        const title = `${assertion.negate ? 'Negative' : 'Positive'} ${
+          assertion.kind === 'lookahead' ? 'lookahead' : 'lookbehind'
+        }`;
+        return createNode(title, {
+          description: assertion.negate ? 'Requires the pattern to not match' : 'Requires the pattern to match',
+          snippet: escapeSnippet(assertion.raw),
+          children: assertion.alternatives.map((alt, index) =>
+            buildAlternative(alt, index, assertion.alternatives.length, 'lookaround'),
+          ),
+        });
+      }
+      default:
+        return createNode('Assertion', {
+          snippet: escapeSnippet(assertion.raw),
+        });
+    }
+  };
+
+  const describeQuantifier = (quantifier: AST.Quantifier): string => {
+    if (quantifier.min === 0 && quantifier.max === 1) {
+      return `Zero or one time${quantifier.greedy ? '' : ' (lazy)'}`;
+    }
+    if (quantifier.min === 0 && quantifier.max === Infinity) {
+      return `Zero or more times${quantifier.greedy ? '' : ' (lazy)'}`;
+    }
+    if (quantifier.min === 1 && quantifier.max === Infinity) {
+      return `One or more times${quantifier.greedy ? '' : ' (lazy)'}`;
+    }
+    if (quantifier.min === quantifier.max) {
+      return `Exactly ${quantifier.min} time${quantifier.min === 1 ? '' : 's'}${
+        quantifier.greedy ? '' : ' (lazy)'
+      }`;
+    }
+    if (quantifier.max === Infinity) {
+      return `At least ${quantifier.min} times${quantifier.greedy ? '' : ' (lazy)'}`;
+    }
+    return `Between ${quantifier.min} and ${quantifier.max} times${
+      quantifier.greedy ? '' : ' (lazy)'
+    }`;
+  };
+
+  const buildQuantifier = (quantifier: AST.Quantifier): ExplanationNode => {
+    return createNode('Quantifier', {
+      description: describeQuantifier(quantifier),
+      snippet: escapeSnippet(quantifier.raw),
+      children: [buildElement(quantifier.element)],
+    });
+  };
+
+  const buildBackreference = (backreference: AST.Backreference): ExplanationNode => {
+    const resolved = Array.isArray(backreference.resolved)
+      ? backreference.resolved.map((group) => escapeSnippet(group.raw)).join(', ')
+      : escapeSnippet(backreference.resolved.raw);
+
+    return createNode('Backreference', {
+      description: `Refers to ${Array.isArray(backreference.resolved) ? 'groups' : 'group'} ${resolved}`,
+      snippet: escapeSnippet(backreference.raw),
+    });
+  };
+
+  const buildElement = (element: AST.Element): ExplanationNode => {
+    switch (element.type) {
+      case 'Character':
+        return createNode('Literal', {
+          description: formatCodePoint(element.value),
+          snippet: escapeSnippet(element.raw),
+        });
+      case 'CharacterSet':
+        return buildCharacterSet(element);
+      case 'CharacterClass':
+        return buildCharacterClass(element);
+      case 'Quantifier':
+        return buildQuantifier(element);
+      case 'CapturingGroup': {
+        const index = captureIndex++;
+        const nameSuffix = element.name ? ` <${element.name}>` : '';
+        return createNode(`Capturing group #${index}${nameSuffix}`, {
+          snippet: escapeSnippet(element.raw),
+          children: element.alternatives.map((alt, altIndex) =>
+            buildAlternative(alt, altIndex, element.alternatives.length, 'group'),
+          ),
+        });
+      }
+      case 'Group':
+        return createNode('Non-capturing group', {
+          description: describeModifierFlags(element.modifiers),
+          snippet: escapeSnippet(element.raw),
+          children: element.alternatives.map((alt, altIndex) =>
+            buildAlternative(alt, altIndex, element.alternatives.length, 'group'),
+          ),
+        });
+      case 'Assertion':
+        return buildAssertion(element);
+      case 'Backreference':
+        return buildBackreference(element);
+      case 'ExpressionCharacterClass':
+        return createNode('Expression character class', {
+          snippet: escapeSnippet(element.raw),
+        });
+      default:
+        return createNode(element.type, {
+          snippet: escapeSnippet(element.raw),
+        });
+    }
+  };
+
+  const rootChildren = pattern.alternatives.map((alternative, index) =>
+    buildAlternative(alternative, index, pattern.alternatives.length, 'pattern'),
+  );
+
+  const rootDescriptionParts = [describeFlags(flags)];
+  if (!pattern.raw.length) {
+    rootDescriptionParts.push('Empty pattern matches the empty string');
+  }
+
+  return createNode('Pattern', {
+    description: rootDescriptionParts.filter(Boolean).join(' · '),
+    snippet: escapeSnippet(pattern.raw),
+    children: rootChildren,
+  });
+}
+
+const ExplainView: React.FC<ExplainViewProps> = ({ pattern, flags }) => {
+  const result = useMemo(() => {
+    if (!pattern) {
+      return { status: 'empty' as const };
+    }
+
+    try {
+      const unicode = flags.includes('u') || flags.includes('v');
+      const unicodeSets = flags.includes('v');
+      const parser = new RegExpParser({ ecmaVersion: 2025 });
+      const ast = parser.parsePattern(pattern, 0, pattern.length, {
+        unicode,
+        unicodeSets,
+      });
+      return {
+        status: 'success' as const,
+        tree: buildTree(ast, flags),
+      };
+    } catch (error) {
+      return {
+        status: 'error' as const,
+        message: error instanceof Error ? error.message : 'Failed to parse pattern',
+      };
+    }
+  }, [pattern, flags]);
+
+  return (
+    <div className="flex h-full flex-col rounded-lg border border-slate-700 bg-slate-900 p-4 text-slate-100">
+      <div>
+        <h2 className="text-lg font-semibold text-slate-100">Regex structure</h2>
+        <p className="text-xs text-slate-400">Understand how each token fits together.</p>
+      </div>
+      <div className="mt-3 flex-1 overflow-y-auto pr-1">
+        {result.status === 'empty' ? (
+          <p className="text-sm text-slate-400">Enter a pattern to see its parsed structure.</p>
+        ) : result.status === 'error' ? (
+          <div className="rounded border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">
+            <p className="font-semibold">Parser error</p>
+            <p className="mt-1 whitespace-pre-wrap text-red-100">{result.message}</p>
+          </div>
+        ) : (
+          <ul className="space-y-3" role="tree">
+            {renderNode(result.tree)}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+function renderNode(node: ExplanationNode): JSX.Element {
+  return (
+    <li key={node.id} className="border-l border-slate-700 pl-3" role="treeitem">
+      <div className="rounded bg-slate-800/60 px-2 py-1">
+        <div className="text-sm font-semibold text-sky-200">{node.title}</div>
+        {node.description ? (
+          <p className="text-xs text-slate-300">{node.description}</p>
+        ) : null}
+        {node.snippet ? (
+          <code className="mt-1 inline-block rounded bg-slate-900 px-1 py-0.5 text-xs text-emerald-200">
+            {node.snippet}
+          </code>
+        ) : null}
+      </div>
+      {node.children && node.children.length ? (
+        <ul className="mt-2 space-y-2 pl-2" role="group">
+          {node.children.map((child) => renderNode(child))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+export default ExplainView;

--- a/apps/regex-tester/index.tsx
+++ b/apps/regex-tester/index.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import { useMemo, useRef, useState } from 'react';
+import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import ExplainView from './components/ExplainView';
+
+type MatchInfo = {
+  match: string;
+  index: number;
+  groups: (string | undefined)[];
+  namedGroups: Record<string, string | undefined>;
+};
+
+type EvaluationResult =
+  | { status: 'idle' }
+  | { status: 'error'; message: string }
+  | {
+      status: 'ready' | 'success';
+      regex: RegExp;
+      normalizedFlags: string;
+      matches: MatchInfo[];
+    };
+
+const DEFAULT_PATTERN = String.raw`^(?<word>[A-Za-z]+)-(\d+)$`;
+const DEFAULT_FLAGS = 'g';
+const DEFAULT_TEST_TEXT = String.raw`server-01
+alpha-10
+beta-7`;
+
+const formatMatchValue = (value: string | undefined): string => {
+  if (value === undefined) {
+    return '—';
+  }
+
+  return value
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+};
+
+const RegexTesterPane: React.FC = () => {
+  const [pattern, setPattern] = useState<string>(DEFAULT_PATTERN);
+  const [flags, setFlags] = useState<string>(DEFAULT_FLAGS);
+  const [testText, setTestText] = useState<string>(DEFAULT_TEST_TEXT);
+
+  const evaluation = useMemo<EvaluationResult>(() => {
+    if (!pattern) {
+      return { status: 'idle' };
+    }
+
+    try {
+      const regex = new RegExp(pattern, flags);
+      if (!testText) {
+        return { status: 'ready', regex, normalizedFlags: regex.flags, matches: [] };
+      }
+
+      const iteratorRegex = regex.global ? regex : new RegExp(pattern, `${regex.flags}g`);
+      const matches = Array.from(testText.matchAll(iteratorRegex)).map((match) => ({
+        match: match[0],
+        index: match.index ?? 0,
+        groups: match.slice(1),
+        namedGroups: { ...(match.groups ?? {}) },
+      }));
+
+      return { status: 'success', regex, normalizedFlags: regex.flags, matches };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Invalid pattern';
+      return { status: 'error', message };
+    }
+  }, [pattern, flags, testText]);
+
+  const explainFlags =
+    evaluation.status === 'success' || evaluation.status === 'ready'
+      ? evaluation.normalizedFlags
+      : flags;
+
+  return (
+    <div className="grid h-full gap-4 lg:grid-cols-2">
+      <div className="flex min-h-0 flex-col gap-4 overflow-y-auto rounded-lg border border-slate-700 bg-slate-900 p-4 text-slate-100">
+        <header>
+          <h1 className="text-2xl font-semibold text-slate-100">Regex tester</h1>
+          <p className="text-sm text-slate-400">
+            Try JavaScript-compatible regular expressions without executing commands or sending any
+            requests.
+          </p>
+        </header>
+
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="regex-pattern" className="block text-sm font-medium text-slate-200">
+              Pattern
+            </label>
+            <input
+              id="regex-pattern"
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-slate-100 focus:border-sky-400 focus:outline-none"
+              placeholder="Enter a regex pattern"
+              value={pattern}
+              onChange={(event) => setPattern(event.target.value)}
+              spellCheck={false}
+            />
+            <p className="mt-1 text-xs text-slate-500">
+              Use JavaScript syntax. Do not include surrounding <code>/</code> delimiters.
+            </p>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr),minmax(0,1fr)]">
+            <div>
+              <label htmlFor="regex-flags" className="block text-sm font-medium text-slate-200">
+                Flags
+              </label>
+              <input
+                id="regex-flags"
+                className="mt-1 w-full rounded border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-slate-100 focus:border-sky-400 focus:outline-none"
+                placeholder="Example: gimsv"
+                value={flags}
+                onChange={(event) => setFlags(event.target.value)}
+                spellCheck={false}
+              />
+              <p className="mt-1 text-xs text-slate-500">Duplicates will raise an error.</p>
+            </div>
+            {evaluation.status === 'success' || evaluation.status === 'ready' ? (
+              <div className="rounded border border-slate-700 bg-slate-800/60 p-3 text-xs text-slate-300">
+                <p className="font-semibold text-sky-200">Normalized regex</p>
+                <code className="mt-1 block font-mono text-emerald-200">{evaluation.regex.toString()}</code>
+                <p className="mt-1 text-slate-400">
+                  Flags resolved to <span className="font-semibold text-slate-200">{evaluation.normalizedFlags || 'none'}</span>.
+                </p>
+              </div>
+            ) : null}
+          </div>
+
+          <div>
+            <label htmlFor="regex-test-text" className="block text-sm font-medium text-slate-200">
+              Test string
+            </label>
+            <textarea
+              id="regex-test-text"
+              className="mt-1 h-40 w-full rounded border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-slate-100 focus:border-sky-400 focus:outline-none"
+              placeholder="Paste the content you want to test"
+              value={testText}
+              onChange={(event) => setTestText(event.target.value)}
+            />
+          </div>
+        </div>
+
+        <section className="space-y-3">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-100">Matches</h2>
+            <p className="text-xs text-slate-500">
+              Evaluate your pattern against the test string. Results update automatically as you type.
+            </p>
+          </div>
+
+          {evaluation.status === 'idle' ? (
+            <p className="text-sm text-slate-400">Enter a pattern to begin.</p>
+          ) : evaluation.status === 'error' ? (
+            <div className="rounded border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">
+              <p className="font-semibold">Invalid regular expression</p>
+              <p className="mt-1 whitespace-pre-wrap text-red-100">{evaluation.message}</p>
+            </div>
+          ) : !testText ? (
+            <p className="text-sm text-slate-400">Add a test string to search for matches.</p>
+          ) : evaluation.matches.length === 0 ? (
+            <p className="text-sm text-slate-400">No matches found.</p>
+          ) : (
+            <div className="space-y-2">
+              {evaluation.matches.map((match, index) => (
+                <div key={`${match.index}-${match.match}-${index}`} className="rounded border border-slate-700 bg-slate-800/60 p-3 text-sm">
+                  <div className="flex items-center justify-between text-xs text-slate-400">
+                    <span className="font-semibold text-sky-200">Match {index + 1}</span>
+                    <span>Index {match.index}</span>
+                  </div>
+                  <code className="mt-2 block rounded bg-slate-900 px-2 py-1 font-mono text-emerald-200">
+                    {formatMatchValue(match.match)}
+                  </code>
+
+                  {match.groups.length ? (
+                    <div className="mt-2 space-y-1 text-xs text-slate-300">
+                      {match.groups.map((value, groupIndex) => (
+                        <div key={groupIndex} className="flex items-center justify-between gap-4">
+                          <span>Group {groupIndex + 1}</span>
+                          <code className="rounded bg-slate-900 px-1 py-0.5 font-mono text-emerald-200">
+                            {formatMatchValue(value)}
+                          </code>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+
+                  {Object.keys(match.namedGroups).length ? (
+                    <div className="mt-2 space-y-1 text-xs text-slate-300">
+                      {Object.entries(match.namedGroups).map(([name, value]) => (
+                        <div key={name} className="flex items-center justify-between gap-4">
+                          <span>Group "{name}"</span>
+                          <code className="rounded bg-slate-900 px-1 py-0.5 font-mono text-emerald-200">
+                            {formatMatchValue(value)}
+                          </code>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+
+      <div className="min-h-0">
+        <ExplainView pattern={pattern} flags={explainFlags} />
+      </div>
+    </div>
+  );
+};
+
+const RegexTesterApp: React.FC = () => {
+  const counterRef = useRef(1);
+
+  const createTab = (): TabDefinition => {
+    const id = `${Date.now()}-${counterRef.current}`;
+    const tabLabel = `Tester ${counterRef.current}`;
+    counterRef.current += 1;
+
+    return { id, title: tabLabel, content: <RegexTesterPane /> };
+  };
+
+  return (
+    <TabbedWindow
+      className="min-h-screen bg-gray-950 text-white"
+      initialTabs={[createTab()]}
+      onNewTab={createTab}
+    />
+  );
+};
+
+export default RegexTesterApp;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.9",
     "@emailjs/browser": "^3.10.0",
+    "@eslint-community/regexpp": "^4.12.1",
     "@monaco-editor/react": "^4.7.0",
     "@mozilla/readability": "^0.6.0",
     "@supabase/ssr": "^0.7.0",

--- a/pages/apps/regex-tester.jsx
+++ b/pages/apps/regex-tester.jsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const RegexTesterPreview = dynamic(() => import('../../apps/regex-tester'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function RegexTesterPage() {
+  return <RegexTesterPreview />;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13856,6 +13856,7 @@ __metadata:
     "@axe-core/playwright": "npm:^4.10.2"
     "@ducanh2912/next-pwa": "npm:^10.2.9"
     "@emailjs/browser": "npm:^3.10.0"
+    "@eslint-community/regexpp": "npm:^4.12.1"
     "@eslint/eslintrc": "npm:^3.3.1"
     "@monaco-editor/react": "npm:^4.7.0"
     "@mozilla/readability": "npm:^0.6.0"


### PR DESCRIPTION
## Summary
- add a regex tester utility window with inputs, match results, and an inline explanation panel
- parse patterns with `@eslint-community/regexpp` to render nested AST details and handle parser failures
- register the new app route and cover complex grouping scenarios in the ExplainView tests

## Testing
- yarn lint *(fails: repository has pre-existing jsx-a11y and no-top-level-window violations across legacy apps)*
- yarn test *(fails: pre-existing window keyboard handler and nmap NSE assertions in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68cc38eaed748328b427f13678afb6e1