### PR TITLE
[apps] add pentest report finding form

### DIFF
--- a/components/apps/pentest-report/FindingForm.tsx
+++ b/components/apps/pentest-report/FindingForm.tsx
@@ -1,0 +1,431 @@
+import React from 'react';
+import { z } from 'zod';
+
+const severityLevels = ['Informational', 'Low', 'Medium', 'High', 'Critical'] as const;
+
+type Severity = (typeof severityLevels)[number];
+
+const severitySchema = z.enum(severityLevels);
+
+const requiredText = (label: string) => z.string().trim().min(1, `${label} is required.`);
+
+const findingSchema = z.object({
+  title: requiredText('Title'),
+  severity: severitySchema,
+  cwe: requiredText('CWE designation'),
+  description: requiredText('Description'),
+  reproduction: requiredText('Reproduction steps'),
+  impact: requiredText('Impact assessment'),
+  fix: requiredText('Recommended fix'),
+  references: requiredText('References'),
+  evidence: requiredText('Evidence placeholder'),
+});
+
+type FindingFormData = z.infer<typeof findingSchema>;
+
+export type Finding = FindingFormData & { id: string };
+
+const storedFindingSchema = findingSchema.extend({
+  id: z.string(),
+});
+
+const STORAGE_KEY = 'pentest-report-findings';
+
+const createId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `finding-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const loadFindings = (): Finding[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    const valid: Finding[] = [];
+    parsed.forEach((item) => {
+      const result = storedFindingSchema.safeParse(item);
+      if (result.success) {
+        valid.push(result.data);
+      }
+    });
+    return valid;
+  } catch {
+    return [];
+  }
+};
+
+const persistFindings = (data: Finding[]) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch {
+    // Ignore persistence failures (e.g. storage quota exceeded).
+  }
+};
+
+const severityBadgeStyles: Record<Severity, string> = {
+  Informational: 'border-sky-500/60 bg-sky-500/10 text-sky-200',
+  Low: 'border-emerald-500/60 bg-emerald-500/10 text-emerald-200',
+  Medium: 'border-amber-500/60 bg-amber-500/10 text-amber-200',
+  High: 'border-orange-500/60 bg-orange-500/10 text-orange-200',
+  Critical: 'border-red-500/60 bg-red-500/10 text-red-200',
+};
+
+const createEmptyFinding = (): FindingFormData => ({
+  title: '',
+  severity: 'Medium',
+  cwe: '',
+  description: '',
+  reproduction: '',
+  impact: '',
+  fix: '',
+  references: '',
+  evidence: '',
+});
+
+type FieldErrors = Partial<Record<keyof FindingFormData, string>>;
+
+const FindingForm: React.FC = () => {
+  const [findings, setFindings] = React.useState<Finding[]>(loadFindings);
+  const [formData, setFormData] = React.useState<FindingFormData>(createEmptyFinding);
+  const [activeId, setActiveId] = React.useState<string | null>(null);
+  const [errors, setErrors] = React.useState<FieldErrors>({});
+  const [status, setStatus] = React.useState<string | null>(null);
+
+  const validateField = React.useCallback(
+    (field: keyof FindingFormData, value: string) => {
+      const schema = findingSchema.shape[field];
+      const result = schema.safeParse(value);
+      setErrors((prev) => {
+        const next = { ...prev };
+        if (result.success) {
+          delete next[field];
+        } else {
+          next[field] = result.error.issues[0]?.message ?? 'Invalid value.';
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const clearForm = React.useCallback(() => {
+    setFormData(createEmptyFinding());
+    setActiveId(null);
+    setErrors({});
+  }, []);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY && event.storageArea === window.localStorage) {
+        setFindings(loadFindings());
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
+
+  React.useEffect(() => {
+    if (!status) return;
+    if (typeof window === 'undefined') return;
+    const timer = window.setTimeout(() => setStatus(null), 3000);
+    return () => window.clearTimeout(timer);
+  }, [status]);
+
+  const handleChange = (
+    field: keyof FindingFormData,
+  ) =>
+    (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+      const { value } = event.target;
+      setFormData((prev) => ({
+        ...prev,
+        [field]: value,
+      }));
+      validateField(field, value);
+      setStatus(null);
+    };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus(null);
+
+    const parsed = findingSchema.safeParse(formData);
+    if (!parsed.success) {
+      const fieldErrors = parsed.error.flatten().fieldErrors;
+      const next: FieldErrors = {};
+      (Object.keys(fieldErrors) as (keyof typeof fieldErrors)[]).forEach((key) => {
+        const message = fieldErrors[key]?.[0];
+        if (message) {
+          next[key as keyof FindingFormData] = message;
+        }
+      });
+      setErrors(next);
+      return;
+    }
+
+    const clean = parsed.data;
+    setErrors({});
+
+    setFindings((prev) => {
+      let next: Finding[];
+      if (activeId) {
+        next = prev.map((item) => (item.id === activeId ? { ...clean, id: activeId } : item));
+      } else {
+        next = [...prev, { ...clean, id: createId() }];
+      }
+      persistFindings(next);
+      return next;
+    });
+
+    if (activeId) {
+      setStatus('Finding updated locally.');
+      setFormData(clean);
+    } else {
+      setStatus('Finding saved locally.');
+      clearForm();
+    }
+  };
+
+  const handleEdit = (id: string) => {
+    const selected = findings.find((item) => item.id === id);
+    if (!selected) return;
+    const { id: _ignored, ...rest } = selected;
+    setFormData(rest);
+    setActiveId(id);
+    setErrors({});
+    setStatus('Editing existing finding.');
+  };
+
+  const handleDelete = (id: string) => {
+    setFindings((prev) => {
+      const next = prev.filter((item) => item.id !== id);
+      persistFindings(next);
+      return next;
+    });
+    if (activeId === id) {
+      clearForm();
+    }
+    setStatus('Finding deleted.');
+  };
+
+  type TextFieldConfig = {
+    placeholder?: string;
+    rows?: number;
+    type?: React.HTMLInputTypeAttribute;
+  };
+
+  const renderTextField = (field: keyof FindingFormData, label: string, config: TextFieldConfig = {}) => {
+    const isTextarea =
+      config.rows !== undefined ||
+      field === 'description' ||
+      field === 'reproduction' ||
+      field === 'impact' ||
+      field === 'fix' ||
+      field === 'references' ||
+      field === 'evidence';
+
+    const commonProps = {
+      id: field,
+      name: field,
+      value: formData[field],
+      onChange: handleChange(field),
+      className:
+        'mt-1 w-full rounded-md border border-zinc-700 bg-zinc-950/60 px-3 py-2 text-sm text-zinc-100 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60',
+      placeholder: config.placeholder,
+    };
+
+    return (
+      <div key={field} className="space-y-1">
+        <label htmlFor={field} className="text-sm font-medium text-zinc-200">
+          {label}
+        </label>
+        {isTextarea ? (
+          <textarea
+            {...(commonProps as React.TextareaHTMLAttributes<HTMLTextAreaElement>)}
+            rows={config.rows ?? 4}
+          />
+        ) : (
+          <input
+            {...(commonProps as React.InputHTMLAttributes<HTMLInputElement>)}
+            type={config.type ?? 'text'}
+          />
+        )}
+        {errors[field] ? <p className="text-xs text-red-400">{errors[field]}</p> : null}
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-6 lg:flex-row">
+      <div className="flex-1 overflow-y-auto rounded-lg border border-zinc-800 bg-zinc-900/70 p-6 shadow-lg">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-zinc-100">
+              {activeId ? 'Update finding' : 'Capture a finding'}
+            </h2>
+            <button
+              type="button"
+              onClick={() => {
+                clearForm();
+                setStatus('Ready for a new finding.');
+              }}
+              className="rounded-md border border-zinc-700 px-3 py-1 text-xs font-medium text-zinc-200 transition hover:border-sky-500 hover:text-sky-200"
+            >
+              New
+            </button>
+          </div>
+
+          {renderTextField('title', 'Finding title', {
+            placeholder: 'e.g. Reflected XSS on search endpoint',
+          })}
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1">
+              <label htmlFor="severity" className="text-sm font-medium text-zinc-200">
+                Severity
+              </label>
+              <select
+                id="severity"
+                name="severity"
+                value={formData.severity}
+                onChange={handleChange('severity')}
+                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-950/60 px-3 py-2 text-sm text-zinc-100 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+              >
+                {severityLevels.map((level) => (
+                  <option key={level} value={level}>
+                    {level}
+                  </option>
+                ))}
+              </select>
+              {errors.severity ? <p className="text-xs text-red-400">{errors.severity}</p> : null}
+            </div>
+            {renderTextField('cwe', 'CWE mapping', {
+              placeholder: 'e.g. CWE-79',
+            })}
+          </div>
+
+          {renderTextField('description', 'Description', {
+            placeholder: 'Summarize the vulnerability and what was observed.',
+            rows: 4,
+          })}
+
+          {renderTextField('reproduction', 'Reproduction steps', {
+            placeholder: 'Detail every action required to reproduce the issue.',
+            rows: 4,
+          })}
+
+          {renderTextField('impact', 'Impact analysis', {
+            placeholder: 'Explain the security impact and affected assets.',
+            rows: 3,
+          })}
+
+          {renderTextField('fix', 'Recommended fix', {
+            placeholder: 'Document remediation guidance or compensating controls.',
+            rows: 3,
+          })}
+
+          {renderTextField('references', 'References', {
+            placeholder: 'List supporting references (OWASP, vendor docs, etc.).',
+            rows: 3,
+          })}
+
+          {renderTextField('evidence', 'Evidence placeholder', {
+            placeholder: 'Link to screenshots, log snippets, or note evidence to collect.',
+            rows: 3,
+          })}
+
+          <div className="flex flex-wrap gap-2 pt-2">
+            <button
+              type="submit"
+              className="rounded-md bg-sky-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-400/70 focus:ring-offset-2 focus:ring-offset-zinc-900"
+            >
+              {activeId ? 'Save changes' : 'Save finding'}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                clearForm();
+                setStatus('Form cleared.');
+              }}
+              className="rounded-md border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-200 transition hover:border-sky-500 hover:text-sky-200"
+            >
+              Clear
+            </button>
+          </div>
+
+          {status ? <p className="text-xs text-emerald-400">{status}</p> : null}
+        </form>
+      </div>
+
+      <aside className="lg:w-80 lg:flex-none">
+        <div className="h-full overflow-y-auto rounded-lg border border-zinc-800 bg-zinc-900/70 p-6 shadow-lg">
+          <div className="flex items-center justify-between">
+            <h3 className="text-base font-semibold text-zinc-100">Stored findings</h3>
+            <span className="text-xs text-zinc-400">{findings.length} saved</span>
+          </div>
+          <div className="mt-4 space-y-4">
+            {findings.length === 0 ? (
+              <p className="text-sm text-zinc-400">
+                Start documenting findings. Everything stays in your browser until you export it.
+              </p>
+            ) : (
+              findings.map((finding) => {
+                const isActive = activeId === finding.id;
+                return (
+                  <article
+                    key={finding.id}
+                    className={`space-y-2 rounded-lg border p-4 transition ${
+                      isActive
+                        ? 'border-sky-500 bg-sky-500/10 shadow-md'
+                        : 'border-zinc-800 bg-zinc-950/40 hover:border-sky-500/60'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div>
+                        <h4 className="text-sm font-semibold text-zinc-100">{finding.title}</h4>
+                        <p className="text-xs text-zinc-400">{finding.cwe}</p>
+                      </div>
+                      <span
+                        className={`rounded-full border px-2 py-0.5 text-xs font-medium ${severityBadgeStyles[finding.severity]}`}
+                      >
+                        {finding.severity}
+                      </span>
+                    </div>
+                    <p className="text-xs leading-relaxed text-zinc-300">
+                      {finding.description.length > 160
+                        ? `${finding.description.slice(0, 157)}...`
+                        : finding.description}
+                    </p>
+                    <div className="flex flex-wrap gap-2 pt-1">
+                      <button
+                        type="button"
+                        onClick={() => handleEdit(finding.id)}
+                        className="rounded-md border border-zinc-700 px-3 py-1 text-xs font-medium text-zinc-200 transition hover:border-sky-500 hover:text-sky-200"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(finding.id)}
+                        className="rounded-md border border-red-500/70 px-3 py-1 text-xs font-medium text-red-200 transition hover:bg-red-500/20"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </article>
+                );
+              })
+            )}
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+};
+
+export default FindingForm;


### PR DESCRIPTION
## Summary
- add a pentest report `FindingForm` component with zod-backed validation for every required field
- store findings locally with CRUD controls, inline error messaging, and severity-aware badges
- build a responsive form layout that surfaces placeholders for description, reproduction, impact, fix, references, and evidence

## Testing
- yarn lint *(fails: repository already has numerous jsx-a11y violations in unrelated areas)*
- yarn test *(fails: existing suites such as window and NmapNSE already failing; command interrupted after repeated failures)*

------
https://chatgpt.com/codex/tasks/task_e_68cc472d184483289481b2d4a907f07c