### PR TITLE
[apps] Virtualize security log stream

### DIFF
--- a/components/apps/security-tools/LogStreamViewer.jsx
+++ b/components/apps/security-tools/LogStreamViewer.jsx
@@ -1,0 +1,226 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import VirtualList from 'rc-virtual-list';
+import { getRegisteredLogSchema } from './logSchemaRegistry';
+
+const DEFAULT_HEIGHT = 360;
+const DEFAULT_ITEM_HEIGHT = 88;
+const DEFAULT_BUFFER_OPTIONS = [100, 250, 500];
+const LEVEL_COLORS = {
+  info: 'text-green-400',
+  notice: 'text-blue-300',
+  warning: 'text-yellow-300',
+  critical: 'text-red-400',
+};
+
+const pickLevel = () => {
+  const roll = Math.random();
+  if (roll > 0.9) return 'critical';
+  if (roll > 0.75) return 'warning';
+  if (roll > 0.55) return 'notice';
+  return 'info';
+};
+
+const trimBuffer = (entries, cap) => {
+  if (entries.length <= cap) return entries;
+  return entries.slice(entries.length - cap);
+};
+
+const formatTimestamp = (value) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+  return date.toLocaleTimeString([], {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+};
+
+const ensureIntervalCleared = (ref) => {
+  if (ref.current != null) {
+    clearInterval(ref.current);
+    ref.current = null;
+  }
+};
+
+const useStableId = () => {
+  const idRef = useRef(null);
+  if (idRef.current === null) {
+    idRef.current = `log-${Math.random().toString(36).slice(2, 8)}`;
+  }
+  return idRef.current;
+};
+
+export default function LogStreamViewer({
+  schemaName,
+  fixtures,
+  height = DEFAULT_HEIGHT,
+  itemHeight = DEFAULT_ITEM_HEIGHT,
+  intervalMs = 1200,
+  bufferOptions = DEFAULT_BUFFER_OPTIONS,
+}) {
+  const config = getRegisteredLogSchema(schemaName);
+
+  if (!config) {
+    throw new Error(`Log schema "${schemaName}" has not been registered`);
+  }
+
+  const { schema, timestampKey, fields } = config;
+  const [bufferCap, setBufferCap] = useState(bufferOptions[1] ?? bufferOptions[0]);
+  const [paused, setPaused] = useState(false);
+  const [logs, setLogs] = useState([]);
+
+  const listRef = useRef(null);
+  const intervalRef = useRef(null);
+  const pointerRef = useRef(0);
+  const counterRef = useRef(0);
+  const streamId = useStableId();
+
+  const sanitizedFixtures = useMemo(() => {
+    return fixtures
+      .map((entry) => {
+        const parsed = schema.safeParse(entry);
+        if (!parsed.success) {
+          if (process.env.NODE_ENV !== 'production') {
+            console.warn(`[security-tools] Dropped invalid ${schemaName} log`, parsed.error.flatten());
+          }
+          return null;
+        }
+        return parsed.data;
+      })
+      .filter(Boolean);
+  }, [fixtures, schema, schemaName]);
+
+  useEffect(() => {
+    pointerRef.current = 0;
+    setLogs([]);
+    ensureIntervalCleared(intervalRef);
+  }, [sanitizedFixtures]);
+
+  useEffect(() => {
+    setLogs((prev) => trimBuffer([...prev], bufferCap));
+  }, [bufferCap]);
+
+  useEffect(() => {
+    if (paused || sanitizedFixtures.length === 0) {
+      ensureIntervalCleared(intervalRef);
+      return () => {};
+    }
+
+    const emit = () => {
+      const base = sanitizedFixtures[pointerRef.current % sanitizedFixtures.length];
+      pointerRef.current += 1;
+      counterRef.current += 1;
+
+      const entry = {
+        ...base,
+        [timestampKey]: new Date().toISOString(),
+        level: pickLevel(),
+        __id: `${streamId}-${counterRef.current}`,
+      };
+
+      setLogs((prev) => trimBuffer([...prev, entry], bufferCap));
+    };
+
+    emit();
+    intervalRef.current = window.setInterval(emit, intervalMs);
+
+    return () => {
+      ensureIntervalCleared(intervalRef);
+    };
+  }, [paused, sanitizedFixtures, bufferCap, intervalMs, timestampKey, streamId]);
+
+  useEffect(() => {
+    if (!paused && logs.length && listRef.current) {
+      listRef.current.scrollTo({ index: logs.length - 1, align: 'bottom' });
+    }
+  }, [logs, paused]);
+
+  useEffect(() => () => ensureIntervalCleared(intervalRef), []);
+
+  const togglePaused = () => {
+    setPaused((prev) => !prev);
+  };
+
+  return (
+    <div className="rounded border border-ubc-600 bg-black/40 p-3">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3 text-[11px] uppercase text-slate-300">
+        <span>
+          Streaming {schemaName} logs ({logs.length}/{bufferCap})
+        </span>
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="flex items-center gap-1">
+            Buffer
+            <select
+              className="rounded bg-ub-cool-grey px-1 py-0.5 text-white"
+              value={bufferCap}
+              onChange={(event) => setBufferCap(Number(event.target.value))}
+            >
+              {bufferOptions.map((size) => (
+                <option key={size} value={size}>
+                  {size}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            onClick={togglePaused}
+            className={`rounded px-2 py-0.5 text-xs font-semibold ${
+              paused ? 'bg-ub-yellow text-black' : 'bg-ub-green text-black'
+            }`}
+            type="button"
+          >
+            {paused ? 'Resume' : 'Pause'}
+          </button>
+        </div>
+      </div>
+      <div className="relative" style={{ height }}>
+        <VirtualList
+          ref={listRef}
+          data={logs}
+          height={height}
+          itemHeight={itemHeight}
+          itemKey="__id"
+          className="grid gap-2 overflow-auto"
+        >
+          {(log) => (
+            <article
+              key={log.__id}
+              className="rounded border border-ubc-500 bg-ubc-800/70 p-2 text-xs text-slate-100"
+            >
+              <header className="mb-1 flex items-center justify-between text-[10px] font-semibold">
+                <span className="text-slate-300">{formatTimestamp(log[timestampKey])}</span>
+                <span className={`${LEVEL_COLORS[log.level] || 'text-slate-200'} uppercase`}>
+                  {log.level}
+                </span>
+              </header>
+              <dl className="grid grid-cols-[minmax(0,120px)_1fr] gap-x-2 gap-y-1">
+                {fields
+                  .filter((field) => field.key !== timestampKey)
+                  .map((field) => (
+                    <React.Fragment key={field.key}>
+                      <dt className="text-[10px] uppercase tracking-wide text-slate-400">{field.label}</dt>
+                      <dd className="break-all text-xs text-slate-100">
+                        {log[field.key] != null ? String(log[field.key]) : '-'}
+                      </dd>
+                    </React.Fragment>
+                  ))}
+              </dl>
+            </article>
+          )}
+        </VirtualList>
+        {!logs.length && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-xs text-slate-400">
+            Waiting for new events...
+          </div>
+        )}
+      </div>
+      <p className="mt-3 text-[10px] text-slate-400">
+        Stream is simulated from local fixtures. Pausing halts the emitter and auto-scroll to conserve resources.
+      </p>
+    </div>
+  );
+}
+

--- a/components/apps/security-tools/index.js
+++ b/components/apps/security-tools/index.js
@@ -1,9 +1,46 @@
 import React, { useState, useEffect } from 'react';
+import { z } from 'zod';
 import LabMode from '../../LabMode';
 import CommandBuilder from '../../CommandBuilder';
 import FixturesLoader from '../../FixturesLoader';
 import ResultViewer from '../../ResultViewer';
 import ExplainerPane from '../../ExplainerPane';
+import LogStreamViewer from './LogStreamViewer';
+import { registerLogSchema } from './logSchemaRegistry';
+
+registerLogSchema('suricata', {
+  schema: z.object({
+    timestamp: z.string(),
+    src_ip: z.string(),
+    dest_ip: z.string(),
+    alert: z.string(),
+  }),
+  timestampKey: 'timestamp',
+  fields: [
+    { key: 'timestamp', label: 'Timestamp' },
+    { key: 'src_ip', label: 'Source IP' },
+    { key: 'dest_ip', label: 'Destination IP' },
+    { key: 'alert', label: 'Alert' },
+  ],
+});
+
+registerLogSchema('zeek', {
+  schema: z.object({
+    ts: z.string(),
+    uid: z.string(),
+    id_orig_h: z.string(),
+    id_resp_h: z.string(),
+    note: z.string(),
+  }),
+  timestampKey: 'ts',
+  fields: [
+    { key: 'ts', label: 'Timestamp' },
+    { key: 'uid', label: 'UID' },
+    { key: 'id_orig_h', label: 'Origin Host' },
+    { key: 'id_resp_h', label: 'Responder Host' },
+    { key: 'note', label: 'Note' },
+  ],
+});
 
 const tabs = [
   { id: 'repeater', label: 'Repeater' },
@@ -206,22 +243,18 @@ export default function SecurityTools() {
             )}
 
             {active === 'suricata' && (
-            <div>
-              <p className="text-xs mb-2">Sample Suricata alerts from local JSON fixture.</p>
-              {suricata.map((log, i) => (
-                <pre key={i} className="text-xs bg-black p-1 mb-1 overflow-auto">{JSON.stringify(log, null, 2)}</pre>
-              ))}
-            </div>
-          )}
+              <div className="space-y-2">
+                <p className="text-xs">Simulated Suricata alerts stream derived from local fixtures.</p>
+                <LogStreamViewer schemaName="suricata" fixtures={suricata} />
+              </div>
+            )}
 
             {active === 'zeek' && (
-            <div>
-              <p className="text-xs mb-2">Sample Zeek logs from local JSON fixture.</p>
-              {zeek.map((log, i) => (
-                <pre key={i} className="text-xs bg-black p-1 mb-1 overflow-auto">{JSON.stringify(log, null, 2)}</pre>
-              ))}
-            </div>
-          )}
+              <div className="space-y-2">
+                <p className="text-xs">Zeek connection logs rendered via the streaming virtualized viewer.</p>
+                <LogStreamViewer schemaName="zeek" fixtures={zeek} />
+              </div>
+            )}
 
             {active === 'sigma' && (
             <div>

--- a/components/apps/security-tools/logSchemaRegistry.js
+++ b/components/apps/security-tools/logSchemaRegistry.js
@@ -1,0 +1,31 @@
+const registry = new Map();
+
+export function registerLogSchema(name, config) {
+  if (!config || typeof config !== 'object') {
+    throw new Error('log schema config is required');
+  }
+  const { schema, timestampKey, fields } = config;
+  if (!schema || typeof schema.safeParse !== 'function') {
+    throw new Error(`schema for "${name}" must be a zod schema`);
+  }
+  if (!timestampKey || typeof timestampKey !== 'string') {
+    throw new Error(`timestampKey for "${name}" must be provided`);
+  }
+  if (!Array.isArray(fields)) {
+    throw new Error(`fields for "${name}" must be an array`);
+  }
+
+  registry.set(name, {
+    ...config,
+    fields: fields.map((field) =>
+      typeof field === 'object' && field !== null ? field : { key: String(field), label: String(field) },
+    ),
+  });
+
+  return registry.get(name);
+}
+
+export function getRegisteredLogSchema(name) {
+  return registry.get(name) || null;
+}
+


### PR DESCRIPTION
## Summary
- register Suricata and Zeek schemas so logs can be parsed and rendered consistently
- add a virtualized LogStreamViewer that simulates incoming events, enforces a configurable buffer, and supports pausing/resuming
- swap the security tools log tabs to use the new streamed viewer instead of static pre tags

## Testing
- yarn lint *(fails: numerous existing jsx-a11y and no-top-level-window violations in unrelated files)*
- yarn test *(fails: existing suites such as reconng, window, nmap-nse; run aborted after repeated failures to save time)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4726b9388328bb77f2c9e87338ac