### PR TITLE
[app] add cors tester preflight preview

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -110,6 +110,7 @@ const ReconNGApp = createDynamicApp('reconng', 'Recon-ng');
 const SecurityToolsApp = createDynamicApp('security-tools', 'Security Tools');
 const SSHApp = createDynamicApp('ssh', 'SSH Command Builder');
 const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
+const CorsTesterApp = createDynamicApp('cors-tester', 'CORS Tester');
 const HtmlRewriteApp = createDynamicApp('html-rewriter', 'HTML Rewriter');
 const ContactApp = createDynamicApp('contact', 'Contact');
 
@@ -195,6 +196,7 @@ const displayReconNG = createDisplay(ReconNGApp);
 const displaySecurityTools = createDisplay(SecurityToolsApp);
 const displaySSH = createDisplay(SSHApp);
 const displayHTTP = createDisplay(HTTPApp);
+const displayCorsTester = createDisplay(CorsTesterApp);
 const displayHtmlRewrite = createDisplay(HtmlRewriteApp);
 const displayContact = createDisplay(ContactApp);
 
@@ -897,6 +899,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayHTTP,
+  },
+  {
+    id: 'cors-tester',
+    title: 'CORS Tester',
+    icon: '/themes/Yaru/apps/http.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayCorsTester,
   },
   {
     id: 'html-rewriter',

--- a/apps/cors-tester/index.tsx
+++ b/apps/cors-tester/index.tsx
@@ -1,0 +1,284 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import PreflightPanel from '../../components/apps/cors-tester/PreflightPanel';
+
+const SIMPLE_METHODS = ['GET', 'HEAD', 'POST'];
+const COMPLEX_METHODS = ['PUT', 'PATCH', 'DELETE'];
+const SPECIAL_METHODS = ['OPTIONS'];
+const BLOCKED_METHODS = ['TRACE', 'TRACK', 'CONNECT'];
+
+const DEFAULT_REQUEST_HEADERS = `Content-Type: application/json\nAuthorization: Bearer <token>`;
+const DEFAULT_REQUESTED_HEADERS = 'Content-Type, Authorization';
+const DEFAULT_ALLOWED_ORIGINS = 'https://demo-client.app, https://alt-client.app';
+const DEFAULT_ORIGIN = 'https://demo-client.app';
+const DEFAULT_MAX_AGE = '600';
+
+const parseLines = (raw: string): string[] =>
+  raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+const parseNameList = (raw: string): string[] =>
+  raw
+    .split(/[\n,]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+const extractHeaderNames = (lines: string[]): string[] =>
+  lines
+    .map((line) => line.split(':')[0]?.trim() ?? '')
+    .filter(Boolean);
+
+const CorsTesterApp: React.FC = () => {
+  const [method, setMethod] = useState('POST');
+  const [origin, setOrigin] = useState(DEFAULT_ORIGIN);
+  const [allowCredentials, setAllowCredentials] = useState(false);
+  const [requestHeadersInput, setRequestHeadersInput] = useState(DEFAULT_REQUEST_HEADERS);
+  const [requestedHeadersInput, setRequestedHeadersInput] = useState(DEFAULT_REQUESTED_HEADERS);
+  const [allowedOriginsInput, setAllowedOriginsInput] = useState(DEFAULT_ALLOWED_ORIGINS);
+  const [maxAgeInput, setMaxAgeInput] = useState(DEFAULT_MAX_AGE);
+
+  const requestHeaderLines = useMemo(
+    () => parseLines(requestHeadersInput),
+    [requestHeadersInput],
+  );
+  const requestHeaderNames = useMemo(
+    () => extractHeaderNames(requestHeaderLines),
+    [requestHeaderLines],
+  );
+  const requestedHeaderNames = useMemo(
+    () => parseNameList(requestedHeadersInput),
+    [requestedHeadersInput],
+  );
+  const allowedOrigins = useMemo(
+    () => parseNameList(allowedOriginsInput),
+    [allowedOriginsInput],
+  );
+
+  const { maxAgeSeconds, maxAgeError, usingDefaultMaxAge } = useMemo(() => {
+    const trimmed = maxAgeInput.trim();
+    if (trimmed.length === 0) {
+      return { maxAgeSeconds: Number.parseInt(DEFAULT_MAX_AGE, 10), maxAgeError: null, usingDefaultMaxAge: true };
+    }
+    const parsed = Number.parseInt(trimmed, 10);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return { maxAgeSeconds: Number.parseInt(DEFAULT_MAX_AGE, 10), maxAgeError: 'Enter a non-negative integer.', usingDefaultMaxAge: true };
+    }
+    return { maxAgeSeconds: parsed, maxAgeError: null, usingDefaultMaxAge: false };
+  }, [maxAgeInput]);
+
+  return (
+    <div className="h-full w-full overflow-auto bg-slate-950 text-slate-100">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6 p-6">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-semibold text-sky-200">CORS Preflight Tester</h1>
+          <p className="text-sm text-slate-300">
+            Experiment with request methods and headers to see how a mock server would build its <code>Access-Control-*</code> response.{' '}
+            Everything stays in the browser—no network calls are made.
+          </p>
+        </header>
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+          <form
+            className="space-y-6 rounded border border-slate-800 bg-slate-900/70 p-4 shadow-lg backdrop-blur"
+            onSubmit={(event) => event.preventDefault()}
+          >
+            <fieldset className="space-y-4">
+              <legend className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+                Request
+              </legend>
+              <div className="space-y-2">
+                <label htmlFor="cors-method" className="block text-sm font-medium text-slate-200">
+                  Actual request method
+                </label>
+                <select
+                  id="cors-method"
+                  value={method}
+                  onChange={(event) => setMethod(event.target.value)}
+                  className="w-full rounded border border-slate-700 bg-slate-950/60 p-2 text-slate-100 focus:border-sky-400 focus:outline-none"
+                >
+                  <optgroup label="Simple">
+                    {SIMPLE_METHODS.map((value) => (
+                      <option key={value} value={value}>
+                        {value}
+                      </option>
+                    ))}
+                  </optgroup>
+                  <optgroup label="Preflighted">
+                    {COMPLEX_METHODS.map((value) => (
+                      <option key={value} value={value}>
+                        {value}
+                      </option>
+                    ))}
+                  </optgroup>
+                  <optgroup label="Special">
+                    {SPECIAL_METHODS.map((value) => (
+                      <option key={value} value={value}>
+                        {value} (preflight verb)
+                      </option>
+                    ))}
+                  </optgroup>
+                  <optgroup label="Blocked">
+                    {BLOCKED_METHODS.map((value) => (
+                      <option key={value} value={value}>
+                        {value} (blocked)
+                      </option>
+                    ))}
+                  </optgroup>
+                </select>
+                <p className="text-xs text-slate-400">
+                  The preflight response should mirror this value inside <code>Access-Control-Allow-Methods</code> when it is permitted.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="cors-origin" className="block text-sm font-medium text-slate-200">
+                  Request Origin header
+                </label>
+                <input
+                  id="cors-origin"
+                  type="text"
+                  value={origin}
+                  onChange={(event) => setOrigin(event.target.value)}
+                  placeholder="https://demo-client.app"
+                  className="w-full rounded border border-slate-700 bg-slate-950/60 p-2 text-slate-100 focus:border-sky-400 focus:outline-none"
+                />
+                <p className="text-xs text-slate-400">
+                  Enter the origin of the calling site. The preview will show whether it matches the allowed list.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="cors-request-headers" className="block text-sm font-medium text-slate-200">
+                  Actual request headers
+                </label>
+                <textarea
+                  id="cors-request-headers"
+                  value={requestHeadersInput}
+                  onChange={(event) => setRequestHeadersInput(event.target.value)}
+                  rows={5}
+                  className="w-full rounded border border-slate-700 bg-slate-950/60 p-2 font-mono text-sm text-slate-100 focus:border-sky-400 focus:outline-none"
+                />
+                <p className="text-xs text-slate-400">
+                  Provide one header per line using the <code>Name: value</code> format. Headers such as <code>Cookie</code> will be rejected by browsers.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="cors-requested-headers" className="block text-sm font-medium text-slate-200">
+                  <code>Access-Control-Request-Headers</code>
+                </label>
+                <textarea
+                  id="cors-requested-headers"
+                  value={requestedHeadersInput}
+                  onChange={(event) => setRequestedHeadersInput(event.target.value)}
+                  rows={3}
+                  className="w-full rounded border border-slate-700 bg-slate-950/60 p-2 font-mono text-sm text-slate-100 focus:border-sky-400 focus:outline-none"
+                  placeholder="Content-Type, Authorization"
+                />
+                <p className="text-xs text-slate-400">
+                  Separate names with commas or newlines. The preview highlights non-simple headers that need to be echoed back.
+                </p>
+              </div>
+            </fieldset>
+            <fieldset className="space-y-4">
+              <legend className="text-sm font-semibold uppercase tracking-wide text-slate-400">Policy</legend>
+              <div className="space-y-2">
+                <label htmlFor="cors-allowed-origins" className="block text-sm font-medium text-slate-200">
+                  Allowed origins
+                </label>
+                <textarea
+                  id="cors-allowed-origins"
+                  value={allowedOriginsInput}
+                  onChange={(event) => setAllowedOriginsInput(event.target.value)}
+                  rows={3}
+                  className="w-full rounded border border-slate-700 bg-slate-950/60 p-2 font-mono text-sm text-slate-100 focus:border-sky-400 focus:outline-none"
+                  placeholder="https://demo-client.app, https://alt-client.app"
+                />
+                <p className="text-xs text-slate-400">
+                  Provide a comma or newline separated list. Use <code>*</code> to allow any origin.
+                </p>
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <label htmlFor="cors-credentials" className="flex items-center gap-3 text-sm font-medium text-slate-200">
+                  <input
+                    id="cors-credentials"
+                    type="checkbox"
+                    checked={allowCredentials}
+                    onChange={(event) => setAllowCredentials(event.target.checked)}
+                    className="h-4 w-4 rounded border border-slate-600 bg-slate-900 text-sky-400 focus:ring-2 focus:ring-sky-500"
+                  />
+                  Allow credentials
+                </label>
+                <p className="text-xs text-slate-400">
+                  Required for cookies or Authorization headers. The preview warns when paired with a wildcard origin.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="cors-max-age" className="block text-sm font-medium text-slate-200">
+                  <code>Access-Control-Max-Age</code> (seconds)
+                </label>
+                <input
+                  id="cors-max-age"
+                  type="number"
+                  min={0}
+                  value={maxAgeInput}
+                  onChange={(event) => setMaxAgeInput(event.target.value)}
+                  className="w-full rounded border border-slate-700 bg-slate-950/60 p-2 text-slate-100 focus:border-sky-400 focus:outline-none"
+                />
+                <p className="text-xs text-slate-400">
+                  Controls how long the browser can cache a successful preflight. Values above 86,400 seconds are clamped.
+                </p>
+                {maxAgeError && <p className="text-xs text-rose-400">{maxAgeError}</p>}
+                {usingDefaultMaxAge && !maxAgeError && (
+                  <p className="text-xs text-slate-500">
+                    Empty input uses the default of {DEFAULT_MAX_AGE} seconds.
+                  </p>
+                )}
+              </div>
+            </fieldset>
+          </form>
+          <div className="space-y-6">
+            <PreflightPanel
+              method={method}
+              origin={origin}
+              requestHeaders={requestHeaderLines}
+              requestedHeaders={requestedHeaderNames}
+              allowCredentials={allowCredentials}
+              maxAgeSeconds={maxAgeSeconds}
+              allowedOrigins={allowedOrigins}
+            />
+            <section className="rounded border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300">
+              <h2 className="mb-3 text-base font-semibold text-slate-200">Normalized inputs</h2>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-400">Actual request headers</p>
+                  <ul className="mt-1 space-y-1 font-mono text-xs text-slate-100">
+                    {requestHeaderNames.length > 0 ? (
+                      requestHeaderNames.map((name) => <li key={name}>{name}</li>)
+                    ) : (
+                      <li className="text-slate-500">— none —</li>
+                    )}
+                  </ul>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-400">Access-Control-Request-Headers</p>
+                  <ul className="mt-1 space-y-1 font-mono text-xs text-slate-100">
+                    {requestedHeaderNames.length > 0 ? (
+                      requestedHeaderNames.map((name) => <li key={name}>{name}</li>)
+                    ) : (
+                      <li className="text-slate-500">— none —</li>
+                    )}
+                  </ul>
+                </div>
+              </div>
+              <p className="mt-3 text-xs text-slate-400">
+                These derived lists are sent to the preview component. Adjusting them updates the mock response immediately.
+              </p>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CorsTesterApp;

--- a/components/apps/cors-tester/PreflightPanel.tsx
+++ b/components/apps/cors-tester/PreflightPanel.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import React, { useMemo } from 'react';
+
+type Status = 'ok' | 'warn' | 'error';
+
+export interface PreflightPanelProps {
+  method: string;
+  /** Origin that initiated the preflight request */
+  origin?: string;
+  /** Header names present on the actual request (e.g. "Content-Type") */
+  requestHeaders: string[];
+  /** Values from the Access-Control-Request-Headers preflight header */
+  requestedHeaders: string[];
+  /** Whether Access-Control-Allow-Credentials should be returned */
+  allowCredentials?: boolean;
+  /** Max age advertised to the browser */
+  maxAgeSeconds?: number;
+  /** Explicit allow-list of origins. `*` permits any origin. */
+  allowedOrigins?: string[];
+}
+
+const ALLOWED_METHOD_LIST = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'];
+const ALLOWED_METHODS = new Set(ALLOWED_METHOD_LIST);
+const FORBIDDEN_METHODS = new Set(['TRACE', 'TRACK', 'CONNECT']);
+const SIMPLE_HEADERS = new Set(['accept', 'accept-language', 'content-language', 'content-type']);
+const FORBIDDEN_HEADERS = new Set([
+  'accept-charset',
+  'accept-encoding',
+  'access-control-request-headers',
+  'access-control-request-method',
+  'connection',
+  'content-length',
+  'cookie',
+  'cookie2',
+  'date',
+  'dnt',
+  'expect',
+  'feature-policy',
+  'host',
+  'keep-alive',
+  'origin',
+  'referer',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'via',
+]);
+
+const statusTextStyles: Record<Status, string> = {
+  ok: 'text-emerald-300',
+  warn: 'text-amber-300',
+  error: 'text-rose-400',
+};
+
+const statusBorderStyles: Record<Status, string> = {
+  ok: 'border-emerald-500/40',
+  warn: 'border-amber-500/40',
+  error: 'border-rose-500/50',
+};
+
+const toHeaderCase = (header: string): string =>
+  header
+    .toLowerCase()
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('-');
+
+const sanitizeHeaderList = (values: string[]): string[] =>
+  values
+    .map((value) => value.split(':')[0]?.trim() ?? '')
+    .map((value) => value.replace(/^"|"$/g, ''))
+    .map((value) => value.toLowerCase())
+    .filter(Boolean);
+
+const parseCsv = (values: string[]): string[] =>
+  values
+    .flatMap((value) => value.split(','))
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+const normalizeOrigin = (origin?: string): string =>
+  (origin ?? '').trim().replace(/\/$/, '').toLowerCase();
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);
+
+const unique = <T,>(items: T[]): T[] => Array.from(new Set(items));
+
+const isForbiddenHeader = (header: string): boolean =>
+  FORBIDDEN_HEADERS.has(header) || header.startsWith('proxy-') || header.startsWith('sec-');
+
+const describeForbiddenHeaders = (headers: string[]): string =>
+  headers.map(toHeaderCase).join(', ');
+
+const describeHeaders = (headers: string[]): string =>
+  headers.length ? headers.map(toHeaderCase).join(', ') : '∅';
+
+const joinList = (values: string[]): string =>
+  values.join(', ');
+
+const originMatches = (origin: string, allowList: string[]): boolean => {
+  const normalizedOrigin = normalizeOrigin(origin);
+  const normalizedAllow = allowList.map((entry) => normalizeOrigin(entry));
+  return (
+    normalizedAllow.includes('*') ||
+    (normalizedOrigin.length > 0 && normalizedAllow.includes(normalizedOrigin))
+  );
+};
+
+const DEFAULT_ORIGINS = ['https://demo-client.app'];
+const DEFAULT_MAX_AGE = 600;
+
+const PreflightPanel: React.FC<PreflightPanelProps> = ({
+  method,
+  origin,
+  requestHeaders,
+  requestedHeaders,
+  allowCredentials = false,
+  maxAgeSeconds = DEFAULT_MAX_AGE,
+  allowedOrigins,
+}) => {
+  const analysis = useMemo(() => {
+    const normalizedMethod = method.trim().toUpperCase() || 'GET';
+    const methodForbidden = FORBIDDEN_METHODS.has(normalizedMethod);
+    const methodAllowed = ALLOWED_METHODS.has(normalizedMethod) && !methodForbidden;
+
+    const methodList = methodAllowed
+      ? unique([normalizedMethod, 'OPTIONS'])
+      : unique([...ALLOWED_METHOD_LIST, 'OPTIONS']);
+
+    let methodReason: string;
+    let methodStatus: Status;
+    if (methodForbidden) {
+      methodStatus = 'error';
+      methodReason = `${normalizedMethod} is blocked by browsers because it can expose proxy internals.`;
+    } else if (!ALLOWED_METHODS.has(normalizedMethod)) {
+      methodStatus = 'error';
+      methodReason = `${normalizedMethod} is not enabled in this mock policy. Add it to the allow-list (${ALLOWED_METHOD_LIST.join(', ')}) to let the request through.`;
+    } else {
+      methodStatus = 'ok';
+      methodReason = `${normalizedMethod} is listed as an allowed method and will be echoed back to the browser.`;
+    }
+
+    const headerCandidates = unique([
+      ...sanitizeHeaderList(requestHeaders),
+      ...sanitizeHeaderList(requestedHeaders),
+      ...sanitizeHeaderList(parseCsv(requestedHeaders)),
+    ]);
+
+    const forbiddenHeaders = headerCandidates.filter(isForbiddenHeader);
+    const filteredHeaders = headerCandidates.filter((header) => !isForbiddenHeader(header));
+
+    const simpleHeaders = filteredHeaders.filter((header) => SIMPLE_HEADERS.has(header));
+    const nonSimpleHeaders = filteredHeaders.filter((header) => !SIMPLE_HEADERS.has(header));
+
+    const allowHeaders = unique(nonSimpleHeaders).map(toHeaderCase);
+
+    let headersReason: string;
+    let headersStatus: Status;
+    if (forbiddenHeaders.length > 0) {
+      headersStatus = 'error';
+      headersReason = `Removed forbidden headers (${describeForbiddenHeaders(forbiddenHeaders)}). Browsers will refuse them on cross-origin requests.`;
+    } else if (nonSimpleHeaders.length > 0) {
+      headersStatus = 'ok';
+      headersReason = `Non-simple headers (${describeHeaders(nonSimpleHeaders)}) must appear in Access-Control-Allow-Headers.`;
+    } else if (filteredHeaders.length > 0) {
+      headersStatus = 'warn';
+      headersReason = `Only simple headers detected (${describeHeaders(simpleHeaders)}). They do not need to be listed explicitly.`;
+    } else {
+      headersStatus = 'warn';
+      headersReason = 'No custom headers supplied. The browser will treat this as a simple request.';
+    }
+
+    const normalizedOrigin = origin ?? '';
+    const sourceAllowList = (allowedOrigins ?? DEFAULT_ORIGINS)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    const usingDefaultOrigins = allowedOrigins === undefined;
+    const allowList = usingDefaultOrigins
+      ? sourceAllowList.length > 0
+        ? sourceAllowList
+        : DEFAULT_ORIGINS
+      : sourceAllowList;
+    const originAllowed = allowList.length > 0 && originMatches(normalizedOrigin, allowList);
+
+    const hasWildcard = allowList.some((entry) => normalizeOrigin(entry) === '*');
+
+    const allowOriginValue = originAllowed
+      ? normalizedOrigin || '*'
+      : hasWildcard
+      ? '*'
+      : 'null';
+    const allowListLabel = allowList.length ? joinList(allowList) : '∅';
+
+    const originStatus: Status = originAllowed ? 'ok' : 'error';
+    const originReason = originAllowed
+      ? `${normalizedOrigin || 'Any origin'} matches the allow-list.`
+      : allowList.length === 0
+      ? 'No origins are currently allowed by this policy.'
+      : normalizedOrigin
+      ? `${normalizedOrigin} is not on the allow-list (${allowListLabel}).`
+      : 'No origin supplied. Provide one to see the exact echo value.';
+
+    const clampedMaxAge = clamp(maxAgeSeconds, 0, 86400);
+    const credentialStatus: Status = allowCredentials && allowOriginValue === '*'
+      ? 'warn'
+      : 'ok';
+    const credentialReason = allowCredentials
+      ? allowOriginValue === '*'
+        ? 'Browsers ignore credentialed responses with a wildcard origin. Return a specific origin instead.'
+        : 'Credentials are allowed. Ensure caching layers key on Origin.'
+      : 'Credentials disabled. Responses remain broadly cacheable.';
+
+    return {
+      rows: [
+        {
+          header: 'Access-Control-Allow-Origin',
+          value: allowOriginValue,
+          status: originStatus,
+          reason: originReason,
+        },
+        {
+          header: 'Access-Control-Allow-Methods',
+          value: methodList.join(', '),
+          status: methodStatus,
+          reason: methodReason,
+        },
+        {
+          header: 'Access-Control-Allow-Headers',
+          value: allowHeaders.length ? allowHeaders.join(', ') : '∅',
+          status: headersStatus,
+          reason: headersReason,
+        },
+        {
+          header: 'Access-Control-Allow-Credentials',
+          value: allowCredentials ? 'true' : 'false',
+          status: credentialStatus,
+          reason: credentialReason,
+        },
+        {
+          header: 'Access-Control-Max-Age',
+          value: `${clampedMaxAge}s`,
+          status: 'ok' as Status,
+          reason:
+            clampedMaxAge === 0
+              ? 'Zero seconds disables caching; the browser will preflight every request.'
+              : `Caches the preflight result for ${clampedMaxAge} seconds.`,
+        },
+        {
+          header: 'Vary',
+          value: 'Origin',
+          status: 'ok' as Status,
+          reason: 'Ensures caches keep separate entries per requesting origin.',
+        },
+      ],
+      simpleHeaders: unique(simpleHeaders.map(toHeaderCase)),
+      nonSimpleHeaders: unique(nonSimpleHeaders.map(toHeaderCase)),
+      forbiddenHeaders: unique(forbiddenHeaders.map(toHeaderCase)),
+    };
+  }, [
+    allowCredentials,
+    allowedOrigins,
+    maxAgeSeconds,
+    method,
+    origin,
+    requestHeaders,
+    requestedHeaders,
+  ]);
+
+  return (
+    <section className="space-y-4">
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold text-sky-200">Preflight Response Preview</h2>
+        <p className="text-sm text-slate-300">
+          The fields below mirror what an OPTIONS preflight response would look like for the current inputs.
+        </p>
+      </header>
+      <div className="grid gap-3">
+        {analysis.rows.map((row) => (
+          <div
+            key={row.header}
+            className={`rounded border bg-slate-900/80 p-4 shadow-sm backdrop-blur ${statusBorderStyles[row.status]}`}
+          >
+            <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-slate-400">{row.header}</p>
+                <p className="font-mono text-base text-sky-100">{row.value}</p>
+              </div>
+              <p className={`text-sm leading-relaxed md:w-1/2 ${statusTextStyles[row.status]}`}>{row.reason}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+      <footer className="rounded border border-slate-700/60 bg-slate-900/60 p-4 text-sm text-slate-300">
+        <h3 className="mb-2 font-semibold text-slate-200">Header breakdown</h3>
+        <dl className="grid gap-2 sm:grid-cols-3">
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-slate-400">Non-simple</dt>
+            <dd className="font-mono text-slate-200">{describeHeaders(analysis.nonSimpleHeaders)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-slate-400">Simple</dt>
+            <dd className="font-mono text-slate-200">{describeHeaders(analysis.simpleHeaders)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-slate-400">Rejected</dt>
+            <dd className="font-mono text-slate-200">{describeHeaders(analysis.forbiddenHeaders)}</dd>
+          </div>
+        </dl>
+      </footer>
+    </section>
+  );
+};
+
+export default PreflightPanel;

--- a/pages/apps/cors-tester.jsx
+++ b/pages/apps/cors-tester.jsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const CorsTesterApp = dynamic(() => import('../../apps/cors-tester'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default CorsTesterApp;


### PR DESCRIPTION
## Summary
- add a dedicated PreflightPanel that analyses requested methods/headers and renders an annotated Access-Control-* preview
- build a CORS tester workspace that lets users tune request metadata and see the derived response instantly
- register the utility in the dynamic app registry and expose it under /apps/cors-tester

## Testing
- yarn lint *(fails: repo has existing accessibility and no-top-level-window violations)*
- yarn test *(fails: existing suites that require act() or browser APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68cc475adb5083288642dade9a743f3e