### PR TITLE
[apps] add log console registry and UI

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -78,6 +78,8 @@ const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
 const TrashApp = createDynamicApp('trash', 'Trash');
 const SerialTerminalApp = createDynamicApp('serial-terminal', 'Serial Terminal');
 
+const LogConsoleApp = createDynamicApp('log-console', 'Log Console');
+
 
 const WiresharkApp = createDynamicApp('wireshark', 'Wireshark');
 const BleSensorApp = createDynamicApp('ble-sensor', 'BLE Sensor');
@@ -163,6 +165,7 @@ const displayProjectGallery = createDisplay(ProjectGalleryApp);
 const displayTrash = createDisplay(TrashApp);
 const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
+const displayLogConsole = createDisplay(LogConsoleApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
 
@@ -709,6 +712,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayResourceMonitor,
+  },
+  {
+    id: 'log-console',
+    title: 'Log Console',
+    icon: '/themes/Yaru/apps/radar-symbolic.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayLogConsole,
   },
   {
     id: 'screen-recorder',

--- a/apps/log-console/index.tsx
+++ b/apps/log-console/index.tsx
@@ -1,0 +1,713 @@
+'use client';
+
+import {
+  FormEvent,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+  type SVGProps,
+} from 'react';
+import SourceRegistryProvider, {
+  LogChannel,
+  LogField,
+  LogLevelMap,
+  LogSource,
+  slugify,
+  useSourceRegistry,
+} from '../../components/apps/log-console/SourceRegistry';
+
+const DEFAULT_FIELD_TEMPLATE = 'timestamp:Timestamp:datetime\nmessage:Message:text';
+const DEFAULT_LEVEL_TEMPLATE =
+  'info:Info:#2563EB:20\nwarning:Warning:#D97706:30\nerror:Error:#DC2626:40';
+
+interface ChannelDraft {
+  uid: string;
+  name: string;
+  description: string;
+  fields: string;
+  levels: string;
+}
+
+const ChannelIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}
+  >
+    <rect x={4} y={4} width={16} height={4} rx={1} />
+    <rect x={4} y={10} width={16} height={4} rx={1} />
+    <rect x={4} y={16} width={16} height={4} rx={1} />
+  </svg>
+);
+
+const createDraftId = () => Math.random().toString(36).slice(2, 10);
+
+const createChannelDraft = (): ChannelDraft => ({
+  uid: createDraftId(),
+  name: '',
+  description: '',
+  fields: DEFAULT_FIELD_TEMPLATE,
+  levels: DEFAULT_LEVEL_TEMPLATE,
+});
+
+const toTitleCase = (value: string) =>
+  value
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+
+const parseFields = (raw: string): LogField[] => {
+  const lines = raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (lines.length === 0) {
+    return [
+      { key: 'timestamp', label: 'Timestamp', type: 'datetime' },
+      { key: 'message', label: 'Message', type: 'text' },
+    ];
+  }
+
+  return lines.map((line, index) => {
+    const [keyPart, labelPart, typePart] = line.split(':').map((part) => part.trim());
+    const key = keyPart || `field-${index + 1}`;
+    const label = labelPart || toTitleCase(key);
+    const type = typePart || 'string';
+    return { key, label, type };
+  });
+};
+
+const parseLevels = (raw: string): LogLevelMap => {
+  const lines = raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (lines.length === 0) {
+    return {
+      info: { label: 'Info', color: '#2563EB', severity: 20 },
+      warning: { label: 'Warning', color: '#D97706', severity: 30 },
+      error: { label: 'Error', color: '#DC2626', severity: 40 },
+    };
+  }
+
+  const entries = lines.map((line, index) => {
+    const [idPart, labelPart, colorPart, severityPart] = line
+      .split(':')
+      .map((part) => part.trim());
+    const key = idPart || `level-${index + 1}`;
+    const label = labelPart || toTitleCase(key);
+    const color = colorPart || '#2563EB';
+    const severityValue = Number(severityPart);
+    const severity = Number.isFinite(severityValue)
+      ? severityValue
+      : (index + 1) * 10;
+    return [
+      (key || label).toLowerCase().replace(/\s+/g, '-'),
+      { label, color, severity },
+    ] as const;
+  });
+
+  return Object.fromEntries(entries);
+};
+
+const SourceSidebar = ({
+  selectedId,
+  onSelect,
+}: {
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) => {
+  const { sources } = useSourceRegistry();
+
+  return (
+    <aside className="w-full md:w-64 md:max-w-xs border border-gray-800/80 bg-gray-900/40 rounded-lg overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800/80">
+        <span className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+          Sources
+        </span>
+        <span className="text-xs text-gray-500">{sources.length}</span>
+      </div>
+      <ul className="divide-y divide-gray-800/80">
+        {sources.map((source) => {
+          const isActive = source.id === selectedId;
+          return (
+            <li key={source.id}>
+              <button
+                type="button"
+                onClick={() => onSelect(source.id)}
+                aria-current={isActive ? 'true' : undefined}
+                aria-label={`Select ${source.name || source.id}`}
+                className={`w-full text-left px-4 py-3 transition ${
+                  isActive
+                    ? 'bg-blue-600/20 text-white border-l-2 border-blue-500'
+                    : 'hover:bg-gray-800/60 text-gray-200'
+                }`}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium truncate">{source.name}</p>
+                    {source.description && (
+                      <p className="text-xs text-gray-400 truncate">
+                        {source.description}
+                      </p>
+                    )}
+                  </div>
+                  <span
+                    className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] border ${
+                      isActive
+                        ? 'border-blue-400 bg-blue-500/20 text-blue-100'
+                        : 'border-gray-700 bg-gray-800 text-gray-300'
+                    }`}
+                  >
+                    <ChannelIcon className="w-3 h-3" aria-hidden="true" />
+                    {source.channels.length}
+                  </span>
+                </div>
+              </button>
+            </li>
+          );
+        })}
+        {sources.length === 0 && (
+          <li className="px-4 py-3 text-xs text-gray-400">
+            No sources registered yet.
+          </li>
+        )}
+      </ul>
+    </aside>
+  );
+};
+
+const ChannelCard = ({
+  sourceId,
+  channel,
+  onRemoveChannel,
+}: {
+  sourceId: string;
+  channel: LogChannel;
+  onRemoveChannel: (sourceId: string, channelId: string) => void;
+}) => {
+  const levels = useMemo(
+    () =>
+      Object.entries(channel.levelMap ?? {})
+        .map(([key, meta]) => [key, meta] as const)
+        .sort((a, b) => a[1].severity - b[1].severity),
+    [channel.levelMap],
+  );
+
+  return (
+    <article className="rounded-lg border border-gray-800/80 bg-gray-900/40 p-4 space-y-4">
+      <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-white">{channel.name}</h3>
+          {channel.description && (
+            <p className="text-sm text-gray-400">{channel.description}</p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => onRemoveChannel(sourceId, channel.id)}
+          className="self-start text-xs px-2 py-1 rounded border border-gray-700 text-gray-300 hover:bg-gray-800/70 transition"
+        >
+          Remove channel
+        </button>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <h4 className="text-xs uppercase tracking-widest text-gray-400">Fields</h4>
+          <ul className="mt-2 space-y-2">
+            {channel.fields.length > 0 ? (
+              channel.fields.map((field) => (
+                <li
+                  key={field.key}
+                  className="flex items-center justify-between rounded border border-gray-800/80 px-3 py-2"
+                >
+                  <div>
+                    <p className="text-sm font-medium text-white">{field.label}</p>
+                    <p className="text-xs text-gray-400">{field.key}</p>
+                  </div>
+                  <span className="text-xs uppercase tracking-wide text-gray-200 bg-gray-800 px-2 py-0.5 rounded">
+                    {field.type}
+                  </span>
+                </li>
+              ))
+            ) : (
+              <li className="text-xs text-gray-400">No schema fields defined.</li>
+            )}
+          </ul>
+        </div>
+        <div>
+          <h4 className="text-xs uppercase tracking-widest text-gray-400">Levels</h4>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {levels.length > 0 ? (
+              levels.map(([levelKey, meta]) => (
+                <span
+                  key={levelKey}
+                  className="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-medium text-white shadow-sm"
+                  style={{ backgroundColor: meta.color }}
+                >
+                  <span>{meta.label}</span>
+                  <span className="bg-black/30 px-1.5 py-0.5 rounded text-[10px] uppercase tracking-widest">
+                    {meta.severity}
+                  </span>
+                </span>
+              ))
+            ) : (
+              <span className="text-xs text-gray-400">No level metadata.</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+const SourceDetails = ({
+  source,
+  onRemove,
+  onRemoveChannel,
+}: {
+  source: LogSource | null;
+  onRemove: (sourceId: string) => void;
+  onRemoveChannel: (sourceId: string, channelId: string) => void;
+}) => {
+  if (!source) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-gray-700 bg-gray-900/30 py-16 text-center">
+        <p className="text-sm text-gray-300">Select a source to inspect its schema.</p>
+        <p className="text-xs text-gray-500">
+          Registered apps appear in the sidebar. Use the form above to seed demo data.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <section className="space-y-4">
+      <header className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-semibold text-white">{source.name}</h2>
+          {source.description && (
+            <p className="text-sm text-gray-300">{source.description}</p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => onRemove(source.id)}
+          className="self-start text-sm px-3 py-1.5 rounded border border-red-500/80 text-red-200 hover:bg-red-500/10 transition"
+        >
+          Remove source
+        </button>
+      </header>
+      <div className="space-y-4">
+        {source.channels.map((channel) => (
+          <ChannelCard
+            key={channel.id}
+            sourceId={source.id}
+            channel={channel}
+            onRemoveChannel={onRemoveChannel}
+          />
+        ))}
+        {source.channels.length === 0 && (
+          <p className="text-sm text-gray-400">This source does not expose any channels.</p>
+        )}
+      </div>
+    </section>
+  );
+};
+
+const AddSourceForm = ({ onCreated }: { onCreated?: (id: string) => void }) => {
+  const { registerSource, sources } = useSourceRegistry();
+  const baseId = useId();
+  const idPrefix = useMemo(() => {
+    const sanitized = baseId.replace(/[^a-zA-Z0-9_-]/g, '');
+    return sanitized ? `log-console-${sanitized}` : 'log-console';
+  }, [baseId]);
+  const sourceNameId = `${idPrefix}-name`;
+  const sourceIdentifierId = `${idPrefix}-identifier`;
+  const identifierHelpId = `${idPrefix}-identifier-help`;
+  const descriptionId = `${idPrefix}-description`;
+  const [name, setName] = useState('');
+  const [sourceId, setSourceId] = useState('');
+  const [idDirty, setIdDirty] = useState(false);
+  const [description, setDescription] = useState('');
+  const [channels, setChannels] = useState<ChannelDraft[]>([
+    createChannelDraft(),
+  ]);
+  const [message, setMessage] = useState<
+    | { type: 'error' | 'success'; content: string }
+    | null
+  >(null);
+
+  useEffect(() => {
+    if (!idDirty) {
+      setSourceId(slugify(name));
+    }
+  }, [name, idDirty]);
+
+  const updateChannel = (uid: string, patch: Partial<ChannelDraft>) => {
+    setChannels((prev) =>
+      prev.map((channel) =>
+        channel.uid === uid ? { ...channel, ...patch } : channel,
+      ),
+    );
+  };
+
+  const removeChannel = (uid: string) => {
+    setChannels((prev) => {
+      if (prev.length === 1) {
+        return prev;
+      }
+      return prev.filter((channel) => channel.uid !== uid);
+    });
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setMessage(null);
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setMessage({ type: 'error', content: 'Enter a source name.' });
+      return;
+    }
+
+    const canonicalId = slugify(sourceId || trimmedName);
+    if (!canonicalId) {
+      setMessage({
+        type: 'error',
+        content: 'Provide an identifier using lowercase letters, numbers, or dashes.',
+      });
+      return;
+    }
+
+    if (sources.some((source) => source.id === canonicalId)) {
+      setMessage({
+        type: 'error',
+        content: 'A source with this identifier already exists.',
+      });
+      return;
+    }
+
+    const preparedChannels = channels
+      .map((draft) => {
+        const channelName = draft.name.trim();
+        if (!channelName) {
+          return null;
+        }
+        return {
+          id: slugify(channelName),
+          name: channelName,
+          description: draft.description.trim() || undefined,
+          fields: parseFields(draft.fields),
+          levelMap: parseLevels(draft.levels),
+        } as LogChannel;
+      })
+      .filter(Boolean) as LogChannel[];
+
+    if (preparedChannels.length === 0) {
+      setMessage({
+        type: 'error',
+        content: 'Add at least one channel with a name.',
+      });
+      return;
+    }
+
+    const created = registerSource({
+      id: canonicalId,
+      name: trimmedName,
+      description: description.trim() || undefined,
+      channels: preparedChannels,
+    });
+
+    setMessage({ type: 'success', content: `${created.name} registered.` });
+    setName('');
+    setSourceId('');
+    setIdDirty(false);
+    setDescription('');
+    setChannels([createChannelDraft()]);
+
+    onCreated?.(created.id);
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 rounded-lg border border-gray-800/80 bg-gray-900/40 p-4"
+    >
+      <div>
+        <h2 className="text-lg font-semibold text-white">Register source</h2>
+        <p className="text-xs text-gray-400">
+          Provide metadata for mock apps so the console can render structured logs.
+        </p>
+      </div>
+      {message && (
+        <div
+          className={`rounded border px-3 py-2 text-sm ${
+            message.type === 'error'
+              ? 'border-red-500/80 bg-red-500/10 text-red-200'
+              : 'border-emerald-500/80 bg-emerald-500/10 text-emerald-100'
+          }`}
+        >
+          {message.content}
+        </div>
+      )}
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="flex flex-col gap-1 text-sm text-gray-200">
+          <label
+            htmlFor={sourceNameId}
+            className="text-xs uppercase tracking-wide text-gray-400"
+          >
+            Source name
+          </label>
+          <input
+            id={sourceNameId}
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            aria-label="Source name"
+            className="rounded border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            placeholder="e.g. Container Service"
+          />
+        </div>
+        <div className="flex flex-col gap-1 text-sm text-gray-200">
+          <label
+            htmlFor={sourceIdentifierId}
+            className="text-xs uppercase tracking-wide text-gray-400"
+          >
+            Identifier
+          </label>
+          <input
+            id={sourceIdentifierId}
+            value={sourceId}
+            onChange={(event) => {
+              setSourceId(event.target.value);
+              setIdDirty(true);
+            }}
+            aria-describedby={identifierHelpId}
+            aria-label="Source identifier"
+            className="rounded border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            placeholder="auto-generated"
+          />
+          <span id={identifierHelpId} className="text-xs text-gray-500">
+            Lowercase key used by the registry. Leave blank to auto-generate.
+          </span>
+        </div>
+      </div>
+      <div className="flex flex-col gap-1 text-sm text-gray-200">
+        <label
+          htmlFor={descriptionId}
+          className="text-xs uppercase tracking-wide text-gray-400"
+        >
+          Description
+        </label>
+        <textarea
+          id={descriptionId}
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          rows={2}
+          aria-label="Source description"
+          className="rounded border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          placeholder="Optional summary visible in the sidebar"
+        />
+      </div>
+      <div className="space-y-3">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
+          <h3 className="text-sm font-semibold text-white">Channels</h3>
+          <button
+            type="button"
+            onClick={() => setChannels((prev) => [...prev, createChannelDraft()])}
+            className="self-start rounded border border-blue-500/60 px-3 py-1 text-xs font-medium text-blue-200 hover:bg-blue-500/10 transition"
+          >
+            Add channel
+          </button>
+        </div>
+        <p className="text-xs text-gray-400">
+          Define one channel per log stream. Fields use the format{' '}
+          <code className="bg-gray-800/80 px-1 py-0.5 rounded">key:Label:Type</code> per
+          line. Levels follow{' '}
+          <code className="bg-gray-800/80 px-1 py-0.5 rounded">level:Label:#Color:Severity</code>.
+        </p>
+        {channels.map((channel, index) => {
+          const channelIdPrefix = `${idPrefix}-channel-${channel.uid}`;
+          const channelNameId = `${channelIdPrefix}-name`;
+          const channelDescriptionId = `${channelIdPrefix}-description`;
+          const channelFieldsId = `${channelIdPrefix}-fields`;
+          const channelLevelsId = `${channelIdPrefix}-levels`;
+
+          return (
+            <div
+              key={channel.uid}
+              className="space-y-3 rounded-lg border border-gray-800/80 bg-gray-950/60 p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h4 className="text-sm font-semibold text-white">
+                    Channel {index + 1}
+                  </h4>
+                  <p className="text-xs text-gray-500">
+                    Example: <code>syslog</code>, <code>audit</code>, or <code>pipeline</code>
+                  </p>
+                </div>
+                {channels.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => removeChannel(channel.uid)}
+                    className="text-xs text-red-300 hover:text-red-200"
+                    aria-label={`Remove channel ${channel.name || index + 1}`}
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+              <div className="grid gap-3 md:grid-cols-2">
+                <div className="flex flex-col gap-1 text-sm text-gray-200">
+                  <label
+                    htmlFor={channelNameId}
+                    className="text-xs uppercase tracking-wide text-gray-400"
+                  >
+                    Channel name
+                  </label>
+                  <input
+                    id={channelNameId}
+                    value={channel.name}
+                    onChange={(event) =>
+                      updateChannel(channel.uid, { name: event.target.value })
+                    }
+                    aria-label={`Channel ${index + 1} name`}
+                    className="rounded border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    placeholder="e.g. syslog"
+                  />
+                </div>
+                <div className="flex flex-col gap-1 text-sm text-gray-200">
+                  <label
+                    htmlFor={channelDescriptionId}
+                    className="text-xs uppercase tracking-wide text-gray-400"
+                  >
+                    Description
+                  </label>
+                  <input
+                    id={channelDescriptionId}
+                    value={channel.description}
+                    onChange={(event) =>
+                      updateChannel(channel.uid, {
+                        description: event.target.value,
+                      })
+                    }
+                    aria-label={`Channel ${index + 1} description`}
+                    className="rounded border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    placeholder="Optional details"
+                  />
+                </div>
+              </div>
+              <div className="flex flex-col gap-1 text-sm text-gray-200">
+                <label
+                  htmlFor={channelFieldsId}
+                  className="text-xs uppercase tracking-wide text-gray-400"
+                >
+                  Fields
+                </label>
+                <textarea
+                  id={channelFieldsId}
+                  value={channel.fields}
+                  onChange={(event) =>
+                    updateChannel(channel.uid, { fields: event.target.value })
+                  }
+                  rows={3}
+                  aria-label={`Channel ${index + 1} fields`}
+                  className="rounded border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                />
+              </div>
+              <div className="flex flex-col gap-1 text-sm text-gray-200">
+                <label
+                  htmlFor={channelLevelsId}
+                  className="text-xs uppercase tracking-wide text-gray-400"
+                >
+                  Levels
+                </label>
+                <textarea
+                  id={channelLevelsId}
+                  value={channel.levels}
+                  onChange={(event) =>
+                    updateChannel(channel.uid, { levels: event.target.value })
+                  }
+                  rows={3}
+                  aria-label={`Channel ${index + 1} levels`}
+                  className="rounded border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-500"
+        >
+          Register source
+        </button>
+      </div>
+    </form>
+  );
+};
+
+const RegistryShell = () => {
+  const { sources, unregisterSource, removeChannel } = useSourceRegistry();
+  const [selectedId, setSelectedId] = useState<string | null>(
+    sources[0]?.id ?? null,
+  );
+
+  useEffect(() => {
+    if (sources.length === 0) {
+      setSelectedId(null);
+      return;
+    }
+    if (!selectedId) {
+      setSelectedId(sources[0].id);
+      return;
+    }
+    const exists = sources.some((source) => source.id === selectedId);
+    if (!exists) {
+      setSelectedId(sources[0].id);
+    }
+  }, [sources, selectedId]);
+
+  const selectedSource = useMemo(
+    () => sources.find((source) => source.id === selectedId) ?? null,
+    [sources, selectedId],
+  );
+
+  return (
+    <div className="flex h-full flex-col gap-4 p-4 text-sm text-gray-100 md:flex-row md:gap-6">
+      <div className="md:w-64 md:flex-shrink-0">
+        <SourceSidebar selectedId={selectedId} onSelect={setSelectedId} />
+      </div>
+      <div className="flex-1 space-y-6 overflow-y-auto pb-4 pr-1">
+        <AddSourceForm onCreated={(id) => setSelectedId(id)} />
+        <SourceDetails
+          source={selectedSource}
+          onRemove={(id) => unregisterSource(id)}
+          onRemoveChannel={(sourceId, channelId) =>
+            removeChannel(sourceId, channelId)
+          }
+        />
+      </div>
+    </div>
+  );
+};
+
+const LogConsoleApp = () => {
+  return (
+    <SourceRegistryProvider>
+      <RegistryShell />
+    </SourceRegistryProvider>
+  );
+};
+
+export default LogConsoleApp;

--- a/components/apps/log-console/SourceRegistry.tsx
+++ b/components/apps/log-console/SourceRegistry.tsx
@@ -1,0 +1,431 @@
+'use client';
+
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import seedSources from '../../../data/log-console/sources.json';
+
+export interface LogLevelMetadata {
+  label: string;
+  color: string;
+  severity: number;
+  description?: string;
+}
+
+export type LogLevelMap = Record<string, LogLevelMetadata>;
+
+export interface LogField {
+  key: string;
+  label: string;
+  type: string;
+  description?: string;
+  example?: string;
+}
+
+export interface LogChannel {
+  id: string;
+  name: string;
+  description?: string;
+  fields: LogField[];
+  levelMap: LogLevelMap;
+}
+
+export interface LogSource {
+  id: string;
+  name: string;
+  description?: string;
+  tags?: string[];
+  channels: LogChannel[];
+}
+
+export interface SourceRegistryContextValue {
+  sources: LogSource[];
+  registerSource: (source: LogSource) => LogSource;
+  registerChannel: (
+    sourceId: string,
+    channel: LogChannel,
+    sourceName?: string,
+  ) => LogChannel;
+  removeChannel: (sourceId: string, channelId: string) => boolean;
+  unregisterSource: (sourceId: string) => boolean;
+  reset: () => void;
+}
+
+let generatedIdCounter = 0;
+
+export const slugify = (value: string): string => {
+  const raw = `${value ?? ''}`.trim().toLowerCase();
+  if (!raw) {
+    return '';
+  }
+  const slug = raw
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug;
+};
+
+const ensureIdentifier = (value: string | undefined, prefix: string) => {
+  const slug = value ? slugify(value) : '';
+  if (slug) {
+    return slug;
+  }
+  generatedIdCounter += 1;
+  return `${prefix}-${generatedIdCounter}`;
+};
+
+const toTitleCase = (value: string) => {
+  if (!value) {
+    return '';
+  }
+  return value
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+};
+
+const fallbackFields: LogField[] = [
+  { key: 'timestamp', label: 'Timestamp', type: 'datetime' },
+  { key: 'message', label: 'Message', type: 'text' },
+];
+
+const fallbackLevels: LogLevelMap = {
+  info: { label: 'Info', severity: 20, color: '#2563EB' },
+  warning: { label: 'Warning', severity: 30, color: '#D97706' },
+  error: { label: 'Error', severity: 40, color: '#DC2626' },
+};
+
+const normalizeField = (field: Partial<LogField>, index: number): LogField => {
+  const key = field.key?.trim() || `field-${index + 1}`;
+  return {
+    key,
+    label: field.label?.trim() || toTitleCase(key),
+    type: field.type?.trim() || 'string',
+    description: field.description?.trim() || undefined,
+    example: field.example,
+  };
+};
+
+const dedupeByKey = <T extends { key: string }>(items: T[]) => {
+  const map = new Map<string, T>();
+  items.forEach((item) => {
+    map.set(item.key, item);
+  });
+  return Array.from(map.values());
+};
+
+const sortFields = (fields: LogField[]) =>
+  [...fields].sort((a, b) => a.label.localeCompare(b.label));
+
+const sortChannelsList = (channels: LogChannel[]) =>
+  [...channels].sort((a, b) => a.name.localeCompare(b.name));
+
+const sortSourcesList = (sources: LogSource[]) =>
+  [...sources].sort((a, b) => a.name.localeCompare(b.name));
+
+const normalizeChannel = (channel: LogChannel, index: number): LogChannel => {
+  const id = ensureIdentifier(channel.id ?? channel.name, 'channel');
+  const name = channel.name?.trim() || toTitleCase(id);
+  const fieldsRaw = channel.fields?.length
+    ? channel.fields.map((field, idx) => normalizeField(field, idx))
+    : fallbackFields;
+  const fields = sortFields(dedupeByKey(fieldsRaw));
+
+  const entries = Object.entries(channel.levelMap ?? {}).map(
+    ([levelKey, meta], levelIndex) => {
+      const key = levelKey?.trim() || `level-${levelIndex + 1}`;
+      const severity = Number.isFinite(meta?.severity)
+        ? Number(meta?.severity)
+        : (levelIndex + 1) * 10;
+      return [
+        key,
+        {
+          label: meta?.label?.trim() || toTitleCase(key),
+          color: meta?.color || '#2563EB',
+          severity,
+          description: meta?.description?.trim() || undefined,
+        },
+      ] as const;
+    },
+  );
+
+  const levelMap = entries.length
+    ? Object.fromEntries(entries)
+    : { ...fallbackLevels };
+
+  return {
+    id,
+    name,
+    description: channel.description?.trim() || undefined,
+    fields,
+    levelMap,
+  };
+};
+
+const dedupeChannels = (channels: LogChannel[]) => {
+  const map = new Map<string, LogChannel>();
+  channels.forEach((channel, index) => {
+    const normalized = normalizeChannel(channel, index);
+    map.set(normalized.id, normalized);
+  });
+  return sortChannelsList(Array.from(map.values()));
+};
+
+const normalizeSource = (source: LogSource, index: number): LogSource => {
+  const id = ensureIdentifier(source.id ?? source.name, 'source');
+  const name = source.name?.trim() || toTitleCase(id);
+  const channels = dedupeChannels(source.channels ?? []);
+
+  return {
+    id,
+    name,
+    description: source.description?.trim() || undefined,
+    tags: source.tags?.length ? source.tags : undefined,
+    channels,
+  };
+};
+
+const dedupeSources = (sources: LogSource[] | unknown): LogSource[] => {
+  if (!Array.isArray(sources)) {
+    return [];
+  }
+  const map = new Map<string, LogSource>();
+  sources.forEach((source, index) => {
+    const normalized = normalizeSource(source as LogSource, index);
+    map.set(normalized.id, normalized);
+  });
+  return sortSourcesList(Array.from(map.values()));
+};
+
+const mergeChannels = (existing: LogChannel, incoming: LogChannel): LogChannel => {
+  const fieldMap = new Map<string, LogField>();
+  existing.fields.forEach((field) => fieldMap.set(field.key, field));
+  incoming.fields.forEach((field) => fieldMap.set(field.key, field));
+  const fields = sortFields(Array.from(fieldMap.values()));
+
+  return {
+    ...existing,
+    ...incoming,
+    description: incoming.description ?? existing.description,
+    fields,
+    levelMap: { ...existing.levelMap, ...incoming.levelMap },
+  };
+};
+
+const mergeSources = (existing: LogSource, incoming: LogSource): LogSource => {
+  const channelMap = new Map<string, LogChannel>();
+  existing.channels.forEach((channel) => channelMap.set(channel.id, channel));
+  incoming.channels.forEach((channel) => {
+    const current = channelMap.get(channel.id);
+    channelMap.set(
+      channel.id,
+      current ? mergeChannels(current, channel) : channel,
+    );
+  });
+  const channels = sortChannelsList(Array.from(channelMap.values()));
+
+  return {
+    ...existing,
+    ...incoming,
+    description: incoming.description ?? existing.description,
+    tags: incoming.tags ?? existing.tags,
+    channels,
+  };
+};
+
+const seededSources = dedupeSources(seedSources as LogSource[]);
+
+const SourceRegistryContext =
+  createContext<SourceRegistryContextValue | undefined>(undefined);
+
+interface SourceRegistryProviderProps {
+  children: ReactNode;
+  initialSources?: LogSource[];
+}
+
+export const SourceRegistryProvider = ({
+  children,
+  initialSources,
+}: SourceRegistryProviderProps) => {
+  const normalizedInitial = useMemo(
+    () => dedupeSources(initialSources ?? seededSources),
+    [initialSources],
+  );
+  const seedsRef = useRef<LogSource[]>(normalizedInitial);
+  const [sources, setSources] = useState<LogSource[]>(normalizedInitial);
+
+  useEffect(() => {
+    seedsRef.current = normalizedInitial;
+    setSources(normalizedInitial);
+  }, [normalizedInitial]);
+
+  const registerSource = useCallback((source: LogSource) => {
+    const normalized = normalizeSource(source, 0);
+    let finalSource = normalized;
+
+    setSources((prev) => {
+      const index = prev.findIndex((item) => item.id === normalized.id);
+      if (index === -1) {
+        finalSource = normalized;
+        return sortSourcesList([...prev, normalized]);
+      }
+      const merged = mergeSources(prev[index], normalized);
+      finalSource = merged;
+      const next = [...prev];
+      next[index] = merged;
+      return sortSourcesList(next);
+    });
+
+    return finalSource;
+  }, []);
+
+  const registerChannel = useCallback(
+    (sourceId: string, channel: LogChannel, sourceName?: string) => {
+      const canonicalSourceId = slugify(sourceId) || sourceId;
+      const normalizedChannel = normalizeChannel(channel, 0);
+      let finalChannel = normalizedChannel;
+
+      setSources((prev) => {
+        const index = prev.findIndex((item) => item.id === canonicalSourceId);
+        if (index === -1) {
+          const createdSource = normalizeSource(
+            {
+              id: canonicalSourceId,
+              name: sourceName ?? toTitleCase(canonicalSourceId),
+              channels: [normalizedChannel],
+            },
+            0,
+          );
+          finalChannel = createdSource.channels[0];
+          return sortSourcesList([...prev, createdSource]);
+        }
+
+        const existingSource = prev[index];
+        const channelIndex = existingSource.channels.findIndex(
+          (item) => item.id === normalizedChannel.id,
+        );
+
+        let nextChannels: LogChannel[];
+        if (channelIndex === -1) {
+          finalChannel = normalizedChannel;
+          nextChannels = sortChannelsList([
+            ...existingSource.channels,
+            normalizedChannel,
+          ]);
+        } else {
+          const mergedChannel = mergeChannels(
+            existingSource.channels[channelIndex],
+            normalizedChannel,
+          );
+          finalChannel = mergedChannel;
+          nextChannels = sortChannelsList(
+            existingSource.channels.map((item, idx) =>
+              idx === channelIndex ? mergedChannel : item,
+            ),
+          );
+        }
+
+        const nextSource: LogSource = {
+          ...existingSource,
+          channels: nextChannels,
+        };
+
+        const next = [...prev];
+        next[index] = nextSource;
+        return sortSourcesList(next);
+      });
+
+      return finalChannel;
+    },
+    [],
+  );
+
+  const removeChannel = useCallback(
+    (sourceId: string, channelId: string) => {
+      const canonicalSourceId = slugify(sourceId) || sourceId;
+      const canonicalChannelId = slugify(channelId) || channelId;
+      let removed = false;
+
+      setSources((prev) => {
+        const index = prev.findIndex((item) => item.id === canonicalSourceId);
+        if (index === -1) {
+          return prev;
+        }
+        const target = prev[index];
+        const channels = target.channels.filter(
+          (channel) => channel.id !== canonicalChannelId,
+        );
+        if (channels.length === target.channels.length) {
+          return prev;
+        }
+        removed = true;
+        if (channels.length === 0) {
+          const next = [...prev];
+          next.splice(index, 1);
+          return sortSourcesList(next);
+        }
+        const next = [...prev];
+        next[index] = { ...target, channels: sortChannelsList(channels) };
+        return sortSourcesList(next);
+      });
+
+      return removed;
+    },
+    [],
+  );
+
+  const unregisterSource = useCallback((sourceId: string) => {
+    const canonicalSourceId = slugify(sourceId) || sourceId;
+    let removed = false;
+
+    setSources((prev) => {
+      if (!prev.some((source) => source.id === canonicalSourceId)) {
+        return prev;
+      }
+      removed = true;
+      return prev.filter((source) => source.id !== canonicalSourceId);
+    });
+
+    return removed;
+  }, []);
+
+  const reset = useCallback(() => {
+    setSources(sortSourcesList([...seedsRef.current]));
+  }, []);
+
+  const value = useMemo<SourceRegistryContextValue>(
+    () => ({
+      sources,
+      registerSource,
+      registerChannel,
+      removeChannel,
+      unregisterSource,
+      reset,
+    }),
+    [sources, registerSource, registerChannel, removeChannel, unregisterSource, reset],
+  );
+
+  return (
+    <SourceRegistryContext.Provider value={value}>
+      {children}
+    </SourceRegistryContext.Provider>
+  );
+};
+
+export const useSourceRegistry = () => {
+  const context = useContext(SourceRegistryContext);
+  if (!context) {
+    throw new Error('useSourceRegistry must be used within SourceRegistryProvider');
+  }
+  return context;
+};
+
+export default SourceRegistryProvider;

--- a/data/log-console/sources.json
+++ b/data/log-console/sources.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "system-monitor",
+    "name": "System Monitor",
+    "description": "Kernel and audit telemetry collected from a simulated host.",
+    "channels": [
+      {
+        "id": "syslog",
+        "name": "System Log",
+        "description": "Kernel, init, and service messages.",
+        "fields": [
+          { "key": "timestamp", "label": "Timestamp", "type": "datetime" },
+          { "key": "host", "label": "Host", "type": "string" },
+          { "key": "process", "label": "Process", "type": "string" },
+          { "key": "pid", "label": "PID", "type": "number" },
+          { "key": "message", "label": "Message", "type": "text" }
+        ],
+        "levelMap": {
+          "debug": { "label": "Debug", "severity": 10, "color": "#6B7280" },
+          "info": { "label": "Info", "severity": 20, "color": "#2563EB" },
+          "notice": { "label": "Notice", "severity": 25, "color": "#0EA5E9" },
+          "warn": { "label": "Warning", "severity": 30, "color": "#D97706" },
+          "error": { "label": "Error", "severity": 40, "color": "#DC2626" }
+        }
+      },
+      {
+        "id": "audit",
+        "name": "Audit Trail",
+        "description": "Authentication and authorization activity.",
+        "fields": [
+          { "key": "timestamp", "label": "Timestamp", "type": "datetime" },
+          { "key": "user", "label": "User", "type": "string" },
+          { "key": "action", "label": "Action", "type": "string" },
+          { "key": "target", "label": "Target", "type": "string" },
+          { "key": "ip", "label": "Source IP", "type": "ip" },
+          { "key": "status", "label": "Status", "type": "string" }
+        ],
+        "levelMap": {
+          "info": { "label": "Info", "severity": 20, "color": "#2563EB" },
+          "warning": { "label": "Warning", "severity": 30, "color": "#D97706" },
+          "alert": { "label": "Alert", "severity": 50, "color": "#B91C1C" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "app-firewall",
+    "name": "Application Firewall",
+    "description": "ModSecurity-style HTTP inspection events.",
+    "channels": [
+      {
+        "id": "waf",
+        "name": "WAF Events",
+        "description": "Rule triggers from inbound requests.",
+        "fields": [
+          { "key": "timestamp", "label": "Timestamp", "type": "datetime" },
+          { "key": "client", "label": "Client IP", "type": "ip" },
+          { "key": "path", "label": "Request Path", "type": "string" },
+          { "key": "rule", "label": "Rule ID", "type": "string" },
+          { "key": "action", "label": "Action", "type": "string" },
+          { "key": "impact", "label": "Impact", "type": "number" }
+        ],
+        "levelMap": {
+          "info": { "label": "Info", "severity": 20, "color": "#2563EB" },
+          "notice": { "label": "Notice", "severity": 26, "color": "#0EA5E9" },
+          "warning": { "label": "Warning", "severity": 30, "color": "#D97706" },
+          "critical": { "label": "Critical", "severity": 60, "color": "#BE123C" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "pipeline",
+    "name": "CI Pipeline",
+    "description": "Synthetic logs from a build pipeline.",
+    "channels": [
+      {
+        "id": "build",
+        "name": "Build Steps",
+        "description": "Lifecycle events for builds.",
+        "fields": [
+          { "key": "timestamp", "label": "Timestamp", "type": "datetime" },
+          { "key": "stage", "label": "Stage", "type": "string" },
+          { "key": "duration", "label": "Duration (ms)", "type": "number" },
+          { "key": "message", "label": "Message", "type": "text" }
+        ],
+        "levelMap": {
+          "info": { "label": "Info", "severity": 20, "color": "#2563EB" },
+          "success": { "label": "Success", "severity": 15, "color": "#16A34A" },
+          "warning": { "label": "Warning", "severity": 30, "color": "#D97706" },
+          "error": { "label": "Error", "severity": 40, "color": "#DC2626" }
+        }
+      },
+      {
+        "id": "deploy",
+        "name": "Deployments",
+        "description": "Release notifications.",
+        "fields": [
+          { "key": "timestamp", "label": "Timestamp", "type": "datetime" },
+          { "key": "environment", "label": "Environment", "type": "string" },
+          { "key": "version", "label": "Version", "type": "string" },
+          { "key": "status", "label": "Status", "type": "string" },
+          { "key": "message", "label": "Message", "type": "text" }
+        ],
+        "levelMap": {
+          "info": { "label": "Info", "severity": 20, "color": "#2563EB" },
+          "success": { "label": "Success", "severity": 15, "color": "#16A34A" },
+          "warning": { "label": "Warning", "severity": 30, "color": "#D97706" },
+          "error": { "label": "Error", "severity": 40, "color": "#DC2626" }
+        }
+      }
+    ]
+  }
+]

--- a/pages/apps/log-console.jsx
+++ b/pages/apps/log-console.jsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const LogConsoleApp = dynamic(() => import('../../apps/log-console'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default LogConsoleApp;


### PR DESCRIPTION
## Summary
- add a source registry context that normalizes mock channel metadata and seeds default sources for export-friendly demos
- build the Log Console client UI with an accessible sidebar, channel cards, and a form for registering/removing sources and channels
- register the app in the desktop catalog and expose it through the Next.js dynamic page

## Testing
- yarn lint *(fails: existing jsx-a11y and window/document lint violations across the repo)*
- yarn eslint apps/log-console/index.tsx
- yarn test *(fails: known window.handleKeyDown, nmap NSE clipboard alert, and jsdom localStorage issues)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4727c1d48328af40369706400c30