### PR TITLE
[http] add TLS reference sidebar

### DIFF
--- a/apps/http/index.tsx
+++ b/apps/http/index.tsx
@@ -1,7 +1,150 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import tlsReference from '../../data/tls-reference.json';
+
+type TLSItem = {
+  id: string;
+  name: string;
+  summary: string;
+  compatibility: string;
+  usage: string;
+  version?: string;
+};
+
+type TLSReferenceData = {
+  versions: TLSItem[];
+  ciphers: TLSItem[];
+};
+
+const TLS_REFERENCE: TLSReferenceData = tlsReference as TLSReferenceData;
+const TLS_STORAGE_KEY = 'http-tls-selection';
+
+const TLSReferencePanel: React.FC = () => {
+  const versions = useMemo(() => TLS_REFERENCE.versions ?? [], []);
+  const ciphers = useMemo(() => TLS_REFERENCE.ciphers ?? [], []);
+  const allItems = useMemo(() => [...versions, ...ciphers], [versions, ciphers]);
+  const fallbackId = allItems[0]?.id ?? '';
+  const [selectedId, setSelectedId] = useState(fallbackId);
+
+  useEffect(() => {
+    if (!allItems.length) return;
+    try {
+      const stored = localStorage.getItem(TLS_STORAGE_KEY);
+      if (stored && allItems.some((item) => item.id === stored)) {
+        setSelectedId(stored);
+      }
+    } catch {
+      // ignore persistence errors
+    }
+  }, [allItems]);
+
+  useEffect(() => {
+    if (!selectedId) return;
+    try {
+      localStorage.setItem(TLS_STORAGE_KEY, selectedId);
+    } catch {
+      // ignore persistence errors
+    }
+  }, [selectedId]);
+
+  const selectedItem = useMemo(
+    () => allItems.find((item) => item.id === selectedId) ?? allItems[0],
+    [allItems, selectedId],
+  );
+
+  if (!allItems.length || !selectedItem) {
+    return null;
+  }
+
+  const renderItem = (item: TLSItem) => {
+    const isActive = item.id === selectedItem.id;
+    return (
+      <li key={item.id}>
+        <button
+          type="button"
+          onClick={() => setSelectedId(item.id)}
+          aria-current={isActive ? 'true' : undefined}
+          className={`w-full rounded px-3 py-2 text-left text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-900 ${
+            isActive ? 'bg-blue-600 text-white' : 'bg-gray-800 text-gray-200 hover:bg-gray-700'
+          }`}
+        >
+          <span className="font-semibold">{item.name}</span>
+          <span className="mt-1 block text-xs text-gray-300">{item.summary}</span>
+          {item.version && (
+            <span className="mt-1 block text-[10px] uppercase tracking-wide text-gray-400">
+              {item.version}
+            </span>
+          )}
+        </button>
+      </li>
+    );
+  };
+
+  return (
+    <aside
+      aria-labelledby="tls-reference-heading"
+      className="rounded border border-gray-700 bg-gray-900 p-4 text-sm text-gray-100"
+    >
+      <h2 id="tls-reference-heading" className="text-base font-semibold text-white">
+        TLS versions & cipher suites
+      </h2>
+      <p className="mt-1 mb-3 text-xs text-gray-300">
+        Select an item to review compatibility and rollout notes.
+      </p>
+      <div className="flex flex-col gap-4">
+        <div>
+          <h3
+            id="tls-versions-heading"
+            className="text-xs font-semibold uppercase tracking-wide text-gray-400"
+          >
+            Versions
+          </h3>
+          <ul aria-labelledby="tls-versions-heading" className="mt-1 space-y-2">
+            {versions.map(renderItem)}
+          </ul>
+        </div>
+        <div>
+          <h3
+            id="tls-ciphers-heading"
+            className="text-xs font-semibold uppercase tracking-wide text-gray-400"
+          >
+            Cipher suites
+          </h3>
+          <ul aria-labelledby="tls-ciphers-heading" className="mt-1 space-y-2">
+            {ciphers.map(renderItem)}
+          </ul>
+        </div>
+      </div>
+      <div
+        id="tls-reference-panel"
+        role="region"
+        aria-live="polite"
+        className="mt-4 rounded border border-gray-700 bg-gray-950 p-3 text-sm text-gray-200"
+      >
+        <h3 className="text-sm font-semibold text-white">{selectedItem.name}</h3>
+        <p className="mt-1 text-xs text-gray-300">{selectedItem.summary}</p>
+        <dl className="mt-3 space-y-2 text-xs text-gray-200">
+          {selectedItem.version && (
+            <div>
+              <dt className="font-semibold text-gray-100">Applies to</dt>
+              <dd className="text-gray-300">{selectedItem.version}</dd>
+            </div>
+          )}
+          <div>
+            <dt className="font-semibold text-gray-100">Compatibility notes</dt>
+            <dd className="text-gray-300">{selectedItem.compatibility}</dd>
+          </div>
+          <div>
+            <dt className="font-semibold text-gray-100">Recommended usage</dt>
+            <dd className="text-gray-300">{selectedItem.usage}</dd>
+          </div>
+        </dl>
+      </div>
+    </aside>
+  );
+};
 
 const HTTPBuilder: React.FC = () => {
   const [method, setMethod] = useState('GET');
@@ -9,7 +152,7 @@ const HTTPBuilder: React.FC = () => {
   const command = `curl -X ${method} ${url}`.trim();
 
   return (
-    <div className="h-full bg-gray-900 p-4 text-white overflow-auto">
+    <div className="h-full overflow-auto bg-gray-900 p-4 text-white">
       <h1 className="mb-4 text-2xl">HTTP Request Builder</h1>
       <p className="mb-4 text-sm text-yellow-300">
         Build a curl command without sending any requests. Learn more at{' '}
@@ -17,47 +160,56 @@ const HTTPBuilder: React.FC = () => {
           href="https://curl.se/"
           target="_blank"
           rel="noopener noreferrer"
-          className="underline text-blue-400"
+          className="text-blue-400 underline"
         >
           the curl project page
         </a>
         .
       </p>
-      <form onSubmit={(e) => e.preventDefault()} className="mb-4 space-y-4">
-        <div>
-          <label htmlFor="http-method" className="mb-1 block text-sm font-medium">
-            Method
-          </label>
-          <select
-            id="http-method"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            value={method}
-            onChange={(e) => setMethod(e.target.value)}
-          >
-            <option value="GET">GET</option>
-            <option value="POST">POST</option>
-            <option value="PUT">PUT</option>
-            <option value="DELETE">DELETE</option>
-          </select>
+      <div className="flex flex-col gap-6 lg:flex-row">
+        <div className="flex-1 space-y-4">
+          <form onSubmit={(e) => e.preventDefault()} className="space-y-4">
+            <div>
+              <label htmlFor="http-method" className="mb-1 block text-sm font-medium">
+                Method
+              </label>
+              <select
+                id="http-method"
+                aria-label="HTTP method"
+                className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+                value={method}
+                onChange={(e) => setMethod(e.target.value)}
+              >
+                <option value="GET">GET</option>
+                <option value="POST">POST</option>
+                <option value="PUT">PUT</option>
+                <option value="DELETE">DELETE</option>
+              </select>
+            </div>
+            <div>
+              <label htmlFor="http-url" className="mb-1 block text-sm font-medium">
+                URL
+              </label>
+              <input
+                id="http-url"
+                type="text"
+                aria-label="Request URL"
+                className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+              />
+            </div>
+          </form>
+          <div>
+            <h2 className="mb-2 text-lg">Command Preview</h2>
+            <pre className="overflow-auto rounded bg-black p-2 font-mono text-green-400">
+              {command || '# Fill in the form to generate a command'}
+            </pre>
+          </div>
         </div>
-        <div>
-          <label htmlFor="http-url" className="mb-1 block text-sm font-medium">
-            URL
-          </label>
-          <input
-            id="http-url"
-            type="text"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-          />
+        <div className="lg:w-80 xl:w-96">
+          <TLSReferencePanel />
         </div>
-      </form>
-      <div>
-        <h2 className="mb-2 text-lg">Command Preview</h2>
-        <pre className="overflow-auto rounded bg-black p-2 font-mono text-green-400">
-          {command || '# Fill in the form to generate a command'}
-        </pre>
       </div>
     </div>
   );

--- a/data/tls-reference.json
+++ b/data/tls-reference.json
@@ -1,0 +1,74 @@
+{
+  "versions": [
+    {
+      "id": "tls13",
+      "name": "TLS 1.3",
+      "summary": "Latest TLS revision with shorter handshakes and forward secrecy by default.",
+      "compatibility": "Supported by browsers and OS releases from 2018 onward. Older appliances may require firmware updates but most managed providers enable it.",
+      "usage": "Enable by default and prefer for all clients. Keep TLS 1.2 only for legacy compatibility."
+    },
+    {
+      "id": "tls12",
+      "name": "TLS 1.2",
+      "summary": "Mature workhorse version still required for older clients.",
+      "compatibility": "Universally supported, including legacy Java 8, Windows Server 2012, and embedded stacks.",
+      "usage": "Keep as fallback with a restricted cipher list. Plan migrations to retire it as clients update."
+    },
+    {
+      "id": "tls11",
+      "name": "TLS 1.1",
+      "summary": "Legacy protocol lacking modern ciphers and features.",
+      "compatibility": "Disabled by default in current browsers; only very old clients still rely on it.",
+      "usage": "Disable entirely. If a legacy system mandates it, isolate the traffic and plan an upgrade."
+    },
+    {
+      "id": "tls10",
+      "name": "TLS 1.0",
+      "summary": "Deprecated protocol vulnerable to BEAST and similar attacks.",
+      "compatibility": "Unsupported in modern browsers and compliance frameworks such as PCI DSS.",
+      "usage": "Must remain disabled. Replace or upgrade systems that still require it."
+    }
+  ],
+  "ciphers": [
+    {
+      "id": "tls13_aes256_gcm_sha384",
+      "name": "TLS_AES_256_GCM_SHA384",
+      "summary": "AEAD cipher suite for TLS 1.3 using 256-bit AES-GCM.",
+      "compatibility": "Available wherever TLS 1.3 is negotiated. Hardware acceleration common on servers and desktops.",
+      "usage": "Offer alongside TLS_AES_128_GCM_SHA256. Use when compliance calls for 256-bit keys.",
+      "version": "TLS 1.3"
+    },
+    {
+      "id": "tls13_chacha20_poly1305_sha256",
+      "name": "TLS_CHACHA20_POLY1305_SHA256",
+      "summary": "TLS 1.3 cipher optimized for mobile and CPU-constrained clients.",
+      "compatibility": "Excellent performance on mobile ARM devices; supported by Chrome, Firefox, Safari, and OpenSSL 1.1.1+.",
+      "usage": "Keep enabled as an alternative for clients without AES acceleration.",
+      "version": "TLS 1.3"
+    },
+    {
+      "id": "tls12_ecdhe_rsa_aes128_gcm_sha256",
+      "name": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+      "summary": "Forward-secret TLS 1.2 suite using AES-GCM.",
+      "compatibility": "Works with modern browsers, Java 8u51+, OpenSSL 1.0.1+, and Windows Server 2012.",
+      "usage": "Keep as the default TLS 1.2 option when RSA certificates are in use.",
+      "version": "TLS 1.2"
+    },
+    {
+      "id": "tls12_ecdhe_ecdsa_aes256_gcm_sha384",
+      "name": "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+      "summary": "ECDSA certificate with AES-256-GCM for TLS 1.2.",
+      "compatibility": "Requires ECDSA server certificates and client support (Chrome, Firefox, iOS 11+, Android 7+).",
+      "usage": "Enable for environments issuing ECDSA certificates to get smaller handshake sizes.",
+      "version": "TLS 1.2"
+    },
+    {
+      "id": "tls12_rsa_3des_ede_sha",
+      "name": "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+      "summary": "Legacy 3DES CBC cipher without forward secrecy.",
+      "compatibility": "Only present on outdated stacks; fails modern compliance benchmarks.",
+      "usage": "Remove from configurations. If a device still relies on it, segment and upgrade urgently.",
+      "version": "TLS 1.2 and below"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a TLS reference panel to the HTTP request builder with keyboard and storage support
- load TLS versions and cipher suites from a local JSON data source
- persist the last selection and surface compatibility guidance in the explainer panel

## Testing
- yarn lint *(fails: pre-existing jsx-a11y and no-top-level-window violations across the repo)*
- yarn test *(fails: existing Jest suite issues and runs in watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_68cc474b521883288cd019d0789bc5a4