### PR TITLE
[desktop] Add quadrant tiling controls

### DIFF
--- a/__tests__/components/window-tiling.test.tsx
+++ b/__tests__/components/window-tiling.test.tsx
@@ -1,0 +1,136 @@
+import React, { act } from 'react';
+import { render } from '@testing-library/react';
+import Window from '../../components/base/window';
+
+jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+jest.mock('react-draggable', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const baseProps = {
+  id: 'tiling-window',
+  title: 'Tiling Test',
+  screen: () => <div>content</div>,
+  focus: () => {},
+  hasMinimised: () => {},
+  closed: () => {},
+  hideSideBar: () => {},
+  openApp: () => {},
+};
+
+describe('Window quadrant snapping', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', { value: 1280, writable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 720, writable: true });
+  });
+
+  it('previews top-left quadrant when dragged to the corner', () => {
+    const ref = React.createRef<Window>();
+    render(<Window {...baseProps} ref={ref} />);
+
+    const winEl = document.getElementById('tiling-window');
+    expect(winEl).not.toBeNull();
+    if (!winEl) return;
+
+    winEl.getBoundingClientRect = () => ({
+      left: 5,
+      top: 5,
+      right: 205,
+      bottom: 205,
+      width: 200,
+      height: 200,
+      x: 5,
+      y: 5,
+      toJSON: () => {},
+    } as DOMRect);
+
+    act(() => {
+      ref.current?.handleDrag();
+    });
+
+    expect(ref.current?.state.snapPosition).toBe('top-left');
+  });
+
+  it('identifies bottom snap target near the lower edge', () => {
+    const ref = React.createRef<Window>();
+    render(<Window {...baseProps} ref={ref} />);
+
+    const winEl = document.getElementById('tiling-window');
+    expect(winEl).not.toBeNull();
+    if (!winEl) return;
+
+    winEl.getBoundingClientRect = () => ({
+      left: 400,
+      top: 600,
+      right: 600,
+      bottom: 710,
+      width: 200,
+      height: 110,
+      x: 400,
+      y: 600,
+      toJSON: () => {},
+    } as DOMRect);
+
+    act(() => {
+      ref.current?.handleDrag();
+    });
+
+    expect(ref.current?.state.snapPosition).toBe('bottom');
+  });
+});
+
+describe('Window keyboard tiling shortcuts', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', { value: 1280, writable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 720, writable: true });
+  });
+
+  it('snaps to the bottom half with Meta+ArrowDown', () => {
+    const ref = React.createRef<Window>();
+    render(<Window {...baseProps} ref={ref} />);
+
+    const event = {
+      key: 'ArrowDown',
+      metaKey: true,
+      ctrlKey: false,
+      altKey: false,
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+    } as any;
+
+    act(() => {
+      ref.current?.handleKeyDown(event);
+    });
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(ref.current?.state.snapped).toBe('bottom');
+    expect(ref.current?.state.height).toBe(50);
+  });
+
+  it('promotes a left snap to the top-left quadrant with Meta+ArrowUp', () => {
+    const ref = React.createRef<Window>();
+    render(<Window {...baseProps} ref={ref} />);
+
+    act(() => {
+      ref.current?.snapWindow('left');
+    });
+
+    const event = {
+      key: 'ArrowUp',
+      metaKey: true,
+      ctrlKey: false,
+      altKey: false,
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+    } as any;
+
+    act(() => {
+      ref.current?.handleKeyDown(event);
+    });
+
+    expect(ref.current?.state.snapped).toBe('top-left');
+    expect(ref.current?.state.height).toBe(50);
+    expect(ref.current?.state.width).toBe(50);
+  });
+});

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -155,9 +155,9 @@ describe('Window snapping finalize and release', () => {
       ref.current!.handleStop();
     });
 
-    expect(ref.current!.state.snapped).toBe('left');
+    expect(ref.current!.state.snapped).toBe('top-left');
     expect(ref.current!.state.width).toBe(50);
-    expect(ref.current!.state.height).toBe(96.3);
+    expect(ref.current!.state.height).toBe(50);
   });
 
   it('releases snap with Alt+ArrowDown restoring size', () => {
@@ -196,10 +196,17 @@ describe('Window snapping finalize and release', () => {
       ref.current!.handleStop();
     });
 
-    expect(ref.current!.state.snapped).toBe('left');
+    expect(ref.current!.state.snapped).toBe('top-left');
+
+    const altEvent = {
+      key: 'ArrowDown',
+      altKey: true,
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+    } as any;
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown(altEvent);
     });
 
     expect(ref.current!.state.snapped).toBeNull();
@@ -243,7 +250,7 @@ describe('Window snapping finalize and release', () => {
       ref.current!.handleStop();
     });
 
-    expect(ref.current!.state.snapped).toBe('left');
+    expect(ref.current!.state.snapped).toBe('top-left');
 
     act(() => {
       ref.current!.changeCursorToMove();

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -4,6 +4,10 @@ import logger from '../../utils/logger'
 function DesktopMenu(props) {
 
     const [isFullScreen, setIsFullScreen] = useState(false)
+    const tilingEnabled = props.snapEnabled !== false
+    const snapAssistEnabled = props.snapAssistEnabled !== false
+    const snapCornerEnabled = props.snapCornerEnabled !== false
+    const showTilingControls = Boolean(props.onToggleSnap || props.onToggleSnapAssist || props.onToggleSnapCorner)
 
     useEffect(() => {
         document.addEventListener('fullscreenchange', checkFullScreen);
@@ -118,6 +122,47 @@ function DesktopMenu(props) {
             >
                 <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
             </button>
+            {showTilingControls && (
+                <>
+                    <Devider />
+                    {props.onToggleSnap && (
+                        <button
+                            onClick={props.onToggleSnap}
+                            type="button"
+                            role="menuitemcheckbox"
+                            aria-label="Toggle window snapping"
+                            aria-checked={tilingEnabled}
+                            className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                        >
+                            <span className="ml-5">Snap windows</span>
+                        </button>
+                    )}
+                    {props.onToggleSnapAssist && (
+                        <button
+                            onClick={props.onToggleSnapAssist}
+                            type="button"
+                            role="menuitemcheckbox"
+                            aria-label="Toggle snap target overlays"
+                            aria-checked={snapAssistEnabled}
+                            className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                        >
+                            <span className="ml-9">Show snap targets</span>
+                        </button>
+                    )}
+                    {props.onToggleSnapCorner && (
+                        <button
+                            onClick={props.onToggleSnapCorner}
+                            type="button"
+                            role="menuitemcheckbox"
+                            aria-label="Toggle quadrant snapping"
+                            aria-checked={snapCornerEnabled}
+                            className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                        >
+                            <span className="ml-9">Enable quadrant snaps</span>
+                        </button>
+                    )}
+                </>
+            )}
             <Devider />
             <button
                 onClick={props.clearSession}

--- a/hooks/usePersistentState.js
+++ b/hooks/usePersistentState.js
@@ -49,3 +49,17 @@ export const useSnapSetting = () =>
     true,
     (value) => typeof value === "boolean",
   );
+
+export const useSnapAssistSetting = () =>
+  usePersistentState(
+    "snap-assist-enabled",
+    true,
+    (value) => typeof value === "boolean",
+  );
+
+export const useSnapCornerSetting = () =>
+  usePersistentState(
+    "snap-corners-enabled",
+    true,
+    (value) => typeof value === "boolean",
+  );

--- a/hooks/usePersistentState.ts
+++ b/hooks/usePersistentState.ts
@@ -60,3 +60,17 @@ export const useSnapSetting = () =>
     true,
     (v): v is boolean => typeof v === 'boolean',
   );
+
+export const useSnapAssistSetting = () =>
+  usePersistentState<boolean>(
+    'snap-assist-enabled',
+    true,
+    (v): v is boolean => typeof v === 'boolean',
+  );
+
+export const useSnapCornerSetting = () =>
+  usePersistentState<boolean>(
+    'snap-corners-enabled',
+    true,
+    (v): v is boolean => typeof v === 'boolean',
+  );


### PR DESCRIPTION
## Summary
- expand window snapping with quadrant targets, keyboard shortcuts, and assistive drag overlays
- expose persistent tiling preferences and context menu toggles so users can opt into snap assist and corner snaps
- cover new quadrant and keyboard behaviours with unit tests for the window component

## Testing
- yarn test window-tiling
- yarn test window.test.tsx
- yarn lint *(fails: existing accessibility lint errors throughout apps and public assets)*

------
https://chatgpt.com/codex/tasks/task_e_68cc38d100e083289dec198064bad674