### PR TITLE
[apps] add SameSite lab regression spec

### DIFF
--- a/__tests__/samesiteLab.test.tsx
+++ b/__tests__/samesiteLab.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SameSiteLab from '../components/apps/samesite-lab/SameSiteLab';
+import * as exportModule from '../components/apps/samesite-lab/exportSession';
+
+jest.mock('../components/apps/samesite-lab/exportSession', () => {
+  const actual = jest.requireActual('../components/apps/samesite-lab/exportSession');
+  return {
+    ...actual,
+    exportSessionReport: jest.fn(() => true),
+  };
+});
+
+const memoryThresholdBytes = 80 * 1024 * 1024; // 80MB headroom for Jest environment
+const unhandledRejections: unknown[] = [];
+const handleRejection = (reason: unknown) => {
+  unhandledRejections.push(reason);
+};
+
+let startHeap = 0;
+
+describe('SameSite lab regression', () => {
+  beforeAll(() => {
+    startHeap = process.memoryUsage().heapUsed;
+    process.on('unhandledRejection', handleRejection);
+  });
+
+  afterAll(() => {
+    process.off('unhandledRejection', handleRejection);
+    expect(unhandledRejections).toEqual([]);
+    const endHeap = process.memoryUsage().heapUsed;
+    const diff = Math.max(0, endHeap - startHeap);
+    expect(diff).toBeLessThan(memoryThresholdBytes);
+  });
+
+  it('exercises SameSite modes, header checks, and export flow', async () => {
+    const user = userEvent.setup();
+    const exportSpy = exportModule.exportSessionReport as jest.MockedFunction<
+      typeof exportModule.exportSessionReport
+    >;
+    exportSpy.mockImplementation((session) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      session.headers.Cookie;
+      return true;
+    });
+
+    render(<SameSiteLab />);
+
+    const modeSelect = screen.getByTestId('mode-select');
+    const originToggle = screen.getByTestId('origin-toggle') as HTMLInputElement;
+    const refererToggle = screen.getByTestId('referer-toggle') as HTMLInputElement;
+    const submitButton = screen.getByTestId('submit-button');
+    const submissionLog = screen.getByTestId('submission-log');
+
+    const modes: exportModule.SameSiteMode[] = ['Strict', 'Lax', 'None'];
+    const combos = [
+      { origin: true, referer: true },
+      { origin: true, referer: false },
+      { origin: false, referer: true },
+      { origin: false, referer: false },
+    ];
+
+    let attempts = 0;
+
+    for (const mode of modes) {
+      await user.selectOptions(modeSelect, mode);
+      for (const combo of combos) {
+        if (originToggle.checked !== combo.origin) {
+          await user.click(originToggle);
+        }
+        if (refererToggle.checked !== combo.referer) {
+          await user.click(refererToggle);
+        }
+
+        for (let i = 0; i < 3; i += 1) {
+          await user.click(submitButton);
+          attempts += 1;
+          const logEntries = await within(submissionLog).findAllByRole('listitem');
+          const latest = logEntries[logEntries.length - 1];
+          expect(latest).toBeDefined();
+          if (latest.textContent?.includes('Rejected')) {
+            expect(latest.textContent).toMatch(/SameSite|Origin|Referer/);
+          } else {
+            expect(latest.textContent).toContain('Accepted');
+          }
+        }
+      }
+    }
+
+    await user.click(screen.getByTestId('export-button'));
+    await screen.findByText(/Session exported/i);
+
+    expect(exportSpy).toHaveBeenCalledTimes(1);
+    const sessionArg = exportSpy.mock.calls[0][0];
+    expect(sessionArg.submissions).toHaveLength(attempts);
+    expect(sessionArg.submissions.some((entry) => entry.success)).toBe(true);
+    sessionArg.submissions
+      .filter((entry) => !entry.success)
+      .forEach((entry) => {
+        expect(entry.reasons.join(' ')).toMatch(/SameSite|Origin|Referer/);
+      });
+
+    exportSpy.mockReset();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -72,6 +72,7 @@ const QuoteApp = createDynamicApp('quote', 'Quote');
 const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery');
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
+const SameSiteLabApp = createDynamicApp('samesite-lab', 'SameSite Lab');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
@@ -165,6 +166,7 @@ const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
+const displaySameSiteLab = createDisplay(SameSiteLabApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 
@@ -897,6 +899,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayHTTP,
+  },
+  {
+    id: 'samesite-lab',
+    title: 'SameSite Lab',
+    icon: '/themes/Yaru/apps/http.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displaySameSiteLab,
   },
   {
     id: 'html-rewriter',

--- a/apps/samesite-lab/index.tsx
+++ b/apps/samesite-lab/index.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import React from 'react';
+import SameSiteLab from '../../components/apps/samesite-lab/SameSiteLab';
+
+const SameSiteLabApp: React.FC = () => {
+  return <SameSiteLab />;
+};
+
+export default SameSiteLabApp;

--- a/components/apps/samesite-lab/SameSiteLab.tsx
+++ b/components/apps/samesite-lab/SameSiteLab.tsx
@@ -1,0 +1,268 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import {
+  SESSION_FILENAME,
+  SameSiteMode,
+  SessionHeaders,
+  SessionState,
+  SubmissionOutcome,
+  buildSessionReport,
+  exportSessionReport,
+} from './exportSession';
+
+const TRUSTED_ORIGIN = 'https://target.example';
+const MALICIOUS_ORIGIN = 'https://evil.example';
+const MALICIOUS_REFERER = 'https://evil.example/form';
+
+const sameSiteModes: SameSiteMode[] = ['Strict', 'Lax', 'None'];
+
+type SubmissionEvaluation = {
+  success: boolean;
+  reasons: string[];
+};
+
+const evaluateSubmission = (
+  mode: SameSiteMode,
+  originChecked: boolean,
+  refererChecked: boolean,
+): SubmissionEvaluation => {
+  const reasons: string[] = [];
+
+  if (mode === 'Strict') {
+    reasons.push('SameSite=Strict blocked the cross-site request.');
+  } else if (mode === 'Lax') {
+    reasons.push('SameSite=Lax blocked this cross-site POST request.');
+  }
+
+  if (originChecked) {
+    reasons.push(
+      `Origin header ${MALICIOUS_ORIGIN} did not match expected ${TRUSTED_ORIGIN}.`,
+    );
+  }
+
+  if (refererChecked) {
+    reasons.push(
+      `Referer ${MALICIOUS_REFERER} was outside the trusted site and rejected.`,
+    );
+  }
+
+  return { success: reasons.length === 0, reasons };
+};
+
+const formatStatusMessage = (evaluation: SubmissionEvaluation): string => {
+  if (evaluation.success) {
+    return 'Accepted: Cookies sent with the simulated request.';
+  }
+  return `Rejected: ${evaluation.reasons.join(' ')}`;
+};
+
+const createOutcomeRecord = (
+  attempt: number,
+  mode: SameSiteMode,
+  originChecked: boolean,
+  refererChecked: boolean,
+  evaluation: SubmissionEvaluation,
+): SubmissionOutcome => ({
+  attempt,
+  mode,
+  originChecked,
+  refererChecked,
+  success: evaluation.success,
+  reasons: evaluation.reasons,
+  message: formatStatusMessage(evaluation),
+  timestamp: new Date().toISOString(),
+});
+
+const SameSiteLab: React.FC = () => {
+  const [mode, setMode] = useState<SameSiteMode>('Strict');
+  const [originChecked, setOriginChecked] = useState(true);
+  const [refererChecked, setRefererChecked] = useState(true);
+  const [submissions, setSubmissions] = useState<SubmissionOutcome[]>([]);
+  const [status, setStatus] = useState('');
+  const [exportStatus, setExportStatus] = useState('');
+
+  const headers: SessionHeaders = useMemo(
+    () => ({
+      Origin: MALICIOUS_ORIGIN,
+      Referer: MALICIOUS_REFERER,
+      Cookie: `sessionid=demo123; SameSite=${mode}`,
+    }),
+    [mode],
+  );
+
+  const handleSubmit = () => {
+    const evaluation = evaluateSubmission(mode, originChecked, refererChecked);
+    const outcome = createOutcomeRecord(
+      submissions.length + 1,
+      mode,
+      originChecked,
+      refererChecked,
+      evaluation,
+    );
+
+    setSubmissions((prev) => [...prev, outcome]);
+    setStatus(outcome.message);
+    setExportStatus('');
+  };
+
+  const handleExport = () => {
+    const session: SessionState = {
+      mode,
+      originChecked,
+      refererChecked,
+      headers,
+      submissions,
+    };
+
+    try {
+      exportSessionReport(session);
+      setExportStatus('Session exported to ' + SESSION_FILENAME);
+    } catch (error) {
+      console.warn('Export failed', error);
+      setExportStatus('Export failed. Please try again.');
+    }
+  };
+
+  const reportPreview = useMemo(() => buildSessionReport({
+    mode,
+    originChecked,
+    refererChecked,
+    headers,
+    submissions,
+  }), [headers, mode, originChecked, refererChecked, submissions]);
+
+  return (
+    <div className="flex min-h-screen flex-col gap-4 bg-gray-900 p-4 text-white">
+      <header>
+        <h1 className="text-2xl font-semibold">SameSite Lab</h1>
+        <p className="text-sm text-gray-300">
+          Explore how SameSite cookies interact with Origin and Referer checks using
+          safe, simulated requests.
+        </p>
+      </header>
+
+      <section className="grid gap-4 rounded border border-gray-800 bg-gray-950 p-4 md:grid-cols-2">
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="same-site-mode" className="mb-1 block text-sm font-medium">
+              SameSite Mode
+            </label>
+            <select
+              id="same-site-mode"
+              data-testid="mode-select"
+              className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+              value={mode}
+              onChange={(event) => setMode(event.target.value as SameSiteMode)}
+            >
+              {sameSiteModes.map((value) => (
+                <option key={value} value={value}>
+                  {value}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <fieldset className="space-y-2">
+            <legend className="text-sm font-medium text-gray-200">
+              Server-side enforcement
+            </legend>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                data-testid="origin-toggle"
+                checked={originChecked}
+                onChange={(event) => setOriginChecked(event.target.checked)}
+              />
+              Enforce Origin header check
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                data-testid="referer-toggle"
+                checked={refererChecked}
+                onChange={(event) => setRefererChecked(event.target.checked)}
+              />
+              Enforce Referer header check
+            </label>
+          </fieldset>
+
+          <div className="rounded border border-gray-800 bg-gray-900 p-3 text-xs">
+            <h2 className="text-sm font-semibold text-gray-200">Simulated Request</h2>
+            <p>Method: POST</p>
+            <p>Origin: {MALICIOUS_ORIGIN}</p>
+            <p>Referer: {MALICIOUS_REFERER}</p>
+            <p>Expected Origin: {TRUSTED_ORIGIN}</p>
+            <p>Cookie: sessionid=demo123; SameSite={mode}</p>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <button
+            type="button"
+            data-testid="submit-button"
+            onClick={handleSubmit}
+            className="rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-500"
+          >
+            Send simulated request
+          </button>
+          <div
+            role="status"
+            data-testid="status-message"
+            className="min-h-[3rem] rounded border border-gray-800 bg-gray-900 p-3 text-sm"
+          >
+            {status || 'No submissions yet.'}
+          </div>
+
+          <div>
+            <h2 className="text-sm font-semibold text-gray-200">Submission log</h2>
+            <ul
+              data-testid="submission-log"
+              className="max-h-60 space-y-2 overflow-auto rounded border border-gray-800 bg-gray-900 p-3 text-xs"
+            >
+              {submissions.length === 0 && (
+                <li className="text-gray-500">No requests submitted.</li>
+              )}
+              {submissions.map((entry) => (
+                <li
+                  key={entry.attempt}
+                  className={entry.success ? 'text-green-400' : 'text-red-400'}
+                >
+                  Attempt {entry.attempt}: {entry.message}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-3 rounded border border-gray-800 bg-gray-950 p-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <button
+            type="button"
+            data-testid="export-button"
+            onClick={handleExport}
+            className="rounded bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-500"
+          >
+            Export session report
+          </button>
+          <div
+            role="status"
+            data-testid="export-status"
+            className="min-h-[2.5rem] rounded border border-gray-800 bg-gray-900 p-2 text-xs"
+          >
+            {exportStatus || 'Export a report to capture this session.'}
+          </div>
+        </div>
+        <div>
+          <h2 className="text-sm font-semibold text-gray-200">Report preview</h2>
+          <pre className="max-h-64 overflow-auto rounded border border-gray-800 bg-black p-3 text-xs text-green-300">
+            {reportPreview}
+          </pre>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default SameSiteLab;

--- a/components/apps/samesite-lab/exportSession.ts
+++ b/components/apps/samesite-lab/exportSession.ts
@@ -1,0 +1,96 @@
+export type SameSiteMode = 'Strict' | 'Lax' | 'None';
+
+export interface SessionHeaders {
+  Origin: string;
+  Referer: string;
+  Cookie: string;
+}
+
+export interface SubmissionOutcome {
+  attempt: number;
+  mode: SameSiteMode;
+  originChecked: boolean;
+  refererChecked: boolean;
+  success: boolean;
+  reasons: string[];
+  message: string;
+  timestamp: string;
+}
+
+export interface SessionState {
+  mode: SameSiteMode;
+  originChecked: boolean;
+  refererChecked: boolean;
+  headers: SessionHeaders;
+  submissions: SubmissionOutcome[];
+}
+
+export type DownloadHandler = (content: string, filename: string) => void;
+
+export const SESSION_FILENAME = 'same-site-session.txt';
+
+export const buildSessionReport = (session: SessionState): string => {
+  const headerLines = [`SameSite Mode: ${session.mode}`];
+  headerLines.push(`Origin Check: ${session.originChecked ? 'Enabled' : 'Disabled'}`);
+  headerLines.push(
+    `Referer Check: ${session.refererChecked ? 'Enabled' : 'Disabled'}`,
+  );
+
+  const headerSnapshot = Object.entries(session.headers)
+    .map(([key, value]) => `- ${key}: ${value}`)
+    .join('\n');
+
+  const outcomeLines = session.submissions.length
+    ? session.submissions
+        .map((entry) => {
+          const status = entry.success ? 'ACCEPTED' : 'REJECTED';
+          const detail = entry.success
+            ? 'Cookies delivered successfully.'
+            : entry.reasons.join(' ');
+          return `#${entry.attempt} ${status}: ${detail}`;
+        })
+        .join('\n')
+    : 'No submissions recorded.';
+
+  return [
+    'SameSite Lab Session Report',
+    headerLines.join('\n'),
+    '',
+    'Simulated Headers:',
+    headerSnapshot,
+    '',
+    'Outcomes:',
+    outcomeLines,
+    '',
+  ].join('\n');
+};
+
+const defaultDownload: DownloadHandler = (content, filename) => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
+
+  try {
+    const blob = new Blob([content], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  } catch (error) {
+    console.error('Failed to export session', error);
+    throw error;
+  }
+};
+
+export const exportSessionReport = (
+  session: SessionState,
+  download: DownloadHandler = defaultDownload,
+): boolean => {
+  const report = buildSessionReport(session);
+  download(report, SESSION_FILENAME);
+  return true;
+};

--- a/components/apps/samesite-lab/index.ts
+++ b/components/apps/samesite-lab/index.ts
@@ -1,0 +1,2 @@
+export { default } from './SameSiteLab';
+export * from './exportSession';

--- a/pages/apps/samesite-lab.jsx
+++ b/pages/apps/samesite-lab.jsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const SameSiteLabApp = dynamic(() => import('../../apps/samesite-lab'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function SameSiteLabPage() {
+  return <SameSiteLabApp />;
+}


### PR DESCRIPTION
## Summary
- build a SameSite Lab simulation app that surfaces cookie, origin, and referer interactions and offers an export preview
- add a reusable session export helper and register the lab in the desktop application registry and route map
- create a regression spec that exercises every SameSite/header combination, checks helpful rejections, and asserts export success while watching for resource issues

## Testing
- yarn lint *(fails: repository already has extensive accessibility lint errors unrelated to this change)*
- yarn test __tests__/samesiteLab.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68cc475b4f6c83289f0f3acb1a1ec95e