### PR TITLE
[wireshark] add synchronized hex editor

### DIFF
--- a/apps/wireshark/components/HexView.tsx
+++ b/apps/wireshark/components/HexView.tsx
@@ -1,0 +1,157 @@
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
+import type { FieldRange } from './LayerView';
+
+interface HexViewProps {
+  buffer: Uint8Array;
+  highlight?: FieldRange | null;
+  onChange: (next: Uint8Array) => void;
+  onFocusRange?: (range: FieldRange | null) => void;
+  onValidation?: (message: string | null) => void;
+}
+
+const COLUMNS = 16;
+
+const byteToHex = (value: number) => value.toString(16).padStart(2, '0').toUpperCase();
+
+const HexView: React.FC<HexViewProps> = ({
+  buffer,
+  highlight,
+  onChange,
+  onFocusRange,
+  onValidation,
+}) => {
+  const [draft, setDraft] = useState<string[]>([]);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const inputsRef = useRef<(HTMLInputElement | null)[]>([]);
+  const instructionsId = useId();
+
+  useEffect(() => {
+    setDraft(Array.from(buffer, (byte) => byteToHex(byte)));
+    inputsRef.current = inputsRef.current.slice(0, buffer.length);
+  }, [buffer]);
+
+  const isHighlighted = useMemo(() => {
+    if (!highlight) return () => false;
+    const start = highlight.start;
+    const end = start + highlight.length;
+    return (index: number) => index >= start && index < end;
+  }, [highlight]);
+
+  const focusByte = (index: number) => {
+    const target = inputsRef.current[index];
+    if (target) {
+      target.focus();
+      target.select();
+    }
+  };
+
+  const handleChange = (index: number, value: string) => {
+    const sanitized = value.replace(/[^0-9a-fA-F]/g, '').toUpperCase();
+    const hasInvalidChars = sanitized.length !== value.length;
+    const nextDraft = [...draft];
+    nextDraft[index] = sanitized;
+    setDraft(nextDraft);
+
+    if (hasInvalidChars) {
+      const message = 'Only hexadecimal digits (0-9 and A-F) are allowed.';
+      setLocalError(message);
+      onValidation?.(message);
+    } else {
+      setLocalError(null);
+      onValidation?.(null);
+    }
+
+    if (sanitized.length === 2) {
+      const nextValue = parseInt(sanitized, 16);
+      if (!Number.isNaN(nextValue)) {
+        const nextBuffer = new Uint8Array(buffer);
+        nextBuffer[index] = nextValue;
+        onChange(nextBuffer);
+      }
+    }
+  };
+
+  const handleBlur = (index: number) => {
+    onFocusRange?.(null);
+    const normalized = byteToHex(buffer[index] ?? 0);
+    setDraft((prev) => {
+      const next = [...prev];
+      next[index] = normalized;
+      return next;
+    });
+    setLocalError(null);
+    onValidation?.(null);
+  };
+
+  const handleFocus = (index: number) => {
+    onFocusRange?.({ start: index, length: 1, label: `Byte ${index}` });
+  };
+
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+    index: number
+  ) => {
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      focusByte(Math.min(buffer.length - 1, index + 1));
+    } else if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      focusByte(Math.max(0, index - 1));
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      const target = index - COLUMNS;
+      if (target >= 0) focusByte(target);
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      const target = index + COLUMNS;
+      if (target < buffer.length) focusByte(target);
+    }
+  };
+
+  return (
+    <div className="space-y-2" role="group" aria-labelledby={`${instructionsId}-label`}>
+      <div id={`${instructionsId}-label`} className="text-[11px] font-semibold text-gray-300">
+        Hex editor
+      </div>
+      <p id={instructionsId} className="sr-only">
+        Use Tab or the arrow keys to move between bytes. Type two hexadecimal digits to edit the
+        focused byte. Changes automatically update the parsed fields and recompute checksums.
+      </p>
+      {localError && (
+        <p className="text-red-400 text-[11px]" role="alert">
+          {localError}
+        </p>
+      )}
+      <div
+        className="grid gap-1"
+        style={{ gridTemplateColumns: `repeat(${COLUMNS}, minmax(0, 1fr))` }}
+      >
+        {draft.map((value, index) => {
+          const highlighted = isHighlighted(index);
+          return (
+            <input
+              key={index}
+              ref={(el) => {
+                inputsRef.current[index] = el;
+              }}
+              className={`w-12 text-center px-1 py-0.5 bg-gray-900 border border-gray-700 rounded text-xs text-green-300 font-mono focus:outline focus:outline-1 focus:outline-yellow-400 ${
+                highlighted ? 'bg-yellow-900 text-yellow-100 border-yellow-500' : ''
+              }`}
+              value={value}
+              onChange={(e) => handleChange(index, e.target.value)}
+              onFocus={() => handleFocus(index)}
+              onBlur={() => handleBlur(index)}
+              onKeyDown={(e) => handleKeyDown(e, index)}
+              maxLength={2}
+              inputMode="text"
+              spellCheck={false}
+              aria-describedby={instructionsId}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default HexView;

--- a/apps/wireshark/components/LayerView.tsx
+++ b/apps/wireshark/components/LayerView.tsx
@@ -1,19 +1,42 @@
-import React, { useState } from 'react';
+import React, { useId, useState } from 'react';
+
+export interface LayerField {
+  label: string;
+  value: string;
+  start: number;
+  length: number;
+  description?: string;
+}
+
+export interface FieldRange {
+  start: number;
+  length: number;
+  label: string;
+}
 
 interface Props {
   name: string;
-  fields: Record<string, string>;
+  fields: LayerField[];
+  onFocusField?: (range: FieldRange | null) => void;
+  instructionsId?: string;
 }
 
-const LayerView: React.FC<Props> = ({ name, fields }) => {
+const LayerView: React.FC<Props> = ({
+  name,
+  fields,
+  onFocusField,
+  instructionsId,
+}) => {
   const [open, setOpen] = useState(true);
+  const descriptionBaseId = useId();
 
   return (
-    <div className="text-xs">
+    <div className="text-xs space-y-1">
       <button
         onClick={() => setOpen(!open)}
         className="flex items-center cursor-pointer select-none"
         type="button"
+        aria-expanded={open}
       >
         <svg
           className={`w-4 h-4 mr-1 transition-transform ${open ? 'rotate-90' : ''}`}
@@ -26,11 +49,46 @@ const LayerView: React.FC<Props> = ({ name, fields }) => {
       </button>
       {open && (
         <ul className="pl-5 mt-1 space-y-0.5">
-          {Object.entries(fields).map(([k, v]) => (
-            <li key={k} className="whitespace-pre-wrap">
-              {k}: {v}
-            </li>
-          ))}
+          {fields.map((field, index) => {
+            const fieldDescriptionId = `${descriptionBaseId}-${index}`;
+            const describedBy = [instructionsId]
+              .concat(field.description ? fieldDescriptionId : [])
+              .filter(Boolean)
+              .join(' ');
+            return (
+              <li key={field.label} className="whitespace-pre-wrap">
+                {field.description && (
+                  <span id={fieldDescriptionId} className="sr-only">
+                    {field.description}
+                  </span>
+                )}
+                <button
+                  type="button"
+                  className="w-full text-left rounded px-1 py-0.5 hover:bg-gray-800 focus:outline focus:outline-1 focus:outline-yellow-400 focus:bg-gray-800"
+                  onFocus={() =>
+                    onFocusField?.({
+                      start: field.start,
+                      length: field.length,
+                      label: `${name} ${field.label}`,
+                    })
+                  }
+                  onBlur={() => onFocusField?.(null)}
+                  onMouseEnter={() =>
+                    onFocusField?.({
+                      start: field.start,
+                      length: field.length,
+                      label: `${name} ${field.label}`,
+                    })
+                  }
+                  onMouseLeave={() => onFocusField?.(null)}
+                  aria-describedby={describedBy || undefined}
+                  title={field.description}
+                >
+                  <span className="font-semibold">{field.label}:</span> {field.value}
+                </button>
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add an editable HexView that renders packet bytes, validates hex input, and exposes keyboard navigation hints
- expose structured field ranges in LayerView so packet detail focus drives byte highlighting and screen reader guidance
- refactor PcapViewer to share a mutable buffer across views, recompute IPv4 checksums on edit, and announce highlight/validation states

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations across unrelated apps)*
- yarn test *(fails: existing act/localStorage issues in unrelated test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4742a11c8328bb3053c522ef02f6