### PR TITLE
[apps] reset alt text when changing evidence image

### DIFF
--- a/__tests__/evidenceVault.test.tsx
+++ b/__tests__/evidenceVault.test.tsx
@@ -1,0 +1,126 @@
+import 'fake-indexeddb/auto';
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import EvidenceVaultApp from '../components/apps/evidence-vault';
+
+const resetEvidenceDb = () =>
+  new Promise<void>((resolve) => {
+    const request = indexedDB.deleteDatabase('evidence-vault');
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+
+describe('EvidenceVaultApp', () => {
+  beforeEach(async () => {
+    await resetEvidenceDb();
+  });
+
+  afterEach(async () => {
+    await resetEvidenceDb();
+  });
+
+  afterAll(async () => {
+    await resetEvidenceDb();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  });
+
+  it('allows creating findings and linking code snippets as evidence', async () => {
+    const user = userEvent.setup();
+    render(<EvidenceVaultApp />);
+
+    await user.type(screen.getByLabelText(/Finding title/i), 'SQL Injection');
+    await user.type(
+      screen.getByLabelText(/Finding summary/i),
+      'Login form vulnerable to injection'
+    );
+    await user.click(screen.getByRole('button', { name: /add finding/i }));
+
+    await screen.findByRole('button', {
+      name: (name) => /^SQL Injection/i.test(name),
+    });
+
+    const addEvidenceButton = screen.getByRole('button', { name: /add evidence/i });
+    expect(addEvidenceButton).toBeDisabled();
+
+    await user.click(screen.getByLabelText(/Code snippet evidence/i));
+    expect(addEvidenceButton).toBeDisabled();
+
+    const snippetField = screen.getByLabelText(/^Snippet/, { selector: 'textarea' });
+    await user.type(snippetField, 'SELECT * FROM users;');
+    expect(addEvidenceButton).toBeEnabled();
+
+    await user.click(addEvidenceButton);
+
+    await waitFor(() => {
+      expect(snippetField).toHaveValue('');
+    });
+
+    await screen.findByText(/SELECT \* FROM users;/i);
+    expect(screen.getByText(/Linked findings:/i)).toHaveTextContent('SQL Injection');
+
+    await user.click(screen.getByRole('button', { name: /Delete evidence/i }));
+    await screen.findByText(/No evidence linked to this finding yet./i);
+  });
+
+  it('requires alt text before saving image evidence', async () => {
+    const user = userEvent.setup();
+    render(<EvidenceVaultApp />);
+
+    const file = new File(['fake'], 'screenshot.png', { type: 'image/png' });
+    const addEvidenceButton = screen.getByRole('button', { name: /add evidence/i });
+
+    const readSpy = jest
+      .spyOn(FileReader.prototype, 'readAsDataURL')
+      .mockImplementation(function mockRead(this: FileReader) {
+        if (this.onload) {
+          Object.defineProperty(this, 'result', {
+            configurable: true,
+            value: 'data:image/png;base64,ZmFrZQ==',
+          });
+          this.onload(new Event('load') as ProgressEvent<FileReader>);
+        }
+      });
+
+    await user.upload(screen.getByLabelText(/Upload image/i), file);
+    expect(addEvidenceButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/Alt text/i), 'Screenshot of the login portal');
+    expect(addEvidenceButton).toBeEnabled();
+
+    readSpy.mockRestore();
+  });
+
+  it('clears previously entered alt text when a new image is selected', async () => {
+    const user = userEvent.setup();
+    render(<EvidenceVaultApp />);
+
+    const altInput = screen.getByLabelText(/Alt text/i);
+    await user.type(altInput, 'Placeholder description');
+
+    const file = new File(['fake'], 'screenshot.png', { type: 'image/png' });
+    const readSpy = jest
+      .spyOn(FileReader.prototype, 'readAsDataURL')
+      .mockImplementation(function mockRead(this: FileReader) {
+        if (this.onload) {
+          Object.defineProperty(this, 'result', {
+            configurable: true,
+            value: 'data:image/png;base64,ZmFrZQ==',
+          });
+          this.onload(new Event('load') as ProgressEvent<FileReader>);
+        }
+      });
+
+    await user.upload(screen.getByLabelText(/Upload image/i), file);
+
+    await waitFor(() => {
+      expect(altInput).toHaveValue('');
+    });
+
+    readSpy.mockRestore();
+  });
+});
+

--- a/components/apps/evidence-vault/index.js
+++ b/components/apps/evidence-vault/index.js
@@ -1,168 +1,681 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { getDb } from '../../../utils/safeIDB';
 
-// Build hierarchical tree from slash-delimited tags
-const buildTagTree = (items) => {
-  const root = {};
-  items.forEach((item) => {
-    item.tags.forEach((tag) => {
-      const parts = tag.split('/').filter(Boolean);
-      let node = root;
-      parts.forEach((part, idx) => {
-        node[part] = node[part] || { children: {}, items: [] };
-        if (idx === parts.length - 1) {
-          node[part].items.push(item);
-        }
-        node = node[part].children;
-      });
-    });
+const DB_NAME = 'evidence-vault';
+const STORE_NAME = 'state';
+const DB_VERSION = 1;
+
+const openDb = () =>
+  getDb(DB_NAME, DB_VERSION, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    },
   });
-  return root;
-};
-
-const TagTree = ({ data, onSelect }) => (
-  <ul className="pl-4">
-    {Object.entries(data).map(([name, node]) => (
-      <TagTreeNode key={name} name={name} node={node} onSelect={onSelect} />
-    ))}
-  </ul>
-);
-
-const TagTreeNode = ({ name, node, onSelect }) => {
-  const hasChildren = Object.keys(node.children).length > 0;
-  return (
-    <li className="mb-1">
-      {hasChildren ? (
-        <details>
-          <summary className="cursor-pointer">{name}</summary>
-          {node.items.length > 0 && (
-            <button
-              onClick={() => onSelect(node)}
-              className="ml-2 text-xs text-blue-400 hover:underline"
-            >
-              View items
-            </button>
-          )}
-          <TagTree data={node.children} onSelect={onSelect} />
-        </details>
-      ) : (
-        <button
-          onClick={() => onSelect(node)}
-          className="text-left hover:underline focus:outline-none"
-        >
-          {name}
-        </button>
-      )}
-    </li>
-  );
-};
 
 const EvidenceVaultApp = () => {
-  const [items, setItems] = useState([]);
-  const [selectedNode, setSelectedNode] = useState(null);
+  const [findings, setFindings] = useState([]);
+  const [evidence, setEvidence] = useState([]);
+  const [selectedFindingId, setSelectedFindingId] = useState(null);
+  const [loaded, setLoaded] = useState(false);
+
+  const [findingTitle, setFindingTitle] = useState('');
+  const [findingDescription, setFindingDescription] = useState('');
+
+  const [evidenceType, setEvidenceType] = useState('image');
+  const [caption, setCaption] = useState('');
+  const [altText, setAltText] = useState('');
+  const [codeSnippet, setCodeSnippet] = useState('');
+  const [language, setLanguage] = useState('');
+  const [imageData, setImageData] = useState(null);
+  const [linkedFindingIds, setLinkedFindingIds] = useState([]);
+
   const fileInputRef = useRef(null);
+  const dbConnectionRef = useRef(null);
 
   useEffect(() => {
-    // reset selection when items change
-    setSelectedNode(null);
-  }, [items]);
+    let cancelled = false;
 
-  const addNote = () => {
-    const title = prompt('Note title');
+    const loadState = async () => {
+      try {
+        const dbPromise = openDb();
+        if (!dbPromise) {
+          if (!cancelled) setLoaded(true);
+          return;
+        }
+        const db = await dbPromise;
+        dbConnectionRef.current = db;
+        const stored = await db.get(STORE_NAME, 'state');
+        if (!cancelled && stored) {
+          setFindings(stored.findings || []);
+          setEvidence(stored.evidence || []);
+          if (stored.findings?.length) {
+            setSelectedFindingId(stored.selectedFindingId || null);
+          }
+        }
+      } catch {
+        // ignore persistence issues
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    };
+
+    loadState();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!loaded) return;
+    (async () => {
+      try {
+        const dbPromise = openDb();
+        if (!dbPromise) return;
+        const db = await dbPromise;
+        dbConnectionRef.current = db;
+        await db.put(
+          STORE_NAME,
+          {
+            findings,
+            evidence,
+            selectedFindingId,
+          },
+          'state'
+        );
+      } catch {
+        // ignore persistence issues
+      }
+    })();
+  }, [findings, evidence, selectedFindingId, loaded]);
+
+  useEffect(() => {
+    return () => {
+      if (dbConnectionRef.current) {
+        dbConnectionRef.current.close();
+        dbConnectionRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedFindingId) return;
+    setLinkedFindingIds((prev) => {
+      if (prev.length === 0) {
+        return [selectedFindingId];
+      }
+      return prev;
+    });
+  }, [selectedFindingId]);
+
+  const evidenceCounts = useMemo(() => {
+    return findings.reduce((acc, finding) => {
+      const count = evidence.filter((item) =>
+        item.linkedFindingIds?.includes(finding.id)
+      ).length;
+      acc[finding.id] = count;
+      return acc;
+    }, {});
+  }, [findings, evidence]);
+
+  const linkedFindingMap = useMemo(() => {
+    const map = new Map();
+    findings.forEach((finding) => {
+      map.set(finding.id, finding);
+    });
+    return map;
+  }, [findings]);
+
+  const filteredEvidence = useMemo(() => {
+    if (!selectedFindingId) return evidence;
+    return evidence.filter((item) =>
+      item.linkedFindingIds?.includes(selectedFindingId)
+    );
+  }, [evidence, selectedFindingId]);
+
+  const isImage = evidenceType === 'image';
+  const canSubmitEvidence = useMemo(() => {
+    if (isImage) {
+      return Boolean(imageData?.dataUrl && altText.trim().length > 0);
+    }
+    return codeSnippet.trim().length > 0;
+  }, [isImage, imageData, altText, codeSnippet]);
+
+  const resetEvidenceForm = () => {
+    setCaption('');
+    setAltText('');
+    setCodeSnippet('');
+    setLanguage('');
+    setImageData(null);
+    setLinkedFindingIds(selectedFindingId ? [selectedFindingId] : []);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handleAddFinding = (event) => {
+    event.preventDefault();
+    const title = findingTitle.trim();
+    const description = findingDescription.trim();
     if (!title) return;
-    const content = prompt('Note content') || '';
-    const tagInput = prompt('Tags (comma separated, use / for hierarchy)') || '';
-    const tags = tagInput
-      .split(',')
-      .map((t) => t.trim())
-      .filter(Boolean);
-    setItems((prev) => [
-      ...prev,
-      { id: Date.now(), type: 'note', title, content, tags },
-    ]);
+
+    const id = `finding-${Date.now()}`;
+    const newFinding = {
+      id,
+      title,
+      description,
+      createdAt: new Date().toISOString(),
+    };
+
+    setFindings((prev) => [...prev, newFinding]);
+    setFindingTitle('');
+    setFindingDescription('');
+    setSelectedFindingId(id);
+    setLinkedFindingIds([id]);
   };
 
-  const handleFileChange = (e) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    const tagInput = prompt('Tags (comma separated, use / for hierarchy)') || '';
-    const tags = tagInput
-      .split(',')
-      .map((t) => t.trim())
-      .filter(Boolean);
-    const url = URL.createObjectURL(file);
-    setItems((prev) => [
-      ...prev,
-      { id: Date.now(), type: 'file', name: file.name, url, tags },
-    ]);
-    e.target.value = '';
+  const handleDeleteFinding = (id) => {
+    setFindings((prev) => prev.filter((finding) => finding.id !== id));
+    setEvidence((prev) =>
+      prev.map((item) => ({
+        ...item,
+        linkedFindingIds: item.linkedFindingIds.filter((fid) => fid !== id),
+      }))
+    );
+    setLinkedFindingIds((prev) => prev.filter((fid) => fid !== id));
+    setSelectedFindingId((current) => (current === id ? null : current));
   };
 
-  const treeData = buildTagTree(items);
-  const displayItems = selectedNode ? selectedNode.items : items;
+  const handleImageChange = (event) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      setImageData(null);
+      setAltText('');
+      return;
+    }
+    setAltText('');
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        setImageData({
+          dataUrl: reader.result,
+          name: file.name,
+          mimeType: file.type,
+          size: file.size,
+        });
+      }
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleToggleLinkedFinding = (id) => {
+    setLinkedFindingIds((prev) =>
+      prev.includes(id)
+        ? prev.filter((fid) => fid !== id)
+        : [...prev, id]
+    );
+  };
+
+  const handleAddEvidence = (event) => {
+    event.preventDefault();
+    if (!canSubmitEvidence) return;
+
+    const cleanedLinks = linkedFindingIds.filter((id) =>
+      findings.some((finding) => finding.id === id)
+    );
+
+    const baseEntry = {
+      id: `evidence-${Date.now()}`,
+      type: evidenceType,
+      caption: caption.trim(),
+      linkedFindingIds: cleanedLinks,
+      createdAt: new Date().toISOString(),
+    };
+
+    if (isImage && imageData) {
+      setEvidence((prev) => [
+        {
+          ...baseEntry,
+          altText: altText.trim(),
+          dataUrl: imageData.dataUrl,
+          fileName: imageData.name,
+          mimeType: imageData.mimeType,
+          size: imageData.size,
+        },
+        ...prev,
+      ]);
+    } else {
+      setEvidence((prev) => [
+        {
+          ...baseEntry,
+          code: codeSnippet,
+          language: language.trim(),
+        },
+        ...prev,
+      ]);
+    }
+
+    resetEvidenceForm();
+  };
+
+  const handleDeleteEvidence = (id) => {
+    setEvidence((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  const handleExport = () => {
+    const payload = {
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      findings,
+      evidence,
+    };
+
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'evidence-vault-export.json';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
 
   return (
-    <div className="h-full w-full bg-gray-900 text-white p-4 flex">
-      <div className="w-1/3 border-r border-gray-700 pr-2 overflow-auto">
+    <div className="flex h-full w-full flex-col bg-gray-900 p-4 text-white">
+      <header className="mb-4 flex flex-wrap items-center justify-between gap-2 border-b border-gray-700 pb-3">
+        <h1 className="text-lg font-semibold">Evidence Vault</h1>
         <button
-          onClick={() => setSelectedNode(null)}
-          className="text-sm text-blue-400 hover:underline mb-2"
+          type="button"
+          onClick={handleExport}
+          className="rounded bg-blue-600 px-3 py-1 text-sm hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
         >
-          All Items
+          Export evidence bundle
         </button>
-        <TagTree data={treeData} onSelect={setSelectedNode} />
-      </div>
-      <div className="flex-1 pl-4 flex flex-col">
-        <div className="mb-2 space-x-2">
-          <button
-            onClick={addNote}
-            className="px-2 py-1 bg-blue-600 rounded"
-          >
-            Add Note
-          </button>
-          <button
-            onClick={() => fileInputRef.current?.click()}
-            className="px-2 py-1 bg-blue-600 rounded"
-          >
-            Add File
-          </button>
-          <input
-            ref={fileInputRef}
-            type="file"
-            className="hidden"
-            onChange={handleFileChange}
-          />
-        </div>
-        <ul className="flex-1 overflow-auto space-y-2">
-          {displayItems.map((item) => (
-            <li key={item.id} className="p-2 bg-gray-800 rounded">
-              {item.type === 'note' ? (
-                <div>
-                  <h4 className="font-semibold">{item.title}</h4>
-                  <p className="text-sm whitespace-pre-wrap">{item.content}</p>
+      </header>
+      <div className="flex h-full flex-col gap-4 md:flex-row">
+        <aside className="w-full rounded border border-gray-700 bg-gray-950 p-4 md:w-1/3">
+          <h2 className="text-base font-semibold">Findings</h2>
+          <form className="mt-3 space-y-3" onSubmit={handleAddFinding}>
+            <div>
+              <label className="block text-xs font-medium uppercase tracking-wide" htmlFor="finding-title">
+                Finding title
+              </label>
+              <input
+                id="finding-title"
+                type="text"
+                value={findingTitle}
+                onChange={(event) => setFindingTitle(event.target.value)}
+                aria-label="Finding title"
+                className="mt-1 w-full rounded border border-gray-700 bg-gray-900 p-2 text-sm focus:border-blue-400 focus:outline-none"
+                placeholder="e.g. SQL injection on login"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium uppercase tracking-wide" htmlFor="finding-description">
+                Finding summary
+              </label>
+              <textarea
+                id="finding-description"
+                value={findingDescription}
+                onChange={(event) => setFindingDescription(event.target.value)}
+                rows={3}
+                aria-label="Finding summary"
+                className="mt-1 w-full rounded border border-gray-700 bg-gray-900 p-2 text-sm focus:border-blue-400 focus:outline-none"
+                placeholder="Key details for the report"
+              />
+            </div>
+            <button
+              type="submit"
+              className="w-full rounded bg-blue-600 px-3 py-2 text-sm font-medium disabled:cursor-not-allowed disabled:bg-gray-700"
+              disabled={!findingTitle.trim()}
+            >
+              Add finding
+            </button>
+          </form>
+
+          <div className="mt-6 space-y-3">
+            <button
+              type="button"
+              onClick={() => setSelectedFindingId(null)}
+              className={`flex w-full items-center justify-between rounded border px-3 py-2 text-left text-sm ${
+                selectedFindingId === null
+                  ? 'border-blue-500 bg-blue-950'
+                  : 'border-gray-700 hover:border-blue-400'
+              }`}
+            >
+              <span>All evidence</span>
+              <span className="text-xs text-gray-300">{evidence.length}</span>
+            </button>
+
+            {findings.length === 0 ? (
+              <p className="text-sm text-gray-400">
+                Add findings to organise supporting evidence.
+              </p>
+            ) : (
+              <ul className="space-y-2">
+                {findings.map((finding) => {
+                  const count = evidenceCounts[finding.id] || 0;
+                  const isSelected = selectedFindingId === finding.id;
+                  return (
+                    <li key={finding.id} className="rounded border border-gray-800 bg-gray-900">
+                      <button
+                        type="button"
+                        onClick={() => setSelectedFindingId(finding.id)}
+                        className={`flex w-full items-start justify-between gap-2 rounded-t px-3 py-2 text-left text-sm ${
+                          isSelected
+                            ? 'bg-blue-950 text-blue-100'
+                            : 'hover:bg-gray-800'
+                        }`}
+                        aria-pressed={isSelected}
+                      >
+                        <div>
+                          <p className="font-medium">{finding.title}</p>
+                          {finding.description && (
+                            <p className="mt-1 text-xs text-gray-300">
+                              {finding.description}
+                            </p>
+                          )}
+                        </div>
+                        <span className="rounded bg-gray-800 px-2 py-0.5 text-xs text-gray-200">
+                          {count}
+                        </span>
+                      </button>
+                      <div className="flex items-center justify-between border-t border-gray-800 px-3 py-2 text-xs text-gray-300">
+                        <span>{count === 1 ? '1 linked item' : `${count} linked items`}</span>
+                        <button
+                          type="button"
+                          onClick={() => handleDeleteFinding(finding.id)}
+                          className="text-red-400 hover:underline"
+                          aria-label={`Delete finding ${finding.title}`}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </aside>
+
+        <main className="flex h-full flex-1 flex-col gap-4">
+          <section className="rounded border border-gray-700 bg-gray-950 p-4">
+            <h2 className="text-base font-semibold">Add evidence</h2>
+            <form className="mt-3 space-y-4" onSubmit={handleAddEvidence}>
+              <fieldset>
+                <legend className="text-xs font-medium uppercase tracking-wide text-gray-300">
+                  Evidence type
+                </legend>
+                <div className="mt-2 flex flex-wrap gap-4 text-sm">
+                    <div className="flex items-center gap-2">
+                      <input
+                        id="evidence-type-image"
+                        type="radio"
+                        name="evidence-type"
+                        value="image"
+                        checked={evidenceType === 'image'}
+                        onChange={() => setEvidenceType('image')}
+                        aria-label="Image evidence"
+                      />
+                      <label htmlFor="evidence-type-image">Image</label>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <input
+                        id="evidence-type-code"
+                        type="radio"
+                        name="evidence-type"
+                        value="code"
+                        checked={evidenceType === 'code'}
+                        onChange={() => setEvidenceType('code')}
+                        aria-label="Code snippet evidence"
+                      />
+                      <label htmlFor="evidence-type-code">Code snippet</label>
+                    </div>
+                </div>
+              </fieldset>
+
+              {isImage ? (
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div>
+                    <label className="block text-xs font-medium uppercase tracking-wide" htmlFor="evidence-image">
+                      Upload image
+                    </label>
+                    <input
+                      id="evidence-image"
+                      ref={fileInputRef}
+                      type="file"
+                      accept="image/*"
+                      onChange={handleImageChange}
+                      aria-label="Upload evidence image"
+                      className="mt-1 w-full rounded border border-gray-700 bg-gray-900 p-2 text-sm focus:border-blue-400 focus:outline-none"
+                    />
+                    {imageData?.dataUrl && (
+                      <div className="mt-3 rounded border border-gray-800 bg-gray-900 p-2">
+                        <p className="text-xs text-gray-300">Preview</p>
+                        <img
+                          src={imageData.dataUrl}
+                          alt={altText || 'Selected evidence preview'}
+                          className="mt-2 max-h-40 w-full rounded object-contain"
+                        />
+                      </div>
+                    )}
+                  </div>
+                  <div className="space-y-4">
+                    <div>
+                      <label className="block text-xs font-medium uppercase tracking-wide" htmlFor="evidence-alt">
+                        Alt text <span className="text-red-400">*</span>
+                      </label>
+                      <input
+                        id="evidence-alt"
+                        type="text"
+                        value={altText}
+                        onChange={(event) => setAltText(event.target.value)}
+                        required
+                        aria-label="Image alt text"
+                        className="mt-1 w-full rounded border border-gray-700 bg-gray-900 p-2 text-sm focus:border-blue-400 focus:outline-none"
+                        placeholder="Describe the image for screen readers"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium uppercase tracking-wide" htmlFor="evidence-caption">
+                        Caption
+                      </label>
+                      <input
+                        id="evidence-caption"
+                        type="text"
+                        value={caption}
+                        onChange={(event) => setCaption(event.target.value)}
+                        aria-label="Image caption"
+                        className="mt-1 w-full rounded border border-gray-700 bg-gray-900 p-2 text-sm focus:border-blue-400 focus:outline-none"
+                        placeholder="Shown under the preview"
+                      />
+                    </div>
+                  </div>
                 </div>
               ) : (
-                <div>
-                  <h4 className="font-semibold">{item.name}</h4>
-                  <a
-                    href={item.url}
-                    download
-                    className="text-blue-400 underline text-sm"
-                  >
-                    Download
-                  </a>
+                <div className="space-y-4">
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label className="block text-xs font-medium uppercase tracking-wide" htmlFor="snippet-language">
+                        Language / tool
+                      </label>
+                      <input
+                        id="snippet-language"
+                        type="text"
+                        value={language}
+                        onChange={(event) => setLanguage(event.target.value)}
+                        aria-label="Snippet language or tool"
+                        className="mt-1 w-full rounded border border-gray-700 bg-gray-900 p-2 text-sm focus:border-blue-400 focus:outline-none"
+                        placeholder="Optional context (e.g. bash, python)"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium uppercase tracking-wide" htmlFor="snippet-caption">
+                        Caption
+                      </label>
+                      <input
+                        id="snippet-caption"
+                        type="text"
+                        value={caption}
+                        onChange={(event) => setCaption(event.target.value)}
+                        aria-label="Snippet caption"
+                        className="mt-1 w-full rounded border border-gray-700 bg-gray-900 p-2 text-sm focus:border-blue-400 focus:outline-none"
+                        placeholder="Short explanation"
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium uppercase tracking-wide" htmlFor="code-snippet">
+                      Snippet <span className="text-red-400">*</span>
+                    </label>
+                    <textarea
+                      id="code-snippet"
+                      value={codeSnippet}
+                      onChange={(event) => setCodeSnippet(event.target.value)}
+                      rows={6}
+                      required
+                      aria-label="Code snippet"
+                      className="mt-1 w-full rounded border border-gray-700 bg-gray-900 p-2 font-mono text-sm focus:border-blue-400 focus:outline-none"
+                      placeholder="Paste relevant output or code"
+                    />
+                  </div>
                 </div>
               )}
-              {item.tags.length > 0 && (
-                <p className="text-xs mt-1 text-gray-400">
-                  Tags: {item.tags.join(', ')}
+
+              <fieldset className="space-y-2">
+                <legend className="text-xs font-medium uppercase tracking-wide text-gray-300">
+                  Link to findings
+                </legend>
+                {findings.length === 0 ? (
+                  <p className="text-sm text-gray-400">
+                    Add a finding to enable linking.
+                  </p>
+                ) : (
+                  <div className="flex flex-col gap-1 text-sm">
+                      {findings.map((finding) => (
+                        <div key={finding.id} className="flex items-center gap-2">
+                          <input
+                            id={`link-finding-${finding.id}`}
+                            type="checkbox"
+                            checked={linkedFindingIds.includes(finding.id)}
+                            onChange={() => handleToggleLinkedFinding(finding.id)}
+                            aria-label={`Link evidence to ${finding.title}`}
+                          />
+                          <label htmlFor={`link-finding-${finding.id}`}>{finding.title}</label>
+                        </div>
+                      ))}
+                  </div>
+                )}
+              </fieldset>
+
+              <button
+                type="submit"
+                className="rounded bg-green-600 px-4 py-2 text-sm font-medium disabled:cursor-not-allowed disabled:bg-gray-700"
+                disabled={!canSubmitEvidence}
+              >
+                Add evidence
+              </button>
+            </form>
+          </section>
+
+          <section className="flex-1 overflow-hidden rounded border border-gray-700 bg-gray-950">
+            <header className="flex items-center justify-between border-b border-gray-800 px-4 py-3">
+              <h2 className="text-base font-semibold">Evidence library</h2>
+              {selectedFindingId && (
+                <p className="text-xs text-gray-300">
+                  Filtering by: {linkedFindingMap.get(selectedFindingId)?.title || 'Unknown finding'}
                 </p>
               )}
-            </li>
-          ))}
-        </ul>
+            </header>
+            <div className="h-full overflow-y-auto p-4">
+              {filteredEvidence.length === 0 ? (
+                <p className="text-sm text-gray-400">
+                  {selectedFindingId
+                    ? 'No evidence linked to this finding yet.'
+                    : 'No evidence captured yet.'}
+                </p>
+              ) : (
+                <ul className="space-y-4">
+                  {filteredEvidence.map((item) => (
+                    <li key={item.id} className="rounded border border-gray-800 bg-gray-900 p-4">
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                          <p className="text-sm uppercase tracking-wide text-gray-300">
+                            {item.type === 'image' ? 'Image evidence' : 'Code snippet'}
+                          </p>
+                          {item.caption && (
+                            <h3 className="mt-1 text-lg font-semibold">{item.caption}</h3>
+                          )}
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => handleDeleteEvidence(item.id)}
+                          className="text-xs text-red-400 hover:underline"
+                          aria-label="Delete evidence"
+                        >
+                          Remove
+                        </button>
+                      </div>
+
+                      <div className="mt-3">
+                        {item.type === 'image' ? (
+                          <figure>
+                            <img
+                              src={item.dataUrl}
+                              alt={item.altText}
+                              className="max-h-64 w-full rounded object-contain"
+                            />
+                            {item.caption && (
+                              <figcaption className="mt-2 text-sm text-gray-300">
+                                {item.caption}
+                              </figcaption>
+                            )}
+                            <p className="mt-2 text-xs text-gray-500">
+                              Alt text: {item.altText}
+                            </p>
+                          </figure>
+                        ) : (
+                          <div>
+                            {item.language && (
+                              <p className="text-xs uppercase tracking-wide text-gray-400">
+                                {item.language}
+                              </p>
+                            )}
+                            <pre className="mt-2 max-h-64 overflow-auto rounded border border-gray-800 bg-black p-3 text-sm text-gray-100">
+                              <code>{item.code}</code>
+                            </pre>
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="mt-3 text-xs text-gray-400">
+                        {item.linkedFindingIds.length > 0 ? (
+                          <p>
+                            Linked findings:{' '}
+                            {item.linkedFindingIds
+                              .map((id) => linkedFindingMap.get(id)?.title)
+                              .filter(Boolean)
+                              .join(', ')}
+                          </p>
+                        ) : (
+                          <p>Not linked to any findings yet.</p>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </section>
+        </main>
       </div>
     </div>
   );
 };
 
 export default EvidenceVaultApp;
+


### PR DESCRIPTION
## Summary
- clear any previously entered alt text whenever the image picker is reset so descriptions always match the selected file
- add a regression test that verifies the alt text field is cleared after uploading a new screenshot

## Testing
- yarn exec eslint components/apps/evidence-vault/index.js __tests__/evidenceVault.test.tsx
- yarn test evidenceVault

------
https://chatgpt.com/codex/tasks/task_e_68cc472b421c8328b5f19a81af28e276