### PR TITLE
[hydra] summarize results and stop runs

### DIFF
--- a/__tests__/hydra.test.tsx
+++ b/__tests__/hydra.test.tsx
@@ -1,5 +1,20 @@
 import React from 'react';
-import { render, fireEvent, screen, act } from '@testing-library/react';
+import {
+  render,
+  fireEvent,
+  screen,
+  act,
+  within,
+  waitFor,
+} from '@testing-library/react';
+
+jest.mock('../components/apps/hydra/Stepper', () => {
+  const React = require('react');
+  return function MockStepper() {
+    return <div data-testid="mock-stepper" />;
+  };
+});
+
 import HydraApp from '../components/apps/hydra';
 
 describe('Hydra wordlists', () => {
@@ -95,6 +110,65 @@ describe('Hydra pause and resume', () => {
   });
 });
 
+describe('Hydra stop action', () => {
+  beforeEach(() => {
+    localStorage.setItem(
+      'hydraUserLists',
+      JSON.stringify([{ name: 'u', content: 'alpha' }])
+    );
+    localStorage.setItem(
+      'hydraPassLists',
+      JSON.stringify([{ name: 'p', content: 'one' }])
+    );
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    // @ts-ignore
+    global.fetch = undefined;
+  });
+
+  it('cancels the run and logs a stop event', async () => {
+    let resolveRun: Function = () => {};
+    // @ts-ignore
+    global.fetch = jest.fn((url, options) => {
+      if (options && options.body && options.body.includes('action')) {
+        return Promise.resolve({ json: async () => ({}) });
+      }
+      return new Promise((resolve) => {
+        resolveRun = () => resolve({ json: async () => ({ output: '' }) });
+      });
+    });
+
+    render(<HydraApp />);
+
+    fireEvent.change(screen.getByPlaceholderText('192.168.0.1'), {
+      target: { value: '1.1.1.1' },
+    });
+    fireEvent.click(screen.getByText('Run Hydra'));
+
+    const stopBtn = await screen.findByTestId('stop-button');
+    fireEvent.click(stopBtn);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/hydra',
+      expect.objectContaining({
+        body: JSON.stringify({ action: 'cancel' }),
+      })
+    );
+
+    await screen.findByText(/Results Summary/i);
+    const logTable = screen.getByRole('table', { name: /attempt log/i });
+    expect(
+      within(logTable).getByText(/Stopped — Run stopped by user/)
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      resolveRun();
+    });
+  });
+});
+
 describe('Hydra session restore', () => {
   beforeEach(() => {
     localStorage.setItem(
@@ -141,5 +215,202 @@ describe('Hydra session restore', () => {
     await act(async () => {
       runResolve();
     });
+  });
+});
+
+describe('Hydra results summary', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem(
+      'hydraUserLists',
+      JSON.stringify([{ name: 'u', content: 'alpha' }])
+    );
+    localStorage.setItem(
+      'hydraPassLists',
+      JSON.stringify([{ name: 'p', content: 'one\ntwo\nthree' }])
+    );
+    localStorage.setItem(
+      'hydra/session',
+      JSON.stringify({
+        target: '1.1.1.1',
+        service: 'ssh',
+        selectedUser: 'u',
+        selectedPass: 'p',
+        attempt: 3,
+        timeline: [
+          {
+            attempt: 1,
+            time: 0.5,
+            user: 'alpha',
+            password: 'one',
+            status: 'failure',
+            host: '1.1.1.1',
+            timestamp: '2024-01-01T00:00:00.000Z',
+          },
+          {
+            attempt: 2,
+            time: 1.2,
+            user: 'alpha',
+            password: 'two',
+            status: 'throttled',
+            host: '1.1.1.1',
+            timestamp: '2024-01-01T00:00:01.000Z',
+          },
+          {
+            attempt: 3,
+            time: 2.1,
+            user: 'alpha',
+            password: 'three',
+            status: 'lockout',
+            host: '1.1.1.1',
+            timestamp: '2024-01-01T00:00:02.000Z',
+          },
+        ],
+      })
+    );
+    // @ts-ignore
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ json: async () => ({ output: '' }) })
+    );
+    // @ts-ignore
+    window.matchMedia = window.matchMedia || function () {
+      return {
+        matches: false,
+        addListener: () => {},
+        removeListener: () => {},
+      };
+    };
+    // @ts-ignore
+    window.requestAnimationFrame = (cb: FrameRequestCallback) => cb(0);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    // @ts-ignore
+    global.fetch = undefined;
+  });
+
+  it('summarizes outcomes and filters the attempt log', async () => {
+    render(<HydraApp />);
+
+    await screen.findByText(/Results Summary/i);
+
+    const summaryTable = screen.getByRole('table', { name: /attempt summary/i });
+    const rows = within(summaryTable).getAllByRole('row');
+    const failureRow = rows.find((row) =>
+      within(row).queryByText('Failure')
+    );
+    const throttledRow = rows.find((row) =>
+      within(row).queryByText('Throttled')
+    );
+    const lockoutRow = rows.find((row) =>
+      within(row).queryByText('Lockout')
+    );
+
+    expect(failureRow).toBeTruthy();
+    expect(throttledRow).toBeTruthy();
+    expect(lockoutRow).toBeTruthy();
+    expect(within(failureRow as HTMLElement).getByText('1')).toBeInTheDocument();
+    expect(within(throttledRow as HTMLElement).getByText('1')).toBeInTheDocument();
+    expect(within(lockoutRow as HTMLElement).getByText('1')).toBeInTheDocument();
+
+    const logTable = screen.getByRole('table', { name: /attempt log/i });
+    await screen.findByText('one');
+    expect(within(logTable).getByText('two')).toBeInTheDocument();
+    expect(within(logTable).getByText('three')).toBeInTheDocument();
+
+    const failureCheckbox = screen.getByLabelText('Failure');
+    fireEvent.click(failureCheckbox);
+
+    await waitFor(() => {
+      expect(within(logTable).queryByText('one')).not.toBeInTheDocument();
+    });
+    expect(within(logTable).getByText('two')).toBeInTheDocument();
+    expect(within(logTable).getByText('three')).toBeInTheDocument();
+  });
+
+  it('exports the attempt log as CSV', async () => {
+    const originalCreate = URL.createObjectURL;
+    const originalRevoke = URL.revokeObjectURL;
+    const originalBlob = globalThis.Blob;
+    let exportedBlob: Blob | undefined;
+
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      writable: true,
+      value: jest.fn((blob: Blob) => {
+        exportedBlob = blob;
+        return 'blob:mock';
+      }),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      writable: true,
+      value: jest.fn(),
+    });
+
+    const clickSpy = jest
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+
+    class MockBlob {
+      private parts: any[];
+      constructor(parts: any[], public options?: BlobPropertyBag) {
+        this.parts = parts;
+      }
+
+      async text() {
+        return this.parts.map((part) => part ?? '').join('');
+      }
+    }
+
+    Object.defineProperty(globalThis, 'Blob', {
+      configurable: true,
+      writable: true,
+      value: MockBlob,
+    });
+
+    try {
+      render(<HydraApp />);
+
+      const exportButton = await screen.findByRole('button', {
+        name: /export csv/i,
+      });
+      fireEvent.click(exportButton);
+
+      expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+      expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      expect(exportedBlob).toBeInstanceOf(MockBlob);
+
+      const csvText = await exportedBlob!.text();
+      expect(csvText).toContain('Host,User,Password,Result,Timestamp');
+      expect(csvText).toContain(
+        '"1.1.1.1","alpha","one","Failure","2024-01-01T00:00:00.000Z"'
+      );
+      expect(csvText).toContain(
+        '"1.1.1.1","alpha","two","Throttled","2024-01-01T00:00:01.000Z"'
+      );
+      expect(csvText).toContain(
+        '"1.1.1.1","alpha","three","Lockout","2024-01-01T00:00:02.000Z"'
+      );
+    } finally {
+      clickSpy.mockRestore();
+      Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        writable: true,
+        value: originalCreate,
+      });
+      Object.defineProperty(URL, 'revokeObjectURL', {
+        configurable: true,
+        writable: true,
+        value: originalRevoke,
+      });
+      Object.defineProperty(globalThis, 'Blob', {
+        configurable: true,
+        writable: true,
+        value: originalBlob,
+      });
+    }
   });
 });

--- a/components/apps/hydra/Timeline.js
+++ b/components/apps/hydra/Timeline.js
@@ -1,5 +1,22 @@
 import React from 'react';
 
+const formatStatus = (status) => {
+  if (!status) return 'Unknown';
+  return status.charAt(0).toUpperCase() + status.slice(1);
+};
+
+const formatTime = (time) => {
+  if (typeof time === 'number' && Number.isFinite(time)) {
+    const formatted = time.toFixed(1);
+    return formatted.endsWith('.0')
+      ? formatted.slice(0, -2)
+      : formatted;
+  }
+  return time;
+};
+
+const valueOrDash = (value) => (value ? value : '—');
+
 const AttemptTimeline = ({ attempts = [] }) => {
   if (attempts.length === 0) {
     return null;
@@ -9,11 +26,24 @@ const AttemptTimeline = ({ attempts = [] }) => {
     <div className="mt-4">
       <h3 className="mb-2 text-lg">Attempt Timeline</h3>
       <ol className="space-y-1 text-sm">
-        {attempts.map((a, i) => (
-          <li key={i} className="font-mono">
-            {a.time}s - {a.user}/{a.password} ({a.result})
-          </li>
-        ))}
+        {attempts.map((a, i) => {
+          const status = formatStatus(a.status || a.result);
+          const attemptId =
+            typeof a.attempt === 'number' && a.attempt > 0
+              ? `#${a.attempt} `
+              : '';
+          return (
+            <li
+              key={a.timestamp || i}
+              className="font-mono text-gray-100"
+            >
+              {attemptId}
+              {formatTime(a.time)}s - {valueOrDash(a.user)}/
+              {valueOrDash(a.password)} ({status}
+              {a.note ? ` – ${a.note}` : ''})
+            </li>
+          );
+        })}
       </ol>
     </div>
   );


### PR DESCRIPTION
## Summary
- normalize Hydra attempt entries with explicit status metadata and persist stop events in the timeline
- surface a results summary with filtering, CSV export, and improved timeline formatting
- expand Hydra tests with a stable Stepper mock plus coverage for stop logging, filters, and CSV output

## Testing
- yarn test hydra.test.tsx
- npx eslint components/apps/hydra/index.js components/apps/hydra/Timeline.js __tests__/hydra.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc4734b3308328b330defbeed53608