### PR TITLE
[markdown-editor] add snippet palette with shortcuts

### DIFF
--- a/__tests__/apps/markdown-editor/snippets.test.tsx
+++ b/__tests__/apps/markdown-editor/snippets.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import Snippets from '../../../apps/markdown-editor/components/Snippets';
+import {
+  MarkdownEditorProvider,
+  useMarkdownEditor,
+} from '../../../apps/markdown-editor/state/MarkdownEditorContext';
+
+describe('Markdown editor snippets', () => {
+  const TestEditor: React.FC = () => {
+    const { value, setValue, textareaRef } = useMarkdownEditor();
+    return (
+      <>
+        <textarea
+          aria-label="Markdown editor"
+          ref={textareaRef}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+        />
+        <Snippets />
+      </>
+    );
+  };
+
+  const setup = (initialValue = '') => {
+    const utils = render(
+      <MarkdownEditorProvider initialValue={initialValue}>
+        <TestEditor />
+      </MarkdownEditorProvider>,
+    );
+    const textarea = utils.getByLabelText('Markdown editor') as HTMLTextAreaElement;
+    textarea.focus();
+    return { ...utils, textarea };
+  };
+
+  it('wraps selection as heading via keyboard shortcut', () => {
+    const { textarea } = setup('hello world');
+    textarea.setSelectionRange(0, textarea.value.length);
+    fireEvent.keyDown(window, { key: '1', ctrlKey: true, shiftKey: true });
+
+    expect(textarea.value).toBe('## hello world\n');
+  });
+
+  it('creates a markdown table from CSV selection', () => {
+    const csv = 'Feature,Priority\nSnippets,High\nTables,Medium';
+    const { textarea } = setup(csv);
+    textarea.setSelectionRange(0, textarea.value.length);
+
+    fireEvent.keyDown(window, { key: '2', ctrlKey: true, shiftKey: true });
+
+    expect(textarea.value).toBe(
+      ['| Feature | Priority |', '| --- | --- |', '| Snippets | High |', '| Tables | Medium |', ''].join('\n'),
+    );
+  });
+
+  it('turns selected lines into a task list', () => {
+    const { textarea } = setup('Write docs\nShip feature');
+    textarea.setSelectionRange(0, textarea.value.length);
+
+    fireEvent.keyDown(window, { key: '3', ctrlKey: true, shiftKey: true });
+
+    expect(textarea.value).toBe(
+      ['- [ ] Write docs', '- [ ] Ship feature', ''].join('\n'),
+    );
+  });
+
+  it('builds a callout from selection', () => {
+    const { textarea } = setup('Remember to test');
+    textarea.setSelectionRange(0, textarea.value.length);
+
+    fireEvent.keyDown(window, { key: '4', ctrlKey: true, shiftKey: true });
+
+    expect(textarea.value).toBe(['> [!NOTE]', '> Remember to test', ''].join('\n'));
+  });
+
+  it('inserts placeholder heading when clicking palette button', () => {
+    const { textarea, getByText } = setup('');
+
+    fireEvent.click(getByText('Heading'));
+
+    expect(textarea.value).toBe('## Section title\n\n');
+    const placeholderStart = textarea.value.indexOf('Section title');
+    expect(placeholderStart).toBeGreaterThan(-1);
+    expect(textarea.selectionStart).toBe(placeholderStart);
+    expect(textarea.selectionEnd).toBe(placeholderStart + 'Section title'.length);
+  });
+});

--- a/apps/markdown-editor/components/DocsOverlay.tsx
+++ b/apps/markdown-editor/components/DocsOverlay.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React from 'react';
+import {
+  SNIPPETS,
+  formatShortcut,
+  parseShortcut,
+} from './snippetLibrary';
+
+interface DocsOverlayProps {
+  onClose: () => void;
+}
+
+const DocsOverlay: React.FC<DocsOverlayProps> = ({ onClose }) => {
+  const isMac =
+    typeof window !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/75 p-4 text-slate-100"
+    >
+      <div className="w-full max-w-2xl space-y-4 rounded-lg border border-slate-700 bg-slate-900/95 p-6 shadow-xl">
+        <header className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Markdown Snippets Reference</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm text-cyan-300 underline hover:text-cyan-200"
+          >
+            Close
+          </button>
+        </header>
+        <p className="text-sm text-slate-300">
+          The snippets palette augments the editor with ready-made building blocks. Use the
+          shortcuts below while the editor is focused to insert the corresponding markdown at the
+          caret. When text is selected the snippets adapt, wrapping or restructuring the selection
+          instead of starting from scratch.
+        </p>
+        <ul className="space-y-3">
+          {SNIPPETS.map((snippet) => {
+            const shortcut = parseShortcut(snippet.shortcut);
+            return (
+              <li key={snippet.id} className="rounded border border-slate-700/80 p-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-semibold text-slate-100">{snippet.label}</p>
+                    <p className="text-xs text-slate-300">{snippet.description}</p>
+                  </div>
+                  <kbd className="rounded bg-slate-800 px-2 py-1 text-xs font-medium text-slate-200">
+                    {formatShortcut(shortcut, isMac ? 'mac' : 'default')}
+                  </kbd>
+                </div>
+                <pre className="mt-2 overflow-x-auto rounded bg-slate-950/70 p-2 text-xs text-slate-200">
+                  {snippet.preview}
+                </pre>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default DocsOverlay;

--- a/apps/markdown-editor/components/MarkdownEditor.tsx
+++ b/apps/markdown-editor/components/MarkdownEditor.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React, { useState } from 'react';
+import { MarkdownEditorProvider, useMarkdownEditor } from '../state/MarkdownEditorContext';
+import Snippets from './Snippets';
+import DocsOverlay from './DocsOverlay';
+
+const EditorSurface: React.FC = () => {
+  const { value, setValue, textareaRef } = useMarkdownEditor();
+  const [showDocs, setShowDocs] = useState(false);
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <header className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-100">Markdown Editor</h1>
+          <p className="text-sm text-slate-300">
+            Draft notes, write documentation, and enrich content with reusable snippets.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowDocs(true)}
+          className="rounded border border-cyan-500 px-3 py-1 text-sm text-cyan-200 transition hover:bg-cyan-500/10 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+        >
+          Snippet Reference
+        </button>
+      </header>
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        className="min-h-[220px] flex-1 rounded-md border border-slate-700 bg-slate-950/70 p-4 font-mono text-sm text-slate-100 shadow-inner focus:outline-none focus:ring-2 focus:ring-cyan-500"
+        placeholder="Start typing markdown..."
+        aria-label="Markdown editor"
+      />
+      <Snippets />
+      {showDocs && <DocsOverlay onClose={() => setShowDocs(false)} />}
+    </div>
+  );
+};
+
+const MarkdownEditor: React.FC = () => (
+  <MarkdownEditorProvider>
+    <EditorSurface />
+  </MarkdownEditorProvider>
+);
+
+export default MarkdownEditor;

--- a/apps/markdown-editor/components/Snippets.tsx
+++ b/apps/markdown-editor/components/Snippets.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo } from 'react';
+import {
+  SNIPPETS,
+  formatShortcut,
+  parseShortcut,
+  type MarkdownSnippet,
+  type ShortcutDef,
+} from './snippetLibrary';
+import { useMarkdownEditor } from '../state/MarkdownEditorContext';
+
+const isMacPlatform = () =>
+  typeof window !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+
+const matchesShortcut = (event: KeyboardEvent, shortcut: ShortcutDef) => {
+  const key = event.key.toLowerCase();
+  const matchesKey = key === shortcut.key;
+  if (!matchesKey) return false;
+
+  if (shortcut.mod && !(event.metaKey || event.ctrlKey)) return false;
+  if (!shortcut.mod && (event.metaKey || event.ctrlKey)) return false;
+  if (shortcut.shift !== undefined && event.shiftKey !== shortcut.shift) return false;
+  if (shortcut.alt !== undefined && event.altKey !== shortcut.alt) return false;
+
+  return true;
+};
+
+const shouldHandleEvent = (
+  target: EventTarget | null,
+  editor: HTMLTextAreaElement | null,
+) => {
+  if (!editor) return false;
+  if (!target) return false;
+  if (target === editor) return true;
+  if (target === window || target === document || target === document.body) return true;
+  if (target instanceof HTMLElement && target.dataset.snippetButton) return true;
+  return false;
+};
+
+const Snippets: React.FC = () => {
+  const { applySnippet, textareaRef } = useMarkdownEditor();
+  const platform = isMacPlatform() ? 'mac' : 'default';
+
+  const entries = useMemo(
+    () =>
+      SNIPPETS.map((snippet) => ({
+        ...snippet,
+        shortcutDef: parseShortcut(snippet.shortcut),
+      })),
+    [],
+  );
+
+  const handleInsert = useCallback(
+    (snippet: MarkdownSnippet) => {
+      applySnippet(snippet.build);
+    },
+    [applySnippet],
+  );
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (!textareaRef.current) return;
+      if (!shouldHandleEvent(event.target, textareaRef.current)) return;
+
+      for (const entry of entries) {
+        if (matchesShortcut(event, entry.shortcutDef)) {
+          event.preventDefault();
+          handleInsert(entry);
+          break;
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [entries, handleInsert, textareaRef]);
+
+  return (
+    <section aria-label="Markdown snippets" className="space-y-2">
+      <header className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-200">
+          Snippets
+        </h2>
+        <p className="text-xs text-slate-400">
+          Use keyboard shortcuts for quick inserts
+        </p>
+      </header>
+      <div className="grid gap-2 md:grid-cols-2">
+        {entries.map((snippet) => (
+          <button
+            key={snippet.id}
+            type="button"
+            data-snippet-button
+            onClick={() => handleInsert(snippet)}
+            className="group rounded-md border border-slate-700 bg-slate-900/40 p-3 text-left transition hover:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+          >
+            <div className="flex items-center justify-between">
+              <span className="font-semibold text-slate-100">{snippet.label}</span>
+              <kbd className="rounded bg-slate-800 px-2 py-1 text-[10px] font-medium text-slate-200">
+                {formatShortcut(snippet.shortcutDef, platform)}
+              </kbd>
+            </div>
+            <p className="mt-1 text-xs text-slate-300">{snippet.description}</p>
+            <pre className="mt-2 overflow-x-auto rounded bg-slate-950/70 p-2 text-xs text-slate-200">
+              {snippet.preview}
+            </pre>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default Snippets;

--- a/apps/markdown-editor/components/snippetLibrary.ts
+++ b/apps/markdown-editor/components/snippetLibrary.ts
@@ -1,0 +1,216 @@
+import type {
+  SnippetBuilder,
+  SnippetBuilderArgs,
+  SnippetBuilderResult,
+} from '../state/MarkdownEditorContext';
+
+const HEADING_PLACEHOLDER = 'Section title';
+const TABLE_PLACEHOLDER = 'Item';
+const TASK_PLACEHOLDER = 'First task';
+const CALLOUT_PLACEHOLDER = 'Explain the callout here.';
+
+const normalizeLine = (line: string) => line.trim();
+
+const headingBuilder: SnippetBuilder = ({ text }) => {
+  const trimmed = text.trim();
+  if (trimmed) {
+    const lines = text.split(/\r?\n/);
+    const converted = lines
+      .map((line) => {
+        const normalized = normalizeLine(line);
+        return normalized ? `## ${normalized}` : '## Heading';
+      })
+      .join('\n');
+    return { text: `${converted}\n` };
+  }
+
+  const snippet = `## ${HEADING_PLACEHOLDER}\n\n`;
+  const start = snippet.indexOf(HEADING_PLACEHOLDER);
+  return {
+    text: snippet,
+    select: [start, start + HEADING_PLACEHOLDER.length],
+  };
+};
+
+const detectColumns = (rows: string[][]) =>
+  rows.reduce((max, row) => Math.max(max, row.length), 0);
+
+const parseSelection = (value: string) =>
+  value
+    .split(/\r?\n/)
+    .map((line) =>
+      line
+        .split(/\s*[|,\t]\s*/)
+        .map((cell) => cell.trim())
+        .filter((cell) => cell.length > 0),
+    )
+    .filter((row) => row.length > 0);
+
+const buildTableFromSelection = (text: string) => {
+  const rows = parseSelection(text);
+  if (!rows.length) return null;
+
+  const columnCount = detectColumns(rows);
+  if (columnCount === 0) return null;
+
+  const normalizedRows = rows.map((row) => {
+    const next = [...row];
+    while (next.length < columnCount) {
+      next.push('');
+    }
+    return next;
+  });
+
+  const [headerRow, ...bodyRows] = normalizedRows;
+  const header = headerRow.map((cell, index) => cell || `Column ${index + 1}`);
+  const body = bodyRows.length
+    ? bodyRows
+    : [header.map((_, index) => `${TABLE_PLACEHOLDER} ${index + 1}`)];
+
+  const lines = [
+    `| ${header.join(' | ')} |`,
+    `| ${new Array(columnCount).fill('---').join(' | ')} |`,
+    ...body.map((row, rowIndex) =>
+      `| ${row
+        .map((cell, columnIndex) =>
+          cell || `${TABLE_PLACEHOLDER} ${rowIndex + 1}.${columnIndex + 1}`,
+        )
+        .join(' | ')} |`,
+    ),
+  ];
+
+  return `${lines.join('\n')}\n`;
+};
+
+const tableBuilder: SnippetBuilder = ({ text }) => {
+  const converted = buildTableFromSelection(text);
+  if (converted) {
+    return { text: converted };
+  }
+
+  const snippet = `| Column 1 | Column 2 |\n| --- | --- |\n| ${TABLE_PLACEHOLDER} | Details |\n`;
+  const start = snippet.indexOf(TABLE_PLACEHOLDER);
+  return {
+    text: snippet,
+    select: [start, start + TABLE_PLACEHOLDER.length],
+  };
+};
+
+const taskBuilder: SnippetBuilder = ({ text }) => {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length) {
+    const list = lines
+      .map((line) => line.replace(/^[-*]?\s*\[[^\]]\]\s*/, ''))
+      .map((line) => `- [ ] ${line}`)
+      .join('\n');
+    return { text: `${list}\n` };
+  }
+
+  const snippet = `- [ ] ${TASK_PLACEHOLDER}\n- [ ] Second task\n- [ ] Third task\n`;
+  const start = snippet.indexOf(TASK_PLACEHOLDER);
+  return {
+    text: snippet,
+    select: [start, start + TASK_PLACEHOLDER.length],
+  };
+};
+
+const calloutBuilder: SnippetBuilder = ({ text }) => {
+  const trimmed = text.trim();
+  if (trimmed) {
+    const body = trimmed
+      .split(/\r?\n/)
+      .map((line) => `> ${line.trim()}`)
+      .join('\n');
+    return { text: `> [!NOTE]\n${body}\n` };
+  }
+
+  const snippet = `> [!NOTE]\n> ${CALLOUT_PLACEHOLDER}\n`;
+  const start = snippet.indexOf(CALLOUT_PLACEHOLDER);
+  return {
+    text: snippet,
+    select: [start, start + CALLOUT_PLACEHOLDER.length],
+  };
+};
+
+export interface ShortcutDef {
+  key: string;
+  mod?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+}
+
+export const parseShortcut = (shortcut: string): ShortcutDef => {
+  const parts = shortcut.toLowerCase().split('+');
+  const key = parts.pop() ?? '';
+  return {
+    key,
+    mod: parts.includes('mod'),
+    shift: parts.includes('shift'),
+    alt: parts.includes('alt'),
+  };
+};
+
+export const formatShortcut = (shortcut: ShortcutDef, platform: 'mac' | 'default' = 'default') => {
+  const parts: string[] = [];
+  if (shortcut.mod) {
+    parts.push(platform === 'mac' ? '⌘' : 'Ctrl');
+  }
+  if (shortcut.alt) {
+    parts.push(platform === 'mac' ? '⌥' : 'Alt');
+  }
+  if (shortcut.shift) {
+    parts.push(platform === 'mac' ? '⇧' : 'Shift');
+  }
+  parts.push(shortcut.key.length === 1 ? shortcut.key.toUpperCase() : shortcut.key);
+  return parts.join(platform === 'mac' ? '' : ' + ');
+};
+
+export interface MarkdownSnippet {
+  id: string;
+  label: string;
+  description: string;
+  preview: string;
+  shortcut: string;
+  build: SnippetBuilder;
+}
+
+export const SNIPPETS: readonly MarkdownSnippet[] = [
+  {
+    id: 'heading',
+    label: 'Heading',
+    description: 'Create or convert selection into a level 2 heading.',
+    preview: '## Section title',
+    shortcut: 'mod+shift+1',
+    build: headingBuilder,
+  },
+  {
+    id: 'table',
+    label: 'Table',
+    description: 'Generate a markdown table or structure selected CSV data.',
+    preview: '| Column 1 | Column 2 |\n| --- | --- |\n| Item | Details |',
+    shortcut: 'mod+shift+2',
+    build: tableBuilder,
+  },
+  {
+    id: 'tasks',
+    label: 'Task List',
+    description: 'Turn each selected line into an unchecked task item.',
+    preview: '- [ ] First task\n- [ ] Second task',
+    shortcut: 'mod+shift+3',
+    build: taskBuilder,
+  },
+  {
+    id: 'callout',
+    label: 'Callout',
+    description: 'Insert a note callout for tips, warnings, or summaries.',
+    preview: '> [!NOTE]\n> Explain the callout here.',
+    shortcut: 'mod+shift+4',
+    build: calloutBuilder,
+  },
+] as const;
+
+export type { SnippetBuilderArgs, SnippetBuilderResult };

--- a/apps/markdown-editor/index.tsx
+++ b/apps/markdown-editor/index.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+import MarkdownEditor from './components/MarkdownEditor';
+
+export default MarkdownEditor;

--- a/apps/markdown-editor/state/MarkdownEditorContext.tsx
+++ b/apps/markdown-editor/state/MarkdownEditorContext.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+interface SnippetBuilderArgs {
+  text: string;
+  before: string;
+  after: string;
+  start: number;
+  end: number;
+}
+
+interface SnippetBuilderResult {
+  text: string;
+  select?: [number, number] | number;
+}
+
+export type SnippetBuilder = (
+  args: SnippetBuilderArgs,
+) => SnippetBuilderResult;
+
+interface MarkdownEditorContextValue {
+  value: string;
+  setValue: React.Dispatch<React.SetStateAction<string>>;
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
+  applySnippet: (builder: SnippetBuilder) => void;
+}
+
+const MarkdownEditorContext =
+  createContext<MarkdownEditorContextValue | null>(null);
+
+interface ProviderProps {
+  children: React.ReactNode;
+  initialValue?: string;
+}
+
+export const MarkdownEditorProvider: React.FC<ProviderProps> = ({
+  children,
+  initialValue = '',
+}) => {
+  const [value, setValue] = useState(initialValue);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const applySnippet = useCallback((builder: SnippetBuilder) => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    const start = textarea.selectionStart ?? textarea.value.length;
+    const end = textarea.selectionEnd ?? start;
+    const before = textarea.value.slice(0, start);
+    const after = textarea.value.slice(end);
+    const selected = textarea.value.slice(start, end);
+
+    const { text, select } = builder({
+      text: selected,
+      before,
+      after,
+      start,
+      end,
+    });
+
+    textarea.setRangeText(text, start, end, 'end');
+    setValue(textarea.value);
+
+    const base = start;
+    if (Array.isArray(select)) {
+      const [selStart, selEnd] = select;
+      textarea.setSelectionRange(base + selStart, base + selEnd);
+    } else if (typeof select === 'number') {
+      const pos = base + select;
+      textarea.setSelectionRange(pos, pos);
+    } else {
+      const pos = base + text.length;
+      textarea.setSelectionRange(pos, pos);
+    }
+
+    textarea.focus();
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      value,
+      setValue,
+      textareaRef,
+      applySnippet,
+    }),
+    [value, applySnippet],
+  );
+
+  return (
+    <MarkdownEditorContext.Provider value={contextValue}>
+      {children}
+    </MarkdownEditorContext.Provider>
+  );
+};
+
+export const useMarkdownEditor = () => {
+  const ctx = useContext(MarkdownEditorContext);
+  if (!ctx) {
+    throw new Error(
+      'useMarkdownEditor must be used within a MarkdownEditorProvider',
+    );
+  }
+  return ctx;
+};
+
+export type { SnippetBuilderArgs, SnippetBuilderResult };


### PR DESCRIPTION
## Summary
- add a markdown snippets palette with keyboard shortcuts that adapt to selections
- share snippet definitions through a helper library and surface guidance via the docs overlay
- cover keyboard and palette interactions with dedicated unit tests

## Testing
- yarn test __tests__/apps/markdown-editor/snippets.test.tsx
- yarn lint *(fails: existing accessibility labeling and no-top-level-window violations in unrelated apps)*

------
https://chatgpt.com/codex/tasks/task_e_68cc38d3b2d88328b393c41bd3d44762