### PR TITLE
[wireshark] Add timeline filters and exports

### DIFF
--- a/__tests__/wiresharkExport.test.ts
+++ b/__tests__/wiresharkExport.test.ts
@@ -1,0 +1,43 @@
+import { packetsToCsv, packetsToNdjson, toStructuredPacket } from '../apps/wireshark/utils/export';
+import type { Packet } from '../apps/wireshark/types';
+
+const mockPackets: Packet[] = [
+  {
+    timestamp: '1000.000001',
+    src: '10.0.0.1',
+    dest: '10.0.0.2',
+    protocol: 6,
+    info: 'HTTP,GET /index.html',
+    data: new Uint8Array([0, 1, 2]),
+    sport: 443,
+    dport: 515,
+  },
+  {
+    timestamp: '1001.125000',
+    src: '10.0.0.2',
+    dest: '10.0.0.3',
+    protocol: 17,
+    info: 'DNS response',
+    data: new Uint8Array([3, 4, 5]),
+    sport: 53,
+  },
+];
+
+describe('Wireshark export helpers', () => {
+  it('serialises packets to NDJSON with structured fields', () => {
+    const ndjson = packetsToNdjson(mockPackets);
+    const lines = ndjson.split('\n');
+    expect(lines).toHaveLength(mockPackets.length);
+    lines.forEach((line, idx) => {
+      expect(line).toBe(JSON.stringify(toStructuredPacket(mockPackets[idx])));
+    });
+  });
+
+  it('orders CSV columns consistently', () => {
+    const csv = packetsToCsv(mockPackets);
+    const rows = csv.split('\n');
+    expect(rows[0]).toBe('timestamp,source,destination,protocol,info,sport,dport');
+    expect(rows[1]).toBe('1000.000001,10.0.0.1,10.0.0.2,TCP,"HTTP,GET /index.html",443,515');
+    expect(rows[2]).toBe('1001.125000,10.0.0.2,10.0.0.3,UDP,DNS response,53,');
+  });
+});

--- a/apps/wireshark/types.ts
+++ b/apps/wireshark/types.ts
@@ -1,0 +1,32 @@
+export interface Packet {
+  timestamp: string;
+  src: string;
+  dest: string;
+  protocol: number;
+  info: string;
+  data: Uint8Array;
+  sport?: number;
+  dport?: number;
+}
+
+export interface StructuredPacket {
+  timestamp: string;
+  source: string;
+  destination: string;
+  protocol: string;
+  info: string;
+  sport: number | null;
+  dport: number | null;
+}
+
+export const EXPORT_COLUMNS = [
+  'timestamp',
+  'source',
+  'destination',
+  'protocol',
+  'info',
+  'sport',
+  'dport',
+] as const;
+
+export type ExportColumn = (typeof EXPORT_COLUMNS)[number];

--- a/apps/wireshark/utils/export.ts
+++ b/apps/wireshark/utils/export.ts
@@ -1,0 +1,36 @@
+import { protocolName } from '../../../components/apps/wireshark/utils';
+import type { Packet, StructuredPacket } from '../types';
+import { EXPORT_COLUMNS } from '../types';
+
+export const toStructuredPacket = (packet: Packet): StructuredPacket => ({
+  timestamp: packet.timestamp,
+  source: packet.src,
+  destination: packet.dest,
+  protocol: String(protocolName(packet.protocol)),
+  info: packet.info ?? '',
+  sport: typeof packet.sport === 'number' ? packet.sport : null,
+  dport: typeof packet.dport === 'number' ? packet.dport : null,
+});
+
+export const packetsToNdjson = (packets: Packet[]): string =>
+  packets.map((packet) => JSON.stringify(toStructuredPacket(packet))).join('\n');
+
+const escapeCsv = (value: string | number | null): string => {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (/[",\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+};
+
+export const packetsToCsv = (packets: Packet[]): string => {
+  const header = EXPORT_COLUMNS.join(',');
+  const rows = packets.map((packet) => {
+    const structured = toStructuredPacket(packet);
+    return EXPORT_COLUMNS.map((column) =>
+      escapeCsv(structured[column] as string | number | null)
+    ).join(',');
+  });
+  return [header, ...rows].join('\n');
+};


### PR DESCRIPTION
## Summary
- add a draggable mini timeline to clamp Wireshark packet views by timestamp
- add NDJSON and CSV exporters with confirmation messaging tied to the filtered subset
- share packet export helpers and cover them with NDJSON/CSV unit tests

## Testing
- yarn lint *(fails: pre-existing jsx-a11y/no-top-level-window violations in unrelated apps)*
- yarn test *(fails: existing window keyboard handling and Nmap NSE clipboard tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cc47204384832889bb31a8449f7e05