### PR TITLE
[tests] add ssh simulator regression coverage

### DIFF
--- a/apps/ssh/index.tsx
+++ b/apps/ssh/index.tsx
@@ -1,7 +1,250 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+
+type TransferDirection = 'Upload' | 'Download';
+type TransferStatus = 'Idle' | 'Transferring' | 'Completed';
+
+interface TransferTemplate {
+  id: string;
+  file: string;
+  size: string;
+  direction: TransferDirection;
+}
+
+interface TransferState extends TransferTemplate {
+  status: TransferStatus;
+  progress: number;
+  lastCompleted?: string;
+}
+
+interface PortForwardState {
+  id: string;
+  label: string;
+  local: string;
+  remote: string;
+  protocol: string;
+  enabled: boolean;
+}
+
+const SFTP_QUEUE: TransferTemplate[] = [
+  {
+    id: 'logs',
+    file: 'logs/secure-copy.tar.gz',
+    size: '24 MB',
+    direction: 'Download',
+  },
+  {
+    id: 'reports',
+    file: 'reports/latest-findings.csv',
+    size: '2 MB',
+    direction: 'Upload',
+  },
+  {
+    id: 'artifacts',
+    file: 'artifacts/session-memo.txt',
+    size: '4 KB',
+    direction: 'Upload',
+  },
+];
+
+const PORT_FORWARD_RULES: PortForwardState[] = [
+  {
+    id: 'jump-host',
+    label: 'Jump host shell',
+    local: '127.0.0.1:2222',
+    remote: '10.0.5.10:22',
+    protocol: 'SSH',
+    enabled: true,
+  },
+  {
+    id: 'wiki',
+    label: 'Internal wiki',
+    local: '127.0.0.1:8443',
+    remote: '10.0.5.11:443',
+    protocol: 'HTTPS',
+    enabled: false,
+  },
+  {
+    id: 'metrics',
+    label: 'Metrics dashboard',
+    local: '127.0.0.1:9000',
+    remote: '10.0.5.42:9000',
+    protocol: 'HTTP',
+    enabled: true,
+  },
+];
+
+const statusTone = {
+  Completed: 'text-green-300',
+  Transferring: 'text-yellow-300',
+  Idle: 'text-gray-200',
+} as const;
+
+const SFTPSidecar: React.FC = () => {
+  const [transfers, setTransfers] = useState<TransferState[]>(() =>
+    SFTP_QUEUE.map((item) => ({ ...item, status: 'Idle', progress: 0 })),
+  );
+  const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
+  useEffect(() => {
+    return () => {
+      Object.values(timers.current).forEach((timer) => clearTimeout(timer));
+      timers.current = {};
+    };
+  }, []);
+
+  const runTransfer = (id: string) => {
+    setTransfers((prev) =>
+      prev.map((transfer) =>
+        transfer.id === id
+          ? { ...transfer, status: 'Transferring', progress: 15 }
+          : transfer,
+      ),
+    );
+
+    if (timers.current[id]) {
+      clearTimeout(timers.current[id]);
+    }
+
+    timers.current[id] = setTimeout(() => {
+      setTransfers((prev) =>
+        prev.map((transfer) =>
+          transfer.id === id
+            ? {
+                ...transfer,
+                status: 'Completed',
+                progress: 100,
+                lastCompleted: new Date().toLocaleTimeString(),
+              }
+            : transfer,
+        ),
+      );
+      delete timers.current[id];
+    }, 400);
+  };
+
+  return (
+    <section
+      className="mt-6 rounded border border-gray-700 bg-gray-800 p-4"
+      data-testid="sftp-sidecar"
+      aria-label="SFTP sidecar"
+    >
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-lg font-semibold">SFTP Sidecar</h2>
+        <span className="rounded bg-gray-700 px-2 py-1 text-xs text-gray-300">Mock transfers</span>
+      </div>
+      <p className="mb-4 text-xs text-gray-300">
+        Queue simulated SFTP transfers. All actions stay on this page and never reach a live host.
+      </p>
+      <ul className="space-y-3">
+        {transfers.map((transfer) => (
+          <li
+            key={transfer.id}
+            data-testid={`sftp-transfer-${transfer.id}`}
+            className="flex items-start justify-between rounded border border-gray-700 bg-gray-900 p-3"
+          >
+            <div>
+              <div className="text-sm font-medium text-white">{transfer.file}</div>
+              <div className="text-xs text-gray-400">
+                {transfer.direction} • {transfer.size}
+              </div>
+              <div className="text-xs text-gray-400">
+                Status:{' '}
+                <span
+                  data-testid={`sftp-status-${transfer.id}`}
+                  className={statusTone[transfer.status]}
+                >
+                  {transfer.status}
+                </span>{' '}
+                • Progress:{' '}
+                <span data-testid={`sftp-progress-${transfer.id}`}>{transfer.progress}%</span>
+              </div>
+              {transfer.lastCompleted && (
+                <div className="text-[10px] text-gray-500">
+                  Last completed: {transfer.lastCompleted}
+                </div>
+              )}
+            </div>
+            <button
+              type="button"
+              data-testid={`sftp-action-${transfer.id}`}
+              className="self-center rounded bg-blue-600 px-3 py-1 text-xs font-semibold text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-gray-600"
+              onClick={() => runTransfer(transfer.id)}
+              disabled={transfer.status === 'Transferring'}
+            >
+              {transfer.status === 'Completed' ? 'Re-run' : 'Run transfer'}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+const PortForwardPanel: React.FC = () => {
+  const [forwards, setForwards] = useState<PortForwardState[]>(() =>
+    PORT_FORWARD_RULES.map((rule) => ({ ...rule })),
+  );
+
+  const toggleForward = (id: string) => {
+    setForwards((prev) =>
+      prev.map((forward) =>
+        forward.id === id
+          ? { ...forward, enabled: !forward.enabled }
+          : forward,
+      ),
+    );
+  };
+
+  return (
+    <section
+      className="mt-6 rounded border border-gray-700 bg-gray-800 p-4"
+      data-testid="port-forward-panel"
+      aria-label="Port forwarding"
+    >
+      <h2 className="mb-3 text-lg font-semibold">Port Forwarding</h2>
+      <p className="mb-4 text-xs text-gray-300">
+        Toggle forwards to keep track of simulated SSH tunnels. These switches only update UI state.
+      </p>
+      <ul className="space-y-3">
+        {forwards.map((forward) => (
+          <li
+            key={forward.id}
+            data-testid={`port-forward-${forward.id}`}
+            className="flex items-start justify-between rounded border border-gray-700 bg-gray-900 p-3"
+          >
+            <div>
+              <div className="text-sm font-medium text-white">{forward.label}</div>
+              <div className="text-xs text-gray-400">
+                Local {forward.local} → Remote {forward.remote} ({forward.protocol})
+              </div>
+              <div className="text-xs text-gray-400">
+                Status:{' '}
+                <span
+                  data-testid={`port-forward-status-${forward.id}`}
+                  className={forward.enabled ? 'text-green-300' : 'text-red-300'}
+                >
+                  {forward.enabled ? 'Enabled' : 'Disabled'}
+                </span>
+              </div>
+            </div>
+            <button
+              type="button"
+              data-testid={`port-forward-toggle-${forward.id}`}
+              className="self-center rounded bg-purple-600 px-3 py-1 text-xs font-semibold text-white hover:bg-purple-500"
+              onClick={() => toggleForward(forward.id)}
+              aria-pressed={forward.enabled}
+            >
+              {forward.enabled ? 'Disable' : 'Enable'}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
 
 const SSHBuilder: React.FC = () => {
   const [user, setUser] = useState('');
@@ -68,6 +311,8 @@ const SSHBuilder: React.FC = () => {
           {command || '# Fill in the form to generate a command'}
         </pre>
       </div>
+      <SFTPSidecar />
+      <PortForwardPanel />
     </div>
   );
 };

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,44 @@
+# Testing and quality gates
+
+This project uses a mix of linting, unit tests, and end-to-end checks to keep
+the Kali-style desktop stable.
+
+## Summary of automated suites
+
+| Gate | Command | Notes |
+| --- | --- | --- |
+| ESLint | `yarn lint` | Static analysis with repo rules. |
+| Jest | `yarn test` | Unit coverage for utilities and React components. |
+| Playwright (pages) | `npx playwright test --project=pages` | Runs smoke coverage under `tests/`. |
+| Playwright (SSH simulator) | `npx playwright test --project=ssh-simulator` | Validates the SSH simulator flows, SFTP sidecar, and port forwarding controls. |
+
+## SSH simulator regression
+
+The SSH Command Builder now ships with a Playwright scenario that exercises the
+multi-tab session manager and the supporting sidecars. The spec lives at
+`playwright/tests/ssh-simulator.spec.ts` and covers:
+
+- Opening two SSH sessions to ensure tab lifecycle events remain wired.
+- Triggering the mock SFTP queue and waiting for a transfer to complete.
+- Toggling port forwards to verify UI state updates without errors.
+- Collecting console output to guarantee no runtime exceptions leak to the
+  developer tools.
+- Instrumenting `performance.memory.usedJSHeapSize` and `PerformanceObserver`
+  entries so the run fails if heap usage grows by more than **8 MB** or any input
+  latency exceeds **100 ms**.
+
+Run the test in isolation with:
+
+```bash
+npx playwright test --project=ssh-simulator
+```
+
+The suite expects the Next.js dev server to be running on
+`http://localhost:3000` (override with `BASE_URL`).
+
+## Notes
+
+- All tooling must stay within the simulation boundary—no network calls leave
+the local environment.
+- When adding new apps or regression checks, document the gate here so CI and
+contributors can opt in.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,19 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests',
   testMatch: /.*\.spec\.ts/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },
+  projects: [
+    {
+      name: 'pages',
+      testDir: './tests',
+    },
+    {
+      name: 'ssh-simulator',
+      testDir: './playwright/tests',
+      testMatch: /ssh-simulator\.spec\.ts/,
+    },
+  ],
 });

--- a/playwright/tests/ssh-simulator.spec.ts
+++ b/playwright/tests/ssh-simulator.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('SSH simulator workflows', () => {
+  test('manages sessions, transfers, and port forwards without console errors', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        consoleErrors.push(message.text());
+      }
+    });
+
+    await page.goto('/apps/ssh');
+    await expect(page.getByRole('heading', { name: 'SSH Command Builder' })).toBeVisible();
+
+    const startHeap = await page.evaluate(() => {
+      return typeof performance.memory?.usedJSHeapSize === 'number'
+        ? performance.memory.usedJSHeapSize
+        : 0;
+    });
+
+    await page.evaluate(() => {
+      const latencies: number[] = [];
+      const observers: PerformanceObserver[] = [];
+
+      if ('PerformanceObserver' in window) {
+        try {
+          const eventObserver = new PerformanceObserver((list) => {
+            for (const entry of list.getEntries()) {
+              const anyEntry = entry as any;
+              if (typeof anyEntry.processingStart === 'number') {
+                latencies.push(anyEntry.processingStart - anyEntry.startTime);
+              }
+            }
+          });
+          eventObserver.observe({ type: 'event', buffered: true, durationThreshold: 16 });
+          observers.push(eventObserver);
+        } catch (err) {
+          console.warn('PerformanceObserver event type unsupported', err);
+        }
+
+        try {
+          const firstInputObserver = new PerformanceObserver((list) => {
+            for (const entry of list.getEntries()) {
+              const anyEntry = entry as any;
+              if (typeof anyEntry.processingStart === 'number') {
+                latencies.push(anyEntry.processingStart - anyEntry.startTime);
+              }
+            }
+          });
+          firstInputObserver.observe({ type: 'first-input', buffered: true });
+          observers.push(firstInputObserver);
+        } catch (err) {
+          console.warn('PerformanceObserver first-input unsupported', err);
+        }
+      }
+
+      (window as typeof window & {
+        __sshMetrics?: { latencies: number[]; observers: PerformanceObserver[] };
+      }).__sshMetrics = { latencies, observers };
+    });
+
+    await page.locator('#ssh-user').fill('analyst');
+    await page.locator('#ssh-host').fill('jump-box.internal');
+    await page.locator('#ssh-port').fill('22');
+
+    await page.getByRole('button', { name: 'New Tab' }).click();
+    await expect(page.locator('text=Session 2')).toBeVisible();
+
+    await page.locator('#ssh-user').fill('ops');
+    await page.locator('#ssh-host').fill('10.0.5.10');
+    await page.locator('#ssh-port').fill('2222');
+
+    const sidecar = page.getByTestId('sftp-sidecar');
+    await expect(sidecar).toBeVisible();
+    await page.getByTestId('sftp-action-logs').click();
+    await expect(page.getByTestId('sftp-status-logs')).toHaveText('Completed');
+    await expect(page.getByTestId('sftp-progress-logs')).toHaveText('100%');
+
+    const jumpToggle = page.getByTestId('port-forward-toggle-jump-host');
+    await jumpToggle.click();
+    await expect(page.getByTestId('port-forward-status-jump-host')).toHaveText('Disabled');
+    await jumpToggle.click();
+    await expect(page.getByTestId('port-forward-status-jump-host')).toHaveText('Enabled');
+
+    const wikiToggle = page.getByTestId('port-forward-toggle-wiki');
+    await wikiToggle.click();
+    await expect(page.getByTestId('port-forward-status-wiki')).toHaveText('Enabled');
+
+    await page.locator('button[aria-label="Close Tab"]').last().click();
+    await expect(page.locator('text=Session 2')).toHaveCount(0);
+
+    const metrics = await page.evaluate(() => {
+      const metric = (window as typeof window & {
+        __sshMetrics?: { latencies: number[]; observers: PerformanceObserver[] };
+      }).__sshMetrics;
+
+      metric?.observers.forEach((observer) => observer.disconnect());
+
+      return {
+        latencies: metric?.latencies ?? [],
+        heap: typeof performance.memory?.usedJSHeapSize === 'number' ? performance.memory.usedJSHeapSize : 0,
+      };
+    });
+
+    const endHeap = metrics.heap ?? 0;
+    const heapGrowth = Math.max(0, endHeap - startHeap);
+    expect(heapGrowth).toBeLessThanOrEqual(8 * 1024 * 1024);
+
+    const latencies = metrics.latencies;
+    const maxLatency = latencies.length > 0 ? Math.max(...latencies) : 0;
+    expect(maxLatency).toBeLessThanOrEqual(100);
+
+    expect(consoleErrors, 'No console errors expected').toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add simulated SFTP sidecar and port forwarding controls to the SSH Command Builder
- introduce a Playwright regression spec that validates sessions, transfers, latency, and heap growth
- document the new gate in docs/testing.md and register a Playwright project for it

## Testing
- yarn lint *(fails: repository has existing accessibility and no-top-level-window lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68cc38fe40e08328bc89a914522928e1