### PR TITLE
[hydra] sync rate control simulation with API stub

### DIFF
--- a/__tests__/hydraStepper.test.tsx
+++ b/__tests__/hydraStepper.test.tsx
@@ -21,7 +21,7 @@ describe('Hydra Stepper', () => {
     jest.useRealTimers();
   });
 
-  it('shows backoff indicator', () => {
+  it('shows backoff indicator and rate info', () => {
     render(
       <Stepper
         active
@@ -33,6 +33,9 @@ describe('Hydra Stepper', () => {
     );
     expect(screen.getByTestId('backoff-bar')).toBeInTheDocument();
     expect(screen.getByText(/Delay: 500ms/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Concurrency: 1 \| Throughput: 2\.0 attempts\/s/)
+    ).toBeInTheDocument();
   });
 
   it('locks out after reaching threshold', () => {
@@ -55,5 +58,21 @@ describe('Hydra Stepper', () => {
       jest.advanceTimersByTime(1000);
     });
     expect(screen.getAllByText(/Locked out/i).length).toBeGreaterThan(0);
+  });
+
+  it('reflects higher throughput for additional concurrency', () => {
+    render(
+      <Stepper
+        totalAttempts={20}
+        lockoutThreshold={10}
+        runId={2}
+        concurrency={4}
+        baseDelayMs={250}
+      />
+    );
+
+    expect(
+      screen.getByText(/Concurrency: 4 \| Throughput: 16\.0 attempts\/s/)
+    ).toBeInTheDocument();
   });
 });

--- a/components/apps/hydra/Stepper.js
+++ b/components/apps/hydra/Stepper.js
@@ -1,5 +1,33 @@
 import React, { useEffect, useRef, useState } from 'react';
 
+const MAX_DELAY_MS = 4000;
+
+const computeDelay = (count, baseDelay, threshold) => {
+  if (!baseDelay || baseDelay <= 0) {
+    return 0;
+  }
+  if (count < threshold) {
+    return baseDelay;
+  }
+  let delay = baseDelay;
+  const over = count - threshold + 1;
+  for (let i = 0; i < over; i += 1) {
+    delay = Math.min(delay * 2, MAX_DELAY_MS);
+  }
+  return delay;
+};
+
+const computeThroughput = (concurrency, delay, remaining) => {
+  if (!delay || delay <= 0) {
+    return 0;
+  }
+  const batchSize = Math.min(concurrency, remaining);
+  if (batchSize <= 0) {
+    return 0;
+  }
+  return (batchSize / delay) * 1000;
+};
+
 const Stepper = ({
   active,
   totalAttempts,
@@ -8,32 +36,61 @@ const Stepper = ({
   runId,
   initialAttempt = 0,
   onAttemptChange = () => {},
+  concurrency = 1,
+  baseDelayMs = 500,
 }) => {
+  const initialDelay = computeDelay(initialAttempt, baseDelayMs, backoffThreshold);
+  const limit = Math.min(lockoutThreshold, totalAttempts);
+
   const [attempt, setAttempt] = useState(initialAttempt);
   const [locked, setLocked] = useState(initialAttempt >= lockoutThreshold);
-  const [delayMs, setDelayMs] = useState(500);
+  const [delayMs, setDelayMs] = useState(initialDelay);
+  const [throughput, setThroughput] = useState(() =>
+    computeThroughput(concurrency, initialDelay, Math.max(0, limit - initialAttempt))
+  );
+
   const timerRef = useRef(null);
-  const delayRef = useRef(500);
+  const delayRef = useRef(initialDelay);
 
   useEffect(() => {
     setAttempt(initialAttempt);
     setLocked(initialAttempt >= lockoutThreshold);
-    onAttemptChange(initialAttempt);
-    // onAttemptChange is stable enough for this use
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [runId, initialAttempt, lockoutThreshold]);
-
-  useEffect(() => {
-    if (!active || locked) return;
-
-    let delay = 500;
-    if (initialAttempt >= backoffThreshold) {
-      for (let i = backoffThreshold; i < initialAttempt; i++) {
-        delay = Math.min(delay * 2, 4000);
-      }
-    }
+    const delay = computeDelay(initialAttempt, baseDelayMs, backoffThreshold);
     delayRef.current = delay;
     setDelayMs(delay);
+    const updatedLimit = Math.min(lockoutThreshold, totalAttempts);
+    setThroughput(
+      computeThroughput(concurrency, delay, Math.max(0, updatedLimit - initialAttempt))
+    );
+    // onAttemptChange is stable enough for this use
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    runId,
+    initialAttempt,
+    lockoutThreshold,
+    baseDelayMs,
+    backoffThreshold,
+    totalAttempts,
+    concurrency,
+  ]);
+
+  useEffect(() => {
+    const currentLimit = Math.min(lockoutThreshold, totalAttempts);
+    const delay = computeDelay(attempt, baseDelayMs, backoffThreshold);
+    delayRef.current = delay;
+    setDelayMs(delay);
+    setThroughput(
+      computeThroughput(concurrency, delay, Math.max(0, currentLimit - attempt))
+    );
+  }, [attempt, baseDelayMs, backoffThreshold, lockoutThreshold, totalAttempts, concurrency]);
+
+  useEffect(() => {
+    if (!active || locked) return undefined;
+
+    const currentLimit = Math.min(lockoutThreshold, totalAttempts);
+    if (attempt >= currentLimit) {
+      return undefined;
+    }
 
     const prefersReducedMotion =
       typeof window !== 'undefined' &&
@@ -41,41 +98,95 @@ const Stepper = ({
       window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
     if (prefersReducedMotion) {
-      const final = Math.min(lockoutThreshold, totalAttempts);
+      const final = currentLimit;
+      const batchSize = final - attempt;
+      for (let i = attempt + 1; i <= final; i += 1) {
+        onAttemptChange({
+          attempt: i,
+          throughput: 0,
+          delayMs: 0,
+          batchSize,
+        });
+      }
       setAttempt(final);
       setDelayMs(0);
       delayRef.current = 0;
+      setThroughput(0);
       if (final >= lockoutThreshold) {
         setLocked(true);
       }
-      return;
+      return undefined;
     }
 
     const tick = () => {
       requestAnimationFrame(() => {
         setAttempt((prev) => {
-          const next = prev + 1;
-          const final = Math.min(next, lockoutThreshold, totalAttempts);
-          onAttemptChange(final);
-          if (final >= lockoutThreshold || final >= totalAttempts) {
-            if (final >= lockoutThreshold) {
+          const limitWithinTick = Math.min(lockoutThreshold, totalAttempts);
+          if (prev >= limitWithinTick) {
+            return prev;
+          }
+
+          const currentDelay =
+            typeof delayRef.current === 'number'
+              ? delayRef.current
+              : computeDelay(prev, baseDelayMs, backoffThreshold);
+
+          const available = limitWithinTick - prev;
+          const batchSize = Math.min(concurrency, available);
+          const rate = computeThroughput(concurrency, currentDelay, available);
+          if (batchSize > 0) {
+            setThroughput(rate);
+          }
+
+          let next = prev;
+          let lockedOut = false;
+
+          for (let i = 0; i < batchSize; i += 1) {
+            next += 1;
+            onAttemptChange({
+              attempt: next,
+              throughput: rate,
+              delayMs: currentDelay,
+              batchSize,
+            });
+            if (next >= lockoutThreshold || next >= totalAttempts) {
+              lockedOut = next >= lockoutThreshold;
+              break;
+            }
+          }
+
+          if (lockedOut || next >= limitWithinTick) {
+            if (lockedOut) {
               setLocked(true);
             }
-            setDelayMs(0);
             delayRef.current = 0;
-            return final;
+            setDelayMs(0);
+            setThroughput(0);
+            return next;
           }
-          if (next >= backoffThreshold) {
-            delayRef.current = Math.min(delayRef.current * 2, 4000);
-          }
-          setDelayMs(delayRef.current);
-          timerRef.current = setTimeout(tick, delayRef.current);
+
+          const nextDelay = computeDelay(next, baseDelayMs, backoffThreshold);
+          delayRef.current = nextDelay;
+          setDelayMs(nextDelay);
+          setThroughput(
+            computeThroughput(
+              concurrency,
+              nextDelay,
+              Math.max(0, limitWithinTick - next)
+            )
+          );
+          timerRef.current = setTimeout(tick, nextDelay);
           return next;
         });
       });
     };
 
-    timerRef.current = setTimeout(tick, delayRef.current);
+    const initialTimeoutDelay =
+      typeof delayRef.current === 'number'
+        ? delayRef.current
+        : computeDelay(attempt, baseDelayMs, backoffThreshold);
+
+    timerRef.current = setTimeout(tick, initialTimeoutDelay);
 
     return () => {
       if (timerRef.current) {
@@ -85,13 +196,14 @@ const Stepper = ({
     };
   }, [
     active,
+    locked,
     backoffThreshold,
     lockoutThreshold,
     totalAttempts,
     runId,
-    locked,
+    concurrency,
+    baseDelayMs,
     onAttemptChange,
-    initialAttempt,
   ]);
 
   return (
@@ -113,11 +225,14 @@ const Stepper = ({
           <div className="text-white mt-1">
             Attempt {attempt} of {lockoutThreshold}
           </div>
+          <div className="text-xs text-blue-300 mt-1">
+            Concurrency: {concurrency} | Throughput: {throughput.toFixed(1)} attempts/s
+          </div>
           <div className="mt-2 w-full bg-gray-700 h-2 rounded">
             <div
               data-testid="backoff-bar"
               className="bg-yellow-500 h-2 rounded"
-              style={{ width: `${(delayMs / 4000) * 100}%` }}
+              style={{ width: `${(delayMs / MAX_DELAY_MS) * 100}%` }}
             />
           </div>
           <div className="text-xs text-yellow-300 mt-1">

--- a/components/apps/hydra/Timeline.js
+++ b/components/apps/hydra/Timeline.js
@@ -9,11 +9,19 @@ const AttemptTimeline = ({ attempts = [] }) => {
     <div className="mt-4">
       <h3 className="mb-2 text-lg">Attempt Timeline</h3>
       <ol className="space-y-1 text-sm">
-        {attempts.map((a, i) => (
-          <li key={i} className="font-mono">
-            {a.time}s - {a.user}/{a.password} ({a.result})
-          </li>
-        ))}
+        {attempts.map((a, i) => {
+          const rate =
+            typeof a.throughput === 'number' && Number.isFinite(a.throughput)
+              ? a.throughput
+              : null;
+          const attemptNumber = a.attempt ?? i + 1;
+          const rateText = rate !== null ? `, ${rate.toFixed(1)} attempts/s` : '';
+          return (
+            <li key={i} className="font-mono">
+              {`${a.time}s - Attempt ${attemptNumber}: ${a.user}/${a.password} (${a.result}${rateText})`}
+            </li>
+          );
+        })}
       </ol>
     </div>
   );


### PR DESCRIPTION
## Summary
- add concurrency and base delay controls to the Hydra app UI, persisting choices and threading them through saved configs
- update the stepper/timeline simulation to batch attempts, show throughput, and honor throttling/lockout thresholds
- forward the selected rate limits to the Hydra API (run/resume) so the stub stays in sync with the UI scheduler

## Testing
- yarn test hydraStepper
- yarn test hydra.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc47363af0832881056179dfd03f5b