### PR TITLE
[tests] add subnet calculator regression coverage

### DIFF
--- a/__tests__/apps/subnet-calculator/csv.test.ts
+++ b/__tests__/apps/subnet-calculator/csv.test.ts
@@ -1,0 +1,116 @@
+import { parseSubnetCsv, serializeSubnetRows, CSV_HEADERS, SubnetCsvRow } from '../../../apps/subnet-calculator/csv';
+
+describe('subnet calculator CSV helpers', () => {
+  const sampleRows: SubnetCsvRow[] = [
+    {
+      address: '192.0.2.1',
+      prefix: 24,
+      version: 'IPv4',
+      network: '192.0.2.0',
+      firstHost: '192.0.2.1',
+      lastHost: '192.0.2.254',
+      hostCount: '254',
+      mask: '255.255.255.0',
+      notes: 'v4 row',
+    },
+    {
+      address: '2001:db8::1',
+      prefix: 64,
+      version: 'IPv6',
+      network: '2001:db8::',
+      firstHost: '2001:db8::1',
+      lastHost: '2001:db8::ffff:ffff:ffff:ffff',
+      hostCount: '18446744073709551616',
+      mask: 'ffff:ffff:ffff:ffff::',
+      notes: 'ipv6 sample',
+    },
+  ];
+
+  it('serialises and parses rows symmetrically', () => {
+    const csv = serializeSubnetRows(sampleRows);
+    const [headerLine, ...body] = csv.split('\r\n');
+    expect(headerLine).toBe(CSV_HEADERS.join(','));
+    expect(body).toHaveLength(sampleRows.length);
+
+    const parsed = parseSubnetCsv(csv);
+    expect(parsed).toEqual(sampleRows);
+  });
+
+  it('parses CSV with quoted content, BOM, and CRLF endings', () => {
+    const csv = [
+      '\ufeffAddress,Prefix,Type,Notes',
+      '"192.0.2.25", "24", "ipv4", "multi-line\ncomment"',
+      '"2001:db8::25",64,IPv6,"quoted, field"',
+    ].join('\r\n');
+
+    const parsed = parseSubnetCsv(csv);
+    expect(parsed).toEqual([
+      {
+        address: '192.0.2.25',
+        prefix: 24,
+        version: 'IPv4',
+        notes: 'multi-line\ncomment',
+      },
+      {
+        address: '2001:db8::25',
+        prefix: 64,
+        version: 'IPv6',
+        notes: 'quoted, field',
+      },
+    ]);
+  });
+
+  it('ignores malformed or incomplete rows', () => {
+    const csv = [
+      'ip,prefix,version,notes',
+      '10.0.0.1,,IPv4,missing prefix',
+      ',24,IPv4,missing ip',
+      'fd00::1,64,ipv6,valid row',
+    ].join('\n');
+
+    const parsed = parseSubnetCsv(csv);
+    expect(parsed).toEqual([
+      {
+        address: 'fd00::1',
+        prefix: 64,
+        version: 'IPv6',
+        notes: 'valid row',
+      },
+    ]);
+  });
+
+  it('ignores unknown columns and trims whitespace', () => {
+    const csv = [
+      'host,maskLength,family,owner,comment',
+      '192.168.0.5, 27, ipV4, Alice , " extra space "',
+    ].join('\n');
+
+    const parsed = parseSubnetCsv(csv);
+    expect(parsed).toEqual([
+      {
+        address: '192.168.0.5',
+        prefix: 27,
+        version: 'IPv4',
+        notes: 'extra space',
+      },
+    ]);
+  });
+
+  it('escapes commas, quotes and newlines on serialisation', () => {
+    const trickyRow: SubnetCsvRow = {
+      address: '198.51.100.10',
+      prefix: 30,
+      version: 'IPv4',
+      notes: 'Contains "quotes", comma, and newline\nhere',
+    };
+
+    const csv = serializeSubnetRows([trickyRow]);
+    const [, dataLine] = csv.split('\r\n');
+    expect(dataLine).toBe(
+      '198.51.100.10,30,IPv4,,,,,,"Contains ""quotes"", comma, and newline\nhere"',
+    );
+
+    const parsed = parseSubnetCsv(csv);
+    expect(parsed).toEqual([trickyRow]);
+  });
+});

--- a/apps/subnet-calculator/csv.ts
+++ b/apps/subnet-calculator/csv.ts
@@ -1,0 +1,231 @@
+export type SubnetVersion = 'IPv4' | 'IPv6';
+
+export interface SubnetCsvRow {
+  address: string;
+  prefix: number;
+  version: SubnetVersion;
+  network?: string;
+  firstHost?: string;
+  lastHost?: string;
+  hostCount?: string;
+  mask?: string;
+  notes?: string;
+}
+
+const HEADER_CONFIG: Array<{ header: string; key: keyof SubnetCsvRow }> = [
+  { header: 'ip', key: 'address' },
+  { header: 'prefix', key: 'prefix' },
+  { header: 'version', key: 'version' },
+  { header: 'network', key: 'network' },
+  { header: 'firstHost', key: 'firstHost' },
+  { header: 'lastHost', key: 'lastHost' },
+  { header: 'hostCount', key: 'hostCount' },
+  { header: 'mask', key: 'mask' },
+  { header: 'notes', key: 'notes' },
+];
+
+export const CSV_HEADERS = HEADER_CONFIG.map((config) => config.header);
+
+const HEADER_ALIASES: Record<string, keyof SubnetCsvRow> = {
+  ip: 'address',
+  address: 'address',
+  host: 'address',
+  target: 'address',
+  cidr: 'prefix',
+  prefix: 'prefix',
+  masklength: 'prefix',
+  netmasklength: 'prefix',
+  bits: 'prefix',
+  version: 'version',
+  type: 'version',
+  family: 'version',
+  network: 'network',
+  networkaddress: 'network',
+  base: 'network',
+  firsthost: 'firstHost',
+  first: 'firstHost',
+  start: 'firstHost',
+  lasthost: 'lastHost',
+  last: 'lastHost',
+  end: 'lastHost',
+  hostcount: 'hostCount',
+  hosts: 'hostCount',
+  totalhosts: 'hostCount',
+  usablehosts: 'hostCount',
+  mask: 'mask',
+  netmask: 'mask',
+  subnetmask: 'mask',
+  notes: 'notes',
+  note: 'notes',
+  comment: 'notes',
+  description: 'notes',
+};
+
+const stripBom = (value: string) => value.replace(/^\uFEFF/, '');
+
+const escapeCsvValue = (value: string) => {
+  if (value === '') return '';
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+};
+
+const tokeniseCsv = (input: string): string[][] => {
+  const rows: string[][] = [];
+  let currentCell = '';
+  let currentRow: string[] = [];
+  let inQuotes = false;
+
+  const pushCell = () => {
+    currentRow.push(currentCell);
+    currentCell = '';
+  };
+
+  const pushRow = () => {
+    const cleaned = currentRow.map((cell) => stripBom(cell).trim());
+    const hasContent = cleaned.some((cell) => cell.length > 0);
+    if (rows.length === 0 || hasContent) {
+      rows.push(cleaned);
+    }
+    currentRow = [];
+  };
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+    if (char === '"') {
+      if (inQuotes && input[i + 1] === '"') {
+        currentCell += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === ',' && !inQuotes) {
+      pushCell();
+    } else if ((char === '\n' || char === '\r') && !inQuotes) {
+      if (char === '\r' && input[i + 1] === '\n') {
+        i += 1;
+      }
+      pushCell();
+      pushRow();
+    } else {
+      currentCell += char;
+    }
+  }
+
+  pushCell();
+  if (currentRow.length) {
+    pushRow();
+  }
+
+  return rows;
+};
+
+const normalizeVersion = (value: unknown): SubnetVersion => {
+  if (typeof value === 'number') {
+    return value === 6 ? 'IPv6' : 'IPv4';
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) return 'IPv4';
+    if (
+      normalized === 'ipv6' ||
+      normalized === 'ip6' ||
+      normalized === 'v6' ||
+      normalized === '6'
+    ) {
+      return 'IPv6';
+    }
+    if (normalized.includes('ipv6') || normalized.includes('v6') || normalized.includes('6')) {
+      return 'IPv6';
+    }
+  }
+  return 'IPv4';
+};
+
+const sanitizeNumeric = (value: unknown): number | null => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string') {
+    const cleaned = value.trim();
+    if (!cleaned) return null;
+    const parsed = Number(cleaned);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const sanitizeText = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  if (typeof value === 'number') {
+    return value.toString();
+  }
+  return undefined;
+};
+
+export const serializeSubnetRows = (rows: SubnetCsvRow[]): string => {
+  const header = CSV_HEADERS.join(',');
+  const body = rows.map((row) => {
+    return HEADER_CONFIG.map(({ key }) => {
+      const raw = row[key];
+      if (raw === undefined || raw === null) return '';
+      const value = typeof raw === 'number' ? raw.toString() : raw;
+      return escapeCsvValue(value);
+    }).join(',');
+  });
+  return [header, ...body].join('\r\n');
+};
+
+export const parseSubnetCsv = (csv: string): SubnetCsvRow[] => {
+  if (!csv || !csv.trim()) return [];
+  const rows = tokeniseCsv(stripBom(csv));
+  if (!rows.length) return [];
+  const [headerRow, ...dataRows] = rows;
+  const columnKeys = headerRow.map((header) => {
+    const normalized = header.toLowerCase().replace(/[^a-z0-9]/g, '');
+    return HEADER_ALIASES[normalized] ?? null;
+  });
+
+  const output: SubnetCsvRow[] = [];
+
+  dataRows.forEach((row) => {
+    if (row.length === 0) return;
+    const draft: Partial<Record<keyof SubnetCsvRow, unknown>> = {};
+    row.forEach((value, index) => {
+      const key = columnKeys[index];
+      if (!key) return;
+      if (key === 'prefix') {
+        draft.prefix = sanitizeNumeric(value);
+      } else if (key === 'version') {
+        draft.version = value;
+      } else {
+        draft[key] = value;
+      }
+    });
+
+    const address = sanitizeText(draft.address);
+    const prefix = sanitizeNumeric(draft.prefix ?? undefined);
+    if (!address || prefix === null) return;
+
+    const normalized: SubnetCsvRow = {
+      address,
+      prefix,
+      version: normalizeVersion(draft.version),
+    };
+
+    (['network', 'firstHost', 'lastHost', 'hostCount', 'mask', 'notes'] as const).forEach((key) => {
+      const value = sanitizeText(draft[key]);
+      if (value !== undefined) {
+        normalized[key] = value;
+      }
+    });
+
+    output.push(normalized);
+  });
+
+  return output;
+};

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,35 @@
+# Testing Reference
+
+## Subnet Calculator E2E Gate
+
+The subnet calculator workflow is covered by a gated Playwright suite located at
+`playwright/tests/subnet-calculator.spec.ts`. The scenario seeds 50 random IPv4
+and IPv6 calculations, exercises keyboard navigation, exports the grid to CSV,
+re-loads the app, and re-imports the saved file while checking that no
+exceptions are raised and heap usage growth stays below 6 MB in Chromium.
+
+Because the workflow is resource intensive, the suite is disabled by default.
+Enable it by starting the dev server (`yarn dev`) and setting the
+`SUBNET_E2E=1` environment variable before launching Playwright:
+
+```bash
+SUBNET_E2E=1 npx playwright test playwright/tests/subnet-calculator.spec.ts
+```
+
+The helpers inside the spec intentionally accept multiple selector shapes so
+the test can run against both local development builds and production snapshots
+without DOM-specific tweaks.
+
+## Related Unit Tests
+
+CSV helpers that back the export/import flow live in
+`apps/subnet-calculator/csv.ts` and are exercised by
+`__tests__/apps/subnet-calculator/csv.test.ts`. Run them with the standard Jest
+command:
+
+```bash
+yarn test __tests__/apps/subnet-calculator/csv.test.ts
+```
+
+These tests validate round-tripping, BOM/CRLF handling, quoting, and filtering
+of malformed rows.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testDir: '.',
+  testMatch: /(?:^|\/(?:tests|playwright(?:\/tests)?))\/.*\.spec\.ts$/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/playwright/tests/subnet-calculator.spec.ts
+++ b/playwright/tests/subnet-calculator.spec.ts
@@ -1,0 +1,413 @@
+import { test, expect, Locator, Page } from '@playwright/test';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import crypto from 'crypto';
+
+type IpVersion = 'IPv4' | 'IPv6';
+
+interface RandomSubnetCase {
+  address: string;
+  prefix: number;
+  version: IpVersion;
+}
+
+const RUN_SUBNET_E2E = (() => {
+  const raw =
+    process.env.SUBNET_E2E ||
+    process.env.PW_SUBNET_E2E ||
+    process.env.PLAYWRIGHT_SUBNET ||
+    '';
+  return ['1', 'true', 'yes'].includes(raw.toLowerCase());
+})();
+
+const SUBNET_URL = '/apps/subnet-calculator';
+
+const escapeForSelector = (value: string) =>
+  value.replace(/[\0-\x1F\x7F\s!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]/g, '\\$&');
+
+const readHeapUsage = async (page: Page): Promise<number | null> => {
+  try {
+    const usage = await page.evaluate(() => {
+      const memory = (performance as any).memory;
+      if (memory && typeof memory.usedJSHeapSize === 'number') {
+        return memory.usedJSHeapSize as number;
+      }
+      return null;
+    });
+    return typeof usage === 'number' ? usage : null;
+  } catch {
+    return null;
+  }
+};
+
+const locateField = async (
+  form: Locator,
+  hints: string[],
+  tags: Array<'input' | 'textarea'>,
+): Promise<Locator> => {
+  for (const hint of hints) {
+    const labelled = form.getByLabel(new RegExp(hint, 'i'));
+    if ((await labelled.count()) > 0) {
+      return labelled.first();
+    }
+  }
+
+  for (const tag of tags) {
+    const selector = hints
+      .map(
+        (hint) =>
+          `${tag}[name*="${hint}" i], ${tag}[id*="${hint}" i], ${tag}[placeholder*="${hint}" i], ${tag}[aria-label*="${hint}" i], ${tag}[data-testid*="${hint}" i]`,
+      )
+      .join(', ');
+    if (selector) {
+      const candidate = form.locator(selector);
+      if ((await candidate.count()) > 0) {
+        return candidate.first();
+      }
+    }
+  }
+
+  if (tags.includes('input')) {
+    const firstInput = form.locator('input');
+    if ((await firstInput.count()) > 0) {
+      return firstInput.first();
+    }
+  }
+
+  throw new Error(`Unable to locate field for hints: ${hints.join(', ')}`);
+};
+
+const locateButton = async (
+  scope: Page | Locator,
+  keywords: string[],
+  fallbackSelector?: string,
+): Promise<Locator> => {
+  for (const keyword of keywords) {
+    const button = scope.getByRole('button', { name: new RegExp(keyword, 'i') });
+    if ((await button.count()) > 0) {
+      return button.first();
+    }
+  }
+
+  if (fallbackSelector) {
+    const fallback = scope.locator(fallbackSelector);
+    if ((await fallback.count()) > 0) {
+      return fallback.first();
+    }
+  }
+
+  const submit = scope.locator('button[type="submit"]');
+  if ((await submit.count()) > 0) {
+    return submit.first();
+  }
+
+  throw new Error('Unable to locate action button');
+};
+
+const locateImportInput = async (page: Page): Promise<Locator> => {
+  const selectors = [
+    'input[type="file"][data-testid*="import" i]',
+    'input[type="file"][name*="import" i]',
+    'input[type="file"][aria-label*="import" i]',
+    'input[type="file"][id*="import" i]',
+    'input[type="file"][data-testid*="upload" i]',
+  ];
+
+  for (const selector of selectors) {
+    const input = page.locator(selector);
+    if ((await input.count()) > 0) {
+      return input.first();
+    }
+  }
+
+  const label = page.locator('label:has-text("Import"), label:has-text("Upload")');
+  if ((await label.count()) > 0) {
+    const targetId = await label.first().evaluate((node) => node.getAttribute('for'));
+    if (targetId) {
+      const input = page.locator(`#${escapeForSelector(targetId)}`);
+      if ((await input.count()) > 0) {
+        return input.first();
+      }
+    }
+    const nested = label.locator('input[type="file"]');
+    if ((await nested.count()) > 0) {
+      return nested.first();
+    }
+  }
+
+  const generic = page.locator('input[type="file"]');
+  if ((await generic.count()) > 0) {
+    return generic.first();
+  }
+
+  throw new Error('Unable to locate file import control');
+};
+
+const locateRowLocator = async (page: Page): Promise<Locator> => {
+  const containers = [
+    '[data-testid*="subnet-results" i]',
+    '[data-testid*="subnet-table" i]',
+    '[data-testid*="subnet" i]',
+    'main',
+  ];
+
+  for (const selector of containers) {
+    const container = page.locator(selector);
+    if ((await container.count()) > 0) {
+      return container.locator(
+        '[data-testid*="subnet-row" i], table tbody tr, table tr:has(td)',
+      );
+    }
+  }
+
+  return page.locator('table tbody tr');
+};
+
+const toggleVersionIfNeeded = async (
+  form: Locator,
+  version: IpVersion,
+): Promise<void> => {
+  const radioCandidates = form.locator('input[type="radio"], [role="radio"]');
+  if ((await radioCandidates.count()) > 0) {
+    const target = radioCandidates.filter({ hasText: new RegExp(version, 'i') });
+    if ((await target.count()) > 0) {
+      const control = target.first();
+      const isActive = await control.evaluate((node) => {
+        if (node instanceof HTMLInputElement) {
+          return node.checked;
+        }
+        return (
+          node.getAttribute('aria-checked') === 'true' ||
+          node.getAttribute('aria-pressed') === 'true'
+        );
+      });
+      if (!isActive) {
+        await control.click({ force: true });
+      }
+      return;
+    }
+  }
+
+  const select = form.locator('select');
+  if ((await select.count()) > 0) {
+    try {
+      await select.first().selectOption({ label: version });
+      return;
+    } catch {
+      // ignore inability to select by label
+    }
+  }
+};
+
+const buildRandomCases = (total: number): RandomSubnetCase[] => {
+  const cases: RandomSubnetCase[] = [];
+  for (let i = 0; i < total; i += 1) {
+    if (i % 2 === 0) {
+      const octets = Array.from({ length: 4 }, () => Math.floor(Math.random() * 256));
+      const prefix = Math.floor(Math.random() * 33); // 0-32 inclusive
+      cases.push({
+        address: octets.join('.'),
+        prefix,
+        version: 'IPv4',
+      });
+    } else {
+      const segments = Array.from({ length: 8 }, () =>
+        Math.floor(Math.random() * 0xffff)
+          .toString(16)
+          .padStart(4, '0'),
+      );
+      const prefix = Math.floor(Math.random() * 129); // 0-128 inclusive
+      cases.push({
+        address: segments.join(':'),
+        prefix,
+        version: 'IPv6',
+      });
+    }
+  }
+  return cases;
+};
+
+const computeFocusOrder = async (form: Locator): Promise<string[]> => {
+  const descriptors = await form.evaluate((node) => {
+    const focusableSelector = 'input, select, textarea, button, [tabindex]';
+    const candidates = Array.from(
+      node.querySelectorAll<HTMLElement>(focusableSelector),
+    ).filter((el) => {
+      if (el.hasAttribute('disabled')) return false;
+      if (el.tabIndex < 0) return false;
+      const style = window.getComputedStyle(el);
+      if (style.visibility === 'hidden' || style.display === 'none') return false;
+      return true;
+    });
+    return candidates.map((el, index) => {
+      const descriptor =
+        el.dataset.testid ||
+        el.id ||
+        el.getAttribute('name') ||
+        el.getAttribute('aria-label') ||
+        el.getAttribute('placeholder') ||
+        el.textContent?.trim() ||
+        `${el.tagName.toLowerCase()}-${index}`;
+      return descriptor;
+    });
+  });
+
+  const unique: string[] = [];
+  descriptors.forEach((value) => {
+    if (value && !unique.includes(value)) {
+      unique.push(value);
+    }
+  });
+  return unique;
+};
+
+const describeActiveElement = (page: Page) =>
+  page.evaluate(() => {
+    const active = document.activeElement as HTMLElement | null;
+    if (!active) return '';
+    return (
+      active.dataset.testid ||
+      active.id ||
+      active.getAttribute('name') ||
+      active.getAttribute('aria-label') ||
+      active.getAttribute('placeholder') ||
+      active.textContent?.trim() ||
+      active.tagName.toLowerCase()
+    );
+  });
+
+const adjustPrefixWithArrows = async (prefixField: Locator) => {
+  const typeAttr = (await prefixField.getAttribute('type'))?.toLowerCase();
+  if (typeAttr !== 'number') return;
+  await prefixField.fill('12');
+  await prefixField.focus();
+  await prefixField.press('ArrowUp');
+  const afterUp = Number(await prefixField.inputValue());
+  await prefixField.press('ArrowDown');
+  const afterDown = Number(await prefixField.inputValue());
+  expect(afterUp).toBeGreaterThanOrEqual(12);
+  expect(afterDown).toBeLessThanOrEqual(afterUp);
+};
+
+const exerciseVersionArrows = async (page: Page, form: Locator) => {
+  const radios = form.locator('input[type="radio"], [role="radio"]');
+  if ((await radios.count()) < 2) return;
+
+  const ipv4 = radios.filter({ hasText: /ipv4/i }).first();
+  const ipv6 = radios.filter({ hasText: /ipv6/i }).first();
+  if ((await ipv4.count()) === 0 || (await ipv6.count()) === 0) return;
+
+  await ipv4.focus();
+  await page.keyboard.press('ArrowRight');
+  await expect.poll(async () => ipv6.evaluate((node) => node === document.activeElement)).toBeTruthy();
+  await page.keyboard.press('ArrowLeft');
+  await expect.poll(async () => ipv4.evaluate((node) => node === document.activeElement)).toBeTruthy();
+};
+
+const countCsvRows = (csv: string) => {
+  const lines = csv.trim().split(/\r?\n/);
+  return lines.length > 1 ? lines.length - 1 : 0;
+};
+
+if (!RUN_SUBNET_E2E) {
+  test.describe.skip(
+    'Subnet calculator regression (gated)',
+    () => {
+      test('subnet calculator tests disabled', () => {
+        test.info().annotations.push({ type: 'skip', description: 'Set SUBNET_E2E=1 to enable subnet calculator tests.' });
+      });
+    },
+  );
+} else {
+  test.describe('Subnet calculator regression', () => {
+    test('random IPv4/IPv6 runs export/import without regressions', async ({ page, browserName }) => {
+      const consoleErrors: string[] = [];
+      const pageErrors: string[] = [];
+
+      page.on('pageerror', (error) => {
+        pageErrors.push(error.message);
+      });
+      page.on('console', (message) => {
+        if (message.type() === 'error') {
+          consoleErrors.push(message.text());
+        }
+      });
+
+      await page.goto(SUBNET_URL, { waitUntil: 'domcontentloaded' });
+      const form = page.locator('[data-testid="subnet-form"], form').first();
+      await expect(form).toBeVisible();
+
+      const ipField = await locateField(form, ['ip', 'address', 'host', 'cidr'], ['input', 'textarea']);
+      const prefixField = await locateField(form, ['prefix', 'cidr', 'mask'], ['input']);
+      const submitButton = await locateButton(form, ['add', 'calculate', 'submit', 'generate', 'compute', 'analyze']);
+      const exportButton = await locateButton(page, ['export', 'download'], 'button[data-testid*="export" i]');
+      const rowsLocator = await locateRowLocator(page);
+
+      await expect(ipField).toBeVisible();
+      await expect(prefixField).toBeVisible();
+      await expect(submitButton).toBeVisible();
+      await expect(exportButton).toBeVisible();
+
+      const initialHeap = await readHeapUsage(page);
+      let expectedCount = await rowsLocator.count();
+
+      const cases = buildRandomCases(50);
+      for (const entry of cases) {
+        await ipField.fill('');
+        await prefixField.fill('');
+        await ipField.fill(entry.address);
+        await prefixField.fill(String(entry.prefix));
+        await toggleVersionIfNeeded(form, entry.version);
+        await submitButton.click();
+        expectedCount += 1;
+        await expect(rowsLocator).toHaveCount(expectedCount, { timeout: 15_000 });
+      }
+
+      const focusOrder = await computeFocusOrder(form);
+      const tabChecks = Math.min(focusOrder.length, 8);
+      if (tabChecks > 1) {
+        await ipField.focus();
+        const visited: string[] = [await describeActiveElement(page)];
+        for (let i = 1; i < tabChecks; i += 1) {
+          await page.keyboard.press('Tab');
+          visited.push(await describeActiveElement(page));
+        }
+        expect(visited).toEqual(focusOrder.slice(0, tabChecks));
+      }
+
+      await adjustPrefixWithArrows(prefixField);
+      await exerciseVersionArrows(page, form);
+
+      const [download] = await Promise.all([
+        page.waitForEvent('download'),
+        exportButton.click(),
+      ]);
+      const tempFile = path.join(os.tmpdir(), `subnet-${crypto.randomUUID()}.csv`);
+      await download.saveAs(tempFile);
+      const csvContent = await fs.readFile(tempFile, 'utf8');
+      const csvRows = countCsvRows(csvContent);
+
+      await page.reload({ waitUntil: 'domcontentloaded' });
+
+      const postReloadRows = await locateRowLocator(page);
+      const existingCount = await postReloadRows.count();
+      const importAfterReload = await locateImportInput(page);
+      await importAfterReload.setInputFiles(tempFile);
+      await expect(postReloadRows).toHaveCount(
+        Math.max(existingCount, csvRows),
+        { timeout: 20_000 },
+      );
+
+      const finalHeap = await readHeapUsage(page);
+      if (initialHeap !== null && finalHeap !== null && browserName === 'chromium') {
+        expect(finalHeap - initialHeap).toBeLessThanOrEqual(6 * 1024 * 1024);
+      }
+
+      expect(consoleErrors).toEqual([]);
+      expect(pageErrors).toEqual([]);
+
+      await fs.unlink(tempFile).catch(() => {});
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add CSV serialization/parsing helpers and unit tests for the subnet calculator
- add a gated Playwright regression that seeds random IPv4/IPv6 runs, exercises keyboard navigation, and checks export/import
- document the new test gate and ensure Playwright config picks up the subnet calculator spec

## Testing
- yarn test __tests__/apps/subnet-calculator/csv.test.ts
- yarn eslint playwright/tests/subnet-calculator.spec.ts
- yarn eslint apps/subnet-calculator/csv.ts
- yarn eslint __tests__/apps/subnet-calculator/csv.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc38f423a083289b3e030afa376630