### PR TITLE
ui: add rtl preview toggle

### DIFF
--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -3,6 +3,7 @@ import UbuntuApp from '../base/ubuntu_app';
 import apps from '../../apps.config';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { Grid } from 'react-window';
+import { useSettings } from '../../hooks/useSettings';
 
 function fuzzyHighlight(text, query) {
   const q = query.toLowerCase();
@@ -25,6 +26,8 @@ export default function AppGrid({ openApp }) {
   const gridRef = useRef(null);
   const columnCountRef = useRef(1);
   const [focusedIndex, setFocusedIndex] = useState(0);
+  const { direction } = useSettings();
+  const isRTL = direction === 'rtl';
 
   const filtered = useMemo(() => {
     if (!query) return apps.map((app) => ({ ...app, nodes: app.title }));
@@ -55,8 +58,10 @@ export default function AppGrid({ openApp }) {
       e.preventDefault();
       const colCount = columnCountRef.current;
       let idx = focusedIndex;
-      if (e.key === 'ArrowRight') idx = Math.min(idx + 1, filtered.length - 1);
-      if (e.key === 'ArrowLeft') idx = Math.max(idx - 1, 0);
+      const forwardKey = isRTL ? 'ArrowLeft' : 'ArrowRight';
+      const backwardKey = isRTL ? 'ArrowRight' : 'ArrowLeft';
+      if (e.key === forwardKey) idx = Math.min(idx + 1, filtered.length - 1);
+      if (e.key === backwardKey) idx = Math.max(idx - 1, 0);
       if (e.key === 'ArrowDown') idx = Math.min(idx + colCount, filtered.length - 1);
       if (e.key === 'ArrowUp') idx = Math.max(idx - colCount, 0);
       setFocusedIndex(idx);
@@ -68,7 +73,7 @@ export default function AppGrid({ openApp }) {
         el?.focus();
       }, 0);
     },
-    [filtered, focusedIndex]
+    [filtered, focusedIndex, isRTL]
   );
 
   const Cell = ({ columnIndex, rowIndex, style, data }) => {
@@ -89,30 +94,33 @@ export default function AppGrid({ openApp }) {
   };
 
   return (
-    <div className="flex flex-col items-center h-full">
+    <div className="flex flex-col items-center h-full" dir={direction}>
       <input
         className="mb-6 mt-4 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
         placeholder="Search"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
       />
-      <div className="w-full flex-1 h-[70vh] outline-none" onKeyDown={handleKeyDown}>
+      <div
+        className={`w-full flex-1 h-[70vh] outline-none ${isRTL ? 'rtl-grid-container' : ''}`}
+        onKeyDown={handleKeyDown}
+      >
         <AutoSizer>
           {({ height, width }) => {
             const columnCount = getColumnCount(width);
             columnCountRef.current = columnCount;
             const rowCount = Math.ceil(filtered.length / columnCount);
-            return (
-              <Grid
-                gridRef={gridRef}
-                columnCount={columnCount}
-                columnWidth={width / columnCount}
-                height={height}
-                rowCount={rowCount}
-                rowHeight={112}
-                width={width}
-                className="scroll-smooth"
-              >
+              return (
+                <Grid
+                  gridRef={gridRef}
+                  className={`${isRTL ? 'rtl-grid ' : ''}scroll-smooth`}
+                  columnCount={columnCount}
+                  columnWidth={width / columnCount}
+                  height={height}
+                  rowCount={rowCount}
+                  rowHeight={112}
+                  width={width}
+                >
                 {(props) => <Cell {...props} data={{ items: filtered, columnCount }} />}
               </Grid>
             );

--- a/docs/keyboard-only-test-plan.md
+++ b/docs/keyboard-only-test-plan.md
@@ -17,6 +17,8 @@
    - **Alt + ArrowUp** snaps it to the top half.
    - **Alt + ArrowDown** restores the window to its previous size and position.
 
+> **RTL note:** When the RTL toggle is enabled in **UI → Settings → Theme**, launcher grids and other directional lists treat **ArrowLeft** as forward and **ArrowRight** as backward so focus moves visually with the layout. Window management shortcuts (Shift/Alt + arrows) continue to use the physical key directions; snapping/resizing is not mirrored yet.
+
 ## Focus
 1. After resizing or snapping, press **Tab** to move focus inside the window.
 2. Continue pressing **Tab** to confirm focus can leave the window and is not trapped.

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -6,6 +6,8 @@ import {
   setWallpaper as saveWallpaper,
   getDensity as loadDensity,
   setDensity as saveDensity,
+  getDirection as loadDirectionSetting,
+  setDirection as saveDirectionSetting,
   getReducedMotion as loadReducedMotion,
   setReducedMotion as saveReducedMotion,
   getFontScale as loadFontScale,
@@ -24,6 +26,7 @@ import {
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
 type Density = 'regular' | 'compact';
+type Direction = 'ltr' | 'rtl';
 
 // Predefined accent palette exposed to settings UI
 export const ACCENT_OPTIONS = [
@@ -55,6 +58,7 @@ interface SettingsContextValue {
   accent: string;
   wallpaper: string;
   density: Density;
+  direction: Direction;
   reducedMotion: boolean;
   fontScale: number;
   highContrast: boolean;
@@ -66,6 +70,7 @@ interface SettingsContextValue {
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
+  setDirection: (value: Direction) => void;
   setReducedMotion: (value: boolean) => void;
   setFontScale: (value: number) => void;
   setHighContrast: (value: boolean) => void;
@@ -80,6 +85,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   accent: defaults.accent,
   wallpaper: defaults.wallpaper,
   density: defaults.density as Density,
+  direction: (defaults.direction as Direction) || 'ltr',
   reducedMotion: defaults.reducedMotion,
   fontScale: defaults.fontScale,
   highContrast: defaults.highContrast,
@@ -91,6 +97,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
+  setDirection: () => {},
   setReducedMotion: () => {},
   setFontScale: () => {},
   setHighContrast: () => {},
@@ -105,6 +112,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [accent, setAccent] = useState<string>(defaults.accent);
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
   const [density, setDensity] = useState<Density>(defaults.density as Density);
+  const [direction, setDirection] = useState<Direction>(
+    (defaults.direction as Direction) || 'ltr',
+  );
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
   const [highContrast, setHighContrast] = useState<boolean>(defaults.highContrast);
@@ -120,6 +130,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setAccent(await loadAccent());
       setWallpaper(await loadWallpaper());
       setDensity((await loadDensity()) as Density);
+      setDirection((await loadDirectionSetting()) as Direction);
       setReducedMotion(await loadReducedMotion());
       setFontScale(await loadFontScale());
       setHighContrast(await loadHighContrast());
@@ -183,6 +194,22 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [density]);
 
   useEffect(() => {
+    saveDirectionSetting(direction);
+    if (typeof document !== 'undefined') {
+      document.documentElement.setAttribute('dir', direction);
+      document.body?.setAttribute('data-direction', direction);
+    }
+  }, [direction]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    return () => {
+      document.documentElement.setAttribute('dir', 'ltr');
+      document.body?.setAttribute('data-direction', 'ltr');
+    };
+  }, []);
+
+  useEffect(() => {
     document.documentElement.classList.toggle('reduced-motion', reducedMotion);
     saveReducedMotion(reducedMotion);
   }, [reducedMotion]);
@@ -242,6 +269,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         accent,
         wallpaper,
         density,
+        direction,
         reducedMotion,
         fontScale,
         highContrast,
@@ -253,6 +281,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAccent,
         setWallpaper,
         setDensity,
+        setDirection,
         setReducedMotion,
         setFontScale,
         setHighContrast,

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -8,10 +8,20 @@ import { useSettings } from '../../../hooks/useSettings';
 function Toggle({
   checked,
   onChange,
+  direction = 'ltr',
+  className = '',
 }: {
   checked: boolean;
   onChange: (val: boolean) => void;
+  direction?: 'ltr' | 'rtl';
+  className?: string;
 }) {
+  const isRTL = direction === 'rtl';
+  const knobTranslation = checked
+    ? isRTL
+      ? '-translate-x-6'
+      : 'translate-x-6'
+    : '';
   return (
     <button
       type="button"
@@ -20,39 +30,49 @@ function Toggle({
       onClick={() => onChange(!checked)}
       className={`relative w-12 h-6 rounded-full transition-colors duration-200 focus:outline-none ${
         checked ? 'bg-ubt-blue' : 'bg-ubt-grey'
-      }`}
+      } ${className}`.trim()}
     >
       <span
-        className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform duration-200 ${
-          checked ? 'translate-x-6' : ''
-        }`}
+        className={`absolute top-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform duration-200 ${knobTranslation}`}
+        style={isRTL ? { right: '0.125rem' } : { left: '0.125rem' }}
       ></span>
     </button>
   );
 }
 
 export default function ThemeSettings() {
-  const { theme, setTheme } = useSettings();
+  const { theme, setTheme, direction, setDirection } = useSettings();
   const [panelSize, setPanelSize] = usePersistentState('app:panel-icons', 16);
   const [gridSize, setGridSize] = usePersistentState('app:grid-icons', 64);
+  const isRTL = direction === 'rtl';
 
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
     setTheme(e.target.value);
   };
 
   return (
-    <div className="flex h-full">
-      <nav className="w-48 p-4 border-r border-ubt-cool-grey text-sm">
+    <div className={`flex h-full ${isRTL ? 'flex-row-reverse' : ''}`} dir={direction}>
+      <nav
+        className={`w-48 p-4 text-sm ${
+          isRTL ? 'border-l border-ubt-cool-grey text-right' : 'border-r border-ubt-cool-grey'
+        }`}
+      >
         <ul className="space-y-1.5">
           <li>
-            <a className="flex items-center gap-2 p-2 rounded-l-md border-l-2 border-ubt-blue bg-ub-cool-grey">
+            <a
+              className={`flex items-center gap-2 p-2 bg-ub-cool-grey ${
+                isRTL
+                  ? 'flex-row-reverse rounded-r-md border-r-2 border-ubt-blue'
+                  : 'rounded-l-md border-l-2 border-ubt-blue'
+              }`}
+            >
               <span className="w-6 h-6 bg-ubt-grey rounded"></span>
               <span>Theme</span>
             </a>
           </li>
         </ul>
       </nav>
-      <div className="flex-1 p-4 overflow-y-auto">
+      <div className={`flex-1 p-4 overflow-y-auto ${isRTL ? 'text-right' : ''}`}>
         <h1 className="text-xl mb-4">Theme</h1>
         <select
           value={theme}
@@ -66,16 +86,36 @@ export default function ThemeSettings() {
         </select>
 
         <div className="mt-6">
+          <h2 className="text-lg mb-2">Layout Direction</h2>
+          <div className={`flex items-center gap-2 ${isRTL ? 'flex-row-reverse' : ''}`}>
+            <span className="text-sm text-ubt-grey">LTR</span>
+            <Toggle
+              checked={isRTL}
+              onChange={(val) => setDirection(val ? 'rtl' : 'ltr')}
+              direction={direction}
+            />
+            <span className="text-sm text-ubt-grey">RTL</span>
+          </div>
+          <p className="text-xs text-ubt-grey mt-2">
+            Preview how panels, icon flows, and keyboard navigation respond when mirrored for
+            right-to-left audiences.
+          </p>
+        </div>
+
+        <div className="mt-6">
           <h2 className="text-lg mb-2">Panel Icons</h2>
-          <div className="flex items-center gap-2 mb-2">
+          <div className={`flex items-center gap-2 mb-2 ${isRTL ? 'flex-row-reverse' : ''}`}>
             <span className="w-6 h-6 bg-ubt-grey rounded"></span>
             <Toggle
               checked={panelSize === 32}
               onChange={(val) => setPanelSize(val ? 32 : 16)}
+              direction={direction}
             />
             <span className="w-6 h-6 bg-ubt-grey rounded"></span>
           </div>
-          <div className="flex gap-2 p-2 bg-ub-cool-grey rounded">
+          <div
+            className={`flex gap-2 p-2 bg-ub-cool-grey rounded ${isRTL ? 'flex-row-reverse' : ''}`}
+          >
             <div
               className="bg-ubt-grey rounded"
               style={{ width: panelSize, height: panelSize }}
@@ -93,15 +133,21 @@ export default function ThemeSettings() {
 
         <div className="mt-6">
           <h2 className="text-lg mb-2">Grid Icons</h2>
-          <div className="flex items-center gap-2 mb-2">
+          <div className={`flex items-center gap-2 mb-2 ${isRTL ? 'flex-row-reverse' : ''}`}>
             <span className="w-6 h-6 bg-ubt-grey rounded"></span>
             <Toggle
               checked={gridSize === 96}
               onChange={(val) => setGridSize(val ? 96 : 64)}
+              direction={direction}
             />
             <span className="w-6 h-6 bg-ubt-grey rounded"></span>
           </div>
-          <div className="grid grid-cols-2 gap-2 p-2 bg-ub-cool-grey rounded">
+          <div
+            className={`grid grid-cols-2 gap-2 p-2 bg-ub-cool-grey rounded ${
+              isRTL ? 'rtl-preview' : ''
+            }`}
+            dir={direction}
+          >
             {[1, 2, 3, 4].map((n) => (
               <div
                 key={n}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -77,3 +77,19 @@ html[data-theme='matrix'] {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
+
+.rtl-preview {
+  direction: rtl;
+}
+
+.rtl-grid-container {
+  direction: rtl;
+}
+
+.rtl-grid {
+  direction: rtl;
+}
+
+.rtl-grid > div {
+  direction: rtl;
+}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -7,6 +7,7 @@ const DEFAULT_SETTINGS = {
   accent: '#1793d1',
   wallpaper: 'wall-2',
   density: 'regular',
+  direction: 'ltr',
   reducedMotion: false,
   fontScale: 1,
   highContrast: false,
@@ -44,6 +45,18 @@ export async function getDensity() {
 export async function setDensity(density) {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem('density', density);
+}
+
+export async function getDirection() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.direction;
+  const stored = window.localStorage.getItem('direction');
+  return stored === 'rtl' ? 'rtl' : 'ltr';
+}
+
+export async function setDirection(direction) {
+  if (typeof window === 'undefined') return;
+  const value = direction === 'rtl' ? 'rtl' : 'ltr';
+  window.localStorage.setItem('direction', value);
 }
 
 export async function getReducedMotion() {
@@ -130,6 +143,7 @@ export async function resetSettings() {
     del('bg-image'),
   ]);
   window.localStorage.removeItem('density');
+  window.localStorage.removeItem('direction');
   window.localStorage.removeItem('reduced-motion');
   window.localStorage.removeItem('font-scale');
   window.localStorage.removeItem('high-contrast');
@@ -144,6 +158,7 @@ export async function exportSettings() {
     accent,
     wallpaper,
     density,
+    direction,
     reducedMotion,
     fontScale,
     highContrast,
@@ -155,6 +170,7 @@ export async function exportSettings() {
     getAccent(),
     getWallpaper(),
     getDensity(),
+    getDirection(),
     getReducedMotion(),
     getFontScale(),
     getHighContrast(),
@@ -168,6 +184,7 @@ export async function exportSettings() {
     accent,
     wallpaper,
     density,
+    direction,
     reducedMotion,
     fontScale,
     highContrast,
@@ -192,6 +209,7 @@ export async function importSettings(json) {
     accent,
     wallpaper,
     density,
+    direction,
     reducedMotion,
     fontScale,
     highContrast,
@@ -204,6 +222,7 @@ export async function importSettings(json) {
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
   if (density !== undefined) await setDensity(density);
+  if (direction === 'rtl' || direction === 'ltr') await setDirection(direction);
   if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
   if (fontScale !== undefined) await setFontScale(fontScale);
   if (highContrast !== undefined) await setHighContrast(highContrast);


### PR DESCRIPTION
## Summary
- add a layout direction toggle to the theme settings preview so panels and icon grids mirror in RTL
- persist the RTL preference in the settings store/context and update the document direction with cleanup on unmount
- adjust the app grid keyboard navigation and styling for RTL along with helper CSS and documentation for remaining limitations

## Testing
- yarn lint *(fails: repository already contains hundreds of accessibility lint errors)*
- yarn test *(fails: existing jest suites error on act/localStorage usage)*

------
https://chatgpt.com/codex/tasks/task_e_68cc470d310c8328b56176a484d359db