### PR TITLE
[wireshark] add JSON snapshot import/export

### DIFF
--- a/__tests__/PcapViewer.test.tsx
+++ b/__tests__/PcapViewer.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PcapViewer from '../apps/wireshark/components/PcapViewer';
+import captureTemplates from '../apps/wireshark/templates';
+import {
+  deserializeCapture,
+  serializeCapture,
+} from '../utils/network/packetSerializer';
+
+describe('PcapViewer JSON export/import flows', () => {
+  const template = captureTemplates.handshake;
+  const rawJson = JSON.stringify(template, null, 2);
+  const canonical = serializeCapture(deserializeCapture(rawJson));
+  const originalCreate = URL.createObjectURL;
+  const originalRevoke = URL.revokeObjectURL;
+  let anchorClickSpy: jest.SpyInstance;
+  const createJsonFile = (contents: string, name = 'capture.json') => {
+    const file = new File([contents], name, { type: 'application/json' });
+    Object.defineProperty(file, 'text', {
+      configurable: true,
+      value: () => Promise.resolve(contents),
+    });
+    return file;
+  };
+
+  beforeEach(() => {
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: jest.fn(() => 'blob:mock-url'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: jest.fn(),
+    });
+    anchorClickSpy = jest
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalCreate) {
+      Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        value: originalCreate,
+      });
+    } else {
+      delete (URL as any).createObjectURL;
+    }
+    if (originalRevoke) {
+      Object.defineProperty(URL, 'revokeObjectURL', {
+        configurable: true,
+        value: originalRevoke,
+      });
+    } else {
+      delete (URL as any).revokeObjectURL;
+    }
+    anchorClickSpy.mockRestore();
+  });
+
+  it('shows an error when exporting without packets', async () => {
+    const user = userEvent.setup();
+    render(<PcapViewer showLegend={false} />);
+
+    await user.click(screen.getByRole('button', { name: /export json/i }));
+
+    expect(
+      screen.getByText('No packets available to export.')
+    ).toBeInTheDocument();
+  });
+
+  it('exports packets and verifies identical imports', async () => {
+    const user = userEvent.setup();
+    render(<PcapViewer showLegend={false} />);
+
+    const importInput = screen.getByLabelText(/import capture json/i);
+    const initialFile = createJsonFile(rawJson);
+
+    fireEvent.change(importInput, { target: { files: [initialFile] } });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Imported 3 frames from JSON.')
+      ).toBeInTheDocument()
+    );
+
+    await user.click(screen.getByRole('button', { name: /export json/i }));
+
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(
+        screen.getByText('Exported 3 frames to JSON.')
+      ).toBeInTheDocument()
+    );
+
+    const verifyFile = createJsonFile(canonical);
+    fireEvent.change(importInput, { target: { files: [verifyFile] } });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          'Import verified: 3 frames match the exported snapshot.'
+        )
+      ).toBeInTheDocument()
+    );
+  });
+
+  it('rejects imports that do not match the last export', async () => {
+    const user = userEvent.setup();
+    render(<PcapViewer showLegend={false} />);
+
+    const importInput = screen.getByLabelText(/import capture json/i);
+    const initialFile = createJsonFile(rawJson);
+    fireEvent.change(importInput, { target: { files: [initialFile] } });
+    await waitFor(() =>
+      expect(
+        screen.getByText('Imported 3 frames from JSON.')
+      ).toBeInTheDocument()
+    );
+
+    await user.click(screen.getByRole('button', { name: /export json/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByText('Exported 3 frames to JSON.')
+      ).toBeInTheDocument()
+    );
+
+    const mutated = JSON.parse(canonical) as any;
+    mutated.frames[0].info = 'tampered';
+    const tamperedJson = JSON.stringify(mutated, null, 2);
+    const tamperedFile = createJsonFile(tamperedJson);
+
+    fireEvent.change(importInput, { target: { files: [tamperedFile] } });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          'Imported capture does not match the last exported snapshot.'
+        )
+      ).toBeInTheDocument()
+    );
+  });
+});

--- a/__tests__/packetSerializer.test.ts
+++ b/__tests__/packetSerializer.test.ts
@@ -1,0 +1,37 @@
+import captureTemplates from '../apps/wireshark/templates';
+import {
+  deserializeCapture,
+  serializeCapture,
+  snapshotFingerprint,
+} from '../utils/network/packetSerializer';
+
+describe('packetSerializer', () => {
+  it.each(Object.entries(captureTemplates))(
+    'round-trips the %s template without data loss',
+    (_, snapshot) => {
+      const json = JSON.stringify(snapshot);
+      const frames = deserializeCapture(json);
+      const canonical = serializeCapture(frames);
+
+      expect(JSON.parse(canonical)).toEqual(JSON.parse(json));
+
+      const replay = deserializeCapture(canonical);
+      expect(serializeCapture(replay)).toBe(canonical);
+      expect(snapshotFingerprint(frames)).toBe(snapshotFingerprint(replay));
+    }
+  );
+
+  it('rejects unsupported snapshot versions', () => {
+    expect(() =>
+      deserializeCapture(JSON.stringify({ version: 99, frames: [] }))
+    ).toThrow('Unsupported capture snapshot version');
+  });
+
+  it('rejects malformed frame payloads', () => {
+    expect(() =>
+      deserializeCapture(
+        JSON.stringify({ version: 1, frames: [{}, { timestamp: 1 }] })
+      )
+    ).toThrow('Frame 0 is missing required address metadata');
+  });
+});

--- a/apps/wireshark/components/FlowGraph.tsx
+++ b/apps/wireshark/components/FlowGraph.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import { toPng } from 'html-to-image';
 import type cytoscape from 'cytoscape';
+import { PacketFrame } from '../../../utils/network/packetSerializer';
 
 interface CytoscapeComponentProps {
   elements: cytoscape.ElementDefinition[];
@@ -20,14 +21,8 @@ const CytoscapeComponent = dynamic(
   { ssr: false }
 ) as React.ComponentType<CytoscapeComponentProps>;
 
-interface Packet {
-  src: string;
-  dest: string;
-  data?: Uint8Array;
-}
-
 interface FlowGraphProps {
-  packets: Packet[];
+  packets: PacketFrame[];
 }
 
 const FlowGraph: React.FC<FlowGraphProps> = ({ packets }) => {
@@ -47,7 +42,7 @@ const FlowGraph: React.FC<FlowGraphProps> = ({ packets }) => {
           data: { id: key, source: p.src, target: p.dest, count: 0 }
         };
       edges[key].data.count += 1;
-      bytes += p.data?.length || 0;
+      bytes += p.data.length;
     });
     const elements = [
       ...Object.values(nodes),

--- a/apps/wireshark/templates/index.ts
+++ b/apps/wireshark/templates/index.ts
@@ -1,0 +1,291 @@
+import type { CaptureSnapshot } from '../../../utils/network/packetSerializer';
+
+const handshake: CaptureSnapshot = {
+  version: 1,
+  frames: [
+    {
+      timestamp: '0.000001',
+      src: '10.0.0.1',
+      dest: '10.0.0.2',
+      protocol: 6,
+      info: 'TCP SYN',
+      sport: 12345,
+      dport: 80,
+      data: '3q2+7wE=',
+      layers: [
+        {
+          name: 'Ethernet',
+          fields: {
+            Destination: 'ff:ee:dd:cc:bb:aa',
+            Source: 'aa:bb:cc:dd:ee:ff',
+            Type: '0x0800',
+          },
+        },
+        {
+          name: 'IPv4',
+          fields: {
+            Source: '10.0.0.1',
+            Destination: '10.0.0.2',
+            Protocol: 'TCP',
+          },
+        },
+        {
+          name: 'TCP',
+          fields: {
+            'Source Port': '12345',
+            'Destination Port': '80',
+            Flags: 'SYN',
+          },
+        },
+      ],
+    },
+    {
+      timestamp: '0.000245',
+      src: '10.0.0.2',
+      dest: '10.0.0.1',
+      protocol: 6,
+      info: 'TCP SYN-ACK',
+      sport: 80,
+      dport: 12345,
+      data: '3q2+7wI=',
+      layers: [
+        {
+          name: 'Ethernet',
+          fields: {
+            Destination: 'aa:bb:cc:dd:ee:ff',
+            Source: 'ff:ee:dd:cc:bb:aa',
+            Type: '0x0800',
+          },
+        },
+        {
+          name: 'IPv4',
+          fields: {
+            Source: '10.0.0.2',
+            Destination: '10.0.0.1',
+            Protocol: 'TCP',
+          },
+        },
+        {
+          name: 'TCP',
+          fields: {
+            'Source Port': '80',
+            'Destination Port': '12345',
+            Flags: 'SYN-ACK',
+          },
+        },
+      ],
+    },
+    {
+      timestamp: '0.000512',
+      src: '10.0.0.1',
+      dest: '10.0.0.2',
+      protocol: 6,
+      info: 'TCP ACK',
+      sport: 12345,
+      dport: 80,
+      data: '3q2+7wM=',
+      layers: [
+        {
+          name: 'Ethernet',
+          fields: {
+            Destination: 'ff:ee:dd:cc:bb:aa',
+            Source: 'aa:bb:cc:dd:ee:ff',
+            Type: '0x0800',
+          },
+        },
+        {
+          name: 'IPv4',
+          fields: {
+            Source: '10.0.0.1',
+            Destination: '10.0.0.2',
+            Protocol: 'TCP',
+          },
+        },
+        {
+          name: 'TCP',
+          fields: {
+            'Source Port': '12345',
+            'Destination Port': '80',
+            Flags: 'ACK',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const dnsLookup: CaptureSnapshot = {
+  version: 1,
+  frames: [
+    {
+      timestamp: '5.010000',
+      src: '10.0.0.5',
+      dest: '8.8.8.8',
+      protocol: 17,
+      info: 'Standard query A example.com',
+      sport: 53000,
+      dport: 53,
+      data: 'qrvM3Q==',
+      layers: [
+        {
+          name: 'Ethernet',
+          fields: {
+            Destination: '44:55:66:77:88:99',
+            Source: '99:88:77:66:55:44',
+            Type: '0x0800',
+          },
+        },
+        {
+          name: 'IPv4',
+          fields: {
+            Source: '10.0.0.5',
+            Destination: '8.8.8.8',
+            Protocol: 'UDP',
+          },
+        },
+        {
+          name: 'UDP',
+          fields: {
+            'Source Port': '53000',
+            'Destination Port': '53',
+          },
+        },
+        {
+          name: 'DNS',
+          fields: {
+            Query: 'example.com',
+            Type: 'A',
+          },
+        },
+      ],
+    },
+    {
+      timestamp: '5.012000',
+      src: '8.8.8.8',
+      dest: '10.0.0.5',
+      protocol: 17,
+      info: 'Standard query response A example.com 93.184.216.34',
+      sport: 53,
+      dport: 53000,
+      data: 'qrvM3g==',
+      layers: [
+        {
+          name: 'Ethernet',
+          fields: {
+            Destination: '99:88:77:66:55:44',
+            Source: '44:55:66:77:88:99',
+            Type: '0x0800',
+          },
+        },
+        {
+          name: 'IPv4',
+          fields: {
+            Source: '8.8.8.8',
+            Destination: '10.0.0.5',
+            Protocol: 'UDP',
+          },
+        },
+        {
+          name: 'UDP',
+          fields: {
+            'Source Port': '53',
+            'Destination Port': '53000',
+          },
+        },
+        {
+          name: 'DNS',
+          fields: {
+            Answer: '93.184.216.34',
+            TTL: '300',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const icmpPing: CaptureSnapshot = {
+  version: 1,
+  frames: [
+    {
+      timestamp: '10.000000',
+      src: '192.168.0.10',
+      dest: '192.168.0.1',
+      protocol: 1,
+      info: 'Echo (ping) request id=0x1 seq=1',
+      data: 'CAD3/w==',
+      layers: [
+        {
+          name: 'Ethernet',
+          fields: {
+            Destination: '00:11:22:33:44:55',
+            Source: '66:77:88:99:aa:bb',
+            Type: '0x0800',
+          },
+        },
+        {
+          name: 'IPv4',
+          fields: {
+            Source: '192.168.0.10',
+            Destination: '192.168.0.1',
+            Protocol: 'ICMP',
+          },
+        },
+        {
+          name: 'ICMP',
+          fields: {
+            Type: '8',
+            Code: '0',
+            Identifier: '0x0001',
+            Sequence: '1',
+          },
+        },
+      ],
+    },
+    {
+      timestamp: '10.001200',
+      src: '192.168.0.1',
+      dest: '192.168.0.10',
+      protocol: 1,
+      info: 'Echo (ping) reply id=0x1 seq=1',
+      data: 'AAD6zg==',
+      layers: [
+        {
+          name: 'Ethernet',
+          fields: {
+            Destination: '66:77:88:99:aa:bb',
+            Source: '00:11:22:33:44:55',
+            Type: '0x0800',
+          },
+        },
+        {
+          name: 'IPv4',
+          fields: {
+            Source: '192.168.0.1',
+            Destination: '192.168.0.10',
+            Protocol: 'ICMP',
+          },
+        },
+        {
+          name: 'ICMP',
+          fields: {
+            Type: '0',
+            Code: '0',
+            Identifier: '0x0001',
+            Sequence: '1',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+export const captureTemplates: Record<string, CaptureSnapshot> = {
+  handshake,
+  dnsLookup,
+  icmpPing,
+};
+
+export type CaptureTemplateName = keyof typeof captureTemplates;
+
+export default captureTemplates;

--- a/utils/network/packetSerializer.ts
+++ b/utils/network/packetSerializer.ts
@@ -1,0 +1,183 @@
+const SNAPSHOT_VERSION = 1 as const;
+
+export type SnapshotVersion = typeof SNAPSHOT_VERSION;
+
+export interface PacketLayer {
+  name: string;
+  fields: Record<string, string>;
+}
+
+export interface PacketFrame {
+  timestamp: string;
+  src: string;
+  dest: string;
+  protocol: number;
+  info: string;
+  data: Uint8Array;
+  sport?: number;
+  dport?: number;
+  layers: PacketLayer[];
+}
+
+export interface SerializedPacketFrame
+  extends Omit<PacketFrame, 'data' | 'layers'> {
+  data: string;
+  layers: PacketLayer[];
+}
+
+export interface CaptureSnapshot {
+  version: SnapshotVersion;
+  frames: SerializedPacketFrame[];
+}
+
+const toBase64 = (bytes: Uint8Array): string => {
+  if (typeof (globalThis as any).Buffer !== 'undefined') {
+    return (globalThis as any).Buffer.from(bytes).toString('base64');
+  }
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  if (typeof btoa === 'function') {
+    return btoa(binary);
+  }
+  throw new Error('Base64 encoding not supported in this environment');
+};
+
+const fromBase64 = (value: string): Uint8Array => {
+  if (typeof (globalThis as any).Buffer !== 'undefined') {
+    const buffer = (globalThis as any).Buffer.from(value, 'base64');
+    return new Uint8Array(buffer);
+  }
+  if (typeof atob === 'function') {
+    const binary = atob(value);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+  throw new Error('Base64 decoding not supported in this environment');
+};
+
+const cloneLayer = (layer: PacketLayer): PacketLayer => ({
+  name: layer.name,
+  fields: Object.fromEntries(
+    Object.entries(layer.fields || {}).map(([key, val]) => [key, String(val)])
+  ),
+});
+
+export const createSnapshot = (frames: PacketFrame[]): CaptureSnapshot => ({
+  version: SNAPSHOT_VERSION,
+  frames: frames.map((frame) => ({
+    timestamp: frame.timestamp,
+    src: frame.src,
+    dest: frame.dest,
+    protocol: frame.protocol,
+    info: frame.info,
+    sport: frame.sport,
+    dport: frame.dport,
+    data: toBase64(frame.data),
+    layers: frame.layers.map(cloneLayer),
+  })),
+});
+
+export const serializeCapture = (frames: PacketFrame[]): string =>
+  JSON.stringify(createSnapshot(frames), null, 2);
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const validateLayer = (layer: unknown, index: number): PacketLayer => {
+  if (!isObject(layer)) {
+    throw new Error(`Invalid layer at index ${index}`);
+  }
+  const name = typeof layer.name === 'string' ? layer.name : '';
+  const fields = isObject(layer.fields) ? layer.fields : {};
+  const normalized: Record<string, string> = {};
+  for (const [key, val] of Object.entries(fields)) {
+    normalized[key] = String(val);
+  }
+  return { name, fields: normalized };
+};
+
+const validateFrame = (
+  frame: unknown,
+  index: number
+): SerializedPacketFrame => {
+  if (!isObject(frame)) {
+    throw new Error(`Invalid frame at index ${index}`);
+  }
+  const { timestamp, src, dest, protocol, info, sport, dport, data, layers } =
+    frame as Record<string, unknown>;
+  if (typeof timestamp !== 'string' || typeof src !== 'string' || typeof dest !== 'string') {
+    throw new Error(`Frame ${index} is missing required address metadata`);
+  }
+  if (typeof protocol !== 'number') {
+    throw new Error(`Frame ${index} protocol must be numeric`);
+  }
+  if (typeof data !== 'string') {
+    throw new Error(`Frame ${index} is missing packet payload`);
+  }
+  const textInfo = typeof info === 'string' ? info : '';
+  const numericSport = typeof sport === 'number' ? sport : undefined;
+  const numericDport = typeof dport === 'number' ? dport : undefined;
+  const layerArray = Array.isArray(layers)
+    ? layers.map((layer, i) => validateLayer(layer, i))
+    : [];
+  return {
+    timestamp,
+    src,
+    dest,
+    protocol,
+    info: textInfo,
+    sport: numericSport,
+    dport: numericDport,
+    data,
+    layers: layerArray,
+  };
+};
+
+export const deserializeCapture = (json: string): PacketFrame[] => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (err) {
+    throw new Error('Unable to parse capture JSON');
+  }
+  if (!isObject(parsed)) {
+    throw new Error('Invalid capture snapshot');
+  }
+  const { version, frames } = parsed as Record<string, unknown>;
+  if (version !== SNAPSHOT_VERSION) {
+    throw new Error('Unsupported capture snapshot version');
+  }
+  if (!Array.isArray(frames)) {
+    throw new Error('Capture snapshot is missing frames');
+  }
+  return frames.map((frame, index) => {
+    const validated = validateFrame(frame, index);
+    return {
+      timestamp: validated.timestamp,
+      src: validated.src,
+      dest: validated.dest,
+      protocol: validated.protocol,
+      info: validated.info,
+      sport: validated.sport,
+      dport: validated.dport,
+      data: fromBase64(validated.data),
+      layers: validated.layers.map(cloneLayer),
+    };
+  });
+};
+
+export const snapshotFingerprint = (frames: PacketFrame[]): string => {
+  const snapshot = serializeCapture(frames);
+  let hash = 0;
+  for (let i = 0; i < snapshot.length; i += 1) {
+    hash = (hash * 31 + snapshot.charCodeAt(i)) | 0;
+  }
+  return hash.toString(16);
+};
+
+export default serializeCapture;


### PR DESCRIPTION
## Summary
- add packet snapshot serializer utilities and reusable capture templates
- update the Wireshark viewer to export/import JSON captures with integrity checks and status messaging
- extend FlowGraph typing and add targeted tests for serializer and UI flows

## Testing
- yarn lint *(fails: repository has pre-existing accessibility and window/document lint errors)*
- yarn test packetSerializer.test.ts
- yarn test PcapViewer.test.tsx
- yarn test *(fails: repository has numerous baseline test failures unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cc474213c48328b5f90bd1815a3c76