### PR TITLE
[dsniff] Add interactive capture walkthrough

### DIFF
--- a/__tests__/dsniff.test.tsx
+++ b/__tests__/dsniff.test.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { render, fireEvent, screen, within } from '@testing-library/react';
+import {
+  render,
+  fireEvent,
+  screen,
+  within,
+  waitFor,
+} from '@testing-library/react';
 import Dsniff from '../components/apps/dsniff';
 
 describe('Dsniff component', () => {
@@ -37,6 +43,100 @@ describe('Dsniff component', () => {
     const showBtn = screen.getByText('Show');
     fireEvent.click(showBtn);
     expect(await screen.findByText('demo123')).toBeInTheDocument();
+  });
+
+  it('steps through capture frames and updates explanation', async () => {
+    render(<Dsniff />);
+    await screen.findByText('PCAP credential leakage demo');
+    const explanation = screen.getByTestId('frame-explanation');
+    expect(explanation).toHaveTextContent(
+      /attacker poisons the victim's arp cache/i,
+    );
+
+    const nextButton = screen.getByRole('button', { name: /next frame/i });
+    fireEvent.click(nextButton);
+    await waitFor(() =>
+      expect(explanation).toHaveTextContent(/the gateway is poisoned/i),
+    );
+    fireEvent.click(nextButton);
+    await waitFor(() =>
+      expect(explanation).toHaveTextContent(/victim browses to the login page/i),
+    );
+  });
+
+  it('highlights topology and ARP entries for the active frame', async () => {
+    render(<Dsniff />);
+    const topologyPanel = await screen.findByTestId('topology-panel');
+    const attackerNode = within(topologyPanel).getByText(/attacker \(dsniff\)/i);
+    const attackerItem = attackerNode.closest('li') as HTMLElement;
+    expect(attackerItem).toHaveAttribute('aria-current', 'true');
+    const serverNode = within(topologyPanel).getByText(/web server/i);
+    const serverItem = serverNode.closest('li') as HTMLElement;
+    expect(serverItem).not.toHaveAttribute('aria-current', 'true');
+
+    const arpTable = screen.getByTestId('arp-table');
+    const gatewayRow = within(arpTable)
+      .getByText('192.168.0.1')
+      .closest('tr') as HTMLElement;
+    const victimRow = within(arpTable)
+      .getByText('192.168.0.5')
+      .closest('tr') as HTMLElement;
+    expect(gatewayRow.className).toMatch(/bg-ubt-blue\/40/);
+    expect(victimRow.className).toMatch(/bg-ubt-blue\/40/);
+
+    const nextButton = screen.getByRole('button', { name: /next frame/i });
+    fireEvent.click(nextButton);
+    fireEvent.click(nextButton);
+
+    await waitFor(() =>
+      expect(serverItem).toHaveAttribute('aria-current', 'true'),
+    );
+    await waitFor(() =>
+      expect(gatewayRow.className).not.toMatch(/bg-ubt-blue\/40/),
+    );
+    await waitFor(() =>
+      expect(victimRow.className).toMatch(/bg-ubt-blue\/40/),
+    );
+  });
+
+  it('exports the current capture slice', async () => {
+    render(<Dsniff />);
+    await screen.findByText('PCAP credential leakage demo');
+
+    const createObjectURL = jest.fn(() => 'blob:dsniff');
+    const revokeObjectURL = jest.fn();
+    const originalCreate = window.URL.createObjectURL;
+    const originalRevoke = window.URL.revokeObjectURL;
+
+    Object.defineProperty(window.URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(window.URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+
+    const appendSpy = jest.spyOn(document.body, 'appendChild');
+    const removeSpy = jest.spyOn(document.body, 'removeChild');
+
+    fireEvent.click(screen.getByRole('button', { name: /export slice/i }));
+
+    expect(createObjectURL).toHaveBeenCalled();
+    expect(revokeObjectURL).toHaveBeenCalled();
+    expect(appendSpy).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalled();
+
+    appendSpy.mockRestore();
+    removeSpy.mockRestore();
+    Object.defineProperty(window.URL, 'createObjectURL', {
+      configurable: true,
+      value: originalCreate,
+    });
+    Object.defineProperty(window.URL, 'revokeObjectURL', {
+      configurable: true,
+      value: originalRevoke,
+    });
   });
 });
 

--- a/public/demo-data/dsniff/pcap.json
+++ b/public/demo-data/dsniff/pcap.json
@@ -1,10 +1,144 @@
 {
   "summary": [
     {
+      "src": "192.168.0.50",
+      "dst": "192.168.0.5",
+      "protocol": "ARP",
+      "info": "Reply 192.168.0.1 is-at 00:50:56:aa:bb:cc"
+    },
+    {
+      "src": "192.168.0.50",
+      "dst": "192.168.0.1",
+      "protocol": "ARP",
+      "info": "Reply 192.168.0.5 is-at 00:50:56:aa:bb:cc"
+    },
+    {
+      "src": "192.168.0.5",
+      "dst": "192.168.0.10",
+      "protocol": "HTTP",
+      "info": "GET /login"
+    },
+    {
+      "src": "192.168.0.10",
+      "dst": "192.168.0.5",
+      "protocol": "HTTP",
+      "info": "HTTP/1.1 200 OK (Login)"
+    },
+    {
       "src": "192.168.0.5",
       "dst": "192.168.0.10",
       "protocol": "HTTP",
       "info": "POST /login username=demo password=demo123"
+    }
+  ],
+  "frames": [
+    {
+      "frame": 12,
+      "timestamp": "00:00:00.900",
+      "src": "192.168.0.50",
+      "dst": "192.168.0.5",
+      "protocol": "ARP",
+      "info": "Reply 192.168.0.1 is-at 00:50:56:aa:bb:cc",
+      "timeline": "Attacker poisons the victim's ARP cache by impersonating the gateway.",
+      "explanation": "The attacker-hosted dsniff box forges an ARP reply claiming the router's IP (192.168.0.1) now maps to its own MAC. The victim will start sending traffic for the gateway to the attacker.",
+      "topologyFocus": ["attacker", "victim", "gateway"],
+      "arpFocus": ["192.168.0.1", "192.168.0.5"]
+    },
+    {
+      "frame": 18,
+      "timestamp": "00:00:01.200",
+      "src": "192.168.0.50",
+      "dst": "192.168.0.1",
+      "protocol": "ARP",
+      "info": "Reply 192.168.0.5 is-at 00:50:56:aa:bb:cc",
+      "timeline": "The gateway is poisoned so that traffic headed back to the victim also detours through the attacker.",
+      "explanation": "A second forged ARP reply convinces the router that the victim's IP should resolve to the attacker's MAC. With both directions poisoned, the attacker is in the middle of the victim's conversations.",
+      "topologyFocus": ["attacker", "victim", "gateway"],
+      "arpFocus": ["192.168.0.1", "192.168.0.5"]
+    },
+    {
+      "frame": 36,
+      "timestamp": "00:00:02.200",
+      "src": "192.168.0.5",
+      "dst": "192.168.0.10",
+      "protocol": "HTTP",
+      "info": "GET /login",
+      "timeline": "Victim browses to the login page; packets traverse the attacker-controlled path.",
+      "explanation": "With ARP tables poisoned, the victim's HTTP request is relayed through the attacker. The HTTP GET for /login is visible in clear text.",
+      "topologyFocus": ["victim", "attacker", "server"],
+      "arpFocus": ["192.168.0.5"]
+    },
+    {
+      "frame": 48,
+      "timestamp": "00:00:02.450",
+      "src": "192.168.0.10",
+      "dst": "192.168.0.5",
+      "protocol": "HTTP",
+      "info": "HTTP/1.1 200 OK (Login)",
+      "timeline": "Server response also flows through the attacker before reaching the victim.",
+      "explanation": "The HTTP 200 OK carrying the login page assets passes through the dsniff host. The attacker can monitor or alter responses at this stage.",
+      "topologyFocus": ["server", "attacker", "victim"],
+      "arpFocus": ["192.168.0.5"]
+    },
+    {
+      "frame": 60,
+      "timestamp": "00:00:03.000",
+      "src": "192.168.0.5",
+      "dst": "192.168.0.10",
+      "protocol": "HTTP",
+      "info": "POST /login username=demo password=demo123",
+      "timeline": "Credentials are submitted in plain text and captured by dsniff.",
+      "explanation": "The victim posts credentials to the server over HTTP. Because the session is unencrypted, the attacker sees the username and password within the captured packet payload.",
+      "topologyFocus": ["victim", "attacker", "server"],
+      "arpFocus": ["192.168.0.5"]
+    }
+  ],
+  "topology": [
+    {
+      "id": "victim",
+      "label": "Victim workstation",
+      "role": "User endpoint",
+      "ip": "192.168.0.5"
+    },
+    {
+      "id": "attacker",
+      "label": "Attacker (dsniff)",
+      "role": "Man-in-the-middle",
+      "ip": "192.168.0.50"
+    },
+    {
+      "id": "gateway",
+      "label": "Gateway/Router",
+      "role": "Default route",
+      "ip": "192.168.0.1"
+    },
+    {
+      "id": "server",
+      "label": "Web server",
+      "role": "Target application",
+      "ip": "192.168.0.10"
+    }
+  ],
+  "arpTable": [
+    {
+      "ip": "192.168.0.1",
+      "mac": "00:50:56:aa:bb:cc",
+      "note": "Gateway IP now resolves to the attacker on the victim host"
+    },
+    {
+      "ip": "192.168.0.5",
+      "mac": "00:50:56:aa:bb:cc",
+      "note": "Gateway sees the victim IP mapped to the attacker"
+    },
+    {
+      "ip": "192.168.0.10",
+      "mac": "00:10:20:30:40:50",
+      "note": "Legitimate web server"
+    },
+    {
+      "ip": "192.168.0.50",
+      "mac": "00:50:56:aa:bb:cc",
+      "note": "Attacker machine"
     }
   ],
   "remediation": [


### PR DESCRIPTION
## Summary
- add a frame-by-frame capture viewer with keyboard controls, timeline syncing, and export helpers to the dsniff app
- expand the curated PCAP JSON with frame metadata, topology nodes, and ARP table annotations to drive the walkthrough
- cover the new behavior with tests for frame stepping, highlighting, and export flows

## Testing
- yarn test --runTestsByPath __tests__/dsniff.test.tsx
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label violations across unrelated apps)*

------
https://chatgpt.com/codex/tasks/task_e_68cc473e2e148328962c041e922314fc