### PR TITLE
[apps] Add CSP builder utility with preset diffing

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -110,6 +110,7 @@ const ReconNGApp = createDynamicApp('reconng', 'Recon-ng');
 const SecurityToolsApp = createDynamicApp('security-tools', 'Security Tools');
 const SSHApp = createDynamicApp('ssh', 'SSH Command Builder');
 const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
+const CspBuilderApp = createDynamicApp('csp-builder', 'CSP Builder');
 const HtmlRewriteApp = createDynamicApp('html-rewriter', 'HTML Rewriter');
 const ContactApp = createDynamicApp('contact', 'Contact');
 
@@ -200,6 +201,8 @@ const displayContact = createDisplay(ContactApp);
 
 const displayHashcat = createDisplay(HashcatApp);
 
+const displayCspBuilder = createDisplay(CspBuilderApp);
+
 const displayKismet = createDisplay(KismetApp);
 
 // Utilities list used for the "Utilities" folder on the desktop
@@ -257,6 +260,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayProjectGallery,
+  },
+  {
+    id: 'csp-builder',
+    title: 'CSP Builder',
+    icon: '/themes/Yaru/apps/gnome-control-center.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayCspBuilder,
   },
   {
     id: 'input-lab',

--- a/apps/csp-builder/index.tsx
+++ b/apps/csp-builder/index.tsx
@@ -1,0 +1,487 @@
+'use client';
+
+import { useMemo, useState, type ChangeEvent } from 'react';
+import {
+  CSP_PRESETS,
+  PRESET_LIST,
+  type CspDirectiveDefinition,
+  type CspPreset,
+  type CspPresetId,
+} from '../../components/apps/csp-builder/presets';
+import { logEvent } from '../../utils/analytics';
+
+type DirectiveField = 'name' | 'value';
+
+interface DirectiveEntry extends CspDirectiveDefinition {
+  id: string;
+}
+
+interface DiffEntry {
+  name: string;
+  previous?: string;
+  next?: string;
+}
+
+interface DiffSummary {
+  added: DiffEntry[];
+  removed: DiffEntry[];
+  changed: DiffEntry[];
+}
+
+interface PresetTransition {
+  previousPresetId: CspPresetId | null;
+  nextPresetId: CspPresetId;
+  diff: DiffSummary;
+  summary: string;
+  notes: string[];
+  hasChanges: boolean;
+  clearedViolations: boolean;
+}
+
+interface ViolationEntry {
+  id: string;
+  directive?: string;
+  blockedUri?: string;
+  documentUri?: string;
+  lineNumber?: number;
+  columnNumber?: number;
+  raw: string;
+}
+
+const initialPresetId: CspPresetId = 'balanced';
+
+const createId = (): string => `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+const createDirectiveEntries = (preset: CspPreset): DirectiveEntry[] =>
+  preset.directives.map((definition) => ({
+    id: createId(),
+    name: definition.name,
+    value: definition.value,
+    description: definition.description,
+  }));
+
+const diffDirectives = (previous: DirectiveEntry[], next: DirectiveEntry[]): DiffSummary => {
+  const previousMap = new Map<string, string>();
+  previous.forEach((directive) => {
+    const key = directive.name.trim() || '[custom]';
+    previousMap.set(key, directive.value.trim());
+  });
+
+  const nextMap = new Map<string, string>();
+  next.forEach((directive) => {
+    const key = directive.name.trim() || '[custom]';
+    nextMap.set(key, directive.value.trim());
+  });
+
+  const added: DiffEntry[] = [];
+  const removed: DiffEntry[] = [];
+  const changed: DiffEntry[] = [];
+
+  nextMap.forEach((value, key) => {
+    if (!previousMap.has(key)) {
+      added.push({ name: key, next: value });
+      return;
+    }
+    const previousValue = previousMap.get(key);
+    if (previousValue !== value) {
+      changed.push({ name: key, previous: previousValue, next: value });
+    }
+  });
+
+  previousMap.forEach((value, key) => {
+    if (!nextMap.has(key)) {
+      removed.push({ name: key, previous: value });
+    }
+  });
+
+  return { added, removed, changed };
+};
+
+const getPresetTitle = (id: CspPresetId | null): string => {
+  if (!id) {
+    return 'Custom configuration';
+  }
+  const preset = CSP_PRESETS[id];
+  return preset?.title ?? 'Custom configuration';
+};
+
+const formatDiffEntry = (entry: DiffEntry): string => {
+  if (entry.previous && entry.next) {
+    return `${entry.name}: ${entry.previous} → ${entry.next}`;
+  }
+  if (entry.next) {
+    return `${entry.name}: ${entry.next}`;
+  }
+  if (entry.previous) {
+    return `${entry.name}: ${entry.previous}`;
+  }
+  return entry.name;
+};
+
+const parseViolationInput = (raw: string): Omit<ViolationEntry, 'id'> => {
+  try {
+    const payload = JSON.parse(raw);
+    const directive =
+      payload.effectiveDirective ||
+      payload.violatedDirective ||
+      payload['csp-directive'];
+    return {
+      directive,
+      blockedUri: payload.blockedURI || payload.blockedUri,
+      documentUri: payload.documentURI || payload.documentUri,
+      lineNumber: typeof payload.lineNumber === 'number' ? payload.lineNumber : undefined,
+      columnNumber: typeof payload.columnNumber === 'number' ? payload.columnNumber : undefined,
+      raw,
+    };
+  } catch {
+    return { raw };
+  }
+};
+
+const CspBuilder = () => {
+  const [directives, setDirectives] = useState<DirectiveEntry[]>(() =>
+    createDirectiveEntries(CSP_PRESETS[initialPresetId]),
+  );
+  const [selectedPresetId, setSelectedPresetId] = useState<CspPresetId>(initialPresetId);
+  const [transition, setTransition] = useState<PresetTransition | null>(null);
+  const [violations, setViolations] = useState<ViolationEntry[]>([]);
+  const [violationInput, setViolationInput] = useState('');
+
+  const policy = useMemo(() => {
+    const lines = directives
+      .map((directive) => {
+        const name = directive.name.trim();
+        const value = directive.value.trim();
+        if (!name) {
+          return '';
+        }
+        return value ? `${name} ${value};` : `${name};`;
+      })
+      .filter(Boolean);
+    return lines.join('\n');
+  }, [directives]);
+
+  const activePreset = CSP_PRESETS[selectedPresetId];
+
+  const updateDirective = (id: string, field: DirectiveField) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      setDirectives((current) =>
+        current.map((directive) =>
+          directive.id === id ? { ...directive, [field]: value } : directive,
+        ),
+      );
+    };
+
+  const removeDirective = (id: string) => {
+    setDirectives((current) => current.filter((directive) => directive.id !== id));
+  };
+
+  const addDirective = () => {
+    setDirectives((current) => [
+      ...current,
+      {
+        id: createId(),
+        name: '',
+        value: '',
+        description: 'Custom directive added manually for fine-grained tuning.',
+      },
+    ]);
+  };
+
+  const handlePresetChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const nextId = event.target.value as CspPresetId;
+    const nextPreset = CSP_PRESETS[nextId];
+    if (!nextPreset) {
+      return;
+    }
+
+    const previousPresetId = selectedPresetId ?? null;
+    const nextDirectives = createDirectiveEntries(nextPreset);
+    const diff = diffDirectives(directives, nextDirectives);
+    const hasChanges = Boolean(
+      diff.added.length || diff.removed.length || diff.changed.length,
+    );
+    const hadViolations = violations.length > 0;
+
+    setDirectives(nextDirectives);
+    setSelectedPresetId(nextId);
+    setViolations([]);
+    setViolationInput('');
+    setTransition({
+      previousPresetId,
+      nextPresetId: nextId,
+      diff,
+      summary: nextPreset.summary,
+      notes: nextPreset.notes,
+      hasChanges,
+      clearedViolations: hadViolations,
+    });
+
+    logEvent({ category: 'csp-builder', action: 'apply-preset', label: nextId });
+  };
+
+  const addViolation = () => {
+    const raw = violationInput.trim();
+    if (!raw) {
+      return;
+    }
+
+    const entry = parseViolationInput(raw);
+    setViolations((current) => [
+      {
+        id: createId(),
+        ...entry,
+      },
+      ...current,
+    ]);
+    setViolationInput('');
+  };
+
+  const clearViolations = () => {
+    setViolations([]);
+    setViolationInput('');
+  };
+
+  return (
+    <div className="h-full overflow-auto bg-gray-900 p-4 text-white">
+      <div className="mx-auto max-w-5xl space-y-6">
+        <header>
+          <h1 className="text-2xl font-semibold">Content Security Policy Builder</h1>
+          <p className="mt-2 text-sm text-gray-300">
+            Compose CSP directives, compare opinionated presets, and track sample violation reports
+            without touching production headers.
+          </p>
+        </header>
+
+        <section className="space-y-3 rounded border border-gray-700 bg-gray-800 p-4">
+          <label className="block text-sm font-medium" htmlFor="csp-preset">
+            Preset profile
+          </label>
+          <select
+            id="csp-preset"
+            value={selectedPresetId}
+            onChange={handlePresetChange}
+            className="w-full rounded border border-gray-600 bg-gray-900 p-2 text-sm"
+          >
+            {PRESET_LIST.map((preset) => (
+              <option key={preset.id} value={preset.id}>
+                {preset.title}
+              </option>
+            ))}
+          </select>
+          <div className="rounded border border-gray-700 bg-gray-900 p-3 text-sm text-gray-200">
+            <p className="font-medium text-white">{activePreset.summary}</p>
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              {activePreset.notes.map((note) => (
+                <li key={note}>{note}</li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        {transition && (
+          <section className="space-y-3 rounded border border-blue-500 bg-blue-900/40 p-4 text-sm">
+            <div>
+              <h2 className="text-base font-semibold text-blue-200">Preset diff summary</h2>
+              <p className="mt-1 text-blue-100">
+                Switched from <span className="font-medium">{getPresetTitle(transition.previousPresetId)}</span>{' '}
+                to <span className="font-medium">{getPresetTitle(transition.nextPresetId)}</span>.
+              </p>
+            </div>
+
+            {transition.hasChanges ? (
+              <div className="space-y-2">
+                {transition.diff.added.length > 0 && (
+                  <div>
+                    <h3 className="font-medium text-blue-100">Added directives</h3>
+                    <ul className="list-disc space-y-1 pl-5 text-blue-100">
+                      {transition.diff.added.map((entry) => (
+                        <li key={`added-${entry.name}`}>{formatDiffEntry(entry)}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {transition.diff.changed.length > 0 && (
+                  <div>
+                    <h3 className="font-medium text-blue-100">Updated directives</h3>
+                    <ul className="list-disc space-y-1 pl-5 text-blue-100">
+                      {transition.diff.changed.map((entry) => (
+                        <li key={`changed-${entry.name}`}>{formatDiffEntry(entry)}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {transition.diff.removed.length > 0 && (
+                  <div>
+                    <h3 className="font-medium text-blue-100">Removed directives</h3>
+                    <ul className="list-disc space-y-1 pl-5 text-blue-100">
+                      {transition.diff.removed.map((entry) => (
+                        <li key={`removed-${entry.name}`}>{formatDiffEntry(entry)}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <p className="text-blue-100">
+                The selected preset matches the current directive list—no policy changes were required.
+              </p>
+            )}
+
+            <div className="rounded border border-blue-400/60 bg-blue-900/30 p-3 text-blue-100">
+              <p className="font-medium">{transition.summary}</p>
+              <ul className="mt-2 list-disc space-y-1 pl-5">
+                {transition.notes.map((note) => (
+                  <li key={note}>{note}</li>
+                ))}
+              </ul>
+              {transition.clearedViolations && (
+                <p className="mt-2 text-xs text-blue-200">
+                  Previous violation entries were cleared to avoid cross-preset confusion.
+                </p>
+              )}
+            </div>
+          </section>
+        )}
+
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold">Directive editor</h2>
+            <button
+              type="button"
+              onClick={addDirective}
+              className="rounded bg-ub-green px-3 py-1 text-sm font-medium text-black hover:bg-ub-light-green"
+            >
+              Add directive
+            </button>
+          </div>
+          <div className="space-y-4">
+            {directives.map((directive) => {
+              const nameInputId = `${directive.id}-name`;
+              const sourcesInputId = `${directive.id}-sources`;
+
+              return (
+                <div
+                  key={directive.id}
+                  className="space-y-3 rounded border border-gray-700 bg-gray-800 p-4"
+                >
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <label className="block text-sm font-medium" htmlFor={nameInputId}>
+                      <span>Directive</span>
+                      <input
+                        id={nameInputId}
+                        className="mt-1 w-full rounded border border-gray-600 bg-gray-900 p-2 text-sm"
+                        value={directive.name}
+                        onChange={updateDirective(directive.id, 'name')}
+                        placeholder="default-src"
+                        aria-label="Directive name"
+                      />
+                    </label>
+                    <label className="block text-sm font-medium" htmlFor={sourcesInputId}>
+                      <span>Sources</span>
+                      <input
+                        id={sourcesInputId}
+                        className="mt-1 w-full rounded border border-gray-600 bg-gray-900 p-2 text-sm"
+                        value={directive.value}
+                        onChange={updateDirective(directive.id, 'value')}
+                        placeholder="'self' https://cdn.example.com"
+                        aria-label="Directive sources"
+                      />
+                    </label>
+                  </div>
+                  {directive.description && (
+                    <p className="text-xs text-gray-300">{directive.description}</p>
+                  )}
+                  <div className="flex justify-end">
+                    <button
+                      type="button"
+                      onClick={() => removeDirective(directive.id)}
+                      className="rounded border border-red-500 px-3 py-1 text-xs font-semibold text-red-200 hover:bg-red-500/10"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">Policy preview</h2>
+          <pre className="max-h-64 overflow-auto rounded border border-gray-700 bg-black p-4 text-sm text-green-300">
+            {policy || '# Add directives to generate a Content-Security-Policy header'}
+          </pre>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">Violation log</h2>
+          <p className="text-sm text-gray-300">
+            Paste JSON from a <code className="font-mono">SecurityPolicyViolationEvent</code> or Reporting API payload to
+            capture how the policy behaves. Logs are cleared automatically whenever a preset is applied.
+          </p>
+          <label className="block text-sm font-medium" htmlFor="violation-log-input">
+            Violation payload
+          </label>
+          <textarea
+            id="violation-log-input"
+            value={violationInput}
+            onChange={(event) => setViolationInput(event.target.value)}
+            className="min-h-[120px] w-full rounded border border-gray-600 bg-gray-900 p-2 text-sm"
+            placeholder='{"effectiveDirective":"img-src","blockedURI":"https://cdn.example.com/logo.png"}'
+            aria-label="Violation payload"
+          />
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={addViolation}
+              className="rounded bg-ub-green px-3 py-1 text-sm font-semibold text-black hover:bg-ub-light-green"
+            >
+              Log violation
+            </button>
+            <button
+              type="button"
+              onClick={clearViolations}
+              className="rounded border border-gray-500 px-3 py-1 text-sm text-gray-200 hover:bg-gray-800"
+            >
+              Clear log
+            </button>
+          </div>
+          {violations.length === 0 ? (
+            <p className="text-sm text-gray-400">No violation entries recorded yet.</p>
+          ) : (
+            <ul className="space-y-2">
+              {violations.map((violation) => (
+                <li
+                  key={violation.id}
+                  className="rounded border border-gray-700 bg-gray-800 p-3 text-sm"
+                >
+                  <p className="font-medium text-white">
+                    {violation.directive || 'Unknown directive'}
+                  </p>
+                  <p className="text-xs text-gray-300">
+                    Blocked: {violation.blockedUri || 'N/A'}
+                    {violation.documentUri ? ` · Document: ${violation.documentUri}` : ''}
+                    {typeof violation.lineNumber === 'number'
+                      ? ` · Line ${violation.lineNumber}${
+                          typeof violation.columnNumber === 'number'
+                            ? `:${violation.columnNumber}`
+                            : ''
+                        }`
+                      : ''}
+                  </p>
+                  <pre className="mt-2 overflow-auto rounded bg-black/60 p-2 text-xs text-green-300">
+                    {violation.raw}
+                  </pre>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default CspBuilder;

--- a/components/apps/csp-builder/presets.ts
+++ b/components/apps/csp-builder/presets.ts
@@ -1,0 +1,238 @@
+export type CspPresetId = 'strict' | 'balanced' | 'relaxed';
+
+export interface CspDirectiveDefinition {
+  /**
+   * CSP directive key such as `default-src` or `img-src`.
+   */
+  name: string;
+  /**
+   * Space separated list of sources for the directive.
+   */
+  value: string;
+  /**
+   * Human readable description that explains the intent of the directive.
+   */
+  description: string;
+}
+
+export interface CspPreset {
+  id: CspPresetId;
+  /** Display name for the preset in the UI. */
+  title: string;
+  /** Short blurb that summarises the focus of the profile. */
+  summary: string;
+  /** Full list of directives that should be applied when the preset is selected. */
+  directives: CspDirectiveDefinition[];
+  /** Supplemental guidance that is surfaced beside the preset diff summary. */
+  notes: string[];
+}
+
+const strictPreset: CspPreset = {
+  id: 'strict',
+  title: 'Strict lockdown',
+  summary:
+    'Locks every resource to the application origin and disables inline execution for a hardened baseline.',
+  directives: [
+    {
+      name: 'default-src',
+      value: "'self'",
+      description: 'Fallback for any directive not explicitly set. Only same-origin resources are permitted.',
+    },
+    {
+      name: 'script-src',
+      value: "'self'",
+      description: 'Blocks third-party scripts and inline execution to reduce the risk of XSS gadgets.',
+    },
+    {
+      name: 'style-src',
+      value: "'self'",
+      description: 'Prevents inline styles and remote stylesheets that could inject unreviewed CSS.',
+    },
+    {
+      name: 'img-src',
+      value: "'self' data:",
+      description: 'Allows same-origin images or embedded data URIs so UI icons still render.',
+    },
+    {
+      name: 'font-src',
+      value: "'self'",
+      description: 'Fonts must be served from the app to avoid tracking via third-party CDNs.',
+    },
+    {
+      name: 'connect-src',
+      value: "'self'",
+      description: 'Restricts fetch/XHR/WebSocket connections to the primary origin.',
+    },
+    {
+      name: 'frame-ancestors',
+      value: "'self'",
+      description: 'Prevents the site from being embedded in other origins, mitigating clickjacking.',
+    },
+    {
+      name: 'form-action',
+      value: "'self'",
+      description: 'Ensures form submissions only target same-origin endpoints.',
+    },
+    {
+      name: 'object-src',
+      value: "'none'",
+      description: 'Blocks legacy plug-in content such as Flash or PDF object embeds.',
+    },
+    {
+      name: 'base-uri',
+      value: "'self'",
+      description: 'Stops attackers from tampering with the document base URL to hijack relative links.',
+    },
+  ],
+  notes: [
+    'Best starting point for new apps that have full control over their resources.',
+    'Expect to add granular exceptions for analytics, fonts, or integrations as requirements grow.',
+    'Inline scripts and styles are blocked so legacy snippets may require refactoring before rollout.',
+  ],
+};
+
+const balancedPreset: CspPreset = {
+  id: 'balanced',
+  title: 'Balanced production',
+  summary:
+    'Keeps a same-origin default but whitelists the most common SaaS integrations used by dashboards.',
+  directives: [
+    {
+      name: 'default-src',
+      value: "'self'",
+      description: 'Same-origin fallback keeps the policy easy to reason about.',
+    },
+    {
+      name: 'script-src',
+      value: "'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com",
+      description: 'Allows analytics tag loaders while keeping third-party script hosts explicit.',
+    },
+    {
+      name: 'style-src',
+      value: "'self' 'unsafe-inline' https://fonts.googleapis.com",
+      description: 'Inline styles remain for component libraries while permitting Google Fonts CSS.',
+    },
+    {
+      name: 'img-src',
+      value: "'self' data: https:",
+      description: 'Supports CDN-hosted avatars, screenshots, and data URIs for UI sprites.',
+    },
+    {
+      name: 'font-src',
+      value: "'self' https://fonts.gstatic.com",
+      description: 'Fonts may load from Google Fonts in addition to the primary origin.',
+    },
+    {
+      name: 'connect-src',
+      value: "'self' https://api.example.com https://www.google-analytics.com",
+      description: 'Permits API calls to the backend and analytics beacons for instrumentation.',
+    },
+    {
+      name: 'frame-src',
+      value: "'self' https://www.youtube.com https://player.vimeo.com",
+      description: 'Whitelists trusted media providers for embedded walkthrough videos.',
+    },
+    {
+      name: 'frame-ancestors',
+      value: "'self'",
+      description: 'Still prevents third-party framing of the main app surface.',
+    },
+    {
+      name: 'form-action',
+      value: "'self'",
+      description: 'Forms continue to post back to the application to avoid credential phishing.',
+    },
+    {
+      name: 'object-src',
+      value: "'none'",
+      description: 'Legacy plug-ins remain disabled for broad compatibility.',
+    },
+    {
+      name: 'base-uri',
+      value: "'self'",
+      description: 'Protects relative links from being rewritten by injected scripts.',
+    },
+  ],
+  notes: [
+    'Intended for production dashboards that embed analytics and hosted media players.',
+    'Inline scripts are still enabled to accommodate legacy widgets—migrate to non-inline scripts when possible.',
+    'Review the allowlists regularly and tighten hosts that are no longer required.',
+  ],
+};
+
+const relaxedPreset: CspPreset = {
+  id: 'relaxed',
+  title: 'Relaxed staging',
+  summary:
+    'Opens additional sources that make it easier to prototype integrations while still avoiding obvious anti-patterns.',
+  directives: [
+    {
+      name: 'default-src',
+      value: "'self' https:",
+      description: 'Permits loading most content over HTTPS which is common during discovery work.',
+    },
+    {
+      name: 'script-src',
+      value: "'self' 'unsafe-inline' 'unsafe-eval' https:",
+      description: 'Allows inline scripts and eval for debugging frameworks, but still forces HTTPS.',
+    },
+    {
+      name: 'style-src',
+      value: "'self' 'unsafe-inline' https:",
+      description: 'Developers can iterate with remote style frameworks without constant CSP edits.',
+    },
+    {
+      name: 'img-src',
+      value: "'self' data: blob: https:",
+      description: 'Supports screenshots and files from a wide range of HTTPS origins during testing.',
+    },
+    {
+      name: 'font-src',
+      value: "'self' data: https:",
+      description: 'Allows hosted icon fonts and data URIs generated during rapid prototyping.',
+    },
+    {
+      name: 'connect-src',
+      value: "'self' https: wss:",
+      description: 'Permits WebSocket experimentation and calls to remote APIs over HTTPS.',
+    },
+    {
+      name: 'media-src',
+      value: "'self' https:",
+      description: 'Enables streaming audio or video content from remote providers.',
+    },
+    {
+      name: 'frame-src',
+      value: '* data:',
+      description: 'Allows embedding arbitrary HTTPS tools or sandboxes while iterating on integrations.',
+    },
+    {
+      name: 'frame-ancestors',
+      value: "'self' https://trusted.example.com",
+      description: 'Keeps clickjacking protections but permits a known partner to frame the app.',
+    },
+    {
+      name: 'form-action',
+      value: "'self' https:",
+      description: 'Forms may submit to partner HTTPS endpoints commonly used in staging tests.',
+    },
+    {
+      name: 'object-src',
+      value: "'none'",
+      description: 'Even in relaxed mode, legacy plug-ins remain blocked.',
+    },
+  ],
+  notes: [
+    'Use for staging or demo environments where developer velocity is prioritised over a locked-down CSP.',
+    'Continuously audit remote hosts that creep into the policy and prune before promoting to production.',
+    'Because eval and inline execution are enabled, never deploy this profile to untrusted environments.',
+  ],
+};
+
+export const CSP_PRESETS: Record<CspPresetId, CspPreset> = {
+  strict: strictPreset,
+  balanced: balancedPreset,
+  relaxed: relaxedPreset,
+};
+
+export const PRESET_LIST = Object.values(CSP_PRESETS);

--- a/pages/apps/csp-builder.jsx
+++ b/pages/apps/csp-builder.jsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const CspBuilderPreview = dynamic(() => import('../../apps/csp-builder'), {
+  ssr: false,
+  loading: () => <p>Loading CSP builder...</p>,
+});
+
+export default function CspBuilderPage() {
+  return <CspBuilderPreview />;
+}


### PR DESCRIPTION
## Summary
- add CSP preset definitions for strict, balanced, and relaxed profiles including directive notes
- build a CSP Builder utility with preset selector, diff summary, analytics logging, and violation log handling
- register the builder in the utilities catalog and expose a dynamic `/apps/csp-builder` route

## Testing
- yarn lint *(fails: pre-existing jsx-a11y and no-top-level-window violations across legacy apps)*
- yarn test *(fails: pre-existing suites like window, nmapNse, contact API, and jsdom localStorage errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cc475087788328b0e4557a8709ea82