### PR TITLE
[wireshark] add interaction metrics and regression test

### DIFF
--- a/__tests__/wireshark.regression.test.tsx
+++ b/__tests__/wireshark.regression.test.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import WiresharkApp from '../components/apps/wireshark';
+import {
+  calculateChecksum,
+  getInteractionMetrics,
+  resetInteractionMetrics,
+} from '../apps/wireshark/components/interactionMetrics';
+
+const fivePacketFixture = () => [
+  {
+    timestamp: '1',
+    src: '10.0.0.1',
+    dest: '10.0.0.2',
+    protocol: 6,
+    info: 'tcp handshake',
+  },
+  {
+    timestamp: '2',
+    src: '192.168.0.5',
+    dest: '192.168.0.53',
+    protocol: 17,
+    info: 'udp dns query',
+  },
+  {
+    timestamp: '3',
+    src: '172.16.0.1',
+    dest: '172.16.0.50',
+    protocol: 1,
+    info: 'icmp ping',
+  },
+  {
+    timestamp: '4',
+    src: '10.0.0.3',
+    dest: '10.0.0.4',
+    protocol: 6,
+    info: 'tcp payload',
+  },
+  {
+    timestamp: '5',
+    src: '192.168.0.60',
+    dest: '192.168.0.53',
+    protocol: 17,
+    info: 'udp response',
+  },
+];
+
+const findLast = <T,>(values: T[], predicate: (item: T) => boolean) => {
+  for (let i = values.length - 1; i >= 0; i -= 1) {
+    if (predicate(values[i])) {
+      return values[i];
+    }
+  }
+  return undefined;
+};
+
+describe('Wireshark color rule regression', () => {
+  beforeEach(() => {
+    resetInteractionMetrics();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('tracks latency, checksums, and memory for color rule lifecycle', async () => {
+    const packets = fivePacketFixture();
+    const clipboardWrite = jest.fn();
+    if (navigator.clipboard) {
+      jest
+        .spyOn(navigator.clipboard, 'writeText')
+        .mockImplementation(clipboardWrite);
+    } else {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText: clipboardWrite },
+      });
+    }
+
+    const user = userEvent.setup();
+    const { unmount } = render(<WiresharkApp initialPackets={packets} />);
+
+    await user.click(screen.getByRole('button', { name: /add rule/i }));
+    const expressionInput = screen.getByPlaceholderText(/filter expression/i);
+    await user.type(expressionInput, 'tcp');
+    await user.selectOptions(screen.getByLabelText(/^color$/i), 'Red');
+
+    await user.click(screen.getByRole('button', { name: /export json/i }));
+
+    const importPayload = [
+      { expression: 'udp', color: 'Green' },
+      { expression: 'icmp', color: 'Blue' },
+    ];
+    const importFile = new File(
+      [JSON.stringify(importPayload)],
+      'rules.json',
+      { type: 'application/json' }
+    );
+    const fileInput = screen.getByLabelText(/color rules json file/i);
+    fireEvent.change(fileInput, { target: { files: [importFile] } });
+
+    await waitFor(() =>
+      expect(screen.getByText('udp dns query').closest('tr')).toHaveClass(
+        'text-green-500'
+      )
+    );
+
+    await user.click(screen.getByRole('button', { name: /clear rules/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('udp dns query').closest('tr')).not.toHaveClass(
+        'text-green-500'
+      )
+    );
+
+    unmount();
+
+    const metrics = getInteractionMetrics();
+
+    expect(metrics.latencies.length).toBeGreaterThan(0);
+    metrics.latencies.forEach((sample) => {
+      expect(sample.latency).toBeLessThan(32);
+    });
+
+    const expectedExportChecksum = calculateChecksum([
+      { expression: 'tcp', color: 'Red' },
+    ]);
+    const expectedImportChecksum = calculateChecksum(importPayload);
+    const expectedClearedChecksum = calculateChecksum([]);
+
+    const exportSnapshot = findLast(
+      metrics.checksums,
+      (sample) => sample.context === 'export'
+    );
+    const importSnapshot = findLast(
+      metrics.checksums,
+      (sample) => sample.context === 'import'
+    );
+    const clearSnapshot = findLast(
+      metrics.checksums,
+      (sample) => sample.context === 'clear'
+    );
+
+    expect(exportSnapshot?.checksum).toBe(expectedExportChecksum);
+    expect(importSnapshot?.checksum).toBe(expectedImportChecksum);
+    expect(clearSnapshot?.checksum).toBe(expectedClearedChecksum);
+
+    const mountSample = metrics.memorySamples.find(
+      (sample) => sample.phase === 'mount'
+    );
+    const unmountSample = findLast(
+      metrics.memorySamples,
+      (sample) => sample.phase === 'unmount'
+    );
+
+    expect(mountSample).toBeTruthy();
+    expect(unmountSample).toBeTruthy();
+    if (mountSample && unmountSample) {
+      expect(unmountSample.size).toBeLessThanOrEqual(mountSample.size);
+    }
+
+  });
+});
+

--- a/apps/wireshark/components/interactionMetrics.ts
+++ b/apps/wireshark/components/interactionMetrics.ts
@@ -1,0 +1,137 @@
+interface RuleLike {
+  expression?: string;
+  color?: string;
+}
+
+interface LatencySample {
+  event: string;
+  latency: number;
+  timestamp: number;
+}
+
+interface MemorySample {
+  phase: string;
+  size: number;
+  timestamp: number;
+}
+
+interface ChecksumSample {
+  context: string;
+  checksum: string;
+  ruleCount: number;
+  timestamp: number;
+}
+
+interface MetricsStore {
+  latencies: LatencySample[];
+  memorySamples: MemorySample[];
+  checksums: ChecksumSample[];
+}
+
+const metrics: MetricsStore = {
+  latencies: [],
+  memorySamples: [],
+  checksums: [],
+};
+
+const getPerformance = () =>
+  typeof performance !== 'undefined'
+    ? performance
+    : ({
+        now: () => Date.now(),
+        timeOrigin: Date.now(),
+      } as Performance);
+
+const safeNow = () => getPerformance().now();
+
+const normalizeTimestamp = (start?: number): number => {
+  if (!Number.isFinite(start)) return safeNow();
+  const perf = getPerformance();
+  const candidate = start as number;
+  if (candidate > 1e12 && typeof perf.timeOrigin === 'number') {
+    const adjusted = candidate - perf.timeOrigin;
+    if (Number.isFinite(adjusted)) {
+      return adjusted;
+    }
+  }
+  return candidate;
+};
+
+const approximateRuleSize = (rules: RuleLike[]) =>
+  rules.reduce(
+    (total, rule) =>
+      total + (rule.expression?.length ?? 0) + (rule.color?.length ?? 0),
+    0
+  );
+
+const computeChecksum = (rules: RuleLike[]) => {
+  const normalized = rules.map((rule) => ({
+    expression: rule.expression ?? '',
+    color: rule.color ?? '',
+  }));
+  const json = JSON.stringify(normalized);
+  let hash = 0;
+  for (let i = 0; i < json.length; i += 1) {
+    hash = (hash * 31 + json.charCodeAt(i)) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+};
+
+export const recordLatency = (event: string, startedAt?: number): number => {
+  const end = safeNow();
+  const latency = Math.max(0, end - normalizeTimestamp(startedAt));
+  metrics.latencies.push({ event, latency, timestamp: end });
+  return latency;
+};
+
+export const recordMemorySample = (phase: string, rules: RuleLike[] = []) => {
+  const perf = getPerformance();
+  const perfMemory = (perf as Performance & { memory?: { usedJSHeapSize?: number } })
+    .memory;
+  const size = Number.isFinite(perfMemory?.usedJSHeapSize)
+    ? (perfMemory?.usedJSHeapSize as number)
+    : approximateRuleSize(rules);
+  const timestamp = perf.now();
+  metrics.memorySamples.push({ phase, size, timestamp });
+  return size;
+};
+
+export const recordChecksum = (
+  rules: RuleLike[],
+  context: string
+): string => {
+  const checksum = computeChecksum(rules);
+  metrics.checksums.push({
+    context,
+    checksum,
+    ruleCount: rules.length,
+    timestamp: safeNow(),
+  });
+  return checksum;
+};
+
+export const finalizeInteraction = (
+  event: string,
+  startedAt: number | undefined,
+  rules: RuleLike[]
+) => {
+  recordLatency(event, startedAt);
+  recordChecksum(rules, event);
+  recordMemorySample(event, rules);
+};
+
+export const getInteractionMetrics = (): MetricsStore => ({
+  latencies: [...metrics.latencies],
+  memorySamples: [...metrics.memorySamples],
+  checksums: [...metrics.checksums],
+});
+
+export const resetInteractionMetrics = () => {
+  metrics.latencies.length = 0;
+  metrics.memorySamples.length = 0;
+  metrics.checksums.length = 0;
+};
+
+export const calculateChecksum = (rules: RuleLike[]) => computeChecksum(rules);
+
+export type { RuleLike, LatencySample, MemorySample, ChecksumSample, MetricsStore };


### PR DESCRIPTION
## Summary
- instrument the Wireshark color rule editor to record latency, checksums, and memory snapshots while adding a clear action
- expose a shared interaction metrics helper for the Wireshark app so tests can assert timing and checksum integrity
- add a regression test that seeds packets, exercises export/import/clear, and verifies metrics remain consistent

## Testing
- yarn lint *(fails: pre-existing accessibility and no-top-level-window violations across unrelated apps)*
- yarn test wireshark.regression


------
https://chatgpt.com/codex/tasks/task_e_68cc4741366c8328b9d591d2a501b161